### PR TITLE
fix(test): repair 33 pre-existing tests/services runtime failures exposed by #11478 (#11737)

### DIFF
--- a/autobot-slm-backend/tests/services/code_version_test.py
+++ b/autobot-slm-backend/tests/services/code_version_test.py
@@ -2,30 +2,108 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for code version tracking (Issue #741)."""
+"""Tests for code version tracking (Issue #741).
 
-# Import from slm-server models
+The slm-backend root conftest stubs ``sqlalchemy`` / ``models.database`` /
+``models.schemas`` as MagicMocks for api/* tests, so a bare import here would
+assert against inert mock chains instead of the real ORM/schema contracts
+(#11737).  Following the established real-load pattern
+(tests/services/test_node_ansible_target_11717.py, #11224/#11478), this module
+swaps in the REAL sqlalchemy + models modules at import time, binds what it
+needs, then restores the stubs so sibling test files are unaffected.  The
+swap is re-activated around runtime work (in-memory engine creation,
+``api.nodes`` import) via ``_real_modules_swapped()`` — SQLAlchemy lazy-loads
+dialect machinery through ``sys.modules`` at ``create_engine()`` time, which
+would otherwise resolve into the restored MagicMock stubs.
+"""
+
+import contextlib
+import importlib
+import importlib.util
 import sys
+from pathlib import Path
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-sys.path.insert(0, "slm-server")
-from models.database import Base, CodeStatus, Node  # noqa: E402, F401
+_SLM_ROOT = Path(__file__).parent.parent.parent
+if str(_SLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SLM_ROOT))
+
+_SQLALCHEMY_MODULES = ("sqlalchemy", "sqlalchemy.ext", "sqlalchemy.ext.asyncio", "sqlalchemy.orm")
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so relative imports work)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_orig_modules = {name: sys.modules.get(name) for name in [*_SQLALCHEMY_MODULES, "models.database", "models.schemas"]}
+for _name in _SQLALCHEMY_MODULES:
+    sys.modules.pop(_name, None)
+try:
+    for _name in _SQLALCHEMY_MODULES:
+        importlib.import_module(_name)
+    # The sqlite dialect is resolved lazily at create_engine() time; import it
+    # now while the real package tree is intact so the fixture below works at
+    # test runtime regardless of later sys.modules state.
+    importlib.import_module("sqlalchemy.dialects.sqlite")
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    _real_md = _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+    _real_ms = _load_real_module("models.schemas", _SLM_ROOT / "models" / "schemas.py")
+
+    Base = _real_md.Base
+    CodeStatus = _real_md.CodeStatus
+    Node = _real_md.Node
+    HeartbeatRequest = _real_ms.HeartbeatRequest
+    HeartbeatResponse = _real_ms.HeartbeatResponse
+
+    _REAL_MODULES = {
+        **{name: sys.modules[name] for name in _SQLALCHEMY_MODULES},
+        "models.database": _real_md,
+        "models.schemas": _real_ms,
+    }
+finally:
+    for _name, _mod in _orig_modules.items():
+        if _mod is not None:
+            sys.modules[_name] = _mod
+        else:
+            sys.modules.pop(_name, None)
+
+
+@contextlib.contextmanager
+def _real_modules_swapped():
+    """Temporarily put the real sqlalchemy/models modules back into sys.modules."""
+    saved = {name: sys.modules.get(name) for name in _REAL_MODULES}
+    sys.modules.update(_REAL_MODULES)
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
 
 
 @pytest.fixture(scope="function")
 def slm_db_session():
     """Create an in-memory SQLite database for SLM models."""
