### PR TITLE
tokenise(user): FailureAnalysisDashboard + ScreenCaptureViewer + MediaGallery px → spacing tokens (#12076, #12077, #12078)

### DIFF
--- a/autobot-frontend/src/components/vision/MediaGallery.vue
+++ b/autobot-frontend/src/components/vision/MediaGallery.vue
@@ -416,10 +416,10 @@ onUnmounted(() => {
 
 .item-type-badge {
   position: absolute;
-  top: 8px;
-  right: 8px;
-  width: 28px;
-  height: 28px;
+  top: var(--spacing-2);
+  right: var(--spacing-2);
+  width: var(--spacing-7);
+  height: var(--spacing-7);
   background: rgba(0, 0, 0, 0.6);
   border-radius: var(--radius-md);
   display: flex;
@@ -491,8 +491,8 @@ onUnmounted(() => {
 }
 
 .empty-icon {
-  width: 80px;
-  height: 80px;
+  width: var(--spacing-20);
+  height: var(--spacing-20);
   border-radius: 50%;
   background: var(--bg-tertiary);
   display: flex;
@@ -779,9 +779,9 @@ onUnmounted(() => {
 }
 
 .confirm-icon {
-  width: 48px;
-  height: 48px;
-  margin: 0 auto 16px;
+  width: var(--spacing-12);
+  height: var(--spacing-12);
+  margin: 0 auto var(--spacing-4);
   background: var(--color-warning-bg);
   border-radius: 50%;
   display: flex;

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -460,8 +460,8 @@ onUnmounted(() => {
 }
 
 .toggle-switch {
-  width: 36px;
-  height: 20px;
+  width: var(--spacing-9);
+  height: var(--spacing-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-xl);
   position: relative;
@@ -471,10 +471,10 @@ onUnmounted(() => {
 .toggle-switch::after {
   content: '';
   position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 16px;
-  height: 16px;
+  top: var(--spacing-0-5);
+  left: var(--spacing-0-5);
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   background: var(--text-tertiary);
   border-radius: 50%;
   transition: all var(--duration-200);
@@ -519,7 +519,7 @@ onUnmounted(() => {
 }
 
 .filter-group input[type="range"] {
-  width: 80px;
+  width: var(--spacing-20);
 }
 
 .confidence-value {
@@ -621,8 +621,8 @@ onUnmounted(() => {
 }
 
 .element-icon {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border-radius: var(--radius-md);
   display: flex;
   align-items: center;
@@ -719,8 +719,8 @@ onUnmounted(() => {
 }
 
 .empty-icon {
-  width: 80px;
-  height: 80px;
+  width: var(--spacing-20);
+  height: var(--spacing-20);
   border-radius: 50%;
   background: var(--bg-tertiary);
   display: flex;

--- a/autobot-frontend/src/views/FailureAnalysisDashboard.vue
+++ b/autobot-frontend/src/views/FailureAnalysisDashboard.vue
@@ -334,7 +334,7 @@ function levelClass(level: string): string {
 
 .required {
   color: var(--color-red-500);
-  margin-left: 2px;
+  margin-left: var(--spacing-0-5);
 }
 
 .form-input,
@@ -409,8 +409,8 @@ function levelClass(level: string): string {
 
 .spinner {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: var(--spacing-3-5);
+  height: var(--spacing-3-5);
   border: 2px solid rgba(255, 255, 255, 0.4);
   border-top-color: var(--faildash-on-accent);
   border-radius: 50%;
@@ -451,8 +451,8 @@ function levelClass(level: string): string {
 }
 
 .dismiss-icon {
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
 }
 
 /* Result panel */
@@ -572,7 +572,7 @@ function levelClass(level: string): string {
 }
 
 .event-type-badge {
-  padding: 2px var(--spacing-2);
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-tertiary, var(--bg-secondary));
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
@@ -582,7 +582,7 @@ function levelClass(level: string): string {
 
 .confidence-pill {
   margin-left: auto;
-  padding: 2px var(--spacing-2);
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--color-blue-50);
   border-radius: var(--radius-full);
   font-size: var(--text-xs);
@@ -620,8 +620,8 @@ function levelClass(level: string): string {
 
 .chain-index {
   flex-shrink: 0;
-  width: 24px;
-  height: 24px;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -675,7 +675,7 @@ function levelClass(level: string): string {
 }
 
 .rec-type-badge {
-  padding: 2px var(--spacing-2);
+  padding: var(--spacing-0-5) var(--spacing-2);
   border-radius: var(--radius-sm);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -718,7 +718,7 @@ function levelClass(level: string): string {
 }
 
 .meta-pill {
-  padding: 2px var(--spacing-2);
+  padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-full);
@@ -751,7 +751,7 @@ function levelClass(level: string): string {
   color: var(--text-secondary);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 /* Confounders */
@@ -792,8 +792,8 @@ function levelClass(level: string): string {
 }
 
 .empty-icon {
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-12);
+  height: var(--spacing-12);
   color: var(--border-default);
 }
 </style>


### PR DESCRIPTION
Closes #12076
Closes #12077
Closes #12078
Part of #11515 sizing pass. 34 px→spacing (byte-exact). No design-tokens.css change. Left literal: off-scale, 1-3px borders, font-size, %. 0 undefined refs; `<style>`-only.

## Model Used
Claude Fable 5 (subagent)