### PR TITLE
cleanup(advanced-control): accurate 404/409 detail + fix info-payload endpoint paths (#12126)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -226,10 +226,10 @@ async def approve_takeover(
         logger.info("Takeover approved: %s -> %s", request_id, session_id)
         return {"success": True, "session_id": session_id}
 
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Internal server error")
-    except RuntimeError:
-        raise HTTPException(status_code=409, detail="Internal server error")
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e))
 
 
 @router.post("/takeover/sessions/{session_id}/action", response_model=AdvancedControlTakeoverActionResponse)
@@ -258,8 +258,8 @@ async def execute_takeover_action(
         logger.info(f"Takeover action executed: {action.action_type} in session {session_id}")
         return {"success": True, "result": result}
 
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Internal server error")
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
 
 @router.post("/takeover/sessions/{session_id}/pause", response_model=AdvancedControlTakeoverSessionStatusResponse)
@@ -589,12 +589,12 @@ async def advanced_control_info(
             "Emergency stop capabilities",
         ],
         "endpoints": {
-            "streaming": "/api/control/streaming/",
-            "takeover": "/api/control/takeover/",
-            "system": "/api/control/system/",
+            "streaming": "/api/advanced-control/streaming/",
+            "takeover": "/api/advanced-control/takeover/",
+            "system": "/api/advanced-control/system/",
             "websockets": {
-                "monitoring": "/api/control/ws/monitoring",
-                "desktop": "/api/control/ws/desktop/{session_id}",
+                "monitoring": "/api/advanced-control/ws/monitoring",
+                "desktop": "/api/advanced-control/ws/desktop/{session_id}",
             },
         },
     }


### PR DESCRIPTION
## Thinking Path

Flagged during #12102 (UI wiring). Two cosmetic correctness issues in `api/advanced_control.py`: client-error handlers returned a misleading "Internal server error" detail, and the `/` info payload advertised stale `/api/control/*` paths while the router is mounted at `/api/advanced-control/*`.

## What Changed

`autobot-backend/api/advanced_control.py`:
- **Accurate client-error details** (3 sites): `approve_takeover` and `execute_takeover_action` caught `ValueError`→404 / `RuntimeError`→409 but raised `detail="Internal server error"`. Now `except … as e: … detail=str(e)`, surfacing the real not-found/conflict/validation cause instead of masking a client error as a server error.
- **Fixed info-payload doc drift**: `advanced_control_info` endpoints map advertised `/api/control/{streaming,takeover,system,ws/…}`. The router is mounted at `/advanced-control` (`feature_routers.py:372-375` → `/api/advanced-control`), so these now read `/api/advanced-control/*`, matching the actual `@router` paths (`/streaming/*`, `/takeover/*`, `/system/*`, `/ws/monitoring`, `/ws/desktop/{session_id}`).

## Verification

- `grep 'detail="Internal server error"'` → 0 remaining; `grep '/api/control/'` → 0 remaining.
- Payload paths cross-checked against the router mount prefix and every `@router` decorator in the file.
- `py_compile` OK; flake8 (`.flake8`) clean; black (120) no changes.
- No test harness exists for this module; a full one is disproportionate for a cosmetic detail/doc fix (issue: "cosmetic; fast-follow"). Correctness is static-verifiable.

## Model Used

Claude Opus 4.8

Closes #12126
