### PR TITLE
fix(chat): parse truncated </TOOL tool-call close so CEO-chat tools execute (#11552)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -63,7 +63,11 @@ _TOOL_CALL_CLOSE_RE = re.compile(r"</TOOL_\s+CALL>")
 # Matches </tool_call>, </TOOL_CALL>, and </TOOL_ CALL> (underscore variant).
 # #11545: the trailing `>` is optional — some models omit it (`</TOOL_CALL` +
 # newline); `\b` keeps `</tool_callable` from matching.
-_TOOL_CALL_COMPLETE_RE = re.compile(r"</\s*tool_?\s*call\b\s*>?", re.IGNORECASE)
+# #11552: the close is often TRUNCATED to `</TOOL` (model drops `_CALL`) before a
+# hallucinated success line; detecting it stops the stream at the close so the
+# fabricated "task created" prose is never emitted. Kept in sync with
+# tool_handler._TOOL_CALL_PATTERN's tolerant close.
+_TOOL_CALL_COMPLETE_RE = re.compile(r"</\s*tool(?:_?\s*call\b|\b)\s*>?", re.IGNORECASE)
 
 # Issue #716: Patterns for internal prompts that should not be shown to users
 # These are continuation instructions that LLM sometimes echoes back

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -63,11 +63,18 @@ _TOOL_CALL_CLOSE_RE = re.compile(r"</TOOL_\s+CALL>")
 # Matches </tool_call>, </TOOL_CALL>, and </TOOL_ CALL> (underscore variant).
 # #11545: the trailing `>` is optional — some models omit it (`</TOOL_CALL` +
 # newline); `\b` keeps `</tool_callable` from matching.
-# #11552: the close is often TRUNCATED to `</TOOL` (model drops `_CALL`) before a
-# hallucinated success line; detecting it stops the stream at the close so the
-# fabricated "task created" prose is never emitted. Kept in sync with
-# tool_handler._TOOL_CALL_PATTERN's tolerant close.
-_TOOL_CALL_COMPLETE_RE = re.compile(r"</\s*tool(?:_?\s*call\b|\b)\s*>?", re.IGNORECASE)
+_TOOL_CALL_COMPLETE_RE = re.compile(r"</\s*tool_?\s*call\b\s*>?", re.IGNORECASE)
+
+# #11552: chat models frequently TRUNCATE the close to a bare `</TOOL` (dropping
+# `_CALL`) and then hallucinate a success line. Detecting that stops the stream so
+# the fabricated prose is never shown — but a bare `</tool…` also appears in
+# legitimate prose (HTML/XML/JSX talk), and this detector scans the WHOLE response
+# with no structural anchor. So the bare close only counts as a completed tool
+# call when a well-formed opening `<TOOL_CALL …>` is already in the buffer (the
+# only way a real truncated call can occur). `\b` after `tool` keeps `</tool_call`
+# (handled above) and `</toolbox` from matching here.
+_TOOL_CALL_BARE_CLOSE_RE = re.compile(r"</\s*tool\b", re.IGNORECASE)
+_TOOL_CALL_OPENING_RE = re.compile(r"<\s*tool_?\s*call\b[^>]*>", re.IGNORECASE)
 
 # Issue #716: Patterns for internal prompts that should not be shown to users
 # These are continuation instructions that LLM sometimes echoes back
@@ -678,7 +685,15 @@ class ChatWorkflowManager(
         Returns:
             True if tool call is now complete, False otherwise. Issue #620.
         """
-        if not tool_call_completed and _TOOL_CALL_COMPLETE_RE.search(llm_response):
+        if tool_call_completed:
+            return tool_call_completed
+        # A well-formed close, OR (#11552) a truncated bare `</tool` close but only
+        # once a real opening tag is present — so legit prose mentioning `</tool>`
+        # never truncates a general-chat response.
+        completed = bool(_TOOL_CALL_COMPLETE_RE.search(llm_response)) or bool(
+            _TOOL_CALL_OPENING_RE.search(llm_response) and _TOOL_CALL_BARE_CLOSE_RE.search(llm_response)
+        )
+        if completed:
             logger.info(
                 "[Issue #727] Tool call completion detected - stopping frontend streaming "
                 "to prevent hallucination display. Response length: %d",

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -488,12 +488,18 @@ def _approval_category_for(tool_name: str, declared: list[str]) -> str | None:
 # Issue #650: Pre-compiled regex for tool call parsing (performance optimization)
 # Handles both uppercase and lowercase TOOL_CALL tags with nested JSON in params
 # #11545: the closing `>` is optional — some chat models emit `</TOOL_CALL`
-# (newline/prose after) without it, which previously left the whole tool call
-# unparsed (raw tag leaked to the user, tool never executed). `\b` guards
-# against matching `</tool_callable…`. The opening tag's `>` (after params) is
-# still required.
+# (newline/prose after) without it.
+# #11552: the closing tag itself is often TRUNCATED to `</TOOL` (the model drops
+# `_CALL`) or spaced (`</TOOL_ CALL>`), then a hallucinated success line follows.
+# Both previously left the tool call unparsed → raw tag leaked, tool never ran
+# (0 work items, CEO chat). The close now tolerates `</TOOL[_[ ]CALL][>]`: the
+# `_CALL` and trailing `>` are both optional. The close requires a word boundary
+# after `tool` (either the proper `_call\b` continuation, or `\b` when `_CALL` is
+# dropped) so `</tool_callable…`/`</toolbox…` never match; the opening tag
+# (`<TOOL_CALL name=… params=…>`) is still required, so a bare `</tool>` in prose
+# can never match on its own.
 _TOOL_CALL_PATTERN = re.compile(
-    r'<tool_call\s+name="([^"]+)"\s+params=(["\'])(.+?)\2>([^<]*)</tool_call\b\s*>?',
+    r'<tool_call\s+name="([^"]+)"\s+params=(["\'])(.+?)\2>([^<]*)</tool(?:_?\s*call\b|\b)\s*>?',
     re.IGNORECASE | re.DOTALL,
 )
 

--- a/autobot-backend/tests/unit/chat_workflow/test_ceo_dispatch_routing.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_ceo_dispatch_routing.py
@@ -1,0 +1,73 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11552: does _dispatch_tool_call actually ROUTE create_task to the LLC
+handler (through the enforcement guards), or is it blocked/misrouted before
+_handle_llc_tool? The earlier chain test called _handle_llc_tool directly and
+bypassed the guards + routing — this closes that gap.
+
+Imports the real ToolHandlerMixin; skips where the heavy chain can't load.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _mixin():
+    try:
+        from chat_workflow.tool_handler import ToolHandlerMixin
+    except ImportError as exc:
+        pytest.skip(f"chat_workflow not importable here: {exc}")
+
+    class _M(ToolHandlerMixin):
+        pass
+
+    return _M()
+
+
+def _ctx():
+    # Mirrors a CEO-chat iteration context: company scope, no approval gates.
+    return SimpleNamespace(
+        context={"company_id": "co-1", "user_id": "u-1"},
+        consecutive_invalid_tool_calls=0,
+        requires_approval_before=None,
+        work_item_id=None,
+        agent_context=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_create_task_to_llc_handler():
+    m = _mixin()
+    tool_call = {"name": "create_task", "params": {"title": "Write Q3 report", "priority": "high"}}
+    exec_results: list = []
+    with patch(
+        "chat_workflow.tool_handler.dispatch_llc_tool",
+        new=AsyncMock(return_value={"status": "success", "entity_type": "work_item", "entity_id": "wi-1"}),
+    ) as disp:
+        msgs = [
+            msg
+            async for msg in m._dispatch_tool_call(
+                tool_call,
+                "sess-1",
+                "term-1",
+                "http://x/api/generate",
+                "model",
+                exec_results,
+                [],
+                ctx=_ctx(),
+                role="user",
+            )
+        ]
+    # The routing must reach the LLC branch and dispatch (not be blocked by a
+    # guard, and not fall through to MCP/unknown).
+    disp.assert_awaited_once()
+    assert disp.await_args.args[0] == "create_task"
+    assert disp.await_args.args[2] == "co-1"  # company_id from ctx.context
+    assert exec_results and exec_results[-1].get("status") == "success"
+    assert not any(getattr(x, "type", "") == "approval_required" for x in msgs)

--- a/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
@@ -38,8 +38,8 @@ def _mixin_instance():
 # tag omits the '>' (`</TOOL_CALL` + newline + more prose).
 _BOARD_OUTPUT = (
     "Creating the high priority task.\n\n"
-    "<TOOL_CALL name=\"create_task\" "
-    "params='{\"title\":\"Write the Q3 financial report\",\"priority\":\"high\"}'>"
+    '<TOOL_CALL name="create_task" '
+    'params=\'{"title":"Write the Q3 financial report","priority":"high"}\'>'
     "Create task</TOOL_CALL\n\nHigh priority task created."
 )
 

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_call_truncated_close.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_call_truncated_close.py
@@ -1,0 +1,70 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11552 root cause: chat models emit a TRUNCATED closing tag `</TOOL`
+(missing `_CALL`) instead of `</TOOL_CALL>`, then hallucinate a success line.
+#11545 only made the trailing `>` optional, so `</TOOL` still failed to parse →
+tool_calls empty → should_stop → the tool never executed (0 work items live).
+
+These use the EXACT body captured from the live CEO-chat E2E send.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The verbatim assistant body persisted by the live managed backend (2026-07-11).
+LIVE_BODY = (
+    'Creating task "Write Q3 financial report" with high priority.\n\n'
+    "<TOOL_CALL name=\"create_task\" params='"
+    '{"title":"Write Q3 financial report","priority":"high",'
+    '"description":"Generate the Q3 financial report for the company"}'
+    "'>Create task</TOOL\n\n"
+    "Task 'Write Q3 financial report' created with high priority."
+)
+
+
+def _pattern():
+    try:
+        from chat_workflow.tool_handler import _TOOL_CALL_PATTERN
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"chat_workflow not importable here: {exc}")
+    return _TOOL_CALL_PATTERN
+
+
+def _complete_re():
+    try:
+        from chat_workflow.manager import _TOOL_CALL_COMPLETE_RE
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"chat_workflow not importable here: {exc}")
+    return _TOOL_CALL_COMPLETE_RE
+
+
+def test_parser_extracts_create_task_from_truncated_close():
+    matches = list(_pattern().finditer(LIVE_BODY))
+    assert len(matches) == 1, "the </TOOL truncated close must still parse"
+    assert matches[0].group(1) == "create_task"
+    assert '"title":"Write Q3 financial report"' in matches[0].group(3)
+
+
+@pytest.mark.parametrize(
+    "close",
+    ["</TOOL", "</TOOL_CALL", "</TOOL_CALL>", "</tool_call>", "</TOOL_ CALL>", "</Tool "],
+)
+def test_parser_tolerates_all_close_variants(close):
+    body = (
+        "<TOOL_CALL name=\"create_task\" params='{\"title\":\"X\"}'>desc" + close + "\nprose"
+    )
+    matches = list(_pattern().finditer(body))
+    assert len(matches) == 1 and matches[0].group(1) == "create_task"
+
+
+def test_parser_does_not_match_bare_close_without_opening():
+    # A stray </tool> in prose must never be treated as a tool call.
+    assert list(_pattern().finditer("some </tool> markup in prose")) == []
+
+
+def test_completion_detector_fires_on_truncated_close():
+    # So streaming stops at </TOOL and the hallucinated success line is not emitted.
+    assert _complete_re().search("...>Create task</TOOL\n") is not None

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_call_truncated_close.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_call_truncated_close.py
@@ -17,7 +17,7 @@ import pytest
 # The verbatim assistant body persisted by the live managed backend (2026-07-11).
 LIVE_BODY = (
     'Creating task "Write Q3 financial report" with high priority.\n\n'
-    "<TOOL_CALL name=\"create_task\" params='"
+    '<TOOL_CALL name="create_task" params=\''
     '{"title":"Write Q3 financial report","priority":"high",'
     '"description":"Generate the Q3 financial report for the company"}'
     "'>Create task</TOOL\n\n"
@@ -53,9 +53,7 @@ def test_parser_extracts_create_task_from_truncated_close():
     ["</TOOL", "</TOOL_CALL", "</TOOL_CALL>", "</tool_call>", "</TOOL_ CALL>", "</Tool "],
 )
 def test_parser_tolerates_all_close_variants(close):
-    body = (
-        "<TOOL_CALL name=\"create_task\" params='{\"title\":\"X\"}'>desc" + close + "\nprose"
-    )
+    body = '<TOOL_CALL name="create_task" params=\'{"title":"X"}\'>desc' + close + "\nprose"
     matches = list(_pattern().finditer(body))
     assert len(matches) == 1 and matches[0].group(1) == "create_task"
 

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_call_truncated_close.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_call_truncated_close.py
@@ -33,12 +33,22 @@ def _pattern():
     return _TOOL_CALL_PATTERN
 
 
-def _complete_re():
+def _completion_fires(text):
+    """Mirror manager._check_tool_call_completion's structural gate (#11552):
+    a well-formed close, OR a bare `</tool` close only when an opening tag is
+    already present. Keeps legit `</tool>` prose from truncating a response.
+    """
     try:
-        from chat_workflow.manager import _TOOL_CALL_COMPLETE_RE
+        from chat_workflow.manager import (
+            _TOOL_CALL_BARE_CLOSE_RE,
+            _TOOL_CALL_COMPLETE_RE,
+            _TOOL_CALL_OPENING_RE,
+        )
     except ImportError as exc:  # pragma: no cover
         pytest.skip(f"chat_workflow not importable here: {exc}")
-    return _TOOL_CALL_COMPLETE_RE
+    return bool(_TOOL_CALL_COMPLETE_RE.search(text)) or bool(
+        _TOOL_CALL_OPENING_RE.search(text) and _TOOL_CALL_BARE_CLOSE_RE.search(text)
+    )
 
 
 def test_parser_extracts_create_task_from_truncated_close():
@@ -63,6 +73,29 @@ def test_parser_does_not_match_bare_close_without_opening():
     assert list(_pattern().finditer("some </tool> markup in prose")) == []
 
 
-def test_completion_detector_fires_on_truncated_close():
-    # So streaming stops at </TOOL and the hallucinated success line is not emitted.
-    assert _complete_re().search("...>Create task</TOOL\n") is not None
+def test_completion_detector_fires_on_truncated_close_after_opening():
+    # With a real opening tag present, the truncated </TOOL close stops the stream
+    # so the hallucinated success line is not emitted.
+    assert _completion_fires(LIVE_BODY) is True
+    assert _completion_fires("<TOOL_CALL name=\"create_task\" params='{}'>go</TOOL\n") is True
+
+
+def test_completion_detector_still_fires_on_wellformed_close():
+    assert _completion_fires("...>Create task</TOOL_CALL>\n") is True
+    assert _completion_fires("...>Create task</TOOL_CALL\n") is True  # #11545 missing >
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "To close the element you write </tool>.",
+        "The markup uses <tool>x</tool> pairs, not real calls.",
+        "I recommend the </tool-belt> naming pattern here.",
+        "a bare </tool. sentence with no opening",
+        "</tool_callable> is a different token entirely",
+    ],
+)
+def test_completion_detector_does_not_fire_on_legit_prose(prose):
+    # HIGH review finding: bare </tool… in ordinary prose (no opening tag) must
+    # NOT truncate a general-chat response.
+    assert _completion_fires(prose) is False


### PR DESCRIPTION
Closes #11552

## Thinking Path

Continuation of #11552. After #11545 (optional trailing `>`) + #11552 (graph tenant context) were merged and deployed, CEO chat still created **0 work items** — the raw tool-call tag leaked to the user and no tool ran. Extensive tracing proved every layer works in isolation (parse, guards, routing, dispatch, LLC handler — see the two new tests). The break had to be that `tool_calls` was **empty** at parse time.

I captured the **exact** assistant body from a live managed-backend (`:8001`) CEO-chat E2E send:

```
Creating task "Write Q3 financial report" with high priority.

<TOOL_CALL name="create_task" params='{"title":"Write Q3 financial report","priority":"high","description":"..."}'>Create task</TOOL

Task 'Write Q3 financial report' created with high priority.
```

The close is **`</TOOL`** — the model drops `_CALL` and then hallucinates a success line. `_TOOL_CALL_PATTERN` required `</tool_call`, so it matched **0** tool calls → `tool_calls` empty → `_run_continuation_iteration` sees `should_stop=True` (the "no tool calls = task complete" branch) → `_yield_tool_results_and_decide` is skipped → the tool is never dispatched. My earlier isolation test used `</TOOL_CALL` (the wrong input), which masked this.

## What Changed

Both sibling tool-call-close regexes now tolerate the truncated/spaced close `</TOOL[_[ ]CALL][>]` (both `_CALL` and trailing `>` optional), while requiring a **word boundary** after `tool` so `</tool_callable>`/`</toolbox>` never match (the #11545 guard is preserved):

- `chat_workflow/tool_handler.py::_TOOL_CALL_PATTERN` — the tool call now parses and executes.
- `chat_workflow/manager.py::_TOOL_CALL_COMPLETE_RE` — streaming stops at the close, so the fabricated "task created" prose is no longer streamed to the user.

## Verification

- **New tests** (`tests/unit/chat_workflow/`):
  - `test_tool_call_truncated_close.py` — exact live body, all close variants (`</TOOL`, `</TOOL_CALL`, `</TOOL_CALL>`, `</TOOL_ CALL>`, `</Tool `), negative bare-close-without-opening, and the completion detector.
  - `test_ceo_dispatch_routing.py` — drives the full `_dispatch_tool_call` guards + routing to `dispatch_llc_tool` with company scope.
- `python3 -m pytest tests/unit/chat_workflow/ -q` → **206 passed** (includes the #11545 `test_tool_call_missing_gt.py` guard tests).
- Live E2E re-verification after deploy is the next step (send → assert a work item is created).

## Model Used

Claude Opus 4.8