### PR TITLE
fix(deploy): autobot_shared-first ordering, co-located service coverage, consolidate slm-agent runtime (#11611, #11605, #11508)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
@@ -27,10 +27,19 @@ slm_agent_group: autobot
 slm_agent_dir: /opt/autobot/autobot-slm-agent
 slm_agent_data_dir: /var/lib/slm-agent
 
-# Python dependencies for the agent
+# Python dependencies for the agent (#11508)
+# The agent runs on the system interpreter (/usr/bin/python3, see the service
+# unit's ExecStart) and MUST have every module it + autobot_shared import on ONE
+# interpreter — it can no longer borrow modules from the SLM backend venv.
+#   - aiohttp: agent.py HTTP client/server
+#   - psutil:  health_collector resource metrics
+#   - redis:   autobot_shared.redis_client (health_collector.py imports it at
+#              module load) — was MISSING here, so a fresh restart on the system
+#              python crash-looped with ModuleNotFoundError: No module named 'redis'.
 slm_agent_python_packages:
   - aiohttp
   - psutil
+  - redis
 
 # Services to monitor (systemd service names)
 # Override per-host in inventory, e.g.:

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/clean.yml
@@ -45,3 +45,21 @@
     state: absent
   become: true
   tags: ['clean']
+
+# #11508: a stale, hand-created systemd drop-in repointed the agent's ExecStart
+# interpreter at the SLM backend venv (/opt/autobot/autobot-slm-backend/venv/bin/
+# python). That venv has no aiohttp, so a fresh restart crash-looped
+# (ModuleNotFoundError: No module named 'aiohttp'). The role owns the agent
+# runtime on the SYSTEM interpreter (see slm-agent.service.j2 + the redis dep in
+# defaults) — remove the override so the base unit's ExecStart is authoritative.
+# Ansible manages this on-box artifact (it is NOT tracked in the repo); the
+# systemd reload/restart later in main.yml picks up the change.
+- name: "SLM Agent | Clean: remove stale pythonpath.conf systemd drop-in (#11508)"
+  ansible.builtin.file:
+    path: /etc/systemd/system/slm-agent.service.d/pythonpath.conf
+    state: absent
+  become: true
+  notify:
+    - Reload systemd
+    - Restart SLM agent
+  tags: ['clean', 'systemd']

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -34,7 +34,12 @@ WorkingDirectory={{ slm_agent_dir }}
 # Environment variables
 Environment=SLM_NODE_ID={{ slm_node_id }}
 Environment=SLM_ADMIN_URL={{ effective_admin_url }}
-Environment=PYTHONPATH={{ slm_agent_dir }}
+# #11508: PYTHONPATH must let the SYSTEM interpreter (ExecStart below) import
+# autobot_shared on its own — the agent no longer borrows it from the SLM backend
+# venv. `{{ slm_agent_dir }}` resolves `slm.agent.*`; `{{ slm_agent_dir | dirname }}`
+# is the install base (/opt/autobot) so `import autobot_shared` finds
+# /opt/autobot/autobot_shared directly, independent of the per-dir symlink.
+Environment=PYTHONPATH={{ slm_agent_dir }}:{{ slm_agent_dir | dirname }}
 Environment=PYTHONUNBUFFERED=1
 # Issue #9226: Redis connection for autobot_shared imports
 Environment=REDIS_HOST={{ slm_agent_redis_host }}
@@ -46,6 +51,10 @@ EnvironmentFile=-{{ slm_agent_data_dir }}/agent-secrets.env
 
 # Agent execution — admin_url resolved from SLM_ADMIN_URL env var above,
 # not baked into CLI args, so re-provisioning updates it (#2833).
+# #11508: the interpreter is the system python3, which the role provisions with
+# ALL agent deps (aiohttp + psutil + redis). A stale drop-in that repointed this
+# at the backend venv (which lacks aiohttp) is removed by the role's clean tasks
+# so this ExecStart stays authoritative.
 ExecStart=/usr/bin/python3 -m slm.agent.agent \
     --node-id {{ slm_node_id }} \
     --interval {{ slm_heartbeat_interval }}{% if slm_services_to_monitor | length > 0 %} \

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -247,6 +247,24 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
             deployed_dir,
         )
 
