### PR TITLE
test: remediate scoped-failing services tests (#11248)

### DIFF
--- a/autobot-backend/tests/services/rag_service_events_test.py
+++ b/autobot-backend/tests/services/rag_service_events_test.py
@@ -5,13 +5,6 @@
 """Unit tests for RAGService retrieval feedback event emission (#1516)."""
 
 import asyncio
-import json
-import time
-from unittest.mock import AsyncMock, patch
-
-import pytest
-
-from tests.fixtures import make_async_redis
 
 # Real-load and parent-bind ``services.rag_service`` at collection time.
 #
@@ -24,8 +17,15 @@ from tests.fixtures import make_async_redis
 # ``_real_load_and_bind`` helper (#11661) binds the real module as a parent
 # attribute up front, making the patch resolve correctly regardless of order.
 import importlib.util as _ilu  # noqa: E402
+import json
 import sys as _sys  # noqa: E402
+import time
 from pathlib import Path as _Path  # noqa: E402
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.fixtures import make_async_redis
 
 
 def _bind_real_rag_service() -> None:

--- a/autobot-backend/tests/services/rag_service_events_test.py
+++ b/autobot-backend/tests/services/rag_service_events_test.py
@@ -13,6 +13,37 @@ import pytest
 
 from tests.fixtures import make_async_redis
 
+# Real-load and parent-bind ``services.rag_service`` at collection time.
+#
+# The backend conftest registers ``services`` as a MagicMock package stub. When
+# a test does ``patch("services.rag_service.publish_event")``, unittest.mock
+# resolves the target via ``getattr(sys.modules["services"], "rag_service")``,
+# which hits the stub's catch-all ``__getattr__`` and returns a throwaway mock
+# on the FIRST use — so the patch silently lands on the wrong object and the
+# first test in the class saw 0 publish calls (#11248). Mirroring the conftest
+# ``_real_load_and_bind`` helper (#11661) binds the real module as a parent
+# attribute up front, making the patch resolve correctly regardless of order.
+import importlib.util as _ilu  # noqa: E402
+import sys as _sys  # noqa: E402
+from pathlib import Path as _Path  # noqa: E402
+
+
+def _bind_real_rag_service() -> None:
+    name = "services.rag_service"
+    path = _Path(__file__).resolve().parents[2] / "services" / "rag_service.py"
+    spec = _ilu.spec_from_file_location(name, str(path))
+    if not spec or not spec.loader:
+        return
+    mod = _ilu.module_from_spec(spec)
+    _sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    parent, _, child = name.rpartition(".")
+    if parent in _sys.modules:
+        setattr(_sys.modules[parent], child, mod)
+
+
+_bind_real_rag_service()
+
 # =============================================================================
 # _emit_retrieval_feedback Tests
 # =============================================================================

--- a/autobot-backend/tests/services/test_causal_inference_engine.py
+++ b/autobot-backend/tests/services/test_causal_inference_engine.py
@@ -35,6 +35,23 @@ from services.causal_inference_engine import (
 from services.root_cause_analyzer import CausalEvent, RootCauseReport
 
 
+@pytest.fixture(autouse=True)
+def _mock_engine_redis(monkeypatch):
+    """Keep ``analyze_failure`` off real Redis.
+
+    ``CausalInferenceEngine._ensure_initialized()`` opens an async Redis
+    client (database ``knowledge``) and runs a readiness check. When run
+    scoped against an unreachable Redis it retries for ~30s per call,
+    making the suite pathologically slow / appear to hang. These tests
+    mock the root-cause analyzer, so a stub client keeps them fast and
+    deterministic without touching resolution logic.
+    """
+    monkeypatch.setattr(
+        "services.causal_inference_engine.get_async_redis_client",
+        AsyncMock(return_value=AsyncMock()),
+    )
+
+
 class TestInterventionGeneration:
     """Tests for intervention generation from causal events."""
 

--- a/autobot-backend/tests/services/test_conflict_resolver.py
+++ b/autobot-backend/tests/services/test_conflict_resolver.py
@@ -40,6 +40,27 @@ from api.knowledge_grounding_models import (
 from services.conflict_resolver import ConflictResolver
 
 
+@pytest.fixture(autouse=True)
+def _mock_async_redis_client(monkeypatch):
+    """Prevent real Redis I/O in resolution-logic tests.
+
+    ``ConflictResolver.resolve()`` calls ``flag_for_human_review()`` (which
+    performs Redis writes) whenever a result requires human review. Unit tests
+    that only assert on resolution *logic* do not pre-set ``_redis``, so the
+    lazy ``_get_redis()`` would otherwise open a real async client and block.
+    Patching the mixin factory returns an ``AsyncMock`` client, keeping these
+    tests deterministic and scoped-safe. Tests that explicitly assign
+    ``resolver._redis`` (persistence/audit tests) are unaffected because
+    ``_get_redis()`` short-circuits on the pre-set instance client.
+    """
+    fake_redis = AsyncMock()
+    monkeypatch.setattr(
+        "autobot_shared.redis_mixin.get_async_redis_client",
+        AsyncMock(return_value=fake_redis),
+    )
+    return fake_redis
+
+
 class TestConflictResolverInit:
     """Tests for ConflictResolver initialization."""
 


### PR DESCRIPTION
## Thinking Path
10 files were listed as scoped-failing; investigating against current base, 9 were already green (fixed by prior merged PRs #11273/#11282/#11285/#11288/#11329/#11332/#11390 — verified). 3 still failed.

## What Changed (3 files, no tests weakened)
- `test_conflict_resolver.py` — resolution tests called `resolve()` → real Redis I/O (unmocked) → ~30s hang each, file timed out. Added a module-level autouse fixture mocking `get_async_redis_client`. Persistence tests that set `_redis` explicitly are untouched (short-circuit preserved). 51 passed.
- `test_causal_inference_engine.py` — `_ensure_initialized()` opened a real async Redis client (30s retry) → hang. Autouse mock; no logic/assertions touched. 19 passed in 0.4s (was hanging).
- `rag_service_events_test.py` — conftest-stub inert-patch (the #11282 residual anomaly): `patch("services.rag_service.publish_event")` resolved against the `services` MagicMock package stub for the first test → inert patch → 0 publish calls. Fixed with a file-local spec-based real-load bind (mirrors conftest `_real_load_and_bind`, #11661). 37p/1f → 38 passed.

## Verification
- All 10 services tests together: **360 passed**; + slm require_permission 22 + health_collector 14 = **396 passed, 0 failed, 0 hangs**.
- Flagged latent test-infra bug (services MagicMock stub → order-dependent inert patches) in the issue for a general fix.

Closes #11248

## Model Used
Opus 4.8 (subagent: testing-engineer)