### PR TITLE
fix(ci): hard-exclude @pinia/testing >=2 from dependabot group — unsatisfiable with pinia 3 (#11753)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -134,6 +134,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "vega-lite"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@pinia/testing"
+        # #11753: @pinia/testing 2.x requires peer pinia>=4 while the group
+        # keeps pinia 3 — grouped bump re-proposes an unsatisfiable member
+        # (ERESOLVE on every PR, see #11746). Same pattern as the protobuf/
+        # websockets caps above. Unblock when the pinia 4 major is taken.
+        versions: [">=2.0.0"]
 
   - package-ecosystem: "npm"
     directory: "/autobot-slm-frontend"


### PR DESCRIPTION
Closes #11753

## Thinking Path

PR #11746 (frontend all-dependencies group) fails npm install with ERESOLVE: `@pinia/testing@2.0.1` requires peer `pinia>=4.0.2` while the group keeps `pinia@^3.0.4`. A semver-major ignore alone does not stop grouped bumps from re-proposing unsatisfiable members (established on protobuf #10474 and websockets #10386) — hard version exclusion is the working pattern.

## What Changed

- `.github/dependabot.yml` frontend npm entry: `@pinia/testing` `versions: [">=2.0.0"]` hard-exclude with explanatory comment; unblock when the pinia 4 major is taken deliberately.

## Verification

- `yaml.safe_load` parses cleanly.
- Pattern-identical to the two existing hard-excludes (protobuf `>=7.0.0`, websockets `>=16.0.0`) in the same file.
- NOTE: Dependabot reads config from the default branch (`main`) — this rule becomes effective at the next Dev_new_gui→main promotion. After that, `@dependabot recreate` on #11746 regenerates the group without the poisoned member.

## Model Used

Claude Fable 5