### PR TITLE
fix(test): repair colocated llm_shared run-phase rot (#11840)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -444,19 +444,20 @@ if "llm_shared" not in sys.modules:
     if _bp_mod is not None and hasattr(_bp_mod, "BaseProvider"):
         _llm_stub.BaseProvider = _bp_mod.BaseProvider  # type: ignore[attr-defined]
 
-    # Stub llm_shared.optimization.model_inspector so complexity_router.py can
-    # load without the full optimization stack (inspect_model is only called in
-    # model_fits_in_vram which tests don't exercise).
-    if "llm_shared.optimization.model_inspector" not in sys.modules:
-        _mi_stub = _make_pkg_stub("llm_shared.optimization.model_inspector")
-        _mi_stub.inspect_model = MagicMock(return_value=None)  # type: ignore[attr-defined]
-        _mi_stub.ModelInfo = MagicMock()  # type: ignore[attr-defined]
-        sys.modules["llm_shared.optimization.model_inspector"] = _mi_stub
+    # #11840: Real-load llm_shared.optimization.model_inspector — it is light
+    # (transformers/accelerate are lazily imported inside functions, so the
+    # bare env just gets the formula/None fallbacks).  It was previously
+    # stubbed here, which silently fed MagicMocks to its own colocated
+    # optimization/model_inspector_test.py (never-run-test-files pattern).
+    _real_load_and_bind(
+        "llm_shared.optimization.model_inspector",
+        _llm_root / "optimization" / "model_inspector.py",
+    )
 
     # #11618: Real-load llm_shared.hardware so patch("llm_shared.hardware.X") in
     # test_hardware.py targets the real module globals instead of the MagicMock
     # package stub.  Deps: autobot_shared.logging_manager (already patched) and
-    # llm_shared.optimization.model_inspector (stubbed just above).
+    # llm_shared.optimization.model_inspector (real-loaded just above).
     _real_load_and_bind("llm_shared.hardware", _llm_root / "hardware.py")
     _hw_mod = sys.modules.get("llm_shared.hardware")
     if _hw_mod is not None:

--- a/autobot-backend/llm_shared/optimization/token_optimizer_test.py
+++ b/autobot-backend/llm_shared/optimization/token_optimizer_test.py
@@ -8,6 +8,8 @@ import json
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from .token_optimizer import (
     CompactionEntry,
     ContextFingerprinter,
@@ -300,34 +302,48 @@ class TestL1ToL2Fallback:
 
 
 class TestGetTokenOptimizerSingleton:
-    """Tests for the get_token_optimizer module-level singleton."""
+    """Tests for the get_token_optimizer module-level singleton.
 
-    @patch("llm_shared.optimization.token_optimizer._optimizer", None)
+    #11635 replaced the hand-rolled ``_optimizer`` module global with the
+    canonical ``lazy_singleton`` factory: reset via ``get_token_optimizer.reset()``
+    (the old ``patch(..._optimizer, None)`` seam no longer exists), and a
+    repeat call with *different* args now raises RuntimeError instead of
+    silently ignoring the new config.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_singleton(self):
+        get_token_optimizer.reset()
+        yield
+        get_token_optimizer.reset()
+
     def test_returns_token_optimizer_instance(self):
         """get_token_optimizer should return a TokenOptimizer."""
         result = get_token_optimizer()
         assert isinstance(result, TokenOptimizer)
 
-    @patch("llm_shared.optimization.token_optimizer._optimizer", None)
     def test_returns_same_instance_on_repeated_calls(self):
         """get_token_optimizer should return the same singleton instance."""
         first = get_token_optimizer()
         second = get_token_optimizer()
         assert first is second
 
-    @patch("llm_shared.optimization.token_optimizer._optimizer", None)
     def test_accepts_custom_config(self):
         """get_token_optimizer should accept a custom config on first call."""
         config = TokenOptimizerConfig(enabled=False, min_repeat_threshold=5)
         result = get_token_optimizer(config)
         assert result.enabled is False
 
-    @patch("llm_shared.optimization.token_optimizer._optimizer", None)
-    def test_ignores_config_on_subsequent_calls(self):
-        """Once created, get_token_optimizer ignores new config args."""
+    def test_no_arg_call_returns_cached_instance(self):
+        """After construction, a no-arg call returns the cached singleton."""
         config1 = TokenOptimizerConfig(enabled=True)
         first = get_token_optimizer(config1)
-        config2 = TokenOptimizerConfig(enabled=False)
-        second = get_token_optimizer(config2)
+        second = get_token_optimizer()
         assert first is second
         assert second.enabled is True
+
+    def test_different_config_after_first_call_raises(self):
+        """lazy_singleton rejects re-configuration after first construction."""
+        get_token_optimizer(TokenOptimizerConfig(enabled=True))
+        with pytest.raises(RuntimeError, match="different args"):
+            get_token_optimizer(TokenOptimizerConfig(enabled=False))

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -163,7 +163,11 @@ class TestBaseProviderAuthIntegration:
 
 
 class TestOAuthAuth:
-    _TOKEN_URL = "https://example.com/oauth/token"
+    # #11061 added an SSRF allowlist to OAuthAuth._refresh (require_allowlisted_https
+    # + get_oauth_allowed_hosts).  The token_url must be a default-allowlisted host
+    # or the refresh path raises ProviderAuthError before hitting the mocked
+    # token endpoint (the old "https://example.com/oauth/token" is blocked).
+    _TOKEN_URL = "https://github.com/login/oauth/access_token"
 
     def _make_auth(self, **kwargs):
         return OAuthAuth(
@@ -418,10 +422,17 @@ class TestTokenHelpers:
 
 
 def _sync(coro):
-    """Run a coroutine synchronously in a new event loop."""
+    """Run a coroutine synchronously in a new event loop.
+
+    #11840: asyncio.run() creates (and closes) a fresh loop per call.  The
+    previous ``asyncio.get_event_loop().run_until_complete`` relied on the
+    deprecated implicit current loop, which no longer exists after any
+    pytest-asyncio test file has run earlier in the session — every _sync
+    caller then failed with "There is no current event loop".
+    """
     import asyncio
 
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _sync_resolve(strategy, session=None):

--- a/autobot-backend/llm_shared/tiered_routing_test.py
+++ b/autobot-backend/llm_shared/tiered_routing_test.py
@@ -6,19 +6,62 @@
 Unit tests for tiered model routing.
 
 Issue #748: Tiered Model Distribution Implementation.
+
+Updated for the current contracts (issue #11840):
+- conftest.py stubs the llm_shared.tiered_routing package (and tier_router),
+  so imports go through the real submodules (tier_config, complexity_scorer,
+  complexity_router) which resolve on disk via the stub's real __path__.
+- The router class is imported under its canonical post-#6595 name
+  ComplexityRouter (TieredModelRouter is the backward-compat alias living in
+  the stubbed tier_router module).
+- GH#9050 added a "trivial" tier below "simple": ultra-short queries now
+  score < trivial_threshold and route to TRIVIAL_MODEL, so fixture messages
+  are tiered accordingly (same message set as tests/llm_interface_pkg/
+  test_routing_strategies.py, #11834).
 """
 
 import pytest
 
-from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
-from llm_shared.tiered_routing import (
+from autobot_shared.ssot_config import CLASSIFICATION_MODEL, DEFAULT_LLM_MODEL, TRIVIAL_MODEL
+from llm_shared.tiered_routing.complexity_router import ComplexityRouter as TieredModelRouter
+from llm_shared.tiered_routing.complexity_scorer import TaskComplexityScorer
+from llm_shared.tiered_routing.tier_config import (
     ComplexityResult,
-    TaskComplexityScorer,
     TierConfig,
-    TieredModelRouter,
     TierMetrics,
     TierModels,
 )
+
+# Scores ~1.9 → "simple" tier (between trivial_threshold=1.0 and
+# complexity_threshold=3.0 under the current factor weights).
+SIMPLE_MSG = [
+    {
+        "role": "user",
+        "content": (
+            "Can you compare the pros and cons of using Redis as a cache "
+            "for our api? Also mention performance considerations."
+        ),
+    }
+]
+
+# Scores ~8.6 → "complex" tier (code + technical + multistep + question factors).
+COMPLEX_MSG = [
+    {
+        "role": "user",
+        "content": (
+            "Design a distributed microservice architecture with authentication, "
+            "authorization, encryption, and cache layers backed by Redis and a sql "
+            "database. First analyze the trade-offs between optimistic and "
+            "pessimistic concurrency control, then implement a Python module for "
+            "the replication algorithm:\n"
+            "```python\nimport asyncio\n\nasync def replicate_log(entries):\n    ...\n```\n"
+            "Step 1: explain how leader election works. Step 2: implement an "
+            "error-handling strategy for network partitions. Finally, explain why "
+            "the design avoids deadlock and race condition issues, and optimize "
+            "the hot path for performance and scalability."
+        ),
+    }
+]
 
 
 class TestTierConfig:
@@ -28,8 +71,10 @@ class TestTierConfig:
         """Test default configuration values."""
         config = TierConfig()
         assert config.enabled is True
+        assert config.trivial_threshold == 1.0
         assert config.complexity_threshold == 3.0
-        assert config.models.simple == "gemma2:2b"
+        assert config.models.trivial == TRIVIAL_MODEL
+        assert config.models.simple == CLASSIFICATION_MODEL
         assert config.models.complex == DEFAULT_LLM_MODEL
         assert config.fallback_to_complex is True
 
@@ -128,12 +173,19 @@ class TestTaskComplexityScorer:
         assert result.score == 0.0
         assert result.tier == "simple"
 
-    def test_simple_question(self, scorer):
-        """Test scoring a simple question."""
+    def test_trivial_question(self, scorer):
+        """Ultra-simple questions score below trivial_threshold (GH#9050)."""
         messages = [{"role": "user", "content": "What is Python?"}]
         result = scorer.score(messages)
 
-        assert result.score < 3.0
+        assert result.score < 1.0
+        assert result.tier == "trivial"
+
+    def test_simple_question(self, scorer):
+        """Test scoring a simple (but non-trivial) question."""
+        result = scorer.score(SIMPLE_MSG)
+
+        assert 1.0 <= result.score < 3.0
         assert result.tier == "simple"
 
     def test_complex_code_request(self, scorer):
@@ -218,27 +270,25 @@ class TestTieredModelRouter:
         config = TierConfig()
         return TieredModelRouter(config)
 
-    def test_route_simple_request(self, router):
-        """Test routing a simple request."""
+    def test_route_trivial_request(self, router):
+        """Ultra-simple requests route to the trivial tier (GH#9050)."""
         messages = [{"role": "user", "content": "What time is it?"}]
 
         model, result = router.route(messages)
 
-        assert model == "gemma2:2b"
+        assert model == TRIVIAL_MODEL
+        assert result.tier == "trivial"
+
+    def test_route_simple_request(self, router):
+        """Test routing a simple request."""
+        model, result = router.route(SIMPLE_MSG)
+
+        assert model == CLASSIFICATION_MODEL
         assert result.tier == "simple"
 
     def test_route_complex_request(self, router):
         """Test routing a complex request."""
-        messages = [
-            {
-                "role": "user",
-                "content": "Design a microservices architecture with "
-                "Kubernetes deployment, Redis caching, and OAuth2 "
-                "authentication using JWT tokens.",
-            }
-        ]
-
-        model, result = router.route(messages)
+        model, result = router.route(COMPLEX_MSG)
 
         assert model == DEFAULT_LLM_MODEL
         assert result.tier == "complex"
@@ -267,7 +317,8 @@ class TestTieredModelRouter:
 
     def test_get_model_for_tier(self, router):
         """Test getting model for specific tier."""
-        assert router.get_model_for_tier("simple") == "gemma2:2b"
+        assert router.get_model_for_tier("trivial") == TRIVIAL_MODEL
+        assert router.get_model_for_tier("simple") == CLASSIFICATION_MODEL
         assert router.get_model_for_tier("complex") == DEFAULT_LLM_MODEL
         assert router.get_model_for_tier("long_context") == DEFAULT_LLM_MODEL
 
@@ -301,14 +352,19 @@ class TestLongContextTier:
         return TieredModelRouter(config)
 
     def _make_long_messages(self, token_count: int) -> list:
-        """Build a message list whose total char count implies ~token_count tokens."""
-        content = "word " * (token_count * 4)
+        """Build a message list whose char count implies exactly token_count tokens.
+
+        The scorer's fallback tokenizer estimates len(content) // 4, so
+        token_count * 4 chars ≡ token_count tokens.  (The old "word " * 4n
+        builder produced 5x the intended tokens, so the below-threshold case
+        still exceeded the threshold — #11840.)
+        """
+        content = "x" * (token_count * 4)
         return [{"role": "user", "content": content}]
 
     def test_short_low_complexity_routes_to_simple(self, router):
-        """Short input with low complexity → simple tier."""
-        messages = [{"role": "user", "content": "What time is it?"}]
-        model, result = router.route(messages)
+        """Short input with low (but non-trivial) complexity → simple tier."""
+        model, result = router.route(SIMPLE_MSG)
         assert result.tier == "simple"
         assert model == "gemma2:2b"
 


### PR DESCRIPTION
Closes #11840

## Thinking Path

81 failures hidden until #11837 unblocked collection — all four clusters proved to be test-side rot (never-run-test-files pattern): stub-fed imports, a retired singleton seam, a deprecated event-loop API, a pre-SSRF-guard fixture URL, and post-#9050 tier-contract drift. Zero product code modified.

## What Changed

1. `model_inspector` (21): conftest stubbed the light module — its own colocated tests ran against MagicMocks; replaced with `_real_load_and_bind` (the #11834 un-stub precedent). 25/25.
2. `token_optimizer` (4): tests patched the retired `_optimizer` global; rewritten onto the #11635 `get_token_optimizer.reset()` seam with the current cached/RuntimeError contract. 27/27.
3. `provider_auth` (18): polluter bisected to `npu_pipeline_routing_test`'s deprecated implicit `get_event_loop()` → `asyncio.run()` (order-independent); one genuine rot: fixture token_url predates the #11061 SSRF allowlist → allowlisted URL. 56/56 both orders.
4. `tiered_routing` (38): file imported through the stubbed package — rewired to real submodules (canonical `ComplexityRouter`); GH#9050 trivial-tier drift repaired with calibrated fixtures; latent test-helper token-math bug fixed (`5n` tokens instead of `n`). 40/40.

## Verification

- `llm_shared/`: 81F/435P → **0 failed / 519 passed / 115 pre-existing skips** (agent + independent re-run identical); collection 634/0 (not increased).
- Whole-dir gate held: `tests/` **5568 passed / 0 failed / 0 errors**. flake8 + black clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)