### PR TITLE
tokenise(slm): GrafanaDashboard + ToastContainer + SetupWizardView px → spacing tokens (#12090, #12091, #12092)

### DIFF
--- a/autobot-slm-frontend/src/components/common/ToastContainer.vue
+++ b/autobot-slm-frontend/src/components/common/ToastContainer.vue
@@ -64,11 +64,11 @@ const getIconPath = (type: string): string => {
 .toast-container {
   position: fixed;
   top: 80px;
-  right: 20px;
+  right: var(--spacing-5);
   z-index: 9999;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
   max-width: 400px;
   pointer-events: none;
 }
@@ -76,9 +76,9 @@ const getIconPath = (type: string): string => {
 .toast {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  border-radius: 8px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   pointer-events: auto;
   min-width: 300px;
@@ -136,8 +136,8 @@ const getIconPath = (type: string): string => {
   background: transparent;
   border: none;
   color: var(--a11y-text-muted);
-  min-width: 32px;
-  min-height: 32px;
+  min-width: var(--spacing-8);
+  min-height: var(--spacing-8);
   border-radius: var(--radius-md);
   cursor: pointer;
   display: flex;
@@ -180,8 +180,8 @@ const getIconPath = (type: string): string => {
 
 @media (max-width: 480px) {
   .toast-container {
-    left: 12px;
-    right: 12px;
+    left: var(--spacing-3);
+    right: var(--spacing-3);
     top: 70px;
     max-width: none;
   }

--- a/autobot-slm-frontend/src/components/monitoring/GrafanaDashboard.vue
+++ b/autobot-slm-frontend/src/components/monitoring/GrafanaDashboard.vue
@@ -265,8 +265,8 @@ onUnmounted(() => {
 }
 
 .loading-spinner {
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-12);
+  height: var(--spacing-12);
   border: 4px solid var(--slm-gray-200);
   border-top-color: var(--slm-blue-500);
   border-radius: 50%;
@@ -280,17 +280,17 @@ onUnmounted(() => {
 .controls {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 8px 16px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-2) var(--spacing-4);
   background: var(--slm-gray-50);
   border-top: 1px solid var(--slm-gray-200);
 }
 
 .select-sm {
-  padding: 6px 12px;
+  padding: 6px var(--spacing-3);
   background: white;
   border: 1px solid var(--slm-gray-200);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 13px;
   cursor: pointer;
 }
@@ -303,10 +303,10 @@ onUnmounted(() => {
 
 .btn-icon {
   margin-left: auto;
-  padding: 6px 12px;
+  padding: 6px var(--spacing-3);
   background: white;
   border: 1px solid var(--slm-gray-200);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   cursor: pointer;
   font-size: 14px;
   transition: background 0.2s;

--- a/autobot-slm-frontend/src/views/SetupWizardView.vue
+++ b/autobot-slm-frontend/src/views/SetupWizardView.vue
@@ -1122,8 +1122,8 @@ onMounted(async () => {
   background: none;
   border: 1px solid var(--border-color);
   color: var(--text-secondary);
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border-radius: var(--radius-default);
   cursor: pointer;
   font-size: 1rem;
@@ -1154,8 +1154,8 @@ onMounted(async () => {
 }
 
 .step-indicator {
-  width: 32px;
-  height: 32px;
+  width: var(--spacing-8);
+  height: var(--spacing-8);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -1718,8 +1718,8 @@ input.full-width {
 }
 
 .success-icon {
-  width: 64px;
-  height: 64px;
+  width: var(--spacing-16);
+  height: var(--spacing-16);
   border-radius: 50%;
   background: var(--color-success);
   color: var(--color-white);


### PR DESCRIPTION
Closes #12090
Closes #12091
Closes #12092
Part of #11515 sizing pass (final SLM px batch). 25 px→SLM `--spacing-*`/`--radius-*` (byte-exact against main.css @theme). No main.css change. Left literal: off-scale (SLM has no -7/-0-5/-9/-20), 1-3px borders, font-size, %. `<style>`-only.

## Model Used
Claude Fable 5 (subagent)