### PR TITLE
refactor(llm): consolidate OpenAI-compatible providers onto one base (#11517)

### DIFF
--- a/autobot-backend/llm_shared/providers/__init__.py
+++ b/autobot-backend/llm_shared/providers/__init__.py
@@ -11,6 +11,7 @@ have been moved from ``llm_providers/`` into this package.
 Cloud API providers:
     AnthropicProvider      — Anthropic Claude (with OTel tracing restored, #697)
     BedrockProvider        — AWS Bedrock (Claude, Llama, Mistral, Titan, Nova, GH#9010)
+    OpenAICompatibleProvider — Shared base for the OpenAI chat-completions dialect (#11517)
     OpenAIProvider         — OpenAI GPT/o1 (OTel tracing, circuit breaker)
     GroqProvider           — Groq ultra-low-latency inference
     MistralProvider        — Mistral Le Chat / Codestral / Devstral (#10549)
@@ -51,6 +52,7 @@ from .mock_handler import LocalHandler, MockHandler
 from .nous_portal import NOUS_MODELS, NousPortalProvider
 from .ollama_provider import OllamaProvider  # registry-facing
 from .openai import OpenAIProvider
+from .openai_compatible import OpenAICompatibleProvider
 from .openrouter import OpenRouterProvider
 from .transformers_provider import TransformersProvider
 from .vertexai import VERTEX_MODELS, VertexAIProvider
@@ -62,6 +64,7 @@ __all__ = [
     "AnthropicProvider",
     "BedrockProvider",
     "BEDROCK_MODELS",
+    "OpenAICompatibleProvider",
     "OpenAIProvider",
     "GroqProvider",
     "GROQ_MODELS",

--- a/autobot-backend/llm_shared/providers/custom_openai.py
+++ b/autobot-backend/llm_shared/providers/custom_openai.py
@@ -16,23 +16,21 @@ Configuration (via settings dict or environment variables):
   - ``default_model``                            — model to use when not specified
 
 Moved from llm_providers/ as part of Phase 2 consolidation (MVA-178 / GH#7637).
+Consolidated onto :class:`OpenAICompatibleProvider` (#11517) — only the genuine
+deltas live here: mandatory base_url, permissive api_key default, and optional
+per-instance provider naming.
 """
 
 from __future__ import annotations
 
-import time
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, Dict
 
-from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
-from llm_shared.models import LLMRequest, LLMResponse, ToolCall
 
-from ..base_provider import BaseProvider
-
-logger = get_logger(__name__)
+from .openai_compatible import OpenAICompatibleProvider
 
 
-class CustomOpenAIProvider(BaseProvider):
+class CustomOpenAIProvider(OpenAICompatibleProvider):
     """
     Provider for any server exposing an OpenAI-compatible REST API.
 
@@ -51,10 +49,9 @@ class CustomOpenAIProvider(BaseProvider):
         super().__init__(settings)
         if instance_name:
             self.provider_name = instance_name
-        self._client = None
 
     def _resolve_base_url(self) -> str:
-        """Resolve the endpoint base URL from settings or environment."""
+        """Resolve the endpoint base URL from settings or environment (required)."""
         url = self._get_setting("base_url") or config.custom_openai_base_url
         if not url:
             raise ValueError(
@@ -66,147 +63,6 @@ class CustomOpenAIProvider(BaseProvider):
     def _resolve_api_key(self) -> str:
         """Resolve the API key (many local servers accept any non-empty string)."""
         return self._get_setting("api_key") or config.custom_openai_api_key or "none"
-
-    def _ensure_client(self):
-        """Lazily initialize the async OpenAI client pointed at the custom URL."""
-        if self._client is not None:
-            return self._client
-        try:
-            import openai
-        except ImportError as exc:
-            raise ImportError("openai package not installed. Run: pip install openai") from exc
-        self._client = openai.AsyncOpenAI(
-            base_url=self._resolve_base_url(),
-            api_key=self._resolve_api_key(),
-        )
-        return self._client
-
-    def _default_model(self) -> str:
-        """Return configured default model or an empty string."""
-        return self._get_setting("default_model", "")
-
-    def _build_params(self, request: LLMRequest, model: str) -> Dict[str, Any]:
-        """Build chat completion parameters from an LLMRequest."""
-        params: Dict[str, Any] = {
-            "model": model,
-            "messages": request.messages,
-            "temperature": request.temperature,
-            "top_p": request.top_p,
-        }
-        if request.max_tokens:
-            params["max_tokens"] = request.max_tokens
-        if request.stop:
-            params["stop"] = request.stop
-        if request.tools:
-            params["tools"] = [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": t.name,
-                        "description": t.description,
-                        "parameters": t.input_schema,
-                    },
-                }
-                for t in request.tools
-            ]
-            if request.tool_choice:
-                params["tool_choice"] = request.tool_choice
-        return params
-
-    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
-        """Execute a non-streaming chat completion via the custom endpoint."""
-        self._total_requests += 1
-        start = time.time()
-        model = request.model_name or self._default_model()
-        try:
-            client = self._ensure_client()
-            params = self._build_params(request, model)
-            response = await client.chat.completions.create(**params)
-            choice = response.choices[0]
-            usage = response.usage
-            api_model = response.model or model
-            total_tokens = usage.total_tokens if usage else 0
-            tool_calls = []
-            if choice.message.tool_calls:
-                import json as _json
-
-                for tc in choice.message.tool_calls:
-                    try:
-                        args = _json.loads(tc.function.arguments) if tc.function.arguments else {}
-                    except Exception:
-                        args = {}
-                    tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
-            # #10582: capture reasoning_content from providers that surface it
-            # (DeepSeek-R1, QwQ, SGLang, and similar OpenAI-compat servers).
-            reasoning_content: str | None = getattr(choice.message, "reasoning_content", None) or None
-            return LLMResponse(
-                content=choice.message.content or "",
-                model=api_model,
-                provider=self.provider_name,
-                processing_time=time.time() - start,
-                request_id=request.request_id,
-                finish_reason=choice.finish_reason,
-                usage={
-                    "prompt_tokens": usage.prompt_tokens if usage else 0,
-                    "completion_tokens": usage.completion_tokens if usage else 0,
-                    "total_tokens": total_tokens,
-                },
-                tool_calls=tool_calls or None,
-                provider_metadata=self._build_provider_metadata(
-                    model_api_name=api_model,
-                    api_kwargs_applied=params,
-                    total_tokens=total_tokens,
-                ),
-                reasoning_content=reasoning_content,
-            )
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("CustomOpenAI (%s) chat_completion error: %s", self.provider_name, exc)
-            return LLMResponse(
-                content="",
-                model=model,
-                provider=self.provider_name,
-                processing_time=time.time() - start,
-                request_id=request.request_id,
-                error=str(exc),
-            )
-
-    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
-        """Stream chat completion from the custom endpoint."""
-        self._total_requests += 1
-        model = request.model_name or self._default_model()
-        try:
-            client = self._ensure_client()
-            params = self._build_params(request, model)
-            params["stream"] = True
-            async with await client.chat.completions.create(**params) as stream:
-                async for chunk in stream:
-                    delta = chunk.choices[0].delta.content
-                    if delta:
-                        yield delta
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("CustomOpenAI (%s) stream_completion error: %s", self.provider_name, exc)
-            raise
-
-    async def is_available(self) -> bool:
-        """Return True if the custom endpoint responds to a model listing."""
-        try:
-            client = self._ensure_client()
-            await client.models.list()
-            return True
-        except Exception:
-            return False
-
-    async def list_models(self) -> List[str]:
-        """Discover models available at the custom endpoint."""
-        try:
-            client = self._ensure_client()
-            model_list = await client.models.list()
-            return [m.id for m in model_list.data]
-        except Exception:
-            configured = self._default_model()
-            return [configured] if configured else []
 
 
 __all__ = ["CustomOpenAIProvider"]

--- a/autobot-backend/llm_shared/providers/groq.py
+++ b/autobot-backend/llm_shared/providers/groq.py
@@ -6,9 +6,9 @@
 Groq provider for the multi-provider LLM layer (#4096).
 
 Groq exposes an OpenAI-compatible Chat Completions API so this implementation
-delegates directly to the ``groq`` SDK (which mirrors the ``openai`` SDK
-surface).  The local ``groq`` package is imported lazily so the rest of the
-application boots normally when the package is absent.
+delegates to the ``groq`` SDK (which mirrors the ``openai`` SDK surface).
+The local ``groq`` package is imported lazily so the rest of the application
+boots normally when the package is absent.
 
 API key is read (in priority order) from:
   1. ``settings["api_key"]``
@@ -17,14 +17,15 @@ API key is read (in priority order) from:
 API keys are never logged.
 
 Moved from llm_providers/ as part of Phase 2 consolidation (MVA-178 / GH#7637).
+Consolidated onto :class:`OpenAICompatibleProvider` (#11517) — only the genuine
+Groq deltas live here: the ``groq`` SDK client and the historical omission of
+``top_p`` from the payload.
 """
 
 from __future__ import annotations
 
-import time
-from typing import Any, AsyncIterator, Dict, List
+from typing import List
 
-from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from constants.model_constants import (
     GROQ_GEMMA2_9B,
@@ -34,12 +35,9 @@ from constants.model_constants import (
     GROQ_LLAMA33_70B,
     GROQ_MIXTRAL_8X7B,
 )
-from llm_shared.models import LLMRequest, LLMResponse, ToolCall
 from llm_shared.types import ProviderType
 
-from ..base_provider import BaseProvider
-
-logger = get_logger(__name__)
+from .openai_compatible import OpenAICompatibleProvider
 
 GROQ_MODELS: List[str] = [
     GROQ_LLAMA33_70B,
@@ -53,7 +51,7 @@ GROQ_MODELS: List[str] = [
 _DEFAULT_MODEL = GROQ_LLAMA31_8B
 
 
-class GroqProvider(BaseProvider):
+class GroqProvider(OpenAICompatibleProvider):
     """
     Groq LLM provider implementation.
 
@@ -63,11 +61,10 @@ class GroqProvider(BaseProvider):
     """
 
     provider_name = ProviderType.GROQ.value
-
-    def __init__(self, settings: Dict[str, Any] | None = None) -> None:
-        super().__init__(settings)
-        self._api_key: str | None = None
-        self._client = None
+    default_model = _DEFAULT_MODEL
+    fallback_models = tuple(GROQ_MODELS)
+    include_top_p = False  # historical Groq payload never sent top_p
+    missing_key_error = "Groq API key not configured. Set GROQ_API_KEY or provide api_key in provider settings."
 
     def _resolve_api_key(self) -> str | None:
         """Resolve API key from settings or environment."""
@@ -76,137 +73,16 @@ class GroqProvider(BaseProvider):
         self._api_key = self._get_setting("api_key") or config.groq_api_key
         return self._api_key
 
-    def _ensure_client(self):
-        """Lazily initialize the async Groq client."""
-        if self._client is not None:
-            return self._client
+    def _create_client(self):
+        """Lazily construct the async Groq client (mirrors the openai SDK surface)."""
         try:
             import groq
         except ImportError as exc:
             raise ImportError("groq package not installed. Run: pip install groq") from exc
         api_key = self._resolve_api_key()
         if not api_key:
-            raise ValueError(
-                "Groq API key not configured. " "Set GROQ_API_KEY or provide api_key in provider settings."
-            )
-        self._client = groq.AsyncGroq(api_key=api_key)
-        return self._client
-
-    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
-        """Execute a non-streaming chat completion via Groq."""
-        self._total_requests += 1
-        start = time.time()
-        model = request.model_name or self._get_setting("default_model", _DEFAULT_MODEL)
-        try:
-            client = self._ensure_client()
-            params: Dict[str, Any] = {
-                "model": model,
-                "messages": request.messages,
-                "temperature": request.temperature,
-            }
-            if request.max_tokens:
-                params["max_tokens"] = request.max_tokens
-            if request.stop:
-                params["stop"] = request.stop
-            if request.tools:
-                params["tools"] = [
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": t.name,
-                            "description": t.description,
-                            "parameters": t.input_schema,
-                        },
-                    }
-                    for t in request.tools
-                ]
-                if request.tool_choice:
-                    params["tool_choice"] = request.tool_choice
-            response = await client.chat.completions.create(**params)
-            choice = response.choices[0]
-            processing_time = time.time() - start
-            tool_calls = []
-            if choice.message.tool_calls:
-                import json as _json
-
-                for tc in choice.message.tool_calls:
-                    try:
-                        args = _json.loads(tc.function.arguments) if tc.function.arguments else {}
-                    except Exception:
-                        args = {}
-                    tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
-            return LLMResponse(
-                content=choice.message.content or "",
-                model=response.model,
-                provider=self.provider_name,
-                processing_time=processing_time,
-                request_id=request.request_id,
-                finish_reason=choice.finish_reason,
-                usage={
-                    "prompt_tokens": response.usage.prompt_tokens,
-                    "completion_tokens": response.usage.completion_tokens,
-                    "total_tokens": response.usage.total_tokens,
-                },
-                tool_calls=tool_calls or None,
-                provider_metadata=self._build_provider_metadata(
-                    model_api_name=response.model,
-                    api_kwargs_applied=params,
-                    total_tokens=response.usage.total_tokens,
-                ),
-            )
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("Groq chat_completion error: %s", exc)
-            return LLMResponse(
-                content="",
-                model=model,
-                provider=self.provider_name,
-                processing_time=time.time() - start,
-                request_id=request.request_id,
-                error=str(exc),
-            )
-
-    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
-        """Stream a chat completion from Groq, yielding text chunks."""
-        self._total_requests += 1
-        model = request.model_name or self._get_setting("default_model", _DEFAULT_MODEL)
-        try:
-            client = self._ensure_client()
-            params: Dict[str, Any] = {
-                "model": model,
-                "messages": request.messages,
-                "temperature": request.temperature,
-                "stream": True,
-            }
-            if request.max_tokens:
-                params["max_tokens"] = request.max_tokens
-            stream = await client.chat.completions.create(**params)
-            async for chunk in stream:
-                delta = chunk.choices[0].delta.content
-                if delta:
-                    yield delta
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("Groq stream_completion error: %s", exc)
-            raise
-
-    async def is_available(self) -> bool:
-        """Return True if the API key is set and the models endpoint responds."""
-        try:
-            client = self._ensure_client()
-            await client.models.list()
-            return True
-        except Exception:
-            return False
-
-    async def list_models(self) -> List[str]:
-        """Return available Groq models, falling back to the static list."""
-        try:
-            client = self._ensure_client()
-            model_list = await client.models.list()
-            return [m.id for m in model_list.data]
-        except Exception:
-            return list(GROQ_MODELS)
+            raise ValueError(self.missing_key_error)
+        return groq.AsyncGroq(api_key=api_key)
 
 
 __all__ = ["GroqProvider", "GROQ_MODELS"]

--- a/autobot-backend/llm_shared/providers/nous_portal.py
+++ b/autobot-backend/llm_shared/providers/nous_portal.py
@@ -13,19 +13,17 @@ Configuration:
   - default_model: Default model name
 
 Moved from llm_providers/ as part of Phase 2 consolidation (MVA-178 / GH#7637).
+Consolidated onto :class:`OpenAICompatibleProvider` (#11517) — only the genuine
+deltas live here: the HF token fallback chain, the HF inference base URL,
+a 2048 default ``max_tokens``, and penalty-param forwarding from
+``metadata["api_kwargs"]``.
 """
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict, List
-
-from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
-from llm_shared.models import LLMRequest, LLMResponse
 
-from ..base_provider import BaseProvider
-
-logger = get_logger(__name__)
+from .openai_compatible import OpenAICompatibleProvider
 
 NOUS_MODELS = [
     "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
@@ -36,7 +34,7 @@ NOUS_MODELS = [
 ]
 
 
-class NousPortalProvider(BaseProvider):
+class NousPortalProvider(OpenAICompatibleProvider):
     """
     Nous Portal provider implementation.
 
@@ -46,152 +44,28 @@ class NousPortalProvider(BaseProvider):
     """
 
     provider_name = "nous"
-
-    def __init__(self, settings: Dict[str, Any] | None = None) -> None:
-        super().__init__(settings)
-        self._api_key: str | None = None
-        self._base_url: str | None = None
-        self._client = None
+    default_model = NOUS_MODELS[0]
+    fallback_models = tuple(NOUS_MODELS)
+    default_max_tokens = 2048  # HF inference endpoints reject unbounded generations
+    forward_penalty_params = True
+    missing_key_error = "Nous API key not found. Set HF_TOKEN or provide api_key in settings."
 
     def _resolve_api_key(self) -> str | None:
-        """Resolve API key from settings or environment."""
+        """Resolve API key from settings or the HF token fallback chain."""
         if self._api_key:
             return self._api_key
-        key = self._get_setting("api_key") or config.hf_token or config.huggingface_api_token or config.nous_api_key
-        self._api_key = key
+        self._api_key = (
+            self._get_setting("api_key") or config.hf_token or config.huggingface_api_token or config.nous_api_key
+        )
         return self._api_key
 
     def _resolve_base_url(self) -> str:
-        """Resolve base URL with defaults."""
+        """Resolve base URL with the HF inference default."""
         if self._base_url:
             return self._base_url
-        url = self._get_setting("base_url") or config.nous_api_base_url or "https://api-inference.huggingface.co/v1"
-        self._base_url = url
-        return url
-
-    def _ensure_client(self):
-        """Lazily initialize the async OpenAI client."""
-        if self._client is not None:
-            return
-
-        try:
-            from openai import AsyncOpenAI
-        except ImportError as exc:
-            raise ImportError("openai package not installed. Run: pip install openai") from exc
-
-        api_key = self._resolve_api_key()
-        if not api_key:
-            raise ValueError("Nous API key not found. Set HF_TOKEN or provide api_key in settings.")
-
-        base_url = self._resolve_base_url()
-        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-        logger.info("Nous Portal client initialized with base_url: %s", base_url)
-
-    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
-        """Execute a chat completion via Nous models."""
-        try:
-            self._total_requests += 1
-            self._ensure_client()
-
-            messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
-
-            api_kwargs = request.metadata.get("api_kwargs", {})
-            chat_kwargs = {
-                "model": request.model_name or self._get_setting("default_model", NOUS_MODELS[0]),
-                "messages": messages,
-                "temperature": api_kwargs.get("temperature", 0.7),
-                "max_tokens": api_kwargs.get("max_tokens", 2048),
-                "top_p": api_kwargs.get("top_p", 0.95),
-            }
-
-            if "presence_penalty" in api_kwargs:
-                chat_kwargs["presence_penalty"] = api_kwargs["presence_penalty"]
-            if "frequency_penalty" in api_kwargs:
-                chat_kwargs["frequency_penalty"] = api_kwargs["frequency_penalty"]
-            if "stop" in api_kwargs:
-                chat_kwargs["stop"] = api_kwargs["stop"]
-
-            response = await self._client.chat.completions.create(**chat_kwargs)
-
-            content = response.choices[0].message.content or ""
-            usage = {
-                "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
-                "completion_tokens": response.usage.completion_tokens if response.usage else 0,
-            }
-
-            return LLMResponse(
-                content=content,
-                model_name=request.model_name or chat_kwargs["model"],
-                provider_name=self.provider_name,
-                usage=usage,
-                provider_metadata=self._build_provider_metadata(
-                    model_api_name=chat_kwargs["model"],
-                    api_kwargs_applied=chat_kwargs,
-                    total_tokens=usage["prompt_tokens"] + usage["completion_tokens"],
-                ),
-            )
-
-        except Exception as exc:
-            self._total_errors += 1
-            error_msg = f"Nous API error: {exc}"
-            logger.error(error_msg)
-            return LLMResponse(
-                content="",
-                model_name=request.model_name or "nous-model",
-                provider_name=self.provider_name,
-                error=error_msg,
-            )
-
-    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
-        """Stream a chat completion from Nous models."""
-        try:
-            self._total_requests += 1
-            self._ensure_client()
-
-            messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
-
-            api_kwargs = request.metadata.get("api_kwargs", {})
-            chat_kwargs = {
-                "model": request.model_name or self._get_setting("default_model", NOUS_MODELS[0]),
-                "messages": messages,
-                "temperature": api_kwargs.get("temperature", 0.7),
-                "max_tokens": api_kwargs.get("max_tokens", 2048),
-                "top_p": api_kwargs.get("top_p", 0.95),
-                "stream": True,
-            }
-
-            if "stop" in api_kwargs:
-                chat_kwargs["stop"] = api_kwargs["stop"]
-
-            async with await self._client.chat.completions.create(**chat_kwargs) as stream:
-                async for chunk in stream:
-                    if chunk.choices[0].delta.content:
-                        yield chunk.choices[0].delta.content
-
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("Nous stream error: %s", exc)
-            yield "Error: Stream completion failed"
-
-    async def is_available(self) -> bool:
-        """Check if Nous Portal is reachable and properly configured."""
-        try:
-            self._ensure_client()
-            await self._client.models.list()
-            return True
-        except Exception as exc:
-            logger.warning("Nous health check failed: %s", exc)
-            return False
-
-    async def list_models(self) -> List[str]:
-        """List available Nous Research models."""
-        try:
-            self._ensure_client()
-            response = await self._client.models.list()
-            return [model.id for model in response.data] if response.data else NOUS_MODELS
-        except Exception:
-            logger.debug("Could not fetch Nous models from API; using defaults")
-            return NOUS_MODELS
+        default_url = "https://api-inference.huggingface.co/v1"
+        self._base_url = self._get_setting("base_url") or config.nous_api_base_url or default_url
+        return self._base_url
 
 
 __all__ = ["NousPortalProvider", "NOUS_MODELS"]

--- a/autobot-backend/llm_shared/providers/openai.py
+++ b/autobot-backend/llm_shared/providers/openai.py
@@ -14,14 +14,15 @@ API key is read (in priority order) from:
 API keys are never logged.
 
 Moved from llm_providers/ as part of Phase 2 consolidation (MVA-178 / GH#7637).
+Consolidated onto :class:`OpenAICompatibleProvider` (#11517) — only the genuine
+OpenAI deltas live here: SSOT key fallback chain, optional base_url override,
+reasoning-effort mapping (#9017), and prompt-cache payload normalisation (#7368).
 """
 
 from __future__ import annotations
 
-import time
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, Dict
 
-from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from constants.model_constants import OPENAI_O1_MINI  # used in _OPENAI_MODELS list
 from constants.model_constants import (
@@ -31,14 +32,11 @@ from constants.model_constants import (
     OPENAI_GPT4O_MINI,
     OPENAI_GPT35_TURBO,
 )
-from llm_shared.models import LLMRequest, LLMResponse, ToolCall
+from llm_shared.models import LLMRequest
 from llm_shared.types import ProviderType
 
-from ..base_provider import BaseProvider
-from .cache_utils import sorted_for_cache
+from .openai_compatible import OpenAICompatibleProvider
 from .reasoning_effort import map_effort_to_provider_params
-
-logger = get_logger(__name__)
 
 _OPENAI_MODELS = [
     OPENAI_GPT4O,
@@ -51,7 +49,7 @@ _OPENAI_MODELS = [
 ]
 
 
-class OpenAIProvider(BaseProvider):
+class OpenAIProvider(OpenAICompatibleProvider):
     """
     OpenAI provider implementation.
 
@@ -60,15 +58,13 @@ class OpenAIProvider(BaseProvider):
     """
 
     provider_name = ProviderType.OPENAI.value
-
-    def __init__(self, settings: Dict[str, Any] | None = None) -> None:
-        super().__init__(settings)
-        self._api_key: str | None = None
-        self._base_url: str | None = None
-        self._client = None
+    default_model = OPENAI_GPT4O_MINI
+    fallback_models = tuple(_OPENAI_MODELS)
+    sort_params_for_cache = True  # #7368: byte-exact payloads keep prompt caching warm
+    missing_key_error = "OpenAI API key not configured. Set OPENAI_API_KEY or provide api_key in provider settings."
 
     def _resolve_api_key(self) -> str | None:
-        """Resolve API key from settings, environment, or config."""
+        """Resolve API key from settings, environment, or SSOT config."""
         if self._api_key:
             return self._api_key
         key = self._get_setting("api_key") or config.openai_api_key
@@ -82,159 +78,14 @@ class OpenAIProvider(BaseProvider):
         self._api_key = key
         return self._api_key
 
-    def _ensure_client(self):
-        """Lazily initialize the async OpenAI client."""
-        if self._client is not None:
-            return self._client
-        try:
-            import openai
-        except ImportError as exc:
-            raise ImportError("openai package not installed. Run: pip install openai") from exc
-        api_key = self._resolve_api_key()
-        if not api_key:
-            raise ValueError(
-                "OpenAI API key not configured. " "Set OPENAI_API_KEY or provide api_key in provider settings."
-            )
-        base_url = self._get_setting("base_url") or config.openai_api_base_url
-        kwargs: Dict[str, Any] = {"api_key": api_key}
-        if base_url:
-            kwargs["base_url"] = base_url
-        self._client = openai.AsyncOpenAI(**kwargs)
-        return self._client
+    def _resolve_base_url(self) -> str | None:
+        """Optional base URL override (Azure/OpenAI-compatible gateways)."""
+        return self._get_setting("base_url") or config.openai_api_base_url
 
-    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
-        """Execute a non-streaming chat completion via OpenAI.
-
-        Circuit-breaker protection lives in ``BaseProvider._guarded_completion``
-        (GH#11488) — the old per-method decorator never saw failures because
-        errors are returned via ``LLMResponse.error``, and its 30s default
-        timeout killed healthy long completions.
-        """
-        self._total_requests += 1
-        start = time.time()
-        model = request.model_name or self._get_setting("default_model", OPENAI_GPT4O_MINI)
-        try:
-            client = self._ensure_client()
-            params: Dict[str, Any] = {
-                "model": model,
-                "messages": request.messages,
-                "temperature": request.temperature,
-                "top_p": request.top_p,
-            }
-            if request.max_tokens:
-                params["max_tokens"] = request.max_tokens
-            if request.stop:
-                params["stop"] = request.stop
-            if request.tools:
-                params["tools"] = [
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": t.name,
-                            "description": t.description,
-                            "parameters": t.input_schema,
-                        },
-                    }
-                    for t in request.tools
-                ]
-                if request.tool_choice:
-                    params["tool_choice"] = request.tool_choice
-            # #9017: merge reasoning_effort params (e.g. {"reasoning_effort": "high"} for o1/o3).
-            api_kwargs: Dict[str, Any] = request.metadata.get("api_kwargs") or {}
-            effort_params = map_effort_to_provider_params(api_kwargs.get("reasoning_effort"), self.provider_name)
-            if effort_params:
-                params.update(effort_params)
-            params = sorted_for_cache(params)
-            response = await client.chat.completions.create(**params)
-            choice = response.choices[0]
-            processing_time = time.time() - start
-            tool_calls = []
-            if choice.message.tool_calls:
-                import json as _json
-
-                for tc in choice.message.tool_calls:
-                    try:
-                        args = _json.loads(tc.function.arguments) if tc.function.arguments else {}
-                    except Exception:
-                        args = {}
-                    tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
-            # #10582: capture reasoning_content from o1/o3 or compatible models
-            # that expose it as a separate field on the message object.
-            reasoning_content: str | None = getattr(choice.message, "reasoning_content", None) or None
-            return LLMResponse(
-                content=choice.message.content or "",
-                model=response.model,
-                provider=self.provider_name,
-                processing_time=processing_time,
-                request_id=request.request_id,
-                finish_reason=choice.finish_reason,
-                usage={
-                    "prompt_tokens": response.usage.prompt_tokens,
-                    "completion_tokens": response.usage.completion_tokens,
-                    "total_tokens": response.usage.total_tokens,
-                },
-                tool_calls=tool_calls or None,
-                provider_metadata=self._build_provider_metadata(
-                    model_api_name=response.model,
-                    api_kwargs_applied=params,
-                    total_tokens=response.usage.total_tokens,
-                ),
-                reasoning_content=reasoning_content,
-            )
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("OpenAI chat_completion error: %s", exc)
-            return LLMResponse(
-                content="",
-                model=model,
-                provider=self.provider_name,
-                processing_time=time.time() - start,
-                request_id=request.request_id,
-                error=str(exc),
-            )
-
-    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
-        """Stream a chat completion from OpenAI, yielding text chunks."""
-        self._total_requests += 1
-        model = request.model_name or self._get_setting("default_model", OPENAI_GPT4O_MINI)
-        try:
-            client = self._ensure_client()
-            params: Dict[str, Any] = {
-                "model": model,
-                "messages": request.messages,
-                "temperature": request.temperature,
-                "stream": True,
-            }
-            if request.max_tokens:
-                params["max_tokens"] = request.max_tokens
-            params = sorted_for_cache(params)
-            stream = await client.chat.completions.create(**params)
-            async for chunk in stream:
-                delta = chunk.choices[0].delta.content
-                if delta:
-                    yield delta
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("OpenAI stream_completion error: %s", exc)
-            raise
-
-    async def is_available(self) -> bool:
-        """Return True if the API key is set and the models endpoint responds."""
-        try:
-            client = self._ensure_client()
-            await client.models.list()
-            return True
-        except Exception:
-            return False
-
-    async def list_models(self) -> List[str]:
-        """Return available OpenAI models, falling back to a static list."""
-        try:
-            client = self._ensure_client()
-            model_list = await client.models.list()
-            return [m.id for m in model_list.data]
-        except Exception:
-            return list(_OPENAI_MODELS)
+    def _extra_params(self, request: LLMRequest) -> Dict[str, Any]:
+        """#9017: merge reasoning_effort params (e.g. ``{"reasoning_effort": "high"}`` for o1/o3)."""
+        api_kwargs: Dict[str, Any] = request.metadata.get("api_kwargs") or {}
+        return map_effort_to_provider_params(api_kwargs.get("reasoning_effort"), self.provider_name)
 
 
 __all__ = ["OpenAIProvider"]

--- a/autobot-backend/llm_shared/providers/openai_compatible.py
+++ b/autobot-backend/llm_shared/providers/openai_compatible.py
@@ -1,0 +1,283 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Shared base for providers speaking the OpenAI chat-completions dialect (#11517).
+
+OpenAI, Groq, OpenRouter, CustomOpenAI, and NousPortal all speak the same
+OpenAI-compatible Chat Completions API.  The request-building,
+response-mapping, tool-call parsing, streaming, and model-listing flow lives
+here exactly once; concrete subclasses supply only their genuine deltas:
+client construction, credential/base-url resolution, default model, static
+fallback model list, and provider-specific params.
+
+Circuit-breaker protection lives in ``BaseProvider._guarded_completion``
+(GH#11488) — ``_chat_completion_impl`` must not raise; errors travel via
+``LLMResponse.error`` so the registry can perform fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, AsyncIterator, Dict, List, Sequence
+
+from autobot_shared.logging_manager import get_logger
+from llm_shared.models import LLMRequest, LLMResponse, ToolCall
+
+from ..base_provider import BaseProvider
+from .cache_utils import sorted_for_cache
+
+logger = get_logger(__name__)
+
+
+class OpenAICompatibleProvider(BaseProvider):
+    """
+    Base implementation for any OpenAI-compatible chat-completions provider.
+
+    Subclasses set the class attributes below and override the hook methods
+    (``_resolve_api_key`` / ``_resolve_base_url`` / ``_create_client`` /
+    ``_extra_params`` / ``_fallback_model_list``) only where their behavior
+    genuinely differs from the shared flow.
+    """
+
+    #: Default model used when neither the request nor settings specify one.
+    default_model: str = ""
+    #: Static model list returned when the live models endpoint is unreachable.
+    fallback_models: Sequence[str] = ()
+    #: Whether ``top_p`` is forwarded to the API (Groq historically omits it).
+    include_top_p: bool = True
+    #: Whether payloads are normalised for prompt-cache determinism (#7368).
+    sort_params_for_cache: bool = False
+    #: Default ``max_tokens`` applied when the request does not set one.
+    default_max_tokens: int | None = None
+    #: Forward presence/frequency penalties supplied via ``metadata["api_kwargs"]``
+    #: (historically honoured by OpenRouter and NousPortal only).
+    forward_penalty_params: bool = False
+    #: Error message raised when no API key can be resolved.
+    missing_key_error: str = "API key not configured. Provide api_key in provider settings."
+
+    def __init__(self, settings: Dict[str, Any] | None = None) -> None:
+        super().__init__(settings)
+        self._api_key: str | None = None
+        self._base_url: str | None = None
+        self._client = None
+
+    # ------------------------------------------------------------------
+    # Subclass hooks — override only genuine per-provider deltas
+    # ------------------------------------------------------------------
+
+    def _resolve_api_key(self) -> str | None:
+        """Resolve the API key (subclasses add their config fallback chain)."""
+        if self._api_key:
+            return self._api_key
+        self._api_key = self._get_setting("api_key")
+        return self._api_key
+
+    def _resolve_base_url(self) -> str | None:
+        """Resolve the endpoint base URL, or None for the SDK default."""
+        return self._get_setting("base_url")
+
+    def _extra_params(self, request: LLMRequest) -> Dict[str, Any]:
+        """Provider-specific params merged into the payload (e.g. #9017)."""
+        return {}
+
+    def _create_client(self):
+        """Construct the async SDK client (Groq swaps in its own SDK)."""
+        try:
+            import openai
+        except ImportError as exc:
+            raise ImportError("openai package not installed. Run: pip install openai") from exc
+        api_key = self._resolve_api_key()
+        if not api_key:
+            raise ValueError(self.missing_key_error)
+        kwargs: Dict[str, Any] = {"api_key": api_key}
+        base_url = self._resolve_base_url()
+        if base_url:
+            kwargs["base_url"] = base_url
+        return openai.AsyncOpenAI(**kwargs)
+
+    def _fallback_model_list(self) -> List[str]:
+        """Models reported when the live listing fails or comes back empty."""
+        if self.fallback_models:
+            return list(self.fallback_models)
+        configured = self._default_model_name()
+        return [configured] if configured else []
+
+    # ------------------------------------------------------------------
+    # Shared flow
+    # ------------------------------------------------------------------
+
+    def _default_model_name(self) -> str:
+        """Return the settings-configured default model, else the class default."""
+        return self._get_setting("default_model", self.default_model)
+
+    def _ensure_client(self):
+        """Lazily initialize and cache the async client."""
+        if self._client is None:
+            self._client = self._create_client()
+        return self._client
+
+    def _build_params(self, request: LLMRequest, model: str) -> Dict[str, Any]:
+        """Build the chat-completions payload from an LLMRequest."""
+        params: Dict[str, Any] = {
+            "model": model,
+            "messages": request.messages,
+            "temperature": request.temperature,
+        }
+        if self.include_top_p:
+            params["top_p"] = request.top_p
+        max_tokens = request.max_tokens or self.default_max_tokens
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+        if request.stop:
+            params["stop"] = request.stop
+        if request.tools:
+            params["tools"] = self._tools_payload(request)
+            if request.tool_choice:
+                params["tool_choice"] = request.tool_choice
+        if self.forward_penalty_params:
+            api_kwargs: Dict[str, Any] = request.metadata.get("api_kwargs") or {}
+            for key in ("presence_penalty", "frequency_penalty"):
+                if key in api_kwargs:
+                    params[key] = api_kwargs[key]
+        extra = self._extra_params(request)
+        if extra:
+            params.update(extra)
+        if self.sort_params_for_cache:
+            params = sorted_for_cache(params)
+        return params
+
+    @staticmethod
+    def _tools_payload(request: LLMRequest) -> List[Dict[str, Any]]:
+        """Map ToolDefinition objects to OpenAI function-tool dicts."""
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.input_schema,
+                },
+            }
+            for t in request.tools
+        ]
+
+    @staticmethod
+    def _parse_tool_calls(message: Any) -> List[ToolCall]:
+        """Parse SDK tool calls, falling back to ``{}`` on malformed JSON args."""
+        calls: List[ToolCall] = []
+        if not getattr(message, "tool_calls", None):
+            return calls
+        for tc in message.tool_calls:
+            try:
+                args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+            except Exception:
+                args = {}
+            calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
+        return calls
+
+    def _build_response(
+        self,
+        request: LLMRequest,
+        response: Any,
+        params: Dict[str, Any],
+        start: float,
+    ) -> LLMResponse:
+        """Map an SDK chat-completions response onto the shared LLMResponse."""
+        choice = response.choices[0]
+        usage = response.usage
+        api_model = response.model or params["model"]
+        total_tokens = usage.total_tokens if usage else 0
+        tool_calls = self._parse_tool_calls(choice.message)
+        # #10582: reasoning/thinking text surfaced by o1/o3, DeepSeek-R1, QwQ,
+        # SGLang, and similar OpenAI-compat servers.
+        reasoning_content: str | None = getattr(choice.message, "reasoning_content", None) or None
+        return LLMResponse(
+            content=choice.message.content or "",
+            model=api_model,
+            provider=self.provider_name,
+            processing_time=time.time() - start,
+            request_id=request.request_id,
+            finish_reason=choice.finish_reason,
+            usage={
+                "prompt_tokens": usage.prompt_tokens if usage else 0,
+                "completion_tokens": usage.completion_tokens if usage else 0,
+                "total_tokens": total_tokens,
+            },
+            tool_calls=tool_calls or None,
+            provider_metadata=self._build_provider_metadata(
+                model_api_name=api_model,
+                api_kwargs_applied=params,
+                total_tokens=total_tokens,
+            ),
+            reasoning_content=reasoning_content,
+        )
+
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
+        """Execute a non-streaming chat completion.
+
+        Must not raise — errors are returned via ``LLMResponse.error`` so the
+        registry can fall back; circuit-breaker accounting happens in
+        ``BaseProvider._guarded_completion`` (GH#11488).
+        """
+        self._total_requests += 1
+        start = time.time()
+        model = request.model_name or self._default_model_name()
+        try:
+            client = self._ensure_client()
+            params = self._build_params(request, model)
+            response = await client.chat.completions.create(**params)
+            return self._build_response(request, response, params, start)
+        except Exception as exc:
+            self._total_errors += 1
+            logger.error("%s chat_completion error: %s", self.provider_name, exc)
+            return LLMResponse(
+                content="",
+                model=model,
+                provider=self.provider_name,
+                processing_time=time.time() - start,
+                request_id=request.request_id,
+                error=str(exc),
+            )
+
+    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
+        """Stream a chat completion, yielding text chunks as they arrive."""
+        self._total_requests += 1
+        model = request.model_name or self._default_model_name()
+        try:
+            client = self._ensure_client()
+            params = self._build_params(request, model)
+            params["stream"] = True
+            stream = await client.chat.completions.create(**params)
+            async for chunk in stream:
+                delta = chunk.choices[0].delta.content
+                if delta:
+                    yield delta
+        except Exception as exc:
+            self._total_errors += 1
+            logger.error("%s stream_completion error: %s", self.provider_name, exc)
+            raise
+
+    async def is_available(self) -> bool:
+        """Return True if credentials resolve and the models endpoint responds."""
+        try:
+            client = self._ensure_client()
+            await client.models.list()
+            return True
+        except Exception:
+            return False
+
+    async def list_models(self) -> List[str]:
+        """Return live models, falling back to the provider's static list."""
+        try:
+            client = self._ensure_client()
+            model_list = await client.models.list()
+            models = [m.id for m in (model_list.data or [])]
+            return models or self._fallback_model_list()
+        except Exception:
+            return self._fallback_model_list()
+
+
+__all__ = ["OpenAICompatibleProvider"]

--- a/autobot-backend/llm_shared/providers/openrouter.py
+++ b/autobot-backend/llm_shared/providers/openrouter.py
@@ -13,23 +13,23 @@ Configuration:
   - default_model: Default model name for completions
 
 Moved from llm_providers/ as part of Phase 2 consolidation (MVA-178 / GH#7637).
+Consolidated onto :class:`OpenAICompatibleProvider` (#11517) — only the genuine
+deltas live here: the OpenRouter gateway base URL, penalty-param forwarding
+from ``metadata["api_kwargs"]``, and an empty static fallback (200+ live models
+make any hardcoded list meaningless).
 """
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict, List
+from typing import List
 
-from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
-from llm_shared.models import LLMRequest, LLMResponse
 from llm_shared.types import ProviderType
 
-from ..base_provider import BaseProvider
-
-logger = get_logger(__name__)
+from .openai_compatible import OpenAICompatibleProvider
 
 
-class OpenRouterProvider(BaseProvider):
+class OpenRouterProvider(OpenAICompatibleProvider):
     """
     OpenRouter provider implementation.
 
@@ -41,152 +41,28 @@ class OpenRouterProvider(BaseProvider):
     """
 
     provider_name = ProviderType.OPENROUTER.value if hasattr(ProviderType, "OPENROUTER") else "openrouter"
-
-    def __init__(self, settings: Dict[str, Any] | None = None) -> None:
-        super().__init__(settings)
-        self._api_key: str | None = None
-        self._base_url: str | None = None
-        self._client = None
+    default_model = "gpt-3.5-turbo"
+    forward_penalty_params = True
+    missing_key_error = "OpenRouter API key not found. Set OPENROUTER_API_KEY or provide api_key in settings."
 
     def _resolve_api_key(self) -> str | None:
         """Resolve API key from settings or environment."""
         if self._api_key:
             return self._api_key
-        key = self._get_setting("api_key") or config.openrouter_api_key
-        self._api_key = key
+        self._api_key = self._get_setting("api_key") or config.openrouter_api_key
         return self._api_key
 
     def _resolve_base_url(self) -> str:
-        """Resolve base URL with default."""
+        """Resolve base URL with the OpenRouter gateway default."""
         if self._base_url:
             return self._base_url
-        url = self._get_setting("base_url") or config.openrouter_api_base_url or "https://openrouter.ai/api/v1"
-        self._base_url = url
-        return url
+        default_url = "https://openrouter.ai/api/v1"
+        self._base_url = self._get_setting("base_url") or config.openrouter_api_base_url or default_url
+        return self._base_url
 
-    def _ensure_client(self):
-        """Lazily initialize the async OpenAI client."""
-        if self._client is not None:
-            return
-
-        try:
-            from openai import AsyncOpenAI
-        except ImportError as exc:
-            raise ImportError("openai package not installed. Run: pip install openai") from exc
-
-        api_key = self._resolve_api_key()
-        if not api_key:
-            raise ValueError("OpenRouter API key not found. Set OPENROUTER_API_KEY or provide api_key in settings.")
-
-        base_url = self._resolve_base_url()
-        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-        logger.info("OpenRouter client initialized")
-
-    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
-        """Execute a chat completion via OpenRouter."""
-        try:
-            self._total_requests += 1
-            self._ensure_client()
-
-            messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
-
-            api_kwargs = request.metadata.get("api_kwargs", {})
-            chat_kwargs = {
-                "model": request.model_name or self._get_setting("default_model", "gpt-3.5-turbo"),
-                "messages": messages,
-                "temperature": api_kwargs.get("temperature", 0.7),
-                "max_tokens": api_kwargs.get("max_tokens"),
-                "top_p": api_kwargs.get("top_p", 0.95),
-            }
-
-            if "presence_penalty" in api_kwargs:
-                chat_kwargs["presence_penalty"] = api_kwargs["presence_penalty"]
-            if "frequency_penalty" in api_kwargs:
-                chat_kwargs["frequency_penalty"] = api_kwargs["frequency_penalty"]
-            if "stop" in api_kwargs:
-                chat_kwargs["stop"] = api_kwargs["stop"]
-
-            response = await self._client.chat.completions.create(**chat_kwargs)
-
-            content = response.choices[0].message.content or ""
-            usage = {
-                "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
-                "completion_tokens": response.usage.completion_tokens if response.usage else 0,
-            }
-
-            return LLMResponse(
-                content=content,
-                model=request.model_name or chat_kwargs["model"],
-                provider=self.provider_name,
-                usage=usage,
-                provider_metadata=self._build_provider_metadata(
-                    model_api_name=chat_kwargs["model"],
-                    api_kwargs_applied=chat_kwargs,
-                    total_tokens=usage["prompt_tokens"] + usage["completion_tokens"],
-                ),
-            )
-
-        except Exception as exc:
-            self._total_errors += 1
-            error_msg = f"OpenRouter API error: {exc}"
-            logger.error(error_msg)
-            return LLMResponse(
-                content="",
-                model=request.model_name or "openrouter-model",
-                provider=self.provider_name,
-                error=error_msg,
-            )
-
-    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
-        """Stream a chat completion from OpenRouter."""
-        try:
-            self._total_requests += 1
-            self._ensure_client()
-
-            messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
-
-            api_kwargs = request.metadata.get("api_kwargs", {})
-            chat_kwargs = {
-                "model": request.model_name or self._get_setting("default_model", "gpt-3.5-turbo"),
-                "messages": messages,
-                "temperature": api_kwargs.get("temperature", 0.7),
-                "max_tokens": api_kwargs.get("max_tokens"),
-                "top_p": api_kwargs.get("top_p", 0.95),
-                "stream": True,
-            }
-
-            if "stop" in api_kwargs:
-                chat_kwargs["stop"] = api_kwargs["stop"]
-
-            async with await self._client.chat.completions.create(**chat_kwargs) as stream:
-                async for chunk in stream:
-                    if chunk.choices[0].delta.content:
-                        yield chunk.choices[0].delta.content
-
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("OpenRouter stream error: %s", exc)
-            yield "Error: Stream completion failed"
-
-    async def is_available(self) -> bool:
-        """Check if OpenRouter is reachable and properly configured."""
-        try:
-            self._ensure_client()
-            models = await self._client.models.list()
-            return models is not None and len(models.data) > 0
-        except Exception as exc:
-            logger.warning("OpenRouter health check failed: %s", exc)
-            return False
-
-    async def list_models(self) -> List[str]:
-        """List available models via OpenRouter API."""
-        try:
-            self._ensure_client()
-            response = await self._client.models.list()
-            return [model.id for model in response.data] if response.data else []
-        except Exception as exc:
-            logger.error("Failed to list OpenRouter models: %s", exc)
-            return []
+    def _fallback_model_list(self) -> List[str]:
+        """No static fallback — OpenRouter's catalogue is live-only."""
+        return []
 
 
 __all__ = ["OpenRouterProvider"]


### PR DESCRIPTION
Closes #11517

## Thinking Path

Five near-identical OpenAI-compatible providers each hand-rolled request-building, response-mapping, tool-call parsing, and streaming — and had drifted. New `OpenAICompatibleProvider(BaseProvider)` owns the shared flow; each provider is a thin subclass carrying only its genuine deltas. Module paths, class names, and `provider_name` ids are unchanged (config compatibility), so registry/adapters/re-exports needed zero changes.

## What Changed

- New `llm_shared/providers/openai_compatible.py` (283 lines) replaces ~750 lines of duplicated flow across `openai.py`, `groq.py`, `custom_openai.py`, `openrouter.py`, `nous_portal.py` (net −381).
- Per-provider deltas preserved as explicit hooks: OpenAI (SSOT key chain, reasoning-effort #9017, sorted params #7368), Groq (AsyncGroq client, historical top_p omission), CustomOpenAI (mandatory base_url, instance_name), OpenRouter (gateway URL, penalty forwarding), NousPortal (HF token chain, 2048 default max_tokens).
- Drift bugs the shared flow fixes (all latent, verified by harness): openrouter/nous crashed with AttributeError on dict messages on EVERY call; nous passed nonexistent LLMResponse kwargs (TypeError, violating must-not-raise); openrouter/nous lacked tool wiring/finish_reason/usage propagation; openai/groq streams silently dropped top_p/stop/tools; openrouter/nous streams yielded literal "Error:" text into output instead of raising.

## Verification

- Seams: breaker untouched at `BaseProvider._guarded_completion`; `_chat_completion_impl` returns via `LLMResponse.error`; `TestNoMethodLevelBreaker` guard passes (repo rule: method-level breaker decorators are inert).
- 135/139 provider tests pass real-loaded; the 4 failures proven pre-existing by replaying the OLD provider files through the identical harness (same failures). mistral/ollama 26 pass; startup imports 344 pass (agent + independent re-run). py_compile/flake8/black clean.
- Independent: all 6 provider modules real-import cleanly in the worktree.
- Note: these test files error at collection on clean base too (root conftest stubs `llm_shared.providers`) — the real-load runs are the stricter verification.

## Model Used

Claude Fable 5 (subagent: general-purpose)