### PR TITLE
refactor(ui): migrate deferred modals to @autobot/ui BaseModal + custom-width prop + footer-clip fix (#10882)

### DIFF
--- a/autobot-frontend/src/components/audit/AuditLogTable.vue
+++ b/autobot-frontend/src/components/audit/AuditLogTable.vue
@@ -165,19 +165,14 @@
     </div>
 
     <!-- Detail Modal -->
-    <div v-if="selectedEntry" class="modal-overlay" @click="closeDetails">
-      <div class="modal-content" @click.stop>
-        <div class="modal-header">
-          <h3>{{ $t('audit.logTable.entryDetails') }}</h3>
-          <button
-            class="btn btn-icon"
-            :aria-label="$t('common.close')"
-            @click="closeDetails"
-          >
-            <Icon name="times" />
-          </button>
-        </div>
-        <div class="modal-body">
+    <BaseModal
+      :model-value="!!selectedEntry"
+      :title="$t('audit.logTable.entryDetails')"
+      :close-label="$t('common.close')"
+      :width="700"
+      @close="closeDetails"
+    >
+      <div v-if="selectedEntry" class="modal-body">
           <div class="detail-grid">
             <div class="detail-item">
               <label>{{ $t('audit.logTable.id') }}</label>
@@ -228,8 +223,7 @@
             </div>
           </div>
         </div>
-      </div>
-    </div>
+    </BaseModal>
 
     <!-- Loading Overlay -->
     <div v-if="loading" class="loading-overlay">
@@ -242,6 +236,7 @@
 <script setup lang="ts">
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
+import { BaseModal } from '@autobot/ui'
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { AuditEntry } from '@/types/audit'
@@ -664,48 +659,7 @@ th span {
 }
 
 /* Modal Styles */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal-backdrop);
-  padding: var(--spacing-4);
-}
-
-.modal-content {
-  background: var(--bg-card);
-  border-radius: var(--radius-default);
-  max-width: 700px;
-  width: 100%;
-  max-height: 90vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--border-default);
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-4);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-header h3 {
-  margin: var(--spacing-0);
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-}
-
-.modal-body {
-  padding: var(--spacing-4);
-  overflow-y: auto;
-}
-
+/* #10882: overlay/header chrome now provided by @autobot/ui BaseModal. */
 .detail-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/autobot-frontend/src/components/knowledge/KnowledgeDocumentsBranch.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeDocumentsBranch.vue
@@ -108,42 +108,36 @@
     </details>
 
     <!-- Delete confirmation dialog -->
-    <div
-      v-if="deleteTarget"
-      ref="deleteDialogRef"
-      class="modal-overlay"
-      role="dialog"
-      aria-modal="true"
-      :aria-label="$t('documents.confirmDeleteAria', { title: deleteTarget.title })"
-      tabindex="-1"
-      @keydown="onDeleteDialogKeydown"
-      @keydown.escape="deleteTarget = null"
+    <BaseModal
+      :model-value="!!deleteTarget"
+      :title="$t('documents.deleteHeading')"
+      :close-label="$t('ui.modal.closeDialog')"
+      :width="360"
+      @close="deleteTarget = null"
     >
-      <div class="modal-card">
-        <h3 class="modal-title">{{ $t('documents.deleteHeading') }}</h3>
-        <p class="modal-body">
-          {{ $t('documents.deleteBody', { title: deleteTarget.title }) }}
-        </p>
-        <div class="modal-actions">
-          <BaseButton variant="ghost" size="sm" @click="deleteTarget = null">
-            {{ $t('common.cancel') }}
-          </BaseButton>
-          <BaseButton
-            variant="error"
-            size="sm"
-            :disabled="composable.isLoading.value"
-            @click="executeDelete"
-          >
-            {{ $t('common.delete') }}
-          </BaseButton>
-        </div>
-      </div>
-    </div>
+      <p v-if="deleteTarget" class="modal-body">
+        {{ $t('documents.deleteBody', { title: deleteTarget.title }) }}
+      </p>
+
+      <template #actions>
+        <BaseButton variant="ghost" size="sm" @click="deleteTarget = null">
+          {{ $t('common.cancel') }}
+        </BaseButton>
+        <BaseButton
+          variant="error"
+          size="sm"
+          :disabled="composable.isLoading.value"
+          @click="executeDelete"
+        >
+          {{ $t('common.delete') }}
+        </BaseButton>
+      </template>
+    </BaseModal>
   </details>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import Icon from '@/components/ui/Icon.vue'
@@ -151,7 +145,7 @@ import { useAIDocument } from '@/composables/useAIDocument'
 import { useTranscriberApi } from '@/composables/transcriber/useTranscriberApi'
 import type { Project } from '@/composables/transcriber/useTranscriberApi'
 import { createLogger } from '@/utils/debugUtils'
-import { useFocusTrap, useFocusRestore, useInitialFocus, useBodyScrollLock } from '@autobot/ui'
+import { BaseModal } from '@autobot/ui'
 
 const PAGE_SIZE = 50
 
@@ -192,14 +186,6 @@ const currentOffset = ref(0)
 // ---------------------------------------------------------------------------
 
 const deleteTarget = ref<{ id: string; title: string } | null>(null)
-const deleteDialogRef = ref<HTMLElement | null>(null)
-const isDeleteDialogOpen = computed(() => deleteTarget.value !== null)
-
-const { onKeydown: onDeleteDialogKeydown } = useFocusTrap(deleteDialogRef)
-useFocusRestore(isDeleteDialogOpen)
-useBodyScrollLock(isDeleteDialogOpen)
-const { focusFirst: focusDeleteFirst } = useInitialFocus(deleteDialogRef)
-watch(isDeleteDialogOpen, (open) => { if (open) focusDeleteFirst() }, { immediate: true })
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -460,41 +446,12 @@ function formatDate(iso: string): string {
 }
 
 /* Modal */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-}
-
-.modal-card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-6);
-  width: 360px;
-  max-width: 90vw;
-}
-
-.modal-title {
-  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3);
-  font-size: var(--text-base);
-  font-weight: 600;
-}
-
+/* #10882: overlay/header/footer chrome + focus-trap/scroll-lock now provided
+   by @autobot/ui BaseModal; only the confirmation copy styling remains. */
 .modal-body {
-  margin: var(--spacing-0) var(--spacing-0) var(--spacing-5);
+  margin: var(--spacing-0);
   font-size: 0.9rem;
   color: var(--text-muted);
   line-height: 1.5;
-}
-
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-2);
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -281,15 +281,17 @@
     </transition>
 
     <!-- Create Entity Modal -->
-    <div v-if="showCreateModal" class="modal-overlay" @click.self="showCreateModal = false">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4><Icon name="plus-circle" /> {{ $t('knowledge.graph.createEntityTitle') }}</h4>
-          <button @click="showCreateModal = false" class="close-btn">
-            <Icon name="times" />
-          </button>
-        </div>
-        <form @submit.prevent="createEntity" class="entity-form">
+    <BaseModal
+      :model-value="showCreateModal"
+      :title="$t('knowledge.graph.createEntityTitle')"
+      :close-label="$t('common.close')"
+      :width="480"
+      @close="showCreateModal = false"
+    >
+      <template #title>
+        <Icon name="plus-circle" /> {{ $t('knowledge.graph.createEntityTitle') }}
+      </template>
+      <form id="entity-form" @submit.prevent="createEntity" class="entity-form">
           <div class="form-group">
             <label for="entity-name">{{ $t('knowledge.graph.nameLabel') }}</label>
             <input
@@ -326,19 +328,19 @@
               :placeholder="$t('knowledge.graph.observationsPlaceholder')"
             ></textarea>
           </div>
-          <div class="form-actions">
-            <button type="button" @click="showCreateModal = false" class="action-btn">
-              {{ $t('knowledge.graph.cancel') }}
-            </button>
-            <button type="submit" class="action-btn primary" :disabled="isCreating">
-              <Icon name="spinner" class="animate-spin" v-if="isCreating" />
-              <Icon name="plus" v-else />
-              {{ $t('knowledge.graph.create') }}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+      </form>
+
+      <template #actions>
+        <button type="button" @click="showCreateModal = false" class="action-btn">
+          {{ $t('knowledge.graph.cancel') }}
+        </button>
+        <button type="submit" form="entity-form" class="action-btn primary" :disabled="isCreating">
+          <Icon name="spinner" class="animate-spin" v-if="isCreating" />
+          <Icon name="plus" v-else />
+          {{ $t('knowledge.graph.create') }}
+        </button>
+      </template>
+    </BaseModal>
 
     <!-- Legend -->
     <div class="graph-legend">
@@ -387,6 +389,7 @@
 // Author: mrveiss
 
 import Icon from '@/components/ui/Icon.vue'
+import { BaseModal } from '@autobot/ui'
 import { ref, shallowRef, computed, onMounted, onUnmounted, watch, nextTick, defineAsyncComponent } from 'vue'
 // Type-only imports — runtime load handled by the shared composable (#5234).
 import type cytoscape from 'cytoscape'
@@ -1781,53 +1784,7 @@ watch(layoutMode, () => {
 }
 
 /* Modal */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-bg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal);
