### PR TITLE
tokenise(user): AIDocumentEditor + ProjectBrowserView + TemplateBrowser → design tokens (#12029, #12030, #12031)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -906,6 +906,51 @@
   --coportability-error-text: #991b1b;    /* error banner + failed-result foreground */
   --coportability-success-text: #166534;  /* success-result foreground */
   --coportability-on-accent: #fff;        /* white button label + spinner highlight on accent */
+
+  /* ============================================
+   * AI DOCUMENT EDITOR TOKENS (#12029, umbrella #11515)
+   * Scoped to documents/AIDocumentEditor.vue. Hex-only (deliberately NO OKLCH
+   * override) so the editor renders pixel-identical to its previous hardcoded
+   * values across all browsers. These are the literal fallbacks the editor
+   * rendered because --color-background-hover, --color-background-input and
+   * --color-background-secondary are never defined in any theme; preserved
+   * behind those intended token names via nested var().
+   * ============================================ */
+  --aidoc-hover-bg: #2a2a2a;   /* title hover fill (undefined --color-background-hover fallback) */
+  --aidoc-input-bg: #2a2a2a;   /* title/refine input fill (undefined --color-background-input fallback) */
+  --aidoc-panel-bg: #252525;   /* refine panel fill (undefined --color-background-secondary fallback) */
+
+  /* ============================================
+   * PROJECT BROWSER VIEW TOKENS (#12030, umbrella #11515)
+   * Scoped to llc/ProjectBrowserView.vue. The action/repo links render the
+   * ember-orange fallback because --color-accent-text and --color-accent are
+   * defined only by the ember theme; preserved hex-only (deliberately NO OKLCH
+   * override) behind those intended token names via nested var() so ember
+   * still wins where it defines them and the links render pixel-identical to
+   * their previous hardcoded value everywhere else.
+   * ============================================ */
+  --projbrowser-accent-text: #c4651a;  /* action/repo link text (non-ember --color-accent-text fallback) */
+
+  /* ============================================
+   * TEMPLATE BROWSER TOKENS (#12031, umbrella #11515)
+   * Scoped to llc/TemplateBrowser.vue. Per-category icon gradient stops — a
+   * decorative category palette, NOT semantic chrome, so each stop is
+   * preserved verbatim rather than mapped to semantic tokens. Hex-only
+   * (deliberately NO OKLCH override) so the category icons render
+   * pixel-identical to their previous hardcoded gradients across all browsers.
+   * ============================================ */
+  --tmplbrowser-cat-software-start: #667eea;    /* software-team icon gradient start */
+  --tmplbrowser-cat-software-end: #764ba2;      /* software-team icon gradient end */
+  --tmplbrowser-cat-marketing-start: #f093fb;   /* marketing-agency icon gradient start */
+  --tmplbrowser-cat-marketing-end: #f5576c;     /* marketing-agency icon gradient end */
+  --tmplbrowser-cat-consulting-start: #4facfe;  /* consulting-firm icon gradient start */
+  --tmplbrowser-cat-consulting-end: #00f2fe;    /* consulting-firm icon gradient end */
+  --tmplbrowser-cat-research-start: #43e97b;    /* research-lab icon gradient start */
+  --tmplbrowser-cat-research-end: #38f9d7;      /* research-lab icon gradient end */
+  --tmplbrowser-cat-startup-start: #fa709a;     /* startup icon gradient start */
+  --tmplbrowser-cat-startup-end: #fee140;       /* startup icon gradient end */
+  --tmplbrowser-cat-custom-start: #a8edea;      /* custom icon gradient start */
+  --tmplbrowser-cat-custom-end: #fed6e3;        /* custom icon gradient end */
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -263,8 +263,8 @@ const formattedUpdatedAt = computed(() => {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
@@ -274,7 +274,7 @@ const formattedUpdatedAt = computed(() => {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-3) var(--spacing-4);
-  border-bottom: 1px solid var(--border-default, #333);
+  border-bottom: 1px solid var(--border-default);
   gap: var(--spacing-3);
 }
 
@@ -302,14 +302,14 @@ const formattedUpdatedAt = computed(() => {
 }
 
 .document-title:hover {
-  background: var(--color-background-hover, #2a2a2a);
+  background: var(--color-background-hover, var(--aidoc-hover-bg));
 }
 
 .title-input {
   width: 100%;
-  background: var(--color-background-input, #2a2a2a);
+  background: var(--color-background-input, var(--aidoc-input-bg));
   color: inherit;
-  border: 1px solid var(--color-primary, #4caf50);
+  border: 1px solid var(--color-primary);
   border-radius: var(--radius-default);
   font-size: 1.1rem;
   font-weight: 600;
@@ -328,17 +328,17 @@ const formattedUpdatedAt = computed(() => {
 }
 
 .error-banner {
-  background: var(--color-error-bg, #3c1515);
-  color: var(--color-error, #f87171);
+  background: var(--color-error-bg);
+  color: var(--color-error);
   padding: var(--spacing-2) var(--spacing-4);
   font-size: 0.85rem;
-  border-bottom: 1px solid var(--color-error, #f87171);
+  border-bottom: 1px solid var(--color-error);
 }
 
 .refine-panel {
   padding: var(--spacing-3) var(--spacing-4);
-  border-bottom: 1px solid var(--border-default, #333);
-  background: var(--color-background-secondary, #252525);
+  border-bottom: 1px solid var(--border-default);
+  background: var(--color-background-secondary, var(--aidoc-panel-bg));
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2);
@@ -347,9 +347,9 @@ const formattedUpdatedAt = computed(() => {
 .refine-textarea {
   width: 100%;
   resize: vertical;
-  background: var(--color-background-input, #2a2a2a);
+  background: var(--color-background-input, var(--aidoc-input-bg));
   color: inherit;
-  border: 1px solid var(--border-default, #444);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-default);
   padding: var(--spacing-2);
   font-size: 0.9rem;
@@ -359,7 +359,7 @@ const formattedUpdatedAt = computed(() => {
 }
 
 .refine-textarea:focus {
-  border-color: var(--color-primary, #4caf50);
+  border-color: var(--color-primary);
 }
 .refine-textarea:focus-visible {
   outline: 2px solid var(--color-primary);
@@ -402,8 +402,8 @@ const formattedUpdatedAt = computed(() => {
   gap: var(--spacing-4);
   padding: var(--spacing-1-5) var(--spacing-4);
   font-size: var(--text-xs);
-  color: var(--text-muted, #888);
-  border-top: 1px solid var(--border-default, #333);
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-default);
 }
 
 .source-facts-count {

--- a/autobot-frontend/src/components/llc/TemplateBrowser.vue
+++ b/autobot-frontend/src/components/llc/TemplateBrowser.vue
@@ -443,32 +443,56 @@ onMounted(() => {
 }
 
 .category-software-team {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(
+    135deg,
+    var(--tmplbrowser-cat-software-start) 0%,
+    var(--tmplbrowser-cat-software-end) 100%
+  );
   color: white;
 }
 
 .category-marketing-agency {
-  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  background: linear-gradient(
+    135deg,
+    var(--tmplbrowser-cat-marketing-start) 0%,
+    var(--tmplbrowser-cat-marketing-end) 100%
+  );
   color: white;
 }
 
 .category-consulting-firm {
-  background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+  background: linear-gradient(
+    135deg,
+    var(--tmplbrowser-cat-consulting-start) 0%,
+    var(--tmplbrowser-cat-consulting-end) 100%
+  );
   color: white;
 }
 
 .category-research-lab {
-  background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+  background: linear-gradient(
+    135deg,
+    var(--tmplbrowser-cat-research-start) 0%,
+    var(--tmplbrowser-cat-research-end) 100%
+  );
   color: white;
 }
 
 .category-startup {
-  background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
+  background: linear-gradient(
+    135deg,
+    var(--tmplbrowser-cat-startup-start) 0%,
+    var(--tmplbrowser-cat-startup-end) 100%
+  );
   color: white;
 }
 
 .category-custom {
-  background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+  background: linear-gradient(
+    135deg,
+    var(--tmplbrowser-cat-custom-start) 0%,
+    var(--tmplbrowser-cat-custom-end) 100%
+  );
   color: white;
 }
 

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -828,7 +828,7 @@ onMounted(loadProjects)
   flex-direction: column;
   gap: 0.5rem;
   padding: 1rem;
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-default);
   background: var(--bg-surface);
 }
@@ -915,7 +915,7 @@ onMounted(loadProjects)
 .action-link {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--color-accent-text, var(--color-accent, #c4651a));
+  color: var(--color-accent-text, var(--color-accent, var(--projbrowser-accent-text)));
   text-decoration: none;
 }
 
@@ -944,7 +944,7 @@ onMounted(loadProjects)
 .create-textarea {
   width: 100%;
   padding: 0.5rem 0.75rem;
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-default);
   background: var(--bg-surface);
   color: var(--text-primary);
@@ -956,7 +956,7 @@ onMounted(loadProjects)
 .create-select {
   width: 100%;
   padding: 0.5rem 0.75rem;
-  border-radius: var(--radius-md, 8px);
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-default);
   background: var(--bg-surface);
   color: var(--text-primary);
@@ -970,7 +970,7 @@ onMounted(loadProjects)
 }
 
 .create-help-error {
-  color: var(--color-error, #dc2626);
+  color: var(--color-error);
 }
 
 /* GH#11129: repo linkage styles */
@@ -1004,7 +1004,7 @@ onMounted(loadProjects)
 
 .repo-link {
   font-size: 0.8125rem;
-  color: var(--color-accent-text, var(--color-accent, #c4651a));
+  color: var(--color-accent-text, var(--color-accent, var(--projbrowser-accent-text)));
   text-decoration: none;
   word-break: break-all;
 }
@@ -1019,7 +1019,7 @@ onMounted(loadProjects)
   color: var(--text-secondary);
   background: var(--bg-hover);
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   word-break: break-all;
 }
 
@@ -1033,18 +1033,18 @@ onMounted(loadProjects)
 }
 
 .repo-status-ready {
-  color: var(--color-success, #16a34a);
-  background: var(--color-success-bg, #dcfce7);
+  color: var(--color-success);
+  background: var(--color-success-bg);
 }
 
 .repo-status-error {
-  color: var(--color-error, #dc2626);
-  background: var(--color-error-bg, #fee2e2);
+  color: var(--color-error);
+  background: var(--color-error-bg);
 }
 
 .repo-status-syncing {
-  color: var(--color-warning, #d97706);
-  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
 }
 
 .repo-actions {
@@ -1062,7 +1062,7 @@ onMounted(loadProjects)
   color: var(--text-muted);
   display: inline-flex;
   align-items: center;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   transition: color var(--duration-200);
 }
 
@@ -1092,18 +1092,18 @@ onMounted(loadProjects)
 }
 
 .lifecycle-active {
-  color: var(--color-success, #16a34a);
-  background: var(--color-success-bg, #dcfce7);
+  color: var(--color-success);
+  background: var(--color-success-bg);
 }
 
 .lifecycle-archived {
-  color: var(--color-warning, #d97706);
-  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
 }
 
 .lifecycle-pending_disposal {
-  color: var(--color-error, #dc2626);
-  background: var(--color-error-bg, #fee2e2);
+  color: var(--color-error);
+  background: var(--color-error-bg);
 }
 
 .lifecycle-disposed {


### PR DESCRIPTION
Closes #12029
Closes #12030
Closes #12031
Part of #11515 (Task 4.3/4.4)

## What Changed
Combined single-commit PR. **AIDocumentEditor**: 12 dead-drops + 3 scoped `--aidoc-*` (undefined `--color-background-*` nested). **ProjectBrowserView**: 17 dead-drops + 1 scoped `--projbrowser-accent-text` (ember-only) + 1 px→radius. **TemplateBrowser**: 12 scoped `--tmplbrowser-*` gradient-stop tokens (decorative category palette, hex-only). design-tokens.css tail auto-merged clean with batch-15 blocks.

## Verification
Main-tree-clean; postcss PARSE OK; no dup defs; 16 scoped tokens defined 1:1.

## Model Used
Claude Fable 5 (subagent)