### PR TITLE
build(slm): wire @autobot/ui kit + SLM token file into autobot-slm-frontend (#12019)

### DIFF
--- a/autobot-slm-frontend/package-lock.json
+++ b/autobot-slm-frontend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@autobot/terminal": "file:../autobot-plugins/terminal",
+        "@autobot/ui": "file:../libs/autobot-ui",
         "@autobot/vnc": "file:../autobot-plugins/vnc",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -65,6 +66,19 @@
     },
     "../autobot-plugins/vnc": {
       "name": "@autobot/vnc",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^6.0.0",
+        "typescript": "~5.8.0",
+        "vite": "^6.0.0",
+        "vue": "^3.5.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.0"
+      }
+    },
+    "../libs/autobot-ui": {
+      "name": "@autobot/ui",
       "version": "0.1.0",
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -149,6 +163,10 @@
     },
     "node_modules/@autobot/terminal": {
       "resolved": "../autobot-plugins/terminal",
+      "link": true
+    },
+    "node_modules/@autobot/ui": {
+      "resolved": "../libs/autobot-ui",
       "link": true
     },
     "node_modules/@autobot/vnc": {

--- a/autobot-slm-frontend/package.json
+++ b/autobot-slm-frontend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@autobot/terminal": "file:../autobot-plugins/terminal",
+    "@autobot/ui": "file:../libs/autobot-ui",
     "@autobot/vnc": "file:../autobot-plugins/vnc",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/autobot-slm-frontend/src/assets/styles/aui-theme.css
+++ b/autobot-slm-frontend/src/assets/styles/aui-theme.css
@@ -1,0 +1,100 @@
+/* Copyright 2025-2026 mrveiss
+   SPDX-License-Identifier: Apache-2.0
+
+   @autobot/ui token adapter — SLM control-plane identity.
+
+   Maps every semantic token in the kit's contract (libs/autobot-ui/src/tokens/
+   contract.css, all `--aui-*`) onto the SLM control plane's OWN design tokens
+   (defined in ./main.css: the theme-adaptive `--a11y-*` set + the `--color-*`
+   scale + the sizing scales from #11515). Same contract NAMES, SLM's VALUES →
+   the shared components (BaseModal, BaseButton, BaseBadge, …) render in the SLM
+   control plane's distinct sky/slate identity, NOT the main GUI's palette
+   (colors are deliberately NOT shared across the two frontends — see #10860).
+
+   Every value is a var() reference to an SLM token — no hardcoded colors — so
+   this adapter auto-adapts across the SLM light / dark / high-contrast themes at
+   runtime (the `--a11y-*` and status vars are redefined per :root[data-theme]).
+
+   Load order (see main.ts): import '@autobot/ui/tokens' (neutral fallbacks)
+   BEFORE this file (SLM overrides win), and this file AFTER main.css so the SLM
+   tokens it references are already declared. */
+
+:root {
+  /* ---- Color: brand / interactive ------------------------------------
+     SLM's brand is the sky ramp (--color-primary-*), distinct from the main
+     GUI. Hover/active step down the same ramp. */
+  --aui-color-primary: var(--color-primary-500);
+  --aui-color-primary-hover: var(--color-primary-600);
+  --aui-color-primary-active: var(--color-primary-700);
+  --aui-color-primary-contrast: var(--color-white);
+
+  /* ---- Color: neutrals / chrome (theme-adaptive via --a11y-*) --------- */
+  --aui-color-surface: var(--a11y-bg);
+  --aui-color-surface-raised: var(--a11y-bg-surface);
+  --aui-color-surface-sunken: var(--a11y-bg-muted);
+  --aui-color-border: var(--a11y-border);
+  /* No dedicated "strong border" token in SLM; the muted-text shade reads as a
+     stronger, still theme-adaptive divider. */
+  --aui-color-border-strong: var(--a11y-text-muted);
+  --aui-color-text: var(--a11y-text);
+  --aui-color-text-muted: var(--a11y-text-muted);
+  /* Light chrome text (as used on the SLM dark sidebar) for inverse surfaces. */
+  --aui-color-text-inverse: var(--a11y-sidebar-text);
+
+  /* ---- Color: status ------------------------------------------------- */
+  --aui-color-success: var(--color-success-500);
+  --aui-color-success-contrast: var(--color-white);
+  --aui-color-warning: var(--color-warning-500);
+  --aui-color-warning-contrast: var(--color-white);
+  --aui-color-danger: var(--color-danger-500);
+  --aui-color-danger-contrast: var(--color-white);
+  /* SLM maps "info" onto its sky brand (see main.css --color-info alias). */
+  --aui-color-info: var(--color-primary-500);
+  --aui-color-info-contrast: var(--color-white);
+
+  /* ---- Overlay (modal/dialog backdrop scrim) -------------------------
+     SLM has no overlay token; use the canonical dark scrim (matches the kit
+     fallback). */
+  --aui-color-overlay: rgb(0 0 0 / 0.5);
+
+  /* ---- Focus (theme-adaptive) ---------------------------------------- */
+  --aui-color-focus-ring: var(--a11y-focus-ring);
+  --aui-focus-ring-width: var(--a11y-focus-width);
+
+  /* ---- Radius (map onto SLM's scale by pixel intent) -----------------
+     contract sm/md/lg = 0.25/0.5/0.75rem = SLM default/lg/xl. */
+  --aui-radius-sm: var(--radius-default);
+  --aui-radius-md: var(--radius-lg);
+  --aui-radius-lg: var(--radius-xl);
+  --aui-radius-full: var(--radius-full);
+
+  /* ---- Elevation ----------------------------------------------------- */
+  --aui-shadow-sm: var(--shadow-sm);
+  --aui-shadow-md: var(--shadow-md);
+  --aui-shadow-lg: var(--shadow-lg);
+  /* SLM has no xl elevation; reuse lg (its largest defined shadow). */
+  --aui-shadow-xl: var(--shadow-lg);
+
+  /* ---- Typography (sizes; SLM defines no font-family / weight tokens,
+     so those keep the kit's neutral fallbacks) ------------------------- */
+  --aui-text-xs: var(--text-xs);
+  --aui-text-sm: var(--text-sm);
+  --aui-text-base: var(--text-base);
+  --aui-text-lg: var(--text-lg);
+  --aui-text-xl: var(--text-xl);
+
+  /* ---- Spacing (control padding scale) ------------------------------- */
+  --aui-space-1: var(--spacing-1);
+  --aui-space-2: var(--spacing-2);
+  --aui-space-3: var(--spacing-3);
+  --aui-space-4: var(--spacing-4);
+  --aui-space-5: var(--spacing-5);
+  --aui-space-6: var(--spacing-6);
+
+  /* ---- Layering ------------------------------------------------------ */
+  --aui-z-modal: var(--z-modal);
+
+  /* ---- Motion -------------------------------------------------------
+     SLM defines no transition-duration tokens; the kit's neutral fallbacks
+     (which already honor prefers-reduced-motion) are left in place. */
+}

--- a/autobot-slm-frontend/src/kit-wiring.test.ts
+++ b/autobot-slm-frontend/src/kit-wiring.test.ts
@@ -1,0 +1,34 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+//
+// Proof-of-wiring for the @autobot/ui shared kit into autobot-slm-frontend
+// (#12019, #10860 Task D / PR-5). This is the ONLY consumer of @autobot/ui in
+// SLM until PR-6 adopts the composables in views — its job is to prove the
+// `file:` dependency + lockfile wiring resolves end-to-end (npm ci → import),
+// so CI fails loudly if the kit link ever breaks. No view is touched here.
+
+import { describe, it, expect } from 'vitest'
+import {
+  BaseButton,
+  BaseBadge,
+  BaseCard,
+  BaseModal,
+  EmptyState,
+  usePagination,
+  useFormValidation,
+} from '@autobot/ui'
+
+describe('@autobot/ui kit wiring (#12019)', () => {
+  it('resolves the file: dependency and exports the shared composables', () => {
+    expect(typeof usePagination).toBe('function')
+    expect(typeof useFormValidation).toBe('function')
+  })
+
+  it('resolves the shared Vue components from the kit', () => {
+    expect(BaseButton).toBeDefined()
+    expect(BaseBadge).toBeDefined()
+    expect(BaseCard).toBeDefined()
+    expect(BaseModal).toBeDefined()
+    expect(EmptyState).toBeDefined()
+  })
+})

--- a/autobot-slm-frontend/src/main.ts
+++ b/autobot-slm-frontend/src/main.ts
@@ -12,6 +12,13 @@ import i18n from './i18n'
 
 import './assets/styles/main.css'
 
+// @autobot/ui shared kit: token contract fallbacks first, then the SLM adapter
+// (mapping --aui-* onto the SLM control plane's own design tokens). Loaded AFTER
+// main.css so the SLM tokens the adapter references are already defined — the
+// SLM keeps its own color identity; only the token contract is shared (#10860).
+import '@autobot/ui/tokens'
+import './assets/styles/aui-theme.css'
+
 const app = createApp(App)
 
 app.use(createPinia())

--- a/autobot-slm-frontend/src/vite-env.d.ts
+++ b/autobot-slm-frontend/src/vite-env.d.ts
@@ -5,6 +5,12 @@
 
 /// <reference types="vite/client" />
 
+// @autobot/ui ships its design-token contract as CSS via the "./tokens" export
+// subpath (a side-effect-only import). vite/client's `*.css` glob only matches
+// specifiers ending in `.css`, not this bare specifier, so declare it explicitly
+// for vue-tsc (bundler resolution maps it to src/tokens/contract.css at build).
+declare module '@autobot/ui/tokens'
+
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
   readonly VITE_WS_URL: string

--- a/autobot-slm-frontend/vitest.config.ts
+++ b/autobot-slm-frontend/vitest.config.ts
@@ -11,6 +11,11 @@ export default mergeConfig(
   defineConfig({
     plugins: [vue()],
     resolve: {
+      // Match vite.config.ts: keep resolution relative to the symlink path so
+      // `file:` workspace packages (@autobot/ui, @autobot/terminal, @autobot/vnc)
+      // find their vue/pinia peers in this app's own node_modules rather than
+      // walking up from the real ../libs / ../autobot-plugins path (MVA-893).
+      preserveSymlinks: true,
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
       },

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -42,6 +42,10 @@ WORKDIR /app
 # autobot-plugins/ must be at /autobot-plugins/ because package-lock.json
 # references file:../autobot-plugins/terminal and ../vnc (resolved from /app/)
 COPY autobot-plugins/ /autobot-plugins/
+# libs/ must be present at /libs/ before npm ci because package-lock.json now
+# references file:../libs/autobot-ui (@autobot/ui shared kit, #12019), resolved
+# from /app/ — same requirement as the main-frontend builder stage above.
+COPY libs/ /libs/
 COPY autobot-slm-frontend/package.json autobot-slm-frontend/package-lock.json ./
 # Copy shared module (referenced by @shared alias)
 COPY autobot_shared/ /autobot_shared/


### PR DESCRIPTION
## Thinking Path
PR-5 of the @autobot/ui consolidation — the enabling wiring for SLM adoption (#10860 Task D). autobot-slm-frontend consumed zero from the kit; this adds the `file:` dep + an SLM-owned token file so kit components render in SLM's OWN color identity (per #10860: structure shared, color NOT unified). No view adoption yet (that's PR-6).

## What Changed
- `package.json`: `@autobot/ui: file:../libs/autobot-ui` (alphabetical between the existing @autobot/terminal + @autobot/vnc siblings).
- `package-lock.json`: 3 surgical inserts (root dep, linked-package source block copied verbatim from autobot-frontend's canonical entry, node_modules link stub) — coherent by mirroring siblings + autobot-frontend exactly. **CI's `npm ci` is the validator** (no Linux npm on WSL — memory `windows_npm_wsl_lockfile`).
- `src/assets/styles/aui-theme.css` (new): maps every `--aui-*` contract var onto SLM's own tokens (sky `--color-primary-*`, theme-adaptive `--a11y-*` surfaces so kit components follow SLM light/dark/high-contrast, `--color-{success,warning,danger}-*`, SLM radius/shadow/text/spacing/z). No hardcoded colors, no autobot-frontend colors imported.
- `main.ts`: import `@autobot/ui/tokens` then `aui-theme.css` (SLM overrides win), after main.css.
- `vitest.config.ts`: added `preserveSymlinks: true` (vite.config already had it; needed for the `file:` kit to resolve its vue peer in tests).
- `src/kit-wiring.test.ts` (new): imports BaseButton/Badge/Card/Modal/EmptyState + usePagination/useFormValidation from @autobot/ui and asserts resolution — CI fails loudly if the link breaks.

Closes #12019

## Verification
- Local: package.json + package-lock.json valid JSON; every lockfile insert anchor-unique; inserted `../libs/autobot-ui` block byte-identical to autobot-frontend's; correct lexicographic placement.
- **Deferred to CI (the point of waiting for CI):** `npm ci`, `vue-tsc`, `vite build`, `vitest` — no Linux npm locally.

## Model Used
Opus 4.8 (subagent: frontend-engineer)