### PR TITLE
tokenise(ci): stylelint ignoreFiles for token-source CSS — stop color-no-hex false-positives on SSOT (#11871)

### DIFF
--- a/autobot-frontend/.stylelintrc.json
+++ b/autobot-frontend/.stylelintrc.json
@@ -1,4 +1,13 @@
 {
+  "ignoreFiles": [
+    "**/design-tokens.css",
+    "**/themes/*.css",
+    "**/aui-theme.css",
+    "**/styles/theme.css",
+    "**/tailwind.css",
+    "**/vue-notus.css",
+    "**/tokens/contract.css"
+  ],
   "overrides": [
     {
       "files": ["**/*.vue"],

--- a/autobot-slm-frontend/.stylelintrc.json
+++ b/autobot-slm-frontend/.stylelintrc.json
@@ -1,4 +1,7 @@
 {
+  "ignoreFiles": [
+    "**/assets/styles/main.css"
+  ],
   "overrides": [
     {
       "files": ["**/*.vue"],


### PR DESCRIPTION
Closes #11871
Part of #11515 (Task 1.3 prereq)

## Thinking Path

The `color-no-hex` stylelint rule fires on the token-DEFINITION files (design-tokens.css, themes/*.css, main.css @theme, contract.css …) — those legitimately hold hex literals (they ARE the token source). This false-positive reds the "Stylelint (changed CSS/Vue)" job on every PR that adds a token to the SSOT (observed on #11863/#11864). #11515 Task 1.3 names this as its prereq.

## What Changed

- `autobot-frontend/.stylelintrc.json`: `ignoreFiles` for `design-tokens.css`, `themes/*.css`, `aui-theme.css`, `styles/theme.css`, `tailwind.css`, `vue-notus.css`, `tokens/contract.css`.
- `autobot-slm-frontend/.stylelintrc.json`: `ignoreFiles` for `assets/styles/main.css`.
- Does NOT make stylelint a required check (that branch-protection change is separate/owner-gated). The rule stays fully active on consumer components.

## Verification

- Scratch stylelint@16 run: `main.css` and `design-tokens.css` now exit 0 (ignored); a consumer .vue with a raw hex (`PopoutChromiumBrowser.vue`) STILL reports `color-no-hex` (rule intact for consumers). JSON valid.

## Model Used

Claude Fable 5