### PR TITLE
tokenise(user): WorkflowLiveDashboard + CapabilityAuditLog + CodeQualityDashboard px → spacing tokens (#12062, #12063, #12064)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -1081,8 +1081,8 @@ watch(selectedPeriod, () => {
 }
 
 .status-dot {
-  width: 8px;
-  height: 8px;
+  width: var(--spacing-2);
+  height: var(--spacing-2);
   border-radius: var(--radius-full);
   background: currentColor;
   animation: pulse 2s infinite;
@@ -1302,7 +1302,7 @@ watch(selectedPeriod, () => {
 
 .metric-card:hover {
   border-color: var(--color-info);
-  transform: translateY(-2px);
+  transform: translateY(var(--spacing-neg-2px));
 }
 
 .metric-card.low-score {
@@ -1343,7 +1343,7 @@ watch(selectedPeriod, () => {
 }
 
 .metric-bar {
-  height: 4px;
+  height: var(--spacing-1);
   background: var(--border-subtle);
   border-radius: var(--radius-xs);
   overflow: hidden;
@@ -1487,7 +1487,7 @@ watch(selectedPeriod, () => {
 
 .bar-container {
   flex: 1;
-  height: 8px;
+  height: var(--spacing-2);
   background: var(--bg-surface);
   border-radius: var(--radius-default);
   overflow: hidden;
@@ -1583,8 +1583,8 @@ watch(selectedPeriod, () => {
 }
 
 .hotspot-rank {
-  width: 24px;
-  height: 24px;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1650,8 +1650,8 @@ watch(selectedPeriod, () => {
 }
 
 .threshold-color {
-  width: 12px;
-  height: 12px;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
   border-radius: var(--radius-xs);
 }
 

--- a/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
+++ b/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
@@ -182,7 +182,7 @@ onMounted(() => {
 .filter-input {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background-color: var(--bg-primary);
   color: var(--text-primary);
   font-size: 0.875rem;
@@ -198,7 +198,7 @@ onMounted(() => {
   padding: 0.5rem;
   background: none;
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   color: var(--text-secondary);
   transition: all 0.2s;
@@ -216,8 +216,8 @@ onMounted(() => {
 }
 
 .refresh-icon {
-  width: 20px;
-  height: 20px;
+  width: var(--spacing-5);
+  height: var(--spacing-5);
 }
 
 .refresh-icon.spinning {
@@ -239,8 +239,8 @@ onMounted(() => {
 }
 
 .spinner {
-  width: 24px;
-  height: 24px;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
   animation: spin 1s linear infinite;
 }
 
@@ -251,13 +251,13 @@ onMounted(() => {
   padding: 1rem;
   background-color: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: #ef4444;
 }
 
 .error-banner svg {
-  width: 20px;
-  height: 20px;
+  width: var(--spacing-5);
+  height: var(--spacing-5);
   flex-shrink: 0;
 }
 
@@ -271,8 +271,8 @@ onMounted(() => {
 }
 
 .empty-icon {
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-12);
+  height: var(--spacing-12);
   margin-bottom: 1rem;
   opacity: 0.5;
 }
@@ -280,7 +280,7 @@ onMounted(() => {
 .audit-table-container {
   overflow-x: auto;
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .audit-table {
@@ -336,7 +336,7 @@ onMounted(() => {
 .capability code {
   background-color: var(--color-background-secondary);
   padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.8125rem;
   font-family: monospace;
 }
@@ -348,7 +348,7 @@ onMounted(() => {
 .status-badge {
   display: inline-block;
   padding: 0.25rem 0.75rem;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -452,8 +452,8 @@ onUnmounted(() => {
 }
 
 .btn-refresh-sm {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -570,7 +570,7 @@ onUnmounted(() => {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
-  padding: 3px 10px;
+  padding: 3px var(--spacing-2-5);
   border-radius: var(--radius-xl);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -593,7 +593,7 @@ onUnmounted(() => {
 }
 
 .progress-track {
-  height: 6px;
+  height: var(--spacing-1-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
   overflow: hidden;
@@ -626,8 +626,8 @@ onUnmounted(() => {
 }
 
 .timeline-dot {
-  width: 24px;
-  height: 24px;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
   border-radius: 50%;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #12062
Closes #12063
Closes #12064
Part of #11515 sizing pass. 29 px→spacing/radius (byte-exact). No design-tokens.css change. Left literal: font-size, 1-3px borders, off-scale, %. Main-tree-clean; 0 undefined refs; `<style>`-only.

## Model Used
Claude Fable 5 (subagent)