### PR TITLE
fix(slm/security): pass ansible extra_vars via 0600 temp file, not argv (#11735)

### DIFF
--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -44,6 +44,7 @@ Groups parameterised at runtime (``target``, ``autobot-backend``,
 they are resolved via --limit or passed as extra-vars.
 """
 
+import json
 import logging
 import os
 import re
@@ -377,6 +378,38 @@ def write_temp_inventory(inv: dict, uid_tmp_dir: str | None = None) -> Path:
     tmp_path = Path(tmp_path_str)
     _write_inventory_file(inv, tmp_path)
     return tmp_path
+
+
+def write_temp_extra_vars(extra_vars: dict, uid_tmp_dir: str | None = None) -> Path:
+    """Write *extra_vars* to a unique 0600 JSON temp file and return its Path.
+
+    Passed to ansible-playbook as ``-e @<file>`` so secret extra_vars (the
+    stored SLM secrets auto-merged by PlaybookExecutor, #3519) never appear
+    in the process argv, which any local user can read via
+    ``/proc/<pid>/cmdline`` for the whole playbook run (#11735).  The caller
+    deletes the file after the run, same contract as write_temp_inventory.
+
+    Args:
+        extra_vars: Mapping passed to the playbook as extra vars.
+        uid_tmp_dir: Directory for the temp file.  If None, uses
+            ``/tmp/ansible_local_tmp_<uid>`` (nosec B108 — uid-scoped).
+
+    Returns:
+        Path to the written 0600 JSON file.
+    """
+    if uid_tmp_dir is None:
+        uid_tmp_dir = f"/tmp/ansible_local_tmp_{os.getuid()}"  # nosec B108
+    tmp_dir = Path(uid_tmp_dir)
+    tmp_dir.mkdir(mode=0o700, exist_ok=True)
+
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix="autobot_evars_",
+        suffix=".json",
+        dir=str(tmp_dir),
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(extra_vars, fh)
+    return Path(tmp_path_str)
 
 
 def scan_playbook_dir_for_groups(playbook_dir: Path) -> frozenset:

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -21,6 +21,7 @@ from services.ansible_secrets import fetch_deploy_secrets
 from services.inventory_builder import (
     build_registry_inventory,
     validate_inventory,
+    write_temp_extra_vars,
     write_temp_inventory,
 )
 from services.provision_progress import TaskProgressTracker
@@ -229,7 +230,7 @@ class PlaybookExecutor:
         playbook_path: Path,
         limit: List[str] | None,
         tags: List[str] | None,
-        extra_vars: Dict[str, str] | None,
+        extra_vars_file: Path | None,
         check_mode: bool,
         inventory_path: Path | None = None,
     ) -> List[str]:
@@ -237,6 +238,12 @@ class PlaybookExecutor:
         Build Ansible command with parameters.
 
         Helper for execute_playbook (Issue #880).
+
+        extra_vars are passed as ``-e @<file>`` (a 0600 temp JSON written by
+        write_temp_extra_vars), never as ``-e key=value`` argv: extra_vars
+        always include the stored SLM secrets (#3519), and argv is readable
+        by every local user via /proc/<pid>/cmdline for the whole run
+        (#11735).
         """
         ansible_cmd = self._find_ansible_playbook()
         effective_inventory = inventory_path or self.inventory_path
@@ -246,9 +253,8 @@ class PlaybookExecutor:
             cmd.extend(["--limit", ",".join(limit)])
         if tags:
             cmd.extend(["--tags", ",".join(tags)])
-        if extra_vars:
-            for key, value in extra_vars.items():
-                cmd.extend(["-e", f"{key}={value}"])
+        if extra_vars_file:
+            cmd.extend(["-e", f"@{extra_vars_file}"])
         if check_mode:
             cmd.append("--check")
 
@@ -538,11 +544,17 @@ class PlaybookExecutor:
         deploy_secrets = await fetch_deploy_secrets()
         merged_extra_vars: Dict[str, str] = {**deploy_secrets, **(extra_vars or {})}
 
+        # Secrets ride along in extra_vars — hand them to ansible via a 0600
+        # temp file (-e @file), never argv (#11735).
+        extra_vars_file: Path | None = None
+        if merged_extra_vars:
+            extra_vars_file = write_temp_extra_vars(merged_extra_vars)
+
         cmd = self._build_ansible_command(
             playbook_path,
             limit,
             tags,
-            merged_extra_vars or None,
+            extra_vars_file,
             check_mode,
             inventory_path=effective_inventory,
         )
@@ -573,12 +585,17 @@ class PlaybookExecutor:
                 "returncode": -1,
             }
         finally:
-            # Clean up the per-run temp inventory file
+            # Clean up the per-run temp inventory and extra-vars files
             if dynamic_inv_path is not None:
                 try:
                     dynamic_inv_path.unlink(missing_ok=True)
                 except OSError as exc:
                     logger.debug("Could not remove temp inventory %s: %s", dynamic_inv_path, exc)
+            if extra_vars_file is not None:
+                try:
+                    extra_vars_file.unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.debug("Could not remove temp extra-vars file %s: %s", extra_vars_file, exc)
 
 
 # Singleton instance

--- a/autobot-slm-backend/tests/services/test_extra_vars_file_11735.py
+++ b/autobot-slm-backend/tests/services/test_extra_vars_file_11735.py
@@ -1,0 +1,123 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Secret extra_vars must never appear in the ansible argv (#11735).
+
+PlaybookExecutor auto-merges stored SLM secrets into extra_vars (#3519);
+passing them as ``-e key=value`` exposed the values in /proc/<pid>/cmdline
+to every local user for the whole playbook run.  They now travel via a
+0600 temp JSON file passed as ``-e @<file>``.
+
+Loads the modules under test directly from their file paths via importlib
+(same approach as tests/api/test_apply_secrets.py): the shared conftest
+stubs the ``services`` package with MagicMocks, so normal package imports
+resolve to stubs when this file runs standalone (#11248).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_from_file(module_name: str, rel_path: str, extra_stubs: dict | None = None):
+    """Load a module from its file path with sys.modules snapshot/restore."""
+    snapshot = sys.modules.copy()
+    for name, stub in (extra_stubs or {}).items():
+        sys.modules[name] = stub
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, _BACKEND_ROOT / rel_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.clear()
+        sys.modules.update(snapshot)
+
+
+def _load_inventory_builder():
+    return _load_from_file("_ib_11735", "services/inventory_builder.py")
+
+
+def _load_playbook_executor():
+    services_pkg = MagicMock()
+    stubs = {
+        "services": services_pkg,
+        "services.ansible_secrets": MagicMock(),
+        "services.inventory_builder": MagicMock(),
+        "services.provision_progress": MagicMock(),
+    }
+    return _load_from_file("_pe_11735", "services/playbook_executor.py", extra_stubs=stubs)
+
+
+# ============================================================
+# write_temp_extra_vars
+# ============================================================
+
+
+def test_written_file_is_0600_and_round_trips(tmp_path):
+    ib = _load_inventory_builder()
+    vars_in = {"tts_hf_token": "hf_dummy_value", "plain": "x"}  # nosec B106 - test fixture, not a credential
+    path = ib.write_temp_extra_vars(vars_in, uid_tmp_dir=str(tmp_path))
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+        assert json.loads(path.read_text(encoding="utf-8")) == vars_in
+        assert path.parent == tmp_path
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_unique_file_per_call(tmp_path):
+    ib = _load_inventory_builder()
+    a = ib.write_temp_extra_vars({"k": "1"}, uid_tmp_dir=str(tmp_path))
+    b = ib.write_temp_extra_vars({"k": "2"}, uid_tmp_dir=str(tmp_path))
+    try:
+        assert a != b
+    finally:
+        a.unlink(missing_ok=True)
+        b.unlink(missing_ok=True)
+
+
+# ============================================================
+# _build_ansible_command
+# ============================================================
+
+
+def _build_command(extra_vars_file):
+    pe = _load_playbook_executor()
+    executor = pe.PlaybookExecutor.__new__(pe.PlaybookExecutor)  # skip __init__ (env probing)
+    executor.inventory_path = Path("/tmp/inv.yml")  # nosec B108 - test fixture path
+    executor._find_ansible_playbook = lambda: "ansible-playbook"
+    return executor._build_ansible_command(
+        Path("/tmp/play.yml"),  # nosec B108 - test fixture path
+        limit=["node-1"],
+        tags=None,
+        extra_vars_file=extra_vars_file,
+        check_mode=False,
+    )
+
+
+def test_command_uses_at_file_reference():
+    cmd = _build_command(Path("/tmp/evars.json"))  # nosec B108 - test fixture path
+    assert "-e" in cmd
+    assert "@/tmp/evars.json" in cmd
+
+
+def test_no_key_value_pairs_in_argv():
+    cmd = _build_command(Path("/tmp/evars.json"))  # nosec B108 - test fixture path
+    joined = " ".join(cmd)
+    assert "=" not in joined.replace("@/tmp/evars.json", ""), f"argv leaks key=value: {cmd}"
+
+
+def test_no_extra_vars_flag_when_no_file():
+    cmd = _build_command(None)
+    assert "-e" not in cmd


### PR DESCRIPTION
## Thinking Path

Found while reviewing #11728's CodeQL alert: `PlaybookExecutor._build_ansible_command` passed every extra_var as `-e key=value` argv. Since `execute_playbook` auto-merges the stored SLM secrets into extra_vars (#3519 — `tts_hf_token`, `autobot_internal_api_key`), secret values sat in `/proc/<pid>/cmdline`, readable by ANY local user, for the entire playbook run (deploys run minutes). Log lines were already safe (`cmd[:5]` only) — this is strictly the argv exposure.

## What Changed

- `services/inventory_builder.py` — new `write_temp_extra_vars()` beside `write_temp_inventory()` (same uid-scoped temp-dir convention): 0600 JSON via `mkstemp`, caller-deletes contract.
- `services/playbook_executor.py` — `_build_ansible_command` now takes `extra_vars_file: Path | None` and emits `-e @<file>`; `execute_playbook` writes the file when extra_vars are present and unlinks it in the same `finally` as the per-run temp inventory. No playbook changes needed (`-e @file` supplies identical vars, ansible-native).
- `tests/services/test_extra_vars_file_11735.py` — 5 tests: 0600 perms + JSON round-trip, unique file per call, `-e @file` in argv, **no `key=value` anywhere in argv**, no `-e` when no vars. (Loads modules by file path via importlib — the plain-import path is the pre-existing #11248 conftest fragility.)

## Verification

- `pytest tests/services/test_extra_vars_file_11735.py tests/api/test_apply_secrets.py` → **14 passed** (new + adjacent apply-secrets suite)
- `black --check` / `py_compile` / bandit clean on changed files
- Only internal caller of `_build_ansible_command` is `execute_playbook` (grepped — no external call sites)

Closes #11735

## Model Used

Fable 5 (inline implementation)
