### PR TITLE
fix(chat): drop useless empty spread fallback → unblock frontend-tests (#11940)

### DIFF
--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -104,7 +104,7 @@ export class ChatController {
       // general /chat send is unchanged.
       const activeCtx = this.chatStore.activeChatContext
       if (activeCtx && Object.keys(activeCtx).length > 0) {
-        options = { ...activeCtx, ...(options || {}) }
+        options = { ...activeCtx, ...options }
       }
 
       // Validate message content


### PR DESCRIPTION
## Thinking Path
Autonomous CI-health tick: after the build hotfix (#11937) restored the frontend build, `frontend-tests` on Dev_new_gui was still red — the sole cause was `oxlint -D correctness` erroring on `ChatController.ts:107` (unicorn/no-useless-fallback-in-spread). Pre-existing line from #11690; spreading a falsy value in an object literal is a no-op, so the `|| {}` fallback is useless.

## What Changed
- `autobot-frontend/src/models/controllers/ChatController.ts:107`: `{ ...activeCtx, ...(options || {}) }` → `{ ...activeCtx, ...options }`. Behavior-preserving (undefined/null spreads add no keys).

## Verification
`oxlint . -D correctness ...` → exit 0 (was 1 error). `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.

## Model Used
Opus 4.8

Closes #11940