### PR TITLE
tokenise(user): CompanyCreationWizard + ImportTreeChart + KnowledgeResearchPanel → design tokens (#12021, #12022, #12023)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -863,6 +863,22 @@
   --backlogview-selected-row-bg: #eff6ff;  /* selected row fill (undefined --color-primary-subtle fallback) */
   --backlogview-sprint-tag-bg: #e0f2fe;    /* sprint tag badge fill */
   --backlogview-sprint-tag-text: #0369a1;  /* sprint tag badge text */
+
+  /* ============================================
+   * KNOWLEDGE RESEARCH PANEL TOKENS
+   * Issues #12021, #12022, #12023 (umbrella #11515), batch 14:
+   * CompanyCreationWizard.vue, ImportTreeChart.vue,
+   * knowledge/KnowledgeResearchPanel.vue.
+   * Only KnowledgeResearchPanel needed a scoped token: its buttons render a
+   * pure-white label on the info, success and error accent fills, and there
+   * is no plain-white design token (--text-on-primary carries an OKLCH
+   * override that would drift). Hex-only (deliberately NO OKLCH override) so
+   * the labels render pixel-identical to the previous hardcoded #fff across
+   * all browsers. CompanyCreationWizard's hexes are category-icon gradient
+   * stops (intentionally literal); ImportTreeChart's style hexes were all
+   * dead fallbacks of defined tokens and were dropped.
+   * ============================================ */
+  --kresearch-on-accent: #fff;  /* white button label on info, success and error fills */
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -857,8 +857,8 @@ onUnmounted(() => {
 }
 
 .loading-spinner {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border: 3px solid var(--border-color);
   border-top-color: var(--color-primary);
   border-radius: 50%;
@@ -871,7 +871,7 @@ onUnmounted(() => {
 
 .chart-error {
   background: var(--bg-error, rgba(239, 68, 68, 0.1));
-  border: 1px solid var(--border-error, #ef4444);
+  border: 1px solid var(--border-error);
   border-radius: var(--radius-md);
   padding: var(--spacing-3);
   gap: var(--spacing-2);
@@ -880,7 +880,7 @@ onUnmounted(() => {
 .error-icon {
   font-weight: bold;
   font-size: var(--text-xl);
-  color: var(--color-error, #ef4444);
+  color: var(--color-error);
 }
 
 .btn-link {
@@ -995,26 +995,26 @@ onUnmounted(() => {
 }
 
 .dot {
-  width: 8px;
-  height: 8px;
+  width: var(--spacing-2);
+  height: var(--spacing-2);
   border-radius: 50%;
   display: inline-block;
 }
 
 .legend-item.importer .dot {
-  background: var(--color-success, #10b981);
+  background: var(--color-success);
 }
 
 .legend-item.imported .dot {
-  background: var(--chart-purple, #8b5cf6);
+  background: var(--chart-purple);
 }
 
 .legend-item.hub .dot {
-  background: var(--color-warning, #f59e0b);
+  background: var(--color-warning);
 }
 
 .legend-item.external .dot {
-  background: var(--text-tertiary, #6b7280);
+  background: var(--text-tertiary);
 }
 
 .cytoscape-container {
@@ -1089,7 +1089,7 @@ onUnmounted(() => {
 
 .detail-icon {
   font-size: var(--text-2xl);
-  min-width: 24px;
+  min-width: var(--spacing-6);
 }
 
 .detail-name {
@@ -1107,8 +1107,8 @@ onUnmounted(() => {
   cursor: pointer;
   font-size: var(--text-lg);
   padding: var(--spacing-0);
-  width: 24px;
-  height: 24px;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1155,22 +1155,22 @@ onUnmounted(() => {
 }
 
 .detail-value.node-type-hub {
-  color: var(--color-warning, #f59e0b);
+  color: var(--color-warning);
   font-weight: var(--font-semibold);
 }
 
 .detail-value.node-type-importer {
-  color: var(--color-success, #10b981);
+  color: var(--color-success);
   font-weight: var(--font-semibold);
 }
 
 .detail-value.node-type-imported {
-  color: var(--chart-purple, #8b5cf6);
+  color: var(--chart-purple);
   font-weight: var(--font-semibold);
 }
 
 .detail-value.node-type-isolated {
-  color: var(--text-tertiary, #6b7280);
+  color: var(--text-tertiary);
   font-weight: var(--font-semibold);
 }
 
@@ -1211,7 +1211,7 @@ onUnmounted(() => {
 }
 
 .expand-icon {
-  width: 20px;
+  width: var(--spacing-5);
   text-align: center;
   font-size: 0.8rem;
   color: var(--text-tertiary);
@@ -1241,12 +1241,12 @@ onUnmounted(() => {
 }
 
 .imports-out {
-  color: var(--color-success, #10b981);
+  color: var(--color-success);
   font-weight: var(--font-medium);
 }
 
 .imports-in {
-  color: var(--chart-purple, #8b5cf6);
+  color: var(--chart-purple);
   font-weight: var(--font-medium);
 }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -709,8 +709,8 @@ onUnmounted(() => {
 }
 
 .query-icon {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   color: var(--text-muted);
   flex-shrink: 0;
 }
@@ -742,7 +742,7 @@ onUnmounted(() => {
   flex-shrink: 0;
   padding: var(--spacing-2) var(--spacing-3);
   background: var(--color-info);
-  color: #fff;
+  color: var(--kresearch-on-accent);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -781,7 +781,7 @@ onUnmounted(() => {
 
 .btn-stop:hover {
   background: var(--color-error);
-  color: #fff;
+  color: var(--kresearch-on-accent);
 }
 
 /* ── Error banner ────────────────────────────────────────────────────────── */
@@ -984,7 +984,7 @@ onUnmounted(() => {
 
 .btn-accept:hover {
   background: var(--color-success);
-  color: #fff;
+  color: var(--kresearch-on-accent);
 }
 
 .btn-reject {
@@ -995,7 +995,7 @@ onUnmounted(() => {
 
 .btn-reject:hover {
   background: var(--color-error);
-  color: #fff;
+  color: var(--kresearch-on-accent);
 }
 
 .card-decision {
@@ -1043,8 +1043,8 @@ onUnmounted(() => {
 }
 
 .status-dot {
-  width: 8px;
-  height: 8px;
+  width: var(--spacing-2);
+  height: var(--spacing-2);
   border-radius: 50%;
   flex-shrink: 0;
 }

--- a/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
+++ b/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
@@ -543,7 +543,7 @@ async function createCompany() {
 
 .step-connector {
   position: absolute;
-  top: 20px;
+  top: var(--spacing-5);
   left: 50%;
   width: 100%;
   height: 2px;
@@ -773,8 +773,8 @@ async function createCompany() {
 
 .color-swatch {
   display: inline-block;
-  width: 20px;
-  height: 20px;
+  width: var(--spacing-5);
+  height: var(--spacing-5);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-color);
 }


### PR DESCRIPTION
Closes #12021
Closes #12022
Closes #12023
Part of #11515 (Task 4.3/4.4)

## What Changed
Combined single-commit PR. **CompanyCreationWizard**: 3 px→spacing (12 hexes are all `linear-gradient` stops — correctly literal). **ImportTreeChart**: 12 dead-drops + 8 px→spacing (chart palette lives in `<script>` as data — untouched). **KnowledgeResearchPanel**: 1 scoped `--kresearch-on-accent` + 4 px→spacing. design-tokens.css tail union-resolved with batch-13 blocks.

## Verification
Main-tree-clean; postcss PARSE OK; scoped token defined 1:1; no dup defs; `<style>`+`:root`-tail only.

## Model Used
Claude Fable 5 (subagent)