### PR TITLE
fix(auth): repair require_device_jwt rot — await, canonical scopes, wire to device endpoints (#11736)

### DIFF
--- a/autobot-backend/api/mobile_devices.py
+++ b/autobot-backend/api/mobile_devices.py
@@ -9,6 +9,7 @@ Endpoints:
   POST   /api/devices/pair          — complete pairing via QR challenge token
   GET    /api/devices/pair-qr       — get a time-limited QR challenge token
   GET    /api/devices               — list devices for the current user
+  GET    /api/devices/me            — device-JWT-only identity + heartbeat (#11736)
   DELETE /api/devices/{device_id}   — unpair a device
 
 Device tokens expire after 90 days of inactivity; the GET list endpoint
@@ -26,7 +27,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_db_session
-from auth_middleware import get_current_user
+from auth_middleware import get_current_user, require_device_jwt
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
@@ -37,6 +38,10 @@ from models.mobile_device import DevicePlatform, MobileDevice
 logger = get_logger(__name__)
 metrics = get_metrics_manager()
 router = APIRouter()
+
+# GH#9493/#11736: device-JWT-only auth (read scope suffices for GET /me).
+# Module-level so tests can target it with app.dependency_overrides.
+_device_jwt_auth = require_device_jwt()
 
 # QR challenge TTL — 5 minutes is ample for a human to scan
 _QR_CHALLENGE_TTL_SECONDS = 300
@@ -79,6 +84,13 @@ class PairSuccessResponse(BaseModel):
     device_id: uuid.UUID
     device_jwt: str = Field(description="Long-lived JWT for device authentication (GH#9493)")
     message: str = "Device paired successfully"
+
+
+class DeviceIdentityResponse(BaseModel):
+    device_id: uuid.UUID
+    user_id: str
+    scope: str = Field(description="Device JWT scope: 'read' or 'write' (GH#9493)")
+    last_seen_at: str = Field(description="Heartbeat timestamp refreshed by this call")
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +242,45 @@ async def list_devices(
             )
             for d in active
         ]
+    )
+
+
+@router.get("/me", response_model=DeviceIdentityResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_device_identity",
+    error_code_prefix="MOBILE_DEVICE",
+)
+async def get_device_identity(
+    device_user: dict = Depends(_device_jwt_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> DeviceIdentityResponse:
+    """Device token introspection + activity heartbeat (GH#9493, #11736).
+
+    Accepts ONLY a device JWT (require_device_jwt); user sessions get 401.
+    Returns the calling device's identity claims and refreshes last_seen_at
+    so actively-used devices are not pruned by the 90-day inactivity sweep.
+    """
+    try:
+        device_uuid = uuid.UUID(str(device_user["device_id"]))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Valid device token required")
+
+    result = await session.execute(select(MobileDevice).where(MobileDevice.id == device_uuid))
+    device = result.scalar_one_or_none()
+    if device is None:
+        # validate_device_jwt caches device existence for up to 60 s — the
+        # row can vanish between the cached check and this fresh read.
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Device has been revoked")
+
+    device.last_seen_at = now_utc()
+    await session.commit()
+
+    return DeviceIdentityResponse(
+        device_id=device.id,
+        user_id=str(device_user["user_id"]),
+        scope=str(device_user.get("scope", "read")),
+        last_seen_at=device.last_seen_at.isoformat(),
     )
 
 

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -842,8 +842,10 @@ async def get_current_user(request: Request) -> Dict:
     MCP bridge workers and long-running tasks can authenticate without a
     full user session.  Scope enforcement is left to individual endpoints.
 
-    MVA-3237: Device JWTs are REJECTED by default. Use require_device_jwt()
-    dependency instead for mobile-accessible endpoints.
+    GH#9493: Device JWTs authenticate ONLY on /api/devices/ endpoints
+    (path allow-list + read/write scope enforcement below). Device-only
+    endpoints use the require_device_jwt() dependency factory instead
+    (#11736).
 
     Raises HTTPException if authentication fails.
     """
@@ -856,8 +858,8 @@ async def get_current_user(request: Request) -> Dict:
     # Primary: user JWT / session / dev-header auth (sync, no Redis needed)
     user_data = middleware.get_user_from_request(request)
     if user_data:
-        # MVA-3237 Security: Reject device JWTs from get_current_user
-        # Device tokens must use require_device_jwt() dependency explicitly
+        # Defensive: get_user_from_request never yields device-JWT users; the
+        # GH#9493 device-JWT path (allow-list + scope checks) is below.
         if user_data.get("auth_method") == "device_jwt":
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -952,79 +954,57 @@ def check_admin_permission(request: Request) -> bool:
     return True
 
 
-async def require_device_jwt(
-    request: Request,
-    min_scope: str = "read-only",
-) -> Dict:
+def require_device_jwt(min_scope: str = "read"):
     """
-    FastAPI dependency for mobile device JWT authentication (MVA-3237).
+    FastAPI dependency factory for device-JWT-ONLY endpoints (GH#9493, #11736).
 
-    This is the ONLY way device JWTs can authenticate to API endpoints.
-    Validates the device still exists and enforces minimum scope.
+    Unlike :func:`get_current_user` (which accepts device JWTs only as a
+    fallback on ``/api/devices/`` paths), the returned dependency accepts
+    ONLY device JWTs — user sessions and every other token type get 401.
+    Use it on endpoints a paired mobile device calls about itself.
 
-    Security model (fail-closed):
-    - Device JWTs are REJECTED by get_current_user() by default
-    - Only endpoints using this dependency accept device tokens
-    - Device existence is validated on every request (revocation check)
-    - Minimum scope is enforced
+    Delegates validation to the canonical ``services.device_jwt`` contract
+    via ``_extract_user_from_device_jwt`` (signature + ``aud`` claim +
+    device-existence/revocation check) so there is a single validation seam.
+    A revoked (unpaired) device fails extraction and receives 401.
 
     Use as:
-        # Read-only endpoint (default)
-        Depends(require_device_jwt)
-
-        # Admin-only endpoint
-        Depends(lambda r: require_device_jwt(r, min_scope="admin"))
+        Depends(require_device_jwt())         # read scope suffices
+        Depends(require_device_jwt("write"))  # mutating endpoints
 
     Args:
-        request: FastAPI Request object
-        min_scope: Minimum required scope ("read-only" or "admin")
+        min_scope: Minimum required scope — one of
+            ``services.device_jwt.VALID_SCOPES`` ({"read", "write"}).
 
     Returns:
-        User dict with device-specific fields
+        Async dependency returning the synthetic device-user dict
+        (``auth_method="device_jwt"``).
 
     Raises:
-        HTTPException: 401 if not a device JWT, 403 if insufficient scope or device revoked
+        ValueError: At route-definition time if ``min_scope`` is not a
+            canonical scope (the legacy MVA-3237 "read-only"/"admin"
+            scopes are not mintable and are rejected here too).
     """
-    middleware = get_auth_middleware()
-    user_data = middleware._extract_user_from_device_jwt(request)
+    from services.device_jwt import VALID_SCOPES
 
-    if not user_data:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Valid device token required",
-        )
+    if min_scope not in VALID_SCOPES:
+        raise ValueError(f"Invalid min_scope: {min_scope!r}. Valid: {sorted(VALID_SCOPES)}")
 
-    # Validate device still exists (revocation check)
-    device_id = user_data.get("device_id")
-    if device_id:
-        from sqlalchemy import select
+    async def _require_device_jwt(request: Request) -> Dict:
+        user_data = await get_auth_middleware()._extract_user_from_device_jwt(request)
+        if not user_data:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Valid device token required",
+            )
+        if min_scope == "write" and user_data.get("scope") != "write":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Device token requires write scope for this operation",
+            )
+        return user_data
 
-        from api.user_management.dependencies import get_db_session
-        from models.mobile_device import MobileDevice
-
-        # Get DB session
-        session_gen = get_db_session()
-        session = await anext(session_gen)
-        try:
-            result = await session.execute(select(MobileDevice).where(MobileDevice.id == device_id))
-            device = result.scalar_one_or_none()
-            if device is None:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Device has been revoked",
-                )
-        finally:
-            await session.close()
-
-    # Enforce minimum scope
-    scope = user_data.get("scope", "")
-    if min_scope == "admin" and scope != "admin":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Device token requires admin scope for this operation",
-        )
-
-    return user_data
+    return _require_device_jwt
 
 
 async def authenticate_websocket(websocket) -> dict | None:

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -482,6 +482,25 @@ if "auth_middleware" not in sys.modules:
         return True
 
     _auth_stub.check_admin_permission = _check_admin_permission_stub  # type: ignore[attr-defined]
+
+    # require_device_jwt is a dependency FACTORY (GH#9493/#11736) invoked at
+    # module import time — it must return a no-arg callable so FastAPI can
+    # inspect the signature at route registration without producing spurious
+    # (*args, **kwargs) query parameters (same rationale as above, #10472).
+    def _require_device_jwt_stub(min_scope: str = "read"):  # noqa: E301
+        def _device_jwt_dep():
+            return {
+                "username": "device:stub-device",
+                "user_id": "stub-user",
+                "role": "device",
+                "device_id": "00000000-0000-0000-0000-000000000000",
+                "scope": min_scope,
+                "auth_method": "device_jwt",
+            }
+
+        return _device_jwt_dep
+
+    _auth_stub.require_device_jwt = _require_device_jwt_stub  # type: ignore[attr-defined]
     _auth_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
     sys.modules["auth_middleware"] = _auth_stub
 

--- a/autobot-backend/docs/device-token-authentication.md
+++ b/autobot-backend/docs/device-token-authentication.md
@@ -1,67 +1,54 @@
-# Device Token JWT Authentication (MVA-3237)
+# Device JWT Authentication (GH#9493)
 
-Security audit [MVA-3084](/MVA/issues/MVA-3084) identified that device token JWT authentication and scoping specified in Phase 1 ([MVA-3081](/MVA/issues/MVA-3081)) was not implemented. This document describes the implementation.
+Mobile devices paired via QR code receive a long-lived, device-scoped JWT that
+authenticates API requests independently from the desktop session. This
+document describes the canonical GH#9493 contract (the earlier MVA-3237
+`read-only`/`admin` design was retired; see #11648/#11736 for the cleanup).
 
 ## Overview
 
-Mobile devices paired via QR code receive a JWT token that allows them to authenticate API requests independently from the desktop session. This provides:
+- **Independent authentication**: devices don't need the desktop to stay connected
+- **Scoped access**: `read` / `write` scopes prevent privilege escalation
+- **Narrow allow-list**: device JWTs authenticate only on `/api/devices/` endpoints
+- **Active revocation**: device existence is checked on every validation
 
-- **Independent authentication**: Devices don't need the desktop to stay connected
-- **Scoped access**: Tokens are scoped to prevent privilege escalation
-- **Audit trail**: Device actions are logged separately from user sessions
+Canonical implementation: `autobot-backend/services/device_jwt.py`
+(`mint_device_jwt`, `validate_device_jwt`, `VALID_SCOPES`).
 
 ## JWT Structure
 
-Device JWTs contain the following claims:
-
 ```json
 {
-  "sub": "<device_id>",
+  "aud": "autobot:device",
+  "device_id": "<device_id>",
   "user_id": "<user_id>",
-  "scope": "read-only" | "admin",
-  "type": "device_token",
-  "exp": <timestamp>
+  "scope": "read" | "write",
+  "exp": 1234567890
 }
 ```
 
-- **sub**: Device UUID from `desktop_mobile_devices.id`
+- **aud**: Audience claim, `autobot:device` by default (`DEVICE_JWT_AUDIENCE`)
+- **device_id**: Device UUID from `desktop_mobile_devices.id`
 - **user_id**: Owner user ID
-- **scope**: Token scope (`read-only` or `admin`)
-- **type**: Always `"device_token"` to distinguish from user JWTs
-- **exp**: Expiry timestamp (default 90 days)
+- **scope**: One of `services.device_jwt.VALID_SCOPES` — `read` or `write`
+- **exp**: Expiry timestamp (default 90 days, `DEVICE_JWT_TTL_DAYS`)
 
 ## Scopes
 
-### read-only
+| Scope | HTTP methods allowed |
+| --- | --- |
+| `read` (default) | GET / HEAD / OPTIONS only |
+| `write` | All methods, including POST / PUT / PATCH / DELETE |
 
-**Default scope** for all newly paired devices. Allows:
-- Reading conversations
-- Reading knowledge base entries
-- Receiving push notifications
-- Syncing conversation history
-
-**Rejects**:
-- Creating/updating/deleting conversations
-- Modifying knowledge base
-- Admin operations
-- User management
-
-### admin
-
-**Elevated scope** (requires manual promotion). Allows:
-- All read-only operations
-- Creating/updating conversations
-- Modifying knowledge base (if user has permission)
-
-**Still rejects**:
-- User management (requires full user session)
-- System admin operations (requires full user session)
+Newly paired devices are minted `read` tokens (least privilege). Any other
+scope value (including the retired `read-only`/`admin`) is rejected by
+`mint_device_jwt` and by the `require_device_jwt` dependency factory.
 
 ## Authentication Flow
 
 ### 1. Device Pairing
 
-```
+```text
 Desktop                                Mobile App
    |                                       |
    | GET /api/devices/pair-qr             |
@@ -83,175 +70,115 @@ Desktop                                Mobile App
 
 ### 2. API Requests
 
-Mobile app includes the device JWT in the `Authorization` header:
+The mobile app sends the device JWT in the `Authorization` header:
 
 ```http
-GET /api/conversations
+GET /api/devices/me
 Authorization: Bearer <device_jwt>
 ```
 
-The middleware:
-1. Extracts the Bearer token
-2. Validates it as a device JWT (checks `type: "device_token"`)
-3. Returns a synthetic user dict with `auth_method: "device_jwt"`
+`get_current_user` accepts device JWTs as a fallback and enforces:
 
-### 3. Scope Enforcement (Fail-Closed Security Model)
+1. Signature + expiry + `aud` claim via `validate_device_jwt`
+2. Device still exists in the database (revocation check, 60 s Redis cache)
+3. Path allow-list — device JWTs are valid ONLY under `/api/devices/`
+4. Scope — `read` tokens are rejected for mutating HTTP methods
 
-**Important**: Device JWTs are **REJECTED by default** by `get_current_user()`. This fail-closed model prevents accidental privilege escalation.
+### 3. Device-Only Endpoints — `require_device_jwt`
 
-Endpoints that should be accessible to mobile devices must explicitly use the `require_device_jwt` dependency:
+`require_device_jwt` (in `auth_middleware.py`) is a **dependency factory**
+for endpoints that accept ONLY device JWTs — user sessions and every other
+token type get 401. It delegates to the same canonical validation seam as
+`get_current_user` (`validate_device_jwt`, including the revocation check).
 
 ```python
-# Read-only endpoint (accessible to all device tokens)
-@router.get("/conversations")
-async def list_conversations(
-    current_user: Dict = Depends(require_device_jwt),  # Accepts read-only and admin
-    ...
+from auth_middleware import require_device_jwt
+
+# read scope suffices
+@router.get("/me")
+async def get_device_identity(
+    device_user: dict = Depends(require_device_jwt()),
 ):
     ...
 
-# Admin-only endpoint (requires admin scope)
-@router.post("/conversations")
-async def create_conversation(
-    current_user: Dict = Depends(lambda r: require_device_jwt(r, min_scope="admin")),
-    ...
+# mutating endpoint — write scope required (read tokens get 403)
+@router.post("/heartbeat")
+async def device_heartbeat(
+    device_user: dict = Depends(require_device_jwt("write")),
 ):
-    # Only device tokens with admin scope can access this
-    ...
-
-# User-only endpoint (device tokens blocked)
-@router.get("/admin/users")
-async def list_users(
-    current_user: Dict = Depends(get_current_user),  # Rejects device JWTs
-    ...
-):
-    # Only full user sessions can access this
     ...
 ```
 
-The `require_device_jwt` dependency:
-- Validates the device JWT
-- Checks the device still exists in the database (revocation check)
-- Enforces minimum scope requirement
-- Returns user data with device-specific fields
+An invalid `min_scope` raises `ValueError` at route-definition time.
+
+Production wiring: `GET /api/devices/me` (`api/mobile_devices.py`) — device
+token introspection plus a `last_seen_at` heartbeat so actively-used devices
+are not pruned by the 90-day inactivity sweep (#11736).
 
 ## API Endpoint Authorization
 
-### Accepts Device Tokens (Read-Only)
-
-| Endpoint | Method | Scope Required |
-|----------|--------|----------------|
-| `/api/conversations` | GET | read-only |
-| `/api/conversations/{id}` | GET | read-only |
-| `/api/conversations/{id}/messages` | GET | read-only |
-| `/api/knowledge` | GET | read-only |
-| `/api/devices` | GET | read-only |
-
-### Requires Admin Scope or User Session
-
-| Endpoint | Method | Scope Required |
-|----------|--------|----------------|
-| `/api/conversations` | POST | admin or user session |
-| `/api/conversations/{id}` | PATCH | admin or user session |
-| `/api/conversations/{id}` | DELETE | admin or user session |
-| `/api/conversations/{id}/messages` | POST | admin or user session |
-| `/api/knowledge` | POST/PATCH/DELETE | admin or user session |
-
-### Requires User Session Only (No Device Tokens)
-
-| Endpoint | Method | Reason |
-|----------|--------|--------|
-| `/api/users` | ALL | User management requires full session |
-| `/api/admin/*` | ALL | System admin operations |
-| `/api/devices/pair-qr` | GET | QR generation tied to active desktop session |
-| `/api/devices/{id}` | DELETE | Device unpairing requires desktop confirmation |
+| Endpoint | Method | Auth |
+| --- | --- | --- |
+| `/api/devices/pair-qr` | GET | User session (QR generation tied to desktop) |
+| `/api/devices/pair` | POST | Challenge token (bound to user at QR time) |
+| `/api/devices` | GET | User session (list own devices) |
+| `/api/devices/me` | GET | Device JWT ONLY (`require_device_jwt()`) |
+| `/api/devices/{id}` | DELETE | User session, or write-scoped device JWT |
+| Everything else | ALL | Device JWTs rejected (403 outside `/api/devices/`) |
 
 ## Configuration
 
-### Environment Variables
-
 ```bash
-# Device JWT signing secret (separate from user JWT secret)
-DEVICE_JWT_SECRET=<64-char-secret>
-
-# Token lifetime in days (default: 90)
-DEVICE_JWT_TTL_DAYS=90
+DEVICE_JWT_SECRET=<64-char-secret>   # falls back to AUTOBOT_JWT_SECRET
+DEVICE_JWT_TTL_DAYS=90               # token lifetime
+DEVICE_JWT_CACHE_TTL=60              # device-existence cache TTL (seconds)
+DEVICE_JWT_AUDIENCE=autobot:device   # expected aud claim
 ```
-
-If `DEVICE_JWT_SECRET` is not set, falls back to `AUTOBOT_JWT_SECRET`.
-
-### Database
-
-The `desktop_mobile_devices` table includes a `token_scope` column:
-
-```sql
-ALTER TABLE desktop_mobile_devices 
-ADD COLUMN token_scope VARCHAR(32) NOT NULL DEFAULT 'read-only';
-```
-
-Migration: `20260604_052_device_token_scope.py`
 
 ## Security Considerations
 
 ### Fail-Closed Authorization Model
 
-Device JWTs use a **fail-closed** security model:
-
-1. **Default Deny**: `get_current_user()` rejects device JWTs - they cannot access standard user endpoints
-2. **Explicit Allowlist**: Only endpoints using `require_device_jwt` accept device tokens
-3. **Revocation Check**: Every request validates the device still exists in the database
-4. **Scope Enforcement**: Minimum scope is validated on every request
-
-This prevents:
-- Privilege escalation via device tokens
-- Revoked devices from accessing APIs (JWT still valid but device deleted)
-- Accidental exposure of admin endpoints to mobile devices
-
-### Scope Promotion
-
-Promoting a device from `read-only` to `admin` scope:
-
-1. Requires desktop user session (not another device token)
-2. Requires explicit user confirmation
-3. Logged to audit trail
-4. New JWT minted with updated scope
-
-**TODO**: Implement scope promotion endpoint (future work)
+1. **Narrow allow-list**: device JWTs authenticate only under `/api/devices/`
+2. **Method gating**: `read` tokens cannot use mutating HTTP methods
+3. **Revocation check**: every validation confirms the device row still exists
+4. **Single validation seam**: `get_current_user` and `require_device_jwt`
+   both delegate to `services.device_jwt.validate_device_jwt`
 
 ### Token Revocation
 
-Device tokens are **actively validated** on every request:
-
-1. `require_device_jwt` checks the database for device existence
-2. If the device was deleted, the request is rejected with 403
-3. Revocation is **immediate** - no delay waiting for JWT expiry
-
 Deleting a device via `DELETE /api/devices/{id}`:
-- Removes the device from `desktop_mobile_devices` table
-- All subsequent API requests with that device's JWT fail instantly
-- No need for Redis denylist (device existence check is sufficient)
+
+- Removes the row from `desktop_mobile_devices`
+- Invalidates the Redis existence cache (`invalidate_device_cache`), so
+  revocation takes effect immediately rather than after the cache TTL
+- All subsequent requests with that device's JWT fail validation
 
 ### Expiry
 
-Device tokens expire after 90 days (configurable via `DEVICE_JWT_TTL_DAYS`). Expired tokens are rejected by the JWT validation layer.
+Tokens expire after `DEVICE_JWT_TTL_DAYS` (default 90). Separately, devices
+inactive for 90+ days are pruned by the device-list sweep; `GET
+/api/devices/me` refreshes `last_seen_at` so active devices survive it.
 
-Mobile apps should:
-- Store the expiry timestamp
-- Prompt re-pairing when near expiry
-- Handle 401 responses gracefully
+Mobile apps should store the expiry timestamp, prompt re-pairing near expiry,
+and handle 401 responses gracefully.
 
 ## Testing
 
-Integration tests: `autobot-backend/tests/integration/test_device_jwt_auth.py`
+- `autobot-backend/tests/integration/test_device_jwt_auth.py` — mint/validate,
+  middleware fallback chain, allow-list + scope enforcement,
+  `require_device_jwt` dependency (401/403/200)
+- `autobot-backend/tests/integration/test_mobile_device_me.py` —
+  `GET /api/devices/me` wiring and heartbeat
 
-Run tests:
 ```bash
-pytest autobot-backend/tests/integration/test_device_jwt_auth.py -v
+pytest autobot-backend/tests/integration/test_device_jwt_auth.py \
+       autobot-backend/tests/integration/test_mobile_device_me.py -v
 ```
 
 ## Related Issues
 
-- [MVA-3237](/MVA/issues/MVA-3237) - Phase 1.5 implementation
-- [MVA-3084](/MVA/issues/MVA-3084) - Security audit findings
-- [MVA-3081](/MVA/issues/MVA-3081) - Phase 1 (incomplete)
-- [MVA-3036](/MVA/issues/MVA-3036#document-adr) - Parent ADR
+- GH#9493 — canonical device-JWT implementation (scopes, allow-list, revocation)
+- GH#4463 — mobile device pairing (QR challenge flow)
+- GH#11648 — test-side rewrite to the canonical contract
+- GH#11736 — `require_device_jwt` rot fix + production wiring

--- a/autobot-backend/tests/integration/test_device_jwt_auth.py
+++ b/autobot-backend/tests/integration/test_device_jwt_auth.py
@@ -273,3 +273,150 @@ class TestDeviceScopeEnforcement:
 
         assert user["auth_method"] == "device_jwt"
         assert user["scope"] == "write"
+
+
+class TestRequireDeviceJwtDependency:
+    """require_device_jwt dependency factory — #11736 rot fix.
+
+    The pre-fix implementation never awaited the async extraction (a truthy
+    coroutine passed the guard, then ``.get()`` raised AttributeError) and
+    enforced the retired MVA-3237 "read-only"/"admin" scopes. These tests pin
+    the canonical GH#9493 behaviour.
+    """
+
+    @staticmethod
+    def _patched_factory(real_auth_middleware):
+        cls = real_auth_middleware.AuthenticationMiddleware
+        middleware = cls.__new__(cls)
+        return patch.object(real_auth_middleware, "get_auth_middleware", return_value=middleware)
+
+    def test_factory_rejects_legacy_scopes(self, real_auth_middleware):
+        """Retired MVA-3237 scopes fail fast at route-definition time."""
+        for legacy_scope in ("read-only", "admin"):
+            with pytest.raises(ValueError, match="Invalid min_scope"):
+                real_auth_middleware.require_device_jwt(legacy_scope)
+
+    @pytest.mark.asyncio
+    async def test_valid_token_authenticates(self, device_jwt_env, device_exists, real_auth_middleware):
+        """Await-rot regression: extraction is awaited and yields the device user."""
+        device_id = str(uuid.uuid4())
+        token = mint_device_jwt(device_id, "user123", scope="read")
+
+        dependency = real_auth_middleware.require_device_jwt()
+        with self._patched_factory(real_auth_middleware):
+            user = await dependency(_bearer_request(token))
+
+        assert user["device_id"] == device_id
+        assert user["user_id"] == "user123"
+        assert user["auth_method"] == "device_jwt"
+
+    @pytest.mark.asyncio
+    async def test_missing_token_returns_401(self, device_jwt_env, real_auth_middleware):
+        """No Bearer token → 401."""
+        dependency = real_auth_middleware.require_device_jwt()
+        with self._patched_factory(real_auth_middleware):
+            with pytest.raises(HTTPException) as exc_info:
+                await dependency(_bearer_request(None))
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_returns_401(self, device_jwt_env, real_auth_middleware):
+        """Garbage Bearer token → 401."""
+        dependency = real_auth_middleware.require_device_jwt()
+        with self._patched_factory(real_auth_middleware):
+            with pytest.raises(HTTPException) as exc_info:
+                await dependency(_bearer_request("not-a-jwt"))
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_revoked_device_returns_401(self, device_jwt_env, real_auth_middleware, monkeypatch):
+        """Unpaired device fails the canonical revocation check → 401."""
+        monkeypatch.setattr(
+            "services.device_jwt._device_exists_cached",
+            AsyncMock(return_value=False),
+        )
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="write")
+
+        dependency = real_auth_middleware.require_device_jwt()
+        with self._patched_factory(real_auth_middleware):
+            with pytest.raises(HTTPException) as exc_info:
+                await dependency(_bearer_request(token))
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_read_token_rejected_by_write_min_scope(self, device_jwt_env, device_exists, real_auth_middleware):
+        """Canonical scope enforcement: read token on a write dependency → 403."""
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="read")
+
+        dependency = real_auth_middleware.require_device_jwt("write")
+        with self._patched_factory(real_auth_middleware):
+            with pytest.raises(HTTPException) as exc_info:
+                await dependency(_bearer_request(token))
+
+        assert exc_info.value.status_code == 403
+        assert "write scope" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_write_token_passes_write_min_scope(self, device_jwt_env, device_exists, real_auth_middleware):
+        """Write-scoped token satisfies min_scope='write'."""
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="write")
+
+        dependency = real_auth_middleware.require_device_jwt("write")
+        with self._patched_factory(real_auth_middleware):
+            user = await dependency(_bearer_request(token))
+
+        assert user["scope"] == "write"
+
+
+class TestRequireDeviceJwtHTTPWiring:
+    """require_device_jwt exercised through real FastAPI routes (#11736)."""
+
+    @pytest.fixture
+    def http_client(self, real_auth_middleware):
+        """TestClient for an app with read- and write-guarded device routes."""
+        from fastapi import Depends, FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        read_dep = real_auth_middleware.require_device_jwt()
+        write_dep = real_auth_middleware.require_device_jwt("write")
+
+        @app.get("/device-read")
+        async def device_read(user: dict = Depends(read_dep)):
+            return {"device_id": user["device_id"], "scope": user["scope"]}
+
+        @app.post("/device-write")
+        async def device_write(user: dict = Depends(write_dep)):
+            return {"device_id": user["device_id"], "scope": user["scope"]}
+
+        cls = real_auth_middleware.AuthenticationMiddleware
+        middleware = cls.__new__(cls)
+        with patch.object(real_auth_middleware, "get_auth_middleware", return_value=middleware):
+            yield TestClient(app)
+
+    def test_401_without_token(self, device_jwt_env, http_client):
+        response = http_client.get("/device-read")
+        assert response.status_code == 401
+
+    def test_401_with_user_style_garbage_token(self, device_jwt_env, http_client):
+        response = http_client.get("/device-read", headers={"Authorization": "Bearer not-a-device-jwt"})
+        assert response.status_code == 401
+
+    def test_403_read_token_on_write_route(self, device_jwt_env, device_exists, http_client):
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="read")
+        response = http_client.post("/device-write", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 403
+
+    def test_200_valid_read_token(self, device_jwt_env, device_exists, http_client):
+        device_id = str(uuid.uuid4())
+        token = mint_device_jwt(device_id, "user123", scope="read")
+        response = http_client.get("/device-read", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        assert response.json() == {"device_id": device_id, "scope": "read"}
+
+    def test_200_valid_write_token_on_write_route(self, device_jwt_env, device_exists, http_client):
+        device_id = str(uuid.uuid4())
+        token = mint_device_jwt(device_id, "user123", scope="write")
+        response = http_client.post("/device-write", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        assert response.json()["scope"] == "write"

--- a/autobot-backend/tests/integration/test_mobile_device_me.py
+++ b/autobot-backend/tests/integration/test_mobile_device_me.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+GET /api/devices/me — require_device_jwt wiring tests (#11736).
+
+Separate from test_mobile_pairing.py on purpose: that module's autouse
+Redis-cleanup fixture skips the whole file when Redis is unavailable
+(CI included), and these tests need only the in-memory database. Keeping
+them here guarantees the #11736 wiring is always exercised.
+"""
+
+import uuid
+from datetime import timedelta
+from typing import AsyncGenerator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio.session import async_sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from api.mobile_devices import _device_jwt_auth
+from api.mobile_devices import router as mobile_router
+from api.user_management.dependencies import get_db_session
+from autobot_shared.time_utils import now_utc
+from models.mobile_device import MobileDevice
+from user_management.models.base import Base
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+_USER_ID = "device-me-user"
+
+
+@pytest.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory database session with the mobile-device schema."""
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        TEST_DB_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.fixture
+async def paired_device(db_session, monkeypatch) -> MobileDevice:
+    """A paired device whose last_seen_at is 10 days stale."""
+    # Token encryption needs AUTOBOT_ENCRYPTION_KEY; these tests only care
+    # about identity/heartbeat, so stub the at-rest encryption.
+    monkeypatch.setattr("encryption_service.encrypt_data", lambda value: value)
+    device = MobileDevice(
+        user_id=_USER_ID,
+        device_name="Heartbeat Phone",
+        device_token="tok-hb",
+        platform="ios",
+        last_seen_at=now_utc() - timedelta(days=10),
+    )
+    db_session.add(device)
+    await db_session.commit()
+    return device
+
+
+def _client(db_session, device_user: dict) -> TestClient:
+    """Client with the DB and device-JWT dependencies overridden."""
+    app = FastAPI()
+    app.include_router(mobile_router, prefix="/api/devices")
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db_session] = override_get_db
+    app.dependency_overrides[_device_jwt_auth] = lambda: device_user
+    return TestClient(app)
+
+
+def test_device_me_route_wired_to_require_device_jwt():
+    """GET /me is guarded by the module-level require_device_jwt dependency."""
+    from api import mobile_devices
+
+    route = next(r for r in mobile_devices.router.routes if r.path == "/me")
+    dependency_calls = [d.call for d in route.dependant.dependencies]
+    assert mobile_devices._device_jwt_auth in dependency_calls
+
+
+@pytest.mark.asyncio
+async def test_device_me_returns_identity_and_updates_last_seen(db_session, paired_device):
+    """A device JWT caller gets its identity back and last_seen_at refreshes."""
+    old_seen = paired_device.last_seen_at
+    client = _client(
+        db_session,
+        {
+            "device_id": str(paired_device.id),
+            "user_id": _USER_ID,
+            "scope": "read",
+            "auth_method": "device_jwt",
+        },
+    )
+
+    response = client.get("/api/devices/me")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["device_id"] == str(paired_device.id)
+    assert data["user_id"] == _USER_ID
+    assert data["scope"] == "read"
+    assert data["last_seen_at"] is not None
+
+    result = await db_session.execute(select(MobileDevice).where(MobileDevice.id == paired_device.id))
+    refreshed = result.scalar_one()
+    assert refreshed.last_seen_at.replace(tzinfo=None) > old_seen.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_device_me_unknown_device_returns_403(db_session):
+    """A token for a device row that no longer exists is rejected (revoked)."""
+    client = _client(
+        db_session,
+        {
+            "device_id": str(uuid.uuid4()),
+            "user_id": "ghost-user",
+            "scope": "read",
+            "auth_method": "device_jwt",
+        },
+    )
+
+    response = client.get("/api/devices/me")
+    assert response.status_code == 403
+    assert "revoked" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_device_me_malformed_device_id_returns_401(db_session):
+    """A non-UUID device_id claim cannot reach the database query."""
+    client = _client(
+        db_session,
+        {
+            "device_id": "not-a-uuid",
+            "user_id": "ghost-user",
+            "scope": "read",
+            "auth_method": "device_jwt",
+        },
+    )
+
+    response = client.get("/api/devices/me")
+    assert response.status_code == 401

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -3629,6 +3629,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/devices/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Device Identity
+         * @description Device token introspection + activity heartbeat (GH#9493, #11736).
+         *
+         *     Accepts ONLY a device JWT (require_device_jwt); user sessions get 401.
+         *     Returns the calling device's identity claims and refreshes last_seen_at
+         *     so actively-used devices are not pruned by the 90-day inactivity sweep.
+         */
+        get: operations["get_device_identity_api_devices_me_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/devices/{device_id}": {
         parameters: {
             query?: never;
@@ -69444,6 +69468,28 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** DeviceIdentityResponse */
+        DeviceIdentityResponse: {
+            /**
+             * Device Id
+             * Format: uuid
+             */
+            device_id: string;
+            /** User Id */
+            user_id: string;
+            /**
+             * Scope
+             * @description Device JWT scope: 'read' or 'write' (GH#9493)
+             */
+            scope: string;
+            /**
+             * Last Seen At
+             * @description Heartbeat timestamp refreshed by this call
+             */
+            last_seen_at: string;
+        } & {
+            [key: string]: unknown;
+        };
         /** DeviceInitiateRequest */
         DeviceInitiateRequest: {
             /** Provider Name */
@@ -105970,6 +106016,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeviceListResponse"];
+                };
+            };
+        };
+    };
+    get_device_identity_api_devices_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeviceIdentityResponse"];
                 };
             };
         };


### PR DESCRIPTION
Closes #11736

## Thinking Path

`require_device_jwt` had rotted against the GH#9493 contract: missing `await` on the async validator, retired `read-only`/`admin` scope names, and zero callers. Audit showed `get_current_user` already enforces the full canonical contract for `/api/devices/` — so the fix is consolidation, not a parallel implementation: rebuild `require_device_jwt` as a thin dependency factory delegating to the same canonical seam, then give it a real production caller.

## What Changed

- `auth_middleware.py`: `require_device_jwt` → dependency FACTORY (`require_device_jwt(min_scope="read")`) delegating to `_extract_user_from_device_jwt` → canonical `validate_device_jwt` (aud + revocation); duplicated inline DB revocation query deleted; canonical `VALID_SCOPES` enforced — legacy scope names raise at route-definition time. Factory form also fixes a latent flaw: under bare `Depends`, `min_scope` would have become a client-controlled query param.
- `api/mobile_devices.py`: new `GET /api/devices/me` guarded by the dependency — device introspection + `last_seen_at` heartbeat (previously NOTHING updated `last_seen_at`, so every device expired 90 days after pairing regardless of activity).
- conftest auth stub gained a matching factory stub; stale MVA-3237 docstrings and `docs/device-token-authentication.md` rewritten to GH#9493.

## Verification

- `test_device_jwt_auth.py` 28/28 (incl. await-bug regression pin, 401/403/200 HTTP wiring matrix) + new `test_mobile_device_me.py` 4/4; startup imports 344/344 (real `main` app import proves wiring). Independent re-run: 32 passed. flake8/black clean.

Discoveries (pre-existing, verified on clean base — filed separately): rotted `test_device_jwt_integration.py` awaits the conftest-stubbed `get_current_user` (38 fails, largely superseded by #11648's rewrite); product question — device-JWT allow-list `("/api/devices/",)` excludes no-trailing-slash `GET /api/devices`, so read tokens can't list devices while write tokens can DELETE; documented as-is, owner call.

## Model Used

Claude Fable 5 (subagent: general-purpose)