### PR TITLE
fix(deploy): sync libs/ + relink @autobot workspace deps before frontend builds → no white-page (#12112, #11820)

### DIFF
--- a/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
@@ -88,6 +88,43 @@
     recurse: true
   tags: ['frontend', 'deploy']
 
+# ============================================================
+# Shared @autobot/* workspace packages (#12112)
+# autobot-frontend package.json declares three file: deps:
+#   "@autobot/ui":       "file:../libs/autobot-ui"
+#   "@autobot/vnc":      "file:../autobot-plugins/vnc"
+#   "@autobot/terminal": "file:../autobot-plugins/terminal"
+# npm install symlinks node_modules/@autobot/* → those sibling dirs at install
+# time; if the target is absent the symlink dangles and Vite's rolldown bundler
+# fails to resolve the import at build time (SLM/user UI white-page). The
+# frontend code sync above only copies autobot-frontend/, so these shared trees
+# must be synced separately — mirrors the slm_manager role (MVA-893 / #10750 C2c).
+- name: "Frontend | Sync autobot-plugins (shared @autobot/vnc,terminal) from code_source (#12112)"
+  ansible.posix.synchronize:
+    src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot-plugins/"
+    dest: "{{ frontend_install_dir }}/autobot-plugins/"
+    rsync_opts:
+      - "--exclude=node_modules"
+      - "--exclude=dist"
+      - "--exclude=.git"
+      - "--exclude=.env"
+      - "--exclude=*.env"
+    delete: true
+  tags: ['frontend', 'deploy']
+
+- name: "Frontend | Sync libs (shared @autobot/ui kit) from code_source (#12112)"
+  ansible.posix.synchronize:
+    src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/libs/"
+    dest: "{{ frontend_install_dir }}/libs/"
+    rsync_opts:
+      - "--exclude=node_modules"
+      - "--exclude=dist"
+      - "--exclude=.git"
+      - "--exclude=.env"
+      - "--exclude=*.env"
+    delete: true
+  tags: ['frontend', 'deploy']
+
 - name: "Frontend | Ensure TLS cert directory exists"
   file:
     path: "{{ frontend_tls_cert_dir }}"
@@ -131,6 +168,21 @@
   stat:
     path: "{{ frontend_install_dir }}/autobot-frontend/package.json"
   register: package_json_path
+  tags: ['frontend', 'npm']
+
+# #12112: a stale lockfile or pre-existing node_modules can leave
+# node_modules/@autobot/* unlinked (or dangling at an old libs revision) so the
+# install below does NOT recreate the file: symlinks — vite then externalises
+# @autobot/ui to a bare specifier and the app white-pages at runtime. Remove the
+# @autobot scope first so `npm install` re-creates every file: workspace symlink
+# against the freshly-synced libs/ + autobot-plugins/ trees.
+- name: "Frontend | Remove stale @autobot workspace symlinks so npm relinks file: deps (#12112)"
+  ansible.builtin.file:
+    path: "{{ frontend_install_dir }}/autobot-frontend/node_modules/@autobot"
+    state: absent
+  become: true
+  become_user: "{{ frontend_user }}"
+  when: package_json_path.stat.exists
   tags: ['frontend', 'npm']
 
 - name: "Frontend | Install npm dependencies"

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -477,6 +477,8 @@
       - "--exclude=node_modules"
       - "--exclude=dist"
       - "--exclude=.git"
+      - "--exclude=.env"
+      - "--exclude=*.env"
     delete: true
   tags: ['slm', 'frontend']
 
@@ -493,6 +495,8 @@
       - "--exclude=node_modules"
       - "--exclude=dist"
       - "--exclude=.git"
+      - "--exclude=.env"
+      - "--exclude=*.env"
     delete: true
   tags: ['slm', 'frontend']
 
@@ -500,6 +504,18 @@
   ansible.builtin.stat:
     path: "{{ slm_frontend_dir }}/package.json"
   register: slm_package_json
+  tags: ['slm', 'frontend']
+
+# #12112: force npm to recreate the @autobot/* file: workspace symlinks against
+# the freshly-synced libs/ + autobot-plugins/ trees — a stale node_modules can
+# otherwise leave them unlinked/dangling (bare specifier) and the SLM UI
+# white-pages at runtime.
+- name: "SLM | Remove stale @autobot workspace symlinks so npm relinks file: deps (#12112)"
+  ansible.builtin.file:
+    path: "{{ slm_frontend_dir }}/node_modules/@autobot"
+    state: absent
+  become_user: "{{ slm_user }}"
+  when: slm_frontend_build and slm_package_json.stat.exists
   tags: ['slm', 'frontend']
 
 - name: "SLM | Install frontend npm dependencies"
@@ -535,6 +551,14 @@
   ansible.builtin.stat:
     path: "{{ frontend_dist_dir | dirname }}/package.json"
   register: user_frontend_package_json
+  tags: ['slm', 'frontend', 'colocated']
+
+- name: "SLM | Remove stale @autobot workspace symlinks (user frontend) so npm relinks file: deps (#12112)"
+  ansible.builtin.file:
+    path: "{{ frontend_dist_dir | dirname }}/node_modules/@autobot"
+    state: absent
+  become_user: "{{ slm_user }}"
+  when: user_frontend_package_json.stat.exists | default(false)
   tags: ['slm', 'frontend', 'colocated']
 
 - name: "SLM | Install user frontend npm dependencies"


### PR DESCRIPTION
## Thinking Path
Live incident: SLM UI white-paged because the frontend build couldn't resolve `@autobot/ui` (`file:../libs/autobot-ui`) — (1) `node_modules/@autobot/ui` was never linked during the box build, and (2) `/opt/autobot/libs` was stale (missing `usePagination`/`SemanticVariant`). Root: the frontend deploys don't reliably sync `libs/` + relink file: workspace deps. Manually restored the box; this is the durable fix.

## What Changed (ansible roles only)
- **User `frontend` role** LACKED any libs/plugins sync (it only synced `autobot-frontend/`), so all three of its file: workspace deps (`@autobot/ui`→libs, `@autobot/terminal`+`@autobot/vnc`→autobot-plugins) froze. Added `synchronize` tasks for `{{ code_source_dir }}/libs/` and `/autobot-plugins/` → `{{ frontend_install_dir }}`, BEFORE npm install/build, mirroring the canonical slm_manager pattern (#10750 C2c / MVA-893), env-var-driven.
- **Relink guarantee** (root cause #1): before every frontend `npm install`, an `ansible.builtin.file: path=.../node_modules/@autobot state=absent` removes the stale scope so npm recreates the file: workspace symlinks fresh against the just-synced trees (what the manual restore did). Added to BOTH the `frontend` role and slm_manager (SLM + co-located user-frontend build steps).
- Secret safety: all new + touched syncs carry `--exclude=.env --exclude=*.env` (+ node_modules/dist/.git); `delete:true` scoped to `libs/`+`autobot-plugins/` subtrees only (can't touch `autobot-frontend/` or secrets).
- No vite alias (deliberate — it would MASK the unlinked-symlink staleness this fixes). `preserveSymlinks:true` already set.

## Verification
YAML valid on both role files. Applies via the ansible `deploy_role.yml` frontend path (what #12083's per-role procedures + Migrate/Redeploy run FROM code_source, which contains libs/).

## Follow-up flagged (separate issue, NOT here)
The COMPONENT self-update code-sync path (`role_registry` source_paths / sync_orchestrator, `-avz --delete` into /opt/autobot) also misses `libs/` on a clean box — fixing it safely needs confirming the trailing-slash/`--delete` target semantics first; high blast radius, out of scope here.

## Model Used
Opus 4.8

Closes #12112