### PR TITLE
refactor(llc): consolidate SLM-policy reader + LLC IDOR guard to canonical sources (#11359)

### DIFF
--- a/autobot-backend/llc/api/findings.py
+++ b/autobot-backend/llc/api/findings.py
@@ -19,9 +19,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
-from llc.deps import get_session
+from llc.deps import get_session, load_owned_project as _load_owned_project
 from llc.models.finding_proposal import LLCFindingProposal
-from llc.models.sprint import LLCProject
 from llc.services.finding_proposal_service import (
     FindingsDisabledError,
     ProposalStateError,
@@ -70,15 +69,6 @@ class DismissRequest(BaseModel):
 # ---------------------------------------------------------------------------
 # IDOR guards
 # ---------------------------------------------------------------------------
-
-
-async def _load_owned_project(project_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCProject:
-    """Load project by id; 404 when missing or owned by a different org."""
-    result = await session.execute(select(LLCProject).where(LLCProject.id == project_id))
-    project = result.scalar_one_or_none()
-    if project is None or str(project.company_id) != str(ctx.org_id):
-        raise HTTPException(status_code=404, detail="Project not found")
-    return project
 
 
 async def _load_owned_proposal(proposal_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCFindingProposal:

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -41,7 +41,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
-from llc.deps import get_session
+from llc.deps import get_session, load_owned_project as _load_owned_project
 from user_management.services import TenantContext
 
 from ..kb.collections import KbCollectionManager
@@ -694,15 +694,6 @@ async def update_project(
         setattr(project, field, value)
     await session.commit()
     await session.refresh(project)
-    return project
-
-
-async def _load_owned_project(project_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCProject:
-    """Load project by id; 404 when missing or owned by a different org (IDOR guard)."""
-    result = await session.execute(select(LLCProject).where(LLCProject.id == project_id))
-    project = result.scalar_one_or_none()
-    if project is None or str(project.company_id) != str(ctx.org_id):
-        raise HTTPException(status_code=404, detail="Project not found")
     return project
 
 

--- a/autobot-backend/llc/deps.py
+++ b/autobot-backend/llc/deps.py
@@ -38,10 +38,13 @@ import uuid
 from typing import AsyncGenerator, Callable, Set, Type, TypeVar
 
 from fastapi import Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.singleton_factory import lazy_singleton
+from llc.models.sprint import LLCProject
 from user_management.database import get_async_session_factory
+from user_management.services import TenantContext
 
 _T = TypeVar("_T")
 
@@ -134,4 +137,25 @@ async def require_board_role(
     return str(user_id)
 
 
-__all__ = ["get_session", "postgres_required", "require_board_role", "service_dep"]
+async def load_owned_project(project_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCProject:
+    """Load a project by id; 404 when missing or owned by a different org.
+
+    IDOR guard (#10148): canonical implementation shared by sprints.py and
+    findings.py, which previously each defined an identical
+    ``_load_owned_project`` (#11359). 404 (not 403) is used for both "missing"
+    and "wrong org" to avoid disclosing project existence to non-owners.
+    """
+    result = await session.execute(select(LLCProject).where(LLCProject.id == project_id))
+    project = result.scalar_one_or_none()
+    if project is None or str(project.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+__all__ = [
+    "get_session",
+    "load_owned_project",
+    "postgres_required",
+    "require_board_role",
+    "service_dep",
+]

--- a/autobot-backend/llc/services/disposal_policy.py
+++ b/autobot-backend/llc/services/disposal_policy.py
@@ -2,13 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Read the SLM-configured project disposal policy with safe defaults (#11129 P2)."""
 
-import json
-import logging
 from dataclasses import dataclass
 
-from services.slm_client import get_slm_client
-
-logger = logging.getLogger(__name__)
+from llc.services.slm_policy import fetch_slm_policy_json
 
 POLICY_SETTING_KEY = "llc.project_disposal_policy"
 
@@ -20,25 +16,8 @@ class DisposalPolicy:
 
 
 async def _fetch_policy_json() -> dict | None:
-    """GET the policy setting from the SLM settings API; None on any failure."""
-    client = get_slm_client()
-    if client is None:
-        return None
-    try:
-        session = await client._get_session()
-        url = f"{client.slm_url}/api/settings/{POLICY_SETTING_KEY}"
-        async with session.get(url) as response:
-            if response.status != 200:
-                return None
-            setting = await response.json()
-            raw = setting.get("value")
-            # ``value`` is stored as an escaped JSON string; if the SLM API is ever
-            # changed to return it pre-decoded (a dict), json.loads raises TypeError
-            # and the outer except returns None → get_disposal_policy uses defaults.
-            return json.loads(raw) if raw else None
-    except Exception as exc:  # noqa: BLE001 — policy read is best-effort
-        logger.warning("Disposal policy read failed: %s", exc)
-        return None
+    """GET the disposal policy setting from the SLM settings API; None on any failure."""
+    return await fetch_slm_policy_json(POLICY_SETTING_KEY)
 
 
 async def get_disposal_policy() -> DisposalPolicy:

--- a/autobot-backend/llc/services/findings_policy.py
+++ b/autobot-backend/llc/services/findings_policy.py
@@ -2,13 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Read the SLM-configured findings policy with safe defaults (#11271)."""
 
-import json
-import logging
 from dataclasses import dataclass
 
-from services.slm_client import get_slm_client
-
-logger = logging.getLogger(__name__)
+from llc.services.slm_policy import fetch_slm_policy_json
 
 POLICY_SETTING_KEY = "llc.findings_policy"
 
@@ -25,22 +21,8 @@ class FindingsPolicy:
 
 
 async def _fetch_policy_json() -> dict | None:
-    """GET the policy setting from the SLM settings API; None on any failure."""
-    client = get_slm_client()
-    if client is None:
-        return None
-    try:
-        session = await client._get_session()
-        url = f"{client.slm_url}/api/settings/{POLICY_SETTING_KEY}"
-        async with session.get(url) as response:
-            if response.status != 200:
-                return None
-            setting = await response.json()
-            raw = setting.get("value")
-            return json.loads(raw) if raw else None
-    except Exception as exc:  # noqa: BLE001 — policy read is best-effort
-        logger.warning("Findings policy read failed: %s", exc)
-        return None
+    """GET the findings policy setting from the SLM settings API; None on any failure."""
+    return await fetch_slm_policy_json(POLICY_SETTING_KEY)
 
 
 async def get_findings_policy() -> FindingsPolicy:

--- a/autobot-backend/llc/services/slm_policy.py
+++ b/autobot-backend/llc/services/slm_policy.py
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical SLM-settings JSON policy reader (#11359).
+
+Both ``disposal_policy.py`` and ``findings_policy.py`` independently defined
+a structurally-identical ``_fetch_policy_json()``: GET the SLM settings API
+for a given key, return ``None`` on any failure (missing client, non-200
+response, malformed JSON) so callers fall back to safe defaults. This module
+is the single, shared implementation; each policy module keeps only its
+dataclass + coercion logic.
+"""
+
+import json
+import logging
+
+from services.slm_client import get_slm_client
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_slm_policy_json(key: str) -> dict | None:
+    """GET the SLM setting ``key``'s JSON value; ``None`` on any failure.
+
+    Best-effort read: no SLM client configured, a non-200 response, or a
+    malformed/undecodable ``value`` all resolve to ``None`` rather than
+    raising, so callers can apply safe defaults.
+    """
+    client = get_slm_client()
+    if client is None:
+        return None
+    try:
+        session = await client._get_session()
+        url = f"{client.slm_url}/api/settings/{key}"
+        async with session.get(url) as response:
+            if response.status != 200:
+                return None
+            setting = await response.json()
+            raw = setting.get("value")
+            # ``value`` is stored as an escaped JSON string; if the SLM API is ever
+            # changed to return it pre-decoded (a dict), json.loads raises TypeError
+            # and the outer except returns None -> caller uses its safe defaults.
+            return json.loads(raw) if raw else None
+    except Exception as exc:  # noqa: BLE001 - policy read is best-effort
+        logger.warning("SLM policy read failed for key=%s: %s", key, exc)
+        return None

--- a/autobot-backend/llc/tests/test_disposal_policy.py
+++ b/autobot-backend/llc/tests/test_disposal_policy.py
@@ -11,7 +11,7 @@ from llc.services.disposal_policy import DisposalPolicy, get_disposal_policy
 
 @pytest.mark.asyncio
 async def test_defaults_when_no_slm_client():
-    with patch("llc.services.disposal_policy.get_slm_client", return_value=None):
+    with patch("llc.services.slm_policy.get_slm_client", return_value=None):
         policy = await get_disposal_policy()
     assert policy == DisposalPolicy(retention_days=0, require_approval=False)
 

--- a/autobot-backend/llc/tests/test_findings_policy.py
+++ b/autobot-backend/llc/tests/test_findings_policy.py
@@ -11,7 +11,7 @@ from llc.services.findings_policy import FindingsPolicy, get_findings_policy
 
 @pytest.mark.asyncio
 async def test_defaults_when_no_slm_client():
-    with patch("llc.services.findings_policy.get_slm_client", return_value=None):
+    with patch("llc.services.slm_policy.get_slm_client", return_value=None):
         policy = await get_findings_policy()
     assert policy == FindingsPolicy(
         enabled=False,

--- a/autobot-backend/llc/tests/test_slm_policy.py
+++ b/autobot-backend/llc/tests/test_slm_policy.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical SLM-settings JSON policy reader (#11359)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.services.slm_policy import fetch_slm_policy_json
+
+
+@pytest.mark.asyncio
+async def test_none_when_no_slm_client():
+    with patch("llc.services.slm_policy.get_slm_client", return_value=None):
+        assert await fetch_slm_policy_json("some.key") is None
+
+
+@pytest.mark.asyncio
+async def test_none_on_non_200_response():
+    response = AsyncMock()
+    response.status = 404
+    response.__aenter__.return_value = response
+    session = MagicMock()
+    session.get.return_value = response
+    client = MagicMock()
+    client._get_session = AsyncMock(return_value=session)
+    client.slm_url = "http://slm"
+    with patch("llc.services.slm_policy.get_slm_client", return_value=client):
+        assert await fetch_slm_policy_json("some.key") is None
+
+
+@pytest.mark.asyncio
+async def test_parses_escaped_json_value():
+    response = AsyncMock()
+    response.status = 200
+    response.json = AsyncMock(return_value={"value": '{"enabled": true}'})
+    response.__aenter__.return_value = response
+    session = MagicMock()
+    session.get.return_value = response
+    client = MagicMock()
+    client._get_session = AsyncMock(return_value=session)
+    client.slm_url = "http://slm"
+    with patch("llc.services.slm_policy.get_slm_client", return_value=client):
+        assert await fetch_slm_policy_json("some.key") == {"enabled": True}
+
+
+@pytest.mark.asyncio
+async def test_none_on_exception():
+    client = MagicMock()
+    client._get_session = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch("llc.services.slm_policy.get_slm_client", return_value=client):
+        assert await fetch_slm_policy_json("some.key") is None

--- a/autobot-slm-frontend/src/composables/useSlmJsonSetting.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmJsonSetting.test.ts
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useSlmJsonSetting } from './useSlmJsonSetting'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    getApiUrl: () => '',
+    getAuthHeaders: () => ({}),
+  }),
+}))
+
+interface Payload {
+  enabled: boolean
+}
+
+describe('useSlmJsonSetting', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('load() returns the parsed JSON value on a 200 response', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ value: JSON.stringify({ enabled: true }) }),
+    })) as unknown as typeof fetch
+
+    const { load } = useSlmJsonSetting<Payload>('some.key')
+    await expect(load()).resolves.toEqual({ enabled: true })
+  })
+
+  it('load() returns null on a non-ok response', async () => {
+    global.fetch = vi.fn(async () => ({ ok: false, status: 404 })) as unknown as typeof fetch
+
+    const { load } = useSlmJsonSetting<Payload>('some.key')
+    await expect(load()).resolves.toBeNull()
+  })
+
+  it('save() PUTs first and falls back to POST on 404', async () => {
+    const calls: Array<{ url: string; method?: string }> = []
+    global.fetch = vi.fn(async (url, opts) => {
+      calls.push({ url: String(url), method: opts?.method })
+      if (opts?.method === 'PUT') {
+        return { ok: false, status: 404 } as Response
+      }
+      return { ok: true, status: 201 } as Response
+    }) as unknown as typeof fetch
+
+    const { save, saving, saved } = useSlmJsonSetting<Payload>('some.key')
+    const ok = await save({ enabled: true }, 'a description')
+
+    expect(ok).toBe(true)
+    expect(saved.value).toBe(true)
+    expect(saving.value).toBe(false)
+    expect(calls.map((c) => c.method)).toEqual(['PUT', 'POST'])
+    expect(calls[0].url).toContain('/api/settings/some.key')
+  })
+
+  it('save() does not fall back to POST when PUT succeeds', async () => {
+    const calls: Array<string | undefined> = []
+    global.fetch = vi.fn(async (_url, opts) => {
+      calls.push(opts?.method)
+      return { ok: true, status: 200 } as Response
+    }) as unknown as typeof fetch
+
+    const { save, saved } = useSlmJsonSetting<Payload>('some.key')
+    const ok = await save({ enabled: false }, 'desc')
+
+    expect(ok).toBe(true)
+    expect(saved.value).toBe(true)
+    expect(calls).toEqual(['PUT'])
+  })
+})

--- a/autobot-slm-frontend/src/composables/useSlmJsonSetting.ts
+++ b/autobot-slm-frontend/src/composables/useSlmJsonSetting.ts
@@ -1,0 +1,65 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * useSlmJsonSetting - shared GET-on-mount + PUT-then-POST-on-404 save for a
+ * single SLM JSON settings-API key (#11359).
+ *
+ * `DisposalPolicySettings.vue` and `FindingsPolicySettings.vue` both fetch a
+ * setting key, JSON.parse its `value` string, and save it back via
+ * PUT (falling back to POST when the key doesn't exist yet). This composable
+ * is the one shared implementation of that fetch/save mechanics; each panel
+ * keeps its own field defaults, coercion, and error-message ownership (i18n
+ * strings differ per panel).
+ */
+
+import { ref, type Ref } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+
+export interface SlmJsonSetting<T> {
+  saving: Ref<boolean>
+  saved: Ref<boolean>
+  /** GET the setting; returns the parsed JSON value, or null on a non-ok response. */
+  load: () => Promise<T | null>
+  /** PUT the setting (falling back to POST on 404); returns whether it succeeded. */
+  save: (payload: T, description: string) => Promise<boolean>
+}
+
+export function useSlmJsonSetting<T>(key: string): SlmJsonSetting<T> {
+  const authStore = useAuthStore()
+  const saving = ref(false)
+  const saved = ref(false)
+
+  async function load(): Promise<T | null> {
+    const res = await fetch(`${authStore.getApiUrl()}/api/settings/${key}`, {
+      headers: authStore.getAuthHeaders(),
+    })
+    if (!res.ok) {
+      return null
+    }
+    const setting = await res.json()
+    return setting.value ? (JSON.parse(setting.value) as T) : ({} as T)
+  }
+
+  async function save(payload: T, description: string): Promise<boolean> {
+    saving.value = true
+    saved.value = false
+    try {
+      const url = `${authStore.getApiUrl()}/api/settings/${key}`
+      const headers = { ...authStore.getAuthHeaders(), 'Content-Type': 'application/json' }
+      const body = JSON.stringify({ value: JSON.stringify(payload), description })
+      let res = await fetch(url, { method: 'PUT', headers, body })
+      if (res.status === 404) {
+        res = await fetch(url, { method: 'POST', headers, body })
+      }
+      saved.value = res.ok
+      return res.ok
+    } finally {
+      saving.value = false
+    }
+  }
+
+  return { saving, saved, load, save }
+}

--- a/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.test.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
 import DisposalPolicySettings from './DisposalPolicySettings.vue'
+import en from '@/locales/en.json'
 
 vi.mock('@/stores/auth', () => ({
   useAuthStore: () => ({
@@ -10,6 +12,10 @@ vi.mock('@/stores/auth', () => ({
     getAuthHeaders: () => ({}),
   }),
 }))
+
+// vue-i18n 11 requires app.use(); install a real i18n plugin since the
+// template uses the global $t (#11359).
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
 
 describe('DisposalPolicySettings', () => {
   beforeEach(() => {
@@ -21,14 +27,14 @@ describe('DisposalPolicySettings', () => {
   })
 
   it('loads the current policy on mount', async () => {
-    const wrapper = mount(DisposalPolicySettings)
+    const wrapper = mount(DisposalPolicySettings, { global: { plugins: [i18n] } })
     await flushPromises()
     const number = wrapper.find('input[type="number"]').element as HTMLInputElement
     expect(number.value).toBe('14')
   })
 
   it('PUTs the policy as JSON on save', async () => {
-    const wrapper = mount(DisposalPolicySettings)
+    const wrapper = mount(DisposalPolicySettings, { global: { plugins: [i18n] } })
     await flushPromises()
     await wrapper.find('button[data-test="save-policy"]').trigger('click')
     await flushPromises()

--- a/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue
@@ -9,29 +9,28 @@
  *
  * Reads/writes the SLM setting key `llc.project_disposal_policy` (stored as a
  * JSON string: {retention_days: int, require_approval: bool}) via the SLM
- * settings API. Mirrors the GeneralSettings.vue auth-store + fetch pattern.
- * Issue #11129 P2.
+ * settings API, using the shared `useSlmJsonSetting` fetch/save composable
+ * (#11359). Issue #11129 P2.
  */
 
 import { onMounted, reactive, ref } from 'vue'
-import { useAuthStore } from '@/stores/auth'
+import { useSlmJsonSetting } from '@/composables/useSlmJsonSetting'
+
+interface DisposalPolicyPayload {
+  retention_days: number
+  require_approval: boolean
+}
 
 const KEY = 'llc.project_disposal_policy'
-const authStore = useAuthStore()
+const { saving, saved, load: loadJson, save: saveJson } = useSlmJsonSetting<DisposalPolicyPayload>(KEY)
 const policy = reactive({ retention_days: 0, require_approval: false })
-const saving = ref(false)
-const saved = ref(false)
 const error = ref<string | null>(null)
 
 async function load(): Promise<void> {
   error.value = null
   try {
-    const res = await fetch(`${authStore.getApiUrl()}/api/settings/${KEY}`, {
-      headers: authStore.getAuthHeaders(),
-    })
-    if (res.ok) {
-      const setting = await res.json()
-      const parsed = setting.value ? JSON.parse(setting.value) : {}
+    const parsed = await loadJson()
+    if (parsed) {
       policy.retention_days = Number(parsed.retention_days ?? 0)
       policy.require_approval = Boolean(parsed.require_approval ?? false)
     }
@@ -41,28 +40,17 @@ async function load(): Promise<void> {
 }
 
 async function save(): Promise<void> {
-  saving.value = true
-  saved.value = false
   error.value = null
-  const body = JSON.stringify({
-    value: JSON.stringify({ retention_days: policy.retention_days, require_approval: policy.require_approval }),
-    description: 'Company OS project disposal policy',
-  })
-  const url = `${authStore.getApiUrl()}/api/settings/${KEY}`
-  const headers = { ...authStore.getAuthHeaders(), 'Content-Type': 'application/json' }
   try {
-    let res = await fetch(url, { method: 'PUT', headers, body })
-    if (res.status === 404) {
-      res = await fetch(url, { method: 'POST', headers, body })
-    }
-    saved.value = res.ok
-    if (!res.ok) {
+    const ok = await saveJson(
+      { retention_days: policy.retention_days, require_approval: policy.require_approval },
+      'Company OS project disposal policy',
+    )
+    if (!ok) {
       error.value = 'Failed to save disposal policy'
     }
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to save disposal policy'
-  } finally {
-    saving.value = false
   }
 }
 

--- a/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.test.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
 import FindingsPolicySettings from './FindingsPolicySettings.vue'
+import en from '@/locales/en.json'
 
 vi.mock('@/stores/auth', () => ({
   useAuthStore: () => ({
@@ -10,6 +12,10 @@ vi.mock('@/stores/auth', () => ({
     getAuthHeaders: () => ({}),
   }),
 }))
+
+// vue-i18n 11 requires app.use(); install a real i18n plugin since the
+// component uses useI18n() and the template uses the global $t (#11359).
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
 
 describe('FindingsPolicySettings', () => {
   beforeEach(() => {
@@ -29,7 +35,7 @@ describe('FindingsPolicySettings', () => {
   })
 
   it('loads the current policy on mount', async () => {
-    const wrapper = mount(FindingsPolicySettings)
+    const wrapper = mount(FindingsPolicySettings, { global: { plugins: [i18n] } })
     await flushPromises()
     const batchInput = wrapper.find('input[data-test="input-verify-batch-size"]').element as HTMLInputElement
     expect(batchInput.value).toBe('25')
@@ -38,7 +44,7 @@ describe('FindingsPolicySettings', () => {
   })
 
   it('PUTs the policy as JSON on save', async () => {
-    const wrapper = mount(FindingsPolicySettings)
+    const wrapper = mount(FindingsPolicySettings, { global: { plugins: [i18n] } })
     await flushPromises()
     await wrapper.find('button[data-test="save-policy"]').trigger('click')
     await flushPromises()
@@ -73,7 +79,7 @@ describe('FindingsPolicySettings', () => {
       } as Response
     }) as unknown as typeof fetch
 
-    const wrapper = mount(FindingsPolicySettings)
+    const wrapper = mount(FindingsPolicySettings, { global: { plugins: [i18n] } })
     await flushPromises()
     await wrapper.find('button[data-test="save-policy"]').trigger('click')
     await flushPromises()

--- a/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.vue
@@ -9,18 +9,26 @@
  *
  * Reads/writes the SLM setting key `llc.findings_policy` (stored as a
  * JSON string: {enabled: bool, min_severity: str, require_approval_to_promote: bool,
- * run_on_index: bool, verify_batch_size: int}) via the SLM settings API.
- * Mirrors the DisposalPolicySettings.vue auth-store + fetch pattern.
+ * run_on_index: bool, verify_batch_size: int}) via the SLM settings API,
+ * using the shared `useSlmJsonSetting` fetch/save composable (#11359).
  * Issue #11271 P3.
  */
 
 import { onMounted, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useAuthStore } from '@/stores/auth'
+import { useSlmJsonSetting } from '@/composables/useSlmJsonSetting'
+
+interface FindingsPolicyPayload {
+  enabled: boolean
+  min_severity: 'high' | 'medium' | 'low'
+  require_approval_to_promote: boolean
+  run_on_index: boolean
+  verify_batch_size: number
+}
 
 const KEY = 'llc.findings_policy'
-const authStore = useAuthStore()
 const { t } = useI18n()
+const { saving, saved, load: loadJson, save: saveJson } = useSlmJsonSetting<FindingsPolicyPayload>(KEY)
 const policy = reactive({
   enabled: false,
   min_severity: 'medium' as 'high' | 'medium' | 'low',
@@ -28,19 +36,13 @@ const policy = reactive({
   run_on_index: false,
   verify_batch_size: 10,
 })
-const saving = ref(false)
-const saved = ref(false)
 const error = ref<string | null>(null)
 
 async function load(): Promise<void> {
   error.value = null
   try {
-    const res = await fetch(`${authStore.getApiUrl()}/api/settings/${KEY}`, {
-      headers: authStore.getAuthHeaders(),
-    })
-    if (res.ok) {
-      const setting = await res.json()
-      const parsed = setting.value ? JSON.parse(setting.value) : {}
+    const parsed = await loadJson()
+    if (parsed) {
       policy.enabled = Boolean(parsed.enabled ?? false)
       policy.min_severity = (parsed.min_severity ?? 'medium') as 'high' | 'medium' | 'low'
       policy.require_approval_to_promote = Boolean(parsed.require_approval_to_promote ?? false)
@@ -53,34 +55,23 @@ async function load(): Promise<void> {
 }
 
 async function save(): Promise<void> {
-  saving.value = true
-  saved.value = false
   error.value = null
-  const body = JSON.stringify({
-    value: JSON.stringify({
-      enabled: policy.enabled,
-      min_severity: policy.min_severity,
-      require_approval_to_promote: policy.require_approval_to_promote,
-      run_on_index: policy.run_on_index,
-      verify_batch_size: policy.verify_batch_size,
-    }),
-    description: 'Company OS findings policy',
-  })
-  const url = `${authStore.getApiUrl()}/api/settings/${KEY}`
-  const headers = { ...authStore.getAuthHeaders(), 'Content-Type': 'application/json' }
   try {
-    let res = await fetch(url, { method: 'PUT', headers, body })
-    if (res.status === 404) {
-      res = await fetch(url, { method: 'POST', headers, body })
-    }
-    saved.value = res.ok
-    if (!res.ok) {
+    const ok = await saveJson(
+      {
+        enabled: policy.enabled,
+        min_severity: policy.min_severity,
+        require_approval_to_promote: policy.require_approval_to_promote,
+        run_on_index: policy.run_on_index,
+        verify_batch_size: policy.verify_batch_size,
+      },
+      'Company OS findings policy',
+    )
+    if (!ok) {
       error.value = t('settings.findingsPolicySettings.failedToSaveFindingsPolicy')
     }
   } catch (e) {
     error.value = e instanceof Error ? e.message : t('settings.findingsPolicySettings.failedToSaveFindingsPolicy')
-  } finally {
-    saving.value = false
   }
 }
 


### PR DESCRIPTION
## Thinking Path
Company OS Phase 2/3 tech-debt: the SLM-policy reader/panel and the LLC IDOR guard were each duplicated. Consolidate to one canonical source each — the IDOR guard conservatively (security-sensitive: no auth-semantics change).

## What Changed
**Part A — SLM-policy reader:**
- Backend: `disposal_policy.py` + `findings_policy.py` had identical `_fetch_policy_json()` → new canonical `llc/services/slm_policy.py::fetch_slm_policy_json(key)`; each keeps a one-line wrapper (preserves test-patch targets).
- Frontend: `DisposalPolicySettings.vue` + `FindingsPolicySettings.vue` hand-rolled identical GET-on-mount + PUT→POST-on-404 → extracted `useSlmJsonSetting<T>(key)`. Panels keep their own defaults + error/i18n ownership (no behavior/i18n change).

**Part B — LLC IDOR guard:**
- `sprints.py` + `findings.py` had a literally identical `_load_owned_project` (404 on missing-or-cross-org to avoid existence disclosure) → moved verbatim into `llc/deps.py::load_owned_project` (alongside the existing `require_board_role` pattern), imported in both. Byte-identical, zero authorization-semantics change.

**Fixed in-scope (resolves #11952):** `DisposalPolicySettings.test.ts` / `FindingsPolicySettings.test.ts` were pre-existing-broken (mount without the vue-i18n plugin → `$t is not a function`). Fixed with the repo's standard `createI18n` test pattern; all 9 now pass.

Closes #11359, closes #11952

## Verification (CI down — local gate)
- `llc/` 1283 passed; `test_startup_imports.py` 344 (no circular-import from new deps.py imports); py_compile/black/pyflakes clean. Frontend vitest 16 + panel tests 9, vue-tsc 0 errors, eslint clean.

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)