### PR TITLE
docs(license): correct landing-page footer MIT → Apache 2.0 (#12097)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,7 +32,7 @@ nav_external_links:
 
 # Footer
 footer_content: >
-  &copy; 2026 mrveiss &mdash; <a href="https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/LICENSE">MIT License</a>
+  &copy; 2026 mrveiss &mdash; <a href="https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/LICENSE">Apache 2.0 License</a>
 
 # Back to top
 back_to_top: true


### PR DESCRIPTION
Closes #12097

## What Changed
`docs/_config.yml` footer said `MIT License` while the repo relicensed to Apache-2.0 (#9830; LICENSE is Apache 2.0). The GitHub Pages landing page templates its footer from this value, so it advertised the wrong license. Corrected to `Apache 2.0 License`. Sole remaining MIT reference in docs (verified).

## Verification
No `MIT License` refs remain in docs/README. LICENSE file confirmed Apache 2.0.

## Model Used
Claude Opus 4.8