### PR TITLE
fix(slm): self/manager node reports online while control plane is up (#11963)

### DIFF
--- a/autobot-slm-backend/services/compose_fleet.py
+++ b/autobot-slm-backend/services/compose_fleet.py
@@ -151,6 +151,19 @@ def _compose_nodes_enabled() -> bool:
     return os.getenv("SLM_COMPOSE_NODES", "false").strip().lower() in ("1", "true", "yes")
 
 
+def is_manager_node(node_id: str) -> bool:
+    """True when node_id is the SLM's own (manager/self) node (#11963).
+
+    The manager node's status is derived solely from
+    ``_heartbeat_self_managed_nodes`` — real-time psutil metrics of this very
+    process — so the reconciler's ICMP-ping reachability fallback in
+    ``_check_node_health`` (designed for externally-agent-heartbeating VM
+    nodes) must never override it. Ping is an unreliable/redundant signal for
+    a node that is, by definition, up while it is serving the health check.
+    """
+    return node_id == settings.slm_node_id
+
+
 async def _probe_tcp(host: str, port: int, timeout: float = 2.0) -> bool:
     """Return True if a TCP connection to host:port succeeds within timeout."""
     try:

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -180,9 +180,17 @@ class ReconcilerService:
         await self._broadcast_node_status(node.node_id, NodeStatus.OFFLINE.value, node.hostname)
 
     async def _check_node_health(self) -> None:
-        """Check node health based on heartbeats and network reachability."""
+        """Check node health based on heartbeats and network reachability.
+
+        Issue #11963: the manager/self node is excluded from the ping-based
+        demotion below — it is heartbeated locally (compose_fleet.py) from
+        real-time metrics of this very process, so ICMP reachability (which
+        can be blocked/unreliable and races the self-heartbeat loop) must
+        never mark it degraded/offline.
+        """
         from sqlalchemy import or_
 
+        from services.compose_fleet import is_manager_node
         from services.database import db_service
 
         async with db_service.session() as db:
@@ -210,6 +218,9 @@ class ReconcilerService:
             stale_nodes = result.scalars().all()
 
             for node in stale_nodes:
+                if is_manager_node(node.node_id):
+                    continue
+
                 is_reachable = await self._ping_host(node.ip_address)
                 old_status = node.status
 

--- a/autobot-slm-backend/services/reconciler_check_node_health_test.py
+++ b/autobot-slm-backend/services/reconciler_check_node_health_test.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for ReconcilerService._check_node_health() (#11963).
+
+Verifies the reconciler's ICMP-ping-based offline/degraded demotion never
+overrides the manager/self node's status -- it is heartbeated locally from
+real-time metrics of this very process (services/compose_fleet.py) -- while a
+genuinely stale + unreachable remote node is still correctly demoted.
+"""
+
+import importlib.util
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap (mirrors main_ensure_local_node_test.py's #11798 fix)
+# ---------------------------------------------------------------------------
+_SLM_ROOT = Path(__file__).parent.parent
+if str(_SLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SLM_ROOT))
+
+_MANAGER_NODE_ID = "00-SLM-Manager"
+_REMOTE_NODE_ID = "01-Backend"
+
+# ---------------------------------------------------------------------------
+# Persistent stubs for reconciler.py's LAZY (function-body) imports.
+# ``_check_node_health`` imports ``services.compose_fleet`` and
+# ``services.database`` at call time, not at module-load time, so a
+# ``patch.dict`` scoped to ``_load_module()``'s ``exec_module`` call would be
+# reverted before the function under test ever runs. Register real, persistent
+# stand-ins instead (mirrors the root conftest's ``_stub()`` pattern).
+# ---------------------------------------------------------------------------
+for _lazy_mod in ("services.compose_fleet", "services.database"):
+    if _lazy_mod not in sys.modules:
+        sys.modules[_lazy_mod] = MagicMock(unsafe=True, name=_lazy_mod)
+
+
+def _fake_node(node_id: str, status: str, ip: str = "10.0.0.5") -> SimpleNamespace:
+    """Minimal stand-in for a Node row: attribute access only, no DB behavior."""
+    return SimpleNamespace(node_id=node_id, status=status, ip_address=ip)
+
+
+class _AlwaysComparableColumn:
+    """Stand-in for ``Node.last_heartbeat`` (a mocked SQLAlchemy Column).
+
+    Only the operators ``_check_node_health`` builds its query with need to
+    resolve without raising; the resulting (fake) expression is never
+    evaluated -- ``db.execute`` is mocked to return canned rows directly.
+    """
+
+    def __lt__(self, other):
+        return True
+
+    def is_(self, other):
+        return True
+
+
+_MODULE_CACHE: dict = {}
+
+
+def _load_module():
+    """Load services/reconciler.py with its heavy module-level imports stubbed.
+
+    Follows the isolated-load pattern established in
+    main_ensure_local_node_test.py (#11798) so the real function body under
+    test runs unmodified, without pulling in sqlalchemy/models/config.
+    """
+    if "isolated_reconciler" in _MODULE_CACHE:
+        return _MODULE_CACHE["isolated_reconciler"]
+
+    stubs = {
+        "sqlalchemy": MagicMock(),
+        "sqlalchemy.ext": MagicMock(),
+        "sqlalchemy.ext.asyncio": MagicMock(),
+        "config": MagicMock(),
+        "models.database": MagicMock(),
+        "services.service_categorizer": MagicMock(),
+        "services.service_extra_data": MagicMock(),
+    }
+    stubs["config"].settings = SimpleNamespace(heartbeat_interval=30, unhealthy_threshold=3)
+    stubs["models.database"].NodeStatus = SimpleNamespace(
+        ONLINE=SimpleNamespace(value="online"),
+        DEGRADED=SimpleNamespace(value="degraded"),
+        OFFLINE=SimpleNamespace(value="offline"),
+        ERROR=SimpleNamespace(value="error"),
+    )
+    # ``Node.last_heartbeat < cutoff`` is a real Python comparison at query-build
+    # time (SQLAlchemy's Column overloads ``__lt__``); a bare MagicMock's default
+    # comparison returns NotImplemented -> TypeError, so give it a stand-in that
+    # tolerates the operators the query actually uses.
+    stubs["models.database"].Node.last_heartbeat = _AlwaysComparableColumn()
+
+    with patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location("isolated_reconciler", _SLM_ROOT / "services" / "reconciler.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+    _MODULE_CACHE["isolated_reconciler"] = mod
+    return mod
+
+
+class TestCheckNodeHealthManagerExclusion:
+    """ReconcilerService._check_node_health() manager-node exclusion (#11963)."""
+
+    def setup_method(self):
+        self._mod = _load_module()
+
+    def _make_service(self, nodes, is_manager_side_effect):
+        """Build a ReconcilerService instance wired to a fake DB session."""
+        service = self._mod.ReconcilerService()
+        service._ping_host = AsyncMock(return_value=False)  # unreachable
+        service._handle_offline_node = AsyncMock()
+        service._handle_degraded_node = AsyncMock()
+
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None  # no timeout override
+        execute_result.scalars.return_value.all.return_value = nodes
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=execute_result)
+        db.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def _session():
+            yield db
+
+        mock_db_service = MagicMock()
+        mock_db_service.session = _session
+
+        compose_fleet_stub = sys.modules["services.compose_fleet"]
+        compose_fleet_stub.is_manager_node = MagicMock(side_effect=is_manager_side_effect)
+
+        return service, mock_db_service
+
+    @pytest.mark.asyncio
+    async def test_manager_node_skipped_even_when_unreachable_and_stale(self):
+        """The manager/self node is never pinged or demoted (#11963)."""
+        node = _fake_node(_MANAGER_NODE_ID, "online")
+        service, mock_db_service = self._make_service(
+            [node], is_manager_side_effect=lambda nid: nid == _MANAGER_NODE_ID
+        )
+
+        with patch.object(sys.modules["services.database"], "db_service", mock_db_service):
+            await service._check_node_health()
+
+        service._ping_host.assert_not_called()
+        service._handle_offline_node.assert_not_called()
+        service._handle_degraded_node.assert_not_called()
+        assert node.status == "online"
+
+    @pytest.mark.asyncio
+    async def test_genuinely_stale_remote_node_still_marked_offline(self):
+        """A real remote node that is stale + unreachable is still demoted (#11963)."""
+        node = _fake_node(_REMOTE_NODE_ID, "online")
+        service, mock_db_service = self._make_service(
+            [node], is_manager_side_effect=lambda nid: nid == _MANAGER_NODE_ID
+        )
+
+        with patch.object(sys.modules["services.database"], "db_service", mock_db_service):
+            await service._check_node_health()
+
+        service._ping_host.assert_awaited_once_with(node.ip_address)
+        service._handle_offline_node.assert_awaited_once()
+        service._handle_degraded_node.assert_not_called()


### PR DESCRIPTION
## Thinking Path
A node showed "Offline" while serving the SLM frontend from that same node. `NodeCard` faithfully renders backend `node.status`, so the fault was backend node-status determination.

## Root Cause
`services/reconciler.py:212` `_check_node_health` applies an ICMP-`ping` reachability fallback to EVERY node with stale/NULL `last_heartbeat` — including the SLM **manager/self** node, which is authoritatively heartbeated by a separate local loop (`compose_fleet.py _heartbeat_self_managed_nodes`). On backend cold-start there's a window where the manager's `last_heartbeat` is NULL (row created without it), and the reconciler's ping loop wins the race and demotes the manager via ICMP (unreliable/blocked in many envs) → flapping "Offline" until the next self-heartbeat tick.

## What Changed
- Added `is_manager_node()` to `compose_fleet.py` (`node_id == settings.slm_node_id`).
- `_check_node_health` now skips the manager node before ping-demotion — its status derives solely from its own heartbeat. Real remote nodes still get ping-based degraded/offline detection unchanged.
- Added `reconciler_check_node_health_test.py` (these modules had ZERO prior coverage): manager stays online despite stale/unreachable; genuinely-stale remote still goes offline. Verified meaningful (revert → test 1 fails).

Closes #11963

## Verification (CI down — local gate)
- New test 2 passed. Full `autobot-slm-backend` suite: **1232 passed, 3 skipped, 0 failed**. py_compile + black clean.

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)