### PR TITLE
chore(deps): guard vega-functions against semver-major auto-bumps (#11697)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -132,6 +132,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "vega-embed"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "vega-functions"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "vega-lite"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@pinia/testing"


### PR DESCRIPTION
## Thinking Path
`vega`, `vega-embed`, `vega-lite` are already guarded against `version-update:semver-major` in dependabot; `vega-functions` was missing the same guard, so a major bump could auto-open a breaking PR.

## What Changed
- `.github/dependabot.yml`: added a `vega-functions` ignore entry mirroring the existing vega/vega-lite guards exactly (placed alphabetically). +2 lines, no other changes.

Closes #11697

## Verification
- YAML validates (`yaml.safe_load`). Only one npm ecosystem block guards vega deps; the new entry sits alongside them.

## Model Used
Opus 4.8 (subagent: general-purpose)