### PR TITLE
fix(deploy): post-restart health poll + rollback in autobot_shared restart path (#11496)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1108,6 +1108,10 @@ _COMPONENT_BUILD_SCRIPT: Dict[str, str] = {
 # resolve jobs accepted in that window get killed mid-run and (pre-#11437)
 # were reconciled to failed with their migrations silently skipped.
 _SELF_KILLING_COMPONENTS = frozenset({"autobot-slm-backend", "autobot_shared"})
+# #11496: the systemd unit THIS process runs under. Restarting it kills this
+# process (#11460), so restart chains must schedule it last — anything after it
+# in a restart sequence never runs when the self-restart lands.
+_SELF_SERVICE_NAME = "autobot-slm-backend"
 _restart_pending: bool = False
 
 
@@ -1125,13 +1129,16 @@ _COMPONENT_SERVICES: Dict[str, List[str]] = {
     # must restart them all (else they keep running the old shared code and may
     # ImportError on a newly-referenced symbol). Restarts tolerate absent units
     # (distributed nodes won't have every service) — failures are logged, not fatal.
+    # #11496: our own unit (_SELF_SERVICE_NAME) is deliberately LAST — its restart
+    # kills this process (#11460), so any service listed after it would never be
+    # restarted and no post-restart health verification could run.
     "autobot_shared": [
-        "autobot-slm-backend",
         "autobot-backend",
         "autobot-ai-stack",
         "autobot-celery",
         "autobot-celery-beat",
         "autobot-npu-worker",
+        "autobot-slm-backend",
     ],
 }
 
@@ -1835,17 +1842,24 @@ async def _build_npm_frontend_for_component(component: str, steps: List[str]) ->
         return False
 
 
-async def _restart_component_services(component: str, steps: List[str]) -> None:
+async def _restart_component_services(
+    component: str, steps: List[str], services: Optional[List[str]] = None
+) -> None:
     """Restart the systemd service(s) associated with a deployed component (#9982).
+
+    *services* overrides the _COMPONENT_SERVICES lookup so a caller can restart
+    a subset (#11496: the autobot_shared path restarts non-self dependents first,
+    health-verifies them, then restarts our own unit last).
 
     Appends human-readable step notes to *steps*.
     """
     global _restart_pending
+    if services is None:
+        services = _COMPONENT_SERVICES.get(component, [])
     if component in _SELF_KILLING_COMPONENTS:
         # #11437: this chain will restart autobot-slm-backend itself — reject
         # new resolve jobs until the process dies (flag resets on boot).
         _restart_pending = True
-    services = _COMPONENT_SERVICES.get(component, [])
     for service in services:
         steps.append(f"restart: {service}")
         try:
@@ -2097,6 +2111,60 @@ async def _wait_component_healthy(component: str, steps: List[str], *, slow_star
     return True
 
 
+async def _restart_dependents_with_health(
+    component: str, snapshot: Optional[str], steps: List[str]
+) -> bool:
+    """Restart *component*'s dependent services with post-restart verification (#11496).
+
+    A shared-lib (autobot_shared) sync fans out to restart BOTH backends — an
+    import-heavy cold start — yet previously had zero post-restart health
+    verification. Restart every dependent EXCEPT this process's own unit first,
+    health-poll each (slow_start=True — cold re-import), and roll back the
+    component dir when any dependent fails. Dependents without an HTTP health
+    URL are verified via systemd state: a broken shared import surfaces as a
+    'failed' unit. Only when all others are healthy is our own unit restarted
+    last (which kills this process when it lands — #11437/#11460).
+
+    Returns True when all verified dependents are healthy; False after rollback.
+    """
+    global _restart_pending
+    dependents = _COMPONENT_SERVICES.get(component, [])
+    others = [s for s in dependents if s != _SELF_SERVICE_NAME]
+    await _restart_component_services(component, steps, services=others)
+    # The chain is still in flight — its final step (or a rollback) restarts our
+    # own unit. Keep the #11437 guard armed through the verification window (the
+    # surviving return above disarmed it, #11460) so resolve jobs accepted while
+    # we poll aren't killed mid-run by the upcoming self-restart.
+    self_restart_ahead = _SELF_SERVICE_NAME in dependents
+    if self_restart_ahead:
+        _restart_pending = True
+    unhealthy: List[str] = []
+    for dep in others:
+        if dep in _COMPONENT_HEALTH_URLS:
+            if not await _wait_component_healthy(dep, steps, slow_start=True):
+                unhealthy.append(dep)
+        elif await _is_systemd_unit_failed(dep):
+            steps.append(f"health: {dep} unit entered 'failed' state after {component} restart")
+            unhealthy.append(dep)
+    if unhealthy:
+        await _rollback_component(component, snapshot, steps, None)
+        steps.append(
+            "post-sync: rolled back to last-known-good due to unhealthy "
+            f"dependents after {component} restart: {', '.join(unhealthy)}"
+        )
+        # Still alive ⇒ no self-restart landed (rollback restarted us last and
+        # failed, or errored before restarting). Disarm so recovery resolves
+        # aren't 409-blocked forever (#11460).
+        _restart_pending = False
+        return False
+    if self_restart_ahead:
+        # All other dependents verified healthy — restart ourselves last. When
+        # this lands the process dies inside the call; a surviving return means
+        # the self-restart failed (and disarmed the guard, #11460).
+        await _restart_component_services(component, steps, services=[_SELF_SERVICE_NAME])
+    return True
+
+
 # Python backend components that embed an autobot_shared symlink (#10912).
 _BACKEND_COMPONENTS = frozenset(_COMPONENT_PIP_PATHS.keys())
 
@@ -2185,7 +2253,8 @@ async def _run_post_sync_steps(
           constraints deploy (#11322) + venv version check (#11323) +
           pip install + symlink restore (#10912) + alembic + restart + health
       - Frontend (autobot-frontend, autobot-slm-frontend): npm ci (conditional) + build + nginx reload + health
-      - autobot_shared: restore BOTH backends' symlinks (#10912) + restart dependents
+      - autobot_shared: restore BOTH backends' symlinks (#10912) + restart
+          dependents (self last) + per-dependent health + rollback (#11496)
     """
     steps: List[str] = []
     pip_ok = True
@@ -2257,7 +2326,11 @@ async def _run_post_sync_steps(
         for backend in sorted(_BACKEND_COMPONENTS):
             await _ensure_autobot_shared_symlink(backend, steps)
         if restart:
-            await _restart_component_services(component, steps)
+            # #11496: was the only sync path with no post-restart health poll
+            # or rollback — a shared-lib change that broke a backend import
+            # restarted onto a dead service undetected.
+            if not await _restart_dependents_with_health(component, snapshot, steps):
+                pip_ok = False
         else:
             steps.append("post-sync: restart deferred")
     else:

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1842,9 +1842,7 @@ async def _build_npm_frontend_for_component(component: str, steps: List[str]) ->
         return False
 
 
-async def _restart_component_services(
-    component: str, steps: List[str], services: Optional[List[str]] = None
-) -> None:
+async def _restart_component_services(component: str, steps: List[str], services: Optional[List[str]] = None) -> None:
     """Restart the systemd service(s) associated with a deployed component (#9982).
 
     *services* overrides the _COMPONENT_SERVICES lookup so a caller can restart
@@ -2111,9 +2109,7 @@ async def _wait_component_healthy(component: str, steps: List[str], *, slow_star
     return True
 
 
-async def _restart_dependents_with_health(
-    component: str, snapshot: Optional[str], steps: List[str]
-) -> bool:
+async def _restart_dependents_with_health(component: str, snapshot: Optional[str], steps: List[str]) -> bool:
     """Restart *component*'s dependent services with post-restart verification (#11496).
 
     A shared-lib (autobot_shared) sync fans out to restart BOTH backends — an

--- a/autobot-slm-backend/tests/api/test_shared_restart_health.py
+++ b/autobot-slm-backend/tests/api/test_shared_restart_health.py
@@ -190,9 +190,7 @@ def test_guard_stays_armed_during_verification_window() -> None:
 def test_unhealthy_backend_triggers_rollback_and_blocks_self_restart() -> None:
     """A dependent backend failing its health poll rolls back the shared dir and
     the self-restart never runs (would restart onto broken code)."""
-    steps, pip_ok, mocks = _run_shared_post_sync(
-        {"_wait_component_healthy": AsyncMock(return_value=False)}
-    )
+    steps, pip_ok, mocks = _run_shared_post_sync({"_wait_component_healthy": AsyncMock(return_value=False)})
 
     assert pip_ok is False
     mocks["_rollback_component"].assert_awaited_once()
@@ -217,9 +215,7 @@ def test_failed_url_less_dependent_triggers_rollback() -> None:
     async def _celery_failed(service: str) -> bool:
         return service == "autobot-celery"
 
-    steps, pip_ok, mocks = _run_shared_post_sync(
-        {"_is_systemd_unit_failed": AsyncMock(side_effect=_celery_failed)}
-    )
+    steps, pip_ok, mocks = _run_shared_post_sync({"_is_systemd_unit_failed": AsyncMock(side_effect=_celery_failed)})
 
     assert pip_ok is False
     mocks["_rollback_component"].assert_awaited_once()

--- a/autobot-slm-backend/tests/api/test_shared_restart_health.py
+++ b/autobot-slm-backend/tests/api/test_shared_restart_health.py
@@ -1,0 +1,304 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11496: post-restart health poll + rollback in the autobot_shared restart path.
+
+The _COMPONENT_SERVICES branch of _run_post_sync_steps (the autobot_shared
+library component) restarts every dependent service but previously had NO
+_wait_component_healthy poll and NO rollback — the only sync path without
+post-restart verification, despite being the one that cold-restarts BOTH
+backends onto freshly-imported shared code.
+
+Now: non-self dependents restart first, each is verified (HTTP health poll for
+dependents with a URL, systemd 'failed' check for the rest), a failure rolls
+back the shared dir from the pre-mutation snapshot, and only when all others
+are healthy is our own unit (autobot-slm-backend) restarted last — the
+self-restart kills this process (#11460), so it must never run before
+verification.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Minimal real Pydantic models for models.schemas so the router imports without a
+# full SLM venv (mirrors the sibling code-sync tests).
+if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
+    from pydantic import BaseModel as _BM
+
+    def _pydantic_stub(name: str) -> type:
+        return type(name, (_BM,), {})
+
+    _schemas = types.ModuleType("models.schemas")
+    for _cls in [
+        "CodeSyncStatusResponse",
+        "CodeSyncRefreshResponse",
+        "CodeVersionNotification",
+        "CodeVersionNotificationResponse",
+        "ComponentSyncJobStatus",
+        "DriftResolveJobResponse",
+        "DriftResolveRequest",
+        "DriftResolveResponse",
+        "FileDriftReport",
+        "FleetSyncJobStatus",
+        "FleetSyncNodeStatus",
+        "FleetSyncRequest",
+        "FleetSyncResponse",
+        "MarkSyncedResponse",
+        "NodeSyncRequest",
+        "NodeSyncResponse",
+        "PendingNodeResponse",
+        "PendingNodesResponse",
+        "ScheduleCreate",
+        "ScheduleResponse",
+        "ScheduleRunResponse",
+        "ScheduleUpdate",
+    ]:
+        setattr(_schemas, _cls, _pydantic_stub(_cls))
+    _models = sys.modules.get("models") or types.ModuleType("models")
+    _models.schemas = _schemas  # type: ignore[attr-defined]
+    sys.modules["models"] = _models
+    sys.modules["models.schemas"] = _schemas
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+import asyncio  # noqa: E402
+
+import api.code_sync as cs  # noqa: E402
+from api.code_sync import _run_post_sync_steps  # noqa: E402
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+_SHARED = "autobot_shared"
+_SELF = cs._SELF_SERVICE_NAME
+_OTHERS = [s for s in cs._COMPONENT_SERVICES[_SHARED] if s != _SELF]
+
+
+def _shared_branch_patches(**overrides):
+    """Common patches for driving _run_post_sync_steps('autobot_shared', ...)."""
+    mocks = {
+        "_compute_deps_changed": AsyncMock(return_value=False),
+        "_snapshot_component": AsyncMock(return_value="/opt/autobot/snapshots/autobot_shared_X"),
+        "_ensure_autobot_shared_symlink": AsyncMock(),
+        "_restart_component_services": AsyncMock(),
+        "_wait_component_healthy": AsyncMock(return_value=True),
+        "_is_systemd_unit_failed": AsyncMock(return_value=False),
+        "_rollback_component": AsyncMock(),
+    }
+    mocks.update(overrides)
+    patchers = [patch(f"api.code_sync.{name}", mock) for name, mock in mocks.items()]
+    return patchers, mocks
+
+
+def _run_shared_post_sync(mocks_overrides=None):
+    patchers, mocks = _shared_branch_patches(**(mocks_overrides or {}))
+    for p in patchers:
+        p.start()
+    try:
+        deps_changed, steps, pip_ok = _run(
+            _run_post_sync_steps(_SHARED, "/opt/autobot/code_source/autobot_shared", "/opt/autobot/autobot_shared")
+        )
+        mocks["guard_after"] = cs._restart_is_pending()
+    finally:
+        for p in patchers:
+            p.stop()
+        # The helper arms the #11437 guard through the verification window; the
+        # mocked restart never disarms it — reset so state can't leak.
+        cs._restart_pending = False
+    return steps, pip_ok, mocks
+
+
+# ---------------------------------------------------------------------------
+# Ordering invariant — self-restart must be last (#11460/#11496)
+# ---------------------------------------------------------------------------
+
+
+def test_self_unit_is_last_in_shared_restart_order() -> None:
+    """autobot-slm-backend restarts LAST: its restart kills this process, so any
+    service after it would never restart and no verification could run."""
+    assert cs._COMPONENT_SERVICES[_SHARED][-1] == _SELF
+
+
+# ---------------------------------------------------------------------------
+# poll-success path
+# ---------------------------------------------------------------------------
+
+
+def test_shared_sync_polls_dependents_then_restarts_self_last() -> None:
+    """All dependents healthy → pip_ok True, no rollback, and the restart order
+    is: non-self dependents first, self alone last."""
+    steps, pip_ok, mocks = _run_shared_post_sync()
+
+    assert pip_ok is True
+    mocks["_rollback_component"].assert_not_awaited()
+
+    restart_calls = mocks["_restart_component_services"].await_args_list
+    assert len(restart_calls) == 2
+    # First: every dependent except our own unit.
+    assert restart_calls[0].kwargs["services"] == _OTHERS
+    assert _SELF not in restart_calls[0].kwargs["services"]
+    # Last: our own unit alone (kills this process when it lands).
+    assert restart_calls[1].kwargs["services"] == [_SELF]
+
+    # Each URL-bearing dependent is polled with slow_start=True (cold re-import).
+    polled = [c.args[0] for c in mocks["_wait_component_healthy"].await_args_list]
+    assert polled == [d for d in _OTHERS if d in cs._COMPONENT_HEALTH_URLS]
+    assert all(c.kwargs.get("slow_start") is True for c in mocks["_wait_component_healthy"].await_args_list)
+
+
+def test_shared_sync_checks_systemd_state_of_url_less_dependents() -> None:
+    """Dependents without an HTTP health URL (celery, ai-stack, npu-worker) are
+    verified via systemd 'failed' state."""
+    _, pip_ok, mocks = _run_shared_post_sync()
+
+    assert pip_ok is True
+    checked = [c.args[0] for c in mocks["_is_systemd_unit_failed"].await_args_list]
+    assert checked == [d for d in _OTHERS if d not in cs._COMPONENT_HEALTH_URLS]
+
+
+def test_guard_stays_armed_during_verification_window() -> None:
+    """#11437: the 409 resolve-guard must stay armed while dependents are being
+    health-polled — the chain still ends in a self-restart, so a resolve job
+    accepted during the poll window would be killed mid-run."""
+    seen: list[bool] = []
+
+    async def _poll(dep, steps, *, slow_start=False):
+        seen.append(cs._restart_is_pending())
+        return True
+
+    _run_shared_post_sync({"_wait_component_healthy": AsyncMock(side_effect=_poll)})
+    assert seen and all(seen), seen
+
+
+# ---------------------------------------------------------------------------
+# poll-timeout / unhealthy → rollback
+# ---------------------------------------------------------------------------
+
+
+def test_unhealthy_backend_triggers_rollback_and_blocks_self_restart() -> None:
+    """A dependent backend failing its health poll rolls back the shared dir and
+    the self-restart never runs (would restart onto broken code)."""
+    steps, pip_ok, mocks = _run_shared_post_sync(
+        {"_wait_component_healthy": AsyncMock(return_value=False)}
+    )
+
+    assert pip_ok is False
+    mocks["_rollback_component"].assert_awaited_once()
+    rb_args = mocks["_rollback_component"].await_args.args
+    assert rb_args[0] == _SHARED
+    assert rb_args[1] == "/opt/autobot/snapshots/autobot_shared_X"
+
+    restart_calls = mocks["_restart_component_services"].await_args_list
+    # Only the initial non-self restart — never the self-restart.
+    assert len(restart_calls) == 1
+    assert restart_calls[0].kwargs["services"] == _OTHERS
+    assert any("rolled back to last-known-good" in s for s in steps), steps
+    # Survived the rollback ⇒ the #11437 guard is disarmed so recovery resolves
+    # aren't 409-blocked (#11460).
+    assert mocks["guard_after"] is False
+
+
+def test_failed_url_less_dependent_triggers_rollback() -> None:
+    """A systemd-'failed' dependent without a health URL (e.g. celery crashloop
+    on a broken shared import) also triggers rollback."""
+
+    async def _celery_failed(service: str) -> bool:
+        return service == "autobot-celery"
+
+    steps, pip_ok, mocks = _run_shared_post_sync(
+        {"_is_systemd_unit_failed": AsyncMock(side_effect=_celery_failed)}
+    )
+
+    assert pip_ok is False
+    mocks["_rollback_component"].assert_awaited_once()
+    assert any("autobot-celery" in s and "'failed'" in s for s in steps), steps
+
+
+# ---------------------------------------------------------------------------
+# rollback-failure path — no snapshot available (structured failure, no swallow)
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_without_snapshot_surfaces_manual_recovery() -> None:
+    """snapshot=None + unhealthy dependent → real _rollback_component records the
+    'manual recovery required' step and the sync still reports failure."""
+    from api.code_sync import _rollback_component as real_rollback
+
+    steps, pip_ok, _ = _run_shared_post_sync(
+        {
+            "_snapshot_component": AsyncMock(return_value=None),
+            "_wait_component_healthy": AsyncMock(return_value=False),
+            "_rollback_component": real_rollback,
+        }
+    )
+
+    assert pip_ok is False
+    assert any("no snapshot available" in s and "manual recovery" in s for s in steps), steps
+
+
+# ---------------------------------------------------------------------------
+# deferred restart (async job path) — unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_restart_false_defers_and_skips_health_poll() -> None:
+    """restart=False (async job path, #11303) defers the restart entirely — no
+    restart, no poll, no rollback."""
+    patchers, mocks = _shared_branch_patches()
+    for p in patchers:
+        p.start()
+    try:
+        _, steps, pip_ok = _run(
+            _run_post_sync_steps(
+                _SHARED,
+                "/opt/autobot/code_source/autobot_shared",
+                "/opt/autobot/autobot_shared",
+                restart=False,
+            )
+        )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    assert pip_ok is True
+    mocks["_restart_component_services"].assert_not_awaited()
+    mocks["_wait_component_healthy"].assert_not_awaited()
+    mocks["_rollback_component"].assert_not_awaited()
+    assert any("restart deferred" in s for s in steps), steps
+
+
+# ---------------------------------------------------------------------------
+# _restart_component_services — services override (#11496)
+# ---------------------------------------------------------------------------
+
+
+def test_restart_component_services_honours_services_override() -> None:
+    """The services= override restricts which units restart (subset restarts)."""
+    restarted: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        restarted.append(cmd[-1])
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    steps: list[str] = []
+    with patch("api.code_sync.asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        _run(cs._restart_component_services(_SHARED, steps, services=["autobot-backend"]))
+
+    assert restarted == ["autobot-backend"]
+    # Surviving return disarms the #11437 guard (#11460) — unchanged contract.
+    assert cs._restart_is_pending() is False


### PR DESCRIPTION
Closes #11496

## Thinking Path

The autobot_shared code-sync restart path restarted dependents blind — no health verification, no rollback. Two load-bearing defects surfaced during implementation and are fixed in the same path (required for the health poll to be non-inert): `_COMPONENT_SERVICES["autobot_shared"]` listed `autobot-slm-backend` FIRST, so the landed self-restart (#11460 contract) killed the process before the other five services were ever restarted; and the #11437 409-guard had to stay armed across the verification window so resolve jobs can't be accepted mid-window and killed by the final self-restart.

## What Changed

- New `_restart_dependents_with_health()` in `autobot-slm-backend/api/code_sync.py`: restarts non-self dependents first → verifies each via canonical `_wait_component_healthy` (`slow_start=True`, `_COMPONENT_HEALTH_URLS`; units without HTTP checked via `_is_systemd_unit_failed`) → on any failure calls existing `_rollback_component` (rsync-restore from the pre-mutation snapshot, restart dependents on restored code) and surfaces `success=False`; snapshot-missing rollback failure surfaces "manual recovery required" — never swallowed. Self-restart happens last, only after everything else is verified healthy.
- Timeouts: existing env-derived constants (`AUTOBOT_HEALTH_POLL_TIMEOUT` 180s window, per-attempt connect 3s) — no new hardcoded values.
- 409-guard `_restart_pending` held across the verification window, explicitly disarmed after a survived rollback (pinned by a dedicated test).

## Verification

- New `tests/api/test_shared_restart_health.py`: 9/9 (poll-success, poll-timeout→rollback, rollback-failure, guard-window, ordering).
- Full affected set: 125 passed, 2 failed — both topology failures verified pre-existing on clean base (pydantic-stub artifact).
- Independent re-run (main session): restart-health + adaptive-poll suites 15 passed. py_compile clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)