+        # #11611: autobot_shared-first — sync the shared library BEFORE this
+        # component's own rsync + restart so a newly-added `from autobot_shared.X`
+        # import resolves at startup and the control plane cannot crash-loop on a
+        # half-deployed shared tree. Fail the job if it cannot be synced.
+        shared_ok, shared_msg = await _ensure_autobot_shared_synced(component)
+        if not shared_ok:
+            async with db_service.session() as db:
+                result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
+                job_row = result.scalar_one_or_none()
+                if job_row:
+                    job_row.status = "failed"
+                    job_row.success = False
+                    job_row.message = shared_msg
+                    job_row.completed_at = datetime.now(timezone.utc)
+                    await db.commit()
+            logger.error("component resolve job %s: %s", job_id, shared_msg)
+            return
+
         ok, msg = await _rsync_component_local(source_root, component, excludes)
 
         if not ok:
@@ -681,6 +699,20 @@ async def resolve_drift(
         request.component,
         deployed_dir,
     )
+
+    # #11611: autobot_shared-first — sync the shared library BEFORE this
+    # component's own rsync + restart so a newly-added `from autobot_shared.X`
+    # import resolves at startup and the control plane cannot crash-loop on a
+    # half-deployed shared tree. Fail the resolve if it cannot be synced.
+    shared_ok, shared_msg = await _ensure_autobot_shared_synced(request.component)
+    if not shared_ok:
+        return DriftResolveResponse(
+            success=False,
+            component=request.component,
+            message=shared_msg,
+            source_dir=source_dir,
+            deployed_dir=deployed_dir,
+        )
 
     ok, msg = await _rsync_component_local(source_root, request.component, excludes)
 
@@ -2220,6 +2252,46 @@ async def _ensure_autobot_shared_symlink(component: str, steps: List[str]) -> No
     except Exception as exc:
         logger.error("drift resolve: symlink restore failed for %s: %s", component, exc)
         steps.append(f"symlink: restore failed for {component}: {exc}")
