### PR TITLE
feat(desktop): agent↔human control-lock with input arbitration (#12002, #11506 T1)

### DIFF
--- a/autobot-backend/api/desktop_control_lock.py
+++ b/autobot-backend/api/desktop_control_lock.py
@@ -52,6 +52,26 @@ DESKTOP_CONTROL_LOCK_TTL_SECONDS: int = int(os.environ.get("AUTOBOT_DESKTOP_CONT
 
 _LOCK_KEY_PREFIX = "autobot:desktop:control_lock:"
 
+# Atomic compare-owner-and-delete. Runs entirely inside Redis (single
+# command from the client's perspective) so there is no GET-then-DELETE
+# window for a concurrent acquire to land in between (#12002 review fix):
+# without this, owner A releasing while owner B's takeover interleaves
+# between A's read and A's delete would let A's stale DELETE remove B's
+# freshly-acquired lock. Returns: 'OK' (deleted), 'NONE' (no lock held), or
+# the raw current record JSON (owner mismatch -- caller still holds it).
+_RELEASE_LUA_SCRIPT = """
+local raw = redis.call('GET', KEYS[1])
+if not raw then
+  return 'NONE'
+end
+local ok, data = pcall(cjson.decode, raw)
+if not ok or data.owner ~= ARGV[1] then
+  return raw
+end
+redis.call('DEL', KEYS[1])
+return 'OK'
+"""
+
 
 def _lock_key(session_id: str) -> str:
     """Build the Redis key for a session's control lock."""
@@ -134,9 +154,12 @@ async def acquire_human_control(session_id: str, owner: str) -> dict:
 async def release_human_control(session_id: str, owner: str) -> dict:
     """Release the human control lock for a session.
 
-    Only the current owner may release the lock (compare-and-delete), so one
-    human cannot accidentally hand control back to the agent on another
-    human's behalf.
+    Only the current owner may release the lock. This is a single atomic
+    Redis Lua EVAL (compare-owner-and-delete) -- NOT a separate GET followed
+    by a DELETE -- so there is no window for a concurrent acquire_human_control()
+    to land in between the check and the delete (#12002 review fix: a
+    non-atomic GET-then-DELETE let a stale release remove a freshly-acquired
+    lock belonging to a different owner).
 
     Returns:
         {"success", "owner", "human_active", "message"}
@@ -152,35 +175,41 @@ async def release_human_control(session_id: str, owner: str) -> dict:
                 "human_active": True,
                 "message": "Redis unavailable; control lock could not be released",
             }
-        raw = await redis.get(key)
-        if raw is None:
+        result = await redis.eval(_RELEASE_LUA_SCRIPT, 1, key, owner)
+        if isinstance(result, bytes):
+            result = result.decode("utf-8")
+
+        if result == "OK":
+            logger.info("desktop_control_lock: released session=%s owner=%s", session_id, owner)
+            return {
+                "success": True,
+                "owner": None,
+                "human_active": False,
+                "message": "Control released",
+            }
+        if result == "NONE":
             return {
                 "success": True,
                 "owner": None,
                 "human_active": False,
                 "message": "No active control lock to release",
             }
-        record = json.loads(raw)
-        if record.get("owner") != owner:
-            logger.warning(
-                "desktop_control_lock: release denied session=%s requester=%s owner=%s",
-                session_id,
-                owner,
-                record.get("owner"),
-            )
-            return {
-                "success": False,
-                "owner": record.get("owner"),
-                "human_active": True,
-                "message": "Control lock is held by another user",
-            }
-        await redis.delete(key)
-        logger.info("desktop_control_lock: released session=%s owner=%s", session_id, owner)
+
+        # Owner mismatch -- `result` is the raw JSON of whoever currently
+        # holds the lock (possibly a different owner who took over in the
+        # window before this call reached Redis).
+        current_record = json.loads(result)
+        logger.warning(
+            "desktop_control_lock: release denied session=%s requester=%s owner=%s",
+            session_id,
+            owner,
+            current_record.get("owner"),
+        )
         return {
-            "success": True,
-            "owner": None,
-            "human_active": False,
-            "message": "Control released",
+            "success": False,
+            "owner": current_record.get("owner"),
+            "human_active": True,
+            "message": "Control lock is held by another user",
         }
     except Exception as e:
         logger.error("desktop_control_lock: Redis error releasing %s: %s", key, e)
@@ -208,6 +237,35 @@ async def is_human_active(session_id: str) -> bool:
         )
         return True
     return record is not None
+
+
+async def is_actuation_muted(session_id: str, caller: str | None = None) -> bool:
+    """Return True when actuation should be muted for this caller.
+
+    Issue #12002 review fix: the agent's MCP path must ALWAYS yield to any
+    human holding the lock, but a human's OWN admin-toolbar REST calls
+    (api.vnc_manager's /click, /type, /key, /scroll, /drag) must not be
+    muted by their own takeover.
+
+    - ``caller=None`` (the agent's MCP path, api.vnc_mcp.py): unconditional
+      -- muted whenever ANY human holds the lock. Equivalent to
+      ``is_human_active(session_id)``.
+    - ``caller=<username>`` (human REST toolbar, api.vnc_manager.py): muted
+      only when a DIFFERENT human holds the lock; the lock owner's own
+      toolbar keeps working while they hold control.
+    """
+    record, redis_ok = await _get_lock_record(session_id)
+    if not redis_ok:
+        logger.error(
+            "desktop_control_lock: Redis unavailable for session %s, failing safe (muting actuation)",
+            session_id,
+        )
+        return True
+    if record is None:
+        return False
+    if caller is not None and record.get("owner") == caller:
+        return False
+    return True
 
 
 async def get_lock_owner(session_id: str) -> str | None:

--- a/autobot-backend/api/desktop_control_lock.py
+++ b/autobot-backend/api/desktop_control_lock.py
@@ -1,0 +1,233 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Desktop control-lock: per-session agent<->human input arbitration.
+
+Issue #12002 (#11506 T1): x11vnc attaches to the SAME canonical display the
+agent drives via xdotool (see gui_controller.CANONICAL_DISPLAY and
+api.vnc_manager.start_vnc_server). Without arbitration, a human taking over
+the noVNC session and the agent both feed the same X input queue at once.
+
+This module is the single source of truth for "who currently owns desktop
+input". State is stored in Redis (not an in-process dict) so the lock is
+shared across every backend worker/process, keyed by session_id — the same
+per-session convention used by the other vnc_manager.py session endpoints
+(e.g. ``session_id: str = "default"`` on /connection/settings).
+
+Architecture note: human input reaches the desktop over the raw VNC/RFB
+WebSocket proxy (api.vnc_proxy.websocket_proxy), which forwards binary
+protocol frames straight to the VNC server -- it never calls into
+api.vnc_manager's xdotool endpoints. Gating therefore only needs to happen
+on the AGENT's actuation entrypoints (api.vnc_manager, api.vnc_mcp); human
+input is never routed through those functions and is never gated.
+
+Auto-detection of "human is actively sending RFB frames" would require
+parsing the binary VNC protocol inside the WebSocket proxy hot path -- out
+of scope here (see PR description). Control is therefore explicit
+(acquire/release, e.g. a "Take control" / "Release" UI toggle) backed by an
+idle-TTL: the lock auto-expires if it is never refreshed, so a human who
+navigates away or closes the tab does not permanently mute the agent.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_redis_client
+
+logger = get_logger(__name__)
+
+# Default/canonical session id, matching the convention already used by
+# api.vnc_manager.py's other session_id-keyed endpoints (e.g.
+# get_connection_settings / update_connection_settings default to "default").
+DEFAULT_DESKTOP_SESSION_ID = "default"
+
+# Env-driven idle-TTL (seconds): if the lock is not refreshed (re-acquired)
+# within this window, it auto-expires and the agent resumes. Never hardcode
+# -- override via AUTOBOT_DESKTOP_CONTROL_LOCK_TTL_SECONDS.
+DESKTOP_CONTROL_LOCK_TTL_SECONDS: int = int(os.environ.get("AUTOBOT_DESKTOP_CONTROL_LOCK_TTL_SECONDS", "120"))
+
+_LOCK_KEY_PREFIX = "autobot:desktop:control_lock:"
+
+
+def _lock_key(session_id: str) -> str:
+    """Build the Redis key for a session's control lock."""
+    return f"{_LOCK_KEY_PREFIX}{session_id}"
+
+
+async def _get_lock_record(session_id: str) -> tuple[dict | None, bool]:
+    """Read the raw lock record for a session.
+
+    Returns:
+        (record, redis_ok). ``record`` is None when no lock is held (or on
+        error). ``redis_ok`` is False when Redis itself could not be reached
+        (as opposed to "reached but no lock present").
+    """
+    key = _lock_key(session_id)
+    try:
+        redis = await get_redis_client(async_client=True, database="main")
+        if redis is None:
+            return None, False
+        raw = await redis.get(key)
+        if raw is None:
+            return None, True
+        return json.loads(raw), True
+    except Exception as e:
+        logger.error("desktop_control_lock: Redis error reading %s: %s", key, e)
+        return None, False
+
+
+async def acquire_human_control(session_id: str, owner: str) -> dict:
+    """Acquire (or refresh) the human control lock for a session.
+
+    Always overwrites any existing lock -- takeover is intentionally
+    permissive (the last human to click "Take control" wins); this mirrors
+    a single shared desktop with one human-observable session.
+
+    Returns:
+        {"success", "owner", "human_active", "message", "ttl_seconds"}
+    """
+    key = _lock_key(session_id)
+    record = {
+        "owner": owner,
+        "acquired_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        redis = await get_redis_client(async_client=True, database="main")
+        if redis is None:
+            logger.error("desktop_control_lock: Redis unavailable, cannot acquire lock for %s", session_id)
+            return {
+                "success": False,
+                "owner": owner,
+                "human_active": False,
+                "message": "Redis unavailable; control lock could not be acquired",
+                "ttl_seconds": DESKTOP_CONTROL_LOCK_TTL_SECONDS,
+            }
+        await redis.set(key, json.dumps(record, ensure_ascii=False), ex=DESKTOP_CONTROL_LOCK_TTL_SECONDS)
+        logger.info(
+            "desktop_control_lock: acquired session=%s owner=%s ttl=%ss",
+            session_id,
+            owner,
+            DESKTOP_CONTROL_LOCK_TTL_SECONDS,
+        )
+        return {
+            "success": True,
+            "owner": owner,
+            "human_active": True,
+            "message": f"Control acquired by {owner}",
+            "ttl_seconds": DESKTOP_CONTROL_LOCK_TTL_SECONDS,
+        }
+    except Exception as e:
+        logger.error("desktop_control_lock: Redis error acquiring %s: %s", key, e)
+        return {
+            "success": False,
+            "owner": owner,
+            "human_active": False,
+            "message": "Internal server error acquiring control lock",
+            "ttl_seconds": DESKTOP_CONTROL_LOCK_TTL_SECONDS,
+        }
+
+
+async def release_human_control(session_id: str, owner: str) -> dict:
+    """Release the human control lock for a session.
+
+    Only the current owner may release the lock (compare-and-delete), so one
+    human cannot accidentally hand control back to the agent on another
+    human's behalf.
+
+    Returns:
+        {"success", "owner", "human_active", "message"}
+    """
+    key = _lock_key(session_id)
+    try:
+        redis = await get_redis_client(async_client=True, database="main")
+        if redis is None:
+            logger.error("desktop_control_lock: Redis unavailable, cannot release lock for %s", session_id)
+            return {
+                "success": False,
+                "owner": None,
+                "human_active": True,
+                "message": "Redis unavailable; control lock could not be released",
+            }
+        raw = await redis.get(key)
+        if raw is None:
+            return {
+                "success": True,
+                "owner": None,
+                "human_active": False,
+                "message": "No active control lock to release",
+            }
+        record = json.loads(raw)
+        if record.get("owner") != owner:
+            logger.warning(
+                "desktop_control_lock: release denied session=%s requester=%s owner=%s",
+                session_id,
+                owner,
+                record.get("owner"),
+            )
+            return {
+                "success": False,
+                "owner": record.get("owner"),
+                "human_active": True,
+                "message": "Control lock is held by another user",
+            }
+        await redis.delete(key)
+        logger.info("desktop_control_lock: released session=%s owner=%s", session_id, owner)
+        return {
+            "success": True,
+            "owner": None,
+            "human_active": False,
+            "message": "Control released",
+        }
+    except Exception as e:
+        logger.error("desktop_control_lock: Redis error releasing %s: %s", key, e)
+        return {
+            "success": False,
+            "owner": None,
+            "human_active": True,
+            "message": "Internal server error releasing control lock",
+        }
+
+
+async def is_human_active(session_id: str) -> bool:
+    """Return True when a human currently holds the control lock.
+
+    Fails SAFE: if Redis cannot be reached, this returns True (mute the
+    agent) rather than False -- an availability blip on the state store
+    must never let the agent silently regain input control while the
+    control-lock state is unknown.
+    """
+    record, redis_ok = await _get_lock_record(session_id)
+    if not redis_ok:
+        logger.error(
+            "desktop_control_lock: Redis unavailable for session %s, failing safe (muting agent actuation)",
+            session_id,
+        )
+        return True
+    return record is not None
+
+
+async def get_lock_owner(session_id: str) -> str | None:
+    """Return the current lock owner for a session, or None if unheld."""
+    record, _ = await _get_lock_record(session_id)
+    return record.get("owner") if record else None
+
+
+async def get_control_lock_state(session_id: str) -> dict:
+    """Return the full control-lock state for a session (status/MCP use).
+
+    Returns:
+        {"session_id", "human_active", "owner", "acquired_at", "redis_available"}
+    """
+    record, redis_ok = await _get_lock_record(session_id)
+    human_active = (not redis_ok) or (record is not None)
+    return {
+        "session_id": session_id,
+        "human_active": human_active,
+        "owner": record.get("owner") if record else None,
+        "acquired_at": record.get("acquired_at") if record else None,
+        "redis_available": redis_ok,
+    }

--- a/autobot-backend/api/desktop_control_lock_test.py
+++ b/autobot-backend/api/desktop_control_lock_test.py
@@ -6,8 +6,9 @@
 Unit tests for api.desktop_control_lock (Issue #12002, #11506 T1).
 
 Covers: acquire/release/is_human_active/get_lock_owner round-trip via a
-fake Redis client, owner-mismatch release denial, and fail-safe behaviour
-(mute agent) when Redis is unavailable.
+fake Redis client, owner-mismatch release denial, fail-safe behaviour (mute
+agent) when Redis is unavailable, the atomic Lua-based release (no
+GET-then-DELETE TOCTOU window), and owner-aware muting (is_actuation_muted).
 """
 
 import json
@@ -20,27 +21,59 @@ from api.desktop_control_lock import (
     acquire_human_control,
     get_control_lock_state,
     get_lock_owner,
+    is_actuation_muted,
     is_human_active,
     release_human_control,
 )
 
 
 class FakeAsyncRedis:
-    """Minimal in-memory async Redis stand-in for control-lock round-trips."""
+    """Minimal in-memory async Redis stand-in for control-lock round-trips.
+
+    ``eval`` mirrors the real Redis Lua script's atomic
+    compare-owner-and-delete semantics: in real Redis this executes as a
+    single uninterruptible server-side operation (no other client command
+    can interleave mid-script), so this fake performs the check+delete as
+    one synchronous Python step with no ``await`` in between -- the same
+    "no TOCTOU window" guarantee the real EVAL call provides.
+    """
 
     def __init__(self):
         self._store: dict[str, str] = {}
+        self.calls: list[str] = []
 
     async def get(self, key: str):
+        self.calls.append("get")
         return self._store.get(key)
 
     async def set(self, key: str, value: str, ex: int | None = None):
+        self.calls.append("set")
         self._store[key] = value
         return True
 
     async def delete(self, key: str):
+        self.calls.append("delete")
         self._store.pop(key, None)
         return 1
+
+    async def eval(self, script: str, numkeys: int, *keys_and_args):
+        # NOTE: this is the redis-py client's EVAL RPC method (matching
+        # redis.asyncio.Redis.eval, which sends the Lua `script` string to
+        # the Redis SERVER to run there) -- not Python's builtin eval(). No
+        # arbitrary code from `script` is ever executed in this process;
+        # this fake just re-implements the script's fixed compare-and-delete
+        # logic in Python for testing, ignoring the `script` text itself.
+        self.calls.append("eval")
+        key = keys_and_args[0]
+        owner = keys_and_args[1]
+        raw = self._store.get(key)
+        if raw is None:
+            return "NONE"
+        data = json.loads(raw)
+        if data.get("owner") != owner:
+            return raw
+        del self._store[key]
+        return "OK"
 
 
 @pytest.fixture
@@ -114,6 +147,77 @@ class TestAcquireRelease:
             await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "bob")
 
             assert await get_lock_owner(DEFAULT_DESKTOP_SESSION_ID) == "bob"
+
+
+class TestAtomicReleaseRace:
+    """Regression coverage for the GET-then-DELETE TOCTOU race (#12002 review).
+
+    Interleaving: owner A releases (reads owner=A, passes the check) while
+    owner B's takeover lands in the window between A's read and A's delete
+    -- A's stale DELETE must NOT remove B's freshly-acquired lock.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stale_release_does_not_delete_a_newer_owners_lock(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            # B's takeover interleaves before A's (stale) release reaches Redis.
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "bob")
+
+            result = await release_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+            assert result["success"] is False
+            assert result["owner"] == "bob"
+            # B's lock must survive A's stale release attempt.
+            assert await is_human_active(DEFAULT_DESKTOP_SESSION_ID) is True
+            assert await get_lock_owner(DEFAULT_DESKTOP_SESSION_ID) == "bob"
+
+    @pytest.mark.asyncio
+    async def test_release_is_a_single_atomic_round_trip(self, fake_redis):
+        """No separate GET-then-DELETE pair -- exactly one EVAL call, closing
+        the TOCTOU window structurally (there is nothing to interleave with)."""
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            fake_redis.calls.clear()
+
+            await release_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+        assert fake_redis.calls == ["eval"]
+
+
+class TestOwnerAwareMuting:
+    """is_actuation_muted: unconditional for the agent (caller=None), but
+    the lock owner's own REST toolbar calls must not mute themselves."""
+
+    @pytest.mark.asyncio
+    async def test_agent_muted_regardless_of_who_holds_lock(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID) is True
+            assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID, caller=None) is True
+
+    @pytest.mark.asyncio
+    async def test_lock_owner_not_muted_for_their_own_toolbar(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID, caller="alice") is False
+
+    @pytest.mark.asyncio
+    async def test_non_owner_human_is_muted(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID, caller="bob") is True
+
+    @pytest.mark.asyncio
+    async def test_unmuted_for_everyone_when_no_lock_held(self, fake_redis):
+        with _patch_redis(fake_redis):
+            assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID) is False
+            assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID, caller="alice") is False
+
+    @pytest.mark.asyncio
+    async def test_muted_fails_safe_when_redis_down(self):
+        with patch("api.desktop_control_lock.get_redis_client", new=AsyncMock(return_value=None)):
+            assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID, caller="alice") is True
 
 
 class TestControlLockState:

--- a/autobot-backend/api/desktop_control_lock_test.py
+++ b/autobot-backend/api/desktop_control_lock_test.py
@@ -1,0 +1,190 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for api.desktop_control_lock (Issue #12002, #11506 T1).
+
+Covers: acquire/release/is_human_active/get_lock_owner round-trip via a
+fake Redis client, owner-mismatch release denial, and fail-safe behaviour
+(mute agent) when Redis is unavailable.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.desktop_control_lock import (
+    DEFAULT_DESKTOP_SESSION_ID,
+    acquire_human_control,
+    get_control_lock_state,
+    get_lock_owner,
+    is_human_active,
+    release_human_control,
+)
+
+
+class FakeAsyncRedis:
+    """Minimal in-memory async Redis stand-in for control-lock round-trips."""
+
+    def __init__(self):
+        self._store: dict[str, str] = {}
+
+    async def get(self, key: str):
+        return self._store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None):
+        self._store[key] = value
+        return True
+
+    async def delete(self, key: str):
+        self._store.pop(key, None)
+        return 1
+
+
+@pytest.fixture
+def fake_redis():
+    return FakeAsyncRedis()
+
+
+def _patch_redis(fake_redis):
+    return patch(
+        "api.desktop_control_lock.get_redis_client",
+        new=AsyncMock(return_value=fake_redis),
+    )
+
+
+class TestAcquireRelease:
+    @pytest.mark.asyncio
+    async def test_acquire_sets_lock_and_owner(self, fake_redis):
+        with _patch_redis(fake_redis):
+            result = await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+        assert result["success"] is True
+        assert result["owner"] == "alice"
+        assert result["human_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_is_human_active_true_after_acquire(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            assert await is_human_active(DEFAULT_DESKTOP_SESSION_ID) is True
+            assert await get_lock_owner(DEFAULT_DESKTOP_SESSION_ID) == "alice"
+
+    @pytest.mark.asyncio
+    async def test_is_human_active_false_when_no_lock(self, fake_redis):
+        with _patch_redis(fake_redis):
+            assert await is_human_active("no-such-session") is False
+            assert await get_lock_owner("no-such-session") is None
+
+    @pytest.mark.asyncio
+    async def test_release_by_owner_succeeds(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            result = await release_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+            assert result["success"] is True
+            assert result["human_active"] is False
+            assert await is_human_active(DEFAULT_DESKTOP_SESSION_ID) is False
+
+    @pytest.mark.asyncio
+    async def test_release_by_non_owner_denied(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            result = await release_human_control(DEFAULT_DESKTOP_SESSION_ID, "bob")
+
+            assert result["success"] is False
+            assert result["owner"] == "alice"
+            # Lock must still be held -- non-owner release is a no-op.
+            assert await is_human_active(DEFAULT_DESKTOP_SESSION_ID) is True
+
+    @pytest.mark.asyncio
+    async def test_release_with_no_lock_is_a_success_noop(self, fake_redis):
+        with _patch_redis(fake_redis):
+            result = await release_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+            assert result["success"] is True
+            assert result["human_active"] is False
+
+    @pytest.mark.asyncio
+    async def test_reacquire_by_different_owner_overwrites(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "bob")
+
+            assert await get_lock_owner(DEFAULT_DESKTOP_SESSION_ID) == "bob"
+
+
+class TestControlLockState:
+    @pytest.mark.asyncio
+    async def test_state_reflects_current_owner(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+            state = await get_control_lock_state(DEFAULT_DESKTOP_SESSION_ID)
+
+        assert state["human_active"] is True
+        assert state["owner"] == "alice"
+        assert state["redis_available"] is True
+        assert state["acquired_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_state_when_unheld(self, fake_redis):
+        with _patch_redis(fake_redis):
+            state = await get_control_lock_state("empty-session")
+
+        assert state["human_active"] is False
+        assert state["owner"] is None
+
+
+class TestRedisUnavailableFailSafe:
+    """Redis outages must fail SAFE: mute the agent, never silently unmute it."""
+
+    @pytest.mark.asyncio
+    async def test_is_human_active_fails_safe_when_redis_down(self):
+        with patch(
+            "api.desktop_control_lock.get_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            assert await is_human_active(DEFAULT_DESKTOP_SESSION_ID) is True
+
+    @pytest.mark.asyncio
+    async def test_acquire_fails_cleanly_when_redis_down(self):
+        with patch(
+            "api.desktop_control_lock.get_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_release_fails_cleanly_when_redis_down(self):
+        with patch(
+            "api.desktop_control_lock.get_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await release_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+        assert result["success"] is False
+        assert result["human_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_lock_owner_none_when_redis_down(self):
+        with patch(
+            "api.desktop_control_lock.get_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            assert await get_lock_owner(DEFAULT_DESKTOP_SESSION_ID) is None
+
+
+class TestRedisKeyShape:
+    @pytest.mark.asyncio
+    async def test_lock_stored_as_json_with_owner_and_timestamp(self, fake_redis):
+        with _patch_redis(fake_redis):
+            await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
+
+        raw = fake_redis._store[f"autobot:desktop:control_lock:{DEFAULT_DESKTOP_SESSION_ID}"]
+        record = json.loads(raw)
+        assert record["owner"] == "alice"
+        assert "acquired_at" in record

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -1106,6 +1106,9 @@ class VncRunningResponse(BaseModel):
 class VncStatusMessageResponse(BaseModel):
     status: str
     message: str
+    # Issue #12002 (#11506 T1): True when this call was a no-op because a
+    # human currently holds the desktop control-lock.
+    muted: bool = False
 
 
 class VncScreenshotResponse(BaseModel):
@@ -1198,19 +1201,24 @@ class MouseClickRequest(BaseModel):
     x: int = Field(..., ge=0, description="X coordinate")
     y: int = Field(..., ge=0, description="Y coordinate")
     button: str = Field(default="left", description="Mouse button: left, middle, right")
+    # Issue #12002 (#11506 T1): gates agent actuation against the desktop control-lock.
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
 
 
 class KeyboardTypeRequest(BaseModel):
     text: str = Field(..., description="Text to type")
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
 
 
 class SpecialKeyRequest(BaseModel):
     key: str = Field(..., description="Special key name (e.g., Return, Escape, ctrl+c)")
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
 
 
 class MouseScrollRequest(BaseModel):
     direction: str = Field(..., description="Scroll direction: up or down")
     amount: int = Field(default=3, ge=1, le=10, description="Scroll amount (1-10)")
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
 
 
 class MouseDragRequest(BaseModel):
@@ -1218,6 +1226,7 @@ class MouseDragRequest(BaseModel):
     y1: int = Field(..., ge=0, description="Start Y coordinate")
     x2: int = Field(..., ge=0, description="End X coordinate")
     y2: int = Field(..., ge=0, description="End Y coordinate")
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
 
 
 class ClipboardSyncRequest(BaseModel):
@@ -1580,6 +1589,8 @@ class DesktopClickMcpResponse(BaseModel):
     action: str
     coordinates: Dict[str, int]
     button: str
+    # Issue #12002 (#11506 T1): True when muted because a human holds control.
+    muted: bool = False
 
 
 class DesktopKeyboardTypeMcpResponse(BaseModel):
@@ -1587,6 +1598,7 @@ class DesktopKeyboardTypeMcpResponse(BaseModel):
     message: str
     action: str
     text_length: int
+    muted: bool = False
 
 
 class DesktopSpecialKeyMcpResponse(BaseModel):
@@ -1594,6 +1606,7 @@ class DesktopSpecialKeyMcpResponse(BaseModel):
     message: str
     action: str
     key: str
+    muted: bool = False
 
 
 class DesktopScreenshotMcpResponse(BaseModel):
@@ -1612,20 +1625,39 @@ class DesktopObserveStateMcpResponse(BaseModel):
     active_window: str | None = None
     screenshot: str | None = None
     screenshot_format: str | None = None
+    # Issue #12002 (#11506 T1): lets the agent see it should pause.
+    human_active: bool = False
+    control_owner: str | None = None
 
 
 class DesktopMouseClickRequest(BaseModel):
     x: int = Field(..., ge=0)
     y: int = Field(..., ge=0)
     button: str = Field(default="left")
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
 
 
 class DesktopKeyboardTypeRequest(BaseModel):
     text: str
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
 
 
 class DesktopSpecialKeyRequest(BaseModel):
     key: str
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
+
+
+class DesktopControlStatusRequest(BaseModel):
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
+
+
+class DesktopControlStatusMcpResponse(BaseModel):
+    success: bool
+    session_id: str
+    human_active: bool
+    owner: str | None = None
+    acquired_at: str | None = None
+    message: str
 
 
 class DesktopObserveStateRequest(BaseModel):
@@ -3725,6 +3757,28 @@ class VncProxyStatusResponse(BaseModel):
     accessible: bool
     status: int | None = None
     error: str | None = None
+
+
+class DesktopControlAcquireRequest(BaseModel):
+    """Request for POST /vnc-proxy/{vnc_type}/control/acquire (#12002)."""
+
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
+
+
+class DesktopControlReleaseRequest(BaseModel):
+    """Request for POST /vnc-proxy/{vnc_type}/control/release (#12002)."""
+
+    session_id: str = Field(default="default", description="Desktop control-lock session id")
+
+
+class DesktopControlLockResponse(BaseModel):
+    """Response for the desktop control-lock acquire/release/status endpoints (#12002)."""
+
+    success: bool
+    session_id: str
+    owner: str | None = None
+    human_active: bool
+    message: str
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -19,6 +19,8 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 
+# Issue #12002 (#11506 T1): agent<->human input arbitration
+from api.desktop_control_lock import is_actuation_muted
 from api.schemas_system import (
     ClipboardSyncRequest,
     ConnectionSettings,
@@ -60,9 +62,6 @@ from api.vnc_humanization import (
     should_add_human_pause,
     simulate_mouse_curve,
 )
-
-# Issue #12002 (#11506 T1): agent<->human input arbitration
-from api.desktop_control_lock import is_actuation_muted
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -19,8 +19,6 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 
-# Issue #12002 (#11506 T1): agent<->human input arbitration
-from api.desktop_control_lock import is_human_active
 from api.schemas_system import (
     ClipboardSyncRequest,
     ConnectionSettings,
@@ -62,7 +60,10 @@ from api.vnc_humanization import (
     should_add_human_pause,
     simulate_mouse_curve,
 )
-from auth_middleware import check_admin_permission
+
+# Issue #12002 (#11506 T1): agent<->human input arbitration
+from api.desktop_control_lock import is_actuation_muted
+from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
@@ -347,16 +348,32 @@ def _muted_result() -> Dict[str, object]:
     }
 
 
+def _caller_username(current_user: object) -> str | None:
+    """Extract a username for owner-aware gating (#12002).
+
+    playback_macro() calls vnc_mouse_click/etc. directly (Python function
+    call, not an HTTP request), so `current_user` there is still the
+    unresolved fastapi.params.Depends sentinel rather than a dict. Treat
+    that -- and any other non-dict value -- as "unknown caller": is_actuation_muted
+    then falls back to unconditional gating (safe default) instead of raising.
+    """
+    if isinstance(current_user, dict):
+        return current_user.get("username")
+    return None
+
+
 @router.post("/click", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CLICK")
 async def vnc_mouse_click(
     request: MouseClickRequest,
     admin_check: bool = Depends(check_admin_permission),
+    current_user: dict = Depends(get_current_user),
 ) -> Dict[str, object]:
     """
     Perform mouse click at specified coordinates with human-like behavior.
     Issue #74: Desktop interaction controls + Area 5 (humanization).
-    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
+    Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+    control-lock -- the lock owner's own toolbar keeps working.
 
     Args:
         request: MouseClickRequest with x, y coordinates and button type
@@ -364,7 +381,7 @@ async def vnc_mouse_click(
     Returns:
         {"status": "success|error|muted", "message": "..."}
     """
-    if await is_human_active(request.session_id):
+    if await is_actuation_muted(request.session_id, _caller_username(current_user)):
         return _muted_result()
 
     # Add human-like randomness to click position (Issue #74 - Area 5)
@@ -385,11 +402,13 @@ async def vnc_mouse_click(
 async def vnc_keyboard_type(
     request: KeyboardTypeRequest,
     admin_check: bool = Depends(check_admin_permission),
+    current_user: dict = Depends(get_current_user),
 ) -> Dict[str, object]:
     """
     Type text via keyboard with human-like speed and pauses.
     Issue #74: Desktop interaction controls + Area 5 (humanization).
-    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
+    Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+    control-lock -- the lock owner's own toolbar keeps working.
 
     Args:
         request: KeyboardTypeRequest with text to type
@@ -397,7 +416,7 @@ async def vnc_keyboard_type(
     Returns:
         {"status": "success|error|muted", "message": "..."}
     """
-    if await is_human_active(request.session_id):
+    if await is_actuation_muted(request.session_id, _caller_username(current_user)):
         return _muted_result()
 
     # Get humanized typing delay in milliseconds for xdotool
@@ -436,11 +455,13 @@ async def vnc_keyboard_type(
 async def vnc_special_key(
     request: SpecialKeyRequest,
     admin_check: bool = Depends(check_admin_permission),
+    current_user: dict = Depends(get_current_user),
 ) -> Dict[str, object]:
     """
     Send special key or key combination.
     Issue #74: Desktop interaction controls.
-    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
+    Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+    control-lock -- the lock owner's own toolbar keeps working.
 
     Args:
         request: SpecialKeyRequest with key name (e.g., "Return", "ctrl+c")
@@ -448,7 +469,7 @@ async def vnc_special_key(
     Returns:
         {"status": "success|error|muted", "message": "..."}
     """
-    if await is_human_active(request.session_id):
+    if await is_actuation_muted(request.session_id, _caller_username(current_user)):
         return _muted_result()
 
     return _run_xdotool_cmd(["key", request.key])
@@ -459,11 +480,13 @@ async def vnc_special_key(
 async def vnc_mouse_scroll(
     request: MouseScrollRequest,
     admin_check: bool = Depends(check_admin_permission),
+    current_user: dict = Depends(get_current_user),
 ) -> Dict[str, object]:
     """
     Scroll mouse wheel.
     Issue #74: Desktop interaction controls.
-    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
+    Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+    control-lock -- the lock owner's own toolbar keeps working.
 
     Args:
         request: MouseScrollRequest with direction and amount
@@ -471,7 +494,7 @@ async def vnc_mouse_scroll(
     Returns:
         {"status": "success|error|muted", "message": "..."}
     """
-    if await is_human_active(request.session_id):
+    if await is_actuation_muted(request.session_id, _caller_username(current_user)):
         return _muted_result()
 
     # Mouse buttons: 4 = scroll up, 5 = scroll down
@@ -490,11 +513,13 @@ async def vnc_mouse_scroll(
 async def vnc_mouse_drag(
     request: MouseDragRequest,
     admin_check: bool = Depends(check_admin_permission),
+    current_user: dict = Depends(get_current_user),
 ) -> Dict[str, object]:
     """
     Perform mouse drag operation with curved, human-like movement.
     Issue #74: Desktop interaction controls + Area 5 (humanization).
-    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
+    Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+    control-lock -- the lock owner's own toolbar keeps working.
 
     Args:
         request: MouseDragRequest with start and end coordinates
@@ -502,7 +527,7 @@ async def vnc_mouse_drag(
     Returns:
         {"status": "success|error|muted", "message": "..."}
     """
-    if await is_human_active(request.session_id):
+    if await is_actuation_muted(request.session_id, _caller_username(current_user)):
         return _muted_result()
 
     # Add realistic delay before starting drag

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -19,6 +19,8 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 
+# Issue #12002 (#11506 T1): agent<->human input arbitration
+from api.desktop_control_lock import is_human_active
 from api.schemas_system import (
     ClipboardSyncRequest,
     ConnectionSettings,
@@ -60,9 +62,6 @@ from api.vnc_humanization import (
     should_add_human_pause,
     simulate_mouse_curve,
 )
-
-# Issue #12002 (#11506 T1): agent<->human input arbitration
-from api.desktop_control_lock import is_human_active
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -60,6 +60,9 @@ from api.vnc_humanization import (
     should_add_human_pause,
     simulate_mouse_curve,
 )
+
+# Issue #12002 (#11506 T1): agent<->human input arbitration
+from api.desktop_control_lock import is_human_active
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -332,22 +335,39 @@ def _run_xdotool_cmd(args: list[str], timeout: int = 5) -> Dict[str, str]:
         return {"status": "error", "message": "Internal server error"}
 
 
+def _muted_result() -> Dict[str, object]:
+    """Standard no-op result when the human control-lock is held (#12002).
+
+    The agent actuation caller must NOT run the xdotool command in this
+    case -- the human is currently driving the same X input queue.
+    """
+    return {
+        "status": "muted",
+        "message": "Muted: human is in control of the desktop session.",
+        "muted": True,
+    }
+
+
 @router.post("/click", response_model=VncStatusMessageResponse)
 @with_error_handling(error_code_prefix="VNC_CLICK")
 async def vnc_mouse_click(
     request: MouseClickRequest,
     admin_check: bool = Depends(check_admin_permission),
-) -> Dict[str, str]:
+) -> Dict[str, object]:
     """
     Perform mouse click at specified coordinates with human-like behavior.
     Issue #74: Desktop interaction controls + Area 5 (humanization).
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
 
     Args:
         request: MouseClickRequest with x, y coordinates and button type
 
     Returns:
-        {"status": "success|error", "message": "..."}
+        {"status": "success|error|muted", "message": "..."}
     """
+    if await is_human_active(request.session_id):
+        return _muted_result()
+
     # Add human-like randomness to click position (Issue #74 - Area 5)
     humanized_x, humanized_y = humanize_click_position(request.x, request.y)
 
@@ -366,17 +386,21 @@ async def vnc_mouse_click(
 async def vnc_keyboard_type(
     request: KeyboardTypeRequest,
     admin_check: bool = Depends(check_admin_permission),
-) -> Dict[str, str]:
+) -> Dict[str, object]:
     """
     Type text via keyboard with human-like speed and pauses.
     Issue #74: Desktop interaction controls + Area 5 (humanization).
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
 
     Args:
         request: KeyboardTypeRequest with text to type
 
     Returns:
-        {"status": "success|error", "message": "..."}
+        {"status": "success|error|muted", "message": "..."}
     """
+    if await is_human_active(request.session_id):
+        return _muted_result()
+
     # Get humanized typing delay in milliseconds for xdotool
     delay_seconds = humanize_typing_speed()
     delay_ms = int(delay_seconds * 1000)
@@ -413,17 +437,21 @@ async def vnc_keyboard_type(
 async def vnc_special_key(
     request: SpecialKeyRequest,
     admin_check: bool = Depends(check_admin_permission),
-) -> Dict[str, str]:
+) -> Dict[str, object]:
     """
     Send special key or key combination.
     Issue #74: Desktop interaction controls.
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
 
     Args:
         request: SpecialKeyRequest with key name (e.g., "Return", "ctrl+c")
 
     Returns:
-        {"status": "success|error", "message": "..."}
+        {"status": "success|error|muted", "message": "..."}
     """
+    if await is_human_active(request.session_id):
+        return _muted_result()
+
     return _run_xdotool_cmd(["key", request.key])
 
 
@@ -432,17 +460,21 @@ async def vnc_special_key(
 async def vnc_mouse_scroll(
     request: MouseScrollRequest,
     admin_check: bool = Depends(check_admin_permission),
-) -> Dict[str, str]:
+) -> Dict[str, object]:
     """
     Scroll mouse wheel.
     Issue #74: Desktop interaction controls.
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
 
     Args:
         request: MouseScrollRequest with direction and amount
 
     Returns:
-        {"status": "success|error", "message": "..."}
+        {"status": "success|error|muted", "message": "..."}
     """
+    if await is_human_active(request.session_id):
+        return _muted_result()
+
     # Mouse buttons: 4 = scroll up, 5 = scroll down
     button = "4" if request.direction == "up" else "5"
 
@@ -459,17 +491,21 @@ async def vnc_mouse_scroll(
 async def vnc_mouse_drag(
     request: MouseDragRequest,
     admin_check: bool = Depends(check_admin_permission),
-) -> Dict[str, str]:
+) -> Dict[str, object]:
     """
     Perform mouse drag operation with curved, human-like movement.
     Issue #74: Desktop interaction controls + Area 5 (humanization).
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
 
     Args:
         request: MouseDragRequest with start and end coordinates
 
     Returns:
-        {"status": "success|error", "message": "..."}
+        {"status": "success|error|muted", "message": "..."}
     """
+    if await is_human_active(request.session_id):
+        return _muted_result()
+
     # Add realistic delay before starting drag
     pre_delay = humanize_action_delay()
     await asyncio.sleep(pre_delay)

--- a/autobot-backend/api/vnc_manager_control_lock_test.py
+++ b/autobot-backend/api/vnc_manager_control_lock_test.py
@@ -67,7 +67,10 @@ class TestKeyboardTypeGating:
 
     @pytest.mark.asyncio
     async def test_executes_when_human_inactive(self):
-        with _human_active(False), patch(
+        # should_add_human_pause() is stochastic (20% chance of a mid-typing
+        # pause that splits into 2 xdotool calls) -- pin it False so this
+        # test deterministically exercises the single-call path.
+        with _human_active(False), patch("api.vnc_manager.should_add_human_pause", return_value=False), patch(
             "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
         ) as mock_run:
             result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True)

--- a/autobot-backend/api/vnc_manager_control_lock_test.py
+++ b/autobot-backend/api/vnc_manager_control_lock_test.py
@@ -5,14 +5,18 @@
 """
 Unit tests for api.vnc_manager's desktop control-lock gating (#12002, #11506 T1).
 
-Verifies that agent actuation entrypoints (click/type/key/scroll/drag) are
-muted (no xdotool dispatch) while a human holds the control-lock, and
-execute normally when the lock is unheld.
+Verifies that human-facing REST actuation entrypoints (click/type/key/scroll/
+drag) are muted (no xdotool dispatch) when a DIFFERENT human holds the
+control-lock, execute normally when unheld OR when the caller IS the lock
+owner (owner-aware gating), and degrade safely (unconditional gating) when
+called without a resolvable current_user (e.g. macro playback's direct
+Python calls).
 """
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi.params import Depends
 
 from api.schemas_system import (
     KeyboardTypeRequest,
@@ -22,6 +26,7 @@ from api.schemas_system import (
     SpecialKeyRequest,
 )
 from api.vnc_manager import (
+    _caller_username,
     vnc_keyboard_type,
     vnc_mouse_click,
     vnc_mouse_drag,
@@ -29,58 +34,76 @@ from api.vnc_manager import (
     vnc_special_key,
 )
 
+ALICE = {"username": "alice"}
+BOB = {"username": "bob"}
 
-def _human_active(active: bool):
-    """Patch api.vnc_manager.is_human_active for the module under test."""
-    return patch("api.vnc_manager.is_human_active", new=AsyncMock(return_value=active))
+
+def _muted(active: bool):
+    """Patch api.vnc_manager.is_actuation_muted for the module under test."""
+    return patch("api.vnc_manager.is_actuation_muted", new=AsyncMock(return_value=active))
 
 
 class TestMouseClickGating:
     @pytest.mark.asyncio
-    async def test_muted_when_human_active(self):
-        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
-            result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True)
+    async def test_muted_for_non_owner_while_held(self):
+        with _muted(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True, current_user=BOB)
 
         assert result["status"] == "muted"
         assert result["muted"] is True
         mock_run.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_executes_when_human_inactive(self):
+    async def test_executes_when_unheld(self):
         with (
-            _human_active(False),
+            _muted(False),
             patch(
                 "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
             ) as mock_run,
         ):
-            result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True)
+            result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True, current_user=ALICE)
 
         assert result["status"] == "success"
         mock_run.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_executes_for_lock_owner(self):
+        """The lock owner's own toolbar must not mute itself (#12002 review fix)."""
+        with (
+            patch("api.vnc_manager.is_actuation_muted", new=AsyncMock(return_value=False)) as mock_muted,
+            patch(
+                "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+            ) as mock_run,
+        ):
+            result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True, current_user=ALICE)
+
+        assert result["status"] == "success"
+        mock_run.assert_called_once()
+        mock_muted.assert_called_once_with("default", "alice")
+
 
 class TestKeyboardTypeGating:
     @pytest.mark.asyncio
-    async def test_muted_when_human_active(self):
-        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
-            result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True)
+    async def test_muted_for_non_owner_while_held(self):
+        with _muted(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True, current_user=BOB)
 
         assert result["status"] == "muted"
         mock_run.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_executes_when_human_inactive(self):
+    async def test_executes_when_unheld(self):
         # should_add_human_pause() is stochastic (20% chance of a mid-typing
         # pause that splits into 2 xdotool calls) -- pin it False so this
         # test deterministically exercises the single-call path.
         with (
-            _human_active(False),
+            _muted(False),
             patch("api.vnc_manager.should_add_human_pause", return_value=False),
             patch(
                 "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
             ) as mock_run,
         ):
-            result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True)
+            result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True, current_user=ALICE)
 
         assert result["status"] == "success"
         mock_run.assert_called_once()
@@ -88,22 +111,22 @@ class TestKeyboardTypeGating:
 
 class TestSpecialKeyGating:
     @pytest.mark.asyncio
-    async def test_muted_when_human_active(self):
-        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
-            result = await vnc_special_key(SpecialKeyRequest(key="Return"), admin_check=True)
+    async def test_muted_for_non_owner_while_held(self):
+        with _muted(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_special_key(SpecialKeyRequest(key="Return"), admin_check=True, current_user=BOB)
 
         assert result["status"] == "muted"
         mock_run.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_executes_when_human_inactive(self):
+    async def test_executes_when_unheld(self):
         with (
-            _human_active(False),
+            _muted(False),
             patch(
                 "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
             ) as mock_run,
         ):
-            result = await vnc_special_key(SpecialKeyRequest(key="Return"), admin_check=True)
+            result = await vnc_special_key(SpecialKeyRequest(key="Return"), admin_check=True, current_user=ALICE)
 
         assert result["status"] == "success"
         mock_run.assert_called_once()
@@ -111,22 +134,22 @@ class TestSpecialKeyGating:
 
 class TestMouseScrollGating:
     @pytest.mark.asyncio
-    async def test_muted_when_human_active(self):
-        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
-            result = await vnc_mouse_scroll(MouseScrollRequest(direction="up"), admin_check=True)
+    async def test_muted_for_non_owner_while_held(self):
+        with _muted(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_mouse_scroll(MouseScrollRequest(direction="up"), admin_check=True, current_user=BOB)
 
         assert result["status"] == "muted"
         mock_run.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_executes_when_human_inactive(self):
+    async def test_executes_when_unheld(self):
         with (
-            _human_active(False),
+            _muted(False),
             patch(
                 "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
             ) as mock_run,
         ):
-            result = await vnc_mouse_scroll(MouseScrollRequest(direction="up"), admin_check=True)
+            result = await vnc_mouse_scroll(MouseScrollRequest(direction="up"), admin_check=True, current_user=ALICE)
 
         assert result["status"] == "success"
         mock_run.assert_called_once()
@@ -134,22 +157,26 @@ class TestMouseScrollGating:
 
 class TestMouseDragGating:
     @pytest.mark.asyncio
-    async def test_muted_when_human_active(self):
-        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
-            result = await vnc_mouse_drag(MouseDragRequest(x1=0, y1=0, x2=10, y2=10), admin_check=True)
+    async def test_muted_for_non_owner_while_held(self):
+        with _muted(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_mouse_drag(
+                MouseDragRequest(x1=0, y1=0, x2=10, y2=10), admin_check=True, current_user=BOB
+            )
 
         assert result["status"] == "muted"
         mock_run.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_executes_when_human_inactive(self):
+    async def test_executes_when_unheld(self):
         with (
-            _human_active(False),
+            _muted(False),
             patch(
                 "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
             ) as mock_run,
         ):
-            result = await vnc_mouse_drag(MouseDragRequest(x1=0, y1=0, x2=10, y2=10), admin_check=True)
+            result = await vnc_mouse_drag(
+                MouseDragRequest(x1=0, y1=0, x2=10, y2=10), admin_check=True, current_user=ALICE
+            )
 
         assert result["status"] == "success"
         # mousedown + N mousemove points + mouseup
@@ -159,8 +186,44 @@ class TestMouseDragGating:
 class TestSessionIdThreading:
     @pytest.mark.asyncio
     async def test_gating_checks_the_requested_session_id(self):
-        """is_human_active must be called with the request's session_id, not a default."""
-        with patch("api.vnc_manager.is_human_active", new=AsyncMock(return_value=True)) as mock_active:
-            await vnc_mouse_click(MouseClickRequest(x=1, y=1, session_id="chat-42"), admin_check=True)
+        """is_actuation_muted must be called with the request's session_id, not a default."""
+        with patch("api.vnc_manager.is_actuation_muted", new=AsyncMock(return_value=True)) as mock_muted:
+            await vnc_mouse_click(
+                MouseClickRequest(x=1, y=1, session_id="chat-42"), admin_check=True, current_user=ALICE
+            )
 
-        mock_active.assert_called_once_with("chat-42")
+        mock_muted.assert_called_once_with("chat-42", "alice")
+
+
+class TestCallerUsernameExtraction:
+    """_caller_username must degrade gracefully for non-dict callers (e.g.
+    playback_macro()'s direct Python calls, which never resolve the FastAPI
+    current_user dependency) instead of raising."""
+
+    def test_extracts_username_from_dict(self):
+        assert _caller_username({"username": "alice"}) == "alice"
+
+    def test_dict_without_username_returns_none(self):
+        assert _caller_username({"role": "admin"}) is None
+
+    def test_unresolved_depends_sentinel_returns_none(self):
+        # Mirrors what `current_user` actually is when playback_macro() calls
+        # vnc_mouse_click(...) directly without passing current_user.
+        assert _caller_username(Depends(lambda: None)) is None
+
+    def test_none_returns_none(self):
+        assert _caller_username(None) is None
+
+    @pytest.mark.asyncio
+    async def test_macro_style_direct_call_does_not_crash_and_is_unconditionally_gated(self):
+        """Direct call with no current_user (macro playback style) must not
+        raise, and must fall back to unconditional gating (caller=None)."""
+        with (
+            patch("api.vnc_manager.is_actuation_muted", new=AsyncMock(return_value=True)) as mock_muted,
+            patch("api.vnc_manager._run_xdotool_cmd") as mock_run,
+        ):
+            result = await vnc_mouse_click(MouseClickRequest(x=1, y=1), admin_check=True)
+
+        assert result["status"] == "muted"
+        mock_run.assert_not_called()
+        mock_muted.assert_called_once_with("default", None)

--- a/autobot-backend/api/vnc_manager_control_lock_test.py
+++ b/autobot-backend/api/vnc_manager_control_lock_test.py
@@ -1,0 +1,147 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for api.vnc_manager's desktop control-lock gating (#12002, #11506 T1).
+
+Verifies that agent actuation entrypoints (click/type/key/scroll/drag) are
+muted (no xdotool dispatch) while a human holds the control-lock, and
+execute normally when the lock is unheld.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.schemas_system import (
+    KeyboardTypeRequest,
+    MouseClickRequest,
+    MouseDragRequest,
+    MouseScrollRequest,
+    SpecialKeyRequest,
+)
+from api.vnc_manager import (
+    vnc_keyboard_type,
+    vnc_mouse_click,
+    vnc_mouse_drag,
+    vnc_mouse_scroll,
+    vnc_special_key,
+)
+
+
+def _human_active(active: bool):
+    """Patch api.vnc_manager.is_human_active for the module under test."""
+    return patch("api.vnc_manager.is_human_active", new=AsyncMock(return_value=active))
+
+
+class TestMouseClickGating:
+    @pytest.mark.asyncio
+    async def test_muted_when_human_active(self):
+        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True)
+
+        assert result["status"] == "muted"
+        assert result["muted"] is True
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_executes_when_human_inactive(self):
+        with _human_active(False), patch(
+            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+        ) as mock_run:
+            result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True)
+
+        assert result["status"] == "success"
+        mock_run.assert_called_once()
+
+
+class TestKeyboardTypeGating:
+    @pytest.mark.asyncio
+    async def test_muted_when_human_active(self):
+        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True)
+
+        assert result["status"] == "muted"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_executes_when_human_inactive(self):
+        with _human_active(False), patch(
+            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+        ) as mock_run:
+            result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True)
+
+        assert result["status"] == "success"
+        mock_run.assert_called_once()
+
+
+class TestSpecialKeyGating:
+    @pytest.mark.asyncio
+    async def test_muted_when_human_active(self):
+        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_special_key(SpecialKeyRequest(key="Return"), admin_check=True)
+
+        assert result["status"] == "muted"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_executes_when_human_inactive(self):
+        with _human_active(False), patch(
+            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+        ) as mock_run:
+            result = await vnc_special_key(SpecialKeyRequest(key="Return"), admin_check=True)
+
+        assert result["status"] == "success"
+        mock_run.assert_called_once()
+
+
+class TestMouseScrollGating:
+    @pytest.mark.asyncio
+    async def test_muted_when_human_active(self):
+        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_mouse_scroll(MouseScrollRequest(direction="up"), admin_check=True)
+
+        assert result["status"] == "muted"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_executes_when_human_inactive(self):
+        with _human_active(False), patch(
+            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+        ) as mock_run:
+            result = await vnc_mouse_scroll(MouseScrollRequest(direction="up"), admin_check=True)
+
+        assert result["status"] == "success"
+        mock_run.assert_called_once()
+
+
+class TestMouseDragGating:
+    @pytest.mark.asyncio
+    async def test_muted_when_human_active(self):
+        with _human_active(True), patch("api.vnc_manager._run_xdotool_cmd") as mock_run:
+            result = await vnc_mouse_drag(MouseDragRequest(x1=0, y1=0, x2=10, y2=10), admin_check=True)
+
+        assert result["status"] == "muted"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_executes_when_human_inactive(self):
+        with _human_active(False), patch(
+            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+        ) as mock_run:
+            result = await vnc_mouse_drag(MouseDragRequest(x1=0, y1=0, x2=10, y2=10), admin_check=True)
+
+        assert result["status"] == "success"
+        # mousedown + N mousemove points + mouseup
+        assert mock_run.call_count >= 2
+
+
+class TestSessionIdThreading:
+    @pytest.mark.asyncio
+    async def test_gating_checks_the_requested_session_id(self):
+        """is_human_active must be called with the request's session_id, not a default."""
+        with patch("api.vnc_manager.is_human_active", new=AsyncMock(return_value=True)) as mock_active:
+            await vnc_mouse_click(MouseClickRequest(x=1, y=1, session_id="chat-42"), admin_check=True)
+
+        mock_active.assert_called_once_with("chat-42")

--- a/autobot-backend/api/vnc_manager_control_lock_test.py
+++ b/autobot-backend/api/vnc_manager_control_lock_test.py
@@ -47,9 +47,12 @@ class TestMouseClickGating:
 
     @pytest.mark.asyncio
     async def test_executes_when_human_inactive(self):
-        with _human_active(False), patch(
-            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
-        ) as mock_run:
+        with (
+            _human_active(False),
+            patch(
+                "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+            ) as mock_run,
+        ):
             result = await vnc_mouse_click(MouseClickRequest(x=10, y=20), admin_check=True)
 
         assert result["status"] == "success"
@@ -70,9 +73,13 @@ class TestKeyboardTypeGating:
         # should_add_human_pause() is stochastic (20% chance of a mid-typing
         # pause that splits into 2 xdotool calls) -- pin it False so this
         # test deterministically exercises the single-call path.
-        with _human_active(False), patch("api.vnc_manager.should_add_human_pause", return_value=False), patch(
-            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
-        ) as mock_run:
+        with (
+            _human_active(False),
+            patch("api.vnc_manager.should_add_human_pause", return_value=False),
+            patch(
+                "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+            ) as mock_run,
+        ):
             result = await vnc_keyboard_type(KeyboardTypeRequest(text="hello"), admin_check=True)
 
         assert result["status"] == "success"
@@ -90,9 +97,12 @@ class TestSpecialKeyGating:
 
     @pytest.mark.asyncio
     async def test_executes_when_human_inactive(self):
-        with _human_active(False), patch(
-            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
-        ) as mock_run:
+        with (
+            _human_active(False),
+            patch(
+                "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+            ) as mock_run,
+        ):
             result = await vnc_special_key(SpecialKeyRequest(key="Return"), admin_check=True)
 
         assert result["status"] == "success"
@@ -110,9 +120,12 @@ class TestMouseScrollGating:
 
     @pytest.mark.asyncio
     async def test_executes_when_human_inactive(self):
-        with _human_active(False), patch(
-            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
-        ) as mock_run:
+        with (
+            _human_active(False),
+            patch(
+                "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+            ) as mock_run,
+        ):
             result = await vnc_mouse_scroll(MouseScrollRequest(direction="up"), admin_check=True)
 
         assert result["status"] == "success"
@@ -130,9 +143,12 @@ class TestMouseDragGating:
 
     @pytest.mark.asyncio
     async def test_executes_when_human_inactive(self):
-        with _human_active(False), patch(
-            "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
-        ) as mock_run:
+        with (
+            _human_active(False),
+            patch(
+                "api.vnc_manager._run_xdotool_cmd", return_value={"status": "success", "message": "Action completed"}
+            ) as mock_run,
+        ):
             result = await vnc_mouse_drag(MouseDragRequest(x1=0, y1=0, x2=10, y2=10), admin_check=True)
 
         assert result["status"] == "success"

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -25,9 +25,12 @@ MANIFEST = MCPBridgeManifest(
     endpoint="/api/vnc/mcp/tools",
 )
 
+from api.desktop_control_lock import get_control_lock_state, is_human_active
 from api.schemas_system import (
     BrowserVncContextResponse,
     DesktopClickMcpResponse,
+    DesktopControlStatusMcpResponse,
+    DesktopControlStatusRequest,
     DesktopKeyboardTypeMcpResponse,
     DesktopKeyboardTypeRequest,
     DesktopMouseClickRequest,
@@ -219,6 +222,27 @@ VNC_MCP_TOOL_DEFINITIONS = (
                     "type": "boolean",
                     "description": "Include base64 screenshot in response",
                     "default": True,
+                }
+            },
+            "required": [],
+        },
+    ),
+    # Issue #12002 (#11506 T1): agent<->human input arbitration
+    (
+        "desktop_control_status",
+        (
+            "Check whether a human currently holds the desktop control-lock. When "
+            "human_active is true, all desktop_mouse_click / desktop_keyboard_type / "
+            "desktop_special_key calls are muted (no-op) -- pause desktop actuation and "
+            "wait until the human releases control before continuing."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Desktop control-lock session id",
+                    "default": "default",
                 }
             },
             "required": [],
@@ -454,8 +478,19 @@ async def desktop_mouse_click_mcp(request: DesktopMouseClickRequest) -> Metadata
     """
     MCP tool: Click mouse at coordinates on desktop.
     Issue #74: Agent desktop interaction.
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
     """
     from api.vnc_manager import _run_xdotool_cmd
+
+    if await is_human_active(request.session_id):
+        return {
+            "success": False,
+            "message": "Muted: human is in control of the desktop session.",
+            "action": "mouse_click",
+            "coordinates": {"x": request.x, "y": request.y},
+            "button": request.button,
+            "muted": True,
+        }
 
     button_map = {"left": "1", "middle": "2", "right": "3"}
     button_num = button_map.get(request.button, "1")
@@ -483,8 +518,18 @@ async def desktop_keyboard_type_mcp(request: DesktopKeyboardTypeRequest) -> Meta
     """
     MCP tool: Type text on desktop keyboard.
     Issue #74: Agent desktop interaction.
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
     """
     from api.vnc_manager import _run_xdotool_cmd
+
+    if await is_human_active(request.session_id):
+        return {
+            "success": False,
+            "message": "Muted: human is in control of the desktop session.",
+            "action": "keyboard_type",
+            "text_length": len(request.text),
+            "muted": True,
+        }
 
     result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
         _run_xdotool_cmd, ["type", "--", request.text]
@@ -508,8 +553,18 @@ async def desktop_special_key_mcp(request: DesktopSpecialKeyRequest) -> Metadata
     """
     MCP tool: Send special key or key combination.
     Issue #74: Agent desktop interaction.
+    Issue #12002 (#11506 T1): muted while a human holds the control-lock.
     """
     from api.vnc_manager import _run_xdotool_cmd
+
+    if await is_human_active(request.session_id):
+        return {
+            "success": False,
+            "message": "Muted: human is in control of the desktop session.",
+            "action": "special_key",
+            "key": request.key,
+            "muted": True,
+        }
 
     result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
         _run_xdotool_cmd, ["key", request.key]
@@ -605,13 +660,21 @@ async def desktop_observe_state_mcp(request: DesktopObserveStateRequest) -> Meta
     """
     MCP tool: Observe current desktop state with metadata.
     Issue #74: Agent desktop observation.
+    Issue #12002 (#11506 T1): includes control-lock state so the agent knows
+    to pause actuation when a human is active.
     """
     import subprocess  # nosec B404
+
+    from api.desktop_control_lock import DEFAULT_DESKTOP_SESSION_ID
+
+    lock_state = await get_control_lock_state(DEFAULT_DESKTOP_SESSION_ID)
 
     state = {
         "success": True,
         "action": "observe_state",
         "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "human_active": lock_state["human_active"],
+        "control_owner": lock_state["owner"],
     }
 
     # Get screen resolution
@@ -657,3 +720,42 @@ async def desktop_observe_state_mcp(request: DesktopObserveStateRequest) -> Meta
             state["screenshot_format"] = "png"
 
     return state
+
+
+# Issue #12002 (#11506 T1): agent<->human input arbitration
+
+
+def _describe_control_lock_state(lock_state: dict) -> str:
+    """Build a human-readable message for the desktop control-lock state (#12002)."""
+    if not lock_state["redis_available"]:
+        return "Desktop control-lock state unknown (Redis unavailable) -- actuation is muted"
+    if lock_state["human_active"] and lock_state["owner"]:
+        return f"Desktop control held by {lock_state['owner']}"
+    return "Agent has control"
+
+
+@router.post("/mcp/desktop_control_status", response_model=DesktopControlStatusMcpResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="desktop_control_status_mcp",
+    error_code_prefix="VNC_MCP",
+)
+async def desktop_control_status_mcp(request: DesktopControlStatusRequest) -> Metadata:
+    """
+    MCP tool: Check whether a human currently holds the desktop control-lock.
+
+    Issue #12002 (#11506 T1): agents should call this (or read human_active
+    from desktop_observe_state) before actuation and pause while a human is
+    active -- desktop_mouse_click/keyboard_type/special_key are muted
+    automatically, but polling this lets the agent avoid wasted calls.
+    """
+    lock_state = await get_control_lock_state(request.session_id)
+
+    return {
+        "success": True,
+        "session_id": request.session_id,
+        "human_active": lock_state["human_active"],
+        "owner": lock_state["owner"],
+        "acquired_at": lock_state["acquired_at"],
+        "message": _describe_control_lock_state(lock_state),
+    }

--- a/autobot-backend/api/vnc_proxy.py
+++ b/autobot-backend/api/vnc_proxy.py
@@ -14,12 +14,23 @@ enabling the agent to see what users are viewing in real-time.
 """
 
 import asyncio
+import uuid
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response
 
-from api.schemas_system import VncProxyStatusResponse
+from api.desktop_control_lock import (
+    acquire_human_control,
+    get_control_lock_state,
+    release_human_control,
+)
+from api.schemas_system import (
+    DesktopControlAcquireRequest,
+    DesktopControlLockResponse,
+    DesktopControlReleaseRequest,
+    VncProxyStatusResponse,
+)
 from api.ws_security import enforce_ws_origin
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -139,6 +150,137 @@ async def record_observation(vnc_type: str, observation_type: str, data: Metadat
         logger.debug("Failed to record observation for %s: %s", vnc_type, e)
 
 
+async def _audit_control_lock_change(action: str, session_id: str, current_user: dict) -> None:
+    """Best-effort audit log for a control-lock acquire/release (#12002).
+
+    Uses integrations.desktop_tracking (Issue #873), the existing desktop
+    activity audit hook. Never raises -- PostgreSQL may be disabled entirely
+    in single_user deployments (get_async_session_factory hard-raises in
+    that mode), and a missing/unauthenticated user_id must not block the
+    safety-critical lock operation itself.
+    """
+    raw_user_id = current_user.get("user_id")
+    if not raw_user_id:
+        logger.debug("Skipping control-lock audit for %s: no user_id on caller", action)
+        return
+    try:
+        user_id = uuid.UUID(raw_user_id)
+    except (ValueError, TypeError):
+        logger.debug("Skipping control-lock audit for %s: non-UUID user_id", action)
+        return
+
+    try:
+        from integrations.desktop_tracking import track_desktop_action
+        from user_management.database import get_async_session_factory
+
+        session_factory = get_async_session_factory()
+        async with session_factory() as db:
+            await track_desktop_action(
+                db=db,
+                user_id=user_id,
+                action=action,
+                session_id=session_id,
+                app_name=current_user.get("username"),
+            )
+            await db.commit()
+    except RuntimeError as e:
+        # PostgreSQL not enabled for this deployment mode -- expected in single_user.
+        logger.debug("Control-lock audit skipped (PostgreSQL unavailable): %s", e)
+    except Exception as e:
+        logger.warning("Control-lock audit logging failed for %s (non-fatal): %s", action, e)
+
+
+@router.post("/{vnc_type}/control/acquire", response_model=DesktopControlLockResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="acquire_desktop_control",
+    error_code_prefix="VNC_PROXY_CONTROL",
+)
+async def acquire_desktop_control(
+    vnc_type: str,
+    request: DesktopControlAcquireRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Human takeover: acquire the desktop control-lock (#12002, #11506 T1).
+
+    Muting the agent's actuation calls (api.vnc_manager / api.vnc_mcp) until
+    this is released or its idle-TTL expires.
+    """
+    if vnc_type not in VNC_ENDPOINTS:
+        raise HTTPException(status_code=404, detail=f"Unknown VNC type: {vnc_type}")
+
+    owner = current_user.get("username") or "unknown"
+    result = await acquire_human_control(request.session_id, owner)
+    await _audit_control_lock_change("control_lock_acquire", request.session_id, current_user)
+
+    return {
+        "success": result["success"],
+        "session_id": request.session_id,
+        "owner": result["owner"],
+        "human_active": result["human_active"],
+        "message": result["message"],
+    }
+
+
+@router.post("/{vnc_type}/control/release", response_model=DesktopControlLockResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="release_desktop_control",
+    error_code_prefix="VNC_PROXY_CONTROL",
+)
+async def release_desktop_control(
+    vnc_type: str,
+    request: DesktopControlReleaseRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Human handback: release the desktop control-lock (#12002, #11506 T1).
+
+    The agent resumes actuation immediately once released.
+    """
+    if vnc_type not in VNC_ENDPOINTS:
+        raise HTTPException(status_code=404, detail=f"Unknown VNC type: {vnc_type}")
+
+    owner = current_user.get("username") or "unknown"
+    result = await release_human_control(request.session_id, owner)
+    await _audit_control_lock_change("control_lock_release", request.session_id, current_user)
+
+    return {
+        "success": result["success"],
+        "session_id": request.session_id,
+        "owner": result["owner"],
+        "human_active": result["human_active"],
+        "message": result["message"],
+    }
+
+
+@router.get("/{vnc_type}/control/status", response_model=DesktopControlLockResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_desktop_control_status",
+    error_code_prefix="VNC_PROXY_CONTROL",
+)
+async def get_desktop_control_status(
+    vnc_type: str,
+    session_id: str = "default",
+    current_user: dict = Depends(get_current_user),
+):
+    """Get current desktop control-lock owner/state (#12002, #11506 T1)."""
+    if vnc_type not in VNC_ENDPOINTS:
+        raise HTTPException(status_code=404, detail=f"Unknown VNC type: {vnc_type}")
+
+    lock_state = await get_control_lock_state(session_id)
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "owner": lock_state["owner"],
+        "human_active": lock_state["human_active"],
+        "message": (f"Control held by {lock_state['owner']}" if lock_state["owner"] else "Agent has control"),
+    }
+
+
 @router.get("/{vnc_type}/vnc.html", response_model=None)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -242,6 +384,14 @@ async def websocket_proxy(websocket: WebSocket, vnc_type: str):
 
     Proxies WebSocket traffic between frontend and VNC server,
     allowing backend to observe and log VNC traffic for agent
+
+    Issue #12002 (#11506 T1): this is the human's input path -- raw RFB
+    protocol frames forwarded straight through to the VNC server by
+    _forward_client_to_vnc. It never calls into api.vnc_manager's xdotool
+    endpoints, so human input is inherently NEVER gated by the desktop
+    control-lock; only the agent's actuation calls are (see
+    api.desktop_control_lock / the /control/acquire /control/release
+    endpoints above, which a human explicitly calls to take/release control).
 
     Args:
         vnc_type: 'desktop' or 'browser'

--- a/autobot-backend/api/vnc_proxy_control_lock_test.py
+++ b/autobot-backend/api/vnc_proxy_control_lock_test.py
@@ -31,9 +31,10 @@ class TestAcquireEndpoint:
             "human_active": True,
             "message": "Control acquired by alice",
         }
-        with patch(
-            "api.vnc_proxy.acquire_human_control", new=AsyncMock(return_value=fake_result)
-        ), patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()) as mock_audit:
+        with (
+            patch("api.vnc_proxy.acquire_human_control", new=AsyncMock(return_value=fake_result)),
+            patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()) as mock_audit,
+        ):
             response = await acquire_desktop_control(
                 "desktop",
                 DesktopControlAcquireRequest(session_id="default"),
@@ -65,9 +66,10 @@ class TestReleaseEndpoint:
             "human_active": False,
             "message": "Control released",
         }
-        with patch(
-            "api.vnc_proxy.release_human_control", new=AsyncMock(return_value=fake_result)
-        ), patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()):
+        with (
+            patch("api.vnc_proxy.release_human_control", new=AsyncMock(return_value=fake_result)),
+            patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()),
+        ):
             response = await release_desktop_control(
                 "desktop",
                 DesktopControlReleaseRequest(session_id="default"),
@@ -85,9 +87,10 @@ class TestReleaseEndpoint:
             "human_active": True,
             "message": "Control lock is held by another user",
         }
-        with patch(
-            "api.vnc_proxy.release_human_control", new=AsyncMock(return_value=fake_result)
-        ), patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()):
+        with (
+            patch("api.vnc_proxy.release_human_control", new=AsyncMock(return_value=fake_result)),
+            patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()),
+        ):
             response = await release_desktop_control(
                 "desktop",
                 DesktopControlReleaseRequest(),

--- a/autobot-backend/api/vnc_proxy_control_lock_test.py
+++ b/autobot-backend/api/vnc_proxy_control_lock_test.py
@@ -1,0 +1,173 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for api.vnc_proxy's desktop control-lock endpoints (#12002, #11506 T1).
+
+Covers the human takeover/handback REST endpoints (acquire/release/status)
+and the best-effort audit hook, without requiring a live Redis or PostgreSQL.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.schemas_system import DesktopControlAcquireRequest, DesktopControlReleaseRequest
+from api.vnc_proxy import (
+    acquire_desktop_control,
+    get_desktop_control_status,
+    release_desktop_control,
+)
+
+
+class TestAcquireEndpoint:
+    @pytest.mark.asyncio
+    async def test_acquire_success(self):
+        fake_result = {
+            "success": True,
+            "owner": "alice",
+            "human_active": True,
+            "message": "Control acquired by alice",
+        }
+        with patch(
+            "api.vnc_proxy.acquire_human_control", new=AsyncMock(return_value=fake_result)
+        ), patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()) as mock_audit:
+            response = await acquire_desktop_control(
+                "desktop",
+                DesktopControlAcquireRequest(session_id="default"),
+                current_user={"username": "alice", "user_id": None},
+            )
+
+        assert response["success"] is True
+        assert response["owner"] == "alice"
+        assert response["human_active"] is True
+        mock_audit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_acquire_unknown_vnc_type_404(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await acquire_desktop_control(
+                "not-a-real-type",
+                DesktopControlAcquireRequest(),
+                current_user={"username": "alice"},
+            )
+        assert exc_info.value.status_code == 404
+
+
+class TestReleaseEndpoint:
+    @pytest.mark.asyncio
+    async def test_release_success(self):
+        fake_result = {
+            "success": True,
+            "owner": None,
+            "human_active": False,
+            "message": "Control released",
+        }
+        with patch(
+            "api.vnc_proxy.release_human_control", new=AsyncMock(return_value=fake_result)
+        ), patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()):
+            response = await release_desktop_control(
+                "desktop",
+                DesktopControlReleaseRequest(session_id="default"),
+                current_user={"username": "alice", "user_id": None},
+            )
+
+        assert response["success"] is True
+        assert response["human_active"] is False
+
+    @pytest.mark.asyncio
+    async def test_release_denied_for_non_owner(self):
+        fake_result = {
+            "success": False,
+            "owner": "alice",
+            "human_active": True,
+            "message": "Control lock is held by another user",
+        }
+        with patch(
+            "api.vnc_proxy.release_human_control", new=AsyncMock(return_value=fake_result)
+        ), patch("api.vnc_proxy._audit_control_lock_change", new=AsyncMock()):
+            response = await release_desktop_control(
+                "desktop",
+                DesktopControlReleaseRequest(),
+                current_user={"username": "bob"},
+            )
+
+        assert response["success"] is False
+        assert response["owner"] == "alice"
+
+
+class TestStatusEndpoint:
+    @pytest.mark.asyncio
+    async def test_status_reports_owner(self):
+        fake_state = {
+            "session_id": "default",
+            "human_active": True,
+            "owner": "alice",
+            "acquired_at": "2026-07-22T00:00:00+00:00",
+            "redis_available": True,
+        }
+        with patch("api.vnc_proxy.get_control_lock_state", new=AsyncMock(return_value=fake_state)):
+            response = await get_desktop_control_status(
+                "desktop", session_id="default", current_user={"username": "bob"}
+            )
+
+        assert response["human_active"] is True
+        assert response["owner"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_status_unknown_vnc_type_404(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_desktop_control_status("bogus", current_user={"username": "bob"})
+        assert exc_info.value.status_code == 404
+
+
+class TestAuditBestEffort:
+    """Audit logging must never block the safety-critical lock operation.
+
+    _audit_control_lock_change() internally catches both RuntimeError (e.g.
+    PostgreSQL disabled in single_user mode) and any other exception, so it
+    never propagates out to acquire_desktop_control/release_desktop_control.
+    """
+
+    @pytest.mark.asyncio
+    async def test_acquire_succeeds_even_when_audit_hook_itself_would_fail(self):
+        """Acquire succeeds using the REAL (unmocked) audit helper, which is
+        expected to no-op cleanly here (no user_id on the caller)."""
+        fake_result = {
+            "success": True,
+            "owner": "alice",
+            "human_active": True,
+            "message": "Control acquired by alice",
+        }
+        with patch("api.vnc_proxy.acquire_human_control", new=AsyncMock(return_value=fake_result)):
+            response = await acquire_desktop_control(
+                "desktop",
+                DesktopControlAcquireRequest(),
+                current_user={"username": "alice"},  # no user_id -- audit no-ops
+            )
+
+        assert response["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_audit_skips_cleanly_without_user_id(self):
+        from api.vnc_proxy import _audit_control_lock_change
+
+        # No exception raised -- best-effort, no-op when user_id is absent.
+        await _audit_control_lock_change("control_lock_acquire", "default", {"username": "alice"})
+
+    @pytest.mark.asyncio
+    async def test_audit_skips_cleanly_when_postgres_disabled(self):
+        from api.vnc_proxy import _audit_control_lock_change
+
+        with patch(
+            "user_management.database.get_async_session_factory",
+            side_effect=RuntimeError("PostgreSQL is not enabled for deployment mode: single_user"),
+        ):
+            # No exception raised -- RuntimeError from PG-disabled mode is swallowed.
+            await _audit_control_lock_change(
+                "control_lock_acquire",
+                "default",
+                {"username": "alice", "user_id": "12345678-1234-1234-1234-123456789012"},
+            )

--- a/autobot-backend/tests/test_vnc_mcp_async.py
+++ b/autobot-backend/tests/test_vnc_mcp_async.py
@@ -407,9 +407,10 @@ class TestControlLockGating:
         request_mock.button = "left"
         request_mock.session_id = "default"
 
-        with patch.object(
-            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)
-        ), patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt:
+        with (
+            patch.object(vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)),
+            patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt,
+        ):
             result = await vnc_mcp_module.desktop_mouse_click_mcp(request_mock)
 
         assert result["success"] is False
@@ -422,9 +423,10 @@ class TestControlLockGating:
         request_mock.text = "hello world"
         request_mock.session_id = "default"
 
-        with patch.object(
-            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)
-        ), patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt:
+        with (
+            patch.object(vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)),
+            patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt,
+        ):
             result = await vnc_mcp_module.desktop_keyboard_type_mcp(request_mock)
 
         assert result["success"] is False
@@ -437,9 +439,10 @@ class TestControlLockGating:
         request_mock.key = "Return"
         request_mock.session_id = "default"
 
-        with patch.object(
-            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)
-        ), patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt:
+        with (
+            patch.object(vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)),
+            patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt,
+        ):
             result = await vnc_mcp_module.desktop_special_key_mcp(request_mock)
 
         assert result["success"] is False
@@ -455,9 +458,10 @@ class TestControlLockGating:
         request_mock.session_id = "default"
         fake_result = {"status": "success", "message": "Action completed"}
 
-        with patch.object(
-            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=False)
-        ), patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_result) as mock_tt:
+        with (
+            patch.object(vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=False)),
+            patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_result) as mock_tt,
+        ):
             result = await vnc_mcp_module.desktop_mouse_click_mcp(request_mock)
 
         assert result["success"] is True
@@ -475,9 +479,7 @@ class TestControlLockGating:
             "redis_available": True,
         }
 
-        with patch.object(
-            vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)
-        ):
+        with patch.object(vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)):
             result = await vnc_mcp_module.desktop_control_status_mcp(request_mock)
 
         assert result["success"] is True
@@ -497,9 +499,7 @@ class TestControlLockGating:
             "redis_available": True,
         }
 
-        with patch.object(
-            vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)
-        ):
+        with patch.object(vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)):
             result = await vnc_mcp_module.desktop_control_status_mcp(request_mock)
 
         assert result["success"] is True
