### PR TITLE
fix(slm): frontend uses async drift-resolve job so code-sync GUI stays responsive (#11303)

### DIFF
--- a/autobot-slm-frontend/src/composables/useCodeSync.test.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSync.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Issue #11303 — per-component drift/resolve must be an async job (job_id +
+ * status polling) instead of an inline await that blocks the caller for the
+ * full 40-120s rsync + post-sync-steps duration. These tests prove the new
+ * composable methods return promptly with a job_id and that status polling
+ * distinguishes "unknown job" (stop) from "transient error during the
+ * component's own service restart" (keep polling).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useCodeSync } from './useCodeSync'
+
+const mockPost = vi.fn()
+const mockGet = vi.fn()
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ logout: vi.fn() }),
+}))
+
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('axios')>()
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      create: () => ({
+        post: mockPost,
+        get: mockGet,
+        interceptors: {
+          request: { use: vi.fn() },
+          response: { use: vi.fn() },
+        },
+      }),
+    },
+  }
+})
+
+describe('useCodeSync — async drift/resolve job (#11303)', () => {
+  beforeEach(() => {
+    mockPost.mockReset()
+    mockGet.mockReset()
+  })
+
+  it('startResolveDriftAsync resolves immediately with a job_id (no inline rsync/post-steps wait)', async () => {
+    mockPost.mockResolvedValue({
+      data: { job_id: 'job-1', component: 'autobot-slm-backend', status: 'running' },
+    })
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.startResolveDriftAsync('autobot-slm-backend')
+
+    expect(mockPost).toHaveBeenCalledWith('/code-sync/drift/resolve-async', {
+      component: 'autobot-slm-backend',
+    })
+    expect(result).toEqual({ job_id: 'job-1', component: 'autobot-slm-backend', status: 'running' })
+  })
+
+  it('startResolveDriftAsync surfaces a 409 (restart in flight) without throwing', async () => {
+    mockPost.mockRejectedValue({ response: { status: 409, data: { detail: 'restart in flight' } } })
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.startResolveDriftAsync('autobot-slm-backend')
+
+    expect(result).toBeNull()
+    expect(codeSync.error.value).toBe('restart in flight')
+  })
+
+  it('getResolveDriftStatus returns the persisted job row once the job finishes', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        job_id: 'job-1',
+        component: 'autobot-slm-backend',
+        status: 'completed',
+        success: true,
+        deps_changed: false,
+        message: 'Resynced autobot-slm-backend from code_source',
+        post_steps: ['rsync ok', 'pip install ok'],
+        created_at: null,
+        completed_at: null,
+      },
+    })
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getResolveDriftStatus('job-1')
+
+    expect(mockGet).toHaveBeenCalledWith('/code-sync/drift/resolve/status/job-1')
+    expect(result?.status).toBe('completed')
+    expect(result?.success).toBe(true)
+  })
+
+  it('getResolveDriftStatus returns null on a true 404 so the poller stops', async () => {
+    mockGet.mockRejectedValue({ response: { status: 404 } })
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getResolveDriftStatus('unknown-job')
+
+    expect(result).toBeNull()
+  })
+
+  it('getResolveDriftStatus returns undefined on a transient error (component self-restart) so the poller keeps retrying', async () => {
+    mockGet.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getResolveDriftStatus('job-1')
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/autobot-slm-frontend/src/composables/useCodeSync.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSync.ts
@@ -180,6 +180,25 @@ export interface DriftResolveResponse {
   deployed_dir: string
 }
 
+// Issue #11303: Async per-component drift/resolve job types
+export interface DriftResolveJobResponse {
+  job_id: string
+  component: string
+  status: string
+}
+
+export interface ComponentSyncJobStatus {
+  job_id: string
+  component: string
+  status: 'queued' | 'running' | 'completed' | 'failed'
+  success: boolean | null
+  deps_changed: boolean
+  message: string | null
+  post_steps: string[]
+  created_at: string | null
+  completed_at: string | null
+}
+
 // Re-export role types for consumers (Issue #779)
 export type { Role, SyncResult }
 
@@ -743,6 +762,48 @@ export function useCodeSync() {
     }
   }
 
+  /**
+   * Start an async per-component drift/resolve job (#11303).
+   *
+   * Returns immediately with a job_id instead of awaiting the full rsync +
+   * post-sync steps inline, so the GUI never blocks on a slow resync or the
+   * component's own service restart. Poll getResolveDriftStatus() for progress.
+   */
+  async function startResolveDriftAsync(component: string): Promise<DriftResolveJobResponse | null> {
+    error.value = null
+    try {
+      const response = await client.post<DriftResolveJobResponse>('/code-sync/drift/resolve-async', {
+        component,
+      })
+      return response.data
+    } catch (e: unknown) {
+      const axiosErr = e as { response?: { status?: number; data?: { detail?: string } } }
+      error.value = axiosErr?.response?.data?.detail || 'Failed to start drift resolve job'
+      return null
+    }
+  }
+
+  /**
+   * Poll the status of an async drift/resolve job (#11303).
+   *
+   * Returns null ONLY on a true 404 (unknown job_id) so the caller stops
+   * polling. Returns undefined on transient errors (network refused / 5xx
+   * during the component's own restart) so the caller keeps polling instead
+   * of treating a self-restart as job failure.
+   */
+  async function getResolveDriftStatus(jobId: string): Promise<ComponentSyncJobStatus | null | undefined> {
+    try {
+      const response = await client.get<ComponentSyncJobStatus>(`/code-sync/drift/resolve/status/${jobId}`)
+      return response.data
+    } catch (e: unknown) {
+      const axiosErr = e as { response?: { status?: number } }
+      if (axiosErr?.response?.status === 404) {
+        return null
+      }
+      return undefined
+    }
+  }
+
   // =============================================================================
   // Return Public API
   // =============================================================================
@@ -794,9 +855,11 @@ export function useCodeSync() {
     syncRole: rolesComposable.syncRole,
     pullFromSource: rolesComposable.pullFromSource,
 
-    // Drift detection (Issue #2834) + resolution (#7149)
+    // Drift detection (Issue #2834) + resolution (#7149) + async job (#11303)
     fetchDrift,
     resolveDrift,
+    startResolveDriftAsync,
+    getResolveDriftStatus,
 
     // SLM self-update (#9073)
     selfUpdate,

--- a/autobot-slm-frontend/src/views/CodeSyncView.vue
+++ b/autobot-slm-frontend/src/views/CodeSyncView.vue
@@ -21,6 +21,7 @@ import {
   type FileDriftReport,
   type UpdateAllJob,
   type UpdateAllStage,
+  type ComponentSyncJobStatus,
 } from '@/composables/useCodeSync'
 import { createLogger } from '@/utils/debugUtils'
 import { formatDateTime } from '@/composables/useTimezone'
@@ -70,6 +71,17 @@ const isDriftLoading = ref(false)
 const isResolvingDrift = ref(false) // #7149: separate from drift-check spinner
 const showDriftDetails = ref(false)
 const selectedDriftComponent = ref('autobot-slm-backend')
+
+// Async drift/resolve job polling (#11303) — mirrors the update-all pattern so
+// the Resync button returns immediately instead of blocking on the rsync +
+// post-sync steps (which can take 40-120s and may restart the component itself).
+const resolveDriftJob = ref<ComponentSyncJobStatus | null>(null)
+const resolveDriftPolling = ref(false)
+const resolveDriftTransientErrors = ref(0)
+const RESOLVE_DRIFT_MAX_TRANSIENT_ERRORS = 90 // ~3 min at 2s intervals
+const RESOLVE_DRIFT_LOST_CONTACT_ERRORS = 30 // ~1 min before "lost contact" banner
+const resolveDriftLostContact = ref(false)
+let resolveDriftPollTimer: ReturnType<typeof setTimeout> | null = null
 
 // Clear stale results when the user switches to a different component (#3433)
 watch(selectedDriftComponent, () => {
@@ -495,21 +507,101 @@ async function handleCheckDrift(): Promise<void> {
   }
 }
 
-// #7149: Resync the selected component from code_source/, then re-check drift.
+function _stopResolveDriftPoll(): void {
+  if (resolveDriftPollTimer) {
+    clearTimeout(resolveDriftPollTimer)
+    resolveDriftPollTimer = null
+  }
+  resolveDriftPolling.value = false
+}
+
+/**
+ * A transient error means the request never reached the poller (e.g. the
+ * component restarting itself). Returns true if polling should continue.
+ */
+function _handleResolveDriftTransientError(): boolean {
+  resolveDriftTransientErrors.value += 1
+  if (resolveDriftTransientErrors.value >= RESOLVE_DRIFT_MAX_TRANSIENT_ERRORS) {
+    resolveDriftLostContact.value = true
+    _stopResolveDriftPoll()
+    isResolvingDrift.value = false
+    return false
+  }
+  if (resolveDriftTransientErrors.value >= RESOLVE_DRIFT_LOST_CONTACT_ERRORS) {
+    resolveDriftLostContact.value = true
+  }
+  return true
+}
+
+/** Job reached a terminal status ('completed'/'failed') — stop polling and report. */
+async function _handleResolveDriftTerminal(result: ComponentSyncJobStatus): Promise<void> {
+  _stopResolveDriftPoll()
+  isResolvingDrift.value = false
+  if (result.status === 'completed' && result.success) {
+    successMessage.value = result.message || `Resynced ${result.component} from code_source`
+    await handleCheckDrift()
+  } else {
+    codeSync.setError(result.message || 'Drift resolve job failed')
+  }
+}
+
+/**
+ * Resilient polling loop for the async drift/resolve job (#11303). Mirrors
+ * _scheduleUpdateAllPoll: undefined = transient error (component's own
+ * restart) → keep polling; null = unknown job_id → stop; otherwise update the
+ * job state and keep polling until a terminal status.
+ */
+function _scheduleResolveDriftPoll(jobId: string): void {
+  if (resolveDriftPolling.value) return
+  resolveDriftPolling.value = true
+  resolveDriftTransientErrors.value = 0
+
+  const poll = async () => {
+    const result = await codeSync.getResolveDriftStatus(jobId)
+
+    if (result === undefined) {
+      if (_handleResolveDriftTransientError()) {
+        resolveDriftPollTimer = setTimeout(poll, 2000)
+      }
+      return
+    }
+
+    resolveDriftLostContact.value = false
+    resolveDriftTransientErrors.value = 0
+
+    if (result === null) {
+      _stopResolveDriftPoll()
+      isResolvingDrift.value = false
+      return
+    }
+
+    resolveDriftJob.value = result
+    if (result.status === 'running' || result.status === 'queued') {
+      resolveDriftPollTimer = setTimeout(poll, 2000)
+      return
+    }
+
+    await _handleResolveDriftTerminal(result)
+  }
+
+  resolveDriftPollTimer = setTimeout(poll, 1000)
+}
+
+// #7149/#11303: Resync the selected component from code_source/ as an async
+// job so the button returns immediately instead of blocking on the rsync +
+// post-sync steps (which can take 40-120s and may restart the component).
 async function handleResolveDrift(): Promise<void> {
   if (!driftReport.value?.drift_detected) return
+  codeSync.clearError()
+  resolveDriftLostContact.value = false
+  resolveDriftJob.value = null
   isResolvingDrift.value = true
-  try {
-    const result = await codeSync.resolveDrift(selectedDriftComponent.value)
-    if (result?.success) {
-      successMessage.value = `Resynced ${result.component} from code_source`
-      // Re-run drift check to confirm resolution
-      await handleCheckDrift()
-    }
-    // Errors are surfaced via codeSync.error already
-  } finally {
+  const job = await codeSync.startResolveDriftAsync(selectedDriftComponent.value)
+  if (!job) {
     isResolvingDrift.value = false
+    return
   }
+  _scheduleResolveDriftPoll(job.job_id)
 }
 
 // =============================================================================
@@ -621,6 +713,7 @@ onMounted(async () => {
 onUnmounted(() => {
   if (slmRefreshTimer) clearTimeout(slmRefreshTimer)
   _stopUpdateAllPoll()
+  _stopResolveDriftPoll()
 })
 </script>
 
@@ -1039,7 +1132,7 @@ onUnmounted(() => {
           <select
             id="drift-component-select"
             v-model="selectedDriftComponent"
-            :disabled="isDriftLoading"
+            :disabled="isDriftLoading || isResolvingDrift"
             class="form-select text-sm rounded border-gray-300 focus:border-primary-500 focus:ring-primary-500"
           >
             <option value="autobot-slm-backend">autobot-slm-backend</option>
@@ -1124,6 +1217,31 @@ onUnmounted(() => {
           >
             {{ showDriftDetails ? $t('codeSyncView.hideDetails') : $t('codeSyncView.showDetails') }}
           </button>
+        </div>
+
+        <!-- #11303: Async resolve job progress (rsync/pip/build/restart may take 40-120s) -->
+        <div
+          v-if="isResolvingDrift && resolveDriftJob && !resolveDriftLostContact"
+          class="text-sm text-gray-600 mb-3 flex items-center gap-2"
+        >
+          <svg class="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          {{ resolveDriftJob.post_steps[resolveDriftJob.post_steps.length - 1] || $t('codeSyncView.resyncing') }}
+        </div>
+
+        <!-- #11303: Lost contact banner — component's own service restart drops the connection -->
+        <div
+          v-if="resolveDriftLostContact"
+          class="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-3 flex items-center gap-3"
+        >
+          <svg class="w-5 h-5 text-amber-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <div>
+            <div class="font-medium text-amber-900 text-sm">{{ $t('codeSyncView.sLMManagerRestarting') }}</div>
+            <div class="text-sm text-amber-700">{{ $t('codeSyncView.codeSyncedSuccessfullyBackend') }}</div>
+          </div>
         </div>
 
         <!-- Drifted files table -->


### PR DESCRIPTION
## Thinking Path
The backend blocking was already fixed (#11349 added `POST /drift/resolve-async` + background job + status endpoint). The remaining gap: `useCodeSync.ts`/`CodeSyncView.vue`'s "Resync from Source" still called the OLD synchronous `POST /code-sync/drift/resolve`, so the GUI still blocked/timed out 40-120s.

## What Changed
- `useCodeSync.ts`: added `startResolveDriftAsync()` (POSTs `/drift/resolve-async`, returns job_id immediately) + `getResolveDriftStatus()` (polls; `null`=404 stop, `undefined`=transient during the component's own restart = keep polling) — mirrors the existing `startUpdateAll`/`getUpdateAllStatus` fleet-job pattern.
- `CodeSyncView.vue`: rewired `handleResolveDrift` to fire-and-poll (1s initial, 2s interval, ~3min transient tolerance + "lost contact" banner). Reused existing i18n keys (slm-frontend single-locale).
- Old sync `resolveDrift()` + backend `POST /drift/resolve` left in place (superseded, not deleted — no-code-deletion policy).
- Poll state machine split into ≤30-line helpers.

Closes #11303

## Verification
- `vue-tsc --noEmit` clean; eslint clean; new `useCodeSync.test.ts` 5/5. Full vitest: 5 new pass (the 5 unrelated failures are a pre-existing baseline on Dev_new_gui — missing i18n plugin in DisposalPolicySettings/FindingsPolicySettings test setup).

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)