### PR TITLE
fix(utils): connection_utils uses correct config API (get_nested) (#12069)

### DIFF
--- a/autobot-backend/utils/connection_utils.py
+++ b/autobot-backend/utils/connection_utils.py
@@ -17,7 +17,13 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config as _ssot_config
 from autobot_shared.ssot_config import get_ollama_url
-from config import config as global_config_manager
+
+# NOTE: must be `config_manager` (config/manager.py's ConfigManager, backed by
+# config.yaml + defaults.py), not `config` (the SSOT AutoBotConfig proxy from
+# autobot_shared/ssot_config.py, attribute-access only). The `.get()`/
+# `.get_nested()` lookups below require `config_manager`. Using `config` here
+# previously raised AttributeError (#12069, same root cause as #11971).
+from config import config_manager as global_config_manager
 from constants.api_constants import PATH_OLLAMA_GENERATE, PATH_OLLAMA_TAGS
 from constants.model_constants import ModelConstants
 from type_defs.common import Metadata

--- a/autobot-backend/utils/connection_utils_test.py
+++ b/autobot-backend/utils/connection_utils_test.py
@@ -1,0 +1,110 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for connection_utils.py config-access AttributeError (#12069).
+
+Same root cause as #11971 (worker_node.py): the module previously imported
+the SSOT `AutoBotConfig` proxy (`from config import config`, attribute-access
+only) under the name `global_config_manager`, then called `.get()` /
+`.get_nested()` on it — both raise AttributeError because the SSOT proxy has
+no such methods. Fixed by importing the legacy `config_manager` instance
+instead (`from config import config_manager as global_config_manager`),
+which does implement `.get()` / `.get_nested()` / `.get_llm_config()`
+(backed by config.yaml + defaults.py).
+"""
+
+import pytest
+
+from utils.connection_utils import ConnectionTester, ModelManager, global_config_manager
+
+
+class TestGlobalConfigManagerApi:
+    """Directly exercise every config lookup used by connection_utils.py."""
+
+    def test_get_nested_backend_ollama_endpoint(self):
+        """Line ~140 call site: global_config_manager.get_nested(...)."""
+        result = global_config_manager.get_nested("backend.ollama_endpoint", "default-endpoint")
+        assert result is not None
+
+    def test_get_nested_backend_ollama_model(self):
+        """Line ~145 call site: global_config_manager.get_nested(...)."""
+        result = global_config_manager.get_nested("backend.ollama_model", "default-model")
+        assert result is not None
+
+    def test_get_task_transport(self):
+        """Line ~232 call site: global_config_manager.get("task_transport", {})."""
+        result = global_config_manager.get("task_transport", {})
+        assert isinstance(result, dict)
+
+    def test_get_backend_llm_nested_chain(self):
+        """Line ~125 call site: global_config_manager.get("backend", {}).get("llm", {})."""
+        llm_config = global_config_manager.get("backend", {}).get("llm", {})
+        assert isinstance(llm_config, dict)
+
+    def test_get_memory_config(self):
+        """Line ~241 call site: global_config_manager.get("memory", {})."""
+        result = global_config_manager.get("memory", {})
+        assert isinstance(result, dict)
+
+    def test_get_llm_config_method(self):
+        """Line ~336 call site: global_config_manager.get_llm_config()."""
+        result = global_config_manager.get_llm_config()
+        assert isinstance(result, dict)
+
+    def test_get_llm_config_key(self):
+        """Line ~444 call site: global_config_manager.get("llm_config", {})."""
+        result = global_config_manager.get("llm_config", {})
+        assert isinstance(result, dict)
+
+    def test_get_nested_llm_config_ollama(self):
+        """Line ~491 call site: global_config_manager.get_nested("llm_config.ollama", {})."""
+        result = global_config_manager.get_nested("llm_config.ollama", {})
+        assert isinstance(result, dict)
+
+
+class TestConnectionTesterConfigCallSites:
+    """Exercise the actual ConnectionTester helpers that read config."""
+
+    def test_get_ollama_config_from_new_structure(self):
+        endpoint, model = ConnectionTester._get_ollama_config_from_new_structure()
+        assert endpoint is None or isinstance(endpoint, str)
+        assert model is None or isinstance(model, str)
+
+    def test_get_ollama_config_fallback(self):
+        endpoint, model = ConnectionTester._get_ollama_config_fallback(None, None)
+        assert isinstance(endpoint, str)
+        assert isinstance(model, str)
+
+    def test_get_redis_config_values(self):
+        host, port, error = ConnectionTester._get_redis_config_values()
+        assert error is None or isinstance(error, dict)
+        if error is None:
+            assert host is not None
+            assert port is not None
+
+
+@pytest.mark.asyncio
+class TestConnectionTesterAsyncConfigCallSites:
+    """Async helpers whose config lookups previously raised AttributeError."""
+
+    async def test_get_embedding_status_no_attribute_error(self, caplog):
+        # Network access to a real Ollama instance is not guaranteed in the
+        # test sandbox, so this only asserts the config lookup itself
+        # (llm_config.get("unified", {}).get("embedding", {})) never raises
+        # AttributeError — any network failure surfaces as a distinct log
+        # message, not "'AutoBotConfig' object has no attribute ...".
+        status = await ConnectionTester._get_embedding_status()
+        assert isinstance(status, dict)
+        assert "has no attribute" not in caplog.text
+        assert "AttributeError" not in caplog.text
+
+    async def test_get_available_models_no_attribute_error(self):
+        result = await ModelManager.get_available_models()
+        assert result["status"] == "success"
+
+    async def test_get_ollama_models_no_attribute_error(self):
+        # Returns [] on connection failure, but must not raise/log AttributeError.
+        models = await ModelManager._get_ollama_models()
+        assert isinstance(models, list)


### PR DESCRIPTION
## Thinking Path
Same root cause as #11971 (just fixed): `connection_utils.py:20` imported `from config import config` — the SSOT `AutoBotConfig` proxy (attribute-access-only), not the legacy `config_manager` that implements `.get()`/`.get_nested()`/`.get_llm_config()`. So 7 call sites raised `AttributeError` live.

## What Changed
- `utils/connection_utils.py`: minimal import switch `from config import config as global_config_manager` → `config_manager as global_config_manager` (matches #11971's fix). `config_manager` provides `.get()`/`.get_nested()`/`.get_llm_config()` backed by config.yaml/defaults — the config-file-driven nested dicts these 7 sites read (rewriting to SSOT flat-attribute access was rejected: they use dynamic keys / nested iteration the proxy can't represent).
- 7 call sites fixed (issue named 5; found 2 more at lines 125, 241 with the identical bug — covered).
- Callers verified unaffected (they import only `ConnectionTester`/`ModelManager`, never the module-internal name).
- Added `connection_utils_test.py`.

Closes #12069

## Verification
- Tests: 13 failed (`AttributeError`) → **14 passed, 0 failed**. py_compile + black clean. (Real CI confirms.)

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)