### PR TITLE
tokenise(slm): ConfigHistoryTab — 34 hex + 81 px → design tokens

### DIFF
--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -266,6 +266,9 @@
   --slm-emerald-600: #059669;
   --slm-orange-100: #ffedd5;
   --slm-orange-600: #ea580c;
+  /* Amber rollback-action shades (ConfigHistoryTab #11900). */
+  --slm-amber-500: #f59e0b;
+  --slm-amber-600: #d97706;
 }
 
 /* ─── High Contrast Mode (Issue #754) ────────────────────────── */

--- a/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.vue
+++ b/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.vue
@@ -225,41 +225,41 @@ watch([entityType, entityId], () => {
 </template>
 
 <style scoped>
-.selector-bar { display: flex; align-items: flex-end; gap: 16px; margin-bottom: 24px; background: white; padding: 16px 20px; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-.selector-group { display: flex; flex-direction: column; gap: 4px; }
-.selector-group label { font-size: 13px; font-weight: 500; color: var(--text-secondary, #6b7280); }
-.selector-group select, .selector-group input { padding: 8px 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 14px; min-width: 180px; }
-.btn-primary { background: #6366f1; color: white; border: none; padding: 8px 16px; border-radius: 6px; font-size: 14px; font-weight: 500; cursor: pointer; }
-.btn-primary:hover { background: #4f46e5; }
+.selector-bar { display: flex; align-items: flex-end; gap: var(--spacing-4); margin-bottom: var(--spacing-6); background: white; padding: var(--spacing-4) var(--spacing-5); border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.selector-group { display: flex; flex-direction: column; gap: var(--spacing-1); }
+.selector-group label { font-size: 13px; font-weight: 500; color: var(--text-secondary); }
+.selector-group select, .selector-group input { padding: var(--spacing-2) var(--spacing-3); border: 1px solid var(--slm-gray-300); border-radius: var(--radius-lg); font-size: var(--text-sm); min-width: 180px; }
+.btn-primary { background: var(--slm-indigo-500); color: white; border: none; padding: var(--spacing-2) var(--spacing-4); border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; }
+.btn-primary:hover { background: var(--slm-indigo-600); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.revisions-layout { display: grid; grid-template-columns: 400px 1fr; gap: 24px; }
-.revisions-list { background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 20px; max-height: 700px; overflow-y: auto; }
-.revisions-list h3 { font-size: 18px; font-weight: 600; margin: 0 0 16px 0; color: var(--text-primary, #1a1a2e); }
-.revision-item { padding: 12px; border-radius: 8px; cursor: pointer; margin-bottom: 4px; border: 1px solid transparent; }
-.revision-item:hover { background: #f3f4f6; }
-.revision-item.selected { background: #e0e7ff; border-color: #6366f1; }
-.revision-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.source-badge { font-size: 10px; padding: 2px 8px; border-radius: 4px; font-weight: 600; text-transform: uppercase; }
-.badge-blue { background: #dbeafe; color: #2563eb; }
-.badge-orange { background: #ffedd5; color: #ea580c; }
-.badge-gray { background: #f3f4f6; color: #6b7280; }
-.revision-by { font-size: 13px; font-weight: 500; color: var(--text-primary, #1a1a2e); }
-.revision-time { font-size: 11px; color: var(--text-secondary, #6b7280); margin-left: auto; }
-.changed-keys { font-size: 12px; color: var(--text-secondary, #6b7280); margin-top: 4px; }
-.diff-panel { background: white; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 20px; }
-.diff-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
-.diff-header h3 { font-size: 18px; font-weight: 600; margin: 0; color: var(--text-primary, #1a1a2e); }
-.diff-actions { display: flex; align-items: center; gap: 8px; }
-.btn-rollback { background: #f59e0b; color: white; border: none; padding: 6px 14px; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; }
-.btn-rollback:hover { background: #d97706; }
-.btn-confirm { background: #ef4444; color: white; border: none; padding: 6px 14px; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; }
-.btn-cancel { background: #e5e7eb; color: #374151; border: none; padding: 6px 14px; border-radius: 6px; font-size: 13px; cursor: pointer; }
-.confirm-text { font-size: 13px; color: #ef4444; font-weight: 500; }
-.diff-meta { display: flex; gap: 20px; flex-wrap: wrap; font-size: 13px; color: var(--text-secondary, #6b7280); margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid #e5e7eb; }
-.diff-content { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-.diff-column h4 { font-size: 14px; font-weight: 600; margin: 0 0 8px 0; color: var(--text-primary, #1a1a2e); }
-.json-view { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px; font-family: 'IBM Plex Mono', monospace; font-size: 12px; line-height: 1.5; overflow-x: auto; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
-.error-banner { background: #fee2e2; border: 1px solid #ef4444; color: #b91c1c; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; display: flex; justify-content: space-between; align-items: center; }
-.loading { text-align: center; color: var(--text-secondary, #6b7280); padding: 60px; }
-.empty-state { text-align: center; color: var(--text-secondary, #6b7280); padding: 60px; }
+.revisions-layout { display: grid; grid-template-columns: 400px 1fr; gap: var(--spacing-6); }
+.revisions-list { background: white; border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: var(--spacing-5); max-height: 700px; overflow-y: auto; }
+.revisions-list h3 { font-size: var(--text-lg); font-weight: 600; margin: 0 0 var(--spacing-4) 0; color: var(--text-primary); }
+.revision-item { padding: var(--spacing-3); border-radius: var(--radius-lg); cursor: pointer; margin-bottom: var(--spacing-1); border: 1px solid transparent; }
+.revision-item:hover { background: var(--slm-gray-100); }
+.revision-item.selected { background: var(--slm-indigo-100); border-color: var(--slm-indigo-500); }
+.revision-meta { display: flex; align-items: center; gap: var(--spacing-2); flex-wrap: wrap; }
+.source-badge { font-size: 10px; padding: 2px var(--spacing-2); border-radius: var(--radius-default); font-weight: 600; text-transform: uppercase; }
+.badge-blue { background: var(--slm-blue-100); color: var(--slm-blue-600); }
+.badge-orange { background: var(--slm-orange-100); color: var(--slm-orange-600); }
+.badge-gray { background: var(--slm-gray-100); color: var(--slm-gray-500); }
+.revision-by { font-size: 13px; font-weight: 500; color: var(--text-primary); }
+.revision-time { font-size: 11px; color: var(--text-secondary); margin-left: auto; }
+.changed-keys { font-size: var(--text-xs); color: var(--text-secondary); margin-top: var(--spacing-1); }
+.diff-panel { background: white; border-radius: var(--radius-xl); box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: var(--spacing-5); }
+.diff-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--spacing-4); }
+.diff-header h3 { font-size: var(--text-lg); font-weight: 600; margin: 0; color: var(--text-primary); }
+.diff-actions { display: flex; align-items: center; gap: var(--spacing-2); }
+.btn-rollback { background: var(--slm-amber-500); color: white; border: none; padding: 6px 14px; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; }
+.btn-rollback:hover { background: var(--slm-amber-600); }
+.btn-confirm { background: var(--color-danger-500); color: white; border: none; padding: 6px 14px; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; }
+.btn-cancel { background: var(--slm-gray-200); color: var(--slm-gray-700); border: none; padding: 6px 14px; border-radius: var(--radius-md); font-size: 13px; cursor: pointer; }
+.confirm-text { font-size: 13px; color: var(--color-danger-500); font-weight: 500; }
+.diff-meta { display: flex; gap: var(--spacing-5); flex-wrap: wrap; font-size: 13px; color: var(--text-secondary); margin-bottom: var(--spacing-4); padding-bottom: var(--spacing-3); border-bottom: 1px solid var(--slm-gray-200); }
+.diff-content { display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-4); }
+.diff-column h4 { font-size: var(--text-sm); font-weight: 600; margin: 0 0 var(--spacing-2) 0; color: var(--text-primary); }
+.json-view { background: var(--slm-gray-50); border: 1px solid var(--slm-gray-200); border-radius: var(--radius-lg); padding: var(--spacing-3); font-family: 'IBM Plex Mono', monospace; font-size: var(--text-xs); line-height: 1.5; overflow-x: auto; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
+.error-banner { background: var(--slm-red-100); border: 1px solid var(--color-danger-500); color: var(--slm-red-700); padding: var(--spacing-3) var(--spacing-4); border-radius: var(--radius-lg); margin-bottom: var(--spacing-4); display: flex; justify-content: space-between; align-items: center; }
+.loading { text-align: center; color: var(--text-secondary); padding: 60px; }
+.empty-state { text-align: center; color: var(--text-secondary); padding: 60px; }
 </style>


### PR DESCRIPTION
Closes #11900
Part of #11515 (Task 4.1/4.2).

## Thinking Path
ConfigHistoryTab uses hardcoded hexes + px that must render at fixed shades regardless of theme. Captured into the scoped `--slm-*` namespace (no Tailwind v4 palette collision, per #11896) rather than `--color-*`.

## What Changed
- `main.css`: 2 new scoped captures — `--slm-amber-500`, `--slm-amber-600` (byte-exact). All other `--slm-*` tokens used are already defined on base (#11895/#11897/#11898).
- `ConfigHistoryTab.vue`: dead-fallback drops + on-scale px→`--spacing-*`/`--radius-*`/`--text-*`; off-scale px, rgba, and 1px borders left literal.

## Verification
- stylelint `color-no-hex` on `<style>`: clean. `vue-tsc --noEmit -p tsconfig.app.json`: 0 errors. Style-only.

## Model Used
Claude Fable 5 (subagent: general-purpose)