### PR TITLE
fix(async): offload sync MemoryManager writes on async paths in task tracker / orchestrator / decision system (#12101)

### DIFF
--- a/autobot-backend/context_aware_decision/system.py
+++ b/autobot-backend/context_aware_decision/system.py
@@ -11,6 +11,7 @@ Coordinates context collection and decision making.
 Part of Issue #381 - God Class Refactoring
 """
 
+import asyncio
 from dataclasses import asdict
 from typing import Any, Dict, List
 
@@ -97,42 +98,52 @@ class ContextAwareDecisionSystem:
         if len(self.decision_history) > self.max_history:
             self.decision_history = self.decision_history[-self.max_history :]
 
+    def _record_decision_in_memory(self, decision: Decision, context: DecisionContext) -> None:
+        """Create, start, and complete the decision's task record (sync).
+
+        Issue #12101: extracted so ``_store_decision_in_memory`` can offload
+        the create->start->complete sequence via a single asyncio.to_thread
+        call instead of three separate event-loop-blocking sync calls.
+        """
+        task_id = self.memory_manager.create_task_record(
+            task_name=f"Decision: {decision.decision_type.value}",
+            description=(f"Contextual decision making: " f"{decision.chosen_action.get('action', 'unknown')}"),
+            priority=TaskPriority.MEDIUM,
+            agent_type="context_aware_decision_system",
+            inputs={
+                "decision_type": decision.decision_type.value,
+                "primary_goal": context.primary_goal,
+                "context_elements_count": len(context.context_elements),
+            },
+            metadata={
+                "decision_data": asdict(decision),
+                "context_summary": {
+                    "elements_count": len(context.context_elements),
+                    "constraints_count": len(context.constraints),
+                    "actions_count": len(context.available_actions),
+                    "risk_factors_count": len(context.risk_factors),
+                },
+            },
+        )
+
+        self.memory_manager.start_task(task_id)
+        self.memory_manager.complete_task(
+            task_id,
+            outputs={
+                "chosen_action": decision.chosen_action,
+                "confidence": decision.confidence,
+                "requires_approval": decision.requires_approval,
+            },
+        )
+
     async def _store_decision_in_memory(self, decision: Decision, context: DecisionContext) -> None:
-        """Store decision and context in enhanced memory system."""
+        """Store decision and context in enhanced memory system.
+
+        Issue #12101: offloads the sync SQLite MemoryManager writes to a
+        worker thread so they never block the event loop.
+        """
         try:
-            # Create memory task record for the decision
-            task_id = self.memory_manager.create_task_record(
-                task_name=f"Decision: {decision.decision_type.value}",
-                description=(f"Contextual decision making: " f"{decision.chosen_action.get('action', 'unknown')}"),
-                priority=TaskPriority.MEDIUM,
-                agent_type="context_aware_decision_system",
-                inputs={
-                    "decision_type": decision.decision_type.value,
-                    "primary_goal": context.primary_goal,
-                    "context_elements_count": len(context.context_elements),
-                },
-                metadata={
-                    "decision_data": asdict(decision),
-                    "context_summary": {
-                        "elements_count": len(context.context_elements),
-                        "constraints_count": len(context.constraints),
-                        "actions_count": len(context.available_actions),
-                        "risk_factors_count": len(context.risk_factors),
-                    },
-                },
-            )
-
-            # Mark task as started and completed
-            self.memory_manager.start_task(task_id)
-            self.memory_manager.complete_task(
-                task_id,
-                outputs={
-                    "chosen_action": decision.chosen_action,
-                    "confidence": decision.confidence,
-                    "requires_approval": decision.requires_approval,
-                },
-            )
-
+            await asyncio.to_thread(self._record_decision_in_memory, decision, context)
         except Exception as e:
             logger.error("Failed to store decision in memory: %s", e)
 

--- a/autobot-backend/context_aware_decision/tests/test_system_async_offload.py
+++ b/autobot-backend/context_aware_decision/tests/test_system_async_offload.py
@@ -1,0 +1,97 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for async-path MemoryManager offloading in ContextAwareDecisionSystem
+(#12101).
+
+``MemoryManager.create_task_record/start_task/complete_task`` are sync
+SQLite writes. ``_store_decision_in_memory`` is an async method called on
+the event loop, so the create->start->complete sequence must be offloaded
+via a single ``asyncio.to_thread`` call rather than calling the sync
+MemoryManager methods directly.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from context_aware_decision.models import Decision, DecisionContext
+from context_aware_decision.system import ContextAwareDecisionSystem
+from context_aware_decision.types import ConfidenceLevel, DecisionType
+
+
+def _make_decision() -> Decision:
+    return Decision(
+        decision_id="dec-1",
+        decision_type=DecisionType.AUTOMATION_ACTION,
+        chosen_action={"action": "noop"},
+        alternative_actions=[],
+        confidence=0.9,
+        confidence_level=ConfidenceLevel.HIGH,
+        reasoning="test",
+        supporting_evidence=[],
+        risk_assessment={},
+        expected_outcomes=[],
+        monitoring_criteria=[],
+        fallback_plan=None,
+        requires_approval=False,
+        timestamp=0.0,
+    )
+
+
+def _make_context() -> DecisionContext:
+    return DecisionContext(
+        decision_id="dec-1",
+        decision_type=DecisionType.AUTOMATION_ACTION,
+        primary_goal="test goal",
+        context_elements=[],
+        constraints=[],
+        available_actions=[],
+        risk_factors=[],
+        user_preferences={},
+        system_state={},
+        historical_patterns=[],
+        timestamp=0.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_decision_offloads_memory_writes_to_thread():
+    """_store_decision_in_memory must offload the create->start->complete
+    sequence via asyncio.to_thread instead of blocking the event loop."""
+    memory_manager = MagicMock()
+    memory_manager.create_task_record.return_value = "task-1"
+    system = ContextAwareDecisionSystem(memory_manager=memory_manager)
+
+    decision = _make_decision()
+    context = _make_context()
+
+    with patch("context_aware_decision.system.asyncio.to_thread") as mock_to_thread:
+
+        async def _immediate(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        mock_to_thread.side_effect = _immediate
+
+        await system._store_decision_in_memory(decision, context)
+
+    mock_to_thread.assert_called_once()
+    assert mock_to_thread.call_args.args[0] == system._record_decision_in_memory
+    memory_manager.create_task_record.assert_called_once()
+    memory_manager.start_task.assert_called_once_with("task-1")
+    memory_manager.complete_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_store_decision_swallows_errors_without_blocking():
+    """Errors during the offloaded write are logged, not raised (matches
+    prior behavior of the inline try/except)."""
+    memory_manager = MagicMock()
+    memory_manager.create_task_record.side_effect = RuntimeError("db locked")
+    system = ContextAwareDecisionSystem(memory_manager=memory_manager)
+
+    await system._store_decision_in_memory(_make_decision(), _make_context())
+
+    memory_manager.create_task_record.assert_called_once()

--- a/autobot-backend/orchestration/orchestrator_legacy_api.py
+++ b/autobot-backend/orchestration/orchestrator_legacy_api.py
@@ -9,6 +9,7 @@ mixin so Orchestrator maintains API compatibility without inflating its line
 count.
 """
 
+import asyncio
 import time
 import uuid
 import warnings
@@ -30,6 +31,11 @@ class _DeprecatedRequestMixin:
     """
 
     def _start_request_tracking(self, task_id, user_message, priority, context) -> None:
+        """Sync helper wrapping the sync task-tracker API (Issue #12101).
+
+        Called from ``process_user_request`` via ``asyncio.to_thread`` — do
+        NOT call this directly from a running event loop.
+        """
         get_task_tracker().start_task(
             task_id=task_id,
             task_type=TaskType.USER_REQUEST,
@@ -74,7 +80,8 @@ class _DeprecatedRequestMixin:
         logger.info("Processing user request %s: %s...", task_id, user_message[:100])
 
         try:
-            self._start_request_tracking(task_id, user_message, priority, context)
+            # Issue #12101: offload sync SQLite MemoryManager write.
+            await asyncio.to_thread(self._start_request_tracking, task_id, user_message, priority, context)
             classification_result = await self._classify_task(user_message)
             target_llm_model = self._select_model_for_task(classification_result)
 
@@ -85,7 +92,8 @@ class _DeprecatedRequestMixin:
 
             processing_time = time.time() - start_time
             self._update_success_metrics(processing_time)
-            get_task_tracker().complete_task(task_id, result)
+            # Issue #12101: offload sync SQLite MemoryManager write.
+            await asyncio.to_thread(get_task_tracker().complete_task, task_id, result)
             logger.info("✅ Request %s completed in %.2fs", task_id, processing_time)
             return {
                 "task_id": task_id,
@@ -99,7 +107,8 @@ class _DeprecatedRequestMixin:
         except Exception as e:
             processing_time = time.time() - start_time
             self.metrics["tasks_failed"] += 1
-            get_task_tracker().fail_task(task_id, str(e))
+            # Issue #12101: offload sync SQLite MemoryManager write.
+            await asyncio.to_thread(get_task_tracker().fail_task, task_id, str(e))
             logger.error("❌ Request %s failed after %.2fs: %s", task_id, processing_time, e)
             return {
                 "task_id": task_id,

--- a/autobot-backend/orchestration/orchestrator_legacy_api_test.py
+++ b/autobot-backend/orchestration/orchestrator_legacy_api_test.py
@@ -1,0 +1,90 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for async-path MemoryManager offloading in process_user_request (#12101).
+
+``get_task_tracker().start_task/complete_task/fail_task`` are sync
+backward-compatibility wrappers that perform sync SQLite MemoryManager
+writes. When called directly from the async ``process_user_request`` path
+they block the event loop. These tests assert the calls are offloaded via
+``asyncio.to_thread``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestration.orchestrator_legacy_api import _DeprecatedRequestMixin
+
+
+class _FakeOrchestrator(_DeprecatedRequestMixin):
+    """Minimal stand-in exercising only the mixin's deprecated API."""
+
+    def __init__(self):
+        self.metrics = {
+            "tasks_completed": 0,
+            "tasks_failed": 0,
+            "total_processing_time": 0.0,
+            "average_response_time": 0.0,
+        }
+        self.classification_agent = None
+        self.config = MagicMock(orchestrator_llm_model="test-model")
+        self.llm_service = MagicMock()
+        self.llm_service.chat = AsyncMock(return_value=MagicMock(content="hi"))
+        self.run_workflow = AsyncMock(return_value={"type": "workflow_result"})
+
+
+def _immediate_to_thread():
+    async def _run(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    return _run
+
+
+@pytest.mark.asyncio
+async def test_process_user_request_offloads_start_task_to_thread():
+    from orchestrator import OrchestrationMode
+
+    orch = _FakeOrchestrator()
+    mock_tracker = MagicMock()
+
+    with (
+        patch("orchestration.orchestrator_legacy_api.get_task_tracker", return_value=mock_tracker),
+        patch(
+            "orchestration.orchestrator_legacy_api.asyncio.to_thread",
+            side_effect=_immediate_to_thread(),
+        ) as mock_to_thread,
+    ):
+        result = await orch.process_user_request("hello world", mode=OrchestrationMode.SIMPLE)
+
+    assert result["success"] is True
+    called_funcs = [call.args[0] for call in mock_to_thread.call_args_list]
+    assert orch._start_request_tracking in called_funcs
+    assert mock_tracker.complete_task in called_funcs
+    mock_tracker.start_task.assert_called_once()
+    mock_tracker.complete_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_user_request_offloads_fail_task_to_thread_on_exception():
+    from orchestrator import OrchestrationMode
+
+    orch = _FakeOrchestrator()
+    orch.llm_service.chat = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_tracker = MagicMock()
+
+    with (
+        patch("orchestration.orchestrator_legacy_api.get_task_tracker", return_value=mock_tracker),
+        patch(
+            "orchestration.orchestrator_legacy_api.asyncio.to_thread",
+            side_effect=_immediate_to_thread(),
+        ) as mock_to_thread,
+    ):
+        result = await orch.process_user_request("hello world", mode=OrchestrationMode.SIMPLE)
+
+    assert result["success"] is False
+    called_funcs = [call.args[0] for call in mock_to_thread.call_args_list]
+    assert mock_tracker.fail_task in called_funcs
+    mock_tracker.fail_task.assert_called_once()

--- a/autobot-backend/task_execution_tracker.py
+++ b/autobot-backend/task_execution_tracker.py
@@ -119,9 +119,12 @@ class TaskExecutionTracker:
         Args:
             task_id: Task identifier
             task_context: Execution context with outputs. Issue #620.
+
+        Issue #12101: offloads the sync SQLite MemoryManager write to a
+        worker thread so it never blocks the event loop.
         """
         if task_id in self.active_tasks:
-            self.memory_manager.complete_task(task_id, outputs=task_context.outputs)
+            await asyncio.to_thread(self.memory_manager.complete_task, task_id, outputs=task_context.outputs)
         self.active_tasks.pop(task_id, None)
         await self._execute_task_callbacks(task_id, "completed")
 
@@ -231,9 +234,15 @@ class TaskExecutionTracker:
             async with tracker.track_task("Agent Communication", "Chat with user") as task_id:
                 result = await some_agent_operation()
                 return result
+
+        Issue #12101: the create->start sequence in ``_create_and_start_task``
+        performs sync SQLite MemoryManager writes, so it is offloaded to a
+        worker thread via a single asyncio.to_thread call to avoid blocking
+        the event loop while keeping the sequence atomic.
         """
         # Create and start task (Issue #620: uses helper)
-        task_id = self._create_and_start_task(
+        task_id = await asyncio.to_thread(
+            self._create_and_start_task,
             task_name,
             description,
             priority,
@@ -252,7 +261,8 @@ class TaskExecutionTracker:
 
         except Exception as e:
             logger.error("Task %s failed: %s", task_id, e)
-            self.memory_manager.fail_task(task_id, f"Task failed: {type(e).__name__}")
+            # Issue #12101: offload sync SQLite MemoryManager write.
+            await asyncio.to_thread(self.memory_manager.fail_task, task_id, f"Task failed: {type(e).__name__}")
             self.active_tasks.pop(task_id, None)
             await self._execute_task_callbacks(task_id, "completed")
             raise

--- a/autobot-backend/task_execution_tracker_test.py
+++ b/autobot-backend/task_execution_tracker_test.py
@@ -1,0 +1,100 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for async-path MemoryManager offloading in TaskExecutionTracker (#12101).
+
+Sync ``MemoryManager`` methods block the event loop when called directly
+from async code. These tests assert that the async paths (``track_task``
+and ``_finalize_task``) offload the writes via ``asyncio.to_thread`` instead
+of calling the sync MemoryManager methods directly on the loop.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from task_execution_tracker import TaskExecutionTracker
+
+
+def _make_tracker() -> TaskExecutionTracker:
+    """Build a tracker with a mocked, synchronous MemoryManager."""
+    memory_manager = MagicMock()
+    memory_manager.create_task_record.return_value = "task-123"
+    return TaskExecutionTracker(memory_manager=memory_manager)
+
+
+@pytest.mark.asyncio
+async def test_track_task_offloads_create_and_start_to_thread():
+    """track_task's create+start sequence must go through asyncio.to_thread,
+    not call the sync MemoryManager methods directly on the event loop."""
+    tracker = _make_tracker()
+
+    async with tracker.track_task("name", "desc") as task_context:
+        task_context.set_outputs({"ok": True})
+
+    tracker.memory_manager.create_task_record.assert_called_once()
+    tracker.memory_manager.start_task.assert_called_once_with("task-123")
+    tracker.memory_manager.complete_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_track_task_offloads_fail_task_to_thread_on_exception():
+    """On exception, fail_task must be offloaded via asyncio.to_thread."""
+    tracker = _make_tracker()
+
+    with pytest.raises(RuntimeError):
+        async with tracker.track_task("name", "desc"):
+            raise RuntimeError("boom")
+
+    tracker.memory_manager.fail_task.assert_called_once()
+    assert tracker.memory_manager.fail_task.call_args.args[0] == "task-123"
+
+
+@pytest.mark.asyncio
+async def test_track_task_uses_to_thread_not_direct_call():
+    """Explicitly assert asyncio.to_thread is the mechanism used to reach
+    the sync MemoryManager API, confirming the event loop is never blocked."""
+    tracker = _make_tracker()
+
+    with patch("task_execution_tracker.asyncio.to_thread") as mock_to_thread:
+        mock_to_thread.return_value = "task-999"
+
+        async def _immediate(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        mock_to_thread.side_effect = _immediate
+
+        async with tracker.track_task("name", "desc") as task_context:
+            task_context.set_outputs({"ok": True})
+
+    assert mock_to_thread.call_count >= 1
+    called_funcs = [call.args[0] for call in mock_to_thread.call_args_list]
+    assert tracker._create_and_start_task in called_funcs
+    assert tracker.memory_manager.complete_task in called_funcs
+
+
+@pytest.mark.asyncio
+async def test_finalize_task_offloads_complete_task_to_thread():
+    """_finalize_task must offload the complete_task write via to_thread."""
+    tracker = _make_tracker()
+    tracker.active_tasks["task-123"] = {"task_name": "x", "agent_type": None, "inputs": None}
+
+    from task_execution_tracker import TaskExecutionContext
+
+    task_context = TaskExecutionContext(tracker, "task-123")
+    task_context.set_outputs({"result": "done"})
+
+    with patch("task_execution_tracker.asyncio.to_thread") as mock_to_thread:
+
+        async def _immediate(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        mock_to_thread.side_effect = _immediate
+
+        await tracker._finalize_task("task-123", task_context)
+
+    mock_to_thread.assert_called_once()
+    assert mock_to_thread.call_args.args[0] == tracker.memory_manager.complete_task
+    tracker.memory_manager.complete_task.assert_called_once_with("task-123", outputs={"result": "done"})


### PR DESCRIPTION
## Thinking Path

Discovered while fixing #11680 (PR #12100): the same sync-SQLite-`MemoryManager`-on-the-event-loop pattern existed at 4 out-of-scope sites. This PR applies the proven `asyncio.to_thread` remediation across all of them. Care taken to offload ONLY async-path call sites — the sync public wrapper API is left sync.

## What Changed

7 async-path call sites offloaded via `asyncio.to_thread` (each confirmed inside an `async def`):

- **`task_execution_tracker.py`**: `_finalize_task` (complete_task); `track_task` (`_create_and_start_task` create→start in one atomic hop, and `fail_task` in the except path).
- **`orchestration/orchestrator_legacy_api.py`**: `process_user_request` — `_start_request_tracking` (start), `complete_task`, `fail_task`.
- **`context_aware_decision/system.py`**: `_store_decision_in_memory` — extracted `_record_decision_in_memory` sync helper (create→start→complete) offloaded in a single `to_thread` hop (mirrors `takeover_manager._record_completion_in_memory` from #11680).

**Sync API untouched**: the sync helpers/wrappers (`_create_and_start_task`, `create_subtask`, sync `start_task`/`complete_task`/`fail_task`) still call `MemoryManager` directly — only their async call sites changed.

## Verification

- 8 new tests across 3 test files assert `asyncio.to_thread` is the offload mechanism (patched + asserted) plus behavioral correctness (calls made, exceptions propagate/log) → **8 passed**.
- `tests/integration/test_progress_tracker.py` → 9 passed (unaffected).
- flake8 (`.flake8`) clean; black (120) no changes.

## Discoveries

Filed a follow-up for 2 pre-existing, unrelated failures in `memory_consolidation_test.py` (stale API: unawaited async `get_task_statistics`, call to nonexistent `MemoryManager.get_embedding`) — see linked issue.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #12101
Refs #11634, #11680
