### PR TITLE
fix(slm): _ssh_key_usable helper — degrade to default identity on unreadable key, warn once (#11793)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -74,6 +74,7 @@ from services.drift_checker import (
 from services.fleet_sync_guard import assert_no_running_sync, fleet_sync_lock
 from services.git_tracker import DEFAULT_BRANCH, DEFAULT_REPO_PATH, get_git_tracker
 from services.playbook_executor import get_playbook_executor
+from services.ssh_utils import _ssh_key_usable
 from services.sync_orchestrator import get_sync_orchestrator
 
 logger = logging.getLogger(__name__)
@@ -2547,8 +2548,8 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
         logger.info("SLM self-sync: code source is local at %s, using direct rsync", repo_path)
     else:
         ssh_key = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")
-        if not Path(ssh_key).exists():
-            logger.error("SLM self-sync failed: SSH key not found at %s", ssh_key)
+        if not _ssh_key_usable(ssh_key):
+            logger.error("SLM self-sync failed: SSH key not usable at %s", ssh_key)
             return
         logger.info("SLM self-sync: pulling from %s@%s:%s", source_user, source_ip, repo_path)
 

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -72,6 +72,7 @@ from services.auth import get_current_user
 from services.database import get_db
 from services.encryption import encrypt_data
 from services.reconciler import reconciler_service
+from services.ssh_utils import _ssh_key_usable
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/nodes", tags=["nodes"])
@@ -2736,9 +2737,8 @@ def _build_node_ssh_cmd(ip_address: str, ssh_user: str, ssh_port: int) -> list:
         "-p",
         str(ssh_port),
     ]
-    key_path = Path(_DEFAULT_SSH_KEY)
-    if key_path.exists():
-        cmd.extend(["-i", str(key_path)])
+    if _ssh_key_usable(_DEFAULT_SSH_KEY):
+        cmd.extend(["-i", _DEFAULT_SSH_KEY])
     cmd.append(f"{ssh_user}@{ip_address}")
     return cmd
 

--- a/autobot-slm-backend/api/nodes_execution.py
+++ b/autobot-slm-backend/api/nodes_execution.py
@@ -40,6 +40,7 @@ from autobot_shared.auth.permissions import Permission
 from models.database import EventSeverity, EventType, Node, NodeEvent, NodeStatus
 from services.auth import require_permission
 from services.database import get_db
+from services.ssh_utils import _ssh_key_usable
 
 logger = logging.getLogger(__name__)
 
@@ -585,7 +586,7 @@ async def _run_via_ssh(
         "-o",
         f"ConnectTimeout={min(timeout, 30)}",
     ]
-    if Path(_SSH_KEY_PATH).exists():
+    if _ssh_key_usable(_SSH_KEY_PATH):
         cmd.extend(["-i", _SSH_KEY_PATH])
     cmd.append(f"{ssh_user}@{ip}")
     # Pass the command tokens as individual arguments to avoid any shell

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -148,6 +148,24 @@ _EXTRA_SERVICE_MODULES = (
 for _m in ("services", *sorted(_CODE_SYNC_SERVICE_MODULES | set(_EXTRA_SERVICE_MODULES))):
     _stub(_m)
 
+# ── services.ssh_utils — REAL module, not a stub (#11793) ─────────────────────
+# api/code_sync.py imports it, so the AST-derived loop above just stubbed it —
+# but its ``_ssh_key_usable()`` gate must stay real under test: a MagicMock is
+# truthy, which would silently re-add ``-i <key>`` at every migrated ssh build
+# site.  The module is dependency-light (os/logging/pathlib only), so real-load
+# it via its file spec (the ``services`` parent is a MagicMock, not a package,
+# so a normal import cannot traverse it) and re-bind it onto the parent stub
+# so ``patch("services.ssh_utils.X")`` resolves to the same object.
+import importlib.util as _importlib_util  # noqa: E402
+
+_ssh_utils_spec = _importlib_util.spec_from_file_location(
+    "services.ssh_utils", Path(__file__).parent / "services" / "ssh_utils.py"
+)
+_ssh_utils_mod = _importlib_util.module_from_spec(_ssh_utils_spec)
+sys.modules["services.ssh_utils"] = _ssh_utils_mod
+_ssh_utils_spec.loader.exec_module(_ssh_utils_mod)
+setattr(sys.modules["services"], "ssh_utils", _ssh_utils_mod)
+
 # ── python-multipart ─────────────────────────────────────────────────────────
 # FastAPI's ensure_multipart_is_installed() is called when any route uses
 # UploadFile or Form parameters.  It checks for python_multipart.__version__

--- a/autobot-slm-backend/services/code_distributor.py
+++ b/autobot-slm-backend/services/code_distributor.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 
 from models.database import Setting
 from services.database import db_service
+from services.ssh_utils import _ssh_key_usable
 
 logger = logging.getLogger(__name__)
 
@@ -142,12 +143,11 @@ class CodeDistributor:
             "-o",
             "StrictHostKeyChecking=accept-new",
             "-o",
-            "-o",
             "ConnectTimeout=30",
             "-p",
             str(ssh_port),
         ]
