### PR TITLE
fix(test): repair integration env-rot clusters — JSONB-on-SQLite, mobile_push fixtures, watchdog dep (#11687)

### DIFF
--- a/autobot-backend/llm_shared/fallback_chain.py
+++ b/autobot-backend/llm_shared/fallback_chain.py
@@ -217,6 +217,17 @@ class FallbackChainManager:
             if chain:
                 return chain.get_next_fallback(qualified_name)
 
+        # Mid-chain hop (#11687): chains are keyed by PRIMARY model only, so a
+        # fallback model that itself rate-limits resolves no chain and
+        # multi-hop fallback dies after the first hop. Find the chain that
+        # lists current_model as a fallback and continue from there —
+        # FallbackChain.get_next_fallback already handles mid-chain positions.
+        needle = current_model.lower()
+        for chain in self._chains.values():
+            for fb_model in chain.fallback_models:
+                if fb_model.lower() == needle:
+                    return chain.get_next_fallback(fb_model)
+
         return None
 
     def list_chains(self) -> Dict[str, List[str]]:

--- a/autobot-backend/services/documentation_watcher_staleness_test.py
+++ b/autobot-backend/services/documentation_watcher_staleness_test.py
@@ -7,16 +7,28 @@
 Covers:
 - _propagate_staleness_for_doc() triggers propagation, store, and enqueue
 - _propagate_staleness_for_doc() swallows errors to avoid breaking indexing
-- _handle_update() calls _propagate_staleness_for_doc() on successful indexing
-- _handle_update() does NOT call _propagate_staleness_for_doc() on skip/failure
+- _handle_update() calls _propagate_staleness_for_doc() after a successful
+  enqueue_reindex (#4453 moved indexing onto DocumentSyncQueue, so there is
+  no per-file index result anymore — propagation follows the enqueue)
+- _handle_update() does NOT propagate when the indexer is unavailable or the
+  enqueue fails
+
+#11687: realigned with the current module — the Redis seam is the async
+``get_async_redis_client`` and ``get_doc_indexer_service`` is imported
+function-locally from ``services.knowledge.doc_indexer``.
 """
 
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.documentation_watcher import DocumentationWatcherService
+# Import the seam module BEFORE any patch() call so mock.patch targets the
+# canonical sys.modules entry — when patch() itself triggers the first import,
+# the watcher's function-local import can resolve a different module object
+# and the patches silently miss (#11687).
+import services.knowledge.doc_indexer  # noqa: F401
+import services.mesh_brain.staleness_propagator  # noqa: F401
+from services.documentation_watcher import PROJECT_ROOT, DocumentationWatcherService
 
 # =============================================================================
 # _propagate_staleness_for_doc
@@ -38,7 +50,10 @@ class TestPropagateStalnessForDoc:
         mock_staleness_result.flagged_for_reembedding = MagicMock(return_value=["neighbor"])
 
         with (
-            patch("autobot_shared.redis_client.get_redis_client", return_value=mock_redis),
+            patch(
+                "autobot_shared.redis_client.get_async_redis_client",
+                new=AsyncMock(return_value=mock_redis),
+            ),
             patch(
                 "services.mesh_brain.staleness_propagator.RedisGraphAdapter",
                 return_value=mock_graph,
@@ -67,7 +82,7 @@ class TestPropagateStalnessForDoc:
         watcher = DocumentationWatcherService()
 
         with patch(
-            "autobot_shared.redis_client.get_redis_client",
+            "autobot_shared.redis_client.get_async_redis_client",
             side_effect=RuntimeError("Redis is down"),
         ):
             # Must not raise
@@ -80,29 +95,21 @@ class TestPropagateStalnessForDoc:
 
 
 class TestHandleUpdateCallsStaleness:
-    """_handle_update triggers staleness propagation only on success."""
-
-    def _make_index_result(self, success=0, skipped=0, failed=0, errors=None):
-        result = MagicMock()
-        result.success = success
-        result.skipped = skipped
-        result.failed = failed
-        result.errors = errors or []
-        return result
+    """_handle_update triggers staleness propagation only after a good enqueue."""
 
     @pytest.mark.asyncio
     async def test_staleness_called_on_success(self) -> None:
-        """Staleness propagation is triggered when index_file returns success > 0."""
+        """Staleness propagation is triggered after enqueue_reindex succeeds."""
         watcher = DocumentationWatcherService()
-        file_path = Path("/fake/docs/guide.md")
+        file_path = PROJECT_ROOT / "docs" / "guide.md"
 
         mock_indexer = AsyncMock()
         mock_indexer.initialize = AsyncMock(return_value=True)
-        mock_indexer.index_file = AsyncMock(return_value=self._make_index_result(success=1))
+        mock_indexer.enqueue_reindex = AsyncMock()
 
         with (
             patch(
-                "services.documentation_watcher.get_doc_indexer_service",
+                "services.knowledge.doc_indexer.get_doc_indexer_service",
                 return_value=mock_indexer,
             ),
             patch.object(
@@ -113,21 +120,21 @@ class TestHandleUpdateCallsStaleness:
         ):
             await watcher._handle_update(file_path)
 
-        mock_propagate.assert_awaited_once()
+        mock_indexer.enqueue_reindex.assert_awaited_once()
+        mock_propagate.assert_awaited_once_with("docs/guide.md")
 
     @pytest.mark.asyncio
-    async def test_staleness_not_called_on_skip(self) -> None:
-        """Staleness propagation is NOT triggered when file is skipped."""
+    async def test_staleness_not_called_when_indexer_unavailable(self) -> None:
+        """Staleness propagation is NOT triggered when the indexer can't initialize."""
         watcher = DocumentationWatcherService()
-        file_path = Path("/fake/docs/guide.md")
+        file_path = PROJECT_ROOT / "docs" / "guide.md"
 
         mock_indexer = AsyncMock()
-        mock_indexer.initialize = AsyncMock(return_value=True)
-        mock_indexer.index_file = AsyncMock(return_value=self._make_index_result(skipped=1))
+        mock_indexer.initialize = AsyncMock(return_value=False)
 
         with (
             patch(
-                "services.documentation_watcher.get_doc_indexer_service",
+                "services.knowledge.doc_indexer.get_doc_indexer_service",
                 return_value=mock_indexer,
             ),
             patch.object(
@@ -142,17 +149,17 @@ class TestHandleUpdateCallsStaleness:
 
     @pytest.mark.asyncio
     async def test_staleness_not_called_on_failure(self) -> None:
-        """Staleness propagation is NOT triggered when indexing fails."""
+        """Staleness propagation is NOT triggered when enqueue_reindex fails."""
         watcher = DocumentationWatcherService()
-        file_path = Path("/fake/docs/guide.md")
+        file_path = PROJECT_ROOT / "docs" / "guide.md"
 
         mock_indexer = AsyncMock()
         mock_indexer.initialize = AsyncMock(return_value=True)
-        mock_indexer.index_file = AsyncMock(return_value=self._make_index_result(failed=1, errors=["some error"]))
+        mock_indexer.enqueue_reindex = AsyncMock(side_effect=RuntimeError("queue write failed"))
 
         with (
             patch(
-                "services.documentation_watcher.get_doc_indexer_service",
+                "services.knowledge.doc_indexer.get_doc_indexer_service",
                 return_value=mock_indexer,
             ),
             patch.object(
@@ -161,6 +168,7 @@ class TestHandleUpdateCallsStaleness:
                 new=AsyncMock(),
             ) as mock_propagate,
         ):
-            await watcher._handle_update(file_path)
+            with pytest.raises(RuntimeError):
+                await watcher._handle_update(file_path)
 
         mock_propagate.assert_not_awaited()

--- a/autobot-backend/tests/integration/conftest.py
+++ b/autobot-backend/tests/integration/conftest.py
@@ -12,6 +12,16 @@ device-JWT path guards, GH#6473 / GH#9493) would silently assert on mocks.
 ``real_auth_middleware`` loads the real module under an ALIAS key so the stub
 — and every other test relying on it — stays untouched (no ``sys.modules``
 pollution of the canonical name). Issue #11648.
+
+JSONB/ARRAY-on-SQLite (#11687): production models use PostgreSQL-only column
+types (``postgresql.JSONB`` / ``postgresql.ARRAY``) while integration tests
+run ``Base.metadata.create_all`` against in-memory SQLite. SQLite's DDL
+compiler has no renderer for those types, so every such test errored at
+fixture setup. The ``@compiles(..., "sqlite")`` hooks below render both as
+``JSON`` (SQLite has native JSON support; JSONB inherits the generic JSON
+bind/result processors, so round-tripping dict/list values keeps working).
+Registration is global and idempotent — a no-op for every other dialect, so
+PostgreSQL DDL is untouched.
 """
 
 import importlib.util
@@ -19,9 +29,23 @@ import sys
 from pathlib import Path
 
 import pytest
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.ext.compiler import compiles
 
 _BACKEND_ROOT = Path(__file__).parent.parent.parent
 _REAL_AM_KEY = "_integration_real_auth_middleware"
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(element, compiler, **kw):
+    """Render PostgreSQL JSONB columns as JSON on SQLite test databases (#11687)."""
+    return "JSON"
+
+
+@compiles(ARRAY, "sqlite")
+def _compile_pg_array_sqlite(element, compiler, **kw):
+    """Render PostgreSQL ARRAY columns as JSON on SQLite test databases (#11687)."""
+    return "JSON"
 
 
 @pytest.fixture(scope="session")

--- a/autobot-backend/tests/integration/test_budget_hard_stop.py
+++ b/autobot-backend/tests/integration/test_budget_hard_stop.py
@@ -15,10 +15,43 @@ import uuid
 from datetime import datetime, timezone
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from models.heartbeat import AgentRuntimeState, AgentWakeupRequest
+
+# ---------------------------------------------------------------------------
+# Redis fixture: fakeredis for isolation (#11687 — same pattern as
+# test_task_claim_race.py). Without it these tests hit the env-configured
+# ANALYTICS Redis host, which is an unresolvable placeholder in hermetic runs.
+# ---------------------------------------------------------------------------
+
+try:
+    import fakeredis.aioredis as fakeredis_async
+
+    _FAKEREDIS_AVAILABLE = True
+except ImportError:
+    _FAKEREDIS_AVAILABLE = False
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def fake_redis(monkeypatch):
+    """Patch budget_policy's Redis seam with a per-test fakeredis instance."""
+    if not _FAKEREDIS_AVAILABLE:
+        pytest.skip("fakeredis not installed — skipping Redis-backed tests")
+
+    server = fakeredis_async.FakeServer()
+    client = fakeredis_async.FakeRedis(server=server, decode_responses=True)
+
+    import services.budget_policy as bp_mod
+
+    async def _fake_get_client(*_args, **_kwargs):
+        return client
+
+    monkeypatch.setattr(bp_mod, "get_async_redis_client", _fake_get_client)
+    yield client
+    await client.aclose()
 from services.budget_policy import (
     PERIOD_DAY,
     PERIOD_MONTH,
@@ -255,13 +288,15 @@ class TestPauseResume:
         )
         async_db_session.add(state)
 
-        # Add some wakeup requests (unconsumed)
+        # Add some wakeup requests (unconsumed) — #11687: aligned with the
+        # current AgentWakeupRequest model (runtime_state_id FK + reason;
+        # the old source/trigger_time columns no longer exist).
         for i in range(3):
             wake = AgentWakeupRequest(
                 id=uuid.uuid4(),
                 agent_id=agent_id,
-                source="budget_test",
-                trigger_time=datetime.now(timezone.utc),
+                runtime_state_id=state.id,
+                reason=f"budget_test_{i}",
             )
             async_db_session.add(wake)
 
@@ -311,7 +346,10 @@ class TestPauseResume:
         success = await resume_agent(agent_id, approved_by="test_admin")
         assert success is True
 
-        # Verify the state is cleared
+        # Verify the state is cleared. resume_agent committed via its OWN
+        # session; expire this session's identity map so the re-select loads
+        # fresh column values instead of the stale cached instance (#11687).
+        async_db_session.expire_all()
         result = await async_db_session.execute(select(AgentRuntimeState).where(AgentRuntimeState.agent_id == agent_id))
         resumed_state = result.scalar_one_or_none()
         assert resumed_state is not None

--- a/autobot-backend/tests/integration/test_budget_hard_stop.py
+++ b/autobot-backend/tests/integration/test_budget_hard_stop.py
@@ -52,6 +52,8 @@ async def fake_redis(monkeypatch):
     monkeypatch.setattr(bp_mod, "get_async_redis_client", _fake_get_client)
     yield client
     await client.aclose()
+
+
 from services.budget_policy import (
     PERIOD_DAY,
     PERIOD_MONTH,

--- a/autobot-backend/tests/integration/test_execution_snapshot_api.py
+++ b/autobot-backend/tests/integration/test_execution_snapshot_api.py
@@ -19,8 +19,20 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import api.execution_snapshots as execution_snapshots_module
 from api.execution_snapshots import router as execution_snapshots_router
 from services.execution.snapshot_index import SnapshotRecord
+
+# Dependency callables as captured by Depends() at router-import time. The
+# tests below patch the MODULE attributes (api.execution_snapshots.get_*), but
+# FastAPI resolves dependencies through the objects it captured at import — so
+# the app fixture overrides those captured objects with thin delegates that
+# call the CURRENT module attribute, making @patch effective (#11687). Without
+# this, the conftest auth stub (a bare MagicMock whose signature is
+# (*args, **kwargs)) is the dependency and FastAPI turns args/kwargs into
+# required query parameters — every request 422s before reaching the handler.
+_ORIG_GET_CURRENT_USER = execution_snapshots_module.get_current_user
+_ORIG_GET_DOCKER_BACKEND = execution_snapshots_module.get_docker_backend
 
 
 @pytest.fixture
@@ -28,6 +40,8 @@ def app():
     """Create FastAPI app with execution_snapshots router for testing."""
     app = FastAPI()
     app.include_router(execution_snapshots_router)
+    app.dependency_overrides[_ORIG_GET_CURRENT_USER] = lambda: execution_snapshots_module.get_current_user()
+    app.dependency_overrides[_ORIG_GET_DOCKER_BACKEND] = lambda: execution_snapshots_module.get_docker_backend()
     return app
 
 
@@ -159,7 +173,9 @@ class TestListSnapshots:
         """Test listing all snapshots without session filter."""
         mock_get_user.return_value = mock_user
         mock_get_backend.return_value = mock_backend
-        mock_backend._snapshot_index.list_all.return_value = [sample_snapshot_record]
+        # #11687: the endpoint lists ONLY the caller's snapshots now
+        # (list_by_user), not the whole index (list_all).
+        mock_backend._snapshot_index.list_by_user.return_value = [sample_snapshot_record]
 
         response = client.get("/execution/snapshots")
 
@@ -169,7 +185,7 @@ class TestListSnapshots:
         assert data["count"] == 1
         assert len(data["snapshots"]) == 1
 
-        mock_backend._snapshot_index.list_all.assert_called_once()
+        mock_backend._snapshot_index.list_by_user.assert_called_once_with("test-user")
 
     @patch("api.execution_snapshots.get_docker_backend")
     @patch("api.execution_snapshots.get_current_user")
@@ -236,7 +252,9 @@ class TestRestoreSnapshot:
         response = client.post("/execution/snapshots/snap-123/restore")
 
         assert response.status_code == 403
-        assert "User does not own this snapshot" in response.json()["detail"]
+        # #11687: the endpoint deliberately returns a generic message so
+        # internal ownership details never leak to the caller.
+        assert response.json()["detail"] == "Access denied"
 
     @patch("api.execution_snapshots.get_docker_backend")
     @patch("api.execution_snapshots.get_current_user")
@@ -299,7 +317,9 @@ class TestDeleteSnapshot:
         response = client.delete("/execution/snapshots/snap-123")
 
         assert response.status_code == 403
-        assert "User does not own this snapshot" in response.json()["detail"]
+        # #11687: the endpoint deliberately returns a generic message so
+        # internal ownership details never leak to the caller.
+        assert response.json()["detail"] == "Access denied"
 
     @patch("api.execution_snapshots.get_docker_backend")
     @patch("api.execution_snapshots.get_current_user")

--- a/autobot-backend/tests/integration/test_mobile_push.py
+++ b/autobot-backend/tests/integration/test_mobile_push.py
@@ -36,6 +36,22 @@ from user_management.models.base import Base
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
 
+@pytest.fixture(autouse=True)
+def _test_encryption_service(monkeypatch):
+    """Provide a REAL EncryptionService with an injected test master key (#11687).
+
+    ``MobileDevice.device_token`` encrypts/decrypts through the module-level
+    ``get_encryption_service()`` singleton, which requires
+    ``AUTOBOT_ENCRYPTION_KEY`` — absent in the hermetic test env (ssot config
+    reads env once at import, so setting the variable here would be too late).
+    Injecting the key keeps the real AES-GCM round-trip under test.
+    """
+    import encryption_service as enc_mod
+
+    svc = enc_mod.EncryptionService(master_key="integration-test-master-key-0123456789abcdef")
+    monkeypatch.setattr(enc_mod, "get_encryption_service", lambda: svc)
+
+
 @pytest.fixture
 async def test_db_engine():
     """Create an in-memory test database engine."""
@@ -74,12 +90,15 @@ def test_user_id():
 
 
 @pytest.fixture
-async def mock_session_factory(test_db_session):
-    """Mock session factory for push service."""
+def mock_session_factory(test_db_session):
+    """Mock session factory for push service.
 
-    async def factory():
-        """Async context manager that yields test session."""
+    Mirrors ``async_sessionmaker``: a SYNC callable whose return value is an
+    async context manager yielding the session (#11687 — the old async-def
+    version handed ``async with`` a coroutine, which has no ``__aenter__``).
+    """
 
+    def factory():
         class SessionContext:
             async def __aenter__(self):
                 return test_db_session
@@ -100,7 +119,7 @@ async def mock_session_factory(test_db_session):
 @pytest.mark.asyncio
 async def test_get_target_devices_no_devices(mock_session_factory, test_user_id):
     """Test retrieving mobile devices when user has none."""
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         devices = await _get_target_devices(test_user_id)
         assert devices == []
 
@@ -130,7 +149,7 @@ async def test_get_target_devices_with_active_devices(mock_session_factory, test
         test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         retrieved = await _get_target_devices(test_user_id)
 
     assert len(retrieved) == 2
@@ -168,7 +187,7 @@ async def test_get_target_devices_filters_expired(mock_session_factory, test_db_
     test_db_session.add(expired)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         retrieved = await _get_target_devices(test_user_id)
 
     assert len(retrieved) == 1
@@ -189,7 +208,7 @@ async def test_get_target_devices_handles_null_last_seen(mock_session_factory, t
     test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         retrieved = await _get_target_devices(test_user_id)
 
     assert len(retrieved) == 1
@@ -214,7 +233,10 @@ async def test_send_mobile_push_to_ios_device(mock_session_factory, test_db_sess
     test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with (
+        patch("user_management.database.get_async_session_factory", return_value=mock_session_factory),
+        patch("push_notifications.mobile_push._send_apns", return_value=True),
+    ):
         count = await _send_mobile_push(
             user_id=test_user_id,
             title="Test Notification",
@@ -222,7 +244,7 @@ async def test_send_mobile_push_to_ios_device(mock_session_factory, test_db_sess
             url="/dashboard",
         )
 
-    # Stub implementation returns 1 for iOS
+    # One iOS device delivered (APNs transport stubbed to succeed)
     assert count == 1
 
 
@@ -239,7 +261,10 @@ async def test_send_mobile_push_to_android_device(mock_session_factory, test_db_
     test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with (
+        patch("user_management.database.get_async_session_factory", return_value=mock_session_factory),
+        patch("push_notifications.mobile_push._send_fcm", return_value=True),
+    ):
         count = await _send_mobile_push(
             user_id=test_user_id,
             title="Android Alert",
@@ -263,7 +288,7 @@ async def test_send_mobile_push_to_pwa_device(mock_session_factory, test_db_sess
     test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         count = await _send_mobile_push(
             user_id=test_user_id,
             title="PWA Test",
@@ -306,7 +331,11 @@ async def test_send_mobile_push_to_multiple_devices(mock_session_factory, test_d
         test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with (
+        patch("user_management.database.get_async_session_factory", return_value=mock_session_factory),
+        patch("push_notifications.mobile_push._send_apns", return_value=True),
+        patch("push_notifications.mobile_push._send_fcm", return_value=True),
+    ):
         count = await _send_mobile_push(
             user_id=test_user_id,
             title="Multi-device Alert",
@@ -321,7 +350,7 @@ async def test_send_mobile_push_to_multiple_devices(mock_session_factory, test_d
 @pytest.mark.asyncio
 async def test_send_mobile_push_no_devices(mock_session_factory, test_user_id):
     """Test push delivery when user has no devices."""
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         count = await _send_mobile_push(
             user_id=test_user_id,
             title="No Devices",
@@ -353,8 +382,9 @@ async def test_send_push_notification_integration(mock_session_factory, test_db_
 
     # Mock web push to return 0 (no web subscriptions)
     with (
-        patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory),
+        patch("user_management.database.get_async_session_factory", return_value=mock_session_factory),
         patch("services.push_notification_service._send_web_push", return_value=0),
+        patch("push_notifications.mobile_push._send_apns", return_value=True),
     ):
         total_count = await send_push_notification(
             user_id=test_user_id,
@@ -381,8 +411,9 @@ async def test_send_push_notification_with_custom_ttl(mock_session_factory, test
     await test_db_session.commit()
 
     with (
-        patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory),
+        patch("user_management.database.get_async_session_factory", return_value=mock_session_factory),
         patch("services.push_notification_service._send_web_push", return_value=0) as mock_web,
+        patch("push_notifications.mobile_push._send_fcm", return_value=True),
     ):
         await send_push_notification(
             user_id=test_user_id,
@@ -392,9 +423,10 @@ async def test_send_push_notification_with_custom_ttl(mock_session_factory, test
             ttl=3600,  # 1 hour
         )
 
-    # Verify TTL was passed to web push
+    # Verify TTL was passed to web push (positional arg 5 of
+    # _send_web_push(user_id, title, body, url, ttl))
     mock_web.assert_called_once()
-    assert mock_web.call_args[1]["ttl"] == 3600
+    assert mock_web.call_args.args[4] == 3600
 
 
 # =============================================================================
@@ -406,10 +438,10 @@ async def test_send_push_notification_with_custom_ttl(mock_session_factory, test
 async def test_send_mobile_push_handles_db_errors_gracefully(test_user_id):
     """Test push service handles database errors gracefully."""
 
-    async def failing_factory():
+    def failing_factory():
         raise Exception("Database connection failed")
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=failing_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=failing_factory):
         # Should not raise, returns empty list
         devices = await _get_target_devices(test_user_id)
 
@@ -431,7 +463,7 @@ async def test_send_mobile_push_handles_decryption_errors(mock_session_factory, 
     test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         # Should handle decryption error gracefully
         try:
             await _get_target_devices(test_user_id)
@@ -461,7 +493,7 @@ async def test_send_mobile_push_unknown_platform(mock_session_factory, test_db_s
     test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with patch("user_management.database.get_async_session_factory", return_value=mock_session_factory):
         # Should log warning but not crash
         count = await _send_mobile_push(
             user_id=test_user_id,
@@ -505,7 +537,11 @@ async def test_send_push_only_to_user_devices(mock_session_factory, test_db_sess
     test_db_session.add(user2_device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with (
+        patch("user_management.database.get_async_session_factory", return_value=mock_session_factory),
+        patch("push_notifications.mobile_push._send_apns", return_value=True),
+        patch("push_notifications.mobile_push._send_fcm", return_value=True),
+    ):
         count = await _send_mobile_push(
             user_id=test_user_id,  # Target user 1 only
             title="User 1 Notification",
@@ -558,7 +594,11 @@ async def test_send_push_to_many_devices_is_efficient(mock_session_factory, test
         test_db_session.add(device)
     await test_db_session.commit()
 
-    with patch("push_notifications.mobile_push.get_async_session_factory", return_value=mock_session_factory):
+    with (
+        patch("user_management.database.get_async_session_factory", return_value=mock_session_factory),
+        patch("push_notifications.mobile_push._send_apns", return_value=True),
+        patch("push_notifications.mobile_push._send_fcm", return_value=True),
+    ):
         import time
 
         start = time.time()

--- a/requirements-ci/utilities.txt
+++ b/requirements-ci/utilities.txt
@@ -4,3 +4,4 @@ python-dotenv==1.2.2
 click==8.4.2
 jsonschema==4.26.0
 psutil==7.2.2
+watchdog==6.0.0    # services/documentation_watcher imports it; without it documentation_watcher_staleness_test fails collection (#11687)


### PR DESCRIPTION
Closes #11687, #11732

## Thinking Path

Four env-rot clusters kept `tests/integration/` red. Each was reproduced, then fixed at root cause — fixtures and seams repaired against current contracts, not mocked away. One real product bug fell out (multi-hop LLM fallback — #11732).

## What Changed

- **JSONB-on-SQLite** (retention_policies 13E, part of budget/snapshot): ~40 `postgresql.JSONB` + 3 `ARRAY` columns across 38 tables can't render on SQLite; no `with_variant` precedent exists in the repo, so `tests/integration/conftest.py` adds dialect-scoped `@compiles(JSONB|ARRAY, "sqlite") → "JSON"` (covers all current and future models; per-column variants would have touched 15 runtime model files).
- **mobile_push** (15E+1F): fixtures patched a nonexistent module attr, handed `async with` a coroutine, and predated token encryption — repaired the chain (real EncryptionService with test key, `_send_apns`/`_send_fcm` seams, DB/routing/filtering stay real).
- **budget_hard_stop** (9F+4E, 178s): service hit ANALYTICS Redis resolving to the `.env.example` placeholder `YOUR_REDIS_IP` from the machine-local untracked `.env` — hermetic autouse fakeredis (exact `test_task_claim_race.py` pattern) + model-drift fixes (`AgentWakeupRequest` contract) + `expire_all()` for a stale identity map. Now 13 passed in 1.3s.
- **execution_snapshot** (14F): root-conftest auth stub's `(*args, **kwargs)` signature made FastAPI demand `args`/`kwargs` query params (422 on every request); fixed via `dependency_overrides` delegates + current API contract.
- **watchdog dep**: `services/documentation_watcher` imports watchdog (runtime reqs have it) but no requirements-ci group did → `watchdog==6.0.0` in `requirements-ci/utilities.txt`; rotted staleness test rewritten (5 passed).
- **#11732**: `FallbackChainManager.get_next_fallback` only resolved chains keyed by primary model — multi-hop fallback died after hop 1 (verified failing on untouched base). Added mid-chain scan in `llm_shared/fallback_chain.py`.

## Verification

- Agent: full `tests/integration/` = **541 passed, 0 failed, 0 errors, 24 skipped** (skips are the established "Redis not available" guards). Per-cluster before/after in the issue comment.
- Independent re-run (main session): the 5 previously-red files = 63 passed.
- flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)