### PR TITLE
fix(deploy): detach self-update ansible run into a systemd scope with file-backed output so it survives the backend restart (#11492)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -2722,8 +2722,11 @@ async def _ansible_self_update(node_id: str) -> None:
 
     Covers every role Ansible knows about (backend, frontend, shared, agent,
     plugins, npu-worker, browser-worker, etc.) — not just the SLM components.
-    Fire-and-forget: the SLM service restarts mid-run so this coroutine dies;
-    callers must poll health rather than await a result.
+    Fire-and-forget: the SLM service restarts mid-run so this coroutine dies.
+    ``detach=True`` runs the ansible-playbook process in its own systemd
+    transient scope (#11492) so it — unlike this coroutine — survives that
+    restart and completes Play 1's tail plus Play 2/3; callers must poll
+    health rather than await a result.
 
     Issue #9224: Update node version in DB after successful sync.
     C2-a: Clear the resume plan on playbook failure (before restart) so stale
@@ -2735,6 +2738,7 @@ async def _ansible_self_update(node_id: str) -> None:
         result = await executor.execute_playbook(
             playbook_name="update-all-nodes.yml",
             limit=limit,
+            detach=True,
         )
         if not result["success"]:
             logger.error("Ansible full-machine update failed for %s: %s", node_id, result["output"][:500])

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -53,7 +53,21 @@ SELF_UPDATE_DETACH_UNIT_PREFIX = os.getenv("SLM_SELF_UPDATE_UNIT_PREFIX", "autob
 # passed explicitly. Only a narrow allowlist (never secrets) is forwarded;
 # ansible receives its stored secrets via `-e @file` (#11735 pattern), not env.
 SYSTEMD_RUN_ENV_ALLOWLIST_EXACT = ("PATH", "HOME", "USER", "LANG", "LC_ALL", "SSH_AUTH_SOCK")
-SYSTEMD_RUN_ENV_ALLOWLIST_PREFIXES = ("ANSIBLE_",)
+
+# Invariant: no ANSIBLE_* var may carry a secret (e.g. ANSIBLE_VAULT_PASSWORD)
+# through this allowlist — secrets ride via `-e @file` (#11735), never env.
+# Enumerated exactly (not a prefix match) to the keys this module itself sets
+# — _build_ansible_env's fixed set plus ANSIBLE_INVENTORY (execute_playbook)
+# — so a caller-supplied or inherited ANSIBLE_VAULT_PASSWORD/-style var can
+# never slip through just by starting with "ANSIBLE_".
+ANSIBLE_ENV_ALLOWLIST_EXACT = (
+    "ANSIBLE_FORCE_COLOR",
+    "ANSIBLE_NOCOLOR",
+    "ANSIBLE_HOST_KEY_CHECKING",
+    "ANSIBLE_SSH_RETRIES",
+    "ANSIBLE_LOCAL_TEMP",
+    "ANSIBLE_INVENTORY",
+)
 
 # File-backed output for detached self-update runs (#11492). A pipe's read
 # end is owned by this backend process, so once the Play 1 restart task kills
@@ -547,6 +561,9 @@ class PlaybookExecutor:
         try:
             SELF_UPDATE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
             SELF_UPDATE_LOG_PATH.write_text("", encoding="utf-8")
+            # Ansible output can contain sensitive paths/values — 0600, not
+            # the world-readable default umask (#11492 hardening).
+            os.chmod(SELF_UPDATE_LOG_PATH, 0o600)
             return SELF_UPDATE_LOG_PATH
         except OSError as exc:
             logger.error("Could not prepare self-update log file %s: %s", SELF_UPDATE_LOG_PATH, exc)
@@ -554,26 +571,32 @@ class PlaybookExecutor:
 
     @staticmethod
     def _systemd_run_env_args(env: Dict[str, str]) -> List[str]:
-        """Build explicit --setenv=NAME=VALUE args for the detached scope (#11492)."""
-        args = []
-        for key, value in env.items():
-            if key in SYSTEMD_RUN_ENV_ALLOWLIST_EXACT or key.startswith(SYSTEMD_RUN_ENV_ALLOWLIST_PREFIXES):
-                args.append(f"--setenv={key}={value}")
-        return args
+        """Build explicit --setenv=NAME=VALUE args for the detached scope (#11492).
+
+        Allowlist is a fixed enumeration (SYSTEMD_RUN_ENV_ALLOWLIST_EXACT +
+        ANSIBLE_ENV_ALLOWLIST_EXACT), never a prefix match — a caller-supplied
+        or inherited ANSIBLE_VAULT_PASSWORD/-style var must never forward just
+        by starting with "ANSIBLE_".
+        """
+        allowed = SYSTEMD_RUN_ENV_ALLOWLIST_EXACT + ANSIBLE_ENV_ALLOWLIST_EXACT
+        return [f"--setenv={key}={env[key]}" for key in allowed if key in env]
 
     def _wrap_with_systemd_scope(self, cmd: List[str], env: Dict[str, str], log_path: Path) -> List[str]:
         """Wrap an ansible-playbook cmd to run detached, file-backed (#11492).
 
         Two layers:
-          - ``sudo systemd-run --scope --collect``: a separate transient scope
-            = a separate cgroup, so ``systemctl restart autobot-slm-backend``
-            (KillMode=control-group) no longer SIGTERMs this run. ``sudo``
-            mirrors the existing privilege pattern already used for service
-            restarts (_restart_slm_service) — the passwordless-sudo sudoers
-            rule this service already relies on. ``--uid``/``--gid`` drop back
-            to the caller's own identity so ansible-playbook still runs as the
-            SLM service user, not root; ``--working-directory`` replaces the
-            ``cwd=`` kwarg systemd-run does not inherit.
+          - ``sudo -n systemd-run --scope --collect``: a separate transient
+            scope = a separate cgroup, so ``systemctl restart
+            autobot-slm-backend`` (KillMode=control-group) no longer SIGTERMs
+            this run. ``sudo`` mirrors the existing privilege pattern already
+            used for service restarts (_restart_slm_service) — the
+            passwordless-sudo sudoers rule this service already relies on;
+            ``-n`` (non-interactive) fast-fails instead of hanging on a
+            password prompt if that sudoers rule is ever misconfigured.
+            ``--uid``/``--gid`` drop back to the caller's own identity so
+            ansible-playbook still runs as the SLM service user, not root;
+            ``--working-directory`` replaces the ``cwd=`` kwarg systemd-run
+            does not inherit.
           - ``sh -c 'exec "$0" "$@" >> <log> 2>&1'``: reopens the FINAL exec'd
             process's (ansible-playbook, not this shell) stdout/stderr onto
             the log file before replacing the shell image, so its output is
@@ -587,6 +610,7 @@ class PlaybookExecutor:
         file_backed_cmd = ["/bin/sh", "-c", redirect_script, *cmd]
         return [
             "sudo",
+            "-n",
             "systemd-run",
             "--scope",
             "--collect",

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import shutil
+import time
 from pathlib import Path
 from typing import Callable, Dict, List
 
@@ -35,6 +36,32 @@ logger = logging.getLogger(__name__)
 # PrivateTmp=true /tmp is namespaced anyway; the uid suffix protects runs
 # outside systemd (dev mode, manual uvicorn).
 ANSIBLE_LOCAL_TMP = f"/tmp/ansible_local_tmp_{os.getuid()}"  # nosec B108
+
+# #11492: the self-update ansible-playbook run (update-all-nodes.yml against
+# the SLM's own node) restarts autobot-slm-backend mid-run. The service is
+# KillMode=control-group, so systemd SIGTERMs the whole cgroup on restart —
+# including the ansible-playbook child — killing the run before Play 1's tail
+# and all of Play 2/3 execute. Detaching that one run into its own transient
+# systemd scope (a separate cgroup) lets it survive the restart.
+SELF_UPDATE_DETACH_UNIT_PREFIX = os.getenv("SLM_SELF_UPDATE_UNIT_PREFIX", "autobot-selfupdate")
+
+# Env vars forwarded to the detached scope via explicit --setenv=NAME=VALUE.
+# `sudo` (env_reset, see setup-passwordless-sudo.yml) strips the environment
+# before systemd-run ever sees it, and systemd-run does not forward the
+# caller's process environment to the unit it starts — each var must be
+# passed explicitly. Only a narrow allowlist (never secrets) is forwarded;
+# ansible receives its stored secrets via `-e @file` (#11735 pattern), not env.
+SYSTEMD_RUN_ENV_ALLOWLIST_EXACT = ("PATH", "HOME", "USER", "LANG", "LC_ALL", "SSH_AUTH_SOCK")
+SYSTEMD_RUN_ENV_ALLOWLIST_PREFIXES = ("ANSIBLE_",)
+
+# Durable ansible-native log for detached self-update runs (#11492). A pipe's
+# read end is owned by this backend process, so once the Play 1 restart task
+# kills it, the pipe read side closes — a subsequent write from the (now
+# detached, still running) ansible-playbook process would raise
+# BrokenPipeError. ANSIBLE_LOG_PATH gives Play 1's tail and Play 2/3 a durable
+# record on disk independent of that pipe, mirroring the existing
+# /var/log/autobot/provision-wizard.log precedent (api/setup_wizard.py).
+SELF_UPDATE_LOG_PATH = Path(os.getenv("SLM_SELF_UPDATE_LOG_PATH", "/var/log/autobot/self-update-ansible.log"))
 
 
 class PlaybookExecutor:
@@ -425,19 +452,106 @@ class PlaybookExecutor:
             "ANSIBLE_LOCAL_TEMP": ANSIBLE_LOCAL_TMP,
         }
 
+    @staticmethod
+    def _self_update_detach_available() -> bool:
+        """Whether the self-update run can be detached into its own scope (#11492).
+
+        Both must hold:
+          - ``systemd-run`` is on PATH (creates the transient scope)
+          - this process is itself managed by systemd — ``INVOCATION_ID`` is set
+            only for units systemd starts, so it precisely answers "are we
+            running as a systemd service" (as opposed to `sd_booted()`-style
+            checks, which are true on any systemd host regardless of how this
+            process was launched). Without it there is no same-cgroup restart
+            to survive: dev ``uvicorn``, tests, containers without systemd as
+            PID 1 all fall back to the direct exec unchanged.
+        """
+        return shutil.which("systemd-run") is not None and "INVOCATION_ID" in os.environ
+
+    @staticmethod
+    def _ensure_self_update_log_path(env: Dict[str, str]) -> None:
+        """Point ansible at a durable on-disk log for detached runs (#11492).
+
+        Best-effort: a failure to create the log dir must not block the run —
+        it only means the pipe (while attached) remains the sole output.
+        """
+        try:
+            SELF_UPDATE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+            env["ANSIBLE_LOG_PATH"] = str(SELF_UPDATE_LOG_PATH)
+        except OSError as exc:
+            logger.warning("Could not prepare self-update log path %s: %s", SELF_UPDATE_LOG_PATH, exc)
+
+    @staticmethod
+    def _systemd_run_env_args(env: Dict[str, str]) -> List[str]:
+        """Build explicit --setenv=NAME=VALUE args for the detached scope (#11492)."""
+        args = []
+        for key, value in env.items():
+            if key in SYSTEMD_RUN_ENV_ALLOWLIST_EXACT or key.startswith(SYSTEMD_RUN_ENV_ALLOWLIST_PREFIXES):
+                args.append(f"--setenv={key}={value}")
+        return args
+
+    def _wrap_with_systemd_scope(self, cmd: List[str], env: Dict[str, str]) -> List[str]:
+        """Wrap an ansible-playbook cmd to run in its own transient systemd scope.
+
+        A separate scope = a separate cgroup, so ``systemctl restart
+        autobot-slm-backend`` (KillMode=control-group) no longer SIGTERMs this
+        run. ``sudo`` mirrors the existing privilege pattern already used for
+        service restarts (_restart_slm_service) — the passwordless-sudo
+        sudoers rule this service already relies on. ``--uid``/``--gid`` drop
+        back to the caller's own identity so ansible-playbook still runs as
+        the SLM service user, not root; ``--working-directory`` replaces the
+        ``cwd=`` kwarg systemd-run does not inherit.
+        """
+        unit_name = f"{SELF_UPDATE_DETACH_UNIT_PREFIX}-{os.getpid()}-{int(time.time())}"
+        return [
+            "sudo",
+            "systemd-run",
+            "--scope",
+            "--collect",
+            f"--unit={unit_name}",
+            f"--uid={os.getuid()}",
+            f"--gid={os.getgid()}",
+            f"--working-directory={self.ansible_dir}",
+            *self._systemd_run_env_args(env),
+            "--",
+            *cmd,
+        ]
+
     async def _run_subprocess(
         self,
         cmd: List[str],
         env: Dict[str, str],
         progress_callback: Callable | None,
+        detach: bool = False,
     ) -> Dict[str, any]:
         """
         Launch ansible-playbook subprocess and collect output. Ref: #1088.
 
         Helper for execute_playbook.
+
+        Args:
+            detach: When True AND the runtime supports it (#11492), wrap the
+                command in ``systemd-run --scope --collect`` so it survives a
+                same-process ``systemctl restart autobot-slm-backend`` mid-run
+                (the self-update path). Falls back to the direct exec when
+                systemd-run/systemd-service context is unavailable (dev mode,
+                tests, containers).
         """
+        effective_cmd = cmd
+        if detach:
+            self._ensure_self_update_log_path(env)
+            if self._self_update_detach_available():
+                effective_cmd = self._wrap_with_systemd_scope(cmd, env)
+                logger.info("Self-update run detached into transient systemd scope")
+            else:
+                logger.warning(
+                    "Self-update detach requested but systemd-run/service context "
+                    "unavailable — running attached (this run will die if the "
+                    "backend restarts mid-flight)"
+                )
+
         process = await asyncio.create_subprocess_exec(
-            *cmd,
+            *effective_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             cwd=str(self.ansible_dir),
@@ -516,6 +630,7 @@ class PlaybookExecutor:
         check_mode: bool = False,
         progress_callback: Callable | None = None,
         inventory_path: Path | None = None,
+        detach: bool = False,
     ) -> Dict[str, any]:
         """
         Execute an Ansible playbook with optional progress updates (Issue #880).
@@ -534,6 +649,10 @@ class PlaybookExecutor:
             check_mode: Run in check mode (dry run)
             progress_callback: Async function to call with progress updates
             inventory_path: Override inventory file (Issue #1294, wizard provisioning)
+            detach: Run detached in its own systemd scope (#11492). Only pass
+                True for the SLM self-update path (the run that restarts
+                autobot-slm-backend); ordinary per-role/per-node deploys leave
+                this False, since they don't kill their own process.
 
         Returns:
             Dict with keys: success (bool), output (str), returncode (int)
@@ -591,7 +710,7 @@ class PlaybookExecutor:
             # Override ansible.cfg default inventory to prevent merging
             # with production.yml when wizard passes a temp inventory (#2836)
             env["ANSIBLE_INVENTORY"] = str(effective_inventory)
-            proc_result = await self._run_subprocess(cmd, env, progress_callback)
+            proc_result = await self._run_subprocess(cmd, env, progress_callback, detach=detach)
             success = proc_result["returncode"] == 0
             if success:
                 logger.info(f"Playbook {playbook_name} completed successfully")

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import os
 import re
+import shlex
 import shutil
 import time
 from pathlib import Path
@@ -54,14 +55,20 @@ SELF_UPDATE_DETACH_UNIT_PREFIX = os.getenv("SLM_SELF_UPDATE_UNIT_PREFIX", "autob
 SYSTEMD_RUN_ENV_ALLOWLIST_EXACT = ("PATH", "HOME", "USER", "LANG", "LC_ALL", "SSH_AUTH_SOCK")
 SYSTEMD_RUN_ENV_ALLOWLIST_PREFIXES = ("ANSIBLE_",)
 
-# Durable ansible-native log for detached self-update runs (#11492). A pipe's
-# read end is owned by this backend process, so once the Play 1 restart task
-# kills it, the pipe read side closes — a subsequent write from the (now
-# detached, still running) ansible-playbook process would raise
-# BrokenPipeError. ANSIBLE_LOG_PATH gives Play 1's tail and Play 2/3 a durable
-# record on disk independent of that pipe, mirroring the existing
-# /var/log/autobot/provision-wizard.log precedent (api/setup_wizard.py).
+# File-backed output for detached self-update runs (#11492). A pipe's read
+# end is owned by this backend process, so once the Play 1 restart task kills
+# it, the pipe read side closes — a subsequent write from the (now detached,
+# still running) ansible-playbook process would raise BrokenPipeError,
+# killing Play 2/3 exactly like the cgroup-kill this fix exists to prevent.
+# The detached run's stdout/stderr are redirected to this file instead of the
+# backend's pipe (see _wrap_with_systemd_scope), so a dead backend can never
+# crash it; this backend tails the same file for live progress while it is
+# still alive. Mirrors the existing /var/log/autobot/provision-wizard.log
+# precedent (api/setup_wizard.py).
 SELF_UPDATE_LOG_PATH = Path(os.getenv("SLM_SELF_UPDATE_LOG_PATH", "/var/log/autobot/self-update-ansible.log"))
+
+# Poll interval while tailing the detached run's log file for live progress.
+SELF_UPDATE_LOG_TAIL_POLL_SEC = float(os.getenv("SLM_SELF_UPDATE_LOG_TAIL_POLL_SEC", "1.0"))
 
 
 class PlaybookExecutor:
@@ -209,7 +216,13 @@ class PlaybookExecutor:
         if "TASK [" in line and "[PLAY " in line:
             try:
                 task_start = line.index("TASK [")
-                task_name = line[task_start + 6 :].split("]")[0]
+                # rsplit (not split): the task's own display name embeds a
+                # "[PLAY N]" prefix, i.e. its own "]" — splitting on the FIRST
+                # "]" truncated at "[PLAY 1" and "[PLAY 1]" never matched
+                # below (#11492 discovery while adding self-update log-tail
+                # parsing tests). The trailing "] ***" padding never contains
+                # "]" itself, so the LAST "]" is always the true delimiter.
+                task_name = line[task_start + 6 :].rsplit("]", 1)[0]
 
                 if "[PLAY 1]" in task_name:
                     return self._parse_play1_task(task_name)
@@ -287,13 +300,13 @@ class PlaybookExecutor:
 
         return cmd
 
-    async def _stream_playbook_output(
+    async def _process_playbook_lines(
         self,
-        process: asyncio.subprocess.Process,
+        line_iter,
         progress_callback: Callable | None,
     ) -> List[str]:
         """
-        Stream and parse playbook output for progress (Issue #880, #3033).
+        Shared line-processing loop for playbook output (Issue #880, #3033, #11492).
 
         Fires progress_callback for each recognized Ansible output line.
         Between recognized lines — when Ansible is silent during long-running
@@ -302,8 +315,13 @@ class PlaybookExecutor:
 
         A new tracker is started each time a TASK line is detected and the
         previous one is cancelled, so heartbeats are scoped per task.
+
+        ``line_iter`` is any async iterator of decoded, rstripped text lines —
+        either live from the child's stdout pipe, or tailed from a log file
+        for a detached self-update run (#11492) — so both sources share this
+        one parsing/heartbeat implementation.
         """
-        output_lines = []
+        output_lines: List[str] = []
         current_tracker: TaskProgressTracker | None = None
 
         async def _stop_current_tracker() -> None:
@@ -319,34 +337,76 @@ class PlaybookExecutor:
                 current_tracker = TaskProgressTracker(task_name, progress_callback)
                 await current_tracker.__aenter__()
 
-        if process.stdout:
-            try:
-                while True:
-                    line = await process.stdout.readline()
-                    if not line:
-                        break
+        try:
+            async for line_str in line_iter:
+                output_lines.append(line_str)
 
-                    line_str = line.decode("utf-8", errors="replace").rstrip()
-                    output_lines.append(line_str)
-
-                    if progress_callback:
-                        progress = self._parse_progress(line_str)
-                        if progress:
-                            stage = progress.get("stage", "")
-                            # Start a fresh tracker for every new task boundary
-                            # so heartbeats reflect the task currently executing.
-                            if stage in ("task", "heartbeat") or stage.endswith(
-                                ("_starting", "_syncing", "_restarting", "_waiting")
-                            ):
-                                await _start_tracker(progress.get("message", stage))
-                            try:
-                                await progress_callback(progress)
-                            except Exception as e:
-                                logger.debug("Progress callback error: %s", e, exc_info=False)
-            finally:
-                await _stop_current_tracker()
+                if progress_callback:
+                    progress = self._parse_progress(line_str)
+                    if progress:
+                        stage = progress.get("stage", "")
+                        # Start a fresh tracker for every new task boundary
+                        # so heartbeats reflect the task currently executing.
+                        if stage in ("task", "heartbeat") or stage.endswith(
+                            ("_starting", "_syncing", "_restarting", "_waiting")
+                        ):
+                            await _start_tracker(progress.get("message", stage))
+                        try:
+                            await progress_callback(progress)
+                        except Exception as e:
+                            logger.debug("Progress callback error: %s", e, exc_info=False)
+        finally:
+            await _stop_current_tracker()
 
         return output_lines
+
+    @staticmethod
+    async def _iter_pipe_lines(process: asyncio.subprocess.Process):
+        """Yield decoded lines from a live child stdout pipe (Issue #880, #3033)."""
+        if not process.stdout:
+            return
+        while True:
+            line = await process.stdout.readline()
+            if not line:
+                break
+            yield line.decode("utf-8", errors="replace").rstrip()
+
+    @staticmethod
+    async def _iter_log_file_lines(log_path: Path, process: asyncio.subprocess.Process):
+        """Tail a log file for a detached run's output (#11492).
+
+        Polls for newly appended lines while ``process`` (the detaching
+        wrapper) is still running; stops once it has exited and no further
+        lines are pending. The detached ansible-playbook process itself keeps
+        writing to this same file independently after this backend restarts —
+        this generator simply stops watching, it never stops the write side.
+        """
+        with open(log_path, "r", encoding="utf-8", errors="replace") as fh:
+            while True:
+                line = await asyncio.to_thread(fh.readline)
+                if not line:
+                    if process.returncode is not None:
+                        break
+                    await asyncio.sleep(SELF_UPDATE_LOG_TAIL_POLL_SEC)
+                    continue
+                yield line.rstrip("\n")
+
+    async def _stream_playbook_output(
+        self,
+        process: asyncio.subprocess.Process,
+        progress_callback: Callable | None,
+    ) -> List[str]:
+        """Stream and parse live pipe output for progress. Helper for _run_subprocess."""
+        return await self._process_playbook_lines(self._iter_pipe_lines(process), progress_callback)
+
+    async def _tail_playbook_log(
+        self,
+        log_path: Path,
+        process: asyncio.subprocess.Process,
+        progress_callback: Callable | None,
+    ) -> List[str]:
+        """Tail a detached run's log file and parse it for progress (#11492)."""
+        return await self._process_playbook_lines(self._iter_log_file_lines(log_path, process), progress_callback)
 
     @staticmethod
     def _ensure_ansible_temp_dirs() -> None:
@@ -469,17 +529,28 @@ class PlaybookExecutor:
         return shutil.which("systemd-run") is not None and "INVOCATION_ID" in os.environ
 
     @staticmethod
-    def _ensure_self_update_log_path(env: Dict[str, str]) -> None:
-        """Point ansible at a durable on-disk log for detached runs (#11492).
+    def _prepare_self_update_log_file() -> Path | None:
+        """Create/truncate a fresh log file for this detached run (#11492).
 
-        Best-effort: a failure to create the log dir must not block the run —
-        it only means the pipe (while attached) remains the sole output.
+        The detached ansible-playbook process's stdout/stderr are redirected
+        here (see _wrap_with_systemd_scope) instead of the backend's pipe, so
+        a dead backend can never BrokenPipe-crash Play 2/3. Truncated per run
+        so log-tailing starts at byte 0 and a stale prior run's content is
+        never replayed as this run's progress.
+
+        Returns None on failure — the caller must NOT detach without
+        file-backed output in that case (a pipe-only detach would just move
+        the same crash risk this fix exists to close from "cgroup kill" to
+        "broken pipe"; direct-exec, though it dies with the backend, is at
+        least a deterministic, well-understood failure mode).
         """
         try:
             SELF_UPDATE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-            env["ANSIBLE_LOG_PATH"] = str(SELF_UPDATE_LOG_PATH)
+            SELF_UPDATE_LOG_PATH.write_text("", encoding="utf-8")
+            return SELF_UPDATE_LOG_PATH
         except OSError as exc:
-            logger.warning("Could not prepare self-update log path %s: %s", SELF_UPDATE_LOG_PATH, exc)
+            logger.error("Could not prepare self-update log file %s: %s", SELF_UPDATE_LOG_PATH, exc)
+            return None
 
     @staticmethod
     def _systemd_run_env_args(env: Dict[str, str]) -> List[str]:
@@ -490,19 +561,30 @@ class PlaybookExecutor:
                 args.append(f"--setenv={key}={value}")
         return args
 
-    def _wrap_with_systemd_scope(self, cmd: List[str], env: Dict[str, str]) -> List[str]:
-        """Wrap an ansible-playbook cmd to run in its own transient systemd scope.
+    def _wrap_with_systemd_scope(self, cmd: List[str], env: Dict[str, str], log_path: Path) -> List[str]:
+        """Wrap an ansible-playbook cmd to run detached, file-backed (#11492).
 
-        A separate scope = a separate cgroup, so ``systemctl restart
-        autobot-slm-backend`` (KillMode=control-group) no longer SIGTERMs this
-        run. ``sudo`` mirrors the existing privilege pattern already used for
-        service restarts (_restart_slm_service) — the passwordless-sudo
-        sudoers rule this service already relies on. ``--uid``/``--gid`` drop
-        back to the caller's own identity so ansible-playbook still runs as
-        the SLM service user, not root; ``--working-directory`` replaces the
-        ``cwd=`` kwarg systemd-run does not inherit.
+        Two layers:
+          - ``sudo systemd-run --scope --collect``: a separate transient scope
+            = a separate cgroup, so ``systemctl restart autobot-slm-backend``
+            (KillMode=control-group) no longer SIGTERMs this run. ``sudo``
+            mirrors the existing privilege pattern already used for service
+            restarts (_restart_slm_service) — the passwordless-sudo sudoers
+            rule this service already relies on. ``--uid``/``--gid`` drop back
+            to the caller's own identity so ansible-playbook still runs as the
+            SLM service user, not root; ``--working-directory`` replaces the
+            ``cwd=`` kwarg systemd-run does not inherit.
+          - ``sh -c 'exec "$0" "$@" >> <log> 2>&1'``: reopens the FINAL exec'd
+            process's (ansible-playbook, not this shell) stdout/stderr onto
+            the log file before replacing the shell image, so its output is
+            never connected to the backend's pipe in the first place — a dead
+            backend cannot BrokenPipe it. ``exec "$0" "$@"`` keeps every
+            argument a literal positional parameter, so no argv needs shell
+            escaping beyond the already-quoted log path.
         """
         unit_name = f"{SELF_UPDATE_DETACH_UNIT_PREFIX}-{os.getpid()}-{int(time.time())}"
+        redirect_script = f'exec "$0" "$@" >> {shlex.quote(str(log_path))} 2>&1'
+        file_backed_cmd = ["/bin/sh", "-c", redirect_script, *cmd]
         return [
             "sudo",
             "systemd-run",
@@ -514,8 +596,32 @@ class PlaybookExecutor:
             f"--working-directory={self.ansible_dir}",
             *self._systemd_run_env_args(env),
             "--",
-            *cmd,
+            *file_backed_cmd,
         ]
+
+    def _prepare_detached_run(self, cmd: List[str], env: Dict[str, str]) -> tuple[List[str], Path | None]:
+        """Resolve the effective argv + log path for a requested detach (#11492).
+
+        Helper for _run_subprocess. Returns (cmd, None) unchanged whenever
+        detaching isn't possible (no systemd-run/service context, or the log
+        file couldn't be prepared) so the caller falls back to the exact
+        pipe-attached behavior that existed before this fix.
+        """
+        if not self._self_update_detach_available():
+            logger.warning(
+                "Self-update detach requested but systemd-run/service context "
+                "unavailable — running attached (this run will die if the "
+                "backend restarts mid-flight)"
+            )
+            return cmd, None
+
+        log_path = self._prepare_self_update_log_file()
+        if log_path is None:
+            logger.error("Self-update detach requested but log file unavailable — running attached")
+            return cmd, None
+
+        logger.info("Self-update run detached into transient systemd scope, output -> %s", log_path)
+        return self._wrap_with_systemd_scope(cmd, env, log_path), log_path
 
     async def _run_subprocess(
         self,
@@ -531,33 +637,40 @@ class PlaybookExecutor:
 
         Args:
             detach: When True AND the runtime supports it (#11492), wrap the
-                command in ``systemd-run --scope --collect`` so it survives a
-                same-process ``systemctl restart autobot-slm-backend`` mid-run
-                (the self-update path). Falls back to the direct exec when
-                systemd-run/systemd-service context is unavailable (dev mode,
-                tests, containers).
+                command in ``systemd-run --scope --collect`` with file-backed
+                stdout/stderr so it survives a same-process ``systemctl
+                restart autobot-slm-backend`` mid-run (the self-update path)
+                without a dead backend's pipe crashing it. Falls back to the
+                unchanged direct exec + pipe when systemd-run/systemd-service
+                context or the log file is unavailable (dev mode, tests,
+                containers).
         """
         effective_cmd = cmd
+        log_path: Path | None = None
+        stdout_target: int = asyncio.subprocess.PIPE
+        stderr_target: int = asyncio.subprocess.STDOUT
+
         if detach:
-            self._ensure_self_update_log_path(env)
-            if self._self_update_detach_available():
-                effective_cmd = self._wrap_with_systemd_scope(cmd, env)
-                logger.info("Self-update run detached into transient systemd scope")
-            else:
-                logger.warning(
-                    "Self-update detach requested but systemd-run/service context "
-                    "unavailable — running attached (this run will die if the "
-                    "backend restarts mid-flight)"
-                )
+            effective_cmd, log_path = self._prepare_detached_run(cmd, env)
+            if log_path is not None:
+                # Real output goes to the file (see _wrap_with_systemd_scope);
+                # nothing meaningful is expected on this outer pipe, and
+                # leaving it as PIPE-but-unread risks the wrapper deadlocking
+                # once the OS pipe buffer fills.
+                stdout_target = asyncio.subprocess.DEVNULL
+                stderr_target = asyncio.subprocess.DEVNULL
 
         process = await asyncio.create_subprocess_exec(
             *effective_cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+            stdout=stdout_target,
+            stderr=stderr_target,
             cwd=str(self.ansible_dir),
             env=env,
         )
-        output_lines = await self._stream_playbook_output(process, progress_callback)
+        if log_path is not None:
+            output_lines = await self._tail_playbook_log(log_path, process, progress_callback)
+        else:
+            output_lines = await self._stream_playbook_output(process, progress_callback)
         await process.wait()
         return {"output": "\n".join(output_lines), "returncode": process.returncode}
 

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -323,8 +323,7 @@ async def test_run_subprocess_unwrapped_when_detach_false(tmp_path):
 async def test_tail_playbook_log_parses_existing_lines_then_stops(tmp_path):
     log_path = tmp_path / "self-update-ansible.log"
     log_path.write_text(
-        "PLAY [Play 1 - Update SLM Server First] ****\n"
-        "TASK [[PLAY 1] SLM | Restart autobot-slm-backend] ****\n",
+        "PLAY [Play 1 - Update SLM Server First] ****\n" "TASK [[PLAY 1] SLM | Restart autobot-slm-backend] ****\n",
         encoding="utf-8",
     )
     ex = _executor(tmp_path)

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -130,6 +130,9 @@ def test_prepare_self_update_log_file_creates_and_truncates(tmp_path):
 
     assert result == log_path
     assert log_path.read_text(encoding="utf-8") == ""
+    # Ansible output can contain sensitive paths/values — 0600, not the
+    # world-readable default umask (#11492 hardening).
+    assert oct(log_path.stat().st_mode & 0o777) == "0o600"
 
 
 def test_prepare_self_update_log_file_returns_none_on_failure(tmp_path):
@@ -158,7 +161,8 @@ def test_wrap_with_systemd_scope_builds_expected_command(tmp_path):
     wrapped = ex._wrap_with_systemd_scope(cmd, env, log_path)
 
     assert wrapped[0] == "sudo"
-    assert wrapped[1] == "systemd-run"
+    assert wrapped[1] == "-n"  # non-interactive: fast-fail, never hang on a password prompt
+    assert wrapped[2] == "systemd-run"
     assert "--scope" in wrapped
     assert "--collect" in wrapped
     assert any(a.startswith("--unit=autobot-selfupdate-") for a in wrapped)
@@ -195,6 +199,23 @@ def test_systemd_run_env_args_allowlist_excludes_secrets():
     assert not any("POSTGRES_PASSWORD" in a for a in args)
 
 
+def test_systemd_run_env_args_ansible_allowlist_is_enumerated_not_prefix():
+    """An ANSIBLE_*-prefixed var outside the enumerated set (e.g. a vault
+    password) must never forward just by matching the "ANSIBLE_" prefix
+    (#11492 hardening — the allowlist is a fixed enumeration, not a prefix
+    match)."""
+    env = {
+        "ANSIBLE_FORCE_COLOR": "0",  # enumerated -> forwarded
+        "ANSIBLE_VAULT_PASSWORD": "hunter2",  # NOT enumerated -> must never forward
+        "ANSIBLE_UNKNOWN_FUTURE_VAR": "whatever",  # NOT enumerated -> must never forward
+    }
+    args = _pe.PlaybookExecutor._systemd_run_env_args(env)
+
+    assert "--setenv=ANSIBLE_FORCE_COLOR=0" in args
+    assert not any("ANSIBLE_VAULT_PASSWORD" in a for a in args)
+    assert not any("ANSIBLE_UNKNOWN_FUTURE_VAR" in a for a in args)
+
+
 # ---------------------------------------------------------------------------
 # _run_subprocess: wrap+file-backed vs fallback
 # ---------------------------------------------------------------------------
@@ -222,7 +243,8 @@ async def test_run_subprocess_wraps_file_backed_when_systemd_available(tmp_path)
     assert result["returncode"] == 0
     argv = captured["args"]
     assert argv[0] == "sudo"
-    assert argv[1] == "systemd-run"
+    assert argv[1] == "-n"
+    assert argv[2] == "systemd-run"
     assert "--scope" in argv
     assert "--collect" in argv
     tail = list(argv[argv.index("--") + 1 :])
@@ -234,8 +256,9 @@ async def test_run_subprocess_wraps_file_backed_when_systemd_available(tmp_path)
     # BrokenPipe-crash the detached process (#11492 crux).
     assert captured["kwargs"]["stdout"] == asyncio.subprocess.DEVNULL
     assert captured["kwargs"]["stderr"] == asyncio.subprocess.DEVNULL
-    # The log file was truncated fresh for this run.
+    # The log file was truncated fresh for this run and locked to 0600.
     assert log_path.read_text(encoding="utf-8") == ""
+    assert oct(log_path.stat().st_mode & 0o777) == "0o600"
 
 
 @pytest.mark.asyncio

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -1,0 +1,226 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Self-update ansible run must survive the Play-1 backend restart (#11492).
+
+`code-sync self-update` runs update-all-nodes.yml as a subprocess of
+autobot-slm-backend. The service is KillMode=control-group, so when Play 1's
+"Restart backend service" task fires `systemctl restart autobot-slm-backend`,
+systemd SIGTERMs the whole cgroup — including the ansible-playbook child —
+before Play 1's tail and all of Play 2/3 ever run.
+
+The fix: detach that one run into its own transient systemd scope
+(`systemd-run --scope --collect`, a separate cgroup) so it survives the
+restart, gated to the self-update path only and falling back to the direct
+exec when systemd-run / a systemd-service context is unavailable (dev mode,
+tests, containers).
+
+Loaded via importlib to dodge the conftest's session-global stubs (#11248),
+same pattern as test_dynamic_inventory_group_vars_11781.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+_STUBS = [
+    "services",
+    "services.ansible_secrets",
+    "services.inventory_builder",
+    "services.provision_progress",
+]
+
+
+def _load_executor():
+    saved = {n: sys.modules.get(n) for n in _STUBS}
+    try:
+        for n in _STUBS:
+            sys.modules[n] = MagicMock()
+        spec = importlib.util.spec_from_file_location("_pe_11492", _BACKEND_ROOT / "services" / "playbook_executor.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for n, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(n, None)
+            else:
+                sys.modules[n] = orig
+
+
+_pe = _load_executor()
+
+
+def _executor(ansible_dir: Path) -> "_pe.PlaybookExecutor":
+    ex = _pe.PlaybookExecutor.__new__(_pe.PlaybookExecutor)  # skip __init__ (env probing)
+    ex.ansible_dir = ansible_dir
+    return ex
+
+
+class _FakeProcess:
+    """Minimal stand-in for asyncio.subprocess.Process."""
+
+    def __init__(self, returncode: int = 0):
+        self.stdout = None  # skip _stream_playbook_output's readline loop
+        self.returncode = returncode
+
+    async def wait(self):
+        return self.returncode
+
+
+# ---------------------------------------------------------------------------
+# Detection: systemd-run availability + systemd-service context (#11492)
+# ---------------------------------------------------------------------------
+
+
+def test_detach_available_when_systemd_run_present_and_invocation_id_set():
+    with patch.object(_pe.shutil, "which", return_value="/usr/bin/systemd-run"):
+        with patch.dict(os.environ, {"INVOCATION_ID": "abc123"}):
+            assert _pe.PlaybookExecutor._self_update_detach_available() is True
+
+
+def test_detach_unavailable_without_systemd_run_binary():
+    with patch.object(_pe.shutil, "which", return_value=None):
+        with patch.dict(os.environ, {"INVOCATION_ID": "abc123"}):
+            assert _pe.PlaybookExecutor._self_update_detach_available() is False
+
+
+def test_detach_unavailable_without_invocation_id():
+    """No INVOCATION_ID => not running as a systemd service (dev uvicorn, tests, containers)."""
+    with patch.object(_pe.shutil, "which", return_value="/usr/bin/systemd-run"):
+        env = dict(os.environ)
+        env.pop("INVOCATION_ID", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _pe.PlaybookExecutor._self_update_detach_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Command construction
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_with_systemd_scope_builds_expected_command(tmp_path):
+    ex = _executor(tmp_path)
+    cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
+    env = {"ANSIBLE_FORCE_COLOR": "0", "PATH": "/usr/bin", "SECRET_TOKEN": "s3cr3t"}
+
+    wrapped = ex._wrap_with_systemd_scope(cmd, env)
+
+    assert wrapped[0] == "sudo"
+    assert wrapped[1] == "systemd-run"
+    assert "--scope" in wrapped
+    assert "--collect" in wrapped
+    assert any(a.startswith("--unit=autobot-selfupdate-") for a in wrapped)
+    assert f"--uid={os.getuid()}" in wrapped
+    assert f"--gid={os.getgid()}" in wrapped
+    assert f"--working-directory={tmp_path}" in wrapped
+    # The original ansible-playbook invocation is preserved intact after `--`.
+    assert wrapped[wrapped.index("--") + 1 :] == cmd
+
+
+def test_systemd_run_env_args_allowlist_excludes_secrets():
+    env = {
+        "ANSIBLE_FORCE_COLOR": "0",
+        "ANSIBLE_LOCAL_TEMP": "/tmp/x",
+        "PATH": "/usr/bin",
+        "SECRET_TOKEN": "s3cr3t",
+        "POSTGRES_PASSWORD": "hunter2",
+    }
+    args = _pe.PlaybookExecutor._systemd_run_env_args(env)
+
+    assert "--setenv=ANSIBLE_FORCE_COLOR=0" in args
+    assert "--setenv=ANSIBLE_LOCAL_TEMP=/tmp/x" in args
+    assert "--setenv=PATH=/usr/bin" in args
+    assert not any("SECRET_TOKEN" in a for a in args)
+    assert not any("POSTGRES_PASSWORD" in a for a in args)
+
+
+# ---------------------------------------------------------------------------
+# _run_subprocess: wrap vs fallback + pipes preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_wraps_when_systemd_available(tmp_path):
+    ex = _executor(tmp_path)
+    cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
+    env = {"PATH": "/usr/bin"}
+
+    captured = {}
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProcess(returncode=0)
+
+    with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
+        with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
+            result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
+
+    assert result["returncode"] == 0
+    argv = captured["args"]
+    assert argv[0] == "sudo"
+    assert argv[1] == "systemd-run"
+    assert "--scope" in argv
+    assert "--collect" in argv
+    assert list(argv[argv.index("--") + 1 :]) == cmd
+    # Pipes preserved (Ref: requirement — streaming still works while attached).
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.STDOUT
+    # Durable ansible-native log set for the detached run (#11492).
+    assert env["ANSIBLE_LOG_PATH"] == str(_pe.SELF_UPDATE_LOG_PATH)
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_falls_back_without_systemd(tmp_path):
+    ex = _executor(tmp_path)
+    cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
+    env = {"PATH": "/usr/bin"}
+
+    captured = {}
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProcess(returncode=0)
+
+    with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=False):
+        with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
+            result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
+
+    assert result["returncode"] == 0
+    # No systemd-run wrap — the existing direct-exec behavior is unchanged.
+    assert captured["args"] == tuple(cmd)
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.STDOUT
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_unwrapped_when_detach_false(tmp_path):
+    """Ordinary per-role/per-node deploys (detach=False) are unaffected."""
+    ex = _executor(tmp_path)
+    cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "site.yml"]
+    env = {"PATH": "/usr/bin"}
+
+    captured = {}
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        return _FakeProcess(returncode=0)
+
+    with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
+        with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
+            await ex._run_subprocess(cmd, env, progress_callback=None, detach=False)
+
+    assert captured["args"] == tuple(cmd)
+    assert "ANSIBLE_LOG_PATH" not in env

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -10,11 +10,18 @@ autobot-slm-backend. The service is KillMode=control-group, so when Play 1's
 systemd SIGTERMs the whole cgroup — including the ansible-playbook child —
 before Play 1's tail and all of Play 2/3 ever run.
 
-The fix: detach that one run into its own transient systemd scope
-(`systemd-run --scope --collect`, a separate cgroup) so it survives the
-restart, gated to the self-update path only and falling back to the direct
-exec when systemd-run / a systemd-service context is unavailable (dev mode,
-tests, containers).
+The fix has two parts:
+  1. Detach that one run into its own transient systemd scope
+     (`systemd-run --scope --collect`, a separate cgroup) so it survives the
+     restart, gated to the self-update path only and falling back to the
+     direct exec when systemd-run / a systemd-service context is unavailable
+     (dev mode, tests, containers).
+  2. File-back the detached run's stdout/stderr (never the backend's pipe):
+     once the backend dies, the pipe's read end closes, and a further write
+     from the still-running ansible-playbook would raise BrokenPipeError —
+     killing Play 2/3 exactly like the cgroup-kill this fix exists to
+     prevent. This backend tails the same log file for live progress while
+     it is still alive.
 
 Loaded via importlib to dodge the conftest's session-global stubs (#11248),
 same pattern as test_dynamic_inventory_group_vars_11781.py.
@@ -68,7 +75,10 @@ def _executor(ansible_dir: Path) -> "_pe.PlaybookExecutor":
 
 
 class _FakeProcess:
-    """Minimal stand-in for asyncio.subprocess.Process."""
+    """Minimal stand-in for asyncio.subprocess.Process. Already-exited by
+    default (returncode set at construction) so log-tailing loops in tests
+    stop as soon as the file has no more pending lines, instead of polling
+    forever."""
 
     def __init__(self, returncode: int = 0):
         self.stdout = None  # skip _stream_playbook_output's readline loop
@@ -105,6 +115,36 @@ def test_detach_unavailable_without_invocation_id():
 
 
 # ---------------------------------------------------------------------------
+# Log file preparation (truncate-per-run, best-effort)
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_self_update_log_file_creates_and_truncates(tmp_path):
+    log_path = tmp_path / "sub" / "self-update-ansible.log"
+    with patch.object(_pe, "SELF_UPDATE_LOG_PATH", log_path):
+        # Stale content from a prior run must not leak into this run's tail.
+        log_path.parent.mkdir(parents=True)
+        log_path.write_text("stale prior run content\n", encoding="utf-8")
+
+        result = _pe.PlaybookExecutor._prepare_self_update_log_file()
+
+    assert result == log_path
+    assert log_path.read_text(encoding="utf-8") == ""
+
+
+def test_prepare_self_update_log_file_returns_none_on_failure(tmp_path):
+    # Parent path is a FILE, not a directory -> mkdir(parents=True) raises OSError.
+    blocked = tmp_path / "not_a_dir"
+    blocked.write_text("x", encoding="utf-8")
+    log_path = blocked / "self-update-ansible.log"
+
+    with patch.object(_pe, "SELF_UPDATE_LOG_PATH", log_path):
+        result = _pe.PlaybookExecutor._prepare_self_update_log_file()
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
 # Command construction
 # ---------------------------------------------------------------------------
 
@@ -113,8 +153,9 @@ def test_wrap_with_systemd_scope_builds_expected_command(tmp_path):
     ex = _executor(tmp_path)
     cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
     env = {"ANSIBLE_FORCE_COLOR": "0", "PATH": "/usr/bin", "SECRET_TOKEN": "s3cr3t"}
+    log_path = tmp_path / "self-update-ansible.log"
 
-    wrapped = ex._wrap_with_systemd_scope(cmd, env)
+    wrapped = ex._wrap_with_systemd_scope(cmd, env, log_path)
 
     assert wrapped[0] == "sudo"
     assert wrapped[1] == "systemd-run"
@@ -124,8 +165,17 @@ def test_wrap_with_systemd_scope_builds_expected_command(tmp_path):
     assert f"--uid={os.getuid()}" in wrapped
     assert f"--gid={os.getgid()}" in wrapped
     assert f"--working-directory={tmp_path}" in wrapped
-    # The original ansible-playbook invocation is preserved intact after `--`.
-    assert wrapped[wrapped.index("--") + 1 :] == cmd
+
+    # After `--`: a shell that redirects the FINAL exec'd process's stdio to
+    # the log file, never to the backend's pipe, then the original argv.
+    tail = wrapped[wrapped.index("--") + 1 :]
+    assert tail[0] == "/bin/sh"
+    assert tail[1] == "-c"
+    assert 'exec "$0" "$@"' in tail[2]
+    assert str(log_path) in tail[2]
+    assert ">>" in tail[2]  # append, not truncate — this backend already did the one-time truncate
+    assert "2>&1" in tail[2]
+    assert tail[3:] == cmd
 
 
 def test_systemd_run_env_args_allowlist_excludes_secrets():
@@ -146,15 +196,16 @@ def test_systemd_run_env_args_allowlist_excludes_secrets():
 
 
 # ---------------------------------------------------------------------------
-# _run_subprocess: wrap vs fallback + pipes preserved
+# _run_subprocess: wrap+file-backed vs fallback
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_run_subprocess_wraps_when_systemd_available(tmp_path):
+async def test_run_subprocess_wraps_file_backed_when_systemd_available(tmp_path):
     ex = _executor(tmp_path)
     cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
     env = {"PATH": "/usr/bin"}
+    log_path = tmp_path / "self-update-ansible.log"
 
     captured = {}
 
@@ -163,9 +214,10 @@ async def test_run_subprocess_wraps_when_systemd_available(tmp_path):
         captured["kwargs"] = kwargs
         return _FakeProcess(returncode=0)
 
-    with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
-        with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
-            result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
+    with patch.object(_pe, "SELF_UPDATE_LOG_PATH", log_path):
+        with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
+            with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
+                result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
 
     assert result["returncode"] == 0
     argv = captured["args"]
@@ -173,12 +225,17 @@ async def test_run_subprocess_wraps_when_systemd_available(tmp_path):
     assert argv[1] == "systemd-run"
     assert "--scope" in argv
     assert "--collect" in argv
-    assert list(argv[argv.index("--") + 1 :]) == cmd
-    # Pipes preserved (Ref: requirement — streaming still works while attached).
-    assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
-    assert captured["kwargs"]["stderr"] == asyncio.subprocess.STDOUT
-    # Durable ansible-native log set for the detached run (#11492).
-    assert env["ANSIBLE_LOG_PATH"] == str(_pe.SELF_UPDATE_LOG_PATH)
+    tail = list(argv[argv.index("--") + 1 :])
+    assert tail[:2] == ["/bin/sh", "-c"]
+    assert str(log_path) in tail[2]
+    assert tail[3:] == cmd
+
+    # Never the backend's pipe: a dead backend must not be able to
+    # BrokenPipe-crash the detached process (#11492 crux).
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.DEVNULL
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.DEVNULL
+    # The log file was truncated fresh for this run.
+    assert log_path.read_text(encoding="utf-8") == ""
 
 
 @pytest.mark.asyncio
@@ -199,7 +256,35 @@ async def test_run_subprocess_falls_back_without_systemd(tmp_path):
             result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
 
     assert result["returncode"] == 0
-    # No systemd-run wrap — the existing direct-exec behavior is unchanged.
+    # No systemd-run wrap, no file redirection — the pre-#11492 direct-exec
+    # + pipe behavior is unchanged when systemd-run/service context is absent.
+    assert captured["args"] == tuple(cmd)
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.STDOUT
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_falls_back_when_log_file_prep_fails(tmp_path):
+    """systemd-run is available, but the log file can't be prepared: still
+    falls back to the direct pipe-attached exec rather than detaching without
+    file-backed output (which would just trade one crash risk for another)."""
+    ex = _executor(tmp_path)
+    cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
+    env = {"PATH": "/usr/bin"}
+
+    captured = {}
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProcess(returncode=0)
+
+    with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
+        with patch.object(_pe.PlaybookExecutor, "_prepare_self_update_log_file", return_value=None):
+            with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
+                result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
+
+    assert result["returncode"] == 0
     assert captured["args"] == tuple(cmd)
     assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
     assert captured["kwargs"]["stderr"] == asyncio.subprocess.STDOUT
@@ -207,7 +292,8 @@ async def test_run_subprocess_falls_back_without_systemd(tmp_path):
 
 @pytest.mark.asyncio
 async def test_run_subprocess_unwrapped_when_detach_false(tmp_path):
-    """Ordinary per-role/per-node deploys (detach=False) are unaffected."""
+    """Ordinary per-role/per-node deploys (detach=False) are unaffected: PIPE,
+    no wrap, no file redirection — byte-for-byte the pre-#11492 behavior."""
     ex = _executor(tmp_path)
     cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "site.yml"]
     env = {"PATH": "/usr/bin"}
@@ -216,6 +302,7 @@ async def test_run_subprocess_unwrapped_when_detach_false(tmp_path):
 
     async def _fake_create_subprocess_exec(*args, **kwargs):
         captured["args"] = args
+        captured["kwargs"] = kwargs
         return _FakeProcess(returncode=0)
 
     with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
@@ -223,4 +310,34 @@ async def test_run_subprocess_unwrapped_when_detach_false(tmp_path):
             await ex._run_subprocess(cmd, env, progress_callback=None, detach=False)
 
     assert captured["args"] == tuple(cmd)
-    assert "ANSIBLE_LOG_PATH" not in env
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.STDOUT
+
+
+# ---------------------------------------------------------------------------
+# Log-file tailing parses the same progress lines the pipe would have
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tail_playbook_log_parses_existing_lines_then_stops(tmp_path):
+    log_path = tmp_path / "self-update-ansible.log"
+    log_path.write_text(
+        "PLAY [Play 1 - Update SLM Server First] ****\n"
+        "TASK [[PLAY 1] SLM | Restart autobot-slm-backend] ****\n",
+        encoding="utf-8",
+    )
+    ex = _executor(tmp_path)
+    process = _FakeProcess(returncode=0)  # already "exited" -> tail stops after draining the file
+
+    seen = []
+
+    async def _progress_callback(progress):
+        seen.append(progress)
+
+    output_lines = await ex._tail_playbook_log(log_path, process, _progress_callback)
+
+    assert len(output_lines) == 2
+    stages = [p["stage"] for p in seen]
+    assert "play1_start" in stages
+    assert "slm_restarting" in stages


### PR DESCRIPTION
## Thinking Path
`code-sync self-update` runs `update-all-nodes.yml` as a fire-and-forget ansible subprocess spawned by the SLM backend (`playbook_executor.py`). The backend is `KillMode=control-group`, so Play 1's `systemctl restart autobot-slm-backend` SIGTERMs the whole cgroup — killing the ansible child — and Plays 2/3 never run (the control plane went down this way). #11493 only reordered; the real detach fix was missing.

## What Changed
- **Detach into a transient scope**: `_wrap_with_systemd_scope` wraps the self-update run as `sudo systemd-run --scope --collect --uid/--gid --setenv=<allowlist> -- sh -c 'exec ansible-playbook … >> <log> 2>&1'`. The transient scope is a SEPARATE cgroup, so the backend restart doesn't kill it.
- **Pipe-independent output** (closes the BrokenPipeError risk): the `sh -c 'exec … >> log 2>&1'` reopens ansible's fd 1/2 onto `SELF_UPDATE_LOG_PATH` (/var/log/autobot/self-update-ansible.log, override `SLM_SELF_UPDATE_LOG_PATH`) before exec; the outer subprocess uses `DEVNULL` for the detach case. So a dead backend pipe can never crash the still-running ansible — its fds are a plain file.
- **Live-tail progress**: while the backend is alive, `_tail_playbook_log` polls the log file (env `SLM_SELF_UPDATE_LOG_TAIL_POLL_SEC`, default 1.0s) preserving the exact TaskProgressTracker/heartbeat UX; once the backend restarts the tail simply stops, the orphaned run keeps writing to the file.
- **Gated + fail-safe**: only the self-update call site sets `detach=True`; requires systemd-run + `INVOCATION_ID` (systemd-managed) — otherwise falls back to the original PIPE exec (dev/test/containers unchanged). If the log file can't be prepared, falls back rather than detaching without file-backing. Secrets excluded from `--setenv` (asserted).
- **Pre-existing bug fixed**: `_parse_progress` used `.split("]")[0]`, truncating `[PLAY 1]`-named tasks at the first `]` so Play-1/2 self-update progress stages never fired → `.rsplit("]", 1)[0]`.

## Verification
12 tests (argv shape, log prepare/truncate/failure-fallback, env allowlist, DEVNULL-vs-PIPE, detach=False unchanged, tail parsing); full `tests/services/` sweep 337 passed / 1 pre-existing skip; py_compile + flake8 clean. No file deletions.

## Risk for the coordinated on-box apply
Real systemd/D-Bus behavior of `sudo systemd-run --scope --uid=… -- sh -c 'exec … >> file'` (fd redirection surviving the exec chain, NOPASSWD sudoers scope, D-Bus perms for a uid-dropped scope) needs live verification during the coordinated self-update — tests mock subprocess creation.

## Model Used
Opus 4.8

Closes #11492