-    engine = create_engine("sqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine (test-local engine)
-    Base.metadata.create_all(engine)
-    SessionLocal = sessionmaker(bind=engine)  # canonical: ignore py-adhoc-db-engine (test-local session factory)
-    session = SessionLocal()
-    try:
-        yield session
-    finally:
-        session.close()
+    with _real_modules_swapped():
+        engine = create_engine("sqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        Base.metadata.create_all(engine)
+        SessionLocal = sessionmaker(bind=engine)  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
 
 
 class TestNodeCodeVersion:
@@ -121,8 +199,6 @@ class TestHeartbeatSchemas:
 
     def test_heartbeat_request_accepts_code_version(self):
         """HeartbeatRequest should accept code_version field."""
-        from models.schemas import HeartbeatRequest
-
         request = HeartbeatRequest(
             cpu_percent=25.0,
             memory_percent=50.0,
@@ -133,8 +209,6 @@ class TestHeartbeatSchemas:
 
     def test_heartbeat_request_code_version_optional(self):
         """HeartbeatRequest code_version should be optional."""
-        from models.schemas import HeartbeatRequest
-
         request = HeartbeatRequest(
             cpu_percent=10.0,
             memory_percent=20.0,
@@ -144,8 +218,6 @@ class TestHeartbeatSchemas:
 
     def test_heartbeat_response_includes_update_info(self):
         """HeartbeatResponse should include update availability info."""
-        from models.schemas import HeartbeatResponse
-
         response = HeartbeatResponse(
             status="ok",
             update_available=True,
@@ -156,8 +228,6 @@ class TestHeartbeatSchemas:
 
     def test_heartbeat_response_defaults(self):
         """HeartbeatResponse should have sensible defaults."""
-        from models.schemas import HeartbeatResponse
-
         response = HeartbeatResponse()
         assert response.status == "ok"
         assert response.update_available is False
@@ -166,8 +236,6 @@ class TestHeartbeatSchemas:
 
     def test_heartbeat_response_with_update_url(self):
         """HeartbeatResponse should support update_url field."""
-        from models.schemas import HeartbeatResponse
-
         response = HeartbeatResponse(
             status="ok",
             update_available=True,
@@ -227,8 +295,6 @@ class TestHeartbeatVersionTracking:
 
     def test_heartbeat_response_update_available_true(self):
         """Test HeartbeatResponse when update is available."""
-        from models.schemas import HeartbeatResponse
-
         # Simulate outdated node
         code_status = CodeStatus.OUTDATED.value
         latest_version = "def456"
@@ -249,8 +315,6 @@ class TestHeartbeatVersionTracking:
 
     def test_heartbeat_response_update_available_false(self):
         """Test HeartbeatResponse when no update is available."""
-        from models.schemas import HeartbeatResponse
-
         # Simulate up-to-date node
         code_status = CodeStatus.UP_TO_DATE.value
         latest_version = "abc123"
@@ -279,12 +343,14 @@ class TestHasFailedAutobotService:
 
     @staticmethod
     def _call(extra_data):
-        """Import and call the function under test."""
-        import importlib
-        import os
+        """Import and call the function under test.
 
-        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
-        module = importlib.import_module("api.nodes")
+        api/nodes.py imports sqlalchemy.exc and models.schemas at module
+        scope; import it inside the real-module swap so those resolve to the
+        real packages instead of the root-conftest MagicMock stubs (#11737).
+        """
+        with _real_modules_swapped():
+            module = importlib.import_module("api.nodes")
         return module._has_failed_autobot_service(extra_data)
 
     def test_returns_false_when_extra_data_is_none(self):

--- a/autobot-slm-backend/tests/services/code_version_test.py
+++ b/autobot-slm-backend/tests/services/code_version_test.py
@@ -108,7 +108,9 @@ def _real_modules_swapped():
 def slm_db_session():
     """Create an in-memory SQLite database for SLM models."""
     with _real_modules_swapped():
-        engine = create_engine("sqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        engine = create_engine(
+            "sqlite:///:memory:", echo=False
+        )  # canonical: ignore py-adhoc-db-engine (test-local engine)
         Base.metadata.create_all(engine)
         SessionLocal = sessionmaker(bind=engine)  # canonical: ignore py-adhoc-db-engine (test-local session factory)
         session = SessionLocal()

--- a/autobot-slm-backend/tests/services/code_version_test.py
+++ b/autobot-slm-backend/tests/services/code_version_test.py
@@ -41,9 +41,19 @@ def _load_real_module(name: str, path: Path):
     return module
 
 
-_orig_modules = {name: sys.modules.get(name) for name in [*_SQLALCHEMY_MODULES, "models.database", "models.schemas"]}
-for _name in _SQLALCHEMY_MODULES:
-    sys.modules.pop(_name, None)
+def _is_sqlalchemy_key(name: str) -> bool:
+    return name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+# Snapshot and clear EVERY sqlalchemy* key, not just the four the root
+# conftest stubs: earlier-collected test files (tests/api/test_scim.py, …)
+# leave extra child stubs such as ``sqlalchemy.exc`` in sys.modules, and a
+# single cached MagicMock child poisons the real package import (relative
+# imports inside sqlalchemy resolve through sys.modules).
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)}
+_orig_modules.update({name: sys.modules.get(name) for name in ("models.database", "models.schemas")})
+for _name in [name for name in sys.modules if _is_sqlalchemy_key(name)]:
+    del sys.modules[_name]
 try:
     for _name in _SQLALCHEMY_MODULES:
         importlib.import_module(_name)
@@ -65,11 +75,13 @@ try:
     HeartbeatResponse = _real_ms.HeartbeatResponse
 
     _REAL_MODULES = {
-        **{name: sys.modules[name] for name in _SQLALCHEMY_MODULES},
+        **{name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)},
         "models.database": _real_md,
         "models.schemas": _real_ms,
     }
 finally:
+    for _name in [name for name in sys.modules if _is_sqlalchemy_key(name)]:
+        del sys.modules[_name]
     for _name, _mod in _orig_modules.items():
         if _mod is not None:
             sys.modules[_name] = _mod

--- a/autobot-slm-backend/tests/services/drift_checker_test.py
+++ b/autobot-slm-backend/tests/services/drift_checker_test.py
@@ -36,18 +36,33 @@ if "services" not in sys.modules:
     _services_pkg = types.ModuleType("services")
     _services_pkg.__path__ = [str(_services_dir)]  # type: ignore[attr-defined]
     sys.modules["services"] = _services_pkg
-if "services.deploy_artifacts" not in sys.modules:
-    sys.modules["services.deploy_artifacts"] = _load_service_module("services.deploy_artifacts", "deploy_artifacts.py")
-if "services.git_tracker" not in sys.modules:
-    # git_tracker.py transitively imports models.database; drift_checker only
-    # needs its DEFAULT_REPO_PATH constant, so stub it to keep this load fully
-    # standalone (same template as test_deploy_artifacts_lockstep.py).
-    _git_tracker_stub = types.ModuleType("services.git_tracker")
-    _git_tracker_stub.DEFAULT_REPO_PATH = "/opt/autobot/code_source"  # type: ignore[attr-defined]
-    sys.modules["services.git_tracker"] = _git_tracker_stub
 
-# Load drift_checker without triggering services/__init__.py import chain.
-drift_checker = _load_service_module("drift_checker", "drift_checker.py")
+# The slm-backend root conftest pre-stubs ``services.deploy_artifacts`` and
+# ``services.git_tracker`` as MagicMocks (both are api/code_sync.py imports),
+# so ``if X not in sys.modules`` guards are no-ops and drift_checker would
+# bind _SKIP_DIR_SUFFIXES to a MagicMock — ``str.endswith(MagicMock)`` then
+# raises TypeError at walk time (#11737).  Force the REAL deploy_artifacts
+# (import-light constants) and a thin git_tracker shim (drift_checker only
+# needs DEFAULT_REPO_PATH; the real module pulls in models.database) into
+# sys.modules for the duration of the drift_checker load, then restore the
+# pre-existing entries so sibling test files are unaffected (#11478 pattern).
+_real_deploy_artifacts = _load_service_module("services.deploy_artifacts", "deploy_artifacts.py")
+_git_tracker_stub = types.ModuleType("services.git_tracker")
+_git_tracker_stub.DEFAULT_REPO_PATH = "/opt/autobot/code_source"  # type: ignore[attr-defined]
+
+_SWAPPED_KEYS = ("services.deploy_artifacts", "services.git_tracker")
+_orig_modules = {_key: sys.modules.get(_key) for _key in _SWAPPED_KEYS}
+sys.modules["services.deploy_artifacts"] = _real_deploy_artifacts
+sys.modules["services.git_tracker"] = _git_tracker_stub
+try:
+    # Load drift_checker without triggering services/__init__.py import chain.
+    drift_checker = _load_service_module("drift_checker", "drift_checker.py")
+finally:
+    for _key, _mod in _orig_modules.items():
+        if _mod is not None:
+            sys.modules[_key] = _mod
+        else:
+            sys.modules.pop(_key, None)
 
 _is_expected_drift = drift_checker._is_expected_drift
 compute_drift = drift_checker.compute_drift

--- a/autobot-slm-backend/tests/services/test_node_ansible_target_11717.py
+++ b/autobot-slm-backend/tests/services/test_node_ansible_target_11717.py
@@ -31,9 +31,21 @@ if str(_slm_root) not in sys.path:
 
 _SQLALCHEMY_MODULES = ["sqlalchemy", "sqlalchemy.ext", "sqlalchemy.ext.asyncio", "sqlalchemy.orm"]
 
-_orig_modules = {name: sys.modules.get(name) for name in [*_SQLALCHEMY_MODULES, "models.database"]}
-for _name in _SQLALCHEMY_MODULES:
-    sys.modules.pop(_name, None)
+
+def _is_sqlalchemy_key(name: str) -> bool:
+    return name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+# Snapshot and clear EVERY sqlalchemy* key, not just the four the root
+# conftest stubs (#11737): in a whole-backend sweep, earlier-collected test
+# files (tests/api/test_scim.py, …) leave extra child stubs such as
+# ``sqlalchemy.exc`` in sys.modules, and a single cached MagicMock child
+# poisons the real package import below (relative imports inside sqlalchemy
+# resolve through sys.modules).
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)}
+_orig_modules["models.database"] = sys.modules.get("models.database")
+for _name in [name for name in sys.modules if _is_sqlalchemy_key(name)]:
+    del sys.modules[_name]
 try:
     for _name in _SQLALCHEMY_MODULES:
         importlib.import_module(_name)
@@ -44,6 +56,8 @@ try:
     _real_md_spec.loader.exec_module(_real_md)
     Node = _real_md.Node
 finally:
+    for _name in [name for name in sys.modules if _is_sqlalchemy_key(name)]:
+        del sys.modules[_name]
     for _name, _mod in _orig_modules.items():
         if _mod is not None:
             sys.modules[_name] = _mod

--- a/autobot-slm-backend/tests/services/test_sso_security.py
+++ b/autobot-slm-backend/tests/services/test_sso_security.py
@@ -246,7 +246,7 @@ class TestSamlAssertionSecurity:
         """SAML relay state is single-use to prevent replay attacks."""
         # This is already tested in test_sso_service.py TestSamlRelayStateRedisRoundTrip
         # but we verify it here as part of the security suite
-        redis, store = {}, {}
+        store = {}
 
         async def _set(key, value, ex=None):
             store[key] = value
@@ -267,7 +267,7 @@ class TestSamlAssertionSecurity:
             {"headers": [("Location", "https://idp.example.com/sso")]},
         )
 
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis_mock):
+        with patch.object(_sso_mod, "get_async_redis_client", AsyncMock(return_value=redis_mock)):
             with patch.object(service, "_build_saml_client", return_value=mock_client):
                 _, relay_state = await service._generate_saml_authn_request(provider)
             # First use succeeds
