### PR TITLE
fix(types): regenerate api.ts — #11792 list_devices docstring (#11821)

### DIFF
--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -3619,6 +3619,9 @@ export interface paths {
          *
          *     Devices inactive for more than 90 days are pruned from the DB on each
          *     call so storage stays clean without a separate background job.
+         *
+         *     #11792: device-JWT callers (read scope suffices) get the list scoped to
+         *     their own device record; user-session callers get the full list.
          */
         get: operations["list_devices_api_devices_get"];
         put?: never;


### PR DESCRIPTION
Closes #11821

## Thinking Path

Second BEHIND-merge api.ts staleness (recipe established in #11783/PR #11785): #11801 added three docstring lines to the `list_devices` operation after the previous regen. All 11 current dependabot PRs fail `verify-generated-types` on this.

## What Changed

- `api.ts`: +3 lines — the #11792 own-device-scoping description on `list_devices_api_devices_get`. Machine-local defaults normalized to CI values per the recipe; diff is purely semantic (verified: only the docstring lines).

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json`: clean.
- This PR's own verify-generated-types run is the arbiter (passed exactly with this recipe last time).

## Model Used

Claude Fable 5