### PR TITLE
fix(http-client): tracked_session() so raw get_session users defer pool recreation (#11656)

### DIFF
--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -164,14 +164,14 @@ class LinkPipeline(BasePipeline):
 
         jina_url = f"{_JINA_BASE_URL}{url}"
         try:
-            session = await _get_jina_session()
-            async with session.get(jina_url, allow_redirects=True, timeout=_JINA_TIMEOUT) as response:
-                if response.status == 200:
-                    text = await response.text(encoding="utf-8", errors="replace")
-                    _record_jina_success()
-                    return text
-                # Non-200 counts as a failure for circuit-breaker purposes.
-                _record_jina_failure()
+            async with _get_jina_session() as session:
+                async with session.get(jina_url, allow_redirects=True, timeout=_JINA_TIMEOUT) as response:
+                    if response.status == 200:
+                        text = await response.text(encoding="utf-8", errors="replace")
+                        _record_jina_success()
+                        return text
+                    # Non-200 counts as a failure for circuit-breaker purposes.
+                    _record_jina_failure()
         except Exception as exc:
             logger.debug("Jina Reader fast-path failed for %s: %s", url, exc)
             _record_jina_failure()
@@ -446,18 +446,24 @@ async def process_url(url: str, render: str = "auto", timeout: float = 30.0) -> 
 # ----------------------------------------------------------------------
 
 
-async def _get_jina_session() -> "aiohttp.ClientSession":
-    """Return the shared pooled aiohttp session.
+def _get_jina_session():
+    """Return an async context manager yielding the shared pooled aiohttp session.
 
     Issue #11641: the private module-level Jina session forked the concept
     owned by ``autobot_shared.http_client.HTTPClientManager``. Delegates to
     the canonical singleton (lifecycle managed there); the Jina-specific
     timeout stays per-request via ``_JINA_TIMEOUT``. Kept as an indirection
     point — tests patch this seam.
+
+    Issue #11656: delegates to ``HTTPClientManager.tracked_session()`` (not
+    the raw ``get_session()``) so a Jina fetch is counted in the SAME
+    ``_active_requests`` counter ``request()`` uses. Without this, a pool
+    resize driven by concurrent ``request()`` traffic could close the
+    shared session out from under an in-flight Jina fetch.
     """
     from autobot_shared.http_client import get_http_client
 
-    return await get_http_client().get_session()
+    return get_http_client().tracked_session()
 
 
 def _record_jina_failure() -> None:

--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -287,7 +287,7 @@ class TestLinkPipelineJina:
         pipe = LinkPipeline()
         mock_session = self._make_jina_mock_session(status=200, content="Title\n\nSome content text here.")
 
-        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)):
+        with patch("media.link.pipeline._get_jina_session", new=MagicMock(return_value=mock_session)):
             result = await pipe._try_jina("https://example.com")
 
         assert result == "Title\n\nSome content text here."
@@ -348,7 +348,7 @@ class TestLinkPipelineJina:
         bs4_result = {"type": "link_fetch", "confidence": 0.9, "url": "https://example.com"}
 
         with (
-            patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)),
+            patch("media.link.pipeline._get_jina_session", new=MagicMock(return_value=mock_session)),
             patch.object(pipe, "_parse_html", return_value=bs4_result),
         ):
             # _try_jina returns None on non-200, triggering BS4 fallback
@@ -563,10 +563,10 @@ class TestJinaCircuitBreaker:
         pipe = LinkPipeline()
 
         # First N calls raise → circuit opens
-        async def _always_raise(*args, **kwargs):
+        def _always_raise(*args, **kwargs):
             raise RuntimeError("simulated Jina outage")
 
-        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(side_effect=_always_raise)):
+        with patch("media.link.pipeline._get_jina_session", new=MagicMock(side_effect=_always_raise)):
             for _ in range(pl._JINA_FAILURE_THRESHOLD):
                 result = await pipe._try_jina("https://example.com/a")
                 assert result is None
@@ -576,11 +576,11 @@ class TestJinaCircuitBreaker:
         assert pl._jina_cooldown_until > __import__("time").monotonic()
 
         # Subsequent call must NOT invoke _get_jina_session (short-circuit)
-        called = AsyncMock()
+        called = MagicMock()
         with patch("media.link.pipeline._get_jina_session", new=called):
             result = await pipe._try_jina("https://example.com/b")
         assert result is None
-        called.assert_not_awaited()
+        called.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_circuit_expires_after_cooldown(self, _reset_jina_state):
@@ -603,8 +603,10 @@ class TestJinaCircuitBreaker:
 
         mock_session = MagicMock()
         mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)):
+        with patch("media.link.pipeline._get_jina_session", new=MagicMock(return_value=mock_session)):
             result = await pipe._try_jina("https://example.com/c")
 
         assert result == "Title: Foo\n\nBody"
@@ -617,10 +619,10 @@ class TestJinaCircuitBreaker:
         pipe = LinkPipeline()
 
         # Two failures (below threshold)
-        async def _raise(*args, **kwargs):
+        def _raise(*args, **kwargs):
             raise RuntimeError("boom")
 
-        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(side_effect=_raise)):
+        with patch("media.link.pipeline._get_jina_session", new=MagicMock(side_effect=_raise)):
             await pipe._try_jina("https://example.com/x")
             await pipe._try_jina("https://example.com/y")
 
@@ -634,8 +636,10 @@ class TestJinaCircuitBreaker:
         mock_response.__aexit__ = AsyncMock(return_value=False)
         mock_session = MagicMock()
         mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)):
+        with patch("media.link.pipeline._get_jina_session", new=MagicMock(return_value=mock_session)):
             await pipe._try_jina("https://example.com/z")
 
         assert len(pl._jina_failures_in_window) == 0
@@ -646,22 +650,30 @@ class TestJinaPooledSession:
 
     @pytest.mark.asyncio
     async def test_delegates_to_shared_http_client(self, _reset_jina_state):
-        """_get_jina_session returns the canonical shared session."""
+        """_get_jina_session yields the canonical shared session via tracked_session().
+
+        Issue #11656: uses the real HTTPClientManager singleton (only
+        ``get_session`` patched) so the real ``tracked_session()`` delegation
+        path — including active-request tracking — is exercised, not
+        reimplemented in the test.
+        """
+        from autobot_shared.http_client import get_http_client
         from media.link import pipeline as pl
 
-        sentinel_session = MagicMock()
-        mock_manager = MagicMock()
-        mock_manager.get_session = AsyncMock(return_value=sentinel_session)
+        manager = get_http_client()
+        sentinel_session = MagicMock(closed=False)
 
-        with patch("autobot_shared.http_client.get_http_client", return_value=mock_manager):
-            session = await pl._get_jina_session()
+        with patch.object(manager, "get_session", new=AsyncMock(return_value=sentinel_session)):
+            async with pl._get_jina_session() as session:
+                assert session is sentinel_session
 
-        assert session is sentinel_session
-        mock_manager.get_session.assert_awaited_once()
+        assert manager._active_requests == 0, "counter must be back to 0 after the CM exits"
 
     @pytest.mark.asyncio
     async def test_shared_session_reused_across_calls(self, _reset_jina_state):
         """Sequential _try_jina calls fetch through the same shared session."""
+        from autobot_shared.http_client import get_http_client
+
         pipe = LinkPipeline()
 
         mock_response = AsyncMock()
@@ -670,12 +682,11 @@ class TestJinaPooledSession:
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=False)
 
-        shared_session = MagicMock()
+        shared_session = MagicMock(closed=False)
         shared_session.get = MagicMock(return_value=mock_response)
-        mock_manager = MagicMock()
-        mock_manager.get_session = AsyncMock(return_value=shared_session)
 
-        with patch("autobot_shared.http_client.get_http_client", return_value=mock_manager):
+        manager = get_http_client()
+        with patch.object(manager, "get_session", new=AsyncMock(return_value=shared_session)):
             await pipe._try_jina("https://example.com/1")
             await pipe._try_jina("https://example.com/2")
 

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -15,7 +15,8 @@ import hmac
 import logging
 import threading
 import time
-from typing import Any, Dict
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict
 
 import aiohttp
 from aiohttp import ClientSession, ClientTimeout, TCPConnector
@@ -222,9 +223,7 @@ class HTTPClientManager:
         session = await self.get_session()
 
         # Track active requests for utilization calculation
-        async with self._counter_lock:
-            self._request_count += 1
-            self._active_requests += 1
+        await self.increment_active()
 
         # Issue #697: Inject W3C trace context into outgoing headers
         try:
@@ -252,6 +251,48 @@ class HTTPClientManager:
             else:
                 logger.error("HTTP request failed: %s", e)
             raise
+
+    async def increment_active(self) -> None:
+        """
+        Increment the active-request counter (thread-safe).
+
+        Issue #11656: extracted from ``request()`` so both ``request()`` and
+        ``tracked_session()`` share the SAME counter-increment mechanism
+        instead of duplicating the lock/increment logic.
+        """
+        async with self._counter_lock:
+            self._request_count += 1
+            self._active_requests += 1
+
+    @asynccontextmanager
+    async def tracked_session(self) -> AsyncIterator[ClientSession]:
+        """
+        Async context manager for raw-session access that participates in
+        active-request tracking.
+
+        Issue #11656: callers using the raw ``get_session()`` (e.g. the Jina
+        fetch in ``media/link/pipeline.py``) were invisible to the
+        pool-recreation guard in ``_handle_pool_recreation()`` — a resize
+        driven by concurrent ``request()`` traffic could close the shared
+        session mid-flight. This helper increments/decrements the SAME
+        ``_active_requests`` counter that ``request()`` uses (via
+        ``increment_active()``/``decrement_active()``), so deferred pool
+        recreation now also accounts for in-flight raw-session users.
+
+        Usage:
+            async with http_client.tracked_session() as session:
+                async with session.get(url) as response:
+                    ...
+
+        Exception-safe: the counter is always decremented, even if the
+        caller raises.
+        """
+        await self.increment_active()
+        try:
+            session = await self.get_session()
+            yield session
+        finally:
+            await self.decrement_active()
 
     async def decrement_active(self) -> None:
         """

