### PR TITLE
refactor(singletons): migrate remaining locked __new__ singletons to singleton_factory (#11681)

### DIFF
--- a/autobot-backend/cache/__init__.py
+++ b/autobot-backend/cache/__init__.py
@@ -64,14 +64,16 @@ def _get_cache_registry() -> List[Tuple[str, str, Callable[[], CacheProtocol]]]:
         return LLMResponseCache()
 
     def _ast_cache_factory() -> CacheProtocol:
-        from code_intelligence.shared.ast_cache import ASTCache
+        # #11681: shared instance now lives behind the lazy_singleton factory;
+        # direct construction would register a private, non-shared cache.
+        from code_intelligence.shared.ast_cache import get_ast_cache
 
-        return ASTCache()
+        return get_ast_cache()
 
     def _file_cache_factory() -> CacheProtocol:
-        from code_intelligence.shared.file_cache import FileListCache
+        from code_intelligence.shared.file_cache import get_file_list_cache
 
-        return FileListCache()
+        return get_file_list_cache()
 
     return [
         ("src.memory.cache", "LRUCacheManager", _lru_cache_factory),

--- a/autobot-backend/code_intelligence/shared/__init__.py
+++ b/autobot-backend/code_intelligence/shared/__init__.py
@@ -19,6 +19,7 @@ Part of EPIC #217 - Advanced Code Intelligence Methods
 from code_intelligence.shared.ast_cache import (
     ASTCache,
     get_ast,
+    get_ast_cache,
     get_ast_cache_stats,
     get_ast_safe,
     get_ast_with_content,
@@ -28,6 +29,7 @@ from code_intelligence.shared.file_cache import (
     FileListCache,
     get_all_code_files,
     get_file_cache_stats,
+    get_file_list_cache,
     get_frontend_files,
     get_python_files,
     invalidate_file_cache,
@@ -48,6 +50,7 @@ from code_intelligence.shared.scoring import (
 __all__ = [
     # FileListCache
     "FileListCache",
+    "get_file_list_cache",
     "get_python_files",
     "get_frontend_files",
     "get_all_code_files",
@@ -55,6 +58,7 @@ __all__ = [
     "get_file_cache_stats",
     # ASTCache
     "ASTCache",
+    "get_ast_cache",
     "get_ast",
     "get_ast_safe",
     "get_ast_with_content",

--- a/autobot-backend/code_intelligence/shared/ast_cache.py
+++ b/autobot-backend/code_intelligence/shared/ast_cache.py
@@ -128,10 +128,11 @@ class ASTCache:
     Thread Safety:
         Uses threading.Lock for thread-safe cache access.
         Safe to use from multiple async tasks and threads.
-    """
 
-    _instance: "ASTCache" | None = None
-    _lock = threading.Lock()
+    Singleton access (#11681): the shared instance lives behind the
+    ``get_ast_cache`` lazy_singleton factory below — direct construction
+    creates an independent (non-shared) cache.
+    """
 
     # CacheProtocol properties - Issue #743
     @property
@@ -150,24 +151,12 @@ class ASTCache:
         """Maximum capacity."""
         return self._max_size
 
-    def __new__(cls) -> "ASTCache":
-        """Singleton pattern for global cache instance."""
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._initialized = False
-        return cls._instance
-
     def __init__(
         self,
         max_size: int = DEFAULT_CACHE_SIZE,
         content_cache_size: int = DEFAULT_CONTENT_CACHE_SIZE,
     ):
-        """Initialize cache (only runs once due to singleton)."""
-        if self._initialized:
-            return
-
+        """Initialize cache."""
         self._max_size = max_size
         self._content_cache_size = content_cache_size
 
@@ -177,7 +166,6 @@ class ASTCache:
 
         self._stats = ASTCacheStats(max_size=max_size)
         self._cache_lock = threading.Lock()
-        self._initialized = True
 
         logger.info(
             "ASTCache initialized: max_size=%d, content_cache_size=%d",
@@ -469,18 +457,22 @@ class ASTCache:
 
     @classmethod
     def reset_instance(cls) -> None:
-        """Reset singleton instance (for testing)."""
-        global _cache_instance
-        with cls._lock:
-            cls._instance = None
-            _cache_instance = None
+        """Reset the shared instance (test seam).
+
+        Issue #11681: delegates to the ``lazy_singleton`` factory's reset —
+        the previous hand-rolled ``__new__`` singleton kept a second cache
+        layer that this method never cleared (stale-instance bug).
+        """
+        get_ast_cache.reset()  # type: ignore[attr-defined]
 
 
 # =============================================================================
 # Convenience Functions (Module-Level API)
 # =============================================================================
 
-_get_cache = lazy_singleton(ASTCache)
+# Issue #11681: canonical singleton seam — replaces the hand-rolled
+# double-checked ``__new__`` pattern. Carries reset()/set_for_test() (#11635).
+get_ast_cache = lazy_singleton(ASTCache)
 
 
 def get_ast(file_path: str | Path) -> ast.AST:
@@ -503,7 +495,7 @@ def get_ast(file_path: str | Path) -> ast.AST:
             if isinstance(node, ast.FunctionDef):
                 logger.info("Found function: %s", node.name)
     """
-    return _get_cache().get(file_path)
+    return get_ast_cache().get(file_path)
 
 
 def get_ast_safe(file_path: str | Path) -> ast.AST | None:
@@ -522,7 +514,7 @@ def get_ast_safe(file_path: str | Path) -> ast.AST | None:
             # Process AST
             pass
     """
-    return _get_cache().get_safe(file_path)
+    return get_ast_cache().get_safe(file_path)
 
 
 def get_ast_with_content(file_path: str | Path) -> Tuple[ast.AST | None, str]:
@@ -532,7 +524,7 @@ def get_ast_with_content(file_path: str | Path) -> Tuple[ast.AST | None, str]:
     Returns:
         Tuple of (ast, content) - ast may be None on parse error
     """
-    return _get_cache().get_with_content(file_path)
+    return get_ast_cache().get_with_content(file_path)
 
 
 def invalidate_ast_cache(file_path: str | Path | None = None) -> None:
@@ -543,9 +535,13 @@ def invalidate_ast_cache(file_path: str | Path | None = None) -> None:
         file_path: If provided, only invalidate this file.
                   If None, invalidate all entries.
     """
-    _get_cache().invalidate(file_path)
+    get_ast_cache().invalidate(file_path)
 
 
 def get_ast_cache_stats() -> Dict:
-    """Get AST cache statistics as dictionary."""
-    return _get_cache().get_stats().to_dict()
+    """Get AST cache statistics as dictionary.
+
+    Issue #11681: ``get_stats()`` already returns a Dict (#743) — the extra
+    ``.to_dict()`` raised AttributeError on every call.
+    """
+    return get_ast_cache().get_stats()

--- a/autobot-backend/code_intelligence/shared/file_cache.py
+++ b/autobot-backend/code_intelligence/shared/file_cache.py
@@ -122,10 +122,11 @@ class FileListCache:
     Thread Safety:
         Uses threading.Lock for thread-safe cache access.
         Safe to use from multiple async tasks and threads.
-    """
 
-    _instance: "FileListCache" | None = None
-    _lock = threading.Lock()
+    Singleton access (#11681): the shared instance lives behind the
+    ``get_file_list_cache`` lazy_singleton factory below — direct
+    construction creates an independent (non-shared) cache.
+    """
 
     # CacheProtocol properties - Issue #743
     @property
@@ -144,30 +145,17 @@ class FileListCache:
         """Maximum capacity (0 = unlimited, TTL-based expiration)."""
         return 0  # TTL-based, not size-based
 
-    def __new__(cls) -> "FileListCache":
-        """Singleton pattern for global cache instance."""
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._initialized = False
-        return cls._instance
-
     def __init__(
         self,
         ttl: int = DEFAULT_CACHE_TTL,
         root_path: Path | None = None,
     ):
-        """Initialize cache (only runs once due to singleton)."""
-        if self._initialized:
-            return
-
+        """Initialize cache."""
         self._ttl = ttl
         self._root_path = root_path or DEFAULT_ROOT_PATH
         self._cache: Dict[str, CacheEntry] = {}
         self._stats = CacheStats()
         self._cache_lock = threading.Lock()
-        self._initialized = True
 
         logger.info("FileListCache initialized: ttl=%ds, root=%s", self._ttl, self._root_path)
 
@@ -325,18 +313,22 @@ class FileListCache:
 
     @classmethod
     def reset_instance(cls) -> None:
-        """Reset singleton instance (for testing)."""
-        global _cache_instance
-        with cls._lock:
-            cls._instance = None
-            _cache_instance = None
+        """Reset the shared instance (test seam).
+
+        Issue #11681: delegates to the ``lazy_singleton`` factory's reset —
+        the previous hand-rolled ``__new__`` singleton kept a second cache
+        layer that this method never cleared (stale-instance bug).
+        """
+        get_file_list_cache.reset()  # type: ignore[attr-defined]
 
 
 # =============================================================================
 # Convenience Functions (Module-Level API)
 # =============================================================================
 
-_get_cache = lazy_singleton(FileListCache)
+# Issue #11681: canonical singleton seam — replaces the hand-rolled
+# double-checked ``__new__`` pattern. Carries reset()/set_for_test() (#11635).
+get_file_list_cache = lazy_singleton(FileListCache)
 
 
 async def get_python_files(root_path: Path | None = None) -> List[Path]:
@@ -354,7 +346,7 @@ async def get_python_files(root_path: Path | None = None) -> List[Path]:
         for f in python_files:
             logger.info("Processing: %s", f)
     """
-    return await _get_cache().get_files(PYTHON_EXTENSIONS, root_path)
+    return await get_file_list_cache().get_files(PYTHON_EXTENSIONS, root_path)
 
 
 async def get_frontend_files(root_path: Path | None = None) -> List[Path]:
@@ -367,7 +359,7 @@ async def get_frontend_files(root_path: Path | None = None) -> List[Path]:
     Returns:
         List of Path objects for frontend files
     """
-    return await _get_cache().get_files(FRONTEND_EXTENSIONS, root_path)
+    return await get_file_list_cache().get_files(FRONTEND_EXTENSIONS, root_path)
 
 
 async def get_all_code_files(root_path: Path | None = None) -> List[Path]:
@@ -380,7 +372,7 @@ async def get_all_code_files(root_path: Path | None = None) -> List[Path]:
     Returns:
         List of Path objects for all code files
     """
-    return await _get_cache().get_files(ALL_CODE_EXTENSIONS, root_path)
+    return await get_file_list_cache().get_files(ALL_CODE_EXTENSIONS, root_path)
 
 
 def invalidate_file_cache(extensions: FrozenSet[str] | None = None) -> None:
@@ -391,9 +383,13 @@ def invalidate_file_cache(extensions: FrozenSet[str] | None = None) -> None:
         extensions: If provided, only invalidate entries matching these extensions.
                    If None, invalidate all entries.
     """
-    _get_cache().invalidate(extensions)
+    get_file_list_cache().invalidate(extensions)
 
 
 def get_file_cache_stats() -> Dict:
-    """Get file cache statistics as dictionary."""
-    return _get_cache().get_stats().to_dict()
+    """Get file cache statistics as dictionary.
+
+    Issue #11681: ``get_stats()`` already returns a Dict (#743) — the extra
+    ``.to_dict()`` raised AttributeError on every call.
+    """
+    return get_file_list_cache().get_stats()

--- a/autobot-backend/code_intelligence/shared/shared_caches_test.py
+++ b/autobot-backend/code_intelligence/shared/shared_caches_test.py
@@ -16,6 +16,7 @@ import pytest
 from code_intelligence.shared.ast_cache import (
     ASTCache,
     get_ast,
+    get_ast_cache,
     get_ast_cache_stats,
     get_ast_safe,
     get_ast_with_content,
@@ -24,6 +25,7 @@ from code_intelligence.shared.ast_cache import (
 from code_intelligence.shared.file_cache import (
     FileListCache,
     get_file_cache_stats,
+    get_file_list_cache,
     get_frontend_files,
     get_python_files,
     invalidate_file_cache,
@@ -35,14 +37,9 @@ class TestFileListCache:
 
     @pytest.fixture(autouse=True)
     def reset_cache(self):
-        """Reset singleton before and after each test."""
-        # Reset module-level instance as well
-        import code_intelligence.shared.file_cache as fc
-
-        fc._cache_instance = None
+        """Reset the shared instance before and after each test (#11681)."""
         FileListCache.reset_instance()
         yield
-        fc._cache_instance = None
         FileListCache.reset_instance()
 
     @pytest.mark.asyncio
@@ -114,9 +111,9 @@ class TestFileListCache:
         assert len(files) == 3
 
     def test_singleton_pattern(self):
-        """Test that FileListCache is a singleton."""
-        cache1 = FileListCache()
-        cache2 = FileListCache()
+        """The lazy_singleton factory returns one shared instance (#11681)."""
+        cache1 = get_file_list_cache()
+        cache2 = get_file_list_cache()
         assert cache1 is cache2
 
 
@@ -125,14 +122,9 @@ class TestASTCache:
 
     @pytest.fixture(autouse=True)
     def reset_cache(self):
-        """Reset singleton before and after each test."""
-        # Reset module-level instance as well
-        import code_intelligence.shared.ast_cache as ac
-
-        ac._cache_instance = None
+        """Reset the shared instance before and after each test (#11681)."""
         ASTCache.reset_instance()
         yield
-        ac._cache_instance = None
         ASTCache.reset_instance()
 
     def test_get_ast_parses_python_file(self, tmp_path):
@@ -206,21 +198,15 @@ class TestASTCache:
         assert isinstance(tree, ast.Module)
         assert returned_content == content
 
-    def test_lru_eviction(self, tmp_path, monkeypatch):
-        """Test that LRU eviction works when cache is full."""
-        # Monkeypatch env var BEFORE importing/creating cache
-        monkeypatch.setenv("AST_CACHE_MAX_SIZE", "3")
+    def test_lru_eviction(self, tmp_path):
+        """Test that LRU eviction works when cache is full.
 
-        # Force module reload and reset to pick up new env var
-        import importlib
-
-        import code_intelligence.shared.ast_cache as ac
-
-        ac._cache_instance = None
-        ASTCache.reset_instance()
-        importlib.reload(ac)
-
-        cache = ac.ASTCache()
+        #11681: direct construction now yields an independent instance, so
+        a bounded cache can be built directly instead of the old env-var +
+        importlib.reload dance (which stopped working when config moved to
+        the SSOT proxy that does not re-read env on reload).
+        """
+        cache = ASTCache(max_size=3)
 
         # Create test files
         files = []
@@ -234,14 +220,8 @@ class TestASTCache:
             cache.get(f)
 
         stats = cache.get_stats()
-        assert stats.current_size == 3
-        assert stats.evictions == 2
-
-        # Cleanup - restore default env and reset
-        monkeypatch.setenv("AST_CACHE_MAX_SIZE", "1000")
-        ac._cache_instance = None
-        ac.ASTCache.reset_instance()
-        importlib.reload(ac)
+        assert stats["current_size"] == 3
+        assert stats["evictions"] == 2
 
     def test_invalidate_specific_file(self, tmp_path):
         """Test invalidating a specific file."""
@@ -278,9 +258,9 @@ class TestASTCache:
             get_ast(str(test_file))
 
     def test_singleton_pattern(self):
-        """Test that ASTCache is a singleton."""
-        cache1 = ASTCache()
-        cache2 = ASTCache()
+        """The lazy_singleton factory returns one shared instance (#11681)."""
+        cache1 = get_ast_cache()
+        cache2 = get_ast_cache()
         assert cache1 is cache2
 
 
@@ -289,18 +269,10 @@ class TestIntegration:
 
     @pytest.fixture(autouse=True)
     def reset_caches(self):
-        """Reset all caches before and after each test."""
-        # Reset both module-level instances
-        import code_intelligence.shared.ast_cache as ac
-        import code_intelligence.shared.file_cache as fc
-
-        fc._cache_instance = None
-        ac._cache_instance = None
+        """Reset all shared caches before and after each test (#11681)."""
         FileListCache.reset_instance()
         ASTCache.reset_instance()
         yield
-        fc._cache_instance = None
-        ac._cache_instance = None
         FileListCache.reset_instance()
         ASTCache.reset_instance()
 

--- a/autobot-backend/monitoring/redis_prometheus_metrics_test.py
+++ b/autobot-backend/monitoring/redis_prometheus_metrics_test.py
@@ -15,17 +15,27 @@ from monitoring.prometheus_metrics import get_metrics_manager
 
 @pytest.fixture
 def pool_manager():
-    """Create a Redis pool manager for testing"""
+    """Create a fresh Redis pool manager for each test (#11681 reset seam)."""
+    RedisConnectionManager.reset_instance()
     manager = RedisConnectionManager()
-    return manager
+    yield manager
+    RedisConnectionManager.reset_instance()
 
 
 @pytest.fixture
 def mock_metrics():
-    """Mock the Prometheus metrics manager"""
-    with patch("autobot_shared.monitoring.prometheus_metrics.get_metrics_manager") as mock_get:
-        mock_manager = MagicMock()
-        mock_get.return_value = mock_manager
+    """Mock the Prometheus metrics manager.
+
+    #11681: patch the connection manager's own lazy getter — the old patch
+    target (``autobot_shared.monitoring.prometheus_metrics``) is never read
+    by ``connection_manager``, which lazy-imports and caches
+    ``monitoring.prometheus_metrics.get_metrics_manager`` instead.
+    """
+    mock_manager = MagicMock()
+    with patch(
+        "autobot_shared.redis_management.connection_manager._get_metrics_manager",
+        return_value=mock_manager,
+    ):
         yield mock_manager
 
 

--- a/autobot-backend/services/tracing_service.py
+++ b/autobot-backend/services/tracing_service.py
@@ -78,13 +78,32 @@ class TracingService:
     _lock: threading.Lock = threading.Lock()
 
     def __new__(cls) -> "TracingService":
-        """Singleton pattern - only one tracing service per process (thread-safe)."""
+        """Singleton pattern - only one tracing service per process (thread-safe).
+
+        Issue #11681: kept as a locked ``__new__`` (not migrated to
+        ``singleton_factory.lazy_singleton``) — the constructor itself is the
+        public singleton accessor (module-level ``tracing_service`` and
+        thread-safety tests construct ``TracingService()`` directly and rely
+        on identity), so a factory seam would break the constructor contract.
+        """
         if cls._instance is None:
             with cls._lock:
                 # Double-check after acquiring lock (Issue #481 - race condition fix)
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
         return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Drop the singleton so the next construction starts fresh.
+
+        Test seam only (#11681 — uniform reset seams across singletons).
+        Does NOT shut down the tracer provider on the old instance; call
+        ``shutdown()`` first if one was initialized.
+        """
+        with cls._lock:
+            cls._instance = None
+            cls._initialized = False
 
     def __init__(self) -> None:
         """Initialize tracing service (only runs once due to singleton)."""
@@ -528,5 +547,10 @@ tracing_service = TracingService()
 
 
 def get_tracing_service() -> TracingService:
-    """Get the singleton tracing service instance."""
-    return tracing_service
+    """Get the singleton tracing service instance.
+
+    Constructs via ``TracingService()`` (which returns the singleton) instead
+    of the eager module-level instance so ``reset_instance()`` takes effect
+    for accessor callers (#11681).
+    """
+    return TracingService()

--- a/autobot-backend/utils/redis_consolidation_test.py
+++ b/autobot-backend/utils/redis_consolidation_test.py
@@ -125,11 +125,18 @@ class TestPhase3ConnectionManager:
         assert hasattr(manager, "_active_async_connections")
 
     def test_tcp_keepalive_configuration(self):
-        """Test TCP keepalive options are configured"""
+        """Test TCP keepalive options are configured.
+
+        #11681: keys are the platform ``socket`` constants (Linux:
+        TCP_KEEPIDLE=4, TCP_KEEPINTVL=5, TCP_KEEPCNT=6) — the old
+        hardcoded 1/2/3 keys never existed on Linux.
+        """
+        import socket
+
         manager = RedisConnectionManager()
-        assert manager._tcp_keepalive_options[1] == 600  # TCP_KEEPIDLE
-        assert manager._tcp_keepalive_options[2] == 60  # TCP_KEEPINTVL
-        assert manager._tcp_keepalive_options[3] == 5  # TCP_KEEPCNT
+        assert manager._tcp_keepalive_options[socket.TCP_KEEPIDLE] == 600
+        assert manager._tcp_keepalive_options[socket.TCP_KEEPINTVL] == 60
+        assert manager._tcp_keepalive_options[socket.TCP_KEEPCNT] == 5
 
 
 class TestPhase4AdvancedFeatures:

--- a/autobot-backend/utils/thread_safety_test.py
+++ b/autobot-backend/utils/thread_safety_test.py
@@ -27,9 +27,14 @@ class TestTracingServiceSingleton:
 
     @pytest.fixture(autouse=True)
     def skip_if_opentelemetry_unavailable(self):
-        """Skip tests if OpenTelemetry has import issues"""
+        """Skip tests if OpenTelemetry has import issues.
+
+        #11681: the guarded import had rotted to ``pass`` (autoflake-era),
+        so missing otel instrumentation FAILED these tests instead of
+        skipping them.
+        """
         try:
-            pass
+            import services.tracing_service  # noqa: F401
         except ImportError as e:
             pytest.skip(f"TracingService unavailable: {e}")
 
@@ -48,9 +53,8 @@ class TestTracingServiceSingleton:
         """Test that concurrent access returns same singleton instance"""
         from services.tracing_service import TracingService
 
-        # Reset singleton for clean test
-        TracingService._instance = None
-        TracingService._initialized = False
+        # Reset singleton for clean test (#11681: canonical seam)
+        TracingService.reset_instance()
 
         instances = []
         errors = []
@@ -267,9 +271,14 @@ class TestDoubleCheckedLocking:
 
     @pytest.fixture(autouse=True)
     def skip_if_opentelemetry_unavailable(self):
-        """Skip tests if OpenTelemetry has import issues"""
+        """Skip tests if OpenTelemetry has import issues.
+
+        #11681: the guarded import had rotted to ``pass`` (autoflake-era),
+        so missing otel instrumentation FAILED these tests instead of
+        skipping them.
+        """
         try:
-            pass
+            import services.tracing_service  # noqa: F401
         except ImportError as e:
             pytest.skip(f"TracingService unavailable: {e}")
 

--- a/autobot_shared/redis_client.py
+++ b/autobot_shared/redis_client.py
@@ -175,19 +175,18 @@ __all__ = [
 # Lazy initialization prevents Redis connection errors during module imports
 # on dev machines where the Redis VM is unreachable.
 
-_connection_manager: RedisConnectionManager | None = None
-
 
 def _get_connection_manager() -> RedisConnectionManager:
     """Get the singleton RedisConnectionManager, creating it on first use.
 
     Issue #803: Lazy initialization avoids Redis connection errors during
     module imports on dev machines where the Redis VM is unreachable.
+
+    Issue #11681: the class's locked ``__new__`` is the single cache layer —
+    the former module-level ``_connection_manager`` global duplicated it and
+    went stale after ``RedisConnectionManager.reset_instance()``.
     """
-    global _connection_manager
-    if _connection_manager is None:
-        _connection_manager = RedisConnectionManager()
-    return _connection_manager
+    return RedisConnectionManager()
 
 
 # =============================================================================

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -149,12 +149,30 @@ class RedisConnectionManager:
     _lock = Lock()
 
     def __new__(cls):
-        """Singleton pattern for connection manager."""
+        """Singleton pattern for connection manager.
+
+        Issue #11681: kept as a locked ``__new__`` (not migrated to
+        ``singleton_factory.lazy_singleton``) — the constructor itself is the
+        public singleton accessor (``RedisConnectionManager()`` call sites
+        across redis_client.py, celery prefork setup, and identity tests rely
+        on it), so a factory seam would break the constructor contract.
+        """
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
         return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Drop the singleton so the next construction starts fresh.
+
+        Test seam only (#11681 — uniform reset seams across singletons).
+        Does NOT close pools on the old instance; call ``close_all()`` first
+        if pools were created.
+        """
+        with cls._lock:
+            cls._instance = None
 
     def __init__(self) -> None:
         """

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1329,7 +1329,8 @@ class MiscConfig(BaseSettings):
 
     anthropic_api_base_url: str = Field(default="", alias="ANTHROPIC_API_BASE_URL")
     api_key: str = Field(default="", alias="API_KEY")
-    ast_cache_max_size: int = Field(default=0, alias="AST_CACHE_MAX_SIZE")
+    # #11681: restore pre-#7437 default (1000) — 0 silently disabled the AST cache
+    ast_cache_max_size: int = Field(default=1000, alias="AST_CACHE_MAX_SIZE")
     audit_log_file: str = Field(default="/opt/autobot/logs/audit.log", alias="AUTOBOT_AUDIT_LOG_FILE")
     autoresearch_docker_cpus: str = Field(default="", alias="AUTOBOT_AUTORESEARCH_DOCKER_CPUS")
     autoresearch_data_dir: str = Field(default="", alias="AUTOBOT_AUTORESEARCH_DATA_DIR")
@@ -1577,7 +1578,8 @@ class MiscConfig(BaseSettings):
     codebase_parallel_mode: str = Field(default="", alias="CODEBASE_PARALLEL_MODE")
     codebase_scan_parallel_files: str = Field(default="", alias="CODEBASE_SCAN_PARALLEL_FILES")
     config: str = Field(default="", alias="CONFIG")
-    content_cache_max_size: int = Field(default=0, alias="CONTENT_CACHE_MAX_SIZE")
+    # #11681: restore pre-#7437 default (500) — 0 silently disabled the content cache
+    content_cache_max_size: int = Field(default=500, alias="CONTENT_CACHE_MAX_SIZE")
     context_enabled: bool = Field(default=False, alias="CONTEXT_ENABLED")
     context_model: str = Field(default="", alias="CONTEXT_MODEL")
     context_summary_ttl_days: str = Field(default="", alias="CONTEXT_SUMMARY_TTL_DAYS")
@@ -1591,7 +1593,8 @@ class MiscConfig(BaseSettings):
     display_height: str = Field(default="", alias="DISPLAY_HEIGHT")
     display_width: str = Field(default="", alias="DISPLAY_WIDTH")
     encryption_key: str = Field(default="", alias="ENCRYPTION_KEY")  # type: ignore[no-redef]  # GH#7105
-    file_cache_ttl_seconds: int = Field(default=0, alias="FILE_CACHE_TTL_SECONDS")
+    # #11681: restore pre-#7437 default (300 s) — 0 made every file-list entry expire instantly
+    file_cache_ttl_seconds: int = Field(default=300, alias="FILE_CACHE_TTL_SECONDS")
     gateway_enable_sandbox: str = Field(default="", alias="GATEWAY_ENABLE_SANDBOX")
     gateway_heartbeat_interval: str = Field(default="", alias="GATEWAY_HEARTBEAT_INTERVAL")
     gateway_max_message_size: int = Field(default=0, alias="GATEWAY_MAX_MESSAGE_SIZE")


### PR DESCRIPTION
Closes #11681

## Thinking Path

Tail of #11637/PR #11654. Four remaining hand-rolled locked-`__new__` singletons. Two migrate cleanly to `lazy_singleton`; two keep locked `__new__` with justification comments (constructor IS the public accessor with dozens of direct-construction call sites / thread-safety tests inspecting `__new__` source) but gain the missing `reset_instance()` test seams so they stop leaking state across tests.

## What Changed

- `FileListCache` + `ASTCache`: locked `__new__`/`_instance`/`_initialized` removed → `get_file_list_cache`/`get_ast_cache = lazy_singleton(...)`; `reset_instance()` kept as delegating shim (the old one reset a phantom global and never cleared the factory layer — stale-instance bug fixed). `cache/__init__.py` factories and `code_intelligence/shared/__init__.py` exports updated.
- `TracingService`, `RedisConnectionManager`: locked `__new__` kept (justified in-code), `reset_instance()` seams added; `redis_client.py`'s duplicated `_connection_manager` module-global cache removed (went stale after reset).

Pre-existing bugs fixed in-scope (each had baseline-failure evidence):
1. `ssot_config.py` #7437 regression — `AST_CACHE_MAX_SIZE`/`CONTENT_CACHE_MAX_SIZE`/`FILE_CACHE_TTL_SECONDS` defaulted to 0, **silently disabling both caches platform-wide**; restored to 1000/500/300.
2. `get_file_cache_stats()`/`get_ast_cache_stats()` called `.to_dict()` on an already-dict → AttributeError on every call.
3. `redis_prometheus_metrics_test.py` patched a path the manager never reads + singleton stats bled across tests (7 failures) → patches the real `_get_metrics_manager` seam + reset seam.
4. `thread_safety_test.py` skip fixtures rotted to `try: pass` — missing otel FAILED instead of SKIPPED.
5. `redis_consolidation_test.py` hardcoded TCP keepalive keys 1/2/3 instead of `socket.TCP_KEEPIDLE/INTVL/CNT` (KeyError on Linux).

## Verification

- Agent: 82 passed / 4 skipped (otel absent locally) vs baseline 20 failed on identical suites (baseline verified on clean main tree); startup imports 344 passed; flake8 clean on all 12 files.
- Independent re-run (main session): 4 suites = 64 passed / 4 skipped; `tests/test_startup_imports.py` 344 passed.
- Caller sweep: no imports of removed `_get_cache`/`_connection_manager`/`_cache_instance` remain; no sync↔async changes; remaining locked `__new__` singletons (gateway, http_client, plugin_sdk, external_provider_factory, AdapterRegistry) were already handled by #11654 — outside this issue's scope.

## Model Used

Claude Fable 5 (subagent: general-purpose)