### PR TITLE
tokenise(user): InteractiveScreenshot hardcoded values → design tokens (#11967)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -737,7 +737,7 @@
    * INTERACTIVE SCREENSHOT TOKENS
    * Issue #11967 (umbrella #11515). Scoped to browser/InteractiveScreenshot.vue.
    * The region-marking popup (#5136) renders a dark-slate palette; each hue
-   * matches a --bg-*/--text-*/--border-* base value, but those semantic tokens
+   * matches a --bg, --text or --border base value, but those semantic tokens
    * carry OKLCH overrides that would shift the rendered pixels, so they are
    * captured here as hex-only (deliberately NO OKLCH override) so the popup
    * renders pixel-identical to its previous hardcoded values across all

--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -732,6 +732,27 @@
   --costdash-mode-dollars-text: #1d4ed8;  /* "dollars" budget-mode badge text */
   --costdash-mode-tokens-bg: #fef3c7;     /* "tokens" budget-mode badge fill */
   --costdash-mode-tokens-text: #92400e;   /* "tokens" budget-mode badge text */
+
+  /* ============================================
+   * INTERACTIVE SCREENSHOT TOKENS
+   * Issue #11967 (umbrella #11515). Scoped to browser/InteractiveScreenshot.vue.
+   * The region-marking popup (#5136) renders a dark-slate palette; each hue
+   * matches a --bg-*/--text-*/--border-* base value, but those semantic tokens
+   * carry OKLCH overrides that would shift the rendered pixels, so they are
+   * captured here as hex-only (deliberately NO OKLCH override) so the popup
+   * renders pixel-identical to its previous hardcoded values across all
+   * browsers. --intscreenshot-input-bg is the literal fallback the type-input
+   * rendered because --color-bg is never defined in any theme; preserved behind
+   * that intended token name.
+   * ============================================ */
+  --intscreenshot-input-bg: #121212;           /* type-input fill (undefined --color-bg fallback) */
+  --intscreenshot-popup-bg: #1e293b;           /* region popup surface */
+  --intscreenshot-popup-border: #334155;       /* region popup border */
+  --intscreenshot-popup-muted-text: #94a3b8;   /* popup selector + cancel-button text */
+  --intscreenshot-popup-input-bg: #0f172a;     /* popup input fill */
+  --intscreenshot-popup-input-border: #475569; /* popup input + cancel-button border */
+  --intscreenshot-popup-input-text: #e2e8f0;   /* popup input text */
+  --intscreenshot-popup-save-bg: #3b82f6;      /* popup save-button fill */
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -269,10 +269,10 @@ function submitType() {
 }
 
 .loading-spinner {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border: 3px solid rgba(255, 255, 255, 0.3);
-  border-top-color: var(--color-primary, #3b82f6);
+  border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -286,7 +286,7 @@ function submitType() {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted, #9ca3af);
+  color: var(--text-muted);
   font-size: var(--text-sm);
 }
 
@@ -294,8 +294,8 @@ function submitType() {
   display: flex;
   gap: var(--spacing-1);
   padding: var(--spacing-1) var(--spacing-2);
-  background: var(--bg-surface, #1e1e2e);
-  border-top: 1px solid var(--border-default, #333);
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-default);
 }
 
 .toolbar-btn {
@@ -307,7 +307,7 @@ function submitType() {
   border: none;
   border-radius: var(--radius-default);
   background: transparent;
-  color: var(--text-secondary, #a1a1aa);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: var(--text-xs);
   transition: background var(--duration-150), color var(--duration-150);
@@ -315,7 +315,7 @@ function submitType() {
 
 .toolbar-btn:hover:not(:disabled) {
   background: var(--color-hover, rgba(255, 255, 255, 0.1));
-  color: var(--text-primary, #e4e4e7);
+  color: var(--text-primary);
 }
 
 .toolbar-btn:disabled {
@@ -327,23 +327,23 @@ function submitType() {
   display: flex;
   gap: var(--spacing-1);
   padding: var(--spacing-1) var(--spacing-2);
-  background: var(--bg-surface, #1e1e2e);
-  border-top: 1px solid var(--border-default, #333);
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-default);
 }
 
 .type-input {
   flex: 1;
   padding: var(--spacing-1) var(--spacing-2);
-  border: 1px solid var(--border-default, #333);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-default);
-  background: var(--color-bg, #121212);
-  color: var(--text-primary, #e4e4e7);
+  background: var(--color-bg, var(--intscreenshot-input-bg));
+  color: var(--text-primary);
   font-size: 0.8rem;
   outline: none;
 }
 
 .type-input:focus {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 .type-input:focus-visible {
   outline: 2px solid var(--color-primary);
@@ -358,7 +358,7 @@ function submitType() {
   height: 28px;
   border: none;
   border-radius: var(--radius-default);
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
   cursor: pointer;
   font-size: var(--text-xs);
@@ -377,18 +377,18 @@ function submitType() {
 }
 
 .region-popup {
-  background: #1e293b;
-  border: 1px solid #334155;
-  border-radius: 6px;
-  padding: 8px;
+  background: var(--intscreenshot-popup-bg);
+  border: 1px solid var(--intscreenshot-popup-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-2);
   min-width: 200px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .region-popup-selector {
   font-size: 0.7rem;
-  color: #94a3b8;
-  margin-bottom: 6px;
+  color: var(--intscreenshot-popup-muted-text);
+  margin-bottom: var(--spacing-1-5);
   font-family: monospace;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -397,34 +397,34 @@ function submitType() {
 
 .region-popup-input {
   width: 100%;
-  background: #0f172a;
-  border: 1px solid #475569;
-  border-radius: 4px;
-  padding: 4px 6px;
-  color: #e2e8f0;
+  background: var(--intscreenshot-popup-input-bg);
+  border: 1px solid var(--intscreenshot-popup-input-border);
+  border-radius: var(--radius-default);
+  padding: var(--spacing-1) var(--spacing-1-5);
+  color: var(--intscreenshot-popup-input-text);
   font-size: 0.8rem;
-  margin-bottom: 6px;
+  margin-bottom: var(--spacing-1-5);
   box-sizing: border-box;
 }
 
 .region-popup-save,
 .region-popup-cancel {
   font-size: 0.75rem;
-  padding: 3px 8px;
-  border-radius: 4px;
+  padding: 3px var(--spacing-2);
+  border-radius: var(--radius-default);
   cursor: pointer;
 }
 
 .region-popup-save {
-  background: #3b82f6;
+  background: var(--intscreenshot-popup-save-bg);
   color: white;
   border: none;
-  margin-right: 4px;
+  margin-right: var(--spacing-1);
 }
 
 .region-popup-cancel {
   background: transparent;
-  color: #94a3b8;
-  border: 1px solid #475569;
+  color: var(--intscreenshot-popup-muted-text);
+  border: 1px solid var(--intscreenshot-popup-input-border);
 }
 </style>


### PR DESCRIPTION
Closes #11967
Part of #11515 (Task 4.3/4.4)

## Thinking Path

Dead `var(--token,#hex)` fallbacks dropped; the undefined `--color-bg` fallback preserved (nested behind a scoped token — its `#121212` was the rendered value); region-marker popup colors → 8 scoped hex-only `--intscreenshot-*` tokens (each hue's semantic base carries an OKLCH override that would drift, so captured hex-only). px → exact rem-equivalent tokens.

## What Changed

- ~12 dead hex fallbacks dropped; `var(--color-bg,#121212)` → `var(--color-bg, var(--intscreenshot-input-bg))`; 8 new `--intscreenshot-*` hex-only tokens (region-mark popup). 11 px → `--spacing-*`/`--radius-*` (exact at 16px root).
- Left literal: rgba overlays/highlights (functional), 1px/2px/3px borders, off-scale dims, `color: white`.

## Verification

- Dropped fallbacks all on defined tokens (render no-op); scoped tokens hex-only → byte-exact; no Tailwind-palette override. `color-no-hex` on `<style>`: 0. vue-tsc: 0 new errors. Style-only.

## Model Used

Claude Fable 5 (subagent: general-purpose)