### PR TITLE
fix(llc): async-safe work-item relation serialization — fixes MissingGreenlet 500 (#11684)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -316,7 +316,9 @@ async def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
     not-yet-loaded relationship raises ``MissingGreenlet`` (sync IO in an async
     context) → the endpoint 500s even though the row exists. ``awaitable_attrs``
     returns the cached value when already loaded and awaits a load otherwise, so
-    every path serializes correctly with no duplicate query.
+    every path serializes correctly. (``outgoing_relations`` is ``lazy=selectin``;
+    each relation's ``target`` is lazy=select — an N+1 when an item has many
+    relations, tracked as a fast-follow.)
     """
     rows = []
     outgoing = await item.awaitable_attrs.outgoing_relations
@@ -983,7 +985,11 @@ async def set_or_clear_coworker(
                 caller_role="owner",
             )
         await session.commit()
-        return _item_to_dict(item)
+        # #11684: was `return _item_to_dict(item)` — unawaited and missing the
+        # session arg (latent since _item_to_dict became an async 2-arg fn); the
+        # awaitable_attrs relation load makes it a guaranteed crash. Match every
+        # other caller.
+        return await _item_to_dict(item, session)
     except CoWorkingPermissionError as exc:
         logger.error("Exception in API handler: %s", exc, exc_info=True)
         raise HTTPException(status_code=403, detail="Internal server error")

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -306,11 +306,22 @@ def _coworker_display(item: Any) -> Optional[Dict[str, Any]]:
     return None
 
 
-def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
-    """Serialize outgoing + incoming relations for GET response (GH#8252)."""
+async def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
+    """Serialize outgoing relations for the response (GH#8252).
+
+    #11684: use ``awaitable_attrs`` so relationship access is async-safe. Items
+    reach here loaded three ways — eager-loaded (list path), bare-loaded
+    (get/update/transition via ``_service().get()``), or freshly created
+    (create path). Under an AsyncSession a plain ``item.outgoing_relations`` on a
+    not-yet-loaded relationship raises ``MissingGreenlet`` (sync IO in an async
+    context) → the endpoint 500s even though the row exists. ``awaitable_attrs``
+    returns the cached value when already loaded and awaits a load otherwise, so
+    every path serializes correctly with no duplicate query.
+    """
     rows = []
-    for rel in getattr(item, "outgoing_relations", []) or []:
-        tgt = rel.target
+    outgoing = await item.awaitable_attrs.outgoing_relations
+    for rel in outgoing or []:
+        tgt = await rel.awaitable_attrs.target
         rows.append(
             {
                 "id": str(rel.id),
@@ -365,7 +376,7 @@ async def _item_to_dict(item: Any, session: AsyncSession) -> Dict[str, Any]:
         "has_human_handoff_context": bool(getattr(item, "review_brief", None)),
         "created_at": item.created_at.isoformat() if item.created_at else None,
         "updated_at": item.updated_at.isoformat() if item.updated_at else None,
-        "relations": _relations_to_list(item),
+        "relations": await _relations_to_list(item),
     }
 
 

--- a/autobot-backend/llc/tests/test_work_item_ac_completion.py
+++ b/autobot-backend/llc/tests/test_work_item_ac_completion.py
@@ -61,7 +61,7 @@ class TestSerialization:
         session = AsyncMock()
         with (
             patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)),
-            patch.object(work_items, "_relations_to_list", return_value=[]),
+            patch.object(work_items, "_relations_to_list", new=AsyncMock(return_value=[])),
         ):
             result = await work_items._item_to_dict(item, session)
         assert result["acceptance_criteria_done"] == [True, False]
@@ -77,7 +77,7 @@ class TestSerialization:
         session = AsyncMock()
         with (
             patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)),
-            patch.object(work_items, "_relations_to_list", return_value=[]),
+            patch.object(work_items, "_relations_to_list", new=AsyncMock(return_value=[])),
         ):
             result = await work_items._item_to_dict(item, session)
         assert result["acceptance_criteria_done"] == []

--- a/autobot-backend/llc/tests/test_work_item_relations_async.py
+++ b/autobot-backend/llc/tests/test_work_item_relations_async.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11684: _relations_to_list must access relationships via awaitable_attrs so a
+not-yet-loaded relationship (create/get/update paths) doesn't raise
+MissingGreenlet under an AsyncSession. Emulates the awaitable_attrs interface.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class _Awaitable:
+    """Mimic SQLAlchemy's awaitable_attrs: attribute access returns a coroutine."""
+
+    def __init__(self, **values):
+        self._values = values
+
+    def __getattr__(self, name):
+        value = self._values[name]
+
+        async def _coro():
+            return value
+
+        return _coro()
+
+
+def _rel(rid, target):
+    return SimpleNamespace(
+        id=rid,
+        relation_type="blocks",
+        target_id="t-1",
+        awaitable_attrs=_Awaitable(target=target),
+    )
+
+
+@pytest.mark.asyncio
+async def test_relations_to_list_awaits_unloaded_relationship():
+    from llc.api import work_items
+
+    tgt = SimpleNamespace(identifier="MVT-9", title="Target", status="open")
+    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[_rel("r-1", tgt)]))
+
+    rows = await work_items._relations_to_list(item)
+
+    assert rows == [
+        {
+            "id": "r-1",
+            "type": "blocks",
+            "target_id": "t-1",
+            "target_identifier": "MVT-9",
+            "target_title": "Target",
+            "target_status": "open",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_relations_to_list_empty_for_freshly_created_item():
+    # The create path: a brand-new item has no relations — must return [] without
+    # a MissingGreenlet.
+    from llc.api import work_items
+
+    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[]))
+    assert await work_items._relations_to_list(item) == []

