### PR TITLE
refactor(registries): unify credential-gated registries behind shared base (#11664)

### DIFF
--- a/autobot-backend/agent_loop/search/registry.py
+++ b/autobot-backend/agent_loop/search/registry.py
@@ -4,10 +4,11 @@
 # Author: mrveiss
 """Web-search provider registry with selection + graceful fallback.
 
-Mirrors ``llm_shared.provider_registry``: providers self-register, the registry
-applies credential-gating (only registers configured providers) and a fallback
-chain so an unreachable/erroring provider degrades to the next one. Both #9022
-and #9023 require graceful fallback to the default provider.
+Built on ``autobot_shared.credential_gated_registry.CredentialGatedRegistry``
+(#11664), shared with ``llm_shared.provider_registry``: providers self-register,
+the registry applies credential-gating (only registers configured providers)
+and a fallback chain so an unreachable/erroring provider degrades to the next
+one. Both #9022 and #9023 require graceful fallback to the default provider.
 
 Auto-population reads credentials/instance URLs from ``autobot_shared.ssot_config``
 (empty/unset = provider disabled).
@@ -16,34 +17,35 @@ Auto-population reads credentials/instance URLs from ``autobot_shared.ssot_confi
 from __future__ import annotations
 
 import logging
-import threading
-from typing import Dict, List, Optional
+from typing import List, Optional
+
+from autobot_shared.credential_gated_registry import (
+    CredentialGatedRegistry,
+    gated_registry_singleton,
+)
 
 from agent_loop.search.base import DEFAULT_RESULT_COUNT, SearchResult, WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
 
-class SearchProviderRegistry:
+class SearchProviderRegistry(CredentialGatedRegistry[WebSearchProvider]):
     """Registry of web-search providers with an ordered fallback chain."""
 
     def __init__(self) -> None:
         """Create an empty registry."""
-        self._providers: Dict[str, WebSearchProvider] = {}
+        super().__init__()
         self._fallback_chain: List[str] = []
 
     def register(self, provider: WebSearchProvider) -> None:
         """Register a provider and append it to the fallback chain."""
         name = provider.provider_name
-        if name in self._providers:
-            logger.warning("Replacing existing search provider: %s", name)
-        else:
+        if self._store_entry(name, provider, kind="search provider"):
             self._fallback_chain.append(name)
-        self._providers[name] = provider
 
     def get_provider(self, name: str) -> Optional[WebSearchProvider]:
         """Return a registered provider by name (or None)."""
-        return self._providers.get(name)
+        return self._get_entry(name)
 
     def list_providers(self) -> List[str]:
         """Return registered provider names in fallback order."""
@@ -93,10 +95,6 @@ class SearchProviderRegistry:
         if last_error:
             logger.error("All web-search providers failed; last error: %s", last_error)
         return []
-
-
-_registry: Optional[SearchProviderRegistry] = None
-_registry_lock = threading.Lock()
 
 
 def _populate_default_providers(registry: SearchProviderRegistry) -> None:
@@ -150,20 +148,14 @@ def _warn_if_topic_search_degraded(registry: SearchProviderRegistry) -> None:
         )
 
 
-def get_search_registry() -> SearchProviderRegistry:
-    """Return the process-wide registry, populating it on first use."""
-    global _registry
-    if _registry is None:
-        with _registry_lock:
-            if _registry is None:
-                registry = SearchProviderRegistry()
-                try:
-                    _populate_default_providers(registry)
-                except Exception as exc:  # never let config issues break callers
-                    logger.warning("Search provider auto-registration failed: %s", exc)
-                _warn_if_topic_search_degraded(registry)
-                _registry = registry
-    return _registry
+# Process-wide registry accessor: populates lazily on first use; population
+# failures are logged, never raised (see gated_registry_singleton, #11664).
+get_search_registry = gated_registry_singleton(
+    SearchProviderRegistry,
+    _populate_default_providers,
+    log=logger,
+    post_populate=_warn_if_topic_search_degraded,
+)
 
 
 async def search(

--- a/autobot-backend/agent_loop/search/registry.py
+++ b/autobot-backend/agent_loop/search/registry.py
@@ -19,12 +19,11 @@ from __future__ import annotations
 import logging
 from typing import List, Optional
 
+from agent_loop.search.base import DEFAULT_RESULT_COUNT, SearchResult, WebSearchProvider
 from autobot_shared.credential_gated_registry import (
     CredentialGatedRegistry,
     gated_registry_singleton,
 )
-
-from agent_loop.search.base import DEFAULT_RESULT_COUNT, SearchResult, WebSearchProvider
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/integrations/capability_registry.py
+++ b/autobot-backend/integrations/capability_registry.py
@@ -8,8 +8,9 @@ Capability Registry for messaging and voice integrations (#11524).
 Maps capability names to registered implementations. Consumers resolve by
 capability, never by concrete class — eliminating vendor-branching.
 
-Mirrors the credential-gated self-registration style of
-``agent_loop.search.registry.SearchProviderRegistry``:
+Built on ``autobot_shared.credential_gated_registry.CredentialGatedRegistry``
+(#11664), shared with ``agent_loop.search.registry.SearchProviderRegistry`` and
+``llm_shared.provider_registry.ProviderRegistry``:
 
 - Providers declare which capabilities they satisfy at registration time.
 - Absent-capability queries return an empty list (never raise).
@@ -29,26 +30,42 @@ Usage::
 from __future__ import annotations
 
 import logging
-import threading
+from enum import Enum
 from typing import Any
+
+from autobot_shared.credential_gated_registry import (
+    CredentialGatedRegistry,
+    gated_registry_singleton,
+)
 
 logger = logging.getLogger(__name__)
 
-# Well-known capability names — use these constants instead of bare strings.
-MESSAGING = "messaging"
-TTS = "tts"
-STT = "stt"
+
+class Capability(str, Enum):
+    """Well-known capability names (#11664).
+
+    ``str`` mixin keeps members interchangeable with the plain strings they
+    replace (equality, hashing, dict keys).
+    """
+
+    MESSAGING = "messaging"
+    TTS = "tts"
+    STT = "stt"
+
+    __str__ = str.__str__  # render as the bare value in logs / f-strings
 
 
-class CapabilityRegistry:
+# Backward-compatible module constants — use these instead of bare strings.
+MESSAGING = Capability.MESSAGING
+TTS = Capability.TTS
+STT = Capability.STT
+
+
+class CapabilityRegistry(CredentialGatedRegistry[list[Any]]):
     """Registry mapping capability names → ordered list of implementations.
 
     Registration order is preserved; first-registered is first-resolved.
     """
-
-    def __init__(self) -> None:
-        """Create an empty registry."""
-        self._store: dict[str, list[Any]] = {}
 
     def register(self, capability: str, impl: Any) -> None:
         """Register *impl* under *capability*.
@@ -57,14 +74,13 @@ class CapabilityRegistry:
             capability: Capability name constant (e.g. ``MESSAGING``).
             impl:       Any object satisfying the corresponding Protocol.
         """
-        if capability not in self._store:
-            self._store[capability] = []
-        self._store[capability].append(impl)
+        bucket = self._providers.setdefault(capability, [])
+        bucket.append(impl)
         logger.debug(
             "Registered %s as capability=%s (total=%d)",
             type(impl).__name__,
             capability,
-            len(self._store[capability]),
+            len(bucket),
         )
 
     def resolve(self, capability: str) -> list[Any]:
@@ -75,15 +91,11 @@ class CapabilityRegistry:
         Args:
             capability: Capability name to look up.
         """
-        return list(self._store.get(capability, []))
+        return list(self._get_entry(capability) or [])
 
     def capabilities(self) -> list[str]:
         """Return registered capability names in insertion order."""
-        return list(self._store.keys())
-
-
-_registry: CapabilityRegistry | None = None
-_registry_lock = threading.Lock()
+        return self._entry_names()
 
 
 def _register_messaging_if_token(
@@ -186,16 +198,10 @@ def _register_stt_language(registry: CapabilityRegistry, speech_registry, lang: 
         logger.warning("Failed to register STT capability for language '%s': %s", lang, exc)
 
 
-def get_capability_registry() -> CapabilityRegistry:
-    """Return the process-wide registry, populating it lazily on first use."""
-    global _registry
-    if _registry is None:
-        with _registry_lock:
-            if _registry is None:
-                registry = CapabilityRegistry()
-                try:
-                    _populate_default_providers(registry)
-                except Exception as exc:
-                    logger.warning("Capability registry auto-registration failed: %s", exc)
-                _registry = registry
-    return _registry
+# Process-wide registry accessor: populates lazily on first use; population
+# failures are logged, never raised (see gated_registry_singleton, #11664).
+get_capability_registry = gated_registry_singleton(
+    CapabilityRegistry,
+    _populate_default_providers,
+    log=logger,
+)

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -31,10 +31,13 @@ from __future__ import annotations
 
 import asyncio
 import os
-import threading
 import time
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.credential_gated_registry import (
+    CredentialGatedRegistry,
+    gated_registry_singleton,
+)
 from autobot_shared.env_utils import env_float
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -66,16 +69,18 @@ _NPU_PIPELINE_MAX_LATENCY_MULTIPLIER: float = env_float("NPU_PIPELINE_MAX_LATENC
 _NPU_POOL_PROVIDER_NAME = "npu_pool"
 
 
-class ProviderRegistry:
+class ProviderRegistry(CredentialGatedRegistry[BaseProvider]):
     """
     Manages the set of available LLM providers with fallback and per-conversation
     overrides.
 
-    This is a per-process singleton (obtained via ``get_provider_registry()``).
+    Built on ``CredentialGatedRegistry`` (#11664) — shared with the search and
+    capability registries. This is a per-process singleton (obtained via
+    ``get_provider_registry()``).
     """
 
     def __init__(self) -> None:
-        self._providers: Dict[str, BaseProvider] = {}
+        super().__init__()  # sets self._providers (#11664)
         self._fallback_chain: List[str] = []
         self._conversation_overrides: Dict[str, str] = {}
         # {provider_name: (is_available: bool, checked_at: float)}
@@ -101,9 +106,7 @@ class ProviderRegistry:
         name = provider.provider_name
         if not name:
             raise ValueError("Provider must set provider_name before registration.")
-        if name in self._providers:
-            logger.warning("Replacing existing provider: %s", name)
-        self._providers[name] = provider
+        self._store_entry(name, provider)
         self._provider_facts[name] = ProviderRuntimeFact.build_at_startup(name, provider)
         logger.info("Registered provider: %s", name)
 
@@ -499,7 +502,7 @@ class ProviderRegistry:
         This is the public accessor for ``_providers``; callers should use this
         instead of accessing the private attribute directly.
         """
-        return self._providers.get(name)
+        return self._get_entry(name)
 
     def get_provider_facts(self) -> Dict[str, ProviderRuntimeFact]:
         """Return a snapshot of pre-computed provider capability facts (#7370)."""
@@ -521,31 +524,6 @@ class ProviderRegistry:
             "providers": {n: p.get_stats() for n, p in self._providers.items()},
             "fallback_chain": list(self._fallback_chain),
         }
-
-
-# ---------------------------------------------------------------------------
-# Singleton accessor
-# ---------------------------------------------------------------------------
-
-_registry_instance: ProviderRegistry | None = None
-_registry_lock = threading.Lock()  # sync function — threading.Lock, not asyncio.Lock
-
-
-def get_provider_registry() -> ProviderRegistry:
-    """
-    Return the process-level ProviderRegistry singleton.
-
-    The first caller triggers lazy initialisation of default providers from the
-    SSOT config.  Use ``initialize_default_providers()`` explicitly during
-    application startup to control when this happens and to catch errors early.
-    """
-    global _registry_instance
-    if _registry_instance is None:
-        with _registry_lock:
-            if _registry_instance is None:
-                _registry_instance = ProviderRegistry()
-                _populate_default_providers(_registry_instance)
-    return _registry_instance
 
 
 def _populate_default_providers(registry: ProviderRegistry) -> None:
@@ -766,6 +744,20 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
         len(fallback),
         fallback,
     )
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+# Process-level ProviderRegistry singleton: the first caller triggers lazy
+# initialisation of default providers from the SSOT config. Population
+# failures are logged, never raised (see gated_registry_singleton, #11664).
+get_provider_registry = gated_registry_singleton(
+    ProviderRegistry,
+    _populate_default_providers,
+    log=logger,
+)
 
 
 __all__ = [

--- a/autobot_shared/credential_gated_registry.py
+++ b/autobot_shared/credential_gated_registry.py
@@ -1,0 +1,104 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared base for credential-gated provider registries (#11664).
+
+Three subsystems (``integrations.capability_registry``,
+``agent_loop.search.registry``, ``llm_shared.provider_registry``)
+independently implemented the same pattern: a lazily-populated process-wide
+singleton whose default entries are registered only when their
+credentials/config are present, and whose lookups never raise on a missing
+entry. This module holds the shared mechanics:
+
+- :class:`CredentialGatedRegistry` — insertion-ordered name → entry store
+  with never-raise lookups and replace-with-warning semantics.
+- :func:`gated_registry_singleton` — the lazy-singleton accessor builder
+  (reuses :func:`autobot_shared.singleton_factory.lazy_singleton`) that
+  catches population failures so config issues never break callers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, Generic, List, Optional, TypeVar
+
+from autobot_shared.singleton_factory import lazy_singleton
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+R = TypeVar("R", bound="CredentialGatedRegistry")
+
+
+class CredentialGatedRegistry(Generic[T]):
+    """Base registry: insertion-ordered name → entry store, never-raise lookups.
+
+    Subclasses keep their public API (``register``/``resolve``/``get_provider``
+    …) and layer domain behaviour (fallback chains, capability buckets, health
+    caching) on top of these primitives. The store attribute is named
+    ``_providers`` because that is the established name across the concrete
+    registries (and their tests).
+    """
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self._providers: Dict[str, T] = {}
+
+    def _store_entry(self, name: str, entry: T, *, kind: str = "provider") -> bool:
+        """Store *entry* under *name*, warning when an entry is replaced.
+
+        Args:
+            name:  Registration name.
+            entry: The entry to store.
+            kind:  Human label used in the replacement warning.
+
+        Returns:
+            True when *name* was not previously registered.
+        """
+        is_new = name not in self._providers
+        if not is_new:
+            logger.warning("Replacing existing %s: %s", kind, name)
+        self._providers[name] = entry
+        return is_new
+
+    def _get_entry(self, name: str) -> Optional[T]:
+        """Return the entry registered under *name*, or None (never raises)."""
+        return self._providers.get(name)
+
+    def _entry_names(self) -> List[str]:
+        """Return registered names in insertion order."""
+        return list(self._providers)
+
+
+def gated_registry_singleton(
+    registry_factory: Callable[[], R],
+    populate: Callable[[R], None],
+    *,
+    log: Optional[logging.Logger] = None,
+    post_populate: Optional[Callable[[R], None]] = None,
+) -> Callable[[], R]:
+    """Build the process-wide lazy-singleton accessor for a registry.
+
+    *populate* runs once, on first access, and registers the credential-gated
+    default entries. Population failures are caught and logged so a (possibly
+    partially populated) registry is always returned — config issues must
+    never break callers. *post_populate* (e.g. a degraded-mode warning) runs
+    after population, outside the guard.
+
+    Reuses :func:`lazy_singleton`, so the returned accessor carries the
+    standard ``reset()`` / ``set_for_test()`` test seams (#11635).
+    """
+    _log = log or logger
+
+    def _build() -> R:
+        registry = registry_factory()
+        try:
+            populate(registry)
+        except Exception as exc:  # config issues must never break callers
+            _log.warning("%s auto-registration failed: %s", type(registry).__name__, exc)
+        if post_populate is not None:
+            post_populate(registry)
+        return registry
+
+    return lazy_singleton(_build)

--- a/autobot_shared/credential_gated_registry_test.py
+++ b/autobot_shared/credential_gated_registry_test.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the shared credential-gated registry base (#11664)."""
+
+import logging
+
+from autobot_shared.credential_gated_registry import (
+    CredentialGatedRegistry,
+    gated_registry_singleton,
+)
+
+
+class TestCredentialGatedRegistry:
+    def test_get_entry_absent_returns_none(self):
+        registry = CredentialGatedRegistry()
+        assert registry._get_entry("missing") is None
+
+    def test_store_entry_returns_true_when_new(self):
+        registry = CredentialGatedRegistry()
+        assert registry._store_entry("a", object()) is True
+
+    def test_store_entry_returns_false_and_warns_on_replace(self, caplog):
+        registry = CredentialGatedRegistry()
+        registry._store_entry("a", object(), kind="widget")
+        with caplog.at_level(logging.WARNING):
+            assert registry._store_entry("a", object(), kind="widget") is False
+        assert "Replacing existing widget: a" in caplog.text
+
+    def test_entry_names_preserve_insertion_order(self):
+        registry = CredentialGatedRegistry()
+        registry._store_entry("b", 1)
+        registry._store_entry("a", 2)
+        assert registry._entry_names() == ["b", "a"]
+
+    def test_get_entry_returns_stored_value(self):
+        registry = CredentialGatedRegistry()
+        sentinel = object()
+        registry._store_entry("x", sentinel)
+        assert registry._get_entry("x") is sentinel
+
+
+class TestGatedRegistrySingleton:
+    def test_returns_same_instance_and_populates_once(self):
+        calls = []
+        get = gated_registry_singleton(CredentialGatedRegistry, calls.append)
+        first = get()
+        assert get() is first
+        assert calls == [first]
+
+    def test_populate_failure_is_swallowed_and_logged(self, caplog):
+        def boom(_registry):
+            raise RuntimeError("no creds")
+
+        get = gated_registry_singleton(CredentialGatedRegistry, boom)
+        with caplog.at_level(logging.WARNING):
+            registry = get()
+        assert isinstance(registry, CredentialGatedRegistry)
+        assert "auto-registration failed" in caplog.text
+
+    def test_post_populate_runs_after_populate(self):
+        order = []
+        get = gated_registry_singleton(
+            CredentialGatedRegistry,
+            lambda _r: order.append("populate"),
+            post_populate=lambda _r: order.append("post"),
+        )
+        get()
+        assert order == ["populate", "post"]
+
+    def test_reset_seam_reconstructs(self):
+        get = gated_registry_singleton(CredentialGatedRegistry, lambda _r: None)
+        first = get()
+        get.reset()
+        assert get() is not first


### PR DESCRIPTION
Closes #11664

## Thinking Path

Three subsystems (capability registry, search registry, LLM provider registry) each re-derived the same pattern: lazy singleton + try/except-per-provider credential gating + never-raise resolve. Owner green-lit the consolidation today. Base lives in root `autobot_shared` (the copy Ansible syncs), built on the existing `singleton_factory.lazy_singleton` — no hand-rolled singleton, standard `reset()`/`set_for_test()` seams (#11635). No circular imports (base imports only stdlib + singleton_factory; all three subsystems already import `autobot_shared.*`).

## What Changed

- New `autobot_shared/credential_gated_registry.py`: `CredentialGatedRegistry` (insertion-ordered store, replace-with-warning, never-raise get/list) + `gated_registry_singleton()`.
- `integrations/capability_registry.py`: subclass; public API + private helpers tests import all kept; `Capability(str, Enum)` folded in (`MESSAGING == "messaging"` interop verified by runtime probe).
- `agent_loop/search/registry.py`: subclass; `_warn_if_topic_search_degraded` now a `post_populate` hook — #11665 degraded warning still fires once (probed); replace-warning text identical.
- `llm_shared/provider_registry.py`: deliberately minimal/mechanical (in-flight #11747 caution): class header, `__init__` (same `_providers` attribute name — direct-access consumers verified), dup-warn via `_store_entry`, singleton block. The 200-line populate + provider classes untouched. One deliberate unification: populate failures now caught/logged (the issue's requested never-raise contract; the other two already did this).
- Net: three registries shed ~55 lines of triplicated logic each; zero external references to removed globals (repo-wide grep).

## Verification

- Registry suites 88 passed; startup imports 344 passed; `_providers`-touching consumers 64 passed/1 pre-existing skip; new base tests + singleton_factory 39 passed (agent). Independent re-run: search+provider registry suites 46 passed.
- py_compile / flake8 / black clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)