### PR TITLE
tokenise(user): TechnicalDebtDashboard + VoiceConversationOverlay px → spacing tokens (#12085, #12086)

### DIFF
--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -993,7 +993,7 @@ watch(selectedPeriod, () => {
 
 .health-bar {
   width: 100%;
-  height: 6px;
+  height: var(--spacing-1-5);
   background: var(--border-subtle);
   border-radius: var(--radius-sm);
   overflow: hidden;
@@ -1186,8 +1186,8 @@ watch(selectedPeriod, () => {
 }
 
 .legend-color {
-  width: 12px;
-  height: 12px;
+  width: var(--spacing-3);
+  height: var(--spacing-3);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
@@ -1285,7 +1285,7 @@ watch(selectedPeriod, () => {
 }
 
 .category-bar {
-  height: 4px;
+  height: var(--spacing-1);
   background: var(--border-subtle);
   border-radius: var(--radius-xs);
   overflow: hidden;
@@ -1322,8 +1322,8 @@ watch(selectedPeriod, () => {
 }
 
 .priority-rank {
-  width: 24px;
-  height: 24px;
+  width: var(--spacing-6);
+  height: var(--spacing-6);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -885,14 +885,14 @@ onBeforeUnmount(() => {
 }
 .voice-overlay-enter-from .voice-overlay__panel {
   opacity: 0;
-  transform: translateY(24px) scale(0.96);
+  transform: translateY(var(--spacing-6)) scale(0.96);
 }
 .voice-overlay-leave-to {
   opacity: 0;
 }
 .voice-overlay-leave-to .voice-overlay__panel {
   opacity: 0;
-  transform: translateY(12px) scale(0.98);
+  transform: translateY(var(--spacing-3)) scale(0.98);
 }
 
 /* Bubble enter */
@@ -901,7 +901,7 @@ onBeforeUnmount(() => {
 }
 .bubble-enter-from {
   opacity: 0;
-  transform: translateY(8px);
+  transform: translateY(var(--spacing-2));
 }
 
 /* Fade */


### PR DESCRIPTION
Closes #12085
Closes #12086
Part of #11515 sizing pass (last frontend px). 9 px→spacing. No design-tokens.css change. `<style>`-only.

## Model Used
Claude Fable 5 (subagent)