@@ -348,7 +348,7 @@ class TestOauthSecurity:
         """OAuth state tokens are single-use (replay prevention)."""
         # Already tested in test_sso_service.py TestValidateOauthState.test_second_use_raises
         # but we verify it here as part of the security suite
-        redis, store = {}, {}
+        store = {}
 
         async def _set(key, value, ex=None):
             store[key] = value
@@ -362,7 +362,7 @@ class TestOauthSecurity:
 
         service = _make_service()
 
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis_mock):
+        with patch.object(_sso_mod, "get_async_redis_client", AsyncMock(return_value=redis_mock)):
             state, _ = await service._generate_oauth_state(_PROVIDER_ID)
             # First use succeeds
             await service._validate_oauth_state(state)
@@ -379,40 +379,54 @@ class TestOauthSecurity:
 class TestClientSecretHandling:
     """Client secret encryption/decryption and logging prevention."""
 
-    def test_client_secret_never_logged(self, caplog):
+    @pytest.mark.asyncio
+    async def test_client_secret_never_logged(self, caplog):
         """Client secrets must never appear in application logs."""
         service = _make_service()
         provider = MagicMock()
+        provider.id = _PROVIDER_ID
         provider.config = {
             "client_id": "test-client-id",
             "client_secret": "super-secret-value-12345",
         }
 
