### PR TITLE
fix(llc): use CAST(:x AS jsonb) so SQLAlchemy text() doesn't truncate the jsonb bind name — unblocks agent hiring (#12134)

### DIFF
--- a/autobot-backend/llc/api/agent_hires.py
+++ b/autobot-backend/llc/api/agent_hires.py
@@ -264,7 +264,7 @@ async def create_agent_hire(
                 "(id, company_id, senior_agent_id, assistant_agent_id, "
                 "resolved_provider, resolved_model, hire_metadata) "
                 "VALUES (:id, :company_id, :senior_agent_id, :assistant_agent_id, "
-                ":resolved_provider, :resolved_model, :hire_metadata::jsonb) "
+                ":resolved_provider, :resolved_model, CAST(:hire_metadata AS jsonb)) "
                 "ON CONFLICT DO NOTHING"
             ),
             {
@@ -402,7 +402,7 @@ async def hire_agent(
             VALUES
                 (:id, :agent_id, :name, :org_role, :title, :capabilities,
                  :company_id, :reports_to, :heartbeat_cron, :heartbeat_enabled,
-                 :adapter_type, :adapter_config::jsonb, :model, :instructions_file_path)
+                 :adapter_type, CAST(:adapter_config AS jsonb), :model, :instructions_file_path)
         """),
         {
             "id": str(uuid.uuid4()),

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -658,7 +658,7 @@ class PortabilityService(LLCServiceBase):
                    heartbeat_enabled, context_mode)
                 VALUES
                   (:id, :agent_id, :name, :reports_to, :org_role, :title, :capabilities,
-                   :company_id, :adapter_type, :adapter_config::jsonb, :heartbeat_cron,
+                   :company_id, :adapter_type, CAST(:adapter_config AS jsonb), :heartbeat_cron,
                    :heartbeat_enabled, :context_mode)
                 """).bindparams(
                 id=uuid.uuid4(),

--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import uuid
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -116,6 +117,84 @@ class TestAgentsMdGeneration:
         mod = _get_agent_hires_mod()
         req = mod.AgentHireRequest(agent_name="SonnetBot")
         assert req.model is None  # resolved to SONNET_MODEL in the handler
+
+
+# ===========================================================================
+# 1b. GH#12134 — named-bind dict regression for the agent_org_nodes /
+#     llc_agent_hires INSERTs (asyncpg PostgresSyntaxError on ':')
+# ===========================================================================
+
+
+class TestHireAgentNamedBindDict:
+    """A bare ``:name::jsonb`` Postgres cast right after a named bind breaks
+    SQLAlchemy's ``text()`` tokenizer: it truncates the bind name (e.g.
+    ``adapter_config`` -> ``adapter_confi``) and the untranslated ``:name::type``
+    literal is left in the compiled SQL, which asyncpg then rejects with
+    ``PostgresSyntaxError: syntax error at or near ":"``.  Fixed by using
+    ``CAST(:name AS jsonb)`` instead of ``:name::jsonb``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hire_agent_insert_binds_match_named_params(self) -> None:
+        mod = _get_agent_hires_mod()
+        from sqlalchemy.dialects import postgresql
+
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+
+        body = mod.AgentHireRequest(agent_name="ABR CEO", org_role="manager", title="Chief Executive")
+        company_id = uuid.uuid4()
+
+        with (
+            patch.object(mod, "registered_adapter_types", return_value=["claude_code"]),
+            patch.object(mod.BudgetService, "provision_budget", new=AsyncMock()),
+        ):
+            await mod.hire_agent(company_id=company_id, body=body, session=session)
+
+        stmt, params = session.execute.call_args_list[0].args
+        assert isinstance(params, dict), "params must be a named-bind dict, not a positional tuple"
+
+        compiled = stmt.compile(dialect=postgresql.dialect(paramstyle="pyformat"))
+        required = set(compiled.params.keys())
+        assert required == set(params.keys()), (
+            f"SQL bind names {sorted(required)} must exactly match execute() "
+            f"params {sorted(params)} — a mismatch means a ':name::type' cast "
+            "left an unresolved literal ':' in the compiled SQL (GH#12134)."
+        )
+        assert ":" not in compiled.string.replace("%(", "").replace(")s", ""), compiled.string
+
+    @pytest.mark.asyncio
+    async def test_create_agent_hire_insert_binds_match_named_params(self) -> None:
+        mod = _get_agent_hires_mod()
+        from sqlalchemy.dialects import postgresql
+
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+
+        body = mod.AgentHireCreate(company_id=uuid.uuid4())
+        await mod.create_agent_hire(body=body, session=session, ctx=None)
+
+        stmt, params = session.execute.call_args_list[0].args
+        assert isinstance(params, dict), "params must be a named-bind dict, not a positional tuple"
+
+        compiled = stmt.compile(dialect=postgresql.dialect(paramstyle="pyformat"))
+        required = set(compiled.params.keys())
+        assert required == set(params.keys()), (
+            f"SQL bind names {sorted(required)} must exactly match execute() " f"params {sorted(params)} (GH#12134)."
+        )
+
+    def test_no_naked_colon_colon_cast_after_named_bind(self) -> None:
+        """Guard against reintroducing ':name::type' anywhere in the module."""
+        import inspect
+        import re
+
+        mod = _get_agent_hires_mod()
+        source = inspect.getsource(mod)
+        offenders = re.findall(r":\w+::\w+", source)
+        assert not offenders, f"Use CAST(:name AS type), not ':name::type' (GH#12134): {offenders}"
 
 
 # ===========================================================================

--- a/autobot-backend/llc/tests/test_import.py
+++ b/autobot-backend/llc/tests/test_import.py
@@ -293,6 +293,34 @@ async def test_execute_import_target_company_not_found() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _import_agent — GH#12134 named-bind regression (sibling of agent_hires.py bug)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_agent_insert_binds_match_named_params() -> None:
+    """``:adapter_config::jsonb`` truncates the bind name in SQLAlchemy's
+    ``text()`` tokenizer (-> ``adapter_confi``), leaving an unresolved ':'
+    literal in the compiled SQL.  Fixed via ``CAST(:adapter_config AS jsonb)``.
+    """
+    from sqlalchemy.dialects import postgresql
+
+    svc = _make_svc()
+    company_id = uuid.uuid4()
+    agent = {"name": "Bot", "agent_id": "old-id", "adapter_config": {}}
+
+    with patch.object(svc, "_agent_names_exist", return_value=[]):
+        await svc._import_agent(agent, company_id, secret_mapping={}, warnings=[])
+
+    stmt = svc.session.execute.call_args_list[0].args[0]
+    compiled = stmt.compile(dialect=postgresql.dialect(paramstyle="pyformat"))
+    assert "adapter_config" in compiled.params, (
+        f"'adapter_config' bind not recognized (got {sorted(compiled.params)}) — "
+        "a ':name::type' cast truncated the bind name (GH#12134)."
+    )
+
+
+# ---------------------------------------------------------------------------
 # execute_import — skips non-seed work items
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Thinking Path

`POST /api/llc/companies/{id}/agent-hires` 500'd with asyncpg `syntax error at or near ":"`, blocking hiring any agent. The issue hypothesised a positional-tuple-vs-dict bind mismatch — **investigation disproved that**: `git log -p --follow` shows these INSERTs always used named-bind dicts. The real root cause (confirmed via a direct `text().compile()` repro) is a SQLAlchemy `text()` tokenizer defect: a `:name::jsonb` cast written with no separator makes SQLAlchemy mis-parse the bind, **truncating the last character** of the name (`:adapter_config::jsonb` registers internally as bind `adapter_confi`). The supplied dict key (`adapter_config`) then never matches, the `:adapter_config::jsonb` literal is left unresolved in the compiled SQL, and asyncpg chokes on the raw `:`.

## What Changed

Replaced the ambiguous `:name::jsonb` shorthand with the unambiguous `CAST(:name AS jsonb)` (semantically identical in Postgres, immune to the token-adjacency bug) at all 3 occurrences:
- **`llc/api/agent_hires.py:405`** — `hire_agent` → `agent_org_nodes.adapter_config` (the exact line in the traceback).
- **`llc/api/agent_hires.py:267`** — `create_agent_hire` → `llc_agent_hires.hire_metadata` (same-file sibling, same bug).
- **`llc/services/portability.py:661`** — `_import_agent` → `agent_org_nodes.adapter_config`. This one was an even harder failure: `.bindparams(adapter_config=…)` raised `ArgumentError` immediately (key doesn't match the truncated internal bind), blocking every agent import. Fixed per Rule 6 (in-scope, one-line, same root cause).

Column↔bind alignment verified against the ORM model `models/agent_org.py` (`agent_org_nodes`, `adapter_config` is JSONB).

## Verification

- 4 new regression tests (`llc/tests/test_haiku_tier.py`, `llc/tests/test_import.py`) asserting the compiled statement's bind names match the supplied dict keys and guarding against reintroducing `:name::type`. **Confirmed they FAIL against pre-fix code**, pass after. `pytest` → 38 passed.
- flake8/black clean.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer subagent)

Closes #12134
