### PR TITLE
fix(tools): wire gui_read_text_from_region + gui_move_mouse task creation + fix bring_window_to_front payload key (#12070)

### DIFF
--- a/autobot-backend/tests/unit/tools/test_tool_registry_gui.py
+++ b/autobot-backend/tests/unit/tools/test_tool_registry_gui.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for GUI tools in tools/tool_registry.py.
+
+Issue #12070: gui_read_text_from_region (OCR) and gui_move_mouse have
+registered TaskHandlers (task_handlers/gui_handlers.py) but ToolRegistry
+never created tasks of those types, making the handlers unreachable from
+the agent side. Verifies task-creation wiring now exists for both, and
+that they are registered consistently with the 3 pre-existing GUI tools
+(get_available_tools + dispatch table).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# get_available_tools — catalogue registration
+# ---------------------------------------------------------------------------
+
+
+def test_get_available_tools_includes_all_five_gui_tools() -> None:
+    """All 5 GUI tools appear in get_available_tools (Issue #12070)."""
+    with (
+        patch("tools.tool_registry.ToolRegistry.__init__", return_value=None),
+        patch("chat_workflow.tool_handler.BROWSER_TOOL_NAMES", frozenset()),
+    ):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry.__new__(ToolRegistry)
+        tools = registry.get_available_tools()
+
+    assert "type_text" in tools
+    assert "click_element" in tools
+    assert "bring_window_to_front" in tools
+    assert "read_text_from_region" in tools
+    assert "move_mouse" in tools
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table — normalized name lookup
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_readtextfromregion_resolves() -> None:
+    """Normalized 'readtextfromregion' resolves to read_text_from_region handler."""
+    with patch("tools.tool_registry.ToolRegistry.__init__", return_value=None):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry.__new__(ToolRegistry)
+        handler = registry._get_tool_handler("readtextfromregion")
+
+    assert handler is not None
+
+
+def test_dispatch_movemouse_resolves() -> None:
+    """Normalized 'movemouse' resolves to move_mouse handler."""
+    with patch("tools.tool_registry.ToolRegistry.__init__", return_value=None):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry.__new__(ToolRegistry)
+        handler = registry._get_tool_handler("movemouse")
+
+    assert handler is not None
+
+
+# ---------------------------------------------------------------------------
+# Task-creation wiring — previously-missing surface (Issue #12070)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_text_from_region_creates_gui_task_and_reaches_worker() -> None:
+    """read_text_from_region() now creates a 'gui_read_text_from_region' task."""
+    with patch("tools.tool_registry.ToolRegistry.__init__", return_value=None):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry.__new__(ToolRegistry)
+        registry.logger = MagicMock()
+        registry.worker_node = MagicMock()
+        registry.worker_node.execute_task = AsyncMock(return_value={"status": "success", "text": "hi"})
+
+    result = await registry.read_text_from_region(1, 2, 10, 20)
+
+    submitted_task = registry.worker_node.execute_task.call_args[0][0]
+    assert submitted_task["type"] == "gui_read_text_from_region"
+    assert submitted_task["x"] == 1
+    assert submitted_task["y"] == 2
+    assert submitted_task["width"] == 10
+    assert submitted_task["height"] == 20
+    assert result["status"] == "success"
+    assert result["result"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_move_mouse_creates_gui_task_and_reaches_worker() -> None:
+    """move_mouse() now creates a 'gui_move_mouse' task."""
+    with patch("tools.tool_registry.ToolRegistry.__init__", return_value=None):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry.__new__(ToolRegistry)
+        registry.logger = MagicMock()
+        registry.worker_node = MagicMock()
+        registry.worker_node.execute_task = AsyncMock(return_value={"status": "success", "message": "moved"})
+
+    result = await registry.move_mouse(5, 6, duration=0.5)
+
+    submitted_task = registry.worker_node.execute_task.call_args[0][0]
+    assert submitted_task["type"] == "gui_move_mouse"
+    assert submitted_task["x"] == 5
+    assert submitted_task["y"] == 6
+    assert submitted_task["duration"] == 0.5
+    assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Regression: bring_window_to_front payload key must match handler contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bring_window_to_front_task_uses_app_title_key() -> None:
+    """Task payload key must be 'app_title' — GUIBringWindowToFrontHandler
+    (task_handlers/gui_handlers.py) requires that key, not 'window_title'.
+    Discovered alongside Issue #12070's task-creation audit.
+    """
+    with patch("tools.tool_registry.ToolRegistry.__init__", return_value=None):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry.__new__(ToolRegistry)
+        registry.logger = MagicMock()
+        registry.worker_node = MagicMock()
+        registry.worker_node.execute_task = AsyncMock(return_value={"status": "success"})
+
+    await registry.bring_window_to_front("Terminal")
+
+    submitted_task = registry.worker_node.execute_task.call_args[0][0]
+    assert submitted_task["app_title"] == "Terminal"
+    assert "window_title" not in submitted_task

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -535,7 +535,9 @@ class ToolRegistry:
     async def bring_window_to_front(self, window_title: str) -> Dict[str, Any]:
         """Bring a window to the front."""
         task = self._create_base_task("gui_bring_window_to_front")
-        task["window_title"] = window_title
+        # Issue #12070: key must be "app_title" — GUIBringWindowToFrontHandler
+        # (task_handlers/gui_handlers.py) requires that key, not "window_title".
+        task["app_title"] = window_title
 
         result = await self._execute_worker_task(task)
         return {
@@ -544,6 +546,40 @@ class ToolRegistry:
             "result": result.get(
                 "output",
                 result.get("message", f"Brought window to front: {window_title}"),
+            ),
+            "status": result.get("status", "success"),
+        }
+
+    async def read_text_from_region(self, x: int, y: int, width: int, height: int) -> Dict[str, Any]:
+        """OCR-read text from a screen region (Issue #12070)."""
+        task = self._create_base_task("gui_read_text_from_region")
+        task["x"] = x
+        task["y"] = y
+        task["width"] = width
+        task["height"] = height
+
+        result = await self._execute_worker_task(task)
+        return {
+            "tool_name": "read_text_from_region",
+            "tool_args": {"x": x, "y": y, "width": width, "height": height},
+            "result": result.get("text", result.get("message", "")),
+            "status": result.get("status", "success"),
+        }
+
+    async def move_mouse(self, x: int, y: int, duration: float = 0.0) -> Dict[str, Any]:
+        """Move the mouse cursor to the specified coordinates (Issue #12070)."""
+        task = self._create_base_task("gui_move_mouse")
+        task["x"] = x
+        task["y"] = y
+        task["duration"] = duration
+
+        result = await self._execute_worker_task(task)
+        return {
+            "tool_name": "move_mouse",
+            "tool_args": {"x": x, "y": y, "duration": duration},
+            "result": result.get(
+                "output",
+                result.get("message", f"Moved mouse to ({x}, {y})"),
             ),
             "status": result.get("status", "success"),
         }
@@ -625,6 +661,10 @@ class ToolRegistry:
             "typetext": lambda args: self.type_text(args.get("text", "")),
             "clickelement": lambda args: self.click_element(args.get("image_path", "")),
             "bringwindowtofront": lambda args: self.bring_window_to_front(args.get("window_title", "")),
+            "readtextfromregion": lambda args: self.read_text_from_region(
+                args.get("x", 0), args.get("y", 0), args.get("width", 0), args.get("height", 0)
+            ),
+            "movemouse": lambda args: self.move_mouse(args.get("x", 0), args.get("y", 0), args.get("duration", 0.0)),
             "askuserformanual": lambda args: self.ask_user_for_manual(
                 args.get("program_name", ""), args.get("question_text", "")
             ),
@@ -805,6 +845,9 @@ class ToolRegistry:
             "type_text",
             "click_element",
             "bring_window_to_front",
+            # Issue #12070: previously had handlers but no task-creation wiring
+            "read_text_from_region",
+            "move_mouse",
             "ask_user_for_manual",
             "respond_conversationally",
             "code_interpreter",


### PR DESCRIPTION
## Thinking Path
#12070 (from #11970): `tool_registry.py` created tasks for only 3 of 5 GUI task types — `gui_read_text_from_region` (OCR) + `gui_move_mouse` had registered handlers but no task-creation wiring, so the handlers were unreachable.

## What Changed
- Added `read_text_from_region(x,y,width,height)` + `move_mouse(x,y,duration)` task-creation in `tool_registry.py`, mirroring the 3 existing GUI tools (`_create_base_task` → payload keys → `_execute_worker_task`). Params match the handlers' `require_payload_value` (x/y/width/height; x/y/duration).
- Registered consistently everywhere the other 3 are: `get_available_tools()` catalogue + `_get_tool_handler()` dispatch (executor.handlers was already wired).
- Handlers confirmed real (pytesseract OCR + pyautogui.moveTo from #11970/#11579), not stubs.
- **Pre-existing bug fixed in-scope**: `gui_bring_window_to_front` (an already-wired tool) set `task["window_title"]` but the handler requires `app_title` → every invocation raised `KeyError`. Fixed to `app_title` + regression test.

Closes #12070

## Verification
- `tests/unit/tools/` + gui_handlers + worker_node: 34 → **40 passed** (6 new: both new task types + catalogue/dispatch registration + the app_title regression). py_compile + black clean. (Real CI confirms.)

## Model Used
Opus 4.8 (subagent: senior-backend-engineer)