### PR TITLE
fix(voice): dedupe concurrent voice checks — false 'no speech voices installed' (#11802)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
@@ -116,3 +116,51 @@ describe('useVoiceOutput — zero-voices UX (#9999)', () => {
     expect(mockShowToast).not.toHaveBeenCalled()
   })
 })
+
+// #11802: per-sentence streaming fires several speak() calls at once. Each
+// voice check used to call fetchVoices() independently and useApiResource's
+// `abortPrior` default cancelled the previous in-flight request, so the checks
+// aborted each other (nginx 499), left `voices` empty, and surfaced the "no
+// voices" toast on a deployment whose voices were fine.
+describe('useVoiceOutput — concurrent voice checks (#11802)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    voicesRef.value = []
+    _clock += 60_000
+    vi.spyOn(Date, 'now').mockImplementation(() => _clock)
+  })
+
+  it('concurrent speak() calls share ONE voices fetch (no self-aborting race)', async () => {
+    let resolveFetch: () => void = () => {}
+    mockFetchVoices.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFetch = () => {
+            voicesRef.value = [{ id: 'v1' }]
+            resolve()
+          }
+        }),
+    )
+    ;(fetchWithAuth as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    const { speak } = useVoiceOutput()
+    const inFlight = [speak('one', true), speak('two', true), speak('three', true)]
+    resolveFetch()
+    await Promise.all(inFlight)
+
+    expect(mockFetchVoices).toHaveBeenCalledTimes(1)
+    expect(mockShowToast).not.toHaveBeenCalled()
+  })
+
+  it('does not claim "no voices" when the fetch itself fails', async () => {
+    mockFetchVoices.mockRejectedValue(new Error('aborted'))
+
+    const { speak } = useVoiceOutput()
+    await speak('hello', true)
+
+    expect(mockShowToast).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -59,6 +59,11 @@ const _TTS_WS_IDLE_TIMEOUT = 30_000
 let _noVoicesNotifiedAt = 0
 const _NO_VOICES_NOTIFY_COOLDOWN = 30_000
 
+// #11802: shared in-flight voice-list fetch. useApiResource aborts the prior
+// request on every new load(), so concurrent voice checks must await ONE
+// fetch instead of racing and cancelling each other.
+let _voicesFetchInFlight: Promise<void> | null = null
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type VoiceMessage = Record<string, any>
 type VoiceMessageHandler = (msg: VoiceMessage) => void
@@ -88,14 +93,29 @@ function _notifyNoVoices(): void {
  * list once if it has not been loaded yet (it is normally only populated by
  * the settings panel), so an empty list reflects a genuine zero-voices
  * deployment rather than an unfetched cache.
+ *
+ * #11802: concurrent callers share ONE in-flight fetch. Per-sentence
+ * streaming calls speak() several times at once; each check used to call
+ * fetchVoices() independently, and useApiResource's `abortPrior` default
+ * cancels the previous in-flight request — so the checks aborted each other
+ * (nginx 499), left `voices` empty, and fired the "no voices" message on a
+ * deployment whose voices were fine.
  */
 async function _hasVoicesAvailable(): Promise<boolean> {
   const { voices, fetchVoices } = useVoiceProfiles()
   if (voices.value.length === 0) {
+    if (_voicesFetchInFlight === null) {
+      _voicesFetchInFlight = fetchVoices().finally(() => {
+        _voicesFetchInFlight = null
+      })
+    }
     try {
-      await fetchVoices()
+      await _voicesFetchInFlight
     } catch (e) {
+      // An aborted/failed fetch is NOT evidence of a zero-voice deployment,
+      // so stay quiet and let the next call re-check (#11802).
       logger.warn('fetchVoices failed during TTS voice check:', e)
+      return voices.value.length > 0
     }
   }
   if (voices.value.length === 0) {


### PR DESCRIPTION
## Thinking Path

User reported "Text-to-speech is not available on this deployment — no speech voices are installed" on a box where TTS demonstrably works. The nginx access log settled it:

```
22:16:06 GET /api/voice/voices        499 0      <- aborted
22:16:06 GET /api/voice/voices        499 0      <- aborted (concurrent)
22:16:08 GET /api/voice/voices        200 659    <- voices DO exist
22:16:38 POST /api/voice/synthesize   200 14641  <- 14KB of audio synthesized
```

34 × 499 on voice endpoints. Worker `:8083/voices` → 11 voices; backend `TTSClient.list_voices()` → 11 voices. The message was a **false negative**, not a real capability gap.

**Root cause:** per-sentence streaming issues concurrent `speak()` calls → each `_hasVoicesAvailable()` independently calls `fetchVoices()` → `useApiResource` defaults to `abortPrior: true` and aborts the previous in-flight request (useApiResource.ts:99, :110-111). The checks cancelled each other, `voices` stayed empty, and `_notifyNoVoices()` fired.

## What Changed

- `useVoiceOutput.ts` — concurrent callers now share ONE in-flight voices fetch (`_voicesFetchInFlight`); a failed/aborted fetch no longer counts as evidence of a zero-voice deployment (returns the current known state instead of asserting "none").
- `__tests__/useVoiceOutput.test.ts` — +2 tests: concurrent `speak()` triggers exactly one fetch and no toast; a failing fetch doesn't claim "no voices".

## Verification

- `vitest run useVoiceOutput.test.ts` → **6 passed** (4 existing + 2 new)
- **Regression-sensitivity proven:** reverting the fix fails both new tests (the concurrency test times out at 10s — the fetches cannibalise each other exactly as in prod); restoring makes them pass.
- `vue-tsc --noEmit -p tsconfig.app.json` → 0 errors

Closes #11802

## Model Used

Fable 5 (inline implementation)
