### PR TITLE
fix(deploy): compose worker consumes all routed celery queues (#11631)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_process_init
+from kombu import Queue
 
 from autobot_shared.logging_manager import get_logger as _get_logger
 from autobot_shared.redis_management.types import DATABASE_MAPPING
@@ -108,6 +109,18 @@ celery_app.conf.update(
     # GH#11262: enable priority queues so audit preempts low-priority maintenance.
     task_queue_max_priority=_MAX_PRIORITY,
     task_default_priority=_PRIORITY_NORMAL,
+    # #11631: explicit queue set — a worker started WITHOUT -Q (the Ansible
+    # systemd unit autobot-celery.service.j2) consumes exactly these queues;
+    # Celery's default without this is the lone `celery` queue, which left
+    # deployments/memory/analytics tasks unconsumed in that flavor. Every
+    # queue referenced by task_routes below MUST be listed here (guarded by
+    # celery_queue_coverage_test.py) or routed tasks sit in Redis forever.
+    task_queues=(
+        Queue("celery"),
+        Queue("deployments"),
+        Queue("memory"),
+        Queue("analytics"),
+    ),
     # Task routing - route tasks to appropriate queues
     # #11608: phantom routes for tasks.deploy_host / tasks.provision_ssh_key /
     # tasks.manage_service removed — those tasks moved to the SLM server (#729)

--- a/autobot-backend/celery_queue_coverage_test.py
+++ b/autobot-backend/celery_queue_coverage_test.py
@@ -1,0 +1,79 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every queue task_routes can target must have a consumer in every flavor (#11631).
+
+celery_app.py is heavy and pytest-stubbed (#7766), so this parses source text
+instead of importing it. Consumers checked:
+  - task_queues in celery_app.py (SSOT — covers the Ansible systemd unit,
+    which starts without -Q and therefore consumes exactly this set)
+  - docker-compose.yml autobot-worker --queues
+  - autobot-infrastructure/shared/scripts/start-celery-worker.sh --queues
+"""
+
+import re
+from pathlib import Path
+
+import celery_priority as cp
+
+_BACKEND_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _BACKEND_DIR.parent
+_CELERY_APP_SRC = (_BACKEND_DIR / "celery_app.py").read_text(encoding="utf-8")
+
+# Default queue — priority-tier routes and every unrouted task land here.
+_DEFAULT_QUEUE = "celery"
+
+
+def _routed_queues() -> set[str]:
+    """All queues task_routes can send a task to."""
+    queues = set(re.findall(r'\{"queue":\s*"([\w-]+)"\}', _CELERY_APP_SRC))
+    # Priority tiers merged into task_routes may pin explicit queues too.
+    queues |= {route["queue"] for route in cp.PRIORITY_TASK_ROUTES.values() if "queue" in route}
+    queues.add(_DEFAULT_QUEUE)
+    return queues
+
+
+def _task_queues() -> set[str]:
+    """Queue names declared in celery_app.py task_queues."""
+    return set(re.findall(r'Queue\("([\w-]+)"\)', _CELERY_APP_SRC))
+
+
+def _queues_flag(text: str, path: str) -> set[str]:
+    """Extract the --queues=... consumer list from a launcher file."""
+    match = re.search(r"--queues=([\w,-]+)", text)
+    assert match, f"no --queues flag found in {path}"
+    return set(match.group(1).split(","))
+
+
+def test_task_queues_covers_all_routed_queues():
+    # The systemd unit (autobot-celery.service.j2) starts with no -Q and
+    # consumes exactly task_queues — a routed queue missing here is stranded.
+    routed, declared = _routed_queues(), _task_queues()
+    assert routed <= declared, f"task_routes targets queues missing from task_queues: {routed - declared}"
+
+
+def test_compose_worker_consumes_all_routed_queues():
+    text = (_REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    consumed = _queues_flag(text, "docker-compose.yml")
+    missing = _routed_queues() - consumed
+    assert not missing, f"docker-compose.yml autobot-worker does not consume routed queues: {missing}"
+
+
+def test_infra_start_script_consumes_all_routed_queues():
+    script = _REPO_ROOT / "autobot-infrastructure/shared/scripts/start-celery-worker.sh"
+    consumed = _queues_flag(script.read_text(encoding="utf-8"), str(script))
+    missing = _routed_queues() - consumed
+    assert not missing, f"start-celery-worker.sh does not consume routed queues: {missing}"
+
+
+def test_systemd_unit_inherits_task_queues():
+    # No -Q/--queues in the unit means it consumes the full task_queues set;
+    # if someone adds an explicit flag it must cover every routed queue.
+    unit = _REPO_ROOT / "autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2"
+    text = unit.read_text(encoding="utf-8")
+    exec_lines = [line for line in text.splitlines() if not line.lstrip().startswith("#")]
+    flags = re.search(r"(?:--queues=|-Q )([\w,-]+)", "\n".join(exec_lines))
+    if flags:
+        missing = _routed_queues() - set(flags.group(1).split(","))
+        assert not missing, f"systemd unit --queues does not cover routed queues: {missing}"

--- a/autobot-infrastructure/shared/scripts/start-celery-worker.sh
+++ b/autobot-infrastructure/shared/scripts/start-celery-worker.sh
@@ -89,7 +89,7 @@ echo "[4/4] Starting Celery worker..."
 echo ""
 echo "Worker Configuration:"
 echo "  - Concurrency: 4 workers"
-echo "  - Queues: deployments"
+echo "  - Queues: celery,deployments,memory,analytics"
 echo "  - Max tasks per child: 50"
 echo "  - Time limit: 600s (10 minutes)"
 echo "  - Soft time limit: 540s (9 minutes)"
@@ -100,11 +100,16 @@ echo ""
 
 # Start Celery worker with appropriate configuration
 # provisioning/services queues removed — no tasks route to them since
-# deployment tasks moved to the SLM server (#729, cleanup #11608)
+# deployment tasks moved to the SLM server (#729, cleanup #11608).
+# #11631: this is the only worker in this flavor — it must consume every
+# queue task_routes targets (default celery + deployments/memory/analytics)
+# or routed tasks sit in Redis unconsumed. Must stay a superset of the SSOT
+# task_queues in autobot-backend/celery_app.py (guarded by
+# autobot-backend/celery_queue_coverage_test.py).
 exec celery -A backend.celery_app worker \
     --loglevel=info \
     --concurrency=4 \
-    --queues=deployments \
+    --queues=celery,deployments,memory,analytics \
     --max-tasks-per-child=50 \
     --time-limit=600 \
     --soft-time-limit=540 \

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-celery.service.j2
@@ -21,6 +21,11 @@ EnvironmentFile=-{{ service_auth_keys_dir | default('/etc/autobot/service-keys')
 # worker: Start worker process
 # --loglevel=info: Logging level
 # --concurrency=4: Number of worker processes (adjust based on CPU)
+# No -Q/--queues on purpose (#11631): the worker consumes the full task_queues
+# set defined in celery_app.py (celery, deployments, memory, analytics) — the
+# SSOT that keeps every task_routes target queue consumed. Before task_queues
+# existed, no -Q meant only the default `celery` queue, silently stranding
+# deployments/memory/analytics tasks in Redis.
 ExecStart={{ backend_code_dir | default(backend_install_dir) }}/venv/bin/celery -A celery_app worker \
     --loglevel=info \
     --concurrency={{ celery_concurrency | default(4) }} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -326,8 +326,13 @@ services:
       - worker
       - --loglevel=info
       # provisioning/services queues removed — no tasks route to them since
-      # deployment tasks moved to the SLM server (#729, cleanup #11608)
-      - --queues=celery,deployments
+      # deployment tasks moved to the SLM server (#729, cleanup #11608).
+      # #11631: memory + analytics added — task_routes sends memory write-path
+      # and background-analytics tasks there; with no consumer they sat in
+      # Redis until eviction. Must stay a superset of the queues task_routes
+      # targets (SSOT: task_queues in autobot-backend/celery_app.py; guarded
+      # by autobot-backend/celery_queue_coverage_test.py).
+      - --queues=celery,deployments,memory,analytics
       - --concurrency=2
     working_dir: /app/autobot-backend
     env_file:


### PR DESCRIPTION
Closes #11631

## Thinking Path

Routed queues are celery, deployments, memory, analytics (`celery_app.py` task_routes; priority module sets only priorities). The issue reported compose stranding memory/analytics — investigation showed the gap is broader: the ansible/systemd unit sets no `-Q` at all (consumes only default `celery`, stranding deployments too), and the infra worker script consumed only `deployments`. Canonical fix: declare the full queue set once in `celery_app.py` `task_queues` (SSOT) — a no-`-Q` worker then consumes everything with zero unit changes.

## What Changed

- `celery_app.py`: `task_queues=(celery, deployments, memory, analytics)` declared as SSOT (comment documents the intentional absence of `-Q` in the systemd unit).
- `docker-compose.yml` autobot-worker + `autobot-infrastructure/shared/scripts/start-celery-worker.sh`: explicit `--queues=` extended to the full set (hardened compose inherits base command — verified). Concurrency unchanged (compose 2, script/systemd 4); memory/analytics are off-hot-path and #11262 priority ordering still drains critical work first.
- New guard `celery_queue_coverage_test.py` (4 tests): task_queues ⊇ routed, compose ⊇ routed, script ⊇ routed, systemd inherits-or-⊇.

## Verification

- New guard + `celery_priority_test.py`: 9/9 passed (agent and independent re-run). YAML parse of both compose files confirms the queue list; `bash -n` script OK; py_compile OK.
- Box-gated (no docker in this WSL distro): `docker compose config` + live enqueue-and-consume smoke — flagged for the next on-box deploy validation.

## Model Used

Claude Fable 5 (subagent: general-purpose)