--- a/autobot-backend/llc/tests/test_work_item_relations_async.py
+++ b/autobot-backend/llc/tests/test_work_item_relations_async.py
@@ -67,3 +67,22 @@ async def test_relations_to_list_empty_for_freshly_created_item():
 
     item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[]))
     assert await work_items._relations_to_list(item) == []
+
+
+@pytest.mark.asyncio
+async def test_relations_to_list_handles_null_target():
+    # A relation whose target could not be resolved serializes None fields, not a crash.
+    from llc.api import work_items
+
+    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[_rel("r-2", None)]))
+    rows = await work_items._relations_to_list(item)
+    assert rows == [
+        {
+            "id": "r-2",
+            "type": "blocks",
+            "target_id": "t-1",
+            "target_identifier": None,
+            "target_title": None,
+            "target_status": None,
+        }
+    ]

--- a/autobot-backend/llc/tests/test_work_item_requires_approval.py
+++ b/autobot-backend/llc/tests/test_work_item_requires_approval.py
@@ -79,7 +79,7 @@ class TestSerialization:
         session = AsyncMock()
         with (
             patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)),
-            patch.object(work_items, "_relations_to_list", return_value=[]),
+            patch.object(work_items, "_relations_to_list", new=AsyncMock(return_value=[])),
         ):
             result = await work_items._item_to_dict(item, session)
         assert result["requires_approval_before"] == ["pushing commits"]

--- a/autobot-backend/llc/tests/test_work_items_idor.py
+++ b/autobot-backend/llc/tests/test_work_items_idor.py
@@ -135,6 +135,10 @@ def _make_idor_app(
     patch("llc.services.work_item_service.WorkItemService.get", new=AsyncMock(return_value=mock_item)).start()
     # Also patch WorkItemService.update to return mock_item so PATCH succeeds.
     patch("llc.services.work_item_service.WorkItemService.update", new=AsyncMock(return_value=mock_item)).start()
+    # #11684: _item_to_dict now awaits _relations_to_list (awaitable_attrs); these
+    # IDOR tests use a MagicMock item without an awaitable awaitable_attrs and
+    # don't exercise relation serialization — stub it (matches the sibling tests).
+    patch("llc.api.work_items._relations_to_list", new=AsyncMock(return_value=[])).start()
     # Patch product service for /products route.
     patch(
         "llc.services.work_product_service.WorkProductService.list_by_work_item",

--- a/autobot-backend/user_management/models/base.py
+++ b/autobot-backend/user_management/models/base.py
@@ -15,18 +15,23 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, func
+from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
 from sqlalchemy.types import Uuid
 
 from autobot_shared.time_utils import now_utc
 
 
-class Base(DeclarativeBase):
+class Base(AsyncAttrs, DeclarativeBase):
     """Base class for all SQLAlchemy models.
 
     Provides automatic created_at/updated_at timestamp columns to all models.
     Models should inherit from Base only — do not inherit from TimestampMixin
     separately, as it will cause metaclass conflicts (#4300).
+
+    #11684: mixes in ``AsyncAttrs`` so every model exposes ``awaitable_attrs`` —
+    greenlet-safe async access to un-loaded relationships/columns under an
+    AsyncSession. Purely additive (adds one accessor; no behavioral change).
     """
 
     # Timestamp columns provided to all models


### PR DESCRIPTION
Closes #11684

## Thinking Path
During live E2E of #11675, `POST /api/llc/work-items` returned **500** even though the row was created (`MVT-1..4` persisted). Traceback: `create_work_item` → `_item_to_dict` → `_relations_to_list` → `sqlalchemy.exc.MissingGreenlet`. `_relations_to_list` accessed `item.outgoing_relations` synchronously; under an AsyncSession a lazy relationship load is illegal. `list_work_items` works only because `list_by_project` eager-loads; `create`/`get`/`update`/`transition` (bare `_service().get()`) don't.

## What Changed
- `_relations_to_list` is now `async` and reads via `awaitable_attrs` (`item.awaitable_attrs.outgoing_relations`, `rel.awaitable_attrs.target`) — returns cached values when eager-loaded, awaits a load otherwise, so all three load paths serialize correctly with no duplicate query. `_item_to_dict` awaits it.
- Updated two existing tests that stubbed `_relations_to_list` (plain → `AsyncMock`).

## Verification
- New `llc/tests/test_work_item_relations_async.py` (2): unloaded-relationship path + empty (freshly-created) path.
- `test_work_item_requires_approval.py` + `test_work_item_ac_completion.py`: 13 pass.
- CEO-chat `create_task` path unaffected (minimal dict, no relations) — verified `MVT-5` created live.
- Post-merge: live re-verify `POST` → 201 and `GET /{id}` → 200.

## Model Used
Claude Opus 4.8