### PR TITLE
fix(test): eliminate module-scope sys.modules stubbing — tests/ collects clean (#11796)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -321,6 +321,15 @@ if "llm_shared" not in sys.modules:
     ]:
         if _llm_sub not in sys.modules:
             sys.modules[_llm_sub] = _make_pkg_stub(_llm_sub)
+        # #11796: bind each sub-package stub as an attribute on its parent.
+        # Without this, unittest.mock's dotted-name resolution (and
+        # ``import llm_shared.X.Y as m``) walks getattr() through the parent
+        # stub's catch-all __getattr__, gets the mock singleton instead of
+        # the stub/real module in sys.modules, and string-form patch()
+        # silently patches the wrong object (same trap _real_load_and_bind's
+        # parent bind guards against).
+        _llm_parent, _, _llm_child = _llm_sub.rpartition(".")
+        setattr(sys.modules[_llm_parent], _llm_child, sys.modules[_llm_sub])
 
     # Give llm_shared.tiered_routing the real __path__ so submodule imports
     # (e.g. from llm_shared.tiered_routing.complexity_router import ...) can
@@ -328,6 +337,16 @@ if "llm_shared" not in sys.modules:
     # autobot_shared.logging_manager and lightweight config — no heavy deps.
     _tr_real_path = str(backend_root / "llm_shared" / "tiered_routing")
     sys.modules["llm_shared.tiered_routing"].__path__ = [_tr_real_path]  # type: ignore[attr-defined]
+
+    # #11796: same for providers/ and optimization/ — submodules not stubbed
+    # or real-loaded below stay importable from disk (and importlib.reload()
+    # of a real-loaded provider can re-find its spec via the parent __path__).
+    sys.modules["llm_shared.providers"].__path__ = [  # type: ignore[attr-defined]
+        str(backend_root / "llm_shared" / "providers")
+    ]
+    sys.modules["llm_shared.optimization"].__path__ = [  # type: ignore[attr-defined]
+        str(backend_root / "llm_shared" / "optimization")
+    ]
 
     # GH#8998: Register real fallback_chain and model_fallback_coordinator modules
     # so tests inside llm_shared/ can import them without the full heavy __init__.py chain.
@@ -379,6 +398,34 @@ if "llm_shared" not in sys.modules:
     _real_load_and_bind("llm_shared.base_provider", _llm_root / "base_provider.py")
     _real_load_and_bind("llm_shared.model_param_registry", _llm_root / "model_param_registry.py")
     _real_load_and_bind("llm_shared.provider_registry", _llm_root / "provider_registry.py")
+    # #11796: concrete provider modules + profiler — their test modules
+    # (tests/llm_interface_pkg/*) import them at collection time, but the
+    # llm_shared.providers / llm_shared.optimization pkg stubs have an empty
+    # __path__, so without explicit real-loads those imports fail and the
+    # files error out of every whole-dir collection.  All are light imports
+    # (stdlib + the llm_shared seams real-loaded above + jinja2).
+    # Dependency order: cache_utils → openai_compatible → concrete providers.
+    _real_load_and_bind("llm_shared.providers.cache_utils", _llm_root / "providers" / "cache_utils.py")
+    _real_load_and_bind(
+        "llm_shared.providers.openai_compatible",
+        _llm_root / "providers" / "openai_compatible.py",
+    )
+    _real_load_and_bind("llm_shared.providers.anthropic", _llm_root / "providers" / "anthropic.py")
+    _real_load_and_bind("llm_shared.providers.groq", _llm_root / "providers" / "groq.py")
+    _real_load_and_bind("llm_shared.providers.openai", _llm_root / "providers" / "openai.py")
+    _real_load_and_bind("llm_shared.providers.custom_openai", _llm_root / "providers" / "custom_openai.py")
+    _real_load_and_bind(
+        "llm_shared.providers.chat_template_loader",
+        _llm_root / "providers" / "chat_template_loader.py",
+    )
+    # vllm.py guards its heavy `from vllm import ...` in try/except, and
+    # ollama_provider only needs aiohttp + light autobot_shared seams.
+    _real_load_and_bind("llm_shared.providers.vllm", _llm_root / "providers" / "vllm.py")
+    _real_load_and_bind(
+        "llm_shared.providers.ollama_provider",
+        _llm_root / "providers" / "ollama_provider.py",
+    )
+    _real_load_and_bind("llm_shared.optimization.profiler", _llm_root / "optimization" / "profiler.py")
     # Re-export the real classes onto the top-level stub so
     # `from llm_shared import ProviderRegistry, BaseProvider` resolves to the real
     # ones for tests that exercise them (tests/test_provider_registry.py, #10917).

--- a/autobot-backend/tests/agents/test_librarian_assistant_extract.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_extract.py
@@ -32,6 +32,16 @@ import pytest
 _BACKEND_DIR = Path(__file__).resolve().parents[2]
 _AGENTS_DIR = _BACKEND_DIR / "agents"
 
+# #11796: snapshot sys.modules before the stub-heavy bootstrap below.  The
+# _make_stub() helper unconditionally assigns into sys.modules (the
+# setdefault(default=...) is evaluated eagerly), replacing the REAL
+# ``services``/``utils`` packages with __path__ = [] stubs for every test
+# module collected after this one in a whole-dir run.  Everything is rolled
+# back right after the module under test is loaded; tests only use the
+# references extracted at load time (_mod, _fake_config) plus per-test
+# patch.dict overrides.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
 # Plant a minimal 'agents' package so relative imports in the module work.
 if "agents" not in sys.modules:
     _agents_pkg = types.ModuleType("agents")
@@ -134,6 +144,15 @@ _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 
 LibrarianAssistant = _mod.LibrarianAssistant
 _source_for_url = _mod._source_for_url
+
+# #11796: restore the pre-bootstrap sys.modules state (see snapshot above) so
+# none of the stubs leak into later-collected test modules.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/tests/agents/test_librarian_assistant_extract.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_extract.py
@@ -154,6 +154,19 @@ for _k in list(sys.modules):
         sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
 del _PRE_BOOTSTRAP_MODULES
 
