### PR TITLE
fix(browser-worker): per-conversation session isolation via per-session contexts (#11539)

### DIFF
--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -94,6 +94,12 @@ ALLOWED_URL_SCHEMES = {"http", "https"}
 # Security Configuration
 BROWSER_VM_URL = f"http://{NetworkConstants.BROWSER_VM_IP}:{NetworkConstants.BROWSER_SERVICE_PORT}"
 
+# #11539: the browser-worker keys one isolated BrowserContext per session_id
+# (cookies/localStorage/auth state never cross conversations). Every call
+# without an explicit session_id maps to this bucket, preserving prior
+# single-session behavior for a lone conversation.
+DEFAULT_BROWSER_SESSION_ID = "default"
+
 # URL Whitelist - Only these domains are allowed
 ALLOWED_URL_PATTERNS = [
     r"^https?://localhost",
@@ -540,16 +546,28 @@ async def get_browser_mcp_tools() -> List[MCPTool]:
 # Tool Implementations
 
 
-async def send_to_browser_vm(action: str, params: Metadata) -> Metadata:
+async def send_to_browser_vm(
+    action: str,
+    params: Metadata,
+    session_id: str = DEFAULT_BROWSER_SESSION_ID,
+) -> Metadata:
     """
     Send automation command to Browser VM
 
     This is the core communication layer with the Playwright server
     running on the Browser VM (NetworkConstants.BROWSER_VM_IP)
+
+    Issue #11539: ``session_id`` is threaded on every call so the worker
+    routes to the BrowserContext dedicated to that conversation instead of a
+    single context shared (and its cookies leaked) across every caller.
     """
     try:
         http_client = get_http_client()
-        payload = {"action": action, "params": params}
+        payload = {
+            "action": action,
+            "params": params,
+            "session_id": session_id or DEFAULT_BROWSER_SESSION_ID,
+        }
         async with await http_client.post(
             f"{BROWSER_VM_URL}/automation",
             json=payload,
@@ -609,6 +627,7 @@ async def navigate_mcp(request: BrowserNavigateRequest) -> Metadata:
             "wait_until": request.wait_until,
             "timeout": request.timeout,
         },
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
     return {
@@ -636,6 +655,7 @@ async def click_mcp(request: BrowserClickRequest) -> Metadata:
     result = await send_to_browser_vm(
         "click",
         {"selector": request.selector, "timeout": request.timeout},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
     return {
@@ -667,6 +687,7 @@ async def fill_mcp(request: BrowserFillRequest) -> Metadata:
             "value": request.value,
             "timeout": request.timeout,
         },
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
     return {
@@ -695,6 +716,7 @@ async def screenshot_mcp(request: BrowserScreenshotRequest) -> Metadata:
     result = await send_to_browser_vm(
         "screenshot",
         {"selector": request.selector, "full_page": request.full_page},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
     return {
@@ -727,7 +749,11 @@ async def evaluate_mcp(request: BrowserEvaluateRequest) -> Metadata:
 
     logger.info("Browser evaluate: %s...", request.script[:100])
 
-    result = await send_to_browser_vm("evaluate", {"script": request.script})
+    result = await send_to_browser_vm(
+        "evaluate",
+        {"script": request.script},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
 
     return {
         "success": True,
@@ -758,6 +784,7 @@ async def wait_for_selector_mcp(request: BrowserWaitForSelectorRequest) -> Metad
             "timeout": request.timeout,
             "state": request.state,
         },
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
     return {
@@ -783,7 +810,11 @@ async def get_text_mcp(request: BrowserGetTextRequest) -> Metadata:
 
     logger.info("Browser get_text: %s", request.selector)
 
-    result = await send_to_browser_vm("get_text", {"selector": request.selector})
+    result = await send_to_browser_vm(
+        "get_text",
+        {"selector": request.selector},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
 
     return {
         "success": True,
@@ -810,6 +841,7 @@ async def get_attribute_mcp(request: BrowserGetAttributeRequest) -> Metadata:
     result = await send_to_browser_vm(
         "get_attribute",
         {"selector": request.selector, "attribute": request.attribute},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
     return {
@@ -838,6 +870,7 @@ async def select_mcp(request: BrowserSelectRequest) -> Metadata:
     result = await send_to_browser_vm(
         "select",
         {"selector": request.selector, "value": request.value},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
     return {
@@ -863,7 +896,11 @@ async def hover_mcp(request: BrowserHoverRequest) -> Metadata:
 
     logger.info("Browser hover: %s", request.selector)
 
-    result = await send_to_browser_vm("hover", {"selector": request.selector})
+    result = await send_to_browser_vm(
+        "hover",
+        {"selector": request.selector},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
 
     return {
         "success": True,

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -12,6 +12,7 @@ import base64
 import aiohttp
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
+from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID
 from api.schemas_code import (
     AiProposeRegionsResponse,
     FrontendTestRequest,
@@ -24,6 +25,7 @@ from api.schemas_code import (
     PlaywrightReloadRequest,
     PlaywrightScreenshotRequest,
     PlaywrightSearchRequest,
+    PlaywrightSessionRequest,
     PlaywrightStatusResponse,
     PlaywrightWorkerStatusResponse,
     SnapshotWithRegionsRequest,
@@ -312,6 +314,8 @@ async def navigate_to_url(request: PlaywrightNavigateRequest):
                 "url": request.url,
                 "wait_until": request.wait_until,
                 "timeout": request.timeout,
+                # #11539: route to this conversation's isolated browser context.
+                "session_id": request.session_id or DEFAULT_BROWSER_SESSION_ID,
             },
             timeout=aiohttp.ClientTimeout(total=request.timeout / 1000 + 5),
         ) as response:
@@ -353,7 +357,10 @@ async def reload_page(request: PlaywrightReloadRequest):
         http_client = get_http_client()
         async with await http_client.post(
             f"{BROWSER_VM_URL}/reload",
-            json={"wait_until": request.wait_until},
+            json={
+                "wait_until": request.wait_until,
+                "session_id": request.session_id or DEFAULT_BROWSER_SESSION_ID,
+            },
             timeout=aiohttp.ClientTimeout(total=35),
         ) as response:
             result = await response.json()
@@ -382,20 +389,22 @@ async def reload_page(request: PlaywrightReloadRequest):
     operation="go_back",
     error_code_prefix="PLAYWRIGHT",
 )
-async def go_back():
+async def go_back(request: PlaywrightSessionRequest | None = None):
     """
     Navigate back in browser history using Playwright on Browser VM
 
     Forwards back navigation request to Browser VM (NetworkConstants.BROWSER_VM_IP)
     Issue #552: Added missing endpoint for frontend PopoutChromiumBrowser.vue
+    Issue #11539: threads session_id so this routes to the caller's isolated context.
     """
     try:
         logger.info("Back navigation request")
+        session_id = (request.session_id if request else None) or DEFAULT_BROWSER_SESSION_ID
 
         http_client = get_http_client()
         async with await http_client.post(
             f"{BROWSER_VM_URL}/back",
-            json={},
+            json={"session_id": session_id},
             timeout=aiohttp.ClientTimeout(total=35),
         ) as response:
             result = await response.json()
@@ -424,20 +433,22 @@ async def go_back():
     operation="go_forward",
     error_code_prefix="PLAYWRIGHT",
 )
-async def go_forward():
+async def go_forward(request: PlaywrightSessionRequest | None = None):
     """
     Navigate forward in browser history using Playwright on Browser VM
 
     Forwards forward navigation request to Browser VM (NetworkConstants.BROWSER_VM_IP)
     Issue #552: Added missing endpoint for frontend PopoutChromiumBrowser.vue
+    Issue #11539: threads session_id so this routes to the caller's isolated context.
     """
     try:
         logger.info("Forward navigation request")
+        session_id = (request.session_id if request else None) or DEFAULT_BROWSER_SESSION_ID
 
         http_client = get_http_client()
         async with await http_client.post(
             f"{BROWSER_VM_URL}/forward",
-            json={},
+            json={"session_id": session_id},
             timeout=aiohttp.ClientTimeout(total=35),
         ) as response:
             result = await response.json()
@@ -466,16 +477,19 @@ async def go_forward():
     operation="get_worker_status",
     error_code_prefix="PLAYWRIGHT",
 )
-async def get_worker_status():
+async def get_worker_status(session_id: str | None = None):
     """
     Get browser worker connectivity status from Browser VM (#1130)
 
-    Proxies to Browser VM /status endpoint which checks the persistent navPage.
+    Proxies to Browser VM /status endpoint which checks the persistent navPage
+    for this caller's session (#11539 — session_id selects which isolated
+    context's navPage is inspected; omitted = shared default session).
     """
     try:
         http_client = get_http_client()
         async with await http_client.get(
             f"{BROWSER_VM_URL}/status",
+            params={"session_id": session_id or DEFAULT_BROWSER_SESSION_ID},
             timeout=aiohttp.ClientTimeout(total=10),
         ) as response:
             data = await response.json()
@@ -507,18 +521,20 @@ async def get_worker_status():
     operation="take_worker_screenshot",
     error_code_prefix="PLAYWRIGHT",
 )
-async def take_worker_screenshot():
+async def take_worker_screenshot(request: PlaywrightSessionRequest | None = None):
     """
     Take screenshot of the persistent navigation page on Browser VM (#1130)
 
     Unlike /screenshot which takes a fresh-page screenshot for a given URL,
-    this returns a screenshot of the current state of the persistent navPage.
+    this returns a screenshot of the current state of the persistent navPage
+    for this caller's session (#11539).
     """
     try:
+        session_id = (request.session_id if request else None) or DEFAULT_BROWSER_SESSION_ID
         http_client = get_http_client()
         async with await http_client.post(
             f"{BROWSER_VM_URL}/screenshot",
-            json={},
+            json={"session_id": session_id},
             timeout=aiohttp.ClientTimeout(total=30),
         ) as response:
             result = await response.json()
@@ -565,6 +581,9 @@ async def interact_with_page(request: PlaywrightInteractRequest):
             if not request.text:
                 raise HTTPException(status_code=400, detail="text required")
             payload = {"text": request.text}
+
+        # #11539: route to this conversation's isolated browser context.
+        payload["session_id"] = request.session_id or DEFAULT_BROWSER_SESSION_ID
 
         http_client = get_http_client()
         async with await http_client.post(

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2260,16 +2260,22 @@ class PlaywrightScreenshotRequest(BaseModel):
     url: str
     full_page: bool = True
     wait_timeout: int = 5000
+    session_id: str | None = None
 
 
 class PlaywrightNavigateRequest(BaseModel):
     url: str
     wait_until: str = "networkidle"
     timeout: int = 30000
+    session_id: str | None = Field(
+        None,
+        description="Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session",
+    )
 
 
 class PlaywrightReloadRequest(BaseModel):
     wait_until: str = "networkidle"
+    session_id: str | None = None
 
 
 class PlaywrightInteractRequest(BaseModel):
@@ -2279,6 +2285,15 @@ class PlaywrightInteractRequest(BaseModel):
     deltaX: float = 0
     deltaY: float = 0
     text: str | None = None
+    session_id: str | None = None
+
+
+class PlaywrightSessionRequest(BaseModel):
+    """Optional body for worker proxy calls with no other payload (#11539):
+    /back, /forward, /worker-screenshot. GET /status takes the same id as a
+    query param instead (no request body on GET)."""
+
+    session_id: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2269,7 +2269,7 @@ class PlaywrightNavigateRequest(BaseModel):
     timeout: int = 30000
     session_id: str | None = Field(
         None,
-        description="Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session",
+        description="Session id for isolated browser-context routing (#11539); omitted uses shared default",
     )
 
 

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1739,7 +1739,7 @@ class BrowserNavigateRequest(BaseModel):
     timeout: int | None = Field(30000, description="Timeout in milliseconds")
     session_id: str | None = Field(
         None,
-        description="Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session",
+        description="Session id for isolated browser-context routing (#11539); omitted uses shared default",
     )
 
 

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1746,54 +1746,72 @@ class BrowserNavigateRequest(BaseModel):
 class BrowserClickRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element to click")
     timeout: int | None = Field(5000, description="Timeout in milliseconds")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserFillRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for input field")
     value: str = Field(..., description="Value to fill")
     timeout: int | None = Field(5000, description="Timeout in milliseconds")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserScreenshotRequest(BaseModel):
     selector: str | None = Field(None, description="CSS selector for element (full page if omitted)")
     full_page: bool | None = Field(False, description="Capture full scrollable page")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserEvaluateRequest(BaseModel):
     script: str = Field(..., description="JavaScript code to execute")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserWaitForSelectorRequest(BaseModel):
     selector: str = Field(..., description="CSS selector to wait for")
     timeout: int | None = Field(30000, description="Timeout in milliseconds")
     state: str | None = Field("visible", description="State: 'attached', 'detached', 'visible', 'hidden'")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserGetTextRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserGetAttributeRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element")
     attribute: str = Field(..., description="Attribute name to retrieve")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserSelectRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for select element")
     value: str = Field(..., description="Value to select")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserHoverRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element to hover")
-    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
 
 
 class BrowserNavigateResponse(BaseModel):

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1737,50 +1737,63 @@ class BrowserNavigateRequest(BaseModel):
     url: str = Field(..., description="URL to navigate to")
     wait_until: str | None = Field("load", description="Wait condition: 'load', 'domcontentloaded', 'networkidle'")
     timeout: int | None = Field(30000, description="Timeout in milliseconds")
+    session_id: str | None = Field(
+        None,
+        description="Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session",
+    )
 
 
 class BrowserClickRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element to click")
     timeout: int | None = Field(5000, description="Timeout in milliseconds")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserFillRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for input field")
     value: str = Field(..., description="Value to fill")
     timeout: int | None = Field(5000, description="Timeout in milliseconds")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserScreenshotRequest(BaseModel):
     selector: str | None = Field(None, description="CSS selector for element (full page if omitted)")
     full_page: bool | None = Field(False, description="Capture full scrollable page")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserEvaluateRequest(BaseModel):
     script: str = Field(..., description="JavaScript code to execute")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserWaitForSelectorRequest(BaseModel):
     selector: str = Field(..., description="CSS selector to wait for")
     timeout: int | None = Field(30000, description="Timeout in milliseconds")
     state: str | None = Field("visible", description="State: 'attached', 'detached', 'visible', 'hidden'")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserGetTextRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserGetAttributeRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element")
     attribute: str = Field(..., description="Attribute name to retrieve")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserSelectRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for select element")
     value: str = Field(..., description="Value to select")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserHoverRequest(BaseModel):
     selector: str = Field(..., description="CSS selector for element to hover")
+    session_id: str | None = Field(None, description="Conversation/session id for isolated browser-context routing (#11539)")
 
 
 class BrowserNavigateResponse(BaseModel):

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2023,9 +2023,15 @@ class ToolHandlerMixin:
                 )
                 return
 
-            from api.browser_mcp import send_to_browser_vm
+            from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
 
-            result = await send_to_browser_vm(tool_name, params)
+            # #11539: route this call to the BrowserContext dedicated to this
+            # conversation so cookies/login state never bleed into another one.
+            result = await send_to_browser_vm(
+                tool_name,
+                params,
+                session_id=session_id or DEFAULT_BROWSER_SESSION_ID,
+            )
 
             # Issue #4261: Wire AFTER_TOOL_EXECUTE hook for browser tools
             result_text = str(result)
@@ -2186,12 +2192,12 @@ class ToolHandlerMixin:
 
         try:
             if fetch_full:
-                results = await self._execute_web_search_full(query, max_pages)
+                results = await self._execute_web_search_full(query, max_pages, session_id)
             else:
                 # #7479: snippet path now honors max_pages too (was hardcoded
                 # to 5, ignoring caller's choice — confusingly inconsistent
                 # with fetch_full mode).
-                results = await self._execute_web_search(query, max_pages)
+                results = await self._execute_web_search(query, max_pages, session_id)
 
             # Issue #4261: Wire AFTER_TOOL_EXECUTE hook for web_search
             results = await _emit_after_tool_execute("web_search", results, session_id, {})
@@ -2373,7 +2379,7 @@ class ToolHandlerMixin:
         json_str = json.dumps(result["data"], indent=2, ensure_ascii=False)
         return f"## Extracted data from {url}\n\n```json\n{json_str}\n```"
 
-    async def _execute_web_search(self, query: str, max_pages: int = 5) -> str:
+    async def _execute_web_search(self, query: str, max_pages: int = 5, session_id: str = "") -> str:
         """Run a web search and return formatted results. Issue #2306.
 
         Tries the existing Playwright search service first (structured results),
@@ -2382,6 +2388,9 @@ class ToolHandlerMixin:
         ``max_pages`` (#7479) — caller-requested result count. Threaded into
         ``_web_search_via_playwright`` so the snippet path returns the same
         number of results that the fetch_full path would.
+
+        ``session_id`` (#11539) — threaded into the browser-VM fallback so it
+        reuses this conversation's isolated browser context.
         """
         # Primary: use existing search_web_embedded (Rule 2: reuse existing code)
         try:
@@ -2392,9 +2401,9 @@ class ToolHandlerMixin:
             logger.debug("[Issue #2306] Playwright search unavailable: %s", e)
 
         # Fallback: browser VM with DuckDuckGo HTML
-        return await self._web_search_final_fallback(query)
+        return await self._web_search_final_fallback(query, session_id)
 
-    async def _execute_web_search_full(self, query: str, max_pages: int) -> str:
+    async def _execute_web_search_full(self, query: str, max_pages: int, session_id: str = "") -> str:
         """Search + full-page fetch mode. Issue #7404.
 
         Gets structured entries from Playwright, fans out WebFetcher.fetch
@@ -2407,10 +2416,12 @@ class ToolHandlerMixin:
         call via ``_web_search_via_playwright`` — wasteful when
         ``_web_search_structured_entries`` already determined Playwright
         unavailable (#7478).
+
+        ``session_id`` (#11539) — threaded into the browser-VM fallback.
         """
         entries = await self._web_search_structured_entries(query, max_pages)
         if not entries:
-            return await self._web_search_final_fallback(query)
+            return await self._web_search_final_fallback(query, session_id)
         enriched = await _fetch_pages_concurrent(entries, max_pages)
         return _format_full_search_results(query, enriched)
 
@@ -2467,7 +2478,7 @@ class ToolHandlerMixin:
             lines.append(f"{i}. **{title}**\n   {url}\n   {snippet}\n")
         return "\n".join(lines)
 
-    async def _web_search_final_fallback(self, query: str) -> str:
+    async def _web_search_final_fallback(self, query: str, session_id: str = "") -> str:
         """Browser-VM last resort with actionable guidance instead of silence (#11665).
 
         When the registry and Playwright yielded nothing and even the browser
@@ -2476,30 +2487,39 @@ class ToolHandlerMixin:
         configuration that unlocks topic search.
         """
         try:
-            result = await self._web_search_via_browser_vm(query)
+            result = await self._web_search_via_browser_vm(query, session_id)
             if result:
                 return result
         except Exception as exc:
             logger.debug("[#11665] Browser VM search fallback unavailable: %s", exc)
         return _search_unavailable_message(query)
 
-    async def _web_search_via_browser_vm(self, query: str) -> str:
+    async def _web_search_via_browser_vm(self, query: str, session_id: str = "") -> str:
         """Fallback: search via browser VM DuckDuckGo HTML page. Issue #2306."""
         from urllib.parse import (  # stdlib — lazy to match surrounding pattern
             quote_plus,
         )
 
-        from api.browser_mcp import send_to_browser_vm  # lazy to avoid circular import
+        from api.browser_mcp import (  # lazy to avoid circular import
+            DEFAULT_BROWSER_SESSION_ID,
+            send_to_browser_vm,
+        )
 
         search_url = f"https://html.duckduckgo.com/html/?q={quote_plus(query)}"
+        # #11539: route through this conversation's isolated browser context.
+        vm_session_id = session_id or DEFAULT_BROWSER_SESSION_ID
 
-        nav_result = await send_to_browser_vm("navigate", {"url": search_url})
+        nav_result = await send_to_browser_vm("navigate", {"url": search_url}, session_id=vm_session_id)
         if not nav_result.get("success", True):
             raise RuntimeError(f"Failed to navigate to search page: {nav_result.get('error', 'unknown')}")
 
         # Try results div first, then fall back to body
         for selector in ("div.results", "body"):
-            text_result = await send_to_browser_vm("get_text", {"selector": selector})
+            text_result = await send_to_browser_vm(
+                "get_text",
+                {"selector": selector},
+                session_id=vm_session_id,
+            )
             inner = text_result.get("result", text_result)
             raw_text = inner.get("text", "")
             if raw_text:

--- a/autobot-backend/tests/unit/api/_fake_http_client.py
+++ b/autobot-backend/tests/unit/api/_fake_http_client.py
@@ -1,0 +1,50 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared fake HTTPClientManager for tests that assert on outbound JSON
+payloads without a real Browser VM (#11539).
+
+Reused by test_browser_mcp_session_isolation.py and
+test_playwright_session_isolation.py so both suites share one mock shape
+instead of duplicating it (Rule 2: reuse, don't duplicate).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+
+class FakeResponse:
+    """Minimal async-context-manager stand-in for aiohttp.ClientResponse."""
+
+    def __init__(self, status: int = 200, payload: dict | None = None):
+        self.status = status
+        self._payload = payload if payload is not None else {"success": True}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return json.dumps(self._payload)
+
+
+def fake_http_client(recorder: list, payload: dict | None = None) -> SimpleNamespace:
+    """Build a fake HTTPClientManager whose .get()/.post() record every call."""
+
+    async def _post(url, json: dict | None = None, **kwargs):  # noqa: A002 - match call signature
+        recorder.append({"method": "POST", "url": url, "payload": json, "kwargs": kwargs})
+        return FakeResponse(payload=payload)
+
+    async def _get(url, **kwargs):
+        recorder.append({"method": "GET", "url": url, "payload": kwargs.get("params"), "kwargs": kwargs})
+        return FakeResponse(payload=payload)
+
+    return SimpleNamespace(post=_post, get=_get)

--- a/autobot-backend/tests/unit/api/test_browser_mcp_session_isolation.py
+++ b/autobot-backend/tests/unit/api/test_browser_mcp_session_isolation.py
@@ -21,43 +21,12 @@ runtime).
 
 from __future__ import annotations
 
-import json
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
-
-
-class _FakeResponse:
-    """Minimal async-context-manager stand-in for aiohttp.ClientResponse."""
-
-    def __init__(self, status: int = 200, payload: dict | None = None):
-        self.status = status
-        self._payload = payload if payload is not None else {"success": True}
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-    async def json(self):
-        return self._payload
-
-    async def text(self):
-        return json.dumps(self._payload)
-
-
-def _fake_http_client(recorder: list) -> SimpleNamespace:
-    """Build a fake HTTPClientManager whose .post() records the JSON payload."""
-
-    async def _post(url, json: dict, timeout=None):  # noqa: A002 - match call signature
-        recorder.append({"url": url, "payload": json})
-        return _FakeResponse()
-
-    return SimpleNamespace(post=_post)
+from tests.unit.api._fake_http_client import fake_http_client as _fake_http_client
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tests/unit/api/test_browser_mcp_session_isolation.py
+++ b/autobot-backend/tests/unit/api/test_browser_mcp_session_isolation.py
@@ -1,0 +1,151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Per-conversation browser session isolation (#11539).
+
+The browser worker (autobot-browser-worker/playwright-server.js) now keys one
+isolated Playwright BrowserContext per session_id instead of a single global
+page shared by every conversation/user (session/cookie bleed). These tests
+prove the *backend* half of that contract: ``send_to_browser_vm`` and its
+callers (the ``/mcp/*`` HTTP handlers and the chat-workflow tool dispatcher)
+put the caller's conversation/session id on the wire on every call, and two
+different conversations produce two distinct ``session_id`` values in the
+payload sent to the Browser VM — which is exactly what the worker uses to
+route to (and isolate) the right BrowserContext / cookie jar.
+
+True end-to-end cookie-jar isolation is proven on the JS side, in
+autobot-browser-worker/tests/session-store.test.js (the worker has no Python
+runtime).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
+
+
+class _FakeResponse:
+    """Minimal async-context-manager stand-in for aiohttp.ClientResponse."""
+
+    def __init__(self, status: int = 200, payload: dict | None = None):
+        self.status = status
+        self._payload = payload if payload is not None else {"success": True}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return json.dumps(self._payload)
+
+
+def _fake_http_client(recorder: list) -> SimpleNamespace:
+    """Build a fake HTTPClientManager whose .post() records the JSON payload."""
+
+    async def _post(url, json: dict, timeout=None):  # noqa: A002 - match call signature
+        recorder.append({"url": url, "payload": json})
+        return _FakeResponse()
+
+    return SimpleNamespace(post=_post)
+
+
+@pytest.mark.asyncio
+async def test_send_to_browser_vm_puts_session_id_on_the_wire():
+    """Explicit session_id must appear verbatim in the /automation payload."""
+    calls: list = []
+    with patch("api.browser_mcp.get_http_client", return_value=_fake_http_client(calls)):
+        await send_to_browser_vm("navigate", {"url": "https://github.com"}, session_id="conversation-A")
+
+    assert len(calls) == 1
+    assert calls[0]["url"].endswith("/automation")
+    assert calls[0]["payload"]["session_id"] == "conversation-A"
+    assert calls[0]["payload"]["action"] == "navigate"
+
+
+@pytest.mark.asyncio
+async def test_send_to_browser_vm_defaults_session_id_when_omitted():
+    """A caller with no session_id falls back to the shared default bucket
+    (#11539 backfill requirement: a lone conversation's behavior is unchanged)."""
+    calls: list = []
+    with patch("api.browser_mcp.get_http_client", return_value=_fake_http_client(calls)):
+        await send_to_browser_vm("navigate", {"url": "https://github.com"})
+
+    assert calls[0]["payload"]["session_id"] == DEFAULT_BROWSER_SESSION_ID == "default"
+
+
+@pytest.mark.asyncio
+async def test_two_conversations_route_to_distinct_session_ids_on_the_wire():
+    """SECURITY (#11539): two concurrent conversations must never share a
+    session_id on the wire — that id is what the worker uses to select an
+    isolated BrowserContext, so distinct ids here is the backend-side
+    guarantee that conversation A's cookie jar cannot be reused by B.
+    """
+    calls: list = []
+    with patch("api.browser_mcp.get_http_client", return_value=_fake_http_client(calls)):
+        await send_to_browser_vm("navigate", {"url": "https://bank.example.com/login"}, session_id="conversation-A")
+        await send_to_browser_vm("navigate", {"url": "https://bank.example.com/login"}, session_id="conversation-B")
+
+    session_ids = [c["payload"]["session_id"] for c in calls]
+    assert session_ids == ["conversation-A", "conversation-B"]
+    assert session_ids[0] != session_ids[1]
+
+
+@pytest.mark.asyncio
+async def test_handle_browser_tool_threads_chat_session_id_to_browser_vm():
+    """The chat-workflow dispatch path (_handle_browser_tool) must forward its
+    session_id straight through to send_to_browser_vm — this is the actual
+    call site hit by every browser tool invocation from a live conversation.
+    """
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    handler = ToolHandlerMixin.__new__(ToolHandlerMixin)  # no __init__ side effects needed
+    tool_call = {"name": "navigate", "params": {"url": "https://github.com"}, "description": "go"}
+    execution_results: list = []
+
+    mock_send = AsyncMock(return_value={"success": True, "result": {}})
+    with (
+        patch("api.browser_mcp.send_to_browser_vm", mock_send),
+        patch("chat_workflow.tool_handler._emit_before_tool_execute", AsyncMock(return_value=True)),
+        patch("chat_workflow.tool_handler._emit_after_tool_execute", AsyncMock(side_effect=lambda *a, **k: a[1])),
+    ):
+        async for _msg in handler._handle_browser_tool(tool_call, execution_results, session_id="conversation-A"):
+            pass
+
+    mock_send.assert_awaited_once()
+    _args, kwargs = mock_send.call_args
+    assert kwargs["session_id"] == "conversation-A"
+    assert execution_results[0]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_handle_browser_tool_defaults_session_id_when_blank():
+    """An empty session_id (no conversation context) still falls back to the
+    shared default bucket rather than sending session_id="" to the worker."""
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    handler = ToolHandlerMixin.__new__(ToolHandlerMixin)
+    tool_call = {"name": "navigate", "params": {"url": "https://github.com"}, "description": "go"}
+    execution_results: list = []
+
+    mock_send = AsyncMock(return_value={"success": True, "result": {}})
+    with (
+        patch("api.browser_mcp.send_to_browser_vm", mock_send),
+        patch("chat_workflow.tool_handler._emit_before_tool_execute", AsyncMock(return_value=True)),
+        patch("chat_workflow.tool_handler._emit_after_tool_execute", AsyncMock(side_effect=lambda *a, **k: a[1])),
+    ):
+        async for _msg in handler._handle_browser_tool(tool_call, execution_results, session_id=""):
+            pass
+
+    _args, kwargs = mock_send.call_args
+    assert kwargs["session_id"] == DEFAULT_BROWSER_SESSION_ID

--- a/autobot-backend/tests/unit/api/test_playwright_session_isolation.py
+++ b/autobot-backend/tests/unit/api/test_playwright_session_isolation.py
@@ -119,9 +119,7 @@ async def test_worker_screenshot_threads_session_id():
 async def test_interact_threads_session_id():
     calls: list = []
     with patch("api.playwright.get_http_client", return_value=fake_http_client(calls)):
-        await interact_with_page(
-            PlaywrightInteractRequest(action="click", x=1, y=2, session_id="conversation-A")
-        )
+        await interact_with_page(PlaywrightInteractRequest(action="click", x=1, y=2, session_id="conversation-A"))
 
     assert calls[0]["url"].endswith("/click")
     assert calls[0]["payload"]["session_id"] == "conversation-A"

--- a/autobot-backend/tests/unit/api/test_playwright_session_isolation.py
+++ b/autobot-backend/tests/unit/api/test_playwright_session_isolation.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Visual-browser proxy (`api/playwright.py`) session isolation (#11539).
+
+BLOCKER follow-up: `api/playwright.py` proxies `/navigate`, `/reload`,
+`/back`, `/forward`, `/status`, `/screenshot` (worker-screenshot), and
+`/interact` straight through to the browser-worker's per-session-context
+endpoints (see autobot-browser-worker/playwright-server.js and
+test_browser_mcp_session_isolation.py), but originally sent no session_id at
+all — every visual-browser action landed in the worker's shared "default"
+bucket regardless of which conversation/user was driving it. These tests
+prove every one of those proxy endpoints now puts the caller's session_id on
+the wire (or the explicit default bucket when none is supplied), and that
+two different conversations produce two distinct outbound session_id values.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID
+from api.playwright import (
+    get_worker_status,
+    go_back,
+    go_forward,
+    interact_with_page,
+    navigate_to_url,
+    reload_page,
+    take_worker_screenshot,
+)
+from api.schemas_code import (
+    PlaywrightInteractRequest,
+    PlaywrightNavigateRequest,
+    PlaywrightReloadRequest,
+    PlaywrightSessionRequest,
+)
+from tests.unit.api._fake_http_client import fake_http_client
+
+
+@pytest.mark.asyncio
+async def test_navigate_threads_session_id():
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls, {"url": "https://github.com"})):
+        await navigate_to_url(PlaywrightNavigateRequest(url="https://github.com", session_id="conversation-A"))
+
+    assert calls[0]["url"].endswith("/navigate")
+    assert calls[0]["payload"]["session_id"] == "conversation-A"
+
+
+@pytest.mark.asyncio
+async def test_navigate_defaults_session_id_when_omitted():
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls, {"url": "https://github.com"})):
+        await navigate_to_url(PlaywrightNavigateRequest(url="https://github.com"))
+
+    assert calls[0]["payload"]["session_id"] == DEFAULT_BROWSER_SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_reload_threads_session_id():
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls)):
+        await reload_page(PlaywrightReloadRequest(session_id="conversation-A"))
+
+    assert calls[0]["url"].endswith("/reload")
+    assert calls[0]["payload"]["session_id"] == "conversation-A"
+
+
+@pytest.mark.asyncio
+async def test_back_and_forward_thread_session_id():
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls)):
+        await go_back(PlaywrightSessionRequest(session_id="conversation-A"))
+        await go_forward(PlaywrightSessionRequest(session_id="conversation-B"))
+
+    assert calls[0]["url"].endswith("/back")
+    assert calls[0]["payload"]["session_id"] == "conversation-A"
+    assert calls[1]["url"].endswith("/forward")
+    assert calls[1]["payload"]["session_id"] == "conversation-B"
+
+
+@pytest.mark.asyncio
+async def test_back_defaults_session_id_with_no_body():
+    """PopoutChromiumBrowser.vue / VisualBrowserPanel.vue historically posted
+    no body at all to /back — must still resolve to the default bucket, not
+    crash or send session_id=None literally."""
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls)):
+        await go_back(None)
+
+    assert calls[0]["payload"]["session_id"] == DEFAULT_BROWSER_SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_worker_status_sends_session_id_as_query_param():
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls, {"status": "connected"})):
+        await get_worker_status(session_id="conversation-A")
+
+    assert calls[0]["url"].endswith("/status")
+    assert calls[0]["payload"] == {"session_id": "conversation-A"}
+
+
+@pytest.mark.asyncio
+async def test_worker_screenshot_threads_session_id():
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls)):
+        await take_worker_screenshot(PlaywrightSessionRequest(session_id="conversation-A"))
+
+    assert calls[0]["url"].endswith("/screenshot")
+    assert calls[0]["payload"]["session_id"] == "conversation-A"
+
+
+@pytest.mark.asyncio
+async def test_interact_threads_session_id():
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls)):
+        await interact_with_page(
+            PlaywrightInteractRequest(action="click", x=1, y=2, session_id="conversation-A")
+        )
+
+    assert calls[0]["url"].endswith("/click")
+    assert calls[0]["payload"]["session_id"] == "conversation-A"
+
+
+@pytest.mark.asyncio
+async def test_two_conversations_get_distinct_session_ids_on_visual_browser_navigate():
+    """SECURITY (#11539): the actual regression the blocker flagged — two
+    conversations driving the visual-browser panel must never share a
+    session_id on the wire to the worker's /navigate endpoint."""
+    calls: list = []
+    with patch("api.playwright.get_http_client", return_value=fake_http_client(calls, {"url": "https://github.com"})):
+        await navigate_to_url(PlaywrightNavigateRequest(url="https://github.com/a", session_id="conversation-A"))
+        await navigate_to_url(PlaywrightNavigateRequest(url="https://github.com/b", session_id="conversation-B"))
+
+    session_ids = [c["payload"]["session_id"] for c in calls]
+    assert session_ids == ["conversation-A", "conversation-B"]
+    assert session_ids[0] != session_ids[1]

--- a/autobot-browser-worker/playwright-server.js
+++ b/autobot-browser-worker/playwright-server.js
@@ -368,18 +368,21 @@ app.post('/hover', async (req, res) => {
 
 app.post('/search', async (req, res) => {
   logger.info('Received search request:', req.body);
+  const { query, search_engine = 'duckduckgo' } = req.body;
+
+  if (!query) {
+    return res.status(400).json({
+      success: false,
+      error: 'Query parameter is required'
+    });
+  }
+
+  // Declared outside the try so the finally block can always close it,
+  // even if browser.newPage()/goto() throws before the inner try runs.
+  let page = null;
   try {
-    const { query, search_engine = 'duckduckgo' } = req.body;
-
-    if (!query) {
-      return res.status(400).json({
-        success: false,
-        error: 'Query parameter is required'
-      });
-    }
-
     const browser = await initBrowser();
-    const page = await browser.newPage();
+    page = await browser.newPage();
 
     await page.setExtraHTTPHeaders({
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
@@ -446,8 +449,6 @@ app.post('/search', async (req, res) => {
       logger.error('Error with search:', e.message);
     }
 
-    await page.close();
-
     res.json({
       success: true,
       query: query,
@@ -461,6 +462,14 @@ app.post('/search', async (req, res) => {
       success: false,
       error: error.message
     });
+  } finally {
+    if (page && !page.isClosed()) {
+      try {
+        await page.close();
+      } catch (e) {
+        logger.warn('Search: page close failed: %s', e.message);
+      }
+    }
   }
 });
 

--- a/autobot-browser-worker/playwright-server.js
+++ b/autobot-browser-worker/playwright-server.js
@@ -4,6 +4,7 @@
 // Author: mrveiss
 const { chromium } = require('playwright');
 const express = require('express');
+const { SessionStore } = require('./session-store');
 const app = express();
 
 app.use(express.json({ limit: '50mb' }));
@@ -21,7 +22,87 @@ const logger = {
 };
 
 let browser = null;
-let navPage = null; // Persistent navigation page for visual browser (#1130)
+
+// --- Per-session browser contexts (#11539) ---
+//
+// One Chromium process, N isolated BrowserContexts — one per conversation
+// session_id. Each context has its own cookie jar / localStorage / auth
+// state so logging in to a site in conversation A never leaks into
+// conversation B. A request without a session_id maps to
+// SessionStore.DEFAULT_SESSION_ID, preserving today's single-session
+// behavior for a lone caller.
+//
+// Idle contexts are garbage-collected — see SESSION_IDLE_TIMEOUT_MS /
+// SESSION_GC_INTERVAL_MS below (env-var-driven, mirrors the idle-GC pattern
+// in services/docker_task_workspace.py).
+const SESSION_IDLE_TIMEOUT_MS = parseInt(process.env.BROWSER_SESSION_IDLE_TIMEOUT_MS || String(30 * 60 * 1000), 10);
+const SESSION_GC_INTERVAL_MS = parseInt(process.env.BROWSER_SESSION_GC_INTERVAL_MS || String(5 * 60 * 1000), 10);
+
+const sessionStore = new SessionStore({ idleTimeoutMs: SESSION_IDLE_TIMEOUT_MS });
+
+function sessionIdFromRequest(req) {
+  const raw = (req.body && req.body.session_id) || (req.query && req.query.session_id);
+  return SessionStore.resolveSessionId(raw);
+}
+
+async function getSessionEntry(sessionId) {
+  const b = await initBrowser();
+  const entry = await sessionStore.getOrCreate(sessionId, async () => {
+    const context = await b.newContext();
+    logger.info('Created new browser context for session %s', sessionId);
+    return { context, navPage: null, mcpPage: null };
+  });
+  return entry;
+}
+
+async function closeSessionEntry(entry, sessionId) {
+  if (entry.navPage && !entry.navPage.isClosed()) {
+    try {
+      await entry.navPage.close();
+    } catch (e) {
+      logger.warn('Session cleanup: navPage close failed for %s: %s', sessionId, e.message);
+    }
+  }
+  if (entry.mcpPage && !entry.mcpPage.isClosed()) {
+    try {
+      await entry.mcpPage.close();
+    } catch (e) {
+      logger.warn('Session cleanup: mcpPage close failed for %s: %s', sessionId, e.message);
+    }
+  }
+  await entry.context.close();
+}
+
+async function gcIdleSessions() {
+  const evicted = await sessionStore.gcIdle(closeSessionEntry, (sessionId, err) => {
+    logger.error('Session GC: failed to close context for %s: %s', sessionId, err.message);
+  });
+  if (evicted.length) {
+    logger.info('Session GC: evicted %d idle browser context(s): %s', evicted.length, evicted.join(', '));
+  }
+  return evicted;
+}
+
+async function closeAllSessions() {
+  for (const sessionId of sessionStore.ids()) {
+    const entry = sessionStore.peek(sessionId);
+    sessionStore.delete(sessionId);
+    if (entry) {
+      try {
+        await closeSessionEntry(entry, sessionId);
+      } catch (e) {
+        logger.warn('Shutdown: failed to close session %s: %s', sessionId, e.message);
+      }
+    }
+  }
+}
+
+const sessionGcTimer = setInterval(() => {
+  gcIdleSessions().catch((e) => logger.error('Session GC error:', e.message));
+}, SESSION_GC_INTERVAL_MS);
+if (typeof sessionGcTimer.unref === 'function') sessionGcTimer.unref();
+
+// --- End per-session browser contexts (#11539) ---
 
 async function initBrowser() {
   try {
@@ -80,22 +161,23 @@ app.get('/health', (req, res) => {
   });
 });
 
-// --- Persistent navigation page helpers (#1130) ---
+// --- Persistent navigation page helpers (#1130, per-session since #11539) ---
 
-async function ensureNavPage() {
-  const b = await initBrowser();
-  if (!navPage || navPage.isClosed()) {
-    navPage = await b.newPage();
-    await navPage.setExtraHTTPHeaders({
+async function ensureNavPage(sessionId) {
+  const entry = await getSessionEntry(sessionId);
+  if (!entry.navPage || entry.navPage.isClosed()) {
+    entry.navPage = await entry.context.newPage();
+    await entry.navPage.setExtraHTTPHeaders({
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
     });
-    logger.info('Created new navPage');
+    logger.info('Created new navPage for session %s', sessionId);
   }
-  return navPage;
+  sessionStore.touch(sessionId);
+  return entry.navPage;
 }
 
-async function captureNavScreenshot() {
-  const buf = await navPage.screenshot({ type: 'png' });
+async function captureNavScreenshot(page) {
+  const buf = await page.screenshot({ type: 'png' });
   return buf.toString('base64');
 }
 
@@ -110,7 +192,7 @@ function applyJitter(x, y) {
 
 // Standard response for all interaction endpoints (#1416)
 async function navInteractionResponse(page) {
-  const screenshot = await captureNavScreenshot();
+  const screenshot = await captureNavScreenshot(page);
   const vp = page.viewportSize() || { width: 1280, height: 720 };
   return {
     success: true,
@@ -124,10 +206,19 @@ async function navInteractionResponse(page) {
 
 app.get('/status', async (req, res) => {
   try {
+    const sessionId = sessionIdFromRequest(req);
     const connected = browser && browser.isConnected();
+    const entry = sessionStore.peek(sessionId);
+    const navPage = entry ? entry.navPage : null;
     const pageOpen = navPage && !navPage.isClosed();
     const currentUrl = pageOpen ? navPage.url() : null;
-    res.json({ status: connected ? 'connected' : 'disconnected', browser_connected: connected, page_open: pageOpen, current_url: currentUrl });
+    res.json({
+      status: connected ? 'connected' : 'disconnected',
+      browser_connected: connected,
+      page_open: pageOpen,
+      current_url: currentUrl,
+      session_id: sessionId,
+    });
   } catch (e) {
     res.status(500).json({ status: 'error', browser_connected: false, page_open: false, error: e.message });
   }
@@ -135,9 +226,10 @@ app.get('/status', async (req, res) => {
 
 app.post('/navigate', async (req, res) => {
   const { url } = req.body;
+  const sessionId = sessionIdFromRequest(req);
   if (!url) return res.status(400).json({ success: false, error: 'url required' });
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
     res.json(await navInteractionResponse(page));
   } catch (e) {
@@ -147,8 +239,9 @@ app.post('/navigate', async (req, res) => {
 });
 
 app.post('/screenshot', async (req, res) => {
+  const sessionId = sessionIdFromRequest(req);
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     res.json(await navInteractionResponse(page));
   } catch (e) {
     logger.error('screenshot error:', e.message);
@@ -157,8 +250,9 @@ app.post('/screenshot', async (req, res) => {
 });
 
 app.post('/back', async (req, res) => {
+  const sessionId = sessionIdFromRequest(req);
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     await page.goBack({ waitUntil: 'domcontentloaded', timeout: 15000 });
     res.json(await navInteractionResponse(page));
   } catch (e) {
@@ -168,8 +262,9 @@ app.post('/back', async (req, res) => {
 });
 
 app.post('/forward', async (req, res) => {
+  const sessionId = sessionIdFromRequest(req);
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     await page.goForward({ waitUntil: 'domcontentloaded', timeout: 15000 });
     res.json(await navInteractionResponse(page));
   } catch (e) {
@@ -179,8 +274,9 @@ app.post('/forward', async (req, res) => {
 });
 
 app.post('/reload', async (req, res) => {
+  const sessionId = sessionIdFromRequest(req);
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 15000 });
     res.json(await navInteractionResponse(page));
   } catch (e) {
@@ -195,11 +291,12 @@ app.post('/reload', async (req, res) => {
 
 app.post('/click', async (req, res) => {
   const { x, y } = req.body;
+  const sessionId = sessionIdFromRequest(req);
   if (typeof x !== 'number' || typeof y !== 'number') {
     return res.status(400).json({ success: false, error: 'x and y coordinates required' });
   }
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     const jittered = applyJitter(x, y);
     logger.info('Click at:', { original: { x, y }, jittered });
     await page.mouse.click(jittered.x, jittered.y);
@@ -213,11 +310,12 @@ app.post('/click', async (req, res) => {
 
 app.post('/scroll', async (req, res) => {
   const { deltaX = 0, deltaY = 0 } = req.body;
+  const sessionId = sessionIdFromRequest(req);
   if (typeof deltaX !== 'number' || typeof deltaY !== 'number') {
     return res.status(400).json({ success: false, error: 'deltaX and deltaY must be numbers' });
   }
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     logger.info('Scroll:', { deltaX, deltaY });
     await page.mouse.wheel(deltaX, deltaY);
     await page.waitForTimeout(200);
@@ -230,11 +328,12 @@ app.post('/scroll', async (req, res) => {
 
 app.post('/type', async (req, res) => {
   const { text } = req.body;
+  const sessionId = sessionIdFromRequest(req);
   if (!text || typeof text !== 'string') {
     return res.status(400).json({ success: false, error: 'text string required' });
   }
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     logger.info('Type:', text.substring(0, 50));
     await page.keyboard.type(text, { delay: 30 + Math.random() * 40 });
     await page.waitForTimeout(200);
@@ -247,11 +346,12 @@ app.post('/type', async (req, res) => {
 
 app.post('/hover', async (req, res) => {
   const { x, y } = req.body;
+  const sessionId = sessionIdFromRequest(req);
   if (typeof x !== 'number' || typeof y !== 'number') {
     return res.status(400).json({ success: false, error: 'x and y coordinates required' });
   }
   try {
-    const page = await ensureNavPage();
+    const page = await ensureNavPage(sessionId);
     const jittered = applyJitter(x, y);
     logger.info('Hover at:', { original: { x, y }, jittered });
     await page.mouse.move(jittered.x, jittered.y);
@@ -834,28 +934,30 @@ app.post('/test-frontend', async (req, res) => {
 
 // =============================================================================
 // MCP automation dispatcher – browser_mcp.py sends POST /automation with
-// { action, params } payload to control a dedicated MCP browser page.
+// { action, params, session_id } payload to control the MCP browser page
+// dedicated to that conversation/session (#11539 — was one shared page for
+// every conversation).
 // =============================================================================
 
-let mcpPage = null;
-
-async function ensureMcpPage() {
-  const b = await initBrowser();
-  if (!mcpPage || mcpPage.isClosed()) {
-    mcpPage = await b.newPage();
-    logger.info('MCP automation page created');
+async function ensureMcpPage(sessionId) {
+  const entry = await getSessionEntry(sessionId);
+  if (!entry.mcpPage || entry.mcpPage.isClosed()) {
+    entry.mcpPage = await entry.context.newPage();
+    logger.info('MCP automation page created for session %s', sessionId);
   }
-  return mcpPage;
+  sessionStore.touch(sessionId);
+  return entry.mcpPage;
 }
 
 app.post('/automation', async (req, res) => {
   const { action, params = {} } = req.body;
+  const sessionId = sessionIdFromRequest(req);
   if (!action) {
     return res.status(400).json({ success: false, error: 'action is required' });
   }
-  logger.info('Automation action:', action);
+  logger.info('Automation action:', action, 'session:', sessionId);
   try {
-    const page = await ensureMcpPage();
+    const page = await ensureMcpPage(sessionId);
     let result = {};
     switch (action) {
       case 'navigate': {
@@ -920,7 +1022,7 @@ app.post('/automation', async (req, res) => {
       default:
         return res.status(400).json({ success: false, error: `Unknown action: ${action}` });
     }
-    res.json({ success: true, action, result, timestamp: new Date().toISOString() });
+    res.json({ success: true, action, result, session_id: sessionId, timestamp: new Date().toISOString() });
   } catch (error) {
     logger.error('Automation error:', action, error);
     res.status(500).json({ success: false, error: error.message, action });
@@ -942,6 +1044,8 @@ app.listen(port, '0.0.0.0', async () => {
 // Graceful shutdown
 process.on('SIGTERM', async () => {
   logger.info('Shutting down gracefully...');
+  clearInterval(sessionGcTimer);
+  await closeAllSessions();
   if (browser) {
     await browser.close();
     logger.info('Browser closed');
@@ -951,6 +1055,8 @@ process.on('SIGTERM', async () => {
 
 process.on('SIGINT', async () => {
   logger.info('Received SIGINT, shutting down...');
+  clearInterval(sessionGcTimer);
+  await closeAllSessions();
   if (browser) {
     await browser.close();
     logger.info('Browser closed');

--- a/autobot-browser-worker/session-store.js
+++ b/autobot-browser-worker/session-store.js
@@ -1,0 +1,125 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+'use strict';
+
+/**
+ * Per-session resource store with idle-based garbage collection.
+ *
+ * GH#11539: the browser worker previously held a single global page shared by
+ * every conversation/user, so cookies and login state bled across
+ * conversations. This store keys one resource (a Playwright BrowserContext,
+ * in playwright-server.js) per session_id so each conversation gets its own
+ * isolated cookie jar / localStorage / auth state.
+ *
+ * Mirrors the idle-GC pattern in
+ * autobot-backend/services/docker_task_workspace.py: an env-var-driven idle
+ * timeout constant plus a gc pass that destroys resources idle longer than
+ * that timeout. Kept free of any Playwright dependency so the
+ * creation/reuse/eviction semantics can be unit tested without a browser.
+ */
+
+const DEFAULT_SESSION_ID = 'default';
+
+// Env-configurable idle timeout — never hardcode the TTL (repo convention).
+const DEFAULT_IDLE_TIMEOUT_MS = parseInt(process.env.BROWSER_SESSION_IDLE_TIMEOUT_MS || String(30 * 60 * 1000), 10);
+
+class SessionStore {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.idleTimeoutMs] - evict entries idle longer than this (ms)
+   * @param {() => number} [opts.now] - clock injection point for tests
+   */
+  constructor(opts = {}) {
+    this._idleTimeoutMs = opts.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+    this._now = opts.now || (() => Date.now());
+    this._entries = new Map(); // sessionId -> { value, lastActivity }
+  }
+
+  /** Normalize an incoming session id — falsy/blank input maps to DEFAULT_SESSION_ID
+   * so a lone caller with no session_id keeps today's single-session behavior. */
+  static resolveSessionId(rawId) {
+    return rawId && String(rawId).trim() ? String(rawId).trim() : DEFAULT_SESSION_ID;
+  }
+
+  /** Return the current value for sessionId without touching its idle timer, or null. */
+  peek(sessionId) {
+    const entry = this._entries.get(sessionId);
+    return entry ? entry.value : null;
+  }
+
+  has(sessionId) {
+    return this._entries.has(sessionId);
+  }
+
+  /**
+   * Get the value for sessionId, creating it via `await createFn()` if absent.
+   * Always refreshes the idle timer (touch-on-access), matching the
+   * "active session never GC'd mid-conversation" requirement.
+   */
+  async getOrCreate(sessionId, createFn) {
+    let entry = this._entries.get(sessionId);
+    if (!entry) {
+      const value = await createFn();
+      entry = { value, lastActivity: this._now() };
+      this._entries.set(sessionId, entry);
+    } else {
+      entry.lastActivity = this._now();
+    }
+    return entry.value;
+  }
+
+  /** Refresh the idle timer for an existing session without creating one. */
+  touch(sessionId) {
+    const entry = this._entries.get(sessionId);
+    if (entry) entry.lastActivity = this._now();
+  }
+
+  delete(sessionId) {
+    this._entries.delete(sessionId);
+  }
+
+  ids() {
+    return Array.from(this._entries.keys());
+  }
+
+  size() {
+    return this._entries.size;
+  }
+
+  /**
+   * Evict entries idle longer than idleTimeoutMs, awaiting
+   * `closeFn(value, sessionId)` for each eviction. A `closeFn` rejection is
+   * reported via `onError(sessionId, error)` (if provided) rather than being
+   * swallowed or aborting the remaining evictions; without `onError` it
+   * rethrows on the first failure.
+   *
+   * Returns the list of evicted session ids.
+   */
+  async gcIdle(closeFn, onError) {
+    const cutoff = this._now() - this._idleTimeoutMs;
+    const evicted = [];
+    for (const [sessionId, entry] of this._entries.entries()) {
+      if (entry.lastActivity < cutoff) {
+        evicted.push(sessionId);
+      }
+    }
+    for (const sessionId of evicted) {
+      const entry = this._entries.get(sessionId);
+      this._entries.delete(sessionId);
+      try {
+        if (entry) await closeFn(entry.value, sessionId);
+      } catch (err) {
+        if (onError) {
+          onError(sessionId, err);
+        } else {
+          throw err;
+        }
+      }
+    }
+    return evicted;
+  }
+}
+
+module.exports = { SessionStore, DEFAULT_SESSION_ID, DEFAULT_IDLE_TIMEOUT_MS };

--- a/autobot-browser-worker/session-store.js
+++ b/autobot-browser-worker/session-store.js
@@ -99,17 +99,26 @@ class SessionStore {
    */
   async gcIdle(closeFn, onError) {
     const cutoff = this._now() - this._idleTimeoutMs;
-    const evicted = [];
+    const candidateIds = [];
     for (const [sessionId, entry] of this._entries.entries()) {
       if (entry.lastActivity < cutoff) {
-        evicted.push(sessionId);
+        candidateIds.push(sessionId);
       }
     }
-    for (const sessionId of evicted) {
+    const evicted = [];
+    for (const sessionId of candidateIds) {
+      // Re-check right before evicting: a live request may have touched (or
+      // recreated) this session between the scan above and here, or while
+      // this loop was awaiting an earlier entry's closeFn — don't close a
+      // session out from under it.
       const entry = this._entries.get(sessionId);
+      if (!entry || !(entry.lastActivity < cutoff)) {
+        continue;
+      }
       this._entries.delete(sessionId);
+      evicted.push(sessionId);
       try {
-        if (entry) await closeFn(entry.value, sessionId);
+        await closeFn(entry.value, sessionId);
       } catch (err) {
         if (onError) {
           onError(sessionId, err);

--- a/autobot-browser-worker/tests/session-store.test.js
+++ b/autobot-browser-worker/tests/session-store.test.js
@@ -121,6 +121,33 @@ test('gcIdle evicts only entries idle past the timeout, closing them via closeFn
   assert.equal(store.has('fresh'), true);
 });
 
+test("gcIdle re-checks lastActivity before evicting — a session touched during an earlier entry's closeFn await survives (review fix)", async () => {
+  let now = 0;
+  const store = new SessionStore({ idleTimeoutMs: 100, now: () => now });
+
+  await store.getOrCreate('first', async () => ({}));
+  await store.getOrCreate('second', async () => ({}));
+  now += 200; // both idle past the 100ms timeout at gcIdle-call time
+
+  const closed = [];
+  const closeFn = async (_value, sessionId) => {
+    if (sessionId === 'first') {
+      // Simulate a live request arriving for `second` while `first`'s close
+      // is still in flight — it must not be evicted out from under it.
+      now += 10;
+      store.touch('second');
+    }
+    closed.push(sessionId);
+  };
+
+  const evicted = await store.gcIdle(closeFn);
+
+  assert.deepEqual(evicted, ['first']);
+  assert.deepEqual(closed, ['first']);
+  assert.equal(store.has('first'), false);
+  assert.equal(store.has('second'), true, 'second must survive — it was touched mid-GC');
+});
+
 test('gcIdle surfaces close failures via onError instead of swallowing them or aborting other evictions', async () => {
   let now = 0;
   const store = new SessionStore({ idleTimeoutMs: 10, now: () => now });

--- a/autobot-browser-worker/tests/session-store.test.js
+++ b/autobot-browser-worker/tests/session-store.test.js
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+'use strict';
+
+/**
+ * Tests for the per-session context store backing playwright-server.js
+ * (#11539 — browser worker no longer shares one page/context across every
+ * conversation).
+ *
+ * Uses Node's built-in test runner (`node --test`) so this suite has zero
+ * dependency on Playwright / @playwright/test, neither of which is
+ * installed in every environment this worker's logic is exercised in. The
+ * store itself has no Playwright dependency either — real BrowserContext
+ * objects are swapped for plain mock objects with a `cookies` Map, which is
+ * enough to prove the isolation and GC contracts playwright-server.js
+ * relies on.
+ *
+ * Run: node --test autobot-browser-worker/tests/session-store.test.js
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { SessionStore, DEFAULT_SESSION_ID } = require('../session-store');
+
+test('resolveSessionId falls back to DEFAULT_SESSION_ID for blank/missing input', () => {
+  assert.equal(SessionStore.resolveSessionId(undefined), DEFAULT_SESSION_ID);
+  assert.equal(SessionStore.resolveSessionId(null), DEFAULT_SESSION_ID);
+  assert.equal(SessionStore.resolveSessionId(''), DEFAULT_SESSION_ID);
+  assert.equal(SessionStore.resolveSessionId('   '), DEFAULT_SESSION_ID);
+  assert.equal(SessionStore.resolveSessionId('conversation-123'), 'conversation-123');
+  assert.equal(SessionStore.resolveSessionId('  conversation-123  '), 'conversation-123');
+});
+
+test('getOrCreate reuses the same context for a lone/repeat session_id (backward compatible)', async () => {
+  const store = new SessionStore({ idleTimeoutMs: 60000 });
+  let created = 0;
+  const makeContext = () => {
+    created += 1;
+    return { id: created, cookies: new Map() };
+  };
+
+  const first = await store.getOrCreate(DEFAULT_SESSION_ID, makeContext);
+  const second = await store.getOrCreate(DEFAULT_SESSION_ID, makeContext);
+
+  assert.equal(created, 1, 'a single default-session caller must not create a second context');
+  assert.strictEqual(first, second);
+});
+
+test('getOrCreate gives distinct session_ids distinct contexts', async () => {
+  const store = new SessionStore({ idleTimeoutMs: 60000 });
+  let created = 0;
+  const makeContext = () => {
+    created += 1;
+    return { id: created, cookies: new Map() };
+  };
+
+  const ctxA = await store.getOrCreate('conversation-A', makeContext);
+  const ctxB = await store.getOrCreate('conversation-B', makeContext);
+
+  assert.equal(created, 2);
+  assert.notStrictEqual(ctxA, ctxB);
+});
+
+test('SECURITY (#11539): a cookie set in one conversation is absent from another', async () => {
+  const store = new SessionStore({ idleTimeoutMs: 60000 });
+  const makeContext = () => ({ cookies: new Map() });
+
+  // Conversation A logs in to a site — a real BrowserContext would store this
+  // in its cookie jar; here the mock's `cookies` Map stands in for that jar.
+  const contextA = await store.getOrCreate('conversation-A', makeContext);
+  contextA.cookies.set('session_token', 'A-secret-auth-token');
+
+  // Conversation B (a different — possibly different-user — chat session)
+  // gets its own context and must never see A's cookie jar.
+  const contextB = await store.getOrCreate('conversation-B', makeContext);
+
+  assert.equal(contextB.cookies.has('session_token'), false, "B's cookie jar must not contain A's cookie");
+  assert.equal(contextA.cookies.get('session_token'), 'A-secret-auth-token');
+
+  // A second call in conversation A (e.g. the next tool call in the same
+  // chat turn) must return the SAME jar, so the login state persists within
+  // the conversation.
+  const contextAAgain = await store.getOrCreate('conversation-A', makeContext);
+  assert.equal(contextAAgain.cookies.get('session_token'), 'A-secret-auth-token');
+});
+
+test('touch() refreshes the idle timer so an active session survives gcIdle', async () => {
+  let now = 0;
+  const store = new SessionStore({ idleTimeoutMs: 100, now: () => now });
+  await store.getOrCreate('active', async () => ({}));
+
+  now += 80;
+  store.touch('active');
+  now += 80; // 160ms since creation, but only 80ms since the touch
+
+  const evicted = await store.gcIdle(async () => {});
+  assert.deepEqual(evicted, []);
+  assert.equal(store.has('active'), true);
+});
+
+test('gcIdle evicts only entries idle past the timeout, closing them via closeFn (mirrors docker_task_workspace.py idle-GC)', async () => {
+  let now = 1_000_000;
+  const store = new SessionStore({ idleTimeoutMs: 1000, now: () => now });
+  const closed = [];
+  const closeFn = async (_value, sessionId) => {
+    closed.push(sessionId);
+  };
+
+  await store.getOrCreate('stale', async () => ({}));
+  now += 500;
+  await store.getOrCreate('fresh', async () => ({}));
+  now += 600; // stale: 1100ms idle (evicted); fresh: 600ms idle (kept)
+
+  const evicted = await store.gcIdle(closeFn);
+
+  assert.deepEqual(evicted, ['stale']);
+  assert.deepEqual(closed, ['stale']);
+  assert.equal(store.has('stale'), false);
+  assert.equal(store.has('fresh'), true);
+});
+
+test('gcIdle surfaces close failures via onError instead of swallowing them or aborting other evictions', async () => {
+  let now = 0;
+  const store = new SessionStore({ idleTimeoutMs: 10, now: () => now });
+  await store.getOrCreate('bad', async () => ({}));
+  await store.getOrCreate('good', async () => ({}));
+  now += 100;
+
+  const errors = [];
+  const closeFn = async (_value, sessionId) => {
+    if (sessionId === 'bad') throw new Error('boom');
+  };
+  const evicted = await store.gcIdle(closeFn, (sessionId, err) => errors.push([sessionId, err.message]));
+
+  assert.deepEqual(evicted.sort(), ['bad', 'good']);
+  assert.deepEqual(errors, [['bad', 'boom']]);
+  assert.equal(store.has('bad'), false);
+  assert.equal(store.has('good'), false);
+});
+
+test('gcIdle without onError rethrows on a close failure', async () => {
+  let now = 0;
+  const store = new SessionStore({ idleTimeoutMs: 10, now: () => now });
+  await store.getOrCreate('bad', async () => ({}));
+  now += 100;
+
+  const closeFn = async () => {
+    throw new Error('boom');
+  };
+  await assert.rejects(() => store.gcIdle(closeFn), /boom/);
+});

--- a/autobot-frontend/src/components/chat/ChatTabContent.vue
+++ b/autobot-frontend/src/components/chat/ChatTabContent.vue
@@ -41,7 +41,10 @@
 
     <!-- Browser Tab Content (Issue #1130: screenshot-based visual browser) -->
     <div v-else-if="activeTab === 'browser'" class="flex-1 flex flex-col min-h-0">
-      <VisualBrowserPanel class="flex-1" />
+      <!-- #11539: thread the chat conversation id through so this conversation's
+           browser actions land in an isolated worker context (own cookie jar),
+           never the shared default one another conversation might be using. -->
+      <VisualBrowserPanel class="flex-1" :session-id="currentSessionId" />
     </div>
 
     <!-- noVNC Tab Content (Issue #715: Dynamic hosts from user config, Issue #4977: DesktopInterface) -->

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -28,6 +28,14 @@ import Icon from '@/components/ui/Icon.vue'
 const { t } = useI18n()
 const logger = createLogger('VisualBrowserPanel')
 
+// #11539: the browser-worker keys one isolated context (own cookie jar) per
+// session_id. This panel is mounted per chat conversation (see
+// ChatTabContent.vue), so threading the conversation's id here — instead of
+// omitting it — keeps two concurrent conversations from sharing a browser
+// session/cookie jar. No prop = falls back to the worker's shared default
+// bucket (unchanged single-conversation behavior).
+const props = defineProps<{ sessionId?: string | null }>()
+
 const loading = ref(false)
 const error = ref<string | null>(null)
 const url = ref('https://www.google.com')
@@ -67,7 +75,10 @@ function toggleAutomation(): void {
 
 async function checkStatus(): Promise<void> {
   try {
-    const data = await ApiClient.get<Record<string, unknown>>(`${getApiBase()}/playwright/worker-status`)
+    const statusUrl = props.sessionId
+      ? `${getApiBase()}/playwright/worker-status?session_id=${encodeURIComponent(props.sessionId)}`
+      : `${getApiBase()}/playwright/worker-status`
+    const data = await ApiClient.get<Record<string, unknown>>(statusUrl)
     isConnected.value = data.status === 'connected' || data.browser_connected === true
   } catch (e) {
     logger.warn('Browser status check failed:', e)
@@ -87,7 +98,10 @@ async function navigate(): Promise<void> {
   url.value = targetUrl
 
   try {
-    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/navigate`, { url: targetUrl })
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/navigate`, {
+      url: targetUrl,
+      session_id: props.sessionId || undefined
+    })
     currentUrl.value = (nav.url as string) || targetUrl
     pageTitle.value = (nav.title as string) || null
     isConnected.value = true
@@ -105,7 +119,9 @@ async function navigate(): Promise<void> {
 
 async function captureScreenshot(): Promise<void> {
   try {
-    const data = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/worker-screenshot`, {})
+    const data = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/worker-screenshot`, {
+      session_id: props.sessionId || undefined
+    })
     screenshot.value = (data.screenshot as string) || null
   } catch (e) {
     logger.warn('Screenshot failed:', e)
@@ -117,7 +133,9 @@ async function goBack(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/back`, {})
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/back`, {
+      session_id: props.sessionId || undefined
+    })
     if (nav.url) { currentUrl.value = nav.url as string; url.value = nav.url as string }
     if (nav.title) pageTitle.value = nav.title as string
     if (nav.screenshot) screenshot.value = nav.screenshot as string
@@ -133,7 +151,9 @@ async function goForward(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/forward`, {})
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/forward`, {
+      session_id: props.sessionId || undefined
+    })
     if (nav.url) { currentUrl.value = nav.url as string; url.value = nav.url as string }
     if (nav.title) pageTitle.value = nav.title as string
     if (nav.screenshot) screenshot.value = nav.screenshot as string
@@ -149,7 +169,9 @@ async function reload(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/reload`, {})
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/reload`, {
+      session_id: props.sessionId || undefined
+    })
     if (nav.screenshot) screenshot.value = nav.screenshot as string
   } catch (e) {
     error.value = e instanceof Error ? e.message : t('chat.visualBrowser.reloadFailed')
@@ -165,6 +187,7 @@ async function handleInteract(payload: { action: string; params: Record<string, 
     const result = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/interact`, {
       action: payload.action,
       ...payload.params,
+      session_id: props.sessionId || undefined,
     })
     if (result.screenshot) screenshot.value = result.screenshot as string
     if (result.url) { currentUrl.value = result.url as string; url.value = result.url as string }

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -133,7 +133,7 @@
         @click="runAiPropose"
         :disabled="isAiProposing || !aiGoalText.trim()"
         class="px-3 py-1 text-sm rounded font-medium"
-        style="background: var(--color-primary); color: #fff"
+        style="background: var(--color-primary); color: var(--text-on-primary)"
       >
         {{ isAiProposing ? 'Proposing…' : 'Propose' }}
       </button>

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -703,7 +703,7 @@ export default {
           return null
         }
 
-        return await browserApi.navigateBack()
+        return await browserApi.navigateBack(props.sessionId)
       },
       {
         onSuccess: (result) => {
@@ -737,7 +737,7 @@ export default {
           return null
         }
 
-        return await browserApi.navigateForward()
+        return await browserApi.navigateForward(props.sessionId)
       },
       {
         onSuccess: (result) => {
@@ -770,7 +770,7 @@ export default {
           return 'navigate-fallback'
         }
 
-        return await browserApi.reloadPage()
+        return await browserApi.reloadPage(props.sessionId)
       },
       {
         onSuccess: async (result) => {

--- a/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
+++ b/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
@@ -113,28 +113,35 @@ export function useBrowserSessionData() {
 
   /**
    * Playwright back navigation.
+   *
+   * `sessionId` (#11539) routes this to the caller's isolated browser
+   * context on the worker, same as navigateTo — omit for the shared
+   * default session.
    */
-  async function navigateBack(): Promise<PlaywrightNavigationResponse> {
+  async function navigateBack(sessionId?: string): Promise<PlaywrightNavigationResponse> {
     return await apiClient.post<PlaywrightNavigationResponse>(
-      `${getApiBase()}/playwright/back`
+      `${getApiBase()}/playwright/back`,
+      { session_id: sessionId }
     )
   }
 
   /**
-   * Playwright forward navigation.
+   * Playwright forward navigation. `sessionId` (#11539) — see navigateBack.
    */
-  async function navigateForward(): Promise<PlaywrightNavigationResponse> {
+  async function navigateForward(sessionId?: string): Promise<PlaywrightNavigationResponse> {
     return await apiClient.post<PlaywrightNavigationResponse>(
-      `${getApiBase()}/playwright/forward`
+      `${getApiBase()}/playwright/forward`,
+      { session_id: sessionId }
     )
   }
 
   /**
-   * Playwright page reload.
+   * Playwright page reload. `sessionId` (#11539) — see navigateBack.
    */
-  async function reloadPage(): Promise<PlaywrightNavigationResponse> {
+  async function reloadPage(sessionId?: string): Promise<PlaywrightNavigationResponse> {
     return await apiClient.post<PlaywrightNavigationResponse>(
-      `${getApiBase()}/playwright/reload`
+      `${getApiBase()}/playwright/reload`,
+      { session_id: sessionId }
     )
   }
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -58231,7 +58231,7 @@ export interface components {
             timeout: number | null;
             /**
              * Session Id
-             * @description Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session
+             * @description Session id for isolated browser-context routing (#11539); omitted uses shared default
              */
             session_id?: string | null;
         } & {
@@ -85312,7 +85312,7 @@ export interface components {
             timeout: number;
             /**
              * Session Id
-             * @description Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session
+             * @description Session id for isolated browser-context routing (#11539); omitted uses shared default
              */
             session_id?: string | null;
         } & {

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -33260,6 +33260,7 @@ export interface paths {
          *
          *     Forwards back navigation request to Browser VM (NetworkConstants.BROWSER_VM_IP)
          *     Issue #552: Added missing endpoint for frontend PopoutChromiumBrowser.vue
+         *     Issue #11539: threads session_id so this routes to the caller's isolated context.
          */
         post: operations["go_back_api_playwright_back_post"];
         delete?: never;
@@ -33283,6 +33284,7 @@ export interface paths {
          *
          *     Forwards forward navigation request to Browser VM (NetworkConstants.BROWSER_VM_IP)
          *     Issue #552: Added missing endpoint for frontend PopoutChromiumBrowser.vue
+         *     Issue #11539: threads session_id so this routes to the caller's isolated context.
          */
         post: operations["go_forward_api_playwright_forward_post"];
         delete?: never;
@@ -33302,7 +33304,9 @@ export interface paths {
          * Get Worker Status
          * @description Get browser worker connectivity status from Browser VM (#1130)
          *
-         *     Proxies to Browser VM /status endpoint which checks the persistent navPage.
+         *     Proxies to Browser VM /status endpoint which checks the persistent navPage
+         *     for this caller's session (#11539 — session_id selects which isolated
+         *     context's navPage is inspected; omitted = shared default session).
          */
         get: operations["get_worker_status_api_playwright_worker_status_get"];
         put?: never;
@@ -33327,7 +33331,8 @@ export interface paths {
          * @description Take screenshot of the persistent navigation page on Browser VM (#1130)
          *
          *     Unlike /screenshot which takes a fresh-page screenshot for a given URL,
-         *     this returns a screenshot of the current state of the persistent navPage.
+         *     this returns a screenshot of the current state of the persistent navPage
+         *     for this caller's session (#11539).
          */
         post: operations["take_worker_screenshot_api_playwright_worker_screenshot_post"];
         delete?: never;
@@ -57929,6 +57934,11 @@ export interface components {
              * @default 5000
              */
             timeout: number | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -57954,6 +57964,11 @@ export interface components {
              * @description JavaScript code to execute
              */
             script: string;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -57990,6 +58005,11 @@ export interface components {
              * @default 5000
              */
             timeout: number | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -58022,6 +58042,11 @@ export interface components {
              * @description Attribute name to retrieve
              */
             attribute: string;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -58049,6 +58074,11 @@ export interface components {
              * @description CSS selector for element
              */
             selector: string;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -58074,6 +58104,11 @@ export interface components {
              * @description CSS selector for element to hover
              */
             selector: string;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -58194,6 +58229,11 @@ export interface components {
              * @default 30000
              */
             timeout: number | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -58267,6 +58307,11 @@ export interface components {
              * @default false
              */
             full_page: boolean | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -58301,6 +58346,11 @@ export interface components {
              * @description Value to select
              */
             value: string;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -58449,6 +58499,11 @@ export interface components {
              * @default visible
              */
             state: string | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -85236,6 +85291,8 @@ export interface components {
             deltaY: number;
             /** Text */
             text?: string | null;
+            /** Session Id */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -85253,6 +85310,11 @@ export interface components {
              * @default 30000
              */
             timeout: number;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539); omitted = shared default session
+             */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -85279,6 +85341,8 @@ export interface components {
              * @default networkidle
              */
             wait_until: string;
+            /** Session Id */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -85296,6 +85360,8 @@ export interface components {
              * @default 5000
              */
             wait_timeout: number;
+            /** Session Id */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -85313,6 +85379,18 @@ export interface components {
              * @default 5
              */
             max_results: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * PlaywrightSessionRequest
+         * @description Optional body for worker proxy calls with no other payload (#11539):
+         *     /back, /forward, /worker-screenshot. GET /status takes the same id as a
+         *     query param instead (no request body on GET).
+         */
+        PlaywrightSessionRequest: {
+            /** Session Id */
+            session_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -144357,7 +144435,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PlaywrightSessionRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -144366,6 +144448,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PlaywrightBrowserActionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -144377,7 +144468,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PlaywrightSessionRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -144388,11 +144483,22 @@ export interface operations {
                     "application/json": components["schemas"]["PlaywrightBrowserActionResponse"];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     get_worker_status_api_playwright_worker_status_get: {
         parameters: {
-            query?: never;
+            query?: {
+                session_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -144408,6 +144514,15 @@ export interface operations {
                     "application/json": components["schemas"]["PlaywrightWorkerStatusResponse"];
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     take_worker_screenshot_api_playwright_worker_screenshot_post: {
@@ -144417,7 +144532,11 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PlaywrightSessionRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -144426,6 +144545,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PlaywrightBrowserActionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Thinking Path
Issue #11539 (security, umbrella #11536 Task 3): browser worker held a single global `navPage` for ALL conversations/users — cookies/login state bled across conversations. Per-session contexts existed in `research_browser_manager.py` but the chat path used the shared page.

## What Changed
- New `autobot-browser-worker/session-store.js`: pure session store (create/reuse/touch/gcIdle), one Playwright `BrowserContext` per `session_id`.
- `playwright-server.js`: per-session context routing, idle GC (`setInterval`, `.unref()`), graceful shutdown close-all.
- `browser_mcp.py`: `send_to_browser_vm(action, params, session_id=...)` + `DEFAULT_BROWSER_SESSION_ID`; all 10 `/mcp/*` handlers thread `request.session_id`.
- `schemas_system.py`: optional `session_id` on the 10 Browser*Request models.
- `tool_handler.py`: `_handle_browser_tool` and web_search browser-VM fallback chain thread the chat `session_id`.
- Idle TTL via env (`BROWSER_SESSION_IDLE_TIMEOUT_MS` default 30m, `BROWSER_SESSION_GC_INTERVAL_MS` default 5m) — never hardcoded. Requests without `session_id` map to `default` bucket (back-compat).

## Verification
node --test `session-store.test.js` 8/8 (incl. cookie-in-A absent-in-B isolation proof); pytest `test_browser_mcp_session_isolation.py` 5/5 (distinct session_id on the wire + live tool-dispatch threading + default fallback); regression `tests/unit/chat_workflow/` 238/238. `node --check` + `py_compile` clean. Note: no Chromium in sandbox — real Playwright cookie E2E not run; pure SessionStore logic (the mechanism the worker relies on) is covered.

## Model Used
Opus 4.8

Closes #11539