### PR TITLE
refactor(test): merge conftest real-load helpers + AST-derive services-stub list (#11661, #11575)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -63,6 +63,36 @@ def _make_pkg_stub(name: str) -> types.ModuleType:
     return mod
 
 
+def _real_load_and_bind(name: str, path: Path) -> None:
+    """Real-load module *name* from *path*, overwriting any stub, and ALWAYS
+    bind it as an attribute on its parent package module (#11661 — merged
+    ``_load_real_mod`` + ``_real_load_service``).
+
+    The parent bind is load-bearing (#11532/#11618): ``unittest.mock.patch``
+    resolves ``"pkg.mod.NAME"`` via ``getattr(sys.modules["pkg"], "mod")``.
+    When ``pkg`` is a MagicMock package stub, its catch-all ``__getattr__``
+    returns a mock singleton, so without the setattr patch() silently patches
+    the wrong object while the real module's globals stay untouched (inert
+    patch).  Falls back to a package stub if the real file can't be loaded in
+    this environment.
+    """
+    import importlib.util as _rlb_ilu
+
+    spec = _rlb_ilu.spec_from_file_location(name, str(path))
+    if not spec or not spec.loader:
+        return
+    mod = _rlb_ilu.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules[name] = _make_pkg_stub(name)
+        return
+    parent, _, child = name.rpartition(".")
+    if parent and parent in sys.modules:
+        setattr(sys.modules[parent], child, mod)
+
+
 # Stub chromadb before it is imported. chromadb hangs at import time on
 # machines without a local Chroma server (it fires gRPC keep-alive probes via
 # opentelemetry), AND the version of opentelemetry-exporter-otlp-proto-grpc in
@@ -196,26 +226,7 @@ for _svc_mod in [
 # the *real* pure helper (_strip_ansi). Load it real — overwriting the package stub
 # above — so those tests don't get a MagicMock. Other tests that patch this module
 # still work (patch targets a real module just as well).
-import importlib.util as _svc_ilu  # noqa: E402
-
-# Also bind on the parent package: `import services.tool_output_filter as mod`
-# resolves via getattr(services, "tool_output_filter"), not sys.modules directly,
-# so without this the package stub's catch-all __getattr__ returns a MagicMock.
-for _real_svc, _real_rel in [
-    ("services.tool_output_filter", "services/tool_output_filter.py"),
-]:
-    _rspec = _svc_ilu.spec_from_file_location(_real_svc, str(backend_root / _real_rel))
-    if _rspec and _rspec.loader:
-        _rmod = _svc_ilu.module_from_spec(_rspec)
-        sys.modules[_real_svc] = _rmod
-        try:
-            _rspec.loader.exec_module(_rmod)
-            _parent_name, _, _child_name = _real_svc.rpartition(".")
-            if _parent_name in sys.modules:
-                setattr(sys.modules[_parent_name], _child_name, _rmod)
-        except Exception:
-            # Fall back to the stub if the real module can't load in this env.
-            sys.modules[_real_svc] = _make_pkg_stub(_real_svc)
+_real_load_and_bind("services.tool_output_filter", backend_root / "services" / "tool_output_filter.py")
 
 # npu_pipeline — stub the package and its sub-modules so that the __init__.py
 # import chain (which pulls in Redis/config) doesn't break test collection.
@@ -326,47 +337,36 @@ if "llm_shared" not in sys.modules:
     # GH#8998: Register real fallback_chain and model_fallback_coordinator modules
     # so tests inside llm_shared/ can import them without the full heavy __init__.py chain.
     # Load in dependency order: types → models → optimization.rate_limiter → fallback_chain → coordinator.
-    import importlib.util as _ilu
-
+    # #11661: real-loads go through the canonical _real_load_and_bind helper so
+    # every loaded module is also bound on its parent package stub (patch()
+    # resolves via getattr(parent, child) — see the helper docstring).
     _llm_root = backend_root / "llm_shared"
 
-    def _load_real_mod(name: str, path: "Path") -> None:  # type: ignore[name-defined]
-        if name in sys.modules:
-            return
-        _spec = _ilu.spec_from_file_location(name, str(path))
-        if _spec and _spec.loader:
-            _mod = _ilu.module_from_spec(_spec)
-            sys.modules[name] = _mod
-            try:
-                _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
-            except Exception:
-                sys.modules.pop(name, None)
-
-    _load_real_mod("llm_shared.types", _llm_root / "types.py")
-    _load_real_mod("llm_shared.models", _llm_root / "models.py")
+    _real_load_and_bind("llm_shared.types", _llm_root / "types.py")
+    _real_load_and_bind("llm_shared.models", _llm_root / "models.py")
     # #11520: canonical JSON parser and schema-typed extraction helper — lightweight,
     # no heavy deps; load real so tests importing them don't hit the stub.
-    _load_real_mod("llm_shared.json_utils", _llm_root / "json_utils.py")
-    _load_real_mod("llm_shared.structured_ops", _llm_root / "structured_ops.py")
-    _load_real_mod("llm_shared.optimization.rate_limiter", _llm_root / "optimization" / "rate_limiter.py")
-    _load_real_mod("llm_shared.fallback_chain", _llm_root / "fallback_chain.py")
+    _real_load_and_bind("llm_shared.json_utils", _llm_root / "json_utils.py")
+    _real_load_and_bind("llm_shared.structured_ops", _llm_root / "structured_ops.py")
+    _real_load_and_bind("llm_shared.optimization.rate_limiter", _llm_root / "optimization" / "rate_limiter.py")
+    _real_load_and_bind("llm_shared.fallback_chain", _llm_root / "fallback_chain.py")
     # #11519: provider degradation store — load real BEFORE model_fallback_coordinator
     # and provider_registry which import it at module level.
-    _load_real_mod("llm_shared.provider_degradation", _llm_root / "provider_degradation.py")
-    _load_real_mod("llm_shared.model_fallback_coordinator", _llm_root / "model_fallback_coordinator.py")
+    _real_load_and_bind("llm_shared.provider_degradation", _llm_root / "provider_degradation.py")
+    _real_load_and_bind("llm_shared.model_fallback_coordinator", _llm_root / "model_fallback_coordinator.py")
     # #9017: reasoning_effort utility is imported by chat_workflow.manager at module level;
     # load the real file so tests that import manager don't hit the providers MagicMock stub.
-    _load_real_mod(
+    _real_load_and_bind(
         "llm_shared.providers.reasoning_effort",
         _llm_root / "providers" / "reasoning_effort.py",
     )
     # #9037: per-run credential primitives (ContextVar + RunCredentialContext) live
     # in the lightweight run_credentials module; load it real so tests importing
     # them don't hit the llm_shared MagicMock stub.
-    _load_real_mod("llm_shared.run_credentials", _llm_root / "run_credentials.py")
+    _real_load_and_bind("llm_shared.run_credentials", _llm_root / "run_credentials.py")
     # #10551: provider auth abstraction — load real so tests can import the
     # strategy classes without hitting the llm_shared MagicMock stub.
-    _load_real_mod("llm_shared.provider_auth", _llm_root / "provider_auth.py")
+    _real_load_and_bind("llm_shared.provider_auth", _llm_root / "provider_auth.py")
     # #10551: base_provider — load real so BaseProvider tests can instantiate it.
     # #10917: base_provider's real load (added in #10551) silently failed because
     # the llm_shared stub has an empty __path__, so its relative imports
@@ -375,12 +375,12 @@ if "llm_shared" not in sys.modules:
     # order — all bare-env-importable (observability guards its langfuse/langsmith
     # SDK imports inside methods and does not import otel_observer at top level) —
     # so base_provider (and then provider_registry) load real.
-    _load_real_mod("llm_shared.cross_worker_rate_limiter", _llm_root / "cross_worker_rate_limiter.py")
-    _load_real_mod("llm_shared.observability", _llm_root / "observability" / "__init__.py")
-    _load_real_mod("llm_shared.rate_limit_backoff", _llm_root / "rate_limit_backoff.py")
-    _load_real_mod("llm_shared.base_provider", _llm_root / "base_provider.py")
-    _load_real_mod("llm_shared.model_param_registry", _llm_root / "model_param_registry.py")
-    _load_real_mod("llm_shared.provider_registry", _llm_root / "provider_registry.py")
+    _real_load_and_bind("llm_shared.cross_worker_rate_limiter", _llm_root / "cross_worker_rate_limiter.py")
+    _real_load_and_bind("llm_shared.observability", _llm_root / "observability" / "__init__.py")
+    _real_load_and_bind("llm_shared.rate_limit_backoff", _llm_root / "rate_limit_backoff.py")
+    _real_load_and_bind("llm_shared.base_provider", _llm_root / "base_provider.py")
+    _real_load_and_bind("llm_shared.model_param_registry", _llm_root / "model_param_registry.py")
+    _real_load_and_bind("llm_shared.provider_registry", _llm_root / "provider_registry.py")
     # Re-export the real classes onto the top-level stub so
     # `from llm_shared import ProviderRegistry, BaseProvider` resolves to the real
     # ones for tests that exercise them (tests/test_provider_registry.py, #10917).
@@ -404,13 +404,12 @@ if "llm_shared" not in sys.modules:
     # test_hardware.py targets the real module globals instead of the MagicMock
     # package stub.  Deps: autobot_shared.logging_manager (already patched) and
     # llm_shared.optimization.model_inspector (stubbed just above).
-    _load_real_mod("llm_shared.hardware", _llm_root / "hardware.py")
+    _real_load_and_bind("llm_shared.hardware", _llm_root / "hardware.py")
     _hw_mod = sys.modules.get("llm_shared.hardware")
     if _hw_mod is not None:
-        # Bind on parent stub so patch("llm_shared.hardware.X") resolves via
-        # getattr(sys.modules["llm_shared"], "hardware") rather than the stub's
-        # catch-all __getattr__ which always returns the same MagicMock.
-        setattr(_llm_stub, "hardware", _hw_mod)
+        # Parent bind (so patch("llm_shared.hardware.X") targets the real
+        # module) now happens inside _real_load_and_bind (#11661); only the
+        # top-level re-exports remain here.
         if hasattr(_hw_mod, "HardwareDetector"):
             _llm_stub.HardwareDetector = _hw_mod.HardwareDetector  # type: ignore[attr-defined]
         if hasattr(_hw_mod, "TORCH_AVAILABLE"):
@@ -754,17 +753,12 @@ if "sqlalchemy.orm" in sys.modules:
 # models/__init__.py itself (if forced by other test files) has sqlalchemy stubs
 # already in place.
 if "models" not in sys.modules:
-    _infra_path = str(backend_root / "models" / "infrastructure.py")
-    _spec = _ilu.spec_from_file_location("models.infrastructure", _infra_path)
-    if _spec and _spec.loader:
-        # Create a lightweight 'models' namespace package to hold the sub-module
-        _models_pkg = _make_pkg_stub("models")
-        _models_pkg.__path__ = [str(backend_root / "models")]
-        _infra_mod = _ilu.module_from_spec(_spec)
-        _infra_mod.__package__ = "models"
-        sys.modules["models.infrastructure"] = _infra_mod
-        _spec.loader.exec_module(_infra_mod)  # type: ignore[union-attr]
-        setattr(_models_pkg, "infrastructure", _infra_mod)
+    # Create a lightweight 'models' namespace package to hold the sub-module,
+    # then real-load infrastructure.py onto it (#11661: canonical helper; it
+    # also performs the parent bind this block previously did by hand).
+    _models_pkg = _make_pkg_stub("models")
+    _models_pkg.__path__ = [str(backend_root / "models")]
+    _real_load_and_bind("models.infrastructure", backend_root / "models" / "infrastructure.py")
 
 
 # -- Requirements.txt enforcement (Issue #5032 / #5044) --------------------
@@ -877,37 +871,6 @@ def set_test_environment():
     os.environ.update(original_env)
 
 
-def _real_load_service(name: str, rel_path: str) -> None:  # noqa: ANN001
-    """Real-load a services.* module by path, overwriting any existing stub.
-
-    Must be called from pytest_configure (after all module-level stubs are in
-    place but before collection imports test modules).  Falls back to the
-    existing stub silently if the real file can't be loaded in this env.
-
-    #11532 note: after inserting the real module into sys.modules we ALSO bind
-    it as an attribute on the parent package stub.  ``unittest.mock.patch``
-    resolves ``"services.foo.BAR"`` by calling ``__import__("services.foo")``
-    then ``getattr(services, "foo")``.  Without the setattr the parent stub's
-    ``__getattr__`` always returns a MagicMock singleton, so patch silently
-    patches the wrong object and the real module's globals are never updated.
-    """
-    import importlib.util as _rl_ilu
-
-    _spec = _rl_ilu.spec_from_file_location(name, str(backend_root / rel_path))
-    if _spec and _spec.loader:
-        _mod = _rl_ilu.module_from_spec(_spec)
-        sys.modules[name] = _mod
-        try:
-            _spec.loader.exec_module(_mod)
-        except Exception:
-            sys.modules[name] = _make_pkg_stub(name)
-            return
-        # Bind on parent so patch() resolves via getattr(parent, child_name).
-        _parent, _, _child = name.rpartition(".")
-        if _parent and _parent in sys.modules:
-            setattr(sys.modules[_parent], _child, sys.modules[name])
-
-
 def pytest_configure(config):  # noqa: ANN001
     """#11248/#11532: real-load lightweight service modules whose unit tests need the
     real helpers, AFTER every module-level stub above is in place.
@@ -926,5 +889,5 @@ def pytest_configure(config):  # noqa: ANN001
     Real-loading here ensures ``sys.modules["services.llm_cost_tracker"]`` is the
     same object as ``_check_pricing_staleness.__globals__`` so patch() is effective.
     """
-    _real_load_service("services.llm_api_key_service", "services/llm_api_key_service.py")
-    _real_load_service("services.llm_cost_tracker", "services/llm_cost_tracker.py")
+    _real_load_and_bind("services.llm_api_key_service", backend_root / "services" / "llm_api_key_service.py")
+    _real_load_and_bind("services.llm_cost_tracker", backend_root / "services" / "llm_cost_tracker.py")

--- a/autobot-backend/llm_shared/model_fallback_coordinator_test.py
+++ b/autobot-backend/llm_shared/model_fallback_coordinator_test.py
@@ -132,6 +132,17 @@ async def test_multiple_fallback_hops():
     )
 
     mgr = _chain_manager_with("claude-opus-4", ["claude-sonnet-4", "claude-haiku-4"])
+    # FallbackChainManager.get_next_fallback looks chains up by primary model
+    # only, so each hop model needs its own chain — exactly how the production
+    # defaults in _load_default_chains achieve multi-hop.  (Before #11661 the
+    # patch below was inert — no parent bind, so it patched the llm_shared
+    # MagicMock stub — and this test silently ran against those real defaults.)
+    mgr._chains["claude-sonnet-4"] = FallbackChain(
+        primary_model="claude-sonnet-4",
+        fallback_models=["claude-haiku-4"],
+        primary_provider="anthropic",
+        fallback_providers=["anthropic"],
+    )
 
     with patch("llm_shared.model_fallback_coordinator.get_fallback_chain_manager", return_value=mgr):
         result = await coordinator.execute_with_fallback(_make_request("claude-opus-4"), registry, max_attempts=3)

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 # Module reference for patch.object.  The llm_shared stub package loads provider_auth
-# via _load_real_mod into sys.modules["llm_shared.provider_auth"].  We must patch on
+# via _real_load_and_bind into sys.modules["llm_shared.provider_auth"].  We must patch on
 # the exact module object that OAuthAuth.__globals__ points to — which is the module
 # where OAuthAuth was defined (its __globals__["__name__"] == "llm_shared.provider_auth").
 # Obtain it via the class's function globals to guarantee identity.
@@ -41,7 +41,7 @@ from llm_shared.provider_auth import (
 )
 
 # Use the class's actual globals dict as the authoritative module reference.
-# This handles the case where _load_real_mod creates a fresh module object that
+# This handles the case where _real_load_and_bind creates a fresh module object that
 # patch.object must target to replace the function seen by OAuthAuth.resolve_token.
 _PA_GLOBALS = OAuthAuth.resolve_token.__globals__  # type: ignore[attr-defined]
 import sys as _sys

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -23,6 +23,7 @@ needed for modules that those test files import directly.
 Issue: #3499
 """
 
+import ast
 import sys
 import types
 from pathlib import Path
@@ -103,28 +104,46 @@ for _m in [
     _stub(_m)
 
 # ── services ──────────────────────────────────────────────────────────────────
-for _m in [
-    "services",
-    "services.auth",
-    "services.database",
+# The services.* modules api/code_sync.py imports are AST-derived from its
+# source (#11575) — a hand-maintained list rots the moment code_sync gains a
+# new `from services.X import ...` (exactly how #11481 broke, and the same
+# anti-pattern behind the #11461 schema-list rot).  Pattern mirrors the
+# schema-name derivation in tests/api/test_collect_outdated_node_ids.py.
+_code_sync_ast = ast.parse((Path(__file__).parent / "api" / "code_sync.py").read_text(encoding="utf-8"))
+_CODE_SYNC_SERVICE_MODULES = frozenset(
+    {
+        _node.module
+        for _node in ast.walk(_code_sync_ast)
+        if isinstance(_node, ast.ImportFrom) and _node.module and _node.module.startswith("services.")
+    }
+    | {
+        _alias.name
+        for _node in ast.walk(_code_sync_ast)
+        if isinstance(_node, ast.Import)
+        for _alias in _node.names
+        if _alias.name.startswith("services.")
+    }
+)
+del _code_sync_ast
+
+# services.* modules NOT imported by code_sync.py but stubbed for other api/*
+# modules under test.  These have their own consumers and are not exposed to
+# the code_sync rot source above.
+_EXTRA_SERVICE_MODULES = (
     "services.blue_green",
-    "services.code_distributor",
-    "services.deploy_artifacts",
     "services.deployment",
-    "services.drift_checker",
     "services.encryption",
-    "services.fleet_sync_guard",
-    "services.git_tracker",
-    "services.playbook_executor",
     "services.reconciler",
     "services.replication",
     "services.role_registry",
     "services.service_categorizer",
     "services.service_orchestrator",
-    "services.sync_orchestrator",
     "services.tls_credentials",
     "services.vnc_credentials",
-]:
+)
+
+# Parent package first so each child stub binds onto it (see _stub docstring).
+for _m in ("services", *sorted(_CODE_SYNC_SERVICE_MODULES | set(_EXTRA_SERVICE_MODULES))):
     _stub(_m)
 
 # ── python-multipart ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #11661, #11575

## Thinking Path

Two conftest rot sources, one PR (same area/scope): the backend conftest carried two near-identical real-load helpers (`_load_real_mod` bound to parent package, `_real_load_service` didn't — the asymmetry behind #11618-style manual `setattr` patches), and the SLM conftest hand-maintained a 19-entry services-stub list that rotted every time `api/code_sync.py` gained an import (#11461/#11481).

## What Changed

- `autobot-backend/conftest.py`: one canonical `_real_load_and_bind(name, path)` — spec-load → overwrite `sys.modules` → exec (stub-fallback on failure) → **always** parent-bind. 22 call sites migrated (18 `_load_real_mod`, 2 `_real_load_service`, 2 inline duplicate loaders); both old helpers deleted; the #11618 manual `setattr(_llm_stub, "hardware", …)` removed (now automatic).
- `autobot-slm-backend/conftest.py`: services-stub list = AST-derived modules from `api/code_sync.py` imports (incl. function-level) ∪ explicit extras needed by other api tests. Union verified empirically equal to the previous hand-list.
- `llm_shared/model_fallback_coordinator_test.py`: `test_multiple_fallback_hops` was green-by-accident — its patch was inert on base (no parent bind → patched the stub) and ran against production chains. With the patch now effective it needed per-hop chain registration, mirroring `_load_default_chains`.
- `llm_shared/tests/test_provider_auth.py`: stale comment refs to the deleted helper names.

## Verification

- SLM canary `tests/api/test_collect_outdated_node_ids.py`: 7/7 passed (same count #11481 verified).
- Full-repo `--collect-only`: 0 new collection errors vs base; 6 files that collection-errored on base now collect and pass (61 passed).
- Representative combined run (llm_shared + tests/services + tests/llm_interface_pkg + SLM tests/api): failure sets byte-identical to base (164 pre-existing local-env failures both sides; 432+78 passed).
- Independent re-run by main session: canary 7 passed, `model_fallback_coordinator_test.py` 8 passed.
- flake8 + black clean on all 4 changed files.

Discovery issues filed separately: third near-identical loader `_load_llm_sub`, `npu_profile_suggester` inline load missing parent bind, unreachable mid-chain branch in `FallbackChain.get_next_fallback`.

## Model Used

Claude Fable 5 (subagent: general-purpose)