### PR TITLE
tokenise(slm): GrafanaDashboard hardcoded hexes + rem → design tokens (#12039)

### DIFF
--- a/autobot-slm-frontend/src/components/monitoring/GrafanaDashboard.vue
+++ b/autobot-slm-frontend/src/components/monitoring/GrafanaDashboard.vue
@@ -229,10 +229,10 @@ onUnmounted(() => {
 .grafana-embed {
   position: relative;
   width: 100%;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   overflow: hidden;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
+  background: var(--slm-gray-100);
+  border: 1px solid var(--slm-gray-200);
 }
 
 .grafana-embed.fullscreen {
@@ -260,15 +260,15 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: #f9fafb;
+  background: var(--slm-gray-50);
   z-index: 10;
 }
 
 .loading-spinner {
   width: 48px;
   height: 48px;
-  border: 4px solid #e5e7eb;
-  border-top-color: #3b82f6;
+  border: 4px solid var(--slm-gray-200);
+  border-top-color: var(--slm-blue-500);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
@@ -282,14 +282,14 @@ onUnmounted(() => {
   align-items: center;
   gap: 12px;
   padding: 8px 16px;
-  background: #f9fafb;
-  border-top: 1px solid #e5e7eb;
+  background: var(--slm-gray-50);
+  border-top: 1px solid var(--slm-gray-200);
 }
 
 .select-sm {
   padding: 6px 12px;
   background: white;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--slm-gray-200);
   border-radius: 4px;
   font-size: 13px;
   cursor: pointer;
@@ -297,7 +297,7 @@ onUnmounted(() => {
 
 .select-sm:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--slm-blue-500);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
@@ -305,7 +305,7 @@ onUnmounted(() => {
   margin-left: auto;
   padding: 6px 12px;
   background: white;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--slm-gray-200);
   border-radius: 4px;
   cursor: pointer;
   font-size: 14px;
@@ -313,7 +313,7 @@ onUnmounted(() => {
 }
 
 .btn-icon:hover {
-  background: #f3f4f6;
+  background: var(--slm-gray-100);
 }
 
 .btn {


### PR DESCRIPTION
Closes #12039
Part of #11515 (Task 4.3/4.4)

## What Changed
11 hex → existing `--slm-gray-50/100/200`, `--slm-blue-500` capture tokens (byte-identical) + 1 `0.5rem`→`--radius-lg`. **main.css NOT edited** — no new tokens, no `--color-<palette>` collision. Left literal: 1-4px borders, off-scale px (rem-based SLM scale), rgba, `@apply` utilities.

## Verification
Main-tree-clean; zero hex remain in file; all `--slm-*` refs pre-defined; `<style>`-only diff.

## Model Used
Claude Fable 5 (subagent)