### PR TITLE
fix(ci): hard-exclude oxlint >=1.74 from dependabot group — plugin peer-pin lockstep (#11786)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -140,6 +140,12 @@ updates:
         # (ERESOLVE on every PR, see #11746). Same pattern as the protobuf/
         # websockets caps above. Unblock when the pinia 4 major is taken.
         versions: [">=2.0.0"]
+      - dependency-name: "oxlint"
+        # #11786: eslint-plugin-oxlint peer-pins oxlint@~1.73 (lockstep minor)
+        # and has no 1.74 release — grouped oxlint bump alone is unsatisfiable
+        # (ERESOLVE on every PR, see #11771). Unblock when eslint-plugin-oxlint
+        # ships the matching minor, then bump both together.
+        versions: [">=1.74.0"]
 
   - package-ecosystem: "npm"
     directory: "/autobot-slm-frontend"


### PR DESCRIPTION
Closes #11786

## Thinking Path

PR #11771 (frontend group) fails npm install with ERESOLVE: the group bumps `oxlint` to ~1.74.0 but `eslint-plugin-oxlint@1.73.0` peer-pins `oxlint@~1.73.0` and has no matching 1.74 release. Hard version exclusion is the established remedy for unsatisfiable group members (protobuf #10474, websockets #10386, @pinia/testing #11753) — semver ignores alone don't stop grouped re-proposals.

## What Changed

- `.github/dependabot.yml` frontend npm entry: `oxlint` `versions: [">=1.74.0"]` with explanatory comment; unblock when eslint-plugin-oxlint ships the matching minor (they move in lockstep).

## Verification

- `yaml.safe_load` clean; pattern-identical to the three existing hard-excludes in the same file.
- NOTE: effective from the default branch (main) at the next promotion; then `@dependabot recreate` regenerates the group (20 remaining updates) without the poisoned member.

## Model Used

Claude Fable 5