### PR TITLE
tokenise(user): FailureAnalysisDashboard hardcoded hexes + px → design tokens (#11916)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -687,6 +687,19 @@
   --voiceoverlay-warning-text: #fcd34d;       /* cert-warning title/foreground */
   --voiceoverlay-warning-body-text: #fde68a;  /* cert-warning body */
   --voiceoverlay-muted-text: #94a3b8;         /* cert-warning fallback note */
+
+  /* ============================================
+   * FAILURE ANALYSIS DASHBOARD TOKENS
+   * Issue #11916 (umbrella #11515). Scoped to views/FailureAnalysisDashboard.vue.
+   * The primary-button label, spinner highlight and causal-chain index badge
+   * render pure white on the blue accent. There is no plain-white design token
+   * (--text-on-primary carries an OKLCH override), so the literal is preserved
+   * here as hex-only (deliberately NO OKLCH override) so the view renders
+   * pixel-identical to its previous hardcoded #fff across all browsers. All
+   * other colors in the view already resolve to emitted Tailwind --color-*
+   * tokens; their dead hex fallbacks were dropped.
+   * ============================================ */
+  --faildash-on-accent: #fff;   /* white label/highlight on blue accent surfaces */
 }
 
 /* ============================================

--- a/autobot-frontend/src/views/FailureAnalysisDashboard.vue
+++ b/autobot-frontend/src/views/FailureAnalysisDashboard.vue
@@ -373,7 +373,7 @@ function levelClass(level: string): string {
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-5);
   background: var(--color-blue-600);
-  color: #fff;
+  color: var(--faildash-on-accent);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -412,7 +412,7 @@ function levelClass(level: string): string {
   width: 14px;
   height: 14px;
   border: 2px solid rgba(255, 255, 255, 0.4);
-  border-top-color: #fff;
+  border-top-color: var(--faildash-on-accent);
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
 }
@@ -427,10 +427,10 @@ function levelClass(level: string): string {
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-3) var(--spacing-4);
-  background: var(--color-red-50, #fef2f2);
-  border: 1px solid var(--color-red-200, #fecaca);
+  background: var(--color-red-50);
+  border: 1px solid var(--color-red-200);
   border-radius: var(--radius-md);
-  color: var(--color-red-700, #b91c1c);
+  color: var(--color-red-700);
   font-size: var(--text-sm);
 }
 
@@ -475,25 +475,25 @@ function levelClass(level: string): string {
 
 .summary-badge {
   padding: var(--spacing-1) var(--spacing-3);
-  border-radius: var(--radius-full, 9999px);
+  border-radius: var(--radius-full);
   font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.05em;
 }
 
 .badge-critical {
-  background: var(--color-red-100, #fee2e2);
-  color: var(--color-red-800, #991b1b);
+  background: var(--color-red-100);
+  color: var(--color-red-800);
 }
 
 .badge-degraded {
-  background: var(--color-amber-100, #fef3c7);
-  color: var(--color-amber-800, #92400e);
+  background: var(--color-amber-100);
+  color: var(--color-amber-800);
 }
 
 .badge-warning {
-  background: var(--color-yellow-100, #fef9c3);
-  color: var(--color-yellow-800, #854d0e);
+  background: var(--color-yellow-100);
+  color: var(--color-yellow-800);
 }
 
 .summary-meta {
@@ -555,7 +555,7 @@ function levelClass(level: string): string {
 }
 
 .root-cause-card {
-  border-left: 3px solid var(--color-red-500, #ef4444);
+  border-left: 3px solid var(--color-red-500);
 }
 
 .event-header {
@@ -583,11 +583,11 @@ function levelClass(level: string): string {
 .confidence-pill {
   margin-left: auto;
   padding: 2px var(--spacing-2);
-  background: var(--color-blue-50, #eff6ff);
-  border-radius: var(--radius-full, 9999px);
+  background: var(--color-blue-50);
+  border-radius: var(--radius-full);
   font-size: var(--text-xs);
   font-weight: 600;
-  color: var(--color-blue-700, #1d4ed8);
+  color: var(--color-blue-700);
 }
 
 .event-description {
@@ -626,8 +626,8 @@ function levelClass(level: string): string {
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: var(--color-blue-600, #2563eb);
-  color: #fff;
+  background: var(--color-blue-600);
+  color: var(--faildash-on-accent);
   font-size: var(--text-xs);
   font-weight: 700;
   margin-top: var(--spacing-1);
@@ -683,18 +683,18 @@ function levelClass(level: string): string {
 }
 
 .rec-immediate {
-  background: var(--color-red-100, #fee2e2);
-  color: var(--color-red-700, #b91c1c);
+  background: var(--color-red-100);
+  color: var(--color-red-700);
 }
 
 .rec-short {
-  background: var(--color-amber-100, #fef3c7);
-  color: var(--color-amber-700, #b45309);
+  background: var(--color-amber-100);
+  color: var(--color-amber-700);
 }
 
 .rec-long {
-  background: var(--color-blue-100, #dbeafe);
-  color: var(--color-blue-700, #1d4ed8);
+  background: var(--color-blue-100);
+  color: var(--color-blue-700);
 }
 
 .intv-description {
@@ -721,27 +721,27 @@ function levelClass(level: string): string {
   padding: 2px var(--spacing-2);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: var(--radius-full, 9999px);
+  border-radius: var(--radius-full);
   font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 
 .level-high {
-  background: var(--color-red-50, #fef2f2);
-  border-color: var(--color-red-200, #fecaca);
-  color: var(--color-red-700, #b91c1c);
+  background: var(--color-red-50);
+  border-color: var(--color-red-200);
+  color: var(--color-red-700);
 }
 
 .level-medium {
-  background: var(--color-amber-50, #fffbeb);
-  border-color: var(--color-amber-200, #fde68a);
-  color: var(--color-amber-700, #b45309);
+  background: var(--color-amber-50);
+  border-color: var(--color-amber-200);
+  color: var(--color-amber-700);
 }
 
 .level-low {
-  background: var(--color-green-50, #f0fdf4);
-  border-color: var(--color-green-200, #bbf7d0);
-  color: var(--color-green-700, #15803d);
+  background: var(--color-green-50);
+  border-color: var(--color-green-200);
+  color: var(--color-green-700);
 }
 
 .evidence-list {


### PR DESCRIPTION
Closes #11916
Part of #11515 (Task 4.3/4.4)

## Thinking Path

31 hex. 28 were dead `var(--color-<palette>-N, #hex)` fallbacks — verified via Tailwind v4 compilation that those tokens ARE emitted globally (utilities like `bg-red-500` are used app-wide), so the token already won and the hex never painted. Dropping the fallback is byte-unchanged. NOTE: this adds NO `--color-*` override (unlike the SLM #11896 issue) — only drops fallbacks + adds one scoped token.

## What Changed

- 28 dead `--color-*` hex fallbacks + 3 dead `9999px` fallbacks dropped. 3 `#fff` → `--faildash-on-accent` (scoped hex-only, exact white). No Tailwind-palette override introduced.
- Left literal: 1px/2px/3px borders, off-scale icon/badge dims, 1200/300px.

## Verification

- Tailwind-emission of the referenced `--color-*` tokens confirmed by compiling the stylesheet; file already had 3 bare (fallback-free) refs proving reliance. grep whole `<style>` hex = 0; `vue-tsc --noEmit -p tsconfig.app.json`: 0 errors. Style-only.

## Model Used

Claude Fable 5 (subagent: general-purpose)