+# #11796: the bootstrap may have set ``agent_loop.search`` as an ATTRIBUTE on
+# a real, already-imported ``agent_loop`` package (attribute mutations survive
+# the sys.modules restore above).  Re-sync the attribute with whatever the
+# restored sys.modules now holds so mock.patch's getattr-based dotted-name
+# walk cannot land on a stale stub.
+_al_parent = sys.modules.get("agent_loop")
+if _al_parent is not None:
+    _al_real_child = sys.modules.get("agent_loop.search")
+    if _al_real_child is not None:
+        _al_parent.search = _al_real_child  # type: ignore[attr-defined]
+    elif getattr(_al_parent, "search", None) is _al_search_pkg:
+        del _al_parent.search
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/tests/agents/test_librarian_assistant_extract.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_extract.py
@@ -108,17 +108,17 @@ _fake_config.get_nested = MagicMock(side_effect=lambda key, default=None: defaul
 sys.modules.setdefault("config", types.SimpleNamespace(config=_fake_config))
 
 # Patch autobot_shared stubs if not already real modules.
+# #11796: get_logger is set ONLY on a freshly created stub — assigning it on
+# the REAL logging_manager module is an in-place attribute mutation that the
+# sys.modules restore below cannot undo (it broke get_llm_logger's 2-arg
+# get_logger(name, "llm") call for every later-collected test module).
 for _shared in ["autobot_shared.logging_manager"]:
     if _shared not in sys.modules:
-        _make_stub(_shared)
+        _make_stub(_shared).get_logger = logging.getLogger  # type: ignore[attr-defined]
 
 if "autobot_shared.singleton_factory" not in sys.modules:
     _singleton_stub = _make_stub("autobot_shared.singleton_factory")
     _singleton_stub.lazy_singleton = lambda cls: cls  # type: ignore[attr-defined]
-
-_logging_mod = sys.modules.get("autobot_shared.logging_manager")
-if _logging_mod is not None:
-    _logging_mod.get_logger = logging.getLogger  # type: ignore[attr-defined]
 
 _llm_mod = sys.modules.get("services.llm_service")
 if _llm_mod is not None:

--- a/autobot-backend/tests/agents/test_librarian_assistant_search.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_search.py
@@ -13,6 +13,7 @@ Verifies:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import sys
 import types
@@ -27,6 +28,16 @@ import pytest
 # ---------------------------------------------------------------------------
 _BACKEND_DIR = Path(__file__).resolve().parents[2]
 _AGENTS_DIR = _BACKEND_DIR / "agents"
+
+# #11796: snapshot sys.modules before the stub-heavy bootstrap below.  The
+# _make_stub() helper unconditionally assigns into sys.modules (the
+# setdefault(default=...) is evaluated eagerly), replacing the REAL
+# ``services``/``utils`` packages with __path__ = [] stubs for every test
+# module collected after this one in a whole-dir run.  Everything is rolled
+# back right after the module under test is loaded; tests only use the
+# references extracted at load time (_mod, _fake_config) plus per-test
+# patch()/patch.dict overrides.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
 
 # Plant a minimal 'agents' package so relative imports in the module work.
 if "agents" not in sys.modules:
@@ -137,6 +148,23 @@ _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 
 LibrarianAssistant = _mod.LibrarianAssistant
 
+# #11796: capture the (stub or real) agent_loop.search modules planted above —
+# _patch_registry() re-inserts them per-test via patch.dict so search_web's
+# lazy import resolves deterministically even after the restore below.
+_AL_SEARCH_MODULES = {
+    "agent_loop.search": sys.modules["agent_loop.search"],
+    "agent_loop.search.registry": sys.modules["agent_loop.search.registry"],
+}
+
+# #11796: restore the pre-bootstrap sys.modules state (see snapshot above) so
+# none of the stubs leak into later-collected test modules.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -176,13 +204,23 @@ def _sr(n: int) -> MagicMock:
 
 
 def _patch_registry(mock_registry: MagicMock):
-    """Patch get_search_registry in the module currently in sys.modules.
+    """Patch get_search_registry for the duration of one test.
 
-    Uses patch.object on the live module entry so the patch always targets the
-    right module, regardless of which conftest loaded it first.
+    #11796: the module-scope bootstrap no longer leaves its stubs in
+    sys.modules, so re-insert the captured agent_loop.search modules via
+    patch.dict and patch get_search_registry on that same module object —
+    search_web's lazy import then resolves to exactly the patched module.
     """
-    reg_mod = sys.modules["agent_loop.search.registry"]
-    return patch.object(reg_mod, "get_search_registry", return_value=mock_registry)
+    stack = contextlib.ExitStack()
+    stack.enter_context(patch.dict(sys.modules, _AL_SEARCH_MODULES))
+    stack.enter_context(
+        patch.object(
+            _AL_SEARCH_MODULES["agent_loop.search.registry"],
+            "get_search_registry",
+            return_value=mock_registry,
+        )
+    )
+    return stack
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tests/agents/test_librarian_assistant_search.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_search.py
@@ -108,9 +108,13 @@ _fake_config.get_nested = MagicMock(side_effect=lambda key, default=None: defaul
 sys.modules.setdefault("config", types.SimpleNamespace(config=_fake_config))
 
 # Patch autobot_shared stubs if not already real modules.
+# #11796: get_logger is set ONLY on a freshly created stub — assigning it on
+# the REAL logging_manager module is an in-place attribute mutation that the
+# sys.modules restore below cannot undo (it broke get_llm_logger's 2-arg
+# get_logger(name, "llm") call for every later-collected test module).
 for _shared in ["autobot_shared.logging_manager"]:
     if _shared not in sys.modules:
-        _make_stub(_shared)
+        _make_stub(_shared).get_logger = logging.getLogger  # type: ignore[attr-defined]
 
 # lazy_singleton: if the real module is loaded, use it (don't overwrite its implementation).
 # If not loaded, plant a stub that maps lazy_singleton(cls) -> cls so LibrarianAssistant
@@ -118,11 +122,6 @@ for _shared in ["autobot_shared.logging_manager"]:
 if "autobot_shared.singleton_factory" not in sys.modules:
     _singleton_stub = _make_stub("autobot_shared.singleton_factory")
     _singleton_stub.lazy_singleton = lambda cls: cls  # type: ignore[attr-defined]
-
-# get_logger must return a real logger so log calls don't blow up.
-_logging_mod = sys.modules.get("autobot_shared.logging_manager")
-if _logging_mod is not None:
-    _logging_mod.get_logger = logging.getLogger  # type: ignore[attr-defined]
 
 # get_llm_service can return a mock.
 _llm_mod = sys.modules.get("services.llm_service")

--- a/autobot-backend/tests/agents/test_librarian_assistant_search.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_search.py
@@ -164,6 +164,19 @@ for _k in list(sys.modules):
         sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
 del _PRE_BOOTSTRAP_MODULES
 
+# #11796: the bootstrap may have set ``agent_loop.search`` as an ATTRIBUTE on
+# a real, already-imported ``agent_loop`` package (attribute mutations survive
+# the sys.modules restore above).  Re-sync the attribute with whatever the
+# restored sys.modules now holds so mock.patch's getattr-based dotted-name
+# walk cannot land on a stale stub.
+_al_parent = sys.modules.get("agent_loop")
+if _al_parent is not None:
+    _al_real_child = sys.modules.get("agent_loop.search")
+    if _al_real_child is not None:
+        _al_parent.search = _al_real_child  # type: ignore[attr-defined]
+    elif getattr(_al_parent, "search", None) is _al_search_pkg:
+        del _al_parent.search
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/tests/agents/test_subagent_spawning.py
+++ b/autobot-backend/tests/agents/test_subagent_spawning.py
@@ -9,6 +9,7 @@ Tests autonomous subagent spawning, parallel execution, failure isolation,
 conflict resolution, and constraint validation.
 """
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest

--- a/autobot-backend/tests/conftest.py
+++ b/autobot-backend/tests/conftest.py
@@ -64,9 +64,16 @@ def _repair_stubbed_packages() -> None:
             mod.__path__ = [str(_BACKEND_ROOT / pkg)]
 
 
-@pytest.fixture(scope="session")
-def real_auth_middleware():
-    """The REAL ``auth_middleware`` module, loaded under an alias key."""
+def load_real_auth_middleware():
+    """The REAL ``auth_middleware`` module, loaded once under an alias key.
+
+    Plain-function seam (#11796) so test modules that need the real module at
+    MODULE scope (e.g. tests/security/test_jwt_key_durable.py subclasses
+    AuthenticationMiddleware at class-definition time) can share the fixture's
+    alias-key cache instead of swapping the canonical ``auth_middleware``
+    stub in ``sys.modules`` — a swap leaks the real module into every
+    later-collected test file.
+    """
     if _REAL_AM_KEY in sys.modules:
         return sys.modules[_REAL_AM_KEY]
     _repair_stubbed_packages()
@@ -79,3 +86,9 @@ def real_auth_middleware():
         sys.modules.pop(_REAL_AM_KEY, None)
         raise
     return module
+
+
+@pytest.fixture(scope="session")
+def real_auth_middleware():
+    """The REAL ``auth_middleware`` module, loaded under an alias key."""
+    return load_real_auth_middleware()

--- a/autobot-backend/tests/llm_interface_pkg/optimization/test_profiler.py
+++ b/autobot-backend/tests/llm_interface_pkg/optimization/test_profiler.py
@@ -8,12 +8,27 @@ import json
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+import llm_shared.optimization.profiler as _profiler_mod
 from llm_shared.optimization.profiler import (
     INFERENCE_STAGES,
     LayeredProfiler,
     _StageAccumulator,
     _VRAMTracker,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_cuda(monkeypatch):
+    """Force the no-GPU path for every test (#11796).
+
+    The backend root conftest stubs ``torch`` with a MagicMock, so
+    ``torch.cuda.is_available()`` is truthy and ``stage()`` would try to
+    unpack a MagicMock from ``torch.cuda.mem_get_info()``.  Tests that
+    exercise the CUDA path re-patch ``_check_cuda`` explicitly.
+    """
+    monkeypatch.setattr(_VRAMTracker, "_check_cuda", lambda self: False)
 
 
 class TestStageAccumulator:
@@ -58,15 +73,18 @@ class TestVRAMTracker:
         tracker.sample()
         assert tracker.peak_allocated_bytes == 0
 
-    @patch(
-        "llm_shared.optimization.profiler._VRAMTracker._check_cuda",
-        return_value=True,
-    )
-    def test_cuda_sampling(self, mock_check):
+    def test_cuda_sampling(self):
+        # #11796: patch.object on the imported class — the string form
+        # ("llm_shared.optimization.profiler._VRAMTracker...") resolves a
+        # different module instance under the conftest's real-load seam, so
+        # the patch would miss the class this test actually instantiates.
         tracker = _VRAMTracker()
-        with patch(
-            "torch.cuda.mem_get_info",
-            return_value=(2_000_000_000, 8_000_000_000),
+        with (
+            patch.object(_VRAMTracker, "_check_cuda", return_value=True),
+            patch(
+                "torch.cuda.mem_get_info",
+                return_value=(2_000_000_000, 8_000_000_000),
+            ),
         ):
             tracker.sample()
         assert tracker.peak_allocated_bytes == 6_000_000_000
@@ -188,20 +206,26 @@ class TestLayeredProfilerEnabled:
 
 
 class TestLayeredProfilerEnvironment:
-    """Test environment-based enable/disable."""
+    """Test config-based enable/disable.
 
-    @patch.dict("os.environ", {"AUTOBOT_INFERENCE_PROFILING": "1"})
-    def test_enabled_via_env(self):
+    #11796: _is_profiling_enabled() reads ``config.inference_profiling``
+    (SSOT config, populated from AUTOBOT_INFERENCE_PROFILING at config
+    instantiation) — patching os.environ after import has no effect, so
+    these tests patch the config attribute the code actually reads.
+    """
+
+    def test_enabled_via_env(self, monkeypatch):
+        monkeypatch.setattr(_profiler_mod.config, "inference_profiling", "1")
         profiler = LayeredProfiler("test-model")
         assert profiler.enabled
 
-    @patch.dict("os.environ", {"AUTOBOT_INFERENCE_PROFILING": "true"})
-    def test_enabled_via_env_true(self):
+    def test_enabled_via_env_true(self, monkeypatch):
+        monkeypatch.setattr(_profiler_mod.config, "inference_profiling", "true")
         profiler = LayeredProfiler("test-model")
         assert profiler.enabled
 
-    @patch.dict("os.environ", {"AUTOBOT_INFERENCE_PROFILING": "0"})
-    def test_disabled_via_env(self):
+    def test_disabled_via_env(self, monkeypatch):
+        monkeypatch.setattr(_profiler_mod.config, "inference_profiling", "0")
         profiler = LayeredProfiler("test-model")
         assert not profiler.enabled
 

--- a/autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
@@ -148,9 +148,13 @@ class TestBuildApiKwargs:
 
 class TestExtractTextContent:
     def _make_block(self, block_type: str, text: str = "") -> Any:
+        # #11796: pin .thinking explicitly — a bare MagicMock auto-mints a
+        # truthy .thinking attribute, which _extract_content_pair would then
+        # try to join as reasoning text (TypeError: expected str, MagicMock).
         block = MagicMock()
         block.type = block_type
         block.text = text
+        block.thinking = None
         return block
 
     def test_text_block_extracted(self):
@@ -290,7 +294,15 @@ class TestBuildRequestKwargs:
             ]
         )
         kwargs, _, _ = provider._build_request_kwargs("m", request)
-        assert kwargs["system"] == "You are a helpful assistant."
+        # #8171/#10597: with prompt caching enabled (the default) the system
+        # message is sent as a content-block list with cache_control.
+        assert kwargs["system"] == [
+            {
+                "type": "text",
+                "text": "You are a helpful assistant.",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
         assert all(m["role"] != "system" for m in kwargs["messages"])
 
 
@@ -301,16 +313,24 @@ class TestBuildRequestKwargs:
 
 class TestChatCompletionWithThinking:
     def _make_block(self, block_type: str, text: str = "") -> Any:
+        # #11796: pin .thinking explicitly — a bare MagicMock auto-mints a
+        # truthy .thinking attribute, which _extract_content_pair would then
+        # try to join as reasoning text (TypeError: expected str, MagicMock).
         block = MagicMock()
         block.type = block_type
         block.text = text
+        block.thinking = None
         return block
 
     def _make_sdk_response(self, content_blocks):
         resp = MagicMock()
         resp.content = content_blocks
         resp.model = "claude-sonnet-4-6"
+        resp.stop_reason = "end_turn"
         resp.usage = MagicMock(input_tokens=100, output_tokens=200)
+        # #11796: pin explicitly — an auto-minted MagicMock here makes the
+        # provider's `thinking_tokens > 0` check raise TypeError.
+        resp.usage.output_tokens_details = None
         return resp
 
     @pytest.mark.asyncio

--- a/autobot-backend/tests/llm_interface_pkg/test_groq_provider.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_groq_provider.py
@@ -84,14 +84,16 @@ class TestGroqProviderChatCompletion:
     async def test_error_returned_in_response(self):
         provider = GroqProvider(settings={"api_key": "gsk_test"})
         mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("rate limit exceeded"))
+        # #11796: neutral message — a rate-limit-shaped error now RAISES
+        # after retries (rate_limit_backoff) instead of returning a response.
+        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("simulated provider failure"))
         provider._client = mock_client
 
         request = LLMRequest(messages=[{"role": "user", "content": "hi"}])
         response = await provider.chat_completion(request)
 
         assert response.error is not None
-        assert "rate limit" in response.error
+        assert "simulated provider failure" in response.error
         assert response.content == ""
 
     @pytest.mark.asyncio

--- a/autobot-backend/tests/llm_interface_pkg/test_provider_metadata.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_provider_metadata.py
@@ -205,7 +205,9 @@ class TestGroqProviderMetadata:
     async def test_provider_metadata_none_on_error(self):
         provider = GroqProvider(settings={"api_key": "gsk_test"})
         mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("rate limited"))
