### PR TITLE
fix(sandbox): split stderr from stdout in _parse_logs (#11629)

### DIFF
--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -241,8 +241,13 @@ class SecureSandboxExecutor:
             container.kill()
             exit_code = -9
 
-        logs = container.logs(stdout=True, stderr=True, stream=False)
-        stdout_logs, stderr_logs = self._parse_logs(logs)
+        # Fetch each stream separately: docker-py demuxes non-tty non-stream
+        # logs itself (headers stripped, streams merged), so a combined fetch
+        # can never be split afterwards (GH#11629). The daemon filters
+        # server-side when only one of stdout/stderr is requested.
+        stdout_raw = container.logs(stdout=True, stderr=False, stream=False)
+        stderr_raw = container.logs(stdout=False, stderr=True, stream=False)
+        stdout_logs, stderr_logs = self._parse_logs(stdout_raw, stderr_raw)
         stats = container.stats(stream=False)
         resource_usage = self._parse_resource_usage(stats)
 
@@ -585,10 +590,9 @@ class SecureSandboxExecutor:
             await asyncio.to_thread(container.kill)
             exit_code = -9
         logs = await asyncio.to_thread(lambda: container.logs(stdout=False, stderr=True, stream=False))
-        # logs holds stderr only (stdout=False); _parse_logs lumps all text into
-        # its first element, so that IS the stderr here (result stdout comes from
-        # the pump-captured script_stdout, not logs).
-        stderr_logs, _ = self._parse_logs(logs)
+        # logs holds stderr only (stdout=False); result stdout comes from the
+        # pump-captured script_stdout, not logs (GH#11613).
+        _, stderr_logs = self._parse_logs(b"", logs)
         security_events = await self._collect_security_events(container_id)
         result = self._build_sandbox_result(
             exit_code, script_stdout, stderr_logs, time.time() - start_time, container_id, security_events, {}, cfg
@@ -739,17 +743,23 @@ class SecureSandboxExecutor:
 
         return container_config
 
-    def _parse_logs(self, logs: bytes) -> Tuple[str, str]:
-        """Parse container logs into stdout and stderr"""
-        # Docker logs format includes stream headers
-        # For simplicity, we'll treat all as stdout for now
-        # In production, would parse the stream headers properly
+    def _parse_logs(self, stdout_raw: bytes, stderr_raw: bytes = b"") -> Tuple[str, str]:
+        """Decode per-stream container log bytes into (stdout, stderr) text (GH#11629).
+
+        Callers must fetch each stream separately (``container.logs(stdout=...,
+        stderr=...)``): docker-py already strips Docker's 8-byte stream-frame
+        headers from non-tty non-streaming logs and merges the payloads, so a
+        combined fetch is impossible to demux at this layer.
+        """
         try:
-            log_text = logs.decode("utf-8", errors="replace")
-            log_text = _strip_ansi(_dedup_consecutive(log_text))
-            return log_text, ""
+            return self._decode_log_stream(stdout_raw), self._decode_log_stream(stderr_raw)
         except Exception:
             return "", "Failed to parse logs"
+
+    @staticmethod
+    def _decode_log_stream(raw: bytes) -> str:
+        """Decode and normalize a single container log stream."""
+        return _strip_ansi(_dedup_consecutive(raw.decode("utf-8", errors="replace")))
 
     def _parse_resource_usage(self, stats: Dict[str, Any]) -> Dict[str, Any]:
         """Parse container stats into resource usage metrics"""

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -620,7 +620,7 @@ async def test_run_broker_script_mounts_large_script_via_file_not_argv():
         return {"image": "x"}
 
     ex._prepare_container_config = _prep
-    ex._parse_logs = lambda logs: ("", "")
+    ex._parse_logs = lambda stdout_raw, stderr_raw=b"": ("", "")
     ex._collect_security_events = AsyncMock(return_value=[])
     ex._build_sandbox_result = SecureSandboxExecutor._build_sandbox_result.__get__(ex)
     ex._log_execution_metrics = AsyncMock()
@@ -654,7 +654,7 @@ async def test_run_broker_script_starts_container_once():
     ex.docker_client = docker_client
 
     ex._prepare_container_config = lambda cmd, cfg: {"image": "x"}
-    ex._parse_logs = lambda logs: ("out", "")
+    ex._parse_logs = lambda stdout_raw, stderr_raw=b"": ("out", "")
     ex._collect_security_events = AsyncMock(return_value=[])
     ex._build_sandbox_result = SecureSandboxExecutor._build_sandbox_result.__get__(ex)
     ex._log_execution_metrics = AsyncMock()
@@ -871,6 +871,47 @@ async def test_collect_broker_results_uses_script_stdout_not_rpc_logs():
     # stdout must NOT have been sourced from container.logs (called with stdout=False).
     _, kwargs = container.logs.call_args
     assert kwargs.get("stdout") is False
-    # stderr-only logs are surfaced (not silently dropped): _parse_logs lumps
-    # them into element 0, so the broker path reads them from there (#11613 review).
+    # stderr-only logs are surfaced (not silently dropped): the broker path
+    # passes them as the stderr stream to _parse_logs (#11613 review, #11629).
     assert "RESULT clean" in result.stderr
+
+
+def test_parse_logs_splits_stdout_and_stderr():
+    """#11629: _parse_logs returns a real (stdout, stderr) split per stream."""
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    out, err = ex._parse_logs(b"hello out\n", b"boom err\n")
+    assert out.strip() == "hello out"
+    assert err.strip() == "boom err"
+    # stderr defaults empty when only one stream is supplied
+    out, err = ex._parse_logs(b"only out\n")
+    assert (out.strip(), err) == ("only out", "")
+
+
+def test_execute_container_with_timeout_fetches_streams_separately():
+    """#11629: stdout and stderr are requested as separate log streams."""
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    ex.logger = MagicMock()
+    ex._parse_resource_usage = lambda stats: {}
+
+    def _logs(stdout=True, stderr=True, stream=False):
+        if stdout and not stderr:
+            return b"out line\n"
+        if stderr and not stdout:
+            return b"err line\n"
+        raise AssertionError("combined stdout+stderr fetch cannot be demuxed (GH#11629)")
+
+    container = MagicMock()
+    container.wait.return_value = {"StatusCode": 0}
+    container.logs.side_effect = _logs
+    container.stats.return_value = {}
+
+    cfg = SecureSandboxExecutor._codeexec_config(ex, 30)
+    exit_code, stdout_logs, stderr_logs, _ = ex._execute_container_with_timeout(container, cfg)
+
+    assert exit_code == 0
+    assert stdout_logs.strip() == "out line"
+    assert stderr_logs.strip() == "err line"


### PR DESCRIPTION
Closes #11629

## Thinking Path

`_parse_logs` always returned empty stderr. The issue suggested demuxing frame headers, but docker-py's non-tty, non-streaming `container.logs()` already strips the 8-byte headers and joins payloads (`_multiplexed_buffer_helper`) — the combined bytes are irreversibly merged before we ever see them, so header-parsing in `_parse_logs` can never work. Root cause fix: request the streams separately from the daemon (server-side filtering — same mechanism the #11613 broker path already uses). Sandbox containers are created without tty, so per-stream filtering is valid.

## What Changed

- `secure_sandbox_executor.py`: `_execute_container_with_timeout` fetches `logs(stdout=True, stderr=False)` and `logs(stdout=False, stderr=True)`; `_parse_logs(stdout_raw, stderr_raw)` decodes each via new `_decode_log_stream` and returns a real (stdout, stderr) pair; broker path `_collect_broker_results` reads stderr from element 1 instead of the old lump-into-stdout quirk.
- Tests: monkeypatch lambdas updated to the new signature; new `test_parse_logs_splits_stdout_and_stderr` and `test_execute_container_with_timeout_fetches_streams_separately` (asserts a combined fetch is never made).

## Verification

- `tests/unit/chat_workflow/test_code_exec.py`: 69 passed (agent run and independent re-run identical). py_compile clean.
- `test_codeexec_docker_smoke.py` 4 skipped — Docker-daemon-gated, deferred to the on-box #11596 smoke (code-exec feature remains flag-off).

## Model Used

Claude Fable 5 (subagent: general-purpose)