### PR TITLE
test(chat_history): align 3 stale tests with current code (config accessor / recent-cap constant / async render) (#12132)

### DIFF
--- a/autobot-backend/api/chat_phase2_test.py
+++ b/autobot-backend/api/chat_phase2_test.py
@@ -100,6 +100,7 @@ class TestChatRecentZremrangebyrank:
 
     @pytest.mark.asyncio
     async def test_zremrangebyrank_called_after_zadd_on_chat_recent(self):
+        from chat_history.cache import _CHAT_RECENT_MAX_ENTRIES
         from chat_history.session import SessionMixin
         from constants.redis_constants import REDIS_KEY
 
@@ -136,7 +137,9 @@ class TestChatRecentZremrangebyrank:
         zrem_args = next(e[1] for e in call_log if e[0] == "zremrangebyrank")
         assert zrem_args[0] == REDIS_KEY.CHAT_RECENT, "must use REDIS_KEY.CHAT_RECENT constant"
         assert zrem_args[1] == 0, "must remove from rank 0"
-        assert zrem_args[2] == -(mgr.max_session_files + 1), "must keep max_session_files most recent entries"
+        assert zrem_args[2] == -(
+            _CHAT_RECENT_MAX_ENTRIES + 1
+        ), "must keep _CHAT_RECENT_MAX_ENTRIES (#7570) most recent entries"
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/chat_history/initialize_test.py
+++ b/autobot-backend/chat_history/initialize_test.py
@@ -42,7 +42,7 @@ def manager():
     without touching Redis, the filesystem, or Memory Graph.
     """
     with (
-        patch("chat_history.base.global_config_manager", _make_config_stub()),
+        patch("chat_history.base.get_config_manager", return_value=_make_config_stub()),
         patch("chat_history.base._ssot_config", _make_ssot_stub()),
         patch("chat_history.base.get_redis_client", return_value=None),
         patch("chat_history.base.is_encryption_enabled", return_value=False),

--- a/autobot-backend/chat_history/layers_test.py
+++ b/autobot-backend/chat_history/layers_test.py
@@ -74,11 +74,12 @@ class TestLayer1EssentialStory:
 
         mock_gen = MagicMock()
         mock_gen.generate = AsyncMock(return_value="## Essential Context\n[general] fact1")
-        with patch("chat_history.layers.Layer1EssentialStory.render", wraps=None):
-            with patch("memory.essential_story.EssentialStoryGenerator", return_value=mock_gen):
-                layer = Layer1EssentialStory()
-                result = await layer.render({"model_name": "test-model"})
-                assert isinstance(result, str)
+        with patch("memory.essential_story.EssentialStoryGenerator", return_value=mock_gen):
+            layer = Layer1EssentialStory()
+            result = await layer.render({"model_name": "test-model"})
+            assert isinstance(result, str)
+            assert result == "## Essential Context\n[general] fact1"
+            mock_gen.generate.assert_awaited_once_with("test-model")
 
     @pytest.mark.asyncio
     async def test_render_returns_empty_on_generator_failure(self):


### PR DESCRIPTION
## Thinking Path

3 pre-existing test-rot breakages surfaced while fixing #12129. All three are stale tests that drifted from current code — aligned to current behavior, **no production code changed** (the ambiguous one was verified to be test-rot, not a regression).

## What Changed (test-only)

- **`chat_history/initialize_test.py`**: `chat_history/base.py` no longer exposes module-level `global_config_manager` — it calls `get_config_manager()` (from `config`). Repointed the fixture patch to `patch("chat_history.base.get_config_manager", return_value=<stub>)`. 6 tests restored.
- **`api/chat_phase2_test.py::TestChatRecentZremrangebyrank`**: assertion updated from `mgr.max_session_files` to `_CHAT_RECENT_MAX_ENTRIES`. Verified this is **test-rot, not a regression**: `chat_history/session.py:351` caps the `chat:recent` Redis sorted set via the env-driven `_CHAT_RECENT_MAX_ENTRIES` (chat:recent cardinality cap, #7570), which is a different concern from `max_session_files` (on-disk per-session file count). The code is correct; the test was stale.
- **`chat_history/layers_test.py::TestLayer1EssentialStory`**: removed an erroneous self-patch of `Layer1EssentialStory.render` (auto-substituted an `AsyncMock`, so the real method never ran). Now the real `render` executes and delegates to the mocked generator; assertion strengthened to check the exact returned string and that `generate` was awaited once.

## Verification

- Targeted 3-breakage run → **10 passed**.
- Broader `chat_history/` suite → **64 passed**, no new breakage.
- flake8 clean; black no changes. No production code touched (confirmed via `git diff` — 3 `_test.py` files only).

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #12132
