### PR TITLE
fix(slm): drop double /api in RedisServicePanel fetch URLs so Services view populates (#11450)

### DIFF
--- a/autobot-slm-frontend/src/components/RedisServicePanel.vue
+++ b/autobot-slm-frontend/src/components/RedisServicePanel.vue
@@ -98,7 +98,7 @@ function statusTextClass(status: string | undefined): string {
 
 async function fetchStatus(): Promise<void> {
   try {
-    const response = await fetch(`${getBackendUrl()}/api/redis-service/status`, {
+    const response = await fetch(`${getBackendUrl()}/redis-service/status`, {
       headers: authHeaders(),
     })
     if (!response.ok) {
@@ -122,7 +122,7 @@ async function performAction(action: 'start' | 'stop' | 'restart'): Promise<void
   successMessage.value = null
 
   try {
-    const response = await fetch(`${getBackendUrl()}/api/redis-service/${action}`, {
+    const response = await fetch(`${getBackendUrl()}/redis-service/${action}`, {
       method: 'POST',
       headers: authHeaders(),
     })


### PR DESCRIPTION
## Thinking Path

#11450 hypothesised a backend Redis-config bug (`vm.redis`/#11443-class). Diagnosis disproved that: the "Failed to fetch Redis service status" symptom is a **frontend URL-construction bug**. (The separate "Nodes 0 / Services 0" half of #11450 was already fixed by #11479/#11510 — agent-heartbeat RBAC/internal-key.)

## Root Cause

`RedisServicePanel.vue` fetched `${getBackendUrl()}/api/redis-service/status`. `getBackendUrl()` returns `/autobot-api`, and nginx (`slm-site.conf`: `location /autobot-api/ { proxy_pass …:8001/api/; }`) rewrites the matched prefix to `/api/`. So `/autobot-api/api/redis-service/status` reaches the upstream as **`/api/api/redis-service/status`** (double `/api`), but the route is mounted once at `/api/redis-service/*` → 404 → `!response.ok` → "Failed to fetch Redis service status".

Verified empirically with a live nginx instance against a stub upstream: the buggy pattern yields `/api/api/...`, while the sibling pattern (no leading `/api`) yields the correct `/api/...`. Every other `getBackendUrl()` call site in the SLM frontend (useSkills, CacheSettings, ProcessMonitorTab, ConfigHistoryTab, OrgChartTab, UserManagementSettings) already omits the `/api` segment — `RedisServicePanel` was the outlier.

## What Changed

`autobot-slm-frontend/src/components/RedisServicePanel.vue`: removed the redundant `/api` from both fetch URLs (`GET /redis-service/status`, `POST /redis-service/{action}`) so they land on the real mounted route after nginx's `/api/` prepend.

## Verification

- Empirical nginx-rewrite reproduction (double `/api/api/` for the buggy pattern vs correct single `/api/` for the fixed pattern).
- Pattern cross-check: fixed URL now matches all sibling `getBackendUrl()` call sites.
- CI **SLM Frontend Check** validates build/types.
- ⚠️ Not runtime-confirmed on a live single-node install (no running instance available here; frontend deps aren't installable under WSL per project convention). Recommend a manual smoke of the Services view post-deploy.

## Discoveries

Same double-`/api` bug class at `BackendSettings.vue:78` (`getBackendUrl()}/api/health`) — filed as a separate issue.

## Model Used

Claude Opus 4.8 (diagnosis + fix via senior-backend-engineer subagent)

Closes #11450
