### PR TITLE
fix(slm): reconcile node update-availability badge with live check (#11964)

### DIFF
--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -2497,15 +2497,23 @@ async def get_node_updates(
     db: Annotated[AsyncSession, Depends(get_db)],
     _: Annotated[dict, Depends(get_current_user)],
 ):
-    """Get available updates for a node."""
+    """Get available updates for a node.
+
+    Includes code_update_available/code_status (#11964) computed via the
+    SAME is_code_update_available() helper the fleet update-summary badge
+    uses, so this live "Check for updates" scan can never disagree with
+    the badge shown on the node card.
+    """
     from sqlalchemy import or_
 
+    from api.updates import is_code_update_available
     from models.database import UpdateInfo
     from models.schemas import UpdateCheckResponse, UpdateInfoResponse
 
     # Verify node exists
     node_result = await db.execute(select(Node).where(Node.node_id == node_id))
-    if not node_result.scalar_one_or_none():
+    node = node_result.scalar_one_or_none()
+    if not node:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Node not found",
@@ -2525,6 +2533,8 @@ async def get_node_updates(
     return UpdateCheckResponse(
         updates=[UpdateInfoResponse.model_validate(u) for u in updates],
         total=len(updates),
+        code_update_available=is_code_update_available(node),
+        code_status=node.code_status or "unknown",
     )
 
 

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
 from models.database import (
+    CodeStatus,
     EventSeverity,
     EventType,
     Node,
@@ -754,6 +755,18 @@ async def check_updates(
     )
 
 
+def is_code_update_available(node: Node) -> bool:
+    """Canonical check for whether a node has a pending code update.
+
+    Single source of truth for "code update available" (#11964): consumed by
+    both the fleet update-summary badge (get_fleet_update_summary below) and
+    the live per-node "Check for updates" scan (nodes.get_node_updates), so
+    the two can never disagree — they read the exact same node.code_status
+    field via the same helper.
+    """
+    return (node.code_status or "") == CodeStatus.OUTDATED.value
+
+
 def _build_node_summaries(nodes: list, updates_by_node: dict, global_count: int) -> list:
     """Build per-node update summaries.
 
@@ -763,7 +776,7 @@ def _build_node_summaries(nodes: list, updates_by_node: dict, global_count: int)
     for node in nodes:
         sys_count = len(updates_by_node.get(node.node_id, []))
         sys_count += global_count
-        code_outdated = (node.code_status or "") == "outdated"
+        code_outdated = is_code_update_available(node)
         total = sys_count + (1 if code_outdated else 0)
         summaries.append(
             NodeUpdateSummary(

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -561,10 +561,18 @@ class UpdateInfoResponse(BaseModel):
 
 
 class UpdateCheckResponse(BaseModel):
-    """Update check response."""
+    """Update check response.
+
+    code_update_available/code_status (#11964) surface the SAME
+    node.code_status field the fleet update-summary badge reads
+    (NodeUpdateSummary below), so the live per-node check and the
+    badge can never disagree.
+    """
 
     updates: List[UpdateInfoResponse]
     total: int
+    code_update_available: bool = False
+    code_status: str = "unknown"
 
 
 class UpdateApplyRequest(BaseModel):

--- a/autobot-slm-backend/tests/api/test_node_update_availability_11964.py
+++ b/autobot-slm-backend/tests/api/test_node_update_availability_11964.py
@@ -1,0 +1,216 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the node-card badge / live-check reconciliation (#11964).
+
+Root cause: the fleet update-summary badge (`NodeCard.vue`) read
+`node.code_status` via `_build_node_summaries()`, while the live
+"Check for updates" scan (`NodeLifecyclePanel.vue` -> GET
+`/nodes/{node_id}/updates`) only queried the `UpdateInfo` system-package
+table and never looked at code status at all -- so a node flagged
+"code update available" by the badge would always report "no updates"
+from the live scan, regardless of its real code_status.
+
+Fix: both paths now compute code-update-availability via the single
+`is_code_update_available()` helper in `api/updates.py`, and the live
+per-node response carries `code_update_available`/`code_status` so the
+frontend can reconcile the cached badge with the fresh scan.
+"""
+
+from __future__ import annotations
+
+import ast
+import enum
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# CodeStatus real stand-in (#11964)
+#
+# conftest.py globally stubs models.database as a MagicMock so FastAPI route
+# registration in api/* modules doesn't hit config.Settings()/real DB
+# metadata. is_code_update_available() does a real string comparison against
+# CodeStatus.OUTDATED.value, so that one name must be a REAL enum with the
+# production values (models/database.py CodeStatus, Issue #741) rather than
+# an auto-generated MagicMock attribute -- otherwise every comparison would
+# silently pass/fail by mock identity instead of the actual string contract.
+# ---------------------------------------------------------------------------
+class CodeStatus(str, enum.Enum):
+    UP_TO_DATE = "up_to_date"
+    OUTDATED = "outdated"
+    CODE_CURRENT_SERVICE_FAILED = "code_current_service_failed"
+    UNKNOWN = "unknown"
+
+
+_database_stub = sys.modules.get("models.database")
+if isinstance(_database_stub, MagicMock):
+    _database_stub.CodeStatus = CodeStatus
+
+
+# ---------------------------------------------------------------------------
+# models.schemas stand-ins, derived from api/updates.py's own import block
+# (not hand-listed -- a static list rots the moment a new schema is added,
+# see tests/api/test_collect_outdated_node_ids.py for the same precedent).
+# Every name is a plain `dict` (a valid FastAPI response/body type) EXCEPT
+# NodeUpdateSummary, which _build_node_summaries() actually instantiates and
+# reads attributes off of -- it needs a real attribute-bearing stand-in
+# mirroring models/schemas.py's NodeUpdateSummary fields exactly.
+# ---------------------------------------------------------------------------
+
+
+class _NodeUpdateSummaryStub:
+    def __init__(
+        self,
+        node_id: str,
+        hostname: str,
+        system_updates: int = 0,
+        code_update_available: bool = False,
+        code_status: str = "unknown",
+        total_updates: int = 0,
+    ) -> None:
+        self.node_id = node_id
+        self.hostname = hostname
+        self.system_updates = system_updates
+        self.code_update_available = code_update_available
+        self.code_status = code_status
+        self.total_updates = total_updates
+
+
+def _stub_updates_schemas() -> None:
+    schemas_stub = sys.modules.get("models.schemas")
+    if not isinstance(schemas_stub, MagicMock):
+        return  # real models.schemas module — nothing to do
+
+    updates_src = (_BACKEND_ROOT / "api" / "updates.py").read_text(encoding="utf-8")
+    schema_names = {
+        alias.name
+        for node in ast.walk(ast.parse(updates_src))
+        if isinstance(node, ast.ImportFrom) and node.module == "models.schemas"
+        for alias in node.names
+    }
+    for name in schema_names:
+        setattr(schemas_stub, name, dict)
+    schemas_stub.NodeUpdateSummary = _NodeUpdateSummaryStub
+
+
+_stub_updates_schemas()
+
+
+def _load_updates_module():
+    """Load api/updates.py directly, bypassing api/__init__.py (#11964).
+
+    api/__init__.py eagerly imports every router, pulling in service modules
+    that need real settings/secrets unavailable in a sandboxed test run.
+    services.* are stubbed here; models.database/models.schemas are patched
+    above just enough for FastAPI route registration + the functions under
+    test.
+    """
+    for mod_name in ("services", "services.auth", "services.database", "services.playbook_executor"):
+        sys.modules.setdefault(mod_name, MagicMock(unsafe=True))
+
+    updates_py = _BACKEND_ROOT / "api" / "updates.py"
+    spec = importlib.util.spec_from_file_location("_updates_11964_test", updates_py)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_updates = _load_updates_module()
+is_code_update_available = _updates.is_code_update_available
+_build_node_summaries = _updates._build_node_summaries
+
+
+def _fake_node(node_id: str = "node-1", hostname: str = "host-1", code_status: str | None = None):
+    return SimpleNamespace(node_id=node_id, hostname=hostname, code_status=code_status)
+
+
+# ---------------------------------------------------------------------------
+# is_code_update_available -- the single canonical source (#11964)
+# ---------------------------------------------------------------------------
+
+
+def test_is_code_update_available_true_when_outdated():
+    node = _fake_node(code_status=CodeStatus.OUTDATED.value)
+    assert is_code_update_available(node) is True
+
+
+def test_is_code_update_available_false_when_up_to_date():
+    node = _fake_node(code_status=CodeStatus.UP_TO_DATE.value)
+    assert is_code_update_available(node) is False
+
+
+def test_is_code_update_available_false_when_unknown():
+    node = _fake_node(code_status=CodeStatus.UNKNOWN.value)
+    assert is_code_update_available(node) is False
+
+
+def test_is_code_update_available_false_when_none():
+    node = _fake_node(code_status=None)
+    assert is_code_update_available(node) is False
+
+
+def test_is_code_update_available_false_when_service_failed():
+    """CODE_CURRENT_SERVICE_FAILED means code IS current -- not a code update."""
+    node = _fake_node(code_status=CodeStatus.CODE_CURRENT_SERVICE_FAILED.value)
+    assert is_code_update_available(node) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_node_summaries (fleet-summary badge) agrees with the live-check
+# helper for the SAME node -- reconciliation proof for #11964.
+# ---------------------------------------------------------------------------
+
+
+def test_badge_and_live_check_agree_when_outdated():
+    """The badge's code_update_available and the live-check's
+    is_code_update_available() must return the same answer for a node whose
+    code_status is genuinely outdated (#11964 acceptance criterion)."""
+    node = _fake_node(node_id="node-x", code_status=CodeStatus.OUTDATED.value)
+
+    summaries = _build_node_summaries([node], updates_by_node={}, global_count=0)
+    badge_says_available = summaries[0].code_update_available
+
+    live_check_says_available = is_code_update_available(node)
+
+    assert badge_says_available is True
+    assert live_check_says_available is True
+    assert badge_says_available == live_check_says_available
+
+
+def test_badge_and_live_check_agree_when_up_to_date():
+    """No false-positive badge (#11964): when code_status is up_to_date,
+    both the badge summary and the live-check helper report no code update --
+    this is the exact bug scenario (badge true / scan false) inverted to
+    prove they now can't disagree."""
+    node = _fake_node(node_id="node-y", code_status=CodeStatus.UP_TO_DATE.value)
+
+    summaries = _build_node_summaries([node], updates_by_node={}, global_count=0)
+    badge_says_available = summaries[0].code_update_available
+
+    live_check_says_available = is_code_update_available(node)
+
+    assert badge_says_available is False
+    assert live_check_says_available is False
+    assert badge_says_available == live_check_says_available
+
+
+def test_badge_clears_after_code_status_transitions_to_up_to_date():
+    """After a code-sync/update completes and heartbeat flips code_status to
+    up_to_date, re-running the fleet-summary build (the badge's data source)
+    must clear code_update_available -- it cannot linger stale (#11964)."""
+    node = _fake_node(node_id="node-z", code_status=CodeStatus.OUTDATED.value)
+    before = _build_node_summaries([node], updates_by_node={}, global_count=0)
+    assert before[0].code_update_available is True
+
+    # Simulate the heartbeat-driven transition once the update lands.
+    node.code_status = CodeStatus.UP_TO_DATE.value
+    after = _build_node_summaries([node], updates_by_node={}, global_count=0)
+    assert after[0].code_update_available is False

--- a/autobot-slm-frontend/src/components/fleet/NodeLifecyclePanel.vue
+++ b/autobot-slm-frontend/src/components/fleet/NodeLifecyclePanel.vue
@@ -16,6 +16,7 @@
 
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useSlmApi } from '@/composables/useSlmApi'
+import { useFleetStore } from '@/stores/fleet'
 import { getConfig, getSlmApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { formatRelativeTime } from '@/utils/dateUtils'
@@ -62,6 +63,8 @@ interface UpdatesInfo {
   count: number
   security: number
   updates: AvailableUpdate[]
+  /** #11964: same node.code_status the fleet-summary badge reads. */
+  codeUpdateAvailable: boolean
 }
 
 interface EventFilters {
@@ -91,6 +94,7 @@ const emit = defineEmits<{
 
 // API composable (methods will be added later)
 const api = useSlmApi()
+const fleetStore = useFleetStore()
 
 // State
 const events = ref<LifecycleEvent[]>([])
@@ -163,9 +167,9 @@ const filteredEvents = computed(() => {
 
 const updatesSummary = computed(() => {
   if (!availableUpdates.value) return null
-  const { count, security, updates } = availableUpdates.value
+  const { count, security, updates, codeUpdateAvailable } = availableUpdates.value
   const critical = updates.filter((u) => u.severity === 'critical').length
-  return { count, security, critical }
+  return { count, security, critical, codeUpdateAvailable }
 })
 
 // Methods
@@ -391,25 +395,30 @@ async function loadMoreEvents(): Promise<void> {
 async function checkForUpdates(): Promise<void> {
   isCheckingUpdates.value = true
   try {
-    const updates = await api.checkUpdates(props.nodeId)
+    // #11964: fleetStore.checkNodeUpdates() also reconciles the cached
+    // fleet-summary badge with this fresh scan, so the two can never
+    // disagree after a live check.
+    const result = await fleetStore.checkNodeUpdates(props.nodeId)
 
-    // Map backend response to local UpdatesInfo format
-    // Backend returns update_id, frontend type has id
-    const securityCount = updates.filter((u) => u.severity === 'critical' || u.severity === 'high').length
+    // Map backend response to local UpdatesInfo format.
+    // Backend field names are update_id/available_version (#11964 fix:
+    // these previously read the non-existent u.id/u.version).
+    const securityCount = result.updates.filter((u) => u.severity === 'critical' || u.severity === 'high').length
     availableUpdates.value = {
-      count: updates.length,
+      count: result.total,
       security: securityCount,
-      updates: updates.map((u) => ({
-        id: u.id,
-        version: u.version,
-        description: u.description,
+      updates: result.updates.map((u) => ({
+        id: u.update_id,
+        version: u.available_version,
+        description: u.description ?? '',
         severity: u.severity as 'low' | 'medium' | 'high' | 'critical',
       })),
+      codeUpdateAvailable: result.code_update_available,
     }
   } catch (error) {
     logger.error('Failed to check for updates:', error)
     // Show empty updates if API fails
-    availableUpdates.value = { count: 0, security: 0, updates: [] }
+    availableUpdates.value = { count: 0, security: 0, updates: [], codeUpdateAvailable: false }
   } finally {
     isCheckingUpdates.value = false
   }
@@ -651,12 +660,13 @@ onUnmounted(() => {
       <div class="flex items-center justify-between">
         <!-- Update Status -->
         <div class="flex items-center gap-3">
-          <template v-if="updatesSummary && updatesSummary.count > 0">
+          <template v-if="updatesSummary && (updatesSummary.count > 0 || updatesSummary.codeUpdateAvailable)">
             <div class="flex items-center gap-2 text-warning-600">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12" />
               </svg>
-              <span class="font-medium">{{ $t('fleet.nodeLifecyclePanel.value0UpdatePluralAvailable', { value0: updatesSummary.count, plural: updatesSummary.count === 1 ? '' : 's' }) }}</span>
+              <span v-if="updatesSummary.count > 0" class="font-medium">{{ $t('fleet.nodeLifecyclePanel.value0UpdatePluralAvailable', { value0: updatesSummary.count, plural: updatesSummary.count === 1 ? '' : 's' }) }}</span>
+              <span v-if="updatesSummary.codeUpdateAvailable" class="font-medium">{{ $t('fleet.nodeLifecyclePanel.codeUpdateAvailable') }}</span>
             </div>
             <span v-if="updatesSummary.security > 0" class="text-sm text-red-600">{{ $t('fleet.nodeLifecyclePanel.value0Security', { value0: updatesSummary.security }) }}</span>
             <span v-if="updatesSummary.critical > 0" class="text-sm font-medium text-red-700">{{ $t('fleet.nodeLifecyclePanel.value0Critical', { value0: updatesSummary.critical }) }}</span>

--- a/autobot-slm-frontend/src/composables/useSlmApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.ts
@@ -19,7 +19,7 @@ import type {
   NodeEvent,
   NodeEventFilters,
   CertificateInfo,
-  UpdateInfo,
+  NodeUpdateCheckResponse,
   ConnectionTestRequest,
   ConnectionTestResult,
   Deployment,
@@ -313,9 +313,12 @@ export function useSlmApi() {
   }
 
   // Updates
-  async function checkUpdates(nodeId: string): Promise<UpdateInfo[]> {
-    const response = await client.get<{ updates: UpdateInfo[] }>(`/nodes/${nodeId}/updates`)
-    return response.data.updates
+  // Returns the full check response (#11964): code_update_available/
+  // code_status mirror the same node.code_status field the fleet
+  // update-summary badge reads, so callers can reconcile the two.
+  async function checkUpdates(nodeId: string): Promise<NodeUpdateCheckResponse> {
+    const response = await client.get<NodeUpdateCheckResponse>(`/nodes/${nodeId}/updates`)
+    return response.data
   }
 
   async function applyUpdates(

--- a/autobot-slm-frontend/src/locales/en.json
+++ b/autobot-slm-frontend/src/locales/en.json
@@ -805,6 +805,7 @@
       "checking": "Checking...",
       "clear": "Clear",
       "clickCheckForUpdatesToScan": "Click \"Check for Updates\" to scan",
+      "codeUpdateAvailable": "Code update available",
       "duration": "Duration",
       "eventPlural": "event{plural}",
       "eventsWillAppearHereAsThey": "Events will appear here as they occur.",

--- a/autobot-slm-frontend/src/stores/fleet.test.ts
+++ b/autobot-slm-frontend/src/stores/fleet.test.ts
@@ -1,0 +1,112 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Issue #11964 — node-card "code update available" badge vs. the
+ * NodeLifecyclePanel "Check for updates" live scan disagreeing.
+ *
+ * Root cause: the badge (fleetUpdateSummary, fetched once on page load) and
+ * the live per-node scan read different/stale data. These tests prove that
+ * checkNodeUpdates() -- the store action backing the live scan -- reconciles
+ * the cached fleetUpdateSummary entry with the fresh result, so the badge
+ * can never keep showing "code update available" once a live check finds
+ * none.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useFleetStore } from './fleet'
+
+const mockGetFleetUpdateSummary = vi.fn()
+const mockCheckUpdates = vi.fn()
+
+vi.mock('@/composables/useSlmApi', () => ({
+  useSlmApi: () => ({
+    getFleetUpdateSummary: mockGetFleetUpdateSummary,
+    checkUpdates: mockCheckUpdates,
+  }),
+}))
+
+describe('fleetStore — badge/live-check reconciliation (#11964)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGetFleetUpdateSummary.mockReset()
+    mockCheckUpdates.mockReset()
+  })
+
+  it('clears a stale code_update_available badge once the live scan finds nothing', async () => {
+    // Badge fetched at page load: node flagged as needing a code update.
+    mockGetFleetUpdateSummary.mockResolvedValue({
+      nodes: [
+        {
+          node_id: 'node-1',
+          hostname: 'host-1',
+          system_updates: 0,
+          code_update_available: true,
+          code_status: 'outdated',
+          total_updates: 1,
+        },
+      ],
+      total_system_updates: 0,
+      total_code_updates: 1,
+      nodes_needing_updates: 1,
+    })
+
+    const fleetStore = useFleetStore()
+    await fleetStore.fetchFleetUpdateSummary()
+    expect(fleetStore.getNodeUpdateSummary('node-1')?.code_update_available).toBe(true)
+
+    // Live scan (NodeLifecyclePanel "Check for updates") re-reads node.code_status
+    // fresh and finds it's actually up to date now.
+    mockCheckUpdates.mockResolvedValue({
+      updates: [],
+      total: 0,
+      code_update_available: false,
+      code_status: 'up_to_date',
+    })
+
+    await fleetStore.checkNodeUpdates('node-1')
+
+    const reconciled = fleetStore.getNodeUpdateSummary('node-1')
+    expect(reconciled?.code_update_available).toBe(false)
+    expect(reconciled?.code_status).toBe('up_to_date')
+    expect(reconciled?.total_updates).toBe(0)
+    expect(fleetStore.fleetUpdateSummary?.total_code_updates).toBe(0)
+    expect(fleetStore.fleetUpdateSummary?.nodes_needing_updates).toBe(0)
+  })
+
+  it('keeps the badge in sync when the live scan confirms a code update is still pending', async () => {
+    mockGetFleetUpdateSummary.mockResolvedValue({
+      nodes: [
+        {
+          node_id: 'node-2',
+          hostname: 'host-2',
+          system_updates: 0,
+          code_update_available: true,
+          code_status: 'outdated',
+          total_updates: 1,
+        },
+      ],
+      total_system_updates: 0,
+      total_code_updates: 1,
+      nodes_needing_updates: 1,
+    })
+
+    const fleetStore = useFleetStore()
+    await fleetStore.fetchFleetUpdateSummary()
+
+    mockCheckUpdates.mockResolvedValue({
+      updates: [],
+      total: 0,
+      code_update_available: true,
+      code_status: 'outdated',
+    })
+
+    const result = await fleetStore.checkNodeUpdates('node-2')
+
+    expect(result.code_update_available).toBe(true)
+    expect(fleetStore.getNodeUpdateSummary('node-2')?.code_update_available).toBe(true)
+  })
+})

--- a/autobot-slm-frontend/src/stores/fleet.ts
+++ b/autobot-slm-frontend/src/stores/fleet.ts
@@ -26,7 +26,8 @@ import type {
   NodeEvent,
   NodeEventFilters,
   CertificateInfo,
-  UpdateInfo,
+  NodeUpdateRecord,
+  NodeUpdateCheckResponse,
   ConnectionTestResult,
   RoleInfo,
   NPUNodeStatus,
@@ -59,7 +60,7 @@ export const useFleetStore = defineStore('fleet', () => {
   const certificateStatus = ref<Map<string, CertificateInfo>>(new Map())
 
   /** Cache of available updates by node ID */
-  const nodeUpdates = ref<Map<string, UpdateInfo[]>>(new Map())
+  const nodeUpdates = ref<Map<string, NodeUpdateRecord[]>>(new Map())
 
   /** Available roles from the backend */
   const availableRoles = ref<RoleInfo[]>([])
@@ -178,6 +179,36 @@ export const useFleetStore = defineStore('fleet', () => {
    */
   function getNodeUpdateSummary(nodeId: string): NodeUpdateSummary | undefined {
     return fleetUpdateSummary.value?.nodes.find(n => n.node_id === nodeId)
+  }
+
+  /**
+   * Reconcile a single node's cached update summary with a fresh live-check
+   * result (#11964).
+   *
+   * The live "Check for updates" scan (NodeLifecyclePanel) re-reads
+   * node.code_status directly from the DB at click-time. The fleet-wide
+   * summary that drives the node-card badge is otherwise only fetched once
+   * on page load, so it can go stale. Patching the cached entry here after
+   * every live check keeps the badge and the live scan from disagreeing.
+   */
+  function reconcileNodeUpdateSummary(
+    nodeId: string,
+    systemUpdates: number,
+    codeUpdateAvailable: boolean,
+    codeStatus: string
+  ): void {
+    const summary = fleetUpdateSummary.value
+    const entry = summary?.nodes.find(n => n.node_id === nodeId)
+    if (!summary || !entry) return
+
+    entry.system_updates = systemUpdates
+    entry.code_update_available = codeUpdateAvailable
+    entry.code_status = codeStatus
+    entry.total_updates = systemUpdates + (codeUpdateAvailable ? 1 : 0)
+
+    summary.total_system_updates = summary.nodes.reduce((sum, n) => sum + n.system_updates, 0)
+    summary.total_code_updates = summary.nodes.filter(n => n.code_update_available).length
+    summary.nodes_needing_updates = summary.nodes.filter(n => n.total_updates > 0).length
   }
 
   // ============================================================
@@ -528,13 +559,19 @@ export const useFleetStore = defineStore('fleet', () => {
   // ============================================================
 
   /**
-   * Check for available updates for a node
+   * Check for available updates for a node.
+   *
+   * Reconciles the cached fleet-wide update summary with this fresh scan
+   * (#11964) so the node-card badge can never disagree with a live check.
+   * Returns the full check response so callers get code_update_available/
+   * code_status directly, even if this node has no cached summary entry yet.
    */
-  async function checkNodeUpdates(nodeId: string): Promise<UpdateInfo[]> {
+  async function checkNodeUpdates(nodeId: string): Promise<NodeUpdateCheckResponse> {
     try {
-      const updates = await api.checkUpdates(nodeId)
-      nodeUpdates.value.set(nodeId, updates)
-      return updates
+      const result = await api.checkUpdates(nodeId)
+      nodeUpdates.value.set(nodeId, result.updates)
+      reconcileNodeUpdateSummary(nodeId, result.total, result.code_update_available, result.code_status)
+      return result
     } catch (err) {
       error.value = err instanceof Error
         ? err.message
@@ -891,6 +928,7 @@ export const useFleetStore = defineStore('fleet', () => {
     // Actions - Fleet Update Summary (#682)
     fetchFleetUpdateSummary,
     getNodeUpdateSummary,
+    reconcileNodeUpdateSummary,
 
     // Actions - Roles
     fetchRoles,

--- a/autobot-slm-frontend/src/types/slm.ts
+++ b/autobot-slm-frontend/src/types/slm.ts
@@ -171,6 +171,37 @@ export interface UpdateInfo {
 }
 
 /**
+ * Raw per-package update record as returned by the backend's
+ * UpdateInfoResponse (models/schemas.py) — field names mirror the wire
+ * format exactly (#11964).
+ */
+export interface NodeUpdateRecord {
+  update_id: string
+  node_id: string | null
+  package_name: string
+  current_version: string | null
+  available_version: string
+  severity: string
+  description: string | null
+  is_applied: boolean
+  applied_at: string | null
+  created_at: string
+}
+
+/**
+ * Response from GET /nodes/{node_id}/updates — the live "Check for updates"
+ * scan (#11964). code_update_available/code_status mirror the SAME
+ * node.code_status field NodeUpdateSummary reads, so the live scan and the
+ * fleet-summary badge can never disagree.
+ */
+export interface NodeUpdateCheckResponse {
+  updates: NodeUpdateRecord[]
+  total: number
+  code_update_available: boolean
+  code_status: string
+}
+
+/**
  * Role category for grouping
  */
 export type RoleCategory = 'core' | 'data' | 'application' | 'ai' | 'automation' | 'observability' | 'remote-access' | 'infrastructure'


### PR DESCRIPTION
## Thinking Path
Node card showed a "code update available" badge but the check-for-updates modal reported none — two sources computing different things.

## Root Cause
- Badge: `api/updates.py _build_node_summaries` set `code_update_available` from `node.code_status == "outdated"` (heartbeat DB field) → `GET /updates/fleet-summary` → `fleetStore.getNodeUpdateSummary` → `NodeCard.vue:316`.
- Live check: `api/nodes.py get_node_updates` (`NodeLifecyclePanel.checkForUpdates`) queried **only** the `UpdateInfo` system-package table and never referenced `code_status` — so it could never surface a code update. Compounded by the badge's Pinia cache never being invalidated after mount.

## What Changed (canonical-source reconciliation)
- New `is_code_update_available(node)` in `api/updates.py` — single source of truth (`code_status == CodeStatus.OUTDATED`), used by BOTH the badge summary and the live check (can't diverge). Fixed a pre-existing hardcoded `"outdated"` → enum.
- `GET /nodes/{id}/updates` now returns `code_update_available`/`code_status` (extended `UpdateCheckResponse`); modal surfaces the code-update indicator.
- Frontend `fleetStore.checkNodeUpdates()` reconciles the cached badge summary with each fresh live result (`reconcileNodeUpdateSummary`) → badge can't keep showing stale state.
- **Also fixed in-scope**: `checkForUpdates()` mapped `u.id`/`u.version` from non-existent backend fields (real: `update_id`/`available_version`) — silently broke "Apply Updates" + version display.

Closes #11964

## Verification (CI down — local gate)
- Backend `pytest tests/` 800 passed (+8 new in `test_node_update_availability_11964.py`); `tests/api/` 275 passed. Frontend `vue-tsc` exit 0; `fleet.test.ts` 2 passed. (5 unrelated pre-existing settings-test failures tracked in #11952.)

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)