### PR TITLE
tokenise(user): ThemePresetPicker chrome hardcoded values → design tokens (#11965)

### DIFF
--- a/autobot-frontend/src/components/settings/ThemePresetPicker.vue
+++ b/autobot-frontend/src/components/settings/ThemePresetPicker.vue
@@ -286,7 +286,7 @@ function getThemeIcon(themeOption: Theme): IconName {
 
 .preset-preview {
   display: flex;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   height: 48px;
   border-radius: var(--radius-sm);
   overflow: hidden;


### PR DESCRIPTION
Closes #11965
Part of #11515 (Task 4.3/4.4)

## Thinking Path

Theme-preset picker: the 32 hexes are preset SWATCH/preview DATA (the theme/accent colors the user chooses between — auto/catppuccin/solarized/high-contrast/brand/… previews + 8 accent swatches). Tokenising them would corrupt the picker's meaning. Only ONE value was legit chrome.

## What Changed

- `.preset-preview` `gap: 2px` → `var(--spacing-0-5)` (0.125rem = 2px exact; matches the 23-file repo convention).
- 32 preset-swatch/accent hexes correctly LEFT as data. px chrome (1px borders, sr-only clip, outlines, 32/48px swatch dims, grid tracks) left literal per established convention.

## Verification

- Single-line diff, byte-exact computed value. Style-only. stylelint's color-no-hex report on the swatch DATA is the documented legitimate exception (report-only / non-blocking).

## Model Used

Claude Fable 5 (subagent: general-purpose)