### PR TITLE
fix(llc): scope sprint-board Timeline Gantt to the current board/sprint (#11701)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7981,7 +7981,9 @@
       "noProjects": "No projects in this company yet.",
       "noItems": "This project has no work items to schedule.",
       "ariaChart": "Project timeline Gantt chart",
-      "unscheduled": "unscheduled"
+      "unscheduled": "unscheduled",
+      "scopedTo": "مقصور على {name}",
+      "showAll": "عرض الشركة بأكملها"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7981,7 +7981,9 @@
       "noProjects": "Noch keine Projekte in diesem Unternehmen.",
       "noItems": "Dieses Projekt hat keine planbaren Arbeitselemente.",
       "ariaChart": "Projekt-Zeitachsen-Gantt-Diagramm",
-      "unscheduled": "ungeplant"
+      "unscheduled": "ungeplant",
+      "scopedTo": "Eingegrenzt auf {name}",
+      "showAll": "Gesamtes Unternehmen anzeigen"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7970,7 +7970,9 @@
       "noProjects": "No projects in this company yet.",
       "noItems": "This project has no work items to schedule.",
       "ariaChart": "Project timeline Gantt chart",
-      "unscheduled": "unscheduled"
+      "unscheduled": "unscheduled",
+      "scopedTo": "Scoped to {name}",
+      "showAll": "Show whole company"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7981,7 +7981,9 @@
       "noProjects": "Aún no hay proyectos en esta empresa.",
       "noItems": "Este proyecto no tiene elementos de trabajo para planificar.",
       "ariaChart": "Diagrama de Gantt del cronograma del proyecto",
-      "unscheduled": "sin planificar"
+      "unscheduled": "sin planificar",
+      "scopedTo": "Limitado a {name}",
+      "showAll": "Mostrar toda la empresa"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -7981,7 +7981,9 @@
       "noProjects": "No projects in this company yet.",
       "noItems": "This project has no work items to schedule.",
       "ariaChart": "Project timeline Gantt chart",
-      "unscheduled": "unscheduled"
+      "unscheduled": "unscheduled",
+      "scopedTo": "محدود به {name}",
+      "showAll": "نمایش کل شرکت"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7981,7 +7981,9 @@
       "noProjects": "Aucun projet dans cette entreprise pour le moment.",
       "noItems": "Ce projet n'a aucun élément de travail à planifier.",
       "ariaChart": "Diagramme de Gantt de la chronologie du projet",
-      "unscheduled": "non planifié"
+      "unscheduled": "non planifié",
+      "scopedTo": "Limité à {name}",
+      "showAll": "Afficher toute l'entreprise"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -7981,7 +7981,9 @@
       "noProjects": "No projects in this company yet.",
       "noItems": "This project has no work items to schedule.",
       "ariaChart": "Project timeline Gantt chart",
-      "unscheduled": "unscheduled"
+      "unscheduled": "unscheduled",
+      "scopedTo": "מוגבל אל {name}",
+      "showAll": "הצג את כל החברה"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7981,7 +7981,9 @@
       "noProjects": "No projects in this company yet.",
       "noItems": "This project has no work items to schedule.",
       "ariaChart": "Project timeline Gantt chart",
-      "unscheduled": "unscheduled"
+      "unscheduled": "unscheduled",
+      "scopedTo": "Ierobežots uz {name}",
+      "showAll": "Rādīt visu uzņēmumu"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7981,7 +7981,9 @@
       "noProjects": "No projects in this company yet.",
       "noItems": "This project has no work items to schedule.",
       "ariaChart": "Project timeline Gantt chart",
-      "unscheduled": "unscheduled"
+      "unscheduled": "unscheduled",
+      "scopedTo": "Zawężono do {name}",
+      "showAll": "Pokaż całą firmę"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7981,7 +7981,9 @@
       "noProjects": "Ainda não há projetos nesta empresa.",
       "noItems": "Este projeto não tem itens de trabalho para agendar.",
       "ariaChart": "Gráfico de Gantt da linha do tempo do projeto",
-      "unscheduled": "não agendado"
+      "unscheduled": "não agendado",
+      "scopedTo": "Limitado a {name}",
+      "showAll": "Mostrar toda a empresa"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -7981,7 +7981,9 @@
       "noProjects": "No projects in this company yet.",
       "noItems": "This project has no work items to schedule.",
       "ariaChart": "Project timeline Gantt chart",
-      "unscheduled": "unscheduled"
+      "unscheduled": "unscheduled",
+      "scopedTo": "{name} تک محدود",
+      "showAll": "پوری کمپنی دکھائیں"
     },
     "backlog": {
       "title": "Backlog",

--- a/autobot-frontend/src/views/llc/GanttTimelineView.vue
+++ b/autobot-frontend/src/views/llc/GanttTimelineView.vue
@@ -11,8 +11,13 @@
   <div class="gantt-view">
     <header class="gantt-toolbar">
       <h2 class="gantt-title">{{ $t('llc.gantt.title') }}</h2>
+      <!-- #11701: board/sprint scope banner — shown when opened from a sprint board -->
+      <div v-if="scopeLabel" class="gantt-scope">
+        <span class="gantt-scope-label">{{ $t('llc.gantt.scopedTo', { name: scopeLabel }) }}</span>
+        <button class="gantt-scope-clear" @click="clearScope">{{ $t('llc.gantt.showAll') }}</button>
+      </div>
       <div class="gantt-controls">
-        <label class="gantt-field">
+        <label v-if="!scopeLabel" class="gantt-field">
           <span class="gantt-field-label">{{ $t('llc.gantt.project') }}</span>
           <select v-model="selectedProjectId" class="gantt-select" @change="loadTimeline">
             <option v-for="p in projects" :key="p.id" :value="p.id">{{ p.name }}</option>
@@ -134,7 +139,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { useI18n } from 'vue-i18n'
@@ -143,6 +148,7 @@ import { useNotificationBus } from '@/composables/useNotificationBus'
 const logger = createLogger('GanttTimelineView')
 const api = useApiClient()
 const route = useRoute()
+const router = useRouter()
 const { t } = useI18n()
 const { showToast } = useNotificationBus()
 
@@ -183,6 +189,12 @@ interface Timeline {
 const companyId = computed(() => route.params.companyId as string)
 const projects = ref<Project[]>([])
 const selectedProjectId = ref<string>('')
+// #11701: board/sprint scope. When the Gantt is opened from a sprint board the
+// `board` query param filters the timeline to that board's work items; without
+// it the company-wide roadmap renders unchanged.
+const scopeBoardId = computed(() => (route.query.board as string) || '')
+const scopedItemIds = ref<Set<string> | null>(null)
+const scopeLabel = ref<string>('')
 const items = ref<TimelineItem[]>([])
 const edges = ref<TimelineEdge[]>([])
 const zoom = ref<'day' | 'week' | 'month' | 'quarter'>('week')
@@ -393,13 +405,55 @@ async function loadProjects() {
   }
 }
 
+// #11701: resolve the board query param into the set of work item ids that
+// belong to that sprint board, and pre-select the board's project so the
+// filtered timeline targets the right project.
+async function loadBoardScope() {
+  if (!scopeBoardId.value) {
+    scopedItemIds.value = null
+    scopeLabel.value = ''
+    return
+  }
+  try {
+    const [board, boardItems] = await Promise.all([
+      api.get<{ project_id: string | null; name: string }>(`/api/llc/boards/${scopeBoardId.value}`),
+      api.get<{ items: { id: string }[] }>(`/api/llc/boards/${scopeBoardId.value}/items`),
+    ])
+    scopedItemIds.value = new Set((boardItems.items ?? []).map((i) => i.id))
+    scopeLabel.value = board.name
+    if (board.project_id) selectedProjectId.value = board.project_id
+  } catch (err) {
+    logger.error('Failed to load board scope', err)
+    scopedItemIds.value = null
+    scopeLabel.value = ''
+  }
+}
+
+// Drop the board/sprint filter and return to the company-wide roadmap.
+async function clearScope() {
+  scopedItemIds.value = null
+  scopeLabel.value = ''
+  await router.replace({ name: 'llc-timeline', params: { companyId: companyId.value } })
+  await loadTimeline()
+}
+
 async function loadTimeline() {
   if (!selectedProjectId.value) return
   loading.value = true
   try {
     const data = await api.get<Timeline>(`/api/llc/projects/${selectedProjectId.value}/timeline`)
-    items.value = data.items
-    edges.value = data.edges
+    if (scopedItemIds.value) {
+      // #11701: restrict to the originating board/sprint's work items and keep
+      // only edges whose endpoints both survive the filter.
+      const members = scopedItemIds.value
+      const visible = data.items.filter((it) => members.has(it.id))
+      const visibleIds = new Set(visible.map((it) => it.id))
+      items.value = visible
+      edges.value = data.edges.filter((e) => visibleIds.has(e.from_id) && visibleIds.has(e.to_id))
+    } else {
+      items.value = data.items
+      edges.value = data.edges
+    }
   } catch (err) {
     logger.error('Failed to load timeline', err)
     items.value = []
@@ -411,6 +465,7 @@ async function loadTimeline() {
 
 onMounted(async () => {
   loading.value = true
+  await loadBoardScope()
   await loadProjects()
   await loadTimeline()
 })
@@ -448,6 +503,37 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: flex-end;
   gap: 0.75rem;
+}
+
+.gantt-scope {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+  border: 1px solid var(--border-default, #d1d5db);
+  border-radius: 9999px;
+  background: var(--bg-elevated, #f3f4f6);
+  font-size: 0.8rem;
+}
+
+.gantt-scope-label {
+  color: var(--text-primary, #111827);
+  font-weight: 500;
+}
+
+.gantt-scope-clear {
+  border: none;
+  background: transparent;
+  color: var(--color-primary, #3b82f6);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.1rem 0.35rem;
+  border-radius: 6px;
+}
+
+.gantt-scope-clear:hover {
+  background: var(--bg-surface, #fff);
 }
 
 .gantt-field {

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -200,9 +200,12 @@ function formatDate(iso: string) {
 }
 
 function switchToTimeline() {
+  // #11701: preserve the current board/sprint context so the Gantt scopes to
+  // this board's work items instead of jumping to the company-wide roadmap.
   router.push({
     name: 'llc-timeline',
     params: { companyId: companyId.value },
+    query: { board: boardId.value },
   })
 }
 

--- a/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.spec.ts
+++ b/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.spec.ts
@@ -1,0 +1,132 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+// #11701 — GanttTimelineView scopes to the originating sprint board's work
+// items when opened with a `board` query param; otherwise renders the
+// company-wide roadmap unchanged.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+// --- module mocks ---------------------------------------------------------
+const h = vi.hoisted(() => ({
+  route: { params: {} as Record<string, string>, query: {} as Record<string, string> },
+  router: { replace: vi.fn() },
+  api: { get: vi.fn(), patch: vi.fn() },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => h.route,
+  useRouter: () => h.router,
+}))
+vi.mock('@/plugins/api', () => ({ useApiClient: () => h.api }))
+vi.mock('@/composables/useNotificationBus', () => ({
+  useNotificationBus: () => ({ showToast: vi.fn() }),
+}))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+import GanttTimelineView from '../GanttTimelineView.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+function timelineItem(id: string, identifier: string) {
+  return {
+    id,
+    identifier,
+    title: `Item ${identifier}`,
+    type: 'task',
+    status: 'todo',
+    scheduled_start: '2026-01-01T00:00:00Z',
+    scheduled_end: '2026-01-05T00:00:00Z',
+    started_at: null,
+    completed_at: null,
+    on_critical_path: false,
+  }
+}
+
+// project p1 has three items; the sprint board b1 only contains w1 + w2.
+const PROJECT_TIMELINE = {
+  project_id: 'p1',
+  items: [timelineItem('w1', 'WI-1'), timelineItem('w2', 'WI-2'), timelineItem('w3', 'WI-3')],
+  edges: [{ from_id: 'w1', to_id: 'w3' }],
+}
+
+function wireApi() {
+  h.api.get.mockImplementation((url: string) => {
+    if (url === '/api/llc/boards/b1') return Promise.resolve({ project_id: 'p1', name: 'Sprint 3 Board' })
+    if (url === '/api/llc/boards/b1/items') return Promise.resolve({ items: [{ id: 'w1' }, { id: 'w2' }] })
+    if (url === '/api/llc/companies/c1/projects')
+      return Promise.resolve([{ id: 'p1', name: 'Proj 1' }, { id: 'p2', name: 'Proj 2' }])
+    if (url === '/api/llc/projects/p1/timeline') return Promise.resolve(PROJECT_TIMELINE)
+    return Promise.reject(new Error(`unexpected url ${url}`))
+  })
+}
+
+function mountView() {
+  return mount(GanttTimelineView, { global: { plugins: [i18n] } })
+}
+
+describe('GanttTimelineView board/sprint scope (#11701)', () => {
+  beforeEach(() => {
+    h.route.params = { companyId: 'c1' }
+    h.route.query = {}
+    h.router.replace.mockReset()
+    wireApi()
+  })
+
+  it('scopes the timeline to the sprint board when opened with a board query', async () => {
+    h.route.query = { board: 'b1' }
+    const w = mountView()
+    await flushPromises()
+
+    // Board metadata + membership were fetched to resolve the scope.
+    expect(h.api.get).toHaveBeenCalledWith('/api/llc/boards/b1')
+    expect(h.api.get).toHaveBeenCalledWith('/api/llc/boards/b1/items')
+    // The board's project drove the timeline request.
+    expect(h.api.get).toHaveBeenCalledWith('/api/llc/projects/p1/timeline')
+
+    // Only the two board members render — w3 is filtered out.
+    const rows = w.findAll('.gantt-row')
+    expect(rows).toHaveLength(2)
+    const labels = w.findAll('.gantt-row-label').map((n) => n.text())
+    expect(labels).toEqual(['WI-1', 'WI-2'])
+
+    // The scope banner is visible and the project selector is hidden.
+    expect(w.find('.gantt-scope').exists()).toBe(true)
+    expect(w.text()).toContain('Sprint 3 Board')
+    expect(w.find('select').exists()).toBe(true) // zoom select still present
+    expect(w.findAll('.gantt-field')).toHaveLength(1) // project field hidden, only zoom
+  })
+
+  it('renders the whole company timeline (no scope) when no board query is present', async () => {
+    const w = mountView()
+    await flushPromises()
+
+    expect(h.api.get).not.toHaveBeenCalledWith('/api/llc/boards/b1')
+    const rows = w.findAll('.gantt-row')
+    expect(rows).toHaveLength(3)
+    expect(w.find('.gantt-scope').exists()).toBe(false)
+    // project selector present in the global view.
+    expect(w.findAll('.gantt-field')).toHaveLength(2)
+  })
+
+  it('clears the scope and returns to the company-wide roadmap', async () => {
+    h.route.query = { board: 'b1' }
+    const w = mountView()
+    await flushPromises()
+    expect(w.findAll('.gantt-row')).toHaveLength(2)
+
+    await w.find('.gantt-scope-clear').trigger('click')
+    await flushPromises()
+
+    expect(h.router.replace).toHaveBeenCalledWith({ name: 'llc-timeline', params: { companyId: 'c1' } })
+    // filter dropped — all three items now render.
+    expect(w.findAll('.gantt-row')).toHaveLength(3)
+    expect(w.find('.gantt-scope').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Thinking Path
The sprint-board Timeline button opened a company-wide Gantt, losing the board/sprint context. Owner decision: scope it to the current board/sprint.

## What Changed
- `SprintBoardView.vue` `switchToTimeline`: adds `query: { board: boardId }` to the existing `llc-timeline` route (no new route).
- `GanttTimelineView.vue`: on mount, if `route.query.board` present → `loadBoardScope()` fetches the board's `project_id` + member work-item ids, pre-selects the project, filters the timeline `items` to the member set (drops edges whose endpoints don't survive). Scope banner "Scoped to {name}" + "Show whole company" (`clearScope` → un-scoped route). Project selector hidden while scoped.
- No backend change (board endpoints already expose project_id + item ids; filter is client-side). Global company-wide view preserved when opened without the query.
- i18n keys `llc.gantt.scopedTo`/`showAll` across all 11 locales.

Closes #11701

## Verification (CI down — local gate)
- `vue-tsc --noEmit -p tsconfig.app.json` clean. New `GanttTimelineView.spec.ts` 3 tests (scoped filter + banner + hidden project field; un-scoped renders all; clearScope restores global). Full llc suites 39 passed. 11 locales valid + parity.

## Model Used
Opus 4.8 (subagent: frontend-engineer)