### PR TITLE
refactor(ui): shared SemanticVariant type for presentational variants (#10885 PR-7)

### DIFF
--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -23,7 +23,7 @@ import type { BadgeVariant } from '@/types/component-props'
 import { createLogger } from '@/utils/debugUtils'
 
 const BADGE_SIZES = ['xs', 'sm', 'md', 'lg'] as const
-const BADGE_VARIANTS = ['default', 'primary', 'success', 'warning', 'error', 'info'] as const
+const BADGE_VARIANTS = ['neutral', 'primary', 'success', 'warning', 'danger', 'info'] as const
 
 const logger = createLogger('BaseBadge')
 
@@ -40,7 +40,7 @@ interface Props {
 const { t } = useI18n()
 
 const props = withDefaults(defineProps<Props>(), {
-  variant: 'default',
+  variant: 'neutral',
   size: 'sm',
   rounded: true,
   outline: false,
@@ -144,7 +144,7 @@ if (import.meta.env.DEV) {
 }
 
 /* Color Variants - Solid */
-.badge-default {
+.badge-neutral {
   background-color: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
@@ -168,7 +168,7 @@ if (import.meta.env.DEV) {
   border: 1px solid transparent;
 }
 
-.badge-error {
+.badge-danger {
   background-color: var(--color-error-bg);
   color: var(--color-error-dark);
   border: 1px solid transparent;
@@ -181,7 +181,7 @@ if (import.meta.env.DEV) {
 }
 
 /* Outline Variants */
-.badge-outline.badge-default {
+.badge-outline.badge-neutral {
   background-color: transparent;
   color: var(--text-primary);
   border-color: var(--border-default);
@@ -205,7 +205,7 @@ if (import.meta.env.DEV) {
   border-color: var(--color-warning);
 }
 
-.badge-outline.badge-error {
+.badge-outline.badge-danger {
   background-color: transparent;
   color: var(--color-error);
   border-color: var(--color-error);
@@ -281,7 +281,7 @@ if (import.meta.env.DEV) {
 
 /* Dark Mode Adjustments */
 @media (prefers-color-scheme: dark) {
-  .badge-default {
+  .badge-neutral {
     background-color: var(--bg-tertiary);
     border-color: var(--border-default);
   }

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorHistoryPanel.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorHistoryPanel.vue
@@ -69,12 +69,12 @@ function toggleRow(index: number) {
   }
 }
 
-function statusVariant(status: string | null): 'success' | 'error' | 'warning' | 'default' {
+function statusVariant(status: string | null): 'success' | 'danger' | 'warning' | 'neutral' {
   switch (status) {
     case 'success': return 'success'
-    case 'failed': return 'error'
+    case 'failed': return 'danger'
     case 'partial': return 'warning'
-    default: return 'default'
+    default: return 'neutral'
   }
 }
 

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
@@ -55,10 +55,10 @@ const typeBadgeVariant = computed(() => {
  */
 const tierValue = computed(() => (typeof props.config.tier === 'number' ? props.config.tier : 0))
 
-const tierBadgeVariant = computed<'success' | 'warning' | 'error'>(() => {
+const tierBadgeVariant = computed<'success' | 'warning' | 'danger'>(() => {
   switch (tierValue.value) {
     case 2:
-      return 'error'
+      return 'danger'
     case 1:
       return 'warning'
     default:
@@ -94,13 +94,13 @@ const lastSyncDisplay = computed(() => {
 })
 
 const syncStatusVariant = computed(() => {
-  const map: Record<string, 'success' | 'error' | 'warning' | 'default'> = {
+  const map: Record<string, 'success' | 'danger' | 'warning' | 'neutral'> = {
     success: 'success',
-    failed: 'error',
+    failed: 'danger',
     running: 'warning',
-    never: 'default'
+    never: 'neutral'
   }
-  return map[props.status.last_sync_status] || 'default'
+  return map[props.status.last_sync_status] || 'neutral'
 })
 
 function handleSync() {

--- a/autobot-frontend/src/types/component-props.ts
+++ b/autobot-frontend/src/types/component-props.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Canonical shared prop types for UI components
 export type { Size as ComponentSize } from '@/design-tokens/tokens'
+import type { SemanticVariant } from '@autobot/ui'
 
 export type ButtonVariant =
   | 'primary'
@@ -16,4 +17,7 @@ export type ButtonVariant =
   | 'ghost'
   | 'link'
 
-export type BadgeVariant = 'default' | 'primary' | 'success' | 'warning' | 'error' | 'info'
+// BadgeVariant is the shared presentational semantic vocabulary (#10885):
+// neutral | primary | success | warning | danger | info. The former local
+// 'default'/'error' members were reconciled to canonical 'neutral'/'danger'.
+export type BadgeVariant = SemanticVariant

--- a/autobot-frontend/src/views/ComponentShowcaseView.vue
+++ b/autobot-frontend/src/views/ComponentShowcaseView.vue
@@ -80,11 +80,11 @@
         <div class="component-section">
           <h4 class="section-heading">{{ $t('views.componentShowcase.variants') }}</h4>
           <div class="badge-group">
-            <BaseBadge variant="default">{{ $t('views.componentShowcase.default') }}</BaseBadge>
+            <BaseBadge variant="neutral">{{ $t('views.componentShowcase.default') }}</BaseBadge>
             <BaseBadge variant="primary">{{ $t('views.componentShowcase.primary') }}</BaseBadge>
             <BaseBadge variant="success">{{ $t('views.componentShowcase.success') }}</BaseBadge>
             <BaseBadge variant="warning">{{ $t('views.componentShowcase.warning') }}</BaseBadge>
-            <BaseBadge variant="error">{{ $t('views.componentShowcase.error') }}</BaseBadge>
+            <BaseBadge variant="danger">{{ $t('views.componentShowcase.error') }}</BaseBadge>
             <BaseBadge variant="info">{{ $t('views.componentShowcase.info') }}</BaseBadge>
           </div>
 
@@ -93,7 +93,7 @@
             <BaseBadge variant="primary" outline>{{ $t('views.componentShowcase.primary') }}</BaseBadge>
             <BaseBadge variant="success" outline>{{ $t('views.componentShowcase.success') }}</BaseBadge>
             <BaseBadge variant="warning" outline>{{ $t('views.componentShowcase.warning') }}</BaseBadge>
-            <BaseBadge variant="error" outline>{{ $t('views.componentShowcase.error') }}</BaseBadge>
+            <BaseBadge variant="danger" outline>{{ $t('views.componentShowcase.error') }}</BaseBadge>
           </div>
 
           <h4 class="section-heading">{{ $t('views.componentShowcase.monospace') }}</h4>
@@ -186,7 +186,7 @@
 
             <template #cell-status="{ value }">
               <BaseBadge
-                :variant="value === 'active' ? 'success' : value === 'pending' ? 'warning' : 'default'"
+                :variant="value === 'active' ? 'success' : value === 'pending' ? 'warning' : 'neutral'"
                 size="sm"
               >
                 {{ value }}

--- a/autobot-frontend/src/views/llc/MembersView.vue
+++ b/autobot-frontend/src/views/llc/MembersView.vue
@@ -208,7 +208,7 @@ function roleLabel(role: string): string {
   return label === key ? role : label
 }
 
-function roleBadgeVariant(role: string): 'primary' | 'success' | 'warning' | 'default' {
+function roleBadgeVariant(role: string): 'primary' | 'success' | 'warning' | 'neutral' {
   switch (role) {
     case 'owner':
       return 'primary'
@@ -218,7 +218,7 @@ function roleBadgeVariant(role: string): 'primary' | 'success' | 'warning' | 'de
     case 'guest':
       return 'warning'
     default:
-      return 'default'
+      return 'neutral'
   }
 }
 

--- a/libs/autobot-ui/index.ts
+++ b/libs/autobot-ui/index.ts
@@ -11,6 +11,11 @@
 //
 // See README.md for the token contract and authoring rules.
 
+// Shared semantic vocabulary (#10885) — the single presentational colour
+// type (neutral|primary|success|warning|danger|info) that Badge/Alert/status
+// pills across both apps map onto. Domain-status enums keep their own types.
+export type { SemanticVariant, SemanticColor } from './src/types/semantic'
+
 export { default as BaseButton } from './src/components/BaseButton.vue'
 export type { ButtonVariant, ButtonSize } from './src/components/BaseButton.vue'
 

--- a/libs/autobot-ui/src/components/BaseBadge.vue
+++ b/libs/autobot-ui/src/components/BaseBadge.vue
@@ -6,7 +6,11 @@
   for statuses, counts, and tags. See BaseButton.vue for the kit rules.
 -->
 <script setup lang="ts">
-export type BadgeVariant = 'neutral' | 'primary' | 'success' | 'warning' | 'danger' | 'info'
+import type { SemanticVariant } from '../types/semantic'
+
+// BadgeVariant is the canonical semantic vocabulary (#10885); kept as an alias
+// so existing `BadgeVariant` imports keep working without duplicating the union.
+export type BadgeVariant = SemanticVariant
 export type BadgeSize = 'sm' | 'md'
 
 withDefaults(

--- a/libs/autobot-ui/src/types/semantic.ts
+++ b/libs/autobot-ui/src/types/semantic.ts
@@ -1,0 +1,18 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+//
+// SemanticVariant — the single canonical presentational colour vocabulary for
+// the whole design system (#10885). Badge/Alert/status-pill style props map
+// onto this ONE type so a status→colour mapping is defined once instead of
+// being re-declared as a `*Variant` union per component.
+//
+// This is the presentational vocabulary ONLY. Genuinely domain-specific status
+// enums (ConnectionStatus, ServiceHealthStatus, ProgressStatus, NodeStatus, …)
+// carry meaning beyond colour and MUST keep their own types — do not collapse
+// them into this.
+
+export type SemanticVariant = 'neutral' | 'primary' | 'success' | 'warning' | 'danger' | 'info'
+
+// Alias kept for call-sites that read the value as a "colour" rather than a
+// component "variant"; identical vocabulary, one source of truth.
+export type SemanticColor = SemanticVariant


### PR DESCRIPTION
## Thinking Path
PR-7 of the @autobot/ui consolidation. Owner decision D3: consolidate PRESENTATIONAL variant unions onto the kit's canonical vocabulary; leave domain-status unions as their own types.

## What Changed
- New `libs/autobot-ui/src/types/semantic.ts`: `SemanticVariant = neutral|primary|success|warning|danger|info` (+ `SemanticColor`), exported from the kit. Kit's `BadgeVariant` now aliases it (no duplicate union, identical values).
- App's presentational `BadgeVariant` (component-props.ts) → `= SemanticVariant` from `@autobot/ui`. Reconciled non-canonical members `default→neutral` / `error→danger` across type + all 6 usage sites + CSS class maps (`.badge-default→.badge-neutral`, `.badge-error→.badge-danger`, incl. outline + dark-mode) — pixel-identical.
- **Left untouched per D3** (documented): ConnectionStatus/ServiceHealthStatus/ProgressStatus + ~15 other domain `*Status` unions, ButtonVariant (broader style vocab), BaseAlert (`critical`), StatusBadge (`secondary`), traffic-light `green|yellow|red|gray`, severity/theme enums — members carry meaning beyond presentation.

Part of #10885 (closes with PR-6 SLM pagination adoption, held until CI).

## Verification (CI down — local gate)
- `vue-tsc --noEmit -p tsconfig.app.json` exit 0. Grep-proof: 0 lingering default/error variant members on reconciled sites. `vitest` badge + connectors: 21 passed.

## Model Used
Opus 4.8 (subagent: frontend-engineer)