### PR TITLE
fix(types): regenerate api.ts — ChatSecretScope rename from #11759 (#11783)

### DIFF
--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -60032,6 +60032,17 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * ChatSecretScope
+         * @description Scope enumeration for the legacy Redis chat-secrets store (api/secrets.py).
+         *
+         *     Distinct from the canonical authorization scope ``ScopeLevel``
+         *     (``autobot_shared.scoping.scope_level``, aliased as ``SecretScope`` in
+         *     ``models/secret.py``): this enum adds CHAT/GENERAL for chat-vs-global
+         *     secret pools and has no WORKFLOW member (#11759).
+         * @enum {string}
+         */
+        ChatSecretScope: "chat" | "general" | "user" | "session" | "shared" | "group" | "organization";
+        /**
          * ChatSecretsDeleteData
          * @description Response data for delete_chat_secrets.
          */
@@ -89918,7 +89929,7 @@ export interface components {
             /** Name */
             name: string;
             type: components["schemas"]["SecretType"];
-            scope: components["schemas"]["SecretScope"];
+            scope: components["schemas"]["ChatSecretScope"];
             /** Value */
             value: string;
             /** Chat Id */
@@ -90002,12 +90013,6 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /**
-         * SecretScope
-         * @description Secret scope enumeration.
-         * @enum {string}
-         */
-        SecretScope: "chat" | "general" | "user" | "session" | "shared" | "group" | "organization";
         /** SecretSetRequest */
         SecretSetRequest: {
             /** Name */
@@ -90079,7 +90084,7 @@ export interface components {
         SecretTransferRequest: {
             /** Secret Ids */
             secret_ids: string[];
-            target_scope: components["schemas"]["SecretScope"];
+            target_scope: components["schemas"]["ChatSecretScope"];
             /** Target Chat Id */
             target_chat_id?: string | null;
         } & {
@@ -141430,7 +141435,7 @@ export interface operations {
         parameters: {
             query?: {
                 chat_id?: string | null;
-                scope?: components["schemas"]["SecretScope"] | null;
+                scope?: components["schemas"]["ChatSecretScope"] | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
Closes #11783

## Thinking Path

`verify-generated-types` is red on base for every new PR (#11769–#11776 all fail with "api.ts is stale"): the #11765 `SecretScope`→`ChatSecretScope` rename changed the OpenAPI schema, but its own check ran against the pre-stack base (BEHIND-merge blind spot), so the regen never landed. Regenerated via the CI recipe (audit_api_wiring --dump-openapi → strip x-websocket-paths → openapi-typescript 7.13.0); machine-local `@default` path/URL noise from the local dump was normalized back to CI's values so the diff is purely semantic.

## What Changed

- `autobot-frontend/src/types/generated/api.ts`: `SecretScope` schema block → `ChatSecretScope` (new docstring included), 3 field references updated (`scope`, `target_scope`, optional `scope?`). 14+/9− lines, zero non-semantic churn (verified by filtered diff).

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json`: clean.
- This PR's own `verify-generated-types` run is the authoritative arbiter — if the CI regen still differs, the auto-fix-generated-types bot pushes its version to this branch and that commit wins (repo convention).

## Model Used

Claude Fable 5