### PR TITLE
fix(files): resolve '/' to sandbox root — file browser 400s on every root operation (#11823)

### DIFF
--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -243,6 +243,13 @@ def validate_and_resolve_path(path: str) -> Path:
     # Remove leading/trailing slashes and normalize
     clean_path = path.strip("/")
 
+    # "/" (and "//") address the sandbox root itself — after stripping they
+    # collapse to "", which validate_relative_path rejects as an empty
+    # segment, surfacing a misleading "outside sandbox" 400 and making the
+    # root unlistable for every caller of this helper (#11823).
+    if not clean_path:
+        return SANDBOXED_ROOT
+
     # Enhanced path traversal checks
     if (
         ".." in clean_path

--- a/autobot-backend/api/files_root_path_test.py
+++ b/autobot-backend/api/files_root_path_test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The sandbox ROOT must be addressable as "/" (#11823).
+
+`path="/"` survived the `if not path` early return, was stripped to "",
+and validate_relative_path("") raises on empty segments — surfacing a
+misleading 400 "Path outside sandbox not allowed" and making the root
+unlistable for every endpoint built on the helper (list/create_directory/
+upload/delete/...), i.e. the whole file browser.
+
+Traversal protection must remain intact — asserted below.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(mod_name: str, rel_path: str):
+    """Load an api module by file path with heavy deps stubbed."""
+    stub_names = [
+        "config",
+        "config.manager",
+        "services",
+        "services.auth",
+        "auth_middleware",
+        "utils",
+        "utils.error_handling",
+        "utils.path_validation",
+        "models",
+    ]
+    saved = {n: sys.modules.get(n) for n in stub_names}
+    try:
+        for n in stub_names:
+            sys.modules.setdefault(n, MagicMock())
+        spec = importlib.util.spec_from_file_location(mod_name, _BACKEND_ROOT / rel_path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for n, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(n, None)
+            else:
+                sys.modules[n] = orig
+
+
+@pytest.fixture(scope="module")
+def files_mod():
+    return _load_module("_files_root_test", "api/files.py")
+
+
+@pytest.mark.parametrize("root_path", ["/", "//", ""])
+def test_root_paths_resolve_to_sandbox_root(files_mod, root_path):
+    """ "/" is how the UI addresses the root — it must not 400."""
+    assert files_mod.validate_and_resolve_path(root_path) == files_mod.SANDBOXED_ROOT
+
+
+@pytest.mark.parametrize(
+    "evil",
+    ["../etc/passwd", "foo/../../etc", "~/secrets", "%2e%2e/etc"],
+)
+def test_traversal_still_rejected(files_mod, evil):
+    """Root-addressing fix must not weaken traversal protection."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        files_mod.validate_and_resolve_path(evil)
+    assert exc.value.status_code == 400
+
+
+def test_normal_relative_path_still_resolves_under_root(files_mod):
+    resolved = files_mod.validate_and_resolve_path("subdir/file.txt")
+    assert str(resolved).startswith(str(files_mod.SANDBOXED_ROOT))

--- a/autobot-backend/api/sandbox_files.py
+++ b/autobot-backend/api/sandbox_files.py
@@ -61,6 +61,11 @@ def _validate_path(path: str) -> Path:
 
     clean_path = path.strip("/")
 
+    # "/" collapses to "" after stripping; that is the root, not an escape
+    # attempt — validate_relative_path rejects empty segments (#11823).
+    if not clean_path:
+        return SANDBOX_FILES_ROOT
+
     if (
         ".." in clean_path
         or clean_path.startswith("/")

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -3619,6 +3619,9 @@ export interface paths {
          *
          *     Devices inactive for more than 90 days are pruned from the DB on each
          *     call so storage stays clean without a separate background job.
+         *
+         *     #11792: device-JWT callers (read scope suffices) get the list scoped to
+         *     their own device record; user-session callers get the full list.
          */
         get: operations["list_devices_api_devices_get"];
         put?: never;


### PR DESCRIPTION
## Thinking Path

A browser console dump showed the file browser dead on arrival:
```
GET  /api/files/list?path=%2F     → 400 "Path outside sandbox not allowed"
POST /api/files/create_directory  → 400
POST /api/files/upload            → 422
```
Nothing escaped the sandbox — the **root** was requested. `validate_and_resolve_path("/")` skips the `if not path` early return, strips to `""`, and `validate_relative_path("")` raises on empty segments (`autobot_shared/security/path_validator.py:112`), which the handler reports as "outside sandbox". Since that helper backs 8+ endpoints (list :379, create_directory :658, upload :704, delete/move/read :759/:881/:967/:1016), every root-level operation 400s — the whole browser. `sandbox_files._validate_path` had the identical bug.

## What Changed

- `api/files.py` — after stripping, an empty `clean_path` means "the root": return `SANDBOXED_ROOT` (what the `if not path` branch already does) instead of handing `""` to the validator.
- `api/sandbox_files.py` — same one-line guard for `SANDBOX_FILES_ROOT`.
- `api/files_root_path_test.py` — 8 tests: `/`, `//`, `""` resolve to root; **traversal still rejected** (`../etc/passwd`, `foo/../../etc`, `~/secrets`, `%2e%2e/etc`); normal relative paths still resolve under root.

## Verification

- `pytest api/files_root_path_test.py` → **8 passed**
- **Regression-sensitivity proven:** reverting the guard fails exactly the `/` and `//` cases (2 failed / 6 passed); restoring → 8 pass.
- Traversal protection unchanged — asserted, not assumed.
- black / flake8 clean.

Closes #11823

## Model Used

Fable 5 (inline implementation)
