### PR TITLE
tokenise(user): KnowledgeGraph <style> hardcoded values → design tokens (#11966)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -1254,16 +1254,16 @@ watch(layoutMode, () => {
 }
 
 .action-btn.view-mode-btn {
-  border-color: var(--chart-purple, #8b5cf6);
-  color: var(--chart-purple, #8b5cf6);
+  border-color: var(--chart-purple);
+  color: var(--chart-purple);
 }
 
 .action-btn.view-mode-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--chart-purple, #8b5cf6) 15%, transparent);
+  background: color-mix(in srgb, var(--chart-purple) 15%, transparent);
 }
 
 .action-btn.view-mode-btn.active {
-  background: var(--chart-purple, #8b5cf6);
+  background: var(--chart-purple);
   color: white;
 }
 
@@ -1466,8 +1466,8 @@ watch(layoutMode, () => {
 }
 
 .empty-icon {
-  width: 80px;
-  height: 80px;
+  width: var(--spacing-20);
+  height: var(--spacing-20);
   border-radius: 50%;
   background: var(--color-primary-bg);
   display: flex;
@@ -1534,8 +1534,8 @@ watch(layoutMode, () => {
 }
 
 .loading-spinner {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border: 3px solid var(--border-default, var(--border-subtle));
   border-top-color: var(--color-primary);
   border-radius: 50%;
@@ -1546,10 +1546,10 @@ watch(layoutMode, () => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  background: var(--color-error-bg, rgba(239, 68, 68, 0.12));
-  color: var(--color-error, #ef4444);
+  width: var(--spacing-10);
+  height: var(--spacing-10);
+  background: var(--color-error-bg);
+  color: var(--color-error);
   border-radius: 50%;
   font-weight: bold;
   font-size: var(--text-xl);
@@ -1581,8 +1581,8 @@ watch(layoutMode, () => {
 }
 
 .zoom-controls button {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border: 1px solid var(--border-default);
   background: var(--bg-input);
   border-radius: var(--radius-sm);
@@ -1602,7 +1602,7 @@ watch(layoutMode, () => {
 .zoom-level {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  min-width: 40px;
+  min-width: var(--spacing-10);
   text-align: center;
 }
 
@@ -1640,8 +1640,8 @@ watch(layoutMode, () => {
 }
 
 .entity-icon {
-  width: 28px;
-  height: 28px;
+  width: var(--spacing-7);
+  height: var(--spacing-7);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -1921,8 +1921,8 @@ watch(layoutMode, () => {
 }
 
 .legend-color {
-  width: 12px;
-  height: 12px;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
   border-radius: 50%;
 }
 


### PR DESCRIPTION
Closes #11966
Part of #11515 (Task 4.4)

## Thinking Path

Viz component: ~20 data-viz hexes live in `<script>` (Cytoscape `getNodeColor`/`getCytoscapeStyles` fallbacks + node-selected border) — correctly untouched. Only `<style>` chrome migrated: dead color fallbacks dropped + px→spacing tokens.

## What Changed

- Color fallbacks dropped (token defined & wins): `var(--chart-purple, #8b5cf6)`×4, `var(--color-error, #ef4444)`, `var(--color-error-bg, rgba(...))` (the rgba fallback was even stale — alpha 0.12 vs token 0.1, never rendered).
- 13 px → `--spacing-*` (80/32/40/28/12px, exact at 16px root, dimensions only). 36 px left literal (border widths, off-scale dims, media query).
- Script/template untouched (verified: main tree clean, style-only diff).

## Verification

- Dropped fallbacks all on :root-defined tokens (render no-op). `color-no-hex` on `<style>`: 0. `vue-tsc`: 0 new errors (44 pre-existing @autobot/ui module-resolution baseline, none in this file).

## Model Used

Claude Fable 5 (subagent: general-purpose)