### PR TITLE
fix(cv): implement TemplateMatchingEngine.find_common_elements (#11580)

### DIFF
--- a/autobot-backend/computer_vision/classifiers.py
+++ b/autobot-backend/computer_vision/classifiers.py
@@ -9,7 +9,8 @@ Issue #381: Extracted from computer_vision_system.py god class refactoring.
 Contains classifiers for UI elements, template matching, and context analysis.
 """
 
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
@@ -19,6 +20,19 @@ from .collections import UIElementCollection
 from .types import ElementType, UIElement
 
 logger = get_logger(__name__)
+
+# Issue #3016: lazy cv2 import to avoid startup cost; loaded on first match.
+_cv2 = None
+
+
+def _get_cv2():
+    """Lazy-load cv2 on first use (mirrors screen_analyzer). Issue #3016."""
+    global _cv2  # noqa: PLW0603
+    if _cv2 is None:
+        import cv2
+
+        _cv2 = cv2
+    return _cv2
 
 
 class ElementClassifier:
@@ -113,41 +127,139 @@ class ElementClassifier:
 
 
 class TemplateMatchingEngine:
-    """Template matching for common UI elements"""
+    """Template matching for common UI elements.
 
-    def __init__(self):
-        """Initialize engine with loaded UI element templates."""
+    Discovers template images on disk and locates every occurrence in a
+    screenshot with cv2.matchTemplate, then collapses overlapping detections
+    via non-maximum suppression. Ships without bundled template images, so an
+    empty result is legitimate until templates are added to the templates
+    directory (it is no longer a silent stub — matching is really performed).
+    """
+
+    DEFAULT_MATCH_THRESHOLD = 0.8
+    IOU_SUPPRESSION_THRESHOLD = 0.3
+
+    def __init__(self, templates_dir: Optional[Path] = None) -> None:
+        """Initialize engine, discovering available UI element templates."""
+        self.templates_dir = Path(templates_dir) if templates_dir else Path(__file__).resolve().parent / "templates"
+        self._template_cache: Dict[str, Any] = {}
         self.templates = self._load_templates()
-        logger.info("Template Matching Engine initialized")
+        logger.info("Template Matching Engine initialized (%d templates)", len(self.templates))
 
-    def _load_templates(self) -> Dict[str, Any]:
-        """Load common UI element templates"""
-        # In a real implementation, this would load actual template images
-        return {
-            "close_button": {
-                "template_path": "templates/close_button.png",
-                "element_type": "button",
-                "threshold": 0.8,
-            },
-            "minimize_button": {
-                "template_path": "templates/minimize_button.png",
-                "element_type": "button",
-                "threshold": 0.8,
-            },
-        }
+    def _load_templates(self) -> Dict[str, Dict[str, Any]]:
+        """Discover UI element template PNGs available on disk."""
+        templates: Dict[str, Dict[str, Any]] = {}
+        if not self.templates_dir.is_dir():
+            logger.debug("Templates directory not found: %s", self.templates_dir)
+            return templates
+        for path in sorted(self.templates_dir.glob("*.png")):
+            name = path.stem
+            templates[name] = {
+                "template_path": str(path),
+                "element_type": self._infer_element_type(name),
+                "threshold": self.DEFAULT_MATCH_THRESHOLD,
+            }
+        return templates
+
+    @staticmethod
+    def _infer_element_type(name: str) -> str:
+        """Infer element type from a template filename stem."""
+        lowered = name.lower()
+        if "checkbox" in lowered:
+            return "checkbox"
+        if "input" in lowered or "field" in lowered:
+            return "input_field"
+        if "button" in lowered or lowered in {"close", "minimize", "maximize"}:
+            return "button"
+        return "unknown"
 
     async def find_common_elements(self, screenshot: np.ndarray) -> List[Dict[str, Any]]:
-        """Find common UI elements using template matching"""
+        """Find common UI elements in a screenshot using template matching.
+
+        Returns an empty list only when the screenshot is empty, no templates
+        are configured, or nothing scores at/above a template's threshold.
+        """
+        if screenshot is None or getattr(screenshot, "size", 0) == 0:
+            return []
+        if not self.templates:
+            logger.debug("No templates available for matching")
+            return []
+
+        cv2 = _get_cv2()
+        gray_screenshot = self._to_gray(cv2, screenshot)
         matches: List[Dict[str, Any]] = []
+        for name, meta in self.templates.items():
+            matches.extend(self._match_template(cv2, gray_screenshot, name, meta))
+        return self._suppress_overlaps(matches)
 
-        # For now, return empty list as templates need to be created
-        # In a real implementation, this would:
-        # 1. Load template images
-        # 2. Use cv2.matchTemplate() to find matches
-        # 3. Apply non-maximum suppression
-        # 4. Return matches with confidence scores
+    def _match_template(
+        self, cv2, gray_screenshot: np.ndarray, name: str, meta: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """Run matchTemplate for one template and collect above-threshold hits."""
+        template = self._load_template_image(cv2, name, meta["template_path"])
+        if template is None:
+            return []
+        t_height, t_width = template.shape[:2]
+        if gray_screenshot.shape[0] < t_height or gray_screenshot.shape[1] < t_width:
+            return []
+        threshold = float(meta.get("threshold", self.DEFAULT_MATCH_THRESHOLD))
+        result = cv2.matchTemplate(gray_screenshot, template, cv2.TM_CCOEFF_NORMED)
+        ys, xs = np.where(result >= threshold)
+        return [
+            self._build_match(name, meta, int(x), int(y), t_width, t_height, float(result[y, x]))
+            for y, x in zip(ys, xs)
+        ]
 
-        return matches
+    def _load_template_image(self, cv2, name: str, path: str) -> Optional[np.ndarray]:
+        """Load a template image as grayscale, caching the result."""
+        if name in self._template_cache:
+            return self._template_cache[name]
+        image = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+        if image is None:
+            logger.warning("Failed to read template image: %s", path)
+        self._template_cache[name] = image
+        return image
+
+    @staticmethod
+    def _to_gray(cv2, image: np.ndarray) -> np.ndarray:
+        """Return a single-channel grayscale view of an image."""
+        if image.ndim == 3 and image.shape[2] >= 3:
+            return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        return image
+
+    @staticmethod
+    def _build_match(
+        name: str, meta: Dict[str, Any], x: int, y: int, width: int, height: int, confidence: float
+    ) -> Dict[str, Any]:
+        """Build a match record in the shape expected by screen_analyzer."""
+        return {
+            "template_name": name,
+            "element_type": meta.get("element_type", "unknown"),
+            "bbox": {"x": x, "y": y, "width": width, "height": height},
+            "center": (x + width // 2, y + height // 2),
+            "confidence": confidence,
+            "attributes": {"template_path": meta.get("template_path", "")},
+        }
+
+    def _suppress_overlaps(self, matches: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Greedy non-maximum suppression keeping highest-confidence matches."""
+        ordered = sorted(matches, key=lambda m: m["confidence"], reverse=True)
+        kept: List[Dict[str, Any]] = []
+        for candidate in ordered:
+            if all(self._iou(candidate["bbox"], k["bbox"]) <= self.IOU_SUPPRESSION_THRESHOLD for k in kept):
+                kept.append(candidate)
+        return kept
+
+    @staticmethod
+    def _iou(a: Dict[str, int], b: Dict[str, int]) -> float:
+        """Intersection-over-union of two {x, y, width, height} boxes."""
+        ax2, ay2 = a["x"] + a["width"], a["y"] + a["height"]
+        bx2, by2 = b["x"] + b["width"], b["y"] + b["height"]
+        inter_w = max(0, min(ax2, bx2) - max(a["x"], b["x"]))
+        inter_h = max(0, min(ay2, by2) - max(a["y"], b["y"]))
+        intersection = inter_w * inter_h
+        union = a["width"] * a["height"] + b["width"] * b["height"] - intersection
+        return intersection / union if union > 0 else 0.0
 
 
 class ContextAnalyzer:

--- a/autobot-backend/computer_vision/template_matching_test.py
+++ b/autobot-backend/computer_vision/template_matching_test.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for TemplateMatchingEngine.find_common_elements (Issue #11580).
+
+Verifies real cv2.matchTemplate detection with non-maximum suppression,
+replacing the previous silent stub that always returned an empty list.
+"""
+
+import numpy as np
+import pytest
+
+from computer_vision.classifiers import TemplateMatchingEngine
+
+cv2 = pytest.importorskip("cv2")
+
+
+def _make_patch() -> np.ndarray:
+    """Build a small, visually distinctive grayscale template."""
+    patch = np.zeros((20, 20), dtype=np.uint8)
+    cv2.rectangle(patch, (2, 2), (17, 17), 255, 2)
+    cv2.line(patch, (2, 2), (17, 17), 200, 1)
+    return patch
+
+
+@pytest.fixture
+def template_dir(tmp_path):
+    """A templates directory containing a single close_button template."""
+    tdir = tmp_path / "templates"
+    tdir.mkdir()
+    cv2.imwrite(str(tdir / "close_button.png"), _make_patch())
+    return tdir
+
+
+@pytest.mark.asyncio
+async def test_finds_three_identical_patches(template_dir):
+    """Three identical patches on a screenshot yield exactly three matches."""
+    screen = np.zeros((200, 200), dtype=np.uint8)
+    coords = [(10, 10), (100, 40), (60, 150)]
+    patch = _make_patch()
+    for x, y in coords:
+        screen[y : y + 20, x : x + 20] = patch
+
+    engine = TemplateMatchingEngine(templates_dir=template_dir)
+    matches = await engine.find_common_elements(screen)
+
+    assert len(matches) == 3
+    centers = sorted(m["center"] for m in matches)
+    assert centers == sorted((x + 10, y + 10) for x, y in coords)
+    for match in matches:
+        assert match["template_name"] == "close_button"
+        assert match["element_type"] == "button"
+        assert match["confidence"] >= 0.99
+        assert set(match["bbox"]) == {"x", "y", "width", "height"}
+
+
+@pytest.mark.asyncio
+async def test_no_templates_returns_empty(tmp_path):
+    """Absent a templates directory the engine legitimately returns empty."""
+    engine = TemplateMatchingEngine(templates_dir=tmp_path / "missing")
+    assert await engine.find_common_elements(np.zeros((50, 50), dtype=np.uint8)) == []
+
+
+@pytest.mark.asyncio
+async def test_empty_screenshot_returns_empty(template_dir):
+    """An empty screenshot short-circuits to an empty result."""
+    engine = TemplateMatchingEngine(templates_dir=template_dir)
+    assert await engine.find_common_elements(np.array([])) == []
+
+
+@pytest.mark.asyncio
+async def test_no_match_returns_empty(template_dir):
+    """A flat screenshot with no template present returns empty."""
+    engine = TemplateMatchingEngine(templates_dir=template_dir)
+    flat = np.full((200, 200), 128, dtype=np.uint8)
+    assert await engine.find_common_elements(flat) == []


### PR DESCRIPTION
## Thinking Path
`find_common_elements()` was a silent stub returning empty — the wired caller (`screen_analyzer.py:430` `_process_template_matches`) got zero elements with no error. Implemented for real.

## What Changed
- `computer_vision/classifiers.py`: real matcher — grayscale → `cv2.matchTemplate(TM_CCOEFF_NORMED)` per template, keep all locations ≥ threshold (`np.where`), greedy IoU non-maximum suppression to collapse overlaps. Emits the exact caller shape (`template_name`, `element_type`, `bbox`, `center`, `confidence`, `attributes`).
- Rewrote `_load_templates()` (previously pointed at non-existent files, never read images) to discover `*.png` in a resolvable templates dir (injectable via `__init__(templates_dir=...)`), infer element type from filename, cache grayscale. Empty is now a valid "no templates configured / nothing found", not a no-op.
- Lazy `_get_cv2()` loader mirroring `screen_analyzer.py`'s pattern — fails loud if cv2 missing (it's a hard dep) rather than silently empty.

Closes #11580

## Verification
- New `computer_vision/template_matching_test.py`: 4 tests (3-identical-patches synthetic image + no-templates/empty/no-match) — all pass with real cv2 5.0.0.
- `py_compile` + `black --check` clean.

## Model Used
Opus 4.8 (subagent: ai-ml-engineer)