+
+
+async def _ensure_autobot_shared_synced(component: str) -> Tuple[bool, str]:
+    """Resync autobot_shared from code_source BEFORE a dependent backend deploys (#11611).
+
+    #11611 root cause: autobot_shared is a component deployed by its OWN
+    drift/resolve — it is NOT pulled in when a dependent (autobot-slm-backend /
+    autobot-backend) is resolved. When a resync of a backend deployed new code
+    that imports a freshly-added shared module (e.g. `from autobot_shared.db_url
+    import assemble_postgres_url`, #11583) and then restarted the service while
+    /opt/autobot/autobot_shared still held the OLD tree, the import failed at
+    startup and the control plane crash-looped (taking the code-sync API offline —
+    a chicken-and-egg that needed a manual recovery).
+
+    Enforce autobot_shared-first ordering at the per-component deploy sites: for a
+    Python backend component, rsync the shared library from code_source ahead of
+    the component's own rsync + restart so every new shared import resolves. No-op
+    (returns success) for autobot_shared itself and for frontends — they either ARE
+    the shared component or do not import it at start.
+
+    Returns (ok, message). On rsync failure the caller must fail-safe (do NOT
+    restart the backend onto a half-deployed shared tree).
+    """
+    if component not in _BACKEND_COMPONENTS:
+        return True, ""
+    try:
+        shared_source = get_default_source_dir("autobot_shared")
+    except ValueError:
+        # code_source layout unavailable — leave the existing tree in place rather
+        # than blocking the resolve; the symlink restore still runs downstream.
+        return True, "autobot_shared source path unavailable — left as-is"
+    source_root = str(Path(shared_source).parent)
+    excludes_map = {comp: excl for comp, excl in _SLM_COMPONENTS}
+    excludes = excludes_map.get("autobot_shared", [])
+    ok, msg = await _rsync_component_local(source_root, "autobot_shared", excludes)
+    if ok:
+        logger.info("autobot_shared-first: resynced ahead of %s (#11611)", component)
+        return True, f"autobot_shared-first: resynced ahead of {component} (#11611)"
+    logger.error("autobot_shared-first: resync FAILED before %s: %s (#11611)", component, msg)
+    return False, f"autobot_shared-first: resync failed before {component}: {msg} (#11611)"
 
 
 async def _run_post_sync_steps(
@@ -4120,6 +4192,71 @@ async def _run_pull_stage(job: UpdateAllJob, db_service_ref) -> Optional[str]:
         return None
 
 
+# Managed application services that run co-located on the SLM-Manager node in a
+# single-box install. update-all's slm_self_update stage covers only the SLM
+# control plane and the fleet stage skips the self-node, so these were updated by
+# NEITHER stage whenever the SLM commit was already current — the one-click update
+# reported success while autobot-backend/-frontend stayed stale (#11605). They are
+# resolved via the SAME per-component drift/resolve path as the manual
+# "Resync from Source" button (rsync + _run_post_sync_steps).
+_COLOCATED_MANAGED_COMPONENTS: Tuple[str, ...] = ("autobot-backend", "autobot-frontend")
+
+
+async def _component_has_file_drift(component: str) -> bool:
+    """Return True when *component* is deployed on this host AND drifts from code_source.
+
+    A missing deployed dir means the component is not co-located here (e.g. a pure
+    SLM control-plane box) — treated as "no drift" so we never try to resolve a
+    component that does not run on this node.
+    """
+    try:
+        source_dir = get_default_source_dir(component)
+    except ValueError:
+        return False
+    deployed_dir = get_default_deployed_dir(component)
+    if not Path(deployed_dir).exists():
+        return False
+    report = await asyncio.get_running_loop().run_in_executor(
+        None,
+        functools.partial(build_drift_report, source_dir, deployed_dir, component),
+    )
+    return len(report.get("drifted_files", [])) > 0
+
+
+async def _resolve_colocated_managed_services(stage: UpdateAllStage) -> None:
+    """Resolve co-located managed services on the SLM-Manager node (#11605).
+
+    Runs the existing per-component drift/resolve path (rsync + _run_post_sync_steps,
+    which handles pip/build/migrate/restart + health + rollback) for each co-located
+    managed component that (a) is actually deployed on this host and (b) has file
+    drift. No new deploy mechanism is introduced — this reuses the exact steps the
+    manual resolve_drift endpoint uses, so autobot_shared-first ordering (#11611)
+    and health/rollback are inherited for free. Per-component failures are logged
+    and do not abort the pipeline.
+    """
+    for component in _COLOCATED_MANAGED_COMPONENTS:
+        if component not in ALLOWED_COMPONENTS:
+            continue
+        try:
+            if not await _component_has_file_drift(component):
+                _stage_log(stage, f"co-located {component}: no drift — skipped (#11605)")
+                continue
+            _stage_log(stage, f"co-located {component}: drift detected — resolving (#11605)")
+            source_dir = get_default_source_dir(component)
+            deployed_dir = get_default_deployed_dir(component)
+            source_root = str(Path(source_dir).parent)
+            excludes_map = {comp: excl for comp, excl in _SLM_COMPONENTS}
+            excludes = excludes_map.get(component, [])
+            ok, msg = await _rsync_component_local(source_root, component, excludes)
+            if not ok:
+                _stage_log(stage, f"co-located {component}: rsync failed: {msg} (#11605)")
+                continue
+            _, _post_steps, pip_ok = await _run_post_sync_steps(component, source_dir, deployed_dir)
+            _stage_log(stage, f"co-located {component}: resolved (ok={pip_ok}) (#11605)")
+        except Exception as exc:
+            _stage_log(stage, f"co-located {component}: resolve error: {exc} (#11605)")
+
+
 async def _run_slm_stage(
     job: UpdateAllJob,
     remote_commit: str,
@@ -4157,6 +4294,13 @@ async def _run_slm_stage(
             stage.status = _StageStatus.CURRENT
             stage.sha = _short_sha(remote_commit)
             stage.message = f"SLM already at {_short_sha(remote_commit)} — no restart needed"
+            # #11605: the SLM control plane is current, so no Ansible self-update
+            # fires — but co-located managed services (autobot-backend/-frontend)
+            # can still carry file drift that neither this stage nor the self-node-
+            # skipping fleet stage would otherwise resolve. Resolve them here via
+            # the per-component drift/resolve path so the one-click update actually
+            # brings the whole co-located box current.
+            await _resolve_colocated_managed_services(stage)
             stage.completed_at = _now_iso()
             _stage_log(stage, stage.message)
             return False

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -4226,13 +4226,21 @@ async def _component_has_file_drift(component: str) -> bool:
 async def _resolve_colocated_managed_services(stage: UpdateAllStage) -> None:
     """Resolve co-located managed services on the SLM-Manager node (#11605).
 
-    Runs the existing per-component drift/resolve path (rsync + _run_post_sync_steps,
-    which handles pip/build/migrate/restart + health + rollback) for each co-located
+    Runs the per-component drift/resolve path (rsync + _run_post_sync_steps, which
+    handles pip/build/migrate/restart + health + rollback) for each co-located
     managed component that (a) is actually deployed on this host and (b) has file
-    drift. No new deploy mechanism is introduced — this reuses the exact steps the
-    manual resolve_drift endpoint uses, so autobot_shared-first ordering (#11611)
-    and health/rollback are inherited for free. Per-component failures are logged
-    and do not abort the pipeline.
+    drift.
+
+    #11611: autobot_shared-first ordering is enforced HERE explicitly — this loop
+    is a THIRD deploy site (alongside resolve_drift and _run_component_resolve_job).
+    _run_post_sync_steps only recreates the autobot_shared SYMLINK; it does NOT
+    sync the shared tree CONTENT, so without an explicit _ensure_autobot_shared_synced
+    call this path could rsync + restart autobot-backend onto a STALE autobot_shared
+    and crash-loop it (the exact #11611 failure, on the one-click co-located update).
+    So we call _ensure_autobot_shared_synced BEFORE the component rsync and skip the
+    component (fail-safe, no restart) when the shared tree cannot be synced.
+
+    Per-component failures are logged and do not abort the pipeline.
     """
     for component in _COLOCATED_MANAGED_COMPONENTS:
         if component not in ALLOWED_COMPONENTS:
@@ -4242,6 +4250,13 @@ async def _resolve_colocated_managed_services(stage: UpdateAllStage) -> None:
                 _stage_log(stage, f"co-located {component}: no drift — skipped (#11605)")
                 continue
             _stage_log(stage, f"co-located {component}: drift detected — resolving (#11605)")
+            # #11611: sync autobot_shared BEFORE this component's rsync + restart so
+            # a newly-added `from autobot_shared.X` import resolves at startup. Skip
+            # the component (no restart) if the shared tree cannot be synced.
+            shared_ok, shared_msg = await _ensure_autobot_shared_synced(component)
+            if not shared_ok:
+                _stage_log(stage, f"co-located {component}: {shared_msg} — skipped (#11611)")
+                continue
             source_dir = get_default_source_dir(component)
             deployed_dir = get_default_deployed_dir(component)
             source_root = str(Path(source_dir).parent)

--- a/autobot-slm-backend/tests/api/test_colocated_managed_update_11605.py
+++ b/autobot-slm-backend/tests/api/test_colocated_managed_update_11605.py
@@ -1,0 +1,177 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for co-located managed-service resolution in update-all (#11605).
+
+update-all's slm_self_update stage covers only the SLM control plane and the
+fleet stage skips the self-node, so on a co-located single-box install the
+managed application services (autobot-backend / autobot-frontend) were updated
+by NEITHER stage when the SLM commit was already current. These tests cover the
+_resolve_colocated_managed_services helper that closes that gap via the existing
+per-component drift/resolve path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Dev-host stub for models.schemas so api.code_sync imports without a full venv.
+# ---------------------------------------------------------------------------
+_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
+if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
+    from pydantic import BaseModel as _BM
+
+    def _pydantic_stub(name: str, **fields) -> type:
+        return type(name, (_BM,), {"__annotations__": {k: type(v) for k, v in fields.items()}, **fields})
+
+    _schemas = types.ModuleType("models.schemas")
+    for _cls in [
+        "CodeSyncStatusResponse",
+        "CodeSyncRefreshResponse",
+        "CodeVersionNotification",
+        "CodeVersionNotificationResponse",
+        "ComponentSyncJobStatus",
+        "DriftResolveJobResponse",
+        "DriftResolveRequest",
+        "DriftResolveResponse",
+        "FileDriftReport",
+        "FleetSyncJobStatus",
+        "FleetSyncNodeStatus",
+        "FleetSyncRequest",
+        "FleetSyncResponse",
+        "MarkSyncedResponse",
+        "NodeSyncRequest",
+        "NodeSyncResponse",
+        "PendingNodeResponse",
+        "PendingNodesResponse",
+        "ScheduleCreate",
+        "ScheduleResponse",
+        "ScheduleRunResponse",
+        "ScheduleUpdate",
+    ]:
+        setattr(_schemas, _cls, _pydantic_stub(_cls))
+    _models = sys.modules.get("models") or types.ModuleType("models")
+    _models.schemas = _schemas  # type: ignore[attr-defined]
+    sys.modules["models"] = _models
+    sys.modules["models.schemas"] = _schemas
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+import api.code_sync as _CS  # noqa: E402
+from api.code_sync import (  # noqa: E402
+    UpdateAllStage,
+    _resolve_colocated_managed_services,
+)
+
+for _k, _v in _MODELS_SNAPSHOT.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+if "models" in sys.modules and "models.schemas" in sys.modules:
+    sys.modules["models"].schemas = sys.modules["models.schemas"]
+del _MODELS_SNAPSHOT
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_resolves_only_drifted_colocated_components() -> None:
+    """A drifted co-located component is rsynced + post-synced; a clean one is skipped."""
+    stage = UpdateAllStage(name="slm_self_update")
+
+    # autobot-backend has drift, autobot-frontend does not.
+    async def fake_drift(component: str) -> bool:
+        return component == "autobot-backend"
+
+    rsynced: list = []
+
+    async def fake_rsync(src, comp, excludes):
+        rsynced.append(comp)
+        return True, ""
+
+    post_synced: list = []
+
+    async def fake_post_sync(comp, src, dep):
+        post_synced.append(comp)
+        return False, ["ok"], True
+
+    with (
+        patch("api.code_sync.ALLOWED_COMPONENTS", {"autobot-backend", "autobot-frontend"}),
+        patch("api.code_sync._component_has_file_drift", side_effect=fake_drift),
+        patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/autobot-backend"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/autobot-backend"),
+        patch("api.code_sync._rsync_component_local", side_effect=fake_rsync),
+        patch("api.code_sync._run_post_sync_steps", side_effect=fake_post_sync),
+    ):
+        _run(_resolve_colocated_managed_services(stage))
+
+    # Only the drifted component is resolved.
+    assert rsynced == ["autobot-backend"]
+    assert post_synced == ["autobot-backend"]
+
+
+def test_no_resolution_when_no_drift() -> None:
+    """When neither co-located service drifts, nothing is rsynced or restarted."""
+    stage = UpdateAllStage(name="slm_self_update")
+
+    with (
+        patch("api.code_sync._component_has_file_drift", AsyncMock(return_value=False)),
+        patch("api.code_sync._rsync_component_local", AsyncMock()) as rsync_mock,
+        patch("api.code_sync._run_post_sync_steps", AsyncMock()) as post_mock,
+    ):
+        _run(_resolve_colocated_managed_services(stage))
+
+    rsync_mock.assert_not_called()
+    post_mock.assert_not_called()
+
+
+def test_rsync_failure_does_not_abort_other_components() -> None:
+    """A per-component rsync failure is logged and the loop continues (non-fatal)."""
+    stage = UpdateAllStage(name="slm_self_update")
+
+    async def fake_drift(component: str) -> bool:
+        return True  # both drift
+
+    post_synced: list = []
+
+    async def fake_post_sync(comp, src, dep):
+        post_synced.append(comp)
+        return False, ["ok"], True
+
+    async def fake_rsync(src, comp, excludes):
+        # autobot-backend fails to rsync; autobot-frontend succeeds.
+        if comp == "autobot-backend":
+            return False, "rsync boom"
+        return True, ""
+
+    with (
+        patch("api.code_sync.ALLOWED_COMPONENTS", {"autobot-backend", "autobot-frontend"}),
+        patch("api.code_sync._component_has_file_drift", side_effect=fake_drift),
+        patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/x"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/x"),
+        patch("api.code_sync._rsync_component_local", side_effect=fake_rsync),
+        patch("api.code_sync._run_post_sync_steps", side_effect=fake_post_sync),
+    ):
+        _run(_resolve_colocated_managed_services(stage))
+
+    # backend rsync failed → not post-synced; frontend still resolved.
+    assert post_synced == ["autobot-frontend"]
+
+
+def test_component_has_file_drift_false_when_not_deployed() -> None:
+    """A component whose deployed dir is absent is treated as not co-located (no drift)."""
+    with (
+        patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/autobot-backend"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/nonexistent/path/autobot-backend"),
+    ):
+        result = _run(_CS._component_has_file_drift("autobot-backend"))
+    assert result is False

--- a/autobot-slm-backend/tests/api/test_colocated_managed_update_11605.py
+++ b/autobot-slm-backend/tests/api/test_colocated_managed_update_11605.py
@@ -9,7 +9,9 @@ fleet stage skips the self-node, so on a co-located single-box install the
 managed application services (autobot-backend / autobot-frontend) were updated
 by NEITHER stage when the SLM commit was already current. These tests cover the
 _resolve_colocated_managed_services helper that closes that gap via the existing
-per-component drift/resolve path.
+per-component drift/resolve path — including its explicit #11611 autobot_shared-
+first ordering (this loop is a THIRD deploy site, so shared-first must be enforced
+here too, not inherited).
 """
 
 from __future__ import annotations
@@ -19,6 +21,8 @@ import sys
 import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Dev-host stub for models.schemas so api.code_sync imports without a full venv.
@@ -80,8 +84,20 @@ if "models" in sys.modules and "models.schemas" in sys.modules:
 del _MODELS_SNAPSHOT
 
 
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+_ALLOWED = {"autobot-backend", "autobot-frontend"}
+
+
+@pytest.fixture(autouse=True)
+def _restore_event_loop_after():
+    """asyncio.run() (this module's runner) tears down and NULLs the global event
+    loop. Sibling test modules still use asyncio.get_event_loop() — restore a fresh
+    loop after each test so the cross-module sweep does not RuntimeError.
+    """
+    yield
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
 
 
 def test_resolves_only_drifted_colocated_components() -> None:
@@ -105,31 +121,95 @@ def test_resolves_only_drifted_colocated_components() -> None:
         return False, ["ok"], True
 
     with (
-        patch("api.code_sync.ALLOWED_COMPONENTS", {"autobot-backend", "autobot-frontend"}),
+        patch("api.code_sync.ALLOWED_COMPONENTS", _ALLOWED),
+        patch("api.code_sync._ensure_autobot_shared_synced", AsyncMock(return_value=(True, ""))),
         patch("api.code_sync._component_has_file_drift", side_effect=fake_drift),
         patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/autobot-backend"),
         patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/autobot-backend"),
         patch("api.code_sync._rsync_component_local", side_effect=fake_rsync),
         patch("api.code_sync._run_post_sync_steps", side_effect=fake_post_sync),
     ):
-        _run(_resolve_colocated_managed_services(stage))
+        asyncio.run(_resolve_colocated_managed_services(stage))
 
     # Only the drifted component is resolved.
     assert rsynced == ["autobot-backend"]
     assert post_synced == ["autobot-backend"]
 
 
+def test_shared_first_called_before_component_rsync() -> None:
+    """#11611: _ensure_autobot_shared_synced runs BEFORE the component rsync (order lock)."""
+    stage = UpdateAllStage(name="slm_self_update")
+    calls: list = []
+
+    async def fake_drift(component: str) -> bool:
+        return component == "autobot-backend"
+
+    async def fake_shared(component: str):
+        calls.append(("shared", component))
+        return True, "ok"
+
+    async def fake_rsync(src, comp, excludes):
+        calls.append(("rsync", comp))
+        return True, ""
+
+    async def fake_post_sync(comp, src, dep):
+        calls.append(("post", comp))
+        return False, ["ok"], True
+
+    with (
+        patch("api.code_sync.ALLOWED_COMPONENTS", _ALLOWED),
+        patch("api.code_sync._ensure_autobot_shared_synced", side_effect=fake_shared),
+        patch("api.code_sync._component_has_file_drift", side_effect=fake_drift),
+        patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/autobot-backend"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/autobot-backend"),
+        patch("api.code_sync._rsync_component_local", side_effect=fake_rsync),
+        patch("api.code_sync._run_post_sync_steps", side_effect=fake_post_sync),
+    ):
+        asyncio.run(_resolve_colocated_managed_services(stage))
+
+    # shared-first for autobot-backend precedes its own rsync, which precedes post-sync.
+    assert calls == [
+        ("shared", "autobot-backend"),
+        ("rsync", "autobot-backend"),
+        ("post", "autobot-backend"),
+    ]
+
+
+def test_shared_sync_failure_skips_component_rsync() -> None:
+    """#11611 fail-safe: a failed shared sync skips the component rsync + restart entirely."""
+    stage = UpdateAllStage(name="slm_self_update")
+
+    async def fake_drift(component: str) -> bool:
+        return component == "autobot-backend"
+
+    with (
+        patch("api.code_sync.ALLOWED_COMPONENTS", _ALLOWED),
+        patch("api.code_sync._ensure_autobot_shared_synced", AsyncMock(return_value=(False, "shared boom"))),
+        patch("api.code_sync._component_has_file_drift", side_effect=fake_drift),
+        patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/autobot-backend"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/autobot-backend"),
+        patch("api.code_sync._rsync_component_local", AsyncMock()) as rsync_mock,
+        patch("api.code_sync._run_post_sync_steps", AsyncMock()) as post_mock,
+    ):
+        asyncio.run(_resolve_colocated_managed_services(stage))
+
+    rsync_mock.assert_not_called()
+    post_mock.assert_not_called()
+
+
 def test_no_resolution_when_no_drift() -> None:
