### PR TITLE
fix(test): make files_root_path_test order-independent (#11833)

### DIFF
--- a/autobot-backend/api/files_root_path_test.py
+++ b/autobot-backend/api/files_root_path_test.py
@@ -16,16 +16,33 @@ Traversal protection must remain intact — asserted below.
 
 import importlib.util
 import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel
 
 _BACKEND_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_module(mod_name: str, rel_path: str):
-    """Load an api module by file path with heavy deps stubbed."""
+    """Load an api module by file path with heavy deps stubbed.
+
+    Order-independence (#11833): when autobot-slm-backend tests share the
+    pytest process, its conftest pre-populates sys.modules with same-named
+    stand-ins (hollow ``api`` bound to the SLM api/ directory, MagicMock
+    ``models`` / ``user_management`` that are not packages), so real-loading
+    files.py's ``from api.schemas_system import ...`` chain resolves against
+    the wrong tree and dies somewhere down schemas_system → schemas_workflows
+    → models.approval → user_management.models.base.  The tests here only
+    exercise ``validate_and_resolve_path``, so cut that whole chain at the
+    seam instead: displace the ambient ``api`` subtree, substitute a
+    synthetic ``api.schemas_system`` whose attributes are empty real
+    BaseModel subclasses (FastAPI validates ``response_model=`` at decoration
+    time, so MagicMock is not an option), and restore the ambient state
+    afterwards so this loader never becomes a polluter in turn.
+    """
     stub_names = [
         "config",
         "config.manager",
@@ -38,7 +55,28 @@ def _load_module(mod_name: str, rel_path: str):
         "models",
     ]
     saved = {n: sys.modules.get(n) for n in stub_names}
+    saved_api = {n: m for n, m in sys.modules.items() if n == "api" or n.startswith("api.")}
     try:
+        for n in saved_api:
+            del sys.modules[n]
+        api_pkg = types.ModuleType("api")
+        api_pkg.__path__ = []  # type: ignore[attr-defined]
+        api_pkg.__package__ = "api"
+        api_pkg.__spec__ = None  # type: ignore[attr-defined]
+        sys.modules["api"] = api_pkg
+
+        schemas_stub = types.ModuleType("api.schemas_system")
+        _schema_cache: dict = {}
+
+        def _make_schema(name: str):
+            if name.startswith("__"):
+                raise AttributeError(name)
+            return _schema_cache.setdefault(name, type(name, (BaseModel,), {}))
+
+        schemas_stub.__getattr__ = _make_schema  # type: ignore[attr-defined]  # PEP 562
+        sys.modules["api.schemas_system"] = schemas_stub
+        api_pkg.schemas_system = schemas_stub  # type: ignore[attr-defined]
+
         for n in stub_names:
             sys.modules.setdefault(n, MagicMock())
         spec = importlib.util.spec_from_file_location(mod_name, _BACKEND_ROOT / rel_path)
@@ -47,6 +85,9 @@ def _load_module(mod_name: str, rel_path: str):
         spec.loader.exec_module(mod)
         return mod
     finally:
+        for n in [k for k in sys.modules if k == "api" or k.startswith("api.")]:
+            del sys.modules[n]
+        sys.modules.update(saved_api)
         for n, orig in saved.items():
             if orig is None:
                 sys.modules.pop(n, None)


### PR DESCRIPTION
Closes #11833

## Thinking Path

Cross-BACKEND pollution: the slm conftest pre-populates a session-wide hollow `api` package whose `__path__` points at the SLM tree, so in mixed sweeps `autobot-backend/api/files_root_path_test.py`'s real-load of `files.py` resolved `api.schemas_system` against the WRONG backend. Real-loading the whole chain was proven the wrong seam (failure just moved down 4 imports) — the right fix is fixture-time stubbing with full restore.

## What Changed

- `files_root_path_test.py::_load_module`: displaces the ambient `api` subtree, installs a hollow `api` + synthetic `api.schemas_system` whose attributes are empty real pydantic `BaseModel` subclasses via PEP 562 `__getattr__` (FastAPI validates `response_model=` at decoration time — MagicMock is not an option), full `finally` restore so the loader can never become a polluter itself.

## Verification

- Standalone 8/8 (agent + independent re-run). Order-repro BOTH directions: 5 passed + 8 errors → 13 passed each way.
- Whole `api/` run base-vs-fix: byte-identical failure sets (110F/829P/18E both), file 8/8 in both.
- The issue's 44 other mixed-sweep collection errors are the pre-existing #11248 family (explicitly out of scope per the issue; this file contributes zero). flake8 + black clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)