### PR TITLE
test(memory): align memory_consolidation_test with real MemoryManager API + None-guard update_task_status (#12116)

### DIFF
--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -350,9 +350,9 @@ class MemoryManager:
         """
         if not task_id or not task_id.strip():
             raise ValueError("task_id cannot be empty")
-        if "duration_seconds" in kwargs and kwargs["duration_seconds"] < 0:
+        if kwargs.get("duration_seconds") is not None and kwargs["duration_seconds"] < 0:
             raise ValueError("duration_seconds cannot be negative")
-        if "retry_count" in kwargs and kwargs["retry_count"] < 0:
+        if kwargs.get("retry_count") is not None and kwargs["retry_count"] < 0:
             raise ValueError("retry_count cannot be negative")
         await self._ensure_initialized()
         return await self._task_storage.update_task(task_id, status=status, **kwargs)

--- a/autobot-backend/memory_consolidation_test.py
+++ b/autobot-backend/memory_consolidation_test.py
@@ -7,6 +7,7 @@ Validates core functionality without requiring full backend restart
 """
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 
@@ -14,7 +15,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent))
 
 from markdown_reference_system import MarkdownReferenceSystem
-from memory import MemoryManager, TaskPriority
+from memory import MemoryCategory, MemoryManager, TaskPriority
 from task_execution_tracker import TaskExecutionTracker
 
 
@@ -47,10 +48,10 @@ async def test_memory_consolidation_system():
     print(f"✅ Completed task: {task_id}")  # noqa: print
 
     # Get task statistics
-    stats = memory_manager.get_task_statistics(days_back=1)
-    print(  # noqa: print
-        f"✅ Task statistics: {stats['total_tasks']} tasks, {stats['success_rate_percent']}% success rate"
-    )
+    stats = await memory_manager.get_task_statistics(days_back=1)
+    completed_count = stats["by_status"].get("completed", 0)
+    success_rate_percent = round((completed_count / stats["total_tasks"]) * 100, 2) if stats["total_tasks"] else 0.0
+    print(f"✅ Task statistics: {stats['total_tasks']} tasks, {success_rate_percent}% success rate")  # noqa: print
 
     # Test 2: Task Execution Tracker
     print("\n2. Testing Task Execution Tracker...")  # noqa: print
@@ -110,7 +111,7 @@ async def test_memory_consolidation_system():
     memory_manager.complete_task(integration_task_id)
 
     # Get updated statistics
-    final_stats = memory_manager.get_task_statistics(days_back=1)
+    final_stats = await memory_manager.get_task_statistics(days_back=1)
     print(f"✅ Final statistics: {final_stats['total_tasks']} total tasks")  # noqa: print  # noqa: print
 
     # Test 5: Performance Analysis
@@ -149,8 +150,19 @@ async def test_embedding_system():
     if success:
         print("✅ Embedding stored successfully")  # noqa: print
 
-        # Retrieve embedding
-        retrieved = memory_manager.get_embedding(test_content, "test_model")
+        # Retrieve embedding (store_embedding persists it as a FACT-category memory entry)
+        entries = await memory_manager.retrieve_memories(MemoryCategory.FACT, limit=10)
+        stored_entry = next(
+            (
+                entry
+                for entry in entries
+                if entry.content == test_content and entry.metadata.get("embedding_model") == "test_model"
+            ),
+            None,
+        )
+        retrieved = (
+            json.loads(stored_entry.embedding.decode("utf-8")) if stored_entry and stored_entry.embedding else None
+        )
 
         if retrieved and len(retrieved) == len(test_embedding):
             print("✅ Embedding retrieved successfully")  # noqa: print


### PR DESCRIPTION
## Thinking Path

Filed as a discovery while implementing #12101: `memory_consolidation_test.py` had 2 pre-existing failures from stale `MemoryManager` API usage. Fixing the test against the real API surfaced a genuine one-line production `None`-guard bug in `update_task_status` — fixed in the same PR per Rule 6 (in-scope, required to make the test pass).

## What Changed

- **`autobot-backend/memory_consolidation_test.py`** (test alignment, intent preserved):
  - `get_task_statistics(...)` is `async` → now `await`ed (both call sites are already inside an `async def`; async-first, not the `_sync` variant). Assertions realigned to the real return shape (`{total_tasks, by_status, by_priority}`) — `success_rate_percent` is now computed from `by_status["completed"] / total_tasks` (the key never existed on the API; the old assertion would `KeyError`).
  - Replaced the nonexistent `get_embedding(...)` with the real store→retrieve→decode path: `await retrieve_memories(MemoryCategory.FACT)` then `json.loads(entry.embedding.decode("utf-8"))`, matching how `store_embedding` persists vectors. Exercises real behavior, no weakened assertions.
- **`autobot-backend/memory/manager.py`** (in-scope production fix): `update_task_status` validated `kwargs["duration_seconds"] < 0` / `kwargs["retry_count"] < 0` without a `None` guard — but `complete_task` legitimately passes `duration_seconds=None` (task completed without ever starting), causing `TypeError: '<' not supported between 'NoneType' and 'int'`. Now guarded with `kwargs.get(...) is not None and ... < 0`; negative-value validation preserved.

## Verification

- `pytest memory_consolidation_test.py` → **2 passed** (`test_memory_consolidation_system`, `test_embedding_system`).
- flake8 (`.flake8`) clean on both files; black (120) applied, tests re-verified.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #12116
