### PR TITLE
refactor(deps): consolidate filtered-requirements + constraint rewrite to one script (#11134)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -586,20 +586,21 @@
     - restart backend
     - restart celery
 
-# The filtered file is written to /tmp, so its `-c ../constraints/shared.txt`
-# (kept from requirements.txt, #10524) would resolve relative to /tmp and fail
-# (pip errors on a missing constraint file). Rewrite it to the canonical
-# code_source constraints path, which always exists as the git checkout, so the
-# pinned constraints are actually applied on deploy (#11117).
-- name: Resolve absolute constraints path for filtered requirements
-  ansible.builtin.set_fact:
-    backend_constraints_abs: "{{ code_source_dir | default('/opt/autobot/code_source') }}/constraints/"
-
+# The filtered file is written to /tmp, so its sibling-relative `-c
+# ../constraints/shared.txt` (#10524) and `-r ../requirements.txt` (#11135)
+# includes would resolve relative to /tmp and fail (pip errors on a missing
+# file). Delegate the filter+rewrite to the canonical
+# scripts/build-filtered-requirements.sh (#11134), which rewrites both to the
+# code_source path, which always exists as the git checkout, so the pinned
+# constraints AND root runtime deps are actually applied on deploy (#11117,
+# #11135). services/role_registry.py's backend post_sync_cmd invokes the same
+# script, so both deploy paths share one implementation instead of drifting.
 - name: Create filtered backend requirements file
   ansible.builtin.shell:
     cmd: >-
-      grep -Ev '^-e.*autobot[-_]shared|^-r' {{ backend_code_dir }}/requirements.txt
-      | sed 's|^-c \.\./constraints/|-c {{ backend_constraints_abs }}|'
+      bash {{ code_source_dir | default('/opt/autobot/code_source') }}/scripts/build-filtered-requirements.sh
+      {{ backend_code_dir }}/requirements.txt
+      {{ code_source_dir | default('/opt/autobot/code_source') }}
       > /tmp/requirements-filtered.txt
   become_user: "{{ backend_user }}"
 

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -103,21 +103,25 @@ _BACKEND_ROLES = [
         "auto_restart": True,
         "health_check_port": 8443,
         "health_check_path": "/api/health",
-        # Install deps into the backend venv, then migrate. Mirrors the backend
-        # ansible role (#11117): strip only the editable autobot_shared, and
-        # rewrite the two sibling-relative includes to the canonical code_source
-        # path so pip can resolve them — `-c ../constraints/` (#10524 constraints)
-        # and `-r ../requirements.txt` (the ~23 root runtime deps: paramiko,
-        # asyncssh, pypdf, python-docx/pptx, openpyxl, …). Both siblings live in
-        # code_source but NOT next to the synced autobot-backend/, so stripping
-        # `-r` (as before) silently dropped those deps on deploy — #11135. A bare
-        # `pip install -r requirements.txt` would error on the unresolvable
-        # include and, via the && short-circuit, silently skip alembic (#11069).
+        # Install deps into the backend venv, then migrate. Delegates the
+        # filter+rewrite to the canonical scripts/build-filtered-requirements.sh
+        # (#11134), which strips only the editable autobot_shared and rewrites
+        # the two sibling-relative includes to the canonical code_source path
+        # so pip can resolve them — `-c ../constraints/` (#10524 constraints,
+        # #11117 rewrite) and `-r ../requirements.txt` (the ~23 root runtime
+        # deps: paramiko, asyncssh, pypdf, python-docx/pptx, openpyxl, …). Both
+        # siblings live in code_source but NOT next to the synced
+        # autobot-backend/, so stripping `-r` (as before #11135) silently
+        # dropped those deps on deploy. The backend ansible role
+        # (ansible/roles/backend/tasks/main.yml) invokes the same script, so
+        # both deploy paths share one implementation instead of drifting.
+        # A bare `pip install -r requirements.txt` would error on the
+        # unresolvable include and, via the && short-circuit, silently skip
+        # alembic (#11069).
         "post_sync_cmd": (
             f"cd {_BASE_DIR}/autobot-backend && "
-            "grep -Ev '^-e.*autobot[-_]shared' requirements.txt "
-            f"| sed 's|^-c \\.\\./constraints/|-c {_BASE_DIR}/code_source/constraints/|;"
-            f" s|^-r \\.\\./requirements.txt|-r {_BASE_DIR}/code_source/requirements.txt|' "
+            f"bash {_BASE_DIR}/code_source/scripts/build-filtered-requirements.sh "
+            f"requirements.txt {_BASE_DIR}/code_source "
             "> /tmp/requirements-filtered-slm.txt && "
             "PIP_USE_DEPRECATED=legacy-resolver PIP_DEFAULT_TIMEOUT=120 "
             "venv/bin/pip install -r /tmp/requirements-filtered-slm.txt && "

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -15,6 +15,7 @@ implementation, so it removes the stub from sys.modules before importing.
 """
 
 import importlib
+import subprocess as _subprocess
 import sys
 
 # ---------------------------------------------------------------------------
@@ -316,16 +317,47 @@ def test_seed_default_roles_no_write_when_existing_rows_match_registry():
     db.add.assert_not_called()
 
 
-def test_backend_post_sync_rewrites_root_requirements_not_strips_it():
-    """The backend post_sync_cmd must REWRITE `-r ../requirements.txt` to the
-    code_source path (so the root runtime deps install on deploy), not strip it
-    like the old `grep -Ev '...|^-r'` did — #11135."""
+def test_backend_post_sync_delegates_to_canonical_filter_script():
+    """The backend post_sync_cmd must delegate the filter+rewrite to the
+    canonical scripts/build-filtered-requirements.sh (#11134) — not re-inline
+    its own grep|sed copy, which is what let it drift from the ansible role's
+    copy (that dropped `-r` lines entirely instead of rewriting them — #11135)."""
     backend = next(r for r in DEFAULT_ROLES if r["name"] == "backend")
     cmd = backend["post_sync_cmd"]
-    # rewrite present (sed maps the sibling include to code_source)
-    assert "s|^-r \\.\\./requirements.txt|-r " in cmd
-    assert "/code_source/requirements.txt|" in cmd
-    # and the grep no longer drops -r lines
-    assert "^-r" not in cmd.split("| sed")[0]
-    # the -c constraints rewrite (#11117) is preserved
-    assert "s|^-c \\.\\./constraints/|-c " in cmd
+    assert "scripts/build-filtered-requirements.sh" in cmd
+    assert "requirements.txt" in cmd
+    assert "/code_source" in cmd
+    # no re-inlined grep|sed pipeline duplicating the script's logic
+    assert "grep -Ev" not in cmd
+    assert "sed 's|" not in cmd
+
+
+def test_build_filtered_requirements_script_rewrites_root_requirements_not_strips_it(tmp_path):
+    """Behavioral-equivalence check for scripts/build-filtered-requirements.sh
+    (#11134): must REWRITE `-r ../requirements.txt` and `-c ../constraints/...`
+    to the code_source path, not strip `-r` like the old ansible-role copy did
+    — #11135, #11117."""
+    script = _Path(__file__).parent.parent.parent.parent / "scripts" / "build-filtered-requirements.sh"
+    assert script.is_file(), f"canonical script missing: {script}"
+
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        "-e ../autobot_shared\n"
+        "-c ../constraints/shared.txt  # comment\n"
+        "fastapi>=0.139.2\n"
+        "-r ../requirements.txt\n",
+        encoding="utf-8",
+    )
+
+    result = _subprocess.run(
+        ["bash", str(script), str(requirements), "/opt/autobot/code_source"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = result.stdout
+
+    assert "-e ../autobot_shared" not in output
+    assert "-c /opt/autobot/code_source/constraints/shared.txt" in output
+    assert "-r /opt/autobot/code_source/requirements.txt" in output
+    assert "fastapi>=0.139.2" in output

--- a/scripts/build-filtered-requirements.sh
+++ b/scripts/build-filtered-requirements.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+#
+# Canonical filtered-requirements + constraint/requirements rewrite (#11134).
+#
+# Both the backend ansible role (ansible/roles/backend/tasks/main.yml) and
+# services/role_registry.py's backend post_sync_cmd previously duplicated this
+# grep|sed pipeline independently — a drift hazard (#11134). This script is
+# the single source of truth both now invoke.
+#
+# What it does, and why:
+#  - Strips the editable `-e ../autobot_shared` include: autobot_shared is
+#    installed separately as its own editable package on deploy, so this
+#    self-reference would otherwise fail (../autobot_shared does not exist
+#    relative to the synced autobot-backend/ directory).
+#  - Rewrites the sibling-relative `-c ../constraints/...` include (#10524
+#    shared-version constraints) to the canonical code_source path, which
+#    always exists as the git checkout on deploy targets (#11117). Without
+#    this, pip errors on the missing constraint file.
+#  - Rewrites the sibling-relative `-r ../requirements.txt` include (~23 root
+#    runtime deps: paramiko, asyncssh, pypdf, python-docx/pptx, openpyxl, ...)
+#    to the same code_source path (#11135). An earlier version of this
+#    pipeline stripped `-r` lines entirely instead of rewriting them, which
+#    silently dropped those root deps on deploy.
+#
+# Usage:
+#   build-filtered-requirements.sh <requirements_file> <code_source_dir>
+#
+# Output: filtered requirements written to stdout.
+set -euo pipefail
+
+requirements_file="${1:?usage: build-filtered-requirements.sh <requirements_file> <code_source_dir>}"
+code_source_dir="${2:?usage: build-filtered-requirements.sh <requirements_file> <code_source_dir>}"
+
+grep -Ev '^-e.*autobot[-_]shared' "${requirements_file}" \
+  | sed "s|^-c \\.\\./constraints/|-c ${code_source_dir}/constraints/|; s|^-r \\.\\./requirements.txt|-r ${code_source_dir}/requirements.txt|"


### PR DESCRIPTION
## Thinking Path
The filtered-requirements + `-c` constraint rewrite was duplicated in the ansible backend role and `role_registry.py`'s `post_sync_cmd`. They had **drifted**: the ansible copy still used the pre-#11135 pipeline that **strips `-r ../requirements.txt` entirely** — silently skipping ~23 root runtime deps (paramiko, asyncssh, pypdf, openpyxl, …) on ansible-driven deploys — while `role_registry.py` was fixed by #11237 to rewrite it. This is exactly the drift hazard #11134 flags (and a real deploy bug).

## What Changed
- New canonical `scripts/build-filtered-requirements.sh <requirements> <code_source_dir>` at repo root (present under `code_source_dir` on every deploy target).
- Both consumers now call it instead of maintaining independent grep/sed pipelines:
  - ansible `roles/backend/tasks/main.yml`: replaced inline `set_fact` + `grep|sed` with a call to the script — **gains the `-r` fix it was missing**.
  - `role_registry.py` `post_sync_cmd`: calls the same script.
- Canonical behavior = the correct post-#11135 one (`-e` strip, `-c` rewrite #11117, `-r` rewrite #11135) — nothing dropped.

Closes #11134

## Verification
- `bash -n` script OK; `py_compile`+`black` clean; ansible YAML parses (88 tasks).
- Ran the script against real `requirements.txt` — output matches role_registry's fixed behavior.
- Added subprocess test proving equivalence; `pytest tests/services/test_role_registry.py` → 18 passed.

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)