### PR TITLE
tokenise(user): AgentActivityVisualization + WebResearchSettings + WorkflowVisualization px → spacing tokens (#12054, #12055, #12056)

### DIFF
--- a/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
+++ b/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
@@ -630,8 +630,8 @@ onMounted(() => {
 }
 
 .dismiss-icon {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
 }
 
 /* ── Status Grid ──────────────────────────── */
@@ -662,8 +662,8 @@ onMounted(() => {
 }
 
 .status-card-icon {
-  width: 36px;
-  height: 36px;
+  width: var(--spacing-9);
+  height: var(--spacing-9);
   border-radius: var(--radius-sm);
   background: var(--bg-tertiary);
   display: flex;
@@ -674,8 +674,8 @@ onMounted(() => {
 }
 
 .status-card-icon svg {
-  width: 20px;
-  height: 20px;
+  width: var(--spacing-5);
+  height: var(--spacing-5);
 }
 
 .status-enabled .status-card-icon {
@@ -690,7 +690,7 @@ onMounted(() => {
 }
 
 .status-label {
-  font-size: var(--text-xs, 11px);
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -763,7 +763,7 @@ onMounted(() => {
 }
 
 .field-hint {
-  font-size: var(--text-xs, 12px);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   margin: var(--spacing-0);
   line-height: var(--leading-normal);
@@ -803,7 +803,7 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   width: 44px;
-  height: 24px;
+  height: var(--spacing-6);
   border-radius: var(--radius-xl);
   border: none;
   cursor: pointer;
@@ -830,9 +830,9 @@ onMounted(() => {
 
 .toggle-thumb {
   position: absolute;
-  left: 2px;
-  width: 20px;
-  height: 20px;
+  left: var(--spacing-0-5);
+  width: var(--spacing-5);
+  height: var(--spacing-5);
   border-radius: 50%;
   background: var(--text-inverse);
   transition: transform var(--duration-200);
@@ -840,7 +840,7 @@ onMounted(() => {
 }
 
 .toggle-on .toggle-thumb {
-  transform: translateX(20px);
+  transform: translateX(var(--spacing-5));
 }
 
 /* ── Circuit Breakers ─────────────────────── */
@@ -865,7 +865,7 @@ onMounted(() => {
 }
 
 .cb-name {
-  font-size: var(--text-xs, 11px);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -961,8 +961,8 @@ onMounted(() => {
 }
 
 .btn-icon {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   flex-shrink: 0;
 }
 

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -366,8 +366,8 @@ defineExpose({
 }
 
 .agents-empty-state .empty-icon {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   opacity: 0.7;
 }
 
@@ -468,7 +468,7 @@ defineExpose({
 
 .agent-card:hover {
   border-color: rgba(59, 130, 246, 0.5);
-  transform: translateY(-2px);
+  transform: translateY(var(--spacing-neg-2px));
 }
 
 .agent-card.working {
@@ -508,7 +508,7 @@ defineExpose({
   color: var(--color-error);
   background: transparent;
   border: 1px solid var(--color-error);
-  border-radius: var(--radius-md, 6px);
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: background var(--duration-150) var(--ease-in-out);
 }
@@ -518,8 +518,8 @@ defineExpose({
 }
 
 .view-logs-btn .icon {
-  width: 12px;
-  height: 12px;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
 }
 
 .agent-card.paused {
@@ -527,8 +527,8 @@ defineExpose({
 }
 
 .agent-avatar {
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-12);
+  height: var(--spacing-12);
   border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
@@ -567,10 +567,10 @@ defineExpose({
 
 .status-ring {
   position: absolute;
-  bottom: -2px;
-  right: -2px;
-  width: 14px;
-  height: 14px;
+  bottom: var(--spacing-neg-2px);
+  right: var(--spacing-neg-2px);
+  width: var(--spacing-3-5);
+  height: var(--spacing-3-5);
   border-radius: var(--radius-full);
   border: 2px solid var(--bg-primary);
 }
@@ -627,8 +627,8 @@ defineExpose({
 }
 
 .activity-pulse {
-  width: 8px;
-  height: 8px;
+  width: var(--spacing-2);
+  height: var(--spacing-2);
   border-radius: var(--radius-full);
   background: var(--color-info);
   animation: pulse 1.5s infinite;
@@ -790,7 +790,7 @@ defineExpose({
 .timeline-row {
   display: flex;
   align-items: center;
-  height: 36px;
+  height: var(--spacing-9);
 }
 
 .agent-label {
@@ -812,7 +812,7 @@ defineExpose({
 
 .activity-bars {
   flex: 1;
-  height: 24px;
+  height: var(--spacing-6);
   background: rgba(51, 65, 85, 0.3);
   border-radius: var(--radius-default);
   position: relative;
@@ -926,7 +926,7 @@ defineExpose({
 
 .feed-leave-to {
   opacity: 0;
-  transform: translateX(20px);
+  transform: translateX(var(--spacing-5));
 }
 
 /* Responsive */
@@ -958,7 +958,7 @@ defineExpose({
 
   .activity-bars {
     width: 100%;
-    height: 20px;
+    height: var(--spacing-5);
   }
 }
 </style>

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -802,8 +802,8 @@ defineExpose({
 /* Zoom controls */
 .zoom-controls {
   position: absolute;
-  bottom: 16px;
-  right: 16px;
+  bottom: var(--spacing-4);
+  right: var(--spacing-4);
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
@@ -814,8 +814,8 @@ defineExpose({
 }
 
 .zoom-controls button {
-  width: 28px;
-  height: 28px;
+  width: var(--spacing-7);
+  height: var(--spacing-7);
   border: 1px solid var(--border-subtle);
   background: transparent;
   border-radius: var(--radius-default);
@@ -835,17 +835,17 @@ defineExpose({
 .zoom-level {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  min-width: 40px;
+  min-width: var(--spacing-10);
   text-align: center;
 }
 
 /* Progress bar */
 .progress-bar {
   position: absolute;
-  bottom: 16px;
-  left: 16px;
+  bottom: var(--spacing-4);
+  left: var(--spacing-4);
   width: 200px;
-  height: 24px;
+  height: var(--spacing-6);
   background: rgba(30, 41, 59, 0.9);
   border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
@@ -872,8 +872,8 @@ defineExpose({
 /* Node details panel */
 .node-details {
   position: absolute;
-  top: 80px;
-  right: 20px;
+  top: var(--spacing-20);
+  right: var(--spacing-5);
   width: 280px;
   background: var(--bg-secondary);
   border-radius: var(--radius-xl);
@@ -892,8 +892,8 @@ defineExpose({
 }
 
 .details-icon {
-  width: 40px;
-  height: 40px;
+  width: var(--spacing-10);
+  height: var(--spacing-10);
   border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
@@ -995,7 +995,7 @@ defineExpose({
 .slide-enter-from,
 .slide-leave-to {
   opacity: 0;
-  transform: translateX(20px);
+  transform: translateX(var(--spacing-5));
 }
 
 /* Responsive */
@@ -1017,7 +1017,7 @@ defineExpose({
     left: 0;
     right: 0;
     width: 100%;
-    border-radius: var(--radius-xl) 12px 0 0;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
     max-height: 50vh;
     overflow-y: auto;
   }


### PR DESCRIPTION
Closes #12054
Closes #12055
Closes #12056
Part of #11515 (Task 4.3/4.4) — sizing pass.

## What Changed
Combined single-commit PR (px-only, no design-tokens.css change). **AgentActivityVisualization**: 17 px→spacing + 1 dead-drop. **WebResearchSettings**: 12 px→spacing + 3 dead-drops (incl. wrong 11px fallbacks on defined --text-xs). **WorkflowVisualization**: 14 px→spacing/radius. All byte-exact at 16px root. Left literal: off-scale dims, 1-3px borders, shadow offsets, font-sizes, %.

## Verification
Main-tree-clean; all --spacing-*/--radius-* refs pre-defined (0 undefined); design-tokens.css NOT in diff; `<style>`-only.

## Model Used
Claude Fable 5 (subagent)