### PR TITLE
tokenise(user): ApprovalsInbox + CompanySelectorView + MemoryPrivacyPanel → design tokens (#12035, #12036, #12037)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -922,6 +922,39 @@
   --coportability-error-text: #991b1b;    /* error banner + failed-result foreground */
   --coportability-success-text: #166534;  /* success-result foreground */
   --coportability-on-accent: #fff;        /* white button label + spinner highlight on accent */
+
+  /* ============================================
+   * COMPANY SELECTOR VIEW TOKENS (#12036, umbrella #11515)
+   * Scoped to llc/CompanySelectorView.vue. Hex-only (deliberately NO OKLCH
+   * override) so the view renders pixel-identical to its previous hardcoded
+   * values across all browsers. These are the literal fallbacks the accent
+   * card, dot, status badge and create-link styles rendered because their
+   * intended Ember semantic tokens (--color-accent, --color-accent-subtle,
+   * --color-accent-text, --color-accent-border) are defined only by the
+   * ember theme; preserved behind those intended token names via nested
+   * var() so ember still wins where it defines them. Batch-mate
+   * ApprovalsInbox.vue (#12035) needed no scoped tokens - its style hexes
+   * were all dead fallbacks of defined tokens and were dropped.
+   * ============================================ */
+  --coselector-accent: #c4651a;         /* accent border, dot fill, create link (non-ember --color-accent fallback) */
+  --coselector-accent-subtle: #fcefe0;  /* active card + status badge fill (non-ember --color-accent-subtle fallback) */
+
+  /* ============================================
+   * MEMORY PRIVACY PANEL TOKENS (#12037, umbrella #11515)
+   * Scoped to settings/MemoryPrivacyPanel.vue. Hex-only (deliberately NO
+   * OKLCH override) so the panel renders pixel-identical to its previous
+   * hardcoded values across all browsers. The surface fills are the literal
+   * fallbacks the panel rendered because --surface-secondary,
+   * --surface-tertiary and --color-primary-muted are never defined in any
+   * theme; preserved behind those intended token names via nested var().
+   * --mempriv-on-accent is the white button label on the primary and danger
+   * fills (--text-on-primary carries an OKLCH override that would drift).
+   * ============================================ */
+  --mempriv-surface-secondary: #333;    /* secondary button + store badge fill (undefined --surface-secondary fallback) */
+  --mempriv-item-surface: #2a2a2a;      /* memory-item card fill (undefined --surface-secondary fallback) */
+  --mempriv-surface-tertiary: #1a1a1a;  /* provenance code-block fill (undefined --surface-tertiary fallback) */
+  --mempriv-primary-muted: #1e3a5f;     /* store-tag chip fill (undefined --color-primary-muted fallback) */
+  --mempriv-on-accent: #fff;            /* white button label on primary and danger fills */
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/settings/MemoryPrivacyPanel.vue
+++ b/autobot-frontend/src/components/settings/MemoryPrivacyPanel.vue
@@ -261,7 +261,7 @@ onMounted(loadMemories)
 
 .panel-desc {
   font-size: 0.875rem;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -277,16 +277,16 @@ onMounted(loadMemories)
   gap: 0.4rem;
   padding: 0.45rem 0.9rem;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm, 4px);
+  border-radius: var(--radius-sm);
   font-size: 0.875rem;
   cursor: pointer;
   transition: opacity 0.15s;
 }
 .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-primary { background: var(--color-primary, #4f8ef7); color: #fff; }
-.btn-secondary { background: var(--surface-secondary, #333); color: var(--text-primary, #eee); }
-.btn-danger { background: var(--color-danger, #e24848); color: #fff; }
-.btn-ghost { background: transparent; color: var(--text-secondary, #aaa); border-color: var(--border-color, #444); }
+.btn-primary { background: var(--color-primary); color: var(--mempriv-on-accent); }
+.btn-secondary { background: var(--surface-secondary, var(--mempriv-surface-secondary)); color: var(--text-primary); }
+.btn-danger { background: var(--color-danger); color: var(--mempriv-on-accent); }
+.btn-ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-color); }
 .btn-sm { padding: 0.3rem 0.65rem; font-size: 0.8rem; }
 
 .summary-bar {
@@ -295,19 +295,19 @@ onMounted(loadMemories)
   gap: 0.4rem;
   font-size: 0.8rem;
 }
-.total-badge { font-weight: 600; color: var(--text-primary, #eee); }
+.total-badge { font-weight: 600; color: var(--text-primary); }
 .store-badge {
   padding: 0.15rem 0.5rem;
-  background: var(--surface-secondary, #333);
+  background: var(--surface-secondary, var(--mempriv-surface-secondary));
   border-radius: 999px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-state {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   font-size: 0.9rem;
   padding: 1rem 0;
 }
@@ -323,9 +323,9 @@ onMounted(loadMemories)
 
 .memory-item {
   padding: 0.75rem 1rem;
-  background: var(--surface-secondary, #2a2a2a);
-  border: 1px solid var(--border-color, #3a3a3a);
-  border-radius: var(--radius-md, 6px);
+  background: var(--surface-secondary, var(--mempriv-item-surface));
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
   transition: opacity 0.2s;
 }
 .memory-item.is-deleting { opacity: 0.4; pointer-events: none; }
@@ -343,19 +343,19 @@ onMounted(loadMemories)
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  background: var(--color-primary-muted, #1e3a5f);
-  color: var(--color-primary, #4f8ef7);
+  background: var(--color-primary-muted, var(--mempriv-primary-muted));
+  color: var(--color-primary);
 }
 
 .item-ts {
   font-size: 0.75rem;
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
   margin-left: auto;
 }
 
 .item-content {
   font-size: 0.875rem;
-  color: var(--text-primary, #ddd);
+  color: var(--text-primary);
   margin: 0 0 0.5rem;
   word-break: break-word;
   white-space: pre-wrap;
@@ -364,12 +364,12 @@ onMounted(loadMemories)
 }
 
 .provenance { margin-bottom: 0.5rem; }
-.provenance summary { font-size: 0.8rem; cursor: pointer; color: var(--text-secondary, #888); }
+.provenance summary { font-size: 0.8rem; cursor: pointer; color: var(--text-secondary); }
 .provenance-data {
   font-size: 0.75rem;
-  background: var(--surface-tertiary, #1a1a1a);
+  background: var(--surface-tertiary, var(--mempriv-surface-tertiary));
   padding: 0.5rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow-x: auto;
   margin-top: 0.25rem;
 }

--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -328,13 +328,13 @@ onUnmounted(() => {
   color: white;
   font-size: 0.75rem;
   font-weight: 700;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
 }
 
 .header-tabs {
   display: flex;
   gap: 0.25rem;
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
   overflow: hidden;
 }
@@ -350,7 +350,7 @@ onUnmounted(() => {
 }
 
 .tab-btn.active {
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
 }
 
@@ -363,9 +363,9 @@ onUnmounted(() => {
 .filter-select,
 .filter-search {
   padding: 0.4rem 0.75rem;
-  border: 1px solid var(--border-default, #d1d5db);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   color: var(--text-primary);
   font-size: 0.875rem;
 }
@@ -386,14 +386,14 @@ onUnmounted(() => {
 .state-msg {
   text-align: center;
   padding: 3rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .approval-card {
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
   border-radius: 0.5rem;
   padding: 1rem;
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -412,14 +412,14 @@ onUnmounted(() => {
 
 .card-meta {
   font-size: 0.8rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 
 .type-badge,
 .status-badge {
   display: inline-block;
   padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   font-size: 0.75rem;
   font-weight: 500;
 }
@@ -441,15 +441,15 @@ onUnmounted(() => {
 .toggle-payload {
   font-size: 0.8rem;
   padding: 0.2rem 0.5rem;
-  border: 1px solid var(--border-default, #d1d5db);
+  border: 1px solid var(--border-default);
   border-radius: 0.25rem;
-  background: var(--bg-elevated, #f9fafb);
+  background: var(--bg-elevated);
   cursor: pointer;
 }
 
 .payload-json {
-  background: var(--bg-elevated, #f9fafb);
-  border: 1px solid var(--border-default, #e5e7eb);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
   padding: 0.75rem;
   font-size: 0.8rem;
@@ -491,15 +491,15 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  border-top: 1px solid var(--border-default, #e5e7eb);
+  border-top: 1px solid var(--border-default);
   padding-top: 0.75rem;
 }
 
 .note-textarea {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--border-default, #d1d5db);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   color: var(--text-primary);
   font-size: 0.875rem;
   resize: vertical;
@@ -513,7 +513,7 @@ onUnmounted(() => {
 
 .btn-primary {
   padding: 0.4rem 1rem;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -529,9 +529,9 @@ onUnmounted(() => {
 
 .btn-secondary {
   padding: 0.4rem 1rem;
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   color: var(--text-primary);
-  border: 1px solid var(--border-default, #d1d5db);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
   font-size: 0.875rem;
   font-weight: 500;

--- a/autobot-frontend/src/views/llc/CompanySelectorView.vue
+++ b/autobot-frontend/src/views/llc/CompanySelectorView.vue
@@ -132,13 +132,13 @@ onMounted(async () => {
 .selector-title {
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
 }
 
 .selector-subtitle {
   margin-top: 0.25rem;
   font-size: 0.875rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 
 /* #10502: unavailable (no company-mode deployment) empty-state */
@@ -149,9 +149,9 @@ onMounted(async () => {
   flex-direction: column;
   align-items: center;
   gap: 0.75rem;
-  border: 1px solid var(--border-default, #e5e7eb);
-  border-radius: var(--radius-lg, 12px);
-  background: var(--bg-secondary, #f9fafb);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
 }
 
 .selector-unavailable-icon {
@@ -162,20 +162,20 @@ onMounted(async () => {
 .selector-unavailable-title {
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
 }
 
 .selector-unavailable-desc {
   max-width: 32rem;
   font-size: 0.875rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 
 .selector-error {
   padding: 0.75rem 1rem;
-  border-radius: var(--radius-md, 8px);
-  background: var(--color-danger-bg, #fae5e1);
-  color: var(--color-error, #cb3326);
+  border-radius: var(--radius-md);
+  background: var(--color-danger-bg);
+  color: var(--color-error);
   font-size: 0.875rem;
 }
 
@@ -187,7 +187,7 @@ onMounted(async () => {
 .selector-empty {
   padding: 3rem 0;
   text-align: center;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -210,28 +210,28 @@ onMounted(async () => {
   gap: 0.75rem;
   padding: 0.875rem 1rem;
   text-align: left;
-  border-radius: var(--radius-lg, 12px);
-  border: 1px solid var(--border-default, #e5e7eb);
-  background: var(--bg-card, #ffffff);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-default);
+  background: var(--bg-card);
   cursor: pointer;
 }
 
 .company-card:hover {
-  border-color: var(--color-accent-border, var(--color-accent, #c4651a));
-  background: var(--bg-hover, #f9fafb);
+  border-color: var(--color-accent-border, var(--color-accent, var(--coselector-accent)));
+  background: var(--bg-hover);
 }
 
 .company-card.active {
-  border-color: var(--color-accent, #c4651a);
-  background: var(--color-accent-subtle, #fcefe0);
+  border-color: var(--color-accent, var(--coselector-accent));
+  background: var(--color-accent-subtle, var(--coselector-accent-subtle));
 }
 
 .company-dot {
   width: 0.625rem;
   height: 0.625rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   flex: none;
-  background: var(--color-accent, #c4651a);
+  background: var(--color-accent, var(--coselector-accent));
 }
 
 .company-meta {
@@ -243,12 +243,12 @@ onMounted(async () => {
 
 .company-name {
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
 }
 
 .company-description {
   font-size: 0.8125rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -260,14 +260,14 @@ onMounted(async () => {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
-  background: var(--color-accent-subtle, #fcefe0);
-  color: var(--color-accent-text, var(--color-accent, #c4651a));
+  border-radius: var(--radius-full);
+  background: var(--color-accent-subtle, var(--coselector-accent-subtle));
+  color: var(--color-accent-text, var(--color-accent, var(--coselector-accent)));
   flex: none;
 }
 
 .selector-create {
-  color: var(--color-accent-text, var(--color-accent, #c4651a));
+  color: var(--color-accent-text, var(--color-accent, var(--coselector-accent)));
   font-size: 0.875rem;
   font-weight: 600;
   text-decoration: none;


### PR DESCRIPTION
Closes #12035
Closes #12036
Closes #12037
Part of #11515 (Task 4.3/4.4)

## What Changed
Combined single-commit PR (final autobot-frontend tokenisation batch). **ApprovalsInbox**: 18 dead-drops + 2 px→radius. **CompanySelectorView**: 17 dead-drops + 2 scoped `--coselector-*` (ember-only accent) + 2 px→radius. **MemoryPrivacyPanel**: 16 dead-drops + 5 scoped `--mempriv-*` (undefined surface tokens + on-accent) + 1 px→radius. design-tokens.css tail union-resolved with batch-16 blocks.

## Verification
Main-tree-clean; postcss PARSE OK; no dup defs; all scoped tokens defined 1:1; `<style>`+`:root`-tail only.

## Model Used
Claude Fable 5 (subagent)