### PR TITLE
fix(chat): wire in #716 internal-prompt filtering at final yield + consolidate dup filters (#11867)

### DIFF
--- a/autobot-backend/chat_workflow/internal_prompt_filter_test.py
+++ b/autobot-backend/chat_workflow/internal_prompt_filter_test.py
@@ -22,9 +22,7 @@ from chat_workflow.models import StreamingMessage, filter_internal_prompts
 # A representative internal continuation prompt the LLM echoes back. Contains
 # markers matching multiple canonical patterns.
 ECHO = (
-    "**CRITICAL MULTI-STEP TASK INSTRUCTIONS**\n"
-    "You must keep going until the task is done.\n"
-    "**YOUR RESPONSE:**"
+    "**CRITICAL MULTI-STEP TASK INSTRUCTIONS**\n" "You must keep going until the task is done.\n" "**YOUR RESPONSE:**"
 )
 
 # The genuine, user-facing answer the model produced after the echo.

--- a/autobot-backend/chat_workflow/internal_prompt_filter_test.py
+++ b/autobot-backend/chat_workflow/internal_prompt_filter_test.py
@@ -1,0 +1,162 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for Issue #716 / #11867 internal-prompt-echo filtering.
+
+Proves:
+  (a) the internal-prompt filter now runs at the production final-message yield
+      point (``_execute_llm_workflow`` -> ``_persist_conversation``) — an echo
+      that leaked on base is stripped;
+  (b) normal assistant output passes through byte-for-byte unchanged;
+  (c) the consolidated canonical filter matches the union of BOTH previously
+      duplicated implementations' patterns (the 6th ``---CRITICAL---`` pattern
+      lived only in models.py; manager.py had 5).
+"""
+
+import pytest
+
+from chat_workflow.manager import ChatWorkflowManager
+from chat_workflow.models import StreamingMessage, filter_internal_prompts
+
+# A representative internal continuation prompt the LLM echoes back. Contains
+# markers matching multiple canonical patterns.
+ECHO = (
+    "**CRITICAL MULTI-STEP TASK INSTRUCTIONS**\n"
+    "You must keep going until the task is done.\n"
+    "**YOUR RESPONSE:**"
+)
+
+# The genuine, user-facing answer the model produced after the echo.
+REAL_ANSWER = "Here is the summary you asked for: the deploy succeeded."
+
+
+class TestCanonicalFilter:
+    """(b) + (c): behaviour of the consolidated canonical filter."""
+
+    def test_normal_message_unchanged_byte_for_byte(self):
+        """Legitimate assistant output is returned identical (no strip/collapse)."""
+        text = "  Hello!\n\nHere is my answer.\n  "
+        assert filter_internal_prompts(text) == text
+
+    def test_normal_message_with_triple_newlines_unchanged(self):
+        """No pattern match => untouched, even with blank runs (safer than base)."""
+        text = "Line one.\n\n\n\nLine two."
+        assert filter_internal_prompts(text) == text
+
+    def test_strips_internal_prompt_echo(self):
+        """A genuine echo is removed, leaving the real answer."""
+        out = filter_internal_prompts(f"{ECHO}\n\n{REAL_ANSWER}")
+        assert "CRITICAL MULTI-STEP" not in out
+        assert "YOUR RESPONSE" not in out
+        assert REAL_ANSWER in out
+
+    def test_union_includes_multi_step_progress_marker(self):
+        """Pattern shared by both old impls."""
+        text = "User is in the middle of a multi-step task. 3 step(s) have been completed."
+        assert filter_internal_prompts(text) == ""
+
+    def test_union_includes_original_user_request_marker(self):
+        text = "**ORIGINAL USER REQUEST (analyze this carefully):**"
+        assert filter_internal_prompts(text) == ""
+
+    def test_union_includes_if_more_steps_needed_marker(self):
+        text = "**IF MORE STEPS NEEDED** then emit `<TOOL_CALL"
+        assert filter_internal_prompts(text) == ""
+
+    def test_union_includes_models_only_dashed_critical_pattern(self):
+        """The 6th pattern lived ONLY in models.py on base; consolidation keeps it.
+
+        Manager's 5-pattern list never matched this shape — so on base it would
+        have leaked through the (dead) manager filter. The canonical union covers
+        it now.
+        """
+        text = "---\n**CRITICAL MULTI-STEP TASK**: do the thing\n---"
+        assert filter_internal_prompts(text) == ""
+
+
+class TestStreamingMessageDelegates:
+    """The models.py opt-in path now uses the canonical filter."""
+
+    def test_to_workflow_message_default_leaves_echo(self):
+        """Per #1313, per-chunk streaming (default False) sends raw content."""
+        msg = StreamingMessage(type="response")
+        msg.stream(f"{ECHO}\n\n{REAL_ANSWER}")
+        wm = msg.to_workflow_message()  # default filter_prompts=False (line ~930)
+        assert "CRITICAL MULTI-STEP" in wm.content
+
+    def test_to_workflow_message_filter_true_strips_echo(self):
+        """Opt-in final-message filtering removes the echo, keeps the answer."""
+        msg = StreamingMessage(type="response")
+        msg.stream(f"{ECHO}\n\n{REAL_ANSWER}")
+        wm = msg.to_workflow_message(filter_prompts=True)
+        assert "CRITICAL MULTI-STEP" not in wm.content
+        assert REAL_ANSWER in wm.content
+
+
+class _FakeManager:
+    """Minimal stand-in exposing only what ``_execute_llm_workflow`` touches.
+
+    Uses the REAL ``_filter_internal_prompts`` (bound from ChatWorkflowManager)
+    so the production wiring is exercised end-to-end without constructing the
+    full manager (terminal tool, Redis, error boundary, ...).
+    """
+
+    def __init__(self):
+        self.knowledge_service = None
+        self._filter_internal_prompts = ChatWorkflowManager._filter_internal_prompts.__get__(self)
+        self.persisted = {}
+
+    async def _prepare_llm_workflow_params(self, session, message, context):
+        return {}
+
+    def _create_llm_iteration_context(self, *args, **kwargs):
+        return object()
+
+    async def _execute_llm_continuation_loop(self, ctx):
+        # Model echoed the internal prompt then produced the real answer.
+        yield ([f"{ECHO}\n\n{REAL_ANSWER}"], None, False)
+
+    async def _persist_conversation(self, session_id, session, message, llm_response):
+        self.persisted["conversation"] = llm_response
+
+    async def _persist_workflow_messages(self, session_id, workflow_messages, combined_response):
+        self.persisted["workflow"] = combined_response
+
+    async def _fire_stop_hook(self, *args, **kwargs):
+        return None
+
+
+class TestProductionWirePoint:
+    """(a): #716 filtering now runs at the production final-message yield point."""
+
+    @pytest.mark.asyncio
+    async def test_final_response_is_filtered_before_persist(self):
+        fake = _FakeManager()
+
+        gen = ChatWorkflowManager._execute_llm_workflow(
+            fake,
+            session_id="s1",
+            session=object(),
+            message="hi",
+            context={},
+            terminal_session_id="t1",
+            workflow_messages=[],
+        )
+        # Drive the async generator to completion (it yields nothing here).
+        async for _ in gen:
+            pass
+
+        persisted = fake.persisted["conversation"]
+        # BASE (no filter at line 3040) would persist the raw join -> echo leaks.
+        assert "CRITICAL MULTI-STEP" not in persisted
+        assert "YOUR RESPONSE" not in persisted
+        assert REAL_ANSWER in persisted
+        # Both persist sinks receive the same filtered text.
+        assert fake.persisted["workflow"] == persisted
+
+    def test_raw_join_would_leak_echo_on_base(self):
+        """Documents the base defect: the pre-fix expression leaks the echo."""
+        raw_join = "\n\n".join([f"{ECHO}\n\n{REAL_ANSWER}"])
+        assert "CRITICAL MULTI-STEP" in raw_join  # base behaviour
+        assert "CRITICAL MULTI-STEP" not in filter_internal_prompts(raw_join)  # fix

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -44,6 +44,7 @@ from .models import (
     StreamingMessage,
     WorkflowSession,
     build_governed_identity,
+    filter_internal_prompts,
 )
 from .session_handler import SessionHandlerMixin
 from .tool_handler import ToolHandlerMixin
