### PR TITLE
harden(oauth): per-org token scoping + DNS-rebind pin + audience/issuer validation (#11497)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -39,9 +39,11 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https
 from llm_shared.provider_auth import (
-    _vault_read,
+    _vault_read_dual,
     _vault_write,
     build_token_data,
+    org_vault_subject,
+    validate_token_response,
 )
 
 logger = get_logger(__name__)
@@ -68,14 +70,34 @@ def _validate_outbound_url(url: str) -> None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
 
+async def _pinned_connector(url: str):
+    """Resolve *url* once, assert it is public, and return an IP-pinned connector.
+
+    Finding #2 (#11497): the outbound token/device POST connects to the
+    pre-resolved public IP so DNS cannot be rebound to a private address between
+    the allowlist check and the socket connect. Translates an SSRF failure into
+    HTTP 400. Callers must pass the returned connector to their ClientSession /
+    ``exchange_code`` so the session owns and closes it.
+    """
+    from autobot_shared.security.ssrf_guard import SSRFError, pinned_connector  # noqa: PLC0415
+
+    try:
+        return await pinned_connector(url)
+    except SSRFError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
 # The registry/app-factory prepends "/api" (see feature_routers.py), so this
 # router carries only "/llm-auth" → resolves to /api/llm-auth. A "/api/llm-auth"
 # prefix here would wrongly yield /api/api/llm-auth and 404 every OAuth call
 # (matches the #9864 budget-policies fix; the frontend calls /api/llm-auth/*). #11092
 router = APIRouter(prefix="/llm-auth", tags=["llm-auth"])
 
-# System vault string — provider-level tokens are scoped to the system vault so
-# all authenticated users can use the shared provider connection.
+# System vault string — provider-level tokens live in the system vault. Within it,
+# each token's SUBJECT is keyed to the caller's org/tenant (finding #1, #11497) so
+# an admin connects once and only that org shares the connection; orgs are isolated
+# from one another. A single-tenant deployment (no org_id) keeps the legacy
+# "global" subject, so its behaviour is unchanged.
 _SYSTEM_VAULT = "system"
 
 # OAuth authorize state is single-use and short-lived — a security window, not a
@@ -193,6 +215,26 @@ def _current_user_id(user: Any) -> str:
     return str(uid)
 
 
+def _current_org_id(user: Any) -> str | None:
+    """Return the caller's org/tenant id, or None when not multi-tenant.
+
+    ``get_current_user`` yields a dict principal carrying ``org_id`` when the JWT
+    was minted with an org claim (#11497 finding #1). Objects are supported too
+    so tests/other principals work. None → the token stays on the legacy
+    ``"global"`` subject (single-tenant: byte-identical to pre-#11497 behaviour).
+    """
+    if isinstance(user, dict):
+        org = user.get("org_id")
+    else:
+        org = getattr(user, "org_id", None) or getattr(user, "organization_id", None)
+    return str(org) if org is not None else None
+
+
+def _vault_subject(user: Any) -> str:
+    """Per-org vault subject for the calling principal (finding #1, #11497)."""
+    return org_vault_subject(_current_org_id(user))
+
+
 # ---------------------------------------------------------------------------
 # OAuth authorization-code callback (server-side code exchange)
 # ---------------------------------------------------------------------------
@@ -210,7 +252,7 @@ async def oauth_initiate(
     stashes them in Redis (short TTL, keyed to the initiating admin), and returns
     the provider authorize URL. The client never supplies the verifier — the
     callback takes it from the stored state (#11297). Requires admin: the stored
-    credential is system-wide.
+    credential is shared by the admin's org (per-org scoped, #11497).
     """
     from knowledge.connectors.oauth_flow import (  # noqa: PLC0415
         OAuthProvider,
@@ -268,7 +310,7 @@ async def oauth_callback(
     provides. This closes the CSRF / code-injection hole where a lured admin could
     bind an attacker's account as the shared system credential (#11297).
 
-    Requires admin — stored credential is system-wide (shared by all users).
+    Requires admin — stored credential is per-org scoped (shared within the admin's org, #11497).
     """
     from knowledge.connectors.oauth_flow import OAuthProvider, exchange_code  # noqa: PLC0415
 
@@ -290,6 +332,7 @@ async def oauth_callback(
 
     token_url = stored["token_url"]
     _validate_outbound_url(token_url)  # defensive re-check before the outbound call
+    connector = await _pinned_connector(token_url)  # finding #2: resolve-once + IP pin
 
     provider_cfg = OAuthProvider(
         name=stored["provider_name"],
@@ -308,17 +351,25 @@ async def oauth_callback(
             req.code,
             req.redirect_uri,
             stored["verifier"],
+            connector=connector,
         )
     except RuntimeError as exc:
         # Log provider name only — never log code or token values.
         logger.warning("OAuth code exchange failed for provider %s", stored.get("provider_name"))
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
+    # Finding #3: reject a mismatched token_type / issuer / audience before persist.
+    try:
+        validate_token_response(resp, provider_name=stored["provider_name"], client_id=stored["client_id"])
+    except Exception as exc:
+        logger.warning("OAuth token validation failed for provider %s", stored.get("provider_name"))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
     token_data = build_token_data(resp, created_by=_current_user_id(user))
     await _vault_write(
         session,
         provider_name=stored["provider_name"],
-        subject="global",
+        subject=_vault_subject(user),  # finding #1: per-org scoping
         owner_vault_str=_SYSTEM_VAULT,
         token_data=token_data,
         created_by_id=_current_user_id(user),
@@ -349,17 +400,18 @@ async def device_initiate(
     ``user_code`` + ``verification_uri`` for the user to complete on another device.
     The caller polls ``/device/poll`` until approval or expiry.
 
-    Requires admin — stored credential is system-wide (shared by all users).
+    Requires admin — stored credential is per-org scoped (shared within the admin's org, #11497).
     """
     import aiohttp  # noqa: PLC0415
 
     # Validate outbound URL before any HTTP call — prevents SSRF via device_authorization_url.
     _validate_outbound_url(req.device_authorization_url)
+    connector = await _pinned_connector(req.device_authorization_url)  # finding #2: resolve-once + IP pin
 
     timeout = aiohttp.ClientTimeout(total=30.0)
     payload = {"client_id": req.client_id, "scope": req.scope}
     try:
-        async with aiohttp.ClientSession(timeout=timeout) as http:
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as http:
             async with http.post(
                 req.device_authorization_url,
                 data=payload,
@@ -397,7 +449,7 @@ async def device_poll(
     Returns ``stored=False`` when the grant is still pending (caller should
     retry after the ``interval`` from ``/device/initiate``).
 
-    Requires admin — stored credential is system-wide (shared by all users).
+    Requires admin — stored credential is per-org scoped (shared within the admin's org, #11497).
     """
     import aiohttp  # noqa: PLC0415
 
@@ -430,9 +482,10 @@ async def device_poll(
         "device_code": req.device_code,
         "client_id": req.client_id,
     }
+    connector = await _pinned_connector(req.token_url)  # finding #2: resolve-once + IP pin
     timeout = aiohttp.ClientTimeout(total=30.0)
     try:
-        async with aiohttp.ClientSession(timeout=timeout) as http:
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as http:
             async with http.post(
                 req.token_url,
                 data=payload,
@@ -461,11 +514,18 @@ async def device_poll(
     if error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=data.get("error_description", error))
 
+    # Finding #3: reject a mismatched token_type / issuer / audience before persist.
+    try:
+        validate_token_response(data, provider_name=req.provider_name, client_id=req.client_id)
+    except Exception as exc:
+        logger.warning("Device-code token validation failed for provider %s", req.provider_name)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
     token_data = build_token_data(data, created_by=_current_user_id(user))
     await _vault_write(
         session,
         provider_name=req.provider_name,
-        subject="global",
+        subject=_vault_subject(user),  # finding #1: per-org scoping
         owner_vault_str=_SYSTEM_VAULT,
         token_data=token_data,
         created_by_id=_current_user_id(user),
@@ -488,14 +548,19 @@ async def device_poll(
 async def provider_auth_status(
     provider_name: str,
     session: AsyncSession = Depends(get_db_session),
-    _: Any = Depends(get_current_user),
+    user: Any = Depends(get_current_user),
     _admin: bool = Depends(check_admin_permission),
 ) -> ProviderAuthStatus:
-    """Return the auth connection status for a provider."""
-    token_data = await _vault_read(
+    """Return the auth connection status for a provider.
+
+    Dual-read (finding #1, #11497): reports the caller's org-scoped token when
+    present, else the legacy ``"global"`` token — so orgs that connected before
+    the change still show connected with zero reconnect.
+    """
+    token_data = await _vault_read_dual(
         session,
         provider_name=provider_name,
-        subject="global",
+        subject=_vault_subject(user),
         owner_vault_str=_SYSTEM_VAULT,
     )
     if token_data is None:
@@ -520,14 +585,18 @@ async def revoke_provider_auth(
 ) -> None:
     """Revoke stored OAuth / device-code / session tokens for a provider.
 
-    Requires admin — credential is system-wide (shared by all users).
+    Requires admin — credential is per-org scoped (shared within the admin's org, #11497).
     """
     from sqlalchemy import delete  # noqa: PLC0415
 
     from llm_shared.provider_auth import _vault_secret_name  # noqa: PLC0415
     from models.secret import Secret  # noqa: PLC0415
 
-    name = _vault_secret_name(provider_name, "global")
+    # Finding #1 (#11497): revoke the caller's org-scoped token. In a single-tenant
+    # deployment (no org_id) the subject is the legacy "global" — identical to the
+    # pre-#11497 behaviour. Deleting only the org subject keeps other orgs' shared
+    # legacy credential intact.
+    name = _vault_secret_name(provider_name, _vault_subject(user))
     await session.execute(delete(Secret).where(Secret.name == name, Secret.owner_vault == _SYSTEM_VAULT))
     await session.commit()
     logger.info("Revoked provider auth tokens for %s (user=%s)", provider_name, _current_user_id(user))

--- a/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
+++ b/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
@@ -83,6 +83,9 @@ def ctx(monkeypatch):
     monkeypatch.setattr(mod, "get_oauth_allowed_hosts", lambda: {"token.example.com"})
     monkeypatch.setattr(mod, "_vault_write", AsyncMock(return_value=None))
     monkeypatch.setattr(mod, "build_token_data", lambda data, created_by: {"expires_at": 1.0})
+    # #11497 finding #2: the outbound POST is now IP-pinned. Stub the resolve so the
+    # test never does real DNS on the fake token host.
+    monkeypatch.setattr(mod, "_pinned_connector", AsyncMock(return_value=None))
 
     app = FastAPI()
     app.include_router(mod.router, prefix="/api")

--- a/autobot-backend/api/tests/test_provider_auth_oauth_state.py
+++ b/autobot-backend/api/tests/test_provider_auth_oauth_state.py
@@ -57,6 +57,9 @@ def ctx(monkeypatch):
     # Persist step is exercised elsewhere; isolate the state/PKCE/admin logic.
     monkeypatch.setattr(mod, "_vault_write", AsyncMock(return_value=None))
     monkeypatch.setattr(mod, "build_token_data", lambda resp, created_by: {"expires_at": 111.0})
+    # #11497 finding #2: the outbound POST is now IP-pinned. Stub the resolve so the
+    # test never does real DNS on the fake token host.
+    monkeypatch.setattr(mod, "_pinned_connector", AsyncMock(return_value=None))
 
     app = FastAPI()
     app.include_router(mod.router, prefix="/api")
@@ -119,7 +122,7 @@ def test_callback_happy_path_uses_stored_verifier(ctx, monkeypatch):
     tc, fake_redis, _ = ctx
     captured = {}
 
-    async def fake_exchange(provider, client_id, client_secret, code, redirect_uri, code_verifier):
+    async def fake_exchange(provider, client_id, client_secret, code, redirect_uri, code_verifier, connector=None):
         captured.update(client_id=client_id, client_secret=client_secret, code=code, verifier=code_verifier)
         return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
 
@@ -156,6 +159,45 @@ def test_callback_replayed_state_400(ctx, monkeypatch):
     # Replay the same (now-consumed) state → rejected.
     replay = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
     assert replay.status_code == 400
+
+
+def test_callback_persists_under_org_subject(ctx, monkeypatch):
+    """#11497 finding #1: an org-carrying admin persists the token under org:<id>."""
+    tc, fake_redis, app = ctx
+    write = AsyncMock(return_value=None)
+    monkeypatch.setattr(mod, "_vault_write", write)
+
+    async def fake_exchange(*a, connector=None, **k):
+        return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "exchange_code", fake_exchange)
+    # Principal carrying an org claim. get_current_user yields a dict; the admin
+    # binding compares _current_user_id(user), which for a dict is the zero-UUID,
+    # so the prestored state's admin_id must match that.
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": "admin-1", "org_id": "acme-42"}
+    state = _prestore_state(fake_redis, admin_id="00000000-0000-0000-0000-000000000000")
+
+    resp = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert resp.status_code == 200, resp.text
+    assert write.await_args.kwargs["subject"] == "org:acme-42"
+
+
+def test_callback_no_org_uses_legacy_global_subject(ctx, monkeypatch):
+    """Single-tenant (no org_id) keeps the legacy global subject — byte-identical."""
+    tc, fake_redis, app = ctx
+    write = AsyncMock(return_value=None)
+    monkeypatch.setattr(mod, "_vault_write", write)
+
+    async def fake_exchange(*a, connector=None, **k):
+        return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "exchange_code", fake_exchange)
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": "admin-1"}  # no org_id
+    state = _prestore_state(fake_redis, admin_id="00000000-0000-0000-0000-000000000000")
+
+    resp = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert resp.status_code == 200, resp.text
+    assert write.await_args.kwargs["subject"] == "global"
 
 
 def test_callback_admin_mismatch_403(ctx):

--- a/autobot-backend/knowledge/connectors/oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/oauth_flow.py
@@ -162,14 +162,22 @@ def build_authorize_url(
 # ---------------------------------------------------------------------------
 
 
-async def _post_token(token_url: str, payload: dict) -> dict:
+async def _post_token(token_url: str, payload: dict, *, connector: aiohttp.BaseConnector | None = None) -> dict:
     """POST form-encoded *payload* to *token_url*; return the parsed token dict.
 
     Raises RuntimeError on a non-2xx response or transport error.
+
+    When *connector* is provided (an SSRF-pinned :class:`aiohttp.TCPConnector`
+    from ``ssrf_guard.pinned_connector``), the session connects to the
+    pre-resolved public IP so the token POST cannot be DNS-rebound to a private
+    address between validation and connect. The session owns and closes it.
     """
     timeout = aiohttp.ClientTimeout(total=_TOKEN_REQUEST_TIMEOUT)
+    session_kwargs: dict = {"timeout": timeout}
+    if connector is not None:
+        session_kwargs["connector"] = connector
     try:
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with aiohttp.ClientSession(**session_kwargs) as session:
             async with session.post(
                 token_url,
                 data=payload,
@@ -193,10 +201,14 @@ async def exchange_code(
     code: str,
     redirect_uri: str,
     code_verifier: str,
+    *,
+    connector: aiohttp.BaseConnector | None = None,
 ) -> dict:
     """Exchange an authorization *code* for tokens.
 
     Returns the raw token response (access_token, refresh_token, expires_in, ...).
+    Pass *connector* (an SSRF-pinned connector) to defeat DNS-rebinding on the
+    outbound token POST.
     """
     payload = {
         "grant_type": "authorization_code",
@@ -206,7 +218,7 @@ async def exchange_code(
         "client_secret": client_secret,
         "code_verifier": code_verifier,
     }
-    return await _post_token(provider.token_url, payload)
+    return await _post_token(provider.token_url, payload, connector=connector)
 
 
 async def refresh_access_token(
@@ -214,11 +226,15 @@ async def refresh_access_token(
     client_id: str,
     client_secret: str,
     refresh_token: str,
+    *,
+    connector: aiohttp.BaseConnector | None = None,
 ) -> dict:
     """Exchange a *refresh_token* for a fresh access token.
 
     Returns the raw token response. Some providers (e.g. GitLab) rotate the
     refresh token and return a new one; callers must persist it when present.
+    Pass *connector* (an SSRF-pinned connector) to defeat DNS-rebinding on the
+    outbound token POST.
     """
     payload = {
         "grant_type": "refresh_token",
@@ -226,4 +242,4 @@ async def refresh_access_token(
         "client_id": client_id,
         "client_secret": client_secret,
     }
-    return await _post_token(token_url, payload)
+    return await _post_token(token_url, payload, connector=connector)

--- a/autobot-backend/knowledge/connectors/tests/test_oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/tests/test_oauth_flow.py
@@ -117,7 +117,7 @@ def test_build_authorize_url_custom_scopes_override_defaults():
 async def test_exchange_code_posts_expected_payload(monkeypatch):
     captured = {}
 
-    async def _fake_post(token_url, payload):
+    async def _fake_post(token_url, payload, *, connector=None):
         captured["url"] = token_url
         captured["payload"] = payload
         return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
@@ -138,7 +138,7 @@ async def test_exchange_code_posts_expected_payload(monkeypatch):
 async def test_refresh_access_token_posts_expected_payload(monkeypatch):
     captured = {}
 
-    async def _fake_post(token_url, payload):
+    async def _fake_post(token_url, payload, *, connector=None):
         captured["payload"] = payload
         return {"access_token": "fresh", "expires_in": 3600}
 

--- a/autobot-backend/llm_shared/provider_auth.py
+++ b/autobot-backend/llm_shared/provider_auth.py
@@ -57,6 +57,26 @@ PROVIDER_AUTH_SECRET_TYPE = "provider_auth_token"  # nosec B105 - vault type tag
 # Grace window before expiry at which a refresh is proactively triggered (seconds).
 _REFRESH_GRACE_SECONDS = 300
 
+# Legacy pre-#11497 vault subject: a single system-wide token shared by every
+# authenticated user. Retained as the dual-read fallback so existing connections
+# keep working with zero reconnect while new persists move to a per-org subject.
+LEGACY_SUBJECT = "global"
+
+
+def org_vault_subject(org_id: Any | None) -> str:
+    """Return the per-org vault subject for a token, or the legacy shared subject.
+
+    Finding #1 (#11497): provider tokens are keyed to the caller's org/tenant so
+    an admin connects once and only that org shares the connection — isolated
+    between orgs. When no org is available (single-tenant deployment, or a code
+    path without an org principal) we keep the legacy ``"global"`` subject so
+    behaviour is byte-identical to the pre-#11497 shared model.
+    """
+    if org_id is None:
+        return LEGACY_SUBJECT
+    org_id = str(org_id).strip()
+    return f"org:{org_id}" if org_id else LEGACY_SUBJECT
+
 
 class ProviderAuthError(Exception):
     """Unrecoverable auth failure — the provider cannot be used."""
@@ -165,6 +185,38 @@ async def _vault_read(
         return None
 
 
+async def _vault_read_dual(
+    session: Any,
+    *,
+    provider_name: str,
+    subject: str,
+    owner_vault_str: str,
+) -> dict[str, Any] | None:
+    """Read a token, trying the org-scoped *subject* then the legacy subject.
+
+    Backward-compatible dual-read for finding #1 (#11497): tokens written under
+    the pre-#11497 ``"global"`` subject stay readable after callers move to a
+    per-org subject. The org-scoped entry wins when present; the legacy
+    ``"global"`` entry is the fallback so existing connections keep working with
+    zero reconnect. When *subject* already IS the legacy subject this is a single
+    read (no redundant lookup).
+    """
+    token_data = await _vault_read(
+        session,
+        provider_name=provider_name,
+        subject=subject,
+        owner_vault_str=owner_vault_str,
+    )
+    if token_data is not None or subject == LEGACY_SUBJECT:
+        return token_data
+    return await _vault_read(
+        session,
+        provider_name=provider_name,
+        subject=LEGACY_SUBJECT,
+        owner_vault_str=owner_vault_str,
+    )
+
+
 async def _vault_write(
     session: Any,
     *,
@@ -253,7 +305,7 @@ class OAuthAuth(ProviderAuthStrategy):
     async def resolve_token(self, session: Any | None = None) -> str:
         if session is None:
             raise ProviderAuthError("OAuthAuth.resolve_token requires a DB session")
-        token_data = await _vault_read(
+        token_data = await _vault_read_dual(
             session,
             provider_name=self._provider_name,
             subject=self._subject,
@@ -276,6 +328,7 @@ class OAuthAuth(ProviderAuthStrategy):
         return await self._refresh(session, token_data, refresh_token)
 
     async def _refresh(self, session: Any, old_data: dict, refresh_token: str) -> str:
+        from autobot_shared.security.ssrf_guard import SSRFError, pinned_connector  # noqa: PLC0415
         from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https  # noqa: PLC0415
         from knowledge.connectors.oauth_flow import refresh_access_token  # noqa: PLC0415
 
@@ -286,6 +339,16 @@ class OAuthAuth(ProviderAuthStrategy):
                 f"OAuth refresh blocked: unsafe token_url for {self._provider_name!r}: {exc}"
             ) from exc
 
+        # Finding #2 (#11497): resolve the token host once, assert it is public,
+        # and pin the outbound POST to that IP so DNS cannot be rebound to a
+        # private address between validation and connect (TOCTOU rebinding).
+        try:
+            connector = await pinned_connector(self._token_url)
+        except SSRFError as exc:
+            raise ProviderAuthError(
+                f"OAuth refresh blocked: token_url for {self._provider_name!r} is not publicly routable: {exc}"
+            ) from exc
+
         logger.info("Refreshing OAuth token for provider %s", self._provider_name)
         try:
             resp = await refresh_access_token(
@@ -293,9 +356,14 @@ class OAuthAuth(ProviderAuthStrategy):
                 self._client_id,
                 self._client_secret,
                 refresh_token,
+                connector=connector,
             )
         except RuntimeError as exc:
             raise ProviderAuthError(f"OAuth refresh failed for {self._provider_name!r}: {exc}") from exc
+
+        # Finding #3 (#11497): reject a mismatched token_type / issuer / audience
+        # before the refreshed pair is persisted.
+        validate_token_response(resp, provider_name=self._provider_name, client_id=self._client_id)
 
         new_data = _merge_token_response(old_data, resp)
         await _vault_write(
@@ -353,7 +421,7 @@ class DeviceCodeAuth(ProviderAuthStrategy):
     async def resolve_token(self, session: Any | None = None) -> str:
         if session is None:
             raise ProviderAuthError("DeviceCodeAuth.resolve_token requires a DB session")
-        token_data = await _vault_read(
+        token_data = await _vault_read_dual(
             session,
             provider_name=self._provider_name,
             subject=self._subject,
@@ -417,7 +485,7 @@ class SessionAuth(ProviderAuthStrategy):
     async def resolve_token(self, session: Any | None = None) -> str:
         if session is None:
             raise ProviderAuthError("SessionAuth.resolve_token requires a DB session")
-        token_data = await _vault_read(
+        token_data = await _vault_read_dual(
             session,
             provider_name=self._provider_name,
             subject=self._subject,
@@ -459,6 +527,99 @@ def _merge_token_response(old: dict, resp: dict) -> dict:
     return new
 
 
+# ---------------------------------------------------------------------------
+# Token audience / issuer / type validation (finding #3, #11497)
+# ---------------------------------------------------------------------------
+
+# Known OIDC issuers per provider — the ``iss`` claim of an id_token is matched
+# against these prefixes (tenant / path suffixes vary). Providers absent here
+# (e.g. github, gitlab) rarely mint an id_token; when one is present we still
+# require its issuer host to be an allowlisted OAuth host (defence-in-depth).
+_EXPECTED_ISSUER_PREFIXES: dict[str, tuple[str, ...]] = {
+    "google": ("https://accounts.google.com",),
+    "microsoft": ("https://login.microsoftonline.com/",),
+}
+
+
+def _decode_jwt_claims(id_token: str) -> dict[str, Any]:
+    """Decode (WITHOUT signature verification) the payload of a compact JWS.
+
+    Used only to cross-check the ``iss`` / ``aud`` claims of an OIDC id_token
+    against the expected provider + client_id. The access token's authenticity
+    still rests on the TLS-authenticated token endpoint; this is defence-in-depth
+    against a swapped-audience / wrong-issuer token, not a trust anchor.
+    """
+    import base64
+    import json
+
+    parts = id_token.split(".")
+    if len(parts) != 3:
+        raise ProviderAuthError("id_token is not a well-formed JWT")
+    payload_b64 = parts[1]
+    payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64url padding
+    try:
+        raw = base64.urlsafe_b64decode(payload_b64.encode("ascii"))
+        claims = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        raise ProviderAuthError(f"id_token payload is undecodable: {exc}") from exc
+    if not isinstance(claims, dict):
+        raise ProviderAuthError("id_token payload is not a JSON object")
+    return claims
+
+
+def validate_token_response(resp: dict, *, provider_name: str, client_id: str) -> None:
+    """Validate ``token_type`` / ``iss`` / ``aud`` before a token is persisted.
+
+    Finding #3 (#11497). Lenient-but-strict: a field is only rejected when it is
+    PRESENT and wrong, so providers that legitimately omit ``token_type`` or an
+    ``id_token`` (RFC 6749 token responses) keep working with zero regression.
+
+    - ``token_type``: must be ``bearer`` (case-insensitive) when present.
+    - ``id_token`` (OIDC): when present, its ``aud`` must contain *client_id*
+      and its ``iss`` must be an https URL on an allowlisted OAuth host — and,
+      for a known OIDC provider, match that provider's issuer prefix.
+
+    Raises ``ProviderAuthError`` on any mismatch.
+    """
+    token_type = resp.get("token_type")
+    if token_type is not None and str(token_type).lower() != "bearer":
+        raise ProviderAuthError(f"unexpected token_type {token_type!r} for provider {provider_name!r}")
+
+    id_token = resp.get("id_token")
+    if not id_token:
+        return
+
+    claims = _decode_jwt_claims(id_token)
+
+    aud = claims.get("aud")
+    if aud is not None:
+        audiences = {aud} if isinstance(aud, str) else set(aud or [])
+        azp = claims.get("azp")
+        if client_id and client_id not in audiences and client_id != azp:
+            raise ProviderAuthError(f"id_token audience does not include client_id for provider {provider_name!r}")
+
+    iss = claims.get("iss")
+    if iss is not None:
+        _validate_issuer(str(iss), provider_name)
+
+
+def _validate_issuer(iss: str, provider_name: str) -> None:
+    """Reject an id_token issuer that is not an allowlisted / expected host."""
+    from urllib.parse import urlparse  # noqa: PLC0415
+
+    from autobot_shared.url_safety import get_oauth_allowed_hosts  # noqa: PLC0415
+
+    parsed = urlparse(iss)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise ProviderAuthError(f"id_token issuer {iss!r} is not an https URL for provider {provider_name!r}")
+    if parsed.hostname.lower() not in get_oauth_allowed_hosts():
+        raise ProviderAuthError(f"id_token issuer host {parsed.hostname!r} is not allowlisted")
+
+    expected = _EXPECTED_ISSUER_PREFIXES.get(provider_name.lower())
+    if expected and not any(iss.startswith(prefix) for prefix in expected):
+        raise ProviderAuthError(f"id_token issuer {iss!r} is not valid for provider {provider_name!r}")
+
+
 def build_token_data(
     resp: dict,
     *,
@@ -486,8 +647,11 @@ __all__ = [
     "DeviceCodeAuth",
     "SessionAuth",
     "PROVIDER_AUTH_SECRET_TYPE",
-    "build_token_data",
+    "LEGACY_SUBJECT",
+    "org_vault_subject",
+    "validate_token_response",
     "build_token_data",
     "_vault_write",
     "_vault_read",
+    "_vault_read_dual",
 ]

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -30,6 +30,7 @@ import pytest
 # Obtain it via the class's function globals to guarantee identity.
 import llm_shared.provider_auth as _provider_auth_mod  # standard import path
 from llm_shared.provider_auth import (
+    LEGACY_SUBJECT,
     ApiKeyAuth,
     DeviceCodeAuth,
     OAuthAuth,
@@ -38,6 +39,8 @@ from llm_shared.provider_auth import (
     TokenExpiredError,
     _merge_token_response,
     build_token_data,
+    org_vault_subject,
+    validate_token_response,
 )
 
 # Use the class's actual globals dict as the authoritative module reference.
@@ -219,6 +222,7 @@ class TestOAuthAuth:
         with (
             patch.object(_PA_MOD, "_vault_read", new=AsyncMock(return_value=expired)),
             patch.object(_PA_MOD, "_vault_write", new=AsyncMock()) as mock_write,
+            patch("autobot_shared.security.ssrf_guard.pinned_connector", new=AsyncMock(return_value=MagicMock())),
             patch(
                 "knowledge.connectors.oauth_flow.refresh_access_token",
                 new=AsyncMock(return_value=refreshed),
@@ -414,6 +418,226 @@ class TestTokenHelpers:
         resp = {"access_token": "new_at", "refresh_token": "new_rt", "expires_in": 3600}
         merged = _merge_token_response(old, resp)
         assert merged["refresh_token"] == "new_rt"
+
+
+# ---------------------------------------------------------------------------
+# #11497 finding #1 — per-org vault subject + backward-compatible dual-read
+# ---------------------------------------------------------------------------
+
+
+class TestOrgVaultSubject:
+    def test_none_org_is_legacy_global(self):
+        assert org_vault_subject(None) == LEGACY_SUBJECT == "global"
+
+    def test_empty_org_is_legacy_global(self):
+        assert org_vault_subject("") == "global"
+        assert org_vault_subject("   ") == "global"
+
+    def test_org_id_keyed(self):
+        assert org_vault_subject("acme") == "org:acme"
+        assert org_vault_subject(42) == "org:42"
+
+
+class TestDualRead:
+    """Finding #1 read path: org-scoped subject first, legacy ``global`` fallback."""
+
+    _TOKEN_URL = "https://github.com/login/oauth/access_token"
+
+    def _make_auth(self, subject: str) -> OAuthAuth:
+        return OAuthAuth(
+            provider_name="p",
+            token_url=self._TOKEN_URL,
+            client_id="cid",
+            client_secret="csec",
+            owner_vault_str="system",
+            subject=subject,
+        )
+
+    def _fresh(self, tag: str) -> dict:
+        return {
+            "access_token": tag,
+            "refresh_token": "rt",
+            "expires_at": time.time() + 7200,
+            "created_by": "00000000-0000-0000-0000-000000000000",
+        }
+
+    def test_legacy_global_token_readable_under_org_subject(self):
+        """PROOF: a token stored under legacy ``global`` is still readable when the
+        caller resolves with an org-scoped subject — zero reconnect, no regression."""
+        auth = self._make_auth(subject="org:acme")
+        legacy = self._fresh("at-legacy-global")
+        session = AsyncMock()
+
+        async def fake_read(_session, *, provider_name, subject, owner_vault_str):
+            # Only the legacy "global" entry exists (org:acme has never persisted).
+            return legacy if subject == "global" else None
+
+        with patch.object(_PA_MOD, "_vault_read", new=AsyncMock(side_effect=fake_read)):
+            result = _sync(auth.resolve_token(session))
+
+        assert result == "at-legacy-global"
+
+    def test_org_scoped_token_wins_over_legacy_global(self):
+        auth = self._make_auth(subject="org:acme")
+        org_data = self._fresh("at-org")
+        legacy = self._fresh("at-legacy")
+        session = AsyncMock()
+
+        async def fake_read(_session, *, provider_name, subject, owner_vault_str):
+            return org_data if subject == "org:acme" else legacy
+
+        with patch.object(_PA_MOD, "_vault_read", new=AsyncMock(side_effect=fake_read)):
+            result = _sync(auth.resolve_token(session))
+
+        assert result == "at-org"
+
+    def test_global_subject_single_read_no_fallback(self):
+        """When subject already IS legacy ``global`` there must be no second lookup."""
+        auth = self._make_auth(subject="global")
+        legacy = self._fresh("at-global")
+        session = AsyncMock()
+        read = AsyncMock(return_value=legacy)
+
+        with patch.object(_PA_MOD, "_vault_read", new=read):
+            result = _sync(auth.resolve_token(session))
+
+        assert result == "at-global"
+        read.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# #11497 finding #2 — refresh POST is pinned to a pre-resolved public IP
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshIpPinning:
+    _TOKEN_URL = "https://github.com/login/oauth/access_token"
+
+    def _make_auth(self) -> OAuthAuth:
+        return OAuthAuth(
+            provider_name="test_provider",
+            token_url=self._TOKEN_URL,
+            client_id="cid",
+            client_secret="csec",
+            owner_vault_str="system",
+            subject="global",
+        )
+
+    def _expired(self) -> dict:
+        return {
+            "access_token": "at-expired",
+            "refresh_token": "rt-valid",
+            "expires_at": time.time() - 1,
+            "created_by": "00000000-0000-0000-0000-000000000000",
+        }
+
+    def test_refresh_resolves_once_and_pins_connector(self):
+        auth = self._make_auth()
+        pin = AsyncMock(return_value=MagicMock())
+        refresh = AsyncMock(return_value={"access_token": "at-new", "expires_in": 3600})
+        session = AsyncMock()
+
+        with (
+            patch.object(_PA_MOD, "_vault_read", new=AsyncMock(return_value=self._expired())),
+            patch.object(_PA_MOD, "_vault_write", new=AsyncMock()),
+            patch("autobot_shared.security.ssrf_guard.pinned_connector", new=pin),
+            patch("knowledge.connectors.oauth_flow.refresh_access_token", new=refresh),
+        ):
+            result = _sync(auth.resolve_token(session))
+
+        assert result == "at-new"
+        pin.assert_awaited_once_with(self._TOKEN_URL)  # resolved exactly once
+        # The pinned connector is threaded into the outbound refresh POST.
+        assert "connector" in refresh.await_args.kwargs
+
+    def test_refresh_blocks_when_host_not_public(self):
+        from autobot_shared.security.ssrf_guard import SSRFError
+
+        auth = self._make_auth()
+        refresh = AsyncMock(return_value={"access_token": "at-new", "expires_in": 3600})
+        session = AsyncMock()
+
+        with (
+            patch.object(_PA_MOD, "_vault_read", new=AsyncMock(return_value=self._expired())),
+            patch(
+                "autobot_shared.security.ssrf_guard.pinned_connector",
+                new=AsyncMock(side_effect=SSRFError("non-public")),
+            ),
+            patch("knowledge.connectors.oauth_flow.refresh_access_token", new=refresh),
+        ):
+            with pytest.raises(ProviderAuthError, match="not publicly routable"):
+                _sync(auth.resolve_token(session))
+            refresh.assert_not_awaited()  # never reached the network
+
+
+# ---------------------------------------------------------------------------
+# #11497 finding #3 — token_type / issuer / audience validation before persist
+# ---------------------------------------------------------------------------
+
+
+def _jwt(claims: dict) -> str:
+    """Build an unsigned compact JWS whose payload carries *claims* (test-only)."""
+    import base64
+    import json
+
+    def _seg(obj: dict) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{_seg({'alg': 'none'})}.{_seg(claims)}.sig"
+
+
+class TestValidateTokenResponse:
+    def test_bearer_token_type_accepted(self):
+        validate_token_response({"access_token": "at", "token_type": "Bearer"}, provider_name="p", client_id="cid")
+
+    def test_non_bearer_token_type_rejected(self):
+        with pytest.raises(ProviderAuthError, match="token_type"):
+            validate_token_response({"access_token": "at", "token_type": "mac"}, provider_name="p", client_id="cid")
+
+    def test_missing_token_type_is_lenient(self):
+        # RFC 6749 responses that omit token_type keep working (no regression).
+        validate_token_response({"access_token": "at"}, provider_name="p", client_id="cid")
+
+    def test_id_token_audience_match_accepted(self):
+        resp = {"access_token": "at", "id_token": _jwt({"aud": "cid", "iss": "https://accounts.google.com"})}
+        validate_token_response(resp, provider_name="google", client_id="cid")
+
+    def test_id_token_audience_list_accepted(self):
+        resp = {"access_token": "at", "id_token": _jwt({"aud": ["other", "cid"], "iss": "https://github.com"})}
+        validate_token_response(resp, provider_name="github", client_id="cid")
+
+    def test_id_token_audience_mismatch_rejected(self):
+        resp = {"access_token": "at", "id_token": _jwt({"aud": "someone-else"})}
+        with pytest.raises(ProviderAuthError, match="audience"):
+            validate_token_response(resp, provider_name="google", client_id="cid")
+
+    def test_id_token_azp_fallback_accepted(self):
+        resp = {"access_token": "at", "id_token": _jwt({"aud": "other", "azp": "cid", "iss": "https://github.com"})}
+        validate_token_response(resp, provider_name="github", client_id="cid")
+
+    def test_id_token_issuer_not_allowlisted_rejected(self):
+        resp = {"access_token": "at", "id_token": _jwt({"aud": "cid", "iss": "https://evil.example.com"})}
+        with pytest.raises(ProviderAuthError, match="issuer"):
+            validate_token_response(resp, provider_name="p", client_id="cid")
+
+    def test_id_token_issuer_wrong_for_known_provider_rejected(self):
+        # login.microsoftonline.com is allowlisted, but it is NOT google's issuer.
+        resp = {"access_token": "at", "id_token": _jwt({"aud": "cid", "iss": "https://login.microsoftonline.com/x"})}
+        with pytest.raises(ProviderAuthError, match="issuer"):
+            validate_token_response(resp, provider_name="google", client_id="cid")
+
+    def test_id_token_non_https_issuer_rejected(self):
+        resp = {"access_token": "at", "id_token": _jwt({"aud": "cid", "iss": "http://accounts.google.com"})}
+        with pytest.raises(ProviderAuthError, match="https"):
+            validate_token_response(resp, provider_name="google", client_id="cid")
+
+    def test_malformed_id_token_rejected(self):
+        with pytest.raises(ProviderAuthError, match="well-formed"):
+            validate_token_response({"access_token": "at", "id_token": "not-a-jwt"}, provider_name="p", client_id="cid")
+
+    def test_no_id_token_is_lenient(self):
+        validate_token_response({"access_token": "at", "refresh_token": "rt"}, provider_name="p", client_id="cid")
 
 
 # ---------------------------------------------------------------------------
@@ -769,6 +993,7 @@ class TestOAuthRefreshSsrfGuard:
         with (
             patch.object(_PA_MOD, "_vault_read", new=AsyncMock(return_value=expired)),
             patch.object(_PA_MOD, "_vault_write", new=AsyncMock()),
+            patch("autobot_shared.security.ssrf_guard.pinned_connector", new=AsyncMock(return_value=MagicMock())),
             patch(
                 "knowledge.connectors.oauth_flow.refresh_access_token",
                 new=AsyncMock(return_value=refreshed),

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -29836,7 +29836,7 @@ export interface paths {
          *     stashes them in Redis (short TTL, keyed to the initiating admin), and returns
          *     the provider authorize URL. The client never supplies the verifier — the
          *     callback takes it from the stored state (#11297). Requires admin: the stored
-         *     credential is system-wide.
+         *     credential is shared by the admin's org (per-org scoped, #11497).
          */
         post: operations["oauth_initiate_api_llm_auth_oauth_initiate_post"];
         delete?: never;
@@ -29864,7 +29864,7 @@ export interface paths {
          *     provides. This closes the CSRF / code-injection hole where a lured admin could
          *     bind an attacker's account as the shared system credential (#11297).
          *
-         *     Requires admin — stored credential is system-wide (shared by all users).
+         *     Requires admin — stored credential is per-org scoped (shared within the admin's org, #11497).
          */
         post: operations["oauth_callback_api_llm_auth_oauth_callback_post"];
         delete?: never;
@@ -29890,7 +29890,7 @@ export interface paths {
          *     ``user_code`` + ``verification_uri`` for the user to complete on another device.
          *     The caller polls ``/device/poll`` until approval or expiry.
          *
-         *     Requires admin — stored credential is system-wide (shared by all users).
+         *     Requires admin — stored credential is per-org scoped (shared within the admin's org, #11497).
          */
         post: operations["device_initiate_api_llm_auth_device_initiate_post"];
         delete?: never;
@@ -29915,7 +29915,7 @@ export interface paths {
          *     Returns ``stored=False`` when the grant is still pending (caller should
          *     retry after the ``interval`` from ``/device/initiate``).
          *
-         *     Requires admin — stored credential is system-wide (shared by all users).
+         *     Requires admin — stored credential is per-org scoped (shared within the admin's org, #11497).
          */
         post: operations["device_poll_api_llm_auth_device_poll_post"];
         delete?: never;
@@ -29934,6 +29934,10 @@ export interface paths {
         /**
          * Provider Auth Status
          * @description Return the auth connection status for a provider.
+         *
+         *     Dual-read (finding #1, #11497): reports the caller's org-scoped token when
+         *     present, else the legacy ``"global"`` token — so orgs that connected before
+         *     the change still show connected with zero reconnect.
          */
         get: operations["provider_auth_status_api_llm_auth_status__provider_name__get"];
         put?: never;
@@ -29958,7 +29962,7 @@ export interface paths {
          * Revoke Provider Auth
          * @description Revoke stored OAuth / device-code / session tokens for a provider.
          *
-         *     Requires admin — credential is system-wide (shared by all users).
+         *     Requires admin — credential is per-org scoped (shared within the admin's org, #11497).
          */
         delete: operations["revoke_provider_auth_api_llm_auth__provider_name__delete"];
         options?: never;

--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -25,6 +25,7 @@ Dependencies: stdlib + aiohttp only (no autobot-* imports).
 from __future__ import annotations
 
 import socket
+from urllib.parse import urlparse
 
 import aiohttp
 import aiohttp.abc
@@ -95,6 +96,31 @@ def safe_aiohttp_resolver(host: str, safe_ip: str, port: int) -> aiohttp.abc.Abs
             return None
 
     return _PinnedResolver()
+
+
+async def pinned_connector(url: str) -> aiohttp.TCPConnector:
+    """Return an aiohttp connector pinned to *url*'s pre-resolved public IP.
+
+    Resolves the host once via :func:`resolve_safe_ip` (asserting a public
+    address), then returns a :class:`aiohttp.TCPConnector` whose resolver always
+    maps the host to that IP. Callers pass the connector to a ``ClientSession``
+    for their outbound POST/GET so the TCP connection cannot be re-resolved to a
+    private address between the safety check and the socket connect
+    (DNS-rebind TOCTOU). The original hostname is preserved for TLS SNI.
+
+    Raises
+    ------
+    SSRFError
+        If the host is missing or resolves to a non-public address.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        raise SSRFError("URL has no hostname")
+    safe_ip = await resolve_safe_ip(host)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    resolver = safe_aiohttp_resolver(host, safe_ip, port)
+    return aiohttp.TCPConnector(resolver=resolver, use_dns_cache=False)
 
 
 async def fetch_safe_url(
@@ -171,4 +197,4 @@ async def fetch_safe_url(
     return status, body[:max_bytes], content_type
 
 
-__all__ = ["SSRFError", "resolve_safe_ip", "safe_aiohttp_resolver", "fetch_safe_url"]
+__all__ = ["SSRFError", "resolve_safe_ip", "safe_aiohttp_resolver", "pinned_connector", "fetch_safe_url"]

--- a/autobot_shared/security/ssrf_guard_test.py
+++ b/autobot_shared/security/ssrf_guard_test.py
@@ -25,6 +25,7 @@ import pytest
 from autobot_shared.security.ssrf_guard import (
     SSRFError,
     fetch_safe_url,
+    pinned_connector,
     resolve_safe_ip,
     safe_aiohttp_resolver,
 )
@@ -144,6 +145,39 @@ async def test_safe_aiohttp_resolver_ignores_dns_on_resolve() -> None:
 async def test_safe_aiohttp_resolver_close_is_noop() -> None:
     resolver = safe_aiohttp_resolver("example.com", "1.2.3.4", 80)
     await resolver.close()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# pinned_connector — resolve-once + IP pin for a caller-owned ClientSession (#11497)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pinned_connector_pins_resolved_public_ip() -> None:
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        connector = await pinned_connector("https://token.example.com/token")
+    try:
+        results = await connector._resolver.resolve("token.example.com", 443)
+        assert results[0]["host"] == "93.184.216.34"
+        assert results[0]["hostname"] == "token.example.com"
+        assert results[0]["port"] == 443
+    finally:
+        await connector.close()
+
+
+@pytest.mark.asyncio
+async def test_pinned_connector_rejects_private_ip() -> None:
+    fake_infos = [(2, 1, 6, "", ("10.0.0.1", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        with pytest.raises(SSRFError):
+            await pinned_connector("https://internal.example/token")
+
+
+@pytest.mark.asyncio
+async def test_pinned_connector_rejects_no_host() -> None:
+    with pytest.raises(SSRFError, match="no hostname"):
+        await pinned_connector("https://")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #11497

## Thinking Path

Three MED #11061 residuals. Finding #1's scoping is an owner decision (recorded on the issue): **per-org/tenant** with a backward-compatible dual-read so existing `global` tokens keep working with zero reconnect — no regression. #2 and #3 are pure hardening.

## What Changed

**#1 — per-org scoping.** `org_vault_subject(org_id)` → `org:<id>` (or legacy `global` when org absent). Writes persist under the caller's org subject (`org_id` from the `get_current_user` JWT claim); reads use `_vault_read_dual` (org subject first, then legacy `global`), re-persisting under org on next refresh. Single-tenant deploys and the not-yet-org-wired LLM strategy path stay on `global` (byte-identical to before). Dual-read proven by `test_legacy_global_token_readable_under_org_subject`.

**#2 — DNS-rebinding.** New `ssrf_guard.pinned_connector(url)`: resolves once via existing `resolve_safe_ip` (asserts public, fails closed), returns a `TCPConnector` mapping host→verified IP (SNI preserved). Wired into all 4 outbound POSTs (device_initiate/poll, oauth_callback, OAuthAuth._refresh via a threaded `connector=` kwarg). Existing allowlist check retained, runs first.

**#3 — audience/issuer.** New `validate_token_response(resp, provider, client_id)` before every `_vault_write`: `token_type==bearer` when present; OIDC `id_token` `aud` must contain client_id (azp fallback), `iss` must be an allowlisted https host + per-provider issuer prefix. Lenient on absent fields (RFC-6749 no-regression).

## Verification

- 110 provider/oauth + 22 ssrf_guard + 344 startup-import tests green; independent re-run 110. py_compile/flake8/black clean (9 files).

Discovery filed: #11849 (`_current_user_id` reads object attrs but `get_current_user` returns a dict → always zero UUID; #11297 admin-binding inert — distinct blast radius, out of this behavior-preserving PR).

## Model Used

Claude Fable 5 (subagent: general-purpose)