### PR TITLE
fix(test): stop cross-directory sys.modules leaks — slm-backend sweep collects clean (#11794)

### DIFF
--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -104,27 +104,29 @@ for _m in [
     _stub(_m)
 
 # ── services ──────────────────────────────────────────────────────────────────
-# The services.* modules api/code_sync.py imports are AST-derived from its
-# source (#11575) — a hand-maintained list rots the moment code_sync gains a
-# new `from services.X import ...` (exactly how #11481 broke, and the same
-# anti-pattern behind the #11461 schema-list rot).  Pattern mirrors the
-# schema-name derivation in tests/api/test_collect_outdated_node_ids.py.
-_code_sync_ast = ast.parse((Path(__file__).parent / "api" / "code_sync.py").read_text(encoding="utf-8"))
-_CODE_SYNC_SERVICE_MODULES = frozenset(
-    {
+# The services.* modules api/code_sync.py and api/setup_wizard.py import are
+# AST-derived from their sources (#11575, #11794) — a hand-maintained list rots
+# the moment either module gains a new `from services.X import ...` (exactly
+# how #11481 broke, and the same anti-pattern behind the #11461 schema-list
+# rot).  Pattern mirrors the schema-name derivation in
+# tests/api/test_collect_outdated_node_ids.py.  Both files are stubbed because
+# their test modules (tests/api/*, api/setup_wizard_sanitize_test.py,
+# tests/api/test_setup_wizard_node_roles.py) import them at collection time.
+_CODE_SYNC_SERVICE_MODULES: frozenset = frozenset()
+for _src in ("code_sync.py", "setup_wizard.py"):
+    _src_ast = ast.parse((Path(__file__).parent / "api" / _src).read_text(encoding="utf-8"))
+    _CODE_SYNC_SERVICE_MODULES |= {
         _node.module
-        for _node in ast.walk(_code_sync_ast)
+        for _node in ast.walk(_src_ast)
         if isinstance(_node, ast.ImportFrom) and _node.module and _node.module.startswith("services.")
-    }
-    | {
+    } | {
         _alias.name
-        for _node in ast.walk(_code_sync_ast)
+        for _node in ast.walk(_src_ast)
         if isinstance(_node, ast.Import)
         for _alias in _node.names
         if _alias.name.startswith("services.")
     }
-)
-del _code_sync_ast
+del _src_ast
 
 # services.* modules NOT imported by code_sync.py but stubbed for other api/*
 # modules under test.  These have their own consumers and are not exposed to
@@ -175,5 +177,12 @@ for _m in [
     "user_management.services.base_service",
     "user_management.services.mfa_service",
     "user_management.services.sso_service",
+    # user_management/services/__init__.py is executed for real when pytest
+    # imports test modules inside that package (user_management/services/
+    # sso_e2e_test.py, sso_secrets_test.py); its from-imports must resolve via
+    # sys.modules or the whole package fails to collect (#11794).
+    "user_management.services.organization_service",
+    "user_management.services.team_service",
+    "user_management.services.user_service",
 ]:
     _stub(_m)

--- a/autobot-slm-backend/services/ansible_utils_test.py
+++ b/autobot-slm-backend/services/ansible_utils_test.py
@@ -2,9 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for ansible_utils._extract_failure_summary (Issue #9286)."""
+"""Tests for ansible_utils._extract_failure_summary (Issue #9286).
 
-from services.ansible_utils import _extract_failure_summary
+The slm-backend root conftest stubs ``services.ansible_utils`` as a MagicMock
+(it is imported at module level by api/setup_wizard.py, #11794), so a bare
+``from services.ansible_utils import ...`` here would bind the stub instead of
+the real parser.  Load the real file directly, like the sibling
+drift_checker_test.py does.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).parent / "ansible_utils.py"
+_spec = importlib.util.spec_from_file_location("ansible_utils_under_test", _MODULE_PATH)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+_extract_failure_summary = _mod._extract_failure_summary
 
 
 def test_regular_task_failure():

--- a/autobot-slm-backend/tests/api/test_apply_secrets.py
+++ b/autobot-slm-backend/tests/api/test_apply_secrets.py
@@ -53,6 +53,7 @@ _STUB_MODULE_NAMES = [
     "services.database",
     "services.encryption",
     "services.ansible_secrets",
+    "services.hf_token_validator",
     "services.playbook_executor",
     "autobot_shared",
     "autobot_shared.auth",

--- a/autobot-slm-backend/tests/api/test_auth_logout.py
+++ b/autobot-slm-backend/tests/api/test_auth_logout.py
@@ -36,6 +36,14 @@ sys.path.insert(0, str(_ROOT))
 # ---------------------------------------------------------------------------
 # Module stubs — config first so auth.py loads with the right secret key
 # ---------------------------------------------------------------------------
+# #11478/#11794: snapshot sys.modules before the stub-heavy bootstrap.  The
+# stubs below MUST win even when the real modules are already imported (in a
+# whole-backend sweep an earlier test file legitimately imports the real
+# fastapi; exec'ing api/auth.py against real FastAPI decorators + MagicMock
+# response models raises FastAPIError at collection time).  Everything is
+# rolled back after the bootstrap so nothing leaks into later test files.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 _SECRET_KEY = "test-logout-secret-key-32characters"
 _EXPIRE_MINUTES = 30
 
@@ -67,8 +75,7 @@ for _mod_name in [
     "models.database",
     "api.security",
 ]:
-    if _mod_name not in sys.modules:
-        sys.modules[_mod_name] = MagicMock()
+    sys.modules[_mod_name] = MagicMock()
 
 # Ensure real jwt_core is reachable (decode_jwt_no_verify_exp used in logout impl)
 from autobot_shared.auth.jwt_core import decode_jwt_or_none  # noqa: E402
@@ -115,6 +122,17 @@ exec(compile(_router_src, str(_AUTH_ROUTER_PY), "exec"), _router_ns)  # nosec B1
 
 _build_end_session_url = _router_ns["_build_end_session_url"]
 _get_user_sso_link = _router_ns["_get_user_sso_link"]
+
+# #11478/#11794: restore the pre-bootstrap sys.modules state (see snapshot
+# above).  Tests only use the module references extracted here (_dl_mod,
+# _auth_mod, _router_ns values), so none of the forced stubs may outlive this
+# module's import.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -31,6 +31,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Dev-host stub: provide minimal real Pydantic models for models.schemas so
 # the router can be imported without a full SLM venv.
 # ---------------------------------------------------------------------------
+# #11794: snapshot the models entries — restored right after api.code_sync
+# loads (see below) so the pydantic stand-ins don't leak across directories.
+_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
 if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
     from pydantic import BaseModel as _BM
 
@@ -103,6 +106,20 @@ from api.code_sync import (  # noqa: E402
     _snapshot_component,
     _wait_component_healthy,
 )
+
+# #11794: restore the pre-file models/models.schemas sys.modules entries now
+# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
+# into later-collected directories (tests/services/test_saml_slo.py and
+# test_token_denylist.py real-load services/auth.py, whose
+# `from models.schemas import TokenResponse` breaks against them).
+for _k, _v in _MODELS_SNAPSHOT.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+if "models" in sys.modules and "models.schemas" in sys.modules:
+    sys.modules["models"].schemas = sys.modules["models.schemas"]
+del _MODELS_SNAPSHOT
 
 
 def _run(coro):

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -33,6 +33,9 @@ from unittest.mock import AsyncMock, MagicMock  # MagicMock used in sys.modules 
 # with minimal real BaseModel subclasses so the router can be imported.
 # Must happen before the api.code_sync import below.
 # ---------------------------------------------------------------------------
+# #11794: snapshot the models entries — restored right after api.code_sync
+# loads (see below) so the pydantic stand-ins don't leak across directories.
+_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
 if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
     from pydantic import BaseModel as _BM
 
@@ -84,6 +87,20 @@ from api.code_sync import (  # noqa: E402
     _get_deploy_base,
     _run_post_sync_steps,
 )
+
+# #11794: restore the pre-file models/models.schemas sys.modules entries now
+# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
+# into later-collected directories (tests/services/test_saml_slo.py and
+# test_token_denylist.py real-load services/auth.py, whose
+# `from models.schemas import TokenResponse` breaks against them).
+for _k, _v in _MODELS_SNAPSHOT.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+if "models" in sys.modules and "models.schemas" in sys.modules:
+    sys.modules["models"].schemas = sys.modules["models.schemas"]
+del _MODELS_SNAPSHOT
 
 # ---------------------------------------------------------------------------
 # Helper

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -25,6 +25,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # the router can be imported without a full SLM venv.
 # Must happen before the api.code_sync import below.
 # ---------------------------------------------------------------------------
+# #11794: snapshot the models entries — restored right after api.code_sync
+# loads (see below) so the pydantic stand-ins don't leak across directories.
+_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
 if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
     from pydantic import BaseModel as _BM
 
@@ -66,12 +69,24 @@ if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMoc
 _BACKEND_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_BACKEND_ROOT))
 
-import asyncio  # noqa: E402  (re-import for clarity after path setup)
-
 from api.code_sync import (  # noqa: E402
     _run_component_resolve_job,
     _run_post_sync_steps,
 )
+
+# #11794: restore the pre-file models/models.schemas sys.modules entries now
+# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
+# into later-collected directories (tests/services/test_saml_slo.py and
+# test_token_denylist.py real-load services/auth.py, whose
+# `from models.schemas import TokenResponse` breaks against them).
+for _k, _v in _MODELS_SNAPSHOT.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+if "models" in sys.modules and "models.schemas" in sys.modules:
+    sys.modules["models"].schemas = sys.modules["models.schemas"]
+del _MODELS_SNAPSHOT
 
 
 def _run(coro):

--- a/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
+++ b/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
@@ -37,6 +37,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Dev-host stub: minimal Pydantic models so the router can be imported
 # without a full SLM venv.
 # ---------------------------------------------------------------------------
+# #11794: snapshot the models entries — restored right after api.code_sync
+# loads (see below) so the pydantic stand-ins don't leak across directories.
+_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
 if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
     from pydantic import BaseModel as _BM
 
@@ -86,6 +89,20 @@ from api.code_sync import (  # noqa: E402
     _StageStatus,
     _sync_fleet_node,
 )
+
+# #11794: restore the pre-file models/models.schemas sys.modules entries now
+# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
+# into later-collected directories (tests/services/test_saml_slo.py and
+# test_token_denylist.py real-load services/auth.py, whose
+# `from models.schemas import TokenResponse` breaks against them).
+for _k, _v in _MODELS_SNAPSHOT.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+if "models" in sys.modules and "models.schemas" in sys.modules:
+    sys.modules["models"].schemas = sys.modules["models.schemas"]
+del _MODELS_SNAPSHOT
 
 
 def _run(coro):

--- a/autobot-slm-backend/tests/api/test_health_poll_adaptive.py
+++ b/autobot-slm-backend/tests/api/test_health_poll_adaptive.py
@@ -21,6 +21,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 # Minimal real Pydantic models for models.schemas so the router imports without a
 # full SLM venv (mirrors the sibling code-sync tests).
+# #11794: snapshot the models entries — restored right after api.code_sync
+# loads (see below) so the pydantic stand-ins don't leak across directories.
+_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
 if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
     from pydantic import BaseModel as _BM
 
@@ -65,6 +68,20 @@ import asyncio  # noqa: E402
 
 import api.code_sync as cs  # noqa: E402
 from api.code_sync import _ensure_venv_python, _wait_component_healthy  # noqa: E402
+
+# #11794: restore the pre-file models/models.schemas sys.modules entries now
+# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
+# into later-collected directories (tests/services/test_saml_slo.py and
+# test_token_denylist.py real-load services/auth.py, whose
+# `from models.schemas import TokenResponse` breaks against them).
+for _k, _v in _MODELS_SNAPSHOT.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+if "models" in sys.modules and "models.schemas" in sys.modules:
+    sys.modules["models"].schemas = sys.modules["models.schemas"]
+del _MODELS_SNAPSHOT
 
 
 def _run(coro):

--- a/autobot-slm-backend/tests/api/test_shared_restart_health.py
+++ b/autobot-slm-backend/tests/api/test_shared_restart_health.py
@@ -27,6 +27,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 # Minimal real Pydantic models for models.schemas so the router imports without a
 # full SLM venv (mirrors the sibling code-sync tests).
+# #11794: snapshot the models entries — restored right after api.code_sync
+# loads (see below) so the pydantic stand-ins don't leak across directories.
+_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
 if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
     from pydantic import BaseModel as _BM
 
@@ -71,6 +74,20 @@ import asyncio  # noqa: E402
 
 import api.code_sync as cs  # noqa: E402
 from api.code_sync import _run_post_sync_steps  # noqa: E402
+
+# #11794: restore the pre-file models/models.schemas sys.modules entries now
+# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
+# into later-collected directories (tests/services/test_saml_slo.py and
+# test_token_denylist.py real-load services/auth.py, whose
+# `from models.schemas import TokenResponse` breaks against them).
+for _k, _v in _MODELS_SNAPSHOT.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+if "models" in sys.modules and "models.schemas" in sys.modules:
+    sys.modules["models"].schemas = sys.modules["models.schemas"]
+del _MODELS_SNAPSHOT
 
 
 def _run(coro):

--- a/autobot-slm-backend/tests/services/test_saml_slo.py
+++ b/autobot-slm-backend/tests/services/test_saml_slo.py
@@ -114,6 +114,11 @@ if "config" not in sys.modules:
     _cfg_stub.settings.trusted_proxies = []
     sys.modules["config"] = _cfg_stub
 
+# #11794: forced, not guarded — in a whole-backend sweep the REAL fastapi is
+# legitimately imported by earlier directories, and exec'ing api/auth.py
+# against real FastAPI decorators + MagicMock response models raises
+# FastAPIError at collection time.  The pre-bootstrap snapshot above rolls
+# every forced stub back after the bootstrap.
 for _amod in [
     "models.schemas",
     "user_management",
@@ -134,8 +139,7 @@ for _amod in [
     "models.database",
     "api.security",
 ]:
-    if _amod not in sys.modules:
-        sys.modules[_amod] = MagicMock()
+    sys.modules[_amod] = MagicMock()
 
 # Provide real token_denylist
 _DENYLIST_PY = _BACKEND / "services" / "token_denylist.py"

--- a/autobot-slm-backend/tests/services/test_sso_logout.py
+++ b/autobot-slm-backend/tests/services/test_sso_logout.py
@@ -28,6 +28,15 @@ _ROOT = _BACKEND.parent
 sys.path.insert(0, str(_BACKEND))
 sys.path.insert(0, str(_ROOT))
 
+# #11478/#11794: snapshot sys.modules before the stub-heavy bootstrap below.
+# Tests only use the module references extracted here (_sso_mod attributes),
+# so every stub this file installs — notably the bare
+# "user_management.services.base_service" ModuleType, which broke the real
+# user_management/services/__init__.py import chain for
+# user_management/services/sso_e2e_test.py later in a whole-backend sweep —
+# is rolled back after the module under test is loaded.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 # ---------------------------------------------------------------------------
 # Stubs — mirror the pattern from test_sso_service.py, with a real
 # SSOProviderType enum so dict lookups resolve correctly.
@@ -83,6 +92,16 @@ _sso_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
 _spec.loader.exec_module(_sso_mod)  # type: ignore[union-attr]
 
 SSOService = _sso_mod.SSOService
+
+# #11478/#11794: restore the pre-bootstrap sys.modules state (see snapshot
+# above) so the stubs installed for this file's exec-based bootstrap cannot
+# poison modules collected after it in a sweep.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/services/test_sso_security.py
+++ b/autobot-slm-backend/tests/services/test_sso_security.py
@@ -22,6 +22,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# #11478/#11794: snapshot sys.modules before the stub-heavy bootstrap below.
+# Tests only use the module references extracted here (_sso_mod attributes),
+# so every stub this file installs — notably the bare
+# "user_management.services.base_service" ModuleType, which broke the real
+# user_management/services/__init__.py import chain for
+# user_management/services/sso_e2e_test.py later in a whole-backend sweep —
+# is rolled back after the module under test is loaded.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 # ── Load sso_service.py directly, bypassing conftest stubs ───────────────────
 _MODELS_SSO = "user_management.models.sso"
 if _MODELS_SSO not in sys.modules:
@@ -59,6 +68,16 @@ _spec.loader.exec_module(_sso_mod)  # type: ignore[union-attr]
 
 SSOService = _sso_mod.SSOService
 SSOAuthenticationError = _sso_mod.SSOAuthenticationError
+
+# #11478/#11794: restore the pre-bootstrap sys.modules state (see snapshot
+# above) so the stubs installed for this file's exec-based bootstrap cannot
+# poison modules collected after it in a sweep.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 # ─────────────────────────────────────────────────────────────────────────────
 
 

--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -13,6 +13,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# #11478/#11794: snapshot sys.modules before the stub-heavy bootstrap below.
+# Tests only use the module references extracted here (_sso_mod attributes) —
+# the one runtime sys.modules lookup, _patch_user_service, targets the shared
+# root-conftest stub that this restore puts back — so every stub this file
+# installs (notably the bare "user_management.services.base_service"
+# ModuleType, which broke the real user_management/services/__init__.py import
+# chain for user_management/services/sso_e2e_test.py later in a whole-backend
+# sweep) is rolled back after the module under test is loaded.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 # ── Load sso_service.py directly, bypassing conftest stubs ───────────────────
 # autobot-slm-backend/conftest.py pre-stubs all user_management.* modules as
 # MagicMocks to prevent the api/__init__.py import chain (Issue #3499).
@@ -70,6 +80,16 @@ _spec.loader.exec_module(_sso_mod)  # type: ignore[union-attr]
 SSOService = _sso_mod.SSOService
 SSOAuthenticationError = _sso_mod.SSOAuthenticationError
 _pkce_challenge_s256 = _sso_mod._pkce_challenge_s256
+
+# #11478/#11794: restore the pre-bootstrap sys.modules state (see snapshot
+# above) so the stubs installed for this file's exec-based bootstrap cannot
+# poison modules collected after it in a sweep.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 # ─────────────────────────────────────────────────────────────────────────────
 
 

--- a/autobot-slm-backend/tests/test_bi_dashboard.py
+++ b/autobot-slm-backend/tests/test_bi_dashboard.py
@@ -29,6 +29,31 @@ import pytest
 # We load the .py file directly so the monitoring package __init__ is bypassed.
 # ---------------------------------------------------------------------------
 
+
+# #11794: every sys.modules key this bootstrap writes.  Snapshotted here and
+# restored right after the module under test is loaded — the bare ModuleType
+# stand-ins (autobot_shared.redis_client has no get_async_redis_client, …)
+# otherwise leak into every later-collected test file in a sweep
+# (tests/test_rbac_*.py, tests/test_port_scanner_address.py).  Runtime tests
+# only use patch.object(_bid_mod, ...), never sys.modules lookups.
+_TOUCHED_KEYS = (
+    "matplotlib",
+    "matplotlib.pyplot",
+    "aiofiles",
+    "jinja2",
+    "performance_monitor",
+    "autobot_shared",
+    "autobot_shared.network_constants",
+    "autobot_shared.monitoring",
+    "autobot_shared.monitoring.prometheus_query",
+    "autobot_shared.redis_client",
+    "autobot_shared.http_client",
+    "autobot_shared.logging_manager",
+    "autobot_shared.ssot_config",
+    "business_intelligence_dashboard",
+)
+_PRE_BOOTSTRAP = {_k: sys.modules.get(_k) for _k in _TOUCHED_KEYS}
+
 # matplotlib stub
 _matplotlib = types.ModuleType("matplotlib")
 _matplotlib.use = lambda *a, **kw: None
@@ -140,6 +165,14 @@ _spec.loader.exec_module(_bid_mod)
 
 BusinessIntelligenceDashboard = _bid_mod.BusinessIntelligenceDashboard
 _sum_prometheus_increase = _bid_mod._sum_prometheus_increase
+
+# #11794: restore the pre-bootstrap state of every touched key (see above).
+for _k, _v in _PRE_BOOTSTRAP.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+del _PRE_BOOTSTRAP
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/test_bi_dashboard_10778.py
+++ b/autobot-slm-backend/tests/test_bi_dashboard_10778.py
@@ -28,6 +28,31 @@ import pytest
 # Mirrors the approach in test_bi_dashboard.py.
 # ---------------------------------------------------------------------------
 
+
+# #11794: every sys.modules key this bootstrap writes.  Snapshotted here and
+# restored right after the module under test is loaded — the bare ModuleType
+# stand-ins (autobot_shared.redis_client has no get_async_redis_client, …)
+# otherwise leak into every later-collected test file in a sweep
+# (tests/test_rbac_*.py, tests/test_port_scanner_address.py).  Runtime tests
+# only use patch.object(_bid_mod, ...), never sys.modules lookups.
+_TOUCHED_KEYS = (
+    "matplotlib",
+    "matplotlib.pyplot",
+    "aiofiles",
+    "jinja2",
+    "performance_monitor",
+    "autobot_shared",
+    "autobot_shared.network_constants",
+    "autobot_shared.monitoring",
+    "autobot_shared.monitoring.prometheus_query",
+    "autobot_shared.redis_client",
+    "autobot_shared.http_client",
+    "autobot_shared.logging_manager",
+    "autobot_shared.ssot_config",
+    "business_intelligence_dashboard",
+)
+_PRE_BOOTSTRAP = {_k: sys.modules.get(_k) for _k in _TOUCHED_KEYS}
+
 _matplotlib = types.ModuleType("matplotlib")
 _matplotlib.use = lambda *a, **kw: None
 sys.modules.setdefault("matplotlib", _matplotlib)
@@ -147,6 +172,14 @@ BusinessIntelligenceDashboard = _bid_mod.BusinessIntelligenceDashboard
 _sum_prometheus_increase = _bid_mod._sum_prometheus_increase
 _get_network_utilization_percent = _bid_mod._get_network_utilization_percent
 _sample_net_bytes_per_sec = _bid_mod._sample_net_bytes_per_sec
+
+# #11794: restore the pre-bootstrap state of every touched key (see above).
+for _k, _v in _PRE_BOOTSTRAP.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+del _PRE_BOOTSTRAP
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/test_rbac_middleware_cache.py
+++ b/autobot-slm-backend/tests/test_rbac_middleware_cache.py
@@ -43,6 +43,14 @@ for _p in (str(_SLM_ROOT), str(_SHARED_ROOT)):
 
 # Stub out the modules that pull in pydantic settings or FastAPI's python_multipart.
 # Note: test_require_permission.py documents the same python_multipart env conflict.
+# #11794: snapshot sys.modules and FORCE the stubs below — in a whole-backend
+# sweep the real fastapi/autobot_shared are already imported, and the guarded
+# version of this bootstrap then mutated the REAL fastapi module's
+# HTTPException/Request/status attributes, breaking every later test file that
+# uses FastAPI at runtime (tests/test_redis_service_router.py).  Everything is
+# rolled back right after the module under test is loaded.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 _MOCK_NAMES = [
     # fastapi pulls in starlette → multipart (broken in this env)
     "fastapi",
@@ -57,10 +65,12 @@ _MOCK_NAMES = [
     "user_management.services",
     "user_management.database",
     "user_management.config",
+    # audit model imported at module level by rbac_middleware (#11794)
+    "user_management.models",
+    "user_management.models.audit",
 ]
 for _name in _MOCK_NAMES:
-    if _name not in sys.modules:
-        sys.modules[_name] = MagicMock()
+    sys.modules[_name] = MagicMock()
 
 # fastapi.HTTPException, Request, status must be real enough for isinstance checks
 import http  # noqa: E402
@@ -82,6 +92,14 @@ _SPEC.loader.exec_module(_rbac_mod)
 _CACHE_TTL = _rbac_mod.CACHE_TTL_SECONDS
 _REDIS_PREFIX = _rbac_mod._REDIS_KEY_PREFIX
 _PUBSUB_CHANNEL = _rbac_mod._PUBSUB_CHANNEL
+
+# #11794: restore the pre-bootstrap sys.modules state (see snapshot above).
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
+++ b/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
@@ -35,6 +35,14 @@ for _p in (str(_SLM_ROOT), str(_SHARED_ROOT)):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+# #11794: snapshot sys.modules and FORCE the stubs below — in a whole-backend
+# sweep the real fastapi/autobot_shared are already imported, and the guarded
+# version of this bootstrap then mutated the REAL fastapi module's
+# HTTPException/Request/status attributes, breaking every later test file that
+# uses FastAPI at runtime (tests/test_redis_service_router.py).  Everything is
+# rolled back right after the module under test is loaded.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 _MOCK_NAMES = [
     "fastapi",
     "fastapi.exceptions",
@@ -52,8 +60,7 @@ _MOCK_NAMES = [
     "user_management.models.base",
 ]
 for _name in _MOCK_NAMES:
-    if _name not in sys.modules:
-        sys.modules[_name] = MagicMock()
+    sys.modules[_name] = MagicMock()
 
 import http  # noqa: E402
 
@@ -93,6 +100,14 @@ _SPEC = importlib.util.spec_from_file_location(
 )
 _rbac_mod: types.ModuleType = types.ModuleType(_SPEC.name)
 _SPEC.loader.exec_module(_rbac_mod)
+
+# #11794: restore the pre-bootstrap sys.modules state (see snapshot above).
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/user_management/middleware/rbac_middleware.py
+++ b/autobot-slm-backend/user_management/middleware/rbac_middleware.py
@@ -250,18 +250,24 @@ class RBACMiddleware:
         else:
             # Clear entire fallback; Redis keys expire naturally.
             _permission_cache.clear()
-            asyncio.ensure_future(self._clear_all_redis_keys(None))
+        # #11794: awaited, for BOTH paths — the single-user path previously
+        # never touched Redis L2 / pub-sub at all (other uvicorn workers kept
+        # serving stale permissions after a role change), and the all-users
+        # path was fire-and-forget so callers could observe stale state right
+        # after clear_cache() returned.
+        await self._clear_all_redis_keys(user_id)
 
     async def _clear_all_redis_keys(self, user_id: "uuid.UUID | None") -> None:
         r = await get_async_redis_client()
         if r is None:
             return
-        try:
-            keys = await r.keys("slm:perm:*")
-            if keys:
-                await r.delete(*keys)
-        except Exception as exc:
-            logger.warning("RBAC: failed to clear all Redis permission keys: %s", exc)
+        if user_id is None:
+            try:
+                keys = await r.keys("slm:perm:*")
+                if keys:
+                    await r.delete(*keys)
+            except Exception as exc:
+                logger.warning("RBAC: failed to clear all Redis permission keys: %s", exc)
 
         # Clear Redis L2 and notify other workers
         redis = await get_async_redis_client()


### PR DESCRIPTION
Closes #11794

## Thinking Path

Whole-slm-backend pytest sweeps were interrupted by 7 collection errors from cross-directory `sys.modules` contamination. Bisected each polluter→victim pair with 2-file runs; fixed on the polluter side wherever possible (snapshot/restore per the #11478/#11737 patterns) so the leak stops for everyone, with victim-side forced sandboxes where the victim legitimately needs a specific module world. Cross-ref: #11796 is the same defect class on autobot-backend — patterns kept consistent.

## What Changed

- 8 polluter/victim clusters repaired across 19 files (all test-side except one product fix): AST-derived conftest stubs now also cover `setup_wizard.py` imports; code-sync test sextet snapshots/restores `models.schemas`; bi_dashboard/rbac/sso polluters restore every touched key; rbac tests stop mutating the REAL fastapi module mid-sweep; missing stubs added where victims broke standalone.
- **Product bug fixed** (`user_management/middleware/rbac_middleware.py`): `clear_cache(user_id)` never deleted the Redis L2 key nor published pub/sub invalidation for single users — other workers kept STALE PERMISSIONS; the all-users path was fire-and-forget. Both paths now awaited; the 2 previously-uncollectable tests asserting exactly this now pass.

## Verification

- Collection: `1117 collected, 7 errors — Interrupted` → **1220 collected, 0 errors** (agent + independent re-run).
- Whole-sweep run now completes: 1103P/105F/36E, reconciled EXACTLY against base with the 8 previously-uncollectable files ignored — +46 newly-observable failures from never-run files, −10 improvements, **0 regressions** (per-file verified).
- `tests/services/` 313P/1S identical to base (independent re-run identical); `tests/api/` 267/0 collect; flake8 clean ×19.
- Newly-observable runtime rot inventory filed as #11798.

## Model Used

Claude Fable 5 (subagent: general-purpose)