--- a/autobot_shared/http_client_test.py
+++ b/autobot_shared/http_client_test.py
@@ -46,3 +46,75 @@ async def test_request_failure_suppressed_logs_debug(caplog):
         await _run_request(suppress=True)
     assert _failure_records(caplog, logging.DEBUG), "suppressed failure must log at DEBUG"
     assert not _failure_records(caplog, logging.ERROR)
+
+
+# ---------------------------------------------------------------------------
+# tracked_session() — raw get_session() users must defer pool recreation
+# (#11656)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tracked_session_defers_pool_recreation_while_in_flight():
+    """A tracked_session() request in flight must NOT have its session closed
+    by a concurrent pool-recreation trigger; recreation must defer instead.
+    """
+    client = HTTPClientManager()
+    fake_session = AsyncMock()
+    fake_session.closed = False
+
+    orig_session, orig_pending, orig_pool_size = (
+        client._session,
+        client._pending_pool_recreation,
+        client._current_pool_size,
+    )
+    client._session = fake_session
+    try:
+        with (
+            patch.object(client, "get_session", AsyncMock(return_value=fake_session)),
+            patch.object(client, "_create_session", AsyncMock()) as mock_create,
+        ):
+            async with client.tracked_session() as session:
+                assert session is fake_session
+                assert client._active_requests == 1
+
+                # Simulate a resize-driven recreation attempt while the
+                # tracked raw-session request is still in flight.
+                client._current_pool_size = 150
+                await client._handle_pool_recreation()
+
+                # Deferred: session must NOT have been closed/recreated,
+                # and recreation must be marked pending instead.
+                fake_session.close.assert_not_called()
+                assert client._pending_pool_recreation is True
+                mock_create.assert_not_called()
+
+            # Once the tracked request completes, decrement_active() must
+            # apply the deferred recreation.
+            assert client._active_requests == 0
+            assert client._pending_pool_recreation is False
+            mock_create.assert_called_once()
+    finally:
+        client._session, client._pending_pool_recreation, client._current_pool_size = (
+            orig_session,
+            orig_pending,
+            orig_pool_size,
+        )
+
+
+@pytest.mark.asyncio
+async def test_tracked_session_decrements_on_exception():
+    """The active-request counter must be decremented even if the caller
+    raises inside the `async with` block (exception-safety, #11656).
+    """
+    client = HTTPClientManager()
+    fake_session = AsyncMock()
+    fake_session.closed = False
+
+    with patch.object(client, "get_session", AsyncMock(return_value=fake_session)):
+        with pytest.raises(RuntimeError):
+            async with client.tracked_session():
+                assert client._active_requests == 1
+                raise RuntimeError("boom")
+
+        assert client._active_requests == 0


