### PR TITLE
fix(i18n): StatsOverviewCards uses interpolating knowledge.stats keys (#11869)

### DIFF
--- a/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
+++ b/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
@@ -8,7 +8,7 @@
         <h4 id="analytics-documents-title">{{ $t('knowledge.stats.totalDocuments') }}</h4>
         <p class="stat-value" aria-live="polite">{{ documentCount }}</p>
         <p class="stat-change">
-          {{ $t('knowledge.stats.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
+          {{ $t('knowledge.stats.overview.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
         </p>
       </div>
     </BasePanel>
@@ -21,7 +21,7 @@
         <h4 id="analytics-categories-title">{{ $t('knowledge.stats.categories') }}</h4>
         <p class="stat-value" aria-live="polite">{{ categoryCount }}</p>
         <p class="stat-change">
-          {{ $t('knowledge.stats.avgDocsPerCategoryValue', { count: avgDocsPerCategory }) }}
+          {{ $t('knowledge.stats.overview.avgDocsPerCategory', { count: avgDocsPerCategory }) }}
         </p>
       </div>
     </BasePanel>
@@ -34,7 +34,7 @@
         <h4>{{ $t('knowledge.stats.uniqueTags') }}</h4>
         <p class="stat-value">{{ uniqueTagsCount }}</p>
         <p class="stat-change">
-          {{ $t('knowledge.stats.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
+          {{ $t('knowledge.stats.overview.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
         </p>
       </div>
     </BasePanel>
@@ -47,7 +47,7 @@
         <h4>{{ $t('knowledge.stats.storageUsedTitle') }}</h4>
         <p class="stat-value">{{ formatFileSize(totalStorageSize) }}</p>
         <p class="stat-change">
-          {{ $t('knowledge.stats.avgPerDoc', { size: formatFileSize(avgDocSize) }) }}
+          {{ $t('knowledge.stats.overview.avgPerDoc', { size: formatFileSize(avgDocSize) }) }}
         </p>
       </div>
     </BasePanel>


### PR DESCRIPTION
## Thinking Path
StatsOverviewCards passed `{count}`/`{size}` interpolation params to FLAT `knowledge.stats.*` keys that carry no placeholder (auto-generated English scaffolding), so the numbers never rendered. The correctly-worded strings with placeholders already exist under nested `knowledge.stats.overview.*`.

## What Changed
- Repointed 4 `$t(...)` calls in `StatsOverviewCards.vue` to the existing `overview.*` keys (`avgTagsPerDoc`→`{count} avg tags/doc`, `avgDocsPerCategoryValue`→`overview.avgDocsPerCategory` `{count} avg docs/category`, `avgPerDoc`→`{size} avg/doc`). No new locale strings — all 11 locales already carry these keys with the placeholders.

Closes #11869

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → 0 errors
- All 11 locales valid JSON; `locale-parity.test.ts` → 21/21 passed
- No other refs to the placeholder-less flat keys remain

## Model Used
Opus 4.8 (subagent: frontend-engineer)