### PR TITLE
fix(test): use asyncio.run for graph_redis_unavailable_test under py3.14 (#11868)

### DIFF
--- a/autobot-backend/chat_workflow/graph_redis_unavailable_test.py
+++ b/autobot-backend/chat_workflow/graph_redis_unavailable_test.py
@@ -112,4 +112,7 @@ def test_get_redis_checkpointer_raises_when_unavailable():
     with pytest.raises(RuntimeError, match="AsyncRedisSaver"):
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(mod.get_redis_checkpointer())
+        # Use asyncio.run() instead of get_event_loop(): Python 3.14 no longer
+        # implicitly creates an event loop for a non-running thread, so
+        # get_event_loop() raises RuntimeError before the coroutine runs.
+        asyncio.run(mod.get_redis_checkpointer())


### PR DESCRIPTION
Closes #11868

## Thinking Path

`test_get_redis_checkpointer_raises_when_unavailable` called `asyncio.get_event_loop().run_until_complete(...)`. Under py3.14, `get_event_loop()` raises `RuntimeError: no current event loop` from a non-running MainThread BEFORE the coroutine runs — masking the expected AsyncRedisSaver-unavailable error. Test-only: the product `get_redis_checkpointer` is a clean async fn with no deprecated loop usage (grep-confirmed).

## What Changed

- `graph_redis_unavailable_test.py:115`: `asyncio.get_event_loop().run_until_complete(...)` → `asyncio.run(...)` (matches the sibling `chat_workflow_e2e_test.py` pattern). The `pytest.raises(RuntimeError, match="AsyncRedisSaver")` wrapper is preserved, so it still asserts the expected message, not mere absence of error.

## Verification

- Target test passes; full `chat_workflow/` dir 320 passed / 0 failed. py3.14 path verified independently (raw `get_event_loop()` failure reproduced; fixed `asyncio.run()` coroutine-raise path simulated → propagates the RuntimeError). flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)