-        if Path(SSH_KEY_PATH).exists():
+        if _ssh_key_usable(SSH_KEY_PATH):
             cmd.extend(["-i", SSH_KEY_PATH])
         return cmd
 
@@ -388,7 +388,7 @@ class CodeDistributor:
     def _build_ssh_opts(self, ssh_port: int) -> str:
         """Helper for trigger_node_sync. Ref: #1088."""
         ssh_opts = f"ssh -o StrictHostKeyChecking=accept-new " f"-o ConnectTimeout=30 -p {ssh_port}"
-        if Path(SSH_KEY_PATH).exists():
+        if _ssh_key_usable(SSH_KEY_PATH):
             ssh_opts += f" -i {SSH_KEY_PATH}"
         return ssh_opts
 

--- a/autobot-slm-backend/services/ssh_utils.py
+++ b/autobot-slm-backend/services/ssh_utils.py
@@ -1,0 +1,63 @@
+# Copyright 2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical ssh-key usability gate (#11793).
+
+``Path(SSH_KEY_PATH).exists()`` propagates ``PermissionError`` when the key's
+parent directory is unreadable (EACCES is not in pathlib's ignored-errno set),
+so every ssh command build crashed with an unhandled exception instead of
+degrading.  ``_ssh_key_usable`` is the one safe gate: it returns ``True`` only
+when the key is confirmed readable and fails closed (``False`` -> no ``-i``
+flag, ssh uses its default identity) on ANY doubt, logging an actionable
+WARNING once per path instead of crashing.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Paths already warned about — warn once per path per process so a persistent
+# permissions misconfiguration degrades with a single actionable line instead
+# of replacing crash spam with log spam (#11793).
+_WARNED_PATHS: set = set()
+
+
+def _warn_once(path: str, detail: str) -> None:
+    """Log the not-usable WARNING for *path* at most once per process."""
+    if path in _WARNED_PATHS:
+        return
+    _WARNED_PATHS.add(path)
+    logger.warning(
+        "SSH key %s is not usable (%s); falling back to default ssh identity",
+        path,
+        detail,
+    )
+
+
+def _ssh_key_usable(key_path) -> bool:
+    """Return True only when *key_path* is confirmed readable.
+
+    Fail-closed replacement for the inline ``Path(KEY).exists()`` gates:
+
+    - missing key -> ``False``, quiet (matches the old behavior);
+    - unreadable key, or any ``OSError`` while checking (e.g. EACCES on the
+      key's parent directory) -> ``False`` plus a single WARNING per path.
+
+    ``False`` means the caller builds its ssh/rsync command WITHOUT ``-i`` and
+    ssh falls back to the default identity — never an unhandled
+    ``PermissionError`` (#11793).
+    """
+    path = os.fspath(key_path)
+    try:
+        if not Path(path).exists():
+            return False
+        if os.access(path, os.R_OK):
+            return True
+    except OSError as exc:  # PermissionError included — EACCES on parent dir
+        _warn_once(path, f"errno {exc.errno}: {exc.strerror or exc}")
+        return False
+    _warn_once(path, "exists but is not readable by the SLM process")
+    return False

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import CodeSource, Node, NodeRole, Role, RoleStatus
 from services.database import db_service
+from services.ssh_utils import _ssh_key_usable
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ class SyncOrchestrator:
             f"-o ConnectTimeout=30 "
             f"-p {port}"
         )