-}
-
-.modal-content {
-  background: var(--bg-card);
-  border-radius: var(--radius-lg);
-  width: 90%;
-  max-width: 480px;
-  max-height: 90vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--border-subtle);
-  box-shadow: var(--shadow-xl);
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-md) var(--spacing-lg);
-  background: var(--color-primary);
-  color: white;
-}
-
-.modal-header h4 {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-}
-
-.modal-header .close-btn {
-  color: white;
-}
-
-.entity-form {
-  padding: var(--spacing-lg);
-}
+/* #10882: overlay/header/footer chrome now provided by @autobot/ui BaseModal. */
 
 .form-group {
   margin-bottom: var(--spacing-md);
@@ -1867,15 +1824,6 @@ watch(layoutMode, () => {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
-.form-group input:focus-visible,
-
-.form-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-sm);
-  margin-top: var(--spacing-lg);
-}
-
 /* Legend */
 .graph-legend {
   padding: var(--spacing-md);

--- a/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.vue
+++ b/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.vue
@@ -1,121 +1,101 @@
 <template>
-  <Teleport to="body">
-    <Transition name="modal-fade">
-      <div
-        v-if="open"
-        class="modal-backdrop"
-        role="dialog"
-        aria-modal="true"
-        :aria-label="$t('views.marketplace.sources.title')"
-        @click.self="onClose"
-      >
-        <div class="modal-card" @keydown.esc="onClose">
-          <header class="modal-header">
-            <h2 class="modal-title">{{ $t('views.marketplace.sources.title') }}</h2>
-            <button class="modal-close" :aria-label="$t('common.close')" @click="onClose">
-              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="close-icon">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-          </header>
+  <BaseModal
+    :model-value="open"
+    :title="$t('views.marketplace.sources.title')"
+    :close-label="$t('common.close')"
+    :width="600"
+    @close="onClose"
+  >
+    <div class="modal-body">
+      <p class="hint">{{ $t('views.marketplace.sources.hint') }}</p>
 
-          <div class="modal-body">
-            <p class="hint">{{ $t('views.marketplace.sources.hint') }}</p>
-
-            <!-- Existing sources list -->
-            <ul v-if="sources.length > 0" class="sources-list">
-              <li v-for="src in sources" :key="src.id" class="source-row">
-                <div class="source-info">
-                  <div class="source-name">
-                    {{ src.name }}
-                    <span v-if="src.is_builtin" class="builtin-badge">
-                      {{ $t('views.marketplace.sources.builtin') }}
-                    </span>
-                  </div>
-                  <div v-if="src.url" class="source-url">{{ src.url }}</div>
-                  <div v-if="src.description" class="source-desc">{{ src.description }}</div>
-                </div>
-                <button
-                  v-if="!src.is_builtin"
-                  class="btn btn-danger"
-                  :disabled="busy"
-                  @click="onDelete(src.id)"
-                >
-                  {{ $t('common.remove') }}
-                </button>
-              </li>
-            </ul>
-
-            <!-- Add new source form -->
-            <div class="add-form">
-              <h3 class="add-title">{{ $t('views.marketplace.sources.addTitle') }}</h3>
-              <label class="form-field">
-                <span class="form-label">{{ $t('views.marketplace.sources.nameLabel') }}</span>
-                <input
-                  v-model.trim="newName"
-                  type="text"
-                  class="form-input"
-                  maxlength="64"
-                  :placeholder="$t('views.marketplace.sources.namePlaceholder')"
-                />
-              </label>
-              <label class="form-field">
-                <span class="form-label">{{ $t('views.marketplace.sources.urlLabel') }}</span>
-                <input
-                  v-model.trim="newUrl"
-                  type="url"
-                  class="form-input"
-                  placeholder="https://example.com/plugins.json"
-                  autocomplete="off"
-                  spellcheck="false"
-                />
-              </label>
-              <label class="form-field">
-                <span class="form-label">
-                  {{ $t('views.marketplace.sources.descLabel') }}
-                  <span class="form-label-optional">{{ $t('common.optional') }}</span>
-                </span>
-                <input
-                  v-model.trim="newDesc"
-                  type="text"
-                  class="form-input"
-                  maxlength="200"
-                />
-              </label>
-
-              <div v-if="error" class="error-banner" role="alert">
-                {{ error }}
-              </div>
-
-              <button
-                class="btn btn-primary"
-                :disabled="!canAdd || busy"
-                @click="onAdd"
-              >
-                {{ busy ? $t('views.marketplace.sources.adding') : $t('views.marketplace.sources.add') }}
-              </button>
+      <!-- Existing sources list -->
+      <ul v-if="sources.length > 0" class="sources-list">
+        <li v-for="src in sources" :key="src.id" class="source-row">
+          <div class="source-info">
+            <div class="source-name">
+              {{ src.name }}
+              <span v-if="src.is_builtin" class="builtin-badge">
+                {{ $t('views.marketplace.sources.builtin') }}
+              </span>
             </div>
+            <div v-if="src.url" class="source-url">{{ src.url }}</div>
+            <div v-if="src.description" class="source-desc">{{ src.description }}</div>
           </div>
+          <button
+            v-if="!src.is_builtin"
+            class="btn btn-danger"
+            :disabled="busy"
+            @click="onDelete(src.id)"
+          >
+            {{ $t('common.remove') }}
+          </button>
+        </li>
+      </ul>
 
-          <footer class="modal-footer">
-            <button class="btn btn-ghost" @click="onClose">
-              {{ $t('common.close') }}
-            </button>
-          </footer>
+      <!-- Add new source form -->
+      <div class="add-form">
+        <h3 class="add-title">{{ $t('views.marketplace.sources.addTitle') }}</h3>
+        <label class="form-field">
+          <span class="form-label">{{ $t('views.marketplace.sources.nameLabel') }}</span>
+          <input
+            v-model.trim="newName"
+            type="text"
+            class="form-input"
+            maxlength="64"
+            :placeholder="$t('views.marketplace.sources.namePlaceholder')"
+          />
+        </label>
+        <label class="form-field">
+          <span class="form-label">{{ $t('views.marketplace.sources.urlLabel') }}</span>
+          <input
+            v-model.trim="newUrl"
+            type="url"
+            class="form-input"
+            placeholder="https://example.com/plugins.json"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </label>
+        <label class="form-field">
+          <span class="form-label">
+            {{ $t('views.marketplace.sources.descLabel') }}
+            <span class="form-label-optional">{{ $t('common.optional') }}</span>
+          </span>
+          <input
+            v-model.trim="newDesc"
+            type="text"
+            class="form-input"
+            maxlength="200"
+          />
+        </label>
+
+        <div v-if="error" class="error-banner" role="alert">
+          {{ error }}
         </div>
+
+        <button
+          class="btn btn-primary"
+          :disabled="!canAdd || busy"
+          @click="onAdd"
+        >
+          {{ busy ? $t('views.marketplace.sources.adding') : $t('views.marketplace.sources.add') }}
+        </button>
       </div>
-    </Transition>
-  </Teleport>
+    </div>
+
+    <template #actions>
+      <button class="btn btn-ghost" @click="onClose">
+        {{ $t('common.close') }}
+      </button>
+    </template>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { BaseModal } from '@autobot/ui'
 import { useMarketplaceSources } from '@/composables/useMarketplaceSources'
 
 const props = defineProps<{ open: boolean }>()
@@ -200,66 +180,9 @@ async function onDelete(id: string) {
 </script>
 
 <style scoped>
-.modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.55);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: var(--spacing-md);
-}
-
-.modal-card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg);
-  width: 100%;
-  max-width: 600px;
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  box-shadow: var(--shadow-xl);
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-title {
-  margin: 0;
-  font-size: var(--text-lg);
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.modal-close {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: var(--spacing-xs);
-  border-radius: var(--radius-sm);
-}
-
-.modal-close:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-}
-
-.close-icon {
-  width: 20px;
-  height: 20px;
-}
-
+/* #10882: overlay/header/footer chrome now provided by @autobot/ui BaseModal;
+   only the body layout + form styling remain here. */
 .modal-body {
-  padding: var(--spacing-lg);
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
@@ -386,14 +309,6 @@ async function onDelete(id: string) {
   font-size: var(--text-sm);
 }
 
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-top: 1px solid var(--border-default);
-}
-
 .btn {
   padding: var(--spacing-sm) var(--spacing-md);
   font-size: var(--text-sm);
@@ -431,15 +346,5 @@ async function onDelete(id: string) {
 
 .btn-danger:hover:not(:disabled) {
   filter: brightness(1.1);
-}
-
-.modal-fade-enter-active,
-.modal-fade-leave-active {
-  transition: opacity 150ms ease;
-}
-
-.modal-fade-enter-from,
-.modal-fade-leave-to {
-  opacity: 0;
 }
 </style>

--- a/autobot-frontend/src/components/plugins/PluginInstallModal.vue
+++ b/autobot-frontend/src/components/plugins/PluginInstallModal.vue
@@ -1,144 +1,119 @@
 <template>
-  <Teleport to="body">
-    <Transition name="modal-fade">
-      <div
-        v-if="open"
-        class="modal-backdrop"
-        role="dialog"
-        aria-modal="true"
-        :aria-label="$t('views.plugins.install.title')"
-        @click.self="onClose"
+  <BaseModal
+    :model-value="open"
+    :title="$t('views.plugins.install.title')"
+    :close-label="$t('common.close')"
+    :width="520"
+    @close="onClose"
+  >
+    <div ref="pluginTablistRef" class="modal-tabs" role="tablist">
+      <button
+        v-bind="tabAttrs('zip')"
+        class="modal-tab"
+        :class="{ active: activeTab === 'zip' }"
+        @click="activeTab = 'zip'"
+        @keydown="handleTabKeydown"
       >
-        <div class="modal-card" @keydown.esc="onClose">
-          <header class="modal-header">
-            <h2 class="modal-title">{{ $t('views.plugins.install.title') }}</h2>
-            <button class="modal-close" :aria-label="$t('common.close')" @click="onClose">
-              <svg
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                class="close-icon"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-          </header>
+        {{ $t('views.plugins.install.zipTab') }}
+      </button>
+      <button
+        v-bind="tabAttrs('git')"
+        class="modal-tab"
+        :class="{ active: activeTab === 'git' }"
+        @click="activeTab = 'git'"
+        @keydown="handleTabKeydown"
+      >
+        {{ $t('views.plugins.install.gitTab') }}
+      </button>
+    </div>
 
-          <div ref="pluginTablistRef" class="modal-tabs" role="tablist">
-            <button
-              v-bind="tabAttrs('zip')"
-              class="modal-tab"
-              :class="{ active: activeTab === 'zip' }"
-              @click="activeTab = 'zip'"
-              @keydown="handleTabKeydown"
-            >
-              {{ $t('views.plugins.install.zipTab') }}
-            </button>
-            <button
-              v-bind="tabAttrs('git')"
-              class="modal-tab"
-              :class="{ active: activeTab === 'git' }"
-              @click="activeTab = 'git'"
-              @keydown="handleTabKeydown"
-            >
-              {{ $t('views.plugins.install.gitTab') }}
-            </button>
-          </div>
-
-          <div class="modal-body">
-            <!-- ZIP tab -->
-            <div v-if="activeTab === 'zip'" v-bind="panelAttrs('zip')" class="tab-pane">
-              <p class="hint">{{ $t('views.plugins.install.zipHint') }}</p>
-              <label class="file-drop" :class="{ 'has-file': zipFile }">
-                <input
-                  type="file"
-                  accept=".zip,application/zip"
-                  class="file-input"
-                  @change="onFileChange"
-                />
-                <svg
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  class="drop-icon"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                    d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-                  />
-                </svg>
-                <span v-if="!zipFile" class="drop-label">
-                  {{ $t('views.plugins.install.zipPickFile') }}
-                </span>
-                <span v-else class="drop-label">
-                  {{ zipFile.name }}
-                </span>
-              </label>
-            </div>
-
-            <!-- Git tab -->
-            <div v-if="activeTab === 'git'" v-bind="panelAttrs('git')" class="tab-pane">
-              <p class="hint">{{ $t('views.plugins.install.gitHint') }}</p>
-              <label class="form-field">
-                <span class="form-label">{{ $t('views.plugins.install.gitUrlLabel') }}</span>
-                <input
-                  v-model.trim="gitUrl"
-                  type="url"
-                  class="form-input"
-                  placeholder="https://github.com/owner/repo.git"
-                  autocomplete="off"
-                  spellcheck="false"
-                />
-              </label>
-              <label class="form-field">
-                <span class="form-label">
-                  {{ $t('views.plugins.install.gitRefLabel') }}
-                  <span class="form-label-optional">{{ $t('common.optional') }}</span>
-                </span>
-                <input
-                  v-model.trim="gitRef"
-                  type="text"
-                  class="form-input"
-                  placeholder="main"
-                  autocomplete="off"
-                  spellcheck="false"
-                />
-              </label>
-            </div>
-
-            <div v-if="error" class="error-banner" role="alert">
-              {{ error }}
-            </div>
-            <div v-if="successMessage" class="success-banner" role="status">
-              {{ successMessage }}
-            </div>
-          </div>
-
-          <footer class="modal-footer">
-            <button class="btn btn-ghost" :disabled="busy" @click="onClose">
-              {{ $t('common.cancel') }}
-            </button>
-            <button class="btn btn-primary" :disabled="!canSubmit || busy" @click="submit">
-              {{ busy ? $t('views.plugins.install.installing') : $t('views.plugins.install.install') }}
-            </button>
-          </footer>
-        </div>
+    <div class="modal-body">
+      <!-- ZIP tab -->
+      <div v-if="activeTab === 'zip'" v-bind="panelAttrs('zip')" class="tab-pane">
+        <p class="hint">{{ $t('views.plugins.install.zipHint') }}</p>
+        <label class="file-drop" :class="{ 'has-file': zipFile }">
+          <input
+            type="file"
+            accept=".zip,application/zip"
+            class="file-input"
+            @change="onFileChange"
+          />
+          <svg
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            class="drop-icon"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+            />
+          </svg>
+          <span v-if="!zipFile" class="drop-label">
+            {{ $t('views.plugins.install.zipPickFile') }}
+          </span>
+          <span v-else class="drop-label">
+            {{ zipFile.name }}
+          </span>
+        </label>
       </div>
-    </Transition>
-  </Teleport>
+
+      <!-- Git tab -->
+      <div v-if="activeTab === 'git'" v-bind="panelAttrs('git')" class="tab-pane">
+        <p class="hint">{{ $t('views.plugins.install.gitHint') }}</p>
+        <label class="form-field">
+          <span class="form-label">{{ $t('views.plugins.install.gitUrlLabel') }}</span>
+          <input
+            v-model.trim="gitUrl"
+            type="url"
+            class="form-input"
+            placeholder="https://github.com/owner/repo.git"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </label>
+        <label class="form-field">
+          <span class="form-label">
+            {{ $t('views.plugins.install.gitRefLabel') }}
+            <span class="form-label-optional">{{ $t('common.optional') }}</span>
+          </span>
+          <input
+            v-model.trim="gitRef"
+            type="text"
+            class="form-input"
+            placeholder="main"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </label>
+      </div>
+
+      <div v-if="error" class="error-banner" role="alert">
+        {{ error }}
+      </div>
+      <div v-if="successMessage" class="success-banner" role="status">
+        {{ successMessage }}
+      </div>
+    </div>
+
+    <template #actions>
+      <button class="btn btn-ghost" :disabled="busy" @click="onClose">
+        {{ $t('common.cancel') }}
+      </button>
+      <button class="btn btn-primary" :disabled="!canSubmit || busy" @click="submit">
+        {{ busy ? $t('views.plugins.install.installing') : $t('views.plugins.install.install') }}
+      </button>
+    </template>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { BaseModal } from '@autobot/ui'
 import { usePlugins } from '@/composables/usePlugins'
 import { useTabs } from '@/composables/useTabs'
 
@@ -224,68 +199,12 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.55);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: var(--spacing-md);
-}
-
-.modal-card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg);
-  width: 100%;
-  max-width: 520px;
-  display: flex;
-  flex-direction: column;
-  box-shadow: var(--shadow-xl);
-  /* #10750 C2: cap height so header/tabs/footer stay fixed and body scrolls */
-  max-height: 90vh;
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-title {
-  margin: 0;
-  font-size: var(--text-lg);
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.modal-close {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: var(--spacing-xs);
-  border-radius: var(--radius-sm);
-}
-
-.modal-close:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-}
-
-.close-icon {
-  width: 20px;
-  height: 20px;
-}
-
+/* #10882: overlay/header/footer chrome now provided by @autobot/ui BaseModal;
+   the install tabs + form body remain here. */
 .modal-tabs {
   display: flex;
   border-bottom: 1px solid var(--border-default);
-  padding: 0 var(--spacing-lg);
+  margin-bottom: var(--spacing-md);
 }
 
 .modal-tab {
@@ -306,13 +225,9 @@ onUnmounted(() => {
 }
 
 .modal-body {
-  padding: var(--spacing-lg);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
-  /* #10750 C2: scroll long install forms; keep chrome in view */
-  overflow-y: auto;
-  min-height: 0;
 }
 
 .hint {
@@ -414,14 +329,6 @@ onUnmounted(() => {
   font-size: var(--text-sm);
 }
 
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-top: 1px solid var(--border-default);
-}
-
 .btn {
   padding: var(--spacing-sm) var(--spacing-md);
   font-size: var(--text-sm);
@@ -454,15 +361,5 @@ onUnmounted(() => {
 
 .btn-primary:hover:not(:disabled) {
   filter: brightness(1.1);
-}
-
-.modal-fade-enter-active,
-.modal-fade-leave-active {
-  transition: opacity 150ms ease;
-}
-
-.modal-fade-enter-from,
-.modal-fade-leave-to {
-  opacity: 0;
 }
 </style>

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -3,229 +3,218 @@
 <!-- Copyright (c) 2025 mrveiss -->
 <!-- Author: mrveiss -->
 <template>
-  <div v-if="isOpen" class="modal-overlay" @click="handleClose">
-    <div
-      ref="dialogRef"
-      class="modal-content"
-      @click.stop
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="profile-title"
-      tabindex="-1"
-      @keydown="onFocusTrapKeydown"
-      @keydown.escape="handleClose"
-    >
-      <div class="modal-header">
-        <h2 id="profile-title">{{ $t('profile.title') }}</h2>
-        <button @click="handleClose" class="close-button" :aria-label="$t('profile.closeAria')">&times;</button>
-      </div>
+  <BaseModal
+    :model-value="isOpen"
+    :title="$t('profile.title')"
+    :close-label="$t('profile.closeAria')"
+    :width="600"
+    @close="handleClose"
+  >
+    <!-- Tab Bar -->
+    <div ref="profileTablistRef" class="tab-bar" role="tablist">
+      <button
+        v-for="tab in tabs"
+        :key="tab.key"
+        v-bind="tabAttrs(tab.key)"
+        class="tab-btn"
+        :class="{ active: activeTab === tab.key }"
+        type="button"
+        @click="activeTab = tab.key"
+        @keydown="handleTabKeydown"
+      >
+        <Icon :name="tab.icon" />
+        {{ tab.label }}
+      </button>
+    </div>
 
-      <!-- Tab Bar -->
-      <div ref="profileTablistRef" class="tab-bar" role="tablist">
-        <button
-          v-for="tab in tabs"
-          :key="tab.key"
-          v-bind="tabAttrs(tab.key)"
-          class="tab-btn"
-          :class="{ active: activeTab === tab.key }"
-          type="button"
-          @click="activeTab = tab.key"
-          @keydown="handleTabKeydown"
-        >
-          <Icon :name="tab.icon" />
-          {{ tab.label }}
-        </button>
-      </div>
+    <div class="modal-body">
+      <!-- General Tab -->
+      <div v-if="activeTab === 'general'" v-bind="panelAttrs('general')">
+        <div class="profile-section">
+          <h3>{{ $t('profile.accountInfo') }}</h3>
+          <div class="info-grid">
+            <div class="info-row">
+              <label>{{ $t('profile.username') }}</label>
+              <span>{{ currentUser?.username || 'N/A' }}</span>
+            </div>
+            <div class="info-row">
+              <label>{{ $t('profile.email') }}</label>
+              <span>{{ currentUser?.email || 'N/A' }}</span>
+            </div>
+            <div class="info-row">
+              <label>{{ $t('profile.role') }}</label>
+              <span class="role-badge" :class="`role-${currentUser?.role}`">{{ currentUser?.role || 'N/A' }}</span>
+            </div>
+            <div class="info-row">
+              <label>{{ $t('profile.lastLogin') }}</label>
+              <span>{{ formatDate(currentUser?.lastLoginAt) }}</span>
+            </div>
+          </div>
+        </div>
 
-      <div class="modal-body">
-        <!-- General Tab -->
-        <div v-if="activeTab === 'general'" v-bind="panelAttrs('general')">
-          <div class="profile-section">
-            <h3>{{ $t('profile.accountInfo') }}</h3>
-            <div class="info-grid">
-              <div class="info-row">
-                <label>{{ $t('profile.username') }}</label>
-                <span>{{ currentUser?.username || 'N/A' }}</span>
-              </div>
-              <div class="info-row">
-                <label>{{ $t('profile.email') }}</label>
-                <span>{{ currentUser?.email || 'N/A' }}</span>
-              </div>
-              <div class="info-row">
-                <label>{{ $t('profile.role') }}</label>
-                <span class="role-badge" :class="`role-${currentUser?.role}`">{{ currentUser?.role || 'N/A' }}</span>
-              </div>
-              <div class="info-row">
-                <label>{{ $t('profile.lastLogin') }}</label>
-                <span>{{ formatDate(currentUser?.lastLoginAt) }}</span>
-              </div>
+        <div class="profile-section">
+          <h3>{{ $t('profile.preferences') }}</h3>
+
+          <div class="pref-group">
+            <label class="pref-label">{{ $t('profile.theme') }}</label>
+            <div class="option-row">
+              <button
+                v-for="opt in themeOptions"
+                :key="opt.value"
+                @click="localPrefs.theme = opt.value"
+                class="option-btn"
+                :class="{ active: localPrefs.theme === opt.value }"
+                type="button"
+              >
+                {{ opt.label }}
+              </button>
             </div>
           </div>
 
-          <div class="profile-section">
-            <h3>{{ $t('profile.preferences') }}</h3>
-
-            <div class="pref-group">
-              <label class="pref-label">{{ $t('profile.theme') }}</label>
-              <div class="option-row">
-                <button
-                  v-for="opt in themeOptions"
-                  :key="opt.value"
-                  @click="localPrefs.theme = opt.value"
-                  class="option-btn"
-                  :class="{ active: localPrefs.theme === opt.value }"
-                  type="button"
-                >
-                  {{ opt.label }}
-                </button>
-              </div>
+          <div class="pref-group">
+            <label class="pref-label">{{ $t('profile.notifications') }}</label>
+            <div class="toggle-list">
+              <label class="toggle-item">
+                <input type="checkbox" v-model="localPrefs.notifications.email" />
+                <span>{{ $t('profile.emailNotifications') }}</span>
+              </label>
+              <label class="toggle-item">
+                <input type="checkbox" v-model="localPrefs.notifications.browser" />
+                <span>{{ $t('profile.browserNotifications') }}</span>
+              </label>
+              <label class="toggle-item">
+                <input type="checkbox" v-model="localPrefs.notifications.sound" />
+                <span>{{ $t('profile.soundNotifications') }}</span>
+              </label>
             </div>
+          </div>
 
-            <div class="pref-group">
-              <label class="pref-label">{{ $t('profile.notifications') }}</label>
-              <div class="toggle-list">
-                <label class="toggle-item">
-                  <input type="checkbox" v-model="localPrefs.notifications.email" />
-                  <span>{{ $t('profile.emailNotifications') }}</span>
-                </label>
-                <label class="toggle-item">
-                  <input type="checkbox" v-model="localPrefs.notifications.browser" />
-                  <span>{{ $t('profile.browserNotifications') }}</span>
-                </label>
-                <label class="toggle-item">
-                  <input type="checkbox" v-model="localPrefs.notifications.sound" />
-                  <span>{{ $t('profile.soundNotifications') }}</span>
-                </label>
-              </div>
+          <div class="pref-group">
+            <label class="pref-label">{{ $t('profile.interface') }}</label>
+            <div class="toggle-list">
+              <label class="toggle-item">
+                <input type="checkbox" v-model="localPrefs.ui.compactMode" />
+                <span>{{ $t('profile.compactMode') }}</span>
+              </label>
+              <label class="toggle-item">
+                <input type="checkbox" v-model="localPrefs.ui.showTooltips" />
+                <span>{{ $t('profile.showTooltips') }}</span>
+              </label>
+              <label class="toggle-item">
+                <input type="checkbox" v-model="localPrefs.ui.animationsEnabled" />
+                <span>{{ $t('profile.enableAnimations') }}</span>
+              </label>
             </div>
+          </div>
 
-            <div class="pref-group">
-              <label class="pref-label">{{ $t('profile.interface') }}</label>
-              <div class="toggle-list">
-                <label class="toggle-item">
-                  <input type="checkbox" v-model="localPrefs.ui.compactMode" />
-                  <span>{{ $t('profile.compactMode') }}</span>
-                </label>
-                <label class="toggle-item">
-                  <input type="checkbox" v-model="localPrefs.ui.showTooltips" />
-                  <span>{{ $t('profile.showTooltips') }}</span>
-                </label>
-                <label class="toggle-item">
-                  <input type="checkbox" v-model="localPrefs.ui.animationsEnabled" />
-                  <span>{{ $t('profile.enableAnimations') }}</span>
-                </label>
-              </div>
-            </div>
+          <button @click="savePreferences" class="save-btn" type="button">
+            {{ $t('profile.savePreferences') }}
+          </button>
+        </div>
+      </div>
 
-            <button @click="savePreferences" class="save-btn" type="button">
-              {{ $t('profile.savePreferences') }}
+      <!-- Appearance & Voice Tab -->
+      <div v-if="activeTab === 'appearance'" v-bind="panelAttrs('appearance')">
+        <div class="profile-section">
+          <h3>{{ $t('profile.appearance') }}</h3>
+          <PreferencesPanel />
+        </div>
+
+        <div class="profile-section">
+          <h3>{{ $t('profile.voiceChatDisplay') }}</h3>
+          <div class="option-row">
+            <button
+              @click="setVoiceDisplayMode('modal')"
+              class="option-btn"
+              :class="{ active: voiceDisplayMode === 'modal' }"
+              type="button"
+            >
+              <Icon name="expand-alt" class="mr-1" />
+              {{ $t('profile.fullScreen') }}
+            </button>
+            <button
+              @click="setVoiceDisplayMode('sidepanel')"
+              class="option-btn"
+              :class="{ active: voiceDisplayMode === 'sidepanel' }"
+              type="button"
+            >
+              <Icon name="columns" class="mr-1" />
+              {{ $t('profile.sidePanel') }}
             </button>
           </div>
         </div>
 
-        <!-- Appearance & Voice Tab -->
-        <div v-if="activeTab === 'appearance'" v-bind="panelAttrs('appearance')">
-          <div class="profile-section">
-            <h3>{{ $t('profile.appearance') }}</h3>
-            <PreferencesPanel />
-          </div>
-
-          <div class="profile-section">
-            <h3>{{ $t('profile.voiceChatDisplay') }}</h3>
-            <div class="option-row">
-              <button
-                @click="setVoiceDisplayMode('modal')"
-                class="option-btn"
-                :class="{ active: voiceDisplayMode === 'modal' }"
-                type="button"
-              >
-                <Icon name="expand-alt" class="mr-1" />
-                {{ $t('profile.fullScreen') }}
-              </button>
-              <button
-                @click="setVoiceDisplayMode('sidepanel')"
-                class="option-btn"
-                :class="{ active: voiceDisplayMode === 'sidepanel' }"
-                type="button"
-              >
-                <Icon name="columns" class="mr-1" />
-                {{ $t('profile.sidePanel') }}
-              </button>
-            </div>
-          </div>
-
-          <div class="profile-section">
-            <h3>{{ $t('profile.voiceProfiles') }}</h3>
-            <VoiceSettingsPanel />
-          </div>
-        </div>
-
-        <!-- Language Tab -->
-        <div v-if="activeTab === 'language'" v-bind="panelAttrs('language')">
-          <LanguageSettingsPanel />
-        </div>
-
-        <!-- Security Tab -->
-        <div v-if="activeTab === 'security'" v-bind="panelAttrs('security')">
-          <div class="profile-section">
-            <h3>{{ $t('profile.changePassword') }}</h3>
-            <div class="pw-form">
-              <input
-                v-model="passwordForm.current"
-                type="password"
-                :placeholder="$t('profile.currentPassword')"
-                class="pw-input"
-                autocomplete="current-password"
-              />
-              <input
-                v-model="passwordForm.newPw"
-                type="password"
-                :placeholder="$t('profile.newPassword')"
-                class="pw-input"
-                autocomplete="new-password"
-              />
-              <input
-                v-model="passwordForm.confirm"
-                type="password"
-                :placeholder="$t('profile.confirmNewPassword')"
-                class="pw-input"
-                autocomplete="new-password"
-              />
-              <button
-                @click="changePassword"
-                class="save-btn"
-                type="button"
-                :disabled="isChangingPassword"
-              >
-                {{ isChangingPassword ? $t('profile.changing') : $t('profile.changePassword') }}
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Devices Tab -->
-        <div v-if="activeTab === 'devices'" v-bind="panelAttrs('devices')">
-          <DeviceManagementPanel />
+        <div class="profile-section">
+          <h3>{{ $t('profile.voiceProfiles') }}</h3>
+          <VoiceSettingsPanel />
         </div>
       </div>
 
-      <!-- Success Toast -->
-      <div v-if="successMessage" class="toast success" role="status">
-        {{ successMessage }}
+      <!-- Language Tab -->
+      <div v-if="activeTab === 'language'" v-bind="panelAttrs('language')">
+        <LanguageSettingsPanel />
       </div>
 
-      <!-- Error Toast -->
-      <div v-if="errorMessage" class="toast error" role="alert">
-        {{ errorMessage }}
+      <!-- Security Tab -->
+      <div v-if="activeTab === 'security'" v-bind="panelAttrs('security')">
+        <div class="profile-section">
+          <h3>{{ $t('profile.changePassword') }}</h3>
+          <div class="pw-form">
+            <input
+              v-model="passwordForm.current"
+              type="password"
+              :placeholder="$t('profile.currentPassword')"
+              class="pw-input"
+              autocomplete="current-password"
+            />
+            <input
+              v-model="passwordForm.newPw"
+              type="password"
+              :placeholder="$t('profile.newPassword')"
+              class="pw-input"
+              autocomplete="new-password"
+            />
+            <input
+              v-model="passwordForm.confirm"
+              type="password"
+              :placeholder="$t('profile.confirmNewPassword')"
+              class="pw-input"
+              autocomplete="new-password"
+            />
+            <button
+              @click="changePassword"
+              class="save-btn"
+              type="button"
+              :disabled="isChangingPassword"
+            >
+              {{ isChangingPassword ? $t('profile.changing') : $t('profile.changePassword') }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Devices Tab -->
+      <div v-if="activeTab === 'devices'" v-bind="panelAttrs('devices')">
+        <DeviceManagementPanel />
       </div>
     </div>
-  </div>
+
+    <!-- Success Toast -->
+    <div v-if="successMessage" class="toast success" role="status">
+      {{ successMessage }}
+    </div>
+
+    <!-- Error Toast -->
+    <div v-if="errorMessage" class="toast error" role="alert">
+      {{ errorMessage }}
+    </div>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, watch, toRef } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/useUserStore'
 import PreferencesPanel from '@/components/ui/PreferencesPanel.vue'
@@ -233,19 +222,12 @@ import VoiceSettingsPanel from '@/components/settings/VoiceSettingsPanel.vue'
 import LanguageSettingsPanel from '@/components/settings/LanguageSettingsPanel.vue'
 import DeviceManagementPanel from '@/components/profile/DeviceManagementPanel.vue'
 import { usePreferences } from '@/composables/usePreferences'
-import { useFocusTrap, useFocusRestore, useInitialFocus, useBodyScrollLock } from '@autobot/ui'
+import { BaseModal } from '@autobot/ui'
 import { useTabs } from '@/composables/useTabs'
 
-const props = defineProps<{
+defineProps<{
   isOpen: boolean
 }>()
-
-const dialogRef = ref<HTMLElement | null>(null)
-const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
-useFocusRestore(toRef(props, 'isOpen'))
-useBodyScrollLock(toRef(props, 'isOpen'))
-const { focusFirst } = useInitialFocus(dialogRef)
-watch(() => props.isOpen, (open) => { if (open) focusFirst() }, { immediate: true })
 
 const emit = defineEmits<{
   close: []
@@ -365,72 +347,13 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 </script>
 
 <style scoped>
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal);
-}
-
-.modal-content {
-  background: var(--bg-card);
-  border-radius: var(--radius-xl);
-  width: 90%;
-  max-width: 600px;
-  max-height: 90vh;
-  /* #10750 C2: keep header fixed; scroll only .modal-body */
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: var(--shadow-xl);
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-6);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-header h2 {
-  margin: var(--spacing-0);
-  font-size: var(--text-2xl);
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.close-button {
-  background: none;
-  border: none;
-  font-size: 32px;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: var(--spacing-0);
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-default);
-  transition: background-color var(--duration-200);
-}
-
-.close-button:hover {
-  background: var(--bg-secondary);
-}
-
+/* #10882: overlay/header chrome + focus-trap/scroll-lock now provided by
+   @autobot/ui BaseModal; the tab bar, panels and toasts remain here. */
 .tab-bar {
   display: flex;
   gap: var(--spacing-0);
   border-bottom: 1px solid var(--border-default);
-  padding: var(--spacing-0) var(--spacing-6);
+  margin-bottom: var(--spacing-6);
 }
 
 .tab-btn {
@@ -460,13 +383,6 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 
 .tab-btn i {
   font-size: var(--text-sm);
-}
-
-.modal-body {
-  padding: var(--spacing-6);
-  /* #10750 C2: single scroll region */
-  overflow-y: auto;
-  min-height: 0;
 }
 
 .profile-section {

--- a/autobot-frontend/src/components/ui/__tests__/BaseModal.test.ts
+++ b/autobot-frontend/src/components/ui/__tests__/BaseModal.test.ts
@@ -141,3 +141,45 @@ describe('BaseModal focus trap (#5016)', () => {
     outside.remove()
   })
 })
+
+
+describe('BaseModal custom width prop (#10882)', () => {
+  const mountWithProps = (props: Record<string, unknown>) =>
+    mount(BaseModal, {
+      props: { modelValue: true, title: 'Test', ...props },
+      slots: { default: '<div>body</div>' },
+      global: {
+        plugins: [i18n],
+        stubs: { Teleport: true, Transition: false, Icon: true },
+      },
+      attachTo: document.body,
+    })
+
+  it('applies a numeric width as an inline pixel max-width, overriding size', async () => {
+    const wrapper = mountWithProps({ size: 'sm', width: 640 })
+    await flushPromises()
+    const dialog = wrapper.find('.aui-dialog')
+    // size class stays (default preset behaviour preserved) ...
+    expect(dialog.classes()).toContain('aui-dialog-sm')
+    // ... but the explicit width wins via inline style
+    expect(dialog.attributes('style') || '').toContain('max-width: 640px')
+    wrapper.unmount()
+  })
+
+  it('passes a string width through unchanged', async () => {
+    const wrapper = mountWithProps({ width: '42rem' })
+    await flushPromises()
+    const dialog = wrapper.find('.aui-dialog')
+    expect(dialog.attributes('style') || '').toContain('max-width: 42rem')
+    wrapper.unmount()
+  })
+
+  it('adds no inline max-width when width is absent (size preset governs)', async () => {
+    const wrapper = mountWithProps({ size: 'lg' })
+    await flushPromises()
+    const dialog = wrapper.find('.aui-dialog')
+    expect(dialog.classes()).toContain('aui-dialog-lg')
+    expect(dialog.attributes('style') || '').not.toContain('max-width')
+    wrapper.unmount()
+  })
+})

--- a/autobot-frontend/src/views/BudgetPolicies.vue
+++ b/autobot-frontend/src/views/BudgetPolicies.vue
@@ -159,21 +159,19 @@
     </div>
 
     <!-- Create / Edit Modal -->
-    <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
-      <div class="modal-card" role="dialog" :aria-label="editTarget ? 'Edit Policy' : 'New Policy'">
-        <div class="modal-header">
-          <h3>{{ editTarget ? 'Edit Policy' : 'New Budget Policy' }}</h3>
-          <button class="btn-icon" aria-label="Close" @click="closeModal">
-            <Icon name="times" />
-          </button>
-        </div>
+    <BaseModal
+      :model-value="showModal"
+      :title="editTarget ? 'Edit Policy' : 'New Budget Policy'"
+      close-label="Close"
+      :width="560"
+      @close="closeModal"
+    >
+      <div v-if="modalError" class="error-banner">
+        <Icon name="exclamation-circle" />
+        <span>{{ modalError }}</span>
+      </div>
 
-        <div v-if="modalError" class="error-banner">
-          <Icon name="exclamation-circle" />
-          <span>{{ modalError }}</span>
-        </div>
-
-        <form class="modal-form" @submit.prevent="submitForm">
+      <form id="budget-policy-form" class="modal-form" @submit.prevent="submitForm">
           <div class="form-row">
             <label class="form-label">Name</label>
             <input v-model="form.name" type="text" class="text-input" placeholder="My policy" />
@@ -246,40 +244,44 @@
               Enabled
             </label>
           </div>
-          <div class="modal-actions">
-            <button type="button" class="btn-action-secondary" @click="closeModal">Cancel</button>
-            <button type="submit" class="btn-action-primary" :disabled="saving">
-              <Icon v-if="saving" name="sync-alt" :spin="true" />
-              {{ editTarget ? 'Save Changes' : 'Create Policy' }}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+      </form>
+
+      <template #actions>
+        <button type="button" class="btn-action-secondary" @click="closeModal">Cancel</button>
+        <button
+          type="submit"
+          form="budget-policy-form"
+          class="btn-action-primary"
+          :disabled="saving"
+        >
+          <Icon v-if="saving" name="sync-alt" :spin="true" />
+          {{ editTarget ? 'Save Changes' : 'Create Policy' }}
+        </button>
+      </template>
+    </BaseModal>
 
     <!-- Delete confirm dialog -->
-    <div v-if="deleteTarget" class="modal-overlay" @click.self="deleteTarget = null">
-      <div class="modal-card modal-card-sm" role="dialog" aria-label="Confirm Delete">
-        <div class="modal-header">
-          <h3>Delete Policy</h3>
-          <button class="btn-icon" aria-label="Close" @click="deleteTarget = null">
-            <Icon name="times" />
-          </button>
-        </div>
-        <p class="modal-body-text">
-          Are you sure you want to delete
-          <strong>{{ deleteTarget.name || deleteTarget.id }}</strong>?
-          This cannot be undone.
-        </p>
-        <div class="modal-actions">
-          <button class="btn-action-secondary" @click="deleteTarget = null">Cancel</button>
-          <button class="btn-action-danger" :disabled="deleting" @click="doDelete">
-            <Icon v-if="deleting" name="sync-alt" :spin="true" />
-            Delete
-          </button>
-        </div>
-      </div>
-    </div>
+    <BaseModal
+      :model-value="!!deleteTarget"
+      title="Delete Policy"
+      close-label="Close"
+      :width="420"
+      @close="deleteTarget = null"
+    >
+      <p v-if="deleteTarget" class="modal-body-text">
+        Are you sure you want to delete
+        <strong>{{ deleteTarget.name || deleteTarget.id }}</strong>?
+        This cannot be undone.
+      </p>
+
+      <template #actions>
+        <button class="btn-action-secondary" @click="deleteTarget = null">Cancel</button>
+        <button class="btn-action-danger" :disabled="deleting" @click="doDelete">
+          <Icon v-if="deleting" name="sync-alt" :spin="true" />
+          Delete
+        </button>
+      </template>
+    </BaseModal>
   </div>
 </template>
 
@@ -290,6 +292,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { useUserStore } from '@/stores/useUserStore'
 import Icon from '@/components/ui/Icon.vue'
+import { BaseModal } from '@autobot/ui'
 
 const logger = createLogger('BudgetPolicies')
 
@@ -886,56 +889,11 @@ onMounted(loadPolicies)
 .mt-6 { margin-top: var(--spacing-6); }
 
 /* Modal */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: var(--spacing-4);
-}
-
-.modal-card {
-  background: var(--color-bg);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  width: 100%;
-  max-width: 560px;
-  max-height: 90vh;
-  /* #10750 C2: keep header fixed; scroll only the form body (below) */
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.modal-card-sm {
-  max-width: 420px;
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-5) var(--spacing-6);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-header h3 {
-  font-size: var(--text-lg);
-  font-weight: 600;
-  margin: 0;
-}
-
+/* #10882: overlay/header/actions chrome now provided by @autobot/ui BaseModal. */
 .modal-form {
-  padding: var(--spacing-6);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-4);
-  /* #10750 C2: single scroll region beneath the fixed header */
-  overflow-y: auto;
-  min-height: 0;
 }
 
 .form-row {
@@ -974,16 +932,7 @@ onMounted(loadPolicies)
   cursor: pointer;
 }
 
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-2);
-  padding-top: var(--spacing-2);
-  border-top: 1px solid var(--border-default);
-}
-
 .modal-body-text {
-  padding: var(--spacing-5) var(--spacing-6);
   font-size: var(--text-sm);
   color: var(--text-primary);
   margin: 0;

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -126,21 +126,17 @@
     </div>
 
     <!-- Widget Configuration Modal -->
-    <div v-if="showConfigModal" class="modal-overlay" @click.self="showConfigModal = false">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4><Icon name="cog" class="modal-icon" /> {{ $t('views.customDashboard.configureWidget') }}</h4>
-          <button
-            @click="showConfigModal = false"
-            class="close-btn"
-            :aria-label="$t('common.close')"
-            :title="$t('common.close')"
-            type="button"
-          >
-            <Icon name="times" />
-          </button>
-        </div>
-        <div class="modal-body" v-if="configWidget">
+    <BaseModal
+      :model-value="showConfigModal"
+      :title="$t('views.customDashboard.configureWidget')"
+      :close-label="$t('common.close')"
+      :width="480"
+      @close="showConfigModal = false"
+    >
+      <template #title>
+        <Icon name="cog" class="modal-icon" /> {{ $t('views.customDashboard.configureWidget') }}
+      </template>
+      <div class="modal-body" v-if="configWidget">
           <div class="form-group">
             <label>{{ $t('views.customDashboard.widgetTitle') }}</label>
             <input v-model="configWidget.title" type="text" />
@@ -172,29 +168,24 @@
             </select>
           </div>
         </div>
-        <div class="modal-footer">
-          <button @click="showConfigModal = false" class="action-btn">{{ $t('views.customDashboard.cancel') }}</button>
-          <button @click="saveWidgetConfig" class="action-btn primary">{{ $t('views.customDashboard.saveChanges') }}</button>
-        </div>
-      </div>
-    </div>
+      <template #actions>
+        <button @click="showConfigModal = false" class="action-btn">{{ $t('views.customDashboard.cancel') }}</button>
+        <button @click="saveWidgetConfig" class="action-btn primary">{{ $t('views.customDashboard.saveChanges') }}</button>
+      </template>
+    </BaseModal>
 
     <!-- New Dashboard Modal -->
-    <div v-if="showNewDashboardModal" class="modal-overlay" @click.self="showNewDashboardModal = false">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4><Icon name="plus-circle" class="modal-icon" /> {{ $t('views.customDashboard.createDashboard') }}</h4>
-          <button
-            @click="showNewDashboardModal = false"
-            class="close-btn"
-            :aria-label="$t('common.close')"
-            :title="$t('common.close')"
-            type="button"
-          >
-            <Icon name="times" />
-          </button>
-        </div>
-        <div class="modal-body">
+    <BaseModal
+      :model-value="showNewDashboardModal"
+      :title="$t('views.customDashboard.createDashboard')"
+      :close-label="$t('common.close')"
+      :width="480"
+      @close="showNewDashboardModal = false"
+    >
+      <template #title>
+        <Icon name="plus-circle" class="modal-icon" /> {{ $t('views.customDashboard.createDashboard') }}
+      </template>
+      <div class="modal-body">
           <div class="form-group">
             <label>{{ $t('views.customDashboard.dashboardName') }}</label>
             <input v-model="newDashboardName" type="text" :placeholder="$t('views.customDashboard.myDashboard')" />
@@ -209,29 +200,24 @@
             </select>
           </div>
         </div>
-        <div class="modal-footer">
-          <button @click="showNewDashboardModal = false" class="action-btn">{{ $t('views.customDashboard.cancel') }}</button>
-          <button @click="confirmCreateDashboard" class="action-btn primary">{{ $t('views.customDashboard.create') }}</button>
-        </div>
-      </div>
-    </div>
+      <template #actions>
+        <button @click="showNewDashboardModal = false" class="action-btn">{{ $t('views.customDashboard.cancel') }}</button>
+        <button @click="confirmCreateDashboard" class="action-btn primary">{{ $t('views.customDashboard.create') }}</button>
+      </template>
+    </BaseModal>
 
     <!-- Add Widget Modal -->
-    <div v-if="showAddWidgetModal" class="modal-overlay" @click.self="showAddWidgetModal = false">
-      <div class="modal-content wide">
-        <div class="modal-header">
-          <h4><Icon name="plus-circle" class="modal-icon" /> {{ $t('views.customDashboard.addWidgetTitle') }}</h4>
-          <button
-            @click="showAddWidgetModal = false"
-            class="close-btn"
-            :aria-label="$t('common.close')"
-            :title="$t('common.close')"
-            type="button"
-          >
-            <Icon name="times" />
-          </button>
-        </div>
-        <div class="modal-body">
+    <BaseModal
+      :model-value="showAddWidgetModal"
+      :title="$t('views.customDashboard.addWidgetTitle')"
+      :close-label="$t('common.close')"
+      :width="800"
+      @close="showAddWidgetModal = false"
+    >
+      <template #title>
+        <Icon name="plus-circle" class="modal-icon" /> {{ $t('views.customDashboard.addWidgetTitle') }}
+      </template>
+      <div class="modal-body">
           <div class="widget-gallery">
             <div
               v-for="widget in availableWidgetDefs"
@@ -247,8 +233,7 @@
             </div>
           </div>
         </div>
-      </div>
-    </div>
+    </BaseModal>
   </div>
 </template>
 
@@ -264,6 +249,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useToast } from '@/composables/useToast'
 import Icon, { type IconName } from '@/components/ui/Icon.vue'
+import { BaseModal } from '@autobot/ui'
 
 // Import visualization components
 import ResourceHeatmap from '@/components/visualizations/ResourceHeatmap.vue'
@@ -985,72 +971,9 @@ defineExpose({ stopDashboardPolling })
 }
 
 /* Modals */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--bg-overlay);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal);
