### PR TITLE
fix(sec): _current_user_id reads dict principals — restore OAuth-state admin-binding + real created_by (#11849)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -204,7 +204,19 @@ class ProviderAuthStatus(BaseModel):
 
 
 def _current_user_id(user: Any) -> str:
-    uid = getattr(user, "id", None) or getattr(user, "user_id", None)
+    """Return the calling principal's id as a string, or the zero-UUID when absent.
+
+    ``get_current_user`` yields a **dict** principal in every production branch
+    (``user_id`` is the canonical claim key, #11849), so read dict keys first;
+    an object principal (tests / other callers) still resolves via ``getattr``.
+    The zero-UUID is returned only for a genuinely id-less principal — otherwise
+    the #11297 admin-binding would collapse every real admin to the same id and
+    let a lured admin B complete admin A's minted OAuth state.
+    """
+    if isinstance(user, dict):
+        uid = user.get("user_id") or user.get("id")
+    else:
+        uid = getattr(user, "user_id", None) or getattr(user, "id", None)
     if uid is None:
         return "00000000-0000-0000-0000-000000000000"
     return str(uid)

--- a/autobot-backend/api/tests/test_provider_auth_oauth_state.py
+++ b/autobot-backend/api/tests/test_provider_auth_oauth_state.py
@@ -152,10 +152,10 @@ def test_callback_persists_under_org_subject(ctx, monkeypatch):
 
     monkeypatch.setattr(oauth_flow, "exchange_code", fake_exchange)
     # Principal carrying an org claim. get_current_user yields a dict; the admin
-    # binding compares _current_user_id(user), which for a dict is the zero-UUID,
-    # so the prestored state's admin_id must match that.
+    # binding compares _current_user_id(user), which now reads the dict's
+    # ``user_id`` (#11849), so the prestored state's admin_id must be that real id.
     app.dependency_overrides[get_current_user] = lambda: {"user_id": "admin-1", "org_id": "acme-42"}
-    state = _prestore_state(fake_redis, admin_id="00000000-0000-0000-0000-000000000000")
+    state = _prestore_state(fake_redis, admin_id="admin-1")
 
     resp = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
     assert resp.status_code == 200, resp.text
@@ -173,7 +173,7 @@ def test_callback_no_org_uses_legacy_global_subject(ctx, monkeypatch):
 
     monkeypatch.setattr(oauth_flow, "exchange_code", fake_exchange)
     app.dependency_overrides[get_current_user] = lambda: {"user_id": "admin-1"}  # no org_id
-    state = _prestore_state(fake_redis, admin_id="00000000-0000-0000-0000-000000000000")
+    state = _prestore_state(fake_redis, admin_id="admin-1")
 
     resp = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
     assert resp.status_code == 200, resp.text
@@ -188,3 +188,71 @@ def test_callback_admin_mismatch_403(ctx):
     assert resp.status_code == 403
     # A rejected mismatch still consumed the single-use state (no reuse window).
     assert mod._state_key(state) not in fake_redis.store
+
+
+def test_callback_dict_admin_mismatch_rejected(ctx):
+    """#11849 SECURITY PROOF: a dict principal must NOT collapse to the zero-UUID.
+
+    Models the CSRF hole the #11297 binding was meant to close. Under the buggy
+    ``_current_user_id`` (object-only getattr), a **dict** principal always
+    resolved to the zero-UUID, so a state minted with that zero-UUID admin_id
+    (exactly what buggy /oauth/initiate stored) was completable by ANY other
+    admin — a lured admin B could complete admin A's state. Post-fix the
+    completing admin resolves to its real ``user_id`` (``admin-B``), which does
+    not match the stored id, so the callback is rejected 403.
+
+    This assertion returns 200 against the pre-fix code (binding inert) and 403
+    after the fix.
+    """
+    tc, fake_redis, app = ctx
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": "admin-B"}
+    state = _prestore_state(fake_redis, admin_id="00000000-0000-0000-0000-000000000000")
+    resp = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert resp.status_code == 403, resp.text
+    # The rejected single-use state is still consumed (no reuse window).
+    assert mod._state_key(state) not in fake_redis.store
+
+
+def test_callback_persists_real_created_by(ctx, monkeypatch):
+    """#11849: the persisted token's ``created_by`` is the caller's real id, not zero-UUID."""
+    tc, fake_redis, app = ctx
+    write = AsyncMock(return_value=None)
+    monkeypatch.setattr(mod, "_vault_write", write)
+    # build_token_data must receive the real created_by so the audit trail is populated.
+    captured_created_by = {}
+
+    def _capture_build(resp, created_by):
+        captured_created_by["v"] = created_by
+        return {"expires_at": 1.0}
+
+    monkeypatch.setattr(mod, "build_token_data", _capture_build)
+
+    async def fake_exchange(*a, connector=None, **k):
+        return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "exchange_code", fake_exchange)
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": "admin-1"}
+    state = _prestore_state(fake_redis, admin_id="admin-1")
+
+    resp = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert resp.status_code == 200, resp.text
+    assert captured_created_by["v"] == "admin-1"
+    assert write.await_args.kwargs["created_by_id"] == "admin-1"
+
+
+def test_current_user_id_reads_dict_principal():
+    """#11849: a dict principal yields its real ``user_id`` (falling back to ``id``)."""
+    assert mod._current_user_id({"user_id": "u-42"}) == "u-42"
+    assert mod._current_user_id({"id": "u-99"}) == "u-99"
+
+
+def test_current_user_id_reads_object_principal():
+    """Object principals still resolve via getattr (tests / non-dict callers)."""
+    assert mod._current_user_id(types.SimpleNamespace(user_id="obj-1")) == "obj-1"
+    assert mod._current_user_id(types.SimpleNamespace(id="obj-2")) == "obj-2"
+
+
+def test_current_user_id_absent_id_is_zero_uuid():
+    """Only a genuinely id-less principal falls back to the zero-UUID sentinel."""
+    assert mod._current_user_id({}) == "00000000-0000-0000-0000-000000000000"
+    assert mod._current_user_id(types.SimpleNamespace()) == "00000000-0000-0000-0000-000000000000"

