### PR TITLE
tokenise(user): ActivityFeedView + BudgetPolicies + CompanyPortabilityView → design tokens (#12014, #12015, #12016)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -815,6 +815,49 @@
   --backlogview-selected-row-bg: #eff6ff;  /* selected row fill (undefined --color-primary-subtle fallback) */
   --backlogview-sprint-tag-bg: #e0f2fe;    /* sprint tag badge fill */
   --backlogview-sprint-tag-text: #0369a1;  /* sprint tag badge text */
+
+  /* ============================================
+   * ACTIVITY FEED VIEW TOKENS (#12014, umbrella #11515)
+   * Scoped to llc/ActivityFeedView.vue. Hex-only (deliberately NO OKLCH
+   * override) so the actor badges render pixel-identical to their previous
+   * hardcoded values across all browsers. These are the literal fallbacks the
+   * badges rendered because their intended Ember semantic tokens (--bg-muted,
+   * --color-info-subtle, --color-info-text — undefined in any theme — and
+   * --color-accent-subtle, --color-accent-text — defined only by the ember
+   * theme) do not resolve elsewhere; preserved behind those intended token
+   * names via nested var() so ember still wins where it defines them.
+   * ============================================ */
+  --actfeed-badge-neutral-bg: #f3f4f6;  /* default actor badge fill (undefined --bg-muted fallback) */
+  --actfeed-system-badge-bg: #e5e7eb;   /* system actor badge fill (undefined --bg-muted fallback) */
+  --actfeed-accent-subtle: #fcefe0;     /* agent actor badge fill (non-ember --color-accent-subtle fallback) */
+  --actfeed-accent-text: #c4651a;       /* agent badge + ghost-button text (non-ember --color-accent-text fallback) */
+  --actfeed-info-subtle: #dbeafe;       /* user actor badge fill (undefined --color-info-subtle fallback) */
+  --actfeed-info-text: #1d4ed8;         /* user actor badge text (undefined --color-info-text fallback) */
+
+  /* ============================================
+   * BUDGET POLICIES TOKENS (#12015, umbrella #11515)
+   * Scoped to views/BudgetPolicies.vue. The error-banner border renders the
+   * soft-red fallback because --color-danger-border is never defined in any
+   * theme; preserved hex-only (deliberately NO OKLCH override) behind that
+   * intended token name via nested var() so the banner renders pixel-identical
+   * to its previous hardcoded value across all browsers.
+   * ============================================ */
+  --budgetpol-danger-border: #fca5a5;  /* error-banner border (undefined --color-danger-border fallback) */
+
+  /* ============================================
+   * COMPANY PORTABILITY VIEW TOKENS (#12016, umbrella #11515)
+   * Scoped to llc/CompanyPortabilityView.vue. Hex-only (deliberately NO OKLCH
+   * override) so the view renders pixel-identical to its previous hardcoded
+   * values across all browsers. The error/success result-banner foregrounds
+   * are the literal fallbacks that rendered because --color-error-text and
+   * --color-success-text are never defined in any theme; preserved behind
+   * those intended token names via nested var(). --coportability-on-accent is
+   * the pure-white button label and spinner highlight on accent surfaces
+   * (--text-on-primary carries an OKLCH override that would drift).
+   * ============================================ */
+  --coportability-error-text: #991b1b;    /* error banner + failed-result foreground */
+  --coportability-success-text: #166534;  /* success-result foreground */
+  --coportability-on-accent: #fff;        /* white button label + spinner highlight on accent */
 }
 
 /* ============================================

--- a/autobot-frontend/src/views/BudgetPolicies.vue
+++ b/autobot-frontend/src/views/BudgetPolicies.vue
@@ -573,9 +573,9 @@ onMounted(loadPolicies)
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  background: var(--color-danger-bg, #fee2e2);
-  color: var(--color-error, #dc2626);
-  border: 1px solid var(--color-danger-border, #fca5a5);
+  background: var(--color-danger-bg);
+  color: var(--color-error);
+  border: 1px solid var(--color-danger-border, var(--budgetpol-danger-border));
   border-radius: var(--radius-md);
   padding: var(--spacing-3) var(--spacing-4);
   margin-bottom: var(--spacing-4);
@@ -703,21 +703,21 @@ onMounted(loadPolicies)
 
 .badge {
   display: inline-block;
-  padding: 2px 8px;
-  border-radius: 9999px;
+  padding: 2px var(--spacing-2);
+  border-radius: var(--radius-full);
   font-size: var(--text-xs);
   font-weight: 500;
   white-space: nowrap;
 }
 
 .badge-scope {
-  background: var(--color-info-bg, #dbeafe);
-  color: var(--color-info, #1d4ed8);
+  background: var(--color-info-bg);
+  color: var(--color-info);
 }
 
 .badge-active {
-  background: var(--color-success-bg, #dcfce7);
-  color: var(--color-success, #16a34a);
+  background: var(--color-success-bg);
+  color: var(--color-success);
 }
 
 .badge-inactive {
@@ -726,18 +726,18 @@ onMounted(loadPolicies)
 }
 
 .badge-danger {
-  background: var(--color-danger-bg, #fee2e2);
-  color: var(--color-error, #dc2626);
+  background: var(--color-danger-bg);
+  color: var(--color-error);
 }
 
 .badge-warning {
-  background: var(--color-warning-bg, #fef9c3);
-  color: var(--color-warning, #a16207);
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
 }
 
 .badge-info {
-  background: var(--color-info-bg, #dbeafe);
-  color: var(--color-info, #1d4ed8);
+  background: var(--color-info-bg);
+  color: var(--color-info);
 }
 
 .actions-cell {
@@ -790,7 +790,7 @@ onMounted(loadPolicies)
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-4);
-  background: var(--color-error, #dc2626);
+  background: var(--color-error);
   color: white;
   border: none;
   border-radius: var(--radius-md);
@@ -824,13 +824,13 @@ onMounted(loadPolicies)
 }
 
 .btn-icon.btn-primary:hover {
-  background: var(--color-info-bg, #dbeafe);
-  color: var(--color-info, #1d4ed8);
+  background: var(--color-info-bg);
+  color: var(--color-info);
 }
 
 .btn-icon.btn-danger:hover {
-  background: var(--color-danger-bg, #fee2e2);
-  color: var(--color-error, #dc2626);
+  background: var(--color-danger-bg);
+  color: var(--color-error);
 }
 
 /* Agent pause status section */
