### PR TITLE
feat(voice): overlay & sidepanel voice UIs functionally identical, sidebar default (#11999)

### DIFF
--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -41,6 +41,7 @@
                 <option value="walkie-talkie">{{ $t('chat.voice.walkieTalkie') }}</option>
                 <option value="hands-free">{{ $t('chat.voice.handsFree') }}</option>
                 <option value="full-duplex">{{ $t('chat.voice.fullDuplex') }}</option>
+                <option value="realtime-webrtc">{{ $t('chat.voice.realtimeWebrtc') }}</option>
               </select>
 
               <!-- Language indicator (#1334) -->
@@ -58,9 +59,21 @@
                 class="voice-overlay__ws-indicator"
                 :class="{
                   'voice-overlay__ws-indicator--connected':
-                    wsConnected,
+                    voiceConversation.wsConnected?.value,
                 }"
-                :title="wsConnected
+                :title="voiceConversation.wsConnected?.value
+                  ? $t('chat.voice.connected') : $t('chat.voice.disconnected')"
+              ></div>
+
+              <!-- RTC connection indicator (realtime-webrtc) -->
+              <div
+                v-if="voiceConversation.mode.value === 'realtime-webrtc'"
+                class="voice-overlay__ws-indicator"
+                :class="{
+                  'voice-overlay__ws-indicator--connected':
+                    voiceConversation.realtimeConnectionState.value === 'connected',
+                }"
+                :title="voiceConversation.realtimeConnectionState.value === 'connected'
                   ? $t('chat.voice.connected') : $t('chat.voice.disconnected')"
               ></div>
 
@@ -245,7 +258,7 @@ import {
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVoiceConversation } from '@/composables/useVoiceConversation'
-import { useVoiceOutput } from '@/composables/useVoiceOutput'
+import type { ConversationMode } from '@/composables/useVoiceConversation'
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -253,7 +266,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const voiceConversation = useVoiceConversation()
-const { wsConnected } = useVoiceOutput()
 const overlayRef = ref<HTMLElement | null>(null)
 const conversationRef = ref<HTMLElement | null>(null)
 
