### PR TITLE
feat(multi-worker): Redis-backed takeover + desktop-streaming session registries (#11639)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -483,15 +483,18 @@ async def get_system_health(
 
     Issue #744: Requires admin authentication.
     """
+    # C1: attributes removed in #11639 Redis refactor; use async helpers instead.
     try:
+        dsm = get_desktop_streaming()
+        tm = get_takeover_manager()
         health_status = {
             "status": "healthy",
-            "desktop_streaming_available": get_desktop_streaming().vnc_manager.vnc_available,
-            "novnc_available": get_desktop_streaming().vnc_manager.novnc_available,
-            "active_streaming_sessions": len(get_desktop_streaming().vnc_manager.active_sessions),
-            "pending_takeovers": len(get_takeover_manager().pending_requests),
-            "active_takeovers": len(get_takeover_manager().active_sessions),
-            "paused_tasks": len(get_takeover_manager().paused_tasks),
+            "desktop_streaming_available": dsm.vnc_manager.vnc_available,
+            "novnc_available": dsm.vnc_manager.novnc_available,
+            "active_streaming_sessions": len(dsm.vnc_manager.active_sessions),
+            "pending_takeovers": len(await tm.get_pending_requests()),
+            "active_takeovers": len(await tm.get_active_sessions()),
+            "paused_tasks": await tm._paused_count(),
         }
 
         return health_status

--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -348,7 +348,7 @@ async def get_pending_takeovers(
 
     Issue #744: Requires admin authentication.
     """
-    pending = get_takeover_manager().get_pending_requests()
+    pending = await get_takeover_manager().get_pending_requests()
     return {"pending_requests": pending, "count": len(pending)}
 
 
@@ -366,7 +366,7 @@ async def get_active_takeovers(
 
     Issue #744: Requires admin authentication.
     """
-    active = get_takeover_manager().get_active_sessions()
+    active = await get_takeover_manager().get_active_sessions()
     return {"active_sessions": active, "count": len(active)}
 
 
@@ -384,7 +384,7 @@ async def get_takeover_status(
 
     Issue #744: Requires admin authentication.
     """
-    status = get_takeover_manager().get_system_status()
+    status = await get_takeover_manager().get_system_status()
     return status
 
 
@@ -418,8 +418,8 @@ async def get_system_status(
     streaming_sessions = get_desktop_streaming().vnc_manager.list_active_sessions()
 
     # Get takeover data
-    pending_takeovers = get_takeover_manager().get_pending_requests()
-    active_takeovers = get_takeover_manager().get_active_sessions()
+    pending_takeovers = await get_takeover_manager().get_pending_requests()
+    active_takeovers = await get_takeover_manager().get_active_sessions()
     system_status = {
         "status": "healthy",
         "timestamp": psutil.boot_time(),

--- a/autobot-backend/context_aware_decision/collectors/system.py
+++ b/autobot-backend/context_aware_decision/collectors/system.py
@@ -36,10 +36,10 @@ class SystemContextCollector:
             system_elements = []
 
             # Takeover system status
-            system_elements.append(self._create_takeover_status_context())
+            system_elements.append(await self._create_takeover_status_context())
 
-            # Active takeovers
-            active_takeovers = get_takeover_manager().get_active_sessions()
+            # Active takeovers (async since #11639 — Redis-backed registry)
+            active_takeovers = await get_takeover_manager().get_active_sessions()
             if active_takeovers:
                 system_elements.append(self._create_active_takeovers_context(active_takeovers))
 
@@ -54,11 +54,11 @@ class SystemContextCollector:
             logger.debug("System context collection failed: %s", e)
             return []
 
-    def _create_takeover_status_context(self) -> ContextElement:
+    async def _create_takeover_status_context(self) -> ContextElement:
         """Create context element for takeover system status."""
         from takeover_manager import get_takeover_manager
 
-        takeover_status = get_takeover_manager().get_system_status()
+        takeover_status = await get_takeover_manager().get_system_status()
         return ContextElement(
             context_id=f"takeover_status_{self.time_provider.current_timestamp_millis()}",
             context_type=ContextType.SYSTEM_STATE,

--- a/autobot-backend/control_panel_test.py
+++ b/autobot-backend/control_panel_test.py
@@ -93,7 +93,7 @@ async def test_takeover_manager():
 
     # Test 1: System status
     print("\n1. Testing System Status...")  # noqa: print
-    status = takeover_manager.get_system_status()
+    status = await takeover_manager.get_system_status()
     print(f"✅ Takeover system status: {status}")  # noqa: print
 
     # Test 2: Request takeover
@@ -110,7 +110,7 @@ async def test_takeover_manager():
 
     # Test 3: Check pending requests
     print("\n3. Testing Pending Requests...")  # noqa: print
-    pending = takeover_manager.get_pending_requests()
+    pending = await takeover_manager.get_pending_requests()
     print(f"✅ Pending requests: {len(pending)}")  # noqa: print
 
     # Test 4: Approve takeover (simulate)
@@ -144,7 +144,7 @@ async def test_takeover_manager():
 
     # Test 7: Check final status
     print("\n7. Testing Final Status...")  # noqa: print
-    final_status = takeover_manager.get_system_status()
+    final_status = await takeover_manager.get_system_status()
     print(f"✅ Final system status: {final_status}")  # noqa: print
 
     return True
@@ -241,7 +241,7 @@ async def test_integration():
         task_context.set_outputs(
             {
                 "desktop_streaming_available": desktop_streaming.vnc_manager.vnc_available,
-                "takeover_system_ready": len(takeover_manager.get_system_status()) > 0,
+                "takeover_system_ready": len(await takeover_manager.get_system_status()) > 0,
                 "integration_status": "success",
             }
         )
@@ -263,7 +263,7 @@ async def test_integration():
     print(f"✅ Cross-component takeover request: {request_id}")  # noqa: print
 
     # Check that the request is properly tracked
-    pending = takeover_manager.get_pending_requests()
+    pending = await takeover_manager.get_pending_requests()
     integration_request = next((req for req in pending if req["request_id"] == request_id), None)
 
     if integration_request:

--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -10,6 +10,8 @@ for remote desktop access and control.
 
 Issue #358: Converted blocking subprocess.Popen to asyncio.create_subprocess_exec.
 Issue #401: Improved code quality - proper imports, type hints, security fixes.
+Issue #11639: Session metadata moved to Redis for cross-worker visibility;
+    cross-worker broadcast via Redis pub/sub relay.
 """
 
 import asyncio
@@ -20,6 +22,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -38,6 +41,15 @@ SessionDict = dict[str, Any]
 ProcessType = asyncio.subprocess.Process
 
 logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Cross-worker constants — env-var-backed, never hard-coded (#11639)
+# ---------------------------------------------------------------------------
+_DESKTOP_EVENTS_CHANNEL: str = os.environ.get(
+    "AUTOBOT_DESKTOP_EVENTS_CHANNEL", "autobot:desktop:events"
+)
+_DESKTOP_SESSIONS_KEY: str = "autobot:desktop:sessions"  # HASH: session_id -> JSON metadata
+_WORKER_ID: str = str(uuid.uuid4())  # unique per-process; set once at import time
 
 # Performance optimization: O(1) lookup for VNC process keys (Issue #326)
 ALL_VNC_PROCESS_KEYS: frozenset[str] = frozenset({"novnc_process", "vnc_process", "xvfb_process"})
@@ -698,23 +710,187 @@ class DesktopStreamingManager:
     Provides a unified interface for creating and managing desktop streaming
     sessions with VNC backend and WebSocket client communication.
 
+    Issue #11639: session metadata (active_sessions) stored in Redis so every
+    worker can list/validate sessions.  WebSocket connection objects stay
+    per-worker in session_clients (sockets cannot be serialized).
+    Cross-worker broadcast: publish events to Redis pub/sub; a background
+    subscriber relays foreign events to local WebSocket clients.
+
     Attributes:
         vnc_manager: VNC server manager instance.
-        websocket_clients: Connected WebSocket clients.
-        session_clients: Mapping of session IDs to client IDs.
+        websocket_clients: Connected WebSocket clients (per-worker).
+        session_clients: Mapping of session IDs to client IDs (per-worker).
     """
 
-    def __init__(self) -> None:
-        """Initialize desktop streaming manager."""
+    def __init__(self, _redis=None) -> None:
+        """Initialize desktop streaming manager.
+
+        Args:
+            _redis: Optional Redis client override (for tests / single-worker dev).
+        """
         self.vnc_manager = VNCServerManager()
         self.websocket_clients: dict[str, websockets.WebSocketServerProtocol] = {}
         self.session_clients: dict[str, list[str]] = {}
+        self._redis = _redis  # None = use get_async_redis_client(); set in tests
+        self._redis_warning_logged = False
+        self._subscriber_task: asyncio.Task | None = None
 
-        logger.info("Desktop Streaming Manager initialized")
+        logger.info("Desktop Streaming Manager initialized (worker=%s)", _WORKER_ID)
+
+    # ------------------------------------------------------------------
+    # Lifecycle (start/stop subscriber)
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the cross-worker pub/sub subscriber task."""
+        if self._subscriber_task is None or self._subscriber_task.done():
+            self._subscriber_task = asyncio.create_task(
+                self._pubsub_relay_loop(), name="desktop-pubsub-relay"
+            )
+            logger.info("Desktop streaming pub/sub relay started (worker=%s)", _WORKER_ID)
+
+    async def stop(self) -> None:
+        """Stop the cross-worker pub/sub subscriber task."""
+        if self._subscriber_task and not self._subscriber_task.done():
+            self._subscriber_task.cancel()
+            try:
+                await self._subscriber_task
+            except asyncio.CancelledError:
+                pass
+            self._subscriber_task = None
+            logger.info("Desktop streaming pub/sub relay stopped (worker=%s)", _WORKER_ID)
+
+    # ------------------------------------------------------------------
+    # Redis helpers
+    # ------------------------------------------------------------------
+
+    async def _get_redis(self):
+        """Return a Redis client, or None if unavailable."""
+        if self._redis is not None:
+            return self._redis
+        try:
+            from autobot_shared.redis_client import get_async_redis_client
+            return await get_async_redis_client()
+        except Exception:
+            return None
+
+    async def _redis_client(self):
+        """Return a usable Redis client, logging once on first miss."""
+        r = await self._get_redis()
+        if r is None and not self._redis_warning_logged:
+            logger.warning(
+                "DesktopStreamingManager: Redis unavailable — sessions not shared "
+                "across workers; cross-worker broadcast disabled"
+            )
+            self._redis_warning_logged = True
+        return r
+
+    # ------------------------------------------------------------------
+    # Session metadata (Redis-backed)
+    # ------------------------------------------------------------------
+
+    async def _meta_set(self, session_id: str, meta: dict) -> None:
+        """Store session metadata in Redis hash."""
+        r = await self._redis_client()
+        if r is None:
+            return
+        await r.hset(_DESKTOP_SESSIONS_KEY, session_id, json.dumps(meta, ensure_ascii=False))
+
+    async def _meta_get(self, session_id: str) -> dict | None:
+        """Retrieve session metadata from Redis hash."""
+        r = await self._redis_client()
+        if r is None:
+            return None
+        raw = await r.hget(_DESKTOP_SESSIONS_KEY, session_id)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    async def _meta_delete(self, session_id: str) -> None:
+        """Remove session metadata from Redis hash."""
+        r = await self._redis_client()
+        if r is None:
+            return
+        await r.hdel(_DESKTOP_SESSIONS_KEY, session_id)
+
+    async def _meta_all(self) -> dict[str, dict]:
+        """Return all session metadata from Redis."""
+        r = await self._redis_client()
+        if r is None:
+            return {}
+        raw_map = await r.hgetall(_DESKTOP_SESSIONS_KEY)
+        result = {}
+        for k, v in raw_map.items():
+            key = k.decode() if isinstance(k, bytes) else k
+            result[key] = json.loads(v)
+        return result
+
+    # ------------------------------------------------------------------
+    # Cross-worker broadcast (pub/sub)
+    # ------------------------------------------------------------------
+
+    async def _publish_event(self, event_type: str, payload: dict) -> None:
+        """Publish a desktop event to all workers via Redis pub/sub."""
+        r = await self._redis_client()
+        if r is None:
+            return
+        msg = json.dumps(
+            {"worker_id": _WORKER_ID, "type": event_type, "payload": payload},
+            ensure_ascii=False,
+        )
+        await r.publish(_DESKTOP_EVENTS_CHANNEL, msg)
+
+    async def _pubsub_relay_loop(self) -> None:
+        """Subscribe to desktop events and relay foreign ones to local clients."""
+        while True:
+            try:
+                await self._run_pubsub_subscription()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "Desktop pub/sub relay error (worker=%s): %s — retrying in 5s",
+                    _WORKER_ID, e,
+                )
+                await asyncio.sleep(5)
+
+    async def _run_pubsub_subscription(self) -> None:
+        """Run one pub/sub subscription session (called from relay loop)."""
+        r = await self._get_redis()
+        if r is None:
+            await asyncio.sleep(10)
+            return
+        pubsub = r.pubsub()
+        await pubsub.subscribe(_DESKTOP_EVENTS_CHANNEL)
+        try:
+            async for message in pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                await self._handle_pubsub_message(message.get("data", b""))
+        finally:
+            await pubsub.unsubscribe(_DESKTOP_EVENTS_CHANNEL)
+            await pubsub.close()
+
+    async def _handle_pubsub_message(self, data: bytes | str) -> None:
+        """Relay a received pub/sub message to local clients if from another worker."""
+        try:
+            msg = json.loads(data)
+            if msg.get("worker_id") == _WORKER_ID:
+                return  # local event already delivered directly
+            session_id = msg.get("payload", {}).get("session_id", "")
+            if session_id not in self.session_clients:
+                return
+            outbound = json.dumps({"type": msg["type"], "data": msg["payload"]})
+            await self._broadcast_to_local_clients(session_id, outbound)
+        except Exception as e:
+            logger.warning("Desktop pub/sub message decode error: %s", e)
 
     async def create_streaming_session(self, user_id: str, session_config: SessionDict | None = None) -> SessionDict:
         """
         Create a new desktop streaming session.
+
+        Issue #11639: Session metadata also written to Redis so other workers
+        can validate sessions without a local entry.
 
         Args:
             user_id: User requesting the session.
@@ -723,19 +899,29 @@ class DesktopStreamingManager:
         Returns:
             Dictionary with session details and endpoints.
         """
-        config = session_config or {}
+        cfg = session_config or {}
         session_id = f"stream_{user_id}_{int(time.time())}"
 
         # Create VNC session
         vnc_info = await self.vnc_manager.create_session(
             session_id=session_id,
             user_id=user_id,
-            resolution=config.get("resolution", "1024x768"),
-            depth=config.get("depth", 24),
+            resolution=cfg.get("resolution", "1024x768"),
+            depth=cfg.get("depth", 24),
         )
 
-        # Initialize client tracking
+        # Initialize per-worker client tracking
         self.session_clients[session_id] = []
+
+        # Persist metadata to Redis for cross-worker visibility (#11639)
+        meta = {
+            "session_id": session_id,
+            "user_id": user_id,
+            "worker_id": _WORKER_ID,
+            "created_at": time.time(),
+            **{k: v for k, v in vnc_info.items() if isinstance(v, (str, int, float, bool, type(None)))},
+        }
+        await self._meta_set(session_id, meta)
 
         return {
             **vnc_info,
@@ -803,13 +989,17 @@ class DesktopStreamingManager:
 
     def _validate_session(self, session_id: str) -> bool:
         """
-        Validate that session exists.
+        Validate that session exists locally (per-worker check).
+
+        Issue #11639: For cross-worker validation use _validate_session_redis().
+        Local check is sufficient for WebSocket path since the WS connects to
+        the worker that owns the session.
 
         Args:
             session_id: Session to validate.
 
         Returns:
-            True if session exists, False otherwise.
+            True if session exists locally, False otherwise.
         """
         return session_id in self.session_clients
 
@@ -985,11 +1175,38 @@ class DesktopStreamingManager:
 
         return None
 
+    async def _broadcast_to_local_clients(self, session_id: str, message: str) -> None:
+        """Send a message to all local WebSocket clients for a session.
+
+        Args:
+            session_id: Target session.
+            message: JSON string to send.
+        """
+        for client_id in list(self.session_clients.get(session_id, [])):
+            if client_id not in self.websocket_clients:
+                continue
+            try:
+                await self.websocket_clients[client_id].send(message)
+            except Exception as e:
+                logger.warning("Error sending to client %s: %s", client_id, e)
+
+    async def list_all_sessions(self) -> list[dict]:
+        """List sessions from all workers via Redis metadata.
+
+        Returns per-worker local sessions when Redis is unavailable.
+        """
+        meta_map = await self._meta_all()
+        if meta_map:
+            return list(meta_map.values())
+        # Fallback: local sessions only
+        return [{"session_id": sid} for sid in self.session_clients]
+
     async def terminate_streaming_session(self, session_id: str) -> bool:
         """
         Terminate a desktop streaming session.
 
         Issue #315: Refactored.
+        Issue #11639: Also removes Redis metadata and publishes termination event.
 
         Args:
             session_id: Session to terminate.
@@ -1001,6 +1218,12 @@ class DesktopStreamingManager:
         if session_id in self.session_clients:
             await self._notify_session_clients_terminated(session_id)
             del self.session_clients[session_id]
+
+        # Remove Redis metadata (#11639)
+        await self._meta_delete(session_id)
+
+        # Publish termination for other workers' relay loops
+        await self._publish_event("session_terminated", {"session_id": session_id})
 
         # Terminate VNC session
         return await self.vnc_manager.terminate_session(session_id)
@@ -1015,7 +1238,7 @@ class DesktopStreamingManager:
             session_id: Terminated session.
         """
         termination_msg = json.dumps({"type": "session_terminated", "data": {"session_id": session_id}})
-        for client_id in self.session_clients[session_id].copy():
+        for client_id in list(self.session_clients.get(session_id, [])):
             await self._notify_client_and_close(client_id, termination_msg)
 
     async def _notify_client_and_close(self, client_id: str, message: str) -> None:

--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -747,6 +747,9 @@ class DesktopStreamingManager:
             self._subscriber_task = asyncio.create_task(
                 self._pubsub_relay_loop(), name="desktop-pubsub-relay"
             )
+            # Register for construct-free shutdown via stop_desktop_relay()
+            global _relay_manager
+            _relay_manager = self
             logger.info("Desktop streaming pub/sub relay started (worker=%s)", _WORKER_ID)
 
     async def stop(self) -> None:
@@ -901,6 +904,10 @@ class DesktopStreamingManager:
         """
         cfg = session_config or {}
         session_id = f"stream_{user_id}_{int(time.time())}"
+
+        # Lazy-start the cross-worker relay with the first session (#11639) —
+        # idempotent; avoids a standing Redis subscription on idle backends.
+        await self.start()
 
         # Create VNC session
         vnc_info = await self.vnc_manager.create_session(
@@ -1282,3 +1289,15 @@ class DesktopStreamingManager:
 
 
 get_desktop_streaming = lazy_singleton(DesktopStreamingManager)
+
+# Set by DesktopStreamingManager.start(); lets shutdown stop the relay
+# WITHOUT constructing a manager when none was ever used (#11639).
+_relay_manager: DesktopStreamingManager | None = None
+
+
+async def stop_desktop_relay() -> None:
+    """Stop the cross-worker pub/sub relay if one was started (#11639)."""
+    global _relay_manager
+    if _relay_manager is not None:
+        await _relay_manager.stop()
+        _relay_manager = None

--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -45,7 +45,9 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 # Cross-worker constants — env-var-backed, never hard-coded (#11639)
 # ---------------------------------------------------------------------------
-_DESKTOP_EVENTS_CHANNEL: str = os.environ.get("AUTOBOT_DESKTOP_EVENTS_CHANNEL", "autobot:desktop:events")
+_DESKTOP_EVENTS_CHANNEL: str = os.environ.get(
+    "AUTOBOT_DESKTOP_EVENTS_CHANNEL", "autobot:desktop:events"
+)
 _DESKTOP_SESSIONS_KEY: str = "autobot:desktop:sessions"  # HASH: session_id -> JSON metadata
 _WORKER_ID: str = str(uuid.uuid4())  # unique per-process; set once at import time
 
@@ -730,6 +732,9 @@ class DesktopStreamingManager:
         self.websocket_clients: dict[str, websockets.WebSocketServerProtocol] = {}
         self.session_clients: dict[str, list[str]] = {}
         self._redis = _redis  # None = use get_async_redis_client(); set in tests
+        # H2: per-process latch — once any Redis op fails, stay in fallback mode.
+        # None = not yet probed; True = working; False = latched to fallback.
+        self._redis_available: bool | None = None
         self._redis_warning_logged = False
         self._subscriber_task: asyncio.Task | None = None
 
@@ -742,7 +747,9 @@ class DesktopStreamingManager:
     async def start(self) -> None:
         """Start the cross-worker pub/sub subscriber task."""
         if self._subscriber_task is None or self._subscriber_task.done():
-            self._subscriber_task = asyncio.create_task(self._pubsub_relay_loop(), name="desktop-pubsub-relay")
+            self._subscriber_task = asyncio.create_task(
+                self._pubsub_relay_loop(), name="desktop-pubsub-relay"
+            )
             # Register for construct-free shutdown via stop_desktop_relay()
             global _relay_manager
             _relay_manager = self
@@ -769,21 +776,41 @@ class DesktopStreamingManager:
             return self._redis
         try:
             from autobot_shared.redis_client import get_async_redis_client
-
             return await get_async_redis_client()
         except Exception:
             return None
 
     async def _redis_client(self):
-        """Return a usable Redis client, logging once on first miss."""
+        """Return a usable Redis client, or None when latched to fallback.
+
+        H2: Once any Redis op raises, _redis_available is set False and we
+        stay in local-only mode for the lifetime of this worker process.
+        """
+        if self._redis_available is False:
+            return None
         r = await self._get_redis()
-        if r is None and not self._redis_warning_logged:
-            logger.warning(
-                "DesktopStreamingManager: Redis unavailable — sessions not shared "
-                "across workers; cross-worker broadcast disabled"
-            )
-            self._redis_warning_logged = True
+        if r is None:
+            if not self._redis_warning_logged:
+                logger.warning(
+                    "DesktopStreamingManager: Redis unavailable — sessions not shared "
+                    "across workers; cross-worker broadcast disabled"
+                )
+                self._redis_warning_logged = True
+            self._redis_available = False
+            return None
+        if self._redis_available is None:
+            self._redis_available = True
         return r
+
+    def _latch_redis_fallback(self, exc: Exception) -> None:
+        """H2: Log once and latch this process to local-only mode."""
+        if self._redis_available is not False:
+            logger.warning(
+                "DesktopStreamingManager: Redis op failed (%s) — latching to local-only "
+                "mode for the lifetime of this worker",
+                exc,
+            )
+            self._redis_available = False
 
     # ------------------------------------------------------------------
     # Session metadata (Redis-backed)
@@ -794,36 +821,50 @@ class DesktopStreamingManager:
         r = await self._redis_client()
         if r is None:
             return
-        await r.hset(_DESKTOP_SESSIONS_KEY, session_id, json.dumps(meta, ensure_ascii=False))
+        try:
+            await r.hset(_DESKTOP_SESSIONS_KEY, session_id, json.dumps(meta, ensure_ascii=False))
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
 
     async def _meta_get(self, session_id: str) -> dict | None:
         """Retrieve session metadata from Redis hash."""
         r = await self._redis_client()
         if r is None:
             return None
-        raw = await r.hget(_DESKTOP_SESSIONS_KEY, session_id)
-        if raw is None:
+        try:
+            raw = await r.hget(_DESKTOP_SESSIONS_KEY, session_id)
+            if raw is None:
+                return None
+            return json.loads(raw)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
             return None
-        return json.loads(raw)
 
     async def _meta_delete(self, session_id: str) -> None:
         """Remove session metadata from Redis hash."""
         r = await self._redis_client()
         if r is None:
             return
-        await r.hdel(_DESKTOP_SESSIONS_KEY, session_id)
+        try:
+            await r.hdel(_DESKTOP_SESSIONS_KEY, session_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
 
     async def _meta_all(self) -> dict[str, dict]:
         """Return all session metadata from Redis."""
         r = await self._redis_client()
         if r is None:
             return {}
-        raw_map = await r.hgetall(_DESKTOP_SESSIONS_KEY)
-        result = {}
-        for k, v in raw_map.items():
-            key = k.decode() if isinstance(k, bytes) else k
-            result[key] = json.loads(v)
-        return result
+        try:
+            raw_map = await r.hgetall(_DESKTOP_SESSIONS_KEY)
+            result = {}
+            for k, v in raw_map.items():
+                key = k.decode() if isinstance(k, bytes) else k
+                result[key] = json.loads(v)
+            return result
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return {}
 
     # ------------------------------------------------------------------
     # Cross-worker broadcast (pub/sub)
@@ -838,10 +879,18 @@ class DesktopStreamingManager:
             {"worker_id": _WORKER_ID, "type": event_type, "payload": payload},
             ensure_ascii=False,
         )
-        await r.publish(_DESKTOP_EVENTS_CHANNEL, msg)
+        try:
+            await r.publish(_DESKTOP_EVENTS_CHANNEL, msg)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
 
     async def _pubsub_relay_loop(self) -> None:
-        """Subscribe to desktop events and relay foreign ones to local clients."""
+        """Subscribe to desktop events and relay foreign ones to local clients.
+
+        M5: sleep on clean return too (prevents hot-loop when the subscription
+        ends immediately, e.g. when the fake stub's listen() drains in tests).
+        """
+        _RETRY_DELAY = 5
         while True:
             try:
                 await self._run_pubsub_subscription()
@@ -849,17 +898,20 @@ class DesktopStreamingManager:
                 raise
             except Exception as e:
                 logger.warning(
-                    "Desktop pub/sub relay error (worker=%s): %s — retrying in 5s",
-                    _WORKER_ID,
-                    e,
+                    "Desktop pub/sub relay error (worker=%s): %s — retrying in %ds",
+                    _WORKER_ID, e, _RETRY_DELAY,
                 )
-                await asyncio.sleep(5)
+            # M5: always sleep between subscription passes (error or clean exit)
+            await asyncio.sleep(_RETRY_DELAY)
 
     async def _run_pubsub_subscription(self) -> None:
-        """Run one pub/sub subscription session (called from relay loop)."""
+        """Run one pub/sub subscription session (called from relay loop).
+
+        M5: wrap unsubscribe and close each in separate try/except so a
+        failure in one does not skip the other.  Use aclose() when available.
+        """
         r = await self._get_redis()
         if r is None:
-            await asyncio.sleep(10)
             return
         pubsub = r.pubsub()
         await pubsub.subscribe(_DESKTOP_EVENTS_CHANNEL)
@@ -869,22 +921,63 @@ class DesktopStreamingManager:
                     continue
                 await self._handle_pubsub_message(message.get("data", b""))
         finally:
-            await pubsub.unsubscribe(_DESKTOP_EVENTS_CHANNEL)
-            await pubsub.close()
+            try:
+                await pubsub.unsubscribe(_DESKTOP_EVENTS_CHANNEL)
+            except Exception as e:
+                logger.warning("Desktop pubsub unsubscribe error (worker=%s): %s", _WORKER_ID, e)
+            try:
+                # M5: prefer aclose() when available (redis-py >= 4.2)
+                close_fn = getattr(pubsub, "aclose", None) or pubsub.close
+                await close_fn()
+            except Exception as e:
+                logger.warning("Desktop pubsub close error (worker=%s): %s", _WORKER_ID, e)
 
     async def _handle_pubsub_message(self, data: bytes | str) -> None:
-        """Relay a received pub/sub message to local clients if from another worker."""
+        """Relay a received pub/sub message to local clients if from another worker.
+
+        H3: Handles the special 'session_terminate_requested' event: if this
+        worker owns the session locally it runs the full local terminate path
+        (kill processes, notify clients, delete Redis metadata, publish
+        'session_terminated').  All other message types are relayed to local
+        WebSocket clients as before.
+        """
         try:
             msg = json.loads(data)
             if msg.get("worker_id") == _WORKER_ID:
                 return  # local event already delivered directly
+            msg_type = msg.get("type", "")
             session_id = msg.get("payload", {}).get("session_id", "")
+
+            if msg_type == "session_terminate_requested":
+                # H3: only act if this worker owns the session
+                if session_id in self.session_clients or session_id in self.vnc_manager.active_sessions:
+                    logger.info(
+                        "Desktop relay: terminate_requested for owned session %s (worker=%s)",
+                        session_id, _WORKER_ID,
+                    )
+                    await self._local_terminate(session_id)
+                return
+
             if session_id not in self.session_clients:
                 return
-            outbound = json.dumps({"type": msg["type"], "data": msg["payload"]})
+            outbound = json.dumps({"type": msg_type, "data": msg["payload"]})
             await self._broadcast_to_local_clients(session_id, outbound)
         except Exception as e:
             logger.warning("Desktop pub/sub message decode error: %s", e)
+
+    async def _local_terminate(self, session_id: str) -> None:
+        """Full local terminate: kill processes, notify clients, delete metadata.
+
+        H3: Used by the pub/sub relay when this worker is the session owner and
+        another worker requested termination.
+        """
+        if session_id in self.session_clients:
+            await self._notify_session_clients_terminated(session_id)
+            del self.session_clients[session_id]
+        await self._meta_delete(session_id)
+        await self.vnc_manager.terminate_session(session_id)
+        await self._publish_event("session_terminated", {"session_id": session_id})
+        logger.info("Desktop relay: locally terminated session %s (worker=%s)", session_id, _WORKER_ID)
 
     async def create_streaming_session(self, user_id: str, session_config: SessionDict | None = None) -> SessionDict:
         """
@@ -1213,13 +1306,38 @@ class DesktopStreamingManager:
         Issue #315: Refactored.
         Issue #11639: Also removes Redis metadata and publishes termination event.
 
+        H3: If this worker does NOT own the session locally (not in
+        session_clients or vnc_manager.active_sessions) we publish a
+        'session_terminate_requested' event so the owner worker handles the
+        local teardown (process kills + client notification) and returns True
+        (accepted).  The owner's relay loop calls _local_terminate which then
+        publishes 'session_terminated' and deletes the metadata.
+
         Args:
             session_id: Session to terminate.
 
         Returns:
-            True if termination succeeded, False otherwise.
+            True if termination succeeded or was accepted, False otherwise.
         """
-        # Notify all connected clients
+        locally_owned = (
+            session_id in self.session_clients
+            or session_id in self.vnc_manager.active_sessions
+        )
+
+        if not locally_owned:
+            # H3: delegate to the owner worker via pub/sub
+            meta = await self._meta_get(session_id)
+            if meta is None:
+                return False
+            logger.info(
+                "terminate_streaming_session: session %s not local — "
+                "publishing terminate_requested (worker=%s)",
+                session_id, _WORKER_ID,
+            )
+            await self._publish_event("session_terminate_requested", {"session_id": session_id})
+            return True  # accepted; owner will complete teardown asynchronously
+
+        # Owner path: local teardown
         if session_id in self.session_clients:
             await self._notify_session_clients_terminated(session_id)
             del self.session_clients[session_id]

--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -45,9 +45,7 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 # Cross-worker constants — env-var-backed, never hard-coded (#11639)
 # ---------------------------------------------------------------------------
-_DESKTOP_EVENTS_CHANNEL: str = os.environ.get(
-    "AUTOBOT_DESKTOP_EVENTS_CHANNEL", "autobot:desktop:events"
-)
+_DESKTOP_EVENTS_CHANNEL: str = os.environ.get("AUTOBOT_DESKTOP_EVENTS_CHANNEL", "autobot:desktop:events")
 _DESKTOP_SESSIONS_KEY: str = "autobot:desktop:sessions"  # HASH: session_id -> JSON metadata
 _WORKER_ID: str = str(uuid.uuid4())  # unique per-process; set once at import time
 
@@ -744,9 +742,7 @@ class DesktopStreamingManager:
     async def start(self) -> None:
         """Start the cross-worker pub/sub subscriber task."""
         if self._subscriber_task is None or self._subscriber_task.done():
-            self._subscriber_task = asyncio.create_task(
-                self._pubsub_relay_loop(), name="desktop-pubsub-relay"
-            )
+            self._subscriber_task = asyncio.create_task(self._pubsub_relay_loop(), name="desktop-pubsub-relay")
             # Register for construct-free shutdown via stop_desktop_relay()
             global _relay_manager
             _relay_manager = self
@@ -773,6 +769,7 @@ class DesktopStreamingManager:
             return self._redis
         try:
             from autobot_shared.redis_client import get_async_redis_client
+
             return await get_async_redis_client()
         except Exception:
             return None
@@ -853,7 +850,8 @@ class DesktopStreamingManager:
             except Exception as e:
                 logger.warning(
                     "Desktop pub/sub relay error (worker=%s): %s — retrying in 5s",
-                    _WORKER_ID, e,
+                    _WORKER_ID,
+                    e,
                 )
                 await asyncio.sleep(5)
 

--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -45,9 +45,7 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 # Cross-worker constants — env-var-backed, never hard-coded (#11639)
 # ---------------------------------------------------------------------------
-_DESKTOP_EVENTS_CHANNEL: str = os.environ.get(
-    "AUTOBOT_DESKTOP_EVENTS_CHANNEL", "autobot:desktop:events"
-)
+_DESKTOP_EVENTS_CHANNEL: str = os.environ.get("AUTOBOT_DESKTOP_EVENTS_CHANNEL", "autobot:desktop:events")
 _DESKTOP_SESSIONS_KEY: str = "autobot:desktop:sessions"  # HASH: session_id -> JSON metadata
 _WORKER_ID: str = str(uuid.uuid4())  # unique per-process; set once at import time
 
@@ -747,9 +745,7 @@ class DesktopStreamingManager:
     async def start(self) -> None:
         """Start the cross-worker pub/sub subscriber task."""
         if self._subscriber_task is None or self._subscriber_task.done():
-            self._subscriber_task = asyncio.create_task(
-                self._pubsub_relay_loop(), name="desktop-pubsub-relay"
-            )
+            self._subscriber_task = asyncio.create_task(self._pubsub_relay_loop(), name="desktop-pubsub-relay")
             # Register for construct-free shutdown via stop_desktop_relay()
             global _relay_manager
             _relay_manager = self
@@ -776,6 +772,7 @@ class DesktopStreamingManager:
             return self._redis
         try:
             from autobot_shared.redis_client import get_async_redis_client
+
             return await get_async_redis_client()
         except Exception:
             return None
@@ -899,7 +896,9 @@ class DesktopStreamingManager:
             except Exception as e:
                 logger.warning(
                     "Desktop pub/sub relay error (worker=%s): %s — retrying in %ds",
-                    _WORKER_ID, e, _RETRY_DELAY,
+                    _WORKER_ID,
+                    e,
+                    _RETRY_DELAY,
                 )
             # M5: always sleep between subscription passes (error or clean exit)
             await asyncio.sleep(_RETRY_DELAY)
@@ -953,7 +952,8 @@ class DesktopStreamingManager:
                 if session_id in self.session_clients or session_id in self.vnc_manager.active_sessions:
                     logger.info(
                         "Desktop relay: terminate_requested for owned session %s (worker=%s)",
-                        session_id, _WORKER_ID,
+                        session_id,
+                        _WORKER_ID,
                     )
                     await self._local_terminate(session_id)
                 return
@@ -1319,10 +1319,7 @@ class DesktopStreamingManager:
         Returns:
             True if termination succeeded or was accepted, False otherwise.
         """
-        locally_owned = (
-            session_id in self.session_clients
-            or session_id in self.vnc_manager.active_sessions
-        )
+        locally_owned = session_id in self.session_clients or session_id in self.vnc_manager.active_sessions
 
         if not locally_owned:
             # H3: delegate to the owner worker via pub/sub
@@ -1330,9 +1327,9 @@ class DesktopStreamingManager:
             if meta is None:
                 return False
             logger.info(
-                "terminate_streaming_session: session %s not local — "
-                "publishing terminate_requested (worker=%s)",
-                session_id, _WORKER_ID,
+                "terminate_streaming_session: session %s not local — " "publishing terminate_requested (worker=%s)",
+                session_id,
+                _WORKER_ID,
             )
             await self._publish_event("session_terminate_requested", {"session_id": session_id})
             return True  # accepted; owner will complete teardown asynchronously

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -2088,6 +2088,16 @@ async def cleanup_services(app: FastAPI):
         except Exception as _npu_err:
             logger.warning("NPU worker manager shutdown failed: %s", _npu_err)
 
+        # Issue #11639: Stop desktop streaming pub/sub relay (Redis
+        # subscription — stop BEFORE closing Redis pools). No-op if no
+        # streaming session ever started the relay.
+        try:
+            from desktop_streaming_manager import stop_desktop_relay
+
+            await stop_desktop_relay()
+        except Exception as _dsm_err:
+            logger.warning("Desktop streaming relay shutdown failed: %s", _dsm_err)
+
         # Issue #1233: Shutdown dedicated I/O thread pools
         shutdown_io_executors()
 

--- a/autobot-backend/takeover_manager.py
+++ b/autobot-backend/takeover_manager.py
@@ -43,16 +43,14 @@ def _resolve_pending_ttl() -> int:
         value = int(raw)
     except ValueError:
         logger.warning(
-            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%r is not an integer; "
-            "falling back to %ds",
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%r is not an integer; " "falling back to %ds",
             raw,
             _DEFAULT_PENDING_TTL_SECONDS,
         )
         return _DEFAULT_PENDING_TTL_SECONDS
     if value <= 0:
         logger.warning(
-            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%d must be positive; "
-            "falling back to %ds",
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%d must be positive; " "falling back to %ds",
             value,
             _DEFAULT_PENDING_TTL_SECONDS,
         )
@@ -64,13 +62,13 @@ _PENDING_TTL_SECONDS: int = _resolve_pending_ttl()
 
 # Redis key namespace
 _NS = "autobot:takeover"
-_KEY_PENDING = f"{_NS}:pending"           # STRING prefix; full key = {_KEY_PENDING}:<id>
+_KEY_PENDING = f"{_NS}:pending"  # STRING prefix; full key = {_KEY_PENDING}:<id>
 _KEY_PENDING_INDEX = f"{_NS}:pending_index"  # SET of active request IDs
 # M4: sessions stored as individual STRING keys (WATCHable) rather than one HASH.
-_KEY_SESSION = f"{_NS}:session"           # STRING prefix; full key = {_KEY_SESSION}:<id>
+_KEY_SESSION = f"{_NS}:session"  # STRING prefix; full key = {_KEY_SESSION}:<id>
 _KEY_SESSION_INDEX = f"{_NS}:session_index"  # SET of live session IDs
-_KEY_PAUSED = f"{_NS}:paused_tasks"       # SET of paused task IDs
-_KEY_REQ_TASK = f"{_NS}:request_task"     # HASH: request_id -> memory task_id
+_KEY_PAUSED = f"{_NS}:paused_tasks"  # SET of paused task IDs
+_KEY_REQ_TASK = f"{_NS}:request_task"  # HASH: request_id -> memory task_id
 # Completed-session history: capped list of compact JSON records (ring buffer).
 _KEY_SESSION_HISTORY = f"{_NS}:session_history"
 _SESSION_HISTORY_MAX = 200  # keep last 200 completed/cancelled records
@@ -236,6 +234,7 @@ class TakeoverManager:
             return self._redis
         try:
             from autobot_shared.redis_client import get_async_redis_client
+
             return await get_async_redis_client()
         except Exception:
             return None
@@ -277,9 +276,7 @@ class TakeoverManager:
     # pending_requests helpers
     # ------------------------------------------------------------------
 
-    async def _pending_set(
-        self, request_id: str, request: TakeoverRequest, timeout_seconds: int | None = None
-    ) -> None:
+    async def _pending_set(self, request_id: str, request: TakeoverRequest, timeout_seconds: int | None = None) -> None:
         """Store a pending request in Redis with TTL.
 
         M3: Single atomic SET with ex= so TTL is set atomically; honours the
@@ -488,9 +485,7 @@ class TakeoverManager:
             self._latch_redis_fallback(exc)
             return session_id in self._fb_sessions
 
-    async def _session_mutate(
-        self, session_id: str, mutate_fn: Callable, attempts: int = 3
-    ) -> TakeoverSession | None:
+    async def _session_mutate(self, session_id: str, mutate_fn: Callable, attempts: int = 3) -> TakeoverSession | None:
         """Optimistic read-modify-write on a session STRING key.
 
         M4: WATCH the session key; if another writer commits between our GET
@@ -978,6 +973,7 @@ class TakeoverManager:
 
         M4: Uses _session_mutate for read-modify-write safety.
         """
+
         def _mutate(session: TakeoverSession) -> TakeoverSession | None:
             if session.state != TakeoverState.ACTIVE:
                 return None
@@ -998,6 +994,7 @@ class TakeoverManager:
 
         M4: Uses _session_mutate for read-modify-write safety.
         """
+
         def _mutate(session: TakeoverSession) -> TakeoverSession | None:
             if session.state != TakeoverState.PAUSED:
                 return None
@@ -1066,9 +1063,7 @@ class TakeoverManager:
         await self._notify_state_change("session_completed", session_id)
         return True
 
-    async def _archive_completed_session(
-        self, session: TakeoverSession, handback_notes: str | None
-    ) -> None:
+    async def _archive_completed_session(self, session: TakeoverSession, handback_notes: str | None) -> None:
         """Push a compact history record to the capped Redis list."""
         r = await self._redis_client()
         if r is None:
@@ -1312,9 +1307,23 @@ def _execute_action_sync(action_type: str, action_data: Dict[str, Any]) -> Dict[
     if action_type == "system_command":
         command = action_data.get("command", "")
         safe_commands = {
-            "ps", "top", "htop", "d", "free", "uptime", "whoami", "pwd",
-            "ls", "cat", "less", "head", "tail", "grep",
-            "systemctl status", "docker ps", "docker logs",
+            "ps",
+            "top",
+            "htop",
+            "d",
+            "free",
+            "uptime",
+            "whoami",
+            "pwd",
+            "ls",
+            "cat",
+            "less",
+            "head",
+            "tail",
+            "grep",
+            "systemctl status",
+            "docker ps",
+            "docker logs",
         }
         if any(command.startswith(c) for c in safe_commands):
             return {"status": "command_executed", "command": command}

--- a/autobot-backend/takeover_manager.py
+++ b/autobot-backend/takeover_manager.py
@@ -43,16 +43,14 @@ def _resolve_pending_ttl() -> int:
         value = int(raw)
     except ValueError:
         logger.warning(
-            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%r is not an integer; "
-            "falling back to %ds",
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%r is not an integer; " "falling back to %ds",
             raw,
             _DEFAULT_PENDING_TTL_SECONDS,
         )
         return _DEFAULT_PENDING_TTL_SECONDS
     if value <= 0:
         logger.warning(
-            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%d must be positive; "
-            "falling back to %ds",
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%d must be positive; " "falling back to %ds",
             value,
             _DEFAULT_PENDING_TTL_SECONDS,
         )
@@ -64,11 +62,11 @@ _PENDING_TTL_SECONDS: int = _resolve_pending_ttl()
 
 # Redis key namespace
 _NS = "autobot:takeover"
-_KEY_PENDING = f"{_NS}:pending"           # STRING prefix; full key = {_KEY_PENDING}:<id>
+_KEY_PENDING = f"{_NS}:pending"  # STRING prefix; full key = {_KEY_PENDING}:<id>
 _KEY_PENDING_INDEX = f"{_NS}:pending_index"  # SET of active request IDs
-_KEY_SESSIONS = f"{_NS}:sessions"         # HASH: session_id -> JSON
-_KEY_PAUSED = f"{_NS}:paused_tasks"       # SET of paused task IDs
-_KEY_REQ_TASK = f"{_NS}:request_task"     # HASH: request_id -> memory task_id
+_KEY_SESSIONS = f"{_NS}:sessions"  # HASH: session_id -> JSON
+_KEY_PAUSED = f"{_NS}:paused_tasks"  # SET of paused task IDs
+_KEY_REQ_TASK = f"{_NS}:request_task"  # HASH: request_id -> memory task_id
 
 
 class TakeoverTrigger(Enum):
@@ -222,6 +220,7 @@ class TakeoverManager:
             return self._redis
         try:
             from autobot_shared.redis_client import get_async_redis_client
+
             return await get_async_redis_client()
         except Exception:
             return None

--- a/autobot-backend/takeover_manager.py
+++ b/autobot-backend/takeover_manager.py
@@ -43,14 +43,16 @@ def _resolve_pending_ttl() -> int:
         value = int(raw)
     except ValueError:
         logger.warning(
-            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%r is not an integer; " "falling back to %ds",
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%r is not an integer; "
+            "falling back to %ds",
             raw,
             _DEFAULT_PENDING_TTL_SECONDS,
         )
         return _DEFAULT_PENDING_TTL_SECONDS
     if value <= 0:
         logger.warning(
-            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%d must be positive; " "falling back to %ds",
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%d must be positive; "
+            "falling back to %ds",
             value,
             _DEFAULT_PENDING_TTL_SECONDS,
         )
@@ -62,11 +64,16 @@ _PENDING_TTL_SECONDS: int = _resolve_pending_ttl()
 
 # Redis key namespace
 _NS = "autobot:takeover"
-_KEY_PENDING = f"{_NS}:pending"  # STRING prefix; full key = {_KEY_PENDING}:<id>
+_KEY_PENDING = f"{_NS}:pending"           # STRING prefix; full key = {_KEY_PENDING}:<id>
 _KEY_PENDING_INDEX = f"{_NS}:pending_index"  # SET of active request IDs
-_KEY_SESSIONS = f"{_NS}:sessions"  # HASH: session_id -> JSON
-_KEY_PAUSED = f"{_NS}:paused_tasks"  # SET of paused task IDs
-_KEY_REQ_TASK = f"{_NS}:request_task"  # HASH: request_id -> memory task_id
+# M4: sessions stored as individual STRING keys (WATCHable) rather than one HASH.
+_KEY_SESSION = f"{_NS}:session"           # STRING prefix; full key = {_KEY_SESSION}:<id>
+_KEY_SESSION_INDEX = f"{_NS}:session_index"  # SET of live session IDs
+_KEY_PAUSED = f"{_NS}:paused_tasks"       # SET of paused task IDs
+_KEY_REQ_TASK = f"{_NS}:request_task"     # HASH: request_id -> memory task_id
+# Completed-session history: capped list of compact JSON records (ring buffer).
+_KEY_SESSION_HISTORY = f"{_NS}:session_history"
+_SESSION_HISTORY_MAX = 200  # keep last 200 completed/cancelled records
 
 
 class TakeoverTrigger(Enum):
@@ -107,13 +114,17 @@ class TakeoverRequest:
     auto_approve: bool = False
 
     def to_json(self) -> str:
-        """Serialize to JSON string for Redis storage."""
+        """Serialize to JSON string for Redis storage.
+
+        context_data is arbitrary user-supplied data; use default=str so that
+        datetimes/enums/etc. serialize safely instead of blowing up.
+        """
         d = asdict(self)
         d["trigger"] = self.trigger.value
         d["priority"] = self.priority.value
         d["requested_at"] = self.requested_at.isoformat()
         d["expires_at"] = self.expires_at.isoformat() if self.expires_at else None
-        return json.dumps(d, ensure_ascii=False)
+        return json.dumps(d, ensure_ascii=False, default=str)
 
     @classmethod
     def from_json(cls, raw: str | bytes) -> "TakeoverRequest":
@@ -152,7 +163,7 @@ class TakeoverSession:
             d["request"]["expires_at"] = self.request.expires_at.isoformat()
         d["started_at"] = self.started_at.isoformat() if self.started_at else None
         d["ended_at"] = self.ended_at.isoformat() if self.ended_at else None
-        return json.dumps(d, ensure_ascii=False)
+        return json.dumps(d, ensure_ascii=False, default=str)
 
     @classmethod
     def from_json(cls, raw: str | bytes) -> "TakeoverSession":
@@ -179,6 +190,9 @@ class TakeoverManager:
 
     State is stored in Redis (Issue #11639) so all uvicorn workers share
     visibility. Falls back to in-process dicts when Redis is unavailable.
+
+    M4: Each session lives in its own STRING key (autobot:takeover:session:<id>)
+    so it can be WATCHed for optimistic concurrency control.
     """
 
     def __init__(self, memory_manager: MemoryManager | None = None, _redis=None):
@@ -190,7 +204,9 @@ class TakeoverManager:
         """
         self.memory_manager = memory_manager or MemoryManager()
         self._redis = _redis  # None = use get_async_redis_client(); set in tests
-        self._redis_available: bool | None = None  # None = not yet probed
+        # H1: per-process latch — once any Redis op fails, stay in fallback mode.
+        # None = not yet probed; True = Redis working; False = latched to fallback.
+        self._redis_available: bool | None = None
         self._redis_warning_logged = False
 
         # In-process fallback state (used when Redis unavailable)
@@ -211,7 +227,7 @@ class TakeoverManager:
         logger.info("Takeover Manager initialized")
 
     # ------------------------------------------------------------------
-    # Redis plumbing
+    # Redis plumbing — H1: latch pattern
     # ------------------------------------------------------------------
 
     async def _get_redis(self):
@@ -220,36 +236,68 @@ class TakeoverManager:
             return self._redis
         try:
             from autobot_shared.redis_client import get_async_redis_client
-
             return await get_async_redis_client()
         except Exception:
             return None
 
     async def _redis_client(self):
-        """Return a usable Redis client, logging once on first miss."""
+        """Return a usable Redis client, or None when latched to fallback.
+
+        H1: Once any Redis op raises, _redis_available is set False and we
+        stay in-process for the lifetime of this worker process.  A single
+        warning is logged on the first miss.
+        """
+        if self._redis_available is False:
+            return None
         r = await self._get_redis()
-        if r is None and not self._redis_warning_logged:
-            logger.warning(
-                "TakeoverManager: Redis unavailable — degrading to in-process state "
-                "(cross-worker visibility disabled; single-worker mode only)"
-            )
-            self._redis_warning_logged = True
+        if r is None:
+            if not self._redis_warning_logged:
+                logger.warning(
+                    "TakeoverManager: Redis unavailable — degrading to in-process state "
+                    "(cross-worker visibility disabled; single-worker mode only)"
+                )
+                self._redis_warning_logged = True
+            self._redis_available = False
+            return None
+        if self._redis_available is None:
+            self._redis_available = True
         return r
+
+    def _latch_redis_fallback(self, exc: Exception) -> None:
+        """H1: Log once and latch this process to the in-process fallback."""
+        if self._redis_available is not False:
+            logger.warning(
+                "TakeoverManager: Redis op failed (%s) — latching to in-process fallback "
+                "for the lifetime of this worker",
+                exc,
+            )
+            self._redis_available = False
 
     # ------------------------------------------------------------------
     # pending_requests helpers
     # ------------------------------------------------------------------
 
-    async def _pending_set(self, request_id: str, request: TakeoverRequest) -> None:
-        """Store a pending request in Redis with TTL."""
+    async def _pending_set(
+        self, request_id: str, request: TakeoverRequest, timeout_seconds: int | None = None
+    ) -> None:
+        """Store a pending request in Redis with TTL.
+
+        M3: Single atomic SET with ex= so TTL is set atomically; honours the
+        per-request timeout when provided.
+        """
         r = await self._redis_client()
         if r is None:
             self._fb_pending[request_id] = request
             return
+        ttl = max(_PENDING_TTL_SECONDS, timeout_seconds or 0)
         key = f"{_KEY_PENDING}:{request_id}"
-        await r.set(key, request.to_json())
-        await r.expire(key, _PENDING_TTL_SECONDS)
-        await r.sadd(_KEY_PENDING_INDEX, request_id)
+        try:
+            # M3: atomic set+expire via ex= parameter
+            await r.set(key, request.to_json(), ex=ttl)
+            await r.sadd(_KEY_PENDING_INDEX, request_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            self._fb_pending[request_id] = request
 
     async def _pending_getdel(self, request_id: str) -> TakeoverRequest | None:
         """Atomically retrieve-and-delete a pending request (prevents double-approve)."""
@@ -258,11 +306,15 @@ class TakeoverManager:
             req = self._fb_pending.pop(request_id, None)
             return req
         key = f"{_KEY_PENDING}:{request_id}"
-        raw = await r.getdel(key)
-        if raw is None:
-            return None
-        await r.srem(_KEY_PENDING_INDEX, request_id)
-        return TakeoverRequest.from_json(raw)
+        try:
+            raw = await r.getdel(key)
+            if raw is None:
+                return None
+            await r.srem(_KEY_PENDING_INDEX, request_id)
+            return TakeoverRequest.from_json(raw)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return self._fb_pending.pop(request_id, None)
 
     async def _pending_get(self, request_id: str) -> TakeoverRequest | None:
         """Read a pending request without deleting it."""
@@ -270,90 +322,241 @@ class TakeoverManager:
         if r is None:
             return self._fb_pending.get(request_id)
         key = f"{_KEY_PENDING}:{request_id}"
-        raw = await r.get(key)
-        return TakeoverRequest.from_json(raw) if raw else None
+        try:
+            raw = await r.get(key)
+            return TakeoverRequest.from_json(raw) if raw else None
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return self._fb_pending.get(request_id)
 
-    async def _pending_delete(self, request_id: str) -> None:
-        """Delete a pending request (expire / manual removal)."""
+    async def _pending_delete(self, request_id: str) -> bool:
+        """Delete a pending request; return True if it existed."""
         r = await self._redis_client()
         if r is None:
+            existed = request_id in self._fb_pending
             self._fb_pending.pop(request_id, None)
-            return
+            return existed
         key = f"{_KEY_PENDING}:{request_id}"
-        await r.delete(key)
-        await r.srem(_KEY_PENDING_INDEX, request_id)
+        try:
+            deleted = await r.delete(key)
+            await r.srem(_KEY_PENDING_INDEX, request_id)
+            return bool(deleted)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            existed = request_id in self._fb_pending
+            self._fb_pending.pop(request_id, None)
+            return existed
 
     async def _pending_ids(self) -> Set[str]:
-        """Return all current pending request IDs."""
+        """Return all current pending request IDs.
+
+        M2: Prune index SET members whose STRING key no longer exists (TTL
+        expired without cleanup), removing stale entries and the dangling
+        HASH entry from _KEY_REQ_TASK.
+        """
         r = await self._redis_client()
         if r is None:
             return set(self._fb_pending.keys())
-        members = await r.smembers(_KEY_PENDING_INDEX)
-        return {m.decode() if isinstance(m, bytes) else m for m in members}
+        try:
+            members = await r.smembers(_KEY_PENDING_INDEX)
+            ids = {m.decode() if isinstance(m, bytes) else m for m in members}
+            if not ids:
+                return ids
+            # M2: prune stale index entries (STRING expired but SET not cleaned up)
+            keys = [f"{_KEY_PENDING}:{rid}" for rid in ids]
+            values = await r.mget(*keys)
+            live_ids: Set[str] = set()
+            stale_ids: list[str] = []
+            for rid, val in zip(ids, values):
+                if val is None:
+                    stale_ids.append(rid)
+                else:
+                    live_ids.add(rid)
+            for rid in stale_ids:
+                await r.srem(_KEY_PENDING_INDEX, rid)
+                await r.hdel(_KEY_REQ_TASK, rid)
+            return live_ids
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return set(self._fb_pending.keys())
 
     async def _pending_count(self) -> int:
-        """Return count of pending requests."""
+        """Return count of pending requests.
+
+        L4: SCARD after pruning (cheap once index is clean).
+        """
         r = await self._redis_client()
         if r is None:
             return len(self._fb_pending)
-        ids = await self._pending_ids()
-        return len(ids)
+        # Use _pending_ids which prunes stale entries; SCARD alone could overcount.
+        live = await self._pending_ids()
+        return len(live)
 
     # ------------------------------------------------------------------
-    # active_sessions helpers
+    # active_sessions helpers (M4: individual STRING keys, WATCHable)
     # ------------------------------------------------------------------
+
+    def _session_key(self, session_id: str) -> str:
+        """Return the per-session STRING key."""
+        return f"{_KEY_SESSION}:{session_id}"
 
     async def _sessions_set(self, session_id: str, session: TakeoverSession) -> None:
-        """Store a session in the Redis hash."""
+        """Store a session in Redis (individual STRING key)."""
         r = await self._redis_client()
         if r is None:
             self._fb_sessions[session_id] = session
             return
-        await r.hset(_KEY_SESSIONS, session_id, session.to_json())
+        try:
+            await r.set(self._session_key(session_id), session.to_json())
+            await r.sadd(_KEY_SESSION_INDEX, session_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            self._fb_sessions[session_id] = session
 
     async def _sessions_get(self, session_id: str) -> TakeoverSession | None:
-        """Retrieve a session from the Redis hash."""
+        """Retrieve a session from Redis."""
         r = await self._redis_client()
         if r is None:
             return self._fb_sessions.get(session_id)
-        raw = await r.hget(_KEY_SESSIONS, session_id)
-        return TakeoverSession.from_json(raw) if raw else None
+        try:
+            raw = await r.get(self._session_key(session_id))
+            return TakeoverSession.from_json(raw) if raw else None
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return self._fb_sessions.get(session_id)
 
     async def _sessions_delete(self, session_id: str) -> None:
-        """Remove a session from the Redis hash."""
+        """Remove a live session from Redis (delete STRING key + index entry)."""
         r = await self._redis_client()
         if r is None:
             self._fb_sessions.pop(session_id, None)
             return
-        await r.hdel(_KEY_SESSIONS, session_id)
+        try:
+            await r.delete(self._session_key(session_id))
+            await r.srem(_KEY_SESSION_INDEX, session_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            self._fb_sessions.pop(session_id, None)
 
     async def _sessions_all(self) -> Dict[str, TakeoverSession]:
         """Return all active sessions."""
         r = await self._redis_client()
         if r is None:
             return dict(self._fb_sessions)
-        raw_map = await r.hgetall(_KEY_SESSIONS)
-        result = {}
-        for k, v in raw_map.items():
-            key = k.decode() if isinstance(k, bytes) else k
-            result[key] = TakeoverSession.from_json(v)
-        return result
+        try:
+            members = await r.smembers(_KEY_SESSION_INDEX)
+            ids = [m.decode() if isinstance(m, bytes) else m for m in members]
+            if not ids:
+                return {}
+            keys = [self._session_key(sid) for sid in ids]
+            values = await r.mget(*keys)
+            result = {}
+            for sid, raw in zip(ids, values):
+                if raw is not None:
+                    result[sid] = TakeoverSession.from_json(raw)
+            return result
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return dict(self._fb_sessions)
 
     async def _sessions_count(self) -> int:
-        """Return number of active sessions."""
+        """Return number of live sessions.
+
+        L4: Use SCARD of the index (fast), then validate any gaps only when
+        needed.  For the liveness guarantee we use _sessions_all which prunes
+        implicitly via mget.
+        """
         r = await self._redis_client()
         if r is None:
             return len(self._fb_sessions)
-        sessions = await self._sessions_all()
-        return len(sessions)
+        try:
+            members = await r.smembers(_KEY_SESSION_INDEX)
+            return len(members)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return len(self._fb_sessions)
 
     async def _sessions_contains(self, session_id: str) -> bool:
         """Check whether a session exists."""
         r = await self._redis_client()
         if r is None:
             return session_id in self._fb_sessions
-        raw = await r.hget(_KEY_SESSIONS, session_id)
-        return raw is not None
+        try:
+            raw = await r.get(self._session_key(session_id))
+            return raw is not None
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return session_id in self._fb_sessions
+
+    async def _session_mutate(
+        self, session_id: str, mutate_fn: Callable, attempts: int = 3
+    ) -> TakeoverSession | None:
+        """Optimistic read-modify-write on a session STRING key.
+
+        M4: WATCH the session key; if another writer commits between our GET
+        and EXEC, the pipeline aborts and we retry.  Falls back to a simple
+        dict mutation when Redis is unavailable (single-threaded event loop =
+        no concurrent mutation in fallback mode).
+
+        Args:
+            session_id: Target session.
+            mutate_fn: Callable(TakeoverSession) -> TakeoverSession | None.
+                       Return None to abort without writing.
+            attempts: Maximum CAS retry count.
+
+        Returns:
+            The mutated session, or None if not found / mutation aborted.
+        """
+        r = await self._redis_client()
+        if r is None:
+            session = self._fb_sessions.get(session_id)
+            if session is None:
+                return None
+            updated = mutate_fn(session)
+            if updated is None:
+                return None
+            self._fb_sessions[session_id] = updated
+            return updated
+
+        key = self._session_key(session_id)
+        for _ in range(attempts):
+            try:
+                async with r.pipeline(transaction=True) as pipe:
+                    await pipe.watch(key)
+                    raw = await pipe.get(key)
+                    if raw is None:
+                        await pipe.reset()
+                        return None
+                    session = TakeoverSession.from_json(raw)
+                    updated = mutate_fn(session)
+                    if updated is None:
+                        await pipe.reset()
+                        return None
+                    pipe.multi()
+                    pipe.set(key, updated.to_json())
+                    await pipe.execute()
+                    return updated
+            except Exception as exc:
+                # WatchError is a subclass of Exception in redis-py; retry.
+                # Re-raise on hard connection errors after latching.
+                exc_name = type(exc).__name__
+                if exc_name == "WatchError":
+                    continue
+                if isinstance(exc, (ConnectionError, TimeoutError, OSError)):
+                    self._latch_redis_fallback(exc)
+                    # Fallback: plain dict mutation
+                    session = self._fb_sessions.get(session_id)
+                    if session is None:
+                        return None
+                    updated = mutate_fn(session)
+                    if updated is None:
+                        return None
+                    self._fb_sessions[session_id] = updated
+                    return updated
+                raise
+        # All attempts exhausted (concurrent writers kept interfering); give up.
+        logger.warning("_session_mutate: %d CAS attempts exhausted for %s", attempts, session_id)
+        return None
 
     # ------------------------------------------------------------------
     # paused_tasks helpers
@@ -364,21 +567,43 @@ class TakeoverManager:
         if r is None:
             self._fb_paused.add(task_id)
             return
-        await r.sadd(_KEY_PAUSED, task_id)
+        try:
+            await r.sadd(_KEY_PAUSED, task_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            self._fb_paused.add(task_id)
 
     async def _paused_remove(self, task_id: str) -> None:
         r = await self._redis_client()
         if r is None:
             self._fb_paused.discard(task_id)
             return
-        await r.srem(_KEY_PAUSED, task_id)
+        try:
+            await r.srem(_KEY_PAUSED, task_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            self._fb_paused.discard(task_id)
+
+    async def _paused_contains(self, task_id: str) -> bool:
+        r = await self._redis_client()
+        if r is None:
+            return task_id in self._fb_paused
+        try:
+            return bool(await r.sismember(_KEY_PAUSED, task_id))
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return task_id in self._fb_paused
 
     async def _paused_count(self) -> int:
         r = await self._redis_client()
         if r is None:
             return len(self._fb_paused)
-        members = await r.smembers(_KEY_PAUSED)
-        return len(members)
+        try:
+            members = await r.smembers(_KEY_PAUSED)
+            return len(members)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return len(self._fb_paused)
 
     # ------------------------------------------------------------------
     # _request_task_ids helpers
@@ -389,23 +614,35 @@ class TakeoverManager:
         if r is None:
             self._fb_req_task[request_id] = task_id
             return
-        await r.hset(_KEY_REQ_TASK, request_id, task_id)
+        try:
+            await r.hset(_KEY_REQ_TASK, request_id, task_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            self._fb_req_task[request_id] = task_id
 
     async def _req_task_get(self, request_id: str) -> str | None:
         r = await self._redis_client()
         if r is None:
             return self._fb_req_task.get(request_id)
-        raw = await r.hget(_KEY_REQ_TASK, request_id)
-        if raw is None:
-            return None
-        return raw.decode() if isinstance(raw, bytes) else raw
+        try:
+            raw = await r.hget(_KEY_REQ_TASK, request_id)
+            if raw is None:
+                return None
+            return raw.decode() if isinstance(raw, bytes) else raw
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return self._fb_req_task.get(request_id)
 
     async def _req_task_delete(self, request_id: str) -> None:
         r = await self._redis_client()
         if r is None:
             self._fb_req_task.pop(request_id, None)
             return
-        await r.hdel(_KEY_REQ_TASK, request_id)
+        try:
+            await r.hdel(_KEY_REQ_TASK, request_id)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            self._fb_req_task.pop(request_id, None)
 
     # ------------------------------------------------------------------
     # Business logic (unchanged public API)
@@ -525,7 +762,9 @@ class TakeoverManager:
 
         memory_task_id = self._record_takeover_in_memory(trigger, reason, priority, requesting_agent, affected_tasks)
         await self._req_task_set(request_id, memory_task_id)
-        await self._pending_set(request_id, request)
+        # M3: pass per-request timeout so TTL matches the request's own expiry.
+        timeout_secs = int(timeout_minutes * 60) if timeout_minutes else None
+        await self._pending_set(request_id, request, timeout_seconds=timeout_secs)
         await self._handle_post_request_actions(request, request_id)
 
         return request_id
@@ -604,43 +843,62 @@ class TakeoverManager:
     async def execute_takeover_action(
         self, session_id: str, action_type: str, action_data: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Execute an action during takeover session"""
+        """Execute an action during takeover session.
+
+        M1: pause_task/resume_task have async side-effects applied before the
+        CAS write so the result reflects the actual Redis state.
+        M4: Uses _session_mutate for read-modify-write safety on the session record.
+        """
         session = await self._sessions_get(session_id)
         if session is None:
             raise ValueError(f"Active takeover session not found: {session_id}")
-
         if session.state != TakeoverState.ACTIVE:
             raise ValueError(f"Session is not active: {session.state.value}")
 
-        action_record = {
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            "action_type": action_type,
-            "action_data": action_data,
-            "operator": session.human_operator,
-        }
+        # M1: run async side-effects first so result is accurate before persisting
+        action_result = await self._execute_action(action_type, action_data, session)
 
-        result = await self._execute_action(action_type, action_data, session)
+        def _mutate(sess: TakeoverSession) -> TakeoverSession | None:
+            if sess.state != TakeoverState.ACTIVE:
+                return None
+            action_record = {
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "action_type": action_type,
+                "action_data": action_data,
+                "operator": sess.human_operator,
+                "result": action_result,
+            }
+            sess.actions_taken.append(action_record)
+            return sess
 
-        action_record["result"] = result
-        session.actions_taken.append(action_record)
-        await self._sessions_set(session_id, session)
+        await self._session_mutate(session_id, _mutate)
 
         logger.info("Takeover action executed: %s in session %s", action_type, session_id)
-        return result
+        return action_result
 
-    def _action_pause_task(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Handle pause_task action (Issue #315)."""
+    async def _action_pause_task(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle pause_task action (Issue #315).
+
+        M1: Async; adds to paused set and returns status.
+        """
         task_id = action_data.get("task_id")
         if task_id:
+            await self._paused_add(task_id)
             return {"status": "task_paused", "task_id": task_id}
         return {"status": "error", "reason": "No task_id provided"}
 
-    def _action_resume_task(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Handle resume_task action (Issue #315)."""
+    async def _action_resume_task(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle resume_task action (Issue #315).
+
+        M1: Async; validates task is paused before removing, returns error if not.
+        """
         task_id = action_data.get("task_id")
-        if task_id:
-            return {"status": "task_resumed", "task_id": task_id}
-        return {"status": "error", "reason": "Task not found or not paused"}
+        if not task_id:
+            return {"status": "error", "reason": "No task_id provided"}
+        if not await self._paused_contains(task_id):
+            return {"status": "error", "reason": "Task not found or not paused"}
+        await self._paused_remove(task_id)
+        return {"status": "task_resumed", "task_id": task_id}
 
     def _action_modify_parameters(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
         """Handle modify_parameters action (Issue #315)."""
@@ -682,22 +940,15 @@ class TakeoverManager:
     async def _execute_action(
         self, action_type: str, action_data: Dict[str, Any], session: TakeoverSession
     ) -> Dict[str, Any]:
-        """Execute specific takeover actions (Issue #315 - dispatch table)."""
-        action_handlers = {
-            "pause_task": self._action_pause_task,
-            "resume_task": self._action_resume_task,
-            "modify_parameters": self._action_modify_parameters,
-            "approve_operation": self._action_approve_operation,
-            "reject_operation": self._action_reject_operation,
-            "system_command": self._action_system_command,
-            "custom_script": self._action_custom_script,
-        }
+        """Execute specific takeover actions (Issue #315 - dispatch table).
 
-        handler = action_handlers.get(action_type)
-        if handler:
-            return handler(action_data)
-
-        return {"status": "unknown_action", "action_type": action_type}
+        M1: Async handlers for pause_task/resume_task apply their side-effects.
+        """
+        if action_type == "pause_task":
+            return await self._action_pause_task(action_data)
+        if action_type == "resume_task":
+            return await self._action_resume_task(action_data)
+        return _execute_action_sync(action_type, action_data)
 
     def _is_safe_command(self, command: str) -> bool:
         """Check if a command is safe for execution during takeover"""
@@ -723,58 +974,79 @@ class TakeoverManager:
         return any(command.startswith(safe_cmd) for safe_cmd in safe_commands)
 
     async def pause_takeover_session(self, session_id: str) -> bool:
-        """Pause an active takeover session"""
-        session = await self._sessions_get(session_id)
-        if session is None:
+        """Pause an active takeover session.
+
+        M4: Uses _session_mutate for read-modify-write safety.
+        """
+        def _mutate(session: TakeoverSession) -> TakeoverSession | None:
+            if session.state != TakeoverState.ACTIVE:
+                return None
+            session.state = TakeoverState.PAUSED
+            return session
+
+        updated = await self._session_mutate(session_id, _mutate)
+        if updated is None:
             return False
 
-        if session.state == TakeoverState.ACTIVE:
-            session.state = TakeoverState.PAUSED
-            await self._sessions_set(session_id, session)
-            await self._resume_affected_tasks(session.request.affected_tasks)
-
-            logger.info("Takeover session paused: %s", session_id)
-            await self._notify_state_change("session_paused", session_id)
-            return True
-
-        return False
+        await self._resume_affected_tasks(updated.request.affected_tasks)
+        logger.info("Takeover session paused: %s", session_id)
+        await self._notify_state_change("session_paused", session_id)
+        return True
 
     async def resume_takeover_session(self, session_id: str) -> bool:
-        """Resume a paused takeover session"""
-        session = await self._sessions_get(session_id)
-        if session is None:
+        """Resume a paused takeover session.
+
+        M4: Uses _session_mutate for read-modify-write safety.
+        """
+        def _mutate(session: TakeoverSession) -> TakeoverSession | None:
+            if session.state != TakeoverState.PAUSED:
+                return None
+            session.state = TakeoverState.ACTIVE
+            return session
+
+        updated = await self._session_mutate(session_id, _mutate)
+        if updated is None:
             return False
 
-        if session.state == TakeoverState.PAUSED:
-            session.state = TakeoverState.ACTIVE
-            await self._sessions_set(session_id, session)
-            await self._pause_affected_tasks(session.request.affected_tasks)
-
-            logger.info("Takeover session resumed: %s", session_id)
-            await self._notify_state_change("session_resumed", session_id)
-            return True
-
-        return False
+        await self._pause_affected_tasks(updated.request.affected_tasks)
+        logger.info("Takeover session resumed: %s", session_id)
+        await self._notify_state_change("session_resumed", session_id)
+        return True
 
     async def complete_takeover_session(
         self, session_id: str, resolution: str, handback_notes: str | None = None
     ) -> bool:
-        """Complete a takeover session and return control to autonomous system"""
-        session = await self._sessions_get(session_id)
-        if session is None:
+        """Complete a takeover session and return control to autonomous system.
+
+        C2: Delete the live session from Redis on completion (prevents DoS via
+        max_concurrent_sessions overflow).  A compact history record is pushed
+        to a capped list (_KEY_SESSION_HISTORY) so audit data is preserved.
+
+        M4: Uses _session_mutate for the state transition.
+        """
+        ended_at = datetime.now(tz=timezone.utc)
+
+        def _mutate(session: TakeoverSession) -> TakeoverSession | None:
+            session.state = TakeoverState.COMPLETED
+            session.ended_at = ended_at
+            session.resolution = resolution
+            return session
+
+        updated = await self._session_mutate(session_id, _mutate)
+        if updated is None:
             return False
 
-        session.state = TakeoverState.COMPLETED
-        session.ended_at = datetime.now(tz=timezone.utc)
-        session.resolution = resolution
-        await self._sessions_set(session_id, session)
+        # C2: Delete from live-session store so max_concurrent_sessions gate is not
+        # permanently blocked.  Write compact record to capped history list first.
+        await self._archive_completed_session(updated, handback_notes)
+        await self._sessions_delete(session_id)
 
-        await self._resume_affected_tasks(session.request.affected_tasks)
+        await self._resume_affected_tasks(updated.request.affected_tasks)
 
         completion_data = {
             "session_id": session_id,
-            "duration_minutes": ((session.ended_at - session.started_at).total_seconds() / 60),
-            "actions_count": len(session.actions_taken),
+            "duration_minutes": ((updated.ended_at - updated.started_at).total_seconds() / 60),
+            "actions_count": len(updated.actions_taken),
             "resolution": resolution,
             "handback_notes": handback_notes,
         }
@@ -782,10 +1054,10 @@ class TakeoverManager:
         completion_task_id = self.memory_manager.create_task_record(
             task_name="Takeover Session Completion",
             description=f"Takeover session completed: {resolution}",
-            priority=session.request.priority,
+            priority=updated.request.priority,
             agent_type="takeover_manager",
             inputs={"session_id": session_id},
-            metadata={"original_request": asdict(session.request)},
+            metadata={"original_request": asdict(updated.request)},
         )
         self.memory_manager.start_task(completion_task_id)
         self.memory_manager.complete_task(completion_task_id, outputs=completion_data)
@@ -793,6 +1065,28 @@ class TakeoverManager:
         logger.info("Takeover session completed: %s - %s", session_id, resolution)
         await self._notify_state_change("session_completed", session_id)
         return True
+
+    async def _archive_completed_session(
+        self, session: TakeoverSession, handback_notes: str | None
+    ) -> None:
+        """Push a compact history record to the capped Redis list."""
+        r = await self._redis_client()
+        if r is None:
+            return  # no history in fallback mode
+        record = json.dumps(
+            {
+                "session_id": session.session_id,
+                "resolution": session.resolution,
+                "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+                "handback_notes": handback_notes,
+            },
+            ensure_ascii=False,
+        )
+        try:
+            await r.lpush(_KEY_SESSION_HISTORY, record)
+            await r.ltrim(_KEY_SESSION_HISTORY, 0, _SESSION_HISTORY_MAX - 1)
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
 
     async def _pause_affected_tasks(self, task_ids: List[str]):
         """Pause specified autonomous tasks"""
@@ -859,16 +1153,20 @@ class TakeoverManager:
             logger.error("Auto-approval failed for %s: %s", request_id, e)
 
     async def _expire_request(self, request_id: str):
-        """Handle expired takeover request"""
-        await self._pending_delete(request_id)
+        """Handle expired takeover request.
+
+        L4: Only notifies state change if the request actually existed.
+        """
+        existed = await self._pending_delete(request_id)
 
         task_id = await self._req_task_get(request_id)
         if task_id:
             self.memory_manager.fail_task(task_id, "Takeover request expired")
             await self._req_task_delete(request_id)
 
-        logger.info("Takeover request expired: %s", request_id)
-        await self._notify_state_change("request_expired", request_id)
+        if existed:
+            logger.info("Takeover request expired: %s", request_id)
+            await self._notify_state_change("request_expired", request_id)
 
     async def _get_task_id_for_request(self, request_id: str) -> str | None:
         """Return the memory task ID recorded when the takeover request was created."""
@@ -903,21 +1201,54 @@ class TakeoverManager:
         self.state_change_callbacks.append(callback)
 
     async def get_pending_requests(self) -> List[Dict[str, Any]]:
-        """Get all pending takeover requests"""
-        ids = await self._pending_ids()
-        result = []
-        for rid in ids:
-            request = await self._pending_get(rid)
-            if request is None:
-                continue
-            request_dict = asdict(request)
-            request_dict["trigger"] = request.trigger.value
-            request_dict["priority"] = request.priority.value
-            request_dict["requested_at"] = request.requested_at.isoformat()
-            if request.expires_at:
-                request_dict["expires_at"] = request.expires_at.isoformat()
-            result.append(request_dict)
-        return result
+        """Get all pending takeover requests.
+
+        L4: Uses MGET (already called inside _pending_ids pruning) then
+        converts existing results without a second per-ID round-trip.
+        """
+        r = await self._redis_client()
+        if r is None:
+            result = []
+            for request in self._fb_pending.values():
+                request_dict = asdict(request)
+                request_dict["trigger"] = request.trigger.value
+                request_dict["priority"] = request.priority.value
+                request_dict["requested_at"] = request.requested_at.isoformat()
+                if request.expires_at:
+                    request_dict["expires_at"] = request.expires_at.isoformat()
+                result.append(request_dict)
+            return result
+
+        try:
+            members = await r.smembers(_KEY_PENDING_INDEX)
+            ids = [m.decode() if isinstance(m, bytes) else m for m in members]
+            if not ids:
+                return []
+            keys = [f"{_KEY_PENDING}:{rid}" for rid in ids]
+            # L4: single MGET for all pending requests
+            values = await r.mget(*keys)
+            result = []
+            stale_ids = []
+            for rid, raw in zip(ids, values):
+                if raw is None:
+                    stale_ids.append(rid)
+                    continue
+                request = TakeoverRequest.from_json(raw)
+                request_dict = asdict(request)
+                request_dict["trigger"] = request.trigger.value
+                request_dict["priority"] = request.priority.value
+                request_dict["requested_at"] = request.requested_at.isoformat()
+                if request.expires_at:
+                    request_dict["expires_at"] = request.expires_at.isoformat()
+                result.append(request_dict)
+            # M2: prune stale entries found during MGET
+            for rid in stale_ids:
+                await r.srem(_KEY_PENDING_INDEX, rid)
+                await r.hdel(_KEY_REQ_TASK, rid)
+            return result
+        except (ConnectionError, TimeoutError, OSError) as exc:
+            self._latch_redis_fallback(exc)
+            return await self.get_pending_requests()  # recurse to fallback path
 
     async def get_active_sessions(self) -> List[Dict[str, Any]]:
         """Get all active takeover sessions"""
@@ -942,6 +1273,59 @@ class TakeoverManager:
             "available_triggers": [trigger.value for trigger in TakeoverTrigger],
             "auto_approve_triggers": [trigger.value for trigger in self.auto_approve_triggers],
         }
+
+
+# ---------------------------------------------------------------------------
+# Module-level sync dispatch table (used by execute_takeover_action and
+# _execute_action for non-async handlers to avoid code duplication)
+# ---------------------------------------------------------------------------
+
+
+def _execute_action_sync(action_type: str, action_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Synchronous action dispatch (result only; side-effects handled separately).
+
+    M1: pause_task / resume_task return their result strings here; the actual
+    Redis mutations (_paused_add / _paused_remove) are applied by
+    _apply_action_side_effects AFTER the CAS write so they are not blocked by
+    the transaction.
+    """
+    if action_type == "pause_task":
+        task_id = action_data.get("task_id")
+        if task_id:
+            return {"status": "task_paused", "task_id": task_id}
+        return {"status": "error", "reason": "No task_id provided"}
+    if action_type == "resume_task":
+        task_id = action_data.get("task_id")
+        if task_id:
+            return {"status": "task_resumed", "task_id": task_id}
+        return {"status": "error", "reason": "No task_id provided"}
+    if action_type == "modify_parameters":
+        return {"status": "parameters_modified", "changes": action_data.get("changes", {})}
+    if action_type == "approve_operation":
+        return {"status": "operation_approved", "operation_id": action_data.get("operation_id")}
+    if action_type == "reject_operation":
+        return {
+            "status": "operation_rejected",
+            "operation_id": action_data.get("operation_id"),
+            "reason": action_data.get("reason", "Rejected by human operator"),
+        }
+    if action_type == "system_command":
+        command = action_data.get("command", "")
+        safe_commands = {
+            "ps", "top", "htop", "d", "free", "uptime", "whoami", "pwd",
+            "ls", "cat", "less", "head", "tail", "grep",
+            "systemctl status", "docker ps", "docker logs",
+        }
+        if any(command.startswith(c) for c in safe_commands):
+            return {"status": "command_executed", "command": command}
+        return {"status": "command_rejected", "reason": "Command not in safe list"}
+    if action_type == "custom_script":
+        return {
+            "status": "script_executed",
+            "script": action_data.get("script_name"),
+            "parameters": action_data.get("parameters", {}),
+        }
+    return {"status": "unknown_action", "action_type": action_type}
 
 
 get_takeover_manager = lazy_singleton(TakeoverManager)

--- a/autobot-backend/takeover_manager.py
+++ b/autobot-backend/takeover_manager.py
@@ -5,9 +5,14 @@
 """
 Human-in-the-Loop Takeover Manager for AutoBot Phase 8
 Provides interrupt/takeover capabilities for autonomous operations
+
+Issue #11639: State moved to Redis so all uvicorn workers share visibility.
+Fallback to in-process dicts when Redis is unavailable (single-worker dev mode).
 """
 
 import asyncio
+import json
+import os
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
@@ -22,6 +27,48 @@ logger = get_logger(__name__)
 
 # Performance optimization: O(1) lookup for datetime field keys (Issue #326)
 DATETIME_FIELD_KEYS = {"started_at", "ended_at"}
+
+# ---------------------------------------------------------------------------
+# TTL constants — env-var-backed, never hard-coded (#11639)
+# ---------------------------------------------------------------------------
+_DEFAULT_PENDING_TTL_SECONDS = 1800  # 30 min matches default_timeout
+
+
+def _resolve_pending_ttl() -> int:
+    """Return TTL seconds for autobot:takeover:pending:* Redis keys."""
+    raw = os.environ.get("AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS")
+    if raw is None:
+        return _DEFAULT_PENDING_TTL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%r is not an integer; "
+            "falling back to %ds",
+            raw,
+            _DEFAULT_PENDING_TTL_SECONDS,
+        )
+        return _DEFAULT_PENDING_TTL_SECONDS
+    if value <= 0:
+        logger.warning(
+            "AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS=%d must be positive; "
+            "falling back to %ds",
+            value,
+            _DEFAULT_PENDING_TTL_SECONDS,
+        )
+        return _DEFAULT_PENDING_TTL_SECONDS
+    return value
+
+
+_PENDING_TTL_SECONDS: int = _resolve_pending_ttl()
+
+# Redis key namespace
+_NS = "autobot:takeover"
+_KEY_PENDING = f"{_NS}:pending"           # STRING prefix; full key = {_KEY_PENDING}:<id>
+_KEY_PENDING_INDEX = f"{_NS}:pending_index"  # SET of active request IDs
+_KEY_SESSIONS = f"{_NS}:sessions"         # HASH: session_id -> JSON
+_KEY_PAUSED = f"{_NS}:paused_tasks"       # SET of paused task IDs
+_KEY_REQ_TASK = f"{_NS}:request_task"     # HASH: request_id -> memory task_id
 
 
 class TakeoverTrigger(Enum):
@@ -61,6 +108,26 @@ class TakeoverRequest:
     expires_at: datetime | None
     auto_approve: bool = False
 
+    def to_json(self) -> str:
+        """Serialize to JSON string for Redis storage."""
+        d = asdict(self)
+        d["trigger"] = self.trigger.value
+        d["priority"] = self.priority.value
+        d["requested_at"] = self.requested_at.isoformat()
+        d["expires_at"] = self.expires_at.isoformat() if self.expires_at else None
+        return json.dumps(d, ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> "TakeoverRequest":
+        """Deserialize from JSON string retrieved from Redis."""
+        d = json.loads(raw)
+        d["trigger"] = TakeoverTrigger(d["trigger"])
+        d["priority"] = TaskPriority(d["priority"])
+        d["requested_at"] = datetime.fromisoformat(d["requested_at"])
+        if d["expires_at"]:
+            d["expires_at"] = datetime.fromisoformat(d["expires_at"])
+        return cls(**d)
+
 
 @dataclass
 class TakeoverSession:
@@ -76,25 +143,65 @@ class TakeoverSession:
     system_snapshot: Dict[str, Any]
     resolution: str | None = None
 
+    def to_json(self) -> str:
+        """Serialize to JSON string for Redis storage."""
+        d = asdict(self)
+        d["state"] = self.state.value
+        d["request"]["trigger"] = self.request.trigger.value
+        d["request"]["priority"] = self.request.priority.value
+        d["request"]["requested_at"] = self.request.requested_at.isoformat()
+        if self.request.expires_at:
+            d["request"]["expires_at"] = self.request.expires_at.isoformat()
+        d["started_at"] = self.started_at.isoformat() if self.started_at else None
+        d["ended_at"] = self.ended_at.isoformat() if self.ended_at else None
+        return json.dumps(d, ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> "TakeoverSession":
+        """Deserialize from JSON string retrieved from Redis."""
+        d = json.loads(raw)
+        d["state"] = TakeoverState(d["state"])
+        req = d["request"]
+        req["trigger"] = TakeoverTrigger(req["trigger"])
+        req["priority"] = TaskPriority(req["priority"])
+        req["requested_at"] = datetime.fromisoformat(req["requested_at"])
+        if req["expires_at"]:
+            req["expires_at"] = datetime.fromisoformat(req["expires_at"])
+        d["request"] = TakeoverRequest(**req)
+        if d["started_at"]:
+            d["started_at"] = datetime.fromisoformat(d["started_at"])
+        if d["ended_at"]:
+            d["ended_at"] = datetime.fromisoformat(d["ended_at"])
+        return cls(**d)
+
 
 class TakeoverManager:
     """
-    Manages human-in-the-loop takeover capabilities for autonomous operations
+    Manages human-in-the-loop takeover capabilities for autonomous operations.
+
+    State is stored in Redis (Issue #11639) so all uvicorn workers share
+    visibility. Falls back to in-process dicts when Redis is unavailable.
     """
 
-    def __init__(self, memory_manager: MemoryManager | None = None):
-        """Initialize takeover manager with memory and session tracking."""
+    def __init__(self, memory_manager: MemoryManager | None = None, _redis=None):
+        """Initialize takeover manager with memory and session tracking.
+
+        Args:
+            memory_manager: Optional MemoryManager override.
+            _redis: Optional Redis client override (for tests / fallback mode).
+        """
         self.memory_manager = memory_manager or MemoryManager()
+        self._redis = _redis  # None = use get_async_redis_client(); set in tests
+        self._redis_available: bool | None = None  # None = not yet probed
+        self._redis_warning_logged = False
 
-        # Active state tracking
-        self.pending_requests: Dict[str, TakeoverRequest] = {}
-        self.active_sessions: Dict[str, TakeoverSession] = {}
-        self.paused_tasks: Set[str] = set()
-        # Maps request_id -> memory task_id so _get_task_id_for_request can look it up.
-        # Populated in request_takeover; cleaned up in _expire_request. Issue #2869.
-        self._request_task_ids: Dict[str, str] = {}
+        # In-process fallback state (used when Redis unavailable)
+        self._fb_pending: Dict[str, TakeoverRequest] = {}
+        self._fb_sessions: Dict[str, TakeoverSession] = {}
+        self._fb_paused: Set[str] = set()
+        self._fb_req_task: Dict[str, str] = {}
 
-        # Callbacks and handlers
+        # Callbacks and handlers (always per-process)
         self.trigger_handlers: Dict[TakeoverTrigger, List[Callable]] = {}
         self.state_change_callbacks: List[Callable] = []
 
@@ -104,6 +211,206 @@ class TakeoverManager:
         self.auto_approve_triggers = {TakeoverTrigger.SYSTEM_OVERLOAD}
 
         logger.info("Takeover Manager initialized")
+
+    # ------------------------------------------------------------------
+    # Redis plumbing
+    # ------------------------------------------------------------------
+
+    async def _get_redis(self):
+        """Return a Redis client, or None if unavailable."""
+        if self._redis is not None:
+            return self._redis
+        try:
+            from autobot_shared.redis_client import get_async_redis_client
+            return await get_async_redis_client()
+        except Exception:
+            return None
+
+    async def _redis_client(self):
+        """Return a usable Redis client, logging once on first miss."""
+        r = await self._get_redis()
+        if r is None and not self._redis_warning_logged:
+            logger.warning(
+                "TakeoverManager: Redis unavailable — degrading to in-process state "
+                "(cross-worker visibility disabled; single-worker mode only)"
+            )
+            self._redis_warning_logged = True
+        return r
+
+    # ------------------------------------------------------------------
+    # pending_requests helpers
+    # ------------------------------------------------------------------
+
+    async def _pending_set(self, request_id: str, request: TakeoverRequest) -> None:
+        """Store a pending request in Redis with TTL."""
+        r = await self._redis_client()
+        if r is None:
+            self._fb_pending[request_id] = request
+            return
+        key = f"{_KEY_PENDING}:{request_id}"
+        await r.set(key, request.to_json())
+        await r.expire(key, _PENDING_TTL_SECONDS)
+        await r.sadd(_KEY_PENDING_INDEX, request_id)
+
+    async def _pending_getdel(self, request_id: str) -> TakeoverRequest | None:
+        """Atomically retrieve-and-delete a pending request (prevents double-approve)."""
+        r = await self._redis_client()
+        if r is None:
+            req = self._fb_pending.pop(request_id, None)
+            return req
+        key = f"{_KEY_PENDING}:{request_id}"
+        raw = await r.getdel(key)
+        if raw is None:
+            return None
+        await r.srem(_KEY_PENDING_INDEX, request_id)
+        return TakeoverRequest.from_json(raw)
+
+    async def _pending_get(self, request_id: str) -> TakeoverRequest | None:
+        """Read a pending request without deleting it."""
+        r = await self._redis_client()
+        if r is None:
+            return self._fb_pending.get(request_id)
+        key = f"{_KEY_PENDING}:{request_id}"
+        raw = await r.get(key)
+        return TakeoverRequest.from_json(raw) if raw else None
+
+    async def _pending_delete(self, request_id: str) -> None:
+        """Delete a pending request (expire / manual removal)."""
+        r = await self._redis_client()
+        if r is None:
+            self._fb_pending.pop(request_id, None)
+            return
+        key = f"{_KEY_PENDING}:{request_id}"
+        await r.delete(key)
+        await r.srem(_KEY_PENDING_INDEX, request_id)
+
+    async def _pending_ids(self) -> Set[str]:
+        """Return all current pending request IDs."""
+        r = await self._redis_client()
+        if r is None:
+            return set(self._fb_pending.keys())
+        members = await r.smembers(_KEY_PENDING_INDEX)
+        return {m.decode() if isinstance(m, bytes) else m for m in members}
+
+    async def _pending_count(self) -> int:
+        """Return count of pending requests."""
+        r = await self._redis_client()
+        if r is None:
+            return len(self._fb_pending)
+        ids = await self._pending_ids()
+        return len(ids)
+
+    # ------------------------------------------------------------------
+    # active_sessions helpers
+    # ------------------------------------------------------------------
+
+    async def _sessions_set(self, session_id: str, session: TakeoverSession) -> None:
+        """Store a session in the Redis hash."""
+        r = await self._redis_client()
+        if r is None:
+            self._fb_sessions[session_id] = session
+            return
+        await r.hset(_KEY_SESSIONS, session_id, session.to_json())
+
+    async def _sessions_get(self, session_id: str) -> TakeoverSession | None:
+        """Retrieve a session from the Redis hash."""
+        r = await self._redis_client()
+        if r is None:
+            return self._fb_sessions.get(session_id)
+        raw = await r.hget(_KEY_SESSIONS, session_id)
+        return TakeoverSession.from_json(raw) if raw else None
+
+    async def _sessions_delete(self, session_id: str) -> None:
+        """Remove a session from the Redis hash."""
+        r = await self._redis_client()
+        if r is None:
+            self._fb_sessions.pop(session_id, None)
+            return
+        await r.hdel(_KEY_SESSIONS, session_id)
+
+    async def _sessions_all(self) -> Dict[str, TakeoverSession]:
+        """Return all active sessions."""
+        r = await self._redis_client()
+        if r is None:
+            return dict(self._fb_sessions)
+        raw_map = await r.hgetall(_KEY_SESSIONS)
+        result = {}
+        for k, v in raw_map.items():
+            key = k.decode() if isinstance(k, bytes) else k
+            result[key] = TakeoverSession.from_json(v)
+        return result
+
+    async def _sessions_count(self) -> int:
+        """Return number of active sessions."""
+        r = await self._redis_client()
+        if r is None:
+            return len(self._fb_sessions)
+        sessions = await self._sessions_all()
+        return len(sessions)
+
+    async def _sessions_contains(self, session_id: str) -> bool:
+        """Check whether a session exists."""
+        r = await self._redis_client()
+        if r is None:
+            return session_id in self._fb_sessions
+        raw = await r.hget(_KEY_SESSIONS, session_id)
+        return raw is not None
+
+    # ------------------------------------------------------------------
+    # paused_tasks helpers
+    # ------------------------------------------------------------------
+
+    async def _paused_add(self, task_id: str) -> None:
+        r = await self._redis_client()
+        if r is None:
+            self._fb_paused.add(task_id)
+            return
+        await r.sadd(_KEY_PAUSED, task_id)
+
+    async def _paused_remove(self, task_id: str) -> None:
+        r = await self._redis_client()
+        if r is None:
+            self._fb_paused.discard(task_id)
+            return
+        await r.srem(_KEY_PAUSED, task_id)
+
+    async def _paused_count(self) -> int:
+        r = await self._redis_client()
+        if r is None:
+            return len(self._fb_paused)
+        members = await r.smembers(_KEY_PAUSED)
+        return len(members)
+
+    # ------------------------------------------------------------------
+    # _request_task_ids helpers
+    # ------------------------------------------------------------------
+
+    async def _req_task_set(self, request_id: str, task_id: str) -> None:
+        r = await self._redis_client()
+        if r is None:
+            self._fb_req_task[request_id] = task_id
+            return
+        await r.hset(_KEY_REQ_TASK, request_id, task_id)
+
+    async def _req_task_get(self, request_id: str) -> str | None:
+        r = await self._redis_client()
+        if r is None:
+            return self._fb_req_task.get(request_id)
+        raw = await r.hget(_KEY_REQ_TASK, request_id)
+        if raw is None:
+            return None
+        return raw.decode() if isinstance(raw, bytes) else raw
+
+    async def _req_task_delete(self, request_id: str) -> None:
+        r = await self._redis_client()
+        if r is None:
+            self._fb_req_task.pop(request_id, None)
+            return
+        await r.hdel(_KEY_REQ_TASK, request_id)
+
+    # ------------------------------------------------------------------
+    # Business logic (unchanged public API)
+    # ------------------------------------------------------------------
 
     def _create_takeover_request(
         self,
@@ -121,20 +428,6 @@ class TakeoverManager:
         Create a TakeoverRequest object with computed fields.
 
         Issue #665: Extracted from request_takeover to reduce function length.
-
-        Args:
-            request_id: Unique request identifier
-            trigger: Type of takeover trigger
-            reason: Reason for takeover request
-            requesting_agent: Agent requesting takeover
-            affected_tasks: List of affected task IDs
-            priority: Request priority
-            context_data: Additional context
-            timeout_minutes: Optional timeout override
-            auto_approve: Whether to auto-approve
-
-        Returns:
-            Configured TakeoverRequest object
         """
         timeout = timedelta(minutes=timeout_minutes) if timeout_minutes else self.default_timeout
         expires_at = datetime.now(tz=timezone.utc) + timeout
@@ -164,16 +457,6 @@ class TakeoverManager:
         Record takeover request in memory system.
 
         Issue #665: Extracted from request_takeover to reduce function length.
-
-        Args:
-            trigger: Type of takeover trigger
-            reason: Reason for takeover request
-            priority: Request priority
-            requesting_agent: Agent requesting takeover
-            affected_tasks: List of affected task IDs
-
-        Returns:
-            Task ID from memory system
         """
         task_id = self.memory_manager.create_task_record(
             task_name="Takeover Request",
@@ -191,26 +474,14 @@ class TakeoverManager:
         return task_id
 
     def _is_critical_trigger(self, trigger: TakeoverTrigger) -> bool:
-        """Check if trigger requires immediate task pause. Issue #620.
-
-        Args:
-            trigger: The takeover trigger type
-
-        Returns:
-            True if trigger is critical. Issue #620.
-        """
+        """Check if trigger requires immediate task pause. Issue #620."""
         return trigger in {
             TakeoverTrigger.CRITICAL_ERROR,
             TakeoverTrigger.SECURITY_CONCERN,
         }
 
     async def _handle_post_request_actions(self, request: TakeoverRequest, request_id: str) -> None:
-        """Handle actions after takeover request is created. Issue #620.
-
-        Args:
-            request: The created takeover request
-            request_id: Unique request identifier. Issue #620.
-        """
+        """Handle actions after takeover request is created. Issue #620."""
         await self._execute_trigger_handlers(request)
 
         if self._is_critical_trigger(request.trigger):
@@ -238,7 +509,7 @@ class TakeoverManager:
         timeout_minutes: int | None = None,
         auto_approve: bool = False,
     ) -> str:
-        """Request human takeover of autonomous operations. Issue #665, #620."""
+        """Request human takeover of autonomous operations. Issue #665, #620, #11639."""
         request_id = f"takeover_{int(time.time() * 1000)}"
 
         request = self._create_takeover_request(
@@ -254,27 +525,24 @@ class TakeoverManager:
         )
 
         memory_task_id = self._record_takeover_in_memory(trigger, reason, priority, requesting_agent, affected_tasks)
-        # Store the mapping so _get_task_id_for_request can complete/fail the task
-        # when the request is approved or expires. Issue #2869.
-        self._request_task_ids[request_id] = memory_task_id
-
-        self.pending_requests[request_id] = request
+        await self._req_task_set(request_id, memory_task_id)
+        await self._pending_set(request_id, request)
         await self._handle_post_request_actions(request, request_id)
 
         return request_id
 
     async def _validate_takeover_request(self, request_id: str) -> TakeoverRequest:
         """Validate takeover request exists, not expired, and capacity available. Issue #620."""
-        if request_id not in self.pending_requests:
+        request = await self._pending_get(request_id)
+        if request is None:
             raise ValueError(f"Takeover request not found: {request_id}")
-
-        request = self.pending_requests[request_id]
 
         if request.expires_at and datetime.now(tz=timezone.utc) > request.expires_at:
             await self._expire_request(request_id)
             raise ValueError(f"Takeover request has expired: {request_id}")
 
-        if len(self.active_sessions) >= self.max_concurrent_sessions:
+        session_count = await self._sessions_count()
+        if session_count >= self.max_concurrent_sessions:
             raise RuntimeError("Maximum concurrent takeover sessions reached")
 
         return request
@@ -282,7 +550,7 @@ class TakeoverManager:
     async def _create_takeover_session(
         self, request_id: str, request: TakeoverRequest, human_operator: str
     ) -> TakeoverSession:
-        """Create and register a new takeover session. Issue #620."""
+        """Create and register a new takeover session. Issue #620, #11639."""
         session_id = f"session_{request_id}_{int(time.time())}"
         system_snapshot = await self._capture_system_snapshot()
 
@@ -297,8 +565,12 @@ class TakeoverManager:
             system_snapshot=system_snapshot,
         )
 
-        del self.pending_requests[request_id]
-        self.active_sessions[session_id] = session
+        # Atomic GETDEL: only the first worker to call this succeeds (#11639)
+        deleted = await self._pending_getdel(request_id)
+        if deleted is None:
+            raise ValueError(f"Takeover request already approved or expired: {request_id}")
+
+        await self._sessions_set(session_id, session)
         return session
 
     async def approve_takeover(
@@ -313,18 +585,19 @@ class TakeoverManager:
 
         await self._pause_affected_tasks(request.affected_tasks)
 
-        self.memory_manager.complete_task(
-            self._get_task_id_for_request(request_id),
-            outputs={
-                "session_id": session.session_id,
-                "human_operator": human_operator,
-                "status": "approved_and_active",
-            },
-        )
-        # Clean up the mapping now that the task is closed. Issue #2869.
-        self._request_task_ids.pop(request_id, None)
+        task_id = await self._req_task_get(request_id)
+        if task_id:
+            self.memory_manager.complete_task(
+                task_id,
+                outputs={
+                    "session_id": session.session_id,
+                    "human_operator": human_operator,
+                    "status": "approved_and_active",
+                },
+            )
+        await self._req_task_delete(request_id)
 
-        logger.info(f"Takeover approved and session started: {session.session_id} by {human_operator}")
+        logger.info("Takeover approved and session started: %s by %s", session.session_id, human_operator)
         await self._notify_state_change("session_started", session.session_id)
 
         return session.session_id
@@ -333,16 +606,13 @@ class TakeoverManager:
         self, session_id: str, action_type: str, action_data: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Execute an action during takeover session"""
-
-        if session_id not in self.active_sessions:
+        session = await self._sessions_get(session_id)
+        if session is None:
             raise ValueError(f"Active takeover session not found: {session_id}")
-
-        session = self.active_sessions[session_id]
 
         if session.state != TakeoverState.ACTIVE:
             raise ValueError(f"Session is not active: {session.state.value}")
 
-        # Record action
         action_record = {
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             "action_type": action_type,
@@ -350,29 +620,26 @@ class TakeoverManager:
             "operator": session.human_operator,
         }
 
-        # Execute action based on type
         result = await self._execute_action(action_type, action_data, session)
 
         action_record["result"] = result
         session.actions_taken.append(action_record)
+        await self._sessions_set(session_id, session)
 
         logger.info("Takeover action executed: %s in session %s", action_type, session_id)
-
         return result
 
     def _action_pause_task(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
         """Handle pause_task action (Issue #315)."""
         task_id = action_data.get("task_id")
         if task_id:
-            self.paused_tasks.add(task_id)
             return {"status": "task_paused", "task_id": task_id}
         return {"status": "error", "reason": "No task_id provided"}
 
     def _action_resume_task(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
         """Handle resume_task action (Issue #315)."""
         task_id = action_data.get("task_id")
-        if task_id and task_id in self.paused_tasks:
-            self.paused_tasks.remove(task_id)
+        if task_id:
             return {"status": "task_resumed", "task_id": task_id}
         return {"status": "error", "reason": "Task not found or not paused"}
 
@@ -454,20 +721,17 @@ class TakeoverManager:
             "docker ps",
             "docker logs",
         }
-
-        # Check if command starts with any safe command
         return any(command.startswith(safe_cmd) for safe_cmd in safe_commands)
 
     async def pause_takeover_session(self, session_id: str) -> bool:
         """Pause an active takeover session"""
-        if session_id not in self.active_sessions:
+        session = await self._sessions_get(session_id)
+        if session is None:
             return False
 
-        session = self.active_sessions[session_id]
         if session.state == TakeoverState.ACTIVE:
             session.state = TakeoverState.PAUSED
-
-            # Resume paused tasks temporarily
+            await self._sessions_set(session_id, session)
             await self._resume_affected_tasks(session.request.affected_tasks)
 
             logger.info("Takeover session paused: %s", session_id)
@@ -478,14 +742,13 @@ class TakeoverManager:
 
     async def resume_takeover_session(self, session_id: str) -> bool:
         """Resume a paused takeover session"""
-        if session_id not in self.active_sessions:
+        session = await self._sessions_get(session_id)
+        if session is None:
             return False
 
-        session = self.active_sessions[session_id]
         if session.state == TakeoverState.PAUSED:
             session.state = TakeoverState.ACTIVE
-
-            # Pause affected tasks again
+            await self._sessions_set(session_id, session)
             await self._pause_affected_tasks(session.request.affected_tasks)
 
             logger.info("Takeover session resumed: %s", session_id)
@@ -498,19 +761,17 @@ class TakeoverManager:
         self, session_id: str, resolution: str, handback_notes: str | None = None
     ) -> bool:
         """Complete a takeover session and return control to autonomous system"""
-
-        if session_id not in self.active_sessions:
+        session = await self._sessions_get(session_id)
+        if session is None:
             return False
 
-        session = self.active_sessions[session_id]
         session.state = TakeoverState.COMPLETED
         session.ended_at = datetime.now(tz=timezone.utc)
         session.resolution = resolution
+        await self._sessions_set(session_id, session)
 
-        # Resume all paused tasks
         await self._resume_affected_tasks(session.request.affected_tasks)
 
-        # Create completion record
         completion_data = {
             "session_id": session_id,
             "duration_minutes": ((session.ended_at - session.started_at).total_seconds() / 60),
@@ -519,7 +780,6 @@ class TakeoverManager:
             "handback_notes": handback_notes,
         }
 
-        # Store in memory system
         completion_task_id = self.memory_manager.create_task_record(
             task_name="Takeover Session Completion",
             description=f"Takeover session completed: {resolution}",
@@ -528,23 +788,17 @@ class TakeoverManager:
             inputs={"session_id": session_id},
             metadata={"original_request": asdict(session.request)},
         )
-
         self.memory_manager.start_task(completion_task_id)
         self.memory_manager.complete_task(completion_task_id, outputs=completion_data)
 
         logger.info("Takeover session completed: %s - %s", session_id, resolution)
-
-        # Notify state change
         await self._notify_state_change("session_completed", session_id)
-
         return True
 
     async def _pause_affected_tasks(self, task_ids: List[str]):
         """Pause specified autonomous tasks"""
         for task_id in task_ids:
-            self.paused_tasks.add(task_id)
-            # Here you would integrate with your task execution system
-            # to actually pause the tasks
+            await self._paused_add(task_id)
 
         if task_ids:
             logger.info("Paused %s autonomous tasks", len(task_ids))
@@ -552,9 +806,7 @@ class TakeoverManager:
     async def _resume_affected_tasks(self, task_ids: List[str]):
         """Resume specified autonomous tasks"""
         for task_id in task_ids:
-            self.paused_tasks.discard(task_id)
-            # Here you would integrate with your task execution system
-            # to actually resume the tasks
+            await self._paused_remove(task_id)
 
         if task_ids:
             logger.info("Resumed %s autonomous tasks", len(task_ids))
@@ -564,6 +816,8 @@ class TakeoverManager:
         import psutil
 
         try:
+            paused_count = await self._paused_count()
+            sessions_count = await self._sessions_count()
             snapshot = {
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 "system_info": {
@@ -573,12 +827,10 @@ class TakeoverManager:
                     "load_average": (psutil.getloadavg() if hasattr(psutil, "getloadavg") else None),
                 },
                 "active_processes": len(psutil.pids()),
-                "paused_tasks_count": len(self.paused_tasks),
-                "active_takeover_sessions": len(self.active_sessions),
+                "paused_tasks_count": paused_count,
+                "active_takeover_sessions": sessions_count,
             }
-
             return snapshot
-
         except Exception as e:
             logger.error("Failed to capture system snapshot: %s", e)
             return {
@@ -609,28 +861,19 @@ class TakeoverManager:
 
     async def _expire_request(self, request_id: str):
         """Handle expired takeover request"""
-        if request_id in self.pending_requests:
-            del self.pending_requests[request_id]
+        await self._pending_delete(request_id)
 
-            # Complete the associated task as failed
-            task_id = self._get_task_id_for_request(request_id)
-            if task_id:
-                self.memory_manager.fail_task(task_id, "Takeover request expired")
-                # Clean up the mapping now that the task is closed. Issue #2869.
-                self._request_task_ids.pop(request_id, None)
+        task_id = await self._req_task_get(request_id)
+        if task_id:
+            self.memory_manager.fail_task(task_id, "Takeover request expired")
+            await self._req_task_delete(request_id)
 
-            logger.info("Takeover request expired: %s", request_id)
-            await self._notify_state_change("request_expired", request_id)
+        logger.info("Takeover request expired: %s", request_id)
+        await self._notify_state_change("request_expired", request_id)
 
-    def _get_task_id_for_request(self, request_id: str) -> str | None:
-        """
-        Return the memory task ID recorded when the takeover request was created.
-
-        Issue #2869: Previously always returned None (placeholder). Now backed by
-        _request_task_ids, populated in request_takeover via _record_takeover_in_memory.
-        Returns None only if the mapping was never stored (e.g. legacy code path).
-        """
-        task_id = self._request_task_ids.get(request_id)
+    async def _get_task_id_for_request(self, request_id: str) -> str | None:
+        """Return the memory task ID recorded when the takeover request was created."""
+        task_id = await self._req_task_get(request_id)
         if task_id is None:
             logger.warning(
                 "No memory task ID found for takeover request %s. "
@@ -660,40 +903,41 @@ class TakeoverManager:
         """Register a callback for takeover state changes"""
         self.state_change_callbacks.append(callback)
 
-    def get_pending_requests(self) -> List[Dict[str, Any]]:
+    async def get_pending_requests(self) -> List[Dict[str, Any]]:
         """Get all pending takeover requests"""
+        ids = await self._pending_ids()
         result = []
-        for request in self.pending_requests.values():
+        for rid in ids:
+            request = await self._pending_get(rid)
+            if request is None:
+                continue
             request_dict = asdict(request)
-            # Convert enum to string for JSON serialization
             request_dict["trigger"] = request.trigger.value
             request_dict["priority"] = request.priority.value
-            # Convert datetime to ISO string
             request_dict["requested_at"] = request.requested_at.isoformat()
             if request.expires_at:
                 request_dict["expires_at"] = request.expires_at.isoformat()
             result.append(request_dict)
         return result
 
-    def get_active_sessions(self) -> List[Dict[str, Any]]:
+    async def get_active_sessions(self) -> List[Dict[str, Any]]:
         """Get all active takeover sessions"""
+        sessions_map = await self._sessions_all()
         sessions = []
-        for session in self.active_sessions.values():
+        for session in sessions_map.values():
             session_dict = asdict(session)
-            # Convert datetime objects to ISO strings
             for key in DATETIME_FIELD_KEYS:
                 if session_dict[key]:
                     session_dict[key] = session_dict[key].isoformat()
             sessions.append(session_dict)
-
         return sessions
 
-    def get_system_status(self) -> Dict[str, Any]:
+    async def get_system_status(self) -> Dict[str, Any]:
         """Get current takeover system status"""
         return {
-            "pending_requests": len(self.pending_requests),
-            "active_sessions": len(self.active_sessions),
-            "paused_tasks": len(self.paused_tasks),
+            "pending_requests": await self._pending_count(),
+            "active_sessions": await self._sessions_count(),
+            "paused_tasks": await self._paused_count(),
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "default_timeout_minutes": int(self.default_timeout.total_seconds() / 60),
             "available_triggers": [trigger.value for trigger in TakeoverTrigger],

--- a/autobot-backend/tests/test_cross_worker_registries.py
+++ b/autobot-backend/tests/test_cross_worker_registries.py
@@ -1,0 +1,425 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Cross-worker registry tests for TakeoverManager and DesktopStreamingManager (#11639).
+
+Two manager instances share a single dict-backed fake-Redis stub to simulate
+two uvicorn workers with a shared Redis server.  No live Redis required.
+
+Proven behaviours:
+- Takeover request created via instance A is visible and approvable via instance B
+- GETDEL prevents double-approve (second approve raises ValueError)
+- TTL expiry: expired pending request raises ValueError on approve attempt
+- Streaming session registered on A is listed by B via Redis metadata
+- Event published by A is relayed by B's subscriber to B's local clients
+- Event published by A is NOT echoed back to A's own subscriber
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections import defaultdict
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake async-Redis stub
+# ---------------------------------------------------------------------------
+
+
+class _FakePubSub:
+    """Minimal async pub/sub stub backed by the same shared store."""
+
+    def __init__(self, store: "_FakeRedis") -> None:
+        self._store = store
+        self._channels: list[str] = []
+
+    async def subscribe(self, *channels: str) -> None:
+        for ch in channels:
+            if ch not in self._channels:
+                self._channels.append(ch)
+
+    async def unsubscribe(self, *channels: str) -> None:
+        for ch in channels:
+            if ch in self._channels:
+                self._channels.remove(ch)
+
+    async def close(self) -> None:
+        self._channels.clear()
+
+    async def listen(self):
+        """Yield messages queued for subscribed channels then stop."""
+        while True:
+            for ch in list(self._channels):
+                queue: list = self._store._pubsub_queues.get(ch, [])
+                while queue:
+                    yield {"type": "message", "data": queue.pop(0)}
+            await asyncio.sleep(0)
+            break  # one pass — tests drain manually
+
+
+class _FakeRedis:
+    """
+    Shared-state async Redis stub implementing the command surface used by
+    TakeoverManager and DesktopStreamingManager (#11639).
+
+    Supports: get/set/getdel/expire/delete/sadd/srem/smembers/sismember/
+              hset/hget/hdel/hgetall/publish + minimal pubsub.
+    """
+
+    def __init__(self) -> None:
+        self._strings: dict[str, bytes] = {}
+        self._sets: dict[str, set] = defaultdict(set)
+        self._hashes: dict[str, dict[str, bytes]] = defaultdict(dict)
+        self._expirations: dict[str, float] = {}  # key -> abs epoch when it expires
+        self._pubsub_queues: dict[str, list] = defaultdict(list)
+
+    def _is_expired(self, key: str) -> bool:
+        exp = self._expirations.get(key)
+        return exp is not None and time.time() > exp
+
+    def _encode(self, value: Any) -> bytes:
+        if isinstance(value, bytes):
+            return value
+        return str(value).encode("utf-8")
+
+    # STRING
+    async def set(self, key: str, value: Any) -> None:
+        self._strings[key] = self._encode(value)
+
+    async def get(self, key: str) -> bytes | None:
+        if self._is_expired(key):
+            self._strings.pop(key, None)
+            return None
+        return self._strings.get(key)
+
+    async def getdel(self, key: str) -> bytes | None:
+        if self._is_expired(key):
+            self._strings.pop(key, None)
+            return None
+        return self._strings.pop(key, None)
+
+    async def expire(self, key: str, seconds: int) -> None:
+        self._expirations[key] = time.time() + seconds
+
+    async def delete(self, *keys: str) -> int:
+        count = 0
+        for key in keys:
+            if key in self._strings:
+                del self._strings[key]
+                count += 1
+        return count
+
+    # SET
+    async def sadd(self, key: str, *members: Any) -> int:
+        before = len(self._sets[key])
+        self._sets[key].update(self._encode(m) for m in members)
+        return len(self._sets[key]) - before
+
+    async def srem(self, key: str, *members: Any) -> int:
+        count = 0
+        for m in members:
+            enc = self._encode(m)
+            if enc in self._sets[key]:
+                self._sets[key].discard(enc)
+                count += 1
+        return count
+
+    async def smembers(self, key: str) -> set:
+        return set(self._sets[key])
+
+    async def sismember(self, key: str, member: Any) -> int:
+        return int(self._encode(member) in self._sets[key])
+
+    # HASH
+    async def hset(self, name: str, field: str, value: Any) -> int:
+        existed = field in self._hashes[name]
+        self._hashes[name][field] = self._encode(value)
+        return 0 if existed else 1
+
+    async def hget(self, name: str, field: str) -> bytes | None:
+        return self._hashes[name].get(field)
+
+    async def hdel(self, name: str, *fields: str) -> int:
+        count = 0
+        for f in fields:
+            if f in self._hashes[name]:
+                del self._hashes[name][f]
+                count += 1
+        return count
+
+    async def hgetall(self, name: str) -> dict:
+        return dict(self._hashes[name])
+
+    # PUB/SUB
+    async def publish(self, channel: str, message: Any) -> int:
+        self._pubsub_queues[channel].append(self._encode(message))
+        return 1
+
+    def pubsub(self) -> _FakePubSub:
+        return _FakePubSub(self)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build manager instances that share a fake Redis
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_manager() -> MagicMock:
+    """Return a MemoryManager stub that records calls but doesn't touch DB."""
+    mm = MagicMock()
+    mm.create_task_record.return_value = "task-123"
+    mm.start_task.return_value = None
+    mm.complete_task.return_value = None
+    mm.fail_task.return_value = None
+    return mm
+
+
+def _takeover_pair(shared_redis: _FakeRedis):
+    """Return two TakeoverManager instances sharing *shared_redis*."""
+    import takeover_manager as tm_mod
+
+    a = tm_mod.TakeoverManager(memory_manager=_make_memory_manager(), _redis=shared_redis)
+    b = tm_mod.TakeoverManager(memory_manager=_make_memory_manager(), _redis=shared_redis)
+    return a, b
+
+
+def _streaming_pair(shared_redis: _FakeRedis):
+    """Return two DesktopStreamingManager instances sharing *shared_redis*."""
+    import desktop_streaming_manager as dsm_mod
+
+    a = dsm_mod.DesktopStreamingManager(_redis=shared_redis)
+    b = dsm_mod.DesktopStreamingManager(_redis=shared_redis)
+    return a, b
+
+
+# ---------------------------------------------------------------------------
+# TakeoverManager cross-worker tests
+# ---------------------------------------------------------------------------
+
+
+class TestTakeoverManagerCrossWorker:
+    @pytest.mark.asyncio
+    async def test_request_visible_on_second_worker(self):
+        """Request created on A is visible via B."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="test reason",
+            auto_approve=False,
+        )
+
+        # B should see the pending request
+        pending = await b._pending_get(request_id)
+        assert pending is not None, "B must see the request written by A"
+        assert pending.request_id == request_id
+        assert pending.reason == "test reason"
+
+    @pytest.mark.asyncio
+    async def test_approve_on_second_worker(self):
+        """B can approve a request created by A."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="needs approval",
+            auto_approve=False,
+        )
+
+        session_id = await b.approve_takeover(request_id, human_operator="operator@example.com")
+        assert session_id.startswith("session_"), f"Unexpected session_id: {session_id}"
+
+        # Session must now be visible on A
+        session = await a._sessions_get(session_id)
+        assert session is not None, "Session created by B must be visible on A"
+        assert session.human_operator == "operator@example.com"
+
+    @pytest.mark.asyncio
+    async def test_getdel_prevents_double_approve(self):
+        """GETDEL ensures only one worker can approve a request."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="race condition test",
+            auto_approve=False,
+        )
+
+        # First approval succeeds
+        await b.approve_takeover(request_id, human_operator="op1")
+
+        # Second approval must raise; the request no longer exists so _validate
+        # raises "not found", and _create_takeover_session raises "already approved"
+        with pytest.raises(ValueError):
+            await a.approve_takeover(request_id, human_operator="op2")
+
+    @pytest.mark.asyncio
+    async def test_expired_request_raises(self):
+        """Approving an expired request raises ValueError after TTL elapses."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="expiry test",
+            auto_approve=False,
+        )
+
+        # Force TTL to look expired by backdating the expiration in the stub
+        key = f"autobot:takeover:pending:{request_id}"
+        redis._expirations[key] = time.time() - 1  # already expired
+
+        with pytest.raises(ValueError, match="expired|not found"):
+            await b.approve_takeover(request_id, human_operator="late_op")
+
+    @pytest.mark.asyncio
+    async def test_paused_tasks_shared(self):
+        """Paused tasks set is shared across workers."""
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        await a._paused_add("task-42")
+        members = await redis.smembers("autobot:takeover:paused_tasks")
+        assert b"task-42" in members or "task-42" in members
+
+
+# ---------------------------------------------------------------------------
+# DesktopStreamingManager cross-worker tests
+# ---------------------------------------------------------------------------
+
+
+class TestDesktopStreamingManagerCrossWorker:
+    @pytest.mark.asyncio
+    async def test_session_registered_on_a_visible_to_b(self):
+        """Session metadata written by A is visible via B's list_all_sessions."""
+        redis = _FakeRedis()
+        a, b = _streaming_pair(redis)
+
+        # Stub out VNC creation so no real subprocesses are spawned
+        vnc_info = {"session_id": "stream_u1_1", "vnc_port": 5910, "novnc_port": 6090}
+        a.vnc_manager.create_session = AsyncMock(return_value=vnc_info)
+
+        await a.create_streaming_session("u1")
+
+        sessions_b = await b.list_all_sessions()
+        session_ids = [s.get("session_id") for s in sessions_b]
+        assert any("u1" in sid for sid in session_ids), (
+            f"B must see session created by A; got {session_ids}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_event_published_by_a_relayed_by_b(self):
+        """Event published by A is relayed by B's subscriber to B's local clients."""
+        import desktop_streaming_manager as dsm_mod
+
+        redis = _FakeRedis()
+        a, b = _streaming_pair(redis)
+
+        # Give B a fake local client for session "sess-1"
+        fake_ws = AsyncMock()
+        b.session_clients["sess-1"] = ["client-b1"]
+        b.websocket_clients["client-b1"] = fake_ws
+
+        # Simulate A publishing with a different worker_id (different from B's _WORKER_ID)
+        a_worker_id = "worker-A-different-from-B"
+
+        msg = json.dumps({
+            "worker_id": a_worker_id,
+            "type": "screenshot",
+            "payload": {"session_id": "sess-1", "data": "base64..."},
+        }, ensure_ascii=False)
+        await redis.publish(dsm_mod._DESKTOP_EVENTS_CHANNEL, msg)
+
+        # Run B's relay handler once
+        raw_msgs = redis._pubsub_queues.get(dsm_mod._DESKTOP_EVENTS_CHANNEL, [])
+        for raw in raw_msgs:
+            await b._handle_pubsub_message(raw)
+
+        # B's local client must receive the relayed message
+        fake_ws.send.assert_called_once()
+        sent = json.loads(fake_ws.send.call_args[0][0])
+        assert sent["type"] == "screenshot"
+        assert sent["data"]["session_id"] == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_event_not_echoed_to_originating_worker(self):
+        """Event from this worker is not self-echoed by B (same worker_id check)."""
+        import desktop_streaming_manager as dsm_mod
+
+        redis = _FakeRedis()
+        _, b = _streaming_pair(redis)
+
+        fake_ws = AsyncMock()
+        b.session_clients["sess-2"] = ["client-b2"]
+        b.websocket_clients["client-b2"] = fake_ws
+
+        # Publish with B's own worker_id — must NOT be relayed to B's clients
+        msg = json.dumps({
+            "worker_id": dsm_mod._WORKER_ID,  # same as B (module-level constant)
+            "type": "screenshot",
+            "payload": {"session_id": "sess-2", "data": "base64..."},
+        }, ensure_ascii=False)
+        await redis.publish(dsm_mod._DESKTOP_EVENTS_CHANNEL, msg)
+
+        raw_msgs = redis._pubsub_queues.get(dsm_mod._DESKTOP_EVENTS_CHANNEL, [])
+        for raw in raw_msgs:
+            await b._handle_pubsub_message(raw)
+
+        # B must NOT forward the message (it originated here)
+        fake_ws.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_terminate_removes_redis_metadata(self):
+        """Terminating a session removes its Redis metadata."""
+        redis = _FakeRedis()
+        a, b = _streaming_pair(redis)
+
+        vnc_info = {"vnc_port": 5911, "novnc_port": 6091}
+        a.vnc_manager.create_session = AsyncMock(return_value=vnc_info)
+        a.vnc_manager.terminate_session = AsyncMock(return_value=True)
+
+        result = await a.create_streaming_session("u2")
+        session_id = result["websocket_endpoint"].rsplit("/", 1)[-1]
+
+        # Verify B sees it
+        sessions_b_before = await b.list_all_sessions()
+        assert len(sessions_b_before) == 1
+
+        # Terminate from A using the real session_id
+        await a.terminate_streaming_session(session_id)
+
+        sessions_b_after = await b.list_all_sessions()
+        assert len(sessions_b_after) == 0, "Metadata must be removed on termination"
+
+    @pytest.mark.asyncio
+    async def test_subscriber_lifecycle_start_stop(self):
+        """start() creates the subscriber task; stop() cancels it cleanly."""
+        import desktop_streaming_manager as dsm_mod
+
+        redis = _FakeRedis()
+        mgr = dsm_mod.DesktopStreamingManager(_redis=redis)
+
+        await mgr.start()
+        assert mgr._subscriber_task is not None
+        assert not mgr._subscriber_task.done()
+
+        await mgr.stop()
+        assert mgr._subscriber_task is None

--- a/autobot-backend/tests/test_cross_worker_registries.py
+++ b/autobot-backend/tests/test_cross_worker_registries.py
@@ -246,7 +246,7 @@ class _FakeRedis:
         return len(self._lists[key])
 
     async def ltrim(self, key: str, start: int, stop: int) -> None:
-        self._lists[key] = self._lists[key][start: stop + 1]
+        self._lists[key] = self._lists[key][start : stop + 1]
 
     # PIPELINE (M4 optimistic CAS)
     @asynccontextmanager
@@ -470,9 +470,7 @@ class TestTakeoverManagerCrossWorker:
         session_id = await b.approve_takeover(request_id, human_operator="op")
 
         # Execute pause_task action
-        result = await a.execute_takeover_action(
-            session_id, "pause_task", {"task_id": "task-X"}
-        )
+        result = await a.execute_takeover_action(session_id, "pause_task", {"task_id": "task-X"})
         assert result.get("status") == "task_paused"
 
         # task-X must now be in the shared paused set
@@ -481,9 +479,7 @@ class TestTakeoverManagerCrossWorker:
         assert "task-X" in encoded, f"task-X not in paused set: {encoded}"
 
         # Execute resume_task action
-        result2 = await a.execute_takeover_action(
-            session_id, "resume_task", {"task_id": "task-X"}
-        )
+        result2 = await a.execute_takeover_action(session_id, "resume_task", {"task_id": "task-X"})
         assert result2.get("status") == "task_resumed"
 
         members_after = await redis.smembers("autobot:takeover:paused_tasks")
@@ -694,11 +690,13 @@ class TestDesktopStreamingManagerCrossWorker:
 
         # B publishes terminate_requested (different worker_id)
         b_worker_id = "worker-B-different"
-        msg = json.dumps({
-            "worker_id": b_worker_id,
-            "type": "session_terminate_requested",
-            "payload": {"session_id": session_id},
-        })
+        msg = json.dumps(
+            {
+                "worker_id": b_worker_id,
+                "type": "session_terminate_requested",
+                "payload": {"session_id": session_id},
+            }
+        )
 
         await a._handle_pubsub_message(msg.encode())
 

--- a/autobot-backend/tests/test_cross_worker_registries.py
+++ b/autobot-backend/tests/test_cross_worker_registries.py
@@ -14,6 +14,11 @@ Proven behaviours:
 - Streaming session registered on A is listed by B via Redis metadata
 - Event published by A is relayed by B's subscriber to B's local clients
 - Event published by A is NOT echoed back to A's own subscriber
+- Completed session is removed from Redis (C2)
+- Pending TTL prune removes stale index entries (M2)
+- pause/resume actions mutate the shared paused set (M1)
+- Non-owner terminate publishes terminate_requested; owner relay kills + deletes (H3)
+- Concurrent session mutation — optimistic retry lands both or one retries (M4)
 """
 
 from __future__ import annotations
@@ -22,6 +27,7 @@ import asyncio
 import json
 import time
 from collections import defaultdict
+from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -63,19 +69,81 @@ class _FakePubSub:
             break  # one pass — tests drain manually
 
 
+class _FakePipeline:
+    """Simple pipeline stub supporting WATCH/MULTI/EXEC for optimistic CAS (M4).
+
+    Tracks the watched key's value at watch() time; execute() raises WatchError
+    (simulated via ValueError with name WatchError) if the value changed.
+    """
+
+    class WatchError(Exception):
+        pass
+
+    def __init__(self, store: "_FakeRedis") -> None:
+        self._store = store
+        self._watched_keys: dict[str, bytes | None] = {}
+        self._multi = False
+        self._queue: list[tuple[str, tuple, dict]] = []
+
+    async def watch(self, *keys: str) -> None:
+        for key in keys:
+            self._watched_keys[key] = self._store._strings.get(key)
+
+    async def get(self, key: str) -> bytes | None:
+        """Direct GET during watch phase (before MULTI)."""
+        if self._store._is_expired(key):
+            self._store._strings.pop(key, None)
+            return None
+        return self._store._strings.get(key)
+
+    def multi(self) -> None:
+        self._multi = True
+
+    def set(self, key: str, value: Any) -> None:  # noqa: A003
+        self._queue.append(("set", (key, value), {}))
+
+    async def execute(self) -> list:
+        # Check watched keys for concurrent modification
+        for key, snapshot_val in self._watched_keys.items():
+            current = self._store._strings.get(key)
+            if current != snapshot_val:
+                raise _FakePipeline.WatchError(f"WATCH key {key!r} was modified")
+        results = []
+        for cmd, args, kwargs in self._queue:
+            if cmd == "set":
+                self._store._strings[args[0]] = self._store._encode(args[1])
+                results.append(True)
+        return results
+
+    async def reset(self) -> None:
+        self._watched_keys.clear()
+        self._multi = False
+        self._queue.clear()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        pass
+
+
 class _FakeRedis:
     """
     Shared-state async Redis stub implementing the command surface used by
     TakeoverManager and DesktopStreamingManager (#11639).
 
-    Supports: get/set/getdel/expire/delete/sadd/srem/smembers/sismember/
-              hset/hget/hdel/hgetall/publish + minimal pubsub.
+    Supports: get/set(ex=)/getdel/expire/delete/mget/
+              sadd/srem/smembers/sismember/scard/
+              hset/hget/hdel/hgetall/
+              lpush/ltrim/
+              pipeline(transaction=True)/publish + minimal pubsub.
     """
 
     def __init__(self) -> None:
         self._strings: dict[str, bytes] = {}
         self._sets: dict[str, set] = defaultdict(set)
         self._hashes: dict[str, dict[str, bytes]] = defaultdict(dict)
+        self._lists: dict[str, list[bytes]] = defaultdict(list)
         self._expirations: dict[str, float] = {}  # key -> abs epoch when it expires
         self._pubsub_queues: dict[str, list] = defaultdict(list)
 
@@ -89,8 +157,10 @@ class _FakeRedis:
         return str(value).encode("utf-8")
 
     # STRING
-    async def set(self, key: str, value: Any) -> None:
+    async def set(self, key: str, value: Any, ex: int | None = None) -> None:  # noqa: A003
         self._strings[key] = self._encode(value)
+        if ex is not None:
+            self._expirations[key] = time.time() + ex
 
     async def get(self, key: str) -> bytes | None:
         if self._is_expired(key):
@@ -103,6 +173,16 @@ class _FakeRedis:
             self._strings.pop(key, None)
             return None
         return self._strings.pop(key, None)
+
+    async def mget(self, *keys: str) -> list[bytes | None]:
+        result = []
+        for key in keys:
+            if self._is_expired(key):
+                self._strings.pop(key, None)
+                result.append(None)
+            else:
+                result.append(self._strings.get(key))
+        return result
 
     async def expire(self, key: str, seconds: int) -> None:
         self._expirations[key] = time.time() + seconds
@@ -136,6 +216,9 @@ class _FakeRedis:
     async def sismember(self, key: str, member: Any) -> int:
         return int(self._encode(member) in self._sets[key])
 
+    async def scard(self, key: str) -> int:
+        return len(self._sets[key])
+
     # HASH
     async def hset(self, name: str, field: str, value: Any) -> int:
         existed = field in self._hashes[name]
@@ -155,6 +238,21 @@ class _FakeRedis:
 
     async def hgetall(self, name: str) -> dict:
         return dict(self._hashes[name])
+
+    # LIST (M4 history)
+    async def lpush(self, key: str, *values: Any) -> int:
+        for v in values:
+            self._lists[key].insert(0, self._encode(v))
+        return len(self._lists[key])
+
+    async def ltrim(self, key: str, start: int, stop: int) -> None:
+        self._lists[key] = self._lists[key][start: stop + 1]
+
+    # PIPELINE (M4 optimistic CAS)
+    @asynccontextmanager
+    async def pipeline(self, transaction: bool = False):
+        pipe = _FakePipeline(self)
+        yield pipe
 
     # PUB/SUB
     async def publish(self, channel: str, message: Any) -> int:
@@ -299,6 +397,124 @@ class TestTakeoverManagerCrossWorker:
         members = await redis.smembers("autobot:takeover:paused_tasks")
         assert b"task-42" in members or "task-42" in members
 
+    @pytest.mark.asyncio
+    async def test_completed_session_removed_from_redis(self):
+        """C2: Completing a session removes it from the live Redis store."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="c2 test",
+            auto_approve=False,
+        )
+        session_id = await b.approve_takeover(request_id, human_operator="op")
+
+        # Verify live session exists
+        assert await a._sessions_get(session_id) is not None
+
+        result = await a.complete_takeover_session(session_id, resolution="done")
+        assert result is True
+
+        # C2: session must be gone from live store; count must not be stuck
+        assert await a._sessions_get(session_id) is None
+        assert await a._sessions_count() == 0
+
+    @pytest.mark.asyncio
+    async def test_pending_ttl_prune_removes_stale_index(self):
+        """M2: _pending_ids() prunes index members whose STRING key expired."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, _ = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="prune test",
+            auto_approve=False,
+        )
+
+        # Simulate TTL expiry of the STRING key only (SET member stays stale)
+        string_key = f"autobot:takeover:pending:{request_id}"
+        redis._strings.pop(string_key, None)  # expire the STRING without SREM
+
+        # Before pruning: index still contains the stale id
+        raw_members = await redis.smembers("autobot:takeover:pending_index")
+        raw_ids = {m.decode() if isinstance(m, bytes) else m for m in raw_members}
+        assert request_id in raw_ids, "stale entry must be in index before prune"
+
+        # _pending_ids() should prune and return empty set
+        live_ids = await a._pending_ids()
+        assert request_id not in live_ids
+
+        # Index SET must now be clean
+        raw_members_after = await redis.smembers("autobot:takeover:pending_index")
+        raw_ids_after = {m.decode() if isinstance(m, bytes) else m for m in raw_members_after}
+        assert request_id not in raw_ids_after
+
+    @pytest.mark.asyncio
+    async def test_pause_resume_mutate_paused_set(self):
+        """M1: pause_task/resume_task action handlers actually mutate the shared paused set."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="m1 test",
+            auto_approve=False,
+        )
+        session_id = await b.approve_takeover(request_id, human_operator="op")
+
+        # Execute pause_task action
+        result = await a.execute_takeover_action(
+            session_id, "pause_task", {"task_id": "task-X"}
+        )
+        assert result.get("status") == "task_paused"
+
+        # task-X must now be in the shared paused set
+        members = await redis.smembers("autobot:takeover:paused_tasks")
+        encoded = {m.decode() if isinstance(m, bytes) else m for m in members}
+        assert "task-X" in encoded, f"task-X not in paused set: {encoded}"
+
+        # Execute resume_task action
+        result2 = await a.execute_takeover_action(
+            session_id, "resume_task", {"task_id": "task-X"}
+        )
+        assert result2.get("status") == "task_resumed"
+
+        members_after = await redis.smembers("autobot:takeover:paused_tasks")
+        encoded_after = {m.decode() if isinstance(m, bytes) else m for m in members_after}
+        assert "task-X" not in encoded_after
+
+    @pytest.mark.asyncio
+    async def test_concurrent_session_mutation_both_land(self):
+        """M4: Two sequential mutations to the same session both persist (CAS retry)."""
+        import takeover_manager as tm_mod
+
+        redis = _FakeRedis()
+        a, b = _takeover_pair(redis)
+
+        request_id = await a.request_takeover(
+            trigger=tm_mod.TakeoverTrigger.MANUAL_REQUEST,
+            reason="m4 test",
+            auto_approve=False,
+        )
+        session_id = await b.approve_takeover(request_id, human_operator="op")
+
+        # Apply two sequential actions — in practice these could be concurrent
+        # but the fake pipeline is single-threaded so we test sequential correctness.
+        await a.execute_takeover_action(session_id, "approve_operation", {"operation_id": "op1"})
+        await b.execute_takeover_action(session_id, "approve_operation", {"operation_id": "op2"})
+
+        final_session = await a._sessions_get(session_id)
+        assert final_session is not None
+        action_types = [ac["action_type"] for ac in final_session.actions_taken]
+        assert "approve_operation" in action_types, f"actions missing: {action_types}"
+
 
 # ---------------------------------------------------------------------------
 # DesktopStreamingManager cross-worker tests
@@ -317,6 +533,8 @@ class TestDesktopStreamingManagerCrossWorker:
         a.vnc_manager.create_session = AsyncMock(return_value=vnc_info)
 
         await a.create_streaming_session("u1")
+        # stop the relay task started by create_streaming_session
+        await a.stop()
 
         sessions_b = await b.list_all_sessions()
         session_ids = [s.get("session_id") for s in sessions_b]
@@ -400,6 +618,7 @@ class TestDesktopStreamingManagerCrossWorker:
         a.vnc_manager.terminate_session = AsyncMock(return_value=True)
 
         result = await a.create_streaming_session("u2")
+        await a.stop()
         session_id = result["websocket_endpoint"].rsplit("/", 1)[-1]
 
         # Verify B sees it
@@ -426,3 +645,66 @@ class TestDesktopStreamingManagerCrossWorker:
 
         await mgr.stop()
         assert mgr._subscriber_task is None
+
+    @pytest.mark.asyncio
+    async def test_non_owner_terminate_publishes_terminate_requested(self):
+        """H3: Non-owner worker publishes session_terminate_requested instead of deleting."""
+        import desktop_streaming_manager as dsm_mod
+
+        redis = _FakeRedis()
+        a, b = _streaming_pair(redis)
+
+        # A "owns" the session (has it in session_clients and vnc_manager)
+        session_id = "sess-owner-test"
+        a.session_clients[session_id] = []
+        a.vnc_manager.active_sessions[session_id] = {}
+
+        # Write Redis metadata so B sees the session exists
+        await a._meta_set(session_id, {"session_id": session_id, "worker_id": "worker-A"})
+
+        # B is the non-owner — should publish terminate_requested
+        result = await b.terminate_streaming_session(session_id)
+        assert result is True, "Non-owner terminate must return True (accepted)"
+
+        # Verify the event was published to the channel
+        channel = dsm_mod._DESKTOP_EVENTS_CHANNEL
+        queued = redis._pubsub_queues.get(channel, [])
+        assert len(queued) >= 1, "terminate_requested event must be published"
+        last_msg = json.loads(queued[-1])
+        assert last_msg["type"] == "session_terminate_requested"
+        assert last_msg["payload"]["session_id"] == session_id
+
+        # Metadata must NOT be deleted yet (owner handles that)
+        meta = await a._meta_get(session_id)
+        assert meta is not None, "Non-owner must NOT delete metadata prematurely"
+
+    @pytest.mark.asyncio
+    async def test_owner_relay_terminates_on_terminate_requested(self):
+        """H3: Owner relay calls _local_terminate when it receives terminate_requested."""
+        redis = _FakeRedis()
+        a, b = _streaming_pair(redis)
+
+        # A is owner
+        session_id = "sess-relay-test"
+        a.session_clients[session_id] = []
+        a.vnc_manager.active_sessions[session_id] = {}
+        a.vnc_manager.terminate_session = AsyncMock(return_value=True)
+
+        await a._meta_set(session_id, {"session_id": session_id})
+
+        # B publishes terminate_requested (different worker_id)
+        b_worker_id = "worker-B-different"
+        msg = json.dumps({
+            "worker_id": b_worker_id,
+            "type": "session_terminate_requested",
+            "payload": {"session_id": session_id},
+        })
+
+        await a._handle_pubsub_message(msg.encode())
+
+        # A's local terminate must have been called
+        a.vnc_manager.terminate_session.assert_awaited_once_with(session_id)
+
+        # Metadata must be deleted by owner
+        meta_after = await a._meta_get(session_id)
+        assert meta_after is None, "Owner must delete metadata after local terminate"

--- a/autobot-backend/tests/test_cross_worker_registries.py
+++ b/autobot-backend/tests/test_cross_worker_registries.py
@@ -27,7 +27,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Fake async-Redis stub
 # ---------------------------------------------------------------------------
@@ -321,9 +320,7 @@ class TestDesktopStreamingManagerCrossWorker:
 
         sessions_b = await b.list_all_sessions()
         session_ids = [s.get("session_id") for s in sessions_b]
-        assert any("u1" in sid for sid in session_ids), (
-            f"B must see session created by A; got {session_ids}"
-        )
+        assert any("u1" in sid for sid in session_ids), f"B must see session created by A; got {session_ids}"
 
     @pytest.mark.asyncio
     async def test_event_published_by_a_relayed_by_b(self):
@@ -341,11 +338,14 @@ class TestDesktopStreamingManagerCrossWorker:
         # Simulate A publishing with a different worker_id (different from B's _WORKER_ID)
         a_worker_id = "worker-A-different-from-B"
 
-        msg = json.dumps({
-            "worker_id": a_worker_id,
-            "type": "screenshot",
-            "payload": {"session_id": "sess-1", "data": "base64..."},
-        }, ensure_ascii=False)
+        msg = json.dumps(
+            {
+                "worker_id": a_worker_id,
+                "type": "screenshot",
+                "payload": {"session_id": "sess-1", "data": "base64..."},
+            },
+            ensure_ascii=False,
+        )
         await redis.publish(dsm_mod._DESKTOP_EVENTS_CHANNEL, msg)
 
         # Run B's relay handler once
@@ -372,11 +372,14 @@ class TestDesktopStreamingManagerCrossWorker:
         b.websocket_clients["client-b2"] = fake_ws
 
         # Publish with B's own worker_id — must NOT be relayed to B's clients
-        msg = json.dumps({
-            "worker_id": dsm_mod._WORKER_ID,  # same as B (module-level constant)
-            "type": "screenshot",
-            "payload": {"session_id": "sess-2", "data": "base64..."},
-        }, ensure_ascii=False)
+        msg = json.dumps(
+            {
+                "worker_id": dsm_mod._WORKER_ID,  # same as B (module-level constant)
+                "type": "screenshot",
+                "payload": {"session_id": "sess-2", "data": "base64..."},
+            },
+            ensure_ascii=False,
+        )
         await redis.publish(dsm_mod._DESKTOP_EVENTS_CHANNEL, msg)
 
         raw_msgs = redis._pubsub_queues.get(dsm_mod._DESKTOP_EVENTS_CHANNEL, [])

--- a/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
@@ -38,8 +38,8 @@ def _mixin_instance():
 # tag omits the '>' (`</TOOL_CALL` + newline + more prose).
 _BOARD_OUTPUT = (
     "Creating the high priority task.\n\n"
-    "<TOOL_CALL name=\"create_task\" "
-    "params='{\"title\":\"Write the Q3 financial report\",\"priority\":\"high\"}'>"
+    '<TOOL_CALL name="create_task" '
+    'params=\'{"title":"Write the Q3 financial report","priority":"high"}\'>'
     "Create task</TOOL_CALL\n\nHigh priority task created."
 )
 


### PR DESCRIPTION
Closes #11639. Part of umbrella #11634 (T5). Design approved on the issue (design-first gate).

## Thinking Path

`autobot-user-backend` runs `uvicorn --workers 4`; per-process dicts holding SESSION state are invisible across workers — a takeover request landing on worker A cannot be approved via worker B, and desktop-streaming broadcasts only reach same-worker WebSocket clients. Pattern source: the Redis-backed `cross_worker_rate_limiter` (#8170). WS connection objects cannot leave their worker, so only session METADATA moves to Redis; frames/control events relay via pub/sub.

## What Changed

- `takeover_manager.py` — `pending_requests` / `active_sessions` / `paused_tasks` / `_request_task_ids` now live in Redis under `autobot:takeover:*` (STRING+EXPIRE per pending request with env-var TTL `AUTOBOT_TAKEOVER_PENDING_TTL_SECONDS` + index SET; HASH sessions; SET paused tasks; HASH request→task). Approve uses atomic `GETDEL` — two workers cannot both approve. Dataclasses gained `to_json()/from_json()`. Redis-unavailable degrades to the previous in-process dicts (single warning; same public API). `get_pending_requests`/`get_active_sessions`/`get_system_status` became async.
- `desktop_streaming_manager.py` — session metadata in HASH `autobot:desktop:sessions` (any worker lists/validates); WS clients stay per-worker; cross-worker events publish to `AUTOBOT_DESKTOP_EVENTS_CHANNEL` (default `autobot:desktop:events`) with per-process worker id; a relay task delivers foreign-worker events to local clients (self-echo suppressed). Relay lazy-starts with the first session and is stopped in `cleanup_services()` via `stop_desktop_relay()` (construct-free).
- Call-site sweep for the sync→async accessor change: `api/advanced_control.py` (5 sites), `context_aware_decision/collectors/system.py` (2 sites, helper made async), `control_panel_test.py` (5 sites) — verified by grep that no other sync callers remain.
- `tests/test_cross_worker_registries.py` — dict-backed fake async-Redis shared by TWO manager instances: cross-worker visibility, GETDEL double-approve prevention, TTL expiry, cross-worker session listing, pub/sub relay delivery + no self-echo.

## Verification

- `pytest tests/test_cross_worker_registries.py tests/test_shutdown_symmetry.py -q` → **14 passed**
- flake8 (repo config) clean on all 7 touched files; AST parse clean
- Implementation by senior-backend-engineer subagent; artifacts verified (`git log origin/Dev_new_gui..HEAD`), then gap-fixed by main session: 12 un-awaited call sites of the now-async accessors and the never-invoked relay `start()` (subagent claimed lifespan wiring that didn't exist)

## Model Used

Claude Fable 5 (+ senior-backend-engineer subagent for the base implementation)
