### PR TITLE
fix(slm/deploy): expose static group_vars to dynamic-inventory runs — self-update pre-flight slm_manager_node_id undefined (#11781)

### DIFF
--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -474,12 +474,38 @@ class PlaybookExecutor:
         inv = build_registry_inventory(nodes, is_local_ip)
         validate_inventory(inv)
         tmp_path = write_temp_inventory(inv, uid_tmp_dir=ANSIBLE_LOCAL_TMP)
+        self._link_group_vars(tmp_path)
         logger.info(
             "_build_dynamic_inventory: wrote inventory for %d node(s) to %s",
             len(nodes),
             tmp_path,
         )
         return tmp_path
+
+    def _link_group_vars(self, inventory_path: Path) -> None:
+        """Expose the static group_vars beside the dynamic inventory (#11781).
+
+        Ansible resolves ``group_vars/`` relative to the inventory SOURCE
+        directory. The dynamic inventory is written to a uid-scoped /tmp dir,
+        so none of ``inventory/group_vars/*.yml`` (24 vars in all.yml alone,
+        e.g. ``slm_manager_node_id``) loaded — playbooks referencing them hit
+        "undefined variable" (the self-update pre-flight "Notify SLM of new
+        commit" task failed exactly this way). Symlink the real group_vars dir
+        next to the temp inventory so dynamic runs get the same vars as static
+        ones. Best-effort: a link failure must not block the deploy.
+        """
+        src = self.ansible_dir / "inventory" / "group_vars"
+        if not src.is_dir():
+            return
+        link = inventory_path.parent / "group_vars"
+        try:
+            if link.is_symlink() or link.exists():
+                if link.is_symlink() and link.resolve() == src.resolve():
+                    return
+                link.unlink()
+            link.symlink_to(src, target_is_directory=True)
+        except OSError as exc:
+            logger.warning("Could not link group_vars for dynamic inventory: %s", exc)
 
     async def execute_playbook(
         self,

--- a/autobot-slm-backend/tests/services/test_dynamic_inventory_group_vars_11781.py
+++ b/autobot-slm-backend/tests/services/test_dynamic_inventory_group_vars_11781.py
@@ -1,0 +1,100 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dynamic-inventory runs must expose the static group_vars (#11781).
+
+Ansible resolves ``group_vars/`` relative to the inventory SOURCE directory.
+The dynamic inventory is written to a uid-scoped /tmp dir, so the repo's
+``inventory/group_vars/*.yml`` never loaded and playbooks referencing those
+vars (e.g. ``slm_manager_node_id``) hit "undefined variable" — the
+self-update pre-flight "Notify SLM of new commit" task failed exactly so.
+``_link_group_vars`` symlinks the real group_vars dir beside the temp
+inventory to restore parity with static-inventory runs.
+
+Loaded via importlib to dodge the conftest's session-global stubs (#11248).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+_STUBS = [
+    "services",
+    "services.ansible_secrets",
+    "services.inventory_builder",
+    "services.provision_progress",
+]
+
+
+def _load_executor():
+    saved = {n: sys.modules.get(n) for n in _STUBS}
+    try:
+        for n in _STUBS:
+            sys.modules[n] = MagicMock()
+        spec = importlib.util.spec_from_file_location("_pe_11781", _BACKEND_ROOT / "services" / "playbook_executor.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for n, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(n, None)
+            else:
+                sys.modules[n] = orig
+
+
+_pe = _load_executor()
+
+
+def _executor(ansible_dir: Path):
+    ex = _pe.PlaybookExecutor.__new__(_pe.PlaybookExecutor)  # skip __init__ (env probing)
+    ex.ansible_dir = ansible_dir
+    return ex
+
+
+def _fake_ansible_dir(tmp_path: Path) -> Path:
+    gv = tmp_path / "ansible" / "inventory" / "group_vars"
+    gv.mkdir(parents=True)
+    (gv / "all.yml").write_text("slm_manager_node_id: '00-SLM-Manager'\n", encoding="utf-8")
+    return tmp_path / "ansible"
+
+
+def test_group_vars_symlink_created_beside_inventory(tmp_path):
+    ansible_dir = _fake_ansible_dir(tmp_path)
+    inv_dir = tmp_path / "inv"
+    inv_dir.mkdir()
+    inv = inv_dir / "autobot_inv_x.yml"
+    inv.write_text("all:\n  hosts: {}\n", encoding="utf-8")
+
+    _executor(ansible_dir)._link_group_vars(inv)
+
+    link = inv_dir / "group_vars"
+    assert link.is_symlink()
+    assert link.resolve() == (ansible_dir / "inventory" / "group_vars").resolve()
+    # all.yml is reachable through the link → ansible would load it.
+    assert (link / "all.yml").read_text(encoding="utf-8").startswith("slm_manager_node_id")
+
+
+def test_idempotent_when_link_already_correct(tmp_path):
+    ansible_dir = _fake_ansible_dir(tmp_path)
+    inv = tmp_path / "autobot_inv_y.yml"
+    inv.write_text("all: {}\n", encoding="utf-8")
+    ex = _executor(ansible_dir)
+    ex._link_group_vars(inv)
+    ex._link_group_vars(inv)  # second call must not raise / must keep the link
+    assert (tmp_path / "group_vars").resolve() == (ansible_dir / "inventory" / "group_vars").resolve()
+
+
+def test_missing_group_vars_source_is_noop(tmp_path):
+    ansible_dir = tmp_path / "ansible"  # no inventory/group_vars
+    ansible_dir.mkdir()
+    inv = tmp_path / "autobot_inv_z.yml"
+    inv.write_text("all: {}\n", encoding="utf-8")
+    _executor(ansible_dir)._link_group_vars(inv)  # must not raise
+    assert not (tmp_path / "group_vars").exists()


### PR DESCRIPTION
## Thinking Path

The builtin self-update's Play 0 pre-flight failed live (2026-07-15) with `'slm_manager_node_id' is undefined` on the "Notify SLM of new commit" task. The var IS defined — in `inventory/group_vars/all.yml:377` — but `PlaybookExecutor._build_dynamic_inventory` (#10109) writes the inventory to a uid-scoped `/tmp` dir, and Ansible resolves `group_vars/` relative to the inventory SOURCE directory, so none of the 8 group_vars files (24 vars in all.yml alone) ever loaded. The run limps past (localhost-only task), so the SLM silently never got its new-commit notification during self-update.

## What Changed

- `services/playbook_executor.py` — `_build_dynamic_inventory` now calls `_link_group_vars`, which symlinks `ansible_dir/inventory/group_vars` beside the temp inventory in `ANSIBLE_LOCAL_TMP`. Dynamic runs now load the same group_vars as static-inventory runs — general fix, not a one-var patch. Best-effort (link failure logs + continues) and idempotent (early-returns if the link is already correct, so it doesn't churn across runs).
- `tests/services/test_dynamic_inventory_group_vars_11781.py` — 3 tests: symlink created + resolves to real group_vars + all.yml reachable through it; idempotent on repeat; no-op when the source dir is absent.

## Verification

- `pytest test_dynamic_inventory_group_vars_11781.py` → **3 passed**
- **Regression-sensitivity proven:** neutering `_link_group_vars` to a no-op fails 2 of 3; restoring → 3 pass.
- py_compile / black / flake8 clean.
- Cleanup interaction checked: the per-run temp inventory is still unlinked; the group_vars symlink points at a stable source and is reused, so no accumulation.

Closes #11781

## Model Used

Fable 5 (inline implementation)
