### PR TITLE
fix(frontend): unblock base frontend-tests — allow <i18n-t>, drop stale variant:danger lint rule (#12032)

### DIFF
--- a/autobot-frontend/eslint.config.ts
+++ b/autobot-frontend/eslint.config.ts
@@ -69,7 +69,7 @@ export default defineConfigWithVueTs(
       'vue/no-parsing-error': 'warn',
       'prefer-const': 'warn',
       'vue/no-undef-components': ['error', {
-        ignorePatterns: ['RouterLink', 'RouterView', 'Transition', 'TransitionGroup', 'KeepAlive', 'Teleport', 'Suspense'],
+        ignorePatterns: ['RouterLink', 'RouterView', 'Transition', 'TransitionGroup', 'KeepAlive', 'Teleport', 'Suspense', 'I18nT', 'i18n-t'],
       }],
       // Issue #6487: block new imports of deprecated useApi composable family.
       // Migrate to useFetchEndpoint (data loading) or useApiClient from @/plugins/api (mutations).
@@ -150,7 +150,9 @@ export default defineConfigWithVueTs(
         { key: 'size', value: 'small',  message: "Deprecated size token 'small' — use 'sm' (MVA-192)." },
         { key: 'size', value: 'medium', message: "Deprecated size token 'medium' — use 'md' (MVA-192)." },
         { key: 'size', value: 'large',  message: "Deprecated size token 'large' — use 'lg' (MVA-192)." },
-        { key: 'variant', value: 'danger', message: "Deprecated color token 'danger' — use 'error' (MVA-192)." },
+        // NOTE: no `variant: danger` entry — #11998 reconciled the shared SemanticVariant/BadgeVariant
+        // vocabulary TO canonical 'danger' (BaseBadge accepts 'danger', not 'error'), so forbidding it
+        // here contradicts the component type. ButtonVariant still uses 'error' (its own type enforces it).
       ],
       // Catches the same deprecated values passed as bound string literals, e.g. :size="'small'".
       // Scoped to VExpressionContainer inside VAttribute (template attribute expressions only).


### PR DESCRIPTION
## Thinking Path
`frontend-tests` (`lint:oxlint` + `lint:eslint`) went red base-wide on Dev_new_gui, blocking every PR:
- `TelemetryConsentModal.vue` `<i18n-t>` flagged by `vue/no-undef-components` — but `<i18n-t>` is a legitimate vue-i18n global component (registered via createI18n + `app.use(i18n)`, main.ts:100).
- `ComponentShowcaseView.vue` `variant="danger"` flagged by the MVA-192 `vue/no-restricted-static-attribute` rule — but #11998 (`b576351c3`) reconciled the shared `SemanticVariant`/`BadgeVariant` vocabulary TO canonical `'danger'` (BaseBadge's enum is `[...'danger'...]`, NOT 'error'), so the rule now contradicts the component type. It was also unsatisfiable (BaseBadge rejects 'error' at the type level).

## What Changed
- `eslint.config.ts`: added `I18nT`/`i18n-t` to `vue/no-undef-components` ignorePatterns (vue-i18n global component).
- `eslint.config.ts`: removed the stale `{ key: 'variant', value: 'danger' }` MVA-192 entry (contradicts #11998's canonical 'danger' for SemanticVariant; ButtonVariant still enforces 'error' via its own type). Only one `variant="danger"` usage exists repo-wide (a legitimate BaseBadge) — no button regression.
- `ComponentShowcaseView.vue`: line 96 `variant="error"` → `variant="danger"` to match canonical SemanticVariant (also clears a vue-tsc 'error'-not-assignable error left by the in-flight tokenise edit).

## Verification
`npm run lint:oxlint` exit 0; `eslint .` exit 0 (whole repo); `vue-tsc --noEmit -p tsconfig.app.json` exit 0.

## Model Used
Opus 4.8

Closes #12032