### PR TITLE
ci: self-healing disk cleanup on self-hosted smoke-test jobs (#11924)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -29,7 +29,43 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Remove unused toolchains
+    # Self-healing reclaim runs FIRST on the persistent self-hosted runner
+    # (MV-Stealth-VM / "Little-Slave"). Image layers and — critically — the
+    # containerized buildx *builder* cache accumulate across runs and eventually
+    # exhaust the disk, failing the assert below on EVERY PR regardless of
+    # content (GH#11924). Ephemeral GitHub-hosted runners start clean, so this
+    # is skipped there (nothing to reclaim; a prune would be pointless).
+    #
+    # Safe per the no-persistent-data policy (autobot_docker_no_persistent_data):
+    # AutoBot's compose stack keeps no persistent application data, and the
+    # court-transcriber runs on a SEPARATE host/daemon — nothing on this runner's
+    # Docker daemon belongs to it. Every prune is `|| true` so a transient prune
+    # hiccup never fails the job before the real build.
+    - name: Self-healing Docker reclaim (self-hosted)
+      if: runner.environment == 'self-hosted'
+      shell: bash
+      run: |
+        echo "=== Disk before self-hosted reclaim ==="
+        df -h / | grep -v Filesystem
+
+        echo ""
+        echo "=== Pruning Docker (images, containers, networks, volumes, build cache) ==="
+        docker system prune -af --volumes || true
+        # `docker system prune` does NOT reclaim the containerized buildx builder
+        # cache created by docker/setup-buildx-action; it grows unbounded and is
+        # the primary disk hog on the persistent runner — prune it explicitly.
+        docker builder prune -af || true
+        docker buildx prune -af || true
+
+        echo ""
+        echo "=== Disk after self-hosted reclaim ==="
+        df -h / | grep -v Filesystem
+
+    # GitHub-hosted runner images ship large unused toolchains (~45GB). Remove
+    # them so Docker-heavy builds fit. These paths do not exist on the
+    # self-hosted runner, so this step is scoped to github-hosted only.
+    - name: Remove unused toolchains (github-hosted)
+      if: runner.environment == 'github-hosted'
       shell: bash
       run: |
         echo "=== Before cleanup ==="
@@ -52,12 +88,10 @@ runs:
         sudo rm -rf /usr/share/az_*
 
         echo ""
-        echo "=== After cleanup ==="
+        echo "=== After toolchain cleanup ==="
         df -h / | grep -v Filesystem
 
-    - name: Clean Docker system
-      shell: bash
-      run: |
+        echo ""
         echo "=== Cleaning Docker system ==="
         docker system prune -af --volumes || true
         echo ""


### PR DESCRIPTION
## Thinking Path
The required `smoke-test` fails "Insufficient disk space" on all PRs. Root cause: the shared `free-disk-space` composite action ran `docker system prune -af --volumes` but never pruned the containerized **buildx builder cache** (created by `setup-buildx-action`) — `docker system prune` doesn't touch it, so it grows unbounded across runs on the persistent self-hosted runner.

## What Changed
- `.github/actions/free-disk-space/action.yml`: added a self-hosted-guarded reclaim step (FIRST) — `docker system prune -af --volumes` + `docker builder prune -af` + `docker buildx prune -af`, all `|| true`, with `df -h /` before/after. Gated `if: runner.environment == 'self-hosted'`; the pre-existing GitHub-hosted toolchain `rm -rf` block is now correctly gated to `github-hosted`.
- All three smoke jobs (docker-smoke-test/hardened/co-located) funnel through this one action → DRY fix.
- Volume prune scope unchanged from what already ran (no new risk); court-transcriber is a separate daemon (`autobot_docker_no_persistent_data`). builder/buildx prune only reclaims build cache.

Closes #11924

## Verification
- YAML valid. Reclaim step is first + self-hosted-guarded + safe + df-logged.
- **Note:** self-heals from the next run onward. If the disk is currently too full for the runner to even start a job, a one-time manual `docker system prune -af --volumes && docker builder prune -af` on the box may be needed to bootstrap.

## Model Used
Opus 4.8 (subagent: devops-engineer)