### PR TITLE
fix(slm): drop double /api in BackendSettings testConnection health check (#12121)

### DIFF
--- a/autobot-slm-frontend/src/views/settings/BackendSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/BackendSettings.vue
@@ -75,7 +75,7 @@ async function testConnection(): Promise<void> {
 
   try {
     const startTime = Date.now()
-    const response = await fetch(`${getBackendUrl()}/api/health`)
+    const response = await fetch(`${getBackendUrl()}/health`)
 
     responseTime.value = Date.now() - startTime
 


### PR DESCRIPTION
## Thinking Path

Same double-`/api` bug class as #11450 (PR #12120), found in the same diagnosis. `BackendSettings.vue`'s "test connection" was the last remaining outlier in the SLM frontend.

## What Changed

`autobot-slm-frontend/src/views/settings/BackendSettings.vue:78`: `testConnection()` fetched `${getBackendUrl()}/api/health`. `getBackendUrl()` returns `/autobot-api`, and nginx (`slm-site.conf`: `location /autobot-api/ { proxy_pass …:8001/api/; }`) rewrites the prefix to `/api/`, so the request reached upstream as `/api/api/health` (doubled) → 404 → connection test always "failed". Dropped the redundant `/api` so it lands on the real `/api/health` route (confirmed present in the backend), matching #11450 and every other `getBackendUrl()` call site.

## Verification

- `grep -rn "getBackendUrl()}/api/" autobot-slm-frontend/src` → **0 matches** — this was the last outlier; the double-`/api` bug class is now fully cleared across the SLM frontend.
- Backend `/api/health` route confirmed to exist.
- CI **SLM Frontend Check** validates build/types.
- ⚠️ Not runtime-confirmed on a live instance (frontend deps not installable under WSL); trivial one-line change matching the proven #11450 pattern.

## Model Used

Claude Opus 4.8

Closes #12121
Refs #11450
