### PR TITLE
refactor(authz): rename legacy chat-secrets scope enum — resolve SecretScope name collision (#11759)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -22380,7 +22380,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
         source = inspect.getsource(secrets.get_secret_types)
         self.assertIn("SecretType", source)
-        self.assertIn("SecretScope", source)
+        self.assertIn("ChatSecretScope", source)  # renamed from SecretScope (#11759)
 
     def test_batch_132_migration_preserves_statistics_calculation(self):
         """Verify migration preserves statistics calculation logic"""

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3297,8 +3297,14 @@ def _validate_secret_name(name: str) -> str:
     return name
 
 
-class SecretScope(str, Enum):
-    """Secret scope enumeration."""
+class ChatSecretScope(str, Enum):
+    """Scope enumeration for the legacy Redis chat-secrets store (api/secrets.py).
+
+    Distinct from the canonical authorization scope ``ScopeLevel``
+    (``autobot_shared.scoping.scope_level``, aliased as ``SecretScope`` in
+    ``models/secret.py``): this enum adds CHAT/GENERAL for chat-vs-global
+    secret pools and has no WORKFLOW member (#11759).
+    """
 
     CHAT = "chat"
     GENERAL = "general"
@@ -3328,7 +3334,7 @@ class SecretModel(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
     type: SecretType
-    scope: SecretScope
+    scope: ChatSecretScope
     chat_id: str | None = None
     description: str | None = ""
     tags: List[str] = Field(default_factory=list)
@@ -3343,7 +3349,7 @@ class SecretCreateRequest(BaseModel):
 
     name: str = Field(..., min_length=1, max_length=256)
     type: SecretType
-    scope: SecretScope
+    scope: ChatSecretScope
     value: str = Field(..., min_length=1, max_length=65536)
     chat_id: str | None = Field(None, max_length=128)
     description: str | None = Field("", max_length=1024)
@@ -3367,7 +3373,7 @@ class SecretCreateRequest(BaseModel):
             name=self.name,
             type=self.type,
             scope=self.scope,
-            chat_id=self.chat_id if self.scope == SecretScope.CHAT else None,
+            chat_id=self.chat_id if self.scope == ChatSecretScope.CHAT else None,
             description=self.description,
             tags=self.tags,
             expires_at=self.expires_at,
@@ -3375,7 +3381,7 @@ class SecretCreateRequest(BaseModel):
         )
 
     def is_chat_scoped(self) -> bool:
-        return self.scope == SecretScope.CHAT
+        return self.scope == ChatSecretScope.CHAT
 
     def requires_chat_id(self) -> bool:
         return self.is_chat_scoped() and not self.chat_id
@@ -3405,7 +3411,7 @@ class SecretTransferRequest(BaseModel):
     """Request model for transferring secrets between scopes."""
 
     secret_ids: List[str]
-    target_scope: SecretScope
+    target_scope: ChatSecretScope
     target_chat_id: str | None = None
 
 

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -32,11 +32,11 @@ from fastapi.responses import JSONResponse
 
 from api.schemas_common import DataResponse
 from api.schemas_system import (
+    ChatSecretScope,
     ChatSecretsDeleteData,
     SecretCreatedData,
     SecretCreateRequest,
     SecretModel,
-    ChatSecretScope,
     SecretsListData,
     SecretsStatsData,
     SecretsStatusResponse,

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -36,7 +36,7 @@ from api.schemas_system import (
     SecretCreatedData,
     SecretCreateRequest,
     SecretModel,
-    SecretScope,
+    ChatSecretScope,
     SecretsListData,
     SecretsStatsData,
     SecretsStatusResponse,
@@ -281,7 +281,7 @@ class SecretsManager:
             return None
 
         # Check access permissions
-        if secret_data["scope"] == SecretScope.CHAT:
+        if secret_data["scope"] == ChatSecretScope.CHAT:
             if not chat_id or secret_data["chat_id"] != chat_id:
                 raise PermissionError("Access denied: Chat-scoped secret from different chat")
 
@@ -292,7 +292,7 @@ class SecretsManager:
 
         return secret_data
 
-    def list_secrets(self, chat_id: str | None = None, scope: SecretScope | None = None) -> List[Dict]:
+    def list_secrets(self, chat_id: str | None = None, scope: ChatSecretScope | None = None) -> List[Dict]:
         """List secrets with access control"""
         secrets = self._load_secrets()
         result = []
@@ -303,7 +303,7 @@ class SecretsManager:
                 continue
 
             # Apply access control
-            if secret_data["scope"] == SecretScope.CHAT:
+            if secret_data["scope"] == ChatSecretScope.CHAT:
                 if not chat_id or secret_data["chat_id"] != chat_id:
                     continue
 
@@ -329,7 +329,7 @@ class SecretsManager:
             return None
 
         # Check access permissions
-        if secret_data["scope"] == SecretScope.CHAT:
+        if secret_data["scope"] == ChatSecretScope.CHAT:
             if not chat_id or secret_data["chat_id"] != chat_id:
                 raise PermissionError("Access denied: Cannot modify chat-scoped secret from " "different chat")
 
@@ -366,7 +366,7 @@ class SecretsManager:
             return False
 
         # Check access permissions
-        if secret_data["scope"] == SecretScope.CHAT:
+        if secret_data["scope"] == ChatSecretScope.CHAT:
             if not chat_id or secret_data["chat_id"] != chat_id:
                 raise PermissionError("Access denied: Cannot delete chat-scoped secret from " "different chat")
 
@@ -389,13 +389,13 @@ class SecretsManager:
                 continue
 
             # Check access permissions for source
-            if secret_data["scope"] == SecretScope.CHAT:
+            if secret_data["scope"] == ChatSecretScope.CHAT:
                 if not chat_id or secret_data["chat_id"] != chat_id:
                     failed.append({"secret_id": secret_id, "reason": "Access denied"})
                     continue
 
             # Validate target scope
-            if request.target_scope == SecretScope.CHAT and not request.target_chat_id:
+            if request.target_scope == ChatSecretScope.CHAT and not request.target_chat_id:
                 failed.append(
                     {
                         "secret_id": secret_id,
@@ -406,7 +406,7 @@ class SecretsManager:
 
             # Perform transfer
             secret_data["scope"] = request.target_scope
-            if request.target_scope == SecretScope.CHAT:
+            if request.target_scope == ChatSecretScope.CHAT:
                 secret_data["chat_id"] = request.target_chat_id
             else:
                 secret_data["chat_id"] = None
@@ -442,7 +442,7 @@ class SecretsManager:
 
         # Find all secrets for this chat
         for secret_id, secret_data in secrets.items():
-            if secret_data["scope"] == SecretScope.CHAT and secret_data["chat_id"] == chat_id:
+            if secret_data["scope"] == ChatSecretScope.CHAT and secret_data["chat_id"] == chat_id:
                 chat_secrets.append(
                     {
                         "id": secret_id,
@@ -464,7 +464,7 @@ class SecretsManager:
         deleted = []
 
         for secret_id, secret_data in list(secrets.items()):
-            if secret_data["scope"] == SecretScope.CHAT and secret_data["chat_id"] == chat_id:
+            if secret_data["scope"] == ChatSecretScope.CHAT and secret_data["chat_id"] == chat_id:
                 if secret_ids is None or secret_id in secret_ids:
                     del secrets[secret_id]
                     deleted.append({"id": secret_id, "name": secret_data["name"]})
@@ -590,7 +590,7 @@ async def create_secret(
 async def list_secrets(
     http_request: Request,
     chat_id: str | None = Query(None),
-    scope: SecretScope | None = Query(None),
+    scope: ChatSecretScope | None = Query(None),
     admin_check: bool = Depends(check_admin_permission),
 ):
     """List secrets with optional filtering (Issue #744: requires admin authentication)"""
@@ -626,7 +626,7 @@ async def get_secret_types(
         status_code=200,
         content={
             "types": [{"value": t.value, "label": t.value.replace("_", " ").title()} for t in SecretType],
-            "scopes": [{"value": s.value, "label": s.value.title()} for s in SecretScope],
+            "scopes": [{"value": s.value, "label": s.value.title()} for s in ChatSecretScope],
         },
     )
 

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for the legacy Redis chat-secrets API surface (api/secrets.py).
+
+Pins the GET /api/secrets/types response (scope + type option lists) so the
+#11759 rename of the chat-secrets scope enum (``SecretScope`` ->
+``ChatSecretScope``) provably does not change any served values, and asserts
+the renamed enum stays distinct from the canonical authorization
+``ScopeLevel`` (#11290).
+"""
+
+import json
+
+import pytest
+
+from api.schemas_system import ChatSecretScope, SecretType
+from autobot_shared.scoping.scope_level import ScopeLevel
+
+# Exact response content served by GET /api/secrets/types — order and
+# strings pinned; the #11759 rename must not change any of this.
+EXPECTED_SCOPES = [
+    {"value": "chat", "label": "Chat"},
+    {"value": "general", "label": "General"},
+    {"value": "user", "label": "User"},
+    {"value": "session", "label": "Session"},
+    {"value": "shared", "label": "Shared"},
+    {"value": "group", "label": "Group"},
+    {"value": "organization", "label": "Organization"},
+]
+
+EXPECTED_TYPES = [
+    {"value": "ssh_key", "label": "Ssh Key"},
+    {"value": "password", "label": "Password"},
+    {"value": "api_key", "label": "Api Key"},
+    {"value": "token", "label": "Token"},
+    {"value": "certificate", "label": "Certificate"},
+    {"value": "database_url", "label": "Database Url"},
+    {"value": "infrastructure_host", "label": "Infrastructure Host"},
+    {"value": "other", "label": "Other"},
+]
+
+
+class TestChatSecretScopeEnum:
+    """The chat-secrets scope enum after the #11759 rename."""
+
+    def test_members_and_values_pinned(self):
+        assert [(m.name, m.value) for m in ChatSecretScope] == [
+            ("CHAT", "chat"),
+            ("GENERAL", "general"),
+            ("USER", "user"),
+            ("SESSION", "session"),
+            ("SHARED", "shared"),
+            ("GROUP", "group"),
+            ("ORGANIZATION", "organization"),
+        ]
+
+    def test_distinct_from_canonical_scope_level(self):
+        """ChatSecretScope must never be conflated with ScopeLevel (#11759)."""
+        assert ChatSecretScope is not ScopeLevel
+        assert "chat" not in {level.value for level in ScopeLevel}
+        assert "workflow" not in {scope.value for scope in ChatSecretScope}
+
+    def test_secret_type_values_pinned(self):
+        assert [t.value for t in SecretType] == [t["value"] for t in EXPECTED_TYPES]
+
+
+@pytest.mark.asyncio
+async def test_get_secret_types_response_pinned():
+    """GET /api/secrets/types serves identical content after the rename."""
+    from api.secrets import get_secret_types
+
+    response = await get_secret_types(admin_check=True)
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload == {"types": EXPECTED_TYPES, "scopes": EXPECTED_SCOPES}

--- a/autobot-backend/slash_command_handler.py
+++ b/autobot-backend/slash_command_handler.py
@@ -1154,7 +1154,7 @@ Your secret has been securely encrypted and stored.
             return validation_error
 
         try:
-            from api.secrets import SecretCreateRequest, ChatSecretScope, SecretType
+            from api.secrets import ChatSecretScope, SecretCreateRequest, SecretType
 
             scope = ChatSecretScope.CHAT if self.chat_id else ChatSecretScope.GENERAL
             request = SecretCreateRequest(

--- a/autobot-backend/slash_command_handler.py
+++ b/autobot-backend/slash_command_handler.py
@@ -1127,9 +1127,9 @@ class SecretsAddSubcommand(Command):
 
         Issue #620: Extracted from execute to reduce function length.
         """
-        from api.secrets import SecretScope
+        from api.secrets import ChatSecretScope
 
-        scope_text = "chat-scoped 💬" if scope == SecretScope.CHAT else "general 🌐"
+        scope_text = "chat-scoped 💬" if scope == ChatSecretScope.CHAT else "general 🌐"
         return SlashCommandResult(
             success=True,
             command_type=CommandType.SECRETS,
@@ -1154,9 +1154,9 @@ Your secret has been securely encrypted and stored.
             return validation_error
 
         try:
-            from api.secrets import SecretCreateRequest, SecretScope, SecretType
+            from api.secrets import SecretCreateRequest, ChatSecretScope, SecretType
 
-            scope = SecretScope.CHAT if self.chat_id else SecretScope.GENERAL
+            scope = ChatSecretScope.CHAT if self.chat_id else ChatSecretScope.GENERAL
             request = SecretCreateRequest(
                 name=self._parsed_name,
                 type=SecretType(self._parsed_type),
@@ -1373,19 +1373,19 @@ class SecretsTransferSubcommand(Command):
         Returns:
             Tuple of (SecretTransferRequest, scope_display_text)
         """
-        from api.secrets import SecretScope, SecretTransferRequest
+        from api.secrets import ChatSecretScope, SecretTransferRequest
 
         if target_scope_str == "to-general":
-            new_scope = SecretScope.GENERAL
+            new_scope = ChatSecretScope.GENERAL
             scope_text = "General 🌐"
         else:
-            new_scope = SecretScope.CHAT
+            new_scope = ChatSecretScope.CHAT
             scope_text = "Chat 💬"
 
         request = SecretTransferRequest(
             secret_ids=[target_secret["id"]],
             target_scope=new_scope,
-            target_chat_id=self.chat_id if new_scope == SecretScope.CHAT else None,
+            target_chat_id=self.chat_id if new_scope == ChatSecretScope.CHAT else None,
         )
         return request, scope_text
 

--- a/autobot-infrastructure/shared/scripts/secrets_manager.py
+++ b/autobot-infrastructure/shared/scripts/secrets_manager.py
@@ -38,6 +38,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
 logger = logging.getLogger(__name__)
 
 # Add project root to path
@@ -57,8 +61,12 @@ class SecretType:
     CUSTOM = "custom"
 
 
-class SecretScope:
-    """Secret access scopes."""
+# Standalone copy of the chat-secrets scope values (#11759).
+# Canonical enum: autobot-backend/api/schemas_system.py::ChatSecretScope
+# (distinct from the authorization ScopeLevel in autobot_shared/scoping).
+# Kept as a plain class so this script never imports backend modules.
+class ChatSecretScope:
+    """Secret access scopes (chat-secrets store)."""
 
     GENERAL = "general"  # Available across all chats
     CHAT = "chat"  # Available only within specific chat
@@ -92,13 +100,26 @@ class SecretsManager:
         logger.info("   Secrets Directory: [configured]")
         logger.info("   Indexed Secrets: %s", len(self.secrets_index))
 
-    def print_header(self, title: str):
+    # Standalone copies of ScriptFormatter.print_header/print_step
+    # (autobot-backend/utils/script_utils.py) — this script must not
+    # import backend modules (#11759).
+    def print_header(self, title: str, width: int = 60):
         """Print formatted header."""
-        ScriptFormatter.print_header(title)
+        print(f"\n{'=' * width}")  # noqa: print  # canonical: ignore py-print-smoke
+        print(f"  {title}")  # noqa: print  # canonical: ignore py-print-smoke
+        print("=" * width)  # noqa: print  # canonical: ignore py-print-smoke
 
     def print_step(self, step: str, status: str = "info"):
         """Print step with status."""
-        ScriptFormatter.print_step(step, status)
+        status_symbols = {
+            "info": "📋",
+            "success": "✅",
+            "warning": "⚠️",
+            "error": "❌",
+            "running": "🔄",
+        }
+        symbol = status_symbols.get(status, "📋")
+        print(f"{symbol} {step}")  # noqa: print  # canonical: ignore py-print-smoke
 
     def _initialize_encryption(self) -> Fernet:
         """Initialize encryption system."""
@@ -206,7 +227,7 @@ class SecretsManager:
         name: str,
         value: str,
         secret_type: str = SecretType.CUSTOM,
-        scope: str = SecretScope.GENERAL,
+        scope: str = ChatSecretScope.GENERAL,
         chat_id: str = None,
         description: str = "",
         tags: List[str] = None,
@@ -215,7 +236,7 @@ class SecretsManager:
         secret_id = self.generate_secret_id()
 
         # Validate scope and chat_id
-        if scope == SecretScope.CHAT and not chat_id:
+        if scope == ChatSecretScope.CHAT and not chat_id:
             raise ValueError("chat_id required for chat-scoped secrets")
 
         if tags is None:
@@ -250,7 +271,7 @@ class SecretsManager:
             self.secrets_index["secrets"][secret_id] = secret_metadata
 
             # Update chat index if chat-scoped
-            if scope == SecretScope.CHAT and chat_id:
+            if scope == ChatSecretScope.CHAT and chat_id:
                 if chat_id not in self.secrets_index["chats"]:
                     self.secrets_index["chats"][chat_id] = []
                 self.secrets_index["chats"][chat_id].append(secret_id)
@@ -281,7 +302,7 @@ class SecretsManager:
             secret_name = secret_metadata["name"]
 
         # Check access permissions (outside lock)
-        if secret_scope == SecretScope.CHAT:
+        if secret_scope == ChatSecretScope.CHAT:
             if not chat_id or secret_chat_id != chat_id:
                 self.print_step("Access denied to chat-scoped secret", "error")
                 return None
@@ -337,10 +358,10 @@ class SecretsManager:
                 continue
 
             # Chat scope filtering
-            if scope == SecretScope.CHAT:
+            if scope == ChatSecretScope.CHAT:
                 if not chat_id or metadata["chat_id"] != chat_id:
                     continue
-            elif metadata["scope"] == SecretScope.CHAT and chat_id != metadata["chat_id"]:
+            elif metadata["scope"] == ChatSecretScope.CHAT and chat_id != metadata["chat_id"]:
                 # Skip chat secrets from other chats
                 continue
 
@@ -367,7 +388,7 @@ class SecretsManager:
         secret_metadata = self.secrets_index["secrets"][secret_id]
 
         # Check permissions
-        if secret_metadata["scope"] == SecretScope.CHAT:
+        if secret_metadata["scope"] == ChatSecretScope.CHAT:
             if not chat_id or secret_metadata["chat_id"] != chat_id:
                 self.print_step("Access denied to chat-scoped secret", "error")
                 return False
@@ -420,7 +441,7 @@ class SecretsManager:
             secret_name = secret_metadata["name"]
 
         # Check permissions (outside lock)
-        if secret_scope == SecretScope.CHAT:
+        if secret_scope == ChatSecretScope.CHAT:
             if not chat_id or secret_chat_id != chat_id:
                 self.print_step("Access denied to chat-scoped secret", "error")
                 return False
@@ -434,7 +455,7 @@ class SecretsManager:
             # Thread-safe removal from index
             with self._index_lock:
                 # Remove from chat index if applicable
-                if secret_scope == SecretScope.CHAT and secret_chat_id:
+                if secret_scope == ChatSecretScope.CHAT and secret_chat_id:
                     chat_secrets = self.secrets_index["chats"].get(secret_chat_id, [])
                     if secret_id in chat_secrets:
                         chat_secrets.remove(secret_id)
@@ -474,7 +495,7 @@ class SecretsManager:
             secret_chat_id = secret_metadata.get("chat_id")
 
             # Verify it's a chat-scoped secret from the correct chat
-            if secret_scope != SecretScope.CHAT or secret_chat_id != chat_id:
+            if secret_scope != ChatSecretScope.CHAT or secret_chat_id != chat_id:
                 self.print_step(
                     "Cannot transfer: not a chat-scoped secret from this chat",
                     "error",
@@ -492,7 +513,7 @@ class SecretsManager:
                 secret_name = secret_metadata["name"]
 
                 # Update scope
-                secret_metadata["scope"] = SecretScope.GENERAL
+                secret_metadata["scope"] = ChatSecretScope.GENERAL
                 secret_metadata["chat_id"] = None
                 secret_metadata["updated_at"] = datetime.now().isoformat()
 
@@ -507,7 +528,7 @@ class SecretsManager:
             self._log_audit_event(
                 "transfer_secret",
                 secret_id,
-                SecretScope.GENERAL,
+                ChatSecretScope.GENERAL,
                 chat_id,
                 f"Transferred secret to general scope: {secret_name}",
             )
@@ -559,7 +580,7 @@ class SecretsManager:
         self._log_audit_event(
             "cleanup_chat",
             "",
-            SecretScope.CHAT,
+            ChatSecretScope.CHAT,
             chat_id,
             f"Cleanup completed: {transferred_count} transferred, {deleted_count} deleted",
         )
@@ -644,7 +665,7 @@ class SecretsManager:
             active_chats_count = len(self.secrets_index["chats"])
 
         total_secrets = len(secrets_copy)
-        chat_secrets = sum(1 for s in secrets_copy.values() if s["scope"] == SecretScope.CHAT)
+        chat_secrets = sum(1 for s in secrets_copy.values() if s["scope"] == ChatSecretScope.CHAT)
         general_secrets = total_secrets - chat_secrets
 
         # Secret types distribution
@@ -823,8 +844,8 @@ def _add_parameter_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--scope",
-        choices=[SecretScope.GENERAL, SecretScope.CHAT],
-        default=SecretScope.GENERAL,
+        choices=[ChatSecretScope.GENERAL, ChatSecretScope.CHAT],
+        default=ChatSecretScope.GENERAL,
         help="Secret scope",
     )
     parser.add_argument("--chat-id", help="Chat ID for chat-scoped secrets")


### PR DESCRIPTION
Closes #11759

## Thinking Path

Two enums named `SecretScope` with different members: the canonical `models/secret.py` alias of `ScopeLevel` (#11760) and a legacy chat-secrets enum in `api/schemas_system.py` (7 members, not just CHAT/GENERAL as filed). Same-name-different-members is a live hazard (the #6828 pattern). Renamed the legacy one to `ChatSecretScope`; consumer audit found zero cross-contamination (every importer got the enum it intended).

## What Changed

- `api/schemas_system.py`: `SecretScope` → `ChatSecretScope` (members/values untouched).
- Importers updated: `api/secrets.py` (13 uses), `slash_command_handler.py` (3 lazy imports, 9 uses), frozen migrations-test source assertion.
- `autobot-frontend/src/types/generated/api.ts`: left to the auto-fix-generated-types bot (repo convention).
- Infra copy `secrets_manager.py`: renamed to match + pointer comment, kept standalone. Bycatch fixed in-scope: the script was import-dead (NameError `Fernet`, F821×6) — missing cryptography imports added; same rot in all 6 sibling scripts → filed #11761.

## Verification

- API stability proven two ways: base-vs-new enum extraction → IDENTICAL (same 7 name/value pairs, same order); new `api/secrets_test.py::test_get_secret_types_response_pinned` pins the exact `/api/secrets/types` JSON.
- Agent: 4/4 new + 63 passed/3 skipped authz suites + 22 handler/secrets + 344 startup imports. Independent re-run: 51 passed / 1 failed — the failure (`test_docs_category_api`) fails identically on base (pre-existing, unrelated docs test).
- py_compile + flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)