### PR TITLE
fix(chat_history): persist metadata to session file on create_session (#12129)

### DIFF
--- a/autobot-backend/chat_history/session.py
+++ b/autobot-backend/chat_history/session.py
@@ -233,7 +233,7 @@ class SessionMixin:
 
         session_data = self._build_session_data(session_id, session_title, current_time, metadata)
 
-        await self.save_session(session_id=session_id, messages=[], name=session_title)
+        await self.save_session(session_id=session_id, messages=[], name=session_title, metadata=metadata)
         await self._create_memory_graph_entity(session_id, session_title, current_time, metadata)
 
         logger.info("Created new chat session: %s", session_id)
@@ -460,6 +460,7 @@ class SessionMixin:
         name: str,
         session_messages: List[Dict[str, Any]],
         current_time: str,
+        metadata: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         """
         Build updated chat data dictionary for session save.
@@ -470,11 +471,17 @@ class SessionMixin:
             name: Optional session name.
             session_messages: Messages to include.
             current_time: Current timestamp string.
+            metadata: Optional metadata to merge into the persisted ``metadata``
+                sub-dict. When None, any existing on-disk metadata is left
+                untouched (Issue #12129). When provided, it is merged on top
+                of the existing metadata using the same merge semantics as
+                :meth:`ChatHistoryManager.update_session_metadata` — no
+                clobbering of previously persisted keys.
 
         Returns:
             Updated chat data dictionary.
 
-        Issue #620.
+        Issue #620, #12129.
         """
         chat_data.update(
             {
@@ -485,6 +492,12 @@ class SessionMixin:
                 "created_time": chat_data.get("created_time", current_time),
             }
         )
+
+        if metadata:
+            existing_metadata = chat_data.get("metadata", {})
+            existing_metadata.update(metadata)
+            chat_data["metadata"] = existing_metadata
+
         return chat_data
 
     async def save_session(
@@ -492,6 +505,7 @@ class SessionMixin:
         session_id: str,
         messages: List[Dict[str, Any]] | None = None,
         name: str = "",
+        metadata: Dict[str, Any] | None = None,
     ):
         """
         Save a chat session with messages and metadata.
@@ -500,8 +514,12 @@ class SessionMixin:
             session_id: The identifier for the session to save.
             messages: The messages to save (defaults to empty list).
             name: Optional name for the chat session.
+            metadata: Optional metadata to merge into the persisted session
+                metadata. Defaults to None, which leaves any existing on-disk
+                metadata untouched (Issue #12129) — callers that never pass
+                metadata keep their exact prior behavior.
 
-        Issue #665, #620: Refactored to use extracted helper methods.
+        Issue #665, #620, #12129: Refactored to use extracted helper methods.
         """
         try:
             self._sanitize_session_id(session_id)
@@ -513,7 +531,9 @@ class SessionMixin:
             session_messages = self._prepare_session_messages(session_id, messages)
 
             chat_data = await self._load_existing_chat_data(session_id, chat_file, chats_directory)
-            chat_data = self._build_session_chat_data(chat_data, session_id, name, session_messages, current_time)
+            chat_data = self._build_session_chat_data(
+                chat_data, session_id, name, session_messages, current_time, metadata
+            )
 
             await self._write_session_to_storage(chat_file, chat_data)
             await self._update_redis_cache_on_save(session_id, chat_data)

--- a/autobot-backend/chat_history/session_metadata_persist_test.py
+++ b/autobot-backend/chat_history/session_metadata_persist_test.py
@@ -1,0 +1,123 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for on-disk metadata persistence at session creation — Issue #12129.
+
+Before the fix, ``create_session()`` built a session dict that included
+``metadata`` for the return value / Memory Graph entity only. The actual
+on-disk write went through ``save_session()``, whose signature had no
+``metadata`` parameter, so ``metadata`` (including ``owner``) was never
+written to the session file. ``get_session_owner()`` therefore always
+returned ``None`` for freshly created sessions.
+
+These tests prove:
+- create_session(metadata=...) persists metadata to the session file.
+- get_session_owner() can read the owner back immediately after creation.
+- A later save_session() call WITHOUT metadata does not clobber
+  previously persisted metadata (merge, not clobber).
+
+Uses a lightweight stub manager (real SessionMixin/SecurityMixin/FileIOMixin,
+real disk I/O against a pytest tmp_path) rather than the fully-configured
+ChatHistoryManager, to avoid pulling in Redis/config subsystems.
+"""
+
+import json
+import threading
+
+import pytest
+
+from chat_history.file_io import FileIOMixin
+from chat_history.security import SecurityMixin
+from chat_history.session import SessionMixin
+
+
+class _StubManager(SessionMixin, SecurityMixin, FileIOMixin):
+    """Minimal manager exercising real session persistence on real disk."""
+
+    def __init__(self, chats_directory: str):
+        self._chats_directory = chats_directory
+        self.redis_client = None
+        self.encryption_enabled = False
+        self.max_messages = 10000
+        self.max_session_files = 1000
+        self._counter_lock = threading.Lock()
+        self._session_save_counter = 0
+        self.memory_graph = None
+        self.memory_graph_enabled = False
+
+    def _get_chats_directory(self) -> str:
+        return self._chats_directory
+
+    async def _init_memory_graph(self) -> None:
+        return None
+
+    async def _cleanup_old_session_files(self) -> None:
+        return None
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    return _StubManager(str(tmp_path))
+
+
+def _read_session_file(tmp_path, session_id):
+    chat_file = tmp_path / f"{session_id}_chat.json"
+    with open(chat_file, "r", encoding="utf-8") as f:
+        return json.loads(f.read())
+
+
+class TestCreateSessionPersistsMetadata:
+    """create_session(metadata=...) must persist metadata to disk (#12129)."""
+
+    @pytest.mark.asyncio
+    async def test_metadata_written_to_session_file(self, manager, tmp_path):
+        session_id = "sess-owner-persist"
+        await manager.create_session(session_id=session_id, title="Test", metadata={"owner": "alice"})
+
+        on_disk = _read_session_file(tmp_path, session_id)
+        assert on_disk["metadata"]["owner"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_get_session_owner_reads_back_immediately(self, manager):
+        session_id = "sess-owner-readback"
+        await manager.create_session(session_id=session_id, title="Test", metadata={"owner": "alice"})
+
+        owner = await manager.get_session_owner(session_id)
+        assert owner == "alice"
+
+    @pytest.mark.asyncio
+    async def test_returned_dict_agrees_with_persisted_file(self, manager, tmp_path):
+        session_id = "sess-owner-agree"
+        returned = await manager.create_session(session_id=session_id, title="Test", metadata={"owner": "bob"})
+
+        on_disk = _read_session_file(tmp_path, session_id)
+        assert returned["metadata"]["owner"] == on_disk["metadata"]["owner"] == "bob"
+
+
+class TestSaveSessionMergesNotClobbers:
+    """A later save_session() without metadata must not wipe existing metadata (#12129)."""
+
+    @pytest.mark.asyncio
+    async def test_save_without_metadata_preserves_existing(self, manager, tmp_path):
+        session_id = "sess-merge-not-clobber"
+        await manager.create_session(session_id=session_id, title="Test", metadata={"owner": "alice"})
+
+        # Subsequent save with new messages, no metadata argument.
+        await manager.save_session(session_id, messages=[{"role": "user", "content": "hi"}])
+
+        on_disk = _read_session_file(tmp_path, session_id)
+        assert on_disk["metadata"]["owner"] == "alice"
+        assert on_disk["messages"] == [{"role": "user", "content": "hi"}]
+
+    @pytest.mark.asyncio
+    async def test_save_with_new_metadata_merges_with_existing(self, manager, tmp_path):
+        session_id = "sess-merge-additional"
+        await manager.create_session(session_id=session_id, title="Test", metadata={"owner": "alice"})
+
+        await manager.save_session(session_id, messages=[], metadata={"team_id": "team-1"})
+
+        on_disk = _read_session_file(tmp_path, session_id)
+        assert on_disk["metadata"]["owner"] == "alice"
+        assert on_disk["metadata"]["team_id"] == "team-1"


### PR DESCRIPTION
## Thinking Path

Discovered during #12009's forward-migration. `create_session(..., metadata={...})` returns/graphs the metadata but never persists it to disk: the on-disk write goes through `save_session()`, which had no `metadata` param. So `get_session_owner()` (file-based ownership, used by `api/conversation_files.py:208` to gate conversation-file access) returned None for every freshly-created session — a silent, load-bearing gap. (The separate Redis-based ownership path is unaffected and was already correct.)

## What Changed (`chat_history/session.py`)

- `save_session(session_id, messages=None, name="", **metadata=None**)` — new **trailing optional** kwarg; every existing call site is unchanged (verified: `api/chat.py`, `chat_history/messages.py` ×4, `services/conversation_export.py`, dedup resave, tests — none pass a 4th positional arg).
- `_build_session_chat_data(...)` merges `metadata` into the persisted `metadata` sub-dict **only when truthy**, using the exact merge idiom from `update_session_metadata` (`existing = chat_data.get("metadata", {}); existing.update(metadata)`). When None, on-disk metadata is left **untouched** — no clobber.
- `create_session` now passes its `metadata` through to `save_session`, so the returned object and the on-disk file agree.

## Verification

- New `session_metadata_persist_test.py` (5 tests, all pass): metadata written to file on create; `get_session_owner()` reads it back immediately (the exact bug scenario); returned dict agrees with file; a later metadata-less `save_session` preserves `owner` (merge-not-clobber); a later `save_session(metadata={...})` merges without dropping `owner`.
- Full `chat_history/` suite: 57 passed (pre-existing unrelated failures excluded — filed separately). flake8/black clean.

## Discoveries

3 pre-existing, unrelated test breakages surfaced during verification (stale test/module mismatches, not touched by this fix) — filed as a separate issue.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #12129
