### PR TITLE
refactor(ui): promote usePagination + useFormValidation to @autobot/ui (#10885 PR-4)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useFormValidation.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useFormValidation.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { useFormValidation, quickValidate } from '../useFormValidation'
-import type { ValidationRule } from '../useFormValidation'
+import { useFormValidation, quickValidate } from '@autobot/ui'
+import type { ValidationRule } from '@autobot/ui'
 
 describe('useFormValidation composable', () => {
   // ========================================

--- a/autobot-frontend/src/composables/__tests__/usePagination.test.ts
+++ b/autobot-frontend/src/composables/__tests__/usePagination.test.ts
@@ -20,7 +20,7 @@ import {
   usePagination,
   useSimplePagination,
   useShowAllToggle
-} from '../usePagination'
+} from '@autobot/ui'
 
 // ========================================
 // Test Data

--- a/docs/developer/FRONTEND_COMPOSABLES.md
+++ b/docs/developer/FRONTEND_COMPOSABLES.md
@@ -353,7 +353,7 @@ export function useDocumentMetadata(docId: string) {
 For paginated data, use the canonical `usePagination()`:
 
 ```typescript
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 export function useDocumentList() {
   const documents = ref<Document[]>([])
@@ -454,11 +454,11 @@ Each composable has a co-located `.examples.md` with usage patterns and edge cas
 - [useConnectionTester.examples.md](../../autobot-frontend/src/composables/useConnectionTester.examples.md)
 - [useErrorHandler.examples.md](../../autobot-frontend/src/composables/useErrorHandler.examples.md)
 - [useErrorHandler.api-migration.md](../../autobot-frontend/src/composables/useErrorHandler.api-migration.md)
-- [useFormValidation.examples.md](../../autobot-frontend/src/composables/useFormValidation.examples.md)
+- [useFormValidation.examples.md](../../libs/autobot-ui/src/composables/useFormValidation.examples.md)
 - [useKeyboard.examples.md](../../autobot-frontend/src/composables/useKeyboard.examples.md)
 - [useLocalStorage.examples.md](../../autobot-frontend/src/composables/useLocalStorage.examples.md)
 - [useModal.examples.md](../../autobot-frontend/src/composables/useModal.examples.md)
-- [usePagination.examples.md](../../autobot-frontend/src/composables/usePagination.examples.md)
+- [usePagination.examples.md](../../libs/autobot-ui/src/composables/usePagination.examples.md)
 - [useTimeout.examples.md](../../autobot-frontend/src/composables/useTimeout.examples.md)
 - [iconMappings.examples.md](../../autobot-frontend/src/utils/iconMappings.examples.md)
 

--- a/libs/autobot-ui/index.ts
+++ b/libs/autobot-ui/index.ts
@@ -35,3 +35,17 @@ export { useInitialFocus } from './src/composables/useInitialFocus'
 export type { UseInitialFocusReturn } from './src/composables/useInitialFocus'
 
 export { useBodyScrollLock, __resetLockStateForTests } from './src/composables/useBodyScrollLock'
+
+// Data composables — pagination + form-validation primitives promoted from
+// the main app (#10885) so both frontends import them from one canonical
+// home instead of re-deriving them per view.
+export { usePagination, useSimplePagination, useShowAllToggle } from './src/composables/usePagination'
+export type { PaginationOptions, UsePaginationReturn } from './src/composables/usePagination'
+
+export { useFormValidation, quickValidate, validators } from './src/composables/useFormValidation'
+export type {
+  ValidationRule,
+  ValidationRuleConfig,
+  FieldConfig,
+  UseFormValidationReturn,
+} from './src/composables/useFormValidation'

--- a/libs/autobot-ui/src/composables/useFormValidation.examples.md
+++ b/libs/autobot-ui/src/composables/useFormValidation.examples.md
@@ -125,7 +125,7 @@ async function handleLogin() {
 
 ```vue
 <script setup lang="ts">
-import { useFormValidation } from '@/composables/useFormValidation'
+import { useFormValidation } from '@autobot/ui'
 
 const { fields, errors, isValid, validate, touch, reset } = useFormValidation({
   username: {
@@ -283,7 +283,7 @@ const validatePath = async (pathKey: string) => {
 
 ```vue
 <script setup lang="ts">
-import { useFormValidation } from '@/composables/useFormValidation'
+import { useFormValidation } from '@autobot/ui'
 
 const { fields, errors, isValid, validateField, touch } = useFormValidation({
   api_endpoint: {
@@ -448,7 +448,7 @@ async function importFromUrl() {
 
 ```vue
 <script setup lang="ts">
-import { useFormValidation } from '@/composables/useFormValidation'
+import { useFormValidation } from '@autobot/ui'
 
 const {
   fields: textFields,
@@ -589,7 +589,7 @@ const addWorker = async () => {
 
 ```vue
 <script setup lang="ts">
-import { useFormValidation } from '@/composables/useFormValidation'
+import { useFormValidation } from '@autobot/ui'
 
 const { fields, errors, isValid, validate, reset } = useFormValidation({
   name: {
@@ -907,7 +907,7 @@ const { fields, errors } = useFormValidation({
 
 For each form with validation:
 
-- [ ] Import `useFormValidation` from `@/composables/useFormValidation`
+- [ ] Import `useFormValidation` from `@autobot/ui`
 - [ ] Replace reactive validation objects with `useFormValidation` config
 - [ ] Map validation functions to declarative rules
 - [ ] Update template to use `fields.fieldName.value` and `errors.fieldName.value`
@@ -1009,7 +1009,7 @@ clearErrors()
 Full TypeScript support with type-safe field access:
 
 ```typescript
-import type { UseFormValidationReturn, FieldConfig } from '@/composables/useFormValidation'
+import type { UseFormValidationReturn, FieldConfig } from '@autobot/ui'
 
 const config: Record<string, FieldConfig> = {
   username: {

--- a/libs/autobot-ui/src/composables/useFormValidation.ts
+++ b/libs/autobot-ui/src/composables/useFormValidation.ts
@@ -20,7 +20,7 @@
  *
  * Usage:
  * ```typescript
- * import { useFormValidation } from '@/composables/useFormValidation'
+ * import { useFormValidation } from '@autobot/ui'
  *
  * const { fields, errors, isValid, validate, validateField, touch, reset } = useFormValidation({
  *   username: {
@@ -47,7 +47,7 @@
  */
 
 import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
-import { createLogger } from '@/utils/debugUtils'
+import { createLogger } from '../utils/logger'
 
 // Create scoped logger for useFormValidation
 const logger = createLogger('useFormValidation')

--- a/libs/autobot-ui/src/composables/usePagination.examples.md
+++ b/libs/autobot-ui/src/composables/usePagination.examples.md
@@ -19,7 +19,7 @@ Comprehensive migration guide and examples for the `usePagination` composable.
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 interface Document {
   id: string
@@ -166,7 +166,7 @@ watch([searchQuery, filterCategory, filterType], () => {
 ```vue
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 // All pagination logic in one composable
 const {
@@ -260,7 +260,7 @@ const visibleIssues = computed(() => activeIssues.value.slice(0, 3))
 
 ```vue
 <script setup lang="ts">
-import { useSimplePagination } from '@/composables/usePagination'
+import { useSimplePagination } from '@autobot/ui'
 
 const activeIssues = ref([...])
 
@@ -305,7 +305,7 @@ const recentNotifications = computed(() =>
 
 ```vue
 <script setup lang="ts">
-import { useSimplePagination } from '@/composables/usePagination'
+import { useSimplePagination } from '@autobot/ui'
 
 const notifications = ref([...])
 
@@ -364,7 +364,7 @@ const visibleProblems = computed(() =>
 
 ```vue
 <script setup lang="ts">
-import { useShowAllToggle } from '@/composables/usePagination'
+import { useShowAllToggle } from '@autobot/ui'
 
 const showAllProblems = ref(false)
 const problemsReport = ref([...])
@@ -392,7 +392,7 @@ const visibleProblems = useShowAllToggle(
 
 ```vue
 <script setup lang="ts">
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 const problemsReport = ref([...])
 
@@ -438,7 +438,7 @@ const {
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 interface ApiResponse {
   data: Document[]
@@ -526,7 +526,7 @@ await fetchDocuments(1, 20)
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 const items = ref([...])
 
@@ -574,7 +574,7 @@ const handlePageSizeChange = (size: number) => {
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 const items = ref([...])
 const pagination = usePagination(items, { itemsPerPage: 20 })
@@ -650,7 +650,7 @@ watch(() => pagination.currentPage.value, (newPage) => {
 ```vue
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 const items = ref([...])
 const pagination = usePagination(items, { itemsPerPage: 20 })
@@ -727,7 +727,7 @@ const pageNumbers = computed(() => {
 ```vue
 <script setup lang="ts">
 import { ref, shallowRef } from 'vue'
-import { usePagination } from '@/composables/usePagination'
+import { usePagination } from '@autobot/ui'
 
 // Use shallowRef for large arrays to avoid deep reactivity
 const largeDataset = shallowRef<Item[]>([...])

--- a/libs/autobot-ui/src/composables/usePagination.ts
+++ b/libs/autobot-ui/src/composables/usePagination.ts
@@ -18,7 +18,7 @@
  *
  * Usage:
  * ```typescript
- * import { usePagination } from '@/composables/usePagination'
+ * import { usePagination } from '@autobot/ui'
  *
  * const documents = ref([...100 items...])
  *
@@ -45,7 +45,7 @@
  */
 
 import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
-import { createLogger } from '@/utils/debugUtils'
+import { createLogger } from '../utils/logger'
 
 // Create scoped logger for usePagination
 const logger = createLogger('usePagination')

--- a/libs/autobot-ui/src/utils/logger.ts
+++ b/libs/autobot-ui/src/utils/logger.ts
@@ -1,0 +1,49 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @autobot/ui — scoped console logger.
+ *
+ * Self-contained equivalent of the main app's `createLogger` (from
+ * `autobot-frontend/src/utils/debugUtils`). The kit is consumed by BOTH
+ * frontends via a `file:` dependency and must not reach into either app's
+ * `@/` alias, so it carries its own minimal logger for the composables that
+ * emit developer warnings (usePagination, useFormValidation).
+ *
+ * Behavior is byte-for-byte identical to the app helper: each call forwards
+ * a `[timestamp] [LEVEL]` prefix plus the scoped message to the matching
+ * `console.*` method.
+ */
+
+/** Log levels for console output. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/**
+ * Enhanced console logging with timestamp and level prefix. Supports
+ * variadic args so callers can use printf-style placeholders or pass
+ * multiple values.
+ */
+export function log(level: LogLevel, message: string, ...args: unknown[]): void {
+  const timestamp = new Date().toISOString()
+  const prefix = `[${timestamp}] [${level.toUpperCase()}]`
+  const consoleFn = level === 'debug' ? console.debug
+    : level === 'info' ? console.info
+    : level === 'warn' ? console.warn
+    : console.error
+
+  consoleFn(prefix, message, ...args)
+}
+
+/**
+ * Create a scoped logger with an automatic `[scope]` prefix.
+ *
+ * @param scope - Scope name (e.g. 'usePagination')
+ * @returns Scoped logging functions
+ */
+export function createLogger(scope: string) {
+  return {
+    debug: (message: string, ...args: unknown[]) => log('debug', `[${scope}] ${message}`, ...args),
+    info: (message: string, ...args: unknown[]) => log('info', `[${scope}] ${message}`, ...args),
+    warn: (message: string, ...args: unknown[]) => log('warn', `[${scope}] ${message}`, ...args),
+    error: (message: string, ...args: unknown[]) => log('error', `[${scope}] ${message}`, ...args),
+  }
+}


### PR DESCRIPTION
## Thinking Path
PR-4 of the @autobot/ui consolidation. Owner-approved promoting these two composables to the kit as their canonical home even without current view consumers (future views + the SLM adoption will import from `@autobot/ui`).

## What Changed
- Moved `usePagination.ts` + `useFormValidation.ts` (+ their examples.md) into `libs/autobot-ui/src/composables/` (matches the dialog-a11y precedent from #11961). Tests repointed to `@autobot/ui`.
- Exported from `libs/autobot-ui/index.ts` (usePagination/useSimplePagination/useShowAllToggle + useFormValidation/quickValidate/validators + types).
- Added `libs/autobot-ui/src/utils/logger.ts` — byte-equivalent `createLogger` (the composables used the app-only `@/utils/debugUtils` alias which can't resolve in the standalone kit). Behavior unchanged.
- Removed app-local originals (relocated, not deleted-as-dead); grep-proof 0 stale code refs.

Part of #10885 (closes with PR-6 + PR-7).

## Verification (CI down — local gate)
- `vue-tsc --noEmit -p tsconfig.app.json` exit 0 (kit composables pulled into app type program, confirmed via --listFilesOnly).
- `vitest run` relocated tests: 120 passed (48 pagination + 72 form-validation).

## Model Used
Opus 4.8 (subagent: frontend-engineer)