### PR TITLE
refactor(llm): consolidate json_formatter_agent repair cascade onto llm_shared/json_utils tiers (#11688)

### DIFF
--- a/autobot-backend/agents/json_formatter_agent.py
+++ b/autobot-backend/agents/json_formatter_agent.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import StringParsingConstants
+from llm_shared.json_utils import extract_json_object
 
 from .base_agent import AgentRequest
 from .standardized_agent import ActionHandler, StandardizedAgent
@@ -150,6 +151,38 @@ class JSONFormatterAgent(StandardizedAgent):
             logger.debug("Direct JSON parse failed, trying extraction: %s", e)
         return None
 
+    def _try_canonical_extraction(self, response: str) -> JSONParseResult | None:
+        """
+        Run the canonical llm_shared.json_utils repair cascade (#11688).
+
+        Covers markdown fence stripping (#10672), control-character escaping
+        (#11587), and common syntax repair — trailing commas, bare keys,
+        single-quote swap (#11688, promoted from this agent).
+
+        Args:
+            response: Raw LLM response text
+
+        Returns:
+            JSONParseResult if the canonical tiers produced a dict, None otherwise.
+        """
+        try:
+            parsed = extract_json_object(response)
+        except json.JSONDecodeError as e:
+            logger.debug("Canonical extraction failed, trying agent strategies: %s", e)
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        with self._stats_lock:
+            self.successful_parses += 1
+        return JSONParseResult(
+            success=True,
+            data=parsed,
+            original_text=response,
+            method_used="canonical_extraction",
+            confidence=0.9,
+            warnings=[],
+        )
+
     def parse_llm_response(self, response: str, expected_schema: Dict[str, Any] | None = None) -> JSONParseResult:
         """
         Parse JSON from an LLM response using multiple strategies.
@@ -172,22 +205,28 @@ class JSONFormatterAgent(StandardizedAgent):
         if direct_result:
             return direct_result
 
-        # Strategy 2: Extract JSON from mixed content
+        # Strategy 2: Canonical shared tiers — fence strip, control-char
+        # escape, syntax repair (llm_shared.json_utils, #11688)
+        canonical_result = self._try_canonical_extraction(response)
+        if canonical_result:
+            return canonical_result
+
+        # Strategy 3: Extract JSON from mixed content
         json_result = self._extract_json_from_text(response)
         if json_result.success:
             return json_result
 
-        # Strategy 3: Fix common JSON errors
+        # Strategy 4: Boundary-slice + agent cleanup patterns, then canonical repair
         fixed_result = self._fix_malformed_json(response)
         if fixed_result.success:
             return fixed_result
 
-        # Strategy 4: Pattern-based reconstruction
+        # Strategy 5: Pattern-based reconstruction
         reconstructed_result = self._reconstruct_from_patterns(response, expected_schema)
         if reconstructed_result.success:
             return reconstructed_result
 
-        # Strategy 5: Last resort - create minimal valid JSON
+        # Strategy 6: Last resort - create minimal valid JSON
         return self._create_fallback_json(response, expected_schema)
 
     def _try_parse_json_match(self, match: str) -> Dict[str, Any] | None:
@@ -243,57 +282,14 @@ class JSONFormatterAgent(StandardizedAgent):
             warnings=["No valid JSON found in text"],
         )
 
-    def _apply_json_fixes(self, json_content: str, warnings: List[str]) -> tuple:
-        """Apply common JSON syntax fixes and return fixed content with fixes list (Issue #665: extracted helper)."""
-        fixes_applied = []
-
-        # Fix trailing commas
-        if re.search(r",\s*}", json_content):
-            json_content = re.sub(r",\s*}", "}", json_content)
-            fixes_applied.append("removed_trailing_commas")
-
-        # Fix missing quotes on keys
-        json_content = re.sub(r"(\w+):", r'"\1":', json_content)
-        if '"' in json_content:
-            fixes_applied.append("added_missing_quotes")
-
-        # Fix single quotes to double quotes
-        if "'" in json_content:
-            json_content = json_content.replace("'", '"')
-            fixes_applied.append("converted_single_quotes")
-
-        return json_content, fixes_applied
-
-    def _try_parse_fixed_json(
-        self,
-        json_content: str,
-        text: str,
-        fixes_applied: List[str],
-        warnings: List[str],
-    ) -> JSONParseResult | None:
-        """Attempt to parse fixed JSON and return result if successful (Issue #665: extracted helper)."""
-        try:
-            parsed = json.loads(json_content)
-            if isinstance(parsed, dict):
-                with self._stats_lock:
-                    self.successful_parses += 1
-                confidence = 0.8 - (len(fixes_applied) * 0.1)
-                warnings.extend([f"Applied fix: {fix}" for fix in fixes_applied])
-
-                return JSONParseResult(
-                    success=True,
-                    data=parsed,
-                    original_text=text,
-                    method_used="malformed_json_fix",
-                    confidence=max(confidence, 0.3),
-                    warnings=warnings,
-                )
-        except json.JSONDecodeError as e:
-            warnings.append(f"JSON fix failed: {e}")
-        return None
-
     def _fix_malformed_json(self, text: str) -> JSONParseResult:
-        """Attempt to fix common JSON formatting errors"""
+        """Attempt to fix common JSON formatting errors.
+
+        Boundary-slices the outermost ``{...}`` from surrounding prose and
+        applies agent-specific empty-key cleanup patterns, then delegates
+        syntax repair (trailing commas, bare keys, single quotes, control
+        chars) to the canonical llm_shared.json_utils cascade (#11688).
+        """
         warnings = []
         fixed_text = text.strip()
 
@@ -321,13 +317,25 @@ class JSONFormatterAgent(StandardizedAgent):
             if old_content != json_content:
                 warnings.append(f"Applied cleanup pattern: {pattern}")
 
-        # Apply common fixes
-        json_content, fixes_applied = self._apply_json_fixes(json_content, warnings)
+        # Delegate syntax repair to the canonical cascade (#11688)
+        try:
+            parsed = extract_json_object(json_content)
+        except json.JSONDecodeError as e:
+            warnings.append(f"JSON fix failed: {e}")
+            parsed = None
 
-        # Try parsing the fixed JSON
-        result = self._try_parse_fixed_json(json_content, text, fixes_applied, warnings)
-        if result:
-            return result
+        if isinstance(parsed, dict):
+            with self._stats_lock:
+                self.successful_parses += 1
+            warnings.append("Applied fix: canonical_syntax_repair")
+            return JSONParseResult(
+                success=True,
+                data=parsed,
+                original_text=text,
+                method_used="malformed_json_fix",
+                confidence=0.7,
+                warnings=warnings,
+            )
 
         return JSONParseResult(
             success=False,

--- a/autobot-backend/llm_shared/json_utils.py
+++ b/autobot-backend/llm_shared/json_utils.py
@@ -12,12 +12,19 @@ judges/__init__.py now imports from here instead of defining its own copy.
 
 import json
 import logging
+import re
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
 #: Short JSON escapes for the most common raw control characters (#11587).
 _CONTROL_ESCAPES = {"\n": "\\n", "\t": "\\t", "\r": "\\r"}
+
+#: Trailing comma immediately before a closing brace/bracket (#11688).
+_TRAILING_COMMA_RE = re.compile(r",\s*(?=[}\]])")
+
+#: Bare (unquoted) object key following '{' or ',' (#11688).
+_BARE_KEY_RE = re.compile(r"([{,]\s*)([A-Za-z_]\w*)(\s*:)")
 
 
 def _escape_controls_in_strings(text: str) -> str:
@@ -46,13 +53,33 @@ def _escape_controls_in_strings(text: str) -> str:
     return "".join(out)
 
 
+def repair_json_syntax(text: str) -> str:
+    """Repair common LLM JSON syntax errors (#11688).
+
+    Promoted from agents/json_formatter_agent.py so every extract_json_object()
+    caller (structured_ops, judges, the formatter agent) shares one repair
+    cascade: strips trailing commas before a closing brace/bracket and
+    double-quotes bare object keys. Purely textual — the caller still gates the
+    result through json.loads(), so a repair that is wrong for a given input
+    fails the parse exactly as the unrepaired text would have.
+    """
+    repaired = _TRAILING_COMMA_RE.sub("", text)
+    return _BARE_KEY_RE.sub(r'\1"\2"\3', repaired)
+
+
 def extract_json_object(raw_text: str) -> Dict[str, Any]:
     """Parse a JSON object from an LLM response, tolerating markdown code fences (#10672).
 
     structured_output=True makes supporting providers emit valid JSON; providers
     that ignore it may still wrap the object in a ```json fence, so strip that
-    before parsing. As a final repair tier (#11587), raw control characters
-    inside string literals are escaped before one last parse attempt.
+    before parsing. Repair tiers, each gated by a real parse attempt:
+
+    1. Direct ``json.loads``.
+    2. Markdown fence strip (#10672).
+    3. Raw control characters inside string literals escaped (#11587).
+    4. Common syntax repair — trailing commas, bare keys, then a last-resort
+       single→double quote swap for python-repr style objects (#11688).
+
     Raises json.JSONDecodeError on genuinely unparseable text.
 
     Args:
@@ -77,4 +104,20 @@ def extract_json_object(raw_text: str) -> Dict[str, Any]:
                 return json.loads(candidate)
             except json.JSONDecodeError:
                 pass
-        return json.loads(_escape_controls_in_strings(candidate))
+        candidate = _escape_controls_in_strings(candidate)
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+        # Progressive repairs, safest first: the bare-key regex can touch
+        # colon-bearing string values, so only apply it when the
+        # trailing-comma fix alone was not enough.
+        repaired = _TRAILING_COMMA_RE.sub("", candidate)
+        try:
+            return json.loads(repaired)
+        except json.JSONDecodeError:
+            pass
+        try:
+            return json.loads(_BARE_KEY_RE.sub(r'\1"\2"\3', repaired))
+        except json.JSONDecodeError:
+            return json.loads(repair_json_syntax(candidate.replace("'", '"')))

--- a/autobot-backend/llm_shared/structured_ops_test.py
+++ b/autobot-backend/llm_shared/structured_ops_test.py
@@ -159,6 +159,70 @@ def test_extract_json_escaped_quote_inside_string() -> None:
 
 
 # ---------------------------------------------------------------------------
+# json_utils syntax-repair tier (#11688) — promoted from json_formatter_agent
+# ---------------------------------------------------------------------------
+
+
+def test_extract_json_trailing_commas() -> None:
+    from .json_utils import extract_json_object
+
+    raw = '{"a": 1, "b": [1, 2,],}'
+    assert extract_json_object(raw) == {"a": 1, "b": [1, 2]}
+
+
+def test_extract_json_bare_keys() -> None:
+    from .json_utils import extract_json_object
+
+    raw = '{status: "ok",\n  count: 3}'
+    assert extract_json_object(raw) == {"status": "ok", "count": 3}
+
+
+def test_extract_json_single_quotes() -> None:
+    from .json_utils import extract_json_object
+
+    raw = "{'a': 'b', 'n': 1}"
+    assert extract_json_object(raw) == {"a": "b", "n": 1}
+
+
+def test_extract_json_fence_plus_syntax_errors() -> None:
+    from .json_utils import extract_json_object
+
+    raw = '```json\n{result: "done",}\n```'
+    assert extract_json_object(raw) == {"result": "done"}
+
+
+def test_extract_json_syntax_repair_plus_control_chars() -> None:
+    from .json_utils import extract_json_object
+
+    raw = '{note: "line1\nline2",}'
+    assert extract_json_object(raw) == {"note": "line1\nline2"}
+
+
+def test_extract_json_repair_does_not_mangle_string_values() -> None:
+    from .json_utils import extract_json_object
+
+    # Colons/commas inside string values must survive the bare-key repair;
+    # only reached when the direct parse fails (trailing comma forces repair).
+    raw = '{"url": "http://x/y", "csv": "a, b: c",}'
+    assert extract_json_object(raw) == {"url": "http://x/y", "csv": "a, b: c"}
+
+
+def test_extract_json_syntax_tier_still_raises_on_garbage() -> None:
+    from .json_utils import extract_json_object
+
+    with pytest.raises(json.JSONDecodeError):
+        extract_json_object("still {not json")
+
+
+def test_repair_json_syntax_is_textual_only() -> None:
+    from .json_utils import repair_json_syntax
+
+    assert repair_json_syntax('{"a": 1,}') == '{"a": 1}'
+    assert repair_json_syntax('{key: "v"}') == '{"key": "v"}'
+    assert repair_json_syntax("no json here") == "no json here"
+
+
+# ---------------------------------------------------------------------------
 # structured_ops.extract — dict schema path
 # ---------------------------------------------------------------------------
 

--- a/autobot-backend/tests/agents/test_json_formatter_agent.py
+++ b/autobot-backend/tests/agents/test_json_formatter_agent.py
@@ -1,0 +1,147 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Parity tests for JSONFormatterAgent after consolidation onto the canonical
+llm_shared.json_utils repair cascade (#11688).
+
+The agent's duplicated repair steps (trailing commas, missing key quotes,
+single-quote swap) were promoted into llm_shared.json_utils; these tests prove
+the agent's public contract still succeeds on the representative malformed
+inputs the old in-agent cascade handled, plus the #11587 control-char tier it
+previously lacked.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-populate sys.modules with a hollow 'agents' package so that the module's
+# relative imports work without executing agents/__init__.py (which pulls in
+# llama_index and other unavailable libs). Same pattern as
+# tests/agents/test_memory_hooks.py.
+# ---------------------------------------------------------------------------
+_AGENTS_DIR = Path(__file__).resolve().parents[2] / "agents"
+
+if "agents" not in sys.modules:
+    _agents_pkg = types.ModuleType("agents")
+    _agents_pkg.__path__ = [str(_AGENTS_DIR)]  # type: ignore[assignment]
+    _agents_pkg.__package__ = "agents"
+    sys.modules["agents"] = _agents_pkg
+
+from agents.json_formatter_agent import JSONFormatterAgent  # noqa: E402
+
+
+@pytest.fixture()
+def agent() -> JSONFormatterAgent:
+    return JSONFormatterAgent()
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — direct parse (unchanged contract)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_json_direct_parse(agent: JSONFormatterAgent) -> None:
+    result = agent.parse_llm_response('{"a": 1, "b": "x"}')
+    assert result.success is True
+    assert result.data == {"a": 1, "b": "x"}
+    assert result.method_used == "direct_parse"
+    assert result.confidence == 1.0
+
+
+def test_empty_input(agent: JSONFormatterAgent) -> None:
+    result = agent.parse_llm_response("   ")
+    assert result.success is False
+    assert result.method_used == "empty_input"
+    assert result.data == {}
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — canonical llm_shared.json_utils cascade (#11688)
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_fenced_json(agent: JSONFormatterAgent) -> None:
+    result = agent.parse_llm_response('```json\n{"a": 1}\n```')
+    assert result.success is True
+    assert result.data == {"a": 1}
+    assert result.method_used == "canonical_extraction"
+
+
+def test_raw_control_chars_in_strings(agent: JSONFormatterAgent) -> None:
+    # #11587 tier the formatter agent previously lacked.
+    result = agent.parse_llm_response('{"summary": "line one\nline two"}')
+    assert result.success is True
+    assert result.data == {"summary": "line one\nline two"}
+    assert result.method_used == "canonical_extraction"
+
+
+def test_trailing_commas(agent: JSONFormatterAgent) -> None:
+    result = agent.parse_llm_response('{"a": 1, "b": [1, 2,],}')
+    assert result.success is True
+    assert result.data == {"a": 1, "b": [1, 2]}
+
+
+def test_single_quoted_json(agent: JSONFormatterAgent) -> None:
+    result = agent.parse_llm_response("{'a': 'b', 'n': 1}")
+    assert result.success is True
+    assert result.data == {"a": "b", "n": 1}
+
+
+def test_bare_keys(agent: JSONFormatterAgent) -> None:
+    result = agent.parse_llm_response('{status: "ok", count: 3}')
+    assert result.success is True
+    assert result.data == {"status": "ok", "count": 3}
+
+
+def test_truncated_json_falls_through_without_crash(agent: JSONFormatterAgent) -> None:
+    # Truncated output cannot be repaired; contract is a fallback result,
+    # never an exception.
+    result = agent.parse_llm_response('{"a": 1, "b": "unterminated')
+    assert result.success is True
+    assert result.method_used == "fallback_creation"
+    assert result.data["error"] == "failed_to_parse"
+
+
+# ---------------------------------------------------------------------------
+# Agent-specific tiers layered after the canonical cascade
+# ---------------------------------------------------------------------------
+
+
+def test_json_embedded_in_prose(agent: JSONFormatterAgent) -> None:
+    result = agent.parse_llm_response('Here is your answer: {"a": 1} hope that helps!')
+    assert result.success is True
+    assert result.data == {"a": 1}
+    assert result.method_used == "text_extraction"
+
+
+def test_malformed_json_in_prose_uses_boundary_slice(agent: JSONFormatterAgent) -> None:
+    # Prose + syntax errors: canonical alone fails (prose prefix), regex
+    # extraction fails (trailing comma), boundary-slice + canonical repair wins.
+    result = agent.parse_llm_response('Sure! {"a": 1, "b": 2,} Done.')
+    assert result.success is True
+    assert result.data == {"a": 1, "b": 2}
+    assert result.method_used == "malformed_json_fix"
+
+
+def test_schema_fallback_extracts_fields(agent: JSONFormatterAgent) -> None:
+    schema = {"status": str, "count": int}
+    result = agent.parse_llm_response("status: done, count: 4, nothing parseable here", schema)
+    assert result.success is True
+    assert result.method_used == "fallback_creation"
+    assert result.data["status"] == "done"
+    assert result.data["count"] == 4
+
+
+def test_statistics_track_attempts_and_successes(agent: JSONFormatterAgent) -> None:
+    agent.parse_llm_response('{"a": 1}')
+    agent.parse_llm_response('{"a": 1,}')
+    stats = agent.get_statistics()
+    assert stats["total_attempts"] == 2
+    assert stats["successful_parses"] == 2
+    assert stats["success_rate"] == 1.0


### PR DESCRIPTION
Closes #11688

## Thinking Path

`json_formatter_agent` carried its own JSON-repair cascade duplicating `llm_shared/json_utils` (the canonical tiers, incl. the #11587 control-char tier). Consolidation rule applied: every formatter-only repair step was promoted INTO the canonical tiers (never silently dropped), then the agent delegates.

## What Changed

- `llm_shared/json_utils.py`: Tier 4 gains three progressive stages promoted from the formatter — trailing-comma removal (now also handles `,]`), missing-quotes-on-keys with a safer anchored regex (`([{,]\s*)([A-Za-z_]\w*)(\s*:)`, applied only if the previous stage doesn't parse — protects `"a, b: c"`/URLs), and single→double quote swap as last resort. New public `repair_json_syntax()`. Every tier remains parse-gated; `extract_json_object` still raises on garbage (existing raise-contract tests pass unmodified).
- `agents/json_formatter_agent.py`: new Strategy 2 `canonical_extraction` calls `extract_json_object()` (agent now inherits fence-strip #10672 + control-char #11587 handling it never had); duplicated `_apply_json_fixes`/`_try_parse_fixed_json` removed; `_fix_malformed_json` keeps its additive brace boundary-slicing + empty-key cleanup but delegates all syntax repair to the canonical call. Public contract (`JSONParseResult`, `parse_llm_json`, stats) unchanged; callers verified to read only `.success/.data/.method_used/.confidence/.warnings`.
- Tests: 8 new tier tests in `structured_ops_test.py`, 12 parity tests in new `tests/agents/test_json_formatter_agent.py` (truncated, control chars, trailing commas, single quotes, fenced).

## Verification

- Agent run: 397 passed across structured_ops, judge_json_parsing, formatter parity, startup imports, memory hooks; py_compile clean.
- Independent re-run (main session): structured_ops_test + judge_json_parsing_test + test_json_formatter_agent = 49 passed.

## Model Used

Claude Fable 5 (subagent: general-purpose)