@@ -74,21 +75,9 @@ _TOOL_CALL_COMPLETE_RE = TOOL_CALL_COMPLETE_RE
 _TOOL_CALL_BARE_CLOSE_RE = TOOL_CALL_BARE_CLOSE_RE
 _TOOL_CALL_OPENING_RE = TOOL_CALL_OPENING_RE
 
-# Issue #716: Patterns for internal prompts that should not be shown to users
-# These are continuation instructions that LLM sometimes echoes back
-_INTERNAL_PROMPT_PATTERNS = [
-    re.compile(
-        r"\*\*CRITICAL MULTI-STEP TASK INSTRUCTIONS.*?\*\*YOUR RESPONSE:\*\*",
-        re.DOTALL | re.IGNORECASE,
-    ),
-    re.compile(r"User is in the middle of a multi-step task\. \d+ step\(s\) have been completed\."),
-    re.compile(r"\*\*ORIGINAL USER REQUEST \(analyze this.*?\)\:\*\*"),
-    re.compile(
-        r"\*\*DECISION PROCESS:\*\*.*?\*\*IF TASK IS COMPLETE\*\*.*?TOOL_CALL",
-        re.DOTALL | re.IGNORECASE,
-    ),
-    re.compile(r"\*\*IF MORE STEPS NEEDED\*\*.*?`<TOOL_CALL", re.DOTALL),
-]
+
+# Issue #716/#11867: internal-prompt-echo patterns are consolidated into the
+# canonical `filter_internal_prompts` in chat_workflow.models (imported above).
 
 
 async def _resolve_reasoning_effort(context: Dict[str, Any]) -> str:
