### PR TITLE
fix(llc): CEO Chat button opens the company CEO chat, not the global assistant (#11552)

### DIFF
--- a/autobot-frontend/src/views/llc/CompanyDashboard.vue
+++ b/autobot-frontend/src/views/llc/CompanyDashboard.vue
@@ -198,7 +198,11 @@ async function quickApprove(approvalId: string) {
 }
 
 function launchCeoChat() {
-  router.push({ path: '/chat', query: { mode: 'ceo' } })
+  // #11552 follow-up: the CEO Chat button must open THIS company's CEO chat, not
+  // the global assistant. Route to the company-scoped ceo-chat view (mirrors
+  // LlcSidebar's nav target) so the company context (and its LLC tools) apply.
+  if (!companyId.value) return
+  router.push({ path: `/llc/companies/${companyId.value}/ceo-chat` })
 }
 
 function formatDuration(ms: number | null): string {


### PR DESCRIPTION
Closes #11552

## Thinking Path
Reported alongside the CEO-chat tool-execution work: the CompanyDashboard "CEO Chat" button navigated to `/chat?mode=ceo` (the global assistant) instead of the company's CEO chat. It should open `/llc/companies/{id}/ceo-chat` — the same target `LlcSidebar` already uses — so the company context (and its LLC tools) apply.

## What Changed
- `autobot-frontend/src/views/llc/CompanyDashboard.vue` `launchCeoChat()`: push `/llc/companies/${companyId.value}/ceo-chat` (guarded on a resolved companyId) instead of `/chat?mode=ceo`.

## Verification
- Route `llc-ceo-chat` (path `/llc/companies/:companyId/ceo-chat`) exists in the router; the target matches `LlcSidebar`'s working nav entry.
- Note: this pairs with #11666 (tool-call parsing) + #11675 (work-item creation) which make the CEO chat actually functional; a follow-up will bring the CEO-chat view to 1:1 tooling parity with `/chat`.

## Model Used
Claude Opus 4.8