### PR TITLE
consolidate(code-exec): single tool-classification source for SENSITIVE_TOOLS + CODEEXEC_READONLY_TOOLS (#11662)

### DIFF
--- a/autobot-backend/chat_workflow/code_exec/shim_codegen.py
+++ b/autobot-backend/chat_workflow/code_exec/shim_codegen.py
@@ -9,36 +9,13 @@ Each shim function calls the server-side broker via JSON-RPC over stdio, using a
 per-call monotonic id so concurrent same-tool calls correlate their replies.
 """
 
-import os
-
 from chat_workflow.code_exec.protocol import RPC_SENTINEL
 
-CODEEXEC_INJECTABLE_TOOLS: frozenset[str] = frozenset(
-    os.environ.get(
-        "AUTOBOT_CODEEXEC_INJECTABLE_TOOLS",
-        "web_search,scrape_url,map_site,extract_structured_data",
-    ).split(",")
-)
-
-# GH#11568 MAJOR-3: tools that must NEVER be injectable, regardless of the env
-# allowlist. Subtracted unconditionally so an operator who widens
-# AUTOBOT_CODEEXEC_INJECTABLE_TOOLS can never shim compose/delegate/execute_command.
-SENSITIVE_TOOLS: frozenset[str] = frozenset(
-    {
-        "execute_command",
-        "compose",
-        "delegate",
-        "deploy",
-        "git_push",
-        "navigate",
-        "click",
-        "fill",
-        "select",
-        "evaluate",
-        "write_file",
-        "edit_file",
-        "delete_file",
-    }
+# GH#11662: classification lives in the single tool-policy source; re-exported
+# here so existing consumers (and test patch points) keep working.
+from chat_workflow.code_exec.tool_policy import (  # noqa: F401
+    CODEEXEC_INJECTABLE_TOOLS,
+    SENSITIVE_TOOLS,
 )
 
 

--- a/autobot-backend/chat_workflow/code_exec/tool_policy.py
+++ b/autobot-backend/chat_workflow/code_exec/tool_policy.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Single tool-classification source for code-exec mode (GH#11662).
+
+Code-exec tool policy was split across two modules with two env vars that
+could drift: ``shim_codegen.SENSITIVE_TOOLS`` / ``CODEEXEC_INJECTABLE_TOOLS``
+(what may be shimmed) and ``tool_handler.CODEEXEC_READONLY_TOOLS`` (what may
+be auto-approved). This module is the ONE classification: every tool is
+exactly one of **sensitive** / **mutating** / **readonly**, and the consumer
+sets are derived views with invariants enforced at import:
+
+- ``readonly ⊆ injectable`` — a tool declared read-only via env but absent
+  from the injectable allowlist is dropped from the read-only view (it can
+  never appear in a shim snapshot, so auto-approving it would be dead policy;
+  intersecting resolves toward the safer side rather than widening injectable).
+- ``sensitive ∩ injectable = ∅`` — sensitive tools are structurally
+  unrepresentable in the sandbox regardless of env widening.
+- ``mutating = injectable − readonly`` — the gray zone: shimmable, but every
+  run containing one always forces the WORKFLOW_GATE (never auto-approved).
+
+NOTE: this is the *code-exec sandbox* classification (exact tool names).
+It is distinct from ``autobot_shared.tool_catalogue.SENSITIVE_TOOLS``, the
+agent-loop approval plane (prefix-matched patterns via ``match_tool_name``);
+that plane gates interactive tool calls, this one gates shim injection.
+"""
+
+from __future__ import annotations
+
+import os
+
+#: Tools that must NEVER be injectable into the sandbox, regardless of any
+#: env allowlist (GH#11568 MAJOR-3). Hardcoded — intentionally not
+#: env-representable so an operator cannot widen it away.
+SENSITIVE_TOOLS: frozenset[str] = frozenset(
+    {
+        "execute_command",
+        "compose",
+        "delegate",
+        "deploy",
+        "git_push",
+        "navigate",
+        "click",
+        "fill",
+        "select",
+        "evaluate",
+        "write_file",
+        "edit_file",
+        "delete_file",
+    }
+)
+
+_DEFAULT_READONLY_CSV = "web_search,scrape_url,map_site,extract_structured_data"
+
+
+def _env_toolset(name: str) -> frozenset[str]:
+    """Parse a comma-separated tool-name env var (default = the read-only four)."""
+    return frozenset(os.environ.get(name, _DEFAULT_READONLY_CSV).split(","))
+
+
+def derive_views(
+    env_injectable: "frozenset[str]", env_readonly: "frozenset[str]"
+) -> "tuple[frozenset[str], frozenset[str]]":
+    """Derive the (injectable, readonly) views from the raw env sets.
+
+    Sensitive tools are subtracted from injectable unconditionally, and readonly
+    is intersected with the resulting injectable view, so a drifted env entry can
+    never mark a sensitive — or non-injectable — tool as shimmable/auto-approvable.
+    """
+    injectable = env_injectable - SENSITIVE_TOOLS
+    return injectable, env_readonly & injectable
+
+
+#: Tools that may be shimmed into the sandbox (invariant: sensitive ∩ injectable = ∅)
+#: and the read-only subset eligible for auto-approval (GH#11568 BLOCKER-4, design
+#: §3.1; invariant: readonly ⊆ injectable).
+CODEEXEC_INJECTABLE_TOOLS: frozenset[str]
+CODEEXEC_READONLY_TOOLS: frozenset[str]
+CODEEXEC_INJECTABLE_TOOLS, CODEEXEC_READONLY_TOOLS = derive_views(
+    _env_toolset("AUTOBOT_CODEEXEC_INJECTABLE_TOOLS"),
+    _env_toolset("AUTOBOT_CODEEXEC_READONLY_TOOLS"),
+)
+
+#: Derived gray-zone view: injectable but not read-only. A shim snapshot
+#: containing any of these always forces the WORKFLOW_GATE.
+CODEEXEC_MUTATING_TOOLS: frozenset[str] = CODEEXEC_INJECTABLE_TOOLS - CODEEXEC_READONLY_TOOLS
+
+
+def _check_invariants() -> None:
+    """Fail fast at import if a future edit breaks the classification invariants."""
+    if not CODEEXEC_READONLY_TOOLS <= CODEEXEC_INJECTABLE_TOOLS:
+        raise RuntimeError("code-exec tool policy violated: readonly must be a subset of injectable")
+    if SENSITIVE_TOOLS & CODEEXEC_INJECTABLE_TOOLS:
+        raise RuntimeError("code-exec tool policy violated: sensitive tools must never be injectable")
+    if CODEEXEC_MUTATING_TOOLS != CODEEXEC_INJECTABLE_TOOLS - CODEEXEC_READONLY_TOOLS:
+        raise RuntimeError("code-exec tool policy violated: mutating must equal injectable minus readonly")
+
+
+_check_invariants()
+
+__all__ = [
+    "SENSITIVE_TOOLS",
+    "CODEEXEC_INJECTABLE_TOOLS",
+    "CODEEXEC_READONLY_TOOLS",
+    "CODEEXEC_MUTATING_TOOLS",
+]

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -15,7 +15,6 @@ import ast
 import asyncio
 import html
 import json
-import os
 import re
 import uuid
 from typing import TYPE_CHECKING, Any, AsyncIterator
@@ -24,6 +23,7 @@ from async_chat_workflow import WorkflowMessage
 from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
+from chat_workflow.code_exec.tool_policy import CODEEXEC_READONLY_TOOLS
 from llc.agent_tools import LLC_TOOL_NAMES, LLC_TOOL_SCHEMAS, LLCToolError, dispatch_llc_tool
 from tools.code_interpreter import CODE_INTERPRETER_SCHEMA
 from utils.errors import RepairableException
@@ -48,15 +48,9 @@ logger = get_logger(__name__)
 CODEEXEC_ENABLED: bool = env_flag("AUTOBOT_CODEEXEC_ENABLED", default=False)
 CODEEXEC_AUTOAPPROVE_READONLY: bool = env_flag("AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY", default=True)
 CODEEXEC_MAX_SCRIPT_RETRIES: int = env_int("AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES", default=1)
-# GH#11568 BLOCKER-4: the read-only tool set eligible for auto-approval (design §3.1).
-# Auto-approve fires ONLY when every shimmed tool is in this set. Env-overridable so it
-# tracks the injectable default; sensitive tools are structurally excluded upstream.
-CODEEXEC_READONLY_TOOLS: frozenset[str] = frozenset(
-    os.environ.get(
-        "AUTOBOT_CODEEXEC_READONLY_TOOLS",
-        "web_search,scrape_url,map_site,extract_structured_data",
-    ).split(",")
-)
+# GH#11568 BLOCKER-4 / GH#11662: the read-only tool set eligible for auto-approval
+# (design §3.1) is CODEEXEC_READONLY_TOOLS, imported above from the single
+# tool-policy classification source (readonly ⊆ injectable; sensitive excluded).
 # Approval-wait polling knobs (mirrors terminal-command approval loop).
 CODEEXEC_APPROVAL_WAIT_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS", default=1800)
 CODEEXEC_APPROVAL_POLL_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS", default=2)

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -518,6 +518,59 @@ def test_injectable_excludes_sensitive_even_when_env_widened():
 
 
 # ---------------------------------------------------------------------------
+# GH#11662: single tool-classification source (tool_policy) + derived views
+# ---------------------------------------------------------------------------
+
+
+def test_tool_policy_is_single_source_for_consumers():
+    """shim_codegen and tool_handler must expose the tool_policy objects, not copies."""
+    import chat_workflow.tool_handler as th
+    from chat_workflow.code_exec import shim_codegen, tool_policy
+
+    assert shim_codegen.SENSITIVE_TOOLS is tool_policy.SENSITIVE_TOOLS
+    assert shim_codegen.CODEEXEC_INJECTABLE_TOOLS is tool_policy.CODEEXEC_INJECTABLE_TOOLS
+    assert th.CODEEXEC_READONLY_TOOLS is tool_policy.CODEEXEC_READONLY_TOOLS
+
+
+def test_tool_policy_invariants_hold():
+    """readonly ⊆ injectable; sensitive ∩ injectable = ∅; mutating = injectable − readonly."""
+    from chat_workflow.code_exec import tool_policy as tp
+
+    assert tp.CODEEXEC_READONLY_TOOLS <= tp.CODEEXEC_INJECTABLE_TOOLS
+    assert not (tp.SENSITIVE_TOOLS & tp.CODEEXEC_INJECTABLE_TOOLS)
+    assert tp.CODEEXEC_MUTATING_TOOLS == tp.CODEEXEC_INJECTABLE_TOOLS - tp.CODEEXEC_READONLY_TOOLS
+    tp._check_invariants()  # explicit call must not raise
+
+
+def test_tool_policy_env_drift_resolves_safer():
+    """A drifted env cannot widen policy: sensitive stays out of injectable, and a
+    readonly-only env entry (not injectable) is dropped rather than auto-approvable."""
+    from chat_workflow.code_exec.tool_policy import derive_views
+
+    injectable, readonly = derive_views(
+        frozenset({"web_search", "write_file", "execute_command"}),
+        frozenset({"web_search", "scrape_url"}),
+    )
+    # sensitive tools never injectable, even when env-listed
+    assert "write_file" not in injectable
+    assert "execute_command" not in injectable
+    assert injectable == frozenset({"web_search"})
+    # readonly entry absent from injectable is dropped (readonly ⊆ injectable)
+    assert "scrape_url" not in readonly
+    assert readonly == frozenset({"web_search"})
+
+
+def test_tool_policy_default_classification_unchanged():
+    """Default posture: the four read-only tools are injectable+readonly; no gray zone."""
+    from chat_workflow.code_exec import tool_policy as tp
+
+    default_four = frozenset({"web_search", "scrape_url", "map_site", "extract_structured_data"})
+    assert tp.CODEEXEC_INJECTABLE_TOOLS == default_four
+    assert tp.CODEEXEC_READONLY_TOOLS == default_four
+    assert tp.CODEEXEC_MUTATING_TOOLS == frozenset()
+
+
+# ---------------------------------------------------------------------------
 # MAJOR-1: shim RPC uses per-call ids so concurrent calls correlate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #11662

## Thinking Path

SENSITIVE_TOOLS and CODEEXEC_READONLY_TOOLS were duplicated across the code-exec modules; classification drift between copies is a security hazard. Per the issue's prescription, policy now lives in one module with import-time invariant checks; any drift resolves toward the safer classification.

## What Changed

- New `chat_workflow/code_exec/tool_policy.py` (issue offered `protocol.py` or a new `tool_policy.py`; protocol is wire-constants, so policy got its own file): canonical `SENSITIVE_TOOLS`, `CODEEXEC_INJECTABLE_TOOLS`, `CODEEXEC_READONLY_TOOLS`, derived `CODEEXEC_MUTATING_TOOLS`; `_check_invariants()` fails fast at import if sensitive ∩ injectable ≠ ∅ or readonly ⊄ injectable.
- Safer-drift semantics: a sensitive tool added to the injectable env var is subtracted at the constant level (the old inner guard kept as defense-in-depth); a readonly env entry absent from injectable is dropped by intersection (narrowing — unioning would have widened the sandbox).
- `shim_codegen.py` re-exports from tool_policy (test patch points preserved); `tool_handler.py` imports `CODEEXEC_READONLY_TOOLS` (literal deleted).
- `autobot_shared/tool_catalogue.py`'s SENSITIVE_TOOLS is a different plane (agent-loop approval gating, GH#11206 SSOT) — deliberately not merged; documented in the docstring.

## Verification

- Default posture byte-identical (env defaults were the same four-tool set) — locked by `test_tool_policy_default_classification_unchanged`.
- `test_code_exec.py` 71 passed (4 new tool_policy tests); approval-workflow + tool_catalogue 28 passed; startup imports 344 passed (agent). Independent re-run: 89 passed. flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)