### PR TITLE
tokenise(user): ServiceMessageTimeline <style> hardcoded values → design tokens (#11918)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -687,6 +687,24 @@
   --voiceoverlay-warning-text: #fcd34d;       /* cert-warning title/foreground */
   --voiceoverlay-warning-body-text: #fde68a;  /* cert-warning body */
   --voiceoverlay-muted-text: #94a3b8;         /* cert-warning fallback note */
+
+  /* ============================================
+   * SERVICE MESSAGE TIMELINE TOKENS
+   * Issue #11918 (umbrella #11515). Scoped to
+   * visualizations/ServiceMessageTimeline.vue.
+   * Per-message-type data-viz palette (dot markers + type badges) — these are
+   * a semantic data series, NOT chrome, so they are preserved verbatim rather
+   * than collapsed into semantic UI tokens. Captured hex-only (deliberately NO
+   * OKLCH/theme override) so the timeline renders pixel-identical to its
+   * previous hardcoded values across all browsers.
+   * ============================================ */
+  --timeline-task: #4a90d9;             /* task */
+  --timeline-result: #4caf50;           /* result */
+  --timeline-error: #f44336;            /* error */
+  --timeline-health: #8bc34a;           /* health */
+  --timeline-deploy: #ff9800;           /* deploy */
+  --timeline-workflow-step: #9c27b0;    /* workflow_step */
+  --timeline-notification: #00bcd4;     /* notification */
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
+++ b/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
@@ -160,45 +160,45 @@ onMounted(() => refresh())
 </script>
 
 <style scoped>
-.smt { display:flex; flex-direction:column; height:100%; background:var(--bg-primary,#1a1a2e); border-radius: var(--radius-lg); overflow:hidden; }
-.smt-header { display:flex; justify-content:space-between; align-items:center; padding:var(--spacing-3) var(--spacing-4); border-bottom:1px solid var(--border-color,#2a2a4a); }
-.smt-header h3 { margin:var(--spacing-0); font-size: var(--text-sm); font-weight:600; color:var(--text-primary,#e0e0ff); }
+.smt { display:flex; flex-direction:column; height:100%; background:var(--bg-primary); border-radius: var(--radius-lg); overflow:hidden; }
+.smt-header { display:flex; justify-content:space-between; align-items:center; padding:var(--spacing-3) var(--spacing-4); border-bottom:1px solid var(--border-color); }
+.smt-header h3 { margin:var(--spacing-0); font-size: var(--text-sm); font-weight:600; color:var(--text-primary); }
 .smt-controls { display:flex; gap:var(--spacing-1); align-items:center; }
-.smt-select { background:var(--bg-secondary,#16213e); color:var(--text-secondary,#a0a0c0); border:1px solid var(--border-color,#2a2a4a); border-radius: var(--radius-default); padding:var(--spacing-1) var(--spacing-2); font-size: var(--text-xs); }
-.smt-btn { background:none; border:1px solid var(--border-color,#2a2a4a); color:var(--text-secondary,#a0a0c0); border-radius: var(--radius-default); padding:var(--spacing-1) var(--spacing-2); cursor:pointer; font-size: var(--text-xs); transition:all .2s; }
-.smt-btn:hover { background:var(--bg-hover,#2a2a4a); color:var(--text-primary,#e0e0ff); }
-.smt-btn.active { background:var(--accent-color,#4a90d9); color:#fff; border-color:var(--accent-color,#4a90d9); }
-.smt-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:var(--spacing-10); color:var(--text-secondary,#a0a0c0); gap:var(--spacing-2); }
+.smt-select { background:var(--bg-secondary); color:var(--text-secondary); border:1px solid var(--border-color); border-radius: var(--radius-default); padding:var(--spacing-1) var(--spacing-2); font-size: var(--text-xs); }
+.smt-btn { background:none; border:1px solid var(--border-color); color:var(--text-secondary); border-radius: var(--radius-default); padding:var(--spacing-1) var(--spacing-2); cursor:pointer; font-size: var(--text-xs); transition:all .2s; }
+.smt-btn:hover { background:var(--bg-hover); color:var(--text-primary); }
+.smt-btn.active { background:var(--accent-color); color:var(--text-on-primary); border-color:var(--accent-color); }
+.smt-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:var(--spacing-10); color:var(--text-secondary); gap:var(--spacing-2); }
 .smt-body { flex:1; overflow-y:auto; padding:var(--spacing-1) var(--spacing-3); }
 .smt-entry { display:flex; gap:var(--spacing-2-5); padding:var(--spacing-2) var(--spacing-1); cursor:pointer; border-radius: var(--radius-default); transition:background .15s; align-items:flex-start; }
 .smt-entry:hover { background:rgba(255,255,255,.03); }
 .smt-entry.selected { background:rgba(74,144,217,.1); }
 .smt-dot { width:10px; height:10px; border-radius:50%; margin-top:var(--spacing-1); flex-shrink:0; }
-.smt-dot.t-task { background:#4a90d9; } .smt-dot.t-result { background:#4caf50; } .smt-dot.t-error { background:#f44336; }
-.smt-dot.t-health { background:#8bc34a; } .smt-dot.t-deploy { background:#ff9800; } .smt-dot.t-workflow_step { background:#9c27b0; }
-.smt-dot.t-notification { background:#00bcd4; }
+.smt-dot.t-task { background:var(--timeline-task); } .smt-dot.t-result { background:var(--timeline-result); } .smt-dot.t-error { background:var(--timeline-error); }
+.smt-dot.t-health { background:var(--timeline-health); } .smt-dot.t-deploy { background:var(--timeline-deploy); } .smt-dot.t-workflow_step { background:var(--timeline-workflow-step); }
+.smt-dot.t-notification { background:var(--timeline-notification); }
 .smt-info { flex:1; min-width:0; }
-.smt-route { display:flex; align-items:center; gap:var(--spacing-1); font-size: var(--text-sm); font-weight:500; color:var(--text-primary,#e0e0ff); }
-.smt-route i { font-size: var(--text-xs); color:var(--text-secondary,#a0a0c0); }
-.smt-meta { font-size: var(--text-xs); color:var(--text-muted,#707090); margin-top:var(--spacing-0-5); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.smt-route { display:flex; align-items:center; gap:var(--spacing-1); font-size: var(--text-sm); font-weight:500; color:var(--text-primary); }
+.smt-route i { font-size: var(--text-xs); color:var(--text-secondary); }
+.smt-meta { font-size: var(--text-xs); color:var(--text-muted); margin-top:var(--spacing-0-5); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .smt-badge { font-size: var(--text-xs); padding:var(--spacing-px) var(--spacing-1-5); border-radius: var(--radius-default); font-weight:500; margin-left:auto; }
-.smt-badge.t-task { background:rgba(74,144,217,.2); color:#4a90d9; } .smt-badge.t-result { background:rgba(76,175,80,.2); color:#4caf50; }
-.smt-badge.t-error { background:rgba(244,67,54,.2); color:#f44336; } .smt-badge.t-health { background:rgba(139,195,74,.2); color:#8bc34a; }
-.smt-badge.t-deploy { background:rgba(255,152,0,.2); color:#ff9800; } .smt-badge.t-workflow_step { background:rgba(156,39,176,.2); color:#9c27b0; }
-.smt-badge.t-notification { background:rgba(0,188,212,.2); color:#00bcd4; }
-.smt-detail { border-top:1px solid var(--border-color,#2a2a4a); background:var(--bg-secondary,#16213e); max-height:50%; overflow-y:auto; padding:var(--spacing-3) var(--spacing-4); }
-.smt-detail-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--spacing-2); color:var(--text-primary,#e0e0ff); font-size: var(--text-sm); }
+.smt-badge.t-task { background:rgba(74,144,217,.2); color:var(--timeline-task); } .smt-badge.t-result { background:rgba(76,175,80,.2); color:var(--timeline-result); }
+.smt-badge.t-error { background:rgba(244,67,54,.2); color:var(--timeline-error); } .smt-badge.t-health { background:rgba(139,195,74,.2); color:var(--timeline-health); }
+.smt-badge.t-deploy { background:rgba(255,152,0,.2); color:var(--timeline-deploy); } .smt-badge.t-workflow_step { background:rgba(156,39,176,.2); color:var(--timeline-workflow-step); }
+.smt-badge.t-notification { background:rgba(0,188,212,.2); color:var(--timeline-notification); }
+.smt-detail { border-top:1px solid var(--border-color); background:var(--bg-secondary); max-height:50%; overflow-y:auto; padding:var(--spacing-3) var(--spacing-4); }
+.smt-detail-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--spacing-2); color:var(--text-primary); font-size: var(--text-sm); }
 .smt-table { width:100%; font-size: var(--text-xs); border-collapse:collapse; }
 .smt-table td { padding:3px 0; }
-.smt-table td:first-child { color:var(--text-muted,#707090); font-weight:500; width:120px; }
-.smt-table td:last-child { color:var(--text-primary,#e0e0ff); }
-.smt-table code { font-family:'JetBrains Mono',monospace; font-size: var(--text-xs); background:var(--bg-primary,#1a1a2e); padding:var(--spacing-0-5) var(--spacing-1-5); border-radius: var(--radius-default); }
-.smt-link { cursor:pointer; } .smt-link:hover { color:var(--accent-color,#4a90d9)!important; }
-.smt-pre { background:var(--bg-primary,#1a1a2e); padding:var(--spacing-2) var(--spacing-3); border-radius: var(--radius-default); font-size: var(--text-xs); font-family:'JetBrains Mono',monospace; color:var(--text-secondary,#a0a0c0); overflow-x:auto; max-height:120px; margin:var(--spacing-2) var(--spacing-0) var(--spacing-0); }
-.smt-chain { margin-top:var(--spacing-3); border-top:1px solid var(--border-color,#2a2a4a); padding-top:var(--spacing-2); }
-.smt-chain strong { font-size: var(--text-sm); color:var(--text-primary,#e0e0ff); }
-.smt-chain-row { display:flex; align-items:center; gap:var(--spacing-2); padding:3px 8px; font-size: var(--text-xs); border-radius: var(--radius-default); color:var(--text-primary,#e0e0ff); }
+.smt-table td:first-child { color:var(--text-muted); font-weight:500; width:120px; }
+.smt-table td:last-child { color:var(--text-primary); }
+.smt-table code { font-family:'JetBrains Mono',monospace; font-size: var(--text-xs); background:var(--bg-primary); padding:var(--spacing-0-5) var(--spacing-1-5); border-radius: var(--radius-default); }
+.smt-link { cursor:pointer; } .smt-link:hover { color:var(--accent-color)!important; }
+.smt-pre { background:var(--bg-primary); padding:var(--spacing-2) var(--spacing-3); border-radius: var(--radius-default); font-size: var(--text-xs); font-family:'JetBrains Mono',monospace; color:var(--text-secondary); overflow-x:auto; max-height:120px; margin:var(--spacing-2) var(--spacing-0) var(--spacing-0); }
+.smt-chain { margin-top:var(--spacing-3); border-top:1px solid var(--border-color); padding-top:var(--spacing-2); }
+.smt-chain strong { font-size: var(--text-sm); color:var(--text-primary); }
+.smt-chain-row { display:flex; align-items:center; gap:var(--spacing-2); padding:3px 8px; font-size: var(--text-xs); border-radius: var(--radius-default); color:var(--text-primary); }
 .smt-chain-row.current { background:rgba(74,144,217,.15); }
-.smt-chain-idx { color:var(--text-muted,#707090); font-weight:600; min-width:18px; }
-.smt-muted { color:var(--text-muted,#707090); font-size: var(--text-xs); margin-left:auto; }
+.smt-chain-idx { color:var(--text-muted); font-weight:600; min-width:18px; }
+.smt-muted { color:var(--text-muted); font-size: var(--text-xs); margin-left:auto; }
 </style>


### PR DESCRIPTION
Closes #11918
Part of #11515 (Task 4.3/4.4)

## Thinking Path

Visualization component. 45 `<style>` hexes: 30 dead-fallback drops (tokens defined & win), 14 data-viz msg-type/badge colours → hex-only `--timeline-*` (byte-exact, no OKLCH — data colours must not collapse to semantic tokens), 1 `#fff`→`--text-on-primary`. The `<script>` has zero colour data (nothing to protect there).

## What Changed

- 30 dead `var(--token,#hex)` chrome fallbacks dropped. 7 unique `--timeline-*` hex-only data-viz tokens (msg-type dots + badges). No Tailwind-palette override. All 13 px + rgba left literal (mirrors #11881/#11901 viz precedents).

## Verification

- Dropped fallbacks all on :root-defined tokens (render no-op); `--timeline-*` byte-exact. grep `<style>` hex = 0; `vue-tsc --noEmit -p tsconfig.app.json`: 0 errors. Style-only.

## Model Used

Claude Fable 5 (subagent: general-purpose)