### PR TITLE
fix(llc/sprint): burndown stroke via CSS so var() resolves cross-browser (#9020)

### DIFF
--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -89,15 +89,16 @@
           <svg :viewBox="`0 0 ${CHART_W} ${CHART_H}`" class="burndown-svg">
             <!-- Ideal line -->
             <line
+              class="burndown-ideal-line"
               :x1="0" :y1="0"
               :x2="CHART_W" :y2="CHART_H"
-              stroke="var(--text-secondary)" stroke-width="1" stroke-dasharray="4 4"
+              stroke-width="1" stroke-dasharray="4 4"
             />
             <!-- Actual line -->
             <polyline
+              class="burndown-actual-line"
               :points="burndownPoints"
               fill="none"
-              stroke="var(--color-primary)"
               stroke-width="2"
               stroke-linejoin="round"
             />
@@ -543,6 +544,15 @@ onMounted(async () => {
 .burndown-svg {
   width: 100%;
   height: auto;
+}
+
+/* stroke via CSS (not SVG presentation attr) so var() resolves cross-browser incl. Safari */
+.burndown-ideal-line {
+  stroke: var(--text-secondary);
+}
+
+.burndown-actual-line {
+  stroke: var(--color-primary);
 }
 
 .burndown-legend {


### PR DESCRIPTION
## Thinking Path

Self-review of the just-merged #11698 found a cross-browser regression I introduced: the hex-tokenization changed two burndown-chart SVG **presentation attributes** from `stroke="#hex"` to `stroke="var(--token)"`. `var()` is resolved for CSS properties but **not reliably for SVG presentation attributes** (notably Safari), so the ideal/actual burndown lines could render with no stroke there. Those two strokes weren't even Stylelint-flagged (attributes, not CSS) — changing them was unnecessary risk.

## What Changed

- `SprintBoardView.vue`: moved the two burndown stroke colors off the SVG presentation attributes onto CSS classes (`.burndown-ideal-line`, `.burndown-actual-line`) with `stroke: var(--text-secondary|--color-primary)` in `<style>`, where `var()` is guaranteed to resolve in all browsers.
- Keeps the tokens (theme-adaptive), removes the Safari risk, no raw hex.

## Verification

- No `var()` remains in any SVG presentation attribute; strokes now set via CSS classes.
- No raw hex color values in the file.
- Purely a rendering-robustness fix; no logic change.
- No commit trailers (mrveiss sole author).

## Model Used

Claude Opus 4.8

Closes #9020, #11702


Relates to #11515