### PR TITLE
refactor(authz): secrets + knowledge access decisions on shared is_visible primitive (#11290)

### DIFF
--- a/autobot-backend/knowledge/ownership.py
+++ b/autobot-backend/knowledge/ownership.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import Dict, List, Set
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.scoping import ScopeLevel
+from autobot_shared.scoping import Principal, ResourceDescriptor, ScopeLevel, is_visible
 
 logger = get_logger(__name__)
 
@@ -190,29 +190,30 @@ class KnowledgeOwnership:
         """Helper for check_access. Ref: #1088.
 
         Evaluates owner, visibility, org, group, and share grants.
+
+        #11290: thin adapter over the canonical
+        ``autobot_shared.scoping.is_visible`` primitive — owner, system/public
+        (authenticated), org, and group rules delegate to the shared rule; the
+        explicit ``shared_with`` list is modeled as this subsystem's grant
+        lookup.
         """
-        # Owner always has access
-        if owner_id and owner_id == user_id:
-            return True
-
-        # System-level facts are accessible to all authenticated users
-        if visibility in (VisibilityLevel.SYSTEM, VisibilityLevel.PUBLIC):
-            return is_authenticated
-
-        # Organization-level facts accessible to org members
-        if visibility == VisibilityLevel.ORGANIZATION and user_org_id and fact_org_id == user_org_id:
-            return True
-
-        # Group-level facts accessible to group members
-        if visibility == VisibilityLevel.GROUP and fact_group_ids:
-            if any(gid in user_group_ids for gid in fact_group_ids):
-                return True
-
-        # Check if explicitly shared with user
-        if visibility == VisibilityLevel.SHARED and user_id in shared_with:
-            return True
-
-        return False
+        principal = Principal(
+            user_id=user_id,
+            company_id=user_org_id or None,
+            group_ids=frozenset(user_group_ids),
+            is_authenticated=is_authenticated,
+        )
+        try:
+            scope = ScopeLevel(visibility)
+        except ValueError:
+            scope = ScopeLevel.PRIVATE  # unknown stored visibility: fail closed (owner-only)
+        resource = ResourceDescriptor(
+            owner_id=owner_id or None,
+            company_id=fact_org_id or None,
+            scope=scope,
+            group_ids=frozenset(fact_group_ids),
+        )
+        return is_visible(principal, resource, lambda: scope is ScopeLevel.SHARED and user_id in shared_with)
 
     async def check_access(
         self,

--- a/autobot-backend/knowledge/ownership_test.py
+++ b/autobot-backend/knowledge/ownership_test.py
@@ -58,8 +58,9 @@ def _meta(
 
 # (label, metadata, user_id, user_org_id, user_group_ids, is_authenticated, expected)
 DECISION_TABLE = [
-    # --- owner always wins, any visibility ---
+    # --- owner always wins, any visibility, even unauthenticated ---
     ("owner_private", _meta("private"), OWNER, None, None, True, True),
+    ("owner_anon", _meta("private"), OWNER, None, None, False, True),
     ("owner_shared", _meta("shared"), OWNER, None, None, True, True),
     ("owner_group", _meta("group"), OWNER, None, None, True, True),
     ("owner_org", _meta("organization"), OWNER, None, None, True, True),
@@ -68,6 +69,8 @@ DECISION_TABLE = [
     # --- shared: only listed users ---
     ("shared_listed", _meta("shared", shared_with=[STRANGER]), STRANGER, None, None, True, True),
     ("shared_unlisted", _meta("shared", shared_with=["other"]), STRANGER, None, None, True, False),
+    # shared_with list is only honored under SHARED visibility
+    ("private_shared_listed", _meta("private", shared_with=[STRANGER]), STRANGER, None, None, True, False),
     # --- group: membership intersection ---
     ("group_member", _meta("group", group_ids=[GROUP]), STRANGER, None, [GROUP], True, True),
     ("group_non_member", _meta("group", group_ids=[GROUP]), STRANGER, None, ["other-grp"], True, False),
@@ -84,6 +87,8 @@ DECISION_TABLE = [
     # --- unknown visibility value: fail closed for non-owner ---
     ("unknown_visibility", _meta("bogus"), STRANGER, None, None, True, False),
     ("unknown_visibility_owner", _meta("bogus"), OWNER, None, None, True, True),
+    # secrets-style scope values fall through to owner-only here
+    ("user_visibility_stranger", _meta("user"), STRANGER, None, None, True, False),
     # --- access_level general: public, no auth required ---
     ("general_anon", _meta("private", access_level="general"), STRANGER, None, None, False, True),
     ("general_authed", _meta("private", access_level="general"), STRANGER, None, None, True, True),

--- a/autobot-backend/models/secret.py
+++ b/autobot-backend/models/secret.py
@@ -18,7 +18,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Uuid
 
-from autobot_shared.scoping import ScopeLevel
+from autobot_shared.scoping import Principal, ResourceDescriptor, ScopeLevel, is_visible
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
 
@@ -212,6 +212,20 @@ class Secret(Base):
             return False
         return now_utc() > self.expires_at
 
+    def _grant_lookup(self, user_id: uuid.UUID, session_id: str | None) -> bool:
+        """Secrets grant facts for ``is_visible`` (#11290).
+
+        Models the two subsystem-specific grant tables: session binding
+        (session-scoped secrets are bound to the session, not the user) and
+        the explicit ``shared_with`` list.
+        """
+        if self.scope == SecretScope.SESSION.value:
+            return self.session_id == session_id
+        if self.scope == SecretScope.SHARED.value:
+            shared_list = self.shared_with if isinstance(self.shared_with, list) else []
+            return str(user_id) in shared_list
+        return False
+
     def is_accessible_by(
         self,
         user_id: uuid.UUID,
@@ -223,6 +237,11 @@ class Secret(Base):
         Check if user can access this secret.
 
         Issue #685: Added org and team-based access control.
+        Issue #11290: thin adapter over the canonical
+        ``autobot_shared.scoping.is_visible`` primitive — owner, org, and
+        team rules delegate to the shared rule; session-match and
+        ``shared_with`` semantics are modeled as this subsystem's grant
+        lookup (``_grant_lookup``).
 
         Args:
             user_id: User requesting access
@@ -233,32 +252,25 @@ class Secret(Base):
         Returns:
             True if user has access, False otherwise
         """
-        user_team_ids = user_team_ids or []
-
-        # Owner always has access
-        if self.owner_id == user_id:
-            return True
-
-        # Session-scoped requires matching session
-        if self.scope == SecretScope.SESSION.value:
-            return self.session_id == session_id
-
-        # Organization-scoped: accessible to all org members
-        if self.scope == SecretScope.ORGANIZATION.value:
-            return user_org_id and self.org_id == user_org_id
-
-        # Group-scoped: accessible to team members
-        if self.scope == SecretScope.GROUP.value:
-            secret_teams = self.team_ids if isinstance(self.team_ids, list) else []
-            return any(str(team_id) in secret_teams for team_id in user_team_ids)
-
-        # Shared secrets check shared_with list
-        if self.scope == SecretScope.SHARED.value:
-            shared_list = self.shared_with if isinstance(self.shared_with, list) else []
-            return str(user_id) in shared_list
-
-        # User-scoped is only accessible by owner
-        return False
+        principal = Principal(
+            user_id=str(user_id),
+            company_id=str(user_org_id) if user_org_id else None,
+            group_ids=frozenset(str(team_id) for team_id in (user_team_ids or [])),
+        )
+        try:
+            scope = ScopeLevel(self.scope)
+        except ValueError:
+            scope = ScopeLevel.USER  # unknown stored scope: fail closed (owner-only)
+        secret_teams = self.team_ids if isinstance(self.team_ids, list) else []
+        resource = ResourceDescriptor(
+            owner_id=str(self.owner_id),
+            company_id=str(self.org_id) if self.org_id else None,
+            scope=scope,
+            # keep the stored-value comparison semantics: only string entries
+            # can ever match ``str(team_id)`` membership checks
+            group_ids=frozenset(t for t in secret_teams if isinstance(t, str)),
+        )
+        return is_visible(principal, resource, lambda: self._grant_lookup(user_id, session_id))
 
     def share_with(self, user_id: uuid.UUID) -> None:
         """

--- a/autobot-backend/models/secret_test.py
+++ b/autobot-backend/models/secret_test.py
@@ -254,6 +254,10 @@ _ACCESS_MATRIX = [
     ("session_match", _secret("session", session_id="s1"), dict(user_id=_STRANGER, session_id="s1"), True),
     ("session_mismatch", _secret("session", session_id="s1"), dict(user_id=_STRANGER, session_id="s2"), False),
     ("session_none", _secret("session", session_id="s1"), dict(user_id=_STRANGER), False),
+    # session secret with NULL session_id and no caller session currently
+    # GRANTS (None == None) — pinned as-is (#11290); flagged for deliberate
+    # review together with the session-match rule above.
+    ("session_null_both", _secret("session"), dict(user_id=_STRANGER), True),
     (
         "shared_listed",
         _secret("shared", shared_with=[str(_STRANGER)]),
@@ -262,6 +266,8 @@ _ACCESS_MATRIX = [
     ),
     ("shared_unlisted", _secret("shared", shared_with=["someone-else"]), dict(user_id=_STRANGER), False),
     ("shared_empty", _secret("shared", shared_with=[]), dict(user_id=_STRANGER), False),
+    # non-list JSONB payloads fall back to deny for non-owners
+    ("shared_nonlist_guard", _secret("shared", shared_with={"a": 1}), dict(user_id=_STRANGER), False),
     (
         "group_team_member",
         _secret("group", team_ids=[str(_TEAM)]),
@@ -275,6 +281,13 @@ _ACCESS_MATRIX = [
         False,
     ),
     ("group_no_teams", _secret("group", team_ids=[str(_TEAM)]), dict(user_id=_STRANGER), False),
+    # non-list JSONB payloads fall back to deny for non-owners
+    (
+        "group_nonlist_guard",
+        _secret("group", team_ids={"a": 1}),
+        dict(user_id=_STRANGER, user_team_ids=[_TEAM]),
+        False,
+    ),
     (
         "org_member",
         _secret("organization", org_id=_ORG),

--- a/autobot-backend/services/resource_visibility.py
+++ b/autobot-backend/services/resource_visibility.py
@@ -21,7 +21,7 @@ _cache: dict[tuple[str, str], dict[str, bool]] = {}
 
 
 def _principal_key(p: Principal) -> str:
-    return f"{p.user_id}|{p.company_id}|{','.join(sorted(p.group_ids))}"
+    return f"{p.user_id}|{p.company_id}|{','.join(sorted(p.group_ids))}|{int(p.is_authenticated)}"
 
 
 def invalidate(resource_type: str, resource_id: str) -> None:

--- a/autobot-backend/services/secrets_authz.py
+++ b/autobot-backend/services/secrets_authz.py
@@ -86,7 +86,14 @@ class PrincipalFacts:
         exactly as ``authorize``/``accessible_vaults`` do.
         """
         cid = company_id if company_id is not None and company_id in self.company_roles else None
-        return Principal(user_id=self.user_id, company_id=cid, group_ids=self.team_ids)
+        return Principal(
+            user_id=self.user_id,
+            company_id=cid,
+            group_ids=self.team_ids,
+            # PrincipalFacts only exist for authenticated principals; a
+            # deactivated principal stops counting as authenticated (#11290).
+            is_authenticated=self.active,
+        )
 
 
 def authorize(facts: PrincipalFacts, action: str, vault: VaultRef) -> bool:

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -83352,7 +83352,7 @@ export interface components {
              * @description Default visibility for new knowledge
              * @default private
              */
-            default_visibility: components["schemas"]["VisibilityLevel"];
+            default_visibility: components["schemas"]["ScopeLevel"];
             /**
              * Allow User Private
              * @description Allow users to create private knowledge
@@ -89418,6 +89418,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * ScopeLevel
+         * @description Visibility scope for a shareable resource (secret, knowledge fact, skill, agent).
+         * @enum {string}
+         */
+        ScopeLevel: "user" | "session" | "shared" | "group" | "organization" | "workflow" | "private" | "system" | "public";
         /**
          * ScopedSearchRequest
          * @description Scoped search request with automatic permission filtering.
@@ -96396,7 +96402,7 @@ export interface components {
          */
         UpdatePermissionsRequest: {
             /** @description New visibility level */
-            visibility: components["schemas"]["VisibilityLevel"];
+            visibility: components["schemas"]["ScopeLevel"];
             /**
              * Organization Id
              * @description Organization ID for org-level knowledge
@@ -97666,14 +97672,6 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /**
-         * VisibilityLevel
-         * @description Visibility levels for knowledge facts.
-         *
-         *     Issue #679: Extended with hierarchical scopes.
-         * @enum {string}
-         */
-        VisibilityLevel: "private" | "shared" | "group" | "organization" | "system" | "public";
         /**
          * VisionAutomationOpportunitiesResponse
          * @description Response for GET /vision/automation-opportunities.
@@ -112467,7 +112465,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description Filter by visibility scope */
-                scope?: components["schemas"]["VisibilityLevel"] | null;
+                scope?: components["schemas"]["ScopeLevel"] | null;
                 /** @description Maximum number of items to return */
                 limit?: number;
                 /** @description Number of items to skip before returning results */

--- a/autobot_shared/scoping/visibility.py
+++ b/autobot_shared/scoping/visibility.py
@@ -2,11 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Pure visibility rule for scoped resources (#11277)."""
+"""Pure visibility rule for scoped resources (#11277, #11290)."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from autobot_shared.scoping.scope_level import ScopeLevel
+
+# Either the pre-computed fact "a matching grant row exists for this
+# principal", or a lazy per-subsystem grant lookup evaluated only when
+# ownership does not already decide. Closures let subsystems model their own
+# grant semantics (secrets: session match + shared_with list; knowledge:
+# shared_with list) without contorting Principal (#11290).
+GrantCheck = bool | Callable[[], bool]
 
 
 @dataclass(frozen=True)
@@ -18,36 +26,60 @@ class Principal:
     here because ``autobot_shared`` must not import backend models. Build this
     projection from it via ``PrincipalFacts.scoping_principal(company_id)``
     instead of constructing a parallel principal by hand.
+
+    ``is_authenticated`` defaults to False (fail closed): only the
+    SYSTEM/PUBLIC platform-wide rule consumes it, so existing constructors
+    keep denying those scopes unless they explicitly assert authentication.
     """
 
     user_id: str
     company_id: str | None
     group_ids: frozenset[str]
+    is_authenticated: bool = False
 
 
 @dataclass(frozen=True)
 class ResourceDescriptor:
-    """The resource's ownership + scope."""
+    """The resource's ownership + scope.
 
-    owner_id: str
+    ``group_id`` is the deprecated single-group form (#11290): prefer
+    ``group_ids`` for multi-group resources (secrets ``team_ids``, knowledge
+    fact ``group_ids``). Both are honored — the effective set is their union.
+    """
+
+    owner_id: str | None
     company_id: str | None
     scope: ScopeLevel
     group_id: str | None = None
+    group_ids: frozenset[str] = frozenset()
+
+    def effective_group_ids(self) -> frozenset[str]:
+        """Union of the deprecated single group and the multi-group set."""
+        if self.group_id is None:
+            return self.group_ids
+        return self.group_ids | {self.group_id}
 
 
-def is_visible(principal: Principal, resource: ResourceDescriptor, has_grant: bool) -> bool:
+def is_visible(principal: Principal, resource: ResourceDescriptor, has_grant: GrantCheck) -> bool:
     """Decide whether `principal` may access `resource`.
 
-    `has_grant` is the pre-computed result of "a matching resource_grants row
-    exists for this principal" (Task 6). An explicit grant always grants access.
+    `has_grant` is the result of "a matching resource_grants row exists for
+    this principal" (Task 6) — pre-computed, or a lazy subsystem grant lookup
+    called only when ownership does not already grant. An explicit grant
+    always grants access.
     """
-    if principal.user_id == resource.owner_id:
+    if resource.owner_id and principal.user_id == resource.owner_id:
         return True
-    if has_grant:
+    granted = has_grant() if callable(has_grant) else has_grant
+    if granted:
         return True
+    if resource.scope is ScopeLevel.SYSTEM or resource.scope is ScopeLevel.PUBLIC:
+        # Platform-wide knowledge: any authenticated principal (#11290).
+        return principal.is_authenticated
     if resource.scope is ScopeLevel.ORGANIZATION:
         return resource.company_id is not None and resource.company_id == principal.company_id
     if resource.scope is ScopeLevel.GROUP:
-        return resource.group_id is not None and resource.group_id in principal.group_ids
-    # USER / SESSION / SHARED are private absent ownership or an explicit grant.
+        return bool(resource.effective_group_ids() & principal.group_ids)
+    # USER / PRIVATE / SESSION / SHARED / WORKFLOW are private absent
+    # ownership or an explicit grant.
     return False

--- a/autobot_shared/scoping/visibility_test.py
+++ b/autobot_shared/scoping/visibility_test.py
@@ -48,3 +48,42 @@ def test_domain_specific_members_fail_closed_without_grant():
         assert not is_visible(_p(user="stranger"), _r(owner="owner", scope=scope), False)
         assert is_visible(_p(user="owner"), _r(owner="owner", scope=scope), False)  # owner still wins
         assert is_visible(_p(user="stranger"), _r(owner="owner", scope=scope), True)  # grant still wins
+
+
+def test_system_public_visible_to_authenticated_principal():
+    """#11290: SYSTEM/PUBLIC grant any authenticated principal (knowledge rule)."""
+    authed = Principal(user_id="stranger", company_id=None, group_ids=frozenset(), is_authenticated=True)
+    for scope in (ScopeLevel.SYSTEM, ScopeLevel.PUBLIC):
+        assert is_visible(authed, _r(owner="owner", scope=scope), False)
+        assert not is_visible(_p(user="stranger"), _r(owner="owner", scope=scope), False)  # default: anon
+
+
+def test_group_ids_multi_group_membership():
+    """#11290: multi-group resources union with the deprecated single group_id."""
+    r = ResourceDescriptor(
+        owner_id="owner", company_id=None, scope=ScopeLevel.GROUP, group_id="g0", group_ids=frozenset({"g1", "g2"})
+    )
+    assert is_visible(_p(groups={"g2"}), r, False)
+    assert is_visible(_p(groups={"g0"}), r, False)  # single-group form still honored
+    assert not is_visible(_p(groups={"g9"}), r, False)
+
+
+def test_has_grant_accepts_lazy_callback():
+    """#11290: has_grant may be a subsystem grant-lookup closure."""
+    assert is_visible(_p(user="stranger"), _r(owner="owner", scope=ScopeLevel.USER), lambda: True)
+    assert not is_visible(_p(user="stranger"), _r(owner="owner", scope=ScopeLevel.USER), lambda: False)
+
+
+def test_has_grant_callback_skipped_for_owner():
+    """Owner short-circuits before the grant lookup runs (lazy evaluation)."""
+
+    def _boom() -> bool:
+        raise AssertionError("grant lookup must not run for the owner")
+
+    assert is_visible(_p(user="owner"), _r(owner="owner", scope=ScopeLevel.USER), _boom)
+
+
+def test_falsy_owner_id_never_matches():
+    """#11290: resources without an owner (knowledge) grant no ownership access."""
+    r = ResourceDescriptor(owner_id=None, company_id=None, scope=ScopeLevel.USER)
+    assert not is_visible(_p(user="anyone"), r, False)


### PR DESCRIPTION
Closes #11290

## Thinking Path

Part 2 of the owner-green-lit consolidation (part 1 = PR #11760: canonical enum + principal bridge). Parity-first method again: matrices extended FIRST (+6 rows incl. null-session grant, non-list JSONB guards, anon owner) and verified green against the OLD implementations before any rewrite; after the rewrite every row passes with zero edits.

## What Changed

- `Secret.is_accessible_by` and `KnowledgeOwnership._check_visibility_grants` are now thin adapters delegating to `autobot_shared/scoping/visibility.py::is_visible`. Unknown stored scopes map fail-closed (USER / PRIVATE, matching the original fall-throughs); string-only team filtering and empty-string org normalization preserved exactly.
- The three recorded blockers resolved additively: `ResourceDescriptor.group_ids` frozenset (deprecated `group_id` merged via `effective_group_ids()`); `has_grant` widened to lazy `bool | Callable[[], bool]` closures (evaluated only after the owner short-circuit — laziness test-pinned); `Principal.is_authenticated` (default False, fail-closed) carrying knowledge's system/public rule into `is_visible`.
- Bycatch fix: `resource_visibility._principal_key` now includes `is_authenticated` so the decision cache can't leak authenticated decisions to anonymous principals.

## Verification

- Parity: `TestSecretAccessMatrix` (22 rows) + knowledge decision table (28 rows) unchanged across the rewrite; extension commit (3016e64b5) shown green on old code first.
- Targeted suites 117 passed / 3 skipped; startup imports 344; broad knowledge+models run 999 passed with failure set byte-identical to the part-1 base (diff → IDENTICAL_FAILURE_SETS, all in untouched ChromaDB/Redis integration files). Independent re-run: 65 passed / 3 skipped.
- flake8/black/py_compile clean.

Review flag (pre-existing behavior, now test-pinned in both parts): session-scoped secrets match on presented session_id, including the NULL==no-session case — worth a deliberate owner look.

## Model Used

Claude Fable 5 (subagent: general-purpose)