### PR TITLE
feat(browser): indexed element interaction + vision-in-the-loop (#11537, #11538)

### DIFF
--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -411,6 +411,12 @@ def _get_indexed_interaction_tools() -> List[MCPTool]:
     resolved to a concrete element server-side in the browser worker.
     """
     index_field = {"type": "integer", "description": "Element index from the numbered element menu."}
+    # Stale-index guard (#11538 review MINOR 3): echo browser_state's element_count
+    # back so the worker rejects the call if the page changed shape since then.
+    expected_count_field = {
+        "type": "integer",
+        "description": "Optional: element_count from the browser_state call this index was chosen against.",
+    }
     return [
         MCPTool(
             name="browser_state",
@@ -427,6 +433,7 @@ def _get_indexed_interaction_tools() -> List[MCPTool]:
                 "properties": {
                     "index": index_field,
                     "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+                    "expected_element_count": expected_count_field,
                 },
                 "required": ["index"],
             },
@@ -440,6 +447,7 @@ def _get_indexed_interaction_tools() -> List[MCPTool]:
                     "index": index_field,
                     "value": {"type": "string", "description": "Value to fill into the element"},
                     "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+                    "expected_element_count": expected_count_field,
                 },
                 "required": ["index", "value"],
             },
@@ -449,14 +457,22 @@ def _get_indexed_interaction_tools() -> List[MCPTool]:
             description="Select a dropdown option on an element identified by its numbered index",
             input_schema={
                 "type": "object",
-                "properties": {"index": index_field, "value": {"type": "string", "description": "Value to select"}},
+                "properties": {
+                    "index": index_field,
+                    "value": {"type": "string", "description": "Value to select"},
+                    "expected_element_count": expected_count_field,
+                },
                 "required": ["index", "value"],
             },
         ),
         MCPTool(
             name="hover_index",
             description="Hover over an interactive element by its numbered index",
-            input_schema={"type": "object", "properties": {"index": index_field}, "required": ["index"]},
+            input_schema={
+                "type": "object",
+                "properties": {"index": index_field, "expected_element_count": expected_count_field},
+                "required": ["index"],
+            },
         ),
     ]
 
@@ -1023,7 +1039,11 @@ async def click_index_mcp(request: BrowserClickIndexRequest) -> Metadata:
 
     result = await send_to_browser_vm(
         "click_index",
-        {"index": request.index, "timeout": request.timeout},
+        {
+            "index": request.index,
+            "timeout": request.timeout,
+            "expected_element_count": request.expected_element_count,
+        },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
@@ -1051,7 +1071,12 @@ async def fill_index_mcp(request: BrowserFillIndexRequest) -> Metadata:
 
     result = await send_to_browser_vm(
         "fill_index",
-        {"index": request.index, "value": request.value, "timeout": request.timeout},
+        {
+            "index": request.index,
+            "value": request.value,
+            "timeout": request.timeout,
+            "expected_element_count": request.expected_element_count,
+        },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
@@ -1080,7 +1105,11 @@ async def select_index_mcp(request: BrowserSelectIndexRequest) -> Metadata:
 
     result = await send_to_browser_vm(
         "select_index",
-        {"index": request.index, "value": request.value},
+        {
+            "index": request.index,
+            "value": request.value,
+            "expected_element_count": request.expected_element_count,
+        },
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 
@@ -1109,7 +1138,7 @@ async def hover_index_mcp(request: BrowserHoverIndexRequest) -> Metadata:
 
     result = await send_to_browser_vm(
         "hover_index",
-        {"index": request.index},
+        {"index": request.index, "expected_element_count": request.expected_element_count},
         session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
     )
 

--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -415,8 +415,7 @@ def _get_indexed_interaction_tools() -> List[MCPTool]:
         MCPTool(
             name="browser_state",
             description=(
-                "Get the current page state: URL, title, scroll info, and a numbered "
-                "menu of interactive elements."
+                "Get the current page state: URL, title, scroll info, and a numbered " "menu of interactive elements."
             ),
             input_schema={"type": "object", "properties": {}},
         ),

--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -36,16 +36,22 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from api.schemas_code import MCPTool
 from api.schemas_system import (
+    BrowserClickIndexRequest,
+    BrowserClickIndexResponse,
     BrowserClickRequest,
     BrowserClickResponse,
     BrowserEvaluateRequest,
     BrowserEvaluateResponse,
+    BrowserFillIndexRequest,
+    BrowserFillIndexResponse,
     BrowserFillRequest,
     BrowserFillResponse,
     BrowserGetAttributeRequest,
     BrowserGetAttributeResponse,
     BrowserGetTextRequest,
     BrowserGetTextResponse,
+    BrowserHoverIndexRequest,
+    BrowserHoverIndexResponse,
     BrowserHoverRequest,
     BrowserHoverResponse,
     BrowserInterceptApiRequest,
@@ -57,8 +63,12 @@ from api.schemas_system import (
     BrowserPageSnapshotResponse,
     BrowserScreenshotRequest,
     BrowserScreenshotResponse,
+    BrowserSelectIndexRequest,
+    BrowserSelectIndexResponse,
     BrowserSelectRequest,
     BrowserSelectResponse,
+    BrowserStateRequest,
+    BrowserStateResponse,
     BrowserWaitForSelectorRequest,
     BrowserWaitForSelectorResponse,
 )
@@ -393,6 +403,65 @@ def _get_browser_interaction_tools() -> List[MCPTool]:
     ]
 
 
+def _get_indexed_interaction_tools() -> List[MCPTool]:
+    """MCP tools for indexed interactive-element actions (#11537).
+
+    OpenManus numbers every interactive element on the page so the model
+    clicks/fills by index instead of inventing a CSS selector; the index is
+    resolved to a concrete element server-side in the browser worker.
+    """
+    index_field = {"type": "integer", "description": "Element index from the numbered element menu."}
+    return [
+        MCPTool(
+            name="browser_state",
+            description=(
+                "Get the current page state: URL, title, scroll info, and a numbered "
+                "menu of interactive elements."
+            ),
+            input_schema={"type": "object", "properties": {}},
+        ),
+        MCPTool(
+            name="click_index",
+            description="Click an interactive element by its numbered index from the page's element menu",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "index": index_field,
+                    "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+                },
+                "required": ["index"],
+            },
+        ),
+        MCPTool(
+            name="fill_index",
+            description="Fill an interactive element by its numbered index from the page's element menu",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "index": index_field,
+                    "value": {"type": "string", "description": "Value to fill into the element"},
+                    "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+                },
+                "required": ["index", "value"],
+            },
+        ),
+        MCPTool(
+            name="select_index",
+            description="Select a dropdown option on an element identified by its numbered index",
+            input_schema={
+                "type": "object",
+                "properties": {"index": index_field, "value": {"type": "string", "description": "Value to select"}},
+                "required": ["index", "value"],
+            },
+        ),
+        MCPTool(
+            name="hover_index",
+            description="Hover over an interactive element by its numbered index",
+            input_schema={"type": "object", "properties": {"index": index_field}, "required": ["index"]},
+        ),
+    ]
+
+
 def _create_screenshot_tool() -> MCPTool:
     """Helper for _get_browser_extraction_tools. Build screenshot MCPTool. Ref: #1088."""
     return MCPTool(
@@ -538,6 +607,7 @@ async def get_browser_mcp_tools() -> List[MCPTool]:
     tools = []
     tools.extend(_get_browser_navigation_tools())
     tools.extend(_get_browser_interaction_tools())
+    tools.extend(_get_indexed_interaction_tools())  # #11537
     tools.extend(_get_browser_extraction_tools())
     tools.extend(_get_web_pipeline_tools())  # #5136 Phase 1
     return tools
@@ -911,6 +981,151 @@ async def hover_mcp(request: BrowserHoverRequest) -> Metadata:
     }
 
 
+# --- Indexed interactive-element endpoints (#11537) ---
+
+
+@router.post("/mcp/state", response_model=BrowserStateResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="browser_state_mcp",
+    error_code_prefix="BROWSER_MCP",
+)
+async def browser_state_mcp(request: BrowserStateRequest) -> Metadata:
+    """Get the current page state: URL, title, scroll info, numbered elements."""
+    if not await check_rate_limit():
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+    result = await send_to_browser_vm(
+        "browser_state",
+        {},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
+
+    return {
+        "success": True,
+        "action": "browser_state",
+        "result": result,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+@router.post("/mcp/click_index", response_model=BrowserClickIndexResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="click_index_mcp",
+    error_code_prefix="BROWSER_MCP",
+)
+async def click_index_mcp(request: BrowserClickIndexRequest) -> Metadata:
+    """Click an element by its numbered index, resolved server-side."""
+    if not await check_rate_limit():
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+    logger.info("Browser click_index: %s", request.index)
+
+    result = await send_to_browser_vm(
+        "click_index",
+        {"index": request.index, "timeout": request.timeout},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
+
+    return {
+        "success": True,
+        "action": "click_index",
+        "index": request.index,
+        "result": result,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+@router.post("/mcp/fill_index", response_model=BrowserFillIndexResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="fill_index_mcp",
+    error_code_prefix="BROWSER_MCP",
+)
+async def fill_index_mcp(request: BrowserFillIndexRequest) -> Metadata:
+    """Fill an element by its numbered index, resolved server-side."""
+    if not await check_rate_limit():
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+    logger.info("Browser fill_index: %s", request.index)
+
+    result = await send_to_browser_vm(
+        "fill_index",
+        {"index": request.index, "value": request.value, "timeout": request.timeout},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
+
+    return {
+        "success": True,
+        "action": "fill_index",
+        "index": request.index,
+        "value_length": len(request.value),
+        "result": result,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+@router.post("/mcp/select_index", response_model=BrowserSelectIndexResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="select_index_mcp",
+    error_code_prefix="BROWSER_MCP",
+)
+async def select_index_mcp(request: BrowserSelectIndexRequest) -> Metadata:
+    """Select a dropdown option on an element by its numbered index."""
+    if not await check_rate_limit():
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+    logger.info("Browser select_index: %s -> %s", request.index, request.value)
+
+    result = await send_to_browser_vm(
+        "select_index",
+        {"index": request.index, "value": request.value},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
+
+    return {
+        "success": True,
+        "action": "select_index",
+        "index": request.index,
+        "value": request.value,
+        "result": result,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+@router.post("/mcp/hover_index", response_model=BrowserHoverIndexResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="hover_index_mcp",
+    error_code_prefix="BROWSER_MCP",
+)
+async def hover_index_mcp(request: BrowserHoverIndexRequest) -> Metadata:
+    """Hover over an element by its numbered index, resolved server-side."""
+    if not await check_rate_limit():
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+    logger.info("Browser hover_index: %s", request.index)
+
+    result = await send_to_browser_vm(
+        "hover_index",
+        {"index": request.index},
+        session_id=request.session_id or DEFAULT_BROWSER_SESSION_ID,
+    )
+
+    return {
+        "success": True,
+        "action": "hover_index",
+        "index": request.index,
+        "result": result,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+# --- End indexed interactive-element endpoints (#11537) ---
+
+
 @router.get("/mcp/status", response_model=BrowserMcpStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -956,7 +1171,7 @@ async def get_browser_mcp_status() -> Metadata:
             "max_per_minute": MAX_REQUESTS_PER_MINUTE,
             "reset_time": reset_time_iso,
         },
-        "tools_available": 12,  # updated for page_snapshot + intercept_api (#5136)
+        "tools_available": 17,  # #5136 page_snapshot+intercept_api, #11537 +5 indexed-element tools
         "timestamp": datetime.now(tz=timezone.utc).isoformat(),
     }
 

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1900,6 +1900,95 @@ class BrowserHoverResponse(BaseModel):
     timestamp: str
 
 
+class BrowserStateRequest(BaseModel):
+    """Request for POST /browser/mcp/state (#11537)."""
+
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
+
+
+class BrowserClickIndexRequest(BaseModel):
+    """Request for POST /browser/mcp/click_index (#11537)."""
+
+    index: int = Field(..., description="Element index from the numbered element menu")
+    timeout: int | None = Field(10000, description="Timeout in milliseconds")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
+
+
+class BrowserFillIndexRequest(BaseModel):
+    """Request for POST /browser/mcp/fill_index (#11537)."""
+
+    index: int = Field(..., description="Element index from the numbered element menu")
+    value: str = Field(..., description="Value to fill into the element")
+    timeout: int | None = Field(10000, description="Timeout in milliseconds")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
+
+
+class BrowserSelectIndexRequest(BaseModel):
+    """Request for POST /browser/mcp/select_index (#11537)."""
+
+    index: int = Field(..., description="Element index from the numbered element menu")
+    value: str = Field(..., description="Value to select")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
+
+
+class BrowserHoverIndexRequest(BaseModel):
+    """Request for POST /browser/mcp/hover_index (#11537)."""
+
+    index: int = Field(..., description="Element index from the numbered element menu")
+    session_id: str | None = Field(
+        None, description="Conversation/session id for isolated browser-context routing (#11539)"
+    )
+
+
+class BrowserStateResponse(BaseModel):
+    success: bool
+    action: str
+    result: Any | None = None
+    timestamp: str
+
+
+class BrowserClickIndexResponse(BaseModel):
+    success: bool
+    action: str
+    index: int
+    result: Any | None = None
+    timestamp: str
+
+
+class BrowserFillIndexResponse(BaseModel):
+    success: bool
+    action: str
+    index: int
+    value_length: int
+    result: Any | None = None
+    timestamp: str
+
+
+class BrowserSelectIndexResponse(BaseModel):
+    success: bool
+    action: str
+    index: int
+    value: str
+    result: Any | None = None
+    timestamp: str
+
+
+class BrowserHoverIndexResponse(BaseModel):
+    success: bool
+    action: str
+    index: int
+    result: Any | None = None
+    timestamp: str
+
+
 class BrowserMcpStatusResponse(BaseModel):
     success: bool
     bridge: str

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1908,11 +1908,20 @@ class BrowserStateRequest(BaseModel):
     )
 
 
+# Stale-index guard (#11538 review MINOR 3): echo a prior browser_state's
+# element_count back so the worker rejects the call if the page changed
+# shape since then, instead of silently acting on the wrong element.
+_EXPECTED_ELEMENT_COUNT_DESCRIPTION = (
+    "Optional: element_count from the browser_state call this index was chosen against"
+)
+
+
 class BrowserClickIndexRequest(BaseModel):
     """Request for POST /browser/mcp/click_index (#11537)."""
 
     index: int = Field(..., description="Element index from the numbered element menu")
     timeout: int | None = Field(10000, description="Timeout in milliseconds")
+    expected_element_count: int | None = Field(None, description=_EXPECTED_ELEMENT_COUNT_DESCRIPTION)
     session_id: str | None = Field(
         None, description="Conversation/session id for isolated browser-context routing (#11539)"
     )
@@ -1924,6 +1933,7 @@ class BrowserFillIndexRequest(BaseModel):
     index: int = Field(..., description="Element index from the numbered element menu")
     value: str = Field(..., description="Value to fill into the element")
     timeout: int | None = Field(10000, description="Timeout in milliseconds")
+    expected_element_count: int | None = Field(None, description=_EXPECTED_ELEMENT_COUNT_DESCRIPTION)
     session_id: str | None = Field(
         None, description="Conversation/session id for isolated browser-context routing (#11539)"
     )
@@ -1934,6 +1944,7 @@ class BrowserSelectIndexRequest(BaseModel):
 
     index: int = Field(..., description="Element index from the numbered element menu")
     value: str = Field(..., description="Value to select")
+    expected_element_count: int | None = Field(None, description=_EXPECTED_ELEMENT_COUNT_DESCRIPTION)
     session_id: str | None = Field(
         None, description="Conversation/session id for isolated browser-context routing (#11539)"
     )
@@ -1943,6 +1954,7 @@ class BrowserHoverIndexRequest(BaseModel):
     """Request for POST /browser/mcp/hover_index (#11537)."""
 
     index: int = Field(..., description="Element index from the numbered element menu")
+    expected_element_count: int | None = Field(None, description=_EXPECTED_ELEMENT_COUNT_DESCRIPTION)
     session_id: str | None = Field(
         None, description="Conversation/session id for isolated browser-context routing (#11539)"
     )

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -33,6 +33,7 @@ from chat_workflow.tool_call_grammar import (
     TOOL_CALL_OPENING_RE,
     strip_unparsed_tool_tags,
 )
+from constants.api_constants import PATH_OLLAMA_GENERATE
 from constants.model_constants import ModelConfig
 from constants.ttl_constants import TIMEOUT_HTTP_DEFAULT, TTL_24_HOURS
 from llm_shared.providers.reasoning_effort import map_effort_to_provider_params
@@ -157,6 +158,55 @@ def _extract_latest_tool_screenshot(execution_history: List[Dict[str, Any]]) -> 
         if image:
             return image
     return None
+
+
+def _prune_stale_screenshots(execution_history: List[Dict[str, Any]]) -> None:
+    """Drop ``base64_image`` from entries outside the vision lookback window (#11538).
+
+    _record_browser_success stores the raw screenshot on every screenshot
+    tool's execution_results entry, but only the latest one within
+    VISION_TOOL_LOOKBACK_MESSAGES is ever read (_extract_latest_tool_screenshot).
+    Without pruning, every multi-hundred-KB blob from the whole task would live
+    in execution_history (and therefore conversation state) for the task's
+    entire lifetime. Mutates *execution_history* in place.
+    """
+    if VISION_TOOL_LOOKBACK_MESSAGES <= 0:
+        cutoff = len(execution_history)
+    else:
+        cutoff = max(0, len(execution_history) - VISION_TOOL_LOOKBACK_MESSAGES)
+    for entry in execution_history[:cutoff]:
+        entry.pop("base64_image", None)
+
+
+def _strip_data_url_prefix(image_b64: str) -> str:
+    """Strip a ``data:image/...;base64,`` prefix, if present (#11538).
+
+    Screenshots already arrive as raw base64 from the browser worker, but this
+    is defensive: Ollama's /api/generate ``images`` field wants raw base64
+    only — a data-URL-prefixed string would be treated as invalid image bytes.
+    """
+    if "," in image_b64 and image_b64.strip().lower().startswith("data:"):
+        return image_b64.split(",", 1)[1]
+    return image_b64
+
+
+def _resolve_vision_payload_shape(ollama_endpoint: str) -> str:
+    """Return which image-attachment shape the target endpoint actually consumes (#11538).
+
+    manager.py's continuation loop always POSTs to an Ollama-shaped endpoint —
+    llm_handler._get_ollama_endpoint_for_model() (and every other endpoint
+    resolver in llm_handler.py) unconditionally suffixes PATH_OLLAMA_GENERATE,
+    and the stream is parsed as Ollama-native (_parse_stream_chunk reads
+    chunk_data["response"]). Ollama's /api/generate ignores an OpenAI-style
+    "messages" field entirely and instead expects a top-level "images" list of
+    raw base64 strings — so that's the shape used whenever the endpoint is the
+    Ollama generate path. If/when an OpenAI-compatible /chat/completions path
+    is wired into this loop, route it to "openai_chat" here instead of
+    guessing at the payload builder.
+    """
+    if ollama_endpoint.endswith(PATH_OLLAMA_GENERATE):
+        return "ollama_generate"
+    return "openai_chat"
 
 
 class ChatWorkflowManager(
@@ -1888,17 +1938,36 @@ before summarizing.
         max_tokens = mgr.get_max_history_tokens(model_name)
         return (prompt_tokens + VISION_IMAGE_TOKEN_ESTIMATE) <= max_tokens
 
-    def _build_vision_messages(self, current_prompt: str, image_b64: str) -> list[dict] | None:
-        """Build the OpenAI-style image content block for the payload. Issue #11538.
+    def _build_vision_messages(self, current_prompt: str, image_b64: str) -> list[dict]:
+        """Build the OpenAI-style image content block for an OpenAI-compatible
+        /chat/completions payload. Issue #11538.
 
         Reuses OpenAIGPT4VProvider._build_openai_image_content — the existing
-        content-block builder — rather than inventing a second one. Returns
-        None (caller keeps text-only) when there is no image to attach.
+        content-block builder — rather than inventing a second one. Only used
+        when _resolve_vision_payload_shape() says the target endpoint is
+        "openai_chat" — the continuation loop today always targets Ollama's
+        /api/generate instead (see _attach_vision_payload).
         """
         from modern_ai_integration import OpenAIGPT4VProvider
 
         content = OpenAIGPT4VProvider._build_openai_image_content(current_prompt, [image_b64])
         return [{"role": "user", "content": content}]
+
+    def _attach_vision_payload(self, payload: dict, ollama_endpoint: str, current_prompt: str, image_b64: str) -> None:
+        """Attach *image_b64* to *payload* in the shape the target endpoint reads. Issue #11538.
+
+        Provider-aware: Ollama's /api/generate ignores "messages" entirely and
+        reads images from a top-level raw-base64 "images" list
+        (_resolve_vision_payload_shape picks this for every endpoint this loop
+        currently targets). An OpenAI-compatible /chat/completions path — not
+        wired into this loop today — would read the "messages" content-block
+        shape instead. Mutates *payload* in place.
+        """
+        shape = _resolve_vision_payload_shape(ollama_endpoint)
+        if shape == "ollama_generate":
+            payload["images"] = [_strip_data_url_prefix(image_b64)]
+        else:
+            payload["messages"] = self._build_vision_messages(current_prompt, image_b64)
 
     def _get_llm_request_payload(
         self,
@@ -1907,14 +1976,15 @@ before summarizing.
         system_prompt: str = "",
         api_kwargs: dict | None = None,
         image_b64: str | None = None,
+        ollama_endpoint: str = "",
     ) -> dict:
         """Build LLM request payload.
 
         Issue #8993: api_kwargs are merged at top level for Anthropic extended-thinking.
         Issue #11538: when *image_b64* is set and the model is vision-capable and the
-        image fits the context budget, an OpenAI-style image content block is added
-        under "messages" (vision-capable providers use it; others keep the existing
-        text-only "prompt" field, unaffected).
+        image fits the context budget, it is attached in the shape *ollama_endpoint*
+        actually consumes (see _attach_vision_payload) — vision-capable models get it,
+        non-vision models keep the existing text-only "prompt" field, unaffected.
         """
         payload = {
             "model": selected_model,
@@ -1932,7 +2002,7 @@ before summarizing.
             payload.update(api_kwargs)
         vision_ready = image_b64 and _model_supports_vision(selected_model)
         if vision_ready and self._image_fits_budget(current_prompt, selected_model):
-            payload["messages"] = self._build_vision_messages(current_prompt, image_b64)
+            self._attach_vision_payload(payload, ollama_endpoint, current_prompt, image_b64)
         return payload
 
     async def _log_and_parse_tool_calls(
@@ -2029,12 +2099,18 @@ before summarizing.
         """Process a single LLM iteration. Yields chunks, then (llm_response, tool_calls). Issue #620.
 
         Issue #11538: ``image_b64`` (the latest browser/VNC screenshot, if any) is
-        threaded into the payload, gated on vision support in _get_llm_request_payload.
+        threaded into the payload, gated on vision support and attached in the shape
+        ``ollama_endpoint`` (the actual POST target) consumes — see _attach_vision_payload.
         """
         import aiohttp
 
         payload = self._get_llm_request_payload(
-            selected_model, current_prompt, system_prompt, api_kwargs=api_kwargs, image_b64=image_b64
+            selected_model,
+            current_prompt,
+            system_prompt,
+            api_kwargs=api_kwargs,
+            image_b64=image_b64,
+            ollama_endpoint=ollama_endpoint,
         )
         llm_response = ""
 
@@ -2277,6 +2353,9 @@ before summarizing.
         # Issue #11538: thread the most recent browser/VNC screenshot (last
         # VISION_TOOL_LOOKBACK_MESSAGES tool results) into this iteration's payload.
         latest_screenshot = _extract_latest_tool_screenshot(ctx.execution_history)
+        # Prune older screenshots now that this iteration has read the window —
+        # nothing outside it is ever consulted again (#11538 MINOR: retention).
+        _prune_stale_screenshots(ctx.execution_history)
 
         async for item in self._process_single_llm_iteration(
             http_client,

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -14,12 +14,14 @@ Composes all functionality through mixins:
 
 import asyncio
 import json
+import os
 import re
 import uuid
 from contextvars import ContextVar
 from typing import Any, Dict, FrozenSet, List
 
 from async_chat_workflow import WorkflowMessage
+from autobot_shared.env_utils import env_int
 from autobot_shared.error_boundaries import error_boundary, get_error_boundary_manager
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client as get_redis_manager
@@ -105,6 +107,56 @@ async def _resolve_reasoning_effort(context: Dict[str, Any]) -> str:
             logger.warning("[#9017] Failed to load user reasoning_effort pref: %s", exc)
 
     return "auto"
+
+
+# Issue #11538: vision-in-the-loop. OpenManus threads the current screenshot
+# into the model's context on every step while the browser is active (N=3
+# messages of look-back); mirrored here as a bounded window over the most
+# recent tool execution_results so the model *sees* the effect of its last
+# browser/VNC action instead of driving blind.
+VISION_TOOL_LOOKBACK_MESSAGES = env_int("CHAT_VISION_TOOL_LOOKBACK_MESSAGES", default=3)
+
+# Fixed per-image token cost used to gate attachment against the context
+# budget (OpenAI's high-detail image estimate is ~765-1105 tokens; picked a
+# representative default, env-overridable — never hardcode a tunable).
+VISION_IMAGE_TOKEN_ESTIMATE = env_int("CHAT_VISION_IMAGE_TOKEN_ESTIMATE", default=1100)
+
+# Case-insensitive substrings of a model name that indicate vision support.
+# Ollama exposes no per-tag capability registry (unlike the fixed AIProvider
+# registry in modern_ai_integration.py), so this is the pragmatic gate.
+_DEFAULT_VISION_MODEL_PATTERNS = (
+    "llava,vision,gpt-4o,gpt-4-vision,claude-3,claude-4,gemini,qwen-vl,qwen2-vl,qwen2.5-vl,pixtral,bakllava"
+)
+VISION_MODEL_NAME_PATTERNS = tuple(
+    p.strip().lower()
+    for p in os.getenv("CHAT_VISION_MODEL_PATTERNS", _DEFAULT_VISION_MODEL_PATTERNS).split(",")
+    if p.strip()
+)
+
+
+def _model_supports_vision(model_name: str) -> bool:
+    """Heuristic vision-capability gate for the chat continuation loop (#11538).
+
+    Ollama exposes no per-tag capability registry, so this matches known
+    vision-model name substrings (env-overridable via CHAT_VISION_MODEL_PATTERNS).
+    """
+    name = (model_name or "").lower()
+    return any(pattern in name for pattern in VISION_MODEL_NAME_PATTERNS)
+
+
+def _extract_latest_tool_screenshot(execution_history: List[Dict[str, Any]]) -> str | None:
+    """Return the single most recent base64 screenshot from recent tool results (#11538).
+
+    Looks back over the last VISION_TOOL_LOOKBACK_MESSAGES execution results
+    (OpenManus uses N=3) and returns only the latest ``base64_image`` — older
+    screenshots are dropped so context never accumulates more than one image.
+    """
+    window = execution_history[-VISION_TOOL_LOOKBACK_MESSAGES:] if VISION_TOOL_LOOKBACK_MESSAGES > 0 else []
+    for result in reversed(window):
+        image = result.get("base64_image")
+        if image:
+            return image
+    return None
 
 
 class ChatWorkflowManager(
@@ -1740,6 +1792,11 @@ class ChatWorkflowManager(
             "- get_text: Get text from an element\n"
             "- get_attribute: Get an attribute from an element\n"
             "- wait_for_selector: Wait for an element to appear\n"
+            "- browser_state: Get the current page's numbered interactive-element menu\n"
+            "- click_index: Click an element by its numbered index\n"
+            "- fill_index: Fill an element by its numbered index\n"
+            "- select_index: Select an option on an element by its numbered index\n"
+            "- hover_index: Hover over an element by its numbered index\n"
             "- delegate: Delegate a subtask to a subordinate agent\n"
             "- respond: Signal task completion with a final message\n"
             "Do NOT invent new tool names. Use ONLY the names listed above.\n\n"
@@ -1817,16 +1874,47 @@ before summarizing.
 ---
 {instructions}"""
 
+    def _image_fits_budget(self, prompt: str, model_name: str) -> bool:
+        """Gate image attachment on the context budget (#11538).
+
+        Uses ContextWindowManager's token estimate plus the fixed per-image
+        token cost (VISION_IMAGE_TOKEN_ESTIMATE) so a screenshot never
+        silently blows the model's max-history-token budget.
+        """
+        from context_window_manager import ContextWindowManager
+
+        mgr = ContextWindowManager()
+        prompt_tokens = mgr.estimate_tokens(prompt)
+        max_tokens = mgr.get_max_history_tokens(model_name)
+        return (prompt_tokens + VISION_IMAGE_TOKEN_ESTIMATE) <= max_tokens
+
+    def _build_vision_messages(self, current_prompt: str, image_b64: str) -> list[dict] | None:
+        """Build the OpenAI-style image content block for the payload. Issue #11538.
+
+        Reuses OpenAIGPT4VProvider._build_openai_image_content — the existing
+        content-block builder — rather than inventing a second one. Returns
+        None (caller keeps text-only) when there is no image to attach.
+        """
+        from modern_ai_integration import OpenAIGPT4VProvider
+
+        content = OpenAIGPT4VProvider._build_openai_image_content(current_prompt, [image_b64])
+        return [{"role": "user", "content": content}]
+
     def _get_llm_request_payload(
         self,
         selected_model: str,
         current_prompt: str,
         system_prompt: str = "",
         api_kwargs: dict | None = None,
+        image_b64: str | None = None,
     ) -> dict:
         """Build LLM request payload.
 
         Issue #8993: api_kwargs are merged at top level for Anthropic extended-thinking.
+        Issue #11538: when *image_b64* is set and the model is vision-capable and the
+        image fits the context budget, an OpenAI-style image content block is added
+        under "messages" (vision-capable providers use it; others keep the existing
+        text-only "prompt" field, unaffected).
         """
         payload = {
             "model": selected_model,
@@ -1842,6 +1930,9 @@ before summarizing.
             payload["system"] = system_prompt
         if api_kwargs:
             payload.update(api_kwargs)
+        vision_ready = image_b64 and _model_supports_vision(selected_model)
+        if vision_ready and self._image_fits_budget(current_prompt, selected_model):
+            payload["messages"] = self._build_vision_messages(current_prompt, image_b64)
         return payload
 
     async def _log_and_parse_tool_calls(
@@ -1933,11 +2024,18 @@ before summarizing.
         iteration: int,
         system_prompt: str = "",
         api_kwargs: dict | None = None,
+        image_b64: str | None = None,
     ):
-        """Process a single LLM iteration. Yields chunks, then (llm_response, tool_calls). Issue #620."""
+        """Process a single LLM iteration. Yields chunks, then (llm_response, tool_calls). Issue #620.
+
+        Issue #11538: ``image_b64`` (the latest browser/VNC screenshot, if any) is
+        threaded into the payload, gated on vision support in _get_llm_request_payload.
+        """
         import aiohttp
 
-        payload = self._get_llm_request_payload(selected_model, current_prompt, system_prompt, api_kwargs=api_kwargs)
+        payload = self._get_llm_request_payload(
+            selected_model, current_prompt, system_prompt, api_kwargs=api_kwargs, image_b64=image_b64
+        )
         llm_response = ""
 
         try:
@@ -2176,6 +2274,10 @@ before summarizing.
                         ctx.selected_model,
                         list(effort_params),
                     )
+        # Issue #11538: thread the most recent browser/VNC screenshot (last
+        # VISION_TOOL_LOOKBACK_MESSAGES tool results) into this iteration's payload.
+        latest_screenshot = _extract_latest_tool_screenshot(ctx.execution_history)
+
         async for item in self._process_single_llm_iteration(
             http_client,
             ctx.ollama_endpoint,
@@ -2187,6 +2289,7 @@ before summarizing.
             iteration,
             system_prompt=ctx.system_prompt or "",
             api_kwargs=api_kwargs,
+            image_b64=latest_screenshot,
         ):
             if isinstance(item, tuple):
                 llm_response, tool_calls = item

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -341,12 +341,27 @@ WAIT_FOR_SELECTOR_SCHEMA: dict = {
 # interactive element on the page so the model clicks/fills by index instead
 # of inventing a CSS selector — the index below is resolved to a concrete
 # element server-side (autobot-browser-worker/element-index.js).
+#
+# `expected_element_count` (optional, from a prior browser_state's
+# `element_count`) is the stale-index guard: if the live element count no
+# longer matches, the worker rejects the call instead of silently acting on
+# whatever now sits at that index (review #11538 MINOR 3).
+_EXPECTED_ELEMENT_COUNT_FIELD = {
+    "type": "integer",
+    "description": (
+        "Optional: element_count from the browser_state call this index was chosen against. "
+        "If the live page's element count no longer matches, the action is rejected instead of "
+        "silently acting on the wrong element — re-fetch browser_state and retry."
+    ),
+}
+
 CLICK_INDEX_SCHEMA: dict = {
     "type": "object",
     "description": "Click an interactive element by its numbered index from the page's element menu.",
     "properties": {
         "index": {"type": "integer", "description": "Element index from the numbered element menu."},
         "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+        "expected_element_count": _EXPECTED_ELEMENT_COUNT_FIELD,
     },
     "required": ["index"],
 }
@@ -358,6 +373,7 @@ FILL_INDEX_SCHEMA: dict = {
         "index": {"type": "integer", "description": "Element index from the numbered element menu."},
         "value": {"type": "string", "description": "Value to fill into the element."},
         "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+        "expected_element_count": _EXPECTED_ELEMENT_COUNT_FIELD,
     },
     "required": ["index", "value"],
 }
@@ -368,6 +384,7 @@ SELECT_INDEX_SCHEMA: dict = {
     "properties": {
         "index": {"type": "integer", "description": "Element index from the numbered element menu."},
         "value": {"type": "string", "description": "Value to select."},
+        "expected_element_count": _EXPECTED_ELEMENT_COUNT_FIELD,
     },
     "required": ["index", "value"],
 }
@@ -377,6 +394,7 @@ HOVER_INDEX_SCHEMA: dict = {
     "description": "Hover over an interactive element by its numbered index.",
     "properties": {
         "index": {"type": "integer", "description": "Element index from the numbered element menu."},
+        "expected_element_count": _EXPECTED_ELEMENT_COUNT_FIELD,
     },
     "required": ["index"],
 }

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -407,9 +407,7 @@ _INDEXED_ELEMENT_TOOL_TEXT: dict[str, Any] = {
         f"({(inner.get('resolved') or {}).get('name') or (inner.get('resolved') or {}).get('role', 'element')}) "
         "with value"
     ),
-    "select_index": lambda params, inner: (
-        f"Selected '{params.get('value', '')}' in element [{params.get('index')}]"
-    ),
+    "select_index": lambda params, inner: (f"Selected '{params.get('value', '')}' in element [{params.get('index')}]"),
     "hover_index": lambda params, inner: f"Hovered over element [{params.get('index')}]",
 }
 

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -337,6 +337,82 @@ WAIT_FOR_SELECTOR_SCHEMA: dict = {
     "required": ["selector"],
 }
 
+# Issue #11537: indexed interactive-element schemas. OpenManus numbers every
+# interactive element on the page so the model clicks/fills by index instead
+# of inventing a CSS selector — the index below is resolved to a concrete
+# element server-side (autobot-browser-worker/element-index.js).
+CLICK_INDEX_SCHEMA: dict = {
+    "type": "object",
+    "description": "Click an interactive element by its numbered index from the page's element menu.",
+    "properties": {
+        "index": {"type": "integer", "description": "Element index from the numbered element menu."},
+        "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+    },
+    "required": ["index"],
+}
+
+FILL_INDEX_SCHEMA: dict = {
+    "type": "object",
+    "description": "Fill an interactive element by its numbered index from the page's element menu.",
+    "properties": {
+        "index": {"type": "integer", "description": "Element index from the numbered element menu."},
+        "value": {"type": "string", "description": "Value to fill into the element."},
+        "timeout": {"type": "integer", "description": "Timeout in milliseconds", "default": 10000},
+    },
+    "required": ["index", "value"],
+}
+
+SELECT_INDEX_SCHEMA: dict = {
+    "type": "object",
+    "description": "Select a dropdown option on an element identified by its numbered index.",
+    "properties": {
+        "index": {"type": "integer", "description": "Element index from the numbered element menu."},
+        "value": {"type": "string", "description": "Value to select."},
+    },
+    "required": ["index", "value"],
+}
+
+HOVER_INDEX_SCHEMA: dict = {
+    "type": "object",
+    "description": "Hover over an interactive element by its numbered index.",
+    "properties": {
+        "index": {"type": "integer", "description": "Element index from the numbered element menu."},
+    },
+    "required": ["index"],
+}
+
+BROWSER_STATE_SCHEMA: dict = {
+    "type": "object",
+    "description": (
+        "Get the current page state: URL, title, scroll info, and a numbered menu "
+        "of interactive elements for use with click_index/fill_index/select_index/hover_index."
+    ),
+    "properties": {},
+}
+
+# Issue #11537: how many numbered elements to render in the LLM-visible state
+# block per browser tool result (the browser-worker itself caps the raw list
+# via BROWSER_STATE_MAX_ELEMENTS; this bounds the prompt-text rendering).
+BROWSER_STATE_PROMPT_MAX_ELEMENTS = env_int("AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS", default=30)
+
+# Issue #11537: text formatters for the four indexed-element tool results,
+# keyed by tool name so _format_browser_action_text stays a flat dispatch.
+_INDEXED_ELEMENT_TOOL_TEXT: dict[str, Any] = {
+    "click_index": lambda params, inner: (
+        f"Clicked element [{params.get('index')}]: "
+        f"{(inner.get('resolved') or {}).get('name') or (inner.get('resolved') or {}).get('role', 'element')}"
+    ),
+    "fill_index": lambda params, inner: (
+        f"Filled element [{params.get('index')}] "
+        f"({(inner.get('resolved') or {}).get('name') or (inner.get('resolved') or {}).get('role', 'element')}) "
+        "with value"
+    ),
+    "select_index": lambda params, inner: (
+        f"Selected '{params.get('value', '')}' in element [{params.get('index')}]"
+    ),
+    "hover_index": lambda params, inner: f"Hovered over element [{params.get('index')}]",
+}
+
 # Issue #4529: JSON Schema definitions for built-in tools dispatched directly
 # (not via MCP).  Used by _validate_builtin_tool_arguments() so every dispatch
 # path passes through validate_tool_arguments() before execution.
@@ -355,6 +431,12 @@ _BUILTIN_TOOL_SCHEMAS: dict[str, dict] = {
     "get_text": GET_TEXT_SCHEMA,
     "get_attribute": GET_ATTRIBUTE_SCHEMA,
     "wait_for_selector": WAIT_FOR_SELECTOR_SCHEMA,
+    # Issue #11537: indexed interactive-element actions.
+    "click_index": CLICK_INDEX_SCHEMA,
+    "fill_index": FILL_INDEX_SCHEMA,
+    "select_index": SELECT_INDEX_SCHEMA,
+    "hover_index": HOVER_INDEX_SCHEMA,
+    "browser_state": BROWSER_STATE_SCHEMA,
     # Imported from tools.code_interpreter — single source of truth for the schema.
     # Issue #4561: was missing, causing code_interpreter args to bypass validation
     # (Issue #4562).  All future built-in tool schemas should follow this pattern:
@@ -445,6 +527,12 @@ BROWSER_TOOL_NAMES: frozenset[str] = frozenset(
         "get_text",
         "get_attribute",
         "wait_for_selector",
+        # Issue #11537: indexed interactive-element actions.
+        "click_index",
+        "fill_index",
+        "select_index",
+        "hover_index",
+        "browser_state",
     }
 )
 
@@ -2066,9 +2154,15 @@ class ToolHandlerMixin:
         """Record a successful browser tool execution and return its WorkflowMessage. Issue #2735.
 
         Extracted from _handle_browser_tool to keep parent under 65 lines.
+        Issue #11538: also carries the raw screenshot (if any) into
+        execution_results so the vision-in-the-loop continuation can find it.
         """
         summary = self._format_browser_result(tool_name, params, result)
-        execution_results.append({"tool": tool_name, "status": "success", "output": summary})
+        entry: dict[str, Any] = {"tool": tool_name, "status": "success", "output": summary}
+        base64_image = self._extract_browser_image(result)
+        if base64_image:
+            entry["base64_image"] = base64_image
+        execution_results.append(entry)
         return WorkflowMessage(
             type="command_output",
             content=summary,
@@ -2080,6 +2174,36 @@ class ToolHandlerMixin:
             },
         )
 
+    def _extract_browser_image(self, result: dict[str, Any]) -> str | None:
+        """Pull the base64 PNG out of a browser tool result, if present. Issue #11538.
+
+        Only the ``screenshot`` action returns image bytes today; kept
+        tool-name-agnostic (checks common keys) so a future browser/VNC
+        action that starts returning images is picked up automatically.
+        """
+        inner = result.get("result", result)
+        return inner.get("image") or inner.get("screenshot")
+
+    def _format_page_state_block(self, page_state: dict[str, Any] | None) -> str:
+        """Render the numbered interactive-element menu for LLM consumption. Issue #11537.
+
+        OpenManus-style: the model picks click_index/fill_index targets from
+        this menu instead of guessing a CSS selector. Appended to every
+        browser tool result so the menu is always current (task 4).
+        """
+        if not page_state:
+            return ""
+        elements = page_state.get("elements") or []
+        if not elements:
+            return ""
+        lines = [f"\nInteractive elements ({len(elements)}):"]
+        for el in elements[:BROWSER_STATE_PROMPT_MAX_ELEMENTS]:
+            role = el.get("role", el.get("tag", "element"))
+            name = (el.get("name") or "").strip()
+            label = f' "{name}"' if name else ""
+            lines.append(f"  [{el.get('index')}] {role}{label}")
+        return "\n".join(lines)
+
     def _format_browser_result(
         self,
         tool_name: str,
@@ -2089,10 +2213,25 @@ class ToolHandlerMixin:
         """Format browser tool result as text for LLM context. Issue #1368.
 
         Browser VM returns: {"success": bool, "action": str, "result": {...}}
-        The inner 'result' dict contains tool-specific data.
+        The inner 'result' dict contains tool-specific data. Issue #11537:
+        appends the numbered interactive-element menu when present.
         """
         inner = result.get("result", result)
+        summary = self._format_browser_action_text(tool_name, params, inner, result)
+        # browser_state's payload *is* the page state; every other action
+        # carries it nested under "page_state" (attached post-action).
+        page_state = inner if tool_name == "browser_state" else inner.get("page_state")
+        state_block = self._format_page_state_block(page_state)
+        return summary + state_block if state_block else summary
 
+    def _format_browser_action_text(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+        inner: dict[str, Any],
+        result: dict[str, Any],
+    ) -> str:
+        """Build the tool-specific summary line for _format_browser_result. Issue #1368/#11537."""
         if tool_name == "navigate":
             url = inner.get("url", params.get("url", ""))
             title = inner.get("title", "")
@@ -2137,6 +2276,13 @@ class ToolHandlerMixin:
         if tool_name == "wait_for_selector":
             sel = params.get("selector", "")
             return f"Element found: {sel}"
+
+        if tool_name in _INDEXED_ELEMENT_TOOL_TEXT:
+            return _INDEXED_ELEMENT_TOOL_TEXT[tool_name](params, inner)
+
+        if tool_name == "browser_state":
+            elements = inner.get("elements") or []
+            return f"Page state: {inner.get('url', '')} — {len(elements)} interactive element(s)"
 
         return json.dumps(result, default=str)[:1000]
 

--- a/autobot-backend/modern_ai_integration.py
+++ b/autobot-backend/modern_ai_integration.py
@@ -236,8 +236,14 @@ class OpenAIGPT4VProvider(BaseAIProvider):
             logger.error("OpenAI GPT-4 text generation failed: %s", e)
             return self._create_error_response(request, "AI provider request failed")
 
-    def _build_openai_image_content(self, prompt: str, images: List[str]) -> List[Dict[str, Any]]:
-        """Build content list with text and images for OpenAI API. Issue #620."""
+    @staticmethod
+    def _build_openai_image_content(prompt: str, images: List[str]) -> List[Dict[str, Any]]:
+        """Build content list with text and images for OpenAI API. Issue #620.
+
+        Issue #11538: static (no ``self`` usage) so chat_workflow/manager.py can
+        reuse it to thread browser/VNC screenshots into the continuation payload
+        without instantiating a provider (which needs an API key/client).
+        """
         content = [{"type": "text", "text": prompt}]
         for image_b64 in images:
             content.append(

--- a/autobot-backend/services/web_pipeline/snapshot.py
+++ b/autobot-backend/services/web_pipeline/snapshot.py
@@ -102,6 +102,29 @@ _TYPED_ATTRS = frozenset(
     }
 )
 
+# Issue #11537: ARIA roles considered "interactive" for indexed element
+# numbering — the accessibility-tree analogue of the DOM-role allowlist used
+# by autobot-browser-worker/element-index.js for the chat tool's live page.
+INTERACTIVE_ROLES = frozenset(
+    {
+        "button",
+        "link",
+        "textbox",
+        "searchbox",
+        "checkbox",
+        "radio",
+        "combobox",
+        "listbox",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "switch",
+        "slider",
+        "spinbutton",
+        "tab",
+    }
+)
+
 
 class AccessibilitySnapshot:
     """Captures and queries the accessibility tree of a Playwright page.
@@ -169,6 +192,51 @@ class AccessibilitySnapshot:
         if tree is None:
             return ""
         lines = self._node_to_lines(tree, indent)
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Indexed interactive elements (#11537)
+    # ------------------------------------------------------------------
+
+    def index_interactive(self, tree: AccessibilityTree) -> List[Dict[str, Any]]:
+        """Assign a stable, document-order index to every interactive node.
+
+        Mirrors the numbered-element pattern used by the chat tool's live
+        browser worker (autobot-browser-worker/element-index.js) — the
+        OpenManus fix for LLM selector-guessing — for the accessibility-tree
+        snapshots captured by this class (research-browser sessions).
+
+        Args:
+            tree: Root node returned by :meth:`capture`.
+
+        Returns:
+            List of ``{"index": int, "role": str, "name": str}`` dicts in
+            document order; empty when *tree* is ``None`` or has no
+            interactive nodes.
+        """
+        if tree is None:
+            return []
+        nodes: List[AccessibilityNode] = []
+        self._collect(tree, lambda n: n.role.lower() in INTERACTIVE_ROLES, nodes)
+        return [{"index": i, "role": n.role, "name": n.name} for i, n in enumerate(nodes)]
+
+    def to_indexed_text(self, tree: AccessibilityTree) -> str:
+        """Render the numbered interactive-element menu as plain text for LLM consumption.
+
+        Args:
+            tree: Root node returned by :meth:`capture`.
+
+        Returns:
+            One ``[index] role "name"`` line per interactive element, or an
+            empty string when there are none.
+        """
+        elements = self.index_interactive(tree)
+        if not elements:
+            return ""
+        lines = []
+        for el in elements:
+            prefix = f'[{el["index"]}] {el["role"]}'
+            lines.append(f'{prefix} "{el["name"]}"' if el["name"] else prefix)
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/autobot-backend/services/web_pipeline/web_pipeline_test.py
+++ b/autobot-backend/services/web_pipeline/web_pipeline_test.py
@@ -449,3 +449,79 @@ class TestAccessibilityNodeToDict:
         node = AccessibilityNode(role="button", name="OK", properties={})
         d = node.to_dict()
         assert "properties" not in d
+
+
+class TestIndexInteractive:
+    """AccessibilitySnapshot.index_interactive() — numbered element menu (#11537)."""
+
+    def test_none_tree_returns_empty_list(self) -> None:
+        assert AccessibilitySnapshot().index_interactive(None) == []
+
+    def test_only_interactive_roles_are_indexed(self) -> None:
+        root = AccessibilityNode(
+            role="WebArea",
+            name="",
+            children=[
+                AccessibilityNode(role="button", name="Submit"),
+                AccessibilityNode(role="paragraph", name="Some text"),
+                AccessibilityNode(role="textbox", name="Email"),
+            ],
+        )
+        elements = AccessibilitySnapshot().index_interactive(root)
+        assert [el["role"] for el in elements] == ["button", "textbox"]
+
+    def test_index_is_sequential_and_stable_in_document_order(self) -> None:
+        root = AccessibilityNode(
+            role="WebArea",
+            name="",
+            children=[
+                AccessibilityNode(role="link", name="Home"),
+                AccessibilityNode(role="link", name="About"),
+                AccessibilityNode(role="button", name="Go"),
+            ],
+        )
+        elements = AccessibilitySnapshot().index_interactive(root)
+        assert [el["index"] for el in elements] == [0, 1, 2]
+        assert [el["name"] for el in elements] == ["Home", "About", "Go"]
+
+    def test_role_matching_is_case_insensitive(self) -> None:
+        root = AccessibilityNode(role="BUTTON", name="Submit")
+        elements = AccessibilitySnapshot().index_interactive(root)
+        assert len(elements) == 1
+
+    def test_no_interactive_nodes_returns_empty_list(self) -> None:
+        root = AccessibilityNode(role="WebArea", name="", children=[AccessibilityNode(role="paragraph", name="x")])
+        assert AccessibilitySnapshot().index_interactive(root) == []
+
+
+class TestToIndexedText:
+    """AccessibilitySnapshot.to_indexed_text() — plain-text numbered menu (#11537)."""
+
+    def test_none_tree_returns_empty_string(self) -> None:
+        assert AccessibilitySnapshot().to_indexed_text(None) == ""
+
+    def test_no_interactive_elements_returns_empty_string(self) -> None:
+        root = AccessibilityNode(role="paragraph", name="just text")
+        assert AccessibilitySnapshot().to_indexed_text(root) == ""
+
+    def test_renders_index_role_and_name(self) -> None:
+        root = AccessibilityNode(role="button", name="Submit")
+        text = AccessibilitySnapshot().to_indexed_text(root)
+        assert text == '[0] button "Submit"'
+
+    def test_renders_multiple_elements_one_per_line(self) -> None:
+        root = AccessibilityNode(
+            role="WebArea",
+            name="",
+            children=[
+                AccessibilityNode(role="link", name="Home"),
+                AccessibilityNode(role="button", name="Submit"),
+            ],
+        )
+        text = AccessibilitySnapshot().to_indexed_text(root)
+        assert text.splitlines() == ['[0] link "Home"', '[1] button "Submit"']
+
+    def test_element_without_name_omits_quoted_name(self) -> None:
+        root = AccessibilityNode(role="button", name="")
+        text = AccessibilitySnapshot().to_indexed_text(root)
+        assert text == "[0] button"

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_indexed_browser.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_indexed_browser.py
@@ -1,0 +1,191 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Indexed interactive-element browser tools (#11537).
+
+click_index/fill_index/select_index/hover_index let the chat LLM act on a
+numbered element from the page's element menu instead of inventing a CSS
+selector. These tests prove:
+
+  (a) _handle_browser_tool resolves the tool call to the browser worker with
+      the index intact and threads session_id (#11539 parity).
+  (b) the numbered interactive-element "state block" is appended to browser
+      tool results (task 4) so the model always sees a current menu.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from chat_workflow.tool_handler import BROWSER_TOOL_NAMES, ToolHandlerMixin
+
+_PAGE_STATE = {
+    "url": "https://example.com/form",
+    "title": "Example Form",
+    "scroll": {"x": 0, "y": 0, "maxX": 0, "maxY": 400},
+    "elements": [
+        {"index": 0, "role": "textbox", "name": "Email", "tag": "input", "selector": "xpath=/html/body/input[1]"},
+        {"index": 1, "role": "button", "name": "Submit", "tag": "button", "selector": "xpath=/html/body/button[1]"},
+    ],
+}
+
+
+def _handler() -> ToolHandlerMixin:
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)  # no __init__ side effects needed
+
+
+async def _drive_browser_tool(tool_call: dict, mock_send: AsyncMock, session_id: str = "conversation-A"):
+    handler = _handler()
+    execution_results: list = []
+    with (
+        patch("api.browser_mcp.send_to_browser_vm", mock_send),
+        patch("chat_workflow.tool_handler._emit_before_tool_execute", AsyncMock(return_value=True)),
+        patch("chat_workflow.tool_handler._emit_after_tool_execute", AsyncMock(side_effect=lambda *a, **k: a[1])),
+    ):
+        async for _msg in handler._handle_browser_tool(tool_call, execution_results, session_id=session_id):
+            pass
+    return execution_results
+
+
+def test_indexed_tool_names_are_registered_as_browser_tools() -> None:
+    for name in ("click_index", "fill_index", "select_index", "hover_index", "browser_state"):
+        assert name in BROWSER_TOOL_NAMES
+
+
+@pytest.mark.asyncio
+async def test_click_index_resolves_index_and_threads_session_id() -> None:
+    """(a) click_index dispatch forwards the index untouched and the caller's
+    session_id — resolution to a concrete element happens server-side in the
+    browser worker (autobot-browser-worker/element-index.js)."""
+    tool_call = {"name": "click_index", "params": {"index": 1}, "description": "click submit"}
+    mock_send = AsyncMock(
+        return_value={
+            "success": True,
+            "action": "click_index",
+            "result": {
+                "success": True,
+                "index": 1,
+                "resolved": _PAGE_STATE["elements"][1],
+                "page_state": _PAGE_STATE,
+            },
+        }
+    )
+
+    execution_results = await _drive_browser_tool(tool_call, mock_send, session_id="conversation-A")
+
+    mock_send.assert_awaited_once()
+    args, kwargs = mock_send.call_args
+    assert args[0] == "click_index"
+    assert args[1] == {"index": 1}
+    assert kwargs["session_id"] == "conversation-A"
+    assert execution_results[0]["status"] == "success"
+    assert "Clicked element [1]" in execution_results[0]["output"]
+    assert "Submit" in execution_results[0]["output"]
+
+
+@pytest.mark.asyncio
+async def test_fill_index_resolves_index_and_threads_session_id() -> None:
+    """(a) fill_index parity with click_index — index + value forwarded, session_id threaded."""
+    tool_call = {"name": "fill_index", "params": {"index": 0, "value": "user@example.com"}, "description": "fill email"}
+    mock_send = AsyncMock(
+        return_value={
+            "success": True,
+            "action": "fill_index",
+            "result": {
+                "success": True,
+                "index": 0,
+                "resolved": _PAGE_STATE["elements"][0],
+                "page_state": _PAGE_STATE,
+            },
+        }
+    )
+
+    execution_results = await _drive_browser_tool(tool_call, mock_send, session_id="conversation-B")
+
+    args, kwargs = mock_send.call_args
+    assert args[0] == "fill_index"
+    assert args[1] == {"index": 0, "value": "user@example.com"}
+    assert kwargs["session_id"] == "conversation-B"
+    assert "Filled element [0]" in execution_results[0]["output"]
+    assert "Email" in execution_results[0]["output"]
+
+
+@pytest.mark.asyncio
+async def test_click_index_out_of_range_surfaces_as_tool_error() -> None:
+    """The browser worker rejects an out-of-range index; the failure must
+    still be recorded (not silently dropped) for the model to self-correct."""
+    tool_call = {"name": "click_index", "params": {"index": 99}, "description": "click ghost element"}
+    mock_send = AsyncMock(side_effect=Exception("Browser VM error: 400 - Index 99 out of range (2 elements)"))
+
+    execution_results = await _drive_browser_tool(tool_call, mock_send)
+
+    assert execution_results[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_browser_state_tool_returns_numbered_menu() -> None:
+    """browser_state lets the model explicitly request the current menu."""
+    tool_call = {"name": "browser_state", "params": {}, "description": "get page state"}
+    mock_send = AsyncMock(return_value={"success": True, "action": "browser_state", "result": _PAGE_STATE})
+
+    execution_results = await _drive_browser_tool(tool_call, mock_send)
+
+    assert execution_results[0]["status"] == "success"
+    assert "2 interactive element" in execution_results[0]["output"]
+
+
+class TestFormatBrowserResultAppendsStateBlock:
+    """(b) the indexed-element block is appended to browser tool results (task 4)."""
+
+    def test_state_block_appended_to_click_result(self) -> None:
+        handler = _handler()
+        result = {
+            "success": True,
+            "result": {"success": True, "page_state": _PAGE_STATE},
+        }
+        text = handler._format_browser_result("click", {"index": 1}, result)
+
+        assert "Interactive elements (2):" in text
+        assert '[0] textbox "Email"' in text
+        assert '[1] button "Submit"' in text
+
+    def test_no_state_block_when_page_state_absent(self) -> None:
+        handler = _handler()
+        result = {"success": True, "result": {"title": "x", "url": "https://example.com"}}
+        text = handler._format_browser_result("navigate", {"url": "https://example.com"}, result)
+
+        assert "Interactive elements" not in text
+
+    def test_no_state_block_when_elements_empty(self) -> None:
+        handler = _handler()
+        empty_state = {**_PAGE_STATE, "elements": []}
+        result = {"success": True, "result": {"success": True, "page_state": empty_state}}
+        text = handler._format_browser_result("click", {"selector": "#go"}, result)
+
+        assert "Interactive elements" not in text
+
+    def test_browser_state_result_renders_full_menu(self) -> None:
+        handler = _handler()
+        result = {"success": True, "result": _PAGE_STATE}
+        text = handler._format_browser_result("browser_state", {}, result)
+
+        assert "Page state: https://example.com/form" in text
+        assert '[0] textbox "Email"' in text
+        assert '[1] button "Submit"' in text
+
+    def test_state_block_respects_prompt_element_cap(self) -> None:
+        handler = _handler()
+        many_elements = [
+            {"index": i, "role": "button", "name": f"btn{i}", "tag": "button", "selector": f"xpath=/x[{i}]"}
+            for i in range(50)
+        ]
+        page_state = {**_PAGE_STATE, "elements": many_elements}
+        result = {"success": True, "result": {"success": True, "page_state": page_state}}
+        text = handler._format_browser_result("click_index", {"index": 0}, result)
+
+        assert "Interactive elements (50):" in text
+        assert "btn29" in text  # within default cap (30)
+        assert "btn49" not in text  # beyond default cap — never blows the prompt

--- a/autobot-backend/tests/unit/chat_workflow/test_vision_in_the_loop.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_vision_in_the_loop.py
@@ -1,0 +1,185 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Vision-in-the-loop: browser/VNC screenshots threaded into LLM chat context (#11538).
+
+OpenManus injects the current screenshot into the model's context on every
+step while the browser is active, so the model *sees* the effect of its last
+action instead of driving blind. These tests prove:
+
+  (c) a browser screenshot tool result produces an image content block for a
+      vision-capable provider, and stays text-only for a non-vision provider.
+  (d) only the single most recent screenshot is carried across the lookback
+      window — older ones are dropped, never accumulated.
+"""
+
+from __future__ import annotations
+
+from chat_workflow.manager import (
+    VISION_TOOL_LOOKBACK_MESSAGES,
+    ChatWorkflowManager,
+    _extract_latest_tool_screenshot,
+    _model_supports_vision,
+)
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+_FAKE_PNG_B64 = "aGVsbG8="  # "hello" — stand-in for real screenshot bytes
+
+
+def _manager() -> ChatWorkflowManager:
+    return ChatWorkflowManager.__new__(ChatWorkflowManager)  # no __init__ side effects needed
+
+
+# ---------------------------------------------------------------------------
+# _model_supports_vision
+# ---------------------------------------------------------------------------
+
+
+def test_known_vision_model_names_are_recognised() -> None:
+    for name in ("llava:13b", "gpt-4o", "gpt-4-vision-preview", "claude-3-opus", "gemini-1.5-pro", "qwen2.5-vl:7b"):
+        assert _model_supports_vision(name), name
+
+
+def test_plain_text_model_names_are_not_vision_capable() -> None:
+    for name in ("llama3.1:8b", "mistral", "deepseek-coder", "phi3"):
+        assert not _model_supports_vision(name), name
+
+
+def test_model_name_matching_is_case_insensitive() -> None:
+    assert _model_supports_vision("LLaVA:13B")
+
+
+def test_blank_model_name_is_not_vision_capable() -> None:
+    assert not _model_supports_vision("")
+    assert not _model_supports_vision(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# (c) _get_llm_request_payload — image content block gating
+# ---------------------------------------------------------------------------
+
+
+def test_vision_capable_model_gets_image_content_block() -> None:
+    mgr = _manager()
+    payload = mgr._get_llm_request_payload(
+        selected_model="gpt-4o",
+        current_prompt="What is on the screen?",
+        image_b64=_FAKE_PNG_B64,
+    )
+
+    assert "messages" in payload
+    content = payload["messages"][0]["content"]
+    assert content[0] == {"type": "text", "text": "What is on the screen?"}
+    image_block = content[1]
+    assert image_block["type"] == "image_url"
+    assert image_block["image_url"]["url"] == f"data:image/png;base64,{_FAKE_PNG_B64}"
+    # Text-only "prompt" field is preserved for providers that don't read "messages".
+    assert payload["prompt"] == "What is on the screen?"
+
+
+def test_non_vision_model_stays_text_only() -> None:
+    mgr = _manager()
+    payload = mgr._get_llm_request_payload(
+        selected_model="llama3.1:8b",
+        current_prompt="What is on the screen?",
+        image_b64=_FAKE_PNG_B64,
+    )
+
+    assert "messages" not in payload
+    assert payload["prompt"] == "What is on the screen?"
+
+
+def test_no_image_means_no_messages_key_even_for_vision_model() -> None:
+    mgr = _manager()
+    payload = mgr._get_llm_request_payload(selected_model="gpt-4o", current_prompt="hello", image_b64=None)
+
+    assert "messages" not in payload
+
+
+def test_image_dropped_when_it_would_blow_the_context_budget() -> None:
+    """#11538: image token cost counts toward the context budget — an
+    oversized prompt must not silently grow further with an attached image."""
+    mgr = _manager()
+    huge_prompt = "x" * 50_000  # far beyond the default ~3000-token history budget
+    payload = mgr._get_llm_request_payload(
+        selected_model="gpt-4o",
+        current_prompt=huge_prompt,
+        image_b64=_FAKE_PNG_B64,
+    )
+
+    assert "messages" not in payload
+
+
+# ---------------------------------------------------------------------------
+# (d) _extract_latest_tool_screenshot — only the latest screenshot, dropped after N
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_the_only_screenshot_present() -> None:
+    history = [
+        {"tool": "click", "status": "success", "output": "Clicked"},
+        {"tool": "screenshot", "status": "success", "output": "Screenshot captured.", "base64_image": "img-1"},
+    ]
+    assert _extract_latest_tool_screenshot(history) == "img-1"
+
+
+def test_only_the_most_recent_screenshot_is_returned() -> None:
+    """Multiple screenshots within the lookback window — only the latest wins."""
+    history = [
+        {"tool": "screenshot", "status": "success", "output": "s1", "base64_image": "img-old"},
+        {"tool": "navigate", "status": "success", "output": "nav"},
+        {"tool": "screenshot", "status": "success", "output": "s2", "base64_image": "img-latest"},
+    ]
+    assert _extract_latest_tool_screenshot(history) == "img-latest"
+
+
+def test_screenshot_outside_the_lookback_window_is_dropped() -> None:
+    """A screenshot older than VISION_TOOL_LOOKBACK_MESSAGES steps back must
+    not resurface — context never accumulates stale screenshots."""
+    history = [{"tool": "screenshot", "status": "success", "output": "old", "base64_image": "img-stale"}]
+    # Pad with enough non-image entries to push the screenshot out of the window.
+    padding_count = VISION_TOOL_LOOKBACK_MESSAGES
+    padding = [{"tool": "click", "status": "success", "output": f"click-{i}"} for i in range(padding_count)]
+    history += padding
+
+    assert _extract_latest_tool_screenshot(history) is None
+
+
+def test_no_screenshot_in_history_returns_none() -> None:
+    history = [
+        {"tool": "navigate", "status": "success", "output": "nav"},
+        {"tool": "click", "status": "success", "output": "click"},
+    ]
+    assert _extract_latest_tool_screenshot(history) is None
+
+
+def test_empty_history_returns_none() -> None:
+    assert _extract_latest_tool_screenshot([]) is None
+
+
+# ---------------------------------------------------------------------------
+# Source of the image: _record_browser_success threads base64_image through
+# ---------------------------------------------------------------------------
+
+
+def test_record_browser_success_captures_screenshot_image_for_vision_loop() -> None:
+    handler = ToolHandlerMixin.__new__(ToolHandlerMixin)
+    execution_results: list = []
+    result = {"success": True, "action": "screenshot", "result": {"image": _FAKE_PNG_B64}}
+
+    handler._record_browser_success("screenshot", {}, result, execution_results)
+
+    assert execution_results[0]["base64_image"] == _FAKE_PNG_B64
+
+
+def test_record_browser_success_omits_base64_image_key_when_absent() -> None:
+    """A tool with no image data (e.g. navigate) must not grow execution_results
+    with a stray None-valued key that would need special-casing downstream."""
+    handler = ToolHandlerMixin.__new__(ToolHandlerMixin)
+    execution_results: list = []
+    result = {"success": True, "action": "navigate", "result": {"url": "https://example.com", "title": "Example"}}
+
+    handler._record_browser_success("navigate", {"url": "https://example.com"}, result, execution_results)
+
+    assert "base64_image" not in execution_results[0]

--- a/autobot-backend/tests/unit/chat_workflow/test_vision_in_the_loop.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_vision_in_the_loop.py
@@ -8,23 +8,39 @@ OpenManus injects the current screenshot into the model's context on every
 step while the browser is active, so the model *sees* the effect of its last
 action instead of driving blind. These tests prove:
 
-  (c) a browser screenshot tool result produces an image content block for a
-      vision-capable provider, and stays text-only for a non-vision provider.
+  (c) a browser screenshot tool result produces an image attachment in the
+      SHAPE the target endpoint actually consumes — Ollama's /api/generate
+      (the endpoint this continuation loop always POSTs to; see
+      manager.py::_resolve_vision_payload_shape) reads a top-level raw-base64
+      "images" list and ignores "messages" entirely — and stays text-only for
+      a non-vision provider. A dedicated HTTP-capture test proves the image
+      reaches the field the endpoint actually reads, not just that some dict
+      shape was built (the "green test on wrong shape" trap from review).
   (d) only the single most recent screenshot is carried across the lookback
-      window — older ones are dropped, never accumulated.
+      window — older ones are dropped, never accumulated, and pruned from
+      execution_history once they age out.
 """
 
 from __future__ import annotations
 
+import pytest
+
 from chat_workflow.manager import (
+    VISION_IMAGE_TOKEN_ESTIMATE,
     VISION_TOOL_LOOKBACK_MESSAGES,
     ChatWorkflowManager,
     _extract_latest_tool_screenshot,
     _model_supports_vision,
+    _prune_stale_screenshots,
+    _resolve_vision_payload_shape,
+    _strip_data_url_prefix,
 )
 from chat_workflow.tool_handler import ToolHandlerMixin
+from constants.api_constants import PATH_OLLAMA_GENERATE
+from context_window_manager import ContextWindowManager
 
 _FAKE_PNG_B64 = "aGVsbG8="  # "hello" — stand-in for real screenshot bytes
+_OLLAMA_GENERATE_ENDPOINT = f"http://127.0.0.1:11434{PATH_OLLAMA_GENERATE}"
 
 
 def _manager() -> ChatWorkflowManager:
@@ -56,26 +72,82 @@ def test_blank_model_name_is_not_vision_capable() -> None:
 
 
 # ---------------------------------------------------------------------------
-# (c) _get_llm_request_payload — image content block gating
+# _resolve_vision_payload_shape / _strip_data_url_prefix (MAJOR fix)
 # ---------------------------------------------------------------------------
 
 
-def test_vision_capable_model_gets_image_content_block() -> None:
+def test_ollama_generate_endpoint_resolves_to_ollama_shape() -> None:
+    assert _resolve_vision_payload_shape(_OLLAMA_GENERATE_ENDPOINT) == "ollama_generate"
+    assert _resolve_vision_payload_shape("http://gpu-node:11434/api/generate") == "ollama_generate"
+
+
+def test_non_generate_endpoint_resolves_to_openai_chat_shape() -> None:
+    """Defensive branch for a future OpenAI-compatible /chat/completions path —
+    not wired into this loop today, but the router must not silently misroute
+    it to the Ollama shape either."""
+    assert _resolve_vision_payload_shape("https://api.example.com/v1/chat/completions") == "openai_chat"
+
+
+def test_strip_data_url_prefix_removes_prefix() -> None:
+    assert _strip_data_url_prefix(f"data:image/png;base64,{_FAKE_PNG_B64}") == _FAKE_PNG_B64
+
+
+def test_strip_data_url_prefix_is_noop_on_raw_base64() -> None:
+    """Screenshots already arrive raw from the browser worker — must pass through unchanged."""
+    assert _strip_data_url_prefix(_FAKE_PNG_B64) == _FAKE_PNG_B64
+
+
+# ---------------------------------------------------------------------------
+# (c) _get_llm_request_payload — provider-aware image attachment
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_generate_payload_carries_raw_base64_under_images() -> None:
+    """The real, only endpoint shape this continuation loop targets today:
+    Ollama's /api/generate. It must get the image under "images" as raw
+    base64, and must NOT get a "messages" block (Ollama ignores it)."""
     mgr = _manager()
     payload = mgr._get_llm_request_payload(
         selected_model="gpt-4o",
         current_prompt="What is on the screen?",
         image_b64=_FAKE_PNG_B64,
+        ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT,
     )
 
-    assert "messages" in payload
+    assert payload["images"] == [_FAKE_PNG_B64]
+    assert "messages" not in payload
+    # Text-only "prompt" field is preserved — this is what Ollama actually reads for text.
+    assert payload["prompt"] == "What is on the screen?"
+
+
+def test_ollama_generate_payload_strips_data_url_prefix() -> None:
+    mgr = _manager()
+    payload = mgr._get_llm_request_payload(
+        selected_model="gpt-4o",
+        current_prompt="hello",
+        image_b64=f"data:image/png;base64,{_FAKE_PNG_B64}",
+        ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT,
+    )
+
+    assert payload["images"] == [_FAKE_PNG_B64]  # raw, no data: prefix
+
+
+def test_openai_chat_shaped_endpoint_gets_messages_content_block() -> None:
+    """Routing parity check: a non-Ollama-generate endpoint gets the OpenAI
+    content-block shape instead — proves the branch, not just the default."""
+    mgr = _manager()
+    payload = mgr._get_llm_request_payload(
+        selected_model="gpt-4o",
+        current_prompt="What is on the screen?",
+        image_b64=_FAKE_PNG_B64,
+        ollama_endpoint="https://api.example.com/v1/chat/completions",
+    )
+
+    assert "images" not in payload
     content = payload["messages"][0]["content"]
     assert content[0] == {"type": "text", "text": "What is on the screen?"}
-    image_block = content[1]
-    assert image_block["type"] == "image_url"
-    assert image_block["image_url"]["url"] == f"data:image/png;base64,{_FAKE_PNG_B64}"
-    # Text-only "prompt" field is preserved for providers that don't read "messages".
-    assert payload["prompt"] == "What is on the screen?"
+    assert content[1]["type"] == "image_url"
+    assert content[1]["image_url"]["url"] == f"data:image/png;base64,{_FAKE_PNG_B64}"
 
 
 def test_non_vision_model_stays_text_only() -> None:
@@ -84,31 +156,158 @@ def test_non_vision_model_stays_text_only() -> None:
         selected_model="llama3.1:8b",
         current_prompt="What is on the screen?",
         image_b64=_FAKE_PNG_B64,
+        ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT,
     )
 
+    assert "images" not in payload
     assert "messages" not in payload
     assert payload["prompt"] == "What is on the screen?"
 
 
-def test_no_image_means_no_messages_key_even_for_vision_model() -> None:
+def test_no_image_means_no_images_key_even_for_vision_model() -> None:
     mgr = _manager()
-    payload = mgr._get_llm_request_payload(selected_model="gpt-4o", current_prompt="hello", image_b64=None)
+    payload = mgr._get_llm_request_payload(
+        selected_model="gpt-4o", current_prompt="hello", image_b64=None, ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT
+    )
 
+    assert "images" not in payload
     assert "messages" not in payload
 
 
-def test_image_dropped_when_it_would_blow_the_context_budget() -> None:
-    """#11538: image token cost counts toward the context budget — an
-    oversized prompt must not silently grow further with an attached image."""
+def test_image_dropped_when_prompt_alone_already_exceeds_budget() -> None:
+    """#11538: an oversized prompt must not silently grow further with an attached image."""
     mgr = _manager()
-    huge_prompt = "x" * 50_000  # far beyond the default ~3000-token history budget
+    huge_prompt = "x" * 500_000  # far beyond any configured history budget, alone
     payload = mgr._get_llm_request_payload(
         selected_model="gpt-4o",
         current_prompt=huge_prompt,
         image_b64=_FAKE_PNG_B64,
+        ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT,
     )
 
-    assert "messages" not in payload
+    assert "images" not in payload
+
+
+def test_image_dropped_when_prompt_alone_fits_but_prompt_plus_image_does_not() -> None:
+    """MINOR fix: isolate the +VISION_IMAGE_TOKEN_ESTIMATE term. A prompt that
+    fits the budget on its own must still drop the image once the fixed
+    per-image token cost would tip the total over — proving the image cost
+    (not just prompt size) is what's being gated, per the review's flagged gap.
+
+    Sized dynamically off the real ContextWindowManager budget (rather than a
+    hardcoded char count) so the test stays correct if config/context_windows.yaml
+    is retuned.
+    """
+    mgr = _manager()
+    model = "gpt-4o"
+    cwm = ContextWindowManager()
+    max_tokens = cwm.get_max_history_tokens(model)
+    chars_per_token = cwm.config["token_estimation"]["chars_per_token"]
+
+    # Land just under the budget alone; +VISION_IMAGE_TOKEN_ESTIMATE must tip it over.
+    borderline_tokens = max_tokens - (VISION_IMAGE_TOKEN_ESTIMATE // 2)
+    borderline_prompt = "x" * (borderline_tokens * chars_per_token)
+
+    payload_alone = mgr._get_llm_request_payload(
+        selected_model=model,
+        current_prompt=borderline_prompt,
+        image_b64=None,
+        ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT,
+    )
+    assert "images" not in payload_alone  # no image requested — just sanity on the prompt itself
+    assert cwm.estimate_tokens(borderline_prompt) < max_tokens  # prompt alone genuinely fits
+
+    payload_with_image = mgr._get_llm_request_payload(
+        selected_model=model,
+        current_prompt=borderline_prompt,
+        image_b64=_FAKE_PNG_B64,
+        ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT,
+    )
+    assert "images" not in payload_with_image  # image cost alone tips the budget — dropped
+
+
+def test_image_attached_when_prompt_plus_image_both_fit() -> None:
+    """Sanity counterpart: a genuinely small prompt keeps the image."""
+    mgr = _manager()
+    payload = mgr._get_llm_request_payload(
+        selected_model="gpt-4o",
+        current_prompt="short prompt",
+        image_b64=_FAKE_PNG_B64,
+        ollama_endpoint=_OLLAMA_GENERATE_ENDPOINT,
+    )
+    assert payload["images"] == [_FAKE_PNG_B64]
+
+
+# ---------------------------------------------------------------------------
+# (c) HTTP-capture: the image reaches the field the real endpoint reads
+# ---------------------------------------------------------------------------
+
+
+class _EmptyAsyncIterator:
+    """Stand-in for an aiohttp streaming body that ends immediately (no chunks)."""
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _FakeStreamResponse:
+    def __init__(self) -> None:
+        self.status = 200
+        self.content = _EmptyAsyncIterator()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeHttpClient:
+    """Captures the outgoing POST payload without a real Ollama server."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def post(self, url, json=None, **kwargs):  # noqa: A002 - match aiohttp call signature
+        self.calls.append({"url": url, "json": json})
+        return _FakeStreamResponse()
+
+    async def decrement_active(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_process_single_llm_iteration_posts_raw_base64_images_to_ollama_generate() -> None:
+    """Capture the live outgoing request (mirrors #11539's session-id capture
+    pattern): drive _process_single_llm_iteration end to end against a fake
+    http_client and assert the POSTed JSON body — for the real endpoint this
+    loop targets — carries the image in the field Ollama's /api/generate
+    actually reads, not merely that some payload dict shape was constructed.
+    """
+    mgr = _manager()
+    http_client = _FakeHttpClient()
+
+    async for _item in mgr._process_single_llm_iteration(
+        http_client,
+        _OLLAMA_GENERATE_ENDPOINT,
+        "gpt-4o",
+        "What is on the screen?",
+        "term-1",
+        False,
+        [],
+        1,
+        image_b64=_FAKE_PNG_B64,
+    ):
+        pass
+
+    assert len(http_client.calls) == 1
+    assert http_client.calls[0]["url"] == _OLLAMA_GENERATE_ENDPOINT
+    posted_payload = http_client.calls[0]["json"]
+    assert posted_payload["images"] == [_FAKE_PNG_B64]
+    assert "messages" not in posted_payload
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +355,43 @@ def test_no_screenshot_in_history_returns_none() -> None:
 
 def test_empty_history_returns_none() -> None:
     assert _extract_latest_tool_screenshot([]) is None
+
+
+# ---------------------------------------------------------------------------
+# MINOR fix: _prune_stale_screenshots — bounded base64 retention
+# ---------------------------------------------------------------------------
+
+
+def test_prune_removes_base64_image_outside_the_lookback_window() -> None:
+    history = [{"tool": "screenshot", "status": "success", "output": "old", "base64_image": "img-stale"}]
+    padding = [{"tool": "click", "status": "success", "output": f"c{i}"} for i in range(VISION_TOOL_LOOKBACK_MESSAGES)]
+    history += padding
+
+    _prune_stale_screenshots(history)
+
+    assert "base64_image" not in history[0]
+    # Non-image fields on the pruned entry are untouched.
+    assert history[0]["output"] == "old"
+
+
+def test_prune_keeps_base64_image_inside_the_lookback_window() -> None:
+    history = [{"tool": "screenshot", "status": "success", "output": "recent", "base64_image": "img-recent"}]
+
+    _prune_stale_screenshots(history)
+
+    assert history[0]["base64_image"] == "img-recent"
+
+
+def test_prune_is_a_noop_when_no_entry_has_an_image() -> None:
+    history = [{"tool": "click", "status": "success", "output": "c"} for _ in range(5)]
+    _prune_stale_screenshots(history)  # must not raise
+    assert all("base64_image" not in entry for entry in history)
+
+
+def test_prune_handles_empty_history() -> None:
+    history: list = []
+    _prune_stale_screenshots(history)  # must not raise
+    assert history == []
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-browser-worker/element-index.js
+++ b/autobot-browser-worker/element-index.js
@@ -81,18 +81,33 @@ async function collectIndexedElements(page, maxElements = DEFAULT_MAX_ELEMENTS) 
 }
 
 /**
- * Resolve an `index` param against a previously-collected element list.
- * Pure/no I/O — this is what "resolved server-side" means for click_index /
+ * Resolve an `index` param against a freshly-collected element list. Pure/no
+ * I/O — this is what "resolved server-side" means for click_index /
  * fill_index / select_index / hover_index: the index never reaches the DOM
  * directly, it is translated to a concrete locator here first.
  *
+ * Stale-index guard (review MINOR 3): if the caller supplies `expectedCount`
+ * — the element count it saw when it chose the index, e.g. from a prior
+ * browser_state call — and the live count differs, the page changed shape
+ * since then and the index may no longer point at the element the caller
+ * intended. Returned as a clear error rather than silently acting on
+ * whatever now happens to sit at that index.
+ *
  * @param {Array<object>} elements - Result of collectIndexedElements().
  * @param {*} index - The raw `index` param from the tool call.
+ * @param {*} [expectedCount] - Element count the caller chose the index against.
  * @returns {{element:object}|{error:string}}
  */
-function resolveElementByIndex(elements, index) {
+function resolveElementByIndex(elements, index, expectedCount) {
   if (typeof index !== 'number' || !Number.isInteger(index)) {
     return { error: 'index must be an integer' };
+  }
+  if (typeof expectedCount === 'number' && expectedCount !== elements.length) {
+    return {
+      error:
+        `Page changed since state was captured (expected ${expectedCount} elements, ` +
+        `found ${elements.length}) — call browser_state again before retrying.`,
+    };
   }
   const target = elements[index];
   if (!target) {

--- a/autobot-browser-worker/element-index.js
+++ b/autobot-browser-worker/element-index.js
@@ -1,0 +1,109 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+'use strict';
+
+/**
+ * Indexed interactive-element helpers (#11537).
+ *
+ * The chat LLM used to invent CSS selectors from imagination
+ * (`click({"selector": "button#submit"})` against a page it cannot see).
+ * OpenManus's fix — numbering every interactive element so the model picks
+ * a target from a menu it can see (`click_element index=12`) — is mirrored
+ * here.
+ *
+ * Only the browser-worker process holds the real Playwright `Page`, so
+ * indexing (and resolving an index back to an actionable locator) happens
+ * here rather than in `services/web_pipeline/snapshot.py` (which captures
+ * the accessibility tree of a *different* Playwright subsystem —
+ * `research_browser_manager`, an in-process Python page used by the
+ * research/scraping-template tools, not the chat tool_handler path). The
+ * two stay conceptually aligned (interactive-role filtering, stable index)
+ * without literally sharing code across the Python/Node boundary.
+ *
+ * Kept free of any Playwright import — like session-store.js — so the
+ * resolution logic can be unit tested with `node --test` and a fake `page`.
+ */
+
+const DEFAULT_MAX_ELEMENTS = parseInt(process.env.BROWSER_STATE_MAX_ELEMENTS || '50', 10);
+
+// Executed in-page via page.evaluate(INDEX_ELEMENTS_SCRIPT, maxElements).
+// Walks interactive elements in document order and builds a unique xpath
+// locator per element (Playwright's `xpath=` selector prefix), so each
+// returned entry is directly clickable/fillable server-side. Playwright's
+// Node evaluate() accepts a function source string, matching the pattern
+// already used for `_JS_COLLECT_REGIONS` in api/playwright.py.
+const INDEX_ELEMENTS_SCRIPT = `(maxElements) => {
+  const INTERACTIVE_SELECTOR = [
+    'a[href]', 'button', 'input', 'select', 'textarea',
+    '[role="button"]', '[role="link"]', '[role="checkbox"]', '[role="radio"]',
+    '[role="tab"]', '[role="menuitem"]', '[role="switch"]', '[role="combobox"]',
+    '[role="searchbox"]', '[role="textbox"]', '[onclick]', '[contenteditable="true"]',
+  ].join(',');
+  const candidates = Array.from(document.querySelectorAll(INTERACTIVE_SELECTOR));
+  const results = [];
+  for (const el of candidates) {
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) continue;
+    const style = window.getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') continue;
+    if (el.disabled) continue;
+    let xpath = '';
+    let node = el;
+    while (node && node !== document.body) {
+      const tag = node.tagName.toLowerCase();
+      const siblingIndex = Array.from(node.parentElement ? node.parentElement.children : [])
+        .filter((c) => c.tagName === node.tagName).indexOf(node) + 1;
+      xpath = '/' + tag + '[' + siblingIndex + ']' + xpath;
+      node = node.parentElement;
+    }
+    xpath = '/html/body' + xpath;
+    const role = el.getAttribute('role') || el.tagName.toLowerCase();
+    const name = (el.textContent || '').trim().slice(0, 120)
+      || el.getAttribute('aria-label') || el.getAttribute('placeholder')
+      || el.getAttribute('value') || el.getAttribute('alt') || '';
+    results.push({ role, name, tag: el.tagName.toLowerCase(), selector: 'xpath=' + xpath });
+    if (results.length >= maxElements) break;
+  }
+  return results;
+}`;
+
+/**
+ * Capture the numbered interactive-element menu for `page`.
+ * @param {object} page - Playwright Page (or a test double exposing `.evaluate`).
+ * @param {number} [maxElements]
+ * @returns {Promise<Array<{index:number, role:string, name:string, tag:string, selector:string}>>}
+ */
+async function collectIndexedElements(page, maxElements = DEFAULT_MAX_ELEMENTS) {
+  const elements = await page.evaluate(INDEX_ELEMENTS_SCRIPT, maxElements);
+  return elements.map((el, index) => ({ index, ...el }));
+}
+
+/**
+ * Resolve an `index` param against a previously-collected element list.
+ * Pure/no I/O — this is what "resolved server-side" means for click_index /
+ * fill_index / select_index / hover_index: the index never reaches the DOM
+ * directly, it is translated to a concrete locator here first.
+ *
+ * @param {Array<object>} elements - Result of collectIndexedElements().
+ * @param {*} index - The raw `index` param from the tool call.
+ * @returns {{element:object}|{error:string}}
+ */
+function resolveElementByIndex(elements, index) {
+  if (typeof index !== 'number' || !Number.isInteger(index)) {
+    return { error: 'index must be an integer' };
+  }
+  const target = elements[index];
+  if (!target) {
+    return { error: `Index ${index} out of range (${elements.length} elements)` };
+  }
+  return { element: target };
+}
+
+module.exports = {
+  DEFAULT_MAX_ELEMENTS,
+  INDEX_ELEMENTS_SCRIPT,
+  collectIndexedElements,
+  resolveElementByIndex,
+};

--- a/autobot-browser-worker/playwright-server.js
+++ b/autobot-browser-worker/playwright-server.js
@@ -5,6 +5,7 @@
 const { chromium } = require('playwright');
 const express = require('express');
 const { SessionStore } = require('./session-store');
+const { collectIndexedElements, resolveElementByIndex } = require('./element-index');
 const app = express();
 
 app.use(express.json({ limit: '50mb' }));
@@ -958,6 +959,42 @@ async function ensureMcpPage(sessionId) {
   return entry.mcpPage;
 }
 
+// --- Indexed interactive-element state (#11537) ---
+//
+// "state" here is what OpenManus feeds the model on every step: the current
+// URL/title/scroll position plus a numbered menu of interactive elements, so
+// the model can click_index/fill_index instead of guessing a CSS selector.
+async function capturePageState(page) {
+  const elements = await collectIndexedElements(page);
+  const scroll = await page.evaluate(() => ({
+    x: window.scrollX,
+    y: window.scrollY,
+    maxX: Math.max(0, document.documentElement.scrollWidth - window.innerWidth),
+    maxY: Math.max(0, document.documentElement.scrollHeight - window.innerHeight),
+  }));
+  return {
+    url: page.url(),
+    title: await page.title(),
+    scroll,
+    elements,
+  };
+}
+
+// New browser-worker endpoint (#11537 task 2): current page state, numbered
+// interactive elements included, for the session's MCP automation page.
+app.post('/state', async (req, res) => {
+  const sessionId = sessionIdFromRequest(req);
+  try {
+    const page = await ensureMcpPage(sessionId);
+    const state = await capturePageState(page);
+    res.json({ success: true, session_id: sessionId, ...state, timestamp: new Date().toISOString() });
+  } catch (e) {
+    logger.error('state error:', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+// --- End indexed interactive-element state (#11537) ---
+
 app.post('/automation', async (req, res) => {
   const { action, params = {} } = req.body;
   const sessionId = sessionIdFromRequest(req);
@@ -1028,8 +1065,71 @@ app.post('/automation', async (req, res) => {
         result = { success: true };
         break;
       }
+      // --- Indexed interactive-element actions (#11537) ---
+      // The index is resolved against a freshly-collected element list on
+      // every call (never a stale cache), then acted on via its xpath
+      // locator — "resolved server-side" so the LLM never has to guess a
+      // CSS selector.
+      case 'browser_state': {
+        result = await capturePageState(page);
+        break;
+      }
+      case 'click_index': {
+        const elements = await collectIndexedElements(page);
+        const resolved = resolveElementByIndex(elements, params.index);
+        if (resolved.error) {
+          return res.status(400).json({ success: false, error: resolved.error, action });
+        }
+        await page.click(resolved.element.selector, { timeout: params.timeout || 10000 });
+        result = { success: true, index: params.index, resolved: resolved.element };
+        break;
+      }
+      case 'fill_index': {
+        const elements = await collectIndexedElements(page);
+        const resolved = resolveElementByIndex(elements, params.index);
+        if (resolved.error) {
+          return res.status(400).json({ success: false, error: resolved.error, action });
+        }
+        await page.fill(resolved.element.selector, params.value, { timeout: params.timeout || 10000 });
+        result = { success: true, index: params.index, resolved: resolved.element };
+        break;
+      }
+      case 'select_index': {
+        const elements = await collectIndexedElements(page);
+        const resolved = resolveElementByIndex(elements, params.index);
+        if (resolved.error) {
+          return res.status(400).json({ success: false, error: resolved.error, action });
+        }
+        await page.selectOption(resolved.element.selector, params.value);
+        result = { success: true, index: params.index, resolved: resolved.element };
+        break;
+      }
+      case 'hover_index': {
+        const elements = await collectIndexedElements(page);
+        const resolved = resolveElementByIndex(elements, params.index);
+        if (resolved.error) {
+          return res.status(400).json({ success: false, error: resolved.error, action });
+        }
+        await page.hover(resolved.element.selector);
+        result = { success: true, index: params.index, resolved: resolved.element };
+        break;
+      }
+      // --- End indexed interactive-element actions (#11537) ---
       default:
         return res.status(400).json({ success: false, error: `Unknown action: ${action}` });
+    }
+    // #11537 task 4: every browser tool result carries the current numbered
+    // element menu, refreshed post-action, so the model always sees an
+    // up-to-date menu without a separate round trip. Non-fatal on failure —
+    // a page mid-navigation/closed should not fail the action that just
+    // succeeded. 'browser_state' already *is* the page state — no need to
+    // capture it twice.
+    if (action !== 'browser_state') {
+      try {
+        result.page_state = await capturePageState(page);
+      } catch (stateErr) {
+        logger.warn('Automation: page_state capture failed for %s: %s', action, stateErr.message);
+      }
     }
     res.json({ success: true, action, result, session_id: sessionId, timestamp: new Date().toISOString() });
   } catch (error) {

--- a/autobot-browser-worker/playwright-server.js
+++ b/autobot-browser-worker/playwright-server.js
@@ -977,6 +977,11 @@ async function capturePageState(page) {
     title: await page.title(),
     scroll,
     elements,
+    // #11538 review MINOR 3: callers echo this back as expected_element_count
+    // on a later *_index call so a stale index (page changed shape since this
+    // state was captured) is rejected instead of silently acting on the
+    // wrong element — see resolveElementByIndex's stale-index guard.
+    element_count: elements.length,
   };
 }
 
@@ -1076,7 +1081,7 @@ app.post('/automation', async (req, res) => {
       }
       case 'click_index': {
         const elements = await collectIndexedElements(page);
-        const resolved = resolveElementByIndex(elements, params.index);
+        const resolved = resolveElementByIndex(elements, params.index, params.expected_element_count);
         if (resolved.error) {
           return res.status(400).json({ success: false, error: resolved.error, action });
         }
@@ -1086,7 +1091,7 @@ app.post('/automation', async (req, res) => {
       }
       case 'fill_index': {
         const elements = await collectIndexedElements(page);
-        const resolved = resolveElementByIndex(elements, params.index);
+        const resolved = resolveElementByIndex(elements, params.index, params.expected_element_count);
         if (resolved.error) {
           return res.status(400).json({ success: false, error: resolved.error, action });
         }
@@ -1096,7 +1101,7 @@ app.post('/automation', async (req, res) => {
       }
       case 'select_index': {
         const elements = await collectIndexedElements(page);
-        const resolved = resolveElementByIndex(elements, params.index);
+        const resolved = resolveElementByIndex(elements, params.index, params.expected_element_count);
         if (resolved.error) {
           return res.status(400).json({ success: false, error: resolved.error, action });
         }
@@ -1106,7 +1111,7 @@ app.post('/automation', async (req, res) => {
       }
       case 'hover_index': {
         const elements = await collectIndexedElements(page);
-        const resolved = resolveElementByIndex(elements, params.index);
+        const resolved = resolveElementByIndex(elements, params.index, params.expected_element_count);
         if (resolved.error) {
           return res.status(400).json({ success: false, error: resolved.error, action });
         }

--- a/autobot-browser-worker/tests/element-index.test.js
+++ b/autobot-browser-worker/tests/element-index.test.js
@@ -1,0 +1,91 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+'use strict';
+
+/**
+ * Tests for indexed interactive-element resolution backing playwright-server.js
+ * (#11537 — click/fill by numbered index instead of an LLM-invented CSS
+ * selector).
+ *
+ * Uses Node's built-in test runner, matching session-store.test.js. A fake
+ * `page` object stands in for Playwright's Page — only `.evaluate()` is
+ * exercised, and collectIndexedElements() doesn't care what produced the
+ * array it receives.
+ *
+ * Run: node --test autobot-browser-worker/tests/element-index.test.js
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { collectIndexedElements, resolveElementByIndex, DEFAULT_MAX_ELEMENTS } = require('../element-index');
+
+function fakePage(rawElements) {
+  return {
+    evaluate: async (_script, _maxElements) => rawElements,
+  };
+}
+
+test('collectIndexedElements assigns a stable sequential index to each element', async () => {
+  const raw = [
+    { role: 'button', name: 'Submit', tag: 'button', selector: 'xpath=/html/body/button[1]' },
+    { role: 'textbox', name: 'Email', tag: 'input', selector: 'xpath=/html/body/input[1]' },
+  ];
+  const elements = await collectIndexedElements(fakePage(raw));
+
+  assert.equal(elements.length, 2);
+  assert.equal(elements[0].index, 0);
+  assert.equal(elements[1].index, 1);
+  assert.equal(elements[0].role, 'button');
+  assert.equal(elements[1].name, 'Email');
+});
+
+test('collectIndexedElements passes the configured max element cap into page.evaluate', async () => {
+  let receivedMax = null;
+  const page = {
+    evaluate: async (_script, maxElements) => {
+      receivedMax = maxElements;
+      return [];
+    },
+  };
+
+  await collectIndexedElements(page, 7);
+  assert.equal(receivedMax, 7);
+
+  await collectIndexedElements(page);
+  assert.equal(receivedMax, DEFAULT_MAX_ELEMENTS);
+});
+
+test('resolveElementByIndex returns the matching element for a valid index', () => {
+  const elements = [
+    { index: 0, role: 'button', name: 'Submit', selector: 'xpath=/html/body/button[1]' },
+    { index: 1, role: 'link', name: 'Home', selector: 'xpath=/html/body/a[1]' },
+  ];
+
+  const result = resolveElementByIndex(elements, 1);
+  assert.deepEqual(result, { element: elements[1] });
+});
+
+test('resolveElementByIndex rejects an out-of-range index with a descriptive error', () => {
+  const elements = [{ index: 0, role: 'button', name: 'Submit', selector: 'xpath=/html/body/button[1]' }];
+
+  const result = resolveElementByIndex(elements, 5);
+  assert.ok(result.error);
+  assert.match(result.error, /Index 5 out of range \(1 elements\)/);
+});
+
+test('resolveElementByIndex rejects a non-integer index without touching the DOM', () => {
+  const elements = [{ index: 0, role: 'button', name: 'Submit', selector: 'xpath=/html/body/button[1]' }];
+
+  assert.ok(resolveElementByIndex(elements, '1').error);
+  assert.ok(resolveElementByIndex(elements, 1.5).error);
+  assert.ok(resolveElementByIndex(elements, null).error);
+  assert.ok(resolveElementByIndex(elements, undefined).error);
+});
+
+test('resolveElementByIndex on an empty element list always errors', () => {
+  const result = resolveElementByIndex([], 0);
+  assert.ok(result.error);
+  assert.match(result.error, /0 elements/);
+});

--- a/autobot-browser-worker/tests/element-index.test.js
+++ b/autobot-browser-worker/tests/element-index.test.js
@@ -89,3 +89,43 @@ test('resolveElementByIndex on an empty element list always errors', () => {
   assert.ok(result.error);
   assert.match(result.error, /0 elements/);
 });
+
+// --- Stale-index guard (review MINOR 3) ---
+// A caller that fetched browser_state, then acted on an index against a page
+// that changed shape in between (e.g. a modal opened/closed), must be told
+// to re-fetch rather than silently clicking whatever now sits at that index.
+
+test('resolveElementByIndex succeeds when expectedCount matches the live element count', () => {
+  const elements = [
+    { index: 0, role: 'button', name: 'Submit', selector: 'xpath=/html/body/button[1]' },
+    { index: 1, role: 'link', name: 'Home', selector: 'xpath=/html/body/a[1]' },
+  ];
+
+  const result = resolveElementByIndex(elements, 1, 2);
+  assert.deepEqual(result, { element: elements[1] });
+});
+
+test('resolveElementByIndex rejects a stale index when expectedCount no longer matches', () => {
+  const elements = [{ index: 0, role: 'button', name: 'Submit', selector: 'xpath=/html/body/button[1]' }];
+
+  const result = resolveElementByIndex(elements, 0, 5); // caller expected 5 elements, page now has 1
+  assert.ok(result.error);
+  assert.match(result.error, /Page changed since state was captured/);
+  assert.match(result.error, /expected 5 elements, found 1/);
+});
+
+test('resolveElementByIndex skips the stale-index guard when expectedCount is omitted (backward compatible)', () => {
+  const elements = [{ index: 0, role: 'button', name: 'Submit', selector: 'xpath=/html/body/button[1]' }];
+
+  assert.deepEqual(resolveElementByIndex(elements, 0), { element: elements[0] });
+  assert.deepEqual(resolveElementByIndex(elements, 0, undefined), { element: elements[0] });
+  assert.deepEqual(resolveElementByIndex(elements, 0, null), { element: elements[0] });
+});
+
+test('resolveElementByIndex stale-index guard runs before the out-of-range check', () => {
+  const elements = [{ index: 0, role: 'button', name: 'Submit', selector: 'xpath=/html/body/button[1]' }];
+
+  // index 9 is out of range AND the count is stale — the clearer "page changed" error wins.
+  const result = resolveElementByIndex(elements, 9, 5);
+  assert.match(result.error, /Page changed since state was captured/);
+});

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -14508,6 +14508,106 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/browser/mcp/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Browser State Mcp
+         * @description Get the current page state: URL, title, scroll info, numbered elements.
+         */
+        post: operations["browser_state_mcp_api_browser_mcp_state_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/browser/mcp/click_index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Click Index Mcp
+         * @description Click an element by its numbered index, resolved server-side.
+         */
+        post: operations["click_index_mcp_api_browser_mcp_click_index_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/browser/mcp/fill_index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Fill Index Mcp
+         * @description Fill an element by its numbered index, resolved server-side.
+         */
+        post: operations["fill_index_mcp_api_browser_mcp_fill_index_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/browser/mcp/select_index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Select Index Mcp
+         * @description Select a dropdown option on an element by its numbered index.
+         */
+        post: operations["select_index_mcp_api_browser_mcp_select_index_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/browser/mcp/hover_index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Hover Index Mcp
+         * @description Hover over an element by its numbered index, resolved server-side.
+         */
+        post: operations["hover_index_mcp_api_browser_mcp_hover_index_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/browser/mcp/status": {
         parameters: {
             query?: never;
@@ -57921,6 +58021,50 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * BrowserClickIndexRequest
+         * @description Request for POST /browser/mcp/click_index (#11537).
+         */
+        BrowserClickIndexRequest: {
+            /**
+             * Index
+             * @description Element index from the numbered element menu
+             */
+            index: number;
+            /**
+             * Timeout
+             * @description Timeout in milliseconds
+             * @default 10000
+             */
+            timeout: number | null;
+            /**
+             * Expected Element Count
+             * @description Optional: element_count from the browser_state call this index was chosen against
+             */
+            expected_element_count?: number | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** BrowserClickIndexResponse */
+        BrowserClickIndexResponse: {
+            /** Success */
+            success: boolean;
+            /** Action */
+            action: string;
+            /** Index */
+            index: number;
+            /** Result */
+            result?: unknown | null;
+            /** Timestamp */
+            timestamp: string;
+        } & {
+            [key: string]: unknown;
+        };
         /** BrowserClickRequest */
         BrowserClickRequest: {
             /**
@@ -57980,6 +58124,57 @@ export interface components {
             action: string;
             /** Script Preview */
             script_preview: string;
+            /** Result */
+            result?: unknown | null;
+            /** Timestamp */
+            timestamp: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * BrowserFillIndexRequest
+         * @description Request for POST /browser/mcp/fill_index (#11537).
+         */
+        BrowserFillIndexRequest: {
+            /**
+             * Index
+             * @description Element index from the numbered element menu
+             */
+            index: number;
+            /**
+             * Value
+             * @description Value to fill into the element
+             */
+            value: string;
+            /**
+             * Timeout
+             * @description Timeout in milliseconds
+             * @default 10000
+             */
+            timeout: number | null;
+            /**
+             * Expected Element Count
+             * @description Optional: element_count from the browser_state call this index was chosen against
+             */
+            expected_element_count?: number | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** BrowserFillIndexResponse */
+        BrowserFillIndexResponse: {
+            /** Success */
+            success: boolean;
+            /** Action */
+            action: string;
+            /** Index */
+            index: number;
+            /** Value Length */
+            value_length: number;
             /** Result */
             result?: unknown | null;
             /** Timestamp */
@@ -58092,6 +58287,44 @@ export interface components {
             selector: string;
             /** Text */
             text?: string | null;
+            /** Timestamp */
+            timestamp: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * BrowserHoverIndexRequest
+         * @description Request for POST /browser/mcp/hover_index (#11537).
+         */
+        BrowserHoverIndexRequest: {
+            /**
+             * Index
+             * @description Element index from the numbered element menu
+             */
+            index: number;
+            /**
+             * Expected Element Count
+             * @description Optional: element_count from the browser_state call this index was chosen against
+             */
+            expected_element_count?: number | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** BrowserHoverIndexResponse */
+        BrowserHoverIndexResponse: {
+            /** Success */
+            success: boolean;
+            /** Action */
+            action: string;
+            /** Index */
+            index: number;
+            /** Result */
+            result?: unknown | null;
             /** Timestamp */
             timestamp: string;
         } & {
@@ -58334,6 +58567,51 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * BrowserSelectIndexRequest
+         * @description Request for POST /browser/mcp/select_index (#11537).
+         */
+        BrowserSelectIndexRequest: {
+            /**
+             * Index
+             * @description Element index from the numbered element menu
+             */
+            index: number;
+            /**
+             * Value
+             * @description Value to select
+             */
+            value: string;
+            /**
+             * Expected Element Count
+             * @description Optional: element_count from the browser_state call this index was chosen against
+             */
+            expected_element_count?: number | null;
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** BrowserSelectIndexResponse */
+        BrowserSelectIndexResponse: {
+            /** Success */
+            success: boolean;
+            /** Action */
+            action: string;
+            /** Index */
+            index: number;
+            /** Value */
+            value: string;
+            /** Result */
+            result?: unknown | null;
+            /** Timestamp */
+            timestamp: string;
+        } & {
+            [key: string]: unknown;
+        };
         /** BrowserSelectRequest */
         BrowserSelectRequest: {
             /**
@@ -58460,6 +58738,32 @@ export interface components {
              * @default 0
              */
             mhtml_files_count: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * BrowserStateRequest
+         * @description Request for POST /browser/mcp/state (#11537).
+         */
+        BrowserStateRequest: {
+            /**
+             * Session Id
+             * @description Conversation/session id for isolated browser-context routing (#11539)
+             */
+            session_id?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** BrowserStateResponse */
+        BrowserStateResponse: {
+            /** Success */
+            success: boolean;
+            /** Action */
+            action: string;
+            /** Result */
+            result?: unknown | null;
+            /** Timestamp */
+            timestamp: string;
         } & {
             [key: string]: unknown;
         };
@@ -119632,6 +119936,171 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BrowserHoverResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    browser_state_mcp_api_browser_mcp_state_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BrowserStateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrowserStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    click_index_mcp_api_browser_mcp_click_index_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BrowserClickIndexRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrowserClickIndexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fill_index_mcp_api_browser_mcp_fill_index_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BrowserFillIndexRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrowserFillIndexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    select_index_mcp_api_browser_mcp_select_index_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BrowserSelectIndexRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrowserSelectIndexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    hover_index_mcp_api_browser_mcp_hover_index_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BrowserHoverIndexRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrowserHoverIndexResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Thinking Path
Two tightly-coupled umbrella #11536 features that both enrich the browser tool-result path (`tool_handler.py` _format/_record + `browser_mcp.py` schemas), combined into one coherent PR to avoid self-conflict. Builds on #11539's per-session browser contexts (session_id threading preserved on all new endpoints/actions).

## What Changed
**#11537 — indexed interactive-element interaction**
- `autobot-browser-worker/element-index.js` (new): `collectIndexedElements(page)` walks interactive DOM nodes, assigns stable indices, builds a unique `xpath=` locator each; `resolveElementByIndex` (pure, unit-tested) maps the LLM's `index` → locator server-side before click/fill/select/hover.
- New browser-worker `POST /state` (session-threaded) → {url,title,scroll,elements}; every `/automation` response now carries post-action `page_state`.
- New builtin actions `click_index`/`fill_index`/`select_index`/`hover_index`/`browser_state` in `tool_handler.py` + MCP schemas/endpoints in `browser_mcp.py`. Numbered `[index] role "name"` menu appended to browser tool results (capped via env).
- `snapshot.py`: `index_interactive()`/`to_indexed_text()` for the research-browser subsystem.

**#11538 — vision-in-the-loop**
- `_record_browser_success` extracts `base64_image` from screenshot results; `manager.py::_extract_latest_tool_screenshot()` returns only the single most recent image across the last N (`CHAT_VISION_TOOL_LOOKBACK_MESSAGES`, default 3) history entries.
- Attachment gated on `_model_supports_vision` (`CHAT_VISION_MODEL_PATTERNS`) AND `_image_fits_budget` (ContextWindowManager + `CHAT_VISION_IMAGE_TOKEN_ESTIMATE`), reusing `_build_openai_image_content()`. Non-vision providers keep text-only `prompt`.

## Verification
25 new pytest (10 indexed + 15 vision) + 21 new JS node:test; regression 260/260 chat_workflow, 414/414 (chat_workflow+api+tools+web_pipeline), 344/344 startup imports. flake8 (max-line-length=120) exit 0 on all 9 py files; py_compile + node --check clean.

## Model Used
Opus 4.8

Closes #11537, Closes #11538