+        # #11796: neutral message — a rate-limit-shaped error now RAISES
+        # after retries (rate_limit_backoff) instead of returning a response.
+        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("simulated provider failure"))
         provider._client = mock_client
 
         response = await provider.chat_completion(_basic_request())
@@ -223,10 +225,15 @@ def _make_anthropic_response(text: str, model: str = "claude-sonnet-4-6") -> Mag
     text_block = MagicMock()
     text_block.type = "text"
     text_block.text = text
+    text_block.thinking = None
     resp = MagicMock()
     resp.model = model
     resp.content = [text_block]
+    resp.stop_reason = "end_turn"
     resp.usage = MagicMock(input_tokens=8, output_tokens=12)
+    # #11796: pin explicitly — an auto-minted MagicMock here makes the
+    # provider's `thinking_tokens > 0` check raise TypeError.
+    resp.usage.output_tokens_details = None
     return resp
 
 
@@ -291,7 +298,8 @@ class TestOpenAIProviderMetadata:
     async def test_provider_metadata_none_on_error(self):
         provider = OpenAIProvider(settings={"api_key": "sk-test"})
         mock_client = AsyncMock()
-        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("quota exceeded"))
+        # #11796: neutral message — see note in TestGroqProviderMetadata.
+        mock_client.chat.completions.create = AsyncMock(side_effect=RuntimeError("simulated provider failure"))
         provider._client = mock_client
 
         response = await provider.chat_completion(_basic_request())

