### PR TITLE
tokenise(slm): OrgChartTab hardcoded hexes + px → design tokens (#11893)

### DIFF
--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -240,21 +240,32 @@
   --color-log-warning: #fbbf24;
   --color-log-phase: #a78bfa;
   --color-log-current-task: #93c5fd;
-  /* Neutral gray-scale literals for scoped component chrome (AgentsView, …)
-   * that must stay a fixed shade regardless of the active theme — unlike the
-   * theme-adaptive --a11y-* set. Tailwind gray-scale values, captured verbatim. */
+  /* Scoped fixed-shade component-chrome captures (AgentsView #11892, OrgChartTab
+   * #11893, …) that must stay a fixed shade regardless of the active theme —
+   * unlike the theme-adaptive --a11y-* set. Tailwind-scale values, captured
+   * verbatim (byte-identical, zero pixel change) pending semantic consolidation
+   * (#11515). */
   --slm-gray-50: #f9fafb;
   --slm-gray-100: #f3f4f6;
   --slm-gray-200: #e5e7eb;
   --slm-gray-300: #d1d5db;
+  --slm-gray-500: #6b7280;
   --slm-gray-700: #374151;
+  --slm-red-100: #fee2e2;
+  --slm-red-700: #b91c1c;
+  --slm-blue-100: #dbeafe;
   /* Indigo action shades (agent badges / edit button / focused endpoint input). */
   --slm-indigo-100: #e0e7ff;
   --slm-indigo-500: #6366f1;
+  --slm-indigo-600: #4f46e5;
+  --slm-violet-100: #ede9fe;
+  --slm-violet-600: #7c3aed;
   /* Emerald save-action + red error-banner tints. */
+  --slm-emerald-100: #d1fae5;
   --slm-emerald-500: #10b981;
-  --slm-red-100: #fee2e2;
-  --slm-red-700: #b91c1c;
+  --slm-emerald-600: #059669;
+  --slm-orange-100: #ffedd5;
+  --slm-orange-600: #ea580c;
 }
 
 /* ─── High Contrast Mode (Issue #754) ────────────────────────── */

--- a/autobot-slm-frontend/src/components/agents/OrgChartTab.vue
+++ b/autobot-slm-frontend/src/components/agents/OrgChartTab.vue
@@ -275,52 +275,52 @@ onMounted(fetchTree)
 </template>
 
 <style scoped>
