### PR TITLE
fix(slm-agent): port app-health probe to canonical slm/agent tree — #11723 was inert in prod (#11777)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
@@ -16,12 +16,22 @@ import platform
 import socket
 import subprocess  # nosec B404 - required for systemctl interaction
 import time
+import urllib.request
 from datetime import datetime, timezone
 from typing import Dict, List
 
 import psutil
 
 from autobot_shared.redis_client import get_redis_client
+
+# App-level /health probes for services that expose engine state beyond
+# systemd (#11723/#11777). Local-only URLs, short timeout, never fatal to
+# service discovery. Env-overridable so a non-default port needs no code change.
+TTS_HEALTH_URL = os.getenv("SLM_AGENT_TTS_HEALTH_URL", "http://127.0.0.1:8083/health")
+APP_HEALTH_PROBES: Dict[str, str] = {
+    "autobot-tts-worker": TTS_HEALTH_URL,
+}
+APP_HEALTH_TIMEOUT_SECONDS = float(os.getenv("SLM_AGENT_APP_HEALTH_TIMEOUT", "2.0"))
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +172,7 @@ class HealthCollector:
                 if service_info:
                     if service_info["status"] == "running":
                         service_info.update(self._get_service_details(service_info["name"]))
+                        service_info.update(self._probe_app_health(service_info["name"]))
                     elif service_info["status"] in ("failed", "crash-loop"):
                         # Issue #1019: Capture error context for failed services
                         # Issue #1604: Also capture for crash-looping services
@@ -379,6 +390,34 @@ class HealthCollector:
                 new_state=new_state,
                 error_context=svc.get("error_message", ""),
             )
+
+    def _probe_app_health(self, service_name: str) -> Dict:
+        """Fold app-level /health engine state into service info (#11723/#11777).
+
+        Only services listed in APP_HEALTH_PROBES are probed (local URL,
+        short timeout). Never raises: any failure (timeout, refused,
+        non-JSON, missing fields) returns {} so systemd discovery and the
+        heartbeat are unaffected. The returned keys feed
+        services/service_extra_data.engine_degraded_fields on the SLM
+        backend, which lights the NodeServicesPanel degraded badge (#11718).
+        """
+        url = APP_HEALTH_PROBES.get(service_name)
+        if not url:
+            return {}
+        try:
+            with urllib.request.urlopen(  # nosec B310 - fixed local http:// URL, not user input
+                url, timeout=APP_HEALTH_TIMEOUT_SECONDS
+            ) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            logger.debug("App health probe failed for %s: %s", service_name, e)
+            return {}
+        if not isinstance(payload, dict) or "engine_degraded" not in payload:
+            return {}
+        return {
+            "engine_degraded": bool(payload.get("engine_degraded")),
+            "degraded_reason": payload.get("degraded_reason"),
+        }
 
     def is_healthy(self, thresholds: Dict | None = None) -> bool:
         """Quick health check against thresholds."""

--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -16,12 +16,22 @@ import platform
 import socket
 import subprocess  # nosec B404 - required for systemctl interaction
 import time
+import urllib.request
 from datetime import datetime, timezone
 from typing import Dict, List
 
 import psutil
 
 from autobot_shared.redis_client import get_redis_client
+
+# App-level /health probes for services that expose engine state beyond
+# systemd (#11723/#11777). Local-only URLs, short timeout, never fatal to
+# service discovery. Env-overridable so a non-default port needs no code change.
+TTS_HEALTH_URL = os.getenv("SLM_AGENT_TTS_HEALTH_URL", "http://127.0.0.1:8083/health")
+APP_HEALTH_PROBES: Dict[str, str] = {
+    "autobot-tts-worker": TTS_HEALTH_URL,
+}
+APP_HEALTH_TIMEOUT_SECONDS = float(os.getenv("SLM_AGENT_APP_HEALTH_TIMEOUT", "2.0"))
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +172,7 @@ class HealthCollector:
                 if service_info:
                     if service_info["status"] == "running":
                         service_info.update(self._get_service_details(service_info["name"]))
+                        service_info.update(self._probe_app_health(service_info["name"]))
                     elif service_info["status"] in ("failed", "crash-loop"):
                         # Issue #1019: Capture error context for failed services
                         # Issue #1604: Also capture for crash-looping services
@@ -379,6 +390,34 @@ class HealthCollector:
                 new_state=new_state,
                 error_context=svc.get("error_message", ""),
             )
+
+    def _probe_app_health(self, service_name: str) -> Dict:
+        """Fold app-level /health engine state into service info (#11723/#11777).
+
+        Only services listed in APP_HEALTH_PROBES are probed (local URL,
+        short timeout). Never raises: any failure (timeout, refused,
+        non-JSON, missing fields) returns {} so systemd discovery and the
+        heartbeat are unaffected. The returned keys feed
+        services/service_extra_data.engine_degraded_fields on the SLM
+        backend, which lights the NodeServicesPanel degraded badge (#11718).
+        """
+        url = APP_HEALTH_PROBES.get(service_name)
+        if not url:
+            return {}
+        try:
+            with urllib.request.urlopen(  # nosec B310 - fixed local http:// URL, not user input
+                url, timeout=APP_HEALTH_TIMEOUT_SECONDS
+            ) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            logger.debug("App health probe failed for %s: %s", service_name, e)
+            return {}
+        if not isinstance(payload, dict) or "engine_degraded" not in payload:
+            return {}
+        return {
+            "engine_degraded": bool(payload.get("engine_degraded")),
+            "degraded_reason": payload.get("degraded_reason"),
+        }
 
     def is_healthy(self, thresholds: Dict | None = None) -> bool:
         """Quick health check against thresholds."""

