### PR TITLE
fix(ssot): clear 4 remaining hardcoded-value violations (#11578)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -2547,7 +2547,7 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
     if is_local_source:
         logger.info("SLM self-sync: code source is local at %s, using direct rsync", repo_path)
     else:
-        ssh_key = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")
+        ssh_key = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
         if not _ssh_key_usable(ssh_key):
             logger.error("SLM self-sync failed: SSH key not usable at %s", ssh_key)
             return

--- a/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
+++ b/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
@@ -55,7 +55,7 @@ def _orchestrator() -> SyncOrchestrator:
 
 
 # The ssh builders check Path(SSH_KEY_PATH).exists() for the optional `-i`
-# flag.  The default key path lives under /home/autobot/.ssh — unreadable on
+# flag.  The default key path lives under the autobot ssh dir — unreadable on
 # dev boxes, where Path.exists() propagates PermissionError (EACCES is not in
 # pathlib's ignored-errno set).  Pin the module global to a guaranteed-absent
 # path so the check is a deterministic False in every environment; the argv
@@ -94,5 +94,5 @@ async def test_get_current_git_commit_argv_is_wellformed():
             new=AsyncMock(return_value=proc),
         ) as mock_exec,
     ):
-        await _orchestrator()._get_current_git_commit("10.0.0.5", "autobot", "/home/autobot/code")
+        await _orchestrator()._get_current_git_commit("10.0.0.5", "autobot", "/home/autobot/code")  # noqa: ssot-path
     _assert_ssh_argv_wellformed(list(mock_exec.call_args[0]))

--- a/autobot-slm-backend/tests/test_code_sync_topology.py
+++ b/autobot-slm-backend/tests/test_code_sync_topology.py
@@ -132,7 +132,7 @@ async def test_slm_self_sync_remote_code_source_uses_ssh_rsync():
         stack.enter_context(
             patch(
                 "api.code_sync._fetch_code_source_connection_info",
-                return_value=("192.168.1.100", "autobot", "/home/autobot/code"),
+                return_value=("192.168.1.100", "autobot", "/home/autobot/code"),  # noqa: ssot-path
             )
         )
         stack.enter_context(patch("autobot_shared.network_utils.is_local_ip", return_value=False))


### PR DESCRIPTION
## Thinking Path
The one *blocking* (ssot-category) violation was already fixed upstream (#11589, RFC-5737 doc IP), so the gate technically passed — but 4 non-blocking "other" violations still polluted the report. #11578 asks to restore a fully-green baseline (total=0).

## What Changed
Cleared all 4 via the established `# noqa: ssot-path` allowlist convention (the detect script excludes `#.*noqa` lines):
- `api/code_sync.py:2550` — `SLM_SSH_KEY` env-var-first with an allowlisted fallback path; matched the 5 sibling production lines that already carry the suffix.
- 2 test doubles (`test_code_sync_topology.py`, `test_sync_orchestrator_ssh.py`) — appended noqa.
- 1 prose comment mentioning `/home/autobot/.ssh` — reworded (path not load-bearing).

Before: `{total:4, ssot:0, other:4}` → After: `{total:0, ssot:0, other:0, status:pass}`.

Closes #11578

## Verification
- SSOT detect script: 4 → 0 violations (shown above).
- `py_compile` clean on all 3 files.

## Model Used
Opus 4.8 (subagent: frontend-engineer)