@@ -252,8 +241,9 @@ class ChatWorkflowManager(
     def _filter_internal_prompts(self, text: str) -> str:
         """Filter out internal continuation prompts that LLM echoes back (Issue #716).
 
-        The LLM sometimes echoes the continuation instructions we send it, which
-        should never be shown to the user. This filters those out.
+        Delegates to the canonical module-level
+        :func:`chat_workflow.models.filter_internal_prompts` (Issue #11867
+        consolidation) so the patterns and behaviour live in exactly one place.
 
         Args:
             text: LLM response text that may contain echoed internal prompts
@@ -261,21 +251,7 @@ class ChatWorkflowManager(
         Returns:
             Text with internal prompts removed
         """
-        filtered = text
-        for pattern in _INTERNAL_PROMPT_PATTERNS:
-            filtered = pattern.sub("", filtered)
-
-        # Also clean up any resulting multiple newlines
-        filtered = re.sub(r"\n{3,}", "\n\n", filtered)
-
-        if filtered != text:
-            logger.debug(
-                "[Issue #716] Filtered internal prompts from LLM response " "(original: %d chars, filtered: %d chars)",
-                len(text),
-                len(filtered),
-            )
-
-        return filtered.strip()
+        return filter_internal_prompts(text)
 
     def _find_last_tag_positions(self, content: str) -> Dict[str, int]:
         """Find last occurrence positions of thought/planning tags."""
@@ -3037,7 +3013,11 @@ before summarizing.
             else:
                 yield item
 
-        combined_response = "\n\n".join(all_llm_responses)
+        # Issue #716/#11867: strip any internal continuation prompt the LLM echoed
+        # back before the final response is persisted / shown to the user. Runs once
+        # on the complete text (multi-line patterns intact) — a no-op unless a genuine
+        # internal-prompt echo is present, so legitimate output is never altered.
+        combined_response = self._filter_internal_prompts("\n\n".join(all_llm_responses))
         await self._persist_conversation(session_id, session, message, combined_response)
         await self._persist_workflow_messages(session_id, workflow_messages, combined_response)
 

--- a/autobot-backend/chat_workflow/models.py
+++ b/autobot-backend/chat_workflow/models.py
@@ -9,6 +9,8 @@ Issue #656: Implements Agent Zero's LogItem pattern with StreamingMessage class
 for stable message identity and distinct stream/update operations.
 """
 
+import logging
+import re
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -17,6 +19,61 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 if TYPE_CHECKING:
     from async_chat_workflow import WorkflowMessage
+
+logger = logging.getLogger(__name__)
+
+
+# Issue #716 / #11867: Canonical patterns for internal continuation prompts that
+# the LLM sometimes echoes back verbatim. These are never legitimate user-facing
+# content and must be stripped from the final message. This is the single source
+# of truth — chat_workflow.manager imports from here (no duplicate list).
+_INTERNAL_PROMPT_PATTERNS = [
+    re.compile(
+        r"\*\*CRITICAL MULTI-STEP TASK INSTRUCTIONS.*?\*\*YOUR RESPONSE:\*\*",
+        re.DOTALL | re.IGNORECASE,
+    ),
+    re.compile(r"User is in the middle of a multi-step task\. \d+ step\(s\) have been completed\."),
+    re.compile(r"\*\*ORIGINAL USER REQUEST \(analyze this.*?\)\:\*\*"),
+    re.compile(
+        r"\*\*DECISION PROCESS:\*\*.*?\*\*IF TASK IS COMPLETE\*\*.*?TOOL_CALL",
+        re.DOTALL | re.IGNORECASE,
+    ),
+    re.compile(r"\*\*IF MORE STEPS NEEDED\*\*.*?`<TOOL_CALL", re.DOTALL),
+    re.compile(r"---\s*\n\*\*CRITICAL MULTI-STEP.*?---", re.DOTALL | re.IGNORECASE),
+]
+
+
+def filter_internal_prompts(text: str) -> str:
+    """Strip internal continuation prompts the LLM echoes back (Issue #716).
+
+    Canonical implementation (Issue #11867 consolidation): the union of the two
+    previously-duplicated filters. Behaviour is deliberately conservative — if no
+    internal-prompt pattern matched, the input is returned byte-for-byte unchanged
+    so legitimate assistant output (including its own whitespace) is never touched.
+    Newline collapsing + strip run ONLY when an echo was actually removed.
+
+    Args:
+        text: LLM response text that may contain echoed internal prompts
+
+    Returns:
+        Text with internal prompts removed, or the original text if none present
+    """
+    filtered = text
+    for pattern in _INTERNAL_PROMPT_PATTERNS:
+        filtered = pattern.sub("", filtered)
+
+    if filtered == text:
+        # No internal-prompt echo present — return untouched.
+        return text
+
+    # An echo was stripped; clean up the blank runs it left behind.
+    filtered = re.sub(r"\n{3,}", "\n\n", filtered)
+    logger.debug(
+        "[Issue #716] Filtered internal prompts from response (original: %d chars, filtered: %d chars)",
+        len(text),
+        len(filtered),
+    )
+    return filtered.strip()
 
 
 class StreamingOperation(Enum):
@@ -198,8 +255,9 @@ class StreamingMessage:
     def _filter_internal_prompts(self, text: str) -> str:
         """Filter out internal continuation prompts that LLM echoes back (Issue #716).
 
-        The LLM sometimes echoes the continuation instructions we send it, which
-        should never be shown to the user.
+        Delegates to the canonical module-level :func:`filter_internal_prompts`
+        (Issue #11867 consolidation) so there is a single source of truth for the
+        patterns and behaviour.
 
         Args:
             text: Content that may contain echoed internal prompts
@@ -207,32 +265,7 @@ class StreamingMessage:
         Returns:
             Text with internal prompts removed
         """
-        import re
-
-        # Patterns for internal prompts that should not be shown to users
-        patterns = [
-            re.compile(
-                r"\*\*CRITICAL MULTI-STEP TASK INSTRUCTIONS.*?\*\*YOUR RESPONSE:\*\*",
-                re.DOTALL | re.IGNORECASE,
-            ),
-            re.compile(r"User is in the middle of a multi-step task\. \d+ step\(s\) have been completed\."),
-            re.compile(r"\*\*ORIGINAL USER REQUEST \(analyze this.*?\)\:\*\*"),
-            re.compile(
-                r"\*\*DECISION PROCESS:\*\*.*?\*\*IF TASK IS COMPLETE\*\*.*?TOOL_CALL",
-                re.DOTALL | re.IGNORECASE,
-            ),
-            re.compile(r"\*\*IF MORE STEPS NEEDED\*\*.*?`<TOOL_CALL", re.DOTALL),
-            re.compile(r"---\s*\n\*\*CRITICAL MULTI-STEP.*?---", re.DOTALL | re.IGNORECASE),
-        ]
-
-        filtered = text
-        for pattern in patterns:
-            filtered = pattern.sub("", filtered)
-
-        # Clean up multiple newlines
-        filtered = re.sub(r"\n{3,}", "\n\n", filtered)
-
-        return filtered.strip() if filtered != text else text
+        return filter_internal_prompts(text)
 
     def to_dict(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
Closes #11867

## Thinking Path

#716's internal-prompt-echo filtering was entirely inert: `manager.py`'s `_filter_internal_prompts` was never called, and `models.py`'s was only reachable via `to_workflow_message(filter_prompts=True)` which was never passed True. Fix per "wire it in, never delete": consolidate the two near-duplicates onto one canonical and wire it at the production final-message point.

## What Changed

- New canonical `filter_internal_prompts()` + `_INTERNAL_PROMPT_PATTERNS` in `models.py` — the 6-pattern UNION (manager's list was missing the `**CRITICAL MULTI-STEP…**` pattern). Both former duplicates now delegate (no logic lost; manager's dead method preserved + wired, not deleted). Canonical is strictly SAFER: returns input byte-for-byte when no pattern matches (old impls always ran the `\n{3,}` collapse).
- Wired at `_execute_llm_workflow` (~line 3017): the accumulated final assistant reply is filtered once before persist. Streaming chunks intentionally stay unfiltered (per #1313 — live per-chunk display; the durable final reply is the authoritative record).

## Verification

- New `internal_prompt_filter_test.py` (11 tests): canonical union incl. the 6th pattern, normal-content-byte-identical, opt-in path, and an end-to-end wire test asserting the persisted final response is filtered. Base-fails-without-fix proven (reverting the wire line makes the test fail — echo leaks). Full `chat_workflow/`: 331 passed (independent re-run). flake8 clean.

## Model Used

Claude Fable 5 (subagent: general-purpose)