### PR TITLE
fix(deploy): slm-agent system-python deps — add pydantic-settings + sqlalchemy (#12142, #11820)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
@@ -36,10 +36,16 @@ slm_agent_data_dir: /var/lib/slm-agent
 #   - redis:   autobot_shared.redis_client (health_collector.py imports it at
 #              module load) — was MISSING here, so a fresh restart on the system
 #              python crash-looped with ModuleNotFoundError: No module named 'redis'.
+#   - pydantic-settings / sqlalchemy: autobot_shared transitive deps (its config +
+#              DB modules, per autobot_shared/pyproject.toml). The agent imports
+#              autobot_shared, so these load at agent startup — MISSING here caused
+#              the same ModuleNotFoundError crash-loop on 2026-07-23 (#12142).
 slm_agent_python_packages:
   - aiohttp
   - psutil
   - redis
+  - pydantic-settings
+  - sqlalchemy
 
 # Services to monitor (systemd service names)
 # Override per-host in inventory, e.g.:


### PR DESCRIPTION
## Thinking Path
Live 2026-07-23: after #11508 moved slm-agent to /usr/bin/python3, it crash-looped: ModuleNotFoundError pydantic_settings (then sqlalchemy). The agent imports autobot_shared, which transitively imports pydantic_settings + sqlalchemy (autobot_shared/pyproject.toml), but the #11508 role only installed [aiohttp, psutil, redis] into system python.

## What Changed
- `roles/slm_agent/defaults/main.yml`: added `pydantic-settings` + `sqlalchemy` to `slm_agent_python_packages`, with a comment matching the existing redis-transitive-dep rationale. (Manually installed on the box already → agent stable, 0 restarts.)

## Verification
YAML valid. On-box: agent active, 0 restarts, no ModuleNotFoundError after installing these.

## Follow-up
More robust long-term: drive the agent's dep list from autobot_shared/pyproject.toml so future shared deps don't recur (noted in #12142).

## Model Used
Opus 4.8

Closes #12142