### PR TITLE
fix(test): repair slm sweep run-phase order-rot + never-run files (#11798)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector_state_change_test.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector_state_change_test.py
@@ -5,7 +5,11 @@
 """Unit tests for HealthCollector state-change pub/sub logic (#3404)."""
 
 import json
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from slm.agent.health_collector import _STATE_CHANGE_CHANNEL_TEMPLATE, HealthCollector
 
@@ -151,19 +155,58 @@ class TestPublishStateChange:
 # NotificationEvent.SERVICE_FAILED round-trip (import smoke test)
 # ---------------------------------------------------------------------------
 
+# The consumer of the published event is autobot-backend's NotificationService
+# (the OTHER backend) — "services.notification_service" does not exist in the
+# slm-backend tree, so the bare import could never resolve here (#11798).
+# Spec-load the real module from the repo checkout under a private name, with
+# its environment-bound deps stubbed (ssot_config reads /etc/autobot).  Skip
+# when the sibling checkout is not present (deployment layouts).  Resolved by
+# upward search so the slm/agent and ansible copies (drift-checked identical)
+# both find the repo root from their different depths.
+
+
+def _find_backend_notif_path():
+    for _parent in Path(__file__).resolve().parents:
+        _cand = _parent / "autobot-backend" / "services" / "notification_service.py"
+        if _cand.exists():
+            return _cand
+    return None
+
+
+_BACKEND_NOTIF_PATH = _find_backend_notif_path()
+
+
+def _load_backend_notification_service():
+    import importlib.util
+
+    stubs = {
+        "constants": MagicMock(),
+        "constants.ttl_constants": MagicMock(TTL_7_DAYS=7 * 24 * 3600),
+        "autobot_shared.ssot_config": MagicMock(config=MagicMock()),
+        "autobot_shared.redis_client": MagicMock(),
+        "autobot_shared.logging_manager": MagicMock(get_logger=MagicMock(return_value=MagicMock())),
+    }
+    with patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location("_backend_notification_service", _BACKEND_NOTIF_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
 
 class TestServiceFailedEvent:
+    @pytest.mark.skipif(_BACKEND_NOTIF_PATH is None, reason="autobot-backend checkout not present (env-bound)")
     def test_service_failed_enum_value(self):
-        from services.notification_service import NotificationEvent
+        mod = _load_backend_notification_service()
 
-        assert NotificationEvent.SERVICE_FAILED.value == "service_failed"
+        assert mod.NotificationEvent.SERVICE_FAILED.value == "service_failed"
 
+    @pytest.mark.skipif(_BACKEND_NOTIF_PATH is None, reason="autobot-backend checkout not present (env-bound)")
     def test_service_failed_template_renders(self):
-        from services.notification_service import NotificationEvent, NotificationService
+        mod = _load_backend_notification_service()
 
-        svc = NotificationService()
+        svc = mod.NotificationService()
         result = svc.render_template(
-            NotificationEvent.SERVICE_FAILED.value,
+            mod.NotificationEvent.SERVICE_FAILED.value,
             {
                 "service": "nginx",
                 "hostname": "node-01",

--- a/autobot-slm-backend/api/code_source_test.py
+++ b/autobot-slm-backend/api/code_source_test.py
@@ -41,6 +41,11 @@ sys.modules["config"] = _mock_config
 
 spec.loader.exec_module(code_source_module)
 
+# Register under the spec name so patch("code_source_module.…") can resolve the
+# target — mock.patch imports the path, and an unregistered exec'd module raises
+# ModuleNotFoundError for every test using _LOCAL_NODE_PATCH (#11798).
+sys.modules["code_source_module"] = code_source_module
+
 _find_similar_paths = code_source_module._find_similar_paths
 _validate_repo_path = code_source_module._validate_repo_path
 _is_local_node = code_source_module._is_local_node
@@ -156,7 +161,10 @@ class TestCodeSourceValidation:
 
             result = await _find_similar_paths(mock_node, "/home/${USER:-autobot}/Desktop/autobot")
 
-            assert result == "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}"
+            # The helper returns parent-dir + the case-corrected entry from the
+            # mocked ls output ("AutoBot"), NOT a fallback root (#11798 — a
+            # mechanical path-literal sweep had rotted this expectation).
+            assert result == "/home/${USER:-autobot}/Desktop/AutoBot"
 
     @pytest.mark.asyncio
     async def test_find_similar_paths_no_match(self, mock_node):

--- a/autobot-slm-backend/api/code_source_test.py
+++ b/autobot-slm-backend/api/code_source_test.py
@@ -31,15 +31,30 @@ code_source_path = Path(__file__).parent / "code_source.py"
 spec = __import__("importlib.util").util.spec_from_file_location("code_source_module", code_source_path)
 code_source_module = __import__("importlib.util").util.module_from_spec(spec)
 
-# Mock dependencies before loading the module
-sys.modules["services.auth"] = MagicMock()
-sys.modules["services.database"] = MagicMock()
-sys.modules["models.database"] = MagicMock()
+# Mock dependencies before loading the module — snapshot/restore (#11798):
+# the previous unconditional sys.modules writes permanently replaced the root
+# conftest stubs WITHOUT rebinding the parent-package attributes, so
+# mock.patch("services.database.…") in later sweep files (tests/api/
+# test_fleet_node_update_11511.py) patched the old module object while
+# runtime imports resolved the new one (#9780 divergence).
 _mock_config = MagicMock()
 _mock_config.settings.external_url = "http://10.0.0.9:8080"
-sys.modules["config"] = _mock_config
-
-spec.loader.exec_module(code_source_module)
+_STUBS = {
+    "services.auth": MagicMock(),
+    "services.database": MagicMock(),
+    "models.database": MagicMock(),
+    "config": _mock_config,
+}
+_prev_modules = {name: sys.modules.get(name) for name in _STUBS}
+sys.modules.update(_STUBS)
+try:
+    spec.loader.exec_module(code_source_module)
+finally:
+    for _name, _prev in _prev_modules.items():
+        if _prev is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _prev
 
 # Register under the spec name so patch("code_source_module.…") can resolve the
 # target — mock.patch imports the path, and an unregistered exec'd module raises

--- a/autobot-slm-backend/main_ensure_local_node_test.py
+++ b/autobot-slm-backend/main_ensure_local_node_test.py
@@ -326,7 +326,10 @@ class TestEnsureLocalNode:
         mock_db.session = MagicMock(return_value=_ctx(session))
 
         # URL includes port — regex must not capture the port as part of IP
-        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://172.16.0.10:8443"}):
+        with (
+            _patched_seams(self._mod, mock_db),
+            patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://172.16.0.10:8443"}),
+        ):
             await self._fn()
 
         node_obj = added_objects[0]

--- a/autobot-slm-backend/main_ensure_local_node_test.py
+++ b/autobot-slm-backend/main_ensure_local_node_test.py
@@ -9,12 +9,14 @@ a stale IP when SLM_EXTERNAL_URL has been corrected, without importing the
 full FastAPI application stack.
 """
 
+import contextlib
 import importlib
 import importlib.util
 import os
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,22 +24,41 @@ import pytest
 # ---------------------------------------------------------------------------
 # Path bootstrap
 # ---------------------------------------------------------------------------
-_SLM_ROOT = Path(__file__).parent.parent
+# This file sits directly in autobot-slm-backend/, so the SLM root is
+# .parent — .parent.parent resolved to the REPO root, whose (different)
+# main.py has no _ensure_local_node, erroring every test at setup (#11798).
+_SLM_ROOT = Path(__file__).parent
 if str(_SLM_ROOT) not in sys.path:
     sys.path.insert(0, str(_SLM_ROOT))
 
 # ---------------------------------------------------------------------------
-# Stub models.database before any module load so that the lazy import inside
-# _ensure_local_node() resolves at function-call time.  Python looks up
-# "models" and "models.database" as separate sys.modules keys; both must be
-# present or the submodule lookup raises ImportError.
+# models.database stand-ins for the lazy import inside _ensure_local_node().
+# #11798: the old MagicMock Node/NodeRole never carried constructor kwargs as
+# attributes, so none of the created-row assertions could hold; and the old
+# ``sys.modules.setdefault`` never installed anything because the root
+# conftest already stubs "models.database".  Kwargs-to-attributes factories
+# are swapped in per-test via the autouse fixture below (patch.dict restores).
 # ---------------------------------------------------------------------------
+
+
+class _ColumnMeta(type):
+    """Class-level attribute access (Node.node_id in select().where()) → mock column."""
+
+    def __getattr__(cls, name):
+        return MagicMock(name=f"{cls.__name__}.{name}")
+
+
+class _AttrObj(metaclass=_ColumnMeta):
+    """Minimal ORM-row stand-in: constructor kwargs become attributes."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
 _models_db_stub = MagicMock()
-_models_db_stub.Node = MagicMock()
-_models_db_stub.NodeRole = MagicMock()
-_models_db_stub.NodeStatus = MagicMock()
-sys.modules.setdefault("models", MagicMock())
-sys.modules.setdefault("models.database", _models_db_stub)
+_models_db_stub.Node = type("Node", (_AttrObj,), {})
+_models_db_stub.NodeRole = type("NodeRole", (_AttrObj,), {})
+_models_db_stub.NodeStatus = SimpleNamespace(ONLINE=SimpleNamespace(value="online"))
 
 # ---------------------------------------------------------------------------
 # Constants that must match main.py
@@ -89,19 +110,26 @@ def _load_module():
     stubs = {
         "fastapi": MagicMock(),
         "fastapi.middleware.cors": MagicMock(),
+        # main.py imports grown since this list was written (#11798):
+        "fastapi.responses": MagicMock(),
         "api": MagicMock(),
         "api.code_source": MagicMock(),
         "api.performance": MagicMock(),
         "api.personality_proxy": MagicMock(),
         "api.roles": MagicMock(),
         "api.voice_proxy": MagicMock(),
+        "autobot_shared.integrity_manifest": MagicMock(),
         "config": MagicMock(),
         "middleware": MagicMock(),
         "services.a2a_card_fetcher": MagicMock(),
+        "services.auth": MagicMock(),
+        "services.compose_fleet": MagicMock(),
         "services.database": MagicMock(),
         "services.git_tracker": MagicMock(),
+        "services.node_seeder": MagicMock(),
         "services.reconciler": MagicMock(),
         "services.schedule_executor": MagicMock(),
+        "services.security_posture_auditor": MagicMock(),
     }
     with patch.dict(sys.modules, stubs):
         spec = importlib.util.spec_from_file_location("isolated_main", _SLM_ROOT / "main.py")
@@ -110,6 +138,31 @@ def _load_module():
 
     _MODULE_CACHE["isolated_main"] = mod
     return mod
+
+
+@pytest.fixture(autouse=True)
+def _models_db_active():
+    """Swap the attribute-bearing models.database stand-in in per test."""
+    with patch.dict(sys.modules, {"models": MagicMock(), "models.database": _models_db_stub}):
+        yield
+
+
+def _patched_seams(mod, mock_db):
+    """ExitStack patching the module seams every test needs (#11798).
+
+    - ``settings.slm_node_id``: env-driven since #9956 — pin the sentinel.
+    - ``_compose_nodes_enabled``: the stubbed compose_fleet returns a truthy
+      MagicMock, which would route every test into the compose static-IP branch.
+    - ``sync_slm_node_roles``: the stub module attribute is not awaitable.
+    """
+    stack = contextlib.ExitStack()
+    stack.enter_context(patch.object(mod, "db_service", mock_db))
+    _settings = MagicMock()
+    _settings.slm_node_id = _NODE_ID
+    stack.enter_context(patch.object(mod, "settings", _settings))
+    stack.enter_context(patch.object(mod, "_compose_nodes_enabled", MagicMock(return_value=False)))
+    stack.enter_context(patch.object(mod, "sync_slm_node_roles", AsyncMock()))
+    return stack
 
 
 # ---------------------------------------------------------------------------
@@ -135,10 +188,7 @@ class TestEnsureLocalNode:
         mock_db = MagicMock()
         mock_db.session = MagicMock(return_value=_ctx(session))
 
-        with (
-            patch.object(self._mod, "db_service", mock_db),
-            patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://192.168.1.50"}),
-        ):
+        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://192.168.1.50"}):
             await self._fn()
 
         # 1 Node + 4 NodeRole = 5 objects
@@ -168,14 +218,14 @@ class TestEnsureLocalNode:
         mock_db = MagicMock()
         mock_db.session = MagicMock(return_value=_ctx(session))
 
-        with (
-            patch.object(self._mod, "db_service", mock_db),
-            patch.dict(os.environ, {"SLM_EXTERNAL_URL": f"https://{current_ip}"}),
-        ):
+        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, {"SLM_EXTERNAL_URL": f"https://{current_ip}"}):
             await self._fn()
 
         session.add.assert_not_called()
-        session.commit.assert_not_awaited()
+        # #11798: the existing-node path now also heals detected_roles and
+        # syncs role rows, committing unconditionally — "idempotent" means no
+        # NEW rows, not no commit.
+        session.commit.assert_awaited_once()
 
     # ------------------------------------------------------------------
     # Node present, IP stale — updates IP field only
@@ -191,10 +241,7 @@ class TestEnsureLocalNode:
         mock_db = MagicMock()
         mock_db.session = MagicMock(return_value=_ctx(session))
 
-        with (
-            patch.object(self._mod, "db_service", mock_db),
-            patch.dict(os.environ, {"SLM_EXTERNAL_URL": f"https://{new_ip}"}),
-        ):
+        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, {"SLM_EXTERNAL_URL": f"https://{new_ip}"}):
             await self._fn()
 
         assert existing.ip_address == new_ip
@@ -216,10 +263,7 @@ class TestEnsureLocalNode:
 
         env_without_url = {k: v for k, v in os.environ.items() if k != "SLM_EXTERNAL_URL"}
 
-        with (
-            patch.object(self._mod, "db_service", mock_db),
-            patch.dict(os.environ, env_without_url, clear=True),
-        ):
+        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, env_without_url, clear=True):
             await self._fn()
 
         node_obj = added_objects[0]
@@ -238,10 +282,7 @@ class TestEnsureLocalNode:
         mock_db = MagicMock()
         mock_db.session = MagicMock(return_value=_ctx(session))
 
-        with (
-            patch.object(self._mod, "db_service", mock_db),
-            patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://10.10.10.1"}),
-        ):
+        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://10.10.10.1"}):
             await self._fn()
 
         node_obj = added_objects[0]
@@ -261,10 +302,7 @@ class TestEnsureLocalNode:
         mock_db = MagicMock()
         mock_db.session = MagicMock(return_value=_ctx(session))
 
-        with (
-            patch.object(self._mod, "db_service", mock_db),
-            patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://10.10.10.1"}),
-        ):
+        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://10.10.10.1"}):
             await self._fn()
 
         role_objs = added_objects[1:]
@@ -288,10 +326,7 @@ class TestEnsureLocalNode:
         mock_db.session = MagicMock(return_value=_ctx(session))
 
         # URL includes port — regex must not capture the port as part of IP
-        with (
-            patch.object(self._mod, "db_service", mock_db),
-            patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://172.16.0.10:8443"}),
-        ):
+        with _patched_seams(self._mod, mock_db), patch.dict(os.environ, {"SLM_EXTERNAL_URL": "https://172.16.0.10:8443"}):
             await self._fn()
 
         node_obj = added_objects[0]

--- a/autobot-slm-backend/services/drift_checker_test.py
+++ b/autobot-slm-backend/services/drift_checker_test.py
@@ -33,9 +33,28 @@ _gt_stub = types.ModuleType("services.git_tracker")
 _gt_stub.DEFAULT_REPO_PATH = "/opt/autobot/code_source"  # type: ignore[attr-defined]
 sys.modules.setdefault("services.git_tracker", _gt_stub)
 
-_spec = importlib.util.spec_from_file_location("drift_checker", _MODULE_PATH)
-_dc = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
-_spec.loader.exec_module(_dc)  # type: ignore[union-attr]
+# services.deploy_artifacts must be REAL while drift_checker.py executes: the
+# root conftest stubs it as a MagicMock, and drift_checker derives
+# _SKIP_DIRS / _SKIP_DIR_SUFFIXES from its ARTIFACT_DIRS / ARTIFACT_DIR_SUFFIXES
+# at import time — a MagicMock suffix tuple makes every str.endswith() in
+# _collect_checksums raise TypeError (#11798).  The module is dependency-free,
+# so real-load it and restore the previous sys.modules entry afterwards.
+_da_spec = importlib.util.spec_from_file_location(
+    "services.deploy_artifacts", _SERVICES_DIR / "deploy_artifacts.py"
+)
+_da = importlib.util.module_from_spec(_da_spec)  # type: ignore[arg-type]
+_da_spec.loader.exec_module(_da)  # type: ignore[union-attr]
+_prev_da = sys.modules.get("services.deploy_artifacts")
+sys.modules["services.deploy_artifacts"] = _da
+try:
+    _spec = importlib.util.spec_from_file_location("drift_checker", _MODULE_PATH)
+    _dc = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+    _spec.loader.exec_module(_dc)  # type: ignore[union-attr]
+finally:
+    if _prev_da is None:
+        sys.modules.pop("services.deploy_artifacts", None)
+    else:
+        sys.modules["services.deploy_artifacts"] = _prev_da
 
 # Convenience aliases.
 _file_checksum = _dc._file_checksum
@@ -460,12 +479,14 @@ class TestGetDefaultSourceDir:
 
 class TestAllowedComponents:
     def test_allowlist_contains_expected_components(self):
-        """The allowlist must contain all four expected component names."""
+        """The allowlist must contain exactly the expected component names."""
         expected = {
             "autobot-slm-backend",
             "autobot-slm-frontend",
             "autobot-backend",
             "autobot-frontend",
+            # #10248: the shared library is its own syncable component.
+            "autobot_shared",
         }
         assert expected == set(ALLOWED_COMPONENTS)
 

--- a/autobot-slm-backend/services/drift_checker_test.py
+++ b/autobot-slm-backend/services/drift_checker_test.py
@@ -39,9 +39,7 @@ sys.modules.setdefault("services.git_tracker", _gt_stub)
 # at import time — a MagicMock suffix tuple makes every str.endswith() in
 # _collect_checksums raise TypeError (#11798).  The module is dependency-free,
 # so real-load it and restore the previous sys.modules entry afterwards.
-_da_spec = importlib.util.spec_from_file_location(
-    "services.deploy_artifacts", _SERVICES_DIR / "deploy_artifacts.py"
-)
+_da_spec = importlib.util.spec_from_file_location("services.deploy_artifacts", _SERVICES_DIR / "deploy_artifacts.py")
 _da = importlib.util.module_from_spec(_da_spec)  # type: ignore[arg-type]
 _da_spec.loader.exec_module(_da)  # type: ignore[union-attr]
 _prev_da = sys.modules.get("services.deploy_artifacts")

--- a/autobot-slm-backend/services/jwks_verifier_test.py
+++ b/autobot-slm-backend/services/jwks_verifier_test.py
@@ -91,6 +91,8 @@ _settings_stub.secret_key = "test-hs256-secret-for-unit-tests-only-32ch"
 _settings_stub.algorithm = "HS256"
 _config_stub.settings = _settings_stub
 
+import importlib.util as _ilu  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Now import the modules under test.
 # #11798: jwks_verifier must be spec-loaded from its file — in a whole-backend
@@ -100,8 +102,6 @@ _config_stub.settings = _settings_stub
 # a MagicMock.  All tests use the module object directly (patch.object), so
 # no sys.modules registration is needed.
 from autobot_shared.auth.jwt_core import JWTDecodeError, encode_jwt  # noqa: E402
-
-import importlib.util as _ilu  # noqa: E402
 
 _jwks_spec = _ilu.spec_from_file_location("_jwks_verifier_under_test", _SLM_ROOT / "services" / "jwks_verifier.py")
 jwks_verifier = _ilu.module_from_spec(_jwks_spec)  # type: ignore[arg-type]

--- a/autobot-slm-backend/services/jwks_verifier_test.py
+++ b/autobot-slm-backend/services/jwks_verifier_test.py
@@ -75,7 +75,10 @@ for _name in [
         _mod.__spec__ = None
         sys.modules[_name] = _mod
 
-# Stub config before jwks_verifier imports it
+# config stub — jwks_verifier defers ``from config import settings`` to CALL
+# time, so the stub must be pinned into sys.modules per-test (autouse fixture
+# below), not just at import: other sweep files (tests/services/
+# test_token_denylist.py) overwrite the "config" key at module scope (#11798).
 _config_stub = _types.ModuleType("config")
 _settings_stub = MagicMock()
 _settings_stub.authority_base_url = (
@@ -87,13 +90,43 @@ _settings_stub.jwks_fetch_timeout_seconds = 10.0
 _settings_stub.secret_key = "test-hs256-secret-for-unit-tests-only-32ch"
 _settings_stub.algorithm = "HS256"
 _config_stub.settings = _settings_stub
-sys.modules["config"] = _config_stub
 
 # ---------------------------------------------------------------------------
-# Now import the modules under test
-# ---------------------------------------------------------------------------
+# Now import the modules under test.
+# #11798: jwks_verifier must be spec-loaded from its file — in a whole-backend
+# sweep ``from services import jwks_verifier`` resolves through the root
+# conftest's MagicMock "services" parent, whose auto-created attribute
+# silently replaces the real module and every ``await`` in the tests dies on
+# a MagicMock.  All tests use the module object directly (patch.object), so
+# no sys.modules registration is needed.
 from autobot_shared.auth.jwt_core import JWTDecodeError, encode_jwt  # noqa: E402
-from services import jwks_verifier  # noqa: E402
+
+import importlib.util as _ilu  # noqa: E402
+
+_jwks_spec = _ilu.spec_from_file_location("_jwks_verifier_under_test", _SLM_ROOT / "services" / "jwks_verifier.py")
+jwks_verifier = _ilu.module_from_spec(_jwks_spec)  # type: ignore[arg-type]
+_jwks_spec.loader.exec_module(jwks_verifier)  # type: ignore[union-attr]
+
+
+# services.oidc_token_cache stub — verify_authority_token defers
+# ``from services.oidc_token_cache import cache_claims, get_cached_claims`` to
+# call time; the real module talks to Redis (a unit test must not, and in a
+# whole-backend sweep the shared connection manager may be poisoned by earlier
+# files' config stubs).  Always miss; store is a no-op.
+_oidc_cache_stub = _types.ModuleType("services.oidc_token_cache")
+_oidc_cache_stub.get_cached_claims = AsyncMock(return_value=None)
+_oidc_cache_stub.cache_claims = AsyncMock(return_value=None)
+
+
+@pytest.fixture(autouse=True)
+def _pin_deferred_import_stubs():
+    """Pin stubs for the deferred (call-time) imports of the module under test."""
+    with patch.dict(
+        sys.modules,
+        {"config": _config_stub, "services.oidc_token_cache": _oidc_cache_stub},
+    ):
+        yield
+
 
 # ---------------------------------------------------------------------------
 # RSA keypair fixtures

--- a/autobot-slm-backend/services/oidc_token_cache.py
+++ b/autobot-slm-backend/services/oidc_token_cache.py
@@ -77,6 +77,20 @@ def _cache_key(token: str) -> str:
     return f"{_CACHE_KEY_PREFIX}{digest[:40]}"
 
 
+async def _redis_or_none():
+    """Return the async Redis client, or None when it cannot be obtained.
+
+    #11798: ``get_async_redis_client()`` itself can raise (e.g. the shared
+    connection manager's circuit-breaker path) — a cache-layer failure must
+    degrade to a cache miss, never break token verification/logout.
+    """
+    try:
+        return await get_async_redis_client()
+    except Exception as exc:
+        logger.warning("oidc_token_cache: redis client unavailable: %s", exc)
+        return None
+
+
 async def get_cached_claims(token: str) -> Optional[Dict[str, Any]]:
     """Return cached normalized claims for *token*, or None on cache miss/error.
 
@@ -88,7 +102,7 @@ async def get_cached_claims(token: str) -> Optional[Dict[str, Any]]:
     """
     if OIDC_TOKEN_CACHE_TTL == 0:
         return None
-    redis = await get_async_redis_client()
+    redis = await _redis_or_none()
     if redis is None:
         return None
     try:
@@ -112,7 +126,7 @@ async def cache_claims(token: str, claims: Dict[str, Any]) -> None:
     """
     if OIDC_TOKEN_CACHE_TTL == 0:
         return
-    redis = await get_async_redis_client()
+    redis = await _redis_or_none()
     if redis is None:
         return
     try:
@@ -130,7 +144,7 @@ async def invalidate_token_cache(token: str) -> None:
 
     Called by the A2 logout path (coordinate with jti-denylist).
     """
-    redis = await get_async_redis_client()
+    redis = await _redis_or_none()
     if redis is None:
         logger.warning("oidc_token_cache: invalidate skipped — Redis unavailable")
         return

--- a/autobot-slm-backend/slm/agent/health_collector_state_change_test.py
+++ b/autobot-slm-backend/slm/agent/health_collector_state_change_test.py
@@ -5,7 +5,11 @@
 """Unit tests for HealthCollector state-change pub/sub logic (#3404)."""
 
 import json
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from slm.agent.health_collector import _STATE_CHANGE_CHANNEL_TEMPLATE, HealthCollector
 
@@ -151,19 +155,58 @@ class TestPublishStateChange:
 # NotificationEvent.SERVICE_FAILED round-trip (import smoke test)
 # ---------------------------------------------------------------------------
 
+# The consumer of the published event is autobot-backend's NotificationService
+# (the OTHER backend) — "services.notification_service" does not exist in the
+# slm-backend tree, so the bare import could never resolve here (#11798).
+# Spec-load the real module from the repo checkout under a private name, with
+# its environment-bound deps stubbed (ssot_config reads /etc/autobot).  Skip
+# when the sibling checkout is not present (deployment layouts).  Resolved by
+# upward search so the slm/agent and ansible copies (drift-checked identical)
+# both find the repo root from their different depths.
+
+
+def _find_backend_notif_path():
+    for _parent in Path(__file__).resolve().parents:
+        _cand = _parent / "autobot-backend" / "services" / "notification_service.py"
+        if _cand.exists():
+            return _cand
+    return None
+
+
+_BACKEND_NOTIF_PATH = _find_backend_notif_path()
+
+
+def _load_backend_notification_service():
+    import importlib.util
+
+    stubs = {
+        "constants": MagicMock(),
+        "constants.ttl_constants": MagicMock(TTL_7_DAYS=7 * 24 * 3600),
+        "autobot_shared.ssot_config": MagicMock(config=MagicMock()),
+        "autobot_shared.redis_client": MagicMock(),
+        "autobot_shared.logging_manager": MagicMock(get_logger=MagicMock(return_value=MagicMock())),
+    }
+    with patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location("_backend_notification_service", _BACKEND_NOTIF_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
 
 class TestServiceFailedEvent:
+    @pytest.mark.skipif(_BACKEND_NOTIF_PATH is None, reason="autobot-backend checkout not present (env-bound)")
     def test_service_failed_enum_value(self):
-        from services.notification_service import NotificationEvent
+        mod = _load_backend_notification_service()
 
-        assert NotificationEvent.SERVICE_FAILED.value == "service_failed"
+        assert mod.NotificationEvent.SERVICE_FAILED.value == "service_failed"
 
+    @pytest.mark.skipif(_BACKEND_NOTIF_PATH is None, reason="autobot-backend checkout not present (env-bound)")
     def test_service_failed_template_renders(self):
-        from services.notification_service import NotificationEvent, NotificationService
+        mod = _load_backend_notification_service()
 
-        svc = NotificationService()
+        svc = mod.NotificationService()
         result = svc.render_template(
-            NotificationEvent.SERVICE_FAILED.value,
+            mod.NotificationEvent.SERVICE_FAILED.value,
             {
                 "service": "nginx",
                 "hostname": "node-01",

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
 import types
 from pathlib import Path
@@ -370,6 +371,25 @@ def _make_reconcile_db_mock(rows):
     return db_service_mock
 
 
+@contextlib.contextmanager
+def _patched_db_service(db_service_mock):
+    """setattr/restore on the sys.modules entry (#11798).
+
+    ``patch("services.database.db_service")`` resolves the target via getattr
+    on the PARENT ``services`` module — which in a whole-backend sweep can be
+    a hollow package without a ``database`` attribute — while the code under
+    test resolves ``from services.database import db_service`` through
+    sys.modules (#9780 divergence).  Patch the sys.modules entry directly.
+    """
+    mod = sys.modules["services.database"]
+    prev = getattr(mod, "db_service", None)
+    mod.db_service = db_service_mock
+    try:
+        yield
+    finally:
+        mod.db_service = prev
+
+
 def test_reconcile_requeues_first_interruption() -> None:
     """A job interrupted by a racing restart is re-queued, not failed (#11437)."""
     import api.code_sync as code_sync_mod
@@ -380,7 +400,7 @@ def test_reconcile_requeues_first_interruption() -> None:
     row.job_id = "job-1"
     row.component = "autobot-backend"
 
-    with patch("services.database.db_service", _make_reconcile_db_mock([row])):
+    with _patched_db_service(_make_reconcile_db_mock([row])):
         count, requeued = _run(code_sync_mod.reconcile_stale_component_sync_jobs())
 
     assert count == 1
@@ -399,7 +419,7 @@ def test_reconcile_fails_second_interruption() -> None:
     row.job_id = "job-2"
     row.component = "autobot-backend"
 
-    with patch("services.database.db_service", _make_reconcile_db_mock([row])):
+    with _patched_db_service(_make_reconcile_db_mock([row])):
         count, requeued = _run(code_sync_mod.reconcile_stale_component_sync_jobs())
 
     assert count == 1

--- a/autobot-slm-backend/tests/api/test_drift_resolve.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve.py
@@ -125,6 +125,7 @@ def _pin_private_code_sync():
             else:
                 setattr(_pkg, _child, _prev_attr)
 
+
 # Stub user — endpoint only checks authentication via Depends(get_current_user)
 _FAKE_USER = {"username": "tester", "is_admin": True}
 
@@ -164,7 +165,6 @@ def _noop_post_sync():
         "api.code_sync._run_post_sync_steps",
         side_effect=lambda comp, src, dep: (False, [], True),
     )
-
 
 
 def test_invalid_component_raises_400(stub_user):
@@ -461,7 +461,6 @@ def test_shared_lib_post_steps():
     assert len(symlink_calls) == 2, "both backends' symlinks must be restored"
     restart_dep.assert_awaited_once()
     assert not any("pip:" in s or "npm" in s for s in steps)
-
 
 
 def test_autobot_shared_is_syncable_and_restarts_dependents():

--- a/autobot-slm-backend/tests/api/test_drift_resolve.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve.py
@@ -6,11 +6,25 @@
 
 Calls the route handler directly with mocked rsync + dir helpers so we
 don't need a running app, DB, or actual filesystem operations.
+
+Real-load prologue (#11798, pattern: tests/services/code_version_test.py):
+the root conftest stubs ``models.schemas`` / ``services.drift_checker`` as
+MagicMocks, so the shared in-sweep ``api.code_sync`` module holds a
+MagicMock ``DriftResolveRequest``/``DriftResolveResponse`` and an
+empty-iterating ``ALLOWED_COMPONENTS`` — every request 400s with
+"Must be one of: []" and no response field is assertable.  This module
+instead swaps in the REAL sqlalchemy/models/drift modules, execs a PRIVATE
+copy of api/code_sync.py against them, restores the stubs, and pins that
+private module into ``sys.modules["api.code_sync"]`` per-test (autouse
+fixture) so the existing ``patch("api.code_sync.…")`` targets resolve to it.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import importlib
+import importlib.util
 
 # Add autobot-slm-backend to path so api.code_sync imports resolve.
 import sys
@@ -22,10 +36,94 @@ import pytest
 from fastapi import HTTPException
 
 _BACKEND_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_BACKEND_ROOT))
+for _p in (str(_BACKEND_ROOT), str(_BACKEND_ROOT.parent)):  # + repo root (autobot_shared)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
-from api.code_sync import resolve_drift  # noqa: E402
-from models.schemas import DriftResolveRequest  # noqa: E402
+_SWAP_KEYS = (
+    "models.database",
+    "models.schemas",
+    "services.deploy_artifacts",
+    "services.drift_checker",
+)
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so relative imports work)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+for _name in list(_orig_modules):
+    del sys.modules[_name]
+try:
+    for _name in ("sqlalchemy", "sqlalchemy.ext.asyncio", "sqlalchemy.orm"):
+        importlib.import_module(_name)
+
+    _load_real_module("models.database", _BACKEND_ROOT / "models" / "database.py")
+    _real_schemas = _load_real_module("models.schemas", _BACKEND_ROOT / "models" / "schemas.py")
+    _load_real_module("services.deploy_artifacts", _BACKEND_ROOT / "services" / "deploy_artifacts.py")
+    # services.git_tracker stays the conftest stub — drift_checker only reads
+    # DEFAULT_REPO_PATH from it, and the dir helpers are patched per-test.
+    _real_dc = _load_real_module("services.drift_checker", _BACKEND_ROOT / "services" / "drift_checker.py")
+
+    # Private exec of api/code_sync.py against the REAL modules above (all its
+    # other services.* imports resolve to the root-conftest stubs, as designed).
+    _cs_spec = importlib.util.spec_from_file_location("_code_sync_drift_test", _BACKEND_ROOT / "api" / "code_sync.py")
+    _CS = importlib.util.module_from_spec(_cs_spec)  # type: ignore[arg-type]
+    _cs_spec.loader.exec_module(_CS)  # type: ignore[union-attr]
+
+    DriftResolveRequest = _real_schemas.DriftResolveRequest
+    resolve_drift = _CS.resolve_drift
+finally:
+    for _name in [name for name in sys.modules if _is_swap_key(name)]:
+        del sys.modules[_name]
+    for _name, _mod in _orig_modules.items():
+        sys.modules[_name] = _mod
+
+
+@pytest.fixture(autouse=True)
+def _pin_private_code_sync():
+    """Resolve patch("api.code_sync.…") / in-test imports to the private module."""
+    saved = {
+        "api.code_sync": sys.modules.get("api.code_sync"),
+        "services.drift_checker": sys.modules.get("services.drift_checker"),
+    }
+    sys.modules["api.code_sync"] = _CS
+    sys.modules["services.drift_checker"] = _real_dc
+    # #9780: mock.patch resolves the target via getattr on the PARENT package,
+    # so the parent attribute must point at the same module as sys.modules.
+    saved_attrs = {}
+    for _parent, _child, _mod in (("api", "code_sync", _CS), ("services", "drift_checker", _real_dc)):
+        _pkg = sys.modules.get(_parent)
+        if _pkg is not None:
+            saved_attrs[(_parent, _child)] = getattr(_pkg, _child, None)
+            setattr(_pkg, _child, _mod)
+    try:
+        yield
+    finally:
+        for _k, _m in saved.items():
+            if _m is None:
+                sys.modules.pop(_k, None)
+            else:
+                sys.modules[_k] = _m
+        for (_parent, _child), _prev_attr in saved_attrs.items():
+            _pkg = sys.modules.get(_parent)
+            if _pkg is None:
+                continue
+            if _prev_attr is None:
+                with contextlib.suppress(AttributeError):
+                    delattr(_pkg, _child)
+            else:
+                setattr(_pkg, _child, _prev_attr)
 
 # Stub user — endpoint only checks authentication via Depends(get_current_user)
 _FAKE_USER = {"username": "tester", "is_admin": True}
@@ -56,20 +154,17 @@ def _setup_dir_mocks(component="autobot-slm-backend"):
 
 
 def _noop_post_sync():
-    """Patch _run_post_sync_steps to do nothing (deps_changed=False, no steps)."""
+    """Patch _run_post_sync_steps to do nothing (deps_changed=False, no steps).
+
+    The patch targets are real coroutine functions now (#11798), so patch()
+    selects AsyncMock — plain values / sync side_effects become the awaited
+    result (the old ``_async_return`` coroutine wrapper would double-wrap).
+    """
     return patch(
         "api.code_sync._run_post_sync_steps",
-        side_effect=lambda comp, src, dep: _async_return((False, [])),
+        side_effect=lambda comp, src, dep: (False, [], True),
     )
 
-
-def _async_return(value):
-    """Build an awaitable that resolves to the given value."""
-
-    async def _awaitable():
-        return value
-
-    return _awaitable()
 
 
 def test_invalid_component_raises_400(stub_user):
@@ -94,7 +189,7 @@ def test_happy_path_returns_success(stub_user):
     src_patch, dep_patch = _setup_dir_mocks()
     rsync_patch = patch(
         "api.code_sync._rsync_component_local",
-        return_value=_async_return((True, "")),
+        return_value=(True, ""),
     )
     with src_patch, dep_patch, rsync_patch, _noop_post_sync():
         req = DriftResolveRequest(component="autobot-slm-backend")
@@ -114,13 +209,13 @@ def test_rsync_failure_returns_success_false(stub_user):
     src_patch, dep_patch = _setup_dir_mocks()
     rsync_patch = patch(
         "api.code_sync._rsync_component_local",
-        return_value=_async_return((False, "local rsync failed: permission denied")),
+        return_value=(False, "local rsync failed: permission denied"),
     )
     post_sync_calls: List[str] = []
 
     async def spy_post_sync(comp, src, dep):
         post_sync_calls.append(comp)
-        return False, []
+        return False, [], True
 
     post_patch = patch("api.code_sync._run_post_sync_steps", side_effect=spy_post_sync)
     with src_patch, dep_patch, rsync_patch, post_patch:
@@ -145,7 +240,13 @@ def test_source_dir_value_error_raises_500(stub_user):
 
 
 def test_excludes_for_known_component(stub_user):
-    """rsync receives the per-component exclude list from _SLM_COMPONENTS."""
+    """rsync receives the per-component exclude list from _SLM_COMPONENTS.
+
+    #11798: since #11459 standard artifacts (venv, __pycache__, …) are merged
+    universally at the rsync chokepoint (_rsync_exclude_args), so the handler
+    passes only the component-specific list.  Assert both halves of that
+    contract instead of the pre-#11459 combined list.
+    """
     src_patch, dep_patch = _setup_dir_mocks()
     captured_excludes: List[List[str]] = []
 
@@ -160,9 +261,13 @@ def test_excludes_for_known_component(stub_user):
 
     assert len(captured_excludes) == 1
     excludes = captured_excludes[0]
-    # autobot-slm-backend's excludes from _SLM_COMPONENTS should include venv
-    assert "venv" in excludes
-    assert "__pycache__" in excludes
+    # The handler passes exactly the component's _SLM_COMPONENTS entry …
+    expected = {comp: excl for comp, excl in _CS._SLM_COMPONENTS}["autobot-slm-backend"]
+    assert excludes == expected
+    # … and the rsync chokepoint injects the canonical artifact excludes.
+    chokepoint_args = _CS._rsync_exclude_args(excludes)
+    assert "--exclude=venv" in chokepoint_args
+    assert "--exclude=__pycache__" in chokepoint_args
 
 
 # =============================================================================
@@ -175,12 +280,14 @@ def test_happy_path_includes_post_steps(stub_user):
     src_patch, dep_patch = _setup_dir_mocks()
     rsync_patch = patch(
         "api.code_sync._rsync_component_local",
-        return_value=_async_return((True, "")),
+        return_value=(True, ""),
     )
     post_patch = patch(
         "api.code_sync._run_post_sync_steps",
-        side_effect=lambda comp, src, dep: _async_return(
-            (True, ["pip: install succeeded", "restart autobot-slm-backend: ok"])
+        side_effect=lambda comp, src, dep: (
+            True,
+            ["pip: install succeeded", "restart autobot-slm-backend: ok"],
+            True,
         ),
     )
     with src_patch, dep_patch, rsync_patch, post_patch:
@@ -198,13 +305,13 @@ def test_post_sync_called_with_correct_args(stub_user):
     src_patch, dep_patch = _setup_dir_mocks(component)
     rsync_patch = patch(
         "api.code_sync._rsync_component_local",
-        return_value=_async_return((True, "")),
+        return_value=(True, ""),
     )
     captured: List[tuple] = []
 
     async def spy(comp, src, dep):
         captured.append((comp, src, dep))
-        return False, []
+        return False, [], True
 
     post_patch = patch("api.code_sync._run_post_sync_steps", side_effect=spy)
     with src_patch, dep_patch, rsync_patch, post_patch:
@@ -218,7 +325,12 @@ def test_post_sync_called_with_correct_args(stub_user):
 
 
 def test_python_backend_post_steps(stub_user):
-    """autobot-backend resolve triggers pip install + service restart (#9982)."""
+    """autobot-backend resolve triggers pip install + service restart (#9982).
+
+    #11798: _run_post_sync_steps grew snapshot/constraints/venv/alembic/health
+    stages (#11322/#11323/#11377/#11378) and returns (deps_changed, steps,
+    pip_ok) — every filesystem/service stage is patched so nothing real runs.
+    """
     from api.code_sync import _run_post_sync_steps
 
     pip_calls: List[str] = []
@@ -228,6 +340,7 @@ def test_python_backend_post_steps(stub_user):
     async def fake_pip(comp, steps):
         pip_calls.append(comp)
         steps.append("pip: install succeeded")
+        return True
 
     async def fake_restart(comp, steps):
         restart_calls.append(comp)
@@ -235,14 +348,22 @@ def test_python_backend_post_steps(stub_user):
 
     async def fake_frontend(comp, steps):
         frontend_calls.append(comp)
+        return True
 
-    deps_patch = patch("api.code_sync._compute_deps_changed", return_value=_async_return(True))
-    pip_patch = patch("api.code_sync._install_pip_deps_for_component", side_effect=fake_pip)
-    restart_patch = patch("api.code_sync._restart_component_services", side_effect=fake_restart)
-    frontend_patch = patch("api.code_sync._build_npm_frontend_for_component", side_effect=fake_frontend)
-
-    with deps_patch, pip_patch, restart_patch, frontend_patch:
-        deps_changed, steps = _run(
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", return_value=True))
+        stack.enter_context(patch("api.code_sync._snapshot_component", return_value=None))
+        stack.enter_context(patch("api.code_sync._deploy_constraints_dir"))
+        stack.enter_context(patch("api.code_sync._deploy_repo_root_requirements"))
+        stack.enter_context(patch("api.code_sync._ensure_target_python_installed"))
+        stack.enter_context(patch("api.code_sync._ensure_venv_python", return_value=False))
+        stack.enter_context(patch("api.code_sync._install_pip_deps_for_component", side_effect=fake_pip))
+        stack.enter_context(patch("api.code_sync._run_alembic_migrations", return_value=True))
+        stack.enter_context(patch("api.code_sync._ensure_autobot_shared_symlink"))
+        stack.enter_context(patch("api.code_sync._restart_component_services", side_effect=fake_restart))
+        stack.enter_context(patch("api.code_sync._wait_component_healthy", return_value=True))
+        stack.enter_context(patch("api.code_sync._build_npm_frontend_for_component", side_effect=fake_frontend))
+        deps_changed, steps, pip_ok = _run(
             _run_post_sync_steps(
                 "autobot-backend",
                 "/opt/autobot/code_source/autobot-backend",
@@ -251,6 +372,7 @@ def test_python_backend_post_steps(stub_user):
         )
 
     assert deps_changed is True
+    assert pip_ok is True
     assert pip_calls == ["autobot-backend"]
     assert restart_calls == ["autobot-backend"]
     assert frontend_calls == [], "npm build must not be called for a Python backend"
@@ -258,7 +380,11 @@ def test_python_backend_post_steps(stub_user):
 
 
 def test_frontend_post_steps(stub_user):
-    """autobot-frontend resolve triggers npm build + nginx restart — no pip (#9982)."""
+    """autobot-frontend resolve triggers npm build + nginx restart — no pip (#9982).
+
+    #11798: patched for the snapshot/health stages and 3-tuple return (see
+    test_python_backend_post_steps).
+    """
     from api.code_sync import _run_post_sync_steps
 
     pip_calls: List[str] = []
@@ -267,22 +393,25 @@ def test_frontend_post_steps(stub_user):
 
     async def fake_pip(comp, steps):
         pip_calls.append(comp)
+        return True
 
     async def fake_frontend(comp, steps):
         frontend_calls.append(comp)
         steps.append("npm build: succeeded")
+        return True
 
     async def fake_restart(comp, steps):
         restart_calls.append(comp)
         steps.append("restart nginx: ok")
 
-    deps_patch = patch("api.code_sync._compute_deps_changed", return_value=_async_return(False))
-    pip_patch = patch("api.code_sync._install_pip_deps_for_component", side_effect=fake_pip)
-    frontend_patch = patch("api.code_sync._build_npm_frontend_for_component", side_effect=fake_frontend)
-    restart_patch = patch("api.code_sync._restart_component_services", side_effect=fake_restart)
-
-    with deps_patch, pip_patch, frontend_patch, restart_patch:
-        deps_changed, steps = _run(
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", return_value=False))
+        stack.enter_context(patch("api.code_sync._snapshot_component", return_value=None))
+        stack.enter_context(patch("api.code_sync._install_pip_deps_for_component", side_effect=fake_pip))
+        stack.enter_context(patch("api.code_sync._build_npm_frontend_for_component", side_effect=fake_frontend))
+        stack.enter_context(patch("api.code_sync._restart_component_services", side_effect=fake_restart))
+        stack.enter_context(patch("api.code_sync._wait_component_healthy", return_value=True))
+        deps_changed, steps, pip_ok = _run(
             _run_post_sync_steps(
                 "autobot-frontend",
                 "/opt/autobot/code_source/autobot-frontend",
@@ -291,19 +420,35 @@ def test_frontend_post_steps(stub_user):
         )
 
     assert deps_changed is False
+    assert pip_ok is True
     assert pip_calls == [], "pip install must not run for a frontend component"
     assert frontend_calls == ["autobot-frontend"]
     assert restart_calls == ["autobot-frontend"]
     assert any("npm" in s for s in steps)
 
 
-def test_shared_lib_post_steps_noop():
-    """autobot_shared resolve runs no service or build steps (#9982)."""
+def test_shared_lib_post_steps():
+    """autobot_shared resolve runs no pip/npm step but restarts dependents.
+
+    #11798: the original "noop" premise rotted — since #10248/#11496 the
+    shared lib restores both backends' symlinks and restarts every dependent
+    service with a health gate.  Assert the current contract instead.
+    """
     from api.code_sync import _run_post_sync_steps
 
-    deps_patch = patch("api.code_sync._compute_deps_changed", return_value=_async_return(False))
-    with deps_patch:
-        deps_changed, steps = _run(
+    symlink_calls: List[str] = []
+
+    async def fake_symlink(comp, steps):
+        symlink_calls.append(comp)
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", return_value=False))
+        stack.enter_context(patch("api.code_sync._snapshot_component", return_value=None))
+        stack.enter_context(patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=fake_symlink))
+        restart_dep = stack.enter_context(
+            patch("api.code_sync._restart_dependents_with_health", return_value=True)
+        )
+        deps_changed, steps, pip_ok = _run(
             _run_post_sync_steps(
                 "autobot_shared",
                 "/opt/autobot/code_source/autobot_shared",
@@ -312,12 +457,11 @@ def test_shared_lib_post_steps_noop():
         )
 
     assert deps_changed is False
-    assert any("no service" in s for s in steps)
+    assert pip_ok is True
+    assert len(symlink_calls) == 2, "both backends' symlinks must be restored"
+    restart_dep.assert_awaited_once()
+    assert not any("pip:" in s or "npm" in s for s in steps)
 
-
-def _run_async_return(value):
-    """Backward-compat alias for _async_return."""
-    return _async_return(value)
 
 
 def test_autobot_shared_is_syncable_and_restarts_dependents():

--- a/autobot-slm-backend/tests/api/test_drift_resolve.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve.py
@@ -445,9 +445,7 @@ def test_shared_lib_post_steps():
         stack.enter_context(patch("api.code_sync._compute_deps_changed", return_value=False))
         stack.enter_context(patch("api.code_sync._snapshot_component", return_value=None))
         stack.enter_context(patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=fake_symlink))
-        restart_dep = stack.enter_context(
-            patch("api.code_sync._restart_dependents_with_health", return_value=True)
-        )
+        restart_dep = stack.enter_context(patch("api.code_sync._restart_dependents_with_health", return_value=True))
         deps_changed, steps, pip_ok = _run(
             _run_post_sync_steps(
                 "autobot_shared",

--- a/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
+++ b/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
@@ -26,6 +26,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
 import types
 from datetime import datetime, timezone
@@ -107,6 +108,24 @@ del _MODELS_SNAPSHOT
 
 def _run(coro):
     return asyncio.get_event_loop().run_until_complete(coro)
+
+
+@contextlib.contextmanager
+def _patched_db_service(mock_db_svc):
+    """setattr/restore replacement for patch(..., create=True) (#11798).
+
+    mock.patch with create=True delattr's the attribute on exit when it was
+    an auto-created MagicMock child (not in __dict__); Mock records that
+    deletion, so every LATER ``patch("services.database.db_service")`` in the
+    sweep raises AttributeError (tests/api/test_component_resolve_job.py).
+    """
+    mod = sys.modules["services.database"]
+    prev = getattr(mod, "db_service", None)
+    mod.db_service = mock_db_svc
+    try:
+        yield
+    finally:
+        mod.db_service = prev
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +319,7 @@ def test_sync_fleet_node_skips_degraded_node() -> None:
     mock_executor = MagicMock()
     mock_db_svc = _make_db_service_for_node(degraded)
 
-    with patch("services.database.db_service", mock_db_svc, create=True):
+    with _patched_db_service(mock_db_svc):
         cont = _run(_sync_fleet_node(mock_executor, "node-vnc", job, stage, "10.0.0.1"))
 
     assert cont is True, "loop must continue after skipping a non-operational node"
@@ -326,7 +345,7 @@ def test_sync_fleet_node_skips_never_heartbeated_node() -> None:
     mock_executor = MagicMock()
     mock_db_svc = _make_db_service_for_node(never_beat)
 
-    with patch("services.database.db_service", mock_db_svc, create=True):
+    with _patched_db_service(mock_db_svc):
         cont = _run(_sync_fleet_node(mock_executor, "node-new", job, stage, ""))
 
     assert cont is True

--- a/autobot-slm-backend/tests/api/test_require_permission.py
+++ b/autobot-slm-backend/tests/api/test_require_permission.py
@@ -195,8 +195,12 @@ class TestRolePermissionsMapping:
 
     def test_services_auth_imports_shared_permission(self):
         """Verify services/auth.py imports Permission from autobot_shared."""
+        import re
+
         auth_src = (Path(__file__).parent.parent.parent / "services" / "auth.py").read_text()
-        assert "from autobot_shared.auth.permissions import Permission" in auth_src
+        # Robust to co-imports on the same line (the exact-literal grep rotted
+        # when the import gained ROLE_PERMISSIONS / Role, #11798).
+        assert re.search(r"from autobot_shared\.auth\.permissions import .*\bPermission\b", auth_src)
 
     def test_no_require_admin_in_api_routes(self):
         """Verify no API route file directly imports require_admin."""

--- a/autobot-slm-backend/tests/api/test_scim.py
+++ b/autobot-slm-backend/tests/api/test_scim.py
@@ -39,11 +39,43 @@ for _p in [str(_SLM_BACKEND), str(_SHARED)]:
 # ---------------------------------------------------------------------------
 
 
-def _stub_modules():
-    """Install lightweight stubs for modules the SCIM module imports."""
+# ---------------------------------------------------------------------------
+# Import only the pure-Python helpers from api.scim (no FastAPI dep needed)
+# ---------------------------------------------------------------------------
+from importlib.util import module_from_spec, spec_from_file_location
+
+_scim_spec = spec_from_file_location("api.scim", _SLM_BACKEND / "api" / "scim.py")
+_scim_mod = module_from_spec(_scim_spec)
+
+
+def _load_scim_module():
+    """Load the SCIM module with PRIVATE stubs, restoring sys.modules after.
+
+    #11798: the previous ``setdefault`` + attribute-mutation bootstrap was a
+    sweep polluter twice over: setdefault left the keys installed forever
+    (skipping tests/services/test_saml_slo.py's real-enum stand-in), and
+    ``sys.modules["fastapi.responses"].JSONResponse = …`` mutated the REAL
+    fastapi.responses when the sweep had already imported FastAPI — silently
+    corrupting every later runtime JSONResponse user
+    (tests/test_api_request_counter.py's 4xx route).  All stubs are now
+    private objects force-installed for the exec and rolled back in finally.
+    """
+    _user_service_stub = MagicMock()
+    _user_service_stub.DuplicateUserError = Exception
+    _user_service_stub.UserNotFoundError = Exception
+    _user_service_stub.UserService = MagicMock()
+
+    # JSONResponse stub: store content for assertions
+    def _json_response(content=None, status_code=200):
+        r = SimpleNamespace(status_code=status_code, content=content)
+        return r
+
+    _responses_stub = MagicMock()
+    _responses_stub.JSONResponse = _json_response
+
     stubs = {
         "fastapi": MagicMock(),
-        "fastapi.responses": MagicMock(),
+        "fastapi.responses": _responses_stub,
         "sqlalchemy": MagicMock(),
         "sqlalchemy.exc": MagicMock(),
         "sqlalchemy.ext.asyncio": MagicMock(),
@@ -56,37 +88,18 @@ def _stub_modules():
         "user_management.models.sso": MagicMock(),
         "user_management.services.base_service": MagicMock(),
         "user_management.services.sso_service": MagicMock(),
-        "user_management.services.user_service": MagicMock(),
+        "user_management.services.user_service": _user_service_stub,
     }
-    for mod, stub in stubs.items():
-        sys.modules.setdefault(mod, stub)
-
-
-_stub_modules()
-
-# ---------------------------------------------------------------------------
-# Import only the pure-Python helpers from api.scim (no FastAPI dep needed)
-# ---------------------------------------------------------------------------
-from importlib.util import module_from_spec, spec_from_file_location
-
-_scim_spec = spec_from_file_location("api.scim", _SLM_BACKEND / "api" / "scim.py")
-_scim_mod = module_from_spec(_scim_spec)
-
-
-def _load_scim_module():
-    """Load the SCIM module with stubs active."""
-    # Provide concrete exceptions that the module references at import time
-    sys.modules["user_management.services.user_service"].DuplicateUserError = Exception
-    sys.modules["user_management.services.user_service"].UserNotFoundError = Exception
-    sys.modules["user_management.services.user_service"].UserService = MagicMock()
-
-    # JSONResponse stub: store content for assertions
-    def _json_response(content=None, status_code=200):
-        r = SimpleNamespace(status_code=status_code, content=content)
-        return r
-
-    sys.modules["fastapi.responses"].JSONResponse = _json_response
-    _scim_spec.loader.exec_module(_scim_mod)
+    prev = {key: sys.modules.get(key) for key in stubs}
+    sys.modules.update(stubs)
+    try:
+        _scim_spec.loader.exec_module(_scim_mod)
+    finally:
+        for key, mod in prev.items():
+            if mod is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = mod
     return _scim_mod
 
 

--- a/autobot-slm-backend/tests/api/test_sso_auth.py
+++ b/autobot-slm-backend/tests/api/test_sso_auth.py
@@ -109,6 +109,7 @@ def test_build_callback_url_valid_host_127_0_0_1():
 
 def test_build_callback_url_invalid_host_rejected():
     """Test callback URL rejects host not in allowlist (phishing attempt)."""
+
     # Mock HTTPException to avoid FastAPI import
     class MockHTTPException(Exception):
         def __init__(self, status_code, detail):
@@ -161,6 +162,7 @@ def test_build_callback_url_case_insensitive():
 # ---------------------------------------------------------------------------
 # Helpers for rate-limit tests (Issue #9611)
 # ---------------------------------------------------------------------------
+
 
 class _FakeRateLimiter:
     """Stand-in RateLimiter whose limits are never hit (allows all requests).

--- a/autobot-slm-backend/tests/api/test_sso_auth.py
+++ b/autobot-slm-backend/tests/api/test_sso_auth.py
@@ -46,26 +46,50 @@ def _make_mock_request(scheme: str, netloc: str, headers: dict | None = None) ->
     return request
 
 
+_SSO_AUTH_PY = Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
+
+# Keys stubbed while exec'ing api/sso_auth.py under test.  These writes used
+# to happen INSIDE test functions with no restore, permanently replacing
+# sys.modules["fastapi"] (and 6 more keys) with MagicMocks for the rest of the
+# session — every later starlette TestClient user in the whole-backend sweep
+# failed (tests/test_prometheus_registry_endpoint.py,
+# tests/test_api_request_counter.py; #11798).  All loads now go through this
+# snapshot/restore helper (same pattern as _load_sso_auth_with_real_endpoints).
+_SSO_STUB_KEYS = (
+    "fastapi",
+    "fastapi.responses",
+    "user_management.database",
+    "user_management.models.sso",
+    "user_management.schemas.sso",
+    "user_management.services.base_service",
+    "user_management.services.sso_service",
+    "services.auth",
+)
+
+
+def _load_sso_auth_with_stubs(fastapi_stub: MagicMock | None = None):
+    """Exec a fresh api/sso_auth.py under stubbed deps; restore sys.modules after."""
+    stubs = {key: MagicMock() for key in _SSO_STUB_KEYS}
+    if fastapi_stub is not None:
+        stubs["fastapi"] = fastapi_stub
+    prev = {key: sys.modules.get(key) for key in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location("sso_auth_cb_" + uuid.uuid4().hex[:8], _SSO_AUTH_PY)
+        sso_auth = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(sso_auth)
+    finally:
+        for key, mod in prev.items():
+            if mod is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = mod
+    return sso_auth
+
+
 def test_build_callback_url_valid_host_localhost():
     """Test callback URL construction with valid localhost host."""
-    # Import after path setup to avoid FastAPI import
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "sso_auth", Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
-    )
-    sso_auth = importlib.util.module_from_spec(spec)
-
-    # Pre-stub FastAPI dependencies
-    sys.modules["fastapi"] = MagicMock()
-    sys.modules["fastapi.responses"] = MagicMock()
-    sys.modules["user_management.database"] = MagicMock()
-    sys.modules["user_management.schemas.sso"] = MagicMock()
-    sys.modules["user_management.services.base_service"] = MagicMock()
-    sys.modules["user_management.services.sso_service"] = MagicMock()
-    sys.modules["services.auth"] = MagicMock()
-
-    spec.loader.exec_module(sso_auth)
+    sso_auth = _load_sso_auth_with_stubs()
 
     request = _make_mock_request("http", "localhost", {"x-forwarded-proto": "http", "x-forwarded-host": "localhost"})
 
@@ -75,22 +99,7 @@ def test_build_callback_url_valid_host_localhost():
 
 def test_build_callback_url_valid_host_127_0_0_1():
     """Test callback URL construction with valid 127.0.0.1 host."""
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "sso_auth", Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
-    )
-    sso_auth = importlib.util.module_from_spec(spec)
-
-    sys.modules["fastapi"] = MagicMock()
-    sys.modules["fastapi.responses"] = MagicMock()
-    sys.modules["user_management.database"] = MagicMock()
-    sys.modules["user_management.schemas.sso"] = MagicMock()
-    sys.modules["user_management.services.base_service"] = MagicMock()
-    sys.modules["user_management.services.sso_service"] = MagicMock()
-    sys.modules["services.auth"] = MagicMock()
-
-    spec.loader.exec_module(sso_auth)
+    sso_auth = _load_sso_auth_with_stubs()
 
     request = _make_mock_request("http", "127.0.0.1", {"x-forwarded-proto": "http", "x-forwarded-host": "127.0.0.1"})
 
@@ -100,13 +109,6 @@ def test_build_callback_url_valid_host_127_0_0_1():
 
 def test_build_callback_url_invalid_host_rejected():
     """Test callback URL rejects host not in allowlist (phishing attempt)."""
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "sso_auth", Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
-    )
-    sso_auth = importlib.util.module_from_spec(spec)
-
     # Mock HTTPException to avoid FastAPI import
     class MockHTTPException(Exception):
         def __init__(self, status_code, detail):
@@ -118,15 +120,7 @@ def test_build_callback_url_invalid_host_rejected():
     fastapi_mock.HTTPException = MockHTTPException
     fastapi_mock.status = SimpleNamespace(HTTP_400_BAD_REQUEST=400)
 
-    sys.modules["fastapi"] = fastapi_mock
-    sys.modules["fastapi.responses"] = MagicMock()
-    sys.modules["user_management.database"] = MagicMock()
-    sys.modules["user_management.schemas.sso"] = MagicMock()
-    sys.modules["user_management.services.base_service"] = MagicMock()
-    sys.modules["user_management.services.sso_service"] = MagicMock()
-    sys.modules["services.auth"] = MagicMock()
-
-    spec.loader.exec_module(sso_auth)
+    sso_auth = _load_sso_auth_with_stubs(fastapi_stub=fastapi_mock)
 
     request = _make_mock_request(
         "https", "attacker.com", {"x-forwarded-proto": "https", "x-forwarded-host": "attacker.com"}
@@ -141,22 +135,7 @@ def test_build_callback_url_invalid_host_rejected():
 
 def test_build_callback_url_host_with_port():
     """Test callback URL construction strips port for allowlist validation."""
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "sso_auth", Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
-    )
-    sso_auth = importlib.util.module_from_spec(spec)
-
-    sys.modules["fastapi"] = MagicMock()
-    sys.modules["fastapi.responses"] = MagicMock()
-    sys.modules["user_management.database"] = MagicMock()
-    sys.modules["user_management.schemas.sso"] = MagicMock()
-    sys.modules["user_management.services.base_service"] = MagicMock()
-    sys.modules["user_management.services.sso_service"] = MagicMock()
-    sys.modules["services.auth"] = MagicMock()
-
-    spec.loader.exec_module(sso_auth)
+    sso_auth = _load_sso_auth_with_stubs()
 
     request = _make_mock_request(
         "http", "localhost:8000", {"x-forwarded-proto": "http", "x-forwarded-host": "localhost:8000"}
@@ -170,22 +149,7 @@ def test_build_callback_url_host_with_port():
 
 def test_build_callback_url_case_insensitive():
     """Test callback URL validation is case-insensitive."""
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "sso_auth", Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
-    )
-    sso_auth = importlib.util.module_from_spec(spec)
-
-    sys.modules["fastapi"] = MagicMock()
-    sys.modules["fastapi.responses"] = MagicMock()
-    sys.modules["user_management.database"] = MagicMock()
-    sys.modules["user_management.schemas.sso"] = MagicMock()
-    sys.modules["user_management.services.base_service"] = MagicMock()
-    sys.modules["user_management.services.sso_service"] = MagicMock()
-    sys.modules["services.auth"] = MagicMock()
-
-    spec.loader.exec_module(sso_auth)
+    sso_auth = _load_sso_auth_with_stubs()
 
     request = _make_mock_request("http", "LOCALHOST", {"x-forwarded-proto": "http", "x-forwarded-host": "LOCALHOST"})
 
@@ -197,9 +161,6 @@ def test_build_callback_url_case_insensitive():
 # ---------------------------------------------------------------------------
 # Helpers for rate-limit tests (Issue #9611)
 # ---------------------------------------------------------------------------
-
-_SSO_AUTH_PY = Path(__file__).parent.parent.parent / "api" / "sso_auth.py"
-
 
 class _FakeRateLimiter:
     """Stand-in RateLimiter whose limits are never hit (allows all requests).
@@ -294,6 +255,7 @@ def _load_sso_auth_with_real_endpoints() -> object:
         "fastapi.responses": MagicMock(),
         "services.database": services_database_stub,
         "user_management.database": MagicMock(),
+        "user_management.models.sso": MagicMock(),
         "user_management.schemas.sso": MagicMock(),
         "user_management.services.base_service": MagicMock(),
         "user_management.services.sso_service": MagicMock(),

--- a/autobot-slm-backend/tests/api/test_sso_health.py
+++ b/autobot-slm-backend/tests/api/test_sso_health.py
@@ -53,6 +53,10 @@ def _load_sso_module():
         "services": MagicMock(),
         "services.auth": MagicMock(),
         "services.database": MagicMock(),
+        # api/sso.py gained `from services.step_up_auth import require_step_up`
+        # (#10693) after this loader's stub list was written; without the key
+        # the MagicMock "services" parent cannot resolve it (#11798).
+        "services.step_up_auth": MagicMock(),
         "user_management": MagicMock(),
         "user_management.database": MagicMock(),
         "user_management.schemas": MagicMock(),

--- a/autobot-slm-backend/tests/services/test_saml_slo.py
+++ b/autobot-slm-backend/tests/services/test_saml_slo.py
@@ -63,10 +63,14 @@ class _SSOProviderType(str, enum.Enum):
     SAML = "saml"
 
 
-if _MODELS_SSO not in sys.modules:
-    _sso_stub = MagicMock()
-    _sso_stub.SSOProviderType = _SSOProviderType
-    sys.modules[_MODELS_SSO] = _sso_stub
+# #11798: forced, not guarded — tests/api/test_scim.py leaves a plain
+# MagicMock squatting this key, and the old `not in sys.modules` guard then
+# skipped this real-enum stand-in, so SSOProviderType comparisons inside
+# sso_service silently mismatched in a whole-backend sweep.  The
+# pre-bootstrap snapshot above rolls the forced stub back after bootstrap.
+_sso_stub = MagicMock()
+_sso_stub.SSOProviderType = _SSOProviderType
+sys.modules[_MODELS_SSO] = _sso_stub
 
 for _mod in [
     "user_management.services.sso_secrets",

--- a/autobot-slm-backend/tests/test_api_request_counter.py
+++ b/autobot-slm-backend/tests/test_api_request_counter.py
@@ -31,14 +31,25 @@ sys.path.insert(0, str(_slm_root))
 # `from monitoring.prometheus_metrics import get_metrics_manager` (inside
 # _record_request) resolves without the full manager; patch it there per-test.
 # ---------------------------------------------------------------------------
-_fake_prom_metrics = types.ModuleType("monitoring.prometheus_metrics")
-_stub_get_metrics_manager = MagicMock()
-_fake_prom_metrics.get_metrics_manager = _stub_get_metrics_manager
-sys.modules["monitoring.prometheus_metrics"] = _fake_prom_metrics
-sys.modules.setdefault("monitoring", types.ModuleType("monitoring"))
+# CONVERGE on any stub another sweep file already installed for this key —
+# a second, competing module object desynchronises patch() (which resolves
+# the attribute chain from the parent package) from the middleware's lazy
+# runtime import (which reads sys.modules), and the patched manager is then
+# never called (#11798).
+_fake_prom_metrics = sys.modules.get("monitoring.prometheus_metrics")
+if _fake_prom_metrics is None:
+    _fake_prom_metrics = types.ModuleType("monitoring.prometheus_metrics")
+    _fake_prom_metrics.get_metrics_manager = MagicMock()
+    sys.modules["monitoring.prometheus_metrics"] = _fake_prom_metrics
+# The parent package must be a hollow package with the REAL __path__, never a
+# bare (pathless) ModuleType: a pathless squat shadows the real package for
+# every later sweep file that imports monitoring.claude_api_monitor (#11798).
+_monitoring_pkg = sys.modules.setdefault("monitoring", types.ModuleType("monitoring"))
+if not hasattr(_monitoring_pkg, "__path__"):
+    _monitoring_pkg.__path__ = [str(_slm_root / "monitoring")]
 # Expose as an attribute too so patch("monitoring.prometheus_metrics.…") resolves
 # (mock.patch uses getattr on the package, not sys.modules).
-sys.modules["monitoring"].prometheus_metrics = _fake_prom_metrics
+_monitoring_pkg.prometheus_metrics = _fake_prom_metrics
 
 # ---------------------------------------------------------------------------
 # Stub autobot_shared before loading the shared recorder.

--- a/autobot-slm-backend/tests/test_api_request_counter.py
+++ b/autobot-slm-backend/tests/test_api_request_counter.py
@@ -52,10 +52,17 @@ if not hasattr(_monitoring_pkg, "__path__"):
 _monitoring_pkg.prometheus_metrics = _fake_prom_metrics
 
 # ---------------------------------------------------------------------------
-# Stub autobot_shared before loading the shared recorder.
+# autobot_shared before loading the shared recorder — prefer the REAL package
+# (#11798: a bare pathless ModuleType squat broke every later
+# ``autobot_shared.<submodule>`` import in subset runs; the real package is
+# importable from the repo root).
 # ---------------------------------------------------------------------------
-_shared = types.ModuleType("autobot_shared")
-sys.modules.setdefault("autobot_shared", _shared)
+if str(_slm_root.parent) not in sys.path:
+    sys.path.insert(0, str(_slm_root.parent))
+try:
+    import autobot_shared  # noqa: F401  (real package keeps submodule imports working)
+except ImportError:
+    sys.modules.setdefault("autobot_shared", types.ModuleType("autobot_shared"))
 for _name in [
     "autobot_shared.monitoring",
     "autobot_shared.monitoring.metrics",

--- a/autobot-slm-backend/tests/test_code_sync_topology.py
+++ b/autobot-slm-backend/tests/test_code_sync_topology.py
@@ -7,21 +7,190 @@ Test topology detection for SLM self-sync (#9195).
 
 Verifies that code_sync routes to SSH rsync for remote code sources
 and Ansible for local sources, fixing the multi-server regression.
+
+Real-load prologue (#11798, same pattern as tests/api/test_drift_resolve.py):
+the root conftest stubs ``models.*`` as MagicMocks, so a bare import here
+yields a MagicMock ``Node``/``NodeSyncRequest`` and (solo) exec'ing
+api/code_sync.py against real FastAPI + MagicMock response models raises
+FastAPIError at decoration time.  Swap in the REAL modules, exec a PRIVATE
+api/code_sync.py copy, restore, and pin it per-test so
+``patch("api.code_sync.…")`` resolves to the private module.
 """
 
+import contextlib
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from api.code_sync import sync_node
-from models.database import Node
-from models.schemas import NodeSyncRequest
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+for _p in (str(_BACKEND_ROOT), str(_BACKEND_ROOT.parent)):  # + repo root (autobot_shared)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SWAP_KEYS = (
+    "models.database",
+    "models.schemas",
+    "services.deploy_artifacts",
+    "services.drift_checker",
+)
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so relative imports work)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+for _name in list(_orig_modules):
+    del sys.modules[_name]
+try:
+    for _name in ("sqlalchemy", "sqlalchemy.ext.asyncio", "sqlalchemy.orm"):
+        importlib.import_module(_name)
+
+    _real_md = _load_real_module("models.database", _BACKEND_ROOT / "models" / "database.py")
+    _real_schemas = _load_real_module("models.schemas", _BACKEND_ROOT / "models" / "schemas.py")
+    _load_real_module("services.deploy_artifacts", _BACKEND_ROOT / "services" / "deploy_artifacts.py")
+    _load_real_module("services.drift_checker", _BACKEND_ROOT / "services" / "drift_checker.py")
+
+    _cs_spec = importlib.util.spec_from_file_location(
+        "_code_sync_topology_test", _BACKEND_ROOT / "api" / "code_sync.py"
+    )
+    _CS = importlib.util.module_from_spec(_cs_spec)  # type: ignore[arg-type]
+    _cs_spec.loader.exec_module(_CS)  # type: ignore[union-attr]
+
+    Node = _real_md.Node
+    NodeSyncRequest = _real_schemas.NodeSyncRequest
+    sync_node = _CS.sync_node
+finally:
+    for _name in [name for name in sys.modules if _is_swap_key(name)]:
+        del sys.modules[_name]
+    for _name, _mod in _orig_modules.items():
+        sys.modules[_name] = _mod
+
+
+@pytest.fixture(autouse=True)
+def _pin_private_code_sync():
+    """Resolve patch("api.code_sync.…") to the private module (#9780: parent attr too)."""
+    saved = sys.modules.get("api.code_sync")
+    sys.modules["api.code_sync"] = _CS
+    _api_pkg = sys.modules.get("api")
+    saved_attr = getattr(_api_pkg, "code_sync", None) if _api_pkg is not None else None
+    if _api_pkg is not None:
+        _api_pkg.code_sync = _CS
+    try:
+        yield
+    finally:
+        if saved is None:
+            sys.modules.pop("api.code_sync", None)
+        else:
+            sys.modules["api.code_sync"] = saved
+        if _api_pkg is not None:
+            if saved_attr is None:
+                with contextlib.suppress(AttributeError):
+                    del _api_pkg.code_sync
+            else:
+                _api_pkg.code_sync = saved_attr
 
 
 @pytest.mark.asyncio
-async def test_sync_node_remote_code_source_uses_ssh_rsync():
-    """Test that sync_node uses SSH rsync when code source is remote (#9195)."""
-    # Mock database and node
+async def test_slm_self_sync_remote_code_source_uses_ssh_rsync():
+    """Remote code source → _sync_slm_from_code_source (SSH rsync), not Ansible.
+
+    #11798: the #9195 topology routing moved from sync_node into
+    _sync_slm_self_node (fleet-sync phase 2, #1209) — test the current seam.
+    """
+    node_state = _CS.NodeSyncState(
+        node_id="slm-node-1",
+        hostname="slm.example.com",
+        ip_address="10.0.1.10",
+        ssh_user="autobot",
+        ssh_port=22,
+    )
+    job = _CS.FleetSyncJob(
+        job_id="job-remote",
+        strategy="rolling",
+        batch_size=1,
+        restart=True,
+        nodes={"slm-node-1": node_state},
+    )
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._update_node_state_db"))
+        stack.enter_context(patch("api.code_sync._update_job_status_db"))
+        stack.enter_context(
+            patch(
+                "api.code_sync._fetch_code_source_connection_info",
+                return_value=("192.168.1.100", "autobot", "/home/autobot/code"),
+            )
+        )
+        stack.enter_context(patch("autobot_shared.network_utils.is_local_ip", return_value=False))
+        ssh_sync = stack.enter_context(patch("api.code_sync._sync_slm_from_code_source"))
+        ansible_update = stack.enter_context(patch("api.code_sync._ansible_self_update"))
+
+        await _CS._sync_slm_self_node(MagicMock(), job, node_state)
+
+    ssh_sync.assert_awaited_once_with("slm-node-1")
+    ansible_update.assert_not_called()
+    assert node_state.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_slm_self_sync_local_code_source_uses_ansible():
+    """Local code source → _ansible_self_update, not SSH rsync (#9195)."""
+    node_state = _CS.NodeSyncState(
+        node_id="slm-node-1",
+        hostname="slm.example.com",
+        ip_address="10.0.1.10",
+        ssh_user="autobot",
+        ssh_port=22,
+    )
+    job = _CS.FleetSyncJob(
+        job_id="job-local",
+        strategy="rolling",
+        batch_size=1,
+        restart=True,
+        nodes={"slm-node-1": node_state},
+    )
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._update_node_state_db"))
+        stack.enter_context(patch("api.code_sync._update_job_status_db"))
+        stack.enter_context(
+            patch(
+                "api.code_sync._fetch_code_source_connection_info",
+                return_value=("10.0.1.10", "autobot", "/opt/autobot/code_source"),
+            )
+        )
+        stack.enter_context(patch("autobot_shared.network_utils.is_local_ip", return_value=True))
+        ssh_sync = stack.enter_context(patch("api.code_sync._sync_slm_from_code_source"))
+        ansible_update = stack.enter_context(patch("api.code_sync._ansible_self_update"))
+
+        await _CS._sync_slm_self_node(MagicMock(), job, node_state)
+
+    ansible_update.assert_awaited_once_with("slm-node-1")
+    ssh_sync.assert_not_called()
+    assert node_state.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_sync_node_self_node_routes_to_ansible_self_update():
+    """sync_node on the SLM's own node queues _ansible_self_update (#9073).
+
+    #11798: sync_node no longer branches on code-source locality (that lives
+    in _sync_slm_self_node) — self-node + restart always goes to Ansible.
+    """
     mock_db = MagicMock()
     mock_node = Node(
         node_id="slm-node-1",
@@ -32,89 +201,23 @@ async def test_sync_node_remote_code_source_uses_ssh_rsync():
     )
     mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=mock_node)))
 
-    # Mock settings
     with patch("api.code_sync.settings") as mock_settings:
         mock_settings.external_url = "http://10.0.1.10"
 
-        # Mock code source connection info (remote)
-        with patch("api.code_sync._fetch_code_source_connection_info") as mock_fetch:
-            mock_fetch.return_value = (
-                "192.168.1.100",  # remote IP
-                "autobot",
-                "/home/autobot/code",
+        with patch("api.code_sync.asyncio.create_task") as mock_create_task:
+            request = NodeSyncRequest(restart=True)
+
+            response = await sync_node(
+                node_id="slm-node-1",
+                request=request,
+                db=mock_db,
+                _={"username": "admin"},
             )
 
-            # Mock is_local_ip to return False (remote)
-            with patch("autobot_shared.network_utils.is_local_ip", return_value=False):
-                # Mock _sync_slm_from_code_source to verify it's called
-                with patch("api.code_sync.asyncio.create_task") as mock_create_task:
-                    request = NodeSyncRequest(restart=True)
+            mock_create_task.assert_called_once()
+            task_coro = mock_create_task.call_args[0][0]
+            assert task_coro.__name__ == "_ansible_self_update", "Expected _ansible_self_update for SLM self-node"
+            task_coro.close()  # never scheduled — silence the un-awaited warning
 
-                    # Call sync_node
-                    response = await sync_node(
-                        node_id="slm-node-1",
-                        request=request,
-                        db=mock_db,
-                        _={"username": "admin"},
-                    )
-
-                    # Verify _sync_slm_from_code_source was scheduled (not _ansible_self_update)
-                    mock_create_task.assert_called_once()
-                    task_coro = mock_create_task.call_args[0][0]
-                    assert (
-                        task_coro.__name__ == "_sync_slm_from_code_source"
-                    ), "Expected _sync_slm_from_code_source for remote code source"
-
-                    assert response.success is True
-                    assert "remote code source" in response.message
-
-
-@pytest.mark.asyncio
-async def test_sync_node_local_code_source_uses_ansible():
-    """Test that sync_node uses Ansible when code source is local (#9195)."""
-    # Mock database and node
-    mock_db = MagicMock()
-    mock_node = Node(
-        node_id="slm-node-1",
-        hostname="slm.example.com",
-        ip_address="10.0.1.10",
-        ssh_user="autobot",
-        ssh_port=22,
-    )
-    mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=mock_node)))
-
-    # Mock settings
-    with patch("api.code_sync.settings") as mock_settings:
-        mock_settings.external_url = "http://10.0.1.10"
-
-        # Mock code source connection info (local)
-        with patch("api.code_sync._fetch_code_source_connection_info") as mock_fetch:
-            mock_fetch.return_value = (
-                "10.0.1.10",  # local IP (same as SLM)
-                "autobot",
-                "/opt/autobot/code_source",
-            )
-
-            # Mock is_local_ip to return True (local)
-            with patch("autobot_shared.network_utils.is_local_ip", return_value=True):
-                # Mock _ansible_self_update to verify it's called
-                with patch("api.code_sync.asyncio.create_task") as mock_create_task:
-                    request = NodeSyncRequest(restart=True)
-
-                    # Call sync_node
-                    response = await sync_node(
-                        node_id="slm-node-1",
-                        request=request,
-                        db=mock_db,
-                        _={"username": "admin"},
-                    )
-
-                    # Verify _ansible_self_update was scheduled
-                    mock_create_task.assert_called_once()
-                    task_coro = mock_create_task.call_args[0][0]
-                    assert (
-                        task_coro.__name__ == "_ansible_self_update"
-                    ), "Expected _ansible_self_update for local code source"
-
-                    assert response.success is True
-                    assert "Ansible" in response.message
+            assert response.success is True
+            assert "Ansible" in response.message

--- a/autobot-slm-backend/tests/test_prometheus_registry_endpoint.py
+++ b/autobot-slm-backend/tests/test_prometheus_registry_endpoint.py
@@ -32,12 +32,22 @@ sys.path.insert(0, str(_slm_root))
 # Stub the heavy monitoring package so main.py's deferred import inside the
 # endpoint handler can be patched per-test without pulling the full dep tree.
 # ---------------------------------------------------------------------------
-_fake_monitoring_pkg = types.ModuleType("monitoring")
-_fake_prom_metrics_mod = types.ModuleType("monitoring.prometheus_metrics")
-_fake_prom_metrics_mod.get_metrics_manager = MagicMock()
-_fake_monitoring_pkg.prometheus_metrics = _fake_prom_metrics_mod
-sys.modules.setdefault("monitoring", _fake_monitoring_pkg)
-sys.modules["monitoring.prometheus_metrics"] = _fake_prom_metrics_mod
+# CONVERGE on any stub another sweep file already installed for this key —
+# a second, competing module object desynchronises patch() (attribute chain
+# from the parent package) from the endpoint's lazy runtime import
+# (sys.modules), so the patched manager is never the one called (#11798).
+_fake_prom_metrics_mod = sys.modules.get("monitoring.prometheus_metrics")
+if _fake_prom_metrics_mod is None:
+    _fake_prom_metrics_mod = types.ModuleType("monitoring.prometheus_metrics")
+    _fake_prom_metrics_mod.get_metrics_manager = MagicMock()
+    sys.modules["monitoring.prometheus_metrics"] = _fake_prom_metrics_mod
+# The parent stub is a hollow package with the REAL __path__, never a bare
+# (pathless) ModuleType: a pathless squat shadows the real package for every
+# later sweep file that imports monitoring.claude_api_monitor (#11798).
+_monitoring_pkg = sys.modules.setdefault("monitoring", types.ModuleType("monitoring"))
+if not hasattr(_monitoring_pkg, "__path__"):
+    _monitoring_pkg.__path__ = [str(_slm_root / "monitoring")]
+_monitoring_pkg.prometheus_metrics = _fake_prom_metrics_mod
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/test_websocket_auth_smoke.py
+++ b/autobot-slm-backend/tests/test_websocket_auth_smoke.py
@@ -16,7 +16,7 @@ Key behavior under test (issue #10151 / M1): WS auth must use the **async**
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,6 +27,15 @@ def _fake_ws() -> AsyncMock:
     ws = AsyncMock()
     ws.accept = AsyncMock()
     ws.close = AsyncMock()
+    # _log_ws_reject_context (#10459, added after this test) reads synchronous
+    # request properties on the reject path; on a bare AsyncMock,
+    # ``headers.get(...)`` returns a coroutine which the logger then slices
+    # (TypeError, #11798).  Provide sync stand-ins.
+    ws.headers = MagicMock()
+    ws.headers.get = MagicMock(side_effect=lambda key, default=None: default)
+    ws.url = MagicMock()
+    ws.url.path = "/ws/test"
+    ws.client = ("127.0.0.1", 12345)
     return ws
 
 

--- a/autobot-slm-backend/user_management/services/sso_e2e_test.py
+++ b/autobot-slm-backend/user_management/services/sso_e2e_test.py
@@ -9,36 +9,148 @@ End-to-end tests for SSO authentication flows with encrypted credentials (MVA-38
 Tests OAuth and LDAP flows using encrypted secrets:
 - OAuth: authorization, token exchange, userinfo retrieval
 - LDAP: connection, authentication, user search
+
+The slm-backend root conftest stubs ``sqlalchemy`` / ``models.database`` /
+``services.encryption`` as MagicMocks for api/* tests, so bare imports here
+would run against inert mock chains (``create_async_engine`` returning a
+MagicMock that cannot be awaited — the exact never-run failure #11798 fixed).
+Same real-load prologue as the sibling ``sso_secrets_test.py`` (pattern:
+tests/services/code_version_test.py, #11737/#11794): swap in the REAL
+sqlalchemy + product modules at import time, bind what the tests need,
+restore the stubs, and re-activate the swap per-test via ``async_session``.
 """
 
+import contextlib
+import importlib
+import importlib.util
+import os
+import sys
 import uuid
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
 
-from models.database import Base, SystemSecret
-from services.encryption import encrypt_data
+_SLM_ROOT = Path(__file__).parent.parent.parent
+for _p in (str(_SLM_ROOT), str(_SLM_ROOT.parent)):  # slm root + repo root (autobot_shared)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# The real EncryptionService requires a master key at first use; provide a
+# deterministic test-only default without clobbering a real environment.
+os.environ.setdefault("SLM_ENCRYPTION_KEY", "unit-test-encryption-key-0123456789abcdef")
+
+# ldap3 is a declared dependency (requirements.txt) but not always installed
+# in dev environments; the LDAP-mocking tests are env-bound on it.
+requires_ldap3 = pytest.mark.skipif(
+    importlib.util.find_spec("ldap3") is None,
+    reason="ldap3 not installed (declared in requirements.txt; env-bound)",
+)
+
+_SWAP_PREFIXES = ("sqlalchemy", "aiosqlite")
+_SWAP_KEYS = (
+    "models.database",
+    "services.encryption",
+    "user_management.services.vault_client",
+    "user_management.services.sso_secrets",
+)
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or any(name == p or name.startswith(p + ".") for p in _SWAP_PREFIXES)
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so runtime imports resolve)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# Snapshot and clear EVERY swapped key — one cached MagicMock child poisons
+# the real package import (see code_version_test.py, #11737).
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+for _name in list(_orig_modules):
+    del sys.modules[_name]
+try:
+    for _name in (
+        "sqlalchemy",
+        "sqlalchemy.ext.asyncio",
+        "sqlalchemy.orm",
+        # The aiosqlite dialect is resolved lazily at create_async_engine()
+        # time; import it now while the real package tree is intact.
+        "sqlalchemy.dialects.sqlite.aiosqlite",
+    ):
+        importlib.import_module(_name)
+
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    _real_md = _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+    _real_enc = _load_real_module("services.encryption", _SLM_ROOT / "services" / "encryption.py")
+    _real_vc = _load_real_module(
+        "user_management.services.vault_client",
+        _SLM_ROOT / "user_management" / "services" / "vault_client.py",
+    )
+    # Force the legacy SystemSecret code path deterministically: an env with
+    # AUTOBOT_INTERNAL_API_KEY / SLM_SERVICE_KEY set would flip is_configured()
+    # and route store/retrieve to live HTTP vault calls.  This mutates only our
+    # private real-loaded instance, never the conftest stub other files see.
+    _real_vc._INTERNAL_API_KEY = ""
+    _real_vc._SERVICE_KEY = ""
+    _real_sso = _load_real_module(
+        "user_management.services.sso_secrets",
+        _SLM_ROOT / "user_management" / "services" / "sso_secrets.py",
+    )
+
+    Base = _real_md.Base
+    SystemSecret = _real_md.SystemSecret
+    encrypt_data = _real_enc.encrypt_data
+    SSOSecretsManager = _real_sso.SSOSecretsManager
+
+    _REAL_MODULES = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+finally:
+    for _name in [name for name in sys.modules if _is_swap_key(name)]:
+        del sys.modules[_name]
+    for _name, _mod in _orig_modules.items():
+        sys.modules[_name] = _mod
+
+
+@contextlib.contextmanager
+def _real_modules_swapped():
+    """Temporarily put the real sqlalchemy/product modules back into sys.modules."""
+    saved = {name: sys.modules.get(name) for name in _REAL_MODULES}
+    sys.modules.update(_REAL_MODULES)
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
 
 
 # Test fixtures
 @pytest.fixture
 async def async_session():
-    """Create an async test database session."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
+    """Create an async test database session (real modules swapped in)."""
+    with _real_modules_swapped():
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
 
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
-    async_session_maker = sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
-        engine, class_=AsyncSession, expire_on_commit=False
-    )
+        async_session_maker = sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
 
-    async with async_session_maker() as session:
-        yield session
+        async with async_session_maker() as session:
+            yield session
 
-    await engine.dispose()
+        await engine.dispose()
 
 
 @pytest.fixture
@@ -106,8 +218,6 @@ class TestOAuthFlowWithEncryptedCredentials:
     @pytest.mark.asyncio
     async def test_oauth_authorization_url_generation(self, async_session, oauth_provider_with_encrypted_secret):
         """Test OAuth authorization URL generation with encrypted credentials."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
         provider_id = oauth_provider_with_encrypted_secret["provider_id"]
 
@@ -136,8 +246,6 @@ class TestOAuthFlowWithEncryptedCredentials:
         self, mock_post, async_session, oauth_provider_with_encrypted_secret
     ):
         """Test OAuth token exchange using decrypted client_secret."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
         provider_id = oauth_provider_with_encrypted_secret["provider_id"]
 
@@ -206,8 +314,6 @@ class TestOAuthFlowWithEncryptedCredentials:
     @pytest.mark.asyncio
     async def test_oauth_flow_handles_missing_secret_gracefully(self, async_session, provider_id):
         """Test OAuth flow error handling when secret not found."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Try to retrieve non-existent secret
@@ -219,8 +325,6 @@ class TestOAuthFlowWithEncryptedCredentials:
     @pytest.mark.asyncio
     async def test_oauth_flow_handles_decryption_error(self, async_session, provider_id):
         """Test OAuth flow when secret decryption fails."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         # Store corrupted secret
         secret_key = f"sso:provider:{provider_id}:client_secret"
         secret = SystemSecret(
@@ -245,8 +349,6 @@ class TestLDAPFlowWithEncryptedCredentials:
     @pytest.mark.asyncio
     async def test_ldap_connection_with_encrypted_password(self, async_session, ldap_provider_with_encrypted_password):
         """Test LDAP connection using decrypted bind_password."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
         provider_id = ldap_provider_with_encrypted_password["provider_id"]
 
@@ -265,6 +367,7 @@ class TestLDAPFlowWithEncryptedCredentials:
         assert ldap_params["bind_password"] == "ldap_bind_password_456"
         assert ldap_params["bind_dn"] == "cn=admin,dc=example,dc=com"
 
+    @requires_ldap3
     @pytest.mark.asyncio
     @patch("ldap3.Connection")
     @patch("ldap3.Server")
@@ -272,8 +375,6 @@ class TestLDAPFlowWithEncryptedCredentials:
         self, mock_server, mock_connection, async_session, ldap_provider_with_encrypted_password
     ):
         """Test full LDAP authentication with encrypted credentials."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         # Mock LDAP server and connection
         mock_server_instance = MagicMock()
         mock_server.return_value = mock_server_instance
@@ -325,8 +426,6 @@ class TestLDAPFlowWithEncryptedCredentials:
     @pytest.mark.asyncio
     async def test_ldap_connection_handles_missing_password(self, async_session, provider_id):
         """Test LDAP connection error handling when bind_password missing."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Try to retrieve non-existent password
@@ -335,6 +434,7 @@ class TestLDAPFlowWithEncryptedCredentials:
         # Should return None, allowing caller to handle error
         assert bind_password is None
 
+    @requires_ldap3
     @pytest.mark.asyncio
     @patch("ldap3.Connection")
     @patch("ldap3.Server")
@@ -342,8 +442,6 @@ class TestLDAPFlowWithEncryptedCredentials:
         self, mock_server, mock_connection, async_session, ldap_provider_with_encrypted_password
     ):
         """Test LDAP user authentication flow."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         # Mock successful bind
         mock_conn_instance = MagicMock()
         mock_conn_instance.bind.return_value = True
@@ -369,8 +467,6 @@ class TestLDAPFlowWithEncryptedCredentials:
     @pytest.mark.asyncio
     async def test_ldap_handles_special_characters_in_password(self, async_session, provider_id):
         """Test LDAP with special characters in bind_password."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         # Store password with special chars
         special_password = 'p@ssw0rd!"#$%&*()[]{}:;<>?'
         secret_key = f"sso:provider:{provider_id}:bind_password"
@@ -396,8 +492,6 @@ class TestSSOIntegrationScenarios:
     @pytest.mark.asyncio
     async def test_full_oauth_sso_provider_lifecycle(self, async_session, provider_id):
         """Test complete lifecycle: create, use, update, delete."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # 1. Create provider with encrypted secret
@@ -441,8 +535,6 @@ class TestSSOIntegrationScenarios:
     @pytest.mark.asyncio
     async def test_multiple_providers_with_encrypted_secrets(self, async_session):
         """Test managing secrets for multiple SSO providers simultaneously."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Create three different providers

--- a/autobot-slm-backend/user_management/services/sso_secrets.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets.py
@@ -60,8 +60,19 @@ def _vault_id_config_key(field: str) -> str:
     return f"{field}_vault_id"
 
 
-async def _legacy_retrieve(session: AsyncSession, provider_id: uuid.UUID, field: str) -> str | None:
-    """Read from the legacy SystemSecret table (fallback during migration window)."""
+async def _legacy_retrieve(
+    session: AsyncSession, provider_id: uuid.UUID, field: str, *, strict: bool = False
+) -> str | None:
+    """Read from the legacy SystemSecret table.
+
+    ``strict=True`` (vault not configured — the legacy table IS the primary
+    store): failures propagate, and a decryption failure raises
+    ``ValueError('Failed to decrypt secret <field>')`` so a corrupted secret
+    surfaces instead of masquerading as "no secret stored" (#11798).
+    ``strict=False`` (migration-window fallback behind the vault): all
+    failures are logged and swallowed so the fallback never breaks the
+    vault path.
+    """
     try:
         from models.database import SystemSecret
         from services.encryption import decrypt_data
@@ -71,8 +82,13 @@ async def _legacy_retrieve(session: AsyncSession, provider_id: uuid.UUID, field:
         secret = result.scalar_one_or_none()
         if secret is None:
             return None
-        return decrypt_data(secret.encrypted_value)
+        try:
+            return decrypt_data(secret.encrypted_value)
+        except Exception as exc:
+            raise ValueError(f"Failed to decrypt secret {field}") from exc
     except Exception as exc:
+        if strict:
+            raise
         logger.warning("legacy SSO secret fallback failed for field %s: %s", field, type(exc).__name__)
         return None
 
@@ -186,8 +202,9 @@ class SSOSecretsManager:
         )
 
         # Rollout fallback: vault not provisioned → read straight from legacy.
+        # strict: legacy is the PRIMARY store here, so corruption must raise.
         if not is_configured():
-            return await _legacy_retrieve(self._session, provider_id, field)
+            return await _legacy_retrieve(self._session, provider_id, field, strict=True)
 
         # Try to resolve vault_id from the provider's stored config.
         vault_id = await self._resolve_vault_id(provider_id, field)

--- a/autobot-slm-backend/user_management/services/sso_secrets_test.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets_test.py
@@ -11,39 +11,149 @@ Tests SSOSecretsManager for:
 - Deleting provider secrets
 - Migrating plaintext to encrypted storage
 - Handling decryption failures gracefully
+
+The slm-backend root conftest stubs ``sqlalchemy`` / ``models.database`` /
+``services.encryption`` as MagicMocks for api/* tests, so bare imports here
+would run against inert mock chains (``create_async_engine`` returning a
+MagicMock that cannot be awaited — the exact never-run failure #11798 fixed).
+Following the established real-load pattern (tests/services/code_version_test.py,
+#11737/#11794), this module swaps in the REAL sqlalchemy + product modules at
+import time, binds what it needs, then restores the stubs so sibling test
+files are unaffected.  The swap is re-activated for each test via the
+``async_session`` fixture (``_real_modules_swapped()``) because
+SSOSecretsManager resolves ``models.database`` / ``services.encryption`` /
+``user_management.services.vault_client`` through sys.modules at call time.
 """
 
+import contextlib
+import importlib
+import importlib.util
+import os
+import sys
 import uuid
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
 
-from models.database import Base, SystemSecret
-from services.encryption import decrypt_data
+_SLM_ROOT = Path(__file__).parent.parent.parent
+for _p in (str(_SLM_ROOT), str(_SLM_ROOT.parent)):  # slm root + repo root (autobot_shared)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# The real EncryptionService requires a master key at first use; provide a
+# deterministic test-only default without clobbering a real environment.
+os.environ.setdefault("SLM_ENCRYPTION_KEY", "unit-test-encryption-key-0123456789abcdef")
+
+_SWAP_PREFIXES = ("sqlalchemy", "aiosqlite")
+_SWAP_KEYS = (
+    "models.database",
+    "services.encryption",
+    "user_management.services.vault_client",
+    "user_management.services.sso_secrets",
+)
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or any(name == p or name.startswith(p + ".") for p in _SWAP_PREFIXES)
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so runtime imports resolve)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# Snapshot and clear EVERY swapped key (not just the ones the root conftest
+# stubs): earlier-collected files leave extra child stubs such as
+# ``sqlalchemy.exc`` in sys.modules, and one cached MagicMock child poisons
+# the real package import (see code_version_test.py, #11737).
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+for _name in list(_orig_modules):
+    del sys.modules[_name]
+try:
+    for _name in (
+        "sqlalchemy",
+        "sqlalchemy.ext.asyncio",
+        "sqlalchemy.orm",
+        # The aiosqlite dialect is resolved lazily at create_async_engine()
+        # time; import it now while the real package tree is intact.
+        "sqlalchemy.dialects.sqlite.aiosqlite",
+    ):
+        importlib.import_module(_name)
+
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    _real_md = _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+    _real_enc = _load_real_module("services.encryption", _SLM_ROOT / "services" / "encryption.py")
+    _real_vc = _load_real_module(
+        "user_management.services.vault_client",
+        _SLM_ROOT / "user_management" / "services" / "vault_client.py",
+    )
+    # Force the legacy SystemSecret code path deterministically: an env with
+    # AUTOBOT_INTERNAL_API_KEY / SLM_SERVICE_KEY set would flip is_configured()
+    # and route store/retrieve to live HTTP vault calls.  This mutates only our
+    # private real-loaded instance, never the conftest stub other files see.
+    _real_vc._INTERNAL_API_KEY = ""
+    _real_vc._SERVICE_KEY = ""
+    _real_sso = _load_real_module(
+        "user_management.services.sso_secrets",
+        _SLM_ROOT / "user_management" / "services" / "sso_secrets.py",
+    )
+
+    Base = _real_md.Base
+    SystemSecret = _real_md.SystemSecret
+    decrypt_data = _real_enc.decrypt_data
+    SSOSecretsManager = _real_sso.SSOSecretsManager
+
+    _REAL_MODULES = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+finally:
+    for _name in [name for name in sys.modules if _is_swap_key(name)]:
+        del sys.modules[_name]
+    for _name, _mod in _orig_modules.items():
+        sys.modules[_name] = _mod
+
+
+@contextlib.contextmanager
+def _real_modules_swapped():
+    """Temporarily put the real sqlalchemy/product modules back into sys.modules."""
+    saved = {name: sys.modules.get(name) for name in _REAL_MODULES}
+    sys.modules.update(_REAL_MODULES)
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
 
 
 # Test fixtures setup
 @pytest.fixture
 async def async_session():
-    """Create an async test database session."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
+    """Create an async test database session (real modules swapped in)."""
+    with _real_modules_swapped():
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
 
-    # Create tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+        # Create tables
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
-    # Create session factory
-    async_session_maker = sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
-        engine, class_=AsyncSession, expire_on_commit=False
-    )
+        # Create session factory
+        async_session_maker = sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
 
-    async with async_session_maker() as session:
-        yield session
+        async with async_session_maker() as session:
+            yield session
 
-    await engine.dispose()
+        await engine.dispose()
 
 
 @pytest.fixture
@@ -83,8 +193,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_store_secrets_creates_encrypted_secrets(self, async_session, provider_id, oauth_config):
         """Test that store_secrets extracts and encrypts sensitive fields."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Store secrets
@@ -117,8 +225,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_store_secrets_handles_multiple_sensitive_fields(self, async_session, provider_id, ldap_config):
         """Test storing config with bind_password field."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Store LDAP config with bind_password
@@ -142,8 +248,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_store_secrets_updates_existing_secret(self, async_session, provider_id, oauth_config):
         """Test that updating provider updates the encrypted secret."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Store initial secret
@@ -169,8 +273,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_retrieve_secret_decrypts_successfully(self, async_session, provider_id, oauth_config):
         """Test retrieving and decrypting a stored secret."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Store secret first
@@ -184,8 +286,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_retrieve_secret_returns_none_for_missing(self, async_session, provider_id):
         """Test that retrieve_secret returns None for non-existent secret."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Try to retrieve non-existent secret
@@ -195,8 +295,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_retrieve_secret_handles_decryption_failure(self, async_session, provider_id):
         """Test graceful handling of decryption failures."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Store a secret with corrupted encryption
@@ -216,8 +314,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_delete_secrets_removes_all_provider_secrets(self, async_session, provider_id, oauth_config):
         """Test that delete_secrets removes all associated secrets."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Store secrets
@@ -243,8 +339,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_has_plaintext_secrets_detects_plaintext(self, oauth_config):
         """Test detection of plaintext secrets in config."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(AsyncMock())
 
         # Config with plaintext secret
@@ -257,8 +351,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_migrate_plaintext_to_secrets_converts_successfully(self, async_session, provider_id, oauth_config):
         """Test migration from plaintext to encrypted storage."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Migrate plaintext config
@@ -276,8 +368,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_migrate_plaintext_skips_already_migrated(self, async_session, provider_id):
         """Test that migration skips configs without plaintext secrets."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Config already migrated (has references)
@@ -293,8 +383,6 @@ class TestSSOSecretsManagerIntegration:
     @pytest.mark.asyncio
     async def test_store_secrets_handles_empty_secret_values(self, async_session, provider_id):
         """Test that empty/null secret values are not stored."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Config with empty client_secret
@@ -323,8 +411,6 @@ class TestSSOSecretsManagerEdgeCases:
     @pytest.mark.asyncio
     async def test_concurrent_updates_to_same_secret(self, async_session, provider_id, oauth_config):
         """Test that concurrent updates don't corrupt secrets."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Store initial secret
@@ -351,8 +437,6 @@ class TestSSOSecretsManagerEdgeCases:
     @pytest.mark.asyncio
     async def test_unicode_secrets_handled_correctly(self, async_session, provider_id):
         """Test that Unicode characters in secrets are preserved."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Config with Unicode secret
@@ -372,8 +456,6 @@ class TestSSOSecretsManagerEdgeCases:
     @pytest.mark.asyncio
     async def test_very_long_secret_values(self, async_session, provider_id):
         """Test handling of very long secret values (e.g., long API keys)."""
-        from user_management.services.sso_secrets import SSOSecretsManager
-
         manager = SSOSecretsManager(async_session)
 
         # Generate a 2KB secret


### PR DESCRIPTION
Closes #11798

## Thinking Path

With collection fixed by #11794, the run phase showed 105 failures + 36 errors: never-run files (real-load treatment), runtime `sys.modules` clobbering, and per-file/sweep-order rot. Fixed in 5 incremental commits by cluster, polluter-side first, using the established patterns (real-load prologues, snapshot/restore, #9780 parent-attr binding).

## What Changed

- **Cluster A** (45): never-run `sso_secrets`/`sso_e2e` tests real-loaded (real sqlalchemy+aiosqlite, encryption service w/ test key, legacy vault path); ldap3-decorated tests get declared-dep env skips.
- **Cluster B** (25): `test_sso_auth.py` in-function permanent stubbing → snapshot/restore helper (file now 15/15 solo, was 1/15); `monitoring` pathless squat → hollow real-`__path__` package converged on one shared stub; forced saml enum stub under existing rollback.
- **Cluster C** (46): 12 files repaired against current contracts — incl. `main_ensure_local_node_test` loading the WRONG main.py (repo root, `parents` bug), `jwks_verifier_test` silently replaced by a MagicMock parent auto-attr in sweeps, `test_scim` mutating the REAL `fastapi.responses.JSONResponse`.
- **Product bugs fixed in-scope (test-evidenced):** `sso_secrets._legacy_retrieve` swallowed decryption failures when the legacy table is the PRIMARY store — corruption masqueraded as "no secret"; now strict-raises. `oidc_token_cache` raised through its documented "Redis down → cache miss" contract, breaking token verification/logout — new `_redis_or_none()` degrades all 3 sites (9 in-sweep TypeErrors → 0).
- Filed #11830: connection-manager singleton poisoning under test-stubbed config (fix direction recorded).

## Verification

- Whole sweep: `105 failed / 1111 passed / 36 errors` → **1226 passed / 3 justified skips / 0 failed / 0 errors** (agent AND independent re-run identical, 57s). Collection 1229/0; `tests/services/` 321/1 intact. flake8 clean on every touched file.

## Model Used

Claude Fable 5 (subagent: general-purpose)