### PR TITLE
tokenise(slm): ProcessMonitorTab — 43 hex + 93 px → design tokens

### DIFF
--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -266,6 +266,10 @@
   --slm-emerald-600: #059669;
   --slm-orange-100: #ffedd5;
   --slm-orange-600: #ea580c;
+  /* Amber confirm-action + slate terminal-panel shades (ProcessMonitorTab #11899). */
+  --slm-amber-500: #f59e0b;
+  --slm-slate-200: #e2e8f0;
+  --slm-slate-800: #1e293b;
 }
 
 /* ─── High Contrast Mode (Issue #754) ────────────────────────── */

--- a/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
+++ b/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
@@ -380,50 +380,50 @@ function formatTime(iso: string | null): string {
 </template>
 
 <style scoped>
-.controls-bar { display: flex; align-items: flex-end; gap: 12px; margin-bottom: 20px; background: white; padding: 16px 20px; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); flex-wrap: wrap; }
-.control-group { display: flex; flex-direction: column; gap: 4px; }
-.control-group label { font-size: 13px; font-weight: 500; color: var(--text-secondary, #6b7280); }
-.control-group input, .control-group select { padding: 8px 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 14px; min-width: 160px; }
-.btn-primary { background: #6366f1; color: white; border: none; padding: 8px 16px; border-radius: 6px; font-size: 14px; font-weight: 500; cursor: pointer; }
-.btn-primary:hover { background: #4f46e5; }
+.controls-bar { display: flex; align-items: flex-end; gap: var(--spacing-3); margin-bottom: var(--spacing-5); background: white; padding: var(--spacing-4) var(--spacing-5); border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); flex-wrap: wrap; }
+.control-group { display: flex; flex-direction: column; gap: var(--spacing-1); }
+.control-group label { font-size: 13px; font-weight: 500; color: var(--text-secondary); }
+.control-group input, .control-group select { padding: var(--spacing-2) var(--spacing-3); border: 1px solid var(--slm-gray-300); border-radius: var(--radius-lg); font-size: var(--text-sm); min-width: 160px; }
+.btn-primary { background: var(--slm-indigo-500); color: white; border: none; padding: var(--spacing-2) var(--spacing-4); border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; }
+.btn-primary:hover { background: var(--slm-indigo-600); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-secondary { background: white; color: #374151; border: 1px solid #d1d5db; padding: 8px 16px; border-radius: 6px; font-size: 14px; cursor: pointer; }
-.btn-secondary:hover { background: #f3f4f6; }
-.spawn-form-panel { background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 20px; margin-bottom: 20px; }
-.spawn-form-panel h4 { font-size: 16px; font-weight: 600; margin: 0 0 16px 0; color: var(--text-primary, #1a1a2e); }
-.spawn-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-bottom: 16px; }
-.spawn-actions { display: flex; gap: 8px; }
-.btn-cancel { background: #e5e7eb; color: #374151; border: none; padding: 8px 16px; border-radius: 6px; font-size: 14px; cursor: pointer; }
-.process-table-wrapper { background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: hidden; }
-.process-table { width: 100%; border-collapse: collapse; font-size: 14px; }
-.process-table th { text-align: left; padding: 12px 16px; background: #f9fafb; color: var(--text-secondary, #6b7280); font-weight: 600; font-size: 12px; text-transform: uppercase; border-bottom: 1px solid #e5e7eb; }
-.process-table td { padding: 12px 16px; border-bottom: 1px solid #f3f4f6; color: var(--text-primary, #1a1a2e); }
+.btn-secondary { background: white; color: var(--slm-gray-700); border: 1px solid var(--slm-gray-300); padding: var(--spacing-2) var(--spacing-4); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; }
+.btn-secondary:hover { background: var(--slm-gray-100); }
+.spawn-form-panel { background: white; border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: var(--spacing-5); margin-bottom: var(--spacing-5); }
+.spawn-form-panel h4 { font-size: var(--text-base); font-weight: 600; margin: 0 0 var(--spacing-4) 0; color: var(--text-primary); }
+.spawn-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--spacing-3); margin-bottom: var(--spacing-4); }
+.spawn-actions { display: flex; gap: var(--spacing-2); }
+.btn-cancel { background: var(--slm-gray-200); color: var(--slm-gray-700); border: none; padding: var(--spacing-2) var(--spacing-4); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; }
+.process-table-wrapper { background: white; border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: hidden; }
+.process-table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+.process-table th { text-align: left; padding: var(--spacing-3) var(--spacing-4); background: var(--slm-gray-50); color: var(--text-secondary); font-weight: 600; font-size: var(--text-xs); text-transform: uppercase; border-bottom: 1px solid var(--slm-gray-200); }
+.process-table td { padding: var(--spacing-3) var(--spacing-4); border-bottom: 1px solid var(--slm-gray-100); color: var(--text-primary); }
 .process-table tr { cursor: pointer; }
-.process-table tr:hover { background: #f9fafb; }
-.process-table tr.selected { background: #e0e7ff; }
-.command-cell { font-family: 'IBM Plex Mono', monospace; font-size: 12px; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.time-cell { font-size: 12px; color: var(--text-secondary, #6b7280); }
-.status-badge { font-size: 10px; padding: 2px 8px; border-radius: 4px; font-weight: 600; text-transform: uppercase; }
-.badge-gray { background: #f3f4f6; color: #6b7280; }
-.badge-blue { background: #dbeafe; color: #2563eb; }
-.badge-green { background: #d1fae5; color: #059669; }
-.badge-red { background: #fee2e2; color: #dc2626; }
-.badge-orange { background: #ffedd5; color: #ea580c; }
+.process-table tr:hover { background: var(--slm-gray-50); }
+.process-table tr.selected { background: var(--slm-indigo-100); }
+.command-cell { font-family: 'IBM Plex Mono', monospace; font-size: var(--text-xs); max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.time-cell { font-size: var(--text-xs); color: var(--text-secondary); }
+.status-badge { font-size: 10px; padding: 2px var(--spacing-2); border-radius: var(--radius-default); font-weight: 600; text-transform: uppercase; }
+.badge-gray { background: var(--slm-gray-100); color: var(--slm-gray-500); }
+.badge-blue { background: var(--slm-blue-100); color: var(--slm-blue-600); }
+.badge-green { background: var(--slm-emerald-100); color: var(--slm-emerald-600); }
+.badge-red { background: var(--slm-red-100); color: var(--color-danger-600); }
+.badge-orange { background: var(--slm-orange-100); color: var(--slm-orange-600); }
 .badge-pulse { animation: pulse 2s ease-in-out infinite; }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
-.btn-kill { background: #ef4444; color: white; border: none; padding: 4px 10px; border-radius: 4px; font-size: 12px; font-weight: 500; cursor: pointer; }
-.btn-kill:hover { background: #dc2626; }
-.kill-confirm { display: flex; gap: 4px; align-items: center; }
-.btn-confirm { background: #f59e0b; color: white; border: none; padding: 4px 8px; border-radius: 4px; font-size: 11px; cursor: pointer; }
-.btn-danger { background: #ef4444; }
-.btn-cancel-sm { background: #e5e7eb; color: #374151; border: none; padding: 2px 6px; border-radius: 4px; font-size: 11px; cursor: pointer; }
-.log-panel { background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 20px; margin-top: 20px; }
-.log-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
-.log-header h4 { font-size: 16px; font-weight: 600; margin: 0; color: var(--text-primary, #1a1a2e); display: flex; align-items: center; gap: 8px; }
-.log-actions { display: flex; gap: 8px; }
-.streaming-badge { font-size: 10px; padding: 2px 8px; border-radius: 4px; font-weight: 600; background: #dc2626; color: white; animation: pulse 1.5s ease-in-out infinite; }
-.log-content { background: #1e293b; color: #e2e8f0; border-radius: 8px; padding: 16px; font-family: 'IBM Plex Mono', monospace; font-size: 12px; line-height: 1.6; overflow-x: auto; max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
-.error-banner { background: #fee2e2; border: 1px solid #ef4444; color: #b91c1c; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; display: flex; justify-content: space-between; align-items: center; }
-.loading { text-align: center; color: var(--text-secondary, #6b7280); padding: 60px; }
-.empty-state { text-align: center; color: var(--text-secondary, #6b7280); padding: 60px; }
+.btn-kill { background: var(--color-danger-500); color: white; border: none; padding: var(--spacing-1) 10px; border-radius: var(--radius-default); font-size: var(--text-xs); font-weight: 500; cursor: pointer; }
+.btn-kill:hover { background: var(--color-danger-600); }
+.kill-confirm { display: flex; gap: var(--spacing-1); align-items: center; }
+.btn-confirm { background: var(--slm-amber-500); color: white; border: none; padding: var(--spacing-1) var(--spacing-2); border-radius: var(--radius-default); font-size: 11px; cursor: pointer; }
+.btn-danger { background: var(--color-danger-500); }
+.btn-cancel-sm { background: var(--slm-gray-200); color: var(--slm-gray-700); border: none; padding: 2px 6px; border-radius: var(--radius-default); font-size: 11px; cursor: pointer; }
+.log-panel { background: white; border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: var(--spacing-5); margin-top: var(--spacing-5); }
+.log-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--spacing-3); }
+.log-header h4 { font-size: var(--text-base); font-weight: 600; margin: 0; color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2); }
+.log-actions { display: flex; gap: var(--spacing-2); }
+.streaming-badge { font-size: 10px; padding: 2px var(--spacing-2); border-radius: var(--radius-default); font-weight: 600; background: var(--color-danger-600); color: white; animation: pulse 1.5s ease-in-out infinite; }
+.log-content { background: var(--slm-slate-800); color: var(--slm-slate-200); border-radius: var(--radius-lg); padding: var(--spacing-4); font-family: 'IBM Plex Mono', monospace; font-size: var(--text-xs); line-height: 1.6; overflow-x: auto; max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
+.error-banner { background: var(--slm-red-100); border: 1px solid var(--color-danger-500); color: var(--slm-red-700); padding: var(--spacing-3) var(--spacing-4); border-radius: var(--radius-lg); margin-bottom: var(--spacing-4); display: flex; justify-content: space-between; align-items: center; }
+.loading { text-align: center; color: var(--text-secondary); padding: 60px; }
+.empty-state { text-align: center; color: var(--text-secondary); padding: 60px; }
 </style>


### PR DESCRIPTION
Closes #11899
Part of #11515 (Task 4.1/4.2).

## Thinking Path
ProcessMonitorTab uses hardcoded hexes + px that must render at fixed shades regardless of theme. Captured into the scoped `--slm-*` namespace (no Tailwind v4 palette collision, per #11896) rather than `--color-*`.

## What Changed
- `main.css`: 3 new scoped captures — `--slm-amber-500`, `--slm-slate-200`, `--slm-slate-800` (byte-exact). All other `--slm-gray/blue/indigo/emerald/orange/red-*` used by the component are already defined on base (#11895/#11897/#11898).
- `ProcessMonitorTab.vue`: dead-fallback drops + on-scale px→`--spacing-*`/`--radius-*`/`--text-*`; off-scale px, rgba, and 1px borders left literal.

## Verification
- stylelint `color-no-hex` on `<style>`: clean. `vue-tsc --noEmit -p tsconfig.app.json`: 0 errors. Style-only.

## Model Used
Claude Fable 5 (subagent: general-purpose)