--- a/autobot-backend/llm_shared/provider_auth.py
+++ b/autobot-backend/llm_shared/provider_auth.py
@@ -245,7 +245,14 @@ async def _vault_write(
     plaintext = json.dumps(token_data, separators=(",", ":")).encode("utf-8")
 
     if isinstance(created_by_id, str):
-        created_by_id = uuid.UUID(created_by_id)
+        # The JWT ``user_id`` claim is NOT guaranteed to be a UUID (e.g. the
+        # auth-disabled "admin" principal, or an empty device-JWT claim), so a
+        # malformed id must never break token persistence (#11849). Fall back to
+        # the zero-UUID audit sentinel rather than raising on the write path.
+        try:
+            created_by_id = uuid.UUID(created_by_id)
+        except ValueError:
+            created_by_id = uuid.UUID("00000000-0000-0000-0000-000000000000")
 
     svc = EnvelopeSecretsService()
     await svc.create(

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -1003,3 +1003,51 @@ class TestOAuthRefreshSsrfGuard:
 
         assert result == "at-new"
         mock_post.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _vault_write created_by guard (#11849)
+# ---------------------------------------------------------------------------
+
+
+class TestVaultWriteCreatedByGuard:
+    """The JWT ``user_id`` claim is not guaranteed to be a UUID; a malformed id
+    must fall back to the zero-UUID sentinel rather than raise on the write path."""
+
+    def _run(self, created_by_id):
+        import uuid as _uuid
+
+        captured = {}
+
+        class _FakeSvc:
+            async def create(self, session, *, owner_vault, name, secret_type, plaintext, created_by):
+                captured["created_by"] = created_by
+
+        import services.envelope_secrets_service as _ess
+
+        with patch.object(_ess, "EnvelopeSecretsService", _FakeSvc):
+            session = AsyncMock()
+            _sync(
+                _PA_MOD._vault_write(
+                    session,
+                    provider_name="acme",
+                    subject=LEGACY_SUBJECT,
+                    owner_vault_str="system",
+                    token_data={"access_token": "at"},
+                    created_by_id=created_by_id,
+                )
+            )
+        return captured["created_by"], _uuid
+
+    def test_non_uuid_created_by_falls_back_without_raising(self):
+        created_by, _uuid = self._run("admin")  # NOT a valid UUID
+        assert created_by == _uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+    def test_empty_created_by_falls_back_without_raising(self):
+        created_by, _uuid = self._run("")  # empty device-JWT claim
+        assert created_by == _uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+    def test_valid_uuid_created_by_preserved(self):
+        real = "11111111-2222-3333-4444-555555555555"
+        created_by, _uuid = self._run(real)
+        assert created_by == _uuid.UUID(real)


### PR DESCRIPTION
Closes #11849

## Thinking Path

`get_current_user` returns a dict in every production branch, but `_current_user_id` read object attributes → always the zero-UUID. Both sides of the #11297 OAuth-state admin-binding collapsed to the same zero-UUID, so ANY admin could complete ANY admin's minted state (the CSRF hole the binding was meant to close). Security fix with a test proven to fail pre-fix.

## What Changed

- `_current_user_id` branches on `isinstance(user, dict)` → `user.get("user_id") or user.get("id")`, object principals via getattr fallback; zero-UUID only for a genuinely id-less principal. (`_current_org_id`/`org_vault_subject` already dict-safe — no change.)
- `_vault_write` guards `uuid.UUID(created_by_id)` in try/except → zero-UUID fallback, never raises on the write path. Essential: the `user_id` claim is NOT always a UUID (auth-disabled uses `"admin"`, device-JWT can be empty).

## Verification

- `test_callback_dict_admin_mismatch_rejected` prestores `admin_id=zero-UUID` (what the buggy initiate stored for a dict admin) and completes as a different dict principal → asserts 403. Confirmed FAILS pre-fix (callback got past the binding into the exchange) and PASSES post-fix (403 before any network call).
- Two pre-existing tests that had encoded the buggy zero-UUID behavior updated; added dict-real-id / object-still-works / absent-id / created_by-real-id / 3 UUID-guard tests.
- 102 tests pass (independent re-run: 97 + 3 security). flake8/black/py_compile clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)