### PR TITLE
fix(test): correct stale status assert in code_indexer_test (#11643)

### DIFF
--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -296,7 +296,9 @@ async def test_index_code_accepts_project_root_itself(tmp_path) -> None:
         mock_path.PROJECT_ROOT = str(project)
         response = await index_code({"root_dir": str(project)})
 
-    assert response["status"] == "ok"
+    # #4912: index_code now enqueues a background task and returns immediately.
+    assert response["status"] == "queued"
+    assert response["task_id"]
 
 
 @requires_tree_sitter
@@ -357,7 +359,9 @@ async def test_index_code_accepts_subdir_of_project_root(tmp_path) -> None:
         mock_path.PROJECT_ROOT = str(project)
         response = await index_code({"root_dir": str(subdir)})
 
-    assert response["status"] == "ok"
+    # #4912: index_code now enqueues a background task and returns immediately.
+    assert response["status"] == "queued"
+    assert response["task_id"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
#11643 cited two test failures. Investigated both against current base.

## What Changed
- **(a) py3.10 runtime annotation** — **already fixed on base**: the offending `_jina_session: "aiohttp.ClientSession" | None` module-level annotation (`media/link/pipeline.py:88`) was removed by #11637/#11641 (Jina now routes through the shared `HTTPClientManager`). All `knowledge_scrape_test` tests pass; no speculative change made.
- **(b) stale status assert** — fixed: `code_indexer_test.py:299,360` asserted `response["status"] == "ok"`, but `index_code()` now returns immediately after `asyncio.create_task(...)` with `{"status": "queued", "task_id": ...}` (correct async-enqueue behavior per #4912; a dedicated poll endpoint exists). Confirmed the CODE is correct and the TEST was stale — updated both asserts to `"queued"` + a `task_id` check.

Closes #11643

## Verification
- `pytest knowledge_scrape_test.py code_indexer_test.py`: 2 failed → **0 failed** (27 passed, 12 skipped). (Real CI confirms.)

## Model Used
Opus 4.8 (subagent: testing-engineer)