### PR TITLE
fix(tokens): stop early comment close in design-tokens.css → unblock frontend build (#11936)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -723,7 +723,7 @@
    * COST DASHBOARD TOKENS
    * Issue #11917 (umbrella #11515). Scoped to llc/CostDashboard.vue.
    * The budget-mode badges render a soft blue ("dollars") and amber ("tokens")
-   * palette. The nearest --color-*/--chart-* tokens carry OKLCH overrides that
+   * palette. The nearest --color-* / --chart-* tokens carry OKLCH overrides that
    * would shift the rendered pixels, so these are captured here as hex-only
    * (deliberately NO OKLCH override) so the badges render pixel-identical to
    * their previous hardcoded values across all browsers.


### PR DESCRIPTION
## Thinking Path
Autonomous CI-health check after Batch-1 merges found smoke-test / frontend-tests / hardened-smoke-test failing base-wide on Dev_new_gui. Root cause: #11921 (tokenise CostDashboard #11917) added a comment line `* The nearest --color-*/--chart-* tokens ...` — the `*/` in `--color-*/` closes the block comment opened at line 722, so `--chart-* tokens carry OKLCH...` is parsed as CSS ⇒ `CssSyntaxError: design-tokens.css:726:47: Unknown word tokens` ⇒ `npm run build` fails.

## What Changed
- `autobot-frontend/src/assets/css/design-tokens.css:726`: `--color-*/--chart-*` → `--color-* / --chart-*` (spaces around the slash so no `*/` sequence appears inside the comment). One-character-class change; comment text meaning preserved.

## Verification
`npm run build-only` → `✓ built in 27.45s`, EXIT=0 (was: build failed with the CssSyntaxError). Comment block now closes at its intended `*/` on line 730; CostDashboard tokens parse as CSS.

## Model Used
Opus 4.8

Closes #11936