### PR TITLE
docs: currency refresh (README, Pages, stale docs, CATALOG) — Refs #12045

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,27 @@ AutoBot is three layers, bottom to top:
 
 → Full picture: [The AutoBot Platform Model](docs/architecture/PLATFORM_MODEL.md)
 
-## Quick Start (3 Steps)
+## Quick Start
 
-### 1. Clone the Repository
+**Option A — One-line installer (recommended, full platform).** Deploys the Service
+Lifecycle Manager (SLM) and all dependencies:
+```bash
+curl -fsSL https://raw.githubusercontent.com/mrveiss/AutoBot-AI/main/install.sh | sudo bash
+```
+When it finishes, the installer prints your **SLM URL** (`https://<server-ip>/slm/`) and
+admin credentials. Open that URL and log in — the **Setup Wizard** then walks you through
+adding fleet nodes, enrolling agents, assigning roles, and provisioning.
+
+**Option B — Docker Compose (quick eval / development).**
 ```bash
 git clone https://github.com/mrveiss/AutoBot-AI.git
 cd AutoBot-AI
-```
-
-### 2. Start with Docker
-```bash
 cp .env.example .env
 docker compose up -d
 ```
+User UI at **http://localhost**, SLM admin at **http://localhost/slm**.
 
-### 3. Open Your Dashboard
-Visit **http://localhost** in your browser. AutoBot is ready to use.
+→ Full install options and the two-phase deployment flow: [INSTALL.md](INSTALL.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,6 @@ All configuration uses environment variables in `.env`. See `.env.example` for a
 Key settings:
 - `AUTOBOT_DEPLOYMENT_MODE` — `hybrid` or `distributed`
 - `AUTOBOT_LLM_PROVIDER` — `ollama` (default) or others
-- `AUTOBOT_SINGLE_USER_MODE` — `true` (development) or `false` (multi-user)
 
 ### LLM Providers and Fallback
 
@@ -404,8 +403,10 @@ the support contact path live in **[FUNDING.md](FUNDING.md)**.
 
 ## Roadmap
 
+### Shipped
+- [x] Multi-user authentication and RBAC (single-user mode retired)
+
 ### Upcoming
-- [ ] Multi-user authentication and RBAC
 - [ ] Kubernetes orchestration support
 - [ ] Advanced analytics dashboards
 - [ ] Module ecosystem and registry

--- a/docs/GETTING_STARTED_COMPLETE.md
+++ b/docs/GETTING_STARTED_COMPLETE.md
@@ -46,11 +46,22 @@ For local backend + frontend development you can also run `./run_agent.sh`. For 
 two-phase deployment model, bare-metal (systemd) installs, and full system requirements,
 see [INSTALL.md](../INSTALL.md) and the [Installation Guide](user-guide/01-installation.md).
 
-### Open your dashboard
+### Continue setup in the SLM
 
-Visit **http://localhost** in your browser. AutoBot is ready to use.
+Setup finishes in the **Service Lifecycle Manager (SLM)** — AutoBot's management layer —
+not at a static dashboard:
 
-For a guided first run, see the [Quick Start](user-guide/02-quickstart.md) and
+- **Installer (Option A):** the installer's last phase prints your **SLM URL**
+  (`https://<server-ip>/slm/`) and the **admin credentials**. Open that URL and log in
+  (self-signed certificate — expect a browser warning). The **Setup Wizard** launches
+  automatically and walks you through: add fleet nodes → test connections → enroll agents
+  → assign roles → provision the fleet → verify health → Fleet Overview.
+- **Docker (Option B):** the user UI is at **http://localhost**; the SLM admin is at
+  **http://localhost/slm**.
+
+You can re-run the wizard later from **Settings > General > Re-run Setup Wizard**. For the
+full two-phase flow and the setup-wizard steps, see [INSTALL.md](../INSTALL.md); for a
+guided first run see the [Quick Start](user-guide/02-quickstart.md) and
 [Configuration Guide](user-guide/03-configuration.md).
 
 ## What You Can Do

--- a/docs/GETTING_STARTED_COMPLETE.md
+++ b/docs/GETTING_STARTED_COMPLETE.md
@@ -3,268 +3,97 @@ title: Getting Started
 nav_order: 2
 ---
 
-## 🎯 **Choose Your Path**
+# Getting Started with AutoBot
 
-AutoBot serves different audiences with specialized documentation. Select your role to get started:
+**Your data. Your AI.** AutoBot is a self-hosted, agentic AI platform you own: a small,
+solid core, a management layer that runs the hard infrastructure for you, and modules you
+install on top. Everything — your data, memory, agents, and knowledge graph — runs on
+*your* infrastructure, pointed at any brain you choose.
 
-### 🏢 **For Executives & Decision Makers**
-**Start Here:** [Executive Summary](../EXECUTIVE_SUMMARY.md)
-- **Why AutoBot?** Revolutionary AI platform saving $850K+ annually
-- **Business Impact:** 70% cost savings vs commercial RPA platforms
-- **Strategic Value:** First-mover advantages in autonomous AI
+New here? Start with [The AutoBot Platform Model](architecture/PLATFORM_MODEL.md) for the
+core → SLM → modules picture, then follow the quick start below.
 
-**Next Steps:**
-1. [AutoBot Revolution Overview](AUTOBOT_REVOLUTION.md) - Complete platform vision
-2. [Enterprise Deployment Strategy](deployment/ENTERPRISE_DEPLOYMENT_STRATEGY.md) - Rollout planning
+## Quick Start (Docker, ~5 minutes)
 
-### 💻 **For Developers & Technical Teams**
-**Start Here:** [Quick Reference Card](../QUICK_REFERENCE.md)
-- **Essential Commands** for immediate productivity
-- **Agent Development** patterns and best practices
-- **System Architecture** at-a-glance
+### Prerequisites
 
-**Next Steps:**
-1. [Agent System Architecture](architecture/AGENT_SYSTEM_ARCHITECTURE.md) - Technical deep dive
-2. [Agent System Guide](AGENT_SYSTEM_GUIDE.md) - Development handbook
-3. [Visual Architecture](architecture/VISUAL_ARCHITECTURE.md) - System diagrams
+- Linux or WSL2 (Ubuntu 22.04 LTS recommended)
+- Docker and Docker Compose
+- Python 3.12 and Node.js 20 are installed automatically by the installer for bare-metal setups
+- 16 GB+ RAM recommended
 
-### 🏗️ **For IT Operations & DevOps**
-**Start Here:** [Installation Guide](user_guide/01-installation.md)
-- **Production Setup** with enterprise security
-- **Container Orchestration** with Docker Compose
-- **NPU Optimization** for hardware acceleration
+For bare-metal (systemd) installs and full system requirements, see the
+[Installation Guide](user-guide/01-installation.md).
 
-**Next Steps:**
-1. [Hybrid Deployment Guide](deployment/HYBRID_DEPLOYMENT_GUIDE.md) - Multi-container setup
-2. [Enterprise Deployment Strategy](deployment/ENTERPRISE_DEPLOYMENT_STRATEGY.md) - Full rollout
-3. [Docker Architecture](deployment/DOCKER_ARCHITECTURE.md) - Container patterns
+### Install
 
-### 🛡️ **For Security & Compliance Teams**
-**Start Here:** [Security Implementation Summary](security/SECURITY_IMPLEMENTATION_SUMMARY.md)
-- **Multi-Layer Security** with risk-based agent classification
-- **Compliance Frameworks** (SOX, GDPR, HIPAA, PCI DSS)
-- **Audit & Monitoring** comprehensive logging
-
-**Next Steps:**
-1. [Security Agents Summary](security/SECURITY_AGENTS_SUMMARY.md) - Automated security
-2. [Session Takeover User Guide](security/SESSION_TAKEOVER_USER_GUIDE.md) - Human oversight
-
-### 🎨 **For Product Managers & UX Teams**
-**Start Here:** [Multi-Modal Processing](features/multimodal-processing.md)
-- **Vision + Voice + Text** integration capabilities
-- **User Experience** with intelligent decision making
-- **Workflow Orchestration** for complex tasks
-
-**Next Steps:**
-1. [Workflow API Documentation](workflow/WORKFLOW_API_DOCUMENTATION.md) - API integration
-2. [Advanced Workflow Features](workflow/ADVANCED_WORKFLOW_FEATURES.md) - Capabilities
-
-## 🚀 **Universal Quick Start (5 Minutes)**
-
-Regardless of your role, get AutoBot running in 5 minutes:
-
-### **Prerequisites**
-- Linux/WSL2 environment
-- Python 3.14+
-- Ansible (for fleet deployment)
-- 16GB+ RAM recommended
-
-### **Installation**
 ```bash
-# 1. Clone repository
-git clone <repository-url>
-cd AutoBot
+# 1. Clone the repository
+git clone https://github.com/mrveiss/AutoBot-AI.git
+cd AutoBot-AI
 
-# 2. Deploy with Ansible (recommended for production)
-cd autobot-slm-backend/ansible
-ansible-playbook playbooks/deploy-full.yml
-
-# OR: Run setup script (development/local)
-./run_agent.sh
-
-# 3. Access AutoBot
-# Production frontend: https://<frontend-ip> (Frontend VM)
-# Backend API: https://<backend-ip>:8443
-# SLM Admin: https://<slm-manager-ip>
+# 2. Configure and start with Docker
+cp .env.example .env
+docker compose up -d
 ```
 
-### **Verification**
-```bash
-# Verify backend health (from another VM due to WSL2 loopback)
-ssh autobot@<slm-manager-ip> 'curl --insecure https://<backend-ip>:8443/api/health'
+### Open your dashboard
 
-# Verify Redis
-redis-cli -h <database-ip> ping
+Visit **http://localhost** in your browser. AutoBot is ready to use.
 
-# Check service status
-ansible all -m ping
-```
+For a guided first run, see the [Quick Start](user-guide/02-quickstart.md) and
+[Configuration Guide](user-guide/03-configuration.md).
 
-## 🧭 **Navigation Guide**
+## What You Can Do
 
-### **📚 Documentation Structure**
+AutoBot is agentic — it talks, sees, and acts, all on hardware you control:
 
-AutoBot's documentation is organized for easy navigation:
+- **Chat and voice** — converse in text or hands-free voice against your own models
+- **Browser and desktop control** — vision-in-the-loop browser automation and computer
+  control, with human takeover
+- **Human-in-the-loop approvals** — pause the agent on a proposed plan and resume only
+  after you confirm
+- **Visual workflow builder** — compose multi-step agent workflows on a drag-and-drop canvas
+- **Knowledge graph** — institutional memory built from every conversation, document, and node
+- **Multi-user + RBAC** — role-based access control for teams
+- **Modules** — install AutoBot LLC (agents that work together as a company), Transcriber,
+  and Codebase Analytics *(work in progress)* on the core
+- **Service Lifecycle Manager (SLM)** — deploys, operates, and scales the underlying
+  infrastructure for you
 
-```
-docs/
-├── AUTOBOT_REVOLUTION.md              # 🌟 Platform overview
-├── GETTING_STARTED_COMPLETE.md        # 🎯 This guide
-├── AGENT_SYSTEM_GUIDE.md              # 🤖 Agent development
-├── INDEX.md                           # 📋 Complete index
-│
-├── architecture/                      # 🏗️ System design
-│   ├── AGENT_SYSTEM_ARCHITECTURE.md
-│   ├── VISUAL_ARCHITECTURE.md
-│   └── NPU_WORKER_ARCHITECTURE.json
-│
-├── deployment/                        # 🚀 Production deployment
-│   ├── ENTERPRISE_DEPLOYMENT_STRATEGY.md
-│   ├── HYBRID_DEPLOYMENT_GUIDE.md
-│   └── DOCKER_ARCHITECTURE.md
-│
-├── user_guide/                        # 📖 User documentation
-│   ├── 01-installation.md
-│   ├── 02-quickstart.md
-│   └── 03-configuration.md
-│
-└── features/                         # ✨ Advanced capabilities
-    ├── multimodal-processing.md
-    ├── computer-vision.md
-    └── voice-processing.md
-```
+The full, code-verified feature registry lives in the
+[Feature Catalog](features/CATALOG.md).
 
-### **🔗 Key Cross-References**
+## Learn More
 
-**For Understanding AutoBot:**
-- [AutoBot Revolution](AUTOBOT_REVOLUTION.md) → [Executive Summary](../EXECUTIVE_SUMMARY.md)
-- [Agent Architecture](architecture/AGENT_SYSTEM_ARCHITECTURE.md) → [Agent Guide](AGENT_SYSTEM_GUIDE.md)
-- [Visual Architecture](architecture/VISUAL_ARCHITECTURE.md) → [System Architecture](architecture/NPU_WORKER_ARCHITECTURE.json)
+### Understand the platform
 
-**For Implementation:**
-- [Enterprise Deployment](deployment/ENTERPRISE_DEPLOYMENT_STRATEGY.md) → [Hybrid Deployment](deployment/HYBRID_DEPLOYMENT_GUIDE.md)
-- [Agent Guide](AGENT_SYSTEM_GUIDE.md) → [Quick Reference](../QUICK_REFERENCE.md)
-- [Installation Guide](user_guide/01-installation.md) → [Configuration Guide](user_guide/03-configuration.md)
+- [The AutoBot Platform Model](architecture/PLATFORM_MODEL.md) — core → SLM → modules
+- [Agent System Architecture](architecture/AGENT_SYSTEM_ARCHITECTURE.md) — how agents work
+- [Visual Architecture](architecture/VISUAL_ARCHITECTURE.md) — system diagrams
+- [Glossary](GLOSSARY.md) — terms and definitions (including what SLM actually means)
 
-## 🎓 **Learning Path by Experience Level**
+### Install and operate
 
-### **🟢 Beginner (New to AutoBot)**
-1. **Week 1: Understanding**
-   - [Executive Summary](../EXECUTIVE_SUMMARY.md) - Business value
-   - [AutoBot Revolution](AUTOBOT_REVOLUTION.md) - Platform capabilities
-   - [Quick Start](user_guide/02-quickstart.md) - First interaction
+- [Installation Guide](user-guide/01-installation.md) — bare-metal and Docker
+- [Configuration Guide](user-guide/03-configuration.md) — environment and settings
+- [Troubleshooting Guide](user-guide/04-troubleshooting.md) — common issues
+- [Browser + VNC Quick Start](QUICK_START_BROWSER_VNC.md) — desktop/browser worker setup
 
-2. **Week 2: Basic Usage**
-   - [Installation Guide](user_guide/01-installation.md) - Full setup
-   - [Configuration Guide](user_guide/03-configuration.md) - Customization
-   - [Workflow Basics](workflow/WORKFLOW_API_DOCUMENTATION.md) - Simple workflows
+### Deploy at scale
 
-3. **Week 3: Exploration**
-   - [Multi-Modal Features](features/multimodal-processing.md) - Advanced AI
-   - [Security Features](security/SECURITY_IMPLEMENTATION_SUMMARY.md) - Safety
-   - [Monitoring](features/METRICS_MONITORING_SUMMARY.md) - System health
+- [Hybrid Deployment Guide](deployment/HYBRID_DEPLOYMENT_GUIDE.md) — multi-container setup
+- [Docker Architecture](deployment/DOCKER_ARCHITECTURE.md) — container patterns
+- [Security Implementation Summary](security/SECURITY_IMPLEMENTATION_SUMMARY.md) — RBAC and hardening
+- [Session Takeover User Guide](security/SESSION_TAKEOVER_USER_GUIDE.md) — human oversight
 
-### **🟡 Intermediate (Some Experience)**
-1. **Week 1: Deep Dive**
-   - [Agent System Architecture](architecture/AGENT_SYSTEM_ARCHITECTURE.md) - Technical depth
-   - [Visual Architecture](architecture/VISUAL_ARCHITECTURE.md) - System understanding
-   - [Enterprise Deployment](deployment/ENTERPRISE_DEPLOYMENT_STRATEGY.md) - Production
+### Build with it
 
-2. **Week 2: Customization**
-   - [Agent Development](AGENT_SYSTEM_GUIDE.md) - Build custom agents
-   - [Advanced Workflows](workflow/ADVANCED_WORKFLOW_FEATURES.md) - Complex automation
-   - [Performance Optimization](features/SYSTEM_OPTIMIZATION_REPORT.md) - Tuning
-
-3. **Week 3: Integration**
-   - [Hybrid Deployment](deployment/HYBRID_DEPLOYMENT_GUIDE.md) - Scale up
-   - [API Integration](developer/03-api-reference.md) - External systems
-   - [Testing Framework](testing/TESTING_FRAMEWORK_SUMMARY.md) - Quality assurance
-
-### **🔴 Advanced (Expert Level)**
-1. **Architecture Mastery**
-   - [Complete Agent System](architecture/AGENT_SYSTEM_ARCHITECTURE.md) - Full understanding
-   - [NPU Optimization](architecture/NPU_WORKER_ARCHITECTURE.json) - Hardware acceleration
-   - [Container Orchestration](deployment/DOCKER_ARCHITECTURE.md) - Scalable deployment
-
-2. **Customization Expertise**
-   - [Custom Agent Development](AGENT_SYSTEM_GUIDE.md) - Advanced patterns
-   - [Security Implementation](security/SECURITY_IMPLEMENTATION_SUMMARY.md) - Enterprise security
-   - [Performance Tuning](features/SYSTEM_OPTIMIZATION_REPORT.md) - Maximum efficiency
-
-3. **Innovation Leadership**
-   - [Enterprise Strategy](deployment/ENTERPRISE_DEPLOYMENT_STRATEGY.md) - Organizational rollout
-   - [Future Roadmap](AUTOBOT_REVOLUTION.md#future-evolution) - Technology evolution
-   - [Contributing](../CONTRIBUTING.md) - Platform development
-
-## 🎯 **Success Metrics**
-
-### **Week 1 Goals**
-- [ ] AutoBot system running locally
-- [ ] Understanding of core capabilities
-- [ ] First successful agent interaction
-- [ ] Basic workflow execution
-
-### **Month 1 Goals**
-- [ ] Production deployment completed
-- [ ] Team training finished
-- [ ] Custom workflows implemented
-- [ ] Performance baselines established
-
-### **Quarter 1 Goals**
-- [ ] Enterprise integration complete
-- [ ] Custom agents developed
-- [ ] ROI targets achieved
-- [ ] Scaling plan executed
-
-## 🆘 **Help & Support**
-
-### **Common Questions**
-1. **"Where do I start?"** → [Your role-specific path above](#-choose-your-path)
-2. **"How do I install?"** → [Installation Guide](user_guide/01-installation.md)
-3. **"What can AutoBot do?"** → [AutoBot Revolution](AUTOBOT_REVOLUTION.md)
-4. **"How much does it save?"** → [Executive Summary](../EXECUTIVE_SUMMARY.md)
-
-### **Troubleshooting**
-- **Installation Issues**: [Troubleshooting Guide](user_guide/04-troubleshooting.md)
-- **System Errors**: [Quick Reference](../QUICK_REFERENCE.md#troubleshooting)
-- **Performance Issues**: [System Optimization](features/SYSTEM_OPTIMIZATION_REPORT.md)
-- **Security Concerns**: [Security Implementation](security/SECURITY_IMPLEMENTATION_SUMMARY.md)
-
-### **Advanced Support**
-- **Enterprise Deployment**: [Enterprise Strategy](deployment/ENTERPRISE_DEPLOYMENT_STRATEGY.md)
-- **Custom Development**: [Agent System Guide](AGENT_SYSTEM_GUIDE.md)
-- **Integration Projects**: [API Reference](developer/03-api-reference.md)
-- **Performance Optimization**: [System Optimization Report](features/SYSTEM_OPTIMIZATION_REPORT.md)
-
-## 🏆 **Your AutoBot Journey**
-
-AutoBot is more than software—it's a platform for AI transformation. Your journey depends on your goals:
-
-### **Quick Win (1 Week)**
-Get AutoBot running and see immediate value through basic automation and AI assistance.
-
-### **Team Success (1 Month)**
-Deploy AutoBot across your team with custom workflows and enterprise integration.
-
-### **Organizational Transformation (1 Quarter)**
-Achieve full autonomous AI capabilities with custom agents and enterprise-wide deployment.
-
-### **Innovation Leadership (Ongoing)**
-Lead your industry with cutting-edge AI automation capabilities that competitors can't match.
+- [Workflow API Documentation](workflow/WORKFLOW_API_DOCUMENTATION.md) — workflow integration
+- [Advanced Workflow Features](workflow/ADVANCED_WORKFLOW_FEATURES.md) — complex automation
+- [API Reference](developer/03-api-reference.md) — REST API for external systems
+- [Contributing](../CONTRIBUTING.md) — help build AutoBot
 
 ---
 
-## 🚀 **Ready to Begin?**
-
-**Your AutoBot transformation starts with a single step:**
-
-1. **Choose your path** from the options above
-2. **Follow the recommended reading** for your role
-3. **Start with the Quick Start** to see AutoBot in action
-4. **Progress through the learning path** at your own pace
-
-**Welcome to the future of AI automation. Welcome to AutoBot.** 🎉
-
----
-
-*For additional support and advanced consultation, explore the complete [Documentation Index](INDEX.md) or contact the AutoBot team.*
+*Explore the complete [Documentation Index](INDEX.md) for everything else.*

--- a/docs/GETTING_STARTED_COMPLETE.md
+++ b/docs/GETTING_STARTED_COMPLETE.md
@@ -13,29 +13,38 @@ install on top. Everything — your data, memory, agents, and knowledge graph �
 New here? Start with [The AutoBot Platform Model](architecture/PLATFORM_MODEL.md) for the
 core → SLM → modules picture, then follow the quick start below.
 
-## Quick Start (Docker, ~5 minutes)
+## Quick Start (~5 minutes)
 
 ### Prerequisites
 
 - Linux or WSL2 (Ubuntu 22.04 LTS recommended)
-- Docker and Docker Compose
-- Python 3.12 and Node.js 20 are installed automatically by the installer for bare-metal setups
 - 16 GB+ RAM recommended
+- **Installer path:** `install.sh` installs Python 3.12, Node.js 20, and all dependencies for you
+- **Docker path:** Docker and Docker Compose
 
-For bare-metal (systemd) installs and full system requirements, see the
-[Installation Guide](user-guide/01-installation.md).
+### Install — choose one
 
-### Install
+**Option A — One-line installer (recommended, full platform).** A single Virtualmin-style
+installer that deploys the Service Lifecycle Manager (SLM) and every dependency:
 
 ```bash
-# 1. Clone the repository
+curl -fsSL https://raw.githubusercontent.com/mrveiss/AutoBot-AI/main/install.sh | bash
+# or, after cloning:
+sudo ./install.sh              # add --unattended for a non-interactive install
+```
+
+**Option B — Docker Compose (quick eval / development).**
+
+```bash
 git clone https://github.com/mrveiss/AutoBot-AI.git
 cd AutoBot-AI
-
-# 2. Configure and start with Docker
 cp .env.example .env
 docker compose up -d
 ```
+
+For local backend + frontend development you can also run `./run_agent.sh`. For the
+two-phase deployment model, bare-metal (systemd) installs, and full system requirements,
+see [INSTALL.md](../INSTALL.md) and the [Installation Guide](user-guide/01-installation.md).
 
 ### Open your dashboard
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,7 +33,7 @@ cssclasses:
 | [Glossary](GLOSSARY.md) | Terminology reference |
 | [Changelog](../changelog/_index.md) | Per-version release notes and unreleased fragments |
 | [Dependencies](DEPENDENCIES.md) | Dependency reference |
-| [Roadmap (2025–2026)](ROADMAP_2025.md) | Product roadmap |
+| [Roadmap](ROADMAP.md) | Product roadmap |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,11 +9,16 @@ aliases:
 
 # AutoBot Documentation
 
-> **AutoBot: Autonomous AI-Powered Linux Administration Platform**
+> **Your data. Your AI.**
 >
-> Multi-modal AI with 20+ specialized agents, NPU hardware acceleration, and RBAC security.
+> AutoBot is a self-hosted, agentic AI platform you own: a small, solid core, a Service
+> Lifecycle Manager that runs the hard infrastructure for you, and modules you install on
+> top. Voice and chat, browser and computer control, visual workflows, human-in-the-loop
+> approvals, multi-user RBAC, and a knowledge graph — all on your infrastructure.
 
 This is the root index for all AutoBot documentation. Every section is reachable from here.
+Start with [[architecture/PLATFORM_MODEL|The AutoBot Platform Model]] for the
+core → SLM → modules picture.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,8 +5,8 @@ nav_order: 4
 
 **Project Start**: July 2025
 **Current Status**: Active Development - See [docs/system-state.md](system-state.md) for current status
-**Last Updated**: February 18, 2026
-**Canonical Source**: This is the single authoritative project roadmap
+**Last Updated**: July 22, 2026
+**Canonical Source**: This is the single authoritative project roadmap (rolling; formerly `ROADMAP_2025.md`)
 
 > **Note**: Previous roadmap files have been archived to `docs/archive/`. This document consolidates all roadmap variants and provides accurate implementation status based on actual codebase verification.
 
@@ -16,7 +16,11 @@ nav_order: 4
 
 AutoBot has evolved into a **comprehensive autonomous AI platform** through intensive development. This roadmap consolidates information from all previous roadmap variants and provides verified implementation status.
 
-### Verified Implementation (December 2025)
+### Verified Implementation (snapshot: December 2025)
+
+> These counts are a December 2025 codebase snapshot and have grown since (e.g. the
+> `autobot-backend/agents/` directory now holds 60+ agents and the frontend 360+ Vue
+> components). Treat the table as a point-in-time baseline, not a live count.
 
 | Metric | Verified Count | Source |
 |--------|----------------|--------|
@@ -875,4 +879,4 @@ AutoBot has achieved **~99% production readiness** with a multi-VM distributed f
 
 ---
 
-*This roadmap consolidates all previous variants and provides verified implementation status based on actual codebase analysis. Last updated: February 18, 2026.*
+*This roadmap consolidates all previous variants and provides verified implementation status based on actual codebase analysis. Last updated: July 22, 2026.*

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: AutoBot
-description: Autonomous AI workspace — self-hosted, privacy-first, hardware-accelerated.
+description: Your data. Your AI. Self-hosted, agentic AI you own.
 url: "https://mrveiss.github.io"
 baseurl: "/AutoBot-AI"
 
@@ -32,7 +32,7 @@ nav_external_links:
 
 # Footer
 footer_content: >
-  &copy; 2025 mrveiss &mdash; <a href="https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/LICENSE">MIT License</a>
+  &copy; 2026 mrveiss &mdash; <a href="https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/LICENSE">MIT License</a>
 
 # Back to top
 back_to_top: true

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -62,7 +62,7 @@ for the core → SLM → modules picture, then use this index to navigate everyt
 | Document | Description |
 | --- | --- |
 | [[GLOSSARY]] | Terms and definitions |
-| [[ROADMAP_2025]] | 2025 product roadmap |
+| [[ROADMAP]] | Product roadmap |
 | [[DEPENDENCIES]] | Dependency overview |
 | [[external_apps/_index\|External Apps]] | Archived external AI tool system prompts |
 

--- a/docs/features/CATALOG.md
+++ b/docs/features/CATALOG.md
@@ -95,6 +95,8 @@ The themed tables below break down the capabilities inside the core and these mo
 | Capability | Status | Design doc | Issue | What it does |
 |------------|--------|------------|-------|--------------|
 | Session takeover & control | Shipped | [COMPLETE_SESSION_TAKEOVER_IMPLEMENTATION](COMPLETE_SESSION_TAKEOVER_IMPLEMENTATION.md) | [#9878][i-auto] | Pause/resume, approval gate, risk triggers (`takeover_manager`, `/takeover/*`) |
+| Visual workflow builder | Shipped | [visual-workflow-parallel-execution](../guides/visual-workflow-parallel-execution.md) | [#585](https://github.com/mrveiss/AutoBot-AI/issues/585) | Drag-and-drop workflow canvas for composing multi-step agent workflows, with a code view (`WorkflowBuilderView.vue`, `WorkflowCanvas.vue`, route `/automation`) |
+| Chat approval-gate interrupt | Partial | [#11202](https://github.com/mrveiss/AutoBot-AI/issues/11202) | [#11202](https://github.com/mrveiss/AutoBot-AI/issues/11202) | LangGraph human-in-the-loop interrupt in the chat workflow: pauses on a proposed plan and resumes after confirmation. Opt-in per session via `AUTOBOT_CHAT_APPROVAL_GATE` (`chat_workflow/graph.py`, `session_role.CHAT_APPROVAL_GATE_ENABLED`); distinct from session takeover |
 | Terminal safety | Shipped | [TERMINAL_SAFETY_IMPLEMENTATION](TERMINAL_SAFETY_IMPLEMENTATION.md) | [#9878][i-auto] | Command risk assessment + dangerous-command confirmation gate (`command_patterns`, `security_risk_judge`) |
 | Skills system | Shipped | [skills-system](../archives/plans/2026-02-18-skills-system.md) | [#9878][i-auto] | Skill discovery + 3-phase routing (`skill_router`, `/skills`) |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1124,7 +1124,7 @@
               <div class="icon-wrap"><svg class="icon"><use href="#i-sliders"/></svg></div>
               <div>
                 <strong>Setup wizard</strong>
-                <p>Open the web interface at <code style="font-family:var(--font-mono);font-size:.85em">https://autobot.local</code> and follow the fleet configuration wizard.</p>
+                <p>Open the SLM at <code style="font-family:var(--font-mono);font-size:.85em">https://&lt;server-ip&gt;/slm/</code> and log in with the admin credentials the installer prints, then follow the fleet configuration wizard.</p>
               </div>
             </div>
             <div class="deploy-point">
@@ -1158,8 +1158,9 @@
 <span class="c-dim"># 2. Bootstrap control plane (~10 min)</span>
 <span class="c-cmd">sudo</span> ./install.sh
 
-<span class="c-dim"># 3. Open setup wizard</span>
-<span class="c-dim">#    https://&lt;your-server-ip&gt;</span>
+<span class="c-dim"># 3. Open the SLM setup wizard (URL + admin</span>
+<span class="c-dim">#    login are printed by the installer)</span>
+<span class="c-dim">#    https://&lt;your-server-ip&gt;/slm/</span>
 
 <span class="c-dim"># 4. Add fleet VMs in the wizard</span>
 <span class="c-dim">#    NPU worker · Redis · AI stack · Browser</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="AutoBot — autonomous AI workspace for your infrastructure. Self-hosted, privacy-first, hardware-accelerated.">
+  <meta name="description" content="Self-hosted, agentic AI you own — voice & chat, browser and computer control, visual workflows, RBAC, and a knowledge graph on your infrastructure. Your data. Your AI.">
   <meta name="theme-color" content="#c4651a">
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='9' r='3.5' fill='%23c4651a'/%3E%3Ccircle cx='39' cy='24' r='3.5' fill='%23c4651a'/%3E%3Ccircle cx='24' cy='39' r='3.5' fill='%23c4651a'/%3E%3Ccircle cx='9' cy='24' r='3.5' fill='%23c4651a'/%3E%3Ccircle cx='24' cy='24' r='4.5' fill='%23c4651a'/%3E%3Cpath d='M24 13v6.5M32 24h5.5M24 28.5v6.5M12.5 24H19' stroke='%23c4651a' stroke-width='2.2' stroke-linecap='round'/%3E%3C/svg%3E">
-  <title>AutoBot — Autonomous AI Workspace</title>
+  <title>AutoBot — Your data. Your AI.</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <!-- Consent Mode v2: defaults MUST be set before gtag.js loads -->
@@ -728,6 +728,7 @@
         AutoBot
       </a>
       <div class="nav-links">
+        <a href="#capabilities" class="nav-link">Capabilities</a>
         <a href="#features" class="nav-link">Features</a>
         <a href="#scale" class="nav-link">Scale</a>
         <a href="#knowledge" class="nav-link">Knowledge</a>
@@ -824,6 +825,64 @@
           <div class="feature-icon"><svg class="icon"><use href="#i-mesh"/></svg></div>
           <h3>It scales with you</h3>
           <p>Start single-node; split frontend, databases, and workers across a distributed fleet — no re-architecture.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Capabilities -->
+  <section id="capabilities">
+    <div class="container">
+      <div class="features-header">
+        <span class="section-label">The cloud is just someone else's computer</span>
+        <h2 class="section-title">An agentic AI that runs on your machines</h2>
+        <p class="section-sub">Talk to it, let it drive a browser and desktop, approve what it does, and build agents that work together — all self-hosted. Your data. Your AI.</p>
+      </div>
+      <div class="features-grid">
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-chat"/></svg></div>
+          <h3>Talk to it</h3>
+          <p>Hands-free voice conversations alongside chat — a full-duplex voice panel and overlay run against your own models, so nothing you say leaves your infrastructure.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-scope"/></svg></div>
+          <h3>Let it drive a browser</h3>
+          <p>Vision-in-the-loop browser automation: the agent sees the page, works with indexed on-screen elements, and researches in a live panel — Playwright under your control.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-sliders"/></svg></div>
+          <h3>Give it the desktop</h3>
+          <p>Computer/desktop control via a GUI controller with computer-vision template matching and interactive screenshots, streamed over VNC with human takeover.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-spark"/></svg></div>
+          <h3>Approve what it does</h3>
+          <p>Human-in-the-loop approval interrupts pause the agent on a proposed plan and resume only after you confirm — opt in per session with <code>AUTOBOT_CHAT_APPROVAL_GATE</code>.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-layers"/></svg></div>
+          <h3>Build workflows visually</h3>
+          <p>A drag-and-drop visual workflow builder canvas — compose multi-step agent workflows on a graph, or drop to code when you need it.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-blocks"/></svg></div>
+          <h3>Bring your whole team</h3>
+          <p>Multi-user accounts with role-based access control (RBAC). Single-user mode is retired — AutoBot is built for teams from the start.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-mesh"/></svg></div>
+          <h3>It remembers your system</h3>
+          <p>A knowledge graph of institutional memory grows from every conversation, document, and node — queryable context the agent uses to act.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-blocks"/></svg></div>
+          <h3>Extend it with modules</h3>
+          <p>Install modules on the core: AutoBot LLC (agents that work together as a company), Transcriber, and Codebase Analytics <em>(work in progress)</em>.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon"><svg class="icon"><use href="#i-cpu"/></svg></div>
+          <h3>Point it at any brain</h3>
+          <p>The LLM gateway routes and falls back across providers — local models plus hosted gateways like the Claude API and OpenRouter — per agent, without losing memory.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Thinking Path

Lane B of #12045 (docs currency refresh) is code-repo-only documentation. Lane A (wiki publishing + repo metadata) is delivered directly with no code PR, so this PR closes the discrete Lane-B tracker #12089 rather than the umbrella. Every added capability claim was cross-checked against `git log`-derived shipped features and code — no invented capabilities.

## What Changed

Refreshes stale, off-brand, and factually-wrong documentation. Brand alignment: **"Your data. Your AI."**, wedge **"The cloud is just someone else's computer."**, SLM = **Service Lifecycle Manager** throughout.

- **`README.md`** — removed dead `AUTOBOT_SINGLE_USER_MODE` key (retired in code); moved "Multi-user authentication and RBAC" from Upcoming into a new **Shipped** section.
- **`docs/index.html`** (GitHub Pages) — fixed stale `<title>`/meta; added a **Capabilities** section (voice, vision-in-the-loop browser automation, desktop/computer control, human-in-the-loop approvals via `AUTOBOT_CHAT_APPROVAL_GATE`, visual workflow builder, multi-user + RBAC, knowledge graph, modules, LLM gateway) using existing page markup/CSS; surfaced the wedge line; added nav link.
- **`docs/_config.yml`** — fixed stale `description` (SEO); footer 2025 → 2026.
- **`docs/GETTING_STARTED_COMPLETE.md`** — removed enterprise/RPA framing + wrong "Python 3.14+" (real: 3.12); repaired all dead links (`user_guide/` → `user-guide/`, dropped missing pages, repointed to real docs).
- **`docs/README.md`** — reframed header to the current Platform Model / "Your data. Your AI." positioning.
- **`docs/ROADMAP_2025.md` → `docs/ROADMAP.md`** (`git mv`) — rolling roadmap; refreshed dates; labeled the Dec-2025 metrics table as a point-in-time snapshot; updated refs in `docs/_index.md` / `docs/INDEX.md`.
- **`docs/features/CATALOG.md`** — added Visual workflow builder entry (`WorkflowBuilderView.vue`/`WorkflowCanvas.vue`, `/automation`, #585) and chat approval-gate entry (`AUTOBOT_CHAT_APPROVAL_GATE`, `chat_workflow/graph.py`, #11202, marked Partial).

## Verification

- All docs link targets verified to exist on disk.
- Every added capability claim cross-checked against code (routes, env keys, component files cited inline).
- No retired config keys remain (`grep` clean for `AUTOBOT_SINGLE_USER_MODE` in `autobot-backend/`).
- Historical references (archived plans, file-comparison rows) intentionally preserved as accurate records of past state.

## Model Used

Claude Opus 4.8

Closes #12089
Refs #12045