-        if Path(SSH_KEY_PATH).exists():
+        if _ssh_key_usable(SSH_KEY_PATH):
             ssh_opts += f" -i {SSH_KEY_PATH}"
         return ssh_opts
 
@@ -119,7 +120,7 @@ class SyncOrchestrator:
             "-p",
             str(port),
         ]
-        if Path(SSH_KEY_PATH).exists():
+        if _ssh_key_usable(SSH_KEY_PATH):
             ssh_cmd.extend(["-i", SSH_KEY_PATH])
         ssh_cmd.append(f"{user}@{host}")
         return ssh_cmd
@@ -293,7 +294,7 @@ class SyncOrchestrator:
         Helper for pull_from_source (Issue #665).
         """
         ssh_opts = "ssh -o StrictHostKeyChecking=accept-new " "-o UserKnownHostsFile=/dev/null " "-o ConnectTimeout=30"
-        if Path(SSH_KEY_PATH).exists():
+        if _ssh_key_usable(SSH_KEY_PATH):
             ssh_opts += f" -i {SSH_KEY_PATH}"
 
         return [
@@ -339,7 +340,7 @@ class SyncOrchestrator:
             "-o",
             "ConnectTimeout=10",
         ]
-        if Path(SSH_KEY_PATH).exists():
+        if _ssh_key_usable(SSH_KEY_PATH):
             ssh_cmd.extend(["-i", SSH_KEY_PATH])
 
         ssh_cmd.extend(

--- a/autobot-slm-backend/tests/services/test_ssh_utils.py
+++ b/autobot-slm-backend/tests/services/test_ssh_utils.py
@@ -1,0 +1,190 @@
+# Copyright 2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the canonical ssh-key usability gate (#11793).
+
+``Path(SSH_KEY_PATH).exists()`` propagated PermissionError when the key's
+parent directory was unreadable, crashing every ssh command build in
+sync_orchestrator / code_distributor / nodes_execution / nodes / code_sync.
+``_ssh_key_usable`` must degrade instead: False -> no ``-i`` flag (default
+ssh identity), with a single actionable WARNING per path.
+"""
+
+import importlib
+import logging
+import sys
+from unittest.mock import patch
+
+import pytest
+
+import services.ssh_utils as ssh_utils
+from services.ssh_utils import _ssh_key_usable
+
+# ── Load the REAL services.sync_orchestrator (#11737 pattern) ────────────────
+# The slm-backend root conftest stubs ``services.sync_orchestrator`` as a
+# MagicMock (it is an api/code_sync.py import).  Pop the stub, import the real
+# module through the hollow ``services`` package (its heavy deps stay satisfied
+# by the conftest stubs), then restore the stub so sibling test files and
+# api/* tests are unaffected (#11478 pattern).
+_SO_KEY = "services.sync_orchestrator"
+_orig_so = sys.modules.get(_SO_KEY)
+sys.modules.pop(_SO_KEY, None)
+try:
+    _so_mod = importlib.import_module(_SO_KEY)
+finally:
+    if _orig_so is not None:
+        sys.modules[_SO_KEY] = _orig_so
+    else:
+        sys.modules.pop(_SO_KEY, None)
+
+SyncOrchestrator = _so_mod.SyncOrchestrator
+
+# ── Load the REAL services.code_distributor (same pattern) ───────────────────
+_CD_KEY = "services.code_distributor"
+_orig_cd = sys.modules.get(_CD_KEY)
+sys.modules.pop(_CD_KEY, None)
+try:
+    _cd_mod = importlib.import_module(_CD_KEY)
+finally:
+    if _orig_cd is not None:
+        sys.modules[_CD_KEY] = _orig_cd
+    else:
+        sys.modules.pop(_CD_KEY, None)
+
+CodeDistributor = _cd_mod.CodeDistributor
+
+_LOGGER_NAME = "services.ssh_utils"
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_paths():
+    """Each test starts with a clean warn-once ledger."""
+    ssh_utils._WARNED_PATHS.clear()
+    yield
+    ssh_utils._WARNED_PATHS.clear()
+
+
+def _warnings(caplog) -> list:
+    return [r for r in caplog.records if r.name == _LOGGER_NAME and r.levelno == logging.WARNING]
+
+
+# ── unit: _ssh_key_usable ─────────────────────────────────────────────────────
+
+
+def test_readable_key_returns_true(tmp_path, caplog):
+    key = tmp_path / "autobot_key"
+    key.write_text("fake-key-material", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert _ssh_key_usable(str(key)) is True
+    assert _warnings(caplog) == []
+
+
+def test_missing_key_returns_false_without_warning(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert _ssh_key_usable(str(tmp_path / "absent_key")) is False
+    assert _warnings(caplog) == []
+
+
+def test_permissionerror_returns_false_and_warns_once(caplog):
+    """Unreadable parent dir (EACCES from Path.exists) -> False + ONE warning."""
+    key = "/unreadable-dir/.ssh/autobot_key"
+    with (
+        caplog.at_level(logging.WARNING, logger=_LOGGER_NAME),
+        patch.object(ssh_utils, "Path") as mock_path,
+    ):
+        mock_path.return_value.exists.side_effect = PermissionError(13, "Permission denied")
+        assert _ssh_key_usable(key) is False
+        assert _ssh_key_usable(key) is False  # second call: no duplicate log
+
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert key in message
+    assert "errno 13" in message
+    assert "falling back to default ssh identity" in message
+
+
+def test_os_access_error_returns_false_and_warns_once(tmp_path, caplog):
+    """OSError from os.access itself is also degraded, not propagated."""
+    key = tmp_path / "autobot_key"
+    key.write_text("fake-key-material", encoding="utf-8")
+
+    def _raise(*_args, **_kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    with (
+        caplog.at_level(logging.WARNING, logger=_LOGGER_NAME),
+        patch.object(ssh_utils.os, "access", _raise),
+    ):
+        assert _ssh_key_usable(str(key)) is False
+        assert _ssh_key_usable(str(key)) is False
+
+    assert len(_warnings(caplog)) == 1
+
+
+def test_existing_unreadable_key_returns_false_and_warns(tmp_path, caplog):
+    """Key exists but is not readable (os.access False) -> False + warning."""
+    key = tmp_path / "autobot_key"
+    key.write_text("fake-key-material", encoding="utf-8")
+    with (
+        caplog.at_level(logging.WARNING, logger=_LOGGER_NAME),
+        patch.object(ssh_utils.os, "access", lambda *_a, **_k: False),
+    ):
+        assert _ssh_key_usable(str(key)) is False
+
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1
+    assert "not readable" in warnings[0].getMessage()
+
+
+def test_warn_once_is_per_path(caplog):
+    with (
+        caplog.at_level(logging.WARNING, logger=_LOGGER_NAME),
+        patch.object(ssh_utils, "Path") as mock_path,
+    ):
+        mock_path.return_value.exists.side_effect = PermissionError(13, "Permission denied")
+        assert _ssh_key_usable("/dir-a/key") is False
+        assert _ssh_key_usable("/dir-b/key") is False
+
+    assert len(_warnings(caplog)) == 2
+
+
+# ── integration: previously-crashing site degrades ────────────────────────────
+
+
+def test_build_ssh_command_degrades_on_permissionerror(caplog):
+    """The exact site from the #11793 traceback (sync_orchestrator.py
+    _build_ssh_command) no longer raises: the command is built WITHOUT -i and
+    a single WARNING is logged."""
+    orchestrator = SyncOrchestrator.__new__(SyncOrchestrator)
+    key = "/unreadable-home/.ssh/autobot_key"
+    with (
+        caplog.at_level(logging.WARNING, logger=_LOGGER_NAME),
+        patch.object(_so_mod, "SSH_KEY_PATH", key),
+        patch.object(ssh_utils, "Path") as mock_path,
+    ):
+        mock_path.return_value.exists.side_effect = PermissionError(13, "Permission denied")
+        cmd = orchestrator._build_ssh_command(2222, "autobot", "10.0.0.5")
+
+    assert "-i" not in cmd
+    assert cmd[0] == "ssh"
+    assert cmd[-1] == "autobot@10.0.0.5"
+    assert len(_warnings(caplog)) == 1
+
+
+def test_code_distributor_ssh_argv_is_wellformed(tmp_path):
+    """Regression guard for the stray ``-o`` token fixed with #11793 (same
+    class as #10277): every ``-o`` in CodeDistributor._build_ssh_command must
+    be followed by a ``key=value`` token, and the ssh-key gate is the shared
+    helper (degrades on a missing key)."""
+    distributor = CodeDistributor.__new__(CodeDistributor)
+    with patch.object(_cd_mod, "SSH_KEY_PATH", str(tmp_path / "absent_key")):
+        cmd = distributor._build_ssh_command(2222)
+
+    assert "-i" not in cmd
+    for idx, token in enumerate(cmd):
+        if token == "-o":
+            assert idx + 1 < len(cmd), f"trailing -o with no argument: {cmd!r}"
+            value = cmd[idx + 1]
+            assert "=" in value and not value.startswith("-"), f"-o not followed by key=value: {value!r} in {cmd!r}"


### PR DESCRIPTION
Closes #11793

## Thinking Path

Owner decision (2026-07-16): one safe helper, degrade + warn. Exhaustive grep found **9** sites gating `-i <key>` on crash-prone `Path(...).exists()` — the 7 filed plus `api/nodes.py:2740` and `api/code_sync.py:2550` (the latter keeps its hard-fail semantics, message corrected "not found" → "not usable").

## What Changed

- New `services/ssh_utils.py::_ssh_key_usable(path)` (no existing shared ssh module fits; api modules already import `services.*`): missing key → False quietly (old behavior); PermissionError/OSError → False + ONE actionable WARNING per path (module-level seen-set) → ssh falls back to default identity. Success path unchanged when the key is readable.
- 9 sites migrated across `sync_orchestrator.py`, `code_distributor.py`, `api/nodes_execution.py`, `api/nodes.py`, `api/code_sync.py`.
- Adjacent real bug fixed in-scope: `code_distributor.py` built `-o -o ConnectTimeout=30` (stray duplicate token — ssh rejects it; same #10277 bug class) — removed + regression-guarded by `test_code_distributor_ssh_argv_is_wellformed`.
- Conftest: root conftest real-loads `services.ssh_utils` (the AST-derived stub loop would otherwise MagicMock it truthy, silently re-adding `-i` everywhere).

## Verification

- `tests/services/`: **321 passed / 1 skipped / 0 failed** (313 baseline + 8 new helper tests: readable/missing/unreadable/warn-once-per-path/OSError/integration on the exact #11793 traceback site — command built WITHOUT `-i`, no exception, one WARNING). Independent re-run identical.
- `api/nodes_execution_test.py` 149 passed. flake8 clean ×8. Full-sweep failures byte-identical to clean HEAD (cp-based revert/restore proof) — pre-existing, tracked in #11798.

## Model Used

Claude Fable 5 (subagent: general-purpose)