### PR TITLE
fix(plugin-sdk): accept semver pre-release/build versions + cover plugin install manifest path (#11652)

### DIFF
--- a/autobot-backend/plugin_install_test.py
+++ b/autobot-backend/plugin_install_test.py
@@ -11,6 +11,7 @@ Tests are deliberately lightweight:
 """
 
 import io
+import json
 import zipfile
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from fastapi import HTTPException
 
 import archive_safety as _arch
 import plugin_install
+from plugin_install import _read_manifest
 
 
 def _zip_bytes(entries: dict) -> bytes:
@@ -27,6 +29,20 @@ def _zip_bytes(entries: dict) -> bytes:
         for name, data in entries.items():
             zf.writestr(name, data)
     return buf.getvalue()
+
+
+_BASE_MANIFEST = {
+    "name": "test-plugin",
+    "display_name": "Test Plugin",
+    "description": "A test plugin",
+    "author": "mrveiss",
+    "entry_point": "plugins.test_plugin.main",
+}
+
+
+def _write_manifest(plugin_root: Path, data: dict) -> None:
+    with (plugin_root / "plugin.json").open("w", encoding="utf-8") as f:
+        json.dump(data, f)
 
 
 # (a) Import-level smoke: confirm delegation is wired up
@@ -50,3 +66,101 @@ def test_find_plugin_root_wraps_archive_safety(tmp_path: Path):
     (tmp_path / "myplugin").mkdir()
     (tmp_path / "myplugin" / "plugin.json").write_text("{}", encoding="utf-8")
     assert plugin_install._find_plugin_root(tmp_path) == tmp_path / "myplugin"
+
+
+# ---------------------------------------------------------------------------
+# _read_manifest — install path shared by install_from_zip / install_from_git
+# (Issue #11652: semver pre-release fix + previously-untested error paths)
+# ---------------------------------------------------------------------------
+
+
+def test_read_manifest_valid(tmp_path: Path):
+    _write_manifest(tmp_path, {**_BASE_MANIFEST, "version": "1.0.0"})
+    manifest = _read_manifest(tmp_path)
+    assert manifest.name == "test-plugin"
+    assert manifest.version == "1.0.0"
+
+
+def test_read_manifest_numeric_only_version_accepted(tmp_path: Path):
+    _write_manifest(tmp_path, {**_BASE_MANIFEST, "version": "2.5.11"})
+    manifest = _read_manifest(tmp_path)
+    assert manifest.version == "2.5.11"
+
+
+@pytest.mark.parametrize("version", ["1.0.0-beta", "1.0.0-rc.1", "1.0.0+build.5"])
+def test_read_manifest_semver_prerelease_and_build_accepted(tmp_path: Path, version: str):
+    """Issue #11652: pre-release/build semver must no longer 400 on install."""
+    _write_manifest(tmp_path, {**_BASE_MANIFEST, "version": version})
+    manifest = _read_manifest(tmp_path)
+    assert manifest.version == version
+
+
+def test_read_manifest_with_required_env_with_description(tmp_path: Path):
+    _write_manifest(
+        tmp_path,
+        {
+            **_BASE_MANIFEST,
+            "version": "1.0.0",
+            "required_env": [{"name": "MY_API_KEY", "description": "The API key."}],
+        },
+    )
+    manifest = _read_manifest(tmp_path)
+    assert manifest.required_env[0].name == "MY_API_KEY"
+    assert manifest.required_env[0].description == "The API key."
+
+
+def test_read_manifest_required_env_without_description_rejected(tmp_path: Path):
+    """`description` is required (min_length=1) — omitting it is a malformed manifest."""
+    _write_manifest(
+        tmp_path,
+        {**_BASE_MANIFEST, "version": "1.0.0", "required_env": [{"name": "MY_API_KEY"}]},
+    )
+    with pytest.raises(HTTPException) as exc:
+        _read_manifest(tmp_path)
+    assert exc.value.status_code == 400
+
+
+def test_read_manifest_non_upper_snake_env_name_rejected(tmp_path: Path):
+    _write_manifest(
+        tmp_path,
+        {
+            **_BASE_MANIFEST,
+            "version": "1.0.0",
+            "required_env": [{"name": "my_api_key", "description": "The API key."}],
+        },
+    )
+    with pytest.raises(HTTPException) as exc:
+        _read_manifest(tmp_path)
+    assert exc.value.status_code == 400
+
+
+def test_read_manifest_missing_file_rejected(tmp_path: Path):
+    with pytest.raises(HTTPException) as exc:
+        _read_manifest(tmp_path)
+    assert exc.value.status_code == 400
+    assert "not found" in exc.value.detail
+
+
+def test_read_manifest_malformed_json_rejected(tmp_path: Path):
+    (tmp_path / "plugin.json").write_text("{not valid json", encoding="utf-8")
+    with pytest.raises(HTTPException) as exc:
+        _read_manifest(tmp_path)
+    assert exc.value.status_code == 400
+    assert "not valid JSON" in exc.value.detail
+
+
+def test_read_manifest_invalid_version_rejected(tmp_path: Path):
+    """Genuinely invalid versions (not semver) must still 400."""
+    _write_manifest(tmp_path, {**_BASE_MANIFEST, "version": "v1.0.0"})
+    with pytest.raises(HTTPException) as exc:
+        _read_manifest(tmp_path)
+    assert exc.value.status_code == 400
+
+
+def test_read_manifest_missing_required_field_rejected(tmp_path: Path):
+    """Malformed manifest: missing a required field (`author`)."""
+    incomplete = {k: v for k, v in _BASE_MANIFEST.items() if k != "author"}
+    _write_manifest(tmp_path, {**incomplete, "version": "1.0.0"})
+    with pytest.raises(HTTPException) as exc:
+        _read_manifest(tmp_path)
+    assert exc.value.status_code == 400

--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -28,6 +28,20 @@ from .capabilities import Capability, TrustTier
 
 logger = logging.getLogger(__name__)
 
+# Full semver 2.0.0 grammar (https://semver.org/#backusnaur-form-grammar):
+# MAJOR.MINOR.PATCH, each a non-negative integer with no leading zeroes,
+# optionally followed by a dot-separated pre-release (alphanumeric + '-',
+# numeric identifiers may not have leading zeroes) and/or dot-separated
+# build metadata (alphanumeric + '-', leading zeroes allowed). Issue #11652:
+# the strictly-numeric X.Y.Z check rejected valid pre-releases like
+# "1.0.0-beta" and "1.0.0-rc1" on every plugin install.
+_SEMVER_PATTERN = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-(0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
 
 class PluginLoadError(RuntimeError):
     """Raised when a plugin fails to load due to missing required configuration."""
@@ -125,13 +139,13 @@ class PluginManifest(BaseModel):
     @field_validator("version")
     @classmethod
     def validate_version(cls, v: str) -> str:
-        """Validate semantic version format."""
-        parts = v.split(".")
-        if len(parts) != 3:
-            raise ValueError("Version must be in format X.Y.Z")
-        for part in parts:
-            if not part.isdigit():
-                raise ValueError("Version parts must be numeric")
+        """Validate full semantic version (semver.org): X.Y.Z[-pre][+build]."""
+        if not _SEMVER_PATTERN.match(v):
+            raise ValueError(
+                "Version must be valid semver: X.Y.Z with optional "
+                "-prerelease and/or +build metadata (e.g. '1.0.0', "
+                "'1.0.0-beta', '1.0.0-rc.1+build.5')"
+            )
         return v
 
     @field_validator("name")


### PR DESCRIPTION
## Thinking Path

Discovered during #11636 review: after the plugin_sdk dedup, the install API enforces `PluginManifest.validate_version` on every ZIP/git install, but that validator only accepted strictly-numeric `X.Y.Z` — so valid semver pre-releases (`1.0.0-beta`, `1.0.0-rc1`) that were previously installable now 400. The field is documented "Semantic version," so the validator should honour full semver, and the install path (previously untested) needs coverage to pin the behaviour.

## What Changed

- **`autobot_shared/plugin_sdk/base.py`** (canonical copy — `autobot-backend/plugin_sdk/base.py` is a re-export shim, and `plugin_install.py` imports from `autobot_shared`): replaced the numeric-only `X.Y.Z` check with the official semver.org 2.0.0 grammar (`_SEMVER_PATTERN`) — accepts `X.Y.Z` with optional `-prerelease` and/or `+build` metadata (no leading zeroes in numeric identifiers), still rejects genuinely invalid strings. Decision documented inline.
- **`autobot-backend/plugin_install_test.py`**: extended (in place, preserving the 3 existing #10472 guard tests) with 12 tests for the install `_read_manifest` path — valid manifest, numeric-only accept, semver pre-release/build accept (parametrized), `required_env` with/without description, non-UPPER_SNAKE env name → 400, missing/malformed manifest → 400, invalid version `v1.0.0` → 400, missing required field → 400.

## Verification

- Validator demo — ACCEPT `1.2.3`, `1.0.0-beta`, `1.0.0-rc.1`, `1.0.0+build.5`; REJECT `1.0`, `v1.0.0`, `1.0.0.0`, `01.0.0`.
- All 7 in-repo core `plugin.json` manifests still validate.
- `pytest plugin_install_test.py` → 15 passed; full plugin-sdk regression sweep → **106 passed**, 0 failed.
- flake8 (`.flake8` config) clean; black (line-length 120) no changes.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #11652
Refs #11634
