### PR TITLE
tokenise(user): WorkItemDetail hardcoded hexes + px → design tokens (#11880)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -609,6 +609,17 @@
   --onboarding-tier-fast: #4ade80;           /* "fast" tier badge text */
   --onboarding-banner-error-text: #fca5a5;   /* error banner foreground */
   --onboarding-banner-warning-text: #fde68a; /* soft (warning) banner foreground */
+
+  /* ============================================
+   * WORK ITEM DETAIL TOKENS
+   * Issue #11880 (umbrella #11515). Scoped to llc/WorkItemDetail.vue.
+   * The "AGENT" comment chip renders a soft-violet badge with no existing
+   * exact semantic token. Hex-only (deliberately NO OKLCH override) so the
+   * chip renders pixel-identical to its previous hardcoded values across all
+   * browsers.
+   * ============================================ */
+  --workitem-agent-chip-bg: #ddd6fe;    /* AGENT comment chip background */
+  --workitem-agent-chip-text: #5b21b6;  /* AGENT comment chip text */
 }
 
 /* ============================================

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -563,8 +563,8 @@ onMounted(() => {
   width: 640px;
   max-width: 90vw;
   height: 100%;
-  background: var(--bg-surface, #fff);
-  border-left: 1px solid var(--border-default, #e5e7eb);
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border-default);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -575,7 +575,7 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  border-bottom: 1px solid var(--border-default);
   flex-shrink: 0;
 }
 
@@ -588,7 +588,7 @@ onMounted(() => {
 .item-identifier {
   font-family: monospace;
   font-size: 0.8rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 
 .close-btn {
@@ -596,13 +596,13 @@ onMounted(() => {
   border: none;
   cursor: pointer;
   padding: 0.25rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   border-radius: 0.25rem;
   transition: background 0.15s;
 }
 
 .close-btn:hover {
-  background: var(--bg-hover, #f3f4f6);
+  background: var(--bg-hover);
 }
 
 .close-icon {
@@ -615,15 +615,15 @@ onMounted(() => {
   align-items: center;
   gap: 0.375rem;
   padding: 0.5rem 1.25rem;
-  background: var(--bg-elevated, #f9fafb);
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-default);
   font-size: 0.75rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
 .breadcrumb-sep {
-  color: var(--border-default, #d1d5db);
+  color: var(--border-default);
 }
 
 .title-row {
@@ -643,10 +643,10 @@ onMounted(() => {
   width: 100%;
   font-size: 1.125rem;
   font-weight: 600;
-  border: 1px solid var(--color-primary, #3b82f6);
+  border: 1px solid var(--color-primary);
   border-radius: 0.25rem;
   padding: 0.25rem 0.5rem;
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   color: var(--text-primary);
 }
 
@@ -655,7 +655,7 @@ onMounted(() => {
   flex-wrap: wrap;
   gap: 1rem;
   padding: 0.5rem 1.25rem;
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  border-bottom: 1px solid var(--border-default);
   flex-shrink: 0;
 }
 
@@ -667,7 +667,7 @@ onMounted(() => {
 
 .meta-label {
   font-size: 0.7rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -675,8 +675,8 @@ onMounted(() => {
 .assignee-chip {
   font-size: 0.8rem;
   padding: 0.1rem 0.5rem;
-  background: var(--bg-elevated, #f3f4f6);
-  border-radius: 9999px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-full);
 }
 
 .assignee-row {
@@ -687,7 +687,7 @@ onMounted(() => {
 
 .assignee-edit {
   font-size: 0.75rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   cursor: pointer;
 }
 
@@ -701,18 +701,18 @@ onMounted(() => {
 .assignee-select {
   font-size: 0.8rem;
   padding: 0.25rem;
-  border: 1px solid var(--border-default, #e5e7eb);
-  border-radius: var(--radius-md, 6px);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
 }
 
 .assignee-cancel {
   font-size: 0.75rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 
 .meta-empty {
   font-size: 0.8rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   font-style: italic;
 }
 
@@ -725,15 +725,15 @@ onMounted(() => {
 .label-chip {
   font-size: 0.7rem;
   padding: 0.1rem 0.45rem;
-  background: var(--bg-elevated, #f3f4f6);
-  border-radius: 9999px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-full);
 }
 
 .action-bar {
   display: flex;
   gap: 0.5rem;
   padding: 0.625rem 1.25rem;
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  border-bottom: 1px solid var(--border-default);
   flex-wrap: wrap;
   flex-shrink: 0;
 }
@@ -742,15 +742,15 @@ onMounted(() => {
   font-size: 0.8rem;
   padding: 0.35rem 0.75rem;
   border-radius: 0.375rem;
-  border: 1px solid var(--border-default, #d1d5db);
-  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
   color: var(--text-primary);
   cursor: pointer;
   transition: background 0.15s;
 }
 
 .action-btn:hover:not(:disabled) {
-  background: var(--bg-hover, #f3f4f6);
+  background: var(--bg-hover);
 }
 
 .action-btn:disabled {
@@ -759,18 +759,18 @@ onMounted(() => {
 }
 
 .action-done, .action-ready {
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .action-done:hover:not(:disabled), .action-ready:hover:not(:disabled) {
-  background: var(--color-primary-hover, #2563eb);
+  background: var(--color-primary-hover);
 }
 
 .tab-bar {
   display: flex;
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  border-bottom: 1px solid var(--border-default);
   flex-shrink: 0;
 }
 
@@ -780,15 +780,15 @@ onMounted(() => {
   font-weight: 500;
   border: none;
   background: none;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   cursor: pointer;
   border-bottom: 2px solid transparent;
   transition: color 0.15s, border-color 0.15s;
 }
 
 .tab-btn.active {
-  color: var(--color-primary, #3b82f6);
-  border-bottom-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
 }
 
 .tab-btn:hover:not(.active) {
@@ -813,7 +813,7 @@ onMounted(() => {
 .section-label {
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -828,9 +828,9 @@ onMounted(() => {
 .desc-textarea {
   width: 100%;
   padding: 0.5rem;
-  border: 1px solid var(--color-primary, #3b82f6);
+  border: 1px solid var(--color-primary);
   border-radius: 0.375rem;
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   color: var(--text-primary);
   font-size: 0.875rem;
   resize: vertical;
@@ -852,7 +852,7 @@ onMounted(() => {
 
 .ac-done {
   text-decoration: line-through;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .comments-list {
@@ -881,7 +881,7 @@ onMounted(() => {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 50%;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
   font-size: 0.65rem;
   font-weight: 600;
@@ -901,15 +901,15 @@ onMounted(() => {
 
 .comment-time {
   font-size: 0.7rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .agent-chip {
   font-size: 0.65rem;
   padding: 0.05rem 0.35rem;
-  background: #ddd6fe;
-  color: #5b21b6;
-  border-radius: 9999px;
+  background: var(--workitem-agent-chip-bg);
+  color: var(--workitem-agent-chip-text);
+  border-radius: var(--radius-full);
 }
 
 .comment-body {
@@ -924,15 +924,15 @@ onMounted(() => {
   align-items: flex-end;
   flex-shrink: 0;
   padding-top: 0.5rem;
-  border-top: 1px solid var(--border-default, #e5e7eb);
+  border-top: 1px solid var(--border-default);
 }
 
 .comment-textarea {
   flex: 1;
   padding: 0.5rem;
-  border: 1px solid var(--border-default, #d1d5db);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   color: var(--text-primary);
   font-size: 0.875rem;
   resize: none;
@@ -950,9 +950,9 @@ onMounted(() => {
   align-items: center;
   gap: 0.75rem;
   padding: 0.5rem 0.75rem;
-  background: var(--bg-elevated, #f9fafb);
+  background: var(--bg-elevated);
   border-radius: 0.375rem;
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
 }
 
 .artifact-type-icon {
@@ -973,13 +973,13 @@ onMounted(() => {
 
 .artifact-type-label {
   font-size: 0.7rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   text-transform: capitalize;
 }
 
 .artifact-link {
   font-size: 0.8rem;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   text-decoration: none;
 }
 
@@ -995,7 +995,7 @@ onMounted(() => {
 }
 
 .activity-time {
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   flex-shrink: 0;
   font-size: 0.7rem;
 }
@@ -1016,7 +1016,7 @@ onMounted(() => {
 
 .btn-primary {
   padding: 0.5rem 1rem;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -1028,7 +1028,7 @@ onMounted(() => {
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-hover, #2563eb);
+  background: var(--color-primary-hover);
 }
 
 .btn-primary:disabled {


### PR DESCRIPTION
Closes #11880
Part of #11515 (Task 4.3/4.4)

## Thinking Path

Visual equivalence: 47 dead hex fallbacks dropped (tokens defined → fallback never rendered; one purple fallback was even stale-wrong vs the token's actual `#64748b`); radius px → exact tokens; 2 bare colors with no token → hex-only tokens (no OKLCH drift).

## What Changed

- 47 `var(--token, #hex)` → `var(--token)` (dead fallbacks). `9999px` ×3 → `--radius-full`; dead `--radius-md` px fallback dropped.
- 2 bare `.agent-chip` colors → new hex-only `--workitem-agent-chip-bg/-text` (outside `@supports oklch`, byte-exact).
- Left literal: rgba(0,0,0,0.3) overlay, 640px, 1px/2px borders, `color: white` keyword.

## Verification

- `color-no-hex` on `<style>`: zero hex. `vue-tsc --noEmit -p tsconfig.app.json`: 0 errors. Style-only.

## Model Used

Claude Fable 5 (subagent: general-purpose)