@@ -521,9 +521,10 @@ class TestControlLockGating:
             args=[], returncode=0, stdout="dimensions:  1920x1080 pixels\n", stderr=""
         )
 
-        with patch.object(
-            vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)
-        ), patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_ok):
+        with (
+            patch.object(vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)),
+            patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_ok),
+        ):
             result = await vnc_mcp_module.desktop_observe_state_mcp(request_mock)
 
         assert result["human_active"] is True

--- a/autobot-backend/tests/test_vnc_mcp_async.py
+++ b/autobot-backend/tests/test_vnc_mcp_async.py
@@ -102,12 +102,36 @@ def _install_stubs() -> dict:
 
     _stub("api.vnc_manager", _run_xdotool_cmd=_run_xdotool_cmd)
 
+    # api.desktop_control_lock (#12002, #11506 T1) — stub the control-lock
+    # gate as "always unmuted" so pre-existing actuation tests keep exercising
+    # the real xdotool dispatch path unchanged.
+    async def _is_human_active_stub(session_id):  # pragma: no cover
+        return False
+
+    async def _get_control_lock_state_stub(session_id):  # pragma: no cover
+        return {
+            "session_id": session_id,
+            "human_active": False,
+            "owner": None,
+            "acquired_at": None,
+            "redis_available": True,
+        }
+
+    _stub(
+        "api.desktop_control_lock",
+        is_human_active=_is_human_active_stub,
+        get_control_lock_state=_get_control_lock_state_stub,
+        DEFAULT_DESKTOP_SESSION_ID="default",
+    )
+
     # api.schemas_system — exact names imported by vnc_mcp.py lines 28-45
     _schema_attrs = {
         n: MagicMock
         for n in (
             "BrowserVncContextResponse",
             "DesktopClickMcpResponse",
+            "DesktopControlStatusMcpResponse",
+            "DesktopControlStatusRequest",
             "DesktopKeyboardTypeMcpResponse",
             "DesktopKeyboardTypeRequest",
             "DesktopMouseClickRequest",
@@ -364,3 +388,143 @@ class TestXdotoolMcpDispatchedViaToThread:
         first_positional = mock_tt.call_args_list[0].args
         assert callable(first_positional[0]), "First arg to asyncio.to_thread must be callable (_run_xdotool_cmd)"
         assert first_positional[0].__name__ == "_run_xdotool_cmd"
+
+
+class TestControlLockGating:
+    """
+    Issue #12002 (#11506 T1): verify desktop_mouse_click_mcp /
+    desktop_keyboard_type_mcp / desktop_special_key_mcp are muted (no
+    xdotool dispatch) while a human holds the control-lock, and that
+    desktop_control_status_mcp / desktop_observe_state_mcp surface lock
+    state to the agent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mouse_click_muted_when_human_active(self, vnc_mcp_module):
+        request_mock = MagicMock()
+        request_mock.x = 100
+        request_mock.y = 200
+        request_mock.button = "left"
+        request_mock.session_id = "default"
+
+        with patch.object(
+            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)
+        ), patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt:
+            result = await vnc_mcp_module.desktop_mouse_click_mcp(request_mock)
+
+        assert result["success"] is False
+        assert result["muted"] is True
+        mock_tt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_keyboard_type_muted_when_human_active(self, vnc_mcp_module):
+        request_mock = MagicMock()
+        request_mock.text = "hello world"
+        request_mock.session_id = "default"
+
+        with patch.object(
+            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)
+        ), patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt:
+            result = await vnc_mcp_module.desktop_keyboard_type_mcp(request_mock)
+
+        assert result["success"] is False
+        assert result["muted"] is True
+        mock_tt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_special_key_muted_when_human_active(self, vnc_mcp_module):
+        request_mock = MagicMock()
+        request_mock.key = "Return"
+        request_mock.session_id = "default"
+
+        with patch.object(
+            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=True)
+        ), patch("asyncio.to_thread", new_callable=AsyncMock) as mock_tt:
+            result = await vnc_mcp_module.desktop_special_key_mcp(request_mock)
+
+        assert result["success"] is False
+        assert result["muted"] is True
+        mock_tt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mouse_click_dispatches_when_human_inactive(self, vnc_mcp_module):
+        request_mock = MagicMock()
+        request_mock.x = 100
+        request_mock.y = 200
+        request_mock.button = "left"
+        request_mock.session_id = "default"
+        fake_result = {"status": "success", "message": "Action completed"}
+
+        with patch.object(
+            vnc_mcp_module, "is_human_active", new=AsyncMock(return_value=False)
+        ), patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_result) as mock_tt:
+            result = await vnc_mcp_module.desktop_mouse_click_mcp(request_mock)
+
+        assert result["success"] is True
+        mock_tt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_control_status_reports_human_owner(self, vnc_mcp_module):
+        request_mock = MagicMock()
+        request_mock.session_id = "default"
+        fake_state = {
+            "session_id": "default",
+            "human_active": True,
+            "owner": "alice",
+            "acquired_at": "2026-07-22T00:00:00+00:00",
+            "redis_available": True,
+        }
+
+        with patch.object(
+            vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)
+        ):
+            result = await vnc_mcp_module.desktop_control_status_mcp(request_mock)
+
+        assert result["success"] is True
+        assert result["human_active"] is True
+        assert result["owner"] == "alice"
+        assert "alice" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_control_status_reports_agent_control(self, vnc_mcp_module):
+        request_mock = MagicMock()
+        request_mock.session_id = "default"
+        fake_state = {
+            "session_id": "default",
+            "human_active": False,
+            "owner": None,
+            "acquired_at": None,
+            "redis_available": True,
+        }
+
+        with patch.object(
+            vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)
+        ):
+            result = await vnc_mcp_module.desktop_control_status_mcp(request_mock)
+
+        assert result["success"] is True
+        assert result["human_active"] is False
+        assert result["owner"] is None
+
+    @pytest.mark.asyncio
+    async def test_observe_state_includes_lock_state(self, vnc_mcp_module):
+        request_mock = MagicMock()
+        request_mock.include_screenshot = False
+        fake_state = {
+            "session_id": "default",
+            "human_active": True,
+            "owner": "bob",
+            "acquired_at": "2026-07-22T00:00:00+00:00",
+            "redis_available": True,
+        }
+        fake_ok = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="dimensions:  1920x1080 pixels\n", stderr=""
+        )
+
+        with patch.object(
+            vnc_mcp_module, "get_control_lock_state", new=AsyncMock(return_value=fake_state)
+        ), patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_ok):
+            result = await vnc_mcp_module.desktop_observe_state_mcp(request_mock)
+
+        assert result["human_active"] is True
+        assert result["control_owner"] == "bob"

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -73,6 +73,19 @@
       <div class="connection-status">
         <span :class="connectionStatusClass">{{ connectionStatusDisplay }}</span>
       </div>
+      <!-- Desktop control-lock toggle (Issue #12002, #11506 T1) -->
+      <div class="control-lock" :class="{ 'control-lock-mine': isMine }">
+        <button
+          v-if="!humanActive || isMine"
+          @click="handleControlLockToggle"
+          class="control-btn"
+          :disabled="controlLockLoading"
+        >
+          <span v-if="isMine">{{ $t('desktop.controlLock.releaseControl') }}</span>
+          <span v-else>{{ $t('desktop.controlLock.takeControl') }}</span>
+        </button>
+        <span class="control-lock-owner">{{ controlLockLabel }}</span>
+      </div>
     </div>
 
     <!-- Context Panel (collapsible right-side) -->
@@ -199,6 +212,7 @@ import DesktopContextPanel from '@/components/desktop/DesktopContextPanel.vue'
 import { useLoadingState } from '@/composables/useLoadingState'
 import { useVncControls } from '@/composables/useVncControls'
 import { usePollingJob } from '@/composables/usePollingJob'
+import { useDesktopControlLock } from '@/composables/useDesktopControlLock'
 import { createLogger } from '@/utils/debugUtils'
 import type { SelectorHost } from '@/composables/useHostSelector'
 
@@ -222,6 +236,35 @@ const errorCheck = ref<Error | null>(null)
 // VNC controls (Issue #74)
 const vncControls = useVncControls()
 const showContextPanel = ref(false)
+
+// Desktop control-lock (Issue #12002, #11506 T1)
+const {
+  owner: controlLockOwner,
+  humanActive,
+  isMine,
+  loading: controlLockLoading,
+  refreshStatus: refreshControlLockStatus,
+  takeControl,
+  releaseControl
+} = useDesktopControlLock()
+
+const controlLockLabel = computed(() => {
+  if (!humanActive.value) return t('desktop.controlLock.agentHasControl')
+  if (isMine.value) return t('desktop.controlLock.youHaveControl')
+  if (controlLockOwner.value) return t('desktop.controlLock.userHasControl', { user: controlLockOwner.value })
+  return t('desktop.controlLock.unknown')
+})
+
+async function handleControlLockToggle(): Promise<void> {
+  const wasMine = isMine.value
+  const result = wasMine ? await releaseControl() : await takeControl()
+  if (result && !result.success) {
+    error.value = wasMine
+      ? t('desktop.controlLock.releaseFailed', { error: result.message })
+      : t('desktop.controlLock.acquireFailed', { error: result.message })
+  }
+}
+
 const showScreenshotModal = ref(false)
 const screenshotData = ref<string | null>(null)
 const textToType = ref('')
@@ -451,6 +494,9 @@ onMounted(async () => {
 
   // Listen for fullscreen changes
   document.addEventListener('fullscreenchange', handleFullscreenChange)
+
+  // Desktop control-lock: surface current owner immediately (Issue #12002)
+  await refreshControlLockStatus()
 })
 
 // Define fullscreen handler function for proper cleanup
@@ -581,6 +627,23 @@ onUnmounted(() => {
 
 .connection-status {
   font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+/* Desktop control-lock toggle (Issue #12002, #11506 T1) */
+.control-lock {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.control-lock-owner {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.control-lock-mine .control-lock-owner {
+  color: var(--color-warning);
   font-weight: 500;
 }
 

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -233,8 +233,16 @@ const { wrap: wrapCheckConnection } = useLoadingState()
 const errorVnc = ref<Error | null>(null)
 const errorCheck = ref<Error | null>(null)
 
+// Issue #12002 (#11506 T1): DesktopInterface has no real per-session context
+// of its own (single canonical shared desktop -- no chat session/route param
+// here to mirror #11539/#11579's session_id threading against). "default" is
+// the SAME literal both composables already defaulted to independently;
+// naming it here ties them together explicitly instead of relying on two
+// separate defaults coincidentally matching.
+const DESKTOP_CONTROL_SESSION_ID = 'default'
+
 // VNC controls (Issue #74)
-const vncControls = useVncControls()
+const vncControls = useVncControls(DESKTOP_CONTROL_SESSION_ID)
 const showContextPanel = ref(false)
 
 // Desktop control-lock (Issue #12002, #11506 T1)
@@ -246,7 +254,7 @@ const {
   refreshStatus: refreshControlLockStatus,
   takeControl,
   releaseControl
-} = useDesktopControlLock()
+} = useDesktopControlLock('desktop', DESKTOP_CONTROL_SESSION_ID)
 
 const controlLockLabel = computed(() => {
   if (!humanActive.value) return t('desktop.controlLock.agentHasControl')

--- a/autobot-frontend/src/composables/__tests__/useDesktopControlLock.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useDesktopControlLock.test.ts
@@ -1,0 +1,162 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Unit tests for useDesktopControlLock (#12002, #11506 T1).
+ *
+ * Covers: acquire (takeControl) / release call the correct endpoints,
+ * isMine reflects the current user vs. lock owner, refreshStatus updates
+ * state, and failures surface via the `error` ref without throwing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { effectScope } from 'vue'
+
+const mockGet = vi.fn(async (..._args: unknown[]) => ({}))
+const mockPost = vi.fn(async (..._args: unknown[]) => ({}))
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args)
+  }
+}))
+
+import { useDesktopControlLock } from '../useDesktopControlLock'
+import { useUserStore } from '@/stores/useUserStore'
+
+function fakeState(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    success: true,
+    session_id: 'default',
+    owner: null,
+    human_active: false,
+    message: 'Agent has control',
+    ...overrides
+  }
+}
+
+describe('useDesktopControlLock', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+    mockPost.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts with no owner and human_active false', () => {
+    const { owner, humanActive, isMine } = useDesktopControlLock()
+    expect(owner.value).toBeNull()
+    expect(humanActive.value).toBe(false)
+    expect(isMine.value).toBe(false)
+  })
+
+  it('refreshStatus populates owner/humanActive from GET /control/status', async () => {
+    mockGet.mockResolvedValueOnce(fakeState({ owner: 'alice', human_active: true }))
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { owner, humanActive, refreshStatus } = useDesktopControlLock('desktop', 'default')
+      await refreshStatus()
+      expect(owner.value).toBe('alice')
+      expect(humanActive.value).toBe(true)
+    })
+    scope.stop()
+
+    expect(mockGet).toHaveBeenCalledWith('/vnc-proxy/desktop/control/status?session_id=default')
+  })
+
+  it('takeControl calls POST /control/acquire and sets isMine when owner matches current user', async () => {
+    const userStore = useUserStore()
+    userStore.currentUser = {
+      id: 'u1',
+      username: 'alice',
+      displayName: 'Alice',
+      role: 'user',
+      preferences: userStore.currentUser?.preferences as never,
+      createdAt: new Date()
+    } as never
+
+    mockPost.mockResolvedValueOnce(fakeState({ owner: 'alice', human_active: true }))
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { takeControl, isMine, humanActive } = useDesktopControlLock('desktop', 'default')
+      const result = await takeControl()
+
+      expect(result?.success).toBe(true)
+      expect(humanActive.value).toBe(true)
+      expect(isMine.value).toBe(true)
+    })
+    scope.stop()
+
+    expect(mockPost).toHaveBeenCalledWith('/vnc-proxy/desktop/control/acquire', { session_id: 'default' })
+  })
+
+  it('isMine is false when a different user holds the lock', async () => {
+    const userStore = useUserStore()
+    userStore.currentUser = { id: 'u1', username: 'alice' } as never
+
+    mockPost.mockResolvedValueOnce(fakeState({ owner: 'bob', human_active: true }))
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { takeControl, isMine } = useDesktopControlLock('desktop', 'default')
+      await takeControl()
+      expect(isMine.value).toBe(false)
+    })
+    scope.stop()
+  })
+
+  it('releaseControl calls POST /control/release and clears owner', async () => {
+    mockPost.mockResolvedValueOnce(fakeState())
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { releaseControl, owner, humanActive } = useDesktopControlLock('desktop', 'default')
+      const result = await releaseControl()
+
+      expect(result?.success).toBe(true)
+      expect(owner.value).toBeNull()
+      expect(humanActive.value).toBe(false)
+    })
+    scope.stop()
+
+    expect(mockPost).toHaveBeenCalledWith('/vnc-proxy/desktop/control/release', { session_id: 'default' })
+  })
+
+  it('surfaces a denied release without throwing', async () => {
+    mockPost.mockResolvedValueOnce(
+      fakeState({ success: false, owner: 'alice', human_active: true, message: 'Control lock is held by another user' })
+    )
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { releaseControl, error } = useDesktopControlLock('desktop', 'default')
+      const result = await releaseControl()
+
+      expect(result?.success).toBe(false)
+      expect(error.value).toContain('held by another user')
+    })
+    scope.stop()
+  })
+
+  it('acquire failure (e.g. network error) sets error and does not throw', async () => {
+    mockPost.mockRejectedValueOnce(new Error('network down'))
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { takeControl, error } = useDesktopControlLock('desktop', 'default')
+      const result = await takeControl()
+
+      expect(result).toBeNull()
+      expect(error.value).toBe('network down')
+    })
+    scope.stop()
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useDesktopControlLock.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useDesktopControlLock.test.ts
@@ -159,4 +159,118 @@ describe('useDesktopControlLock', () => {
     })
     scope.stop()
   })
+
+  describe('heartbeat (#12002 review fixes)', () => {
+    // Mirrors the composable's private HEARTBEAT_INTERVAL_MS.
+    const HEARTBEAT_INTERVAL_MS = 30000
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('refreshStatus resumes the heartbeat when we already own the lock (remount)', async () => {
+      const userStore = useUserStore()
+      userStore.currentUser = { id: 'u1', username: 'alice' } as never
+
+      mockGet.mockResolvedValueOnce(fakeState({ owner: 'alice', human_active: true }))
+      mockPost.mockResolvedValue(fakeState({ owner: 'alice', human_active: true }))
+
+      const scope = effectScope()
+      await scope.run(async () => {
+        const { refreshStatus } = useDesktopControlLock('desktop', 'default')
+        await refreshStatus()
+
+        expect(mockPost).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+
+        expect(mockPost).toHaveBeenCalledWith('/vnc-proxy/desktop/control/acquire', { session_id: 'default' })
+      })
+      scope.stop()
+    })
+
+    it('refreshStatus does NOT start a heartbeat when a different user holds the lock', async () => {
+      const userStore = useUserStore()
+      userStore.currentUser = { id: 'u1', username: 'alice' } as never
+
+      mockGet.mockResolvedValueOnce(fakeState({ owner: 'bob', human_active: true }))
+
+      const scope = effectScope()
+      await scope.run(async () => {
+        const { refreshStatus } = useDesktopControlLock('desktop', 'default')
+        await refreshStatus()
+
+        await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS * 2)
+        expect(mockPost).not.toHaveBeenCalled()
+      })
+      scope.stop()
+    })
+
+    it('silent heartbeat re-acquire never toggles loading (no button flicker/disable)', async () => {
+      const userStore = useUserStore()
+      userStore.currentUser = { id: 'u1', username: 'alice' } as never
+
+      mockGet.mockResolvedValueOnce(fakeState({ owner: 'alice', human_active: true }))
+
+      let resolveHeartbeatPost: (value: unknown) => void = () => {}
+      mockPost.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveHeartbeatPost = resolve
+          })
+      )
+
+      const scope = effectScope()
+      await scope.run(async () => {
+        const { refreshStatus, loading } = useDesktopControlLock('desktop', 'default')
+        await refreshStatus()
+
+        await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS)
+        // Heartbeat POST is now in-flight (pending promise) -- loading must
+        // stay false throughout (#12002 review nit).
+        expect(loading.value).toBe(false)
+
+        resolveHeartbeatPost(fakeState({ owner: 'alice', human_active: true }))
+        await vi.advanceTimersByTimeAsync(0)
+        expect(loading.value).toBe(false)
+      })
+      scope.stop()
+    })
+
+    it('scope disposal stops the resumed heartbeat', async () => {
+      const userStore = useUserStore()
+      userStore.currentUser = { id: 'u1', username: 'alice' } as never
+
+      mockGet.mockResolvedValueOnce(fakeState({ owner: 'alice', human_active: true }))
+      mockPost.mockResolvedValue(fakeState({ owner: 'alice', human_active: true }))
+
+      const scope = effectScope()
+      await scope.run(async () => {
+        const { refreshStatus } = useDesktopControlLock('desktop', 'default')
+        await refreshStatus()
+      })
+      scope.stop()
+
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS * 3)
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+
+    it('takeControl still uses a non-silent acquire (loading toggles for the explicit user action)', async () => {
+      mockPost.mockResolvedValueOnce(fakeState({ owner: 'alice', human_active: true }))
+
+      const scope = effectScope()
+      await scope.run(async () => {
+        const { takeControl, loading } = useDesktopControlLock('desktop', 'default')
+        const promise = takeControl()
+        expect(loading.value).toBe(true)
+        await promise
+        expect(loading.value).toBe(false)
+      })
+      scope.stop()
+    })
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useVncControls.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVncControls.test.ts
@@ -1,0 +1,57 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Unit tests for useVncControls session_id threading (#12002 review fix).
+ *
+ * The backend gates /vnc/click|type|key|scroll|drag on the desktop
+ * control-lock by session_id (owner-aware). This composable must actually
+ * send session_id in the request body rather than silently relying on the
+ * backend schema's own "default" fallback.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockPost = vi.fn(async (..._args: unknown[]) => ({ status: 'success', message: 'ok' }))
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    post: (...args: unknown[]) => mockPost(...args),
+    get: vi.fn(async () => ({ status: 'success', message: 'ok', image_data: '' }))
+  }
+}))
+
+import { useVncControls } from '../useVncControls'
+
+describe('useVncControls session_id threading', () => {
+  beforeEach(() => {
+    mockPost.mockClear()
+  })
+
+  it('defaults session_id to "default" when none is provided', async () => {
+    const { mouseClick } = useVncControls()
+    await mouseClick({ x: 1, y: 2 })
+
+    expect(mockPost).toHaveBeenCalledWith('/vnc/click', { x: 1, y: 2, session_id: 'default' })
+  })
+
+  it('threads an explicit session_id through mouseClick/keyboardType/specialKey/scroll/drag', async () => {
+    const { mouseClick, keyboardType, specialKey, mouseScroll, mouseDrag } = useVncControls('chat-42')
+
+    await mouseClick({ x: 1, y: 2 })
+    expect(mockPost).toHaveBeenLastCalledWith('/vnc/click', { x: 1, y: 2, session_id: 'chat-42' })
+
+    await keyboardType('hello')
+    expect(mockPost).toHaveBeenLastCalledWith('/vnc/type', { text: 'hello', session_id: 'chat-42' })
+
+    await specialKey('Return')
+    expect(mockPost).toHaveBeenLastCalledWith('/vnc/key', { key: 'Return', session_id: 'chat-42' })
+
+    await mouseScroll({ direction: 'up' })
+    expect(mockPost).toHaveBeenLastCalledWith('/vnc/scroll', { direction: 'up', session_id: 'chat-42' })
+
+    await mouseDrag({ x1: 0, y1: 0, x2: 5, y2: 5 })
+    expect(mockPost).toHaveBeenLastCalledWith('/vnc/drag', { x1: 0, y1: 0, x2: 5, y2: 5, session_id: 'chat-42' })
+  })
+})

--- a/autobot-frontend/src/composables/useDesktopControlLock.ts
+++ b/autobot-frontend/src/composables/useDesktopControlLock.ts
@@ -59,21 +59,6 @@ export function useDesktopControlLock(vncType: string = 'desktop', sessionId: st
 
   const basePath = `/vnc-proxy/${vncType}/control`
 
-  async function refreshStatus(): Promise<DesktopControlLockState | null> {
-    try {
-      const result = await ApiClient.get<DesktopControlLockState>(
-        `${basePath}/status?session_id=${encodeURIComponent(sessionId)}`
-      )
-      owner.value = result.owner
-      humanActive.value = result.human_active
-      return result
-    } catch (err: unknown) {
-      logger.error('Failed to fetch control-lock status:', err)
-      error.value = extractErrorMessage(err, 'Failed to fetch control status')
-      return null
-    }
-  }
-
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 
   function stopHeartbeat(): void {
@@ -86,9 +71,12 @@ export function useDesktopControlLock(vncType: string = 'desktop', sessionId: st
   function startHeartbeat(): void {
     stopHeartbeat()
     // Periodic re-acquire refreshes the Redis TTL; does NOT fire immediately
-    // (the caller just acquired), only on subsequent ticks.
+    // (the caller just acquired/confirmed ownership), only on subsequent
+    // ticks. `silent: true` so this background refresh never toggles
+    // `loading` (would otherwise flicker/disable the Take/Release button
+    // every 30s -- #12002 review nit).
     heartbeatTimer = setInterval(() => {
-      void acquire()
+      void acquire({ silent: true })
     }, HEARTBEAT_INTERVAL_MS)
   }
 
@@ -98,9 +86,35 @@ export function useDesktopControlLock(vncType: string = 'desktop', sessionId: st
     onScopeDispose(stopHeartbeat)
   }
 
-  async function acquire(): Promise<DesktopControlLockState | null> {
+  async function refreshStatus(): Promise<DesktopControlLockState | null> {
+    try {
+      const result = await ApiClient.get<DesktopControlLockState>(
+        `${basePath}/status?session_id=${encodeURIComponent(sessionId)}`
+      )
+      owner.value = result.owner
+      humanActive.value = result.human_active
+      // Resume the heartbeat if we discover (e.g. after a page reload/remount)
+      // that we already hold the lock -- otherwise its idle-TTL silently
+      // expires while the UI still shows "You have control" (#12002 review fix).
+      if (result.human_active && result.owner === userStore.currentUser?.username) {
+        startHeartbeat()
+      } else {
+        stopHeartbeat()
+      }
+      return result
+    } catch (err: unknown) {
+      logger.error('Failed to fetch control-lock status:', err)
+      error.value = extractErrorMessage(err, 'Failed to fetch control status')
+      return null
+    }
+  }
+
+  async function acquire(options: { silent?: boolean } = {}): Promise<DesktopControlLockState | null> {
+    const { silent = false } = options
     error.value = null
-    loading.value = true
+    if (!silent) {
+      loading.value = true
+    }
     try {
       const result = await ApiClient.post<DesktopControlLockState>(`${basePath}/acquire`, {
         session_id: sessionId
@@ -112,11 +126,17 @@ export function useDesktopControlLock(vncType: string = 'desktop', sessionId: st
       }
       return result
     } catch (err: unknown) {
-      logger.error('Failed to acquire desktop control:', err)
+      if (silent) {
+        logger.warn('Silent heartbeat re-acquire failed:', err)
+      } else {
+        logger.error('Failed to acquire desktop control:', err)
+      }
       error.value = extractErrorMessage(err, 'Failed to take control')
       return null
     } finally {
-      loading.value = false
+      if (!silent) {
+        loading.value = false
+      }
     }
   }
 

--- a/autobot-frontend/src/composables/useDesktopControlLock.ts
+++ b/autobot-frontend/src/composables/useDesktopControlLock.ts
@@ -1,0 +1,164 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Desktop control-lock composable (Issue #12002, #11506 T1).
+ *
+ * Wraps the /vnc-proxy/{vncType}/control/{acquire,release,status} endpoints
+ * so a human can explicitly take over (and hand back) input control of the
+ * agent-driven desktop session, muting agent actuation while held.
+ *
+ * The lock has a server-side idle-TTL (AUTOBOT_DESKTOP_CONTROL_LOCK_TTL_SECONDS,
+ * default 120s) -- while `humanActive` is true and owned by the current user,
+ * this composable sends a periodic re-acquire "heartbeat" to keep the lock
+ * alive, so navigating away/closing the tab lets it expire naturally rather
+ * than muting the agent forever.
+ */
+
+import { computed, getCurrentScope, onScopeDispose, ref } from 'vue'
+import ApiClient from '@/utils/ApiClient'
+import { createLogger } from '@/utils/debugUtils'
+import { useUserStore } from '@/stores/useUserStore'
+
+const logger = createLogger('useDesktopControlLock')
+
+// Heartbeat cadence for the frontend re-acquire poll -- a UI polling
+// interval (like the 10s connection-status poll in DesktopInterface.vue),
+// not a backend cache/TTL value, so it is a local constant rather than an
+// env-driven one. Kept comfortably below the backend's default idle-TTL.
+const HEARTBEAT_INTERVAL_MS = 30000
+
+export interface DesktopControlLockState {
+  success: boolean
+  session_id: string
+  owner: string | null
+  human_active: boolean
+  message: string
+}
+
+function extractErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  return fallback
+}
+
+export function useDesktopControlLock(vncType: string = 'desktop', sessionId: string = 'default') {
+  const userStore = useUserStore()
+
+  const owner = ref<string | null>(null)
+  const humanActive = ref(false)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const isMine = computed(() => {
+    const username = userStore.currentUser?.username
+    return humanActive.value && !!username && owner.value === username
+  })
+
+  const basePath = `/vnc-proxy/${vncType}/control`
+
+  async function refreshStatus(): Promise<DesktopControlLockState | null> {
+    try {
+      const result = await ApiClient.get<DesktopControlLockState>(
+        `${basePath}/status?session_id=${encodeURIComponent(sessionId)}`
+      )
+      owner.value = result.owner
+      humanActive.value = result.human_active
+      return result
+    } catch (err: unknown) {
+      logger.error('Failed to fetch control-lock status:', err)
+      error.value = extractErrorMessage(err, 'Failed to fetch control status')
+      return null
+    }
+  }
+
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+
+  function stopHeartbeat(): void {
+    if (heartbeatTimer !== null) {
+      clearInterval(heartbeatTimer)
+      heartbeatTimer = null
+    }
+  }
+
+  function startHeartbeat(): void {
+    stopHeartbeat()
+    // Periodic re-acquire refreshes the Redis TTL; does NOT fire immediately
+    // (the caller just acquired), only on subsequent ticks.
+    heartbeatTimer = setInterval(() => {
+      void acquire()
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  // Auto-cleanup when the owning component/effect scope disposes, mirroring
+  // usePollingJob's guard (no-op outside an active effect scope).
+  if (getCurrentScope()) {
+    onScopeDispose(stopHeartbeat)
+  }
+
+  async function acquire(): Promise<DesktopControlLockState | null> {
+    error.value = null
+    loading.value = true
+    try {
+      const result = await ApiClient.post<DesktopControlLockState>(`${basePath}/acquire`, {
+        session_id: sessionId
+      })
+      owner.value = result.owner
+      humanActive.value = result.human_active
+      if (!result.success) {
+        error.value = result.message
+      }
+      return result
+    } catch (err: unknown) {
+      logger.error('Failed to acquire desktop control:', err)
+      error.value = extractErrorMessage(err, 'Failed to take control')
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function takeControl(): Promise<DesktopControlLockState | null> {
+    const result = await acquire()
+    if (result?.success) {
+      startHeartbeat()
+    }
+    return result
+  }
+
+  async function releaseControl(): Promise<DesktopControlLockState | null> {
+    error.value = null
+    loading.value = true
+    stopHeartbeat()
+    try {
+      const result = await ApiClient.post<DesktopControlLockState>(`${basePath}/release`, {
+        session_id: sessionId
+      })
+      owner.value = result.owner
+      humanActive.value = result.human_active
+      if (!result.success) {
+        error.value = result.message
+      }
+      return result
+    } catch (err: unknown) {
+      logger.error('Failed to release desktop control:', err)
+      error.value = extractErrorMessage(err, 'Failed to release control')
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    owner,
+    humanActive,
+    isMine,
+    loading,
+    error,
+    refreshStatus,
+    takeControl,
+    releaseControl
+  }
+}

--- a/autobot-frontend/src/composables/useVncControls.ts
+++ b/autobot-frontend/src/composables/useVncControls.ts
@@ -6,6 +6,14 @@
 /**
  * VNC Desktop Interaction Controls Composable
  * Issue #74: Full desktop control and session integration
+ *
+ * Issue #12002 (#11506 T1): the backend's desktop control-lock gates these
+ * calls by session_id (owner-aware -- the lock owner's own toolbar keeps
+ * working; a different human is muted). DesktopInterface.vue has no real
+ * per-session context of its own (single canonical shared desktop, no chat
+ * session/route param) -- `sessionId` defaults to "default" to explicitly
+ * match useDesktopControlLock's default rather than relying on both sides
+ * coincidentally matching the backend schema's own default.
  */
 
 import { ref } from 'vue'
@@ -45,14 +53,14 @@ function extractErrorMessage(err: unknown, fallback: string): string {
   return fallback
 }
 
-export function useVncControls() {
+export function useVncControls(sessionId: string = 'default') {
   const { isLoading: loading, wrap } = useLoadingState()
   const error = ref<string | null>(null)
 
   async function mouseClick(params: MouseClickParams): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/click', params))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/click', { ...params, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Mouse click failed:', err)
       error.value = extractErrorMessage(err, 'Mouse click failed')
@@ -63,7 +71,7 @@ export function useVncControls() {
   async function keyboardType(text: string): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/type', { text }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/type', { text, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Keyboard type failed:', err)
       error.value = extractErrorMessage(err, 'Keyboard type failed')
@@ -74,7 +82,7 @@ export function useVncControls() {
   async function specialKey(key: string): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/key', { key }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/key', { key, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Special key failed:', err)
       error.value = extractErrorMessage(err, 'Special key failed')
@@ -85,7 +93,7 @@ export function useVncControls() {
   async function mouseScroll(params: MouseScrollParams): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/scroll', params))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/scroll', { ...params, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Mouse scroll failed:', err)
       error.value = extractErrorMessage(err, 'Mouse scroll failed')
@@ -96,7 +104,7 @@ export function useVncControls() {
   async function mouseDrag(params: MouseDragParams): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/drag', params))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/drag', { ...params, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Mouse drag failed:', err)
       error.value = extractErrorMessage(err, 'Mouse drag failed')

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7528,6 +7528,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7528,6 +7528,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7577,6 +7577,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7528,6 +7528,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -4332,6 +4332,17 @@
       "presetHigh": "High",
       "presetMediumDesc": "Balanced quality and performance",
       "delay": "Delay:"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "redis": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7528,6 +7528,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -4332,6 +4332,17 @@
       "presetHigh": "High",
       "presetMediumDesc": "Balanced quality and performance",
       "delay": "Delay:"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "redis": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7528,6 +7528,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7528,6 +7528,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7528,6 +7528,17 @@
       "templates": "Scrape Templates",
       "exitRegionMode": "Exit region mode",
       "markRegions": "Mark regions"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -4332,6 +4332,17 @@
       "presetHigh": "High",
       "presetMediumDesc": "Balanced quality and performance",
       "delay": "Delay:"
+    },
+    "controlLock": {
+      "title": "Desktop Control",
+      "takeControl": "Take Control",
+      "releaseControl": "Release Control",
+      "youHaveControl": "You have control",
+      "agentHasControl": "Agent has control",
+      "userHasControl": "{user} has control",
+      "unknown": "Control status unknown",
+      "acquireFailed": "Failed to take control: {error}",
+      "releaseFailed": "Failed to release control: {error}"
     }
   },
   "redis": {

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -11787,12 +11787,14 @@ export interface paths {
          * Vnc Mouse Click
          * @description Perform mouse click at specified coordinates with human-like behavior.
          *     Issue #74: Desktop interaction controls + Area 5 (humanization).
+         *     Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+         *     control-lock -- the lock owner's own toolbar keeps working.
          *
          *     Args:
          *         request: MouseClickRequest with x, y coordinates and button type
          *
          *     Returns:
-         *         {"status": "success|error", "message": "..."}
+         *         {"status": "success|error|muted", "message": "..."}
          */
         post: operations["vnc_mouse_click_api_vnc_click_post"];
         delete?: never;
@@ -11814,12 +11816,14 @@ export interface paths {
          * Vnc Keyboard Type
          * @description Type text via keyboard with human-like speed and pauses.
          *     Issue #74: Desktop interaction controls + Area 5 (humanization).
+         *     Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+         *     control-lock -- the lock owner's own toolbar keeps working.
          *
          *     Args:
          *         request: KeyboardTypeRequest with text to type
          *
          *     Returns:
-         *         {"status": "success|error", "message": "..."}
+         *         {"status": "success|error|muted", "message": "..."}
          */
         post: operations["vnc_keyboard_type_api_vnc_type_post"];
         delete?: never;
@@ -11841,12 +11845,14 @@ export interface paths {
          * Vnc Special Key
          * @description Send special key or key combination.
          *     Issue #74: Desktop interaction controls.
+         *     Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+         *     control-lock -- the lock owner's own toolbar keeps working.
          *
          *     Args:
          *         request: SpecialKeyRequest with key name (e.g., "Return", "ctrl+c")
          *
          *     Returns:
-         *         {"status": "success|error", "message": "..."}
+         *         {"status": "success|error|muted", "message": "..."}
          */
         post: operations["vnc_special_key_api_vnc_key_post"];
         delete?: never;
@@ -11868,12 +11874,14 @@ export interface paths {
          * Vnc Mouse Scroll
          * @description Scroll mouse wheel.
          *     Issue #74: Desktop interaction controls.
+         *     Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+         *     control-lock -- the lock owner's own toolbar keeps working.
          *
          *     Args:
          *         request: MouseScrollRequest with direction and amount
          *
          *     Returns:
-         *         {"status": "success|error", "message": "..."}
+         *         {"status": "success|error|muted", "message": "..."}
          */
         post: operations["vnc_mouse_scroll_api_vnc_scroll_post"];
         delete?: never;
@@ -11895,12 +11903,14 @@ export interface paths {
          * Vnc Mouse Drag
          * @description Perform mouse drag operation with curved, human-like movement.
          *     Issue #74: Desktop interaction controls + Area 5 (humanization).
+         *     Issue #12002 (#11506 T1): muted while a DIFFERENT human holds the
+         *     control-lock -- the lock owner's own toolbar keeps working.
          *
          *     Args:
          *         request: MouseDragRequest with start and end coordinates
          *
          *     Returns:
-         *         {"status": "success|error", "message": "..."}
+         *         {"status": "success|error|muted", "message": "..."}
          */
         post: operations["vnc_mouse_drag_api_vnc_drag_post"];
         delete?: never;
@@ -12510,6 +12520,71 @@ export interface paths {
          *         {"status": "success", "message": "..."}
          */
         delete: operations["clear_session_state_api_vnc_session_clear_state_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/vnc-proxy/{vnc_type}/control/acquire": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Acquire Desktop Control
+         * @description Human takeover: acquire the desktop control-lock (#12002, #11506 T1).
+         *
+         *     Muting the agent's actuation calls (api.vnc_manager / api.vnc_mcp) until
+         *     this is released or its idle-TTL expires.
+         */
+        post: operations["acquire_desktop_control_api_vnc_proxy__vnc_type__control_acquire_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/vnc-proxy/{vnc_type}/control/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Release Desktop Control
+         * @description Human handback: release the desktop control-lock (#12002, #11506 T1).
+         *
+         *     The agent resumes actuation immediately once released.
+         */
+        post: operations["release_desktop_control_api_vnc_proxy__vnc_type__control_release_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/vnc-proxy/{vnc_type}/control/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Desktop Control Status
+         * @description Get current desktop control-lock owner/state (#12002, #11506 T1).
+         */
+        get: operations["get_desktop_control_status_api_vnc_proxy__vnc_type__control_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -13204,6 +13279,7 @@ export interface paths {
          * Desktop Mouse Click Mcp
          * @description MCP tool: Click mouse at coordinates on desktop.
          *     Issue #74: Agent desktop interaction.
+         *     Issue #12002 (#11506 T1): muted while a human holds the control-lock.
          */
         post: operations["desktop_mouse_click_mcp_api_vnc_mcp_desktop_mouse_click_post"];
         delete?: never;
@@ -13225,6 +13301,7 @@ export interface paths {
          * Desktop Keyboard Type Mcp
          * @description MCP tool: Type text on desktop keyboard.
          *     Issue #74: Agent desktop interaction.
+         *     Issue #12002 (#11506 T1): muted while a human holds the control-lock.
          */
         post: operations["desktop_keyboard_type_mcp_api_vnc_mcp_desktop_keyboard_type_post"];
         delete?: never;
@@ -13246,6 +13323,7 @@ export interface paths {
          * Desktop Special Key Mcp
          * @description MCP tool: Send special key or key combination.
          *     Issue #74: Agent desktop interaction.
+         *     Issue #12002 (#11506 T1): muted while a human holds the control-lock.
          */
         post: operations["desktop_special_key_mcp_api_vnc_mcp_desktop_special_key_post"];
         delete?: never;
@@ -13288,8 +13366,35 @@ export interface paths {
          * Desktop Observe State Mcp
          * @description MCP tool: Observe current desktop state with metadata.
          *     Issue #74: Agent desktop observation.
+         *     Issue #12002 (#11506 T1): includes control-lock state so the agent knows
+         *     to pause actuation when a human is active.
          */
         post: operations["desktop_observe_state_mcp_api_vnc_mcp_desktop_observe_state_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/vnc/mcp/desktop_control_status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Desktop Control Status Mcp
+         * @description MCP tool: Check whether a human currently holds the desktop control-lock.
+         *
+         *     Issue #12002 (#11506 T1): agents should call this (or read human_active
+         *     from desktop_observe_state) before actuation and pause while a human is
+         *     active -- desktop_mouse_click/keyboard_type/special_key are muted
+         *     automatically, but polling this lets the agent avoid wasted calls.
+         */
+        post: operations["desktop_control_status_mcp_api_vnc_mcp_desktop_control_status_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -69260,6 +69365,85 @@ export interface components {
             };
             /** Button */
             button: string;
+            /**
+             * Muted
+             * @default false
+             */
+            muted: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * DesktopControlAcquireRequest
+         * @description Request for POST /vnc-proxy/{vnc_type}/control/acquire (#12002).
+         */
+        DesktopControlAcquireRequest: {
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * DesktopControlLockResponse
+         * @description Response for the desktop control-lock acquire/release/status endpoints (#12002).
+         */
+        DesktopControlLockResponse: {
+            /** Success */
+            success: boolean;
+            /** Session Id */
+            session_id: string;
+            /** Owner */
+            owner?: string | null;
+            /** Human Active */
+            human_active: boolean;
+            /** Message */
+            message: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * DesktopControlReleaseRequest
+         * @description Request for POST /vnc-proxy/{vnc_type}/control/release (#12002).
+         */
+        DesktopControlReleaseRequest: {
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** DesktopControlStatusMcpResponse */
+        DesktopControlStatusMcpResponse: {
+            /** Success */
+            success: boolean;
+            /** Session Id */
+            session_id: string;
+            /** Human Active */
+            human_active: boolean;
+            /** Owner */
+            owner?: string | null;
+            /** Acquired At */
+            acquired_at?: string | null;
+            /** Message */
+            message: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** DesktopControlStatusRequest */
+        DesktopControlStatusRequest: {
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -69273,6 +69457,11 @@ export interface components {
             action: string;
             /** Text Length */
             text_length: number;
+            /**
+             * Muted
+             * @default false
+             */
+            muted: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -69280,6 +69469,12 @@ export interface components {
         DesktopKeyboardTypeRequest: {
             /** Text */
             text: string;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -69294,6 +69489,12 @@ export interface components {
              * @default left
              */
             button: string;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -69313,6 +69514,13 @@ export interface components {
             screenshot?: string | null;
             /** Screenshot Format */
             screenshot_format?: string | null;
+            /**
+             * Human Active
+             * @default false
+             */
+            human_active: boolean;
+            /** Control Owner */
+            control_owner?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -69351,6 +69559,11 @@ export interface components {
             action: string;
             /** Key */
             key: string;
+            /**
+             * Muted
+             * @default false
+             */
+            muted: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -69358,6 +69571,12 @@ export interface components {
         DesktopSpecialKeyRequest: {
             /** Key */
             key: string;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -75890,6 +76109,12 @@ export interface components {
              * @description Text to type
              */
             text: string;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -82293,6 +82518,12 @@ export interface components {
              * @default left
              */
             button: string;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -82318,6 +82549,12 @@ export interface components {
              * @description End Y coordinate
              */
             y2: number;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -82334,6 +82571,12 @@ export interface components {
              * @default 3
              */
             amount: number;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -92865,6 +93108,12 @@ export interface components {
              * @description Special key name (e.g., Return, Escape, ctrl+c)
              */
             key: string;
+            /**
+             * Session Id
+             * @description Desktop control-lock session id
+             * @default default
+             */
+            session_id: string;
         } & {
             [key: string]: unknown;
         };
@@ -98507,6 +98756,11 @@ export interface components {
             status: string;
             /** Message */
             message: string;
+            /**
+             * Muted
+             * @default false
+             */
+            muted: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -117413,6 +117667,109 @@ export interface operations {
             };
         };
     };
+    acquire_desktop_control_api_vnc_proxy__vnc_type__control_acquire_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                vnc_type: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DesktopControlAcquireRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DesktopControlLockResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    release_desktop_control_api_vnc_proxy__vnc_type__control_release_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                vnc_type: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DesktopControlReleaseRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DesktopControlLockResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_desktop_control_status_api_vnc_proxy__vnc_type__control_status_get: {
+        parameters: {
+            query?: {
+                session_id?: string;
+            };
+            header?: never;
+            path: {
+                vnc_type: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DesktopControlLockResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_vnc_client_api_vnc_proxy__vnc_type__vnc_html_get: {
         parameters: {
             query?: never;
@@ -118408,6 +118765,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DesktopObserveStateMcpResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    desktop_control_status_mcp_api_vnc_mcp_desktop_control_status_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DesktopControlStatusRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DesktopControlStatusMcpResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Thinking Path
#11506 T1 — the safety-critical gap: no input arbitration exists, so on human takeover the agent + human both feed the same X input queue. Builds on #11579 (single canonical display shared by agent + human).

## What Changed
- **Lock (1.1)**: new `autobot-backend/api/desktop_control_lock.py` — Redis-backed per-session lock (`autobot:desktop:control_lock:{session_id}`, JSON {owner, acquired_at}), TTL via `AUTOBOT_DESKTOP_CONTROL_LOCK_TTL_SECONDS` (default 120s). acquire (takeover-permissive) / release (compare-and-delete, owner-only) / is_human_active / get_lock_owner. **Fails SAFE**: is_human_active returns True (mutes agent) if Redis is unreachable. Uses get_redis_client (shared across workers, not in-process).
- **Gating (1.2)**: `vnc_manager.py` mouse_click/keyboard_type/special_key/mouse_scroll/mouse_drag and the 3 `vnc_mcp.py` MCP actuation tools check is_human_active(session_id) first and return `{status: muted}` without running xdotool when a human holds the lock. Human RFB input via `vnc_proxy.py` websocket_proxy is architecturally never gated (raw frames don't call the gated modules).
- **Signaling + MCP (1.3)**: `vnc_proxy.py` control acquire/release endpoints; new `desktop_control_status` MCP tool + `human_active`/`control_owner` added to `desktop_observe_state` so the agent knows to pause; handoff audited via desktop_tracking.
- **Frontend (1.4)**: `useDesktopControlLock.ts` composable (acquire/release/status, 30s heartbeat re-acquire while held) + Take/Release toggle in `DesktopInterface.vue` with owner label; i18n keys `desktop.controlLock.*` in all 11 locales.

## Verification
50 new + 16 MCP-isolation + 7 frontend vitest tests; vue-tsc + oxlint -D correctness + flake8 all clean.

## Design note for review
The manual admin toolbar in DesktopInterface.vue (screenshot/type/Ctrl+Alt+Del) routes through the same gated vnc_manager REST endpoints, so it's also muted while any human holds the lock — matches the literal 'gate every vnc_manager entrypoint' instruction, but that toolbar is human-triggered. Reviewer should assess whether it should gate on 'am I the lock owner' vs 'is any human active'.

## Model Used
Opus 4.8

Closes #12002