### PR TITLE
fix(llc): work-item creation — bump organizations counter in a SAVEPOINT, not phantom llc_companies (#11675)

### DIFF
--- a/autobot-backend/llc/services/controls_service.py
+++ b/autobot-backend/llc/services/controls_service.py
@@ -343,7 +343,9 @@ class ControlsService:
 
     async def _get_company_row(self, session: AsyncSession, company_id: str) -> Optional[dict]:
         result = await session.execute(
-            text("SELECT id FROM llc_companies WHERE id = :id LIMIT 1"),
+            # #11675: companies are Organization rows in `organizations`; the
+            # legacy `llc_companies` table never existed.
+            text("SELECT id FROM organizations WHERE id = :id LIMIT 1"),
             {"id": company_id},
         )
         row = result.fetchone()

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -12,10 +12,10 @@ Status transitions:
   transition raises ``InvalidTransition``.
 
 Identifier generation:
-  PostgreSQL advisory lock on the company's numeric hash, then RETURNING on an
-  UPDATE to ``llc_companies.issue_counter`` — producing ``<prefix>-<counter>``.
-  Falls back to a UUID-based placeholder when the companies table is absent
-  (unit-test environments without full schema).
+  UPDATE … RETURNING on ``organizations.issue_counter`` (the row lock enforces
+  uniqueness) — producing ``<prefix>-<counter>``. Falls back to a UUID-based
+  placeholder when the organizations table is absent (unit-test environments
+  without full schema).
 
 Co-working (GH#8230):
   enable_coworking / disable_coworking manage the secondary co-worker slot.
@@ -976,26 +976,35 @@ class WorkItemService(LLCServiceBase):
     async def _next_identifier(self, session: AsyncSession, company_id: str) -> str:
         """Generate the next ``<prefix>-<counter>`` identifier for this company.
 
-        Uses PostgreSQL advisory lock + UPDATE RETURNING on ``llc_companies`` to
-        ensure uniqueness under concurrent inserts. Falls back to a random
-        identifier in test environments that lack the ``llc_companies`` table.
+        Bumps ``organizations.issue_counter`` with UPDATE … RETURNING (the row
+        lock guarantees uniqueness under concurrent inserts). Companies are
+        ``Organization`` rows — the counter lives on ``organizations``, NOT the
+        legacy ``llc_companies`` name (#11675: that phantom table never existed;
+        the failed UPDATE aborted the whole create transaction, so every work-item
+        INSERT died with InFailedSQLTransactionError).
+
+        Runs inside a SAVEPOINT (``begin_nested``) so that if the counter bump
+        fails — e.g. a test DB without the ``organizations`` table — only the
+        nested transaction rolls back and the UUID fallback stays usable; the
+        outer create transaction is never poisoned.
         """
         try:
-            row = await session.execute(
-                text("""
-                    UPDATE llc_companies
-                       SET issue_counter = issue_counter + 1
-                     WHERE id = :company_id
-                    RETURNING issue_prefix, issue_counter
-                    """),
-                {"company_id": company_id},
-            )
-            rec = row.fetchone()
-            if rec:
+            async with session.begin_nested():
+                row = await session.execute(
+                    text("""
+                        UPDATE organizations
+                           SET issue_counter = issue_counter + 1
+                         WHERE id = :company_id
+                        RETURNING issue_prefix, issue_counter
+                        """),
+                    {"company_id": company_id},
+                )
+                rec = row.fetchone()
+            if rec and rec.issue_prefix:
                 return f"{rec.issue_prefix}-{rec.issue_counter}"
         except Exception as exc:
             if isinstance(exc, (ProgrammingError, OperationalError)):
-                logger.debug("llc_companies table not available — using UUID identifier fallback")
+                logger.debug("organizations table not available — using UUID identifier fallback")
             else:
                 logger.warning(
                     "Unexpected error generating identifier for company %s — using UUID fallback",

--- a/autobot-backend/tests/unit/llc/test_work_item_identifier.py
+++ b/autobot-backend/tests/unit/llc/test_work_item_identifier.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11675: WorkItemService._next_identifier must bump organizations.issue_counter
+(companies are Organization rows) — the legacy `llc_companies` table never
+existed, so the old UPDATE raised UndefinedTable, and because it ran in the outer
+transaction it aborted the whole create → every work-item INSERT failed with
+InFailedSQLTransactionError. The bump now runs inside a SAVEPOINT so a failure
+can't poison the create transaction.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _svc():
+    try:
+        from llc.services.work_item_service import WorkItemService
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"llc not importable here: {exc}")
+    return WorkItemService()
+
+
+class _NestedCM:
+    entered = False
+
+    async def __aenter__(self):
+        type(self).entered = True
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _session(execute):
+    s = MagicMock()
+    s.begin_nested = MagicMock(return_value=_NestedCM())
+    s.execute = execute
+    return s
+
+
+@pytest.mark.asyncio
+async def test_next_identifier_targets_organizations_in_savepoint():
+    _NestedCM.entered = False
+    captured = {}
+
+    async def execute(clause, params):
+        captured["sql"] = str(clause)
+        return SimpleNamespace(fetchone=lambda: SimpleNamespace(issue_prefix="MVT", issue_counter=1))
+
+    ident = await _svc()._next_identifier(_session(AsyncMock(side_effect=execute)), "co-1")
+
+    assert ident == "MVT-1"
+    assert "organizations" in captured["sql"]
+    assert "llc_companies" not in captured["sql"]
+    assert _NestedCM.entered, "the counter bump must run inside a SAVEPOINT (begin_nested)"
+
+
+@pytest.mark.asyncio
+async def test_next_identifier_falls_back_without_poisoning_on_failure():
+    from sqlalchemy.exc import ProgrammingError
+
+    _NestedCM.entered = False
+
+    async def boom(clause, params):
+        raise ProgrammingError("UPDATE organizations", {}, Exception("relation does not exist"))
+
+    ident = await _svc()._next_identifier(_session(AsyncMock(side_effect=boom)), "co-1")
+
+    # Fallback identifier, exception swallowed, SAVEPOINT was used for isolation.
+    assert ident.startswith("WI-")
+    assert _NestedCM.entered


### PR DESCRIPTION
Closes #11675

## Thinking Path
Dogfooding #11666's deploy: the tool call now parses + dispatches (`[Issue #352] Parsed 1 tool calls` → `Processing 1 tool call(s)`), but the work item still wasn't created. Live logs showed `create_task failed: InFailedSQLTransactionError`. The direct `POST /api/llc/work-items` API failed identically (HTTP 500) — so this is the pre-existing "Unable to create work items" bug, not a chat issue.

## Root Cause
`WorkItemService._next_identifier` ran `UPDATE llc_companies SET issue_counter = issue_counter + 1 …`, but **`llc_companies` does not exist** — companies are `Organization` rows in the `organizations` table (verified: it has `issue_prefix`/`issue_counter`; `MV Corp Test` → prefix `MVT`). The UPDATE raised `UndefinedTable`; the `except` returned a UUID fallback but **never rolled back the failed statement**, leaving the PostgreSQL transaction aborted, so the subsequent work-item INSERT died with `InFailedSQLTransactionError`.

## What Changed
- `_next_identifier`: target `organizations`; run the counter bump inside a **SAVEPOINT** (`session.begin_nested`) so a failure rolls back only the nested tx and the UUID fallback stays usable — the outer create transaction is never poisoned.
- `controls_service._get_company_row`: same phantom `llc_companies` → `organizations`.
- Docstrings updated.

## Verification
- `tests/unit/llc/test_work_item_identifier.py` (2 passed): bump targets `organizations` (not `llc_companies`) inside a SAVEPOINT; a failing bump falls back to `WI-<uuid>` without propagating.
- Live E2E re-verify after deploy (send → work item created) is the next step.

## Model Used
Claude Opus 4.8