### PR TITLE
tokenise(user): VideoCell + KanbanBoardView → design tokens (#12046, #12047)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -1058,6 +1058,37 @@
   --tmplbrowser-cat-startup-end: #fee140;       /* startup icon gradient end */
   --tmplbrowser-cat-custom-start: #a8edea;      /* custom icon gradient start */
   --tmplbrowser-cat-custom-end: #fed6e3;        /* custom icon gradient end */
+
+  /* ============================================
+   * VIDEO CELL TOKENS (#12046, umbrella #11515)
+   * Scoped to artifact-cells/VideoCell.vue. Hex-only (deliberately NO OKLCH
+   * override) so the cell renders pixel-identical to its previous hardcoded
+   * values across all browsers. --videocell-surface-2 is the literal fallback
+   * the badges, spinner track, progress track, error panel and button hover
+   * rendered because --color-surface-2 is never defined in any theme;
+   * preserved behind that intended token name via nested var().
+   * --videocell-video-bg is the pure-black letterbox fill behind the video
+   * element (--bg-dark carries an OKLCH override that would drift).
+   * ============================================ */
+  --videocell-surface-2: #f3f4f6;  /* badge, track, error and hover fill (undefined --color-surface-2 fallback) */
+  --videocell-video-bg: #000;      /* video wrapper letterbox fill */
+
+  /* ============================================
+   * KANBAN BOARD TOKENS (#12047, umbrella #11515)
+   * Scoped to llc/KanbanBoardView.vue. Hex-only (deliberately NO OKLCH
+   * override) so the WIP-limit column-header states render pixel-identical to
+   * their previous hardcoded values across all browsers. The soft-yellow warn
+   * and soft-red exceeded palettes have no existing exact semantic token
+   * (--color-danger-dark matches the exceeded text hex but carries an OKLCH
+   * override that would drift). Work-item status and priority colors live in
+   * component script data, NOT here. Batch-mate CodeCell.vue (#12048) needed
+   * no scoped tokens - its chrome is already fully tokenised and its hljs
+   * syntax-highlighting palette is DATA, preserved literal in the component.
+   * ============================================ */
+  --kanban-wip-warn-bg: #fef9c3;        /* WIP-limit warning column-header fill */
+  --kanban-wip-warn-text: #713f12;      /* WIP-limit warning column-header text */
+  --kanban-wip-exceeded-bg: #fee2e2;    /* WIP-limit exceeded column-header fill */
+  --kanban-wip-exceeded-text: #991b1b;  /* WIP-limit exceeded column-header text */
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/artifact-cells/VideoCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/VideoCell.vue
@@ -162,9 +162,9 @@ const copyVideoUrl = async (url: string) => {
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  border: 1px dashed var(--border-default, #e5e7eb);
+  border: 1px dashed var(--border-default);
   border-radius: 0.5rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .placeholder-content {
@@ -191,9 +191,9 @@ const copyVideoUrl = async (url: string) => {
 .size-badge {
   font-size: 0.75rem;
   padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
-  background: var(--color-surface-2, #f3f4f6);
-  color: var(--text-muted, #6b7280);
+  border-radius: var(--radius-full);
+  background: var(--color-surface-2, var(--videocell-surface-2));
+  color: var(--text-muted);
   font-weight: 500;
 }
 
@@ -202,7 +202,7 @@ const copyVideoUrl = async (url: string) => {
   max-width: 640px;
   border-radius: 0.5rem;
   overflow: hidden;
-  background: #000;
+  background: var(--videocell-video-bg);
 }
 
 .generated-video {
@@ -217,7 +217,7 @@ const copyVideoUrl = async (url: string) => {
   align-items: center;
   gap: 0.5rem;
   padding: 1.5rem;
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
   border-radius: 0.5rem;
   max-width: 640px;
 }
@@ -225,8 +225,8 @@ const copyVideoUrl = async (url: string) => {
 .spinner {
   width: 1.75rem;
   height: 1.75rem;
-  border: 3px solid var(--color-surface-2, #f3f4f6);
-  border-top-color: var(--color-primary, #3b82f6);
+  border: 3px solid var(--color-surface-2, var(--videocell-surface-2));
+  border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -234,20 +234,20 @@ const copyVideoUrl = async (url: string) => {
 .progress-track {
   width: 100%;
   height: 0.375rem;
-  background: var(--color-surface-2, #f3f4f6);
-  border-radius: 9999px;
+  background: var(--color-surface-2, var(--videocell-surface-2));
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 
 .progress-bar {
   height: 100%;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   transition: width 0.3s ease;
 }
 
 .progress-label {
   font-size: 0.8125rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .video-error {
@@ -256,8 +256,8 @@ const copyVideoUrl = async (url: string) => {
   gap: 0.5rem;
   padding: 1rem;
   border-radius: 0.5rem;
-  background: var(--color-surface-2, #f3f4f6);
-  color: var(--color-error, #dc2626);
+  background: var(--color-surface-2, var(--videocell-surface-2));
+  color: var(--color-error);
   font-size: 0.875rem;
   max-width: 640px;
 }
@@ -267,7 +267,7 @@ const copyVideoUrl = async (url: string) => {
   align-items: flex-start;
   gap: 0.375rem;
   font-size: 0.8125rem;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
   font-style: italic;
   line-height: 1.4;
   margin: 0;
@@ -285,17 +285,17 @@ const copyVideoUrl = async (url: string) => {
   gap: 0.25rem;
   padding: 0.25rem 0.625rem;
   font-size: 0.75rem;
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
-  background: var(--bg-surface, #fff);
-  color: var(--text-primary, #374151);
+  background: var(--bg-surface);
+  color: var(--text-primary);
   cursor: pointer;
   text-decoration: none;
   transition: background 0.15s;
 }
 
 .action-btn:hover {
-  background: var(--color-surface-2, #f3f4f6);
+  background: var(--color-surface-2, var(--videocell-surface-2));
 }
 
 @keyframes spin {

--- a/autobot-frontend/src/views/llc/KanbanBoardView.vue
+++ b/autobot-frontend/src/views/llc/KanbanBoardView.vue
@@ -308,9 +308,9 @@ onMounted(async () => {
 
 .kanban-column {
   flex: 0 0 240px;
-  background: var(--bg-elevated, #f9fafb);
+  background: var(--bg-elevated);
   border-radius: 0.5rem;
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
   display: flex;
   flex-direction: column;
   /* #10750 C2: bounded by .board-layout height, not the viewport */
@@ -325,19 +325,19 @@ onMounted(async () => {
   padding: 0.625rem 0.875rem;
   font-weight: 600;
   font-size: 0.875rem;
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  border-bottom: 1px solid var(--border-default);
   border-radius: 0.5rem 0.5rem 0 0;
   transition: background 0.15s;
 }
 
 .column-header.wip-warn {
-  background: #fef9c3;
-  color: #713f12;
+  background: var(--kanban-wip-warn-bg);
+  color: var(--kanban-wip-warn-text);
 }
 
 .column-header.wip-exceeded {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--kanban-wip-exceeded-bg);
+  color: var(--kanban-wip-exceeded-text);
 }
 
 .column-meta {
@@ -353,7 +353,7 @@ onMounted(async () => {
 
 .wip-limit {
   font-size: 0.7rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .column-cards {
@@ -367,7 +367,7 @@ onMounted(async () => {
 }
 
 .swimlane {
-  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  border-bottom: 1px solid var(--border-default);
   padding: 0.5rem;
 }
 
@@ -381,7 +381,7 @@ onMounted(async () => {
   gap: 0.375rem;
   font-size: 0.7rem;
   font-weight: 600;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.375rem;
@@ -400,7 +400,7 @@ onMounted(async () => {
 
 .lane-empty {
   font-size: 0.75rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   text-align: center;
   padding: 0.5rem;
 }
@@ -414,8 +414,8 @@ onMounted(async () => {
 }
 
 .kanban-card-inner {
-  background: var(--bg-surface, #fff);
-  border: 1px solid var(--border-default, #e5e7eb);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
   border-radius: 0.375rem;
   padding: 0.5rem 0.625rem;
   display: flex;
@@ -437,7 +437,7 @@ onMounted(async () => {
 .card-id {
   font-family: monospace;
   font-size: 0.65rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .pr-badge {
@@ -466,7 +466,7 @@ onMounted(async () => {
 .card-pts {
   font-size: 0.65rem;
   font-weight: 600;
-  background: var(--bg-elevated, #f3f4f6);
+  background: var(--bg-elevated);
   padding: 0.1rem 0.35rem;
   border-radius: 0.2rem;
 }
@@ -479,7 +479,7 @@ onMounted(async () => {
   width: 1.4rem;
   height: 1.4rem;
   border-radius: 50%;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
   font-size: 0.55rem;
   font-weight: 600;
@@ -489,8 +489,8 @@ onMounted(async () => {
   text-align: center;
   padding: 1.5rem 0.5rem;
   font-size: 0.75rem;
-  color: var(--text-secondary, #9ca3af);
-  border: 2px dashed var(--border-default, #e5e7eb);
+  color: var(--text-secondary);
+  border: 2px dashed var(--border-default);
   border-radius: 0.375rem;
   margin: 0.5rem;
 }


### PR DESCRIPTION
Closes #12046
Closes #12047
Part of #11515 (Task 4.3/4.4)

## What Changed
Combined single-commit PR. **VideoCell**: 12 dead-drops + 2 scoped `--videocell-*` (undefined surface + letterbox #000) + 2 px→radius. **KanbanBoardView**: 14 dead-drops + 4 scoped `--kanban-wip-*` (WIP-limit badge colors; #991b1b matches --color-danger-dark but it has an OKLCH override → hex-only). **CodeCell (#12048)**: audited, NO change needed — its 15 hexes are the hljs syntax-highlight palette (DATA, correctly literal) and chrome was already tokenised.

## Verification
Main-tree-clean; postcss PARSE OK; 6 scoped tokens defined 1:1; `<style>`+`:root`-tail only. CodeCell absent from diff (audit-only).

## Model Used
Claude Fable 5 (subagent)