### PR TITLE
fix(redis): validate PoolConfig numerics — stubbed config can no longer poison the connection-manager singleton (#11830)

### DIFF
--- a/autobot_shared/redis_management/celery_async_redis_test.py
+++ b/autobot_shared/redis_management/celery_async_redis_test.py
@@ -79,7 +79,11 @@ def test_reset_async_pools_replaces_lock():
     assert isinstance(mgr._async_lock, asyncio.Lock)
 
 
-def test_reset_async_pools_calls_disconnect_on_stale_pools():
+def test_reset_async_pools_does_not_disconnect_stale_pools():
+    """reset_async_pools deliberately does NOT call pool.disconnect(): it runs
+    at a loop boundary where the backing event loop is already closed, so the
+    async disconnect() coroutine could never be awaited — references are
+    dropped for GC instead (see reset_async_pools docstring, #10936/#11830)."""
     mgr = _make_fresh_manager()
     fake_pool = MagicMock()
     fake_pool.disconnect = MagicMock()
@@ -87,7 +91,8 @@ def test_reset_async_pools_calls_disconnect_on_stale_pools():
 
     mgr.reset_async_pools()
 
-    fake_pool.disconnect.assert_called_once()
+    fake_pool.disconnect.assert_not_called()
+    assert mgr._async_pools == {}
 
 
 def test_reset_async_pools_idempotent_on_empty():
@@ -100,8 +105,9 @@ def test_reset_async_pools_idempotent_on_empty():
     assert mgr._async_pools == {}
 
 
-def test_reset_async_pools_swallows_disconnect_errors():
-    """Errors during stale pool disconnect must not propagate."""
+def test_reset_async_pools_safe_with_undisconnectable_pool():
+    """A stale pool whose disconnect() would raise (dead loop) is simply
+    dropped — reset never touches disconnect, so it cannot propagate."""
     mgr = _make_fresh_manager()
     bad_pool = MagicMock()
     bad_pool.disconnect.side_effect = RuntimeError("loop is closed")

--- a/autobot_shared/redis_management/config.py
+++ b/autobot_shared/redis_management/config.py
@@ -258,6 +258,22 @@ class RedisConfigLoader:
             }
 
 