-        # Mock AsyncOAuth2Client to avoid authlib dependency
-        with patch.object(_sso_mod, "AsyncOAuth2Client") as mock_client_cls:
+        # Mock AsyncOAuth2Client to avoid authlib dependency; the secret now
+        # comes from SSOSecretsManager (stubbed) so make retrieve_secret
+        # return it — the assertion below covers the whole build path.
+        _secrets_mgr = MagicMock()
+        _secrets_mgr.retrieve_secret = AsyncMock(return_value="super-secret-value-12345")
+        with (
+            patch.object(_sso_mod, "AsyncOAuth2Client") as mock_client_cls,
+            patch.object(_sso_mod, "SSOSecretsManager", return_value=_secrets_mgr),
+        ):
             mock_client_cls.return_value = MagicMock()
 
             with caplog.at_level(logging.DEBUG):
-                service._build_oauth_client(provider)
+                await service._build_oauth_client(provider)
 
         # Check all log records — secret must never appear
         log_text = " ".join(record.message for record in caplog.records)
         assert "super-secret-value-12345" not in log_text
         assert "client_secret" not in log_text or "***" in log_text  # Redacted is OK
 
-    def test_client_secret_not_in_exception_messages(self):
+    @pytest.mark.asyncio
+    async def test_client_secret_not_in_exception_messages(self):
         """Client secrets must not leak via exception messages."""
         service = _make_service()
         provider = MagicMock()