-}
-
-.modal-content {
-  background: var(--bg-secondary);
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--border-default);
-  width: 90%;
-  max-width: 480px;
-  max-height: 90vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.modal-content.wide {
-  max-width: 800px;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-4) var(--spacing-6);
-  background: var(--bg-tertiary);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-header h4 {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  font-size: var(--text-lg);
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
+/* #10882: overlay/header/footer chrome now provided by @autobot/ui BaseModal. */
 .modal-icon {
   color: var(--color-primary);
-}
-
-.close-btn {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: var(--spacing-1);
-}
-
-.close-btn:hover {
-  color: var(--text-primary);
-}
-
-.modal-body {
-  padding: var(--spacing-6);
-  overflow-y: auto;
-  flex: 1;
-  /* #10750 C2: allow the flex child to shrink so overflow actually scrolls */
-  min-height: 0;
 }
 
 .form-group {
@@ -1085,15 +1008,6 @@ defineExpose({ stopDashboardPolling })
 .form-group select:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
-}
-
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-3);
-  padding: var(--spacing-4) var(--spacing-6);
-  background: var(--bg-primary);
-  border-top: 1px solid var(--border-default);
 }
 
 /* Widget Gallery */

--- a/autobot-frontend/src/views/EvolutionView.vue
+++ b/autobot-frontend/src/views/EvolutionView.vue
@@ -271,19 +271,13 @@
     </div>
 
     <!-- Analysis Modal -->
