### PR TITLE
fix(infra): repair import-dead shared/scripts CLIs — missing imports + phantom modules (#11761)

### DIFF
--- a/autobot-infrastructure/shared/scripts/backup_manager.py
+++ b/autobot-infrastructure/shared/scripts/backup_manager.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import tarfile
 from datetime import datetime, timedelta
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -35,8 +36,85 @@ logger = logging.getLogger(__name__)
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from utils.script_utils import ScriptFormatter
-from utils.service_registry import get_service_registry
+# --- Standalone replacements for backend-only modules (#11761) --------------
+# `utils/` exists only under autobot-backend/ and is not importable from this
+# directory; shared scripts stay standalone (#11759). Canonical source
+# mirrored below: autobot-backend/utils/service_registry.py (surface used
+# by this script: deployment_mode + get_deployment_info).
+
+
+class DeploymentMode(Enum):
+    """Deployment modes (mirrors backend utils/service_registry.py)."""
+
+    LOCAL = "local"
+    DOCKER_LOCAL = "docker_local"
+    DISTRIBUTED = "distributed"
+    KUBERNETES = "kubernetes"
+    CLOUD = "cloud"
+
+
+# Port env aliases + defaults mirror autobot_shared/ssot_config.py.
+_SERVICE_DEFS = {
+    "backend": ("AUTOBOT_BACKEND_PORT", 8001),
+    "frontend": ("AUTOBOT_FRONTEND_PORT", 5173),
+    "redis": ("AUTOBOT_REDIS_PORT", 6379),
+    "ollama": ("AUTOBOT_OLLAMA_PORT", 11434),
+    "ai-stack": ("AUTOBOT_AI_STACK_PORT", 8080),
+    "npu-worker": ("AUTOBOT_NPU_WORKER_PORT", 8081),
+    "playwright-vnc": ("AUTOBOT_BROWSER_SERVICE_PORT", 9001),
+}
+
+
+class ServiceRegistry:
+    """Env-driven standalone stand-in for the backend ServiceRegistry."""
+
+    def __init__(self):
+        """Initialize registry from environment."""
+        self.deployment_mode = self._detect_deployment_mode()
+        self.services: Dict[str, str] = {name: self._build_url(name) for name in _SERVICE_DEFS}
+
+    @staticmethod
+    def _detect_deployment_mode() -> DeploymentMode:
+        """Detect deployment mode from env, falling back to container heuristic."""
+        mode = os.environ.get("AUTOBOT_DEPLOYMENT_MODE", "").lower()
+        if mode:
+            try:
+                return DeploymentMode(mode)
+            except ValueError:
+                logger.warning("Invalid AUTOBOT_DEPLOYMENT_MODE: %s", mode)
+        return DeploymentMode.DOCKER_LOCAL if os.path.exists("/.dockerenv") else DeploymentMode.LOCAL
+
+    @staticmethod
+    def _build_url(name: str) -> str:
+        """Build a service base URL from environment overrides."""
+        host_env = f"AUTOBOT_{name.upper().replace('-', '_')}_HOST"
+        host = os.environ.get(host_env, "localhost")
+        port_env, default_port = _SERVICE_DEFS[name]
+        port = int(os.environ.get(port_env, default_port))
+        scheme = "redis" if name == "redis" else "http"
+        return f"{scheme}://{host}:{port}"
+
+    def get_deployment_info(self) -> Dict[str, Any]:
+        """Get deployment information."""
+        return {
+            "deployment_mode": self.deployment_mode.value,
+            "services_count": len(self.services),
+            "services": {name: {"url": url} for name, url in self.services.items()},
+        }
+
+
+_registry: Optional[ServiceRegistry] = None
+
+
+def get_service_registry() -> ServiceRegistry:
+    """Get the process-wide ServiceRegistry instance."""
+    global _registry
+    if _registry is None:
+        _registry = ServiceRegistry()
+    return _registry
+
+
+# --- end standalone replacements (#11761) -----------------------------------
 
 
 class BackupManager:
@@ -76,13 +154,26 @@ class BackupManager:
         logger.info(f"   Backup Directory: {self.backup_dir}")
         logger.info(f"   Project Root: {self.project_root}")
 
-    def print_header(self, title: str):
+    # Standalone copies of ScriptFormatter.print_header/print_step
+    # (autobot-backend/utils/script_utils.py) — this script must not
+    # import backend modules (#11761).
+    def print_header(self, title: str, width: int = 60):
         """Print formatted header."""
-        ScriptFormatter.print_header(title)
+        print(f"\n{'=' * width}")  # noqa: print  # canonical: ignore py-print-smoke
+        print(f"  {title}")  # noqa: print  # canonical: ignore py-print-smoke
+        print("=" * width)  # noqa: print  # canonical: ignore py-print-smoke
 
     def print_step(self, step: str, status: str = "info"):
         """Print step with status."""
-        ScriptFormatter.print_step(step, status)
+        status_symbols = {
+            "info": "📋",
+            "success": "✅",
+            "warning": "⚠️",
+            "error": "❌",
+            "running": "🔄",
+        }
+        symbol = status_symbols.get(status, "📋")
+        print(f"{symbol} {step}")  # noqa: print  # canonical: ignore py-print-smoke
 
     def generate_backup_id(self) -> str:
         """Generate unique backup ID."""

--- a/autobot-infrastructure/shared/scripts/deploy_autobot.py
+++ b/autobot-infrastructure/shared/scripts/deploy_autobot.py
@@ -22,12 +22,19 @@ Usage:
 import argparse
 import asyncio
 import json
+import logging
 import os
+import socket
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +44,156 @@ import yaml
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from constants.threshold_constants import TimingConstants
-from utils.script_utils import ScriptFormatter
-from utils.service_registry import DeploymentMode, get_service_registry
+# --- Standalone replacements for backend-only modules (#11761) --------------
+# `utils/` and `constants/` exist only under autobot-backend/ and are not
+# importable from this directory; shared scripts stay standalone (#11759).
+# Canonical sources mirrored below:
+#   autobot_shared/ssot_constants.py::TimingConstants
+#   autobot-backend/utils/service_registry.py (surface used by this script)
+
+
+class TimingConstants:
+    """Standalone copy of the timing values used by this script."""
+
+    MEDIUM_DELAY = 5.0
+    LONG_DELAY = 10.0
+
+
+class DeploymentMode(Enum):
+    """Deployment modes (mirrors backend utils/service_registry.py)."""
+
+    LOCAL = "local"
+    DOCKER_LOCAL = "docker_local"
+    DISTRIBUTED = "distributed"
+    KUBERNETES = "kubernetes"
+    CLOUD = "cloud"
+
+
+class ServiceStatus(Enum):
+    """Service health status (mirrors backend utils/service_registry.py)."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ServiceHealth:
+    """Service health state."""
+
+    status: ServiceStatus
+    last_check: float
+    response_time: float = 0.0
+
+
+# Port env aliases + defaults mirror autobot_shared/ssot_config.py;
+# health paths mirror autobot_shared/ssot_constants.py.
+_SERVICE_DEFS = {
+    "backend": ("AUTOBOT_BACKEND_PORT", 8001, "/api/health"),
+    "frontend": ("AUTOBOT_FRONTEND_PORT", 5173, "/"),
+    "redis": ("AUTOBOT_REDIS_PORT", 6379, None),
+    "ollama": ("AUTOBOT_OLLAMA_PORT", 11434, "/api/tags"),
+    "ai-stack": ("AUTOBOT_AI_STACK_PORT", 8080, "/health"),
+    "npu-worker": ("AUTOBOT_NPU_WORKER_PORT", 8081, "/health"),
+    "playwright-vnc": ("AUTOBOT_BROWSER_SERVICE_PORT", 9001, "/health"),
+}
+
+
+class ServiceRegistry:
+    """Env-driven standalone stand-in for the backend ServiceRegistry."""
+
+    def __init__(self, config_file: Optional[str] = None):
+        """Initialize registry from environment (optional config file ignored)."""
+        self.config_file = config_file
+        self.deployment_mode = self._detect_deployment_mode()
+        self.services: Dict[str, str] = {name: self._build_url(name) for name in _SERVICE_DEFS}
+
+    @staticmethod
+    def _detect_deployment_mode() -> DeploymentMode:
+        """Detect deployment mode from env, falling back to container heuristic."""
+        mode = os.environ.get("AUTOBOT_DEPLOYMENT_MODE", "").lower()
+        if mode:
+            try:
+                return DeploymentMode(mode)
+            except ValueError:
+                logger.warning("Invalid AUTOBOT_DEPLOYMENT_MODE: %s", mode)
+        return DeploymentMode.DOCKER_LOCAL if os.path.exists("/.dockerenv") else DeploymentMode.LOCAL
+
+    @staticmethod
+    def _build_url(name: str) -> str:
+        """Build a service base URL from environment overrides."""
+        host_env = f"AUTOBOT_{name.upper().replace('-', '_')}_HOST"
+        host = os.environ.get(host_env, "localhost")
+        port_env, default_port, _health = _SERVICE_DEFS[name]
+        port = int(os.environ.get(port_env, default_port))
+        scheme = "redis" if name == "redis" else "http"
+        return f"{scheme}://{host}:{port}"
+
+    def list_services(self) -> List[str]:
+        """List registered service names."""
+        return list(self.services)
+
+    def get_service_url(self, service_name: str, path: str = "") -> str:
+        """Get full URL for a service."""
+        if service_name not in self.services:
+            raise ValueError(f"Service '{service_name}' not found in registry")
+        return f"{self.services[service_name]}{path}"
+
+    @staticmethod
+    def _probe(url: str, timeout: float = 5.0) -> bool:
+        """Probe a service: TCP connect for redis, HTTP GET otherwise."""
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme == "redis":
+            try:
+                with socket.create_connection((parsed.hostname, parsed.port), timeout=timeout):
+                    return True
+            except OSError:
+                return False
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+                return response.status == 200
+        except (urllib.error.URLError, OSError, ValueError):
+            return False
+
+    async def check_service_health(self, service_name: str) -> ServiceHealth:
+        """Check health of a single service."""
+        _port_env, _default_port, health_path = _SERVICE_DEFS[service_name]
+        url = self.get_service_url(service_name, health_path or "")
+        start = time.time()
+        ok = await asyncio.get_running_loop().run_in_executor(None, self._probe, url)
+        return ServiceHealth(
+            status=ServiceStatus.HEALTHY if ok else ServiceStatus.UNHEALTHY,
+            last_check=time.time(),
+            response_time=time.time() - start,
+        )
+
+    async def check_all_services_health(self) -> Dict[str, ServiceHealth]:
+        """Check health of all registered services."""
+        names = self.list_services()
+        results = await asyncio.gather(*(self.check_service_health(name) for name in names))
+        return dict(zip(names, results))
+
+    def get_deployment_info(self) -> Dict[str, Any]:
+        """Get deployment information."""
+        return {
+            "deployment_mode": self.deployment_mode.value,
+            "services_count": len(self.services),
+            "services": {name: {"url": url} for name, url in self.services.items()},
+        }
+
+
+_registry: Optional[ServiceRegistry] = None
+
+
+def get_service_registry(config_file: Optional[str] = None) -> ServiceRegistry:
+    """Get the process-wide ServiceRegistry instance."""
+    global _registry
+    if _registry is None:
+        _registry = ServiceRegistry(config_file)
+    return _registry
+
+
+# --- end standalone replacements (#11761) -----------------------------------
 
 
 class AutoBotDeployer:
@@ -61,13 +215,26 @@ class AutoBotDeployer:
         logger.info(f"   Config: {config_file or 'default'}")
         logger.info(f"   Namespace: {namespace}")
 
-    def print_header(self, title: str):
+    # Standalone copies of ScriptFormatter.print_header/print_step
+    # (autobot-backend/utils/script_utils.py) — this script must not
+    # import backend modules (#11761).
+    def print_header(self, title: str, width: int = 60):
         """Print formatted header."""
-        ScriptFormatter.print_header(title)
+        print(f"\n{'=' * width}")  # noqa: print  # canonical: ignore py-print-smoke
+        print(f"  {title}")  # noqa: print  # canonical: ignore py-print-smoke
+        print("=" * width)  # noqa: print  # canonical: ignore py-print-smoke
 
     def print_step(self, step: str, status: str = "info"):
         """Print deployment step with status."""
-        ScriptFormatter.print_step(step, status)
+        status_symbols = {
+            "info": "📋",
+            "success": "✅",
+            "warning": "⚠️",
+            "error": "❌",
+            "running": "🔄",
+        }
+        symbol = status_symbols.get(status, "📋")
+        print(f"{symbol} {step}")  # noqa: print  # canonical: ignore py-print-smoke
 
     def run_command(self, command: str, check: bool = True, cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
         """Run shell command with error handling."""

--- a/autobot-infrastructure/shared/scripts/deployment_rollback.py
+++ b/autobot-infrastructure/shared/scripts/deployment_rollback.py
@@ -27,22 +27,170 @@ import argparse
 import asyncio
 import json
 import logging
+import os
+import socket
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+import yaml
 
 logger = logging.getLogger(__name__)
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from constants.threshold_constants import TimingConstants
 from scripts.backup_manager import BackupManager
-from utils.script_utils import ScriptFormatter
-from utils.service_registry import ServiceStatus, get_service_registry
+
+# --- Standalone replacements for backend-only modules (#11761) --------------
+# `utils/` and `constants/` exist only under autobot-backend/ and are not
+# importable from this directory; shared scripts stay standalone (#11759).
+# Canonical sources mirrored below:
+#   autobot_shared/ssot_constants.py::TimingConstants
+#   autobot-backend/utils/service_registry.py (surface used by this script)
+
+
+class TimingConstants:
+    """Standalone copy of the timing values used by this script."""
+
+    MEDIUM_DELAY = 5.0
+
+
+class DeploymentMode(Enum):
+    """Deployment modes (mirrors backend utils/service_registry.py)."""
+
+    LOCAL = "local"
+    DOCKER_LOCAL = "docker_local"
+    DISTRIBUTED = "distributed"
+    KUBERNETES = "kubernetes"
+    CLOUD = "cloud"
+
+
+class ServiceStatus(Enum):
+    """Service health status (mirrors backend utils/service_registry.py)."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ServiceHealth:
+    """Service health state."""
+
+    status: ServiceStatus
+    last_check: float
+    response_time: float = 0.0
+
+
+# Port env aliases + defaults mirror autobot_shared/ssot_config.py;
+# health paths mirror autobot_shared/ssot_constants.py.
+_SERVICE_DEFS = {
+    "backend": ("AUTOBOT_BACKEND_PORT", 8001, "/api/health"),
+    "frontend": ("AUTOBOT_FRONTEND_PORT", 5173, "/"),
+    "redis": ("AUTOBOT_REDIS_PORT", 6379, None),
+    "ollama": ("AUTOBOT_OLLAMA_PORT", 11434, "/api/tags"),
+    "ai-stack": ("AUTOBOT_AI_STACK_PORT", 8080, "/health"),
+    "npu-worker": ("AUTOBOT_NPU_WORKER_PORT", 8081, "/health"),
+    "playwright-vnc": ("AUTOBOT_BROWSER_SERVICE_PORT", 9001, "/health"),
+}
+
+
+class ServiceRegistry:
+    """Env-driven standalone stand-in for the backend ServiceRegistry."""
+
+    def __init__(self, config_file: Optional[str] = None):
+        """Initialize registry from environment (optional config file ignored)."""
+        self.config_file = config_file
+        self.deployment_mode = self._detect_deployment_mode()
+        self.services: Dict[str, str] = {name: self._build_url(name) for name in _SERVICE_DEFS}
+
+    @staticmethod
+    def _detect_deployment_mode() -> DeploymentMode:
+        """Detect deployment mode from env, falling back to container heuristic."""
+        mode = os.environ.get("AUTOBOT_DEPLOYMENT_MODE", "").lower()
+        if mode:
+            try:
+                return DeploymentMode(mode)
+            except ValueError:
+                logger.warning("Invalid AUTOBOT_DEPLOYMENT_MODE: %s", mode)
+        return DeploymentMode.DOCKER_LOCAL if os.path.exists("/.dockerenv") else DeploymentMode.LOCAL
+
+    @staticmethod
+    def _build_url(name: str) -> str:
+        """Build a service base URL from environment overrides."""
+        host_env = f"AUTOBOT_{name.upper().replace('-', '_')}_HOST"
+        host = os.environ.get(host_env, "localhost")
+        port_env, default_port, _health = _SERVICE_DEFS[name]
+        port = int(os.environ.get(port_env, default_port))
+        scheme = "redis" if name == "redis" else "http"
+        return f"{scheme}://{host}:{port}"
+
+    def list_services(self) -> List[str]:
+        """List registered service names."""
+        return list(self.services)
+
+    def get_service_url(self, service_name: str, path: str = "") -> str:
+        """Get full URL for a service."""
+        if service_name not in self.services:
+            raise ValueError(f"Service '{service_name}' not found in registry")
+        return f"{self.services[service_name]}{path}"
+
+    @staticmethod
+    def _probe(url: str, timeout: float = 5.0) -> bool:
+        """Probe a service: TCP connect for redis, HTTP GET otherwise."""
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme == "redis":
+            try:
+                with socket.create_connection((parsed.hostname, parsed.port), timeout=timeout):
+                    return True
+            except OSError:
+                return False
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+                return response.status == 200
+        except (urllib.error.URLError, OSError, ValueError):
+            return False
+
+    async def check_service_health(self, service_name: str) -> ServiceHealth:
+        """Check health of a single service."""
+        _port_env, _default_port, health_path = _SERVICE_DEFS[service_name]
+        url = self.get_service_url(service_name, health_path or "")
+        start = time.time()
+        ok = await asyncio.get_running_loop().run_in_executor(None, self._probe, url)
+        return ServiceHealth(
+            status=ServiceStatus.HEALTHY if ok else ServiceStatus.UNHEALTHY,
+            last_check=time.time(),
+            response_time=time.time() - start,
+        )
+
+    async def check_all_services_health(self) -> Dict[str, ServiceHealth]:
+        """Check health of all registered services."""
+        names = self.list_services()
+        results = await asyncio.gather(*(self.check_service_health(name) for name in names))
+        return dict(zip(names, results))
+
+
+_registry: Optional[ServiceRegistry] = None
+
+
+def get_service_registry(config_file: Optional[str] = None) -> ServiceRegistry:
+    """Get the process-wide ServiceRegistry instance."""
+    global _registry
+    if _registry is None:
+        _registry = ServiceRegistry(config_file)
+    return _registry
+
+
+# --- end standalone replacements (#11761) -----------------------------------
 
 
 class RollbackStrategy:
@@ -76,13 +224,26 @@ class RollbackManager:
         logger.info(f"   Backup Directory: {self.backup_dir}")
         logger.info(f"   Rollback Directory: {self.rollback_dir}")
 
-    def print_header(self, title: str):
+    # Standalone copies of ScriptFormatter.print_header/print_step
+    # (autobot-backend/utils/script_utils.py) — this script must not
+    # import backend modules (#11761).
+    def print_header(self, title: str, width: int = 60):
         """Print formatted header."""
-        ScriptFormatter.print_header(title)
+        print(f"\n{'=' * width}")  # noqa: print  # canonical: ignore py-print-smoke
+        print(f"  {title}")  # noqa: print  # canonical: ignore py-print-smoke
+        print("=" * width)  # noqa: print  # canonical: ignore py-print-smoke
 
     def print_step(self, step: str, status: str = "info"):
         """Print step with status."""
-        ScriptFormatter.print_step(step, status)
+        status_symbols = {
+            "info": "📋",
+            "success": "✅",
+            "warning": "⚠️",
+            "error": "❌",
+            "running": "🔄",
+        }
+        symbol = status_symbols.get(status, "📋")
+        print(f"{symbol} {step}")  # noqa: print  # canonical: ignore py-print-smoke
 
     def _load_rollback_config(self) -> Dict[str, Any]:
         """Load rollback configuration."""

--- a/autobot-infrastructure/shared/scripts/log_aggregator.py
+++ b/autobot-infrastructure/shared/scripts/log_aggregator.py
@@ -29,13 +29,15 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import re
 import sys
 import threading
 from collections import defaultdict
 from datetime import datetime, timedelta
+from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +48,54 @@ import yaml
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from utils.script_utils import ScriptFormatter  # noqa: E402
-from utils.service_registry import get_service_registry  # noqa: E402
+# --- Standalone replacements for backend-only modules (#11761) --------------
+# `utils/` exists only under autobot-backend/ and is not importable from this
+# directory; shared scripts stay standalone (#11759). Canonical source
+# mirrored below: autobot-backend/utils/service_registry.py (surface used
+# by this script: deployment_mode).
+
+
+class DeploymentMode(Enum):
+    """Deployment modes (mirrors backend utils/service_registry.py)."""
+
+    LOCAL = "local"
+    DOCKER_LOCAL = "docker_local"
+    DISTRIBUTED = "distributed"
+    KUBERNETES = "kubernetes"
+    CLOUD = "cloud"
+
+
+class ServiceRegistry:
+    """Env-driven standalone stand-in for the backend ServiceRegistry."""
+
+    def __init__(self):
+        """Initialize registry from environment."""
+        self.deployment_mode = self._detect_deployment_mode()
+
+    @staticmethod
+    def _detect_deployment_mode() -> DeploymentMode:
+        """Detect deployment mode from env, falling back to container heuristic."""
+        mode = os.environ.get("AUTOBOT_DEPLOYMENT_MODE", "").lower()
+        if mode:
+            try:
+                return DeploymentMode(mode)
+            except ValueError:
+                logger.warning("Invalid AUTOBOT_DEPLOYMENT_MODE: %s", mode)
+        return DeploymentMode.DOCKER_LOCAL if os.path.exists("/.dockerenv") else DeploymentMode.LOCAL
+
+
+_registry: Optional[ServiceRegistry] = None
+
+
+def get_service_registry() -> ServiceRegistry:
+    """Get the process-wide ServiceRegistry instance."""
+    global _registry
+    if _registry is None:
+        _registry = ServiceRegistry()
+    return _registry
+
+
+# --- end standalone replacements (#11761) -----------------------------------
 
 
 class LogLevel:
@@ -130,13 +178,26 @@ class LogAggregator:
         logger.info(f"   Logs Directory: {self.logs_dir}")
         logger.info(f"   Archive Directory: {self.archive_dir}")
 
-    def print_header(self, title: str):
+    # Standalone copies of ScriptFormatter.print_header/print_step
+    # (autobot-backend/utils/script_utils.py) — this script must not
+    # import backend modules (#11761).
+    def print_header(self, title: str, width: int = 60):
         """Print formatted header."""
-        ScriptFormatter.print_header(title)
+        print(f"\n{'=' * width}")  # noqa: print  # canonical: ignore py-print-smoke
+        print(f"  {title}")  # noqa: print  # canonical: ignore py-print-smoke
+        print("=" * width)  # noqa: print  # canonical: ignore py-print-smoke
 
     def print_step(self, step: str, status: str = "info"):
         """Print step with status."""
-        ScriptFormatter.print_step(step, status)
+        status_symbols = {
+            "info": "📋",
+            "success": "✅",
+            "warning": "⚠️",
+            "error": "❌",
+            "running": "🔄",
+        }
+        symbol = status_symbols.get(status, "📋")
+        print(f"{symbol} {step}")  # noqa: print  # canonical: ignore py-print-smoke
 
     def _configure_log_sources(self) -> Dict[str, Dict[str, Any]]:
         """Configure log sources based on deployment."""

--- a/autobot-infrastructure/shared/scripts/metrics_collector.py
+++ b/autobot-infrastructure/shared/scripts/metrics_collector.py
@@ -30,23 +30,162 @@ import asyncio
 import json
 import logging
 import os
+import socket
 import statistics
 import sys
 import threading
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from collections import defaultdict, deque
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+import psutil
+import yaml
 
 logger = logging.getLogger(__name__)
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from utils.script_utils import ScriptFormatter
-from utils.service_registry import get_service_registry
+# --- Standalone replacements for backend-only modules (#11761) --------------
+# `utils/` exists only under autobot-backend/ and is not importable from this
+# directory; shared scripts stay standalone (#11759). Canonical source
+# mirrored below: autobot-backend/utils/service_registry.py (surface used
+# by this script: check_all_services_health + get_service_url).
+
+
+class DeploymentMode(Enum):
+    """Deployment modes (mirrors backend utils/service_registry.py)."""
+
+    LOCAL = "local"
+    DOCKER_LOCAL = "docker_local"
+    DISTRIBUTED = "distributed"
+    KUBERNETES = "kubernetes"
+    CLOUD = "cloud"
+
+
+class ServiceStatus(Enum):
+    """Service health status (mirrors backend utils/service_registry.py)."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ServiceHealth:
+    """Service health state."""
+
+    status: ServiceStatus
+    last_check: float
+    response_time: float = 0.0
+
+
+# Port env aliases + defaults mirror autobot_shared/ssot_config.py;
+# health paths mirror autobot_shared/ssot_constants.py.
+_SERVICE_DEFS = {
+    "backend": ("AUTOBOT_BACKEND_PORT", 8001, "/api/health"),
+    "frontend": ("AUTOBOT_FRONTEND_PORT", 5173, "/"),
+    "redis": ("AUTOBOT_REDIS_PORT", 6379, None),
+    "ollama": ("AUTOBOT_OLLAMA_PORT", 11434, "/api/tags"),
+    "ai-stack": ("AUTOBOT_AI_STACK_PORT", 8080, "/health"),
+    "npu-worker": ("AUTOBOT_NPU_WORKER_PORT", 8081, "/health"),
+    "playwright-vnc": ("AUTOBOT_BROWSER_SERVICE_PORT", 9001, "/health"),
+}
+
+
+class ServiceRegistry:
+    """Env-driven standalone stand-in for the backend ServiceRegistry."""
+
+    def __init__(self):
+        """Initialize registry from environment."""
+        self.deployment_mode = self._detect_deployment_mode()
+        self.services: Dict[str, str] = {name: self._build_url(name) for name in _SERVICE_DEFS}
+
+    @staticmethod
+    def _detect_deployment_mode() -> DeploymentMode:
+        """Detect deployment mode from env, falling back to container heuristic."""
+        mode = os.environ.get("AUTOBOT_DEPLOYMENT_MODE", "").lower()
+        if mode:
+            try:
+                return DeploymentMode(mode)
+            except ValueError:
+                logger.warning("Invalid AUTOBOT_DEPLOYMENT_MODE: %s", mode)
+        return DeploymentMode.DOCKER_LOCAL if os.path.exists("/.dockerenv") else DeploymentMode.LOCAL
+
+    @staticmethod
+    def _build_url(name: str) -> str:
+        """Build a service base URL from environment overrides."""
+        host_env = f"AUTOBOT_{name.upper().replace('-', '_')}_HOST"
+        host = os.environ.get(host_env, "localhost")
+        port_env, default_port, _health = _SERVICE_DEFS[name]
+        port = int(os.environ.get(port_env, default_port))
+        scheme = "redis" if name == "redis" else "http"
+        return f"{scheme}://{host}:{port}"
+
+    def list_services(self) -> List[str]:
+        """List registered service names."""
+        return list(self.services)
+
+    def get_service_url(self, service_name: str, path: str = "") -> str:
+        """Get full URL for a service."""
+        if service_name not in self.services:
+            raise ValueError(f"Service '{service_name}' not found in registry")
+        return f"{self.services[service_name]}{path}"
+
+    @staticmethod
+    def _probe(url: str, timeout: float = 5.0) -> bool:
+        """Probe a service: TCP connect for redis, HTTP GET otherwise."""
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme == "redis":
+            try:
+                with socket.create_connection((parsed.hostname, parsed.port), timeout=timeout):
+                    return True
+            except OSError:
+                return False
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+                return response.status == 200
+        except (urllib.error.URLError, OSError, ValueError):
+            return False
+
+    async def check_service_health(self, service_name: str) -> ServiceHealth:
+        """Check health of a single service."""
+        _port_env, _default_port, health_path = _SERVICE_DEFS[service_name]
+        url = self.get_service_url(service_name, health_path or "")
+        start = time.time()
+        ok = await asyncio.get_running_loop().run_in_executor(None, self._probe, url)
+        return ServiceHealth(
+            status=ServiceStatus.HEALTHY if ok else ServiceStatus.UNHEALTHY,
+            last_check=time.time(),
+            response_time=time.time() - start,
+        )
+
+    async def check_all_services_health(self) -> Dict[str, ServiceHealth]:
+        """Check health of all registered services."""
+        names = self.list_services()
+        results = await asyncio.gather(*(self.check_service_health(name) for name in names))
+        return dict(zip(names, results))
+
+
+_registry: Optional[ServiceRegistry] = None
+
+
+def get_service_registry() -> ServiceRegistry:
+    """Get the process-wide ServiceRegistry instance."""
+    global _registry
+    if _registry is None:
+        _registry = ServiceRegistry()
+    return _registry
+
+
+# --- end standalone replacements (#11761) -----------------------------------
 
 
 @dataclass
@@ -130,13 +269,26 @@ class MetricsCollector:
         logger.info(f"   Storage Directory: {self.storage_dir}")
         logger.info(f"   Retention: {retention_days} days")
 
-    def print_header(self, title: str):
+    # Standalone copies of ScriptFormatter.print_header/print_step
+    # (autobot-backend/utils/script_utils.py) — this script must not
+    # import backend modules (#11761).
+    def print_header(self, title: str, width: int = 60):
         """Print formatted header."""
-        ScriptFormatter.print_header(title)
+        print(f"\n{'=' * width}")  # noqa: print  # canonical: ignore py-print-smoke
+        print(f"  {title}")  # noqa: print  # canonical: ignore py-print-smoke
+        print("=" * width)  # noqa: print  # canonical: ignore py-print-smoke
 
     def print_step(self, step: str, status: str = "info"):
         """Print step with status."""
-        ScriptFormatter.print_step(step, status)
+        status_symbols = {
+            "info": "📋",
+            "success": "✅",
+            "warning": "⚠️",
+            "error": "❌",
+            "running": "🔄",
+        }
+        symbol = status_symbols.get(status, "📋")
+        print(f"{symbol} {step}")  # noqa: print  # canonical: ignore py-print-smoke
 
     def _collect_cpu_and_memory_metrics(self, timestamp: float) -> List[Metric]:
         """Collect CPU and memory metrics.

--- a/autobot-infrastructure/shared/scripts/zero_downtime_deploy.py
+++ b/autobot-infrastructure/shared/scripts/zero_downtime_deploy.py
@@ -29,21 +29,80 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+import yaml
 
 logger = logging.getLogger(__name__)
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from constants.threshold_constants import TimingConstants
 from scripts.backup_manager import BackupManager
-from utils.script_utils import ScriptFormatter
-from utils.service_registry import get_service_registry
+
+# --- Standalone replacements for backend-only modules (#11761) --------------
+# `utils/` and `constants/` exist only under autobot-backend/ and are not
+# importable from this directory; shared scripts stay standalone (#11759).
+# Canonical sources mirrored below:
+#   autobot_shared/ssot_constants.py::TimingConstants
+#   autobot-backend/utils/service_registry.py (surface used by this script)
+
+
+class TimingConstants:
+    """Standalone copy of the timing values used by this script."""
+
+    LONG_DELAY = 10.0
+    ERROR_RECOVERY_LONG_DELAY = 30.0
+
+
+class DeploymentMode(Enum):
+    """Deployment modes (mirrors backend utils/service_registry.py)."""
+
+    LOCAL = "local"
+    DOCKER_LOCAL = "docker_local"
+    DISTRIBUTED = "distributed"
+    KUBERNETES = "kubernetes"
+    CLOUD = "cloud"
+
+
+class ServiceRegistry:
+    """Env-driven standalone stand-in for the backend ServiceRegistry."""
+
+    def __init__(self):
+        """Initialize registry from environment."""
+        self.deployment_mode = self._detect_deployment_mode()
+
+    @staticmethod
+    def _detect_deployment_mode() -> DeploymentMode:
+        """Detect deployment mode from env, falling back to container heuristic."""
+        mode = os.environ.get("AUTOBOT_DEPLOYMENT_MODE", "").lower()
+        if mode:
+            try:
+                return DeploymentMode(mode)
+            except ValueError:
+                logger.warning("Invalid AUTOBOT_DEPLOYMENT_MODE: %s", mode)
+        return DeploymentMode.DOCKER_LOCAL if os.path.exists("/.dockerenv") else DeploymentMode.LOCAL
+
+
+_registry: Optional[ServiceRegistry] = None
+
+
+def get_service_registry() -> ServiceRegistry:
+    """Get the process-wide ServiceRegistry instance."""
+    global _registry
+    if _registry is None:
+        _registry = ServiceRegistry()
+    return _registry
+
+
+# --- end standalone replacements (#11761) -----------------------------------
 
 
 class DeploymentStrategy:
@@ -89,13 +148,26 @@ class ZeroDowntimeDeployer:
         logger.info(f"   Deployment Directory: {self.deployment_dir}")
         logger.info("   Strategy Support: Blue-Green, Rolling, Canary")
 
-    def print_header(self, title: str):
+    # Standalone copies of ScriptFormatter.print_header/print_step
+    # (autobot-backend/utils/script_utils.py) — this script must not
+    # import backend modules (#11761).
+    def print_header(self, title: str, width: int = 60):
         """Print formatted header."""
-        ScriptFormatter.print_header(title)
+        print(f"\n{'=' * width}")  # noqa: print  # canonical: ignore py-print-smoke
+        print(f"  {title}")  # noqa: print  # canonical: ignore py-print-smoke
+        print("=" * width)  # noqa: print  # canonical: ignore py-print-smoke
 
     def print_step(self, step: str, status: str = "info"):
         """Print step with status."""
-        ScriptFormatter.print_step(step, status)
+        status_symbols = {
+            "info": "📋",
+            "success": "✅",
+            "warning": "⚠️",
+            "error": "❌",
+            "running": "🔄",
+        }
+        symbol = status_symbols.get(status, "📋")
+        print(f"{symbol} {step}")  # noqa: print  # canonical: ignore py-print-smoke
 
     def _load_deployment_config(self) -> Dict[str, Any]:
         """Load deployment configuration."""


### PR DESCRIPTION
Closes #11761

## Thinking Path

All 6 remaining `autobot-infrastructure/shared/scripts/` CLIs died at import (phantom `utils`/`constants` modules that never existed in the directory, plus missing stdlib/dep imports). Repair pattern follows the merged #11765 `secrets_manager.py` fix exactly: standalone-ness preserved (zero backend imports), real deps imported top-level, small helpers inlined with canonical-source comments (ports/paths mirror `ssot_config`/`ssot_constants` env aliases, env-overridable).

## What Changed

Per script: `log_aggregator` (inline mode-only ServiceRegistry + formatter), `deployment_rollback` (inline TimingConstants + TCP/HTTP health registry + missing `yaml`), `metrics_collector` (registry + missing `psutil`/`yaml`), `backup_manager` (trimmed registry + `Enum`), `zero_downtime_deploy` (TimingConstants + registry + missing `yaml`/`aiohttp`), `deploy_autobot` (missing `logging` + DeploymentMode enum registry). Internal `scripts.backup_manager` cross-import preserved and now clean.

## Verification

- All 7 scripts (6 fixed + secrets_manager): `--help` exit 0 — agent matrix AND independent re-run by main session; py_compile + flake8 clean.
- Inlined registry smoke-tested live on this box: mode detection, redis URL build, `check_all_services_health` return real results.
- Invoker grep (ansible/workflows/Makefiles/package.json/shell/docs): none reference these CLIs — kept per never-delete rule, now healthy for operator use.

Discovery filed: #11779 — zero_downtime_deploy blue-green path calls two never-defined methods (pre-existing runtime rot, out of import-health scope).

## Model Used

Claude Fable 5 (subagent: general-purpose)