+        provider.id = _PROVIDER_ID
         provider.config = {
             "client_id": "test-client-id",
             "client_secret": "super-secret-value-12345",
             "token_url": "https://invalid-url-that-will-fail.example.com/token",
         }
 
+        _secrets_mgr = MagicMock()
+        _secrets_mgr.retrieve_secret = AsyncMock(return_value="super-secret-value-12345")
         try:
             # Trigger an error that might expose config
-            service._build_oauth_client(provider)
+            with patch.object(_sso_mod, "SSOSecretsManager", return_value=_secrets_mgr):
+                await service._build_oauth_client(provider)
         except Exception as e:
             error_msg = str(e)
             # Secret must not appear in error message
@@ -470,7 +484,7 @@ class TestSecurityIntegration:
         """OAuth state validation must fail hard if Redis is unavailable."""
         service = _make_service()
 
-        with patch.object(_sso_mod, "get_redis_client", return_value=None):
+        with patch.object(_sso_mod, "get_async_redis_client", AsyncMock(return_value=None)):
             with pytest.raises(SSOAuthenticationError, match="Redis unavailable"):
                 await service._validate_oauth_state("any-state-token")
 
@@ -492,7 +506,7 @@ class TestSecurityIntegration:
         )
 
         with (
-            patch.object(_sso_mod, "get_redis_client", return_value=None),
+            patch.object(_sso_mod, "get_async_redis_client", AsyncMock(return_value=None)),
             patch.object(service, "_build_saml_client", return_value=mock_client),
         ):
             redirect_url, relay_state = await service._generate_saml_authn_request(provider)

