### PR TITLE
tokenise(user): GUIAutomationControls + AuditStatistics + CodebaseAnalytics px → spacing tokens (#12072, #12073, #12074)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -1102,8 +1102,8 @@ onUnmounted(() => {
 }
 
 .toggle-slider {
-  width: 40px;
-  height: 20px;
+  width: var(--spacing-10);
+  height: var(--spacing-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-xl);
   position: relative;
@@ -1112,13 +1112,13 @@ onUnmounted(() => {
 
 .toggle-slider:before {
   content: '';
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   background: var(--text-on-primary);
   border-radius: 50%;
   position: absolute;
-  top: 2px;
-  left: 2px;
+  top: var(--spacing-0-5);
+  left: var(--spacing-0-5);
   transition: all var(--duration-300);
 }
 
@@ -1127,7 +1127,7 @@ onUnmounted(() => {
 }
 
 .toggle-switch input:checked + .toggle-slider:before {
-  transform: translateX(20px);
+  transform: translateX(var(--spacing-5));
 }
 
 .refresh-all-btn {
@@ -1258,7 +1258,7 @@ onUnmounted(() => {
   border-bottom: 2px solid transparent;
   transition: all var(--duration-150) var(--ease-in-out);
   position: relative;
-  top: 1px;
+  top: var(--spacing-px);
   white-space: nowrap;
 }
 
@@ -1279,8 +1279,8 @@ onUnmounted(() => {
 }
 
 .sub-tab-icon {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   flex-shrink: 0;
 }
 

--- a/autobot-frontend/src/components/audit/AuditStatistics.vue
+++ b/autobot-frontend/src/components/audit/AuditStatistics.vue
@@ -210,8 +210,8 @@ function formatOperationName(operation: string): string {
 }
 
 .stat-icon {
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-12);
+  height: var(--spacing-12);
   border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
@@ -297,7 +297,7 @@ function formatOperationName(operation: string): string {
 }
 
 .progress-bar {
-  height: 6px;
+  height: var(--spacing-1-5);
   background: var(--bg-secondary);
   border-radius: var(--radius-full);
   overflow: hidden;
@@ -372,8 +372,8 @@ function formatOperationName(operation: string): string {
 }
 
 .top-rank {
-  width: 24px;
-  height: 24px;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -433,8 +433,8 @@ function formatOperationName(operation: string): string {
   }
 
   .stat-icon {
-    width: 40px;
-    height: 40px;
+    width: var(--spacing-10);
+    height: var(--spacing-10);
     font-size: var(--text-lg);
   }
 

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -391,7 +391,7 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   gap: var(--spacing-3);
-  padding: 60px 20px;
+  padding: 60px var(--spacing-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -434,8 +434,8 @@ onMounted(() => {
 }
 
 .element-type-badge {
-  width: 40px;
-  height: 40px;
+  width: var(--spacing-10);
+  height: var(--spacing-10);
   border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
@@ -538,15 +538,15 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   gap: var(--spacing-4);
-  padding: 60px 20px;
+  padding: 60px var(--spacing-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
 }
 
 .empty-icon {
-  width: 80px;
-  height: 80px;
+  width: var(--spacing-20);
+  height: var(--spacing-20);
   border-radius: 50%;
   background: var(--bg-tertiary);
   display: flex;
@@ -623,8 +623,8 @@ onMounted(() => {
 }
 
 .type-icon {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border-radius: var(--radius-md);
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #12072
Closes #12073
Closes #12074
Part of #11515 sizing pass. 25 px→spacing/radius (byte-exact). No design-tokens.css change. Left literal: 60px/off-scale, 1-3px borders, font-size, %, rem. Main-tree-clean; 0 undefined refs; `<style>`-only.

## Model Used
Claude Fable 5 (subagent)