@@ -884,8 +884,8 @@ onMounted(loadPolicies)
   min-width: 70px;
 }
 
-.text-danger { color: var(--color-error, #dc2626); font-weight: 500; }
-.text-success { color: var(--color-success, #16a34a); font-weight: 500; }
+.text-danger { color: var(--color-error); font-weight: 500; }
+.text-success { color: var(--color-success); font-weight: 500; }
 
 .mt-2 { margin-top: var(--spacing-2); }
 .mt-6 { margin-top: var(--spacing-6); }
@@ -917,7 +917,7 @@ onMounted(loadPolicies)
 }
 
 .required {
-  color: var(--color-error, #dc2626);
+  color: var(--color-error);
 }
 
 .checkbox-label {
@@ -929,8 +929,8 @@ onMounted(loadPolicies)
 }
 
 .checkbox-input {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   cursor: pointer;
 }
 

--- a/autobot-frontend/src/views/llc/ActivityFeedView.vue
+++ b/autobot-frontend/src/views/llc/ActivityFeedView.vue
@@ -221,7 +221,7 @@ onUnmounted(() => {
 .view-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
 }
 
 .feed-header-actions {
@@ -235,7 +235,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 0.375rem;
   font-size: 0.8125rem;
-  color: var(--text-secondary, #4b5563);
+  color: var(--text-secondary);
 }
 
 .feed-filters {
@@ -245,7 +245,7 @@ onUnmounted(() => {
   gap: 0.75rem;
   padding: 0.75rem 0;
   margin-bottom: 0.5rem;
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  border-bottom: 1px solid var(--border-default);
 }
 
 .filter {
@@ -254,7 +254,7 @@ onUnmounted(() => {
   gap: 0.25rem;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .filter input,
@@ -262,19 +262,19 @@ onUnmounted(() => {
   padding: 0.375rem 0.5rem;
   font-size: 0.875rem;
   font-weight: 400;
-  border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--border-default, #d1d5db);
-  background: var(--bg-input, #fff);
-  color: var(--text-primary, #111827);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-default);
+  background: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .state-msg {
   padding: 1.5rem 0;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .state-error {
-  color: var(--color-danger, #b91c1c);
+  color: var(--color-danger);
 }
 
 .event-list {
@@ -288,7 +288,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 0.75rem;
   padding: 0.5rem 0;
-  border-bottom: 1px solid var(--border-subtle, #f3f4f6);
+  border-bottom: 1px solid var(--border-subtle);
   font-size: 0.875rem;
 }
 
@@ -302,23 +302,23 @@ onUnmounted(() => {
   text-transform: uppercase;
   letter-spacing: 0.03em;
   border-radius: 999px;
-  background: var(--bg-muted, #f3f4f6);
-  color: var(--text-secondary, #4b5563);
+  background: var(--bg-muted, var(--actfeed-badge-neutral-bg));
+  color: var(--text-secondary);
 }
 
 .actor-agent {
-  background: var(--color-accent-subtle, #fcefe0);
-  color: var(--color-accent-text, #c4651a);
+  background: var(--color-accent-subtle, var(--actfeed-accent-subtle));
+  color: var(--color-accent-text, var(--actfeed-accent-text));
 }
 
 .actor-user {
-  background: var(--color-info-subtle, #dbeafe);
-  color: var(--color-info-text, #1d4ed8);
+  background: var(--color-info-subtle, var(--actfeed-info-subtle));
+  color: var(--color-info-text, var(--actfeed-info-text));
 }
 
 .actor-system {
-  background: var(--bg-muted, #e5e7eb);
-  color: var(--text-muted, #6b7280);
+  background: var(--bg-muted, var(--actfeed-system-badge-bg));
+  color: var(--text-muted);
 }
 
 .event-body {
@@ -332,28 +332,28 @@ onUnmounted(() => {
 
 .event-action {
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
 }
 
 .event-entity {
-  color: var(--text-secondary, #4b5563);
+  color: var(--text-secondary);
 }
 
 .event-entity-id {
   font-family: var(--font-mono, monospace);
   font-size: 0.75rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .event-actor-name {
   font-size: 0.75rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .event-time {
   flex: none;
   font-size: 0.75rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
   white-space: nowrap;
 }
 
@@ -367,7 +367,7 @@ onUnmounted(() => {
 
 .page-info {
   font-size: 0.8125rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .page-buttons {
@@ -378,10 +378,10 @@ onUnmounted(() => {
 .btn-sm {
   padding: 0.3125rem 0.75rem;
   font-size: 0.8125rem;
-  border-radius: var(--radius-sm, 6px);
-  border: 1px solid var(--border-default, #d1d5db);
-  background: var(--bg-input, #fff);
-  color: var(--text-primary, #111827);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default);
+  background: var(--bg-input);
+  color: var(--text-primary);
   cursor: pointer;
 }
 
@@ -392,6 +392,6 @@ onUnmounted(() => {
 
 .btn-ghost {
   border-color: transparent;
-  color: var(--color-accent-text, #c4651a);
+  color: var(--color-accent-text, var(--actfeed-accent-text));
 }
 </style>

--- a/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
+++ b/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
@@ -485,12 +485,12 @@ async function executeImport(): Promise<void> {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  background: var(--color-error-bg, #fee2e2);
-  border: 1px solid var(--color-error-border, #fca5a5);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
   border-radius: var(--radius-md);
   padding: var(--spacing-sm) var(--spacing-md);
   margin-bottom: var(--spacing-md);
-  color: var(--color-error-text, #991b1b);
+  color: var(--color-error-text, var(--coportability-error-text));
 }
 
 .btn-dismiss {
@@ -540,7 +540,7 @@ async function executeImport(): Promise<void> {
   gap: var(--spacing-xs);
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-primary);
-  color: #fff;
+  color: var(--coportability-on-accent);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -577,8 +577,8 @@ async function executeImport(): Promise<void> {
   align-items: center;
   gap: var(--spacing-xs);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--color-error, #dc2626);
-  color: #fff;
+  background: var(--color-error);
+  color: var(--coportability-on-accent);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -661,7 +661,7 @@ async function executeImport(): Promise<void> {
 }
 
 .drop-zone--loaded {
-  border-color: var(--color-success, #16a34a);
+  border-color: var(--color-success);
   background: var(--color-success-bg, rgba(22, 163, 74, 0.05));
 }
 
@@ -706,8 +706,8 @@ async function executeImport(): Promise<void> {
 }
 
 .preview-warnings {
-  background: var(--color-warning-bg, #fef9c3);
-  border: 1px solid var(--color-warning-border, #fde047);
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
   border-radius: var(--radius-sm);
   padding: var(--spacing-sm) var(--spacing-md);
   margin-bottom: var(--spacing-md);
@@ -732,7 +732,7 @@ async function executeImport(): Promise<void> {
 }
 
 .row-collision {
-  background: var(--color-warning-bg, #fef9c3);
+  background: var(--color-warning-bg);
 }
 
 .preview-summary {
@@ -809,15 +809,15 @@ async function executeImport(): Promise<void> {
 }
 
 .result-success {
-  background: var(--color-success-bg, #dcfce7);
-  border: 1px solid var(--color-success-border, #86efac);
-  color: var(--color-success-text, #166534);
+  background: var(--color-success-bg);
+  border: 1px solid var(--color-success-border);
+  color: var(--color-success-text, var(--coportability-success-text));
 }
 
 .result-error {
-  background: var(--color-error-bg, #fee2e2);
-  border: 1px solid var(--color-error-border, #fca5a5);
-  color: var(--color-error-text, #991b1b);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error-text, var(--coportability-error-text));
 }
 
 .result-counts {
@@ -835,7 +835,7 @@ async function executeImport(): Promise<void> {
   width: 14px;
   height: 14px;
   border: 2px solid rgba(255, 255, 255, 0.4);
-  border-top-color: #fff;
+  border-top-color: var(--coportability-on-accent);
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
 }


### PR DESCRIPTION
Closes #12014
Closes #12015
Closes #12016
Part of #11515 (Task 4.3/4.4)

## Thinking Path
Combined single-commit PR for 3 similar-scope llc/view tokenisations — grouped to eliminate the design-tokens.css `:root`-tail conflicts that separate PRs incur. Style-only, pixel-equivalent.

## What Changed
- **ActivityFeedView** (#12014): 21 dead-drops + 6 scoped `--actfeed-*` (undefined-token nested fallbacks incl. ember-only accent).
- **BudgetPolicies** (#12015): 23 dead-drops + 1 scoped `--budgetpol-danger-border` + 4 px→spacing/radius.
- **CompanyPortabilityView** (#12016): 11 dead-drops + 3 scoped `--coportability-*` (nested undefined-text fallbacks + on-accent #fff where `--text-on-primary` has OKLCH override).
- Left literal per rules: rgba, 1-3px borders, off-scale dims, keyword colors. Script/template (data-viz) untouched.

## Verification
Main-tree-clean; postcss PARSE OK (no comment-gotcha); all 10 scoped tokens defined 1:1; no duplicate defs; `<style>`+`:root`-tail diff only.

## Model Used
Claude Fable 5 (subagent)