### PR TITLE
fix(chat): propagate lightweight_mode_used through LangGraph path (#11612)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -318,6 +318,14 @@ async def prepare_llm(state: ChatState, config: RunnableConfig) -> dict:
         [],  # workflow_messages managed by graph state
     )
 
+    # #11612: persist lightweight_mode_used into state["context"] so
+    # _build_llm_iteration_context (used by generate_response) re-merges it
+    # into ctx.context. Without this, the ctx built above — which DOES carry
+    # the flag via _create_llm_iteration_context — is discarded, and the
+    # response-metadata cost badge sees it only on the non-graph path.
+    updated_context = dict(state.get("context", {}) or {})
+    updated_context["lightweight_mode_used"] = llm_params.get("lightweight_mode_used", False)
+
     return {
         "llm_params": {
             "ollama_endpoint": ctx.ollama_endpoint,
@@ -327,6 +335,7 @@ async def prepare_llm(state: ChatState, config: RunnableConfig) -> dict:
         },
         "used_knowledge": ctx.used_knowledge,
         "rag_citations": [c for c in (ctx.rag_citations or [])],
+        "context": updated_context,
         # Reset per-turn loop detection state (#3583). LangGraph persists
         # ChatState in Redis across turns; without this reset, loop counts
         # accumulate across different user turns and trigger false aborts.

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2503,6 +2503,11 @@ before summarizing.
         Run a single loop iteration. Yields (llm_response, should_continue) at end.
 
         Issue #375: Uses LLMIterationContext to reduce parameter count from 12 to 4.
+        Issue #11612: Sets the lightweight_mode_used ContextVar here — the single
+        seam both the legacy continuation loop (_run_llm_iterations) and the
+        LangGraph path (graph.py::_run_llm_iteration) call through — instead of
+        in the outer _execute_llm_continuation_loop wrapper, which the graph
+        path bypasses entirely (causing the cost badge to always read False).
         """
         logger.info(
             "[ChatWorkflowManager] Continuation iteration %d/%d",
@@ -2510,16 +2515,23 @@ before summarizing.
             self.MAX_CONTINUATION_ITERATIONS,
         )
 
-        llm_response = None
-        should_continue = False
+        # MVA-1993 / #11216 / #11612: store lightweight_mode_used in a task-local
+        # ContextVar (not on the shared singleton) for the response-metadata badge.
+        _lw_token = _current_lightweight_mode.set(ctx.context.get("lightweight_mode_used", False))
+        try:
+            llm_response = None
+            should_continue = False
 
-        async for item in self._run_continuation_iteration(http_client, current_prompt, iteration, ctx):
-            if isinstance(item, tuple) and len(item) == 3:
-                llm_response, _, should_continue = item
-            else:
-                yield item
+            async for item in self._run_continuation_iteration(http_client, current_prompt, iteration, ctx):
+                if isinstance(item, tuple) and len(item) == 3:
+                    llm_response, _, should_continue = item
+                else:
+                    yield item
 
-        yield (llm_response, should_continue)
+            yield (llm_response, should_continue)
+        finally:
+            # MVA-1993 / #11216: restore the caller's task-local value (token reset).
+            _current_lightweight_mode.reset(_lw_token)
 
     def _log_iteration_start(self, ctx: LLMIterationContext) -> None:
         """Issue #665: Extracted from _run_llm_iterations to reduce function length.
@@ -2664,15 +2676,13 @@ before summarizing.
         Execute the multi-step LLM continuation loop.
 
         Issue #375: Uses LLMIterationContext to reduce parameter count from 10 to 1.
-        Issue MVA-1993: Sets lightweight_mode_used flag for response metadata.
+        Issue MVA-1993 / #11612: lightweight_mode_used ContextVar is now set inside
+        _run_continuation_loop_iteration (the shared seam both this loop and the
+        LangGraph path call through), not here — see that method's docstring.
         """
         import aiohttp
 
         from autobot_shared.http_client import get_http_client
-
-        # MVA-1993 / #11216: store lightweight_mode_used in a task-local ContextVar
-        # (not on the shared singleton) for the response-metadata badge.
-        _lw_token = _current_lightweight_mode.set(ctx.context.get("lightweight_mode_used", False))
 
         try:
             http_client = get_http_client()
@@ -2688,10 +2698,6 @@ before summarizing.
             error_msg = self._create_llm_error_message(error, ctx.workflow_messages)
             yield error_msg
             yield ([], [], error_msg)
-
-        finally:
-            # MVA-1993 / #11216: restore the caller's task-local value (token reset).
-            _current_lightweight_mode.reset(_lw_token)
 
     async def _persist_workflow_messages(
         self,

--- a/autobot-backend/tests/unit/chat_workflow/test_lightweight_mode_graph_path.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_lightweight_mode_graph_path.py
@@ -1,0 +1,164 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11612: lightweight_mode_used must survive the LangGraph path into the
+response metadata the frontend cost badge reads.
+
+Root cause: graph.py::prepare_llm computed a ctx carrying
+lightweight_mode_used (via manager._create_llm_iteration_context) but
+discarded it, never writing it back into state["context"]. generate_response
+then rebuilds ctx from the raw state["context"] via _build_llm_iteration_context,
+so the flag was gone. Separately, the ContextVar that the streamed-message
+metadata reads was only set by _execute_llm_continuation_loop, a wrapper the
+graph path bypasses (it calls _run_continuation_loop_iteration directly).
+
+These tests pin both halves of the fix.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _prepare_llm():
+    try:
+        from chat_workflow.graph import prepare_llm
+    except ImportError as exc:  # env-dependent chain; a real regression still fails
+        pytest.skip(f"chat_workflow not importable here: {exc}")
+    return prepare_llm
+
+
+def _build_ctx():
+    from chat_workflow.graph import _build_llm_iteration_context
+
+    return _build_llm_iteration_context
+
+
+def _mock_manager(lightweight_mode: bool):
+    from chat_workflow.manager import ChatWorkflowManager
+
+    manager = ChatWorkflowManager.__new__(ChatWorkflowManager)
+    manager.get_or_create_session = AsyncMock(return_value=MagicMock(session_id="s1"))
+    manager._prepare_llm_workflow_params = AsyncMock(
+        return_value={
+            "endpoint": "http://x/api/generate",
+            "model": "m",
+            "prompt": "p",
+            "system_prompt": "s",
+            "used_knowledge": False,
+            "citations": [],
+            "lightweight_mode_used": lightweight_mode,
+        }
+    )
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_prepare_llm_persists_lightweight_mode_into_state_context():
+    """prepare_llm must write lightweight_mode_used into the returned
+    state["context"], not just into the ctx it discards."""
+    prepare_llm = _prepare_llm()
+    manager = _mock_manager(lightweight_mode=True)
+    config = {"configurable": {"manager": manager}}
+    state = {
+        "session_id": "s1",
+        "terminal_session_id": "t1",
+        "user_message": "hi",
+        "context": {"company_id": "co-1"},
+    }
+
+    result = await prepare_llm(state, config)
+
+    assert result["context"]["lightweight_mode_used"] is True
+    # Pre-existing context keys must survive the merge.
+    assert result["context"]["company_id"] == "co-1"
+
+
+@pytest.mark.asyncio
+async def test_prepare_llm_to_generate_response_roundtrip_carries_flag():
+    """End-to-end: prepare_llm's state update, fed back into state, must let
+    _build_llm_iteration_context (used by generate_response) see the flag —
+    this is exactly the seam the graph path previously dropped it at."""
+    prepare_llm = _prepare_llm()
+    build_ctx = _build_ctx()
+    manager = _mock_manager(lightweight_mode=True)
+    config = {"configurable": {"manager": manager}}
+    state = {
+        "session_id": "s1",
+        "terminal_session_id": "t1",
+        "user_message": "hi",
+        "context": {},
+    }
+
+    update = await prepare_llm(state, config)
+    state.update(update)
+
+    ctx = build_ctx(state)
+
+    assert ctx.context.get("lightweight_mode_used") is True
+
+
+@pytest.mark.asyncio
+async def test_prepare_llm_carries_false_when_not_lightweight():
+    prepare_llm = _prepare_llm()
+    build_ctx = _build_ctx()
+    manager = _mock_manager(lightweight_mode=False)
+    config = {"configurable": {"manager": manager}}
+    state = {
+        "session_id": "s1",
+        "terminal_session_id": "t1",
+        "user_message": "hi",
+        "context": {},
+    }
+
+    update = await prepare_llm(state, config)
+    state.update(update)
+
+    ctx = build_ctx(state)
+
+    assert ctx.context.get("lightweight_mode_used") is False
+
+
+@pytest.mark.asyncio
+async def test_run_continuation_loop_iteration_sets_contextvar_from_ctx():
+    """The graph path calls _run_continuation_loop_iteration directly, never
+    _execute_llm_continuation_loop — so the ContextVar the streamed-message
+    metadata reads (_current_lightweight_mode, see manager.py _init_streaming_message)
+    must be set inside _run_continuation_loop_iteration itself (#11612)."""
+    import chat_workflow.manager as manager_module
+    from chat_workflow.manager import ChatWorkflowManager, LLMIterationContext
+
+    manager = ChatWorkflowManager.__new__(ChatWorkflowManager)
+    observed = {}
+
+    async def fake_iteration(http_client, current_prompt, iteration, ctx):
+        observed["seen"] = manager_module._current_lightweight_mode.get()
+        yield ("response text", [], False)
+
+    manager._run_continuation_iteration = fake_iteration
+
+    ctx = LLMIterationContext(
+        ollama_endpoint="http://x",
+        selected_model="m",
+        session_id="s1",
+        terminal_session_id="t1",
+        used_knowledge=False,
+        rag_citations=[],
+        workflow_messages=[],
+        system_prompt="s",
+        initial_prompt="p",
+        message="hi",
+        context={"lightweight_mode_used": True},
+    )
+
+    assert manager_module._current_lightweight_mode.get() is False  # ambient default
+
+    async for _item in manager._run_continuation_loop_iteration(None, "p", 1, ctx):
+        pass
+
+    assert observed["seen"] is True
+    # Token must be reset once the iteration completes — no leakage to callers.
+    assert manager_module._current_lightweight_mode.get() is False


### PR DESCRIPTION
## Thinking Path
The cost badge reads `lightweight_mode_used`, but on the LangGraph path it was always false — two distinct drops: (1) `prepare_llm` discarded the `ctx` that carried the flag and never wrote it back to graph state; (2) the ContextVar that the badge reads was set only in the legacy continuation wrapper, which the graph path bypasses.

## What Changed
- `graph.py::prepare_llm`: merges `lightweight_mode_used` into a copy of `state["context"]` (preserving existing keys) so `generate_response`'s rebuilt ctx sees it.
- `manager.py`: moved the `_current_lightweight_mode` set/reset from `_execute_llm_continuation_loop` down into `_run_continuation_loop_iteration` — the single seam BOTH the legacy loop and the graph path call — so the ContextVar is set identically on both. Removed the now-redundant outer set/reset.
- New `test_lightweight_mode_graph_path.py` (4 tests) asserting the flag survives the graph path into response metadata.

Closes #11612

## Verification
- Targeted lightweight-mode suites: 16 passed. Full `tests/unit/chat_workflow/`: 230 passed, 0 failed.
- `black --check` + `py_compile` clean on all 3 files.

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)