### PR TITLE
fix(test): real-load streaming seam so colocated ollama_test collects (#11837)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -425,6 +425,14 @@ if "llm_shared" not in sys.modules:
         "llm_shared.providers.ollama_provider",
         _llm_root / "providers" / "ollama_provider.py",
     )
+    # #11837: providers.ollama (the canonical Ollama provider, #11517) imports
+    # `from ..streaming import StreamingManager` at module level, but the
+    # llm_shared stub's empty __path__ can't resolve streaming.py on disk, so
+    # the colocated providers/ollama_test.py errored out of every collection.
+    # streaming.py is light (stdlib + autobot_shared.logging_manager); load it
+    # first, then the provider itself.
+    _real_load_and_bind("llm_shared.streaming", _llm_root / "streaming.py")
+    _real_load_and_bind("llm_shared.providers.ollama", _llm_root / "providers" / "ollama.py")
     _real_load_and_bind("llm_shared.optimization.profiler", _llm_root / "optimization" / "profiler.py")
     # Re-export the real classes onto the top-level stub so
     # `from llm_shared import ProviderRegistry, BaseProvider` resolves to the real


### PR DESCRIPTION
Closes #11837

## Thinking Path

The #11517 canonical Ollama provider imports `..streaming` at module level, but neither `llm_shared.streaming` nor `llm_shared.providers.ollama` was in the #11796/#11834 real-load seam list — so `ollama_test.py` errored out of every collection. The test itself matches the current contract; only the seam was missing.

## What Changed

- `autobot-backend/conftest.py`: 8 lines — `_real_load_and_bind` for `llm_shared.streaming` then `llm_shared.providers.ollama`, parent-bound, after the existing ollama_provider seam.

## Verification

- `ollama_test.py`: collection error → 20 passed (agent + independent re-run).
- Whole-dir sweep stays **5568 passed / 0 failed / 0 errors**; colocated llm_shared failure set byte-identical (81 pre-existing, diff empty), passing 415 → 435 (+20 new only). flake8 + black clean.

Discovery filed separately: the 81 pre-existing colocated `llm_shared/` run-phase failures previously hidden behind this collection abort.

## Model Used

Claude Fable 5 (subagent: general-purpose)