### PR TITLE
consolidate(files): single shared sandbox path resolver — dedupe validate_and_resolve_path + _validate_path (#11844)

### DIFF
--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -40,7 +40,11 @@ from api.schemas_system import (
 from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.security.path_validator import validate_relative_path
+from autobot_shared.security.path_validator import (
+    SANDBOX_INVALID_PATH_CHARACTERS,
+    SandboxPathError,
+    resolve_within_sandbox,
+)
 from constants.error_constants import (
     ERR_DIRECTORY_NOT_FOUND,
     ERR_FILE_NOT_FOUND,
@@ -136,8 +140,10 @@ ALLOWED_EXTENSIONS = {
     ".gi",
 }
 
-# Performance optimization: O(1) lookup for invalid path characters (Issue #326)
-INVALID_PATH_CHARACTERS = {"<", ">", ":", '"', "|", "?", "*"}
+# Performance optimization: O(1) lookup for invalid path characters (Issue #326).
+# Canonical set lives in autobot_shared.security.path_validator (#11844); this
+# alias preserves the public name that api.sandbox_files historically imported.
+INVALID_PATH_CHARACTERS = SANDBOX_INVALID_PATH_CHARACTERS
 
 # Issue #380: Module-level frozenset for dangerous filename characters
 _DANGEROUS_FILENAME_CHARS = frozenset({"<", ">", '"', "|", "?", "*", "\0", "\r", "\n"})
@@ -235,45 +241,15 @@ def _calculate_parent_path(path: str) -> str | None:
 def validate_and_resolve_path(path: str) -> Path:
     """
     Validate and resolve a path within the sandboxed directory.
-    Prevents path traversal attacks with multiple security layers.
+
+    Thin wrapper over the shared sandbox resolver (#11844); traversal
+    protection and the #11823 root-addressing fix are defined once in
+    autobot_shared.security.path_validator.resolve_within_sandbox.
     """
-    if not path:
-        return SANDBOXED_ROOT
-
-    # Remove leading/trailing slashes and normalize
-    clean_path = path.strip("/")
-
-    # "/" (and "//") address the sandbox root itself — after stripping they
-    # collapse to "", which validate_relative_path rejects as an empty
-    # segment, surfacing a misleading "outside sandbox" 400 and making the
-    # root unlistable for every caller of this helper (#11823).
-    if not clean_path:
-        return SANDBOXED_ROOT
-
-    # Enhanced path traversal checks
-    if (
-        ".." in clean_path
-        or clean_path.startswith("/")
-        or "~" in clean_path
-        or any(char in clean_path for char in INVALID_PATH_CHARACTERS)
-    ):
-        raise HTTPException(status_code=400, detail="Invalid path: path traversal not allowed")
-
-    # URL decode to catch encoded traversal attempts
-    import urllib.parse
-
-    decoded_path = urllib.parse.unquote(clean_path)
-    if ".." in decoded_path or decoded_path.startswith("/"):
-        raise HTTPException(status_code=400, detail="Invalid path: encoded traversal not allowed")
-
-    # Validate via shared security module (#1721)
     try:
-        return validate_relative_path(clean_path, SANDBOXED_ROOT)
-    except ValueError:
-        raise HTTPException(
-            status_code=400,
-            detail="Path outside sandbox not allowed",
-        )
+        return resolve_within_sandbox(path, SANDBOXED_ROOT)
+    except SandboxPathError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 def get_file_info(file_path: Path, relative_path: str) -> FileInfo:

--- a/autobot-backend/api/sandbox_files.py
+++ b/autobot-backend/api/sandbox_files.py
@@ -12,13 +12,12 @@ GH#7409
 
 import logging
 import shutil
-import urllib.parse
 from pathlib import Path
 
 import aiofiles
 from fastapi import APIRouter, Form, HTTPException, Request
 
-from api.files import ALLOWED_EXTENSIONS, INVALID_PATH_CHARACTERS, get_file_info
+from api.files import ALLOWED_EXTENSIONS, get_file_info
 from api.schemas_code import (
     FileSandboxCreateDirResponse,
     FileSandboxDeleteResponse,
@@ -30,7 +29,7 @@ from api.schemas_code import (
 )
 from auth_middleware import get_auth_middleware
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from autobot_shared.security.path_validator import validate_relative_path
+from autobot_shared.security.path_validator import SandboxPathError, resolve_within_sandbox
 from constants.error_constants import ERR_DIRECTORY_NOT_FOUND, ERR_FILE_NOT_FOUND
 from utils.io_executor import run_in_file_executor
 from utils.path_validation import is_invalid_name
@@ -55,33 +54,16 @@ def _check_permission(request: Request, permission: str) -> dict:
 
 
 def _validate_path(path: str) -> Path:
-    """Validate and resolve a path within the sandbox root directory."""
-    if not path:
-        return SANDBOX_FILES_ROOT
+    """Validate and resolve a path within the sandbox root directory.
 
-    clean_path = path.strip("/")
-
-    # "/" collapses to "" after stripping; that is the root, not an escape
-    # attempt — validate_relative_path rejects empty segments (#11823).
-    if not clean_path:
-        return SANDBOX_FILES_ROOT
-
-    if (
-        ".." in clean_path
-        or clean_path.startswith("/")
-        or "~" in clean_path
-        or any(char in clean_path for char in INVALID_PATH_CHARACTERS)
-    ):
-        raise HTTPException(status_code=400, detail="Invalid path: path traversal not allowed")
-
-    decoded_path = urllib.parse.unquote(clean_path)
-    if ".." in decoded_path or decoded_path.startswith("/"):
-        raise HTTPException(status_code=400, detail="Invalid path: encoded traversal not allowed")
-
+    Thin wrapper over the shared sandbox resolver (#11844); traversal
+    protection and the #11823 root-addressing fix live once in
+    autobot_shared.security.path_validator.resolve_within_sandbox.
+    """
     try:
-        return validate_relative_path(clean_path, SANDBOX_FILES_ROOT)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Path outside sandbox not allowed")
+        return resolve_within_sandbox(path, SANDBOX_FILES_ROOT)
+    except SandboxPathError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 @router.get("/view/{file_path:path}", response_model=FileSandboxViewResponse)

--- a/autobot_shared/security/path_validator.py
+++ b/autobot_shared/security/path_validator.py
@@ -18,6 +18,7 @@ Usage:
 from __future__ import annotations
 
 import os
+import urllib.parse
 from pathlib import Path
 from typing import Sequence
 
@@ -25,6 +26,20 @@ _DEFAULT_ALLOWED_ROOTS: tuple[str, ...] = (
     "/opt/autobot",
     "/tmp",  # nosec B108 - test/controlled code uses tmpdir intentionally
 )
+
+# Characters rejected outright in sandbox-relative user paths (Issue #326).
+# Single source of truth for the sandbox resolver shared by files.py and
+# sandbox_files.py (#11844).
+SANDBOX_INVALID_PATH_CHARACTERS: frozenset[str] = frozenset({"<", ">", ":", '"', "|", "?", "*"})
+
+
+class SandboxPathError(ValueError):
+    """A sandbox-relative path failed validation (#11844).
+
+    Carries the exact user-facing message so callers can surface it
+    verbatim (e.g. as a FastAPI ``HTTPException`` detail) without
+    re-deriving wording.
+    """
 
 
 def validate_path(
@@ -124,3 +139,60 @@ def validate_relative_path(
         raise ValueError(f"Path does not exist: {resolved}")
 
     return resolved
+
+
+def resolve_within_sandbox(path: str, root: Path) -> Path:
+    """Strip, reject traversal, and resolve *path* under *root* (#11844).
+
+    Single shared sandbox resolver for the file-management APIs. ``''`` and
+    ``'/'`` (and ``'//'``) address the sandbox root itself and return *root*
+    unchanged: historically these stripped to an empty segment that
+    :func:`validate_relative_path` rejected, surfacing a misleading "outside
+    sandbox" error and making the root unlistable for every endpoint (#11823).
+    All other input is checked for traversal (``..``, leading ``/``, ``~``,
+    invalid characters, and URL-encoded traversal) before resolution.
+
+    Parameters
+    ----------
+    path:
+        Raw, user-supplied sandbox-relative path.
+    root:
+        Trusted sandbox root the result must remain within.
+
+    Returns
+    -------
+    pathlib.Path
+        The resolved path (``root`` for the root-addressing cases).
+
+    Raises
+    ------
+    SandboxPathError
+        On any traversal / escape attempt. The message is safe to surface
+        verbatim to the caller.
+    """
+    if not path:
+        return root
+
+    clean_path = path.strip("/")
+
+    # "/" (and "//") address the sandbox root; after stripping they collapse
+    # to "", which validate_relative_path rejects as an empty segment (#11823).
+    if not clean_path:
+        return root
+
+    if (
+        ".." in clean_path
+        or clean_path.startswith("/")
+        or "~" in clean_path
+        or any(char in clean_path for char in SANDBOX_INVALID_PATH_CHARACTERS)
+    ):
+        raise SandboxPathError("Invalid path: path traversal not allowed")
+
+    decoded_path = urllib.parse.unquote(clean_path)
+    if ".." in decoded_path or decoded_path.startswith("/"):
+        raise SandboxPathError("Invalid path: encoded traversal not allowed")
+
+    try:
+        return validate_relative_path(clean_path, root)
+    except ValueError:
+        raise SandboxPathError("Path outside sandbox not allowed")

--- a/autobot_shared/security/path_validator_test.py
+++ b/autobot_shared/security/path_validator_test.py
@@ -14,6 +14,8 @@ import pytest
 
 from autobot_shared.security.path_validator import (
     _DEFAULT_ALLOWED_ROOTS,
+    SandboxPathError,
+    resolve_within_sandbox,
     validate_path,
     validate_relative_path,
 )
@@ -202,3 +204,50 @@ class TestValidateRelativePath:
         """'./file.txt' resolves within base."""
         result = validate_relative_path("./file.txt", tmp_path)
         assert result == (tmp_path / "file.txt").resolve()
+
+
+# =============================================================================
+# resolve_within_sandbox (shared sandbox resolver, #11844 / #11823)
+# =============================================================================
+
+
+class TestResolveWithinSandbox:
+    """Tests for the shared sandbox resolver behind files.py + sandbox_files.py."""
+
+    @pytest.mark.parametrize("root_path", ["", "/", "//"])
+    def test_root_addressing_returns_root(self, tmp_path, root_path) -> None:
+        """'' and '/' (and '//') address the sandbox root itself (#11823)."""
+        assert resolve_within_sandbox(root_path, tmp_path) == tmp_path
+
+    def test_normal_relative_path_resolves_under_root(self, tmp_path) -> None:
+        """A simple relative sub-path resolves within the root."""
+        result = resolve_within_sandbox("subdir/file.txt", tmp_path)
+        assert result == (tmp_path / "subdir" / "file.txt").resolve()
+
+    def test_leading_slash_stripped_then_resolved(self, tmp_path) -> None:
+        """Leading/trailing slashes are stripped, not treated as escape."""
+        result = resolve_within_sandbox("/subdir/file.txt/", tmp_path)
+        assert result == (tmp_path / "subdir" / "file.txt").resolve()
+
+    @pytest.mark.parametrize(
+        "evil",
+        ["../etc/passwd", "foo/../../etc", "~/secrets", "a<b", 'a"b', "a|b", "a?b", "a*b"],
+    )
+    def test_traversal_rejected(self, tmp_path, evil) -> None:
+        """Traversal / invalid-character inputs raise SandboxPathError."""
+        with pytest.raises(SandboxPathError, match="path traversal not allowed"):
+            resolve_within_sandbox(evil, tmp_path)
+
+    def test_encoded_traversal_rejected(self, tmp_path) -> None:
+        """URL-encoded traversal is caught after decoding."""
+        with pytest.raises(SandboxPathError, match="encoded traversal not allowed"):
+            resolve_within_sandbox("%2e%2e/etc", tmp_path)
+
+    def test_null_byte_rejected_as_outside_sandbox(self, tmp_path) -> None:
+        """A null byte reaches validate_relative_path and surfaces as outside-sandbox."""
+        with pytest.raises(SandboxPathError, match="outside sandbox not allowed"):
+            resolve_within_sandbox("file\x00.txt", tmp_path)
+
+    def test_error_is_valueerror_subclass(self) -> None:
+        """SandboxPathError remains a ValueError for compatibility."""
+        assert issubclass(SandboxPathError, ValueError)


### PR DESCRIPTION
Closes #11844

## Thinking Path

`api/files.py::validate_and_resolve_path` and `api/sandbox_files.py::_validate_path` were near-identical sandbox path resolvers differing ONLY in the root constant — the #11823 `/`→empty-segment bug lived in both and had to be fixed twice. One shared resolver prevents the next divergence.

## What Changed

- `autobot_shared/security/path_validator.py`: new `resolve_within_sandbox(path, root)` + `SandboxPathError(ValueError)` + canonical `SANDBOX_INVALID_PATH_CHARACTERS` frozenset, carrying the #11823 fix once. Imports only stdlib — no circular import (direction stays api → autobot_shared).
- Both `validate_and_resolve_path` and `_validate_path` are now thin wrappers delegating to it (public names/signatures kept → all 17 call sites untouched). The two resolvers had byte-identical error wording, so no per-caller message parametrization was needed. `INVALID_PATH_CHARACTERS` kept as a public alias; sandbox_files.py's now-dead imports dropped.

## Verification

- 47 passed: files_root_path_test (8, incl. #11823 `/`,`//`,`""` root cases + traversal rejections) + new `TestResolveWithinSandbox` in path_validator_test (39, incl. encoded traversal, invalid-char/`..`/`~`, null-byte, ValueError-subclass compat). Independent re-run identical.
- Return-shape parity verified (Path in every branch). py_compile + flake8 + black clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)