### PR TITLE
feat(slm-agent): probe app-level /health for engine state in heartbeat (#11723)

### DIFF
--- a/autobot-slm-agent/health_collector.py
+++ b/autobot-slm-agent/health_collector.py
@@ -8,17 +8,28 @@ Health Collector for SLM Agent
 Collects system and service health metrics for reporting to admin.
 """
 
+import json
 import logging
 import os
 import platform
 import socket
 import subprocess  # nosec B404 - required for systemctl interaction
+import urllib.request
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 import psutil
 
 logger = logging.getLogger(__name__)
+
+# App-level /health probes for services that expose engine state beyond
+# systemd (#11723). Local-only URLs, short timeout, never fatal to service
+# discovery. Env-overridable so a non-default port needs no code change.
+TTS_HEALTH_URL = os.getenv("SLM_AGENT_TTS_HEALTH_URL", "http://127.0.0.1:8083/health")
+APP_HEALTH_PROBES: Dict[str, str] = {
+    "autobot-tts-worker": TTS_HEALTH_URL,
+}
+APP_HEALTH_TIMEOUT_SECONDS = float(os.getenv("SLM_AGENT_APP_HEALTH_TIMEOUT", "2.0"))
 
 
 class HealthCollector:
@@ -135,6 +146,7 @@ class HealthCollector:
                 if service_info:
                     if service_info["status"] == "running":
                         service_info.update(self._get_service_details(service_info["name"]))
+                        service_info.update(self._probe_app_health(service_info["name"]))
                     services.append(service_info)
 
         except subprocess.TimeoutExpired:
@@ -238,6 +250,34 @@ class HealthCollector:
             logger.debug("Could not get details for %s: %s", service_name, e)
 
         return details
+
+    def _probe_app_health(self, service_name: str) -> Dict:
+        """Fold app-level /health engine state into service info (#11723).
+
+        Only services listed in APP_HEALTH_PROBES are probed (local URL,
+        short timeout). Never raises: any failure (timeout, refused,
+        non-JSON, missing fields) returns {} so systemd discovery and the
+        heartbeat are unaffected. The returned keys feed
+        services/service_extra_data.engine_degraded_fields on the SLM
+        backend, which lights the NodeServicesPanel degraded badge (#11718).
+        """
+        url = APP_HEALTH_PROBES.get(service_name)
+        if not url:
+            return {}
+        try:
+            with urllib.request.urlopen(  # nosec B310 - fixed local http:// URL, not user input
+                url, timeout=APP_HEALTH_TIMEOUT_SECONDS
+            ) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            logger.debug("App health probe failed for %s: %s", service_name, e)
+            return {}
+        if not isinstance(payload, dict) or "engine_degraded" not in payload:
+            return {}
+        return {
+            "engine_degraded": bool(payload.get("engine_degraded")),
+            "degraded_reason": payload.get("degraded_reason"),
+        }
 
     def is_healthy(self, thresholds: Optional[Dict] = None) -> bool:
         """Quick health check against thresholds."""

--- a/autobot-slm-agent/health_collector_probe_test.py
+++ b/autobot-slm-agent/health_collector_probe_test.py
@@ -1,0 +1,89 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the app-level /health probe in HealthCollector (#11723).
+
+The probe feeds engine_degraded/degraded_reason from a service's own
+/health endpoint into the heartbeat service dict, which the SLM backend
+merges into Service.extra_data (services/service_extra_data.py, #11718).
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # importable from repo root too
+
+from health_collector import HealthCollector  # noqa: E402
+
+
+def _collector() -> HealthCollector:
+    return HealthCollector(services=[])
+
+
+def _fake_response(body: bytes):
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda self: self
+    resp.__exit__ = lambda self, *a: False
+    return resp
+
+
+def test_unmapped_service_not_probed():
+    with patch("health_collector.urllib.request.urlopen") as urlopen:
+        assert _collector()._probe_app_health("nginx") == {}
+        urlopen.assert_not_called()
+
+
+def test_degraded_fields_extracted():
+    body = json.dumps({"status": "healthy", "engine_degraded": True, "degraded_reason": "HF auth failed"}).encode(
+        "utf-8"
+    )
+    with patch("health_collector.urllib.request.urlopen", return_value=_fake_response(body)):
+        result = _collector()._probe_app_health("autobot-tts-worker")
+    assert result == {"engine_degraded": True, "degraded_reason": "HF auth failed"}
+
+
+def test_healthy_engine_reports_not_degraded():
+    body = json.dumps({"engine_degraded": False, "degraded_reason": None}).encode("utf-8")
+    with patch("health_collector.urllib.request.urlopen", return_value=_fake_response(body)):
+        result = _collector()._probe_app_health("autobot-tts-worker")
+    assert result == {"engine_degraded": False, "degraded_reason": None}
+
+
+def test_missing_field_returns_empty():
+    body = json.dumps({"status": "healthy"}).encode("utf-8")
+    with patch("health_collector.urllib.request.urlopen", return_value=_fake_response(body)):
+        assert _collector()._probe_app_health("autobot-tts-worker") == {}
+
+
+def test_connection_failure_is_non_fatal():
+    with patch("health_collector.urllib.request.urlopen", side_effect=OSError("connection refused")):
+        assert _collector()._probe_app_health("autobot-tts-worker") == {}
+
+
+def test_non_json_body_is_non_fatal():
+    with patch(
+        "health_collector.urllib.request.urlopen",
+        return_value=_fake_response(b"<html>gateway error</html>"),
+    ):
+        assert _collector()._probe_app_health("autobot-tts-worker") == {}
+
+
+def test_discovery_folds_probe_into_running_service():
+    collector = _collector()
+    line = "autobot-tts-worker.service loaded active running AutoBot TTS Worker"
+    with (
+        patch.object(collector, "_run_systemctl_list_units", return_value=line),
+        patch.object(collector, "_get_service_details", return_value={}),
+        patch.object(
+            collector,
+            "_probe_app_health",
+            return_value={"engine_degraded": True, "degraded_reason": "x"},
+        ) as probe,
+    ):
+        services = collector.discover_all_services()
+    probe.assert_called_once_with("autobot-tts-worker")
+    assert services[0]["engine_degraded"] is True


### PR DESCRIPTION
## Thinking Path

#11718 shipped the TTS worker's `engine_degraded` health field, the reconciler merge point (`engine_degraded_fields`), and the NodeServicesPanel badge — but the agent only reads systemd state, so the fields never reach `Service.extra_data` in practice. This adds the missing agent-side link.

## What Changed

- `autobot-slm-agent/health_collector.py` — new `_probe_app_health()`: for services in `APP_HEALTH_PROBES` (currently `autobot-tts-worker` → `http://127.0.0.1:8083/health`, env-overridable via `SLM_AGENT_TTS_HEALTH_URL` / timeout via `SLM_AGENT_APP_HEALTH_TIMEOUT`), issue a short-timeout local GET and fold `engine_degraded`/`degraded_reason` into the discovered-service dict. stdlib `urllib` (agent stays dependency-free); never raises — any failure returns `{}` and discovery proceeds.
- `discover_all_services()` calls the probe for running services only.
- `health_collector_probe_test.py` — 7 tests: unmapped services not probed, degraded/healthy extraction, missing-field / connection-failure / non-JSON all non-fatal, and discovery folds probe output into the service dict.

## Verification

- 7 passed from both repo root and module dir; flake8/black/py_compile clean; bandit adds no new findings (3 pre-existing B603s identical on base).
- End-to-end consumer chain verified present on base: reconciler:1196/1259 `engine_degraded_fields(svc_data)` → `Service.extra_data` → NodeServicesPanel badge (#11718, merged).

Closes #11723

## Model Used

Fable 5 (inline implementation)

## Discoveries

#11748 — slm-agent tests invisible to CI (not in testpaths) + version_test.py standalone failures.
