### PR TITLE
fix(release): grant pull-requests:write so changelog PR step succeeds (#11853)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,15 @@ name: Release
 on:
   push:
     branches: [main]
+    # The workflow's own "chore(release): changelog…" commit touches ONLY these
+    # paths. Ignoring pushes limited to them stops release.yml from re-triggering
+    # on its own changelog PR merge — otherwise git-cliff patch-bumps off the
+    # release range and mints a spurious release every time (infinite loop once
+    # the changelog PR can actually merge, #11855). A real promotion always
+    # touches other files too, so it still triggers exactly one release.
+    paths-ignore:
+      - CHANGELOG.md
+      - changelog/**
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
 
 permissions:
   contents: write
+  # The final "Open changelog PR to main" step calls `gh pr create`, which
+  # needs pull-requests:write — without it GITHUB_TOKEN fails with
+  # "Resource not accessible by integration (createPullRequest)" and the
+  # changelog history never lands on main (#11853).
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #11853, #11855 (umbrella #11825)

Two coupled release.yml fixes — they **must** ship together.

## Thinking Path

Verifying the v0.5.1 release surfaced two problems in the automated flow:

1. **#11853 — changelog PR step fails every release.** The workflow declared `permissions: { contents: write }` only; the final `gh pr create` needs `pull-requests: write`. Both the v0.5.1 and v0.4.1 runs concluded `failure` here (`Resource not accessible by integration (createPullRequest)`), so `CHANGELOG.md` history never reached main automatically.

2. **#11855 — self-trigger loop (found while fixing #1).** Once the changelog PR *can* merge, its push to main re-triggers release.yml; git-cliff patch-bumps off the promotion merge's fix history and mints another release. Observed live: merging the v0.5.1 changelog PR manually fired run 29612048948 → git-cliff returned `v0.5.2` → spurious v0.5.2 published. It stopped at one extra release only because the permission bug (#1) still blocked the next changelog PR. **Fixing #1 without #2 would create an unbounded release loop**, so they are bundled.

## What Changed

`.github/workflows/release.yml`:
- Add `pull-requests: write` to `permissions`.
- Add `on.push.paths-ignore: [CHANGELOG.md, changelog/**]` — the changelog commit touches only those paths, so the workflow no longer self-triggers; real promotions (other files) still trigger exactly one release.

## Verification

- `yaml.safe_load` → OK; parsed trigger = `{branches: [main], paths-ignore: [CHANGELOG.md, changelog/**]}`
- Self-trigger commit 0afb93b4 confirmed to touch only `CHANGELOG.md` + `changelog/v0.5.1.md`
- Permission root cause confirmed from run 29603052976 job log

## Model Used

Claude Opus 4.8