### PR TITLE
fix(test): repair collection rot — imports, FakeRedis nx, services pkg, source-assert (#11648, #11478, #11409)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -29326,11 +29326,17 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         # Verify WorkflowAutomationManager class exists
         self.assertTrue(hasattr(workflow_automation, "WorkflowAutomationManager"))
 
-        # Verify get_workflow_manager singleton pattern
+        # Verify get_workflow_manager singleton pattern (#11409): it is now a
+        # lazy_singleton(WorkflowAutomationManager) factory — the old
+        # module-global `_workflow_manager`/`global` source-substring assert
+        # rotted when the implementation moved.  Assert the canonical
+        # lazy_singleton contract (callable factory exposing the reset /
+        # set_for_test test seams) instead of matching source text.
         self.assertTrue(hasattr(workflow_automation, "get_workflow_manager"))
-        get_manager_source = inspect.getsource(workflow_automation.get_workflow_manager)
-        self.assertIn("_workflow_manager", get_manager_source)
-        self.assertIn("global", get_manager_source)
+        get_manager = workflow_automation.get_workflow_manager
+        self.assertTrue(callable(get_manager))
+        self.assertTrue(hasattr(get_manager, "reset"))
+        self.assertTrue(hasattr(get_manager, "set_for_test"))
 
     def test_batch_168_migration_preserves_workflow_templates(self):
         """Verify migration preserves workflow template functionality"""

--- a/autobot-backend/tests/integration/conftest.py
+++ b/autobot-backend/tests/integration/conftest.py
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Fixtures for integration tests.
+
+The backend root conftest stubs ``auth_middleware`` in ``sys.modules`` (its
+module-level ``__getattr__`` mints a fresh MagicMock per attribute access), so
+integration tests that exercise the REAL middleware fallback chain (run-JWT /
+device-JWT path guards, GH#6473 / GH#9493) would silently assert on mocks.
+
+``real_auth_middleware`` loads the real module under an ALIAS key so the stub
+— and every other test relying on it — stays untouched (no ``sys.modules``
+pollution of the canonical name). Issue #11648.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).parent.parent.parent
+_REAL_AM_KEY = "_integration_real_auth_middleware"
+
+
+@pytest.fixture(scope="session")
+def real_auth_middleware():
+    """The REAL ``auth_middleware`` module, loaded under an alias key."""
+    if _REAL_AM_KEY in sys.modules:
+        return sys.modules[_REAL_AM_KEY]
+    spec = importlib.util.spec_from_file_location(_REAL_AM_KEY, _BACKEND_ROOT / "auth_middleware.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_REAL_AM_KEY] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(_REAL_AM_KEY, None)
+        raise
+    return module

--- a/autobot-backend/tests/integration/test_device_jwt_auth.py
+++ b/autobot-backend/tests/integration/test_device_jwt_auth.py
@@ -3,288 +3,273 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Integration tests for device JWT authentication and scoping (MVA-3237).
+Integration tests for device JWT authentication and scoping (GH#9493).
 
-Tests:
-- Device pairing generates valid JWT
-- Device JWT authenticates API requests
-- Read-only scope enforcement
-- Admin scope bypass (when implemented)
-- JWT expiry handling
+Rewritten for the canonical contract (#11648): the MVA-3237-era
+``DeviceTokenScope`` enum ("read-only"/"admin"), sync ``validate_device_jwt``
+and ``type: device_token`` claim were replaced by GH#9493 —
+
+- scopes are ``"read"`` / ``"write"`` (``services.device_jwt.VALID_SCOPES``)
+- ``validate_device_jwt`` is async and enforces a device-existence
+  (revocation) check plus an ``aud`` claim
+- device JWTs authenticate ONLY on ``/api/devices/`` endpoints, and
+  read-scoped tokens cannot use mutating HTTP methods
 """
 
 import uuid
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import Request, status
+from fastapi import HTTPException, Request
 
-from auth_middleware import get_auth_middleware
-from models.mobile_device import DeviceTokenScope
-from services.device_jwt import mint_device_jwt, validate_device_jwt
+from autobot_shared.auth.jwt_core import JWTDecodeError, JWTExpiredError, encode_jwt
+from services.device_jwt import VALID_SCOPES, mint_device_jwt, validate_device_jwt
+
+_DEVICE_SIGNING_KEY = "d" * 40  # deterministic test key ≥32 chars
+_AUDIENCE = "autobot:device"
+
+
+@pytest.fixture
+def device_jwt_env(monkeypatch):
+    """Set a stable device-JWT signing key for testing."""
+    monkeypatch.setenv("DEVICE_JWT_SECRET", _DEVICE_SIGNING_KEY)
+    return _DEVICE_SIGNING_KEY
+
+
+@pytest.fixture
+def device_exists(monkeypatch):
+    """Pass the GH#9493 revocation check — device exists in the DB."""
+    monkeypatch.setattr(
+        "services.device_jwt._device_exists_cached",
+        AsyncMock(return_value=True),
+    )
+
+
+def _bearer_request(token: str | None, path: str = "/api/devices/list", method: str = "GET") -> MagicMock:
+    """Mock request carrying an optional Bearer token."""
+    request = MagicMock(spec=Request)
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    request.headers.get = lambda k, d=None: headers.get(k, d)
+    request.url.path = path
+    request.method = method
+    request.cookies = {}
+    return request
 
 
 class TestDeviceJWTGeneration:
     """Test device JWT generation during pairing."""
 
-    def test_mint_device_jwt_read_only_scope(self):
-        """JWT should contain correct claims for read-only device."""
-        device_id = uuid.uuid4()
+    @pytest.mark.asyncio
+    async def test_mint_device_jwt_read_scope(self, device_jwt_env, device_exists):
+        """JWT should carry the canonical claims for a read-scoped device."""
+        device_id = str(uuid.uuid4())
         user_id = "user123"
 
-        token = mint_device_jwt(
-            device_id=device_id,
-            user_id=user_id,
-            scope=DeviceTokenScope.READ_ONLY.value,
-        )
+        token = mint_device_jwt(device_id=device_id, user_id=user_id, scope="read")
 
-        # Should be a non-empty string
         assert isinstance(token, str)
-        assert len(token) > 0
+        assert token.count(".") == 2  # header.payload.signature
 
-        # Should be decodable with correct claims
-        claims = validate_device_jwt(token)
-        assert claims["sub"] == str(device_id)
+        claims = await validate_device_jwt(token)
+        assert claims["device_id"] == device_id
         assert claims["user_id"] == user_id
-        assert claims["scope"] == "read-only"
-        assert claims["type"] == "device_token"
+        assert claims["scope"] == "read"
+        assert claims["aud"] == _AUDIENCE
         assert "exp" in claims
 
-    def test_mint_device_jwt_admin_scope(self):
-        """JWT should contain correct claims for admin device."""
-        device_id = uuid.uuid4()
-        user_id = "user456"
+    @pytest.mark.asyncio
+    async def test_mint_device_jwt_write_scope(self, device_jwt_env, device_exists):
+        """JWT should carry the write scope claim."""
+        token = mint_device_jwt(device_id=str(uuid.uuid4()), user_id="user456", scope="write")
 
-        token = mint_device_jwt(
-            device_id=device_id,
-            user_id=user_id,
-            scope=DeviceTokenScope.ADMIN.value,
-        )
+        claims = await validate_device_jwt(token)
+        assert claims["scope"] == "write"
 
-        claims = validate_device_jwt(token)
-        assert claims["scope"] == "admin"
+    def test_mint_device_jwt_rejects_unknown_scope(self, device_jwt_env):
+        """Legacy MVA-3237 scopes ('read-only'/'admin') are no longer mintable."""
+        assert VALID_SCOPES == frozenset({"read", "write"})
+        for legacy_scope in ("read-only", "admin"):
+            with pytest.raises(ValueError, match="Invalid scope"):
+                mint_device_jwt(device_id=str(uuid.uuid4()), user_id="user123", scope=legacy_scope)
+
+    def test_mint_device_jwt_defaults_to_read(self, device_jwt_env):
+        """Least-privilege default: omitted scope mints a read token."""
+        from autobot_shared.auth.jwt_core import decode_jwt
+
+        token = mint_device_jwt(device_id=str(uuid.uuid4()), user_id="user789")
+        claims = decode_jwt(token, _DEVICE_SIGNING_KEY, audience=_AUDIENCE)
+        assert claims["scope"] == "read"
 
 
 class TestDeviceJWTValidation:
-    """Test device JWT validation."""
+    """Test device JWT validation (async, revocation-checked)."""
 
-    def test_validate_device_jwt_success(self):
-        """Valid JWT should decode successfully."""
-        device_id = uuid.uuid4()
-        user_id = "user789"
-        token = mint_device_jwt(device_id, user_id)
+    @pytest.mark.asyncio
+    async def test_validate_device_jwt_success(self, device_jwt_env, device_exists):
+        """Valid JWT for an existing device should decode successfully."""
+        device_id = str(uuid.uuid4())
+        token = mint_device_jwt(device_id, "user789")
 
-        claims = validate_device_jwt(token)
+        claims = await validate_device_jwt(token)
 
-        assert claims["sub"] == str(device_id)
-        assert claims["user_id"] == user_id
-        assert claims["scope"] == "read-only"
-        assert claims["type"] == "device_token"
+        assert claims["device_id"] == device_id
+        assert claims["user_id"] == "user789"
+        assert claims["scope"] == "read"
 
-    def test_validate_device_jwt_wrong_type(self):
-        """JWT with wrong type claim should be rejected."""
-        from autobot_shared.auth.jwt_core import JWTDecodeError, encode_jwt
+    @pytest.mark.asyncio
+    async def test_validate_device_jwt_rejects_unpaired_device(self, device_jwt_env, monkeypatch):
+        """Tokens for deleted (unpaired) devices must be rejected."""
+        monkeypatch.setattr(
+            "services.device_jwt._device_exists_cached",
+            AsyncMock(return_value=False),
+        )
+        token = mint_device_jwt(str(uuid.uuid4()), "user123")
 
-        # Create a JWT with wrong type
-        payload = {
-            "sub": str(uuid.uuid4()),
-            "user_id": "user123",
-            "scope": "read-only",
-            "type": "user_token",  # Wrong type
-        }
+        with pytest.raises(JWTDecodeError, match="unpaired"):
+            await validate_device_jwt(token)
 
-        # Use same secret as device JWT
-        import os
+    @pytest.mark.asyncio
+    async def test_validate_device_jwt_missing_device_id(self, device_jwt_env, device_exists):
+        """JWT missing the device_id claim should be rejected."""
+        token = encode_jwt(
+            {"aud": _AUDIENCE, "user_id": "user123", "scope": "read"},
+            secret=_DEVICE_SIGNING_KEY,
+            expires_delta=timedelta(days=1),
+        )
 
-        secret = os.environ.get("DEVICE_JWT_SECRET") or os.environ.get("AUTOBOT_JWT_SECRET", "test-secret")
-        token = encode_jwt(payload, secret=secret, expires_delta=timedelta(days=1))
+        with pytest.raises(JWTDecodeError, match="device_id"):
+            await validate_device_jwt(token)
 
-        with pytest.raises(JWTDecodeError, match="not a device token"):
-            validate_device_jwt(token)
+    @pytest.mark.asyncio
+    async def test_validate_device_jwt_rejects_expired(self, device_jwt_env, device_exists):
+        """JWT past its exp timestamp should raise JWTExpiredError."""
+        token = encode_jwt(
+            {"aud": _AUDIENCE, "device_id": str(uuid.uuid4()), "user_id": "u", "scope": "read"},
+            secret=_DEVICE_SIGNING_KEY,
+            expires_delta=timedelta(seconds=-1),
+        )
 
-    def test_validate_device_jwt_missing_claims(self):
-        """JWT missing required claims should be rejected."""
-        from autobot_shared.auth.jwt_core import JWTDecodeError, encode_jwt
+        with pytest.raises(JWTExpiredError):
+            await validate_device_jwt(token)
 
-        # Create a JWT missing required claims
-        payload = {
-            "sub": str(uuid.uuid4()),
-            "type": "device_token",
-            # Missing user_id and scope
-        }
+    @pytest.mark.asyncio
+    async def test_validate_device_jwt_rejects_wrong_audience(self, device_jwt_env, device_exists):
+        """JWT without the device audience claim should be rejected."""
+        token = encode_jwt(
+            {"aud": "autobot:other", "device_id": str(uuid.uuid4()), "user_id": "u", "scope": "read"},
+            secret=_DEVICE_SIGNING_KEY,
+            expires_delta=timedelta(days=1),
+        )
 
-        import os
-
-        secret = os.environ.get("DEVICE_JWT_SECRET") or os.environ.get("AUTOBOT_JWT_SECRET", "test-secret")
-        token = encode_jwt(payload, secret=secret, expires_delta=timedelta(days=1))
-
-        with pytest.raises(JWTDecodeError, match="missing required claims"):
-            validate_device_jwt(token)
+        with pytest.raises(JWTDecodeError):
+            await validate_device_jwt(token)
 
 
 class TestDeviceJWTAuthentication:
-    """Test device JWT authentication in middleware."""
+    """Test device JWT extraction in the auth middleware fallback chain."""
 
-    def test_extract_user_from_device_jwt(self):
-        """Middleware should extract user from valid device JWT."""
-        device_id = uuid.uuid4()
-        user_id = "user123"
-        token = mint_device_jwt(device_id, user_id, scope="read-only")
+    @staticmethod
+    def _middleware(real_auth_middleware):
+        cls = real_auth_middleware.AuthenticationMiddleware
+        return cls.__new__(cls)
 
-        # Create mock request with Authorization header
-        request = MagicMock(spec=Request)
-        request.headers.get.return_value = f"Bearer {token}"
+    @pytest.mark.asyncio
+    async def test_extract_user_from_device_jwt(self, device_jwt_env, device_exists, real_auth_middleware):
+        """Middleware should build a synthetic device user from a valid JWT."""
+        device_id = str(uuid.uuid4())
+        token = mint_device_jwt(device_id, "user123", scope="read")
 
-        middleware = get_auth_middleware()
-        user_data = middleware._extract_user_from_device_jwt(request)
+        middleware = self._middleware(real_auth_middleware)
+        user_data = await middleware._extract_user_from_device_jwt(_bearer_request(token))
 
         assert user_data is not None
-        assert user_data["user_id"] == user_id
-        assert user_data["device_id"] == str(device_id)
-        assert user_data["scope"] == "read-only"
+        assert user_data["user_id"] == "user123"
+        assert user_data["device_id"] == device_id
+        assert user_data["scope"] == "read"
         assert user_data["auth_method"] == "device_jwt"
         assert user_data["role"] == "device"
-        assert user_data["username"].startswith("device:")
+        assert user_data["username"] == f"device:{device_id}"
 
-    def test_extract_user_from_device_jwt_no_bearer(self):
-        """Middleware should return None when no Bearer token present."""
-        request = MagicMock(spec=Request)
-        request.headers.get.return_value = None
+    @pytest.mark.asyncio
+    async def test_extract_user_from_device_jwt_no_bearer(self, device_jwt_env, real_auth_middleware):
+        """Middleware should return None when no Bearer token is present."""
+        middleware = self._middleware(real_auth_middleware)
+        assert await middleware._extract_user_from_device_jwt(_bearer_request(None)) is None
 
-        middleware = get_auth_middleware()
-        user_data = middleware._extract_user_from_device_jwt(request)
-
-        assert user_data is None
-
-    def test_extract_user_from_device_jwt_invalid_token(self):
+    @pytest.mark.asyncio
+    async def test_extract_user_from_device_jwt_invalid_token(self, device_jwt_env, real_auth_middleware):
         """Middleware should return None for invalid tokens."""
-        request = MagicMock(spec=Request)
-        request.headers.get.return_value = "Bearer invalid_token"
-
-        middleware = get_auth_middleware()
-        user_data = middleware._extract_user_from_device_jwt(request)
-
-        assert user_data is None
+        middleware = self._middleware(real_auth_middleware)
+        assert await middleware._extract_user_from_device_jwt(_bearer_request("invalid_token")) is None
 
 
 class TestDeviceScopeEnforcement:
-    """Test device token scope enforcement."""
+    """Test the GH#9493 path allow-list and scope enforcement in get_current_user."""
+
+    @staticmethod
+    def _patched(real_auth_middleware):
+        cls = real_auth_middleware.AuthenticationMiddleware
+        middleware = cls.__new__(cls)
+        return (
+            middleware,
+            patch.object(real_auth_middleware, "get_auth_middleware", return_value=middleware),
+            patch.object(middleware, "get_user_from_request", return_value=None),
+        )
 
     @pytest.mark.asyncio
-    async def test_get_current_user_rejects_device_jwt(self):
-        """get_current_user should reject device JWTs by default (fail-closed security)."""
-        from auth_middleware import get_current_user
+    async def test_device_jwt_rejected_outside_devices_prefix(
+        self, device_jwt_env, device_exists, real_auth_middleware
+    ):
+        """A valid device JWT must not authenticate arbitrary REST endpoints."""
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="write")
+        request = _bearer_request(token, path="/api/conversations")
 
-        device_id = uuid.uuid4()
-        user_id = "user123"
-        token = mint_device_jwt(device_id, user_id, scope="read-only")
+        middleware, p_factory, p_user = self._patched(real_auth_middleware)
+        with p_factory, p_user:
+            with pytest.raises(HTTPException) as exc_info:
+                await real_auth_middleware.get_current_user(request)
 
-        request = MagicMock(spec=Request)
-        request.headers.get.return_value = f"Bearer {token}"
-        request.url.path = "/api/conversations"
-
-        # get_current_user should reject device JWTs
-        with pytest.raises(Exception) as exc_info:
-            await get_current_user(request)
-
-        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
-        assert "Device tokens not permitted" in str(exc_info.value.detail)
+        assert exc_info.value.status_code == 403
+        assert "Device JWT not permitted" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_require_device_jwt_read_only_success(self):
-        """require_device_jwt should accept read-only device tokens."""
-        from auth_middleware import require_device_jwt
+    async def test_device_jwt_allowed_on_devices_prefix(self, device_jwt_env, device_exists, real_auth_middleware):
+        """A valid read-scoped device JWT authenticates GETs under /api/devices/."""
+        device_id = str(uuid.uuid4())
+        token = mint_device_jwt(device_id, "user123", scope="read")
+        request = _bearer_request(token, path="/api/devices/list", method="GET")
 
-        device_id = uuid.uuid4()
-        user_id = "user123"
-        token = mint_device_jwt(device_id, user_id, scope="read-only")
+        middleware, p_factory, p_user = self._patched(real_auth_middleware)
+        with p_factory, p_user:
+            user = await real_auth_middleware.get_current_user(request)
 
-        request = MagicMock(spec=Request)
-        request.headers.get.return_value = f"Bearer {token}"
-
-        # Mock database check for device existence
-        with patch("auth_middleware.get_db_session") as mock_get_db:
-            mock_session = MagicMock()
-            mock_result = MagicMock()
-            mock_device = MagicMock()
-            mock_device.id = device_id
-
-            mock_result.scalar_one_or_none.return_value = mock_device
-            mock_session.execute.return_value = mock_result
-            mock_session.close = MagicMock()
-
-            async def mock_session_gen():
-                yield mock_session
-
-            mock_get_db.return_value = mock_session_gen()
-
-            user_data = await require_device_jwt(request, min_scope="read-only")
-
-            assert user_data["user_id"] == user_id
-            assert user_data["scope"] == "read-only"
-            assert user_data["auth_method"] == "device_jwt"
+        assert user["auth_method"] == "device_jwt"
+        assert user["device_id"] == device_id
 
     @pytest.mark.asyncio
-    async def test_require_device_jwt_admin_rejected(self):
-        """require_device_jwt with admin scope should reject read-only tokens."""
-        from auth_middleware import require_device_jwt
+    async def test_read_scope_blocks_mutating_methods(self, device_jwt_env, device_exists, real_auth_middleware):
+        """Read-scoped device JWTs cannot use mutating HTTP methods."""
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="read")
+        request = _bearer_request(token, path="/api/devices/pair", method="POST")
 
-        device_id = uuid.uuid4()
-        user_id = "user123"
-        token = mint_device_jwt(device_id, user_id, scope="read-only")
+        middleware, p_factory, p_user = self._patched(real_auth_middleware)
+        with p_factory, p_user:
+            with pytest.raises(HTTPException) as exc_info:
+                await real_auth_middleware.get_current_user(request)
 
-        request = MagicMock(spec=Request)
-        request.headers.get.return_value = f"Bearer {token}"
-
-        # Mock database check
-        with patch("auth_middleware.get_db_session") as mock_get_db:
-            mock_session = MagicMock()
-            mock_result = MagicMock()
-            mock_device = MagicMock()
-            mock_device.id = device_id
-            mock_result.scalar_one_or_none.return_value = mock_device
-            mock_session.execute.return_value = mock_result
-            mock_session.close = MagicMock()
-
-            async def mock_session_gen():
-                yield mock_session
-
-            mock_get_db.return_value = mock_session_gen()
-
-            with pytest.raises(Exception) as exc_info:
-                await require_device_jwt(request, min_scope="admin")
-
-            assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
-            assert "admin scope" in str(exc_info.value.detail)
+        assert exc_info.value.status_code == 403
+        assert "Read-only device JWT" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_require_device_jwt_revoked_device(self):
-        """require_device_jwt should reject tokens for deleted devices."""
-        from auth_middleware import require_device_jwt
+    async def test_write_scope_allows_mutating_methods(self, device_jwt_env, device_exists, real_auth_middleware):
+        """Write-scoped device JWTs may use mutating HTTP methods on /api/devices/."""
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="write")
+        request = _bearer_request(token, path="/api/devices/pair", method="POST")
 
-        device_id = uuid.uuid4()
-        user_id = "user123"
-        token = mint_device_jwt(device_id, user_id, scope="read-only")
+        middleware, p_factory, p_user = self._patched(real_auth_middleware)
+        with p_factory, p_user:
+            user = await real_auth_middleware.get_current_user(request)
 
-        request = MagicMock(spec=Request)
-        request.headers.get.return_value = f"Bearer {token}"
-
-        # Mock database check - device not found (deleted)
-        with patch("auth_middleware.get_db_session") as mock_get_db:
-            mock_session = MagicMock()
-            mock_result = MagicMock()
-            mock_result.scalar_one_or_none.return_value = None  # Device deleted
-            mock_session.execute.return_value = mock_result
-            mock_session.close = MagicMock()
-
-            async def mock_session_gen():
-                yield mock_session
-
-            mock_get_db.return_value = mock_session_gen()
-
-            with pytest.raises(Exception) as exc_info:
-                await require_device_jwt(request)
-
-            assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
-            assert "revoked" in str(exc_info.value.detail)
+        assert user["auth_method"] == "device_jwt"
+        assert user["scope"] == "write"

--- a/autobot-backend/tests/integration/test_run_jwt_lifecycle.py
+++ b/autobot-backend/tests/integration/test_run_jwt_lifecycle.py
@@ -43,6 +43,39 @@ def jwt_secret(monkeypatch):
     return secret
 
 
+def _make_redis_store():
+    """Return a (store dict, async factory) backed by that store.
+
+    FakeRedis mirrors the redis-py ``set`` semantics the production code
+    relies on (GH#11648): ``nx=True`` returns ``None`` without writing when
+    the key already exists, and ``True`` on a successful write.
+    """
+    store: dict = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in store:
+                return None
+            store[key] = value
+            return True
+
+        async def exists(self, key):
+            return 1 if key in store else 0
+
+    async def factory(*args, **kwargs):
+        return FakeRedis()
+
+    return store, factory
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Route services.run_jwt Redis access to an in-memory FakeRedis."""
+    store, factory = _make_redis_store()
+    monkeypatch.setattr("services.run_jwt.get_async_redis_client", factory)
+    return store
+
+
 def test_mint_run_jwt_creates_valid_token(jwt_secret):
     """Verify mint_run_jwt() creates a properly signed token."""
     run_id = str(uuid.uuid4())
@@ -59,7 +92,7 @@ def test_mint_run_jwt_creates_valid_token(jwt_secret):
 
 
 @pytest.mark.asyncio
-async def test_validate_run_jwt_accepts_valid_token(jwt_secret):
+async def test_validate_run_jwt_accepts_valid_token(jwt_secret, fake_redis):
     """Verify validate_run_jwt() decodes and accepts a valid token."""
     run_id = str(uuid.uuid4())
     task_id = "task-1"
@@ -80,7 +113,7 @@ async def test_validate_run_jwt_accepts_valid_token(jwt_secret):
 
 
 @pytest.mark.asyncio
-async def test_validate_run_jwt_rejects_expired_token(jwt_secret, monkeypatch):
+async def test_validate_run_jwt_rejects_expired_token(jwt_secret, fake_redis, monkeypatch):
     """Verify validate_run_jwt() rejects expired tokens."""
     monkeypatch.setenv("RUN_JWT_TTL_SECONDS", "1")
     run_id = str(uuid.uuid4())
@@ -97,23 +130,9 @@ async def test_validate_run_jwt_rejects_expired_token(jwt_secret, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_denylist_rejection_with_mock_redis(jwt_secret, monkeypatch):
+async def test_denylist_rejection_with_mock_redis(jwt_secret, fake_redis):
     """Verify validate_run_jwt() raises JWTDecodeError after revocation via Redis denylist."""
     from autobot_shared.auth.jwt_core import JWTDecodeError
-
-    denylist: dict[str, str] = {}
-
-    class FakeRedis:
-        async def set(self, key, value, ex=None):
-            denylist[key] = value
-
-        async def exists(self, key):
-            return 1 if key in denylist else 0
-
-    async def fake_get_redis(*args, **kwargs):
-        return FakeRedis()
-
-    monkeypatch.setattr("services.run_jwt.get_async_redis_client", fake_get_redis)
 
     run_id = str(uuid.uuid4())
     token = mint_run_jwt(run_id, "task-1", "agent-1", "tenant-1", ["task:read"])
@@ -197,23 +216,6 @@ _LONG_SIGNING_KEY = "a" * 40  # deterministic test key ≥32 chars
 _ALT_SIGNING_KEY = "b" * 40  # different key to prove secret isolation
 
 
-def _make_redis_store():
-    """Return a (store dict, async factory) backed by that store."""
-    store: dict = {}
-
-    class FakeRedis:
-        async def set(self, key, value, ex=None):
-            store[key] = value
-
-        async def exists(self, key):
-            return 1 if key in store else 0
-
-    async def factory(*args, **kwargs):
-        return FakeRedis()
-
-    return store, factory
-
-
 @pytest.mark.asyncio
 async def test_refresh_extends_access_for_long_running_task(jwt_secret, monkeypatch):
     """Integration: refresh grants a fresh JWT that validates after original is revoked.
@@ -275,7 +277,7 @@ async def test_expired_jwt_cannot_be_refreshed(jwt_secret, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_user_jwt_auth_unaffected_by_run_jwt_fallback(monkeypatch):
+async def test_user_jwt_auth_unaffected_by_run_jwt_fallback(monkeypatch, real_auth_middleware):
     """Integration: _extract_user_from_run_jwt returns None for a user JWT.
 
     A user JWT signed with a different key must not validate in the run JWT
@@ -298,9 +300,8 @@ async def test_user_jwt_auth_unaffected_by_run_jwt_fallback(monkeypatch):
     request = MagicMock()
     request.headers.get = lambda k, d="": f"Bearer {user_token}" if k == "Authorization" else d
 
-    from auth_middleware import AuthenticationMiddleware
-
-    middleware = AuthenticationMiddleware.__new__(AuthenticationMiddleware)
+    cls = real_auth_middleware.AuthenticationMiddleware
+    middleware = cls.__new__(cls)
     result = await middleware._extract_user_from_run_jwt(request)
     # A JWT signed with ALT_SIGNING_KEY must not validate against LONG_SIGNING_KEY
     assert result is None
@@ -312,7 +313,7 @@ async def test_user_jwt_auth_unaffected_by_run_jwt_fallback(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_run_jwt_blocked_on_non_allowed_path(jwt_secret, monkeypatch):
+async def test_run_jwt_blocked_on_non_allowed_path(jwt_secret, monkeypatch, real_auth_middleware):
     """Integration: get_current_user raises 403 for run JWT on a non-allowed path.
 
     A run JWT must not be usable on arbitrary REST endpoints (e.g. /api/llm/chat).
@@ -336,21 +337,20 @@ async def test_run_jwt_blocked_on_non_allowed_path(jwt_secret, monkeypatch):
     request.cookies = {}
     request.state = MagicMock(spec=[])
 
-    from auth_middleware import AuthenticationMiddleware, get_current_user
-
-    middleware = AuthenticationMiddleware.__new__(AuthenticationMiddleware)
+    cls = real_auth_middleware.AuthenticationMiddleware
+    middleware = cls.__new__(cls)
 
     with (
-        patch("auth_middleware.get_auth_middleware", return_value=middleware),
+        patch.object(real_auth_middleware, "get_auth_middleware", return_value=middleware),
         patch.object(middleware, "get_user_from_request", return_value=None),
     ):
         with pytest.raises(HTTPException) as exc_info:
-            await get_current_user(request)
+            await real_auth_middleware.get_current_user(request)
     assert exc_info.value.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_run_jwt_allowed_on_refresh_path(jwt_secret, monkeypatch):
+async def test_run_jwt_allowed_on_refresh_path(jwt_secret, monkeypatch, real_auth_middleware):
     """Integration: get_current_user accepts run JWT on /api/runs/ paths.
 
     The refresh endpoint lives under /api/runs/{run_id}/jwt/refresh — confirming
@@ -371,14 +371,13 @@ async def test_run_jwt_allowed_on_refresh_path(jwt_secret, monkeypatch):
     request.cookies = {}
     request.state = MagicMock(spec=[])
 
-    from auth_middleware import AuthenticationMiddleware, get_current_user
-
-    middleware = AuthenticationMiddleware.__new__(AuthenticationMiddleware)
+    cls = real_auth_middleware.AuthenticationMiddleware
+    middleware = cls.__new__(cls)
 
     with (
-        patch("auth_middleware.get_auth_middleware", return_value=middleware),
+        patch.object(real_auth_middleware, "get_auth_middleware", return_value=middleware),
         patch.object(middleware, "get_user_from_request", return_value=None),
     ):
-        user = await get_current_user(request)
+        user = await real_auth_middleware.get_current_user(request)
     assert user["auth_method"] == "run_jwt"
     assert user["run_id"] == run_id

--- a/autobot-backend/tests/integration/test_transcriber_pipeline.py
+++ b/autobot-backend/tests/integration/test_transcriber_pipeline.py
@@ -62,9 +62,7 @@ async def test_service_availability():
 @pytest.mark.asyncio
 async def test_database_operations(transcriber_db, project_id):
     """Database create/read/update round-trip via the canonical API."""
-    recording_id = await transcriber_db.create_recording(
-        project_id, "test.wav", "/tmp/test.wav", user_id="u1"
-    )
+    recording_id = await transcriber_db.create_recording(project_id, "test.wav", "/tmp/test.wav", user_id="u1")
     assert recording_id > 0
 
     recording = await transcriber_db.get_recording(recording_id)
@@ -91,9 +89,7 @@ async def test_database_operations(transcriber_db, project_id):
 @pytest.mark.asyncio
 async def test_segment_creation(transcriber_db, project_id):
     """Speaker + segment creation and time-ordered retrieval."""
-    recording_id = await transcriber_db.create_recording(
-        project_id, "test.wav", "/tmp/test.wav", user_id="u1"
-    )
+    recording_id = await transcriber_db.create_recording(project_id, "test.wav", "/tmp/test.wav", user_id="u1")
 
     speaker_a = await transcriber_db.create_speaker(recording_id, "SPEAKER_00", "Speaker 1", "lv")
     speaker_b = await transcriber_db.create_speaker(recording_id, "SPEAKER_01", "Speaker 2", "lv")
@@ -123,9 +119,7 @@ async def test_process_recording_unknown_id_raises(orchestrator):
 @pytest.mark.asyncio
 async def test_process_recording_rejects_non_pending(orchestrator, transcriber_db, project_id):
     """Only pending recordings may enter the pipeline (double-run guard)."""
-    recording_id = await transcriber_db.create_recording(
-        project_id, "done.wav", "/tmp/done.wav", user_id="u1"
-    )
+    recording_id = await transcriber_db.create_recording(project_id, "done.wav", "/tmp/done.wav", user_id="u1")
     await transcriber_db.update_recording_status(recording_id, RecordingStatus.COMPLETE.value)
 
     with pytest.raises(ValueError, match="not pending"):

--- a/autobot-backend/tests/integration/test_transcriber_pipeline.py
+++ b/autobot-backend/tests/integration/test_transcriber_pipeline.py
@@ -4,36 +4,41 @@
 # Author: mrveiss
 #
 # Transcriber Pipeline Integration Test
-# Issue #9044, MVA-2186
+# Issue #9044, MVA-2186 — rewritten for the canonical API (#11648):
+# the original targeted a retired contract (TranscriberDatabase with
+# ``initialize()``/object rows, RecordingStatus.COMPLETED/FAILED,
+# orchestrator._merge_segments). Canonical surface: ``transcriber.database.
+# Database`` (dict rows, project-scoped recordings), RecordingStatus
+# ``complete``/``error``, and time-overlap merging inside the orchestrator's
+# persist helpers.
 
-"""Integration test for transcriber pipeline with sample audio."""
-
-import tempfile
-from pathlib import Path
+"""Integration test for the transcriber pipeline services and database."""
 
 import pytest
+import pytest_asyncio
 
 from media.audio.diarization_service import get_diarization_service
 from media.audio.ffmpeg_service import get_ffmpeg_service
-from transcriber.database import TranscriberDatabase
+from transcriber.database import Database
 from transcriber.models import RecordingStatus
 from transcriber.orchestrator import TranscriberOrchestrator
 from voice_processing.language_detection import detect_language
 from voice_processing.providers import get_speech_provider_registry
 
 
-@pytest.fixture
-async def transcriber_db():
-    """Create a test database."""
-    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
-        db_path = tmp.name
-
-    db = TranscriberDatabase(db_path)
-    await db.initialize()
+@pytest_asyncio.fixture
+async def transcriber_db(tmp_path):
+    """Create a connected test database backed by a temp file."""
+    db = Database(str(tmp_path / "transcriber-test.db"))
+    await db.connect()
     yield db
+    await db.close()
 
-    # Cleanup
-    Path(db_path).unlink(missing_ok=True)
+
+@pytest_asyncio.fixture
+async def project_id(transcriber_db):
+    """Create a project to attach recordings to."""
+    return await transcriber_db.create_project("Pipeline Test", "integration", user_id="u1")
 
 
 @pytest.fixture
@@ -42,200 +47,104 @@ def orchestrator(transcriber_db):
     return TranscriberOrchestrator(db=transcriber_db)
 
 
-@pytest.fixture
-def sample_audio_path():
-    """Path to a sample audio file for testing.
-
-    NOTE: For actual testing, you would provide a real audio file path here.
-    This is a placeholder that should be replaced with actual test audio.
-    """
-    # For testing, we'll create a minimal WAV file
-    # In production, use a real test audio file with Latvian + English content
-    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-        # Minimal WAV header (44 bytes) + 1 second of silence
-        wav_header = b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x80\x3e\x00\x00\x00\x7d\x00\x00\x02\x00\x10\x00data\x00\x00\x00\x00"
-        silence = b"\x00" * 16000  # 1 second of silence at 16kHz
-        tmp.write(wav_header)
-        tmp.write(silence)
-        tmp_path = tmp.name
-
-    yield tmp_path
-
-    # Cleanup
-    Path(tmp_path).unlink(missing_ok=True)
-
-
 @pytest.mark.asyncio
 async def test_service_availability():
-    """Test that all required services are available."""
-    # FFmpeg service
-    ffmpeg = get_ffmpeg_service()
-    assert ffmpeg is not None
+    """All pipeline services must be importable and constructible."""
+    assert get_ffmpeg_service() is not None
+    assert get_diarization_service() is not None
+    assert get_speech_provider_registry() is not None
 
-    # Diarization service
-    diarization = get_diarization_service()
-    assert diarization is not None
-
-    # Speech provider registry
-    registry = get_speech_provider_registry()
-    assert registry is not None
-
-    # Check that language detection works
-    # (This will use filename hints since the sample is minimal)
-    result = await detect_language(audio_path=None, filename_hint="sample_lv.wav")
-    assert result in ["lv", "en", None]  # Should return a valid language code or None
+    # Language detection degrades to None for a missing audio file.
+    result = await detect_language(audio_path="/nonexistent/sample_lv.wav", filename_hint="sample_lv.wav")
+    assert result in ["lv", "en", None]
 
 
 @pytest.mark.asyncio
-async def test_database_operations(transcriber_db):
-    """Test database create/read operations."""
-    # Create recording
-    recording = await transcriber_db.create_recording(filename="test.wav", file_path="/tmp/test.wav")
+async def test_database_operations(transcriber_db, project_id):
+    """Database create/read/update round-trip via the canonical API."""
+    recording_id = await transcriber_db.create_recording(
+        project_id, "test.wav", "/tmp/test.wav", user_id="u1"
+    )
+    assert recording_id > 0
 
-    assert recording.id > 0
-    assert recording.filename == "test.wav"
-    assert recording.status == RecordingStatus.PENDING
+    recording = await transcriber_db.get_recording(recording_id)
+    assert recording is not None
+    assert recording["filename"] == "test.wav"
+    assert recording["status"] == RecordingStatus.PENDING.value
 
-    # Get recording
-    retrieved = await transcriber_db.get_recording(recording.id)
-    assert retrieved is not None
-    assert retrieved.id == recording.id
+    await transcriber_db.update_recording_status(
+        recording_id,
+        RecordingStatus.COMPLETE.value,
+        language_detected="lv",
+        speaker_count=2,
+        process_seconds=10.5,
+    )
+    await transcriber_db.update_recording_duration(recording_id, 42.0)
 
-    # Update status
-    await transcriber_db.update_recording_status(recording.id, RecordingStatus.COMPLETED, duration=10.5, language="lv")
-
-    updated = await transcriber_db.get_recording(recording.id)
-    assert updated.status == RecordingStatus.COMPLETED
-    assert updated.duration == 10.5
-    assert updated.language == "lv"
-
-
-@pytest.mark.asyncio
-async def test_segment_creation(transcriber_db):
-    """Test segment creation and retrieval."""
-    # Create recording first
-    recording = await transcriber_db.create_recording(filename="test.wav", file_path="/tmp/test.wav")
-
-    # Create segments
-    segments_data = [
-        {
-            "speaker_label": "SPEAKER_00",
-            "start_time": 0.0,
-            "end_time": 2.5,
-            "text": "Hello world",
-            "confidence": 0.95,
-        },
-        {
-            "speaker_label": "SPEAKER_01",
-            "start_time": 2.5,
-            "end_time": 5.0,
-            "text": "Testing transcription",
-            "confidence": 0.92,
-        },
-    ]
-
-    created_segments = await transcriber_db.create_segments(segments=segments_data, recording_id=recording.id)
-
-    assert len(created_segments) == 2
-    assert created_segments[0].speaker_label == "SPEAKER_00"
-    assert created_segments[1].speaker_label == "SPEAKER_01"
-
-    # Retrieve segments
-    retrieved_segments = await transcriber_db.get_recording_segments(recording.id)
-    assert len(retrieved_segments) == 2
-    assert retrieved_segments[0].start_time < retrieved_segments[1].start_time
+    updated = await transcriber_db.get_recording(recording_id)
+    assert updated["status"] == RecordingStatus.COMPLETE.value
+    assert updated["language_detected"] == "lv"
+    assert updated["speaker_count"] == 2
+    assert updated["duration"] == 42.0
 
 
 @pytest.mark.asyncio
-async def test_merge_segments_logic(orchestrator):
-    """Test the segment merging algorithm."""
-    # Mock speaker segments
-    from media.audio.diarization_service import SpeakerSegment
-
-    speaker_segments = [
-        SpeakerSegment(speaker="SPEAKER_00", start=0.0, end=2.0),
-        SpeakerSegment(speaker="SPEAKER_01", start=2.0, end=4.0),
-        SpeakerSegment(speaker="SPEAKER_00", start=4.0, end=6.0),
-    ]
-
-    transcription_text = "This is the first segment. This is the second segment. This is the third segment."
-
-    merged = orchestrator._merge_segments(
-        speaker_segments=speaker_segments,
-        transcription_text=transcription_text,
-        confidence=0.95,
+async def test_segment_creation(transcriber_db, project_id):
+    """Speaker + segment creation and time-ordered retrieval."""
+    recording_id = await transcriber_db.create_recording(
+        project_id, "test.wav", "/tmp/test.wav", user_id="u1"
     )
 
-    assert len(merged) == 3
-    assert merged[0]["speaker_label"] == "SPEAKER_00"
-    assert merged[1]["speaker_label"] == "SPEAKER_01"
-    assert merged[2]["speaker_label"] == "SPEAKER_00"
+    speaker_a = await transcriber_db.create_speaker(recording_id, "SPEAKER_00", "Speaker 1", "lv")
+    speaker_b = await transcriber_db.create_speaker(recording_id, "SPEAKER_01", "Speaker 2", "lv")
 
-    # Each segment should have some text
-    assert len(merged[0]["text"]) > 0
-    assert len(merged[1]["text"]) > 0
-    assert len(merged[2]["text"]) > 0
+    await transcriber_db.create_segment(recording_id, speaker_b, 2.5, 5.0, "Testing transcription")
+    await transcriber_db.create_segment(recording_id, speaker_a, 0.0, 2.5, "Hello world")
 
-    # All segments together should contain all words
-    all_text = " ".join(seg["text"] for seg in merged)
-    assert len(all_text.split()) == len(transcription_text.split())
+    segments = await transcriber_db.list_segments(recording_id)
+    assert len(segments) == 2
+    # list_segments orders by start_time regardless of insertion order
+    assert segments[0]["start_time"] < segments[1]["start_time"]
+    assert segments[0]["speaker_id"] == speaker_a
+    assert segments[1]["speaker_id"] == speaker_b
+    assert segments[0]["text"] == "Hello world"
 
-
-@pytest.mark.asyncio
-@pytest.mark.skip(reason="Requires real audio file with speech content")
-async def test_full_pipeline_integration(orchestrator, transcriber_db, sample_audio_path):
-    """Integration test for the full transcription pipeline.
-
-    NOTE: This test is skipped by default because it requires:
-    1. A real audio file with actual speech content
-    2. FFmpeg installed
-    3. Pyannote model available (optional, will skip diarization if unavailable)
-    4. Speech provider configured
-
-    To run this test:
-    1. Replace sample_audio_path fixture with path to real audio
-    2. Ensure all dependencies are installed
-    3. Remove the @pytest.mark.skip decorator
-    """
-    # Create recording entry
-    recording = await transcriber_db.create_recording(filename="integration_test.wav", file_path=sample_audio_path)
-
-    # Process through pipeline
-    result = await orchestrator.process_recording(recording.id)
-
-    # Verify results
-    assert result["recording_id"] == recording.id
-    assert result["status"] == RecordingStatus.COMPLETED.value
-    assert result["segments_count"] > 0
-
-    # Verify recording was updated
-    updated_recording = await transcriber_db.get_recording(recording.id)
-    assert updated_recording.status == RecordingStatus.COMPLETED
-    assert updated_recording.duration is not None
-    assert updated_recording.language is not None
-
-    # Verify segments were created
-    segments = await transcriber_db.get_recording_segments(recording.id)
-    assert len(segments) > 0
-    assert segments[0].text != ""
-    assert segments[0].confidence > 0
+    speakers = await transcriber_db.list_speakers(recording_id)
+    assert {s["label"] for s in speakers} == {"SPEAKER_00", "SPEAKER_01"}
 
 
 @pytest.mark.asyncio
-async def test_processing_error_handling(orchestrator, transcriber_db):
-    """Test error handling when processing fails."""
-    # Create recording with invalid file path
-    recording = await transcriber_db.create_recording(filename="invalid.wav", file_path="/nonexistent/path.wav")
-
-    # Processing should fail and mark recording as failed
-    with pytest.raises(Exception):
-        await orchestrator.process_recording(recording.id)
-
-    # Verify status was updated to failed
-    failed_recording = await transcriber_db.get_recording(recording.id)
-    assert failed_recording.status == RecordingStatus.FAILED
+async def test_process_recording_unknown_id_raises(orchestrator):
+    """Processing a nonexistent recording must raise, not silently pass."""
+    with pytest.raises(ValueError, match="not found"):
+        await orchestrator.process_recording(999999)
 
 
-if __name__ == "__main__":
-    # Run tests
-    pytest.main([__file__, "-v"])
+@pytest.mark.asyncio
+async def test_process_recording_rejects_non_pending(orchestrator, transcriber_db, project_id):
+    """Only pending recordings may enter the pipeline (double-run guard)."""
+    recording_id = await transcriber_db.create_recording(
+        project_id, "done.wav", "/tmp/done.wav", user_id="u1"
+    )
+    await transcriber_db.update_recording_status(recording_id, RecordingStatus.COMPLETE.value)
+
+    with pytest.raises(ValueError, match="not pending"):
+        await orchestrator.process_recording(recording_id)
+
+
+@pytest.mark.asyncio
+async def test_process_recording_blocks_path_outside_upload_dir(
+    orchestrator, transcriber_db, project_id, tmp_path, monkeypatch
+):
+    """Issue #9214: files outside the upload base dir must be rejected."""
+    monkeypatch.setenv("AUTOBOT_UPLOAD_DIR", str(tmp_path / "uploads"))
+    recording_id = await transcriber_db.create_recording(
+        project_id, "invalid.wav", "/nonexistent/path.wav", user_id="u1"
+    )
+
+    with pytest.raises(ValueError):
+        await orchestrator.process_recording(recording_id)
+
+    # Validation failure is a caller error: the recording stays pending.
+    recording = await transcriber_db.get_recording(recording_id)
+    assert recording["status"] == RecordingStatus.PENDING.value

--- a/autobot-slm-backend/tests/services/conftest.py
+++ b/autobot-slm-backend/tests/services/conftest.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Conftest for tests/services/ — make real SLM packages importable (#11478).
+
+The slm-backend root conftest (#3499) stubs ``services`` / ``models`` (and a
+fixed list of their submodules) as MagicMocks so api/* tests import without
+heavy dependencies.  A MagicMock is not a package — accessing ``__path__``
+raises AttributeError — so any test here importing a real, non-stubbed
+submodule (``services.inventory_builder``, …) failed with
+"'services' is not a package", and the whole directory could not collect.
+
+Fix: swap the PARENT stubs for hollow ``ModuleType`` packages whose
+``__path__`` points at the real directories (the same trick the root conftest
+uses for ``api``).  Existing per-submodule MagicMock stubs stay in
+``sys.modules`` and keep winning for the stubbed names; only non-stubbed
+submodules fall through to the real files.  Child stubs are re-bound as parent
+attributes so ``patch("services.encryption.x")`` still resolves to the same
+object as ``from services.encryption import x`` (#9780).
+
+Also imports the real ``autobot_shared`` package up front so no test module
+can squat the key with a bare (non-package) ``ModuleType`` stub — that squat
+broke every later ``autobot_shared.*`` import in the directory sweep.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+_SLM_ROOT = Path(__file__).parent.parent.parent
+
+
+def _ensure_real_pkg(name: str, directory: Path) -> None:
+    """Replace a non-package sys.modules entry with a real-path hollow package."""
+    existing = sys.modules.get(name)
+    if existing is not None and hasattr(existing, "__path__"):
+        return  # already a package (real or hollow)
+
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(directory)]  # type: ignore[assignment]
+    pkg.__package__ = name
+    pkg.__spec__ = None  # type: ignore[assignment]
+
+    # Re-bind existing child stubs onto the new parent (#9780).
+    prefix = name + "."
+    depth = name.count(".") + 1
+    for key, child in list(sys.modules.items()):
+        if key.startswith(prefix) and key.count(".") == depth:
+            setattr(pkg, key.rsplit(".", 1)[1], child)
+
+    sys.modules[name] = pkg
+
+
+_ensure_real_pkg("services", _SLM_ROOT / "services")
+_ensure_real_pkg("models", _SLM_ROOT / "models")
+
+# Real packages up front — several test modules in this directory install
+# module-level fallback stubs guarded by `if X not in sys.modules`.  Importing
+# the real packages here makes those guards no-ops, so a bare (non-package)
+# stub can never squat the key for every later module in the sweep
+# (e.g. `import aiohttp.abc` → "'aiohttp' is not a package").
+# NOTE: `fastapi` must NOT be pre-imported here — test_saml_slo deliberately
+# stubs it before exec'ing api/auth.py (real FastAPI would validate routes
+# against MagicMock response models at decoration time).
+import contextlib
+
+import autobot_shared  # noqa: E402,F401
+
+with contextlib.suppress(ImportError):
+    import aiohttp  # noqa: F401

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -33,19 +33,26 @@ from unittest.mock import MagicMock as _MagicMock
 
 _SERVICES_DIR = str(_Path(__file__).parent.parent.parent / "services")
 
+_TOUCHED_KEYS = (
+    "services",
+    "services.role_registry",
+    "models",
+    "models.database",
+    "sqlalchemy",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.asyncio",
+    "sqlalchemy.orm",
+)
+
+# #11478: snapshot every key this bootstrap touches so the pre-import state
+# can be restored after the import below.  Leaking the thin models.database
+# shim broke later modules in the same directory sweep (git_tracker's
+# CodeSource import in version_checker_test).
+_SAVED_MODULES = {_key: sys.modules[_key] for _key in _TOUCHED_KEYS if _key in sys.modules}
+
 # Drop MagicMock stubs for everything role_registry transitively imports.
-for _key in list(sys.modules):
-    if _key in (
-        "services",
-        "services.role_registry",
-        "models",
-        "models.database",
-        "sqlalchemy",
-        "sqlalchemy.ext",
-        "sqlalchemy.ext.asyncio",
-        "sqlalchemy.orm",
-    ):
-        del sys.modules[_key]
+for _key in _TOUCHED_KEYS:
+    sys.modules.pop(_key, None)
 
 # Hollow real-path package for services/ so submodule imports work.
 _svc_pkg = _types.ModuleType("services")
@@ -77,6 +84,15 @@ sys.modules["models.database"] = _models_db
 setattr(_models_pkg, "database", _models_db)
 
 _rr = importlib.import_module("services.role_registry")
+
+# #11478: restore the pre-bootstrap sys.modules state.  The tests below only
+# use the _rr reference, so the shims are not needed at runtime — leaving them
+# in sys.modules poisons every module collected after this one.
+for _key in _TOUCHED_KEYS:
+    if _key in _SAVED_MODULES:
+        sys.modules[_key] = _SAVED_MODULES[_key]
+    else:
+        sys.modules.pop(_key, None)
 
 DEFAULT_ROLES = _rr.DEFAULT_ROLES
 ROLE_ANSIBLE_GROUPS = _rr.ROLE_ANSIBLE_GROUPS
@@ -219,6 +235,8 @@ def test_vnc_in_get_role_definitions():
         if hasattr(_rr.get_role_definitions, "__wrapped__")
         else None
     )
+    if defs_by_name is not None:
+        assert "vnc" in defs_by_name, "vnc must be returned by get_role_definitions"
     # Fallback: inspect DEFAULT_ROLES directly (get_role_definitions is async)
     detectable = {r["name"] for r in DEFAULT_ROLES if r.get("target_path") or r.get("systemd_service")}
     assert "vnc" in detectable, "vnc must be in the detectable role set (has target_path or systemd_service)"

--- a/autobot-slm-backend/tests/services/test_saml_slo.py
+++ b/autobot-slm-backend/tests/services/test_saml_slo.py
@@ -39,6 +39,14 @@ _ROOT = _BACKEND.parent
 sys.path.insert(0, str(_BACKEND))
 sys.path.insert(0, str(_ROOT))
 
+# #11478: snapshot sys.modules before the stub-heavy bootstrap below.  The
+# tests only use the module references extracted here (_sso_mod, _router_ns
+# values), so every stub this file installs (notably the "fastapi" MagicMock
+# needed to exec api/auth.py) can be rolled back afterwards — leaking it broke
+# later modules in the same directory sweep (test_step_up_auth imported the
+# MagicMock instead of real FastAPI).
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 # ---------------------------------------------------------------------------
 # SSO model stubs (must be set before sso_service.py is loaded)
 # ---------------------------------------------------------------------------
@@ -153,6 +161,16 @@ exec(compile(_router_src, str(_AUTH_ROUTER_PY), "exec"), _router_ns)  # nosec B1
 
 _build_sso_logout_url = _router_ns["_build_sso_logout_url"]
 _build_end_session_url = _router_ns["_build_end_session_url"]
+
+# #11478: restore the pre-bootstrap sys.modules state (see snapshot above) so
+# the stubs installed for this file's exec-based bootstrap cannot poison
+# modules collected after it in a directory sweep.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #11648, #11478, #11409

## Thinking Path

Three test-rot clusters, one scope (collection/stub rot), each reproduced before fixing. Tests were repaired against the CURRENT canonical contracts — no retired symbols re-created.

## What Changed

**#11648 — 3 integration collection errors**
- `test_device_jwt_auth.py`: `DeviceTokenScope` is retired; rewrote against the canonical GH#9493 contract in `services/device_jwt.py` (scopes `read`/`write`, async `validate_device_jwt` w/ revocation + `aud`, allow-list + read-scope enforcement).
- `test_transcriber_pipeline.py`: points at canonical `transcriber.database.Database`; rewrote the rest of the rotted file (dict rows, current status strings, deleted `_merge_segments`).
- `test_run_jwt_lifecycle.py`: FakeRedis `set()` now implements real redis-py `nx=` semantics; deduplicated stub copies into one fixture; new `tests/integration/conftest.py` `real_auth_middleware` fixture un-clobbers the root-conftest stub for 3 tests.

**#11478 — services not a package**
- New `autobot-slm-backend/tests/services/conftest.py`: swaps MagicMock parent stubs for hollow real-`__path__` packages (child stubs rebound for `patch()` resolution, #9780), pre-imports real `autobot_shared`/`aiohttp`; stub snapshot/restore hygiene in `test_role_registry.py`/`test_saml_slo.py`. Group collection: **307 collected, 0 errors** (was 150 + 9 errors); all 20 files still collect individually.

**#11409 — source-assert rot**
- `api_endpoint_migrations_test.py`: replaced `inspect.getsource` substring asserts with contract assertions on the canonical `lazy_singleton(WorkflowAutomationManager)` factory (callable + `reset`/`set_for_test` seams).

## Verification

- Agent: touched integration files 34/34 pass; services group 273 passed / 33 failed — all 33 verified pre-existing (fail on untouched base) → filed #11737.
- Independent (main session): full `tests/integration/` run — the only failures are the known #11687 env-rot clusters (mobile_push, retention_policies, budget_hard_stop, execution_snapshot), confirmed byte-count-identical on base (10 failed/19 errors both sides for the two spot-checked files); disjoint from touched files. `tests/services/` collects 307/0 errors independently.
- flake8 clean on changed files (incl. one pre-existing F841 fixed).

Discoveries: #11736 (production rot: `require_device_jwt` missing `await` at auth_middleware.py:989, stale scopes, zero callers — HIGH), #11737 (33 pre-existing services runtime failures).

## Model Used

Claude Fable 5 (subagent: general-purpose)