### PR TITLE
fix(ws/cors): read CORS_ORIGINS env — ALL WebSockets 403 on TLS deployments (#11805)

### DIFF
--- a/autobot-backend/config/cors_origins_env_test.py
+++ b/autobot-backend/config/cors_origins_env_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""get_cors_origins must honour the CORS_ORIGINS env var (#11805).
+
+The backend Ansible role renders CORS_ORIGINS into the service env, but
+nothing read it — so deployments fell through to generated
+``http://{ip}:{port}`` defaults. A TLS browser origin (``https://<host>``,
+no port) matched none of them, and api/ws_security.py rejected EVERY
+WebSocket handshake with 403 (live events, voice streaming).
+"""
+
+from unittest.mock import patch
+
+from config.service_config import ServiceConfigMixin
+
+_TLS_ORIGIN = "https://autobot.example"
+_PLAIN_ORIGIN = "http://autobot.example"
+
+
+class _Cfg(ServiceConfigMixin):
+    """Minimal host for the mixin: `security.cors_origins` unset by default."""
+
+    def __init__(self, nested=None):
+        self._nested = nested or {}
+
+    def get_nested(self, key, default=None):
+        return self._nested.get(key, default)
+
+
+def test_env_origins_used_when_set():
+    with patch.dict("os.environ", {"CORS_ORIGINS": f"{_TLS_ORIGIN},{_PLAIN_ORIGIN}"}):
+        assert _Cfg().get_cors_origins() == [_TLS_ORIGIN, _PLAIN_ORIGIN]
+
+
+def test_env_origins_are_trimmed_and_empties_dropped():
+    with patch.dict("os.environ", {"CORS_ORIGINS": f" {_TLS_ORIGIN} , , {_PLAIN_ORIGIN} "}):
+        assert _Cfg().get_cors_origins() == [_TLS_ORIGIN, _PLAIN_ORIGIN]
+
+
+def test_tls_origin_without_port_is_allowed():
+    """The exact live failure: https://<host> with no port must be present."""
+    with patch.dict("os.environ", {"CORS_ORIGINS": _TLS_ORIGIN}):
+        assert _TLS_ORIGIN in _Cfg().get_cors_origins()
+
+
+def test_config_file_override_still_wins():
+    nested = {"security.cors_origins": ["https://from-config.example"]}
+    with patch.dict("os.environ", {"CORS_ORIGINS": "https://from-env.example"}):
+        assert _Cfg(nested).get_cors_origins() == ["https://from-config.example"]
+
+
+def test_falls_back_to_generated_defaults_when_env_absent():
+    with patch.dict("os.environ", {"CORS_ORIGINS": ""}):
+        origins = _Cfg().get_cors_origins()
+    assert origins, "generated defaults must still apply when nothing is configured"
+    assert all(o.startswith("http") for o in origins)

--- a/autobot-backend/config/service_config.py
+++ b/autobot-backend/config/service_config.py
@@ -255,13 +255,27 @@ class ServiceConfigMixin:
     def get_cors_origins(self) -> list:
         """Generate CORS origins from ALL infrastructure machines (#815).
 
-        Iterates every VM in ``NetworkConstants.get_host_configs()`` so
-        that adding a new machine automatically allows CORS from it.
-        ``security.cors_origins`` in the config file still overrides.
+        Precedence:
+          1. ``security.cors_origins`` in the config file (explicit override).
+          2. ``CORS_ORIGINS`` env — comma-separated; rendered by the backend
+             Ansible role (roles/backend/templates/backend.env.j2) and the
+             single source of truth for a deployed fleet (#11805).
+          3. Generated per-host defaults from ``NetworkConstants`` so that
+             adding a new machine automatically allows CORS from it.
+
+        #11805: the env var was rendered by every deploy but never read here,
+        so real deployments fell through to the generated defaults. Those are
+        ``http://{ip}:{port}`` only — a TLS browser origin (``https://<host>``,
+        no port) could never match, and api/ws_security.py rejected EVERY
+        WebSocket handshake with 403 (live events, voice streaming).
         """
         explicit_origins = self.get_nested("security.cors_origins", [])
         if explicit_origins:
             return explicit_origins
+
+        env_origins = [o.strip() for o in os.getenv("CORS_ORIGINS", "").split(",") if o.strip()]
+        if env_origins:
+            return env_origins
 
         origins: set[str] = set()
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -3619,6 +3619,9 @@ export interface paths {
          *
          *     Devices inactive for more than 90 days are pruned from the DB on each
          *     call so storage stays clean without a separate background job.
+         *
+         *     #11792: device-JWT callers (read scope suffices) get the list scoped to
+         *     their own device record; user-session callers get the full list.
          */
         get: operations["list_devices_api_devices_get"];
         put?: never;


### PR DESCRIPTION
## Thinking Path

A browser console dump showed a WebSocket reconnect storm. The backend log named the culprit outright:

```
api.ws_security - WARNING - Rejected WebSocket handshake:
  Cross-origin WebSocket handshake rejected: https://172.16.168.20
INFO:     connection rejected (403 Forbidden)
```

The UI is served FROM that origin — the backend rejects its own front end. **288 × 403 in one hour**, ongoing, killing `/api/ws`, `/api/ws/live` and `/api/voice/stream` (live events + voice streaming).

**Root cause — rendered config nobody reads.** `roles/backend/templates/backend.env.j2:39` renders `CORS_ORIGINS`, and the live `/opt/autobot/autobot-backend/.env` (loaded by the unit) correctly holds the https origin. But `grep -rn CORS_ORIGINS autobot-backend --include='*.py'` returns **zero readers**, so `get_cors_origins()` fell through to generated `http://{ip}:{port}` defaults. Verified live on the box:

```
get_cors_origins() -> ['http://127.0.0.1:5173', 'http://127.0.0.1:6379', ...]
contains 'https://<host>' ? False
```

A TLS origin (`https://<host>`, no port) can never match a generated `http://<ip>:<port>` entry → every handshake 403s on every real deployment.

## What Changed

- `autobot-backend/config/service_config.py` — `get_cors_origins()` now honours the `CORS_ORIGINS` env var (comma-separated, trimmed). Precedence: `security.cors_origins` file override → **`CORS_ORIGINS` env** → generated per-host defaults. Mirrors the SLM's existing `SLM_CORS_ORIGINS` pattern (`autobot-slm-backend/config.py:59`).
- `autobot-backend/config/cors_origins_env_test.py` — 5 tests: env used, trimming/empties, **TLS-origin-without-port allowed** (the exact live failure), file override still wins, generated fallback intact.

No config change needed — the deployed env already holds the right origins, so this alone clears the storm.

## Verification

- `pytest autobot-backend/config/cors_origins_env_test.py` → **5 passed**
- **Regression-sensitivity proven:** reverting the 3-line read makes **3 of 5 fail** (incl. the TLS-origin case); restoring → 5 pass.
- black / flake8 clean.

Closes #11805

## Model Used

Fable 5 (inline implementation)

## Follow-up

`roles/backend/defaults/main.yml:57` defaults `backend_cors_origins: "*"`. With this fix `*` is an explicit one-entry list that still matches no origin, so role-default deployments stay broken — whether `*` should mean allow-any for WS origins is an owner security call, filed separately.
