### PR TITLE
fix(test): repair orchestration checkpoint-resumer rot + workflow_memory state bleed (#11754)

### DIFF
--- a/autobot-backend/orchestration/conftest.py
+++ b/autobot-backend/orchestration/conftest.py
@@ -1,0 +1,29 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared fixtures for the orchestration test suite.
+
+Issue #11754: circuit-breaker state is process-global (``CircuitBreakerManager``
+singleton via ``lazy_singleton``), so step failures driven by one test file
+(e.g. ``execution_modes_test.py`` exercising real failing steps through the
+``workflow_step_execution`` breaker) tripped the breaker OPEN and made
+unrelated tests fail with ``CircuitBreakerOpenError`` in group runs while
+passing standalone.  Every orchestration test starts with all breakers CLOSED.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_circuit_breakers():
+    """Reset all registered circuit breakers before each test (#11754).
+
+    Import is deferred to test time so the fixture binds to the same
+    ``circuit_breaker`` module object the production code uses (the root
+    conftest real-loads/stubs modules during its own import).
+    """
+    from circuit_breaker import get_circuit_breaker_manager
+
+    get_circuit_breaker_manager().reset_all_circuit_breakers()
+    yield

--- a/autobot-backend/orchestration/workflow_executor_checkpoint_test.py
+++ b/autobot-backend/orchestration/workflow_executor_checkpoint_test.py
@@ -56,8 +56,8 @@ async def test_checkpoint_failure_does_not_propagate_in_execute_step_with_agent(
     step: Dict[str, Any] = {"id": "step-1", "status": None, "result": None}
     successful_result = {"success": True, "output": "done"}
 
-    # Checkpoint storage raises a transient error.
-    executor._checkpoint_manager.save = MagicMock(side_effect=OSError("Redis unavailable"))
+    # Checkpoint storage (CheckpointResumer, #6827) raises a transient error.
+    executor._checkpoint_resumer.save = MagicMock(side_effect=OSError("Redis unavailable"))
 
     async def _fake_retry(s, ec, ctx):
         return successful_result
@@ -82,7 +82,7 @@ async def test_checkpoint_success_called_once_on_happy_path():
     successful_result = {"success": True, "output": "done"}
 
     save_spy = MagicMock()
-    executor._checkpoint_manager.save = save_spy
+    executor._checkpoint_resumer.save = save_spy
 
     async def _fake_retry(s, ec, ctx):
         return successful_result
@@ -104,7 +104,7 @@ async def test_checkpoint_not_called_when_step_fails():
     failed_result = {"success": False, "error": "agent error"}
 
     save_spy = MagicMock()
-    executor._checkpoint_manager.save = save_spy
+    executor._checkpoint_resumer.save = save_spy
 
     async def _fake_retry(s, ec, ctx):
         return failed_result


### PR DESCRIPTION
Closes #11754

## Thinking Path

Five pre-existing orchestration failures (baselined during #6828). Two root causes: the #6827 refactor renamed the checkpoint delegation seam (`_checkpoint_manager` → `_checkpoint_resumer`) and three spies still pointed at the deleted attribute; and the process-global circuit-breaker singleton accumulated failures from `execution_modes_test.py`, opening the `workflow_step_execution` breaker so two workflow_memory tests hit `CircuitBreakerOpenError` in group runs (confirmed with a minimal 2-file repro).

## What Changed

- `orchestration/workflow_executor_checkpoint_test.py`: 3 spies re-pointed to `executor._checkpoint_resumer.save` — the behavioral assertions were already correct against the delegation seam.
- New `orchestration/conftest.py`: autouse fixture calling `get_circuit_breaker_manager().reset_all_circuit_breakers()` (the established reset seam) before every orchestration test — no reordering, no flaky marks; every test starts with breakers CLOSED.

## Verification

- Before: 3 failed standalone (AttributeError) + 2 failed in group runs; full group 5 failed / 708 passed.
- After: full group (`tests/orchestration/ + orchestration/ + services/mesh_brain/`) **713 passed, 0 failed**; polluter pair 60 passed (agent). Independent re-run: the three repaired files 63 passed.
- flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)