### PR TITLE
refactor(slm): adopt shared @autobot/ui usePagination in SLM views (#10885 PR-6)

### DIFF
--- a/autobot-slm-frontend/src/composables/usePaginationServerTotal.test.ts
+++ b/autobot-slm-frontend/src/composables/usePaginationServerTotal.test.ts
@@ -1,0 +1,86 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+//
+// Proves the server-side adoption of the shared @autobot/ui usePagination in
+// ErrorMonitor + TracingView (#10885). Both views paginate server-side: the API
+// returns one page of rows and a separate reactive total. This test locks in the
+// behaviour those views depend on:
+//   1. usePagination tracks a *reactive* serverTotalItems Ref, so
+//      totalPages/hasNext/hasPrev stay in sync after each fetch resolves.
+//   2. next/prev/goToPage re-fetch through onPageChange ONLY when navigation
+//      actually changes the page (matching the prior hand-rolled guards).
+//   3. Assigning currentPage.value directly (the filter-reset path) does NOT
+//      trigger onPageChange, so a filter change does not double-fetch.
+
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { usePagination } from '@autobot/ui'
+
+describe('usePagination server-side reactive total (#10885)', () => {
+  it('derives totalPages/hasNext from a reactive serverTotalItems ref', () => {
+    const serverTotal = ref(0)
+    const { totalPages, hasNext, hasPrev, currentPage } = usePagination(ref([]), {
+      itemsPerPage: 20,
+      serverTotalItems: serverTotal,
+    })
+
+    // Before the first fetch resolves: one empty page, no navigation.
+    expect(totalPages.value).toBe(1)
+    expect(hasNext.value).toBe(false)
+
+    // Server responds with 45 items -> ceil(45 / 20) = 3 pages.
+    serverTotal.value = 45
+    expect(totalPages.value).toBe(3)
+    expect(currentPage.value).toBe(1)
+    expect(hasPrev.value).toBe(false)
+    expect(hasNext.value).toBe(true)
+  })
+
+  it('re-fetches via onPageChange only when navigation changes the page', () => {
+    const serverTotal = ref(45)
+    const onPageChange = vi.fn()
+    const { next, prev, goToPage, currentPage } = usePagination(ref([]), {
+      itemsPerPage: 20,
+      serverTotalItems: serverTotal,
+      onPageChange,
+    })
+
+    // Already on page 1 -> prev is a no-op, no fetch (matches prevPage guard).
+    prev()
+    expect(currentPage.value).toBe(1)
+    expect(onPageChange).not.toHaveBeenCalled()
+
+    next()
+    expect(currentPage.value).toBe(2)
+    expect(onPageChange).toHaveBeenCalledTimes(1)
+    expect(onPageChange).toHaveBeenLastCalledWith(2, 20)
+
+    goToPage(3)
+    expect(currentPage.value).toBe(3)
+    expect(onPageChange).toHaveBeenCalledTimes(2)
+
+    // Beyond the last page -> no-op, no extra fetch (matches nextPage guard).
+    next()
+    expect(currentPage.value).toBe(3)
+    expect(onPageChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fetch when a filter reset assigns currentPage.value directly', () => {
+    const serverTotal = ref(45)
+    const onPageChange = vi.fn()
+    const { next, currentPage } = usePagination(ref([]), {
+      itemsPerPage: 20,
+      serverTotalItems: serverTotal,
+      onPageChange,
+    })
+
+    next()
+    expect(currentPage.value).toBe(2)
+    onPageChange.mockClear()
+
+    // onFilterChange() resets to page 1 by assigning the ref, then fetches once
+    // itself — the assignment must not also fire onPageChange (no double-fetch).
+    currentPage.value = 1
+    expect(onPageChange).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-slm-frontend/src/views/monitoring/ErrorMonitor.vue
+++ b/autobot-slm-frontend/src/views/monitoring/ErrorMonitor.vue
@@ -11,6 +11,7 @@
  */
 
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { usePagination } from '@autobot/ui'
 import { useSlmApi } from '@/composables/useSlmApi'
 import type {
   RecentError,
@@ -44,9 +45,23 @@ const selectedError = ref<RecentError | null>(null)
 const filterSeverity = ref<string>('all')
 const filterResolved = ref<string>('all')
 const searchQuery = ref('')
-const currentPage = ref(1)
 const totalErrors = ref(0)
-const perPage = 20
+
+// Server-side pagination via shared @autobot/ui composable (#10885).
+// The API owns the page slice; the composable drives page state + navigation
+// and re-fetches through onPageChange. serverTotalItems tracks the reactive
+// total so page-count/next/prev stay in sync after each fetch.
+const {
+  currentPage,
+  totalPages,
+  itemsPerPage: perPage,
+  next: nextPage,
+  prev: prevPage,
+} = usePagination<RecentError>(errors, {
+  itemsPerPage: 20,
+  serverTotalItems: totalErrors,
+  onPageChange: () => fetchData(),
+})
 
 let refreshInterval: ReturnType<typeof setInterval> | null = null
 
@@ -137,7 +152,7 @@ async function fetchData() {
         api.getErrorStatistics(),
         api.getRecentErrors({
           page: currentPage.value,
-          per_page: perPage,
+          per_page: perPage.value,
           severity: severityFilter,
           resolved: resolvedFilter,
         }),
@@ -199,20 +214,6 @@ async function clearOldErrors() {
 function onFilterChange() {
   currentPage.value = 1
   fetchData()
-}
-
-function nextPage() {
-  if (currentPage.value * perPage < totalErrors.value) {
-    currentPage.value++
-    fetchData()
-  }
-}
-
-function prevPage() {
-  if (currentPage.value > 1) {
-    currentPage.value--
-    fetchData()
-  }
 }
 
 onMounted(() => {
@@ -406,7 +407,7 @@ onUnmounted(() => {
             v-if="totalErrors > perPage"
             class="px-4 py-3 border-t border-gray-200 flex items-center justify-between"
           >
-            <span class="text-sm text-gray-500">{{ $t('monitoring.errorMonitor.pageValue0OfValue1', { value0: currentPage, value1: Math.ceil(totalErrors / perPage) }) }}</span>
+            <span class="text-sm text-gray-500">{{ $t('monitoring.errorMonitor.pageValue0OfValue1', { value0: currentPage, value1: totalPages }) }}</span>
             <div class="flex gap-2">
               <button
                 @click="prevPage"

--- a/autobot-slm-frontend/src/views/performance/TracingView.vue
+++ b/autobot-slm-frontend/src/views/performance/TracingView.vue
@@ -11,7 +11,8 @@
  * Issue #752 - Comprehensive performance monitoring.
  */
 
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, onMounted, watch } from 'vue'
+import { usePagination } from '@autobot/ui'
 import { usePerformanceMonitoring } from '@/composables/usePerformanceMonitoring'
 import { formatDateTime } from '@/composables/useTimezone'
 import type {
@@ -34,8 +35,21 @@ const {
 const timeRange = ref('24')
 const statusFilter = ref('all')
 const nodeFilter = ref('')
-const page = ref(1)
-const pageSize = ref(50)
+
+// Server-side pagination via shared @autobot/ui composable (#10885).
+// The API returns one page of traces; the composable owns page state +
+// navigation and re-fetches through onPageChange. serverTotalItems tracks the
+// reactive trace total so totalPages/next/prev stay in sync after each fetch.
+const {
+  currentPage: page,
+  itemsPerPage: pageSize,
+  totalPages,
+  goToPage,
+} = usePagination<TraceItem>(traces, {
+  itemsPerPage: 50,
+  serverTotalItems: traceTotal,
+  onPageChange: () => loadTraces(),
+})
 
 // Expanded trace detail
 const expandedTraceId = ref<string | null>(null)
@@ -55,8 +69,6 @@ const statusOptions = [
   { label: 'Error', value: 'error' },
   { label: 'Timeout', value: 'timeout' },
 ]
-
-const totalPages = computed(() => Math.max(1, Math.ceil(traceTotal.value / pageSize.value)))
 
 /**
  * Build query params from current filter state.
@@ -84,16 +96,6 @@ async function loadTraces(): Promise<void> {
 function onFilterChange(): void {
   page.value = 1
   loadTraces()
-}
-
-/**
- * Navigate to a page.
- */
-function goToPage(p: number): void {
-  if (p >= 1 && p <= totalPages.value) {
-    page.value = p
-    loadTraces()
-  }
 }
 
 /**

--- a/libs/autobot-ui/src/composables/usePagination.ts
+++ b/libs/autobot-ui/src/composables/usePagination.ts
@@ -44,7 +44,7 @@
  * ```
  */
 
-import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
+import { ref, computed, watch, unref, type Ref, type ComputedRef } from 'vue'
 import { createLogger } from '../utils/logger'
 
 // Create scoped logger for usePagination
@@ -73,9 +73,11 @@ export interface PaginationOptions {
 
   /**
    * For server-side pagination: total number of items
-   * If provided, switches to server-side pagination mode
+   * If provided, switches to server-side pagination mode.
+   * Accepts a plain number or a reactive Ref so the page-count
+   * stays in sync when the server total is fetched asynchronously.
    */
-  serverTotalItems?: number
+  serverTotalItems?: number | Ref<number>
 
   /**
    * For server-side pagination: current page data
@@ -248,7 +250,7 @@ export function usePagination<T = unknown>(
   // Computed: Total items
   const totalItems = computed(() => {
     if (isServerSide) {
-      return serverTotalItems || 0
+      return unref(serverTotalItems) || 0
     }
     return data.value?.length || 0
   })


### PR DESCRIPTION
## Thinking Path
Final PR of the @autobot/ui consolidation — adopt the shared `usePagination` (promoted to the kit in PR-4, wired into slm-frontend in PR-5) in the SLM hand-rolled views. Closes #10885.

## What Changed
- **ErrorMonitor.vue** + **TracingView.vue** — the 2 views with REAL navigable server-side pagination now use `usePagination` from `@autobot/ui` (exact behavior preserved: page sizes 20/50, first/prev/next/last controls, disabled conditions, i18n unchanged; `onPageChange` fires only on actual page changes — no double-fetch on filter reset).
- **SecurityView** + **LogViewer** left unchanged: SecurityView has vestigial pagination state but NO nav controls; LogViewer has no pagination — adopting would add nothing / change behavior. (Issue said "3 views"; real navigable count is 2.)
- **Kit fix (minimal, backward-compatible):** `usePagination`'s `serverTotalItems` now accepts `number | Ref<number>` (unwrapped via `unref`) — required because both views have a REACTIVE server total; a static number froze `totalPages` at 0. Plain-`number` callers (autobot-frontend) unaffected — CI verifies both frontends type-check.

Closes #10885

## Verification
- Local (isolated scratchpad, real composable source): new `usePaginationServerTotal.test.ts` 3/3; `tsc --strict` on the patched composable + a synthetic replica of both views' exact call patterns → exit 0.
- **Real CI validates** `npm ci` + full vue-tsc (both frontends) + vite build + vitest.

## Model Used
Opus 4.8 (subagent: frontend-engineer)