--- a/autobot-backend/tests/memory/test_essential_story.py
+++ b/autobot-backend/tests/memory/test_essential_story.py
@@ -9,6 +9,7 @@
 # We use importlib to load essential_story.py directly, bypassing the
 # memory package __init__ (which pulls in aiosqlite, ssot_config, etc.).
 # ---------------------------------------------------------------------------
+import contextlib
 import importlib.util
 import sys
 import types
@@ -16,6 +17,15 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+# #11796: snapshot sys.modules before the stub bootstrap.  The stubs below
+# leaked (e.g. a bare "knowledge._composed" stub broke the real knowledge
+# package's lazy `from knowledge import KnowledgeBase` for every test module
+# collected afterwards in a whole-dir run).  Everything is rolled back right
+# after the module under test is loaded; tests only use _es_mod directly
+# (patch.object), never sys.modules lookups.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
 
 
 def _stub(name: str, attrs: dict = None, is_pkg: bool = False):
@@ -52,8 +62,38 @@ def _load_essential_story():
 
 _es_mod = _load_essential_story()
 EssentialStoryGenerator = _es_mod.EssentialStoryGenerator
-# Make the module reachable as an attribute so patch("memory.essential_story.X") works
-sys.modules["memory"].essential_story = _es_mod
+
+# #11796: capture the knowledge._composed module the bootstrap left in
+# sys.modules — _patch_get_kb() re-inserts it per-test so the lazy
+# `from knowledge._composed import get_knowledge_base` inside
+# _fetch_top_facts resolves to the patched stub.
+_composed_stub = sys.modules["knowledge._composed"]
+
+
+def _patch_get_kb(mock_kb):
+    """Patch get_knowledge_base for the duration of one test (#11796)."""
+    stack = contextlib.ExitStack()
+    stack.enter_context(patch.dict(sys.modules, {"knowledge._composed": _composed_stub}))
+    stack.enter_context(
+        patch.object(
+            _composed_stub,
+            "get_knowledge_base",
+            AsyncMock(return_value=mock_kb),
+            create=True,
+        )
+    )
+    return stack
+
+
+# #11796: restore the pre-bootstrap sys.modules state (see snapshot above) so
+# no stub leaks into later-collected test modules.  Tests patch attributes on
+# _es_mod directly (patch.object), so no sys.modules entry is needed.
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -103,7 +143,7 @@ class TestGetTokenBudget:
         yaml_file = tmp_path / "context_windows.yaml"
         yaml_file.write_text(_YAML_CONTENT, encoding="utf-8")
         gen = EssentialStoryGenerator()
-        with patch("memory.essential_story._YAML_PATH", yaml_file):
+        with patch.object(_es_mod, "_YAML_PATH", yaml_file):
             budget = await gen._get_token_budget("big-model")
         assert budget == 800
 
@@ -112,7 +152,7 @@ class TestGetTokenBudget:
         yaml_file = tmp_path / "context_windows.yaml"
         yaml_file.write_text("models:\n  tiny:\n    context_window_tokens: 4096\n", encoding="utf-8")
         gen = EssentialStoryGenerator()
-        with patch("memory.essential_story._YAML_PATH", yaml_file):
+        with patch.object(_es_mod, "_YAML_PATH", yaml_file):
             budget = await gen._get_token_budget("tiny")
         assert budget == 300
 
@@ -121,7 +161,7 @@ class TestGetTokenBudget:
         yaml_file = tmp_path / "context_windows.yaml"
         yaml_file.write_text("models:\n  mid:\n    context_window_tokens: 32768\n", encoding="utf-8")
         gen = EssentialStoryGenerator()
-        with patch("memory.essential_story._YAML_PATH", yaml_file):
+        with patch.object(_es_mod, "_YAML_PATH", yaml_file):
             budget = await gen._get_token_budget("mid")
         assert budget == 600
 
@@ -130,7 +170,7 @@ class TestGetTokenBudget:
         yaml_file = tmp_path / "context_windows.yaml"
         yaml_file.write_text("models:\n  large:\n    context_window_tokens: 128000\n", encoding="utf-8")
         gen = EssentialStoryGenerator()
-        with patch("memory.essential_story._YAML_PATH", yaml_file):
+        with patch.object(_es_mod, "_YAML_PATH", yaml_file):
             budget = await gen._get_token_budget("large")
         assert budget == 800
 
@@ -138,7 +178,7 @@ class TestGetTokenBudget:
     async def test_falls_back_to_default_on_missing_yaml(self, tmp_path):
         missing = tmp_path / "no_such_file.yaml"
         gen = EssentialStoryGenerator()
-        with patch("memory.essential_story._YAML_PATH", missing):
+        with patch.object(_es_mod, "_YAML_PATH", missing):
             budget = await gen._get_token_budget("whatever")
         assert budget == 600  # _DEFAULT_BUDGET
 
@@ -157,8 +197,10 @@ class TestEstimateTokens:
 class TestFetchTopFacts:
     """Tests for _fetch_top_facts.
 
-    Patch the `get_knowledge_base` attribute on the knowledge._composed stub
-    module — that is what the lazy import inside _fetch_top_facts resolves to.
+    _fetch_top_facts lazily does `from knowledge._composed import
+    get_knowledge_base` at call time — _patch_get_kb() re-inserts the
+    captured bootstrap stub for the duration of one test (#11796: the
+    bootstrap no longer leaves stubs in sys.modules).
     """
 
     @pytest.mark.asyncio
@@ -166,10 +208,10 @@ class TestFetchTopFacts:
         facts = _make_facts(5, quality_step=0.2)
         mock_kb = AsyncMock()
         mock_kb.get_all_facts = AsyncMock(return_value=facts)
-        sys.modules["knowledge._composed"].get_knowledge_base = AsyncMock(return_value=mock_kb)
 
         gen = EssentialStoryGenerator()
-        result = await gen._fetch_top_facts(max_tokens=10000)
+        with _patch_get_kb(mock_kb):
+            result = await gen._fetch_top_facts(max_tokens=10000)
 
         qualities = [f["metadata"]["quality_score"] for f in result]
         assert qualities == sorted(qualities, reverse=True)
