### PR TITLE
tokenise(user): ChromaDBExplorer hardcoded px → spacing tokens (#11887)

### DIFF
--- a/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
@@ -461,8 +461,8 @@ onMounted(() => {
 }
 
 .header-icon {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   color: var(--color-info);
 }
 
@@ -496,8 +496,8 @@ onMounted(() => {
 }
 
 .error-alert svg {
-  width: 20px;
-  height: 20px;
+  width: var(--spacing-5);
+  height: var(--spacing-5);
   flex-shrink: 0;
 }
 
@@ -514,8 +514,8 @@ onMounted(() => {
 }
 
 .error-alert button svg {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
 }
 
 /* ============================================
@@ -571,8 +571,8 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   background: transparent;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -664,8 +664,8 @@ onMounted(() => {
 }
 
 .collection-item svg {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   flex-shrink: 0;
 }
 
@@ -684,8 +684,8 @@ onMounted(() => {
 }
 
 .spinner {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border: 3px solid var(--border-default);
   border-top-color: var(--color-info);
   border-radius: 50%;
@@ -694,8 +694,8 @@ onMounted(() => {
 }
 
 .empty-state svg {
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-12);
+  height: var(--spacing-12);
   margin-bottom: var(--spacing-3);
   opacity: 0.5;
 }
@@ -713,8 +713,8 @@ onMounted(() => {
 }
 
 .empty-selection svg {
-  width: 64px;
-  height: 64px;
+  width: var(--spacing-16);
+  height: var(--spacing-16);
   margin-bottom: var(--spacing-4);
   opacity: 0.5;
 }
@@ -763,8 +763,8 @@ onMounted(() => {
 }
 
 .back-btn svg {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
 }
 
 .details-header h2 {
@@ -844,7 +844,7 @@ onMounted(() => {
 }
 
 .search-limit {
-  width: 80px;
+  width: var(--spacing-20);
   padding: var(--spacing-2) var(--spacing-3);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
@@ -878,8 +878,8 @@ onMounted(() => {
 }
 
 .search-btn svg {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
 }
 
 /* ============================================
@@ -1015,8 +1015,8 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   background: transparent;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -1036,8 +1036,8 @@ onMounted(() => {
 }
 
 .page-btn svg {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
 }
 
 .page-info {
@@ -1117,8 +1117,8 @@ onMounted(() => {
 }
 
 .metadata-toggle svg {
-  width: 14px;
-  height: 14px;
+  width: var(--spacing-3-5);
+  height: var(--spacing-3-5);
   transition: transform var(--duration-150) ease;
 }
 


### PR DESCRIPTION
Closes #11887
Part of #11515 (Task 4.4)

## Thinking Path

Px-heavy component. The "5 hex" were false positives (issue-ref comments `#8999`/`#10750`, not colors — color-no-hex confirms zero real hex). Migrated the 27 style px to exact-value spacing tokens.

## What Changed

- 27 width/height px → `--spacing-*` (family-matched per repo convention; exact at 16px root: 32→`--spacing-8`, 16→`--spacing-4`, 48→`--spacing-12`, 64→`--spacing-16`, 80→`--spacing-20`, 20→`--spacing-5`, 14→`--spacing-3-5`).
- Left literal: 1px borders ×20, 3px/0.5px/18px (no exact token), off-scale layout (1400/320/400px, media query), 50%.

## Verification

- Only `width:`/`height:` lines changed, each to an identical-value token — pixels identical. stylelint `color-no-hex` exit 0; `vue-tsc --noEmit -p tsconfig.app.json` exit 0. Style-only (27/27).

## Model Used

Claude Fable 5 (subagent: general-purpose)