### PR TITLE
cleanup(frontend): prune orphaned ceo-chat surface + cosmetic leftovers (#11692, #11659)

### DIFF
--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -134,8 +134,10 @@ const hasUnsavedChanges = computed(() => {
 })
 
 const canDelete = computed(() => {
-  // Cannot delete if has children (backend enforces this)
-  return !props.category?.has_children
+  // Only offer delete when we can positively confirm the category has no
+  // children (backend rejects deleting a parent). `has_children` is undefined
+  // for browser MainCategory objects (#11626) — treat "unknown" as "hide".
+  return props.category?.has_children === false
 })
 
 // =============================================================================

--- a/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
+++ b/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
@@ -8,7 +8,7 @@
         <h4 id="analytics-documents-title">{{ $t('knowledge.stats.totalDocuments') }}</h4>
         <p class="stat-value" aria-live="polite">{{ documentCount }}</p>
         <p class="stat-change">
-          {{ $t('knowledge.stats.avgDocsPerCategoryValue', { count: avgDocsPerCategory }) }}
+          {{ $t('knowledge.stats.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
         </p>
       </div>
     </BasePanel>

--- a/autobot-frontend/src/composables/useConnectionTester.examples.md
+++ b/autobot-frontend/src/composables/useConnectionTester.examples.md
@@ -805,7 +805,7 @@ Estimated **8-12 components** use connection testing:
 - BackendSettings.vue (230 lines → 87 lines)
 - ConnectionStatus.vue (78 lines → 35 lines)
 - NPUWorkersSettings.vue (est. 40 lines → 15 lines)
-- KnowledgeManager.vue (est. 25 lines → 10 lines)
+- KnowledgeHealth.vue (est. 25 lines → 10 lines)
 - MCPDashboard.vue (est. 30 lines → 12 lines)
 - SystemStatus.vue (est. 35 lines → 14 lines)
 - Additional components (est. 50 lines → 20 lines)

--- a/autobot-frontend/src/composables/useModal.examples.md
+++ b/autobot-frontend/src/composables/useModal.examples.md
@@ -7,7 +7,7 @@ This document demonstrates how to migrate existing components to use the central
 ## Table of Contents
 
 1. [SecretsManager.vue Migration](#secretsmanagervue-migration)
-2. [KnowledgeManager.vue Migration](#knowledgemanagervue-migration)
+2. [KnowledgeEntries.vue Migration](#knowledgeentriesvue-migration)
 3. [BackendSettings.vue Migration](#backendsettingsvue-migration)
 4. [MCPDashboard.vue Migration](#mcpdashboardvue-migration)
 5. [Quick Reference](#quick-reference)
@@ -258,7 +258,7 @@ const openTransferModal = (secret) => {
 
 ---
 
-## KnowledgeManager.vue Migration
+## KnowledgeEntries.vue Migration
 
 ### ❌ BEFORE
 
@@ -674,7 +674,7 @@ For each component with modal state management:
 | Component | Lines Before | Lines After | Saved |
 |-----------|--------------|-------------|-------|
 | SecretsManager.vue | 48 | 10 | 38 |
-| KnowledgeManager.vue | 30 | 15 | 15 |
+| KnowledgeEntries.vue | 30 | 15 | 15 |
 | BackendSettings.vue | 16 | 3 | 13 |
 | MCPDashboard.vue | 30 | 20 | 10 |
 | DatabaseManager.vue | ~24 | 10 | 14 |

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Failed to create company"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ New",
-      "selectCompany": "Select a company to view threads.",
-      "loading": "Loading...",
-      "noThreads": "No threads yet.",
-      "emptyState": "Select a thread or create a new one.",
-      "loadingMessages": "Loading messages...",
-      "noMessages": "No messages yet.",
-      "messagePlaceholder": "Type a message...",
-      "send": "Send",
-      "newThreadTitle": "New Thread",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Thread title...",
-      "cancel": "Cancel",
-      "create": "Create",
-      "creating": "Creating..."
+      "selectCompany": "Select a company to view threads."
     },
     "dashboard": {
       "title": "Company Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
-    },
-    "ceoChat": {
-      "sendError": "Failed to send your message. It has been restored so you can retry."
     },
     "timeline": {
       "rescheduleError": "Failed to save the new schedule. The change was reverted."

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Unternehmen konnte nicht erstellt werden"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ Neu",
-      "selectCompany": "Wählen Sie ein Unternehmen, um Threads anzuzeigen.",
-      "loading": "Wird geladen...",
-      "noThreads": "Noch keine Threads.",
-      "emptyState": "Wählen Sie einen Thread aus oder erstellen Sie einen neuen.",
-      "loadingMessages": "Nachrichten werden geladen...",
-      "noMessages": "Noch keine Nachrichten.",
-      "messagePlaceholder": "Nachricht eingeben...",
-      "send": "Senden",
-      "newThreadTitle": "Neuer Thread",
-      "titleLabel": "Titel",
-      "titlePlaceholder": "Thread-Titel...",
-      "cancel": "Abbrechen",
-      "create": "Erstellen",
-      "creating": "Wird erstellt..."
+      "selectCompany": "Wählen Sie ein Unternehmen, um Threads anzuzeigen."
     },
     "dashboard": {
       "title": "Unternehmens-Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Ihre Entscheidung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut."
-    },
-    "ceoChat": {
-      "sendError": "Ihre Nachricht konnte nicht gesendet werden. Sie wurde wiederhergestellt, damit Sie es erneut versuchen können."
     },
     "timeline": {
       "rescheduleError": "Der neue Zeitplan konnte nicht gespeichert werden. Die Änderung wurde rückgängig gemacht."

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7799,22 +7799,7 @@
       "createFailed": "Failed to create company"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ New",
-      "selectCompany": "Select a company to view threads.",
-      "loading": "Loading...",
-      "noThreads": "No threads yet.",
-      "emptyState": "Select a thread or create a new one.",
-      "loadingMessages": "Loading messages...",
-      "noMessages": "No messages yet.",
-      "messagePlaceholder": "Type a message...",
-      "send": "Send",
-      "newThreadTitle": "New Thread",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Thread title...",
-      "cancel": "Cancel",
-      "create": "Create",
-      "creating": "Creating..."
+      "selectCompany": "Select a company to view threads."
     },
     "dashboard": {
       "title": "Company Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
-    },
-    "ceoChat": {
-      "sendError": "Failed to send your message. It has been restored so you can retry."
     },
     "timeline": {
       "rescheduleError": "Failed to save the new schedule. The change was reverted."

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7810,22 +7810,7 @@
       "createFailed": "No se pudo crear la empresa"
     },
     "ceoChat": {
-      "threads": "Hilos",
-      "newThread": "+ Nuevo",
-      "selectCompany": "Seleccione una empresa para ver los hilos.",
-      "loading": "Cargando...",
-      "noThreads": "Aún no hay hilos.",
-      "emptyState": "Seleccione un hilo o cree uno nuevo.",
-      "loadingMessages": "Cargando mensajes...",
-      "noMessages": "Aún no hay mensajes.",
-      "messagePlaceholder": "Escriba un mensaje...",
-      "send": "Enviar",
-      "newThreadTitle": "Nuevo hilo",
-      "titleLabel": "Título",
-      "titlePlaceholder": "Título del hilo...",
-      "cancel": "Cancelar",
-      "create": "Crear",
-      "creating": "Creando..."
+      "selectCompany": "Seleccione una empresa para ver los hilos."
     },
     "dashboard": {
       "title": "Panel de la empresa",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "No se pudo registrar tu decisión. Inténtalo de nuevo."
-    },
-    "ceoChat": {
-      "sendError": "No se pudo enviar tu mensaje. Se ha restaurado para que puedas reintentarlo."
     },
     "timeline": {
       "rescheduleError": "No se pudo guardar la nueva planificación. El cambio se revirtió."

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Failed to create company"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ New",
-      "selectCompany": "Select a company to view threads.",
-      "loading": "Loading...",
-      "noThreads": "No threads yet.",
-      "emptyState": "Select a thread or create a new one.",
-      "loadingMessages": "Loading messages...",
-      "noMessages": "No messages yet.",
-      "messagePlaceholder": "Type a message...",
-      "send": "Send",
-      "newThreadTitle": "New Thread",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Thread title...",
-      "cancel": "Cancel",
-      "create": "Create",
-      "creating": "Creating..."
+      "selectCompany": "Select a company to view threads."
     },
     "dashboard": {
       "title": "Company Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
-    },
-    "ceoChat": {
-      "sendError": "Failed to send your message. It has been restored so you can retry."
     },
     "timeline": {
       "rescheduleError": "Failed to save the new schedule. The change was reverted."

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Échec de la création de l'entreprise"
     },
     "ceoChat": {
-      "threads": "Fils",
-      "newThread": "+ Nouveau",
-      "selectCompany": "Sélectionnez une entreprise pour afficher les fils.",
-      "loading": "Chargement...",
-      "noThreads": "Aucun fil pour le moment.",
-      "emptyState": "Sélectionnez un fil ou créez-en un nouveau.",
-      "loadingMessages": "Chargement des messages...",
-      "noMessages": "Aucun message pour le moment.",
-      "messagePlaceholder": "Saisissez un message...",
-      "send": "Envoyer",
-      "newThreadTitle": "Nouveau fil",
-      "titleLabel": "Titre",
-      "titlePlaceholder": "Titre du fil...",
-      "cancel": "Annuler",
-      "create": "Créer",
-      "creating": "Création..."
+      "selectCompany": "Sélectionnez une entreprise pour afficher les fils."
     },
     "dashboard": {
       "title": "Tableau de bord de l'entreprise",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Échec de l'enregistrement de votre décision. Veuillez réessayer."
-    },
-    "ceoChat": {
-      "sendError": "Échec de l'envoi de votre message. Il a été restauré pour que vous puissiez réessayer."
     },
     "timeline": {
       "rescheduleError": "Échec de l'enregistrement du nouveau planning. La modification a été annulée."

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Failed to create company"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ New",
-      "selectCompany": "Select a company to view threads.",
-      "loading": "Loading...",
-      "noThreads": "No threads yet.",
-      "emptyState": "Select a thread or create a new one.",
-      "loadingMessages": "Loading messages...",
-      "noMessages": "No messages yet.",
-      "messagePlaceholder": "Type a message...",
-      "send": "Send",
-      "newThreadTitle": "New Thread",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Thread title...",
-      "cancel": "Cancel",
-      "create": "Create",
-      "creating": "Creating..."
+      "selectCompany": "Select a company to view threads."
     },
     "dashboard": {
       "title": "Company Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
-    },
-    "ceoChat": {
-      "sendError": "Failed to send your message. It has been restored so you can retry."
     },
     "timeline": {
       "rescheduleError": "Failed to save the new schedule. The change was reverted."

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Failed to create company"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ New",
-      "selectCompany": "Select a company to view threads.",
-      "loading": "Loading...",
-      "noThreads": "No threads yet.",
-      "emptyState": "Select a thread or create a new one.",
-      "loadingMessages": "Loading messages...",
-      "noMessages": "No messages yet.",
-      "messagePlaceholder": "Type a message...",
-      "send": "Send",
-      "newThreadTitle": "New Thread",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Thread title...",
-      "cancel": "Cancel",
-      "create": "Create",
-      "creating": "Creating..."
+      "selectCompany": "Select a company to view threads."
     },
     "dashboard": {
       "title": "Company Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Neizdevās saglabāt jūsu lēmumu. Lūdzu, mēģiniet vēlreiz."
-    },
-    "ceoChat": {
-      "sendError": "Neizdevās nosūtīt jūsu ziņojumu. Tas ir atjaunots, lai jūs varētu mēģināt vēlreiz."
     },
     "timeline": {
       "rescheduleError": "Neizdevās saglabāt jauno grafiku. Izmaiņas tika atceltas."

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Failed to create company"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ New",
-      "selectCompany": "Select a company to view threads.",
-      "loading": "Loading...",
-      "noThreads": "No threads yet.",
-      "emptyState": "Select a thread or create a new one.",
-      "loadingMessages": "Loading messages...",
-      "noMessages": "No messages yet.",
-      "messagePlaceholder": "Type a message...",
-      "send": "Send",
-      "newThreadTitle": "New Thread",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Thread title...",
-      "cancel": "Cancel",
-      "create": "Create",
-      "creating": "Creating..."
+      "selectCompany": "Select a company to view threads."
     },
     "dashboard": {
       "title": "Company Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Nie udało się zapisać Twojej decyzji. Spróbuj ponownie."
-    },
-    "ceoChat": {
-      "sendError": "Nie udało się wysłać wiadomości. Została przywrócona, aby można było spróbować ponownie."
     },
     "timeline": {
       "rescheduleError": "Nie udało się zapisać nowego harmonogramu. Zmiana została cofnięta."

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Falha ao criar a empresa"
     },
     "ceoChat": {
-      "threads": "Tópicos",
-      "newThread": "+ Novo",
-      "selectCompany": "Selecione uma empresa para ver os tópicos.",
-      "loading": "Carregando...",
-      "noThreads": "Ainda não há tópicos.",
-      "emptyState": "Selecione um tópico ou crie um novo.",
-      "loadingMessages": "Carregando mensagens...",
-      "noMessages": "Ainda não há mensagens.",
-      "messagePlaceholder": "Digite uma mensagem...",
-      "send": "Enviar",
-      "newThreadTitle": "Novo tópico",
-      "titleLabel": "Título",
-      "titlePlaceholder": "Título do tópico...",
-      "cancel": "Cancelar",
-      "create": "Criar",
-      "creating": "Criando..."
+      "selectCompany": "Selecione uma empresa para ver os tópicos."
     },
     "dashboard": {
       "title": "Painel da empresa",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Falha ao registrar sua decisão. Tente novamente."
-    },
-    "ceoChat": {
-      "sendError": "Falha ao enviar sua mensagem. Ela foi restaurada para que você possa tentar novamente."
     },
     "timeline": {
       "rescheduleError": "Falha ao salvar o novo cronograma. A alteração foi revertida."

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -7810,22 +7810,7 @@
       "createFailed": "Failed to create company"
     },
     "ceoChat": {
-      "threads": "Threads",
-      "newThread": "+ New",
-      "selectCompany": "Select a company to view threads.",
-      "loading": "Loading...",
-      "noThreads": "No threads yet.",
-      "emptyState": "Select a thread or create a new one.",
-      "loadingMessages": "Loading messages...",
-      "noMessages": "No messages yet.",
-      "messagePlaceholder": "Type a message...",
-      "send": "Send",
-      "newThreadTitle": "New Thread",
-      "titleLabel": "Title",
-      "titlePlaceholder": "Thread title...",
-      "cancel": "Cancel",
-      "create": "Create",
-      "creating": "Creating..."
+      "selectCompany": "Select a company to view threads."
     },
     "dashboard": {
       "title": "Company Dashboard",
@@ -8523,9 +8508,6 @@
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
-    },
-    "ceoChat": {
-      "sendError": "Failed to send your message. It has been restored so you can retry."
     },
     "timeline": {
       "rescheduleError": "Failed to save the new schedule. The change was reverted."

--- a/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
+++ b/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ChatController } from '../ChatController'
 import * as chatRepository from '@/models/repositories'
+import { useChatStore } from '@/stores/useChatStore'
 
 // Mock the repositories
 vi.mock('@/models/repositories', () => ({
@@ -49,6 +50,20 @@ vi.mock('@/stores/useAppStore', () => ({
   useAppStore: vi.fn(() => ({
     setGlobalError: vi.fn()
   }))
+}))
+
+// Mock the request queue so send flows run the enqueued fn synchronously
+vi.mock('@/composables/useRequestQueue', () => ({
+  requestQueue: {
+    enqueue: vi.fn(({ fn }: { fn: () => unknown }) => fn())
+  }
+}))
+
+// Mock ApiClient (cache invalidation is a no-op side effect on send)
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    invalidateCache: vi.fn()
+  }
 }))
 
 describe('ChatController', () => {
@@ -100,6 +115,75 @@ describe('ChatController', () => {
       // Get the store to verify the call
       const store = controller['chatStore']
       expect(store.createNewSession).toHaveBeenCalledWith('Test Chat', sessionId)
+    })
+  })
+
+  describe('sendMessage activeChatContext merge (#11690)', () => {
+    // Build a store whose activeChatContext scopes sends to a company, with an
+    // existing session so the send path never has to mint a new one.
+    function scopedStore(context: Record<string, unknown>) {
+      return {
+        createNewSession: vi.fn((title: string, sessionId: string) => sessionId),
+        switchToSession: vi.fn(),
+        addMessage: vi.fn(() => 'user-msg-1'),
+        updateMessage: vi.fn(),
+        setTyping: vi.fn(),
+        sessions: [],
+        currentSessionId: 'session-1',
+        activeChatContext: context,
+        settings: { autoSave: false, persistHistory: true }
+      }
+    }
+
+    it('merges activeChatContext into the send options', async () => {
+      vi.mocked(useChatStore).mockReturnValue(
+        scopedStore({ company_id: 'company-42' }) as unknown as ReturnType<typeof useChatStore>
+      )
+      vi.mocked(chatRepository.chatRepository.sendMessage).mockResolvedValue({
+        type: 'json',
+        data: {}
+      } as never)
+
+      await controller.sendMessage('hello CEO')
+
+      expect(chatRepository.chatRepository.sendMessage).toHaveBeenCalledWith(
+        'hello CEO',
+        'session-1',
+        expect.objectContaining({ company_id: 'company-42' })
+      )
+    })
+
+    it('lets explicit call-site options win over activeChatContext', async () => {
+      vi.mocked(useChatStore).mockReturnValue(
+        scopedStore({ company_id: 'company-42' }) as unknown as ReturnType<typeof useChatStore>
+      )
+      vi.mocked(chatRepository.chatRepository.sendMessage).mockResolvedValue({
+        type: 'json',
+        data: {}
+      } as never)
+
+      await controller.sendMessage('hello CEO', { company_id: 'override-7', extra: true })
+
+      expect(chatRepository.chatRepository.sendMessage).toHaveBeenCalledWith(
+        'hello CEO',
+        'session-1',
+        expect.objectContaining({ company_id: 'override-7', extra: true })
+      )
+    })
+
+    it('leaves send options untouched when no context is active', async () => {
+      vi.mocked(useChatStore).mockReturnValue(
+        scopedStore({}) as unknown as ReturnType<typeof useChatStore>
+      )
+      vi.mocked(chatRepository.chatRepository.sendMessage).mockResolvedValue({
+        type: 'json',
+        data: {}
+      } as never)
+
+      await controller.sendMessage('hi there')
+
+      const [, , sentOptions] = vi.mocked(chatRepository.chatRepository.sendMessage).mock.calls[0]
+      expect(sentOptions).not.toHaveProperty('company_id')
     })
   })
 

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -31,8 +31,7 @@ import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('CeoChatView')
 const route = useRoute()
-const props = defineProps<{ companyId?: string }>()
-const companyId = computed(() => (route.params.companyId as string) ?? props.companyId ?? '')
+const companyId = computed(() => (route.params.companyId as string) ?? '')
 
 const chatStore = useChatStore()
 const controller = useChatController()


### PR DESCRIPTION
## Thinking Path
Both issues are post-campaign cleanup surfaced by the same review waves (#11690 CEO-chat rewrite, 2026-07-11 review). Grouping them into one cosmetic-cleanup PR.

## What Changed
### #11692 — orphaned ceo-chat surface
- Removed 15 grep-verified-dead `llc.ceoChat.*` keys + `llcBrowser.ceoChat.sendError` across all 11 locales (kept `selectCompany`, still used by CeoChatView).
- Dropped the redundant `companyId` prop on `CeoChatView` (route uses `props:true`; component reads `route.params.companyId`).
- Added 3 positive `ChatController` tests asserting `activeChatContext` merges into send options (explicit call-site options win; empty context is a no-op).
- Left the old `/api/llc/.../ceo-chat/...` backend routes untouched — retire-vs-repurpose is a decision (policy: never hard-delete); filing a separate decision issue.

### #11659 — cosmetic leftovers
- Updated stale `KnowledgeManager.vue` (deleted #11649) doc references in `useModal.examples.md` / `useConnectionTester.examples.md` to living components.
- `StatsOverviewCards`: Documents card now shows a genuine per-document metric (`avgTagsPerDoc`) instead of duplicating the Categories card's `avgDocsPerCategory` — reuses an existing i18n key, no new backend data.
- `CategoryEditModal.canDelete` now requires `has_children === false`, so it hides Delete when the field is `undefined` (browser `MainCategory` objects, #11626) instead of always showing it.

Closes #11692, closes #11659

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0, zero errors
- `vitest` ChatController 9/9 (incl. 3 new); locale-parity 21/21; useConnectionTester+llcGuards 60/60
- All 11 locale files re-validated as JSON; `llc.ceoChat` pruned to `{selectCompany}` only

## Model Used
Opus 4.8