### PR TITLE
consolidate(redis): public single-use-state helpers + workspace validators + shared FakeRedis mock (#11699)

### DIFF
--- a/autobot-backend/api/knowledge_connector_oauth.py
+++ b/autobot-backend/api/knowledge_connector_oauth.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel
 
 from auth_middleware import get_current_user
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import client_getdel, client_setex, get_redis_client
 from autobot_shared.ssot_config import config
 from knowledge.connectors import oauth_flow
 from knowledge.connectors.credential_store import get_credential_store
@@ -110,7 +110,7 @@ async def start_oauth(
         "scopes": list(scopes) if scopes else [],
     }
     redis = get_redis_client(database="knowledge")
-    await _redis_setex(redis, _state_key(state), _OAUTH_STATE_TTL_SECONDS, json.dumps(payload, ensure_ascii=False))
+    await client_setex(redis, _state_key(state), _OAUTH_STATE_TTL_SECONDS, json.dumps(payload, ensure_ascii=False))
 
     # Bind the completing browser to this one: the callback requires this cookie
     # to match the returned state (defends against OAuth CSRF / token attachment).
@@ -144,7 +144,7 @@ async def oauth_callback(
         return _clear_cookie(_result_page(error="state_binding_mismatch"))
 
     redis = get_redis_client(database="knowledge")
-    raw = await _redis_getdel(redis, _state_key(state))
+    raw = await client_getdel(redis, _state_key(state))
     if raw is None:
         return _clear_cookie(_result_page(error="invalid_or_expired_state"))
     payload = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
@@ -237,30 +237,5 @@ def _clear_cookie(response: HTMLResponse) -> HTMLResponse:
     return response
 
 
-# ---------------------------------------------------------------------------
-# Redis helpers (sync client → thread; tolerate async client too)
-# ---------------------------------------------------------------------------
-
-
-async def _redis_setex(redis, key: str, ttl: int, value: str) -> None:
-    result = redis.set(key, value, ex=ttl)
-    if hasattr(result, "__await__"):
-        await result
-
-
-async def _redis_getdel(redis, key: str):
-    """Atomically fetch and delete a key (single-use state)."""
-    getdel = getattr(redis, "getdel", None)
-    if getdel is not None:
-        result = getdel(key)
-        if hasattr(result, "__await__"):
-            result = await result
-        return result
-    # Fallback for clients without GETDEL.
-    value = redis.get(key)
-    if hasattr(value, "__await__"):
-        value = await value
-    deleted = redis.delete(key)
-    if hasattr(deleted, "__await__"):
-        await deleted
-    return value
+# Redis single-use-state helpers now live in autobot_shared.redis_client
+# (client_setex / client_getdel / client_get) — see Issue #11699.

--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -32,11 +32,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.knowledge_connector_oauth import _redis_getdel, _redis_setex
 from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import client_get, client_getdel, client_setex, get_redis_client
 from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https
 from llm_shared.provider_auth import (
     _vault_read,
@@ -103,12 +102,8 @@ def _device_poll_key(device_code: str) -> str:
     return "%s%s" % (_DEVICE_POLL_PREFIX, hashlib.sha256(device_code.encode("utf-8")).hexdigest())
 
 
-async def _redis_get(redis, key: str):
-    """Read a key without deleting it (sync- or async-client tolerant)."""
-    value = redis.get(key)
-    if hasattr(value, "__await__"):
-        value = await value
-    return value
+# Redis single-use-state helpers (client_setex / client_getdel / client_get)
+# now live in autobot_shared.redis_client — see Issue #11699.
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +241,7 @@ async def oauth_initiate(
         "token_url": req.token_url,
         "client_id": req.client_id,
     }
-    await _redis_setex(redis, _state_key(state), _OAUTH_STATE_TTL_SECONDS, json.dumps(payload, ensure_ascii=False))
+    await client_setex(redis, _state_key(state), _OAUTH_STATE_TTL_SECONDS, json.dumps(payload, ensure_ascii=False))
 
     authorize_url = build_authorize_url(provider_cfg, req.client_id, req.redirect_uri, state, challenge, scopes)
     logger.info("OAuth authorize initiated for provider %s", req.provider_name)
@@ -277,7 +272,7 @@ async def oauth_callback(
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="OAuth state store unavailable")
 
     # Single-use: atomically fetch-and-delete. Missing/expired/replayed → 400.
-    raw = await _redis_getdel(redis, _state_key(req.state))
+    raw = await client_getdel(redis, _state_key(req.state))
     if raw is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid or expired OAuth state")
     stored = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
@@ -412,7 +407,7 @@ async def device_poll(
     now = time.time()
     poll_state = {"interval": _DEVICE_POLL_MIN_INTERVAL, "count": 0, "last_ts": 0.0}
     if redis is not None:
-        raw = await _redis_get(redis, poll_key)
+        raw = await client_get(redis, poll_key)
         if raw:
             poll_state = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
         if poll_state["count"] >= _DEVICE_POLL_MAX_ATTEMPTS:
@@ -452,9 +447,9 @@ async def device_poll(
         poll_state["count"] += 1
         poll_state["last_ts"] = now
         if error in ("authorization_pending", "slow_down"):
-            await _redis_setex(redis, poll_key, _DEVICE_POLL_WINDOW, json.dumps(poll_state))
+            await client_setex(redis, poll_key, _DEVICE_POLL_WINDOW, json.dumps(poll_state))
         else:
-            await _redis_getdel(redis, poll_key)
+            await client_getdel(redis, poll_key)
 
     if error in ("authorization_pending", "slow_down"):
         return OAuthInitiateResponse(provider_name=req.provider_name, stored=False)

--- a/autobot-backend/api/task_workspace.py
+++ b/autobot-backend/api/task_workspace.py
@@ -20,7 +20,7 @@ from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission
 from autobot_shared.logging_manager import get_logger
 from models.heartbeat import AgentRuntimeState
-from services.task_workspace import _SAFE_TASK_ID_RE
+from services.task_workspace_common import SAFE_TASK_ID_RE as _SAFE_TASK_ID_RE
 
 logger = get_logger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
+++ b/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
@@ -22,24 +22,6 @@ from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission, get_current_user
 
 
-class _FakeRedis:
-    def __init__(self):
-        self.store = {}
-
-    def set(self, key, value, ex=None):
-        self.store[key] = value
-        return True
-
-    def get(self, key):
-        return self.store.get(key)
-
-    def getdel(self, key):
-        return self.store.pop(key, None)
-
-    def delete(self, key):
-        return 1 if self.store.pop(key, None) is not None else 0
-
-
 class _FakeResp:
     def __init__(self, data):
         self._data = data
@@ -77,8 +59,9 @@ _POLL = "/api/llm-auth/device/poll"
 
 
 @pytest.fixture
-def ctx(monkeypatch):
-    fake_redis = _FakeRedis()
+def ctx(monkeypatch, single_use_fake_redis):
+    # Shared single-use-state Redis stub (conftest fixture — #11699).
+    fake_redis = single_use_fake_redis
     monkeypatch.setattr(mod, "get_redis_client", lambda database="main": fake_redis)
     monkeypatch.setattr(mod, "get_oauth_allowed_hosts", lambda: {"token.example.com"})
     monkeypatch.setattr(mod, "_vault_write", AsyncMock(return_value=None))

--- a/autobot-backend/api/tests/test_provider_auth_oauth_state.py
+++ b/autobot-backend/api/tests/test_provider_auth_oauth_state.py
@@ -22,35 +22,15 @@ from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission, get_current_user
 from knowledge.connectors import oauth_flow
 
-
-class _FakeRedis:
-    """Minimal in-memory redis supporting set(ex=) and getdel() (single-use)."""
-
-    def __init__(self):
-        self.store = {}
-
-    def set(self, key, value, ex=None):
-        self.store[key] = value
-        return True
-
-    def get(self, key):
-        return self.store.get(key)
-
-    def getdel(self, key):
-        return self.store.pop(key, None)
-
-    def delete(self, key):
-        return 1 if self.store.pop(key, None) is not None else 0
-
-
 _ADMIN = types.SimpleNamespace(user_id="admin-1")
 _INITIATE = "/api/llm-auth/oauth/initiate"
 _CALLBACK = "/api/llm-auth/oauth/callback"
 
 
 @pytest.fixture
-def ctx(monkeypatch):
-    fake_redis = _FakeRedis()
+def ctx(monkeypatch, single_use_fake_redis):
+    # Shared single-use-state Redis stub (conftest fixture — #11699).
+    fake_redis = single_use_fake_redis
     monkeypatch.setattr(mod, "get_redis_client", lambda database="main": fake_redis)
     # Allow the test provider hosts through the SSRF guard.
     monkeypatch.setattr(mod, "get_oauth_allowed_hosts", lambda: {"auth.example.com", "token.example.com"})

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -906,6 +906,37 @@ def mock_llm():
     return AsyncMock()
 
 
+@pytest.fixture
+def single_use_fake_redis():
+    """Synchronous in-memory Redis stub for single-use OAuth-state tests (#11699).
+
+    Backs ``set(ex=)`` / ``get`` / ``getdel`` / ``delete`` with an
+    introspectable ``.store`` dict.  Consolidates the byte-identical
+    ``_FakeRedis`` copies that lived in the connector- and provider-auth OAuth
+    endpoint tests (they exercise the ``client_setex`` / ``client_getdel`` /
+    ``client_get`` single-use-state helpers now in autobot_shared.redis_client).
+    """
+
+    class _SingleUseFakeRedis:
+        def __init__(self) -> None:
+            self.store: dict = {}
+
+        def set(self, key, value, ex=None):
+            self.store[key] = value
+            return True
+
+        def get(self, key):
+            return self.store.get(key)
+
+        def getdel(self, key):
+            return self.store.pop(key, None)
+
+        def delete(self, key):
+            return 1 if self.store.pop(key, None) is not None else 0
+
+    return _SingleUseFakeRedis()
+
+
 @pytest.fixture(autouse=True)
 def set_test_environment():
     """

--- a/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
+++ b/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
@@ -15,29 +15,10 @@ from auth_middleware import get_current_user
 from knowledge.connectors import oauth_flow
 
 
-class _FakeRedis:
-    """Minimal in-memory redis supporting set(ex=) and getdel()."""
-
-    def __init__(self):
-        self.store = {}
-
-    def set(self, key, value, ex=None):
-        self.store[key] = value
-        return True
-
-    def get(self, key):
-        return self.store.get(key)
-
-    def getdel(self, key):
-        return self.store.pop(key, None)
-
-    def delete(self, key):
-        return 1 if self.store.pop(key, None) is not None else 0
-
-
 @pytest.fixture
-def client(monkeypatch):
-    fake_redis = _FakeRedis()
+def client(monkeypatch, single_use_fake_redis):
+    # Shared single-use-state Redis stub (conftest fixture — #11699).
+    fake_redis = single_use_fake_redis
     monkeypatch.setattr(mod, "get_redis_client", lambda database=None: fake_redis)
     # Provider configured.
     monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_id", "cid", raising=False)

--- a/autobot-backend/services/docker_task_workspace.py
+++ b/autobot-backend/services/docker_task_workspace.py
@@ -46,6 +46,7 @@ from typing import Any
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from constants.ttl_constants import TTL_7_DAYS
+from services.task_workspace_common import validate_task_id
 
 logger = get_logger(__name__)
 
@@ -202,7 +203,7 @@ class TaskWorkspaceManager:
 
     async def create(self, task_id: str) -> WorkspaceInfo:
         """Create or resume a workspace for *task_id*.  Idempotent."""
-        _validate_task_id(task_id)
+        validate_task_id(task_id)
         existing = await self.get(task_id)
         if existing is not None:
             logger.info("workspace: resuming container for task=%s", task_id)
@@ -215,7 +216,7 @@ class TaskWorkspaceManager:
 
     async def get(self, task_id: str) -> WorkspaceInfo | None:
         """Return WorkspaceInfo if the workspace is registered, else None."""
-        _validate_task_id(task_id)
+        validate_task_id(task_id)
         raw = await asyncio.to_thread(self._redis.get, _redis_meta_key(task_id))
         if raw is None:
             return None
@@ -232,7 +233,7 @@ class TaskWorkspaceManager:
         Reuses SecureSandboxExecutor's validation logic: blocked commands are
         rejected before any Docker call is made.
         """
-        _validate_task_id(task_id)
+        validate_task_id(task_id)
         # GH#11059: shlex.split (not str.split) so quoted args tokenize correctly
         # and the base-command denylist check sees the real argv[0].
         cmd_list = command if isinstance(command, list) else shlex.split(command)
@@ -280,7 +281,7 @@ class TaskWorkspaceManager:
         Tag format: ``autobot-workspace-<task_id>:<checkpoint_name>``
         Also stores step checkpoint in Redis to wire into CheckpointResumer.
         """
-        _validate_task_id(task_id)
+        validate_task_id(task_id)
         _validate_checkpoint_name(checkpoint_name)
         info = await self.get(task_id)
         if info is None:
@@ -310,7 +311,7 @@ class TaskWorkspaceManager:
         Restore workspace from a snapshot: stop current container, recreate
         from the committed image, keep the same named volume.
         """
-        _validate_task_id(task_id)
+        validate_task_id(task_id)
         _validate_checkpoint_name(checkpoint_name)
         info = await self.get(task_id)
         if info is None:
@@ -327,7 +328,7 @@ class TaskWorkspaceManager:
 
     async def destroy(self, task_id: str) -> None:
         """Stop container, remove volume, delete Redis keys.  Best-effort."""
-        _validate_task_id(task_id)
+        validate_task_id(task_id)
         info = await self.get(task_id)
         if info is None:
             return
@@ -344,7 +345,7 @@ class TaskWorkspaceManager:
         handle over the existing xterm WebSocket infrastructure — no new PTY
         layer is created, the existing terminal WS plumbing is reused.
         """
-        _validate_task_id(task_id)
+        validate_task_id(task_id)
         info = await self.get(task_id)
         if info is None:
             raise ValueError(f"No workspace for task {task_id}")
@@ -610,13 +611,6 @@ def validate_exec_command(cmd: list[str]) -> bool:
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
-
-
-def _validate_task_id(task_id: str) -> None:
-    import re
-
-    if not re.match(r"^[0-9a-zA-Z_\-]{1,128}$", task_id):
-        raise ValueError(f"Invalid task_id {task_id!r}")
 
 
 def _validate_checkpoint_name(name: str) -> None:

--- a/autobot-backend/services/task_workspace.py
+++ b/autobot-backend/services/task_workspace.py
@@ -20,7 +20,6 @@ import asyncio
 import fcntl
 import json
 import os
-import re
 import subprocess
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -29,6 +28,7 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from autobot_shared.logging_manager import get_logger
+from services.task_workspace_common import validate_task_id
 
 logger = get_logger(__name__)
 
@@ -75,13 +75,14 @@ def _worktree_guard(workspace_dir: Path, *, blocking: bool = True) -> Iterator[b
         os.close(fd)
 
 
-# task_id must be a safe identifier: UUID hex chars + hyphens, max 128 chars.
-# Rejects path-traversal payloads like "../../etc/passwd" (GH#6471 blocker 2).
-_SAFE_TASK_ID_RE = re.compile(r"^[0-9a-zA-Z_\-]{1,128}$")
-
-
 @dataclass
-class WorkspaceInfo:
+class WorktreeInfo:
+    """Metadata for a git-worktree task workspace.
+
+    GH#11699: renamed from ``WorkspaceInfo`` to disambiguate from the
+    docker-container ``WorkspaceInfo`` in ``services.docker_task_workspace``.
+    """
+
     task_id: str
     agent_id: str
     worktree_path: str
@@ -90,18 +91,12 @@ class WorkspaceInfo:
     created_at: str  # ISO-8601 UTC
 
 
-def _validate_task_id(task_id: str) -> None:
-    """Reject task_ids that could be used for path traversal (GH#6471 blocker 2)."""
-    if not _SAFE_TASK_ID_RE.match(task_id):
-        raise ValueError(f"Invalid task_id {task_id!r}: must match [0-9a-zA-Z_-]{{1,128}}")
-
-
 def allocate(
     task_id: str,
     agent_id: str,
     repo_root: Optional[Path] = None,
     max_per_agent: int = _MAX_WORKTREES_PER_AGENT,
-) -> WorkspaceInfo:
+) -> WorktreeInfo:
     """
     Allocate or resume a worktree for task_id.
 
@@ -112,7 +107,7 @@ def allocate(
 
     Raises ValueError if task_id is not a safe identifier.
     """
-    _validate_task_id(task_id)
+    validate_task_id(task_id)
     root = repo_root or _REPO_ROOT
     workspace_base = root / _WORKSPACE_BASE_NAME
     workspace_dir = workspace_base / f"task-{task_id}"
@@ -137,7 +132,7 @@ def allocate(
                 task_id,
                 workspace_dir,
             )
-            return WorkspaceInfo(
+            return WorktreeInfo(
                 task_id=task_id,
                 agent_id=agent_id,
                 worktree_path=str(workspace_dir),
@@ -170,7 +165,7 @@ def allocate(
         agent_id,
         workspace_dir,
     )
-    return WorkspaceInfo(
+    return WorktreeInfo(
         task_id=task_id,
         agent_id=agent_id,
         worktree_path=str(workspace_dir),
@@ -201,7 +196,7 @@ def release(
 
     Raises ValueError if task_id is not a safe identifier.
     """
-    _validate_task_id(task_id)
+    validate_task_id(task_id)
     root = repo_root or _REPO_ROOT
     workspace_dir = root / _WORKSPACE_BASE_NAME / f"task-{task_id}"
 

--- a/autobot-backend/services/task_workspace_common.py
+++ b/autobot-backend/services/task_workspace_common.py
@@ -1,0 +1,28 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Shared primitives for the task-workspace managers (GH#11699).
+
+Canonical home for the path-traversal ``task_id`` validator that the
+git-worktree workspace manager (``services.task_workspace``) and the
+docker-container workspace manager (``services.docker_task_workspace``) both
+depend on.  Previously each module defined its own ``_validate_task_id`` and
+``_SAFE_TASK_ID_RE`` copy (GH#6471 blocker 2), inviting drift.
+
+This module intentionally has no dependencies beyond ``re`` so both managers
+(and ``api.task_workspace``) can import it without any circular-import risk.
+"""
+
+import re
+
+# task_id must be a safe identifier: alnum + underscore + hyphen, max 128 chars.
+# Rejects path-traversal payloads like "../../etc/passwd" (GH#6471 blocker 2).
+SAFE_TASK_ID_RE = re.compile(r"^[0-9a-zA-Z_\-]{1,128}$")
+
+
+def validate_task_id(task_id: str) -> None:
+    """Reject task_ids that could be used for path traversal (GH#6471 blocker 2)."""
+    if not SAFE_TASK_ID_RE.match(task_id):
+        raise ValueError(f"Invalid task_id {task_id!r}: must match [0-9a-zA-Z_-]{{1,128}}")

--- a/autobot-backend/tests/test_task_workspace.py
+++ b/autobot-backend/tests/test_task_workspace.py
@@ -36,9 +36,9 @@ from services.docker_task_workspace import (
     _serialize_info,
     _snapshot_image_tag,
     _validate_checkpoint_name,
-    _validate_task_id,
     validate_exec_command,
 )
+from services.task_workspace_common import validate_task_id
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -153,22 +153,22 @@ def _store_info(redis, info: WorkspaceInfo) -> None:
 
 
 def test_validate_task_id_accepts_uuid():
-    _validate_task_id("task-1234-abcd")  # must not raise
+    validate_task_id("task-1234-abcd")  # must not raise
 
 
 def test_validate_task_id_rejects_traversal():
     with pytest.raises(ValueError):
-        _validate_task_id("../../etc/passwd")
+        validate_task_id("../../etc/passwd")
 
 
 def test_validate_task_id_rejects_empty():
     with pytest.raises(ValueError):
-        _validate_task_id("")
+        validate_task_id("")
 
 
 def test_validate_task_id_rejects_too_long():
     with pytest.raises(ValueError):
-        _validate_task_id("a" * 129)
+        validate_task_id("a" * 129)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot_shared/redis_client.py
+++ b/autobot_shared/redis_client.py
@@ -163,6 +163,10 @@ __all__ = [
     "redis_get",
     "redis_set",
     "redis_delete",
+    # Await-tolerant single-use-state helpers on a caller-provided client
+    "client_setex",
+    "client_getdel",
+    "client_get",
     # Backward compatibility
     "RedisDatabaseManager",
     "redis_db_manager",
@@ -521,6 +525,61 @@ async def redis_delete(key: str, database: str = "main") -> int:
     if client:
         return await client.delete(key)
     return 0
+
+
+# =============================================================================
+# Await-tolerant single-use-state helpers (client-provided; sync OR async)
+# =============================================================================
+# These operate on a Redis client the caller already holds (as returned by
+# get_redis_client(...) — which may be sync — or get_async_redis_client(...)).
+# They tolerate both by awaiting the result only when it is awaitable, so a
+# single call site works whether the injected client is sync or async.
+#
+# Canonical home for the single-use OAuth-state primitive that the connector
+# and provider auth flows both depend on (Issue #11699 — previously duplicated
+# in api/knowledge_connector_oauth.py + api/provider_auth.py, the latter via a
+# private cross-module import introduced by #11297).
+
+
+async def client_setex(client: Any, key: str, ttl: int, value: str) -> None:
+    """SET *key*=*value* with a *ttl*-second expiry on a caller-provided client.
+
+    The client may be synchronous or asynchronous; the write is awaited only
+    when the underlying call returns an awaitable.
+    """
+    result = client.set(key, value, ex=ttl)
+    if hasattr(result, "__await__"):
+        await result
+
+
+async def client_getdel(client: Any, key: str) -> Any | None:
+    """Atomically fetch and delete a key (single-use state).
+
+    Uses GETDEL when the client exposes it, otherwise falls back to GET+DELETE.
+    The client may be synchronous or asynchronous.
+    """
+    getdel = getattr(client, "getdel", None)
+    if getdel is not None:
+        result = getdel(key)
+        if hasattr(result, "__await__"):
+            result = await result
+        return result
+    # Fallback for clients without GETDEL.
+    value = client.get(key)
+    if hasattr(value, "__await__"):
+        value = await value
+    deleted = client.delete(key)
+    if hasattr(deleted, "__await__"):
+        await deleted
+    return value
+
+
+async def client_get(client: Any, key: str) -> Any | None:
+    """Read a key without deleting it; the client may be sync or async."""
+    value = client.get(key)
+    if hasattr(value, "__await__"):
+        value = await value
+    return value
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #11699

## Thinking Path

Three consolidation opportunities from the #11058 wave. Dedup'd the genuinely-identical cases; deliberately left duplication that could only be folded by changing behavior (documented below) — pure-dedupe scope only, no behavior change.

## What Changed

**Part 1 — redis single-use-state helpers** → public async await-tolerant `client_setex`/`client_getdel`/`client_get` in `autobot_shared/redis_client.py` (named `client_*` to avoid collision with the existing `redis_get(key, database)`). Removed the #11297 private cross-module import in `provider_auth.py`; rewired knowledge_connector_oauth (2) + provider_auth (5) call sites. `workers/audit_tasks.py` LEFT unchanged — its `_redis_get/_set` are sync, JSON-encoding, error-swallowing, single-module (folding into the async helpers would break the sync Celery path).

**Part 2 — `validate_task_id`** → new dependency-free `services/task_workspace_common.py` (`SAFE_TASK_ID_RE` + `validate_task_id`); rewired task_workspace, docker_task_workspace, api/task_workspace + test.

**Part 3 — `WorkspaceInfo` collision** → renamed the internal git-worktree dataclass to `WorktreeInfo` (no external importers); Docker's externally-referenced `WorkspaceInfo` kept.

**Part 4 — `_FakeRedis`** → shared `single_use_fake_redis` conftest fixture repointing the 3 byte-identical SYNC OAuth mocks. The 6 other mocks are genuinely divergent (async, richer surfaces, internal-state introspection) — folding them is a behavior-affecting rewrite, out of scope.

## Verification

- OAuth trio 20/20, workspace suites + audit_tasks 63, combined touched 111 passed; startup imports 344. Independent re-run: 63 + 20. flake8/black/py_compile clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)