### PR TITLE
refactor(orchestration): retire last bare AgentRegistry + canonical capability lookup (#6828)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -1220,52 +1220,90 @@ async def analyze_development_task(
         await handle_ai_stack_error(e, "Development analysis")
 
 
+async def _ai_stack_available_agents() -> List[dict]:
+    """Return AI Stack agents as capability-info dicts; empty list when unreachable.
+
+    #6828: AI Stack unavailability degrades to the local registry instead of a
+    503 (same precedent as the #10511 PG fallback in api/agent_org.py).
+    """
+    try:
+        ai_client = await get_ai_stack_client()
+        agents_info = await ai_client.list_available_agents()
+    except AIStackError as e:
+        logger.warning("AI Stack unavailable for /agents/available — serving local registry only: %s", e)
+        return []
+
+    agents_with_caps = []
+    for agent in agents_info.get("agents", []):
+        # Issue #281: capabilities from module constant, with fallback for unknown agents
+        agent_info = AGENT_CAPABILITIES.get(
+            agent,
+            {
+                "description": f"AI agent: {agent}",
+                "capabilities": ["general_processing"],
+            },
+        ).copy()  # Copy to avoid modifying the constant
+        agent_info["name"] = agent
+        agent_info["status"] = "available"
+        agents_with_caps.append(agent_info)
+    return agents_with_caps
+
+
+def _local_registry_agents() -> List[dict]:
+    """Agents from the canonical in-process AgentCapabilityRegistry (#6828).
+
+    Exposes the orchestration profiles (capabilities + specializations) through
+    the same response shape as AI Stack agents so /agents/available is the one
+    unified "find an agent that can do X" entry point.
+    """
+    from orchestration.agent_registry import get_default_capability_registry
+
+    agents = []
+    for profile in get_default_capability_registry().get_all().values():
+        capabilities = sorted({c.value for c in profile.capabilities} | set(profile.specializations))
+        agents.append(
+            {
+                "name": profile.agent_id,
+                "description": f"Local orchestration agent ({profile.agent_type})",
+                "capabilities": capabilities,
+                "status": profile.availability_status,
+            }
+        )
+    return agents
+
+
 @router.get("/agents/available", response_model=DataResponse[AgentAvailableData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="list_available_agents",
     error_code_prefix="AGENT",
 )
-async def list_available_agents():
+async def list_available_agents(capability: str | None = None):
     """
-    List all available AI Stack agents with their capabilities.
+    List all available agents (AI Stack + local orchestration registry).
 
     Issue #281: Refactored to use module-level AGENT_CAPABILITIES constant.
     Issue #987: Removed auth requirement — read-only status, accessible to SLM admin.
+    Issue #6828: unified entry point — merges AI Stack agents with the canonical
+    AgentCapabilityRegistry profiles; optional ``capability`` query filters to
+    agents that can do X (case-insensitive substring on capability names).
     """
-    try:
-        ai_client = await get_ai_stack_client()
-        agents_info = await ai_client.list_available_agents()
+    agents_with_caps = await _ai_stack_available_agents()
+    known = {a["name"] for a in agents_with_caps}
+    agents_with_caps.extend(a for a in _local_registry_agents() if a["name"] not in known)
 
-        # Issue #281: Use module-level constant for agent capabilities
-        # Combine available agents with capability info
-        available_list = agents_info.get("agents", [])
-        agents_with_caps = []
+    if capability:
+        needle = capability.lower()
+        agents_with_caps = [a for a in agents_with_caps if any(needle in c.lower() for c in a["capabilities"])]
 
-        for agent in available_list:
-            # Get capabilities from module constant, with fallback for unknown agents
-            agent_info = AGENT_CAPABILITIES.get(
-                agent,
-                {
-                    "description": f"AI agent: {agent}",
-                    "capabilities": ["general_processing"],
-                },
-            ).copy()  # Copy to avoid modifying the constant
-            agent_info["name"] = agent
-            agent_info["status"] = "available"
-            agents_with_caps.append(agent_info)
-
-        return create_success_response(
-            {
-                "total_agents": len(agents_with_caps),
-                "agents": agents_with_caps,
-                "coordination_modes": ["parallel", "sequential", "intelligent"],
-                "multi_agent_support": True,
-            }
-        )
-
-    except AIStackError as e:
-        await handle_ai_stack_error(e, "List available agents")
+    return create_success_response(
+        {
+            "total_agents": len(agents_with_caps),
+            "agents": agents_with_caps,
+            "coordination_modes": ["parallel", "sequential", "intelligent"],
+            "multi_agent_support": True,
+        }
+    )
 
 
 @router.get("/agents/status", response_model=DataResponse[AgentStatusData])

--- a/autobot-backend/api/agent_available_unified_test.py
+++ b/autobot-backend/api/agent_available_unified_test.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the unified GET /agent/agents/available entry point (#6828).
+
+The endpoint must merge AI Stack agents with the canonical local
+AgentCapabilityRegistry, support a ``capability`` filter ("find an agent that
+can do X"), and degrade to local-only instead of 503 when the AI Stack is
+unreachable (#10511 precedent).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import api.agent as agent_api
+from services.ai_stack_client import AIStackError
+
+
+def _stub_ai_client(agents: list[str]) -> AsyncMock:
+    client = AsyncMock()
+    client.list_available_agents = AsyncMock(return_value={"agents": agents})
+    return client
+
+
+def _agents_from(result) -> dict:
+    # create_success_response returns a DataResponse pydantic model.
+    return {a["name"]: a for a in result.data["agents"]}
+
+
+async def _call(monkeypatch, ai_client, capability=None):
+    async def _get_client():
+        return ai_client
+
+    monkeypatch.setattr(agent_api, "get_ai_stack_client", _get_client)
+    return await agent_api.list_available_agents(capability=capability)
+
+
+async def test_merges_ai_stack_and_local_registry(monkeypatch) -> None:
+    result = await _call(monkeypatch, _stub_ai_client(["rag"]))
+    agents = _agents_from(result)
+
+    assert "rag" in agents  # AI Stack source preserved
+    assert "research_agent" in agents  # local canonical registry merged in
+    assert agents["rag"]["description"].startswith("Retrieval-Augmented")
+
+
+async def test_ai_stack_entry_wins_name_collisions(monkeypatch) -> None:
+    result = await _call(monkeypatch, _stub_ai_client(["research_agent"]))
+    agents = _agents_from(result)
+
+    # One entry only, and it is the AI Stack one (fallback description).
+    assert agents["research_agent"]["description"] == "AI agent: research_agent"
+
+
+async def test_capability_filter_finds_agent_that_can_do_x(monkeypatch) -> None:
+    result = await _call(monkeypatch, _stub_ai_client(["rag"]), capability="web_search")
+    agents = _agents_from(result)
+
+    assert "research_agent" in agents  # specialization: web_search
+    assert "rag" not in agents  # no web_search capability
+
+
+async def test_degrades_to_local_when_ai_stack_unavailable(monkeypatch) -> None:
+    failing = AsyncMock()
+    failing.list_available_agents = AsyncMock(side_effect=AIStackError("down"))
+
+    result = await _call(monkeypatch, failing)
+    agents = _agents_from(result)
+
+    assert "research_agent" in agents
+    assert "system_agent" in agents
+
+
+async def test_total_agents_matches_list_length(monkeypatch) -> None:
+    result = await _call(monkeypatch, _stub_ai_client(["rag", "chat"]))
+    assert result.data["total_agents"] == len(result.data["agents"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/autobot-backend/api/agent_org.py
+++ b/autobot-backend/api/agent_org.py
@@ -54,9 +54,9 @@ def _fallback_agents_from_registry() -> List[Dict[str, Any]]:
     caller can treat both sources uniformly.
     """
     try:
-        from orchestration.agent_registry import AgentCapabilityRegistry
+        from orchestration.agent_registry import get_default_capability_registry
 
-        registry = AgentCapabilityRegistry(initialize_defaults=True)
+        registry = get_default_capability_registry()  # canonical accessor (#6828)
         agents = []
         for profile in registry.get_all().values():
             agents.append(

--- a/autobot-backend/orchestration/agent_registry.py
+++ b/autobot-backend/orchestration/agent_registry.py
@@ -214,7 +214,10 @@ class AgentCapabilityRegistry:
     Scope (#6828): holds in-memory AgentProfile + AgentCapability catalogue
     populated at orchestrator startup from DEFAULT_AGENT_CONFIGS.  This is
     the **what-can-each-agent-do** registry — it does not track live health or
-    database persistence.  See also:
+    database persistence.  It is the canonical implementer of the shared
+    ``AgentCapabilityLookup`` ("find an agent that can do X") and
+    ``AgentRegistryProtocol`` (specialization updates) protocols in
+    ``autobot_shared.agent_registry_protocol``.  See also:
     - agents.agent_client.AgentHealthRegistry — health-tracking runtime registry
     - services.agent_registry_service.AgentRegistryService — DB-backed CRUD
     - agents.agent_orchestration.distributed_management.DistributedAgentManager — dynamic/distributed
@@ -393,6 +396,29 @@ class AgentCapabilityRegistry:
             agent.current_workload -= 1
         return True
 
+    async def update_specializations(
+        self,
+        agent_id: str,
+        top_types: List[str],
+        rates: Dict[str, float],
+    ) -> None:
+        """Persist discovered specializations onto an agent's profile (#6828).
+
+        Concrete implementation of the shared ``AgentRegistryProtocol`` — the
+        callback surface ``AgentEvolutionTracker`` uses to report emergent
+        specializations.  Discovered types are promoted to the front of the
+        profile's ``specializations`` (existing ones retained, deduplicated);
+        per-type success rates are recorded in ``performance_metrics`` under
+        ``specialization:<task_type>`` keys.
+        """
+        agent = self._agents.get(agent_id)
+        if agent is None:
+            logger.warning("update_specializations: unknown agent %s — ignored", agent_id)
+            return
+        agent.specializations = list(top_types) + [s for s in agent.specializations if s not in top_types]
+        agent.performance_metrics.update({f"specialization:{task_type}": rate for task_type, rate in rates.items()})
+        logger.info("Agent %s specializations updated: %s", agent_id, top_types)
+
     def update_performance(
         self,
         agent_id: str,
@@ -439,6 +465,20 @@ class AgentCapabilityRegistry:
 _default_registry: "AgentCapabilityRegistry | None" = None
 
 
+def get_default_capability_registry() -> AgentCapabilityRegistry:
+    """Return the process-wide default AgentCapabilityRegistry (#6828).
+
+    The canonical read entry point for "find an agent that can do X" against
+    the default profiles — API fallbacks (api/agent_org, api/agent) and the
+    tool-dispatch boundary (``resolve_forbidden_tools``) share this instance
+    instead of constructing ad-hoc registries per call.
+    """
+    global _default_registry  # noqa: PLW0603
+    if _default_registry is None:
+        _default_registry = AgentCapabilityRegistry(initialize_defaults=True)
+    return _default_registry
+
+
 def resolve_forbidden_tools(agent_id: "str | None") -> "frozenset[str]":
     """Resolve *agent_id*'s ``forbidden_work`` manifest from the default profiles.
 
@@ -448,7 +488,4 @@ def resolve_forbidden_tools(agent_id: "str | None") -> "frozenset[str]":
     """
     if not agent_id:
         return frozenset()
-    global _default_registry  # noqa: PLW0603
-    if _default_registry is None:
-        _default_registry = AgentCapabilityRegistry(initialize_defaults=True)
-    return _default_registry.forbidden_tools(agent_id)
+    return get_default_capability_registry().forbidden_tools(agent_id)

--- a/autobot-backend/services/mesh_brain/agent_evolution.py
+++ b/autobot-backend/services/mesh_brain/agent_evolution.py
@@ -37,9 +37,14 @@ class AgentSpecializationDB(Protocol):
     async def get_all_agent_ids(self) -> list[str]: ...
 
 
-# Issue #6828: AgentRegistry Protocol promoted to autobot_shared/agent_registry_protocol.py.
-# Re-exported here for backwards compatibility with any importer of this module.
-AgentRegistry = AgentRegistryProtocol
+# Issue #6828: the registry Protocol lives in autobot_shared/agent_registry_protocol.py
+# (AgentRegistryProtocol); its canonical concrete implementer is
+# orchestration.agent_registry.AgentCapabilityRegistry.update_specializations.
+# The legacy `AgentRegistry = AgentRegistryProtocol` compat alias was retired after
+# a repo-wide importer audit found zero consumers — the bare name was the last
+# remnant of the 4-way AgentRegistry naming collision this issue resolved.
+# NOTE (wire-in): AgentEvolutionTracker itself has no production scheduler/caller
+# yet — parked pending a wire-in issue (see #6828 closure report).
 
 
 class AgentEvolutionTracker:

--- a/autobot-backend/tests/orchestration/test_agent_registry_protocols.py
+++ b/autobot-backend/tests/orchestration/test_agent_registry_protocols.py
@@ -1,0 +1,104 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the AgentRegistry consolidation (#6828).
+
+Acceptance criteria under test:
+  - AgentCapabilityRegistry is the canonical implementer of both shared
+    protocols (AgentCapabilityLookup + AgentRegistryProtocol).
+  - update_specializations persists discovered specializations onto profiles.
+  - get_default_capability_registry() is a process-wide singleton shared by
+    resolve_forbidden_tools and the API fallbacks.
+  - AgentEvolutionTracker works end-to-end against the canonical registry
+    (the Protocol has a real concrete implementer, not just mocks).
+"""
+
+from unittest.mock import AsyncMock
+
+from autobot_shared.agent_registry_protocol import (
+    AgentCapabilityLookup,
+    AgentRegistryProtocol,
+)
+from orchestration.agent_registry import (
+    AgentCapabilityRegistry,
+    get_default_capability_registry,
+    resolve_forbidden_tools,
+)
+from services.mesh_brain.agent_evolution import AgentEvolutionTracker
+
+
+class TestProtocolConformance:
+    def test_capability_registry_implements_lookup_protocol(self) -> None:
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
+        assert isinstance(reg, AgentCapabilityLookup)
+
+    def test_capability_registry_implements_registry_protocol(self) -> None:
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
+        assert isinstance(reg, AgentRegistryProtocol)
+
+    def test_find_by_capability_answers_can_do_x(self) -> None:
+        from orchestration.types import AgentCapability
+
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
+        researchers = reg.find_by_capability(AgentCapability.RESEARCH)
+        assert any(p.agent_id == "research_agent" for p in researchers)
+
+
+class TestUpdateSpecializations:
+    async def test_promotes_discovered_types_and_records_rates(self) -> None:
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
+        before = list(reg.get("research_agent").specializations)
+        assert "code_review" not in before
+
+        await reg.update_specializations("research_agent", ["code_review"], {"code_review": 0.9})
+
+        profile = reg.get("research_agent")
+        assert profile.specializations[0] == "code_review"
+        # Existing specializations retained (no data loss), no duplicates.
+        assert set(before).issubset(set(profile.specializations))
+        assert len(profile.specializations) == len(set(profile.specializations))
+        assert profile.performance_metrics["specialization:code_review"] == 0.9
+
+    async def test_existing_top_type_is_deduplicated(self) -> None:
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
+        existing = reg.get("research_agent").specializations[0]
+
+        await reg.update_specializations("research_agent", [existing], {existing: 1.0})
+
+        specs = reg.get("research_agent").specializations
+        assert specs.count(existing) == 1
+        assert specs[0] == existing
+
+    async def test_unknown_agent_is_ignored(self) -> None:
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
+        await reg.update_specializations("does-not-exist", ["x"], {"x": 1.0})  # no raise
+
+
+class TestDefaultRegistrySingleton:
+    def test_accessor_returns_same_instance(self) -> None:
+        assert get_default_capability_registry() is get_default_capability_registry()
+
+    def test_resolve_forbidden_tools_reads_the_shared_instance(self) -> None:
+        # The tool-dispatch boundary and the API fallbacks share one registry.
+        forbidden = resolve_forbidden_tools("research_agent")
+        assert forbidden == get_default_capability_registry().forbidden_tools("research_agent")
+        assert "bash" in forbidden
+
+
+class TestEvolutionTrackerAgainstCanonicalRegistry:
+    async def test_tracker_updates_real_registry(self) -> None:
+        """End-to-end: the Protocol's consumer works with its concrete implementer."""
+        db = AsyncMock()
+        db.get_agent_specializations = AsyncMock(
+            return_value=[{"task_type": "vuln_triage", "success_rate": 0.95, "task_count": 8}]
+        )
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
+        tracker = AgentEvolutionTracker(db=db, registry=reg)
+
+        specs = await tracker.evaluate("security_scanner")
+
+        assert specs and specs[0].task_type == "vuln_triage"
+        profile = reg.get("security_scanner")
+        assert profile.specializations[0] == "vuln_triage"
+        assert profile.performance_metrics["specialization:vuln_triage"] == 0.95

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -15766,10 +15766,13 @@ export interface paths {
         };
         /**
          * List Available Agents
-         * @description List all available AI Stack agents with their capabilities.
+         * @description List all available agents (AI Stack + local orchestration registry).
          *
          *     Issue #281: Refactored to use module-level AGENT_CAPABILITIES constant.
          *     Issue #987: Removed auth requirement — read-only status, accessible to SLM admin.
+         *     Issue #6828: unified entry point — merges AI Stack agents with the canonical
+         *     AgentCapabilityRegistry profiles; optional ``capability`` query filters to
+         *     agents that can do X (case-insensitive substring on capability names).
          */
         get: operations["list_available_agents_api_agent_agents_available_get"];
         put?: never;
@@ -121028,7 +121031,9 @@ export interface operations {
     };
     list_available_agents_api_agent_agents_available_get: {
         parameters: {
-            query?: never;
+            query?: {
+                capability?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -121042,6 +121047,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DataResponse_AgentAvailableData_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/autobot_shared/agent_registry_protocol.py
+++ b/autobot_shared/agent_registry_protocol.py
@@ -3,48 +3,75 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-AgentRegistry Protocol — canonical interface for all registry implementations.
+Agent registry protocols — canonical interfaces for the scoped registries.
 
-Issue #6828: four concrete classes named AgentRegistry existed with no shared
-interface, making it impossible to know which one to use for "find an agent
-that can do X".  This module promotes the narrow Protocol that was buried in
-services/mesh_brain/agent_evolution.py to a first-class shared interface.
+Issue #6828: four concrete classes named ``AgentRegistry`` existed with no
+shared interface, making it impossible to know which one to use for "find an
+agent that can do X".  The classes now carry distinct, scope-descriptive names
+and this module is the single place that defines their shared surfaces.
 
 Concrete registries and their scopes
 --------------------------------------
-- orchestration.agent_registry.AgentRegistry
-    Static profile registry (AgentProfile + AgentCapability).  Owned by
-    orchestrator startup; holds the in-memory catalogue of what each agent
-    *can* do.  Orphan from #6820 — not wired to live agents.
+- orchestration.agent_registry.AgentCapabilityRegistry
+    Static profile registry (AgentProfile + AgentCapability).  The canonical
+    in-process answer to "find an agent that can do X" — implements
+    ``AgentCapabilityLookup`` and ``AgentRegistryProtocol``.  Production-wired:
+    orchestrator routing projection (#11251), the chat_workflow tool-dispatch
+    boundary via ``resolve_forbidden_tools`` (#11145), and the
+    ``/api/agents/status`` + ``/api/agent/agents/available`` endpoints.
 
-- agents.agent_client.AgentRegistry
-    Health-tracking registry for running BaseAgent instances.  Owned by
-    AgentOrchestrator; tracks reachability of live agents and performs
-    health checks.
+- agents.agent_client.AgentHealthRegistry
+    Health-tracking registry for running BaseAgent instances.  Tracks
+    reachability of live agents and performs health checks.  Documented
+    non-implementer of ``AgentCapabilityLookup``: it answers "is this agent
+    alive?", not "what can it do?" — capability queries belong to
+    AgentCapabilityRegistry.
 
 - services.agent_registry_service.AgentRegistryService
     Central CRUD service (#1754) backed by the agents database table.
-    Canonical for persistent agent metadata; used at startup/shutdown.
+    Canonical for persistent agent metadata; seeded at startup
+    (initialization/lifespan.py).  Documented non-implementer of
+    ``AgentCapabilityLookup``: async/DB-session bound persistence, no
+    in-process capability model.
 
 - agents.agent_orchestration.distributed_management.DistributedAgentManager
     Dynamic registry with circuit-breaker health checks and work-stealing
     (#2109, #4694).  Manages distributed agent lifecycle at runtime.
-
-Only the specialization-update protocol surface needed by AgentEvolutionTracker
-is expressed here.  Broader unification (canonical lookup interface) is tracked
-in #6828.
+    Documented non-implementer of ``AgentCapabilityLookup``: membership and
+    task-liveness, not capability lookup.
 """
 
-from typing import Protocol
+from typing import Any, List, Protocol, runtime_checkable
 
 
+@runtime_checkable
+class AgentCapabilityLookup(Protocol):
+    """Canonical "find an agent that can do X" lookup surface (#6828).
+
+    Implemented by ``orchestration.agent_registry.AgentCapabilityRegistry``.
+    ``capability`` is typed ``Any`` because the concrete capability enum
+    (``orchestration.types.AgentCapability``) lives in the backend and shared
+    code must not import backend modules; implementers narrow the type.
+    """
+
+    def find_by_capability(self, capability: Any) -> List[Any]:
+        """Return profiles/agents that advertise *capability*."""
+        ...
+
+    def find_available(self) -> List[Any]:
+        """Return agents currently available for work (not at capacity)."""
+        ...
+
+
+@runtime_checkable
 class AgentRegistryProtocol(Protocol):
     """Narrow protocol for registries that support specialization updates.
 
-    Implemented (structurally) by any registry that can receive specialization
-    update callbacks from AgentEvolutionTracker.  Concrete registries do not
-    need to explicitly subclass this; Python's structural subtyping enforces
-    the contract at type-check time.
+    The callback surface AgentEvolutionTracker uses to persist discovered
+    specializations.  Implemented by
+    ``orchestration.agent_registry.AgentCapabilityRegistry`` (#6828); any
+    registry that can receive specialization updates conforms structurally —
+    explicit subclassing is not required.
     """
 
     async def update_specializations(


### PR DESCRIPTION
Closes #6828

## Thinking Path

Owner green-lit this design refactor today. Wiring map established first (the issue's table had gone stale): the 4-way class rename already landed via #8082/#11430, and the "orphan" claim on `orchestration/agent_registry.py` is false — it feeds the REAL production tool-dispatch seam (`chat_workflow/tool_handler.py`) plus orchestrator/API callers. This PR delivers the reopened scope's remaining substance, not docs.

## What Changed

- Retired the LAST bare `AgentRegistry` name (zero-importer compat alias in `agent_evolution.py`); post-grep exactly 2 class defs remain (`AgentRegistryService`, `AgentRegistryProtocol`) — issue AC met.
- Canonical "find an agent that can do X": new runtime-checkable `AgentCapabilityLookup` Protocol in `autobot_shared/agent_registry_protocol.py`; `AgentCapabilityRegistry` is the canonical implementer and now concretely implements `AgentRegistryProtocol.update_specializations` — the Protocol's first real implementer, verified end-to-end.
- New `get_default_capability_registry()` singleton accessor — folded 3 ad-hoc registry constructions onto one instance.
- `GET /api/agent/agents/available` now merges AI Stack agents with the canonical local registry, optional `capability` filter, and **degrades to local-only 200 instead of 503** when AI Stack is down (the one deliberate behavior change; follows #10511 precedent; no frontend consumers — grep-verified; covered by test).
- Stale protocol-module docstring fixed (pre-rename names, false orphan claim).

## Verification

- 14 new tests (9 protocol/consolidation, 5 endpoint) pass — agent + independent re-run.
- Touched + adjacent suites: 42 passed; mesh_brain 5; orchestration 708 passed; startup imports 344. 5 pre-existing failures reproduced identically on clean base → filed #11754 (not dropped).
- py_compile + flake8 clean.

Follow-up (orphans left tracked, not deleted): `AgentEvolutionTracker` has a real registry seam now but no scheduler — wire-in issue text provided in #6828 closure; `AgentClient`/`get_agent_client` zero external callers.

## Model Used

Claude Fable 5 (subagent: general-purpose)