@@ -181,10 +223,10 @@ class TestFetchTopFacts:
         facts = _make_facts(20, quality_step=0.05)
         mock_kb = AsyncMock()
         mock_kb.get_all_facts = AsyncMock(return_value=facts)
-        sys.modules["knowledge._composed"].get_knowledge_base = AsyncMock(return_value=mock_kb)
 
         gen = EssentialStoryGenerator()
-        result = await gen._fetch_top_facts(max_tokens=40)
+        with _patch_get_kb(mock_kb):
+            result = await gen._fetch_top_facts(max_tokens=40)
 
         # Each fact is ~13 tokens; 40 tokens allows at most 3
         assert len(result) <= 3
@@ -195,10 +237,10 @@ class TestFetchTopFacts:
         facts = _make_facts(200, quality_step=0.005)
         mock_kb = AsyncMock()
         mock_kb.get_all_facts = AsyncMock(return_value=facts)
-        sys.modules["knowledge._composed"].get_knowledge_base = AsyncMock(return_value=mock_kb)
 
         gen = EssentialStoryGenerator()
-        await gen._fetch_top_facts(max_tokens=100_000)
+        with _patch_get_kb(mock_kb):
+            await gen._fetch_top_facts(max_tokens=100_000)
 
         mock_kb.get_all_facts.assert_awaited_once_with(limit=200)
 
@@ -206,10 +248,10 @@ class TestFetchTopFacts:
     async def test_empty_kb_returns_empty_list(self):
         mock_kb = AsyncMock()
         mock_kb.get_all_facts = AsyncMock(return_value=[])
-        sys.modules["knowledge._composed"].get_knowledge_base = AsyncMock(return_value=mock_kb)
 
         gen = EssentialStoryGenerator()
-        result = await gen._fetch_top_facts(max_tokens=600)
+        with _patch_get_kb(mock_kb):
+            result = await gen._fetch_top_facts(max_tokens=600)
 
         assert result == []
 
@@ -272,7 +314,7 @@ class TestGenerate:
         cached_story = "## Essential Context\n[x] cached"
 
         with (
-            patch("memory.essential_story._YAML_PATH", yaml_file),
+            patch.object(_es_mod, "_YAML_PATH", yaml_file),
             patch.object(gen, "_get_cached", AsyncMock(return_value=cached_story)),
             patch.object(gen, "_fetch_top_facts", AsyncMock(side_effect=AssertionError("KB should not be called"))),
         ):
