### PR TITLE
tokenise(user): FunctionCallGraph <style> hardcoded values → design tokens (#11881)

### DIFF
--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -1989,8 +1989,8 @@ watch(viewMode, async (newMode) => {
 }
 
 .graph-info.warning {
-  background: var(--color-warning-bg, rgba(245, 158, 11, 0.1));
-  color: var(--color-warning, #f59e0b);
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
 }
 
 .orphaned-controls {
@@ -2066,7 +2066,7 @@ watch(viewMode, async (newMode) => {
   padding: var(--spacing-0-5) var(--spacing-1-5);
   font-size: var(--text-xs);
   background: var(--color-secondary-bg, rgba(139, 92, 246, 0.1));
-  color: var(--color-secondary, #8b5cf6);
+  color: var(--color-secondary);
   border-radius: var(--radius-sm);
 }
 
@@ -2127,11 +2127,11 @@ watch(viewMode, async (newMode) => {
 
 .stat-orphaned:hover,
 .stat-orphaned.active {
-  background: var(--color-warning-bg, rgba(245, 158, 11, 0.1));
+  background: var(--color-warning-bg);
 }
 
 .stat-orphaned .stat-value {
-  color: var(--color-warning, #f59e0b);
+  color: var(--color-warning);
 }
 
 /* Issue #711: Virtual scroll container for orphaned functions */


### PR DESCRIPTION
Closes #11881
Part of #11515 (Task 4.3/4.4)

## Thinking Path

Chart component — the vast majority of hex (~40) live in `<script>` (Cytoscape graph stylesheets + the data-series node/edge palette passed to the graph lib). Those are JS values, NOT CSS, and must NOT be tokenised (would break data-viz meaning). Only the `<style>` block is in scope.

## What Changed

- `<style>` block only: 5 dead `var(--token, #fallback)` fallbacks dropped (tokens defined in design-tokens.css → fallback never rendered; one was a misleading purple fallback on a token that actually resolves to `#64748b`). 1 undefined-token rgba fallback (`--color-secondary-bg`) **preserved** — it's load-bearing.
- All `<script>` colors (Cytoscape stylesheets, data-series palette) untouched. Style px (spinner/min-heights/borders/9px font) left literal — no exact size/border-width tokens.

## Verification

- `color-no-hex` on extracted `<style>`: pass. `vue-tsc --noEmit -p tsconfig.app.json`: 0 errors. Diff is 5 changes, style-only, no template/script.

## Model Used

Claude Fable 5 (subagent: general-purpose)