### PR TITLE
tokenise(user): OperationDetail hardcoded hexes → design tokens (#12052)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -1089,6 +1089,26 @@
   --kanban-wip-warn-text: #713f12;      /* WIP-limit warning column-header text */
   --kanban-wip-exceeded-bg: #fee2e2;    /* WIP-limit exceeded column-header fill */
   --kanban-wip-exceeded-text: #991b1b;  /* WIP-limit exceeded column-header text */
+
+  /* ============================================
+   * OPERATION DETAIL TOKENS (#12052, umbrella #11515)
+   * Scoped to operations/OperationDetail.vue. Hex-only (deliberately NO
+   * OKLCH override) so the error section and the cancel and resume action
+   * buttons render pixel-identical to their previous hardcoded values across
+   * all browsers. The soft red and green action palettes have no existing
+   * exact semantic token (--color-danger-dark matches the danger text hex
+   * but carries an OKLCH override that would drift). Operation status, state
+   * and type colors in the component script are DATA, not chrome, and stay
+   * in the component.
+   * ============================================ */
+  --opdetail-error-bg: #fef2f2;            /* error-section fill */
+  --opdetail-danger-soft: #fecaca;         /* error-section and cancel-button border, cancel hover fill */
+  --opdetail-danger-text: #991b1b;         /* error-title and cancel-button text */
+  --opdetail-error-message-text: #7f1d1d;  /* error-message monospace text */
+  --opdetail-cancel-bg: #fee2e2;           /* cancel-button fill */
+  --opdetail-resume-bg: #dcfce7;           /* resume-button fill */
+  --opdetail-resume-text: #166534;         /* resume-button text */
+  --opdetail-success-soft: #bbf7d0;        /* resume-button border and hover fill */
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/operations/OperationDetail.vue
+++ b/autobot-frontend/src/components/operations/OperationDetail.vue
@@ -310,12 +310,12 @@ async function copyId() {
 
 .priority-high {
   background-color: var(--color-warning-bg);
-  color: var(--color-warning-dark, #92400e);
+  color: var(--color-warning-dark);
 }
 
 .priority-critical {
   background-color: var(--color-error-bg);
-  color: var(--color-error-dark, #991b1b);
+  color: var(--color-error-dark);
 }
 
 .section-title {
@@ -364,8 +364,8 @@ async function copyId() {
 
 .error-section {
   padding: var(--spacing-4);
-  background-color: #fef2f2;
-  border: 1px solid #fecaca;
+  background-color: var(--opdetail-error-bg);
+  border: 1px solid var(--opdetail-danger-soft);
   border-radius: var(--radius-md);
 }
 
@@ -373,12 +373,12 @@ async function copyId() {
   display: flex;
   align-items: center;
   gap: var(--spacing-1-5);
-  color: #991b1b;
+  color: var(--opdetail-danger-text);
 }
 
 .error-message {
   font-size: var(--text-sm);
-  color: #7f1d1d;
+  color: var(--opdetail-error-message-text);
   font-family: monospace;
   white-space: pre-wrap;
   word-break: break-word;
@@ -461,23 +461,23 @@ async function copyId() {
 }
 
 .cancel-btn {
-  background-color: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background-color: var(--opdetail-cancel-bg);
+  color: var(--opdetail-danger-text);
+  border: 1px solid var(--opdetail-danger-soft);
 }
 
 .cancel-btn:hover:not(:disabled) {
-  background-color: #fecaca;
+  background-color: var(--opdetail-danger-soft);
 }
 
 .resume-btn {
-  background-color: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
+  background-color: var(--opdetail-resume-bg);
+  color: var(--opdetail-resume-text);
+  border: 1px solid var(--opdetail-success-soft);
 }
 
 .resume-btn:hover:not(:disabled) {
-  background-color: #bbf7d0;
+  background-color: var(--opdetail-success-soft);
 }
 
 .refresh-btn {


### PR DESCRIPTION
Closes #12052
Part of #11515 (Task 4.3/4.4) — the last >=8-hex file.

## What Changed
2 dead-fallback drops + 8 scoped `--opdetail-*` tokens (soft red/green status-badge fills; #991b1b matches --color-danger-dark but it carries an OKLCH override → hex-only). Left literal: 11×1px borders, 640px breakpoint. Script/template status colors untouched.

## Verification
Main-tree-clean; postcss PARSE OK; all 8 scoped tokens defined 1:1; `<style>`+`:root`-tail only.

## Model Used
Claude Fable 5 (subagent)