### PR TITLE
tokenise(user): LoadingSpinner + FunctionCallGraph + SystemArchitectureDiagram px → spacing tokens (#12058, #12059, #12060)

### DIFF
--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -1395,8 +1395,8 @@ watch(viewMode, async (newMode) => {
 }
 
 .loading-spinner {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border: 3px solid var(--border-default);
   border-top-color: var(--color-primary);
   border-radius: 50%;
@@ -1411,8 +1411,8 @@ watch(viewMode, async (newMode) => {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: var(--spacing-10);
+  height: var(--spacing-10);
   background: var(--color-error-bg);
   color: var(--color-error);
   border-radius: 50%;
@@ -1582,8 +1582,8 @@ watch(viewMode, async (newMode) => {
 }
 
 .network-controls button {
-  width: 28px;
-  height: 28px;
+  width: var(--spacing-7);
+  height: var(--spacing-7);
   border: 1px solid var(--border-default);
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
@@ -1604,7 +1604,7 @@ watch(viewMode, async (newMode) => {
 .zoom-level {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  min-width: 36px;
+  min-width: var(--spacing-9);
   text-align: center;
 }
 
@@ -1644,7 +1644,7 @@ watch(viewMode, async (newMode) => {
 }
 
 .expand-icon {
-  width: 16px;
+  width: var(--spacing-4);
   font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
@@ -1756,7 +1756,7 @@ watch(viewMode, async (newMode) => {
 
 .unresolved-badge {
   font-size: 9px;
-  padding: 1px var(--spacing-1);
+  padding: var(--spacing-px) var(--spacing-1);
   background: var(--color-warning-bg);
   color: var(--color-warning);
   border-radius: var(--radius-default);
@@ -1807,8 +1807,8 @@ watch(viewMode, async (newMode) => {
 }
 
 .legend-item .dot {
-  width: 12px;
-  height: 12px;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
   border-radius: 50%;
 }
 
@@ -1852,7 +1852,7 @@ watch(viewMode, async (newMode) => {
   top: var(--spacing-3);
   left: var(--spacing-3);
   width: 320px;
-  max-width: calc(100% - 24px);
+  max-width: calc(100% - var(--spacing-6));
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);

--- a/autobot-frontend/src/components/ui/LoadingSpinner.vue
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.vue
@@ -92,11 +92,11 @@ const customStyle = computed(() => ({
   flex-direction: column;
 }
 
-.loading-spinner.loading-xs { width: 16px; height: 16px; }
-.loading-spinner.loading-sm { width: 20px; height: 20px; }
-.loading-spinner.loading-md { width: 24px; height: 24px; }
-.loading-spinner.loading-lg { width: 32px; height: 32px; }
-.loading-spinner.loading-xl { width: 40px; height: 40px; }
+.loading-spinner.loading-xs { width: var(--spacing-4); height: var(--spacing-4); }
+.loading-spinner.loading-sm { width: var(--spacing-5); height: var(--spacing-5); }
+.loading-spinner.loading-md { width: var(--spacing-6); height: var(--spacing-6); }
+.loading-spinner.loading-lg { width: var(--spacing-8); height: var(--spacing-8); }
+.loading-spinner.loading-xl { width: var(--spacing-10); height: var(--spacing-10); }
 
 /* Circle Spinner */
 .loading-circle {
@@ -232,7 +232,7 @@ const customStyle = computed(() => ({
   width: 1px;
   height: 1px;
   padding: var(--spacing-0);
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -1473,8 +1473,8 @@ watch(() => currentView.value, () => {
 }
 
 .zoom-controls button {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   background: var(--bg-primary);
   border: 1px solid var(--bg-tertiary);
   border-radius: var(--radius-md);
@@ -1500,7 +1500,7 @@ watch(() => currentView.value, () => {
 .zoom-level {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  min-width: 40px;
+  min-width: var(--spacing-10);
   text-align: center;
 }
 
@@ -1561,8 +1561,8 @@ watch(() => currentView.value, () => {
 }
 
 .component-icon-badge {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
@@ -1773,7 +1773,7 @@ watch(() => currentView.value, () => {
 .legend-title {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  min-width: 80px;
+  min-width: var(--spacing-20);
 }
 
 .legend-items {
@@ -1791,8 +1791,8 @@ watch(() => currentView.value, () => {
 }
 
 .legend-color {
-  width: 12px;
-  height: 12px;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
   border-radius: var(--radius-xs);
 }
 
@@ -1818,7 +1818,7 @@ watch(() => currentView.value, () => {
 }
 
 .legend-line {
-  width: 20px;
+  width: var(--spacing-5);
   height: 3px;
   border-radius: 1px;
 }
@@ -1849,7 +1849,7 @@ watch(() => currentView.value, () => {
 .slide-enter-from,
 .slide-leave-to {
   opacity: 0;
-  transform: translateX(20px);
+  transform: translateX(var(--spacing-5));
 }
 
 /* Responsive */


### PR DESCRIPTION
Closes #12058
Closes #12059
Closes #12060
Part of #11515 (Task 4.3/4.4) — sizing pass.

## What Changed
Combined single-commit PR (px-only, no design-tokens.css change). **LoadingSpinner**: 11 px→spacing (size variants + sr-only). **FunctionCallGraph**: 12 px→spacing incl. `calc(100% - var(--spacing-6))`; chart palette untouched. **SystemArchitectureDiagram**: 10 px→spacing. All byte-exact at 16px root. Left literal: 1-3px borders, off-scale, shadow/stroke, font-sizes.

## Verification
Main-tree-clean; all refs pre-defined (0 undefined); design-tokens.css NOT in diff; `<style>`-only.

## Model Used
Claude Fable 5 (subagent)