### PR DESCRIPTION
## Thinking Path

From the #11654 review: raw `HTTPClientManager.get_session()` users bypass `_active_requests` tracking, so the deferred pool-recreation path (`_handle_pool_recreation`, closes the shared session when `_active_requests == 0`) can close a session mid-flight for a raw-session user (e.g. the Jina fetch migrated in #11641), surfacing as spurious circuit-breaker pressure. Fix: give raw-session users a tracked entry point that shares the same counter.

## What Changed

- **`autobot_shared/http_client.py`** (single canonical copy — no shim/dup):
  - Extracted `request()`'s inline counter-increment into `increment_active()` (mirrors existing `decrement_active()`) — no duplicated logic.
  - Added `tracked_session()` (`@asynccontextmanager`): `increment_active()` → `get_session()` → `yield` → `decrement_active()` in `try/finally` (exception-safe). It reuses the **same** `_active_requests` counter and the existing deferred-recreation logic, so `_handle_pool_recreation`'s `== 0` guard now accounts for in-flight raw-session users.
- **`autobot-backend/media/link/pipeline.py`**: migrated the Jina Reader fetch (`_get_jina_session` / `_try_jina`) to `async with ...tracked_session()`.

## Verification

- `pytest media/link/pipeline_test.py` → 50 passed; `pytest autobot_shared/http_client_test.py` → 4 passed (2 new: defers recreation while in-flight; decrements on exception). Combined 54 passed.
- flake8 (`.flake8`) clean; black (120) no changes.

## Discoveries

Other raw `get_session()` callers of `HTTPClientManager` share this pattern and are deferred to a follow-up (the `vnc_proxy.py` long-lived WebSocket is the most severe) — see linked issue. (Several `_get_session()` uses in service/npu/browser clients are private self-owned sessions, NOT `HTTPClientManager` — genuinely out of scope.)

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #11656
Refs #11634
