### PR TITLE
feat(auth): device-JWT own-device-scoped GET /api/devices — close read/write asymmetry (#11792)

### DIFF
--- a/autobot-backend/api/mobile_devices.py
+++ b/autobot-backend/api/mobile_devices.py
@@ -9,6 +9,7 @@ Endpoints:
   POST   /api/devices/pair          — complete pairing via QR challenge token
   GET    /api/devices/pair-qr       — get a time-limited QR challenge token
   GET    /api/devices               — list devices for the current user
+                                      (device-JWT callers: own device only, #11792)
   GET    /api/devices/me            — device-JWT-only identity + heartbeat (#11736)
   DELETE /api/devices/{device_id}   — unpair a device
 
@@ -106,6 +107,22 @@ def _prune_expired(devices: list[MobileDevice]) -> list[MobileDevice]:
     """Return devices active within the last 90 days."""
     cutoff = now_utc() - timedelta(days=_DEVICE_EXPIRY_DAYS)
     return [d for d in devices if d.last_seen_at is None or d.last_seen_at >= cutoff]
+
+
+def _own_device_id(current_user: dict) -> Optional[uuid.UUID]:
+    """Own-device scoping for device-JWT callers (#11792).
+
+    Returns the caller's device UUID when auth came via device JWT (the
+    ``auth_method``/``device_id`` markers get_current_user attaches), so the
+    list endpoint can filter to the device's own record. User-session
+    callers return None (no filtering — full list).
+    """
+    if current_user.get("auth_method") != "device_jwt":
+        return None
+    try:
+        return uuid.UUID(str(current_user.get("device_id")))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Valid device token required")
 
 
 # ---------------------------------------------------------------------------
@@ -218,10 +235,17 @@ async def list_devices(
 
     Devices inactive for more than 90 days are pruned from the DB on each
     call so storage stays clean without a separate background job.
+
+    #11792: device-JWT callers (read scope suffices) get the list scoped to
+    their own device record; user-session callers get the full list.
     """
     user_id: str = str(current_user.get("id") or current_user.get("user_id", ""))
 
-    result = await session.execute(select(MobileDevice).where(MobileDevice.user_id == user_id))
+    stmt = select(MobileDevice).where(MobileDevice.user_id == user_id)
+    own_id = _own_device_id(current_user)
+    if own_id is not None:
+        stmt = stmt.where(MobileDevice.id == own_id)
+    result = await session.execute(stmt)
     devices = list(result.scalars().all())
 
     active = _prune_expired(devices)

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -843,9 +843,10 @@ async def get_current_user(request: Request) -> Dict:
     full user session.  Scope enforcement is left to individual endpoints.
 
     GH#9493: Device JWTs authenticate ONLY on /api/devices/ endpoints
-    (path allow-list + read/write scope enforcement below). Device-only
-    endpoints use the require_device_jwt() dependency factory instead
-    (#11736).
+    (path allow-list + read/write scope enforcement below), plus the
+    GET-only collection route /api/devices whose response is own-device
+    scoped (#11792). Device-only endpoints use the require_device_jwt()
+    dependency factory instead (#11736).
 
     Raises HTTPException if authentication fails.
     """
@@ -884,10 +885,16 @@ async def get_current_user(request: Request) -> Dict:
     # Fallback: device-scoped JWT (GH#9493) — validates device still exists.
     # Device JWTs are valid ONLY on /api/devices/ endpoints. Read-scoped tokens
     # cannot use mutating HTTP methods (POST/PUT/PATCH/DELETE).
+    # #11792: the collection route GET /api/devices (no trailing slash) is also
+    # allowed — the list endpoint filters the response to the caller's own
+    # device. Non-GET methods on the exact collection path stay excluded.
     device_user = await middleware._extract_user_from_device_jwt(request)
     if device_user:
         _DEVICE_JWT_ALLOWED_PREFIXES = ("/api/devices/",)
-        if not any(request.url.path.startswith(p) for p in _DEVICE_JWT_ALLOWED_PREFIXES):
+        path_allowed = any(request.url.path.startswith(p) for p in _DEVICE_JWT_ALLOWED_PREFIXES) or (
+            request.url.path == "/api/devices" and request.method == "GET"
+        )
+        if not path_allowed:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Device JWT not permitted on this endpoint",

--- a/autobot-backend/tests/integration/test_device_jwt_auth.py
+++ b/autobot-backend/tests/integration/test_device_jwt_auth.py
@@ -284,9 +284,7 @@ class TestDeviceScopeEnforcement:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])
-    async def test_collection_non_get_still_excluded(
-        self, method, device_jwt_env, device_exists, real_auth_middleware
-    ):
+    async def test_collection_non_get_still_excluded(self, method, device_jwt_env, device_exists, real_auth_middleware):
         """#11792 widened ONLY GET on the exact collection path.
 
         Every other method on /api/devices (no trailing slash) keeps the

--- a/autobot-backend/tests/integration/test_device_jwt_auth.py
+++ b/autobot-backend/tests/integration/test_device_jwt_auth.py
@@ -262,6 +262,49 @@ class TestDeviceScopeEnforcement:
         assert user["scope"] == "read"
 
     @pytest.mark.asyncio
+    async def test_device_jwt_allowed_on_collection_get(self, device_jwt_env, device_exists, real_auth_middleware):
+        """#11792: GET /api/devices (no trailing slash) authenticates a read token.
+
+        Closes the GH#9493 read/write asymmetry — the list route is the one
+        /api/devices endpoint the trailing-slash prefix allow-list missed.
+        Response scoping to the caller's own device is enforced by the list
+        endpoint (see test_mobile_device_me.py).
+        """
+        device_id = str(uuid.uuid4())
+        token = mint_device_jwt(device_id, "user123", scope="read")
+        request = _bearer_request(token, path="/api/devices", method="GET")
+
+        middleware, p_factory, p_user = self._patched(real_auth_middleware)
+        with p_factory, p_user:
+            user = await real_auth_middleware.get_current_user(request)
+
+        assert user["auth_method"] == "device_jwt"
+        assert user["device_id"] == device_id
+        assert user["scope"] == "read"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])
+    async def test_collection_non_get_still_excluded(
+        self, method, device_jwt_env, device_exists, real_auth_middleware
+    ):
+        """#11792 widened ONLY GET on the exact collection path.
+
+        Every other method on /api/devices (no trailing slash) keeps the
+        pre-existing allow-list 403 — even for write-scoped tokens, proving
+        the change did not widen the mutating surface.
+        """
+        token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="write")
+        request = _bearer_request(token, path="/api/devices", method=method)
+
+        middleware, p_factory, p_user = self._patched(real_auth_middleware)
+        with p_factory, p_user:
+            with pytest.raises(HTTPException) as exc_info:
+                await real_auth_middleware.get_current_user(request)
+
+        assert exc_info.value.status_code == 403
+        assert "Device JWT not permitted on this endpoint" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
     async def test_read_scope_blocks_mutating_methods(self, device_jwt_env, device_exists, real_auth_middleware):
         """Read-scoped device JWTs cannot use mutating HTTP methods."""
         token = mint_device_jwt(str(uuid.uuid4()), "user123", scope="read")

--- a/autobot-backend/tests/integration/test_mobile_device_me.py
+++ b/autobot-backend/tests/integration/test_mobile_device_me.py
@@ -4,11 +4,12 @@
 # Author: mrveiss
 """
 GET /api/devices/me — require_device_jwt wiring tests (#11736).
+GET /api/devices — device-JWT own-device response scoping tests (#11792).
 
 Separate from test_mobile_pairing.py on purpose: that module's autouse
 Redis-cleanup fixture skips the whole file when Redis is unavailable
 (CI included), and these tests need only the in-memory database. Keeping
-them here guarantees the #11736 wiring is always exercised.
+them here guarantees the #11736/#11792 wiring is always exercised.
 """
 
 import uuid
@@ -26,6 +27,7 @@ from sqlalchemy.pool import StaticPool
 from api.mobile_devices import _device_jwt_auth
 from api.mobile_devices import router as mobile_router
 from api.user_management.dependencies import get_db_session
+from auth_middleware import get_current_user
 from autobot_shared.time_utils import now_utc
 from models.mobile_device import MobileDevice
 from user_management.models.base import Base
@@ -75,8 +77,14 @@ async def paired_device(db_session, monkeypatch) -> MobileDevice:
     return device
 
 
-def _client(db_session, device_user: dict) -> TestClient:
-    """Client with the DB and device-JWT dependencies overridden."""
+def _client(db_session, device_user: dict | None = None, current_user: dict | None = None) -> TestClient:
+    """Client with the DB and device-JWT dependencies overridden.
+
+    ``device_user`` overrides require_device_jwt (the /me route);
+    ``current_user`` overrides get_current_user for the routes that accept
+    both principals (the #11792 list-scoping tests) — pass the device-user
+    dict (auth_method="device_jwt") or a plain user-session dict.
+    """
     app = FastAPI()
     app.include_router(mobile_router, prefix="/api/devices")
 
@@ -84,7 +92,10 @@ def _client(db_session, device_user: dict) -> TestClient:
         yield db_session
 
     app.dependency_overrides[get_db_session] = override_get_db
-    app.dependency_overrides[_device_jwt_auth] = lambda: device_user
+    if device_user is not None:
+        app.dependency_overrides[_device_jwt_auth] = lambda: device_user
+    if current_user is not None:
+        app.dependency_overrides[get_current_user] = lambda: current_user
     return TestClient(app)
 
 
@@ -157,4 +168,83 @@ async def test_device_me_malformed_device_id_returns_401(db_session):
     )
 
     response = client.get("/api/devices/me")
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/devices — device-JWT own-device response scoping (#11792)
+# ---------------------------------------------------------------------------
+
+
+def _device_principal(device_id: str, scope: str = "read") -> dict:
+    """Synthetic device user as get_current_user attaches it (GH#9493)."""
+    return {
+        "device_id": device_id,
+        "user_id": _USER_ID,
+        "scope": scope,
+        "auth_method": "device_jwt",
+        "role": "device",
+        "username": f"device:{device_id}",
+    }
+
+
+async def _add_device(db_session, name: str, user_id: str = _USER_ID) -> MobileDevice:
+    """Seed an active sibling device (encryption stubbed by paired_device)."""
+    device = MobileDevice(
+        user_id=user_id,
+        device_name=name,
+        device_token=f"tok-{name}",
+        platform="android",
+        last_seen_at=now_utc(),
+    )
+    db_session.add(device)
+    await db_session.commit()
+    return device
+
+
+@pytest.mark.asyncio
+async def test_list_devices_device_jwt_scoped_to_own_device(db_session, paired_device):
+    """A device read token GETs /api/devices and sees EXACTLY its own record."""
+    sibling = await _add_device(db_session, "Sibling Tablet")
+    client = _client(db_session, current_user=_device_principal(str(paired_device.id)))
+
+    response = client.get("/api/devices")
+
+    assert response.status_code == 200
+    devices = response.json()["devices"]
+    assert [d["id"] for d in devices] == [str(paired_device.id)]
+    assert str(sibling.id) not in {d["id"] for d in devices}
+
+
+@pytest.mark.asyncio
+async def test_list_devices_write_device_token_also_own_scoped(db_session, paired_device):
+    """Own-device scoping keys off auth_method, not scope — write tokens too."""
+    await _add_device(db_session, "Sibling Tablet")
+    client = _client(db_session, current_user=_device_principal(str(paired_device.id), scope="write"))
+
+    response = client.get("/api/devices")
+
+    assert response.status_code == 200
+    assert [d["id"] for d in response.json()["devices"]] == [str(paired_device.id)]
+
+
+@pytest.mark.asyncio
+async def test_list_devices_user_session_gets_full_list(db_session, paired_device):
+    """Zero regression: user-session callers keep the unfiltered full list."""
+    sibling = await _add_device(db_session, "Sibling Tablet")
+    client = _client(db_session, current_user={"id": _USER_ID, "user_id": _USER_ID})
+
+    response = client.get("/api/devices")
+
+    assert response.status_code == 200
+    ids = {d["id"] for d in response.json()["devices"]}
+    assert ids == {str(paired_device.id), str(sibling.id)}
+
+
+@pytest.mark.asyncio
+async def test_list_devices_malformed_device_principal_returns_401(db_session, paired_device):
+    """A non-UUID device_id claim cannot reach the list query."""
+    client = _client(db_session, current_user=_device_principal("not-a-uuid"))
+
+    response = client.get("/api/devices")
     assert response.status_code == 401


### PR DESCRIPTION
Closes #11792

## Thinking Path

Owner decision (2026-07-16): own-device-scoped list — least-privilege symmetric read, zero regression. The allow-list gains exactly one capability: the no-trailing-slash collection route, GET only; the response is server-side filtered to the caller's own device when auth came via device JWT.

## What Changed

- `auth_middleware.py`: allow-list condition now `path == "/api/devices" and method == "GET"` OR the untouched `("/api/devices/",)` prefix — exact-path + GET-only; item routes and the read-scope mutating-method gate are byte-identical.
- `api/mobile_devices.py`: list endpoint filters to `_own_device_id()` (keyed off the `auth_method == "device_jwt"` + `device_id` markers `get_current_user` attaches; malformed claim → 401). User sessions get the unchanged full list.
- 11 new tests: 7 middleware (incl. `test_collection_non_get_still_excluded` — POST/PUT/PATCH/DELETE/HEAD/OPTIONS with a WRITE token still 403 on the collection, proving the allow-list itself still blocks) + 4 list-scoping (own-device-only, sibling invisible, user-session full list, write-token also own-scoped).

## Verification

- Canonical device-jwt + mobile_device suites: 58 passed (agent and independent re-run identical); all pre-existing pins unchanged (outside-prefix 403, scope matrices, revocation).
- Full `tests/integration` sweep: 583 passed / 24 pre-existing env skips (collection-order safe). Startup imports 344. flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)