### PR TITLE
fix(slm/roles): pass role_name so Migrate/Redeploy runs — deploy_role.yml guard was failing every redeploy (#11782)

### DIFF
--- a/autobot-slm-backend/api/roles.py
+++ b/autobot-slm-backend/api/roles.py
@@ -393,8 +393,11 @@ async def _run_role_migration(role: Role, target_node_id: str) -> dict:
     try:
         result = await executor.execute_playbook(
             playbook_name=role.ansible_playbook,
+            # deploy_role.yml requires `role_name` and derives deploy_role from
+            # it; passing `deploy_role` alone tripped its role_name-undefined
+            # guard so every Migrate/Redeploy failed validation (#11782).
             limit=[target_node_id],
-            extra_vars={"deploy_role": role.name},
+            extra_vars={"role_name": role.name},
         )
     except FileNotFoundError as exc:
         logger.exception("Playbook not found: %s", role.ansible_playbook)

--- a/autobot-slm-backend/tests/api/test_role_migration_extra_vars.py
+++ b/autobot-slm-backend/tests/api/test_role_migration_extra_vars.py
@@ -1,0 +1,86 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""_run_role_migration must pass role_name, not deploy_role (#11782).
+
+ansible/playbooks/deploy_role.yml hard-fails ("role_name parameter is
+required") when role_name is undefined and derives deploy_role from it, so
+the endpoint must supply role_name for any Migrate/Redeploy to run.
+
+Loads api/roles.py directly via importlib with fine-grained stubs (mirrors
+tests/api/test_apply_secrets.py) — the shared conftest stubs config/models/
+services for the whole session, so we swap throwaway stand-ins and restore.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+_STUB_MODULE_NAMES = [
+    "sqlalchemy",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.asyncio",
+    "models",
+    "models.database",
+    "services",
+    "services.auth",
+    "services.database",
+    "services.role_registry",
+    "services.playbook_executor",
+]
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _load_roles_module():
+    import fastapi  # noqa: F401
+    import pydantic  # noqa: F401
+    import typing_extensions  # noqa: F401
+
+    saved = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    try:
+        for name in _STUB_MODULE_NAMES:
+            sys.modules[name] = MagicMock()
+        spec = importlib.util.spec_from_file_location("_roles_migration_test", _BACKEND_ROOT / "api" / "roles.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+_roles_mod = _load_roles_module()
+
+
+def test_migration_passes_role_name_not_deploy_role():
+    role = MagicMock()
+    role.name = "tts-worker"
+    role.ansible_playbook = "playbooks/deploy_role.yml"
+
+    fake_exec = MagicMock()
+    fake_exec.execute_playbook = AsyncMock(return_value={"success": True, "output": "ok", "returncode": 0})
+
+    # _run_role_migration does a local `from services.playbook_executor import
+    # PlaybookExecutor`, so install a stub module exposing it for the call.
+    stub_pe = MagicMock()
+    stub_pe.PlaybookExecutor = MagicMock(return_value=fake_exec)
+    with patch.dict(sys.modules, {"services.playbook_executor": stub_pe}):
+        _run(_roles_mod._run_role_migration(role, "00-SLM-Manager"))
+
+    kwargs = fake_exec.execute_playbook.call_args.kwargs
+    assert kwargs["extra_vars"] == {"role_name": "tts-worker"}
+    assert "deploy_role" not in kwargs["extra_vars"]
+    assert kwargs["limit"] == ["00-SLM-Manager"]


### PR DESCRIPTION
## Thinking Path

Deploying #11718's tts-worker.py.j2 change to the live box (builtin-only) surfaced this: the role Migrate/Redeploy path — the only builtin way to redeploy a single managed role — hard-fails. `POST /api/roles/tts-worker/migrate` returned `role_name parameter is required` from `deploy_role.yml`'s guard, because the endpoint passed `deploy_role` while the playbook requires `role_name` (and derives deploy_role from it). This broke the #11719 Redeploy button at its foundation.

## What Changed

- `autobot-slm-backend/api/roles.py` — `_run_role_migration` now passes `extra_vars={"role_name": role.name}` (the SoT the playbook consumes) instead of `deploy_role`.
- `autobot-slm-backend/tests/api/test_role_migration_extra_vars.py` — asserts the endpoint passes `role_name` (not `deploy_role`) and the correct `--limit`.

## Verification

- `pytest tests/api/test_role_migration_extra_vars.py` → **1 passed**
- black / flake8 / py_compile clean
- Live repro on 00-SLM-Manager before fix: `TASK [Validate role_name parameter] fatal: role_name parameter is required` (PLAY RECAP failed=1)

Closes #11782

## Model Used

Fable 5 (inline implementation)
