### PR TITLE
fix(ci): lift oxlint >=1.74 dependabot cap — eslint-plugin-oxlint 1.75 ships (#11943)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -142,12 +142,6 @@ updates:
         # (ERESOLVE on every PR, see #11746). Same pattern as the protobuf/
         # websockets caps above. Unblock when the pinia 4 major is taken.
         versions: [">=2.0.0"]
-      - dependency-name: "oxlint"
-        # #11786: eslint-plugin-oxlint peer-pins oxlint@~1.73 (lockstep minor)
-        # and has no 1.74 release — grouped oxlint bump alone is unsatisfiable
-        # (ERESOLVE on every PR, see #11771). Unblock when eslint-plugin-oxlint
-        # ships the matching minor, then bump both together.
-        versions: [">=1.74.0"]
 
   - package-ecosystem: "npm"
     directory: "/autobot-slm-frontend"


### PR DESCRIPTION
Closes #11943

## Thinking Path

#11786 capped `oxlint >=1.74.0` because eslint-plugin-oxlint had no matching minor. That condition is now met — eslint-plugin-oxlint@1.75.0 ships (surfaced by #11939, where the frontend group bumped the plugin to 1.75 while oxlint stayed capped at ~1.73 → ERESOLVE). The cap is now what BLOCKS the lockstep pair from moving together. Per #11786's own documented unblock condition, remove the cap.

## What Changed

- `.github/dependabot.yml` /autobot-frontend npm entry: removed the `oxlint >=1.74.0` ignore. Dependabot will now bump oxlint + eslint-plugin-oxlint to 1.75 together (satisfiable).

## Verification

- YAML valid; zero remaining `oxlint` references. Effective from main at the next promotion (dependabot reads config from the default branch), then `@dependabot recreate` regenerates the frontend group with the pair bumping together. #11939 was closed as unsatisfiable pending this.

## Model Used

Claude Fable 5