### PR TITLE
fix(test): isolate cross-test state bleed in KnowledgeUpload + useModal (#11625)

### DIFF
--- a/autobot-frontend/src/components/knowledge/__tests__/KnowledgeUpload.spec.ts
+++ b/autobot-frontend/src/components/knowledge/__tests__/KnowledgeUpload.spec.ts
@@ -24,7 +24,7 @@
  * beforeEach.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { nextTick } from 'vue'
@@ -120,13 +120,19 @@ function applyMocks(
 
 // ── Mount helper ─────────────────────────────────────────────────────────────
 
+// #11625: track every mounted wrapper so afterEach can unmount them. Without
+// this, components (and their scoped timers — e.g. useTransientError's 5s
+// timeout — plus reactive effects) survived each test and leaked into later
+// tests / parallel-worker files, causing order-dependent flake.
+const mountedWrappers: VueWrapper[] = []
+
 function mountKnowledgeUpload(
   controllerMock = makeControllerMock(),
   progressMock = makeUploadProgressMock()
 ) {
   applyMocks(controllerMock, progressMock)
 
-  return mount(KnowledgeUpload, {
+  const wrapper = mount(KnowledgeUpload, {
     global: {
       plugins: [
         createTestingPinia({
@@ -152,6 +158,9 @@ function mountKnowledgeUpload(
       }
     }
   })
+
+  mountedWrappers.push(wrapper)
+  return wrapper
 }
 
 // ── File utilities ────────────────────────────────────────────────────────────
@@ -194,6 +203,12 @@ describe('KnowledgeUpload — file upload section', () => {
     controllerMock = makeControllerMock()
     progressMock = makeUploadProgressMock()
     applyMocks(controllerMock, progressMock)
+  })
+
+  afterEach(() => {
+    // Unmount every wrapper so no component, scoped timer or reactive effect
+    // survives into the next test or parallel-worker file (#11625).
+    while (mountedWrappers.length) mountedWrappers.pop()?.unmount()
   })
 
   // ── Idle render ─────────────────────────────────────────────────────────

--- a/autobot-frontend/src/composables/__tests__/useModal.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useModal.test.ts
@@ -7,11 +7,17 @@
  * Target: 100% code coverage
  */
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { useModal, useModals, useModalGroup } from '../useModal'
 import type { ModalOptions } from '../useModal'
 
 describe('useModal composable', () => {
+  // #11625: guarantee no fake-timer state escapes this file into the parallel
+  // worker pool. Leaked fake timers between files was a named flake cause.
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   // ========================================
   // useModal() Basic Functionality Tests
   // ========================================
@@ -465,38 +471,44 @@ describe('useModal composable', () => {
     })
 
     it('should close modals in parallel with closeAll', async () => {
-      const closeTimings: number[] = []
-      const { modals, closeAll } = useModalGroup(['modal1', 'modal2', 'modal3'])
+      // #11625: prove parallelism DETERMINISTICALLY with fake timers instead of a
+      // wall-clock `toBeLessThan(100)` guard. That guard flaked on loaded parallel
+      // runners (reproduced under CPU load) — same class of wall-clock assertion
+      // #10275 already removed from this file's perf block.
+      vi.useFakeTimers()
+      try {
+        const closeTimings: number[] = []
+        const { modals, closeAll } = useModalGroup(['modal1', 'modal2', 'modal3'])
 
-      // Add delays to onClose callbacks
-      modals.modal1.close = async () => {
-        await new Promise(resolve => setTimeout(resolve, 50))
-        closeTimings.push(Date.now())
-        return useModal().close()
+        // Each close waits 50ms before recording its completion instant.
+        const delayedClose = () => async () => {
+          await new Promise(resolve => setTimeout(resolve, 50))
+          closeTimings.push(Date.now())
+          return useModal().close()
+        }
+        modals.modal1.close = delayedClose()
+        modals.modal2.close = delayedClose()
+        modals.modal3.close = delayedClose()
+
+        await modals.modal1.open()
+        await modals.modal2.open()
+        await modals.modal3.open()
+
+        // Kick off all closes WITHOUT awaiting so the three 50ms delays overlap.
+        const closePromise = closeAll()
+
+        // Parallel execution resolves ALL three timers within a single 50ms
+        // virtual advance. Sequential execution would need 150ms (3 x 50ms) and
+        // leave two timers pending after advancing only 50ms.
+        await vi.advanceTimersByTimeAsync(50)
+        await closePromise
+
+        // All three completed, and at the SAME virtual instant -> truly parallel.
+        expect(closeTimings).toHaveLength(3)
+        expect(new Set(closeTimings).size).toBe(1)
+      } finally {
+        vi.useRealTimers()
       }
-
-      modals.modal2.close = async () => {
-        await new Promise(resolve => setTimeout(resolve, 50))
-        closeTimings.push(Date.now())
-        return useModal().close()
-      }
-
-      modals.modal3.close = async () => {
-        await new Promise(resolve => setTimeout(resolve, 50))
-        closeTimings.push(Date.now())
-        return useModal().close()
-      }
-
-      await modals.modal1.open()
-      await modals.modal2.open()
-      await modals.modal3.open()
-
-      const startTime = Date.now()
-      await closeAll()
-      const duration = Date.now() - startTime
-
-      // Should complete in ~50ms (parallel), not ~150ms (sequential)
-      expect(duration).toBeLessThan(100)
     })
   })
 


### PR DESCRIPTION
## Thinking Path
Both files passed in isolation but flaked under full parallel `vitest run` — classic cross-test state bleed, not a product bug.

## What Changed
- **useModal.test.ts**: one test used real `setTimeout(50)`×3 + a wall-clock guard `duration < 100ms` (the exact anti-pattern the file's own #10275 comment documents removing — this one was missed). Rewrote with fake timers to prove parallelism deterministically (`advanceTimersByTimeAsync(50)`; all 3 resolve at the same virtual instant), with try/finally + `afterEach(vi.useRealTimers())` so no fake-timer state leaks into the worker pool.
- **KnowledgeUpload.spec.ts**: wrappers were never unmounted — components + their scoped timers (`useTransientError`'s 5s setTimeout) stayed alive across tests and into other parallel-worker files. Now tracks + `unmount()`s all wrappers in `afterEach` (triggers `onScopeDispose` → clears pending timers).

Verified no product singleton leak: useModal/useModals/useModalGroup/useTransientError/useExpansion all create fresh per-instance refs.

Closes #11625

## Verification
- useModal 6/6 green under the full-core CPU load that previously failed at run 5.
- Full `vitest run` ×2: 2016 passed / 1 skipped / 0 failed. vue-tsc clean.

## Model Used
Opus 4.8 (subagent: frontend-engineer)