-    """When neither co-located service drifts, nothing is rsynced or restarted."""
+    """When neither co-located service drifts, nothing is synced or restarted."""
     stage = UpdateAllStage(name="slm_self_update")
 
     with (
         patch("api.code_sync._component_has_file_drift", AsyncMock(return_value=False)),
+        patch("api.code_sync._ensure_autobot_shared_synced", AsyncMock()) as shared_mock,
         patch("api.code_sync._rsync_component_local", AsyncMock()) as rsync_mock,
         patch("api.code_sync._run_post_sync_steps", AsyncMock()) as post_mock,
     ):
-        _run(_resolve_colocated_managed_services(stage))
+        asyncio.run(_resolve_colocated_managed_services(stage))
 
+    shared_mock.assert_not_called()
     rsync_mock.assert_not_called()
     post_mock.assert_not_called()
 
@@ -154,14 +234,15 @@ def test_rsync_failure_does_not_abort_other_components() -> None:
         return True, ""
 
     with (
-        patch("api.code_sync.ALLOWED_COMPONENTS", {"autobot-backend", "autobot-frontend"}),
+        patch("api.code_sync.ALLOWED_COMPONENTS", _ALLOWED),
+        patch("api.code_sync._ensure_autobot_shared_synced", AsyncMock(return_value=(True, ""))),
         patch("api.code_sync._component_has_file_drift", side_effect=fake_drift),
         patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/x"),
         patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/x"),
         patch("api.code_sync._rsync_component_local", side_effect=fake_rsync),
         patch("api.code_sync._run_post_sync_steps", side_effect=fake_post_sync),
     ):