-.org-layout { display: grid; grid-template-columns: 380px 1fr; gap: 24px; }
-.tree-panel, .detail-panel { background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 20px; }
-.tree-panel h3, .detail-panel h3 { font-size: 18px; font-weight: 600; margin: 0 0 16px 0; color: var(--text-primary, #1a1a2e); }
+.org-layout { display: grid; grid-template-columns: 380px 1fr; gap: var(--spacing-6); }
+.tree-panel, .detail-panel { background: white; border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: var(--spacing-5); }
+.tree-panel h3, .detail-panel h3 { font-size: var(--text-lg); font-weight: 600; margin: 0 0 var(--spacing-4) 0; color: var(--text-primary); }
 .tree-list { list-style: none; padding: 0; margin: 0; max-height: 600px; overflow-y: auto; }
-.tree-list li { padding: 10px 12px; border-radius: 8px; cursor: pointer; display: flex; align-items: center; gap: 8px; margin-bottom: 2px; }
-.tree-list li:hover { background: #f3f4f6; }
-.tree-list li.selected { background: #e0e7ff; }
+.tree-list li { padding: 10px var(--spacing-3); border-radius: var(--radius-lg); cursor: pointer; display: flex; align-items: center; gap: var(--spacing-2); margin-bottom: 2px; }
+.tree-list li:hover { background: var(--slm-gray-100); }
+.tree-list li.selected { background: var(--slm-indigo-100); }
 .indent-1 { padding-left: 36px !important; }
-.node-name { font-weight: 500; color: var(--text-primary, #1a1a2e); }
-.reports-count { font-size: 11px; color: var(--text-secondary, #6b7280); margin-left: auto; }
-.role-badge { font-size: 10px; padding: 2px 8px; border-radius: 4px; font-weight: 600; text-transform: uppercase; }
+.node-name { font-weight: 500; color: var(--text-primary); }
+.reports-count { font-size: 11px; color: var(--text-secondary); margin-left: auto; }
+.role-badge { font-size: 10px; padding: 2px var(--spacing-2); border-radius: var(--radius-default); font-weight: 600; text-transform: uppercase; }
 .role-badge.small { font-size: 9px; padding: 1px 6px; }
-.badge-purple { background: #ede9fe; color: #7c3aed; }
-.badge-blue { background: #dbeafe; color: #2563eb; }
-.badge-green { background: #d1fae5; color: #059669; }
-.badge-gray { background: #f3f4f6; color: #6b7280; }
-.badge-red { background: #fee2e2; color: #dc2626; }
-.badge-orange { background: #ffedd5; color: #ea580c; }
-.agent-title { color: var(--text-secondary, #6b7280); font-size: 14px; margin: 4px 0 16px; }
-.capabilities { font-size: 13px; color: var(--text-secondary, #6b7280); margin-bottom: 16px; line-height: 1.5; }
-.activity-summary, .direct-reports, .delegate-section, .delegations-list { margin-top: 20px; padding-top: 16px; border-top: 1px solid #e5e7eb; }
-h4 { font-size: 14px; font-weight: 600; margin: 0 0 12px 0; color: var(--text-primary, #1a1a2e); }
-.activity-grid { display: flex; gap: 16px; flex-wrap: wrap; }
+.badge-purple { background: var(--slm-violet-100); color: var(--slm-violet-600); }
+.badge-blue { background: var(--slm-blue-100); color: var(--slm-blue-600); }
+.badge-green { background: var(--slm-emerald-100); color: var(--slm-emerald-600); }
+.badge-gray { background: var(--slm-gray-100); color: var(--slm-gray-500); }
+.badge-red { background: var(--slm-red-100); color: var(--color-danger-600); }
+.badge-orange { background: var(--slm-orange-100); color: var(--slm-orange-600); }
+.agent-title { color: var(--text-secondary); font-size: var(--text-sm); margin: var(--spacing-1) 0 var(--spacing-4); }
+.capabilities { font-size: 13px; color: var(--text-secondary); margin-bottom: var(--spacing-4); line-height: 1.5; }
+.activity-summary, .direct-reports, .delegate-section, .delegations-list { margin-top: var(--spacing-5); padding-top: var(--spacing-4); border-top: 1px solid var(--slm-gray-200); }
+h4 { font-size: var(--text-sm); font-weight: 600; margin: 0 0 var(--spacing-3) 0; color: var(--text-primary); }
+.activity-grid { display: flex; gap: var(--spacing-4); flex-wrap: wrap; }
 .activity-stat { text-align: center; }
-.activity-stat .stat-value { display: block; font-size: 20px; font-weight: 700; color: var(--primary, #6366f1); }
-.activity-stat .stat-label { font-size: 11px; color: var(--text-secondary, #6b7280); text-transform: capitalize; }
+.activity-stat .stat-value { display: block; font-size: var(--text-xl); font-weight: 700; color: var(--primary); }
+.activity-stat .stat-label { font-size: 11px; color: var(--text-secondary); text-transform: capitalize; }
 .direct-reports ul { list-style: none; padding: 0; margin: 0; }
-.direct-reports li { padding: 6px 0; display: flex; align-items: center; gap: 8px; font-size: 14px; }
-.delegate-form { background: #f9fafb; border-radius: 8px; padding: 16px; }
-.form-group { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }
-.form-group label { font-size: 13px; font-weight: 500; color: var(--text-secondary, #6b7280); }
-.form-group select, .form-group textarea { padding: 8px 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 14px; font-family: inherit; }
-.form-actions { display: flex; gap: 8px; }
-.btn-primary { background: #6366f1; color: white; border: none; padding: 8px 16px; border-radius: 6px; font-size: 14px; font-weight: 500; cursor: pointer; }
-.btn-primary:hover { background: #4f46e5; }
-.btn-cancel { background: #e5e7eb; color: #374151; border: none; padding: 8px 16px; border-radius: 6px; font-size: 14px; cursor: pointer; }
-.delegation-item { padding: 10px 0; border-bottom: 1px solid #f3f4f6; }
-.delegation-header { display: flex; align-items: center; gap: 8px; }
-.status-badge { font-size: 10px; padding: 2px 8px; border-radius: 4px; font-weight: 600; text-transform: uppercase; }
-.delegation-assignee { font-size: 13px; color: var(--text-secondary, #6b7280); }
-.delegation-desc { font-size: 13px; margin: 4px 0 2px; color: var(--text-primary, #1a1a2e); }
-.delegation-time { font-size: 11px; color: var(--text-secondary, #6b7280); }
-.detail-panel.empty-state { display: flex; align-items: center; justify-content: center; min-height: 400px; color: var(--text-secondary, #6b7280); }
-.empty-state { color: var(--text-secondary, #6b7280); text-align: center; padding: 40px; }
-.error-banner { background: #fee2e2; border: 1px solid #ef4444; color: #b91c1c; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; display: flex; justify-content: space-between; align-items: center; }
-.error-inline { background: #fee2e2; color: #b91c1c; padding: 8px 12px; border-radius: 6px; font-size: 13px; margin-bottom: 12px; }
-.loading { text-align: center; color: var(--text-secondary, #6b7280); padding: 60px; }
-.detail-header { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+.direct-reports li { padding: 6px 0; display: flex; align-items: center; gap: var(--spacing-2); font-size: var(--text-sm); }
+.delegate-form { background: var(--slm-gray-50); border-radius: var(--radius-lg); padding: var(--spacing-4); }
+.form-group { display: flex; flex-direction: column; gap: var(--spacing-1); margin-bottom: var(--spacing-3); }
+.form-group label { font-size: 13px; font-weight: 500; color: var(--text-secondary); }
+.form-group select, .form-group textarea { padding: var(--spacing-2) var(--spacing-3); border: 1px solid var(--slm-gray-300); border-radius: var(--radius-lg); font-size: var(--text-sm); font-family: inherit; }
+.form-actions { display: flex; gap: var(--spacing-2); }
+.btn-primary { background: var(--slm-indigo-500); color: white; border: none; padding: var(--spacing-2) var(--spacing-4); border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; }
+.btn-primary:hover { background: var(--slm-indigo-600); }
+.btn-cancel { background: var(--slm-gray-200); color: var(--slm-gray-700); border: none; padding: var(--spacing-2) var(--spacing-4); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; }
+.delegation-item { padding: 10px 0; border-bottom: 1px solid var(--slm-gray-100); }
+.delegation-header { display: flex; align-items: center; gap: var(--spacing-2); }
+.status-badge { font-size: 10px; padding: 2px var(--spacing-2); border-radius: var(--radius-default); font-weight: 600; text-transform: uppercase; }
+.delegation-assignee { font-size: 13px; color: var(--text-secondary); }
+.delegation-desc { font-size: 13px; margin: var(--spacing-1) 0 2px; color: var(--text-primary); }
+.delegation-time { font-size: 11px; color: var(--text-secondary); }
+.detail-panel.empty-state { display: flex; align-items: center; justify-content: center; min-height: 400px; color: var(--text-secondary); }
+.empty-state { color: var(--text-secondary); text-align: center; padding: var(--spacing-10); }
+.error-banner { background: var(--slm-red-100); border: 1px solid var(--color-danger-500); color: var(--slm-red-700); padding: var(--spacing-3) var(--spacing-4); border-radius: var(--radius-lg); margin-bottom: var(--spacing-4); display: flex; justify-content: space-between; align-items: center; }
+.error-inline { background: var(--slm-red-100); color: var(--slm-red-700); padding: var(--spacing-2) var(--spacing-3); border-radius: var(--radius-md); font-size: 13px; margin-bottom: var(--spacing-3); }
+.loading { text-align: center; color: var(--text-secondary); padding: 60px; }
+.detail-header { display: flex; align-items: center; gap: var(--spacing-3); margin-bottom: var(--spacing-2); }
 </style>


### PR DESCRIPTION
Closes #11893
Part of #11515 (Task 4.1/4.2). Depends on #11897 (defines --slm-blue-600).

## Thinking Path

42 style hexes + 85 px. Literal captures use the scoped `--slm-*` namespace (per #11896 owner decision) — NOT Tailwind `--color-*` palette names — so they don't override Tailwind v4's oklch palette globally.

## What Changed

- Dead `var(--token,#hex)` fallbacks dropped (theme-adaptive tokens win). Raw literals → 18 scoped `--slm-gray/red/blue/indigo/violet/emerald/orange-*` capture tokens (byte-identical hexes). px → `--spacing-*`/`--radius-*`/`--text-*` (exact at 16px root). Reuses `--slm-blue-600` (from #11897) + legit `--color-danger-*` semantic tokens.
- Script (1 hex, org-chart is class-driven — no data-viz script colours) + template untouched. Off-scale px/rgba/1px borders left literal.

## Verification

- Zero Tailwind-palette-colliding `--color-*` refs. All 21 colour tokens byte-identical to originals. Style-only diff.

## Model Used

Claude Fable 5 (subagent: general-purpose)