### PR TITLE
tokenise(user): HostSelectionDialog + LanguageSwitcher + CodebaseOwnershipPanel px → spacing tokens (#12080, #12081, #12082)

### DIFF
--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -565,7 +565,7 @@ function formatFactorName(factor: string): string {
 }
 
 .ownership-metrics .metric-bar {
-  height: 8px;
+  height: var(--spacing-2);
   background: rgba(71, 85, 105, 0.4);
   border-radius: var(--radius-default);
   overflow: hidden;
@@ -776,7 +776,7 @@ function formatFactorName(factor: string): string {
 }
 
 .score-track {
-  height: 6px;
+  height: var(--spacing-1-5);
   background: rgba(71, 85, 105, 0.4);
   border-radius: var(--radius-default);
   overflow: hidden;
@@ -809,7 +809,7 @@ function formatFactorName(factor: string): string {
 }
 
 .area-tag {
-  padding: 3px 8px;
+  padding: 3px var(--spacing-2);
   background: rgba(71, 85, 105, 0.4);
   border-radius: var(--radius-default);
   font-size: 0.75em;
@@ -942,7 +942,7 @@ function formatFactorName(factor: string): string {
 }
 
 .gap-risk-badge {
-  padding: 3px 8px;
+  padding: 3px var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: 0.75em;
   font-weight: 700;

--- a/autobot-frontend/src/components/layout/LanguageSwitcher.vue
+++ b/autobot-frontend/src/components/layout/LanguageSwitcher.vue
@@ -131,8 +131,8 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: var(--spacing-10);
+  height: var(--spacing-10);
   border-radius: var(--radius-md);
   background-color: transparent;
   color: var(--text-secondary);
@@ -154,7 +154,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
 
 .lang-dropdown {
   position: absolute;
-  top: calc(100% + 8px);
+  top: calc(100% + var(--spacing-2));
   right: 0;
   min-width: 160px;
   background: var(--bg-secondary);
@@ -190,7 +190,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
 .lang-option__check {
   font-size: var(--font-size-xs);
   color: var(--color-primary);
-  width: 12px;
+  width: var(--spacing-3);
 }
 
 .lang-option__name {
@@ -207,7 +207,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
 }
 
 .lang-mobile-icon {
-  width: 16px;
+  width: var(--spacing-4);
   text-align: center;
 }
 

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -702,8 +702,8 @@ onUnmounted(() => {
 }
 
 .host-icon {
-  width: 40px;
-  height: 40px;
+  width: var(--spacing-10);
+  height: var(--spacing-10);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -830,8 +830,8 @@ onUnmounted(() => {
 }
 
 .checkmark {
-  width: 20px;
-  height: 20px;
+  width: var(--spacing-5);
+  height: var(--spacing-5);
   border: 2px solid var(--border-secondary);
   border-radius: var(--radius-sm);
   margin-right: var(--spacing-2);
@@ -847,7 +847,7 @@ onUnmounted(() => {
 .checkbox-label input[type="checkbox"]:checked + .checkmark::after {
   content: '\2713';
   position: absolute;
-  top: -2px;
+  top: var(--spacing-neg-2px);
   left: 3px;
   color: var(--text-on-primary);
   font-size: var(--font-size-sm);


### PR DESCRIPTION
Closes #12080
Closes #12081
Closes #12082
Part of #11515 sizing pass. 14 px→spacing (byte-exact). No design-tokens.css change. Left literal: off-scale, 1-3px borders, grid tracks. `<style>`-only.

## Model Used
Claude Fable 5 (subagent)