### PR TITLE
refactor(celery): derive CELERY_TRANSIENT_ERRORS from retry_mechanism canonical sets (#11689)

### DIFF
--- a/autobot-backend/tests/integration/test_celery_reliability.py
+++ b/autobot-backend/tests/integration/test_celery_reliability.py
@@ -155,6 +155,19 @@ def test_redis_unavailable_fails_open(monkeypatch, eager_app):
 # ---------------------------------------------------------------------------
 
 
+def test_transient_errors_match_canonical_retryable_set():
+    """CELERY_TRANSIENT_ERRORS must stay identical to the canonical set (#11689)."""
+    from autobot_shared.retry_mechanism import RETRYABLE_EXCEPTIONS, RetryConfig
+
+    assert CELERY_TRANSIENT_ERRORS == RETRYABLE_EXCEPTIONS
+    # Every celery-transient error must be retryable (and not non-retryable)
+    # under the canonical RetryConfig split.
+    config = RetryConfig()
+    for exc_type in CELERY_TRANSIENT_ERRORS:
+        assert issubclass(exc_type, config.retryable_exceptions)
+        assert not issubclass(exc_type, config.non_retryable_exceptions)
+
+
 def test_transient_error_engages_retry(fake_sync_redis, eager_app):
     """ConnectionError must be converted into a Celery retry, not a failure."""
 

--- a/autobot-backend/utils/celery_reliability.py
+++ b/autobot-backend/utils/celery_reliability.py
@@ -15,10 +15,10 @@ non-retryable error) in a bounded Redis list so failures stay queryable via
 ``GET /api/health/celery-dead-letter`` instead of vanishing when the Celery
 result TTL expires.
 
-``CELERY_TRANSIENT_ERRORS`` mirrors the canonical retryable vs non-retryable
-exception split in ``autobot_shared/retry_mechanism.py`` (#7010):
-ConnectionError/TimeoutError/OSError back off with jitter; validation errors
-(ValueError/TypeError) fail fast and are never retried.
+``CELERY_TRANSIENT_ERRORS`` derives from the canonical
+``RETRYABLE_EXCEPTIONS`` in ``autobot_shared/retry_mechanism.py``
+(#7010, #11689): ConnectionError/TimeoutError/OSError back off with jitter;
+validation errors (ValueError/TypeError) fail fast and are never retried.
 """
 
 import json
@@ -30,15 +30,17 @@ from typing import Any, Callable, Dict
 from celery import Task
 
 from autobot_shared.redis_client import get_async_redis_client, get_redis_client
+from autobot_shared.retry_mechanism import RETRYABLE_EXCEPTIONS
 from autobot_shared.ssot_config import config
 from autobot_shared.status_enums import TaskStatus
 
 logger = logging.getLogger(__name__)
 
-# Transient errors that trigger Celery autoretry — the retryable set from
-# autobot_shared/retry_mechanism.py (#7010). ValueError/TypeError are
-# intentionally absent so validation failures fail fast without retry.
-CELERY_TRANSIENT_ERRORS = (ConnectionError, TimeoutError, OSError)
+# Transient errors that trigger Celery autoretry — derived from the canonical
+# retryable set in autobot_shared/retry_mechanism.py (#7010, #11689).
+# ValueError/TypeError are intentionally absent so validation failures fail
+# fast without retry.
+CELERY_TRANSIENT_ERRORS = RETRYABLE_EXCEPTIONS
 
 DEDUP_KEY_PREFIX = "celery:dedup:"
 DEAD_LETTER_KEY = "celery:dead_letter"

--- a/autobot_shared/retry_mechanism.py
+++ b/autobot_shared/retry_mechanism.py
@@ -55,6 +55,17 @@ class BackoffStrategy(Enum):
         return mapping[self]
 
 
+# Canonical transient (retryable) exception set (#11689). Single source of
+# truth for "which concrete exceptions are transient": Celery derives
+# CELERY_TRANSIENT_ERRORS from this tuple, and RetryConfig builds its
+# retryable default from it, so the split can never silently drift.
+RETRYABLE_EXCEPTIONS: tuple = (
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+
+
 @dataclass
 class RetryConfig:
     """Configuration for retry mechanism (Issue #376 - use named constants)"""
@@ -66,11 +77,10 @@ class RetryConfig:
     jitter: bool = True
     strategy: RetryStrategy = RetryStrategy.EXPONENTIAL_BACKOFF
 
-    # Exceptions that should trigger a retry
-    retryable_exceptions: tuple = (
-        ConnectionError,
-        TimeoutError,
-        OSError,
+    # Exceptions that should trigger a retry — the canonical transient set
+    # plus a catch-all (non_retryable_exceptions takes precedence in
+    # is_retryable_exception, so the catch-all never retries validation errors).
+    retryable_exceptions: tuple = RETRYABLE_EXCEPTIONS + (
         # Add database-specific exceptions
         Exception,  # Temporary - should be more specific
     )


### PR DESCRIPTION
Closes #11689

## Thinking Path

`CELERY_TRANSIENT_ERRORS` hand-duplicated the transient-exception list that `autobot_shared/retry_mechanism` already owns. Direct reuse of `RetryConfig.retryable_exceptions` was NOT safe: that tuple carries a catch-all `Exception` (marked "Temporary"), and Celery's `autoretry_for` has no non-retryable exclusion — importing it wholesale would have made `ValueError`/`TypeError` retryable. So the canonical truly-transient set gets its own exported name and both consumers derive from it.

## What Changed

- `autobot_shared/retry_mechanism.py`: new canonical `RETRYABLE_EXCEPTIONS = (ConnectionError, TimeoutError, OSError)`; `RetryConfig.retryable_exceptions` default now derives as `RETRYABLE_EXCEPTIONS + (Exception,)` (value unchanged).
- `autobot-backend/utils/celery_reliability.py`: `CELERY_TRANSIENT_ERRORS = RETRYABLE_EXCEPTIONS` (value unchanged, duplication gone).
- `tests/integration/test_celery_reliability.py`: new `test_transient_errors_match_canonical_retryable_set` locking the derivation.

## Verification

- `test_celery_reliability.py` + `system_tasks_reliability_test.py`: 16 passed (agent) / 16 passed (independent re-run by main session).
- `retry_mechanism_test.py`: 27 passed (covers the RetryConfig default change).
- Runtime import check: `CELERY_TRANSIENT_ERRORS == RETRYABLE_EXCEPTIONS == (ConnectionError, TimeoutError, OSError)` — byte-identical before/after (BEHAVIOR_DELTA: none).
- `py_compile` clean on all changed files.

## Model Used

Claude Fable 5 (subagent: general-purpose)