### PR TITLE
fix(ci): make detect-hardcoded-values.sh test-exclude convention-complete (#11947)

### DIFF
--- a/pipeline-scripts/detect-hardcoded-values.sh
+++ b/pipeline-scripts/detect-hardcoded-values.sh
@@ -65,10 +65,17 @@ EXCLUDE_PATTERNS=(
     # SSOT definition files (they ARE the config source)
     "registry_defaults.py"
     "ssot_mappings.py"
-    # Test files (assertions verify known config values)
+    # Test files (assertions verify known config values) — cover both pytest
+    # conventions (test_*.py prefix AND *_test.py suffix) and both TS conventions
+    # (*.spec.ts AND *.test.ts). NOTE: this deliberately stops the design-value
+    # scanner from flagging test files; hardcoded prod values in tests (e.g. an
+    # IP address, GH#11589) are a separate concern for a dedicated check, not a
+    # side-effect of this design-token scanner.
     "*_test.py"
+    "test_*.py"
     "*.spec.ts"
     "*_test.ts"
+    "*.test.ts"
 )
 
 build_exclude_args() {


### PR DESCRIPTION
Closes #11947

## Thinking Path
The exclude list's `# Test files` block only had `*_test.py` (suffix) but omitted the dominant pytest `test_*.py` prefix (510 files) — and `*.test.ts` (127 files), while listing `*_test.ts` (0 files). So test files were scanned despite the stated intent to exclude them.

## What Changed
Added `test_*.py` and `*.test.ts` to `EXCLUDE_PATTERNS`. Documented the deliberate trade-off: this stops the DESIGN-VALUE scanner from flagging tests (its stated intent); hardcoded prod values in tests (e.g. the prod-IP in #11589) are a separate concern for a dedicated check, not a side-effect of this design-token scanner.

## Verification
`bash -n` clean. The scanner now honors both pytest and both TS test-naming conventions.

## Model Used
Claude Opus 4.8