+# Documented per-field defaults for PoolConfig — the fallback used by
+# __post_init__ when a caller passes a non-numeric value (#11830).
+_POOL_CONFIG_FIELD_DEFAULTS: Dict[str, Any] = {
+    "max_connections": _MAX_CONNECTIONS_POOL,
+    "min_connections": _MIN_CONNECTIONS_POOL,
+    "socket_timeout": float(_SOCKET_TIMEOUT),
+    "socket_connect_timeout": float(_SOCKET_TIMEOUT),
+    "retry_on_timeout": _RETRY_ON_TIMEOUT,
+    "max_retries": _DEFAULT_RETRIES,
+    "backoff_factor": _BACKOFF_BASE,
+    "health_check_interval": float(_HEALTH_CHECK_INTERVAL),
+    "circuit_breaker_threshold": _CIRCUIT_BREAKER_THRESHOLD,
+    "circuit_breaker_timeout": _CIRCUIT_BREAKER_TIMEOUT,
+}
+
+
 @dataclass
 class PoolConfig:
     """
@@ -280,3 +296,33 @@ class PoolConfig:
     health_check_interval: float = float(_HEALTH_CHECK_INTERVAL)
     circuit_breaker_threshold: int = _CIRCUIT_BREAKER_THRESHOLD
     circuit_breaker_timeout: int = _CIRCUIT_BREAKER_TIMEOUT
+
+    def __post_init__(self) -> None:
+        """Coerce every field to a real value of its documented type (#11830).
+
+        This is shared startup-path code (must-not-crash): a value sourced from
+        a test-stubbed config module (MagicMock/None/str) falls back to the
+        documented default with a single WARNING instead of raising — a
+        MagicMock ``circuit_breaker_threshold`` otherwise survives until
+        ``RedisConnectionManager._record_failure`` and TypeErrors there.
+        """
+        invalid: list[str] = []
+        for field_name, default in _POOL_CONFIG_FIELD_DEFAULTS.items():
+            value = getattr(self, field_name)
+            if isinstance(default, bool):
+                valid = isinstance(value, bool)
+            else:
+                valid = isinstance(value, (int, float)) and not isinstance(value, bool)
+            if valid:
+                if not isinstance(default, bool):
+                    # Normalize to the field's documented type (int fields must
+                    # stay int — redis-py rejects float max_connections).
+                    setattr(self, field_name, type(default)(value))
+                continue
+            invalid.append(f"{field_name}={value!r}")
+            setattr(self, field_name, default)
+        if invalid:
+            logger.warning(
+                "PoolConfig received non-numeric value(s) — falling back to defaults: %s",
+                ", ".join(invalid),
+            )

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -170,9 +170,17 @@ class RedisConnectionManager:
         Test seam only (#11681 — uniform reset seams across singletons).
         Does NOT close pools on the old instance; call ``close_all()`` first
         if pools were created.
+
+        #11830: also drops the lazily-cached backend config manager — a
+        singleton constructed under test-stubbed config caches the stub in
+        ``_config_manager``, so the next construction must re-resolve config
+        instead of reusing the poisoned import.
         """
+        global _config_manager
         with cls._lock:
             cls._instance = None
+        with _config_manager_lock:
+            _config_manager = None
 
     def __init__(self) -> None:
         """

--- a/autobot_shared/redis_management/connection_manager_config_poisoning_test.py
+++ b/autobot_shared/redis_management/connection_manager_config_poisoning_test.py
@@ -1,0 +1,119 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for #11830: a connection-manager singleton constructed under
+test-stubbed config (MagicMock backend config manager) must not poison later
+``get_async_redis_client()`` callers.
+
+- PoolConfig coerces non-numeric field values (MagicMock/None/str) to the
+  documented defaults with a single WARNING — never raises (shared
+  startup-path code, must-not-crash).
+- ``_record_failure`` no longer TypeErrors after a poisoned construction.
+- ``RedisConnectionManager.reset_instance()`` drops both the singleton and
+  the lazily-cached config-manager stub, so the accessor returns a genuinely
+  fresh instance.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+import autobot_shared.redis_management.connection_manager as cm_module
+from autobot_shared.redis_management.config import PoolConfig
+from autobot_shared.redis_management.connection_manager import RedisConnectionManager
+
+_CONFIG_LOGGER = "autobot_shared.redis_management.config"
+
+
+@pytest.fixture()
+def clean_singleton():
+    """Isolate the singleton and the lazy config-manager cache per test.
+
+    ``reset_instance()`` clears both (per #11830); run it before AND after so
+    neither a prior suite's singleton nor ours leaks across tests.
+    """
+    RedisConnectionManager.reset_instance()
+    yield
+    RedisConnectionManager.reset_instance()
+
+
+class TestPoolConfigValidation:
+    def test_magicmock_values_fall_back_to_defaults_with_single_warning(self, caplog):
+        garbage = MagicMock()
+        with caplog.at_level(logging.WARNING, logger=_CONFIG_LOGGER):
+            cfg = PoolConfig(
+                max_connections=garbage,
+                socket_timeout=garbage,
+                socket_connect_timeout=garbage,
+                retry_on_timeout=garbage,
+                max_retries=garbage,
+                health_check_interval=garbage,
+                circuit_breaker_threshold=garbage,
+                circuit_breaker_timeout=garbage,
+            )
+        assert cfg.max_connections == 20
+        assert cfg.socket_timeout == 5.0
+        assert cfg.socket_connect_timeout == 5.0
+        assert cfg.retry_on_timeout is True
+        assert cfg.max_retries == 3
+        assert cfg.health_check_interval == 30.0
+        assert cfg.circuit_breaker_threshold == 5
+        assert cfg.circuit_breaker_timeout == 60
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == _CONFIG_LOGGER]
+        assert len(warnings) == 1, "exactly one WARNING per construction"
+        assert "circuit_breaker_threshold" in warnings[0].getMessage()
+
+    def test_none_and_str_fall_back_to_defaults(self):
+        cfg = PoolConfig(circuit_breaker_threshold=None, max_retries="3", backoff_factor="fast")
+        assert cfg.circuit_breaker_threshold == 5
+        assert cfg.max_retries == 3
+        assert cfg.backoff_factor == 2.0
+
+    def test_bool_rejected_for_numeric_field(self):
+        cfg = PoolConfig(circuit_breaker_threshold=True)
+        assert cfg.circuit_breaker_threshold == 5
+
+    def test_valid_values_pass_through_without_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger=_CONFIG_LOGGER):
+            cfg = PoolConfig(circuit_breaker_threshold=7, socket_timeout=2, max_connections=50)
+        assert cfg.circuit_breaker_threshold == 7
+        assert cfg.socket_timeout == 2.0  # normalized to the field's float type
+        assert cfg.max_connections == 50
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING and r.name == _CONFIG_LOGGER]
+
+    def test_float_normalized_to_int_for_int_fields(self):
+        # redis-py rejects float max_connections — int fields must stay int.
+        cfg = PoolConfig(max_connections=100.0, circuit_breaker_threshold=5.0)
+        assert cfg.max_connections == 100 and isinstance(cfg.max_connections, int)
+        assert cfg.circuit_breaker_threshold == 5 and isinstance(cfg.circuit_breaker_threshold, int)
+
+
+class TestPoisonedSingleton:
+    def test_record_failure_no_typeerror_after_stubbed_construction(self, clean_singleton, monkeypatch):
+        """Pre-#11830: constructing under a MagicMock config manager left a
+        MagicMock circuit_breaker_threshold and _record_failure raised
+        TypeError('>=' not supported between int and MagicMock)."""
+        monkeypatch.setattr(cm_module, "_config_manager", MagicMock())
+        manager = RedisConnectionManager()
+        assert manager._pool_config.circuit_breaker_threshold == 5
+        for _ in range(5):
+            manager._record_failure("main", Exception("boom"))  # must not raise
+        assert manager._circuit_open["main"] is True
+
+    def test_reset_instance_returns_fresh_singleton_from_accessor(self, clean_singleton, monkeypatch):
+        from autobot_shared.redis_client import _get_connection_manager
+
+        monkeypatch.setattr(cm_module, "_config_manager", MagicMock())
+        poisoned = _get_connection_manager()
+        RedisConnectionManager.reset_instance()
+        fresh = _get_connection_manager()
+        assert fresh is not poisoned, "accessor must return a NEW instance after reset_instance()"
+        assert isinstance(fresh._pool_config.circuit_breaker_threshold, int)
+
+    def test_reset_instance_drops_cached_config_manager_stub(self, clean_singleton, monkeypatch):
+        monkeypatch.setattr(cm_module, "_config_manager", MagicMock())
+        RedisConnectionManager()
+        RedisConnectionManager.reset_instance()
+        assert cm_module._config_manager is None, "reset must drop the poisoned lazy config-manager cache"


### PR DESCRIPTION
Closes #11830

## Thinking Path

Found during #11798: the connection-manager singleton, first constructed under test-stubbed config, cached a poisoned instance (`circuit_breaker_threshold` = MagicMock → TypeError in `_record_failure` for every later `get_async_redis_client()` caller). Fix per the recorded direction: validate at PoolConfig construction (must-not-crash startup path → warn-once fallback, never raise) + make the reset seam actually clear the poisoned cache.

## What Changed

- `autobot_shared/redis_management/config.py`: `PoolConfig.__post_init__` validates all 10 fields against a documented `_POOL_CONFIG_FIELD_DEFAULTS` map — non-conforming values (MagicMock/None/str; bool rejected as numeric) fall back to defaults with ONE WARNING listing every bad field; valid floats normalize to documented int types (redis-py rejects float `max_connections`).
- `connection_manager.py`: `reset_instance()` (the #11740 seam) now also clears the lazy `_config_manager` cache so fresh constructions re-resolve config.
- Pre-existing rotted test fixed with base evidence (Rule 6): `celery_async_redis_test` asserted obsolete pre-#10936 `disconnect()` behavior — rewritten to the documented contract.

## Verification

- New co-located poisoning test 8/8 (incl. `_record_failure` ×5 under poisoned construction → breaker opens, no TypeError; accessor returns fresh instance after reset).
- `autobot_shared/redis_management/` 35/35 (independent re-run identical); redis_consolidation + prometheus 36/36; startup imports 344. black + flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)