### PR TITLE
fix(async): track phase-2 init task + drain executor before Redis close; offload takeover MemoryManager writes (#11679, #11680)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -2173,7 +2173,6 @@ async def cleanup_services(app: FastAPI):
         # pools would reopen lazily post-close, leaking connections at exit.
         # shutdown() is a blocking call, so it runs via asyncio.to_thread to
         # avoid blocking the event loop while queued jobs finish.
-        global _executor
         if _executor is not None:
             await asyncio.to_thread(_executor.shutdown, wait=True, cancel_futures=False)
             logger.info("🧵 Thread pool executor drained")

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1852,6 +1852,23 @@ async def cleanup_services(app: FastAPI):
         app: FastAPI application instance
     """
     logger.info("🛑 AutoBot Backend shutting down...")
+
+    # Issue #11679: Cancel + await the phase-2 background-init task FIRST,
+    # before any other cleanup step. Without this, a fast shutdown can race
+    # initialize_background_services() while it is still creating resources
+    # (Redis subscriptions, background loops, etc.), voiding the "Redis
+    # closed LAST" ordering guarantee below for those late-created resources.
+    bg_init_task = getattr(app.state, "background_init_task", None)
+    if bg_init_task is not None and not bg_init_task.done():
+        bg_init_task.cancel()
+        try:
+            await bg_init_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as _bg_init_err:
+            logger.warning("Background init task raised during cancellation: %s", _bg_init_err)
+        logger.info("✅ Phase-2 background init task cancelled before shutdown")
+
     try:
         # GH#9044: Close transcriber DB connection
         transcriber_db = getattr(app.state, "transcriber_db", None)
@@ -2149,6 +2166,18 @@ async def cleanup_services(app: FastAPI):
         except Exception as _db_err:
             logger.warning("Database engine dispose failed: %s", _db_err)
 
+        # Issue #11679: Drain the bounded thread-pool executor BEFORE closing
+        # Redis pools. Ordering decision: queued default-executor jobs (e.g.
+        # chat_history/cache.py offloading a sync redis_client.setex call)
+        # must finish before Redis pools close — otherwise redis-py sync
+        # pools would reopen lazily post-close, leaking connections at exit.
+        # shutdown() is a blocking call, so it runs via asyncio.to_thread to
+        # avoid blocking the event loop while queued jobs finish.
+        global _executor
+        if _executor is not None:
+            await asyncio.to_thread(_executor.shutdown, wait=True, cancel_futures=False)
+            logger.info("🧵 Thread pool executor drained")
+
         # Issue #11638: Close all Redis pools LAST — earlier shutdown steps
         # above may still publish events or flush state through Redis.
         try:
@@ -2218,18 +2247,21 @@ def create_lifespan_manager():
         await initialize_critical_services(app)
 
         # Phase 2: Background initialization (NON-BLOCKING)
+        # Issue #11679: track the task on app.state so cleanup_services() can
+        # cancel+await it FIRST on shutdown, before any resource is torn down.
+        # Without this, a fast shutdown during phase-2 init can race resource
+        # creation (e.g. Redis subscriptions, background loops), voiding the
+        # "Redis closed LAST" cleanup ordering for those late-created resources.
         logger.info("🔄 Starting background services initialization...")
-        asyncio.create_task(initialize_background_services(app))
+        app.state.background_init_task = asyncio.create_task(
+            initialize_background_services(app), name="phase2_background_init"
+        )
 
         yield  # Application starts serving requests here
 
-        # Cleanup on shutdown
+        # Cleanup on shutdown — thread pool is drained INSIDE cleanup_services,
+        # before Redis pools close (Issue #11679; see ordering comment there).
         await cleanup_services(app)
-
-        # Shutdown thread pool
-        if _executor:
-            _executor.shutdown(wait=True, cancel_futures=False)
-            logger.info("🧵 Thread pool shutdown complete")
 
     return lifespan
 

--- a/autobot-backend/initialization/lifespan_test.py
+++ b/autobot-backend/initialization/lifespan_test.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for lifespan shutdown ordering (#11679).
+
+Covers the fast-shutdown race between phase-2 background initialization and
+cleanup_services(), and the executor-drain-before-Redis-close ordering.
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import initialization.lifespan as lifespan_module
+from initialization.lifespan import cleanup_services
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_background_init_task_first():
+    """Fast-shutdown race (#11679): the phase-2 task must be cancelled and
+    awaited before any other cleanup step, and must not leak as an orphan
+    task once cleanup_services() returns."""
+    still_running = asyncio.Event()
+
+    async def _slow_phase2() -> None:
+        still_running.set()
+        await asyncio.sleep(30)
+
+    task = asyncio.create_task(_slow_phase2(), name="phase2_background_init")
+    await still_running.wait()
+
+    app = SimpleNamespace(state=SimpleNamespace(background_init_task=task))
+
+    with (
+        patch("autobot_shared.redis_client.close_all_redis_connections", new=AsyncMock()),
+        patch.object(lifespan_module, "shutdown_tracing", new=AsyncMock()),
+    ):
+        await cleanup_services(app)
+
+    assert task.done()
+    assert task.cancelled()
+    # No orphan phase-2 task left running after cleanup completes.
+    remaining = [t for t in asyncio.all_tasks() if t.get_name() == "phase2_background_init"]
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_drains_executor_before_redis_close():
+    """Ordering decision (#11679): the bounded thread-pool executor must be
+    drained BEFORE Redis pools close, so queued sync jobs (e.g.
+    chat_history/cache.py's setex offload) cannot touch Redis after the
+    pools are gone."""
+    call_order: list[str] = []
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    lifespan_module._executor = executor
+
+    async def _fake_redis_close() -> None:
+        call_order.append("redis_close")
+
+    def _fake_shutdown(*_args, **_kwargs) -> None:
+        call_order.append("executor_shutdown")
+
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    with (
+        patch("autobot_shared.redis_client.close_all_redis_connections", new=_fake_redis_close),
+        patch.object(executor, "shutdown", side_effect=_fake_shutdown),
+        patch.object(lifespan_module, "shutdown_tracing", new=AsyncMock()),
+    ):
+        await cleanup_services(app)
+
+    assert call_order == ["executor_shutdown", "redis_close"]
+
+    lifespan_module._executor = None

--- a/autobot-backend/takeover_manager.py
+++ b/autobot-backend/takeover_manager.py
@@ -688,6 +688,8 @@ class TakeoverManager:
         Record takeover request in memory system.
 
         Issue #665: Extracted from request_takeover to reduce function length.
+        Issue #11680: Synchronous SQLite MemoryManager calls (called via
+        asyncio.to_thread by request_takeover) — must NOT be awaited directly.
         """
         task_id = self.memory_manager.create_task_record(
             task_name="Takeover Request",
@@ -703,6 +705,30 @@ class TakeoverManager:
         )
         self.memory_manager.start_task(task_id)
         return task_id
+
+    def _record_completion_in_memory(
+        self,
+        session_id: str,
+        resolution: str,
+        request: TakeoverRequest,
+        completion_data: Dict[str, Any],
+    ) -> None:
+        """Record takeover-session completion in memory system (sync).
+
+        Issue #11680: extracted so complete_takeover_session can offload the
+        create->start->complete sequence via a single asyncio.to_thread call
+        instead of three separate event-loop-blocking sync calls.
+        """
+        completion_task_id = self.memory_manager.create_task_record(
+            task_name="Takeover Session Completion",
+            description=f"Takeover session completed: {resolution}",
+            priority=request.priority,
+            agent_type="takeover_manager",
+            inputs={"session_id": session_id},
+            metadata={"original_request": asdict(request)},
+        )
+        self.memory_manager.start_task(completion_task_id)
+        self.memory_manager.complete_task(completion_task_id, outputs=completion_data)
 
     def _is_critical_trigger(self, trigger: TakeoverTrigger) -> bool:
         """Check if trigger requires immediate task pause. Issue #620."""
@@ -755,7 +781,11 @@ class TakeoverManager:
             auto_approve,
         )
 
-        memory_task_id = self._record_takeover_in_memory(trigger, reason, priority, requesting_agent, affected_tasks)
+        # Issue #11680: offload sync SQLite MemoryManager writes to a worker
+        # thread so they never block the event loop.
+        memory_task_id = await asyncio.to_thread(
+            self._record_takeover_in_memory, trigger, reason, priority, requesting_agent, affected_tasks
+        )
         await self._req_task_set(request_id, memory_task_id)
         # M3: pass per-request timeout so TTL matches the request's own expiry.
         timeout_secs = int(timeout_minutes * 60) if timeout_minutes else None
@@ -820,7 +850,9 @@ class TakeoverManager:
 
         task_id = await self._req_task_get(request_id)
         if task_id:
-            self.memory_manager.complete_task(
+            # Issue #11680: offload sync SQLite MemoryManager write.
+            await asyncio.to_thread(
+                self.memory_manager.complete_task,
                 task_id,
                 outputs={
                     "session_id": session.session_id,
@@ -1048,16 +1080,11 @@ class TakeoverManager:
             "handback_notes": handback_notes,
         }
 
-        completion_task_id = self.memory_manager.create_task_record(
-            task_name="Takeover Session Completion",
-            description=f"Takeover session completed: {resolution}",
-            priority=updated.request.priority,
-            agent_type="takeover_manager",
-            inputs={"session_id": session_id},
-            metadata={"original_request": asdict(updated.request)},
+        # Issue #11680: offload the create->start->complete sync SQLite
+        # MemoryManager sequence to a single worker-thread hop.
+        await asyncio.to_thread(
+            self._record_completion_in_memory, session_id, resolution, updated.request, completion_data
         )
-        self.memory_manager.start_task(completion_task_id)
-        self.memory_manager.complete_task(completion_task_id, outputs=completion_data)
 
         logger.info("Takeover session completed: %s - %s", session_id, resolution)
         await self._notify_state_change("session_completed", session_id)
@@ -1156,7 +1183,8 @@ class TakeoverManager:
 
         task_id = await self._req_task_get(request_id)
         if task_id:
-            self.memory_manager.fail_task(task_id, "Takeover request expired")
+            # Issue #11680: offload sync SQLite MemoryManager write.
+            await asyncio.to_thread(self.memory_manager.fail_task, task_id, "Takeover request expired")
             await self._req_task_delete(request_id)
 
         if existed:


### PR DESCRIPTION
## Thinking Path

Both #11679 and #11680 are async-correctness follow-ups under umbrella #11634 (from the #11638 and #11639 reviews). They share one theme — sync/blocking work incorrectly placed on, or racing, the event loop — so they land together as one reviewable change. Each fix is localized to a single module.

## What Changed

**#11679 — `initialization/lifespan.py` (two lifecycle gaps)**
- Phase-2 `initialize_background_services` is no longer fire-and-forget: it's tracked as `app.state.background_init_task` (named `phase2_background_init`) and **cancelled + awaited FIRST** in `cleanup_services()`, so a fast shutdown can't race late resource creation (Redis subscriptions, background loops) and void the "Redis closed LAST" guarantee.
- The bounded thread-pool executor is now **drained before Redis pools close**, inside `cleanup_services()`, via `await asyncio.to_thread(_executor.shutdown, wait=True, cancel_futures=False)`. This closes the connection-leak window where a queued default-executor job (e.g. `chat_history/cache.py`'s sync `redis_client.setex` offload) could run after `close_all_redis_connections()` and make redis-py sync pools reopen lazily. The old post-`cleanup_services` executor shutdown is removed (was running after Redis was already closed). Ordering decision documented inline.

**#11680 — `takeover_manager.py` (sync SQLite on async paths)**
- All four sync `MemoryManager` write sites offloaded via `asyncio.to_thread(...)`: `request_takeover` (create+start), `approve_takeover` (complete), `complete_takeover_session` (create→start→complete), `_expire_request` (fail). No async variants exist on `MemoryManager` (its methods are documented "do not call from async code"), so `to_thread` is the correct remediation.
- Extracted `_record_completion_in_memory()` so the completion sequence runs in a single thread hop instead of three separate event-loop-blocking calls.

## Verification

- `python -m py_compile` on both source files → OK.
- New `initialization/lifespan_test.py` → 2/2 pass (`test_cleanup_cancels_background_init_task_first`, `test_cleanup_drains_executor_before_redis_close`).
- `tests/test_cross_worker_registries.py -k Takeover` → 9/9 existing pass (unaffected).
- Combined run: **18 passed**.
- `black --line-length 120` → no changes.

## Discoveries

Filed the same sync-in-async `MemoryManager` pattern found at 4 out-of-scope sites (task_execution_tracker.py, orchestrator_legacy_api.py, context_aware_decision/system.py) as a follow-up discovery issue — see linked issue in comments.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #11679
Closes #11680
Refs #11634