-        _run(_resolve_colocated_managed_services(stage))
+        asyncio.run(_resolve_colocated_managed_services(stage))
 
     # backend rsync failed → not post-synced; frontend still resolved.
     assert post_synced == ["autobot-frontend"]
@@ -173,5 +254,5 @@ def test_component_has_file_drift_false_when_not_deployed() -> None:
         patch("api.code_sync.get_default_source_dir", return_value="/opt/autobot/code_source/autobot-backend"),
         patch("api.code_sync.get_default_deployed_dir", return_value="/nonexistent/path/autobot-backend"),
     ):
-        result = _run(_CS._component_has_file_drift("autobot-backend"))
+        result = asyncio.run(_CS._component_has_file_drift("autobot-backend"))
     assert result is False

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -343,6 +343,39 @@ def test_run_component_resolve_job_rsync_failure() -> None:
     restart_mock.assert_not_called()
 
 
+def test_run_component_resolve_job_shared_sync_failure() -> None:
+    """#11611 fail-safe: a failed autobot_shared sync marks the job failed BEFORE the
+    component rsync — the component is NOT rsynced/restarted onto a stale shared tree.
+    """
+    row = _FakeRow()
+    db_mock = _make_db_service_mock(row)
+
+    rsync_mock = AsyncMock(return_value=(True, ""))
+    restart_mock = AsyncMock()
+
+    with (
+        patch("api.code_sync.get_default_source_dir", return_value="/src/autobot-slm-backend"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/autobot-slm-backend"),
+        patch(
+            "api.code_sync._ensure_autobot_shared_synced",
+            AsyncMock(return_value=(False, "autobot_shared-first: resync failed before autobot-slm-backend")),
+        ),
+        patch("api.code_sync._rsync_component_local", rsync_mock),
+        patch("api.code_sync._run_post_sync_steps", AsyncMock()),
+        patch("api.code_sync._restart_component_services", restart_mock),
+        patch("api.code_sync._running_tasks", {}),
+    ):
+        with patch.dict("sys.modules", {"services.database": MagicMock(db_service=db_mock)}):
+            _run(_run_component_resolve_job("shared-fail", "autobot-slm-backend"))
+
+    assert row.status == "failed"
+    assert row.success is False
+    assert "autobot_shared" in (row.message or "")
+    # Fail-safe: neither the component rsync nor the restart runs after shared failure.
+    rsync_mock.assert_not_called()
+    restart_mock.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # #11437: requeue-once reconcile + pending-restart guard
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/api/test_drift_resolve.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve.py
@@ -30,7 +30,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from typing import List
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -275,6 +275,27 @@ def test_excludes_for_known_component(stub_user):
     chokepoint_args = _CS._rsync_exclude_args(excludes)
     assert "--exclude=venv" in chokepoint_args
     assert "--exclude=__pycache__" in chokepoint_args
+
+
+def test_shared_sync_failure_fails_resolve_and_skips_component_rsync(stub_user):
+    """#11611 fail-safe: a failed autobot_shared sync fails the resolve BEFORE the
+    component rsync — the component is NOT rsynced/restarted onto a stale shared tree.
+    """
+    src_patch, dep_patch = _setup_dir_mocks()
+    rsync_mock = AsyncMock(return_value=(True, ""))
+    shared_patch = patch(
+        "api.code_sync._ensure_autobot_shared_synced",
+        AsyncMock(return_value=(False, "autobot_shared-first: resync failed")),
+    )
+    rsync_patch = patch("api.code_sync._rsync_component_local", rsync_mock)
+    with src_patch, dep_patch, shared_patch, rsync_patch, _noop_post_sync():
+        req = DriftResolveRequest(component="autobot-slm-backend")
+        resp = _run(resolve_drift(req, stub_user))
+
+    assert resp.success is False
+    assert "autobot_shared" in resp.message
+    # Fail-safe: the component's own rsync must NOT run after a shared-sync failure.
+    rsync_mock.assert_not_called()
 
 
 # =============================================================================

--- a/autobot-slm-backend/tests/api/test_drift_resolve.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve.py
@@ -246,12 +246,16 @@ def test_excludes_for_known_component(stub_user):
     universally at the rsync chokepoint (_rsync_exclude_args), so the handler
     passes only the component-specific list.  Assert both halves of that
     contract instead of the pre-#11459 combined list.
+
+    #11611: resolving a Python backend now rsyncs autobot_shared FIRST (shared-
+    first ordering) and then the component — two rsync calls. The component call
+    (the last one) still carries its _SLM_COMPONENTS exclude list.
     """
     src_patch, dep_patch = _setup_dir_mocks()
-    captured_excludes: List[List[str]] = []
+    captured: List[tuple] = []
 
     async def fake_rsync(src, comp, excludes):
-        captured_excludes.append(excludes)
+        captured.append((comp, excludes))
         return True, ""
 
     rsync_patch = patch("api.code_sync._rsync_component_local", side_effect=fake_rsync)
@@ -259,9 +263,12 @@ def test_excludes_for_known_component(stub_user):
         req = DriftResolveRequest(component="autobot-slm-backend")
         _run(resolve_drift(req, stub_user))
 
-    assert len(captured_excludes) == 1
-    excludes = captured_excludes[0]
+    # #11611: autobot_shared is synced ahead of the backend.
+    assert len(captured) == 2
+    assert captured[0][0] == "autobot_shared"
+    assert captured[1][0] == "autobot-slm-backend"
     # The handler passes exactly the component's _SLM_COMPONENTS entry …
+    excludes = captured[1][1]
     expected = {comp: excl for comp, excl in _CS._SLM_COMPONENTS}["autobot-slm-backend"]
     assert excludes == expected
     # … and the rsync chokepoint injects the canonical artifact excludes.


### PR DESCRIPTION
## Thinking Path
Three deploy-execution issues (children of umbrella #11820). REPO-only; on-box apply is the separate coordinated session.

## What Changed
**#11611** (CRITICAL — deploying before autobot_shared crash-loops it): new `_ensure_autobot_shared_synced(component)` rsyncs `autobot_shared` from code_source BEFORE a dependent backend's rsync+restart, wired into both the sync endpoint (`resolve_drift`) and the async job (`_run_component_resolve_job`). Fail-safe: a failed shared rsync fails the resolve and SKIPS the restart (no restart onto a half-deployed tree). No-op for autobot_shared itself + frontends. (The ansible playbook path already deploys shared before the backend restart, so no ansible change there.)
**#11605** (update-all skips co-located managed services): new `_resolve_colocated_managed_services(stage)` called in `_run_slm_stage`'s CURRENT branch — the exact point where `slm_self_update` reports "current" while autobot-backend/frontend still carry drift. Resolves each drifted co-located component via the same per-component drift/resolve path (inherits health/rollback + #11611 shared-first ordering). Per-component failures non-fatal.
**#11508** (slm-agent split across two incomplete pythons + stale pythonpath.conf): consolidated the agent onto the system `/usr/bin/python3` (its existing ExecStart); added `redis` to `slm_agent_python_packages` (agent hard-imports autobot_shared.redis_client); fixed the unit `PYTHONPATH` to resolve autobot_shared directly; ansible-managed removal of the stale `pythonpath.conf` drop-in (state:absent + daemon-reload + restart). No repo file deleted.

## Verification
New pytest `test_colocated_managed_update_11605.py` + updated `test_drift_resolve.py`; no file deletions.

## Risks for the coordinated on-box apply
- #11508: confirm redis+aiohttp+psutil actually install to /usr/bin/python3 (pip3 --break-system-packages; PEP-668/offline box could fail); verify agent survives a fresh restart onto system python.
- #11611: a failed shared rsync fails the whole backend resolve (fail-safe by design) — watch a legitimately-absent code_source/autobot_shared.
- #11605: fixes the SLM-current path; the SLM-outdated path still routes co-located services through update-all Play 2, which depends on the co-located node's backend/frontend inventory group membership (residual topology dependency, not altered here).

## Model Used
Opus 4.8

Closes #11611, Closes #11605, Closes #11508