### PR TITLE
fix(worker): correct inverted GUIController platform gate + AutoBotConfig import (#11970, #11971)

### DIFF
--- a/autobot-backend/gui_controller.py
+++ b/autobot-backend/gui_controller.py
@@ -183,13 +183,96 @@ class GUIController:
         except Exception as e:
             logger.error("Error clicking at (%s, %s): %s", x, y, e)
 
-    async def type_text(self, text):
-        """Simulate typing the specified text."""
+    async def click_element(
+        self,
+        image_path: str,
+        confidence: float = 0.9,
+        button: str = "left",
+        clicks: int = 1,
+        interval: float = 0.0,
+    ) -> Dict[str, Any]:
+        """Locate an element by image and click it (Issue #11970 parity).
+
+        Interface parity with gui_controller_dummy.GUIController.click_element,
+        required by task_handlers/gui_handlers.py's GUIClickElementHandler.
+        """
         try:
-            await asyncio.to_thread(pyautogui.write, text)
+            location = await self.locate_element_by_image(image_path, confidence=confidence)
+            if not location:
+                return {
+                    "status": "error",
+                    "message": f"Element not found for image: {image_path}",
+                }
+            await asyncio.to_thread(
+                pyautogui.click,
+                location.x,
+                location.y,
+                clicks=clicks,
+                interval=interval,
+                button=button,
+            )
+            logger.debug("Clicked element '%s' at %s", image_path, location)
+            return {"status": "success", "message": "GUI click completed"}
+        except Exception as e:
+            logger.error("Error clicking element '%s': %s", image_path, e)
+            return {"status": "error", "message": "Operation failed"}
+
+    async def type_text(self, text: str, interval: float = 0.0) -> Dict[str, Any]:
+        """Simulate typing the specified text.
+
+        Issue #11970: accepts ``interval`` (dummy-controller parity) and
+        returns a status dict, required by task_handlers/gui_handlers.py's
+        GUITypeTextHandler (``result.get("status", ...)``).
+        """
+        try:
+            await asyncio.to_thread(pyautogui.write, text, interval=interval)
             logger.debug("Typed text: %s", text)
+            return {"status": "success", "message": "GUI text type completed"}
         except Exception as e:
             logger.error("Error typing text: %s", e)
+            return {"status": "error", "message": "Operation failed"}
+
+    async def move_mouse(self, x: int, y: int, duration: float = 0.0) -> Dict[str, Any]:
+        """Move the mouse to the specified coordinates (Issue #11970 parity).
+
+        Interface parity with gui_controller_dummy.GUIController.move_mouse,
+        required by task_handlers/gui_handlers.py's GUIMoveMouseHandler.
+        """
+        try:
+            await asyncio.to_thread(pyautogui.moveTo, x, y, duration=duration)
+            logger.debug("Moved mouse to (%s, %s)", x, y)
+            return {"status": "success", "message": "GUI mouse move completed"}
+        except Exception as e:
+            logger.error("Error moving mouse to (%s, %s): %s", x, y, e)
+            return {"status": "error", "message": "Operation failed"}
+
+    async def bring_window_to_front(self, app_title: str) -> Dict[str, Any]:
+        """Bring a window matching app_title to the foreground (Issue #11970 parity).
+
+        Uses xdotool (same tool already relied on by api.vnc_manager for
+        desktop interaction on the canonical display), since pyautogui has
+        no native cross-platform window-focus API. Interface parity with
+        gui_controller_dummy.GUIController.bring_window_to_front, required
+        by task_handlers/gui_handlers.py's GUIBringWindowToFrontHandler.
+        """
+        try:
+            result = await asyncio.to_thread(
+                subprocess.run,  # nosec B603 B607 - fixed argv, app_title passed as a single arg (no shell)
+                ["/usr/bin/xdotool", "search", "--name", app_title, "windowactivate"],
+                capture_output=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                logger.debug("Brought window '%s' to front", app_title)
+                return {"status": "success", "message": "GUI window bring to front completed"}
+            logger.warning("xdotool could not find/activate window '%s'", app_title)
+            return {"status": "error", "message": f"Window not found: {app_title}"}
+        except FileNotFoundError:
+            logger.error("xdotool not installed; cannot bring window '%s' to front", app_title)
+            return {"status": "error", "message": "xdotool not installed"}
+        except Exception as e:
+            logger.error("Error bringing window '%s' to front: %s", app_title, e)
+            return {"status": "error", "message": "Operation failed"}
 
     async def locate_element_by_image(self, image_path, confidence=0.8):
         """Locate an element on the screen by matching an image."""

--- a/autobot-backend/gui_controller_test.py
+++ b/autobot-backend/gui_controller_test.py
@@ -20,7 +20,7 @@ tests/test_vnc_mcp_async.py for scrot/xdotool.
 import os
 import sys
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -179,3 +179,80 @@ class TestReadTextFromRegionPreserved:
         assert result["text"] == ""
 
         gui_controller_module.pyautogui.screenshot.side_effect = None
+
+
+class TestGUIControllerHandlerParity:
+    """Issue #11970: real GUIController must implement the same public
+    method surface as gui_controller_dummy.GUIController, since flipping the
+    platform gate now routes task_handlers/gui_handlers.py's calls to the
+    real controller on Linux.
+    """
+
+    @pytest.mark.asyncio
+    async def test_click_element_success(self, gui_controller_module, display_active):
+        controller = gui_controller_module.GUIController()
+        location = MagicMock(x=10, y=20)
+        controller.locate_element_by_image = AsyncMock(return_value=location)
+
+        result = await controller.click_element("button.png")
+
+        assert result["status"] == "success"
+        gui_controller_module.pyautogui.click.assert_called_with(10, 20, clicks=1, interval=0.0, button="left")
+
+    @pytest.mark.asyncio
+    async def test_click_element_not_found(self, gui_controller_module, display_active):
+        controller = gui_controller_module.GUIController()
+        controller.locate_element_by_image = AsyncMock(return_value=None)
+
+        result = await controller.click_element("missing.png")
+
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_type_text_accepts_interval_and_returns_status(self, gui_controller_module, display_active):
+        """Handler calls type_text(text, interval) positionally (#11970)."""
+        controller = gui_controller_module.GUIController()
+
+        result = await controller.type_text("hello", 0.05)
+
+        assert result["status"] == "success"
+        gui_controller_module.pyautogui.write.assert_called_with("hello", interval=0.05)
+
+    @pytest.mark.asyncio
+    async def test_move_mouse_returns_status(self, gui_controller_module, display_active):
+        controller = gui_controller_module.GUIController()
+
+        result = await controller.move_mouse(5, 6, 0.1)
+
+        assert result["status"] == "success"
+        gui_controller_module.pyautogui.moveTo.assert_called_with(5, 6, duration=0.1)
+
+    @pytest.mark.asyncio
+    async def test_bring_window_to_front_success(self, gui_controller_module, display_active):
+        controller = gui_controller_module.GUIController()
+
+        with patch("gui_controller.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = await controller.bring_window_to_front("My App")
+
+        assert result["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_bring_window_to_front_not_found(self, gui_controller_module, display_active):
+        controller = gui_controller_module.GUIController()
+
+        with patch("gui_controller.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            result = await controller.bring_window_to_front("Unknown App")
+
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_bring_window_to_front_xdotool_missing(self, gui_controller_module, display_active):
+        controller = gui_controller_module.GUIController()
+
+        with patch("gui_controller.subprocess.run", side_effect=FileNotFoundError()):
+            result = await controller.bring_window_to_front("My App")
+
+        assert result["status"] == "error"
+        assert "xdotool" in result["message"]

--- a/autobot-backend/worker_node.py
+++ b/autobot-backend/worker_node.py
@@ -40,8 +40,14 @@ except (ImportError, RuntimeError):
 
 from autobot_shared.redis_client import get_redis_client
 
-# Import the centralized ConfigManager and Redis client utility
-from config import config as global_config_manager
+# Import the centralized ConfigManager and Redis client utility.
+# NOTE: must be `config_manager` (config/manager.py's ConfigManager, backed by
+# config.yaml + defaults.py), NOT `config` (autobot_shared.ssot_config's
+# AutoBotConfig proxy). The two are different objects: `config` only supports
+# attribute-style access (e.g. config.redis_host); `get_nested()` dotted-path
+# lookups below require `config_manager`. Using `config` here previously raised
+# AttributeError: 'AutoBotConfig' object has no attribute 'get_nested' (#11971).
+from config import config_manager as global_config_manager
 from events.bus import PersistStrategy, publish_event
 from knowledge_base import KnowledgeBase
 from security_layer import SecurityLayer
@@ -49,15 +55,39 @@ from services.llm_service import get_llm_service
 from system_integration import SystemIntegration
 from task_handlers import TaskExecutor
 
-# Conditional import for GUIController based on OS
+# Conditional import for GUIController based on OS.
+# Issue #11970: this gate was inverted. AutoBot's desktop-automation stack
+# (Xvfb/Xtigervnc + pyautogui, see api/vnc_manager.py, gui_controller.py's
+# CANONICAL_DISPLAY) is Linux-only — the real controller must run on Linux.
+# Non-Linux dev machines have neither the VNC/X server nor pyautogui's
+# Linux-specific backend available, so they get the no-op dummy.
+#
+# Headless Linux nodes (self-hosted CI runners, non-desktop worker VMs) have
+# no DISPLAY env var, or a stale one pointing at a not-yet-started X server
+# (real CI installs pyautogui via requirements-ci/automation.txt but never
+# sets DISPLAY/starts Xvfb). pyautogui's mouseinfo submodule hard-raises at
+# IMPORT time in either case -- verified: KeyError('DISPLAY') when unset,
+# Xlib.error.DisplayConnectionError when set but unreachable. Same class of
+# startup race already guarded at runtime in gui_controller.py's __init__
+# (Issue #11579's pyautogui.size() guard); broad except here matches that
+# precedent since the exact Xlib/X11 failure surface is environment-dependent
+# and unbounded. Fall back to the dummy controller rather than crashing
+# worker startup/import-smoke -- exactly the "headless or server environment
+# without a display" case gui_controller_dummy.py's own docstring covers.
 if sys.platform.startswith("linux"):
+    try:
+        from gui_controller import GUIController
+
+        GUI_AUTOMATION_SUPPORTED = True
+    except Exception as e:  # noqa: BLE001 - see comment above; unbounded Xlib/X11 import-time surface
+        logger.warning("Real GUIController unavailable on this Linux node (%s); using dummy.", e)
+        from gui_controller_dummy import GUIController
+
+        GUI_AUTOMATION_SUPPORTED = False
+else:
     from gui_controller_dummy import GUIController
 
     GUI_AUTOMATION_SUPPORTED = False
-else:
-    from gui_controller import GUIController
-
-    GUI_AUTOMATION_SUPPORTED = True
 
 
 class WorkerNode:

--- a/autobot-backend/worker_node_test.py
+++ b/autobot-backend/worker_node_test.py
@@ -9,6 +9,8 @@ Verifies that the refactored execute_task method maintains
 all original functionality while reducing nesting depth.
 """
 
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -213,6 +215,78 @@ class TestWorkerNodeRefactored:
 
         # Allow some buffer, but should be dramatically reduced
         assert len(lines) < 100, f"execute_task method still too long: {len(lines)} lines"
+
+
+class TestGUIControllerPlatformGate:
+    """Issue #11970: the GUIController platform gate must select the real
+    (pyautogui/Xvfb) controller on Linux and the no-op dummy elsewhere --
+    NOT the previously-inverted opposite.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_real_worker_node_module(self):
+        """Reload the real worker_node module after each test in this class.
+
+        Tests here mutate sys.modules['worker_node'] via reload-under-mock;
+        leaving a mocked-platform copy cached in sys.modules could leak into
+        any other code in the same session that does `import worker_node`.
+        """
+        yield
+        sys.modules.pop("worker_node", None)
+        import worker_node  # noqa: F401 - re-import restores the real module state
+
+    def _reload_worker_node(self, monkeypatch, platform: str, fake_gui_controller=None):
+        """Reload worker_node with a mocked platform + gui_controller import."""
+        monkeypatch.setattr(sys, "platform", platform)
+        if fake_gui_controller is not None:
+            monkeypatch.setitem(sys.modules, "gui_controller", fake_gui_controller)
+        else:
+            # Force `from gui_controller import GUIController` to raise ImportError.
+            monkeypatch.setitem(sys.modules, "gui_controller", None)
+        sys.modules.pop("worker_node", None)
+        import worker_node as reloaded
+
+        return reloaded
+
+    def _make_fake_gui_controller_module(self):
+        """Build a minimal fake gui_controller module exposing GUIController."""
+        mod = types.ModuleType("gui_controller")
+
+        class FakeGUIController:
+            pass
+
+        mod.GUIController = FakeGUIController
+        return mod
+
+    def test_linux_with_display_uses_real_controller(self, monkeypatch):
+        """Linux + a reachable display must select gui_controller (real)."""
+        fake_module = self._make_fake_gui_controller_module()
+
+        reloaded = self._reload_worker_node(monkeypatch, "linux", fake_gui_controller=fake_module)
+
+        assert reloaded.GUIController is fake_module.GUIController
+        assert reloaded.GUI_AUTOMATION_SUPPORTED is True
+
+    def test_linux_headless_falls_back_to_dummy(self, monkeypatch):
+        """Linux with no display available (import failure) must fall back
+        to gui_controller_dummy rather than crashing worker startup.
+        """
+        import gui_controller_dummy
+
+        reloaded = self._reload_worker_node(monkeypatch, "linux", fake_gui_controller=None)
+
+        assert reloaded.GUIController is gui_controller_dummy.GUIController
+        assert reloaded.GUI_AUTOMATION_SUPPORTED is False
+
+    def test_non_linux_uses_dummy_controller(self, monkeypatch):
+        """Non-Linux platforms must always use the no-op dummy controller."""
+        import gui_controller_dummy
+
+        fake_module = self._make_fake_gui_controller_module()
+        reloaded = self._reload_worker_node(monkeypatch, "win32", fake_gui_controller=fake_module)
+
+        assert reloaded.GUIController is gui_controller_dummy.GUIController
+        assert reloaded.GUI_AUTOMATION_SUPPORTED is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Thinking Path
Two worker_node bugs. The platform gate for `GUIController` was inverted, and 8 tests errored on a wrong-config-object `get_nested` call.

## What Changed
**#11970 — inverted platform gate:** `worker_node.py` used the DUMMY controller on Linux and the REAL pyautogui/Xvfb one on non-Linux — backwards (Xvfb/pyautogui desktop automation is Linux-only). Flipped so Linux → real. **Critically**: a naive flip breaks import on headless Linux (CI: pyautogui → mouseinfo raises `KeyError('DISPLAY')` / `DisplayConnectionError`), so the Linux branch wraps the import in `try/except` and falls back to the dummy with a logged warning (verified: no-DISPLAY→dummy, DISPLAY-unreachable→dummy, real Xvfb→real). Also fixed a regression the flip exposed: real `gui_controller.py` was missing `click_element`/`move_mouse`/`bring_window_to_front` + `type_text(interval=)` that `gui_handlers.py` calls — added with interface parity to the dummy.

**#11971 — `get_nested` AttributeError (8 tests):** `worker_node.py` imported `config` = the SSOT `_ConfigProxy` (attribute-access-only, no `get_nested`) instead of the legacy `ConfigManager` that implements `get_nested` (20+ call sites elsewhere). Fixed the import to `config_manager` (canonical non-deprecated name).

Closes #11970, closes #11971

## Verification
- worker_node_test.py 2→**13 passed** (10 + 3 new gate tests); gui_controller_test.py 12→**19** (7 parity tests); combined **37 passed, 0 failed**. py_compile + black clean. (Real CI confirms headless behavior.)
- Filed discoveries: #12069 (connection_utils same get_nested bug), #12070 (tool_registry missing gui-task wiring).

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)