--- a/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
+++ b/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
@@ -11,11 +11,32 @@ role-sync (_build_ssh_command) and source-commit lookup (_get_current_git_commit
 These tests assert every ssh argv built in the orchestrator is well-formed.
 """
 
+import importlib
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.sync_orchestrator import SyncOrchestrator
+# ── Load the REAL services.sync_orchestrator (#11737) ────────────────────────
+# The slm-backend root conftest stubs ``services.sync_orchestrator`` as a
+# MagicMock (it is an api/code_sync.py import), so a bare import here would
+# hand ``SyncOrchestrator.__new__`` a mock: ``TypeError: issubclass() arg 1
+# must be a class``.  Pop the stub, import the real module through the hollow
+# ``services`` package (its own heavy deps — sqlalchemy, models.database,
+# services.database — stay satisfied by the conftest stubs), then restore the
+# stub so sibling test files and api/* tests are unaffected (#11478 pattern).
+_SO_KEY = "services.sync_orchestrator"
+_orig_so = sys.modules.get(_SO_KEY)
+sys.modules.pop(_SO_KEY, None)
+try:
+    _so_mod = importlib.import_module(_SO_KEY)
+finally:
+    if _orig_so is not None:
+        sys.modules[_SO_KEY] = _orig_so
+    else:
+        sys.modules.pop(_SO_KEY, None)
+
+SyncOrchestrator = _so_mod.SyncOrchestrator
 
 
 def _assert_ssh_argv_wellformed(cmd: list) -> None:
@@ -33,13 +54,24 @@ def _orchestrator() -> SyncOrchestrator:
     return SyncOrchestrator.__new__(SyncOrchestrator)
 
 
+# The ssh builders check Path(SSH_KEY_PATH).exists() for the optional `-i`
+# flag.  The default key path lives under /home/autobot/.ssh — unreadable on
+# dev boxes, where Path.exists() propagates PermissionError (EACCES is not in
+# pathlib's ignored-errno set).  Pin the module global to a guaranteed-absent
+# path so the check is a deterministic False in every environment; the argv
+# assertions below are about `-o`/`-p` shape, not the key flag.
+_MISSING_KEY_PATH = "/nonexistent-test-dir/autobot_key"
+
+
 def test_build_ssh_command_argv_is_wellformed():
-    cmd = _orchestrator()._build_ssh_command(2222, "autobot", "10.0.0.5")
+    with patch.object(_so_mod, "SSH_KEY_PATH", _MISSING_KEY_PATH):
+        cmd = _orchestrator()._build_ssh_command(2222, "autobot", "10.0.0.5")
     _assert_ssh_argv_wellformed(cmd)
 
 
 def test_build_ssh_command_port_and_target():
-    cmd = _orchestrator()._build_ssh_command(2222, "u", "h")
+    with patch.object(_so_mod, "SSH_KEY_PATH", _MISSING_KEY_PATH):
+        cmd = _orchestrator()._build_ssh_command(2222, "u", "h")
     assert "-p" in cmd and cmd[cmd.index("-p") + 1] == "2222"
     assert cmd[-1] == "u@h"
 
@@ -50,9 +82,17 @@ async def test_get_current_git_commit_argv_is_wellformed():
     proc = MagicMock()
     proc.communicate = AsyncMock(return_value=(b"a" * 40 + b"\n", b""))
     proc.returncode = 0
-    with patch(
-        "services.sync_orchestrator.asyncio.create_subprocess_exec",
-        new=AsyncMock(return_value=proc),
-    ) as mock_exec:
+    # NOTE: sys.modules holds the conftest MagicMock stub for
+    # services.sync_orchestrator (restored above), so a string patch target
+    # would patch the stub, not the module under test.  _so_mod.asyncio IS the
+    # stdlib asyncio module the real code resolves at call time — patch there.
+    with (
+        patch.object(_so_mod, "SSH_KEY_PATH", _MISSING_KEY_PATH),
+        patch.object(
+            _so_mod.asyncio,
+            "create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        ) as mock_exec,
+    ):
         await _orchestrator()._get_current_git_commit("10.0.0.5", "autobot", "/home/autobot/code")
     _assert_ssh_argv_wellformed(list(mock_exec.call_args[0]))


### PR DESCRIPTION
Closes #11737

## Thinking Path

The 33 failures baselined when #11478 made `tests/services/` group-collectable cluster into four root causes — all conftest-stub interactions, fixed with the directory's established real-load patterns. Zero product-code changes (one real product crash-mode found was correctly denied by the sandbox as a security-relevant change → filed #11793 for owner-approved fast-follow).

## What Changed

1. `code_version_test.py` (21): real-load sqlalchemy + `models.database`/`models.schemas` with whole-`sqlalchemy*`-prefix sandboxing (a sibling test leaks `sqlalchemy.exc` stubs in sweeps) and runtime re-activation context (SQLAlchemy lazy-loads its sqlite dialect through `sys.modules` at `create_engine()`).
2. `drift_checker_test.py` (5): its `not in sys.modules` guards were no-ops (root conftest pre-stubs those modules) — force real `deploy_artifacts` + thin `git_tracker` shim during load.
3. `test_sso_security.py` (4 + 2 false-greens): patches repointed `get_redis_client` → `get_async_redis_client` with AsyncMock; two sibling tests were calling now-async `_build_oauth_client` without awaiting (asserts vacuous) — fixed.
4. `test_sync_orchestrator_ssh.py` (3): pop-stub → real `sync_orchestrator` import → restore; `SSH_KEY_PATH` pinned to a guaranteed-absent path.

## Verification

- Before: 33 failed / 280 passed / 1 skipped. After: **313 passed / 1 skipped / 0 failed**; collection 314/0 errors. Independent re-run: identical 313/1/0.
- Startup imports 344 passed; flake8 clean on all 5 changed files.
- Whole-backend sweep collection errors reduced 8 → 7 (remaining cross-directory contamination tracked in #11794).

Follow-ups filed: #11793 (PermissionError crash-mode at `sync_orchestrator.py:122` ×7 sites — owner-gated product fix), #11794 (7 sweep collection errors).

## Model Used

Claude Fable 5 (subagent: general-purpose)