### PR TITLE
fix(deploy): bound uvicorn SIGTERM shutdown so code-sync restart doesn't hang 15min (#11668)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
@@ -25,8 +25,16 @@ EnvironmentFile=-{{ service_auth_keys_dir | default('/etc/autobot/service-keys')
 # MVA-1633: Validate env vars before starting to prevent silent crashes
 ExecStartPre={{ backend_code_dir | default(backend_install_dir) }}/venv/bin/python -u {{ backend_code_dir | default(backend_install_dir) }}/startup_validation.py
 # Issue #891: Removed ExecStartPre symlink creation - causes infinite import loops with fixed backend imports
-ExecStart={{ backend_code_dir }}/venv/bin/uvicorn main:app --host {{ backend_host }} --port {{ backend_port }} --workers {{ backend_workers }}
+# #11668: --timeout-graceful-shutdown bounds uvicorn's SIGTERM shutdown. Without it
+# uvicorn waits indefinitely for lingering keep-alive/in-flight connections (nginx,
+# health probes), so `systemctl restart` sat in stop-sigterm for the full 15-min
+# TimeoutStopSec on every code-sync deploy — making the built-in restart look broken.
+ExecStart={{ backend_code_dir }}/venv/bin/uvicorn main:app --host {{ backend_host }} --port {{ backend_port }} --workers {{ backend_workers }} --timeout-graceful-shutdown {{ backend_graceful_shutdown_sec | default(30) }}
 Restart=always
+# #11668: escalate to SIGKILL promptly if uvicorn still hasn't exited, so a
+# code-sync restart never blocks on a hung shutdown. Mirrors autobot-celery.
+KillMode=mixed
+TimeoutStopSec={{ backend_stop_timeout_sec | default(45) }}
 # Issue #957: nginx holds port {{ backend_nginx_port | default(8443) }}; WDF rule tied to nginx not uvicorn
 RestartSec=5
 StartLimitInterval=120

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -13,10 +13,15 @@ Environment="PYTHONPATH={{ slm_backend_dir }}:{{ slm_shared_dir }}:{{ slm_base_d
 Environment="PYTHONUNBUFFERED=1"
 EnvironmentFile=-{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}
 EnvironmentFile=-{{ slm_credentials_dir }}/{{ slm_credentials_file }}
-ExecStart={{ slm_backend_dir }}/venv/bin/uvicorn main:app --host {{ slm_backend_host }} --port {{ slm_backend_port }}
+# #11668: bound uvicorn's SIGTERM shutdown (see autobot-backend.service.j2) so the
+# SLM restart during code-sync self-update doesn't hang on lingering connections.
+# KillMode is intentionally left at the default here — the cgroup-kill behavior
+# during self-update is owned by #11492.
+ExecStart={{ slm_backend_dir }}/venv/bin/uvicorn main:app --host {{ slm_backend_host }} --port {{ slm_backend_port }} --timeout-graceful-shutdown {{ slm_backend_graceful_shutdown_sec | default(30) }}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5
+TimeoutStopSec={{ slm_backend_stop_timeout_sec | default(45) }}
 StandardOutput=append:{{ slm_log_dir }}/slm-backend.log
 StandardError=append:{{ slm_log_dir }}/slm-backend-error.log
 


### PR DESCRIPTION
Closes #11668

## Thinking Path
Dogfooding the built-in code-sync deploy of #11666: after `drift/resolve autobot-backend` rsync'd new code and ran `systemctl restart autobot-backend`, the service sat in `deactivating (stop-sigterm)` for the full 15-min `TimeoutStopSec` before SIGKILL. Root cause: uvicorn is launched via the systemd CLI `ExecStart` with **no `--timeout-graceful-shutdown`**, so it waits indefinitely for lingering keep-alive/in-flight connections (nginx, health probes) on SIGTERM. `main.py`'s `uvicorn_config` also omits it and is bypassed by systemd anyway. This is the real reason the built-in restart kept looking unreliable.

## What Changed
- `roles/backend/templates/autobot-backend.service.j2`: add `--timeout-graceful-shutdown {{ backend_graceful_shutdown_sec | default(30) }}` to ExecStart; add `KillMode=mixed` + `TimeoutStopSec={{ backend_stop_timeout_sec | default(45) }}`.
- `roles/slm_manager/templates/autobot-slm-backend.service.j2`: add the graceful-shutdown flag + `TimeoutStopSec` (KillMode left default — cgroup-kill during self-update is #11492's domain).

## Verification
- Jinja brace balance + flag presence asserted.
- Rendered unit review: ExecStart now bounds shutdown to 30s; systemd escalates to SIGKILL at 45s.
- Runtime note: the co-located box has **stale manual drop-ins** (`autobot-backend.service.d/{single-worker,timeout,override}.conf`) that reset ExecStart and pin `TimeoutStopSec=900`, overriding this canonical unit — tracked in a follow-up to reconcile so the fix reaches already-tuned boxes.

## Model Used
Claude Opus 4.8