### PR TITLE
fix(code-exec): flush residual line buffer on pump EOF so a newline-less final result isn't dropped (#11663)

### DIFF
--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -471,7 +471,9 @@ class SecureSandboxExecutor:
         JSON-RPC requests (reply written back to stdin); every other line is the
         script's own output and is appended to *script_out* so the RPC framing
         never pollutes the returned result (GH#11613). Budget exhaustion aborts
-        the container via teardown.
+        the container via teardown. A final result written without a trailing
+        newline is flushed from the residual ``line_buf`` once recv() hits EOF
+        (GH#11663), instead of being silently dropped.
         """
         sock = container.attach_socket(params={"stdin": 1, "stdout": 1, "stream": 1})
         stream = getattr(sock, "_sock", sock)
@@ -487,6 +489,24 @@ class SecureSandboxExecutor:
             aborted, line_buf = await self._drain_lines(stream, broker, line_buf, container, script_out)
             if aborted:
                 return
+        self._flush_residual_line(line_buf, script_out)
+
+    @staticmethod
+    def _flush_residual_line(line_buf: bytes, script_out: "list[str]") -> None:
+        """Flush a trailing-newline-less final line to *script_out* on pump EOF (GH#11663).
+
+        The recv loop only emits complete ``\\n``-terminated lines via
+        ``_drain_lines``; a script that writes its final result without a
+        trailing newline (e.g. ``sys.stdout.write(json.dumps(r))``) leaves that
+        content stranded in ``line_buf`` once ``recv()`` returns empty (EOF).
+        Without this flush the result is silently lost. An unresolved
+        sentinel-prefixed residual (an RPC call that never got its terminating
+        newline) is discarded rather than surfaced as script output.
+        """
+        from chat_workflow.code_exec.protocol import RPC_SENTINEL_BYTES  # lazy
+
+        if line_buf and not line_buf.startswith(RPC_SENTINEL_BYTES):
+            script_out.append(line_buf.decode("utf-8", errors="replace"))
 
     async def _drain_lines(
         self, stream, broker: Any, line_buf: bytes, container, script_out: "list[str]"

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -899,6 +899,71 @@ async def test_drain_lines_script_print_is_not_a_bogus_tool_call():
     assert script_out == ["hello from the script", json.dumps({"tool": "", "id": 0})]
 
 
+# ---------------------------------------------------------------------------
+# GH#11663: pump EOF flushes a newline-less final result line
+# ---------------------------------------------------------------------------
+
+
+def _stdout_frame(payload: bytes) -> bytes:
+    """Build one Docker-multiplexed stdout frame wrapping *payload*."""
+    return bytes([1, 0, 0, 0]) + len(payload).to_bytes(4, "big") + payload
+
+
+class _FakeAttachSocket:
+    """Minimal fake ``attach_socket`` result exposing only ``.recv`` (GH#11663).
+
+    Deliberately a plain object (not a ``MagicMock``): a ``MagicMock`` would
+    auto-vivify a ``._sock`` attribute on access, defeating the production
+    code's ``getattr(sock, "_sock", sock)`` fallback and hanging the pump on a
+    bottomless mock stream.
+    """
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = list(chunks)
+
+    def recv(self, _size: int) -> bytes:
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+@pytest.mark.asyncio
+async def test_pump_broker_io_flushes_residual_line_without_trailing_newline():
+    """A final result written without a trailing '\\n' must reach script_out on EOF."""
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    broker = MagicMock()
+    broker.handle_line = AsyncMock()
+    broker.budget_exhausted = False
+
+    container = MagicMock()
+    container.attach_socket.return_value = _FakeAttachSocket([_stdout_frame(b'{"answer": 42}')])
+
+    script_out: list[str] = []
+    await ex._pump_broker_io(container, broker, script_out)
+
+    assert script_out == ['{"answer": 42}']
+    broker.handle_line.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pump_broker_io_normal_newline_terminated_stream_unchanged():
+    """A properly newline-terminated stream is captured once, with no duplicate/empty line."""
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    broker = MagicMock()
+    broker.handle_line = AsyncMock()
+    broker.budget_exhausted = False
+
+    container = MagicMock()
+    container.attach_socket.return_value = _FakeAttachSocket([_stdout_frame(b'{"answer": 42}\n')])
+
+    script_out: list[str] = []
+    await ex._pump_broker_io(container, broker, script_out)
+
+    assert script_out == ['{"answer": 42}']
+
+
 @pytest.mark.asyncio
 async def test_collect_broker_results_uses_script_stdout_not_rpc_logs():
     """#11613: result.stdout is the captured script output, not container.logs()."""


### PR DESCRIPTION
## Thinking Path

Flagged in the #11613 security review (untracked until now): the code-exec sandbox pump (`secure_sandbox_executor._pump_broker_io` / `_drain_lines`) only emits complete `\n`-terminated lines to `script_out`. A compose script that writes its result without a trailing newline (`sys.stdout.write(json.dumps(r))`) leaves that content stranded in `line_buf` after recv() hits EOF — silently dropped, result lost. Mitigated in practice only because the prompt teaches `print(...)`; still a latent robustness gap (flag-gated `AUTOBOT_CODEEXEC_ENABLED`, low severity).

## What Changed

- **`autobot-backend/secure_sandbox_executor.py`**: after the recv loop breaks on EOF, `_pump_broker_io` now calls a new static helper `_flush_residual_line(line_buf, script_out)` which appends any non-empty residual buffer (decoded `utf-8`, `errors="replace"`) to `script_out`. An unresolved sentinel-prefixed residual (an RPC call that never got its terminating newline) is **discarded** rather than surfaced as raw RPC framing. Normal newline-terminated output is unchanged (lines are still consumed/emptied by `_drain_lines` during the loop, so nothing is duplicated on EOF).
- **`autobot-backend/tests/unit/chat_workflow/test_code_exec.py`**: two new tests — a newline-less final line is flushed to `script_out`; a normal newline-terminated stream produces no duplicate/empty trailing entry.

## Verification

- `pytest tests/unit/chat_workflow/test_code_exec.py` → **75 passed** (incl. the 2 new).
- `py_compile` OK; flake8 (`.flake8`) clean (exit 0); black (line-length 120) no changes.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #11663