-    <div v-if="showAnalysisModal" class="modal-overlay" @click.self="showAnalysisModal = false">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3 class="modal-title">{{ $t('analytics.evolution.analyzeRepository') }}</h3>
-          <button
-            @click="showAnalysisModal = false"
-            class="modal-close"
-            :aria-label="$t('common.close')"
-          >
-            <Icon name="times" />
-          </button>
-        </div>
-
+    <BaseModal
+      :model-value="showAnalysisModal"
+      :title="$t('analytics.evolution.analyzeRepository')"
+      :close-label="$t('common.close')"
+      :width="600"
+      @close="showAnalysisModal = false"
+    >
         <div class="modal-body">
           <div class="field-group">
             <label>{{ $t('analytics.evolution.modal.repoPath') }}</label>
@@ -333,22 +327,21 @@
           </div>
         </div>
 
-        <div class="modal-footer">
-          <button @click="showAnalysisModal = false" class="btn-action-secondary">
-            {{ $t('analytics.evolution.modal.cancel') }}
-          </button>
-          <button
-            @click="runAnalysis"
-            class="btn-action-primary"
-            :disabled="!analysisForm.repo_path || evolution.loading.value"
-          >
-            <Icon name="sync-alt" :spin="true" v-if="evolution.loading.value" />
-            <Icon name="play-circle" v-else />
-            {{ evolution.loading.value ? $t('analytics.evolution.modal.analyzing') : $t('analytics.evolution.modal.startAnalysis') }}
-          </button>
-        </div>
-      </div>
-    </div>
+      <template #actions>
+        <button @click="showAnalysisModal = false" class="btn-action-secondary">
+          {{ $t('analytics.evolution.modal.cancel') }}
+        </button>
+        <button
+          @click="runAnalysis"
+          class="btn-action-primary"
+          :disabled="!analysisForm.repo_path || evolution.loading.value"
+        >
+          <Icon name="sync-alt" :spin="true" v-if="evolution.loading.value" />
+          <Icon name="play-circle" v-else />
+          {{ evolution.loading.value ? $t('analytics.evolution.modal.analyzing') : $t('analytics.evolution.modal.startAnalysis') }}
+        </button>
+      </template>
+    </BaseModal>
   </div>
 </template>
 