@@ -274,8 +286,11 @@ const isFullDuplex = computed(
 const isHandsFree = computed(
   () => voiceConversation.mode.value === 'hands-free',
 )
+const isRealtimeWebrtc = computed(
+  () => voiceConversation.mode.value === 'realtime-webrtc',
+)
 const isAutoMode = computed(
-  () => isFullDuplex.value || isHandsFree.value,
+  () => isFullDuplex.value || isHandsFree.value || isRealtimeWebrtc.value,
 )
 
 // Show insecure-context warning when a mic-dependent mode is active
@@ -310,9 +325,7 @@ function handleMicClick(): void {
 
 function handleModeChange(event: Event): void {
   const target = event.target as HTMLSelectElement
-  voiceConversation.setMode(
-    target.value as 'walkie-talkie' | 'hands-free' | 'full-duplex',
-  )
+  voiceConversation.setMode(target.value as ConversationMode)
 }
 
 function close(): void {

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="voice-panel h-full flex flex-col bg-autobot-bg-card border-l border-autobot-border">
+  <div
+    class="voice-panel h-full flex flex-col bg-autobot-bg-card border-l border-autobot-border"
+    tabindex="-1"
+    ref="panelRef"
+    @keydown.escape="close"
+  >
     <!-- Header -->
     <div class="flex items-center justify-between p-3 border-b border-autobot-border shrink-0">
       <div class="flex items-center gap-2">
@@ -89,16 +94,29 @@
       {{ voiceConversation.errorMessage.value }}
     </div>
 
-    <!-- Insecure context warning -->
+    <!-- Insecure-context warning (#1059) — shown when mic-dependent mode selected
+         but browser blocks getUserMedia due to an untrusted certificate -->
     <div
       v-if="showInsecureContextWarning"
       class="voice-panel__cert-warning"
     >
-      <p class="font-semibold text-xs">
+      <p class="voice-panel__cert-warning-title">
         <Icon name="lock" class="me-1" />{{ $t('chat.voice.micBlocked') }}
       </p>
-      <p class="text-xs opacity-80">
-        {{ $t('chat.voice.certRequiredShort') }}
+      <p class="voice-panel__cert-warning-body">
+        {{ $t('chat.voice.certRequired') }}
+      </p>
+      <ol class="voice-panel__cert-warning-steps">
+        <li>{{ $t('chat.voice.certStep1') }}</li>
+        <li>
+          {{ $t('chat.voice.certStep2Pre') }}
+          <code>chrome://flags/#unsafely-treat-insecure-origin-as-secure</code>,
+          {{ $t('chat.voice.certStep2Post', { origin: currentOrigin }) }}
+        </li>
+      </ol>
+      <p class="voice-panel__cert-warning-fallback">
+        <Icon name="info-circle" class="me-1" />
+        {{ $t('chat.voice.walkieTalkieFallback') }}
       </p>
     </div>
 
@@ -168,7 +186,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { computed, onBeforeUnmount } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVoiceConversation } from '@/composables/useVoiceConversation'
 import type { ConversationMode } from '@/composables/useVoiceConversation'
@@ -179,6 +197,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const voiceConversation = useVoiceConversation()
+const panelRef = ref<HTMLElement | null>(null)
 
 const isFullDuplex = computed(
   () => voiceConversation.mode.value === 'full-duplex',
@@ -196,6 +215,7 @@ const isAutoMode = computed(
 const showInsecureContextWarning = computed(
   () => isAutoMode.value && !voiceConversation.micAccessAvailable.value,
 )
+const currentOrigin = window.location.origin
 
 const stateClass = computed(() => ({
   'voice-panel__state-ring--idle': voiceConversation.state.value === 'idle',
@@ -268,6 +288,12 @@ function close(): void {
 
 onBeforeUnmount(() => {
   voiceConversation.cleanup()
+})
+
+// Focus panel for keyboard accessibility (mirrors VoiceConversationOverlay)
+onMounted(async () => {
+  await nextTick()
+  panelRef.value?.focus()
 })
 </script>
 
@@ -417,6 +443,37 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
+}
+
+.voice-panel__cert-warning-title {
+  font-weight: 600;
+  font-size: var(--text-xs);
+}
+
+.voice-panel__cert-warning-body {
+  color: var(--voiceoverlay-warning-body-text);
+}
+
+.voice-panel__cert-warning-steps {
+  padding-left: var(--spacing-4);
+  list-style: decimal;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.voice-panel__cert-warning-steps code {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.1rem 0.3rem;
+  border-radius: var(--radius-default);
+  font-size: 0.625rem;
+  word-break: break-all;
+}
+
+.voice-panel__cert-warning-fallback {
+  color: var(--voiceoverlay-muted-text);
+  font-size: 0.625rem;
+  margin-top: var(--spacing-1);
 }
 
 /* Hands-free controls */

--- a/autobot-frontend/src/composables/usePreferences.ts
+++ b/autobot-frontend/src/composables/usePreferences.ts
@@ -59,7 +59,7 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   fontSize: 'medium',
   accentColor: 'blue',
   layoutDensity: 'comfortable',
-  voiceDisplayMode: 'modal',
+  voiceDisplayMode: 'sidepanel',
   language: 'en',
   contextOverflowMode: 'auto',
   reasoningEffort: 'auto'
@@ -69,7 +69,7 @@ const DEFAULT_PREFERENCES: UserPreferences = {
 const fontSize = ref<FontSize>('medium')
 const accentColor = ref<AccentColor>('blue')
 const layoutDensity = ref<LayoutDensity>('comfortable')
-const voiceDisplayMode = ref<VoiceDisplayMode>('modal')
+const voiceDisplayMode = ref<VoiceDisplayMode>('sidepanel')
 const language = ref<string>('en')
 const contextOverflowMode = ref<ContextOverflowMode>('auto')
 const reasoningEffort = ref<ReasoningEffort>('auto')


### PR DESCRIPTION
Closes #11999

## Thinking Path
The two voice-conversation UIs (fullscreen `VoiceConversationOverlay` 'modal' + docked `VoiceConversationPanel` 'sidepanel') already share all logic via the `useVoiceConversation` singleton — differences were purely which template rendered what. Owner: make them functionally identical, sidebar as default, user keeps choosing. Conversation history is intentionally NOT duplicated into the panel — in side-panel mode it's already visible in the adjacent chat window; only the fullscreen overlay needs its own log.

## What Changed
- **Overlay:** added the `realtime-webrtc` conversation mode + its RTC connection indicator (was missing the 4th mode the panel had); `isRealtimeWebrtc` folded into `isAutoMode`; `setMode` cast widened to `ConversationMode`. WS dot now reads `voiceConversation.wsConnected` (dropped the separate `useVoiceOutput` import).
- **Panel:** full inline mic-permission remediation steps (was a short warning); Escape-to-close + focus-on-mount.
- **Default:** `voiceDisplayMode` `'modal'`→`'sidepanel'`; a user's saved choice is preserved (persist-load unchanged), only new users get the sidebar default.
- **Kept:** ProfileModal modal/sidepanel toggle (user-selectable). No composable/backend changes; neither component deleted.

## Verification
- Both mode selects list all 4 modes; both WS dots use `voiceConversation.wsConnected`; panel has esc-close + full cert steps; default is sidepanel; toggle intact.
- All `$t()` keys verified present in `en.json`; `--voiceoverlay-*` tokens used are defined.
- `vue-tsc -p tsconfig.app.json`: zero new errors in the 3 touched files (only pre-existing unrelated `SemanticVariant` error).
- **Manual runtime check recommended** (needs browser+mic+backend): exercise each of the 4 modes end-to-end in both overlay and sidebar — VAD, WS full-duplex, WebRTC realtime.

## Model Used
Claude Sonnet (subagent), reviewed by Opus 4.8