@@ -290,7 +332,7 @@ class TestGenerate:
 
         gen = EssentialStoryGenerator()
         with (
-            patch("memory.essential_story._YAML_PATH", yaml_file),
+            patch.object(_es_mod, "_YAML_PATH", yaml_file),
             patch.object(gen, "_get_cached", AsyncMock(return_value=None)),
             patch.object(gen, "_fetch_top_facts", AsyncMock(return_value=facts)),
             patch.object(gen, "_set_cached", set_cached_mock),

--- a/autobot-backend/tests/memory/test_essential_story.py
+++ b/autobot-backend/tests/memory/test_essential_story.py
@@ -18,7 +18,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-
 # #11796: snapshot sys.modules before the stub bootstrap.  The stubs below
 # leaked (e.g. a bare "knowledge._composed" stub broke the real knowledge
 # package's lazy `from knowledge import KnowledgeBase` for every test module

--- a/autobot-backend/tests/memory_graph/test_invalidate_endpoints.py
+++ b/autobot-backend/tests/memory_graph/test_invalidate_endpoints.py
@@ -22,29 +22,50 @@ from autobot_shared.time_utils import now_utc
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies so api/memory.py imports without a real Redis
 # ---------------------------------------------------------------------------
+# #11796: snapshot sys.modules before the stub bootstrap.  The previous
+# _register_stub reused already-imported REAL packages and clobbered their
+# ``__path__`` to [] in place (autobot_shared/utils/type_defs), which broke
+# `import autobot_shared.scoping` for THIS file's own api.memory import and
+# for every test module collected afterwards in a whole-dir run.  Stubs are
+# now always fresh modules (never in-place mutation), parent packages keep a
+# REAL ``__path__`` so genuine submodule imports still resolve, and the whole
+# mapping is rolled back right after the router import below.
+_PRE_BOOTSTRAP_MODULES = dict(sys.modules)
+
+from pathlib import Path as _FsPath  # noqa: E402
+
+_BACKEND_ROOT = _FsPath(__file__).resolve().parents[2]
+# Real autobot_shared is guaranteed imported (time_utils import above).
+_AUTOBOT_SHARED_DIR = _FsPath(sys.modules["autobot_shared"].__path__[0])
 
 
-def _register_stub(name: str, attrs: dict | None = None) -> types.ModuleType:
-    mod = sys.modules.get(name)
-    if mod is None:
-        mod = types.ModuleType(name)
-    if attrs:
-        for k, v in attrs.items():
-            setattr(mod, k, v)
+def _register_stub(
+    name: str,
+    attrs: dict | None = None,
+    path: list[str] | None = None,
+) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    if path is not None:
+        mod.__path__ = path
+    for k, v in (attrs or {}).items():
+        setattr(mod, k, v)
     sys.modules[name] = mod
     return mod
 
 
-# autobot_shared package stubs
-_autobot_shared = _register_stub("autobot_shared")
-_autobot_shared.__path__ = []
-
 _register_stub(
     "autobot_shared.redis_client",
-    {"get_redis_client": MagicMock(return_value=None)},
+    {
+        "get_redis_client": MagicMock(return_value=None),
+        # services.audit.audit_log (pulled in via the real
+        # autobot_shared.scoping import chain) needs this name too.
+        "get_async_redis_client": AsyncMock(return_value=None),
+    },
 )
-_redis_mgmt = _register_stub("autobot_shared.redis_management")
-_redis_mgmt.__path__ = []
+_register_stub(
+    "autobot_shared.redis_management",
+    path=[str(_AUTOBOT_SHARED_DIR / "redis_management")],
+)
 _register_stub(
     "autobot_shared.redis_management.types",
     {"DATABASE_MAPPING": {"knowledge": 2}},
@@ -74,13 +95,11 @@ _eb_mod = _register_stub(
 _auth_mod = _register_stub("auth_middleware", {"check_admin_permission": MagicMock(return_value=True)})
 
 # type_defs.common stub
-_type_defs = _register_stub("type_defs")
-_type_defs.__path__ = []
+_register_stub("type_defs", path=[str(_BACKEND_ROOT / "type_defs")])
 _register_stub("type_defs.common", {"Metadata": dict})
 
 # utils.request_utils stub
-_utils = _register_stub("utils")
-_utils.__path__ = []
+_register_stub("utils", path=[str(_BACKEND_ROOT / "utils")])
 _utils_req = _register_stub("utils.request_utils")
 
 _req_counter = 0
@@ -95,8 +114,10 @@ def _generate_request_id() -> str:
 _utils_req.generate_request_id = _generate_request_id
 
 # autobot_memory_graph stub — provide a minimal AutoBotMemoryGraph class
-_mg_pkg = _register_stub("autobot_memory_graph")
-_mg_pkg.__path__ = []
+_mg_pkg = _register_stub(
+    "autobot_memory_graph",
+    path=[str(_BACKEND_ROOT / "autobot_memory_graph")],
+)
 
 
 class _FakeMemoryGraph:
@@ -110,7 +131,19 @@ _mg_pkg.AutoBotMemoryGraph = _FakeMemoryGraph
 # ---------------------------------------------------------------------------
 # Import the router under test AFTER stubs are registered
 # ---------------------------------------------------------------------------
-from api.memory import router  # noqa: E402
+from api.memory import get_memory_graph, router  # noqa: E402
+
+# #11796: capture the exact dependency objects api.memory bound at import
+# time (used by _make_client after the restore below), then roll back the
+# pre-bootstrap sys.modules state so no stub leaks into later test modules.
+_check_admin_permission = sys.modules["auth_middleware"].check_admin_permission
+
+for _k in list(sys.modules):
+    if _k not in _PRE_BOOTSTRAP_MODULES:
+        del sys.modules[_k]
+    elif sys.modules[_k] is not _PRE_BOOTSTRAP_MODULES[_k]:
+        sys.modules[_k] = _PRE_BOOTSTRAP_MODULES[_k]
+del _PRE_BOOTSTRAP_MODULES
 
 # ---------------------------------------------------------------------------
 # FastAPI test app
@@ -126,14 +159,11 @@ def _make_client(fake_graph: _FakeMemoryGraph) -> TestClient:
     async def override_memory_graph():
         return fake_graph
 
-    from api.memory import get_memory_graph
-
     app.dependency_overrides[get_memory_graph] = override_memory_graph
 
-    # Bypass admin check
-    from auth_middleware import check_admin_permission
-
-    app.dependency_overrides[check_admin_permission] = lambda: True
+    # Bypass admin check — use the exact object api.memory bound at import
+    # time (#11796: the bootstrap stubs are no longer in sys.modules here).
+    app.dependency_overrides[_check_admin_permission] = lambda: True
 
     return TestClient(app)
 

--- a/autobot-backend/tests/middleware/test_service_auth_enforcement.py
+++ b/autobot-backend/tests/middleware/test_service_auth_enforcement.py
@@ -17,12 +17,13 @@ Covers:
   - enforcement mode gating: logging vs enforcement mode behavior
 """
 
-import os
+import contextlib
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from middleware import service_auth_enforcement as _sae_mod
 from middleware.service_auth_enforcement import (
     EXEMPT_PATHS,
     SERVICE_ONLY_PATHS,
@@ -94,36 +95,51 @@ class TestRequiresServiceAuth:
 # ---------------------------------------------------------------------------
 
 
+def _cfg(**overrides):
+    """Patch SSOT config values for the duration of one test (#11796).
+
+    The middleware reads ``config.service_auth_*`` from autobot_shared's SSOT
+    config object, which is populated from the environment ONCE at
+    instantiation — so the old env-dict patches never influenced it, and on
+    hosts whose real environment sets these variables the tests asserted
+    stale expectations.  Patch the config attributes the code actually reads
+    instead.
+    """
+    stack = contextlib.ExitStack()
+    for _attr, _value in overrides.items():
+        stack.enter_context(patch.object(_sae_mod.config, _attr, _value))
+    return stack
+
+
 class TestGetEnforcementMode:
     def test_false_by_default(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SERVICE_AUTH_ENFORCEMENT_MODE", None)
+        with _cfg(service_auth_enforcement_mode=""):
             assert get_enforcement_mode() is False
 
     def test_true_when_set(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "true"}):
+        with _cfg(service_auth_enforcement_mode="true"):
             assert get_enforcement_mode() is True
 
     def test_case_insensitive_true(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "TRUE"}):
+        with _cfg(service_auth_enforcement_mode="TRUE"):
             assert get_enforcement_mode() is True
 
     def test_false_for_other_values(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "1"}):
+        with _cfg(service_auth_enforcement_mode="1"):
             assert get_enforcement_mode() is False
 
 
 class TestCircuitBreaker:
     def test_full_enforcement_at_100_percent(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE": "100"}):
+        with _cfg(service_auth_circuit_breaker_percentage=100.0):
             assert _should_enforce_by_circuit_breaker() is True
 
     def test_no_enforcement_at_0_percent(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE": "0"}):
+        with _cfg(service_auth_circuit_breaker_percentage=0.0):
             assert _should_enforce_by_circuit_breaker() is False
 
     def test_probabilistic_at_50_percent(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE": "50"}):
+        with _cfg(service_auth_circuit_breaker_percentage=50.0):
             results = {_should_enforce_by_circuit_breaker() for _ in range(200)}
             assert True in results and False in results
 
@@ -139,39 +155,22 @@ class TestRateLimiting:
         _failed_auth_tracker.clear()
 
     def test_not_rate_limited_initially(self):
-        assert _is_rate_limited("1.2.3.4") is False
+        with _cfg(service_auth_rate_limit_window=300, service_auth_rate_limit_max_failures=3):
+            assert _is_rate_limited("1.2.3.4") is False
 
     def test_rate_limited_after_max_failures(self):
-        with patch.dict(
-            os.environ,
-            {
-                "SERVICE_AUTH_RATE_LIMIT_WINDOW": "300",
-                "SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES": "3",
-            },
-        ):
+        with _cfg(service_auth_rate_limit_window=300, service_auth_rate_limit_max_failures=3):
             for _ in range(3):
                 _record_failed_auth("10.0.0.1")
             assert _is_rate_limited("10.0.0.1") is True
 
     def test_expired_failures_pruned(self):
-        with patch.dict(
-            os.environ,
-            {
-                "SERVICE_AUTH_RATE_LIMIT_WINDOW": "1",
-                "SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES": "2",
-            },
-        ):
+        with _cfg(service_auth_rate_limit_window=1, service_auth_rate_limit_max_failures=2):
             _failed_auth_tracker["5.5.5.5"] = [time.time() - 10]  # expired
             assert _is_rate_limited("5.5.5.5") is False
 
     def test_different_ips_tracked_independently(self):
-        with patch.dict(
-            os.environ,
-            {
-                "SERVICE_AUTH_RATE_LIMIT_WINDOW": "300",
-                "SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES": "2",
-            },
-        ):
+        with _cfg(service_auth_rate_limit_window=300, service_auth_rate_limit_max_failures=2):
             for _ in range(2):
                 _record_failed_auth("192.168.1.1")
             assert _is_rate_limited("192.168.1.1") is True
@@ -190,26 +189,26 @@ class TestHasOverrideToken:
         return req
 
     def test_correct_token_returns_true(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_OVERRIDE_TOKEN": "super-secret-token"}):
+        with _cfg(service_auth_override_token="super-secret-token"):
             req = self._make_request("super-secret-token")
             assert _has_override_token(req) is True
 
     def test_wrong_token_returns_false(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_OVERRIDE_TOKEN": "super-secret-token"}):
+        with _cfg(service_auth_override_token="super-secret-token"):
             req = self._make_request("wrong-token")
             assert _has_override_token(req) is False
 
     def test_no_env_token_returns_false(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SERVICE_AUTH_OVERRIDE_TOKEN", None)
+        with _cfg(service_auth_override_token=""):
             req = self._make_request("anything")
             assert _has_override_token(req) is False
 
     def test_missing_header_returns_false(self):
-        with patch.dict(os.environ, {"SERVICE_AUTH_OVERRIDE_TOKEN": "super-secret-token"}):
+        with _cfg(service_auth_override_token="super-secret-token"):
             req = MagicMock()
+            # #11796: a plain dict already provides .get — assigning to
+            # dict.get raised AttributeError and the test never ran green.
             req.headers = {}
-            req.headers.get = lambda k, d=None: d
             assert _has_override_token(req) is False
 
 
@@ -245,8 +244,9 @@ def _make_request(path: str, ip: str = "10.0.0.99") -> MagicMock:
     req.method = "GET"
     req.client = MagicMock()
     req.client.host = ip
+    # #11796: a plain dict already provides .get — assigning to dict.get
+    # raised AttributeError and every test using this helper never ran green.
     req.headers = {}
-    req.headers.get = lambda k, d=None: d
     req.state = MagicMock()
     return req
 
@@ -254,7 +254,7 @@ def _make_request(path: str, ip: str = "10.0.0.99") -> MagicMock:
 class TestEnforceServiceAuth:
     """Integration-level tests for the enforce_service_auth middleware function.
 
-    All tests that check blocking behavior explicitly set SERVICE_AUTH_ENFORCEMENT_MODE=true.
+    All tests that check blocking behavior explicitly set service_auth_enforcement_mode="true".
     See TestEnforcementModeGating for logging-vs-enforcement mode tests.
     """
 
@@ -284,7 +284,7 @@ class TestEnforceServiceAuth:
         call_next = AsyncMock(return_value="should-not-reach")
 
         with (
-            patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "true"}),
+            _cfg(service_auth_enforcement_mode="true"),
             patch(
                 "middleware.service_auth_enforcement._should_enforce_by_circuit_breaker",
                 return_value=True,
@@ -311,7 +311,7 @@ class TestEnforceServiceAuth:
         call_next = AsyncMock(return_value="auth-ok-response")
 
         with (
-            patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "true"}),
+            _cfg(service_auth_enforcement_mode="true"),
             patch(
                 "middleware.service_auth_enforcement._should_enforce_by_circuit_breaker",
                 return_value=True,
@@ -337,7 +337,7 @@ class TestEnforceServiceAuth:
         call_next = AsyncMock(return_value="circuit-bypass")
 
         with (
-            patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "true"}),
+            _cfg(service_auth_enforcement_mode="true"),
             patch(
                 "middleware.service_auth_enforcement._should_enforce_by_circuit_breaker",
                 return_value=False,
@@ -354,12 +354,9 @@ class TestEnforceServiceAuth:
         call_next = AsyncMock(return_value="override-ok")
 
         with (
-            patch.dict(
-                os.environ,
-                {
-                    "SERVICE_AUTH_OVERRIDE_TOKEN": "emergency-token",
-                    "SERVICE_AUTH_ENFORCEMENT_MODE": "true",
-                },
+            _cfg(
+                service_auth_override_token="emergency-token",
+                service_auth_enforcement_mode="true",
             ),
             patch(
                 "middleware.service_auth_enforcement._should_enforce_by_circuit_breaker",
@@ -372,7 +369,6 @@ class TestEnforceServiceAuth:
         ):
             req = _make_request("/api/npu/heartbeat")
             req.headers = {"X-Override-Token": "emergency-token"}
-            req.headers.get = lambda k, d=None: {"X-Override-Token": "emergency-token"}.get(k, d)
 
             await enforce_service_auth(req, call_next)
 
@@ -386,7 +382,7 @@ class TestEnforceServiceAuth:
         call_next = AsyncMock(return_value="should-not-reach")
 
         with (
-            patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "true"}),
+            _cfg(service_auth_enforcement_mode="true"),
             patch(
                 "middleware.service_auth_enforcement._should_enforce_by_circuit_breaker",
                 return_value=True,
@@ -405,12 +401,12 @@ class TestEnforceServiceAuth:
 
 
 # ---------------------------------------------------------------------------
-# Enforcement mode gating (SERVICE_AUTH_ENFORCEMENT_MODE env var)
+# Enforcement mode gating (config.service_auth_enforcement_mode)
 # ---------------------------------------------------------------------------
 
 
 class TestEnforcementModeGating:
-    """Verify that SERVICE_AUTH_ENFORCEMENT_MODE controls enforce-vs-log behaviour."""
+    """Verify that config.service_auth_enforcement_mode controls enforce-vs-log behaviour."""
 
     @pytest.mark.asyncio
     async def test_logging_mode_allows_request_with_invalid_auth(self):
@@ -420,7 +416,7 @@ class TestEnforcementModeGating:
         call_next = AsyncMock(return_value="logging-mode-response")
 
         with (
-            patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "false"}),
+            _cfg(service_auth_enforcement_mode="false"),
             patch(
                 "middleware.service_auth_enforcement.validate_service_auth",
                 side_effect=HTTPException(status_code=401, detail="Missing required headers"),
@@ -441,7 +437,7 @@ class TestEnforcementModeGating:
         call_next = AsyncMock(return_value="should-not-reach")
 
         with (
-            patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "true"}),
+            _cfg(service_auth_enforcement_mode="true"),
             patch(
                 "middleware.service_auth_enforcement._should_enforce_by_circuit_breaker",
                 return_value=True,
@@ -468,7 +464,7 @@ class TestEnforcementModeGating:
         call_next = AsyncMock(return_value="ok")
 
         with (
-            patch.dict(os.environ, {"SERVICE_AUTH_ENFORCEMENT_MODE": "false"}),
+            _cfg(service_auth_enforcement_mode="false"),
             patch(
                 "middleware.service_auth_enforcement.validate_service_auth",
                 return_value={"service_id": "npu-worker", "authenticated": True},
@@ -484,13 +480,12 @@ class TestEnforcementModeGating:
 
     @pytest.mark.asyncio
     async def test_enforcement_mode_default_is_false(self):
-        """Without SERVICE_AUTH_ENFORCEMENT_MODE set, enforcement is disabled."""
+        """Without service_auth_enforcement_mode set, enforcement is disabled."""
         from fastapi import HTTPException
 
         call_next = AsyncMock(return_value="default-mode-ok")
 
-        with patch.dict(os.environ, {}, clear=False) as env:
-            env.pop("SERVICE_AUTH_ENFORCEMENT_MODE", None)
+        with _cfg(service_auth_enforcement_mode=""):
             with patch(
                 "middleware.service_auth_enforcement.validate_service_auth",
                 side_effect=HTTPException(status_code=401, detail="Missing required headers"),

--- a/autobot-backend/tests/orchestration/test_causal_error_recovery.py
+++ b/autobot-backend/tests/orchestration/test_causal_error_recovery.py
@@ -51,25 +51,26 @@ import pytest
 # isinstance() failures in later test files.
 # ---------------------------------------------------------------------------
 
-# The exact set of module names that conftest.py replaced with MagicMock stubs.
-# These are the ONLY entries we need to displace and restore.
+# The exact set of stubbed module names the real causal import chain needs
+# displaced (#11796): causal_error_analyzer only imports agent_loop.think_tool
+# and agent_loop.types (types is never stubbed).  The parent ``agent_loop``
+# entry must NOT be popped — the root-conftest stub (and tests/search's
+# conftest wiring) carries a real ``__path__``, so ``agent_loop.think_tool``
+# re-imports from disk underneath it, and popping the parent forced a full
+# real ``agent_loop/__init__`` re-import that replaced the package identity
+# mid-session for every later-collected test (tests/search lost its wired
+# ``agent_loop.search`` attribute).  Same for the old ``agent_loop.loop`` /
+# ``tools.parallel*`` / ``code_intelligence`` entries — nothing in this
+# module's chain imports them.
 _CONFTEST_STUB_NAMES: tuple = (
     "orchestration.causal_error_recovery",
     "orchestration.causal_error_analyzer",
     "orchestration.causal_validator",
-    "agent_loop",
-    "agent_loop.loop",
     "agent_loop.think_tool",
-    "tools.parallel",
-    "tools.parallel.executor",
-    "code_intelligence",
 )
 
 # Save the current (stub) entries for the specific names we will displace.
 _SAVED_STUBS: dict[str, object] = {name: sys.modules[name] for name in _CONFTEST_STUB_NAMES if name in sys.modules}
-
-# Record all keys present before our real imports so we can compute the delta.
-_KEYS_BEFORE_IMPORT: frozenset = frozenset(sys.modules)
 
 # Displace only the specific stub entries we identified above.
 for _name in _SAVED_STUBS:
@@ -89,31 +90,28 @@ from services.failure_pattern_detector import (  # noqa: E402
     FailurePatternDetector,
 )
 
-# Keys added ONLY by our real imports — these are safe to remove on teardown.
-# Keys that were already in _KEYS_BEFORE_IMPORT (real orchestration modules
-# imported by earlier test files) are excluded and left untouched.
-_KEYS_OUR_IMPORTS_ADDED: frozenset = frozenset(sys.modules) - _KEYS_BEFORE_IMPORT
-
 
 @pytest.fixture(scope="module", autouse=True)
 def _restore_conftest_stubs():
-    """Restore the parent-conftest MagicMock stubs after this module's tests.
+    """Restore the displaced parent-conftest stubs after this module's tests.
 
-    Keeps the real modules loaded for the duration of this file, then puts the
-    original stub objects back so sibling type-only orchestration tests (which
-    depend on the stubbed import chain) see the state they expect.
-
-    Only removes new transitive deps added by OUR imports and re-inserts the
-    specific stub entries we displaced — never touches orchestration modules
-    that were already real before this file's module-level code ran.
+    #11796: the old teardown also popped every key our module-scope imports
+    happened to add (``_KEYS_OUR_IMPORTS_ADDED``) — but this fixture tears
+    down at RUN time, long after collection finished, and by then those keys
+    are shared by every later-collected test module (e.g. popping
+    ``security.content_firewall`` split the module identity out from under
+    tests/test_content_firewall.py, making its monkeypatch inert).  Likewise
+    re-inserting the saved ``agent_loop``/``tools.parallel``/
+    ``code_intelligence`` stubs replaced REAL packages mid-run for every
+    later test (tests/search lost ``agent_loop.search``).  Teardown now
+    restores ONLY the displaced ``orchestration.*`` stub entries, which
+    sibling type-only orchestration tests patch by name; everything else
+    stays as the run left it.
     """
     yield
-    # Remove only the transitive deps that our real imports added.
-    for _name in _KEYS_OUR_IMPORTS_ADDED:
-        sys.modules.pop(_name, None)
-    # Restore the specific stub entries we displaced at import time.
     for _name, _mod in _SAVED_STUBS.items():
-        sys.modules[_name] = _mod  # type: ignore[assignment]
+        if _name.startswith("orchestration."):
+            sys.modules[_name] = _mod  # type: ignore[assignment]
 
 
 # =============================================================================

--- a/autobot-backend/tests/security/test_jwt_key_durable.py
+++ b/autobot-backend/tests/security/test_jwt_key_durable.py
@@ -8,43 +8,24 @@ Root-cause tested: previously config.set_nested() stored the auto-generated key
 in-memory only; after the fix the key is written to / read from a file outside
 the code directory so it survives process restarts and code-sync rsyncs.
 
-Strategy: import the real auth_middleware module (not the conftest stub) by
-removing the stub entry from sys.modules before import, then call the
-_get_rs256_keypair() / _jwt_key_file() methods directly on a minimal stub object
-that bypasses the expensive __init__ side-effects (Redis, SecurityLayer, etc.).
+Strategy: load the real auth_middleware module (not the conftest stub) under
+the shared ALIAS key via tests/conftest.py::load_real_auth_middleware
+(#11648/#11791/#11796 — the canonical "auth_middleware" stub entry in
+sys.modules stays untouched, so nothing leaks into later-collected test
+files), then call the _get_rs256_keypair() / _jwt_key_file() methods directly
+on a minimal stub object that bypasses the expensive __init__ side-effects
+(Redis, SecurityLayer, etc.).
 """
 
 from __future__ import annotations
 
-import importlib
 import os
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch  # noqa: F401 — patch used via patch.object
 
-# ---------------------------------------------------------------------------
-# Import the real auth_middleware module, bypassing the conftest stub.
-# conftest.py guards with ``if "auth_middleware" not in sys.modules``, so we
-# pop the stub, import the real module, then restore it after this module is
-# collected so other tests keep their stub.
-# ---------------------------------------------------------------------------
+from tests.conftest import load_real_auth_middleware
 
-
-def _load_real_auth_middleware():
-    """Return the real auth_middleware module, side-stepping the conftest stub."""
-    sys.modules.pop("auth_middleware", None)
-    try:
-        mod = importlib.import_module("auth_middleware")
-        return mod
-    finally:
-        # Restore: put the real module back so subsequent imports in THIS test
-        # file also get the real one, not the stub.
-        # Other test files that want the stub are unaffected because each
-        # pytest process collects once and conftest guards with `if not in sys.modules`.
-        sys.modules["auth_middleware"] = mod  # real module stays
-
-
-_real_auth = _load_real_auth_middleware()
+_real_auth = load_real_auth_middleware()
 _RealAuthMW = _real_auth.AuthenticationMiddleware
 
 


### PR DESCRIPTION
Closes #11796

## Thinking Path

autobot-backend/tests/ whole-dir collection was interrupted by module-scope `sys.modules` mutation in a handful of polluter files — each stubbing or IN-PLACE mutating first-party packages for every later-collected module (worst: an unconditional `get_logger` assignment mutating the REAL `autobot_shared.logging_manager`, breaking 9 later files). Fixed polluter-side in 5 incremental commits using the established patterns (snapshot/restore, real-load seams, real-`__path__` stubs, the #11648/#11791 alias-key seam extracted as a reusable `load_real_auth_middleware()`).

## What Changed

- 5 polluter files repaired (librarian-assistant ×2, memory_graph invalidate, essential_story, jwt_key_durable) + root conftest real-loads for 10 llm_shared provider/optimization modules with parent-attr binds (string-form `patch()` was silently patching the catch-all mock).
- One run-phase bomb defused: fixing collection ARMED `test_causal_error_recovery`'s teardown, which popped shared real modules and poisoned later tests — displaced set narrowed, teardown restores only `orchestration.*`.
- Product bugs fixed in-scope (all test-evidenced, none large): missing `import asyncio` (3 never-run tests), torch-mock CUDA truthiness crash, stale env-var tests vs SSOT-config migration (`test_service_auth_enforcement` 22/42 → 42/42), MagicMock auto-attr traps + stale prompt-caching shape in provider tests.
- Two guarded root-level stubbers left untouched (zero collection errors, zero run delta — churn avoided).

## Verification

- Collection: 77 error files / 4473 tests → **0 errors / 5694 tests** (agent + independent re-run identical).
- Whole-dir run vs base (cp-based base measurement): 431F/3906P/76E+77 uncollectable → **110F/5393P/61E/0** — scripted failure-set comparison: **0 regressions, 370 base failures now pass**; per-dir identical-failure-set checks for 7 directories. llm_interface_pkg runtime 264s → 3.3s.
- flake8 clean on every touched file.

## Model Used

Claude Fable 5 (subagent: general-purpose)