--- a/autobot-slm-backend/slm/agent/health_collector_probe_test.py
+++ b/autobot-slm-backend/slm/agent/health_collector_probe_test.py
@@ -1,0 +1,75 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the app-level /health probe in HealthCollector (#11723/#11777).
+
+The probe feeds engine_degraded/degraded_reason from a service's own
+/health endpoint into the heartbeat service dict, which the SLM backend
+merges into Service.extra_data (services/service_extra_data.py, #11718).
+
+This is the CANONICAL tree (autobot-slm-backend/slm/agent/) — the one the
+Ansible slm_agent role actually deploys. #11723's original probe landed in
+the non-deployed autobot-slm-agent/ tree, leaving it inert in prod (#11777).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from slm.agent.health_collector import HealthCollector
+
+
+def _collector() -> HealthCollector:
+    return HealthCollector(discover_services=False)
+
+
+def _fake_response(body: bytes):
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda self: self
+    resp.__exit__ = lambda self, *a: False
+    return resp
+
+
+def test_unmapped_service_not_probed():
+    with patch("slm.agent.health_collector.urllib.request.urlopen") as urlopen:
+        assert _collector()._probe_app_health("nginx") == {}
+        urlopen.assert_not_called()
+
+
+def test_degraded_fields_extracted():
+    body = json.dumps({"status": "healthy", "engine_degraded": True, "degraded_reason": "HF auth failed"}).encode(
+        "utf-8"
+    )
+    with patch("slm.agent.health_collector.urllib.request.urlopen", return_value=_fake_response(body)):
+        result = _collector()._probe_app_health("autobot-tts-worker")
+    assert result == {"engine_degraded": True, "degraded_reason": "HF auth failed"}
+
+
+def test_healthy_engine_reports_not_degraded():
+    body = json.dumps({"engine_degraded": False, "degraded_reason": None}).encode("utf-8")
+    with patch("slm.agent.health_collector.urllib.request.urlopen", return_value=_fake_response(body)):
+        result = _collector()._probe_app_health("autobot-tts-worker")
+    assert result == {"engine_degraded": False, "degraded_reason": None}
+
+
+def test_missing_field_returns_empty():
+    body = json.dumps({"status": "healthy"}).encode("utf-8")
+    with patch("slm.agent.health_collector.urllib.request.urlopen", return_value=_fake_response(body)):
+        assert _collector()._probe_app_health("autobot-tts-worker") == {}
+
+
+def test_connection_failure_is_non_fatal():
+    with patch(
+        "slm.agent.health_collector.urllib.request.urlopen",
+        side_effect=OSError("connection refused"),
+    ):
+        assert _collector()._probe_app_health("autobot-tts-worker") == {}
+
+
+def test_non_json_body_is_non_fatal():
+    with patch(
+        "slm.agent.health_collector.urllib.request.urlopen",
+        return_value=_fake_response(b"<html>gateway error</html>"),
+    ):
+        assert _collector()._probe_app_health("autobot-tts-worker") == {}


### PR DESCRIPTION
## Thinking Path

While deploying today's fixes to the live box via code-sync, empirical verification (per "ground truth, not marker") showed the deployed agent `/opt/autobot/autobot-slm-agent/slm/agent/health_collector.py` had NO `_probe_app_health`. Root cause: #11723 edited the repo-root `autobot-slm-agent/` tree, but the Ansible `slm_agent` role deploys from `autobot-slm-backend/slm/agent/` (canonical per `detect-agent-code-drift.sh` #1629). The probe was inert in prod — #11718's degraded badge could never light.

## What Changed

- `autobot-slm-backend/slm/agent/health_collector.py` (canonical) — added `_probe_app_health()` + `discover_all_services` call + `APP_HEALTH_PROBES`/timeout consts (env-overridable). stdlib urllib; never raises.
- `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py` — mirrored (drift-check green).
- `autobot-slm-backend/slm/agent/health_collector_probe_test.py` — 6 tests (mirrors sibling `health_collector_state_change_test.py` import style; `*_test.py` excluded from drift-check).

## Verification

- `pytest slm/agent/health_collector_probe_test.py` → **6 passed** (from repo root)
- `detect-agent-code-drift.sh` → "Agent code in sync: canonical == Ansible copy"
- flake8 / black / py_compile clean

Closes #11777. Note: the repo-root `autobot-slm-agent/` tree that #11723/#11748 targeted is a separate (apparently non-deployed) duplicate — its consolidation/removal is a follow-up canonical-source question, not this fix.

## Model Used

Fable 5 (inline implementation)
