### PR TITLE
feat(llm): wire claude adapter payload-optimization into the structured send path (#10945)

### DIFF
--- a/autobot-backend/llm_shared/providers/anthropic.py
+++ b/autobot-backend/llm_shared/providers/anthropic.py
@@ -55,6 +55,25 @@ def _get_adapter_sync():
         return None
 
 
+async def _apply_adapter_pre_send(request: LLMRequest, context_type: str) -> None:
+    """Route the outbound payload through the adapter's structured pre-send hook.
+
+    Issue #10849 added the hook; Issue #10945 switched it from the flat-string
+    ``optimize_for_send`` (whose optimized result was discarded) to the
+    structured ``optimize_request``, which mutates ``request.messages`` in
+    place so payload-mutation and batching machinery actually reach the
+    payload sent to the Anthropic API. Fail-safe: adapter absent, not
+    initialized, or raising leaves ``request`` unchanged.
+    """
+    adapter = _get_adapter_sync()
+    if adapter is None or not adapter.is_initialized:
+        return
+    try:
+        await adapter.optimize_request(request, context_type=context_type)
+    except Exception as exc:
+        logger.debug("Claude adapter pre-send optimization skipped (fail-safe): %s", exc)
+
+
 from autobot_shared.ssot_config import config
 from constants.model_constants import (
     ANTHROPIC_CLAUDE3_OPUS_DATED,
@@ -300,30 +319,18 @@ class AnthropicProvider(BaseProvider):
         pre-send pipeline (rate-limit check, payload optimization, metric recording)
         before being dispatched to the Anthropic API.  The adapter is accessed via
         its module-level singleton; when absent the call proceeds unchanged (fail-safe).
+        Issue #10945: the pre-send hook now mutates ``request.messages`` through the
+        structured ``optimize_request`` path, so payload optimization actually
+        reaches the messages sent below (previously the optimized string was
+        computed and discarded).
         """
         self._total_requests += 1
         start = time.time()
         model = request.model_name or self._get_setting("default_model", ANTHROPIC_CLAUDE_SONNET4_6)
 
-        # --- Adapter pre-send: rate-limit + payload optimization (#10849) ----------
-        # Serialize the user-visible content for the adapter pipeline.
-        # The adapter operates on the text content; the full structured payload
-        # (tools, extra_headers, etc.) flows unchanged to the Anthropic SDK.
         _adapter = _get_adapter_sync()
         _context_type: str = request.llm_type.value if hasattr(request.llm_type, "value") else "general"
-        if _adapter is not None and _adapter.is_initialized:
-            try:
-                _raw_content = " ".join(m.get("content", "") for m in request.messages if isinstance(m, dict))
-                await _adapter.optimize_for_send(
-                    content=_raw_content,
-                    context_type=_context_type,
-                )
-            except Exception as _adapt_err:
-                logger.debug(
-                    "Claude adapter pre-send optimization skipped (fail-safe): %s",
-                    _adapt_err,
-                )
-        # --------------------------------------------------------------------------
+        await _apply_adapter_pre_send(request, _context_type)
 
         try:
             client = self._ensure_client()
@@ -430,26 +437,16 @@ class AnthropicProvider(BaseProvider):
         is not applied per-chunk; the adapter records the stream open as a single
         individual request.  Streaming cannot be routed through submit_request()
         which is non-streaming by design.
+        Issue #10945: the pre-send hook mutates ``request.messages`` through the
+        structured ``optimize_request`` path so optimization reaches the streamed
+        payload instead of only computing (and discarding) an optimized string.
         """
         self._total_requests += 1
         model = request.model_name or self._get_setting("default_model", ANTHROPIC_CLAUDE_SONNET4_6)
 
-        # --- Adapter pre-send: rate-limit + payload optimization (#10849) ----------
         _stream_adapter = _get_adapter_sync()
         _stream_context_type = request.llm_type.value if hasattr(request.llm_type, "value") else "general"
-        if _stream_adapter is not None and _stream_adapter.is_initialized:
-            try:
-                _stream_raw = " ".join(m.get("content", "") for m in request.messages if isinstance(m, dict))
-                await _stream_adapter.optimize_for_send(
-                    content=_stream_raw,
-                    context_type=_stream_context_type,
-                )
-            except Exception as _sadapt_err:
-                logger.debug(
-                    "Claude adapter stream pre-send optimization skipped (fail-safe): %s",
-                    _sadapt_err,
-                )
-        # --------------------------------------------------------------------------
+        await _apply_adapter_pre_send(request, _stream_context_type)
 
         _stream_start = time.time()
         try:

--- a/autobot-backend/tests/test_claude_adapter_wiring.py
+++ b/autobot-backend/tests/test_claude_adapter_wiring.py
@@ -6,20 +6,26 @@
 Tests for issue #10849: AnthropicProvider routes outbound sends through
 AutoBotClaudeAPIAdapter's pre-send optimization pipeline.
 
+Also covers issue #10945: the provider's pre-send hook was switched from the
+flat-string ``optimize_for_send`` (whose optimized result was discarded) to
+the structured ``optimize_request``, which mutates ``LLMRequest.messages`` in
+place so payload-mutation actually reaches the outbound payload.
+
 Tests are split into two tiers:
   - Tier 1 (always run): adapter-level methods (optimize_for_send,
-    record_send_result) and rate-limit dict-truthiness fix — no runtime deps
-    beyond the autobot-backend package.
+    optimize_request, record_send_result) and rate-limit dict-truthiness fix —
+    no runtime deps beyond the autobot-backend package.
   - Tier 2 (skipped unless anthropic SDK installed): AnthropicProvider
     integration — imported via pytest.importorskip so the suite still green
     when anthropic is absent.
 
 Verifies:
-  - optimize_for_send is called when adapter is present and initialized
+  - optimize_request is called (and applied to request.messages) when the
+    adapter is present and initialized
   - record_send_result is called after a successful send
   - record_send_result is called with success=False after an error
   - everything is skipped (fail-safe) when adapter is absent or not initialized
-  - stream_completion calls optimize_for_send before streaming
+  - stream_completion calls optimize_request before streaming
   - _check_and_apply_rate_limit correctly reads can_proceed from dict result
 """
 
@@ -214,6 +220,137 @@ class TestAdapterNewMethods:
 
 
 # ---------------------------------------------------------------------------
+# Structured LLMRequest path (#10945)
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredLLMRequestPath:
+    """optimize_request wires payload-mutation through structured messages."""
+
+    def setup_method(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        AutoBotClaudeAPIAdapter.reset_instance()
+
+    def teardown_method(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        AutoBotClaudeAPIAdapter.reset_instance()
+
+    @pytest.mark.asyncio
+    async def test_optimize_payload_if_enabled_no_longer_raises_attributeerror(self) -> None:
+        """Bugfix regression (#10945): OptimizationResult has no .optimized/.optimized_content."""
+        from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig
+
+        with patch("utils.graceful_degradation.Path.mkdir"):
+            mgr = ClaudeAPIBatchManager(ClaudeAPIConfig())
+        mgr.payload_optimizer.warning_size = 10
+        mgr.payload_optimizer.max_size = 100000  # avoid the chunking branch
+
+        long_text = "the quick brown fox jumps over the very lazy dog. " * 5
+        result = await mgr._optimize_payload_if_enabled(long_text)
+
+        assert result != long_text
+        assert len(result) < len(long_text)
+
+    @pytest.mark.asyncio
+    async def test_optimize_messages_if_enabled_preserves_message_structure(self) -> None:
+        from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig
+
+        with patch("utils.graceful_degradation.Path.mkdir"):
+            mgr = ClaudeAPIBatchManager(ClaudeAPIConfig())
+        mgr.payload_optimizer.warning_size = 10
+        mgr.payload_optimizer.max_size = 100000
+
+        messages = [
+            {"role": "system", "content": "the quick brown fox jumps over the very lazy dog. " * 5},
+            {"role": "user", "content": "hi"},
+        ]
+        optimized = await mgr._optimize_messages_if_enabled(messages)
+
+        assert optimized[0]["role"] == "system"
+        assert optimized[0]["content"] != messages[0]["content"]
+        assert optimized[1] == {"role": "user", "content": "hi"}
+
+    @pytest.mark.asyncio
+    async def test_optimize_request_mutates_and_returns_request(self) -> None:
+        """optimize_request must write optimized content back onto request.messages."""
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = True
+        mock_manager._increment_metric = AsyncMock()
+        mock_manager._check_and_apply_rate_limit = AsyncMock(return_value=True)
+        mock_manager._optimize_messages_if_enabled = AsyncMock(return_value=[{"role": "user", "content": "optimized"}])
+        mock_manager.rate_limiter = None
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        class _Req:
+            messages = [{"role": "user", "content": "original"}]
+
+        req = _Req()
+        result = await adapter.optimize_request(req, context_type="chat")
+
+        assert result is req
+        assert req.messages == [{"role": "user", "content": "optimized"}]
+        mock_manager._optimize_messages_if_enabled.assert_awaited_once_with([{"role": "user", "content": "original"}])
+
+    @pytest.mark.asyncio
+    async def test_optimize_request_fail_safe_on_rate_limit(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = True
+        mock_manager._increment_metric = AsyncMock()
+        mock_manager._check_and_apply_rate_limit = AsyncMock(return_value=False)
+        mock_manager.degradation_manager = None
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        class _Req:
+            messages = [{"role": "user", "content": "original"}]
+
+        req = _Req()
+        result = await adapter.optimize_request(req, context_type="chat")
+
+        assert result is req
+        assert req.messages == [{"role": "user", "content": "original"}]
+
+    @pytest.mark.asyncio
+    async def test_optimize_request_noop_when_manager_absent(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        adapter.manager = None
+        adapter._initialized = True
+
+        class _Req:
+            messages = [{"role": "user", "content": "original"}]
+
+        req = _Req()
+        result = await adapter.optimize_request(req, context_type="chat")
+        assert result is req
+
+    @pytest.mark.asyncio
+    async def test_content_via_llm_request_round_trips_through_structured_path(self) -> None:
+        """submit_request's flat-string path now optimizes via the same
+        structured messages helper the live provider send path uses."""
+        from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig
+
+        with patch("utils.graceful_degradation.Path.mkdir"):
+            mgr = ClaudeAPIBatchManager(ClaudeAPIConfig())
+        mgr._optimize_messages_if_enabled = AsyncMock(return_value=[{"role": "user", "content": "optimized-content"}])
+
+        result = await mgr._optimize_content_via_llm_request("original-content", "general")
+
+        assert result == "optimized-content"
+        mgr._optimize_messages_if_enabled.assert_awaited_once_with([{"role": "user", "content": "original-content"}])
+
+
+# ---------------------------------------------------------------------------
 # Rate-limit dict-truthiness fix (#10849)
 # ---------------------------------------------------------------------------
 
@@ -328,10 +465,15 @@ def _make_sdk_response(text: str = "pong") -> MagicMock:
     return resp
 
 
+async def _identity_optimize_request(request, context_type="general"):
+    """Mimic the real ``optimize_request`` no-op path (payload optimizer disabled)."""
+    return request
+
+
 def _make_initialized_adapter() -> MagicMock:
     adapter = MagicMock()
     adapter.is_initialized = True
-    adapter.optimize_for_send = AsyncMock(return_value="Hello")
+    adapter.optimize_request = AsyncMock(side_effect=_identity_optimize_request)
     adapter.record_send_result = AsyncMock()
     return adapter
 
@@ -344,7 +486,7 @@ class TestAnthropicProviderAdapterWiring:
         return _AnthropicProvider(settings={"api_key": "test-key"})
 
     @pytest.mark.asyncio
-    async def test_optimize_for_send_called_when_adapter_present(self) -> None:
+    async def test_optimize_request_called_when_adapter_present(self) -> None:
         provider = self._make_provider()
         sdk_resp = _make_sdk_response("response text")
         mock_adapter = _make_initialized_adapter()
@@ -360,9 +502,36 @@ class TestAnthropicProviderAdapterWiring:
             req = _make_request()
             await provider._chat_completion_impl(req)
 
-        mock_adapter.optimize_for_send.assert_awaited_once()
-        call_kwargs = mock_adapter.optimize_for_send.call_args.kwargs
-        assert call_kwargs["content"] == "Hello"
+        mock_adapter.optimize_request.assert_awaited_once()
+        call = mock_adapter.optimize_request.call_args
+        assert call.args[0].messages == [{"role": "user", "content": "Hello"}]
+        assert call.kwargs["context_type"]
+
+    @pytest.mark.asyncio
+    async def test_optimize_request_mutation_reaches_sent_payload(self) -> None:
+        """Issue #10945: optimized message content must reach the SDK call kwargs."""
+        provider = self._make_provider()
+        sdk_resp = _make_sdk_response("response text")
+        mock_adapter = _make_initialized_adapter()
+
+        async def _mutate(request, context_type="general"):
+            request.messages = [{"role": "user", "content": "Hello (optimized)"}]
+            return request
+
+        mock_adapter.optimize_request = AsyncMock(side_effect=_mutate)
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=sdk_resp)
+            mock_client_fn.return_value = mock_client
+
+            await provider._chat_completion_impl(_make_request())
+
+        sent_kwargs = mock_client.messages.create.call_args.kwargs
+        assert sent_kwargs["messages"] == [{"role": "user", "content": "Hello (optimized)"}]
 
     @pytest.mark.asyncio
     async def test_record_send_result_called_on_success(self) -> None:
@@ -443,15 +612,15 @@ class TestAnthropicProviderAdapterWiring:
             resp = await provider._chat_completion_impl(_make_request())
 
         assert resp.content == "direct2"
-        mock_adapter.optimize_for_send.assert_not_called()
+        mock_adapter.optimize_request.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_optimize_exception_is_fail_safe(self) -> None:
-        """If optimize_for_send raises, send still proceeds (fail-safe)."""
+        """If optimize_request raises, send still proceeds (fail-safe)."""
         provider = self._make_provider()
         sdk_resp = _make_sdk_response("safe")
         mock_adapter = _make_initialized_adapter()
-        mock_adapter.optimize_for_send = AsyncMock(side_effect=RuntimeError("optimizer boom"))
+        mock_adapter.optimize_request = AsyncMock(side_effect=RuntimeError("optimizer boom"))
 
         with (
             patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
@@ -469,13 +638,13 @@ class TestAnthropicProviderAdapterWiring:
 
 @_skip_no_provider
 class TestAnthropicStreamAdapterWiring:
-    """AnthropicProvider.stream_completion calls adapter optimize_for_send."""
+    """AnthropicProvider.stream_completion calls adapter optimize_request."""
 
     def _make_provider(self):
         return _AnthropicProvider(settings={"api_key": "test-key"})
 
     @pytest.mark.asyncio
-    async def test_optimize_for_send_called_before_stream(self) -> None:
+    async def test_optimize_request_called_before_stream(self) -> None:
         provider = self._make_provider()
         mock_adapter = _make_initialized_adapter()
 
@@ -500,7 +669,7 @@ class TestAnthropicStreamAdapterWiring:
                 chunks.append(chunk)
 
         assert chunks == ["chunk1", "chunk2"]
-        mock_adapter.optimize_for_send.assert_awaited_once()
+        mock_adapter.optimize_request.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_stream_proceeds_when_adapter_absent(self) -> None:

--- a/autobot-backend/utils/claude_api_integration.py
+++ b/autobot-backend/utils/claude_api_integration.py
@@ -22,7 +22,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
@@ -41,6 +41,13 @@ from .request_batcher import (
 )
 from .todowrite_optimizer import get_todowrite_optimizer
 from .tool_pattern_analyzer import get_tool_pattern_analyzer
+
+if TYPE_CHECKING:
+    # Import-time only (#10945): ``llm_shared`` eagerly imports every cloud
+    # provider module, which this lightweight utils module must not force on
+    # every caller (lifespan, tests). Runtime code below is duck-typed on
+    # ``request.messages`` instead.
+    from llm_shared.models import LLMRequest
 
 logger = get_logger(__name__)
 
@@ -270,15 +277,60 @@ class ClaudeAPIBatchManager:
         return False
 
     async def _optimize_payload_if_enabled(self, content: str) -> str:
-        """Return payload-optimized content string when optimizer is enabled."""
+        """Return payload-optimized content string when optimizer is enabled.
+
+        Bugfix (#10945): ``OptimizationResult`` has no ``optimized``/
+        ``optimized_content``/``size_reduction`` attributes (its real fields are
+        ``optimization_type``, ``chunks``, ``savings_percent``) — the previous
+        implementation raised ``AttributeError`` on every call where the
+        optimizer actually had work to do, silently swallowed by callers'
+        fail-safe try/except, so payload optimization never took effect.
+        Chunking results (``needs_chunking``) can't collapse to a single string
+        without losing chunk boundaries, so those are passed through unchanged.
+        """
         if not self.payload_optimizer:
             return content
-        optimization_result = self.payload_optimizer.optimize_payload(content)
-        if not optimization_result.optimized:
+        result = self.payload_optimizer.optimize_payload(content)
+        if result.optimization_type == "none" or result.needs_chunking:
             return content
         await self._increment_metric("payload_optimizations")
-        logger.debug("Payload optimized: %s%% reduction", optimization_result.size_reduction)
-        return optimization_result.optimized_content
+        logger.debug("Payload optimized: %.1f%% reduction", result.savings_percent)
+        return "".join(str(chunk) for chunk in result.chunks)
+
+    async def _optimize_messages_if_enabled(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Apply payload optimization per-message on structured messages (#10945).
+
+        Structured counterpart to ``_optimize_payload_if_enabled``: operates on
+        the message list AutoBot's providers actually send (``LLMRequest.messages``)
+        instead of a joined flat string, so optimized content can be written
+        back onto the request without losing per-message role/structure.
+        Reuses ``_optimize_payload_if_enabled`` for each message — no separate
+        optimization logic is duplicated.
+        """
+        if not self.payload_optimizer:
+            return messages
+        optimized_messages: List[Dict[str, Any]] = []
+        for message in messages:
+            if not isinstance(message, dict) or not message.get("content"):
+                optimized_messages.append(message)
+                continue
+            optimized_content = await self._optimize_payload_if_enabled(message["content"])
+            optimized_messages.append({**message, "content": optimized_content})
+        return optimized_messages
+
+    async def _optimize_content_via_llm_request(self, content: str, context_type: str) -> str:
+        """Route flat-string payload optimization through the structured path (#10945).
+
+        Wraps ``content`` in an ``LLMRequest.messages``-shaped list and
+        optimizes it via ``_optimize_messages_if_enabled`` — the same
+        structured helper the Anthropic provider's live send path uses — then
+        unwraps the optimized content back to a string so existing
+        string-based callers (``submit_request`` and its batching machinery)
+        are unaffected.
+        """
+        logger.debug("Optimizing content via structured messages path for context=%s", context_type)
+        messages = await self._optimize_messages_if_enabled([{"role": "user", "content": content}])
+        return messages[0].get("content", content)
 
     # ------------------------------------------------------------------
     # Public request API
@@ -308,7 +360,10 @@ class ClaudeAPIBatchManager:
                         return str(fallback.response)
                 raise Exception("Rate limit exceeded")
 
-            optimized_content = await self._optimize_payload_if_enabled(content)
+            # Issue #10945: route through the structured LLMRequest path so
+            # payload-mutation and (below) the batcher operate on the same
+            # representation the live provider send path uses.
+            optimized_content = await self._optimize_content_via_llm_request(content, context_type)
 
             response = await self._process_with_fallback(
                 optimized_content, priority, context_type, timeout, metadata or {}
@@ -668,6 +723,34 @@ class AutoBotClaudeAPIAdapter(AsyncInitializable):
         await self.ensure_initialized()
         return await self.manager.submit_todowrite(todos)
 
+    async def _rate_limit_gate(self, content_for_degradation: str, context_type: str) -> bool:
+        """Return True if the send may proceed; apply degradation + warn when blocked.
+
+        Shared by ``optimize_for_send`` and ``optimize_request`` (#10945) so the
+        rate-limit-check + graceful-degradation flow isn't duplicated between
+        the flat-string and structured entrypoints.
+        """
+        await self.manager._increment_metric("total_requests")
+        if await self.manager._check_and_apply_rate_limit():
+            return True
+        if self.manager.degradation_manager:
+            try:
+                fallback = await self.manager.degradation_manager.handle_request(
+                    content_for_degradation, {"type": context_type}
+                )
+                if fallback.success:
+                    logger.debug(
+                        "Claude adapter: graceful degradation applied for context=%s",
+                        context_type,
+                    )
+            except Exception as _deg_err:
+                logger.debug("Degradation manager error (ignored): %s", _deg_err)
+        logger.warning(
+            "Claude adapter: rate limit exceeded for context=%s; " "proceeding with original payload (fail-safe)",
+            context_type,
+        )
+        return False
+
     async def optimize_for_send(
         self,
         content: str,
@@ -683,31 +766,45 @@ class AutoBotClaudeAPIAdapter(AsyncInitializable):
 
         Issue #10849: wires live outbound Claude requests through the adapter's
         optimization pipeline (rate-limiter, payload optimizer, metric recording).
+        Issue #10945: prefer ``optimize_request`` for structured ``LLMRequest``
+        callers — this flat-string variant is retained for callers (e.g.
+        ``process_chat_request``) that only have a joined string available.
         """
         await self.ensure_initialized()
         if not self.manager or not self.manager.is_running:
             return content
-        await self.manager._increment_metric("total_requests")
-        if not await self.manager._check_and_apply_rate_limit():
-            if self.manager.degradation_manager:
-                try:
-                    fallback = await self.manager.degradation_manager.handle_request(content, {"type": context_type})
-                    if fallback.success:
-                        logger.debug(
-                            "Claude adapter: graceful degradation applied for context=%s",
-                            context_type,
-                        )
-                except Exception as _deg_err:
-                    logger.debug("Degradation manager error (ignored): %s", _deg_err)
-            logger.warning(
-                "Claude adapter: rate limit exceeded for context=%s; " "proceeding with original payload (fail-safe)",
-                context_type,
-            )
+        if not await self._rate_limit_gate(content, context_type):
             return content
         optimized = await self.manager._optimize_payload_if_enabled(content)
         if self.manager.rate_limiter:
             self.manager.rate_limiter.record_request(len(content))
         return optimized
+
+    async def optimize_request(
+        self,
+        request: "LLMRequest",
+        context_type: str = "general",
+    ) -> "LLMRequest":
+        """Apply rate-limit check and payload optimization to a structured LLMRequest.
+
+        Structured counterpart to ``optimize_for_send`` (#10945): mutates and
+        returns ``request`` with each message's content optimized in place
+        (via ``_optimize_messages_if_enabled``), so the payload-mutation
+        machinery actually reaches the outbound API payload instead of only
+        informing side-effect metrics. Called by provider implementations
+        (e.g. AnthropicProvider) before building the SDK call kwargs.
+        Fail-safe: returns ``request`` unchanged on rate-limit or any error.
+        """
+        await self.ensure_initialized()
+        if not self.manager or not self.manager.is_running:
+            return request
+        combined = " ".join(m.get("content", "") for m in request.messages if isinstance(m, dict))
+        if not await self._rate_limit_gate(combined, context_type):
+            return request
+        request.messages = await self.manager._optimize_messages_if_enabled(request.messages)
+        if self.manager.rate_limiter:
+            self.manager.rate_limiter.record_request(len(combined))
+        return request
 
     async def record_send_result(
         self,


### PR DESCRIPTION
## Thinking Path
`AnthropicProvider` joined messages into a flat string, called `optimize_for_send(...)`, and **discarded the optimized result** — it only drove rate-limit/metric side effects, never the real payload sent to `client.messages.create`. So payload-mutation + batching never reached the outbound call.

## What Changed
- New `AutoBotClaudeAPIAdapter.optimize_request(request: LLMRequest, ...) -> LLMRequest` — mutates `request.messages` in place via `ClaudeAPIBatchManager._optimize_messages_if_enabled()` (reuses `_optimize_payload_if_enabled`, no dup).
- `anthropic.py` `_chat_completion_impl`/`stream_completion` now call `optimize_request(...)` so optimized messages flow into `_build_request_kwargs` → the real Anthropic call. Proven by `test_optimize_request_mutation_reaches_sent_payload` (asserts on `messages.create.call_args.kwargs["messages"]`).
- `submit_request()` routes its optimization through the same structured helper — one implementation for both entry points.
- `optimize_for_send` kept for back-compat. `BaseProvider._guarded_completion` guard seam untouched.

**Pre-existing bug fixed in-scope:** `_optimize_payload_if_enabled` referenced `OptimizationResult.optimized/.optimized_content/.size_reduction` — none exist (real fields: `optimization_type`, `chunks`, `savings_percent`) → `AttributeError` swallowed by fail-safe → optimization **never took effect**. Fixed + regression test.

Closes #10945

## Verification
- Targeted: 99 passed. Full `llm_shared/` sweep: 542 passed, 115 skipped, 0 failed. `py_compile`+`black` clean.

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)