### PR TITLE
fix(slm): scope literal-capture blue tokens to --slm-blue-* — stop overriding Tailwind v4 palette globally (#11896)

### DIFF
--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -216,7 +216,9 @@
   --z-toast: 1300;
 }
 
-/* ─── Component literal captures (#11858 / #11515 Task 4) ─────────────
+/* ─── Component literal captures (#11858 / #11896 / #11515 Task 4) ─────
+   * Scoped --slm-* namespace (NOT Tailwind --color-* palette names) so these
+   * fixed hexes do NOT override Tailwind v4's oklch palette globally (#11896).
  * Exact-value tokens for hardcoded colors migrated out of SLM components
  * (SetupWizardView.vue first). Each value is byte-identical to the original
  * literal, so the migration is a pure rename with zero pixel change. Grouped
@@ -227,9 +229,9 @@
   /* Blue action shades used by the setup wizard's buttons/badges — distinct
    * from the sky --color-primary; captured verbatim pending palette
    * consolidation (#11515). */
-  --color-blue-400: #60a5fa;
-  --color-blue-500: #3b82f6;
-  --color-blue-600: #2563eb;
+  --slm-blue-400: #60a5fa;
+  --slm-blue-500: #3b82f6;
+  --slm-blue-600: #2563eb;
   /* Console / provision-log semantics for terminal-style output panels. */
   --color-log-bg: #0d0d0d;
   --color-log-info: #a0d0a0;

--- a/autobot-slm-frontend/src/views/SetupWizardView.vue
+++ b/autobot-slm-frontend/src/views/SetupWizardView.vue
@@ -1260,7 +1260,7 @@ onMounted(async () => {
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: var(--color-blue-600);
+  background: var(--slm-blue-600);
 }
 
 .btn-primary:disabled {
@@ -1343,7 +1343,7 @@ onMounted(async () => {
 
 .status-badge.enrolling {
   background: rgba(59, 130, 246, 0.15);
-  color: var(--color-blue-500);
+  color: var(--slm-blue-500);
 }
 
 .empty-state {
@@ -1587,7 +1587,7 @@ input.full-width {
 }
 
 .log-task {
-  color: var(--color-blue-400);
+  color: var(--slm-blue-400);
   font-weight: 600;
 }
 
@@ -1616,7 +1616,7 @@ input.full-width {
 }
 
 .provision-stage {
-  color: var(--color-blue-400);
+  color: var(--slm-blue-400);
   font-weight: 600;
 }
 
@@ -1642,7 +1642,7 @@ input.full-width {
 
 .phase-active {
   border-color: rgba(96, 165, 250, 0.5);
-  color: var(--color-blue-400);
+  color: var(--slm-blue-400);
   font-weight: 600;
 }
 


### PR DESCRIPTION
Closes #11896

## Thinking Path

Owner decision: scoped names, no regression. #11858's SLM tokenisation added `--color-blue-400/500/600: <hex>` to a global `:root` "literal captures" block that comes after `@import 'tailwindcss'` — overriding Tailwind v4's oklch blue palette. Since Tailwind v4's oklch blue-600 (#155dfc) ≠ the classic hex (#2563eb), **40 SLM files using `bg-blue-600` utilities silently shifted colour**. The SLM `@theme` defines only `--color-primary/success/warning/danger-*`, so these blue names are true Tailwind overrides.

## What Changed

- `main.css`: renamed the 3 captures `--color-blue-400/500/600` → `--slm-blue-400/500/600` (scoped namespace, no Tailwind collision); block header documents the rationale.
- `SetupWizardView.vue`: its 5 `var(--color-blue-*)` refs → `var(--slm-blue-*)` — stays byte-identical (`--slm-blue-600: #2563eb`).
- Net effect: the 40 utility-using files revert to Tailwind's oklch blue (pre-#11858 rendering restored); SetupWizardView unchanged.

## Verification

- Zero `var(--color-blue-*)` refs remain in SLM. Braces balanced. Rename-only, style-only.
- Establishes the `--slm-*` scoped-capture namespace that pending #11892/#11893 will use for their gray/red/indigo captures (prevents the same collision).

## Model Used

Claude Fable 5