### PR TITLE
refactor(frontend): SecretsApiClient uses shared apiClient singleton (#12106)

### DIFF
--- a/autobot-frontend/src/utils/SecretsApiClient.js
+++ b/autobot-frontend/src/utils/SecretsApiClient.js
@@ -7,12 +7,12 @@
  * with proper error handling and chat scope management.
  */
 
-import { ApiClient } from './ApiClient';
+import apiClient from './ApiClient';
 import { getApiBase } from '@/config/ssot-config';
 
 class SecretsApiClient {
     constructor() {
-        this.apiClient = new ApiClient();
+        this.apiClient = apiClient;
         this.currentChatId = null;
     }
 


### PR DESCRIPTION
Closes #12106
Part of #11682 (Tier-1, owner-approved)

## Thinking Path
From the #11682 audit: `SecretsApiClient.js` instantiated a SECOND `new ApiClient()` instead of using the shared `apiClient` Proxy singleton (default export of `ApiClient.ts`) — a duplicate base-URL init/settings cache and a drift from the singleton contract.

## What Changed
2-line change: `import apiClient from './ApiClient'` (the singleton) and `this.apiClient = apiClient`. Verified the default export is the Proxy singleton (delegates to `getApiClient()[prop]`), so method signatures (get/post/put/delete) are byte-identical — transparent to all 5 call-sites (SecretsManager, SecretVault, HostSelectionDialog, ProjectBrowserView + test), which import the unchanged `secretsApiClient` public export. Matches ~25 other files that already import the shared singleton.

## Verification
`node --check` clean; no SecretsApiClient type errors; default export confirmed to be the singleton (not the class); no call-site changes needed.

## Model Used
Claude Sonnet (subagent), reviewed by Opus 4.8
EOF
)