@@ -361,6 +354,7 @@ import EvolutionTimelineChart from '@/components/charts/EvolutionTimelineChart.v
 import PatternEvolutionChart from '@/components/charts/PatternEvolutionChart.vue'
 import CodeEvolutionTimeline from '@/components/analytics/CodeEvolutionTimeline.vue'
 import Icon from '@/components/ui/Icon.vue'
+import { BaseModal } from '@autobot/ui'
 
 // Issue #3436: read sourceId from route param set by codebase/:sourceId parent
 const route = useRoute()
@@ -742,70 +736,8 @@ onMounted(async () => {
 }
 
 /* Modal */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal);
-}
-
-.modal-content {
-  background: var(--bg-primary);
-  border-radius: var(--radius-lg);
-  width: 90%;
-  max-width: 600px;
-  max-height: 90vh;
-  /* #10750 C2: keep header/footer fixed; scroll only .modal-body */
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: var(--shadow-2xl);
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-5);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-title {
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  color: var(--text-primary);
-}
-
-.modal-close {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  font-size: var(--text-lg);
-  cursor: pointer;
-  padding: var(--spacing-1);
-}
-
-.modal-close:hover {
-  color: var(--text-primary);
-}
-
-.modal-body {
-  padding: var(--spacing-5);
-  /* #10750 C2: single scroll region */
-  overflow-y: auto;
-  min-height: 0;
-}
-
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-3);
-  padding: var(--spacing-5);
-  border-top: 1px solid var(--border-default);
-}
+/* #10882: overlay/header/footer chrome now provided by @autobot/ui BaseModal;
+   .modal-body is just an unstyled body wrapper here. */
 
 /* Form Styles */
 .form-row {

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -335,27 +335,14 @@
     </div>
 
     <!-- Plugin Detail Modal -->
-    <div v-if="selectedPlugin" class="modal-overlay" @click.self="closeDetail">
-      <div
-        ref="detailDialogRef"
-        class="modal-panel"
-        role="dialog"
-        aria-modal="true"
-        :aria-label="$t('views.plugins.pluginDetails')"
-        tabindex="-1"
-        @keydown="onDetailKeydown"
-        @keydown.escape="closeDetail"
-      >
-        <div class="modal-header">
-          <h2 class="modal-title">{{ selectedPlugin.display_name }}</h2>
-          <button class="modal-close" @click="closeDetail" :aria-label="$t('views.plugins.close')">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <div class="modal-body">
+    <BaseModal
+      :model-value="!!selectedPlugin"
+      :title="selectedPlugin?.display_name ?? ''"
+      :close-label="$t('views.plugins.close')"
+      :width="560"
+      @close="closeDetail"
+    >
+        <div v-if="selectedPlugin" class="modal-body">
           <!-- Info Grid -->
           <dl class="info-grid">
             <dt>{{ $t('views.plugins.name') }}</dt><dd>{{ selectedPlugin.name }}</dd>
@@ -424,13 +411,13 @@
             <p v-else class="config-empty">{{ $t('views.plugins.noConfig') }}</p>
           </div>
         </div>
-      </div>
 
-      <!-- Audit Log Tab -->
+      <!-- Audit Log Tab (pre-existing: only renders while a plugin detail is
+           open + audit tab active; see #10882 follow-up note) -->
       <div v-if="!isMarketplaceActive && activeTab === 'audit'">
         <CapabilityAuditLog />
       </div>
-    </div>
+    </BaseModal>
 
     <!-- Capability Approval Dialog — Issue #9049 -->
     <CapabilityApprovalDialog
@@ -454,10 +441,10 @@
 // Issue #929 - Plugin Manager UI
 // Issue #1359: i18n string extraction
 // Issue #11522: schema-driven config form
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useFocusTrap, useFocusRestore, useInitialFocus, useBodyScrollLock } from '@autobot/ui'
+import { BaseModal } from '@autobot/ui'
 import { usePlugins, type PluginInfo, type PluginManifest } from '@/composables/usePlugins'
 import PluginInstallModal from '@/components/plugins/PluginInstallModal.vue'
 import CapabilityApprovalDialog from '@/components/plugins/CapabilityApprovalDialog.vue'
@@ -501,13 +488,6 @@ const actionLoading = ref<Record<string, boolean>>({})
 // Modal state
 const selectedPlugin = ref<PluginInfo | null>(null)
 
-const detailDialogRef = ref<HTMLElement | null>(null)
-const isDetailOpen = computed(() => selectedPlugin.value !== null)
-const { onKeydown: onDetailKeydown } = useFocusTrap(detailDialogRef)
-useFocusRestore(isDetailOpen)
-useBodyScrollLock(isDetailOpen)
-const { focusFirst: focusDetailFirst } = useInitialFocus(detailDialogRef)
-watch(isDetailOpen, (open) => { if (open) focusDetailFirst() }, { immediate: true })
 const pluginConfig = ref<Record<string, unknown> | null>(null)
 const configLoading = ref(false)
 const editingConfig = ref(false)
@@ -969,69 +949,9 @@ onMounted(async () => {
 }
 
 /* ---- Modal ---- */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal);
-  padding: var(--spacing-md);
-}
-
-.modal-panel {
-  background: var(--bg-primary);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg);
-  width: 100%;
-  max-width: 560px;
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: var(--shadow-2xl);
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-lg) var(--spacing-xl);
-  border-bottom: 1px solid var(--border-default);
-}
-
-.modal-title {
-  font-size: var(--text-lg);
-  font-weight: 700;
-  color: var(--text-primary);
-  margin: var(--spacing-0);
-}
-
-.modal-close {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: var(--spacing-xs);
-  border-radius: var(--radius-sm);
-  display: flex;
-  align-items: center;
-  transition: color var(--duration-150) var(--ease-in-out);
-}
-
-.modal-close:hover {
-  color: var(--text-primary);
-}
-
-.modal-close svg {
-  width: 20px;
-  height: 20px;
-}
-
+/* #10882: overlay/header chrome now provided by @autobot/ui BaseModal;
+   the detail body keeps its column layout + section gap. */
 .modal-body {
-  padding: var(--spacing-xl);
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
@@ -1170,10 +1090,6 @@ onMounted(async () => {
 
   .plugin-grid {
     grid-template-columns: 1fr;
-  }
-
-  .modal-panel {
-    max-height: 95vh;
   }
 }
 </style>

--- a/autobot-frontend/src/views/llc/BacklogView.vue
+++ b/autobot-frontend/src/views/llc/BacklogView.vue
@@ -122,9 +122,14 @@
     </div>
 
     <!-- AC Suggester create form -->
-    <div v-if="showCreateForm" class="modal-overlay" @click.self="showCreateForm = false">
-      <div class="modal-panel">
-        <h3>{{ t('llc.backlog.createTitle') }}</h3>
+    <BaseModal
+      :model-value="showCreateForm"
+      :title="t('llc.backlog.createTitle')"
+      :close-label="t('ui.modal.closeDialog')"
+      :width="560"
+      @close="showCreateForm = false"
+    >
+      <div class="modal-form-body">
         <div class="form-field">
           <label>{{ t('llc.backlog.fieldTitle') }}</label>
           <input v-model="newItem.title" type="text" class="form-input" :placeholder="t('llc.backlog.titlePlaceholder')" />
@@ -179,19 +184,25 @@
 
         <p v-if="createError" class="create-error" role="alert">{{ createError }}</p>
 
-        <div class="modal-actions">
-          <button class="btn-secondary" @click="showCreateForm = false">{{ t('common.cancel') }}</button>
-          <button class="btn-primary" :disabled="!newItem.title || isCreating" @click="createItem">
-            {{ isCreating ? t('llc.backlog.creating') : t('common.create') }}
-          </button>
-        </div>
       </div>
-    </div>
+
+      <template #actions>
+        <button class="btn-secondary" @click="showCreateForm = false">{{ t('common.cancel') }}</button>
+        <button class="btn-primary" :disabled="!newItem.title || isCreating" @click="createItem">
+          {{ isCreating ? t('llc.backlog.creating') : t('common.create') }}
+        </button>
+      </template>
+    </BaseModal>
 
     <!-- Bulk sprint assign drawer -->
-    <div v-if="showBulkAssign" class="modal-overlay" @click.self="showBulkAssign = false">
-      <div class="modal-panel">
-        <h3>{{ t('llc.backlog.assignToSprint') }}</h3>
+    <BaseModal
+      :model-value="showBulkAssign"
+      :title="t('llc.backlog.assignToSprint')"
+      :close-label="t('ui.modal.closeDialog')"
+      :width="560"
+      @close="showBulkAssign = false"
+    >
+      <div class="modal-form-body">
         <p>{{ t('llc.backlog.itemsSelected', { count: selectedIds.size }) }}</p>
         <div class="form-field">
           <label>{{ t('llc.backlog.project') }}</label>
@@ -211,14 +222,15 @@
             {{ t('llc.backlog.noSprints') }}
           </p>
         </div>
-        <div class="modal-actions">
-          <button class="btn-secondary" @click="showBulkAssign = false">{{ t('common.cancel') }}</button>
-          <button class="btn-primary" :disabled="!bulkSprintId || isBulkAssigning" @click="bulkAssign">
-            {{ isBulkAssigning ? t('llc.backlog.assigning') : t('llc.backlog.assign') }}
-          </button>
-        </div>
       </div>
-    </div>
+
+      <template #actions>
+        <button class="btn-secondary" @click="showBulkAssign = false">{{ t('common.cancel') }}</button>
+        <button class="btn-primary" :disabled="!bulkSprintId || isBulkAssigning" @click="bulkAssign">
+          {{ isBulkAssigning ? t('llc.backlog.assigning') : t('llc.backlog.assign') }}
+        </button>
+      </template>
+    </BaseModal>
 
     <WorkItemDetail
       v-if="detailItem"
@@ -238,6 +250,7 @@ import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import WorkItemDetail from './WorkItemDetail.vue'
 import WorkItemBadge from '@/components/llc/WorkItemBadge.vue'
+import { BaseModal } from '@autobot/ui'
 
 const logger = createLogger('BacklogView')
 const api = useApiClient()
@@ -643,33 +656,12 @@ onMounted(fetchBacklog)
   color: var(--text-secondary, #9ca3af);
 }
 
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
-}
-
-.modal-panel {
-  background: var(--bg-surface, #fff);
-  border-radius: 0.75rem;
-  padding: 1.5rem;
-  width: 100%;
-  max-width: 560px;
+/* #10882: overlay/panel/header/footer chrome now provided by @autobot/ui
+   BaseModal; only the body field stack keeps its 1rem gap here. */
+.modal-form-body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  max-height: 90vh;
-  overflow-y: auto;
-}
-
-.modal-panel h3 {
-  margin: 0;
-  font-size: 1.125rem;
-  font-weight: 600;
 }
 
 .form-field {
@@ -757,12 +749,6 @@ onMounted(fetchBacklog)
   gap: 0.5rem;
   font-size: 0.875rem;
   cursor: pointer;
-}
-
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
 }
 
 .create-error {

--- a/libs/autobot-ui/src/components/BaseModal.vue
+++ b/libs/autobot-ui/src/components/BaseModal.vue
@@ -11,8 +11,9 @@
   ../tokens/contract.css).
 
   Public API is preserved unchanged from the app version:
-    props   : modelValue (v-model), title, size (sm|md|lg), showClose,
-              closeOnOverlay, scrollable, closeLabel
+    props   : modelValue (v-model), title, size (sm|md|lg), width (custom
+              px/CSS width overriding size), showClose, closeOnOverlay,
+              scrollable, closeLabel
     slots   : title (rich header, falls back to `title` prop), default (body),
               actions (footer)
     emits   : update:modelValue, close
@@ -44,6 +45,13 @@ interface Props {
   title: string
   /** Modal size: sm (500px), md (900px), lg (1200px) */
   size?: ModalSize
+  /**
+   * Explicit dialog width — a CSS length string (e.g. "560px", "40rem") or a
+   * number treated as pixels. When set it overrides the `size`-derived width;
+   * when absent the `size` preset is used. The dialog still never exceeds the
+   * viewport (base `width: 90%` keeps it responsive on small screens).
+   */
+  width?: string | number
   /** Show close button */
   showClose?: boolean
   /** Close on overlay click */
@@ -95,6 +103,16 @@ const sizeClass = computed(() => {
   }
 })
 
+// When an explicit `width` is provided, override the size-preset max-width via
+// an inline style. Numbers are treated as pixels; strings pass through as-is.
+const dialogStyle = computed<Record<string, string> | undefined>(() => {
+  if (props.width === undefined || props.width === null || props.width === '') {
+    return undefined
+  }
+  const w = typeof props.width === 'number' ? `${props.width}px` : props.width
+  return { maxWidth: w }
+})
+
 const handleClose = () => {
   emit('update:modelValue', false)
   emit('close')
@@ -127,6 +145,7 @@ const onAfterEnter = () => focusFirst()
           :aria-describedby="descriptionId"
           class="aui-dialog"
           :class="[sizeClass, { 'aui-dialog-scrollable': scrollable }]"
+          :style="dialogStyle"
           tabindex="-1"
           @click.stop
           @keydown="onFocusTrapKeydown"
@@ -226,6 +245,9 @@ const onAfterEnter = () => focusFirst()
   align-items: center;
   padding: var(--aui-space-6);
   border-bottom: 1px solid var(--aui-color-border);
+  /* #10882: pin the chrome so only .aui-dialog-content yields space on short
+     viewports; default flex-shrink:1 let the header/footer compress and clip. */
+  flex-shrink: 0;
 }
 
 .aui-dialog-header h3 {
@@ -277,6 +299,8 @@ const onAfterEnter = () => focusFirst()
   gap: var(--aui-space-3);
   padding: var(--aui-space-6);
   border-top: 1px solid var(--aui-color-border);
+  /* #10882: keep the footer at full height so its buttons are never clipped. */
+  flex-shrink: 0;
 }
 
 /* Transitions */


### PR DESCRIPTION
## Thinking Path
PR-2 of the @autobot/ui consolidation. Migrated the remaining deferred bespoke-overlay modals to the shared BaseModal, fixed the footer-clipping bug, and (per owner decision) added a custom-width prop so migrated modals keep their exact original widths instead of snapping to sm/md/lg.

## What Changed
- **BaseModal**: footer-clip root cause fixed (`flex-shrink:0` on header + footer so only the body scrolls under `max-height:90vh`). New optional `width` prop (CSS string or px number) overrides the size preset; `size` still the default; responsive `width:90%` preserved so it never overflows small screens.
- **15 modal instances across 11 files** migrated to `<BaseModal>` (bespoke overlay/focus-trap/scroll-lock removed — BaseModal handles it), each carrying its exact original `:width` (520/600/560/420/480/800/360/700/…). Net −660 lines.
- No copy/strings changed (i18n is PR-3). Intentionally-bespoke surfaces (chat input, lightbox, bottom-sheet, terminal, slide-over) left untouched.
- Fixed a stray dangling CSS selector in KnowledgeGraph.vue found in-scope.

Part of #10882 (closes with PR-3 modal i18n). Discovered #11980 (PluginsView audit tab renders empty — pre-existing, flagged not silently changed).

## Verification (CI down — local gate)
- `vue-tsc --noEmit -p tsconfig.app.json` exit 0. BaseModal.test.ts 8/8 (3 new width-prop tests); full modal suite 25/25.

## Model Used
Opus 4.8 (subagent: frontend-engineer)