### PR TITLE
fix(security): require auth + tenant authz on LLC goals endpoints (unauth CRUD + IDOR) (#12136)

### DIFF
--- a/autobot-backend/llc/api/goals.py
+++ b/autobot-backend/llc/api/goals.py
@@ -12,6 +12,13 @@ Routes:
   DELETE /llc/goals/{id}           — delete goal + subtree
   GET    /llc/goals/{id}/ancestors — ancestor chain (root-first)
   GET    /llc/goals/{id}/tasks     — work items linked to this goal (GH#6469)
+
+Every endpoint requires an authenticated caller with organization context and
+enforces tenant isolation (GH#12136): company-keyed routes reject a mismatch
+between the caller's org and the requested ``company_id``; goal-keyed routes
+load the goal, derive its ``company_id`` and apply the same check (broken
+object-level authorization / IDOR fix). Platform admins bypass the tenant
+check. This mirrors the sibling ``companies.py`` router.
 """
 
 import uuid
@@ -23,10 +30,12 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session
+from user_management.services import TenantContext
 
-from ..models.goal import GoalLevel, GoalStatus
+from ..models.goal import GoalLevel, GoalStatus, LLCGoal
 from ..models.work_item import LLCWorkItem
 from ..services.goal import GoalService
 
@@ -37,6 +46,33 @@ _get_svc = lazy_singleton(GoalService)
 
 def _svc() -> GoalService:
     return _get_svc()
+
+
+# ---------------------------------------------------------------- Authz helpers
+
+
+def _assert_same_tenant(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access unless the caller is a platform admin (GH#12136).
+
+    Mirrors ``companies.py::get_org_chart``: the caller's org must match the
+    requested ``company_id`` or the request is forbidden.
+    """
+    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
+async def _load_authorized_goal(goal_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCGoal:
+    """Load a goal and enforce tenant ownership (IDOR fix, GH#12136).
+
+    Raises 404 when the goal does not exist and 403 when it belongs to another
+    company and the caller is not a platform admin — a user from org A must not
+    read or modify org B's goal.
+    """
+    goal = await _svc().get(session, goal_id)
+    if goal is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    _assert_same_tenant(ctx, goal.company_id)
+    return goal
 
 
 # ------------------------------------------------------------------ Schemas
@@ -106,7 +142,10 @@ async def list_goals(
     company_id: str = Query(..., description="Company ID to filter goals"),
     parent_goal_id: Optional[uuid.UUID] = Query(None),
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[GoalResponse]:
+    _assert_same_tenant(ctx, company_id)
     goals = await _svc().list_by_company(session, company_id, parent_goal_id)
     return [GoalResponse.model_validate(g) for g in goals]
 
@@ -115,7 +154,10 @@ async def list_goals(
 async def create_goal(
     body: GoalCreate,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> GoalResponse:
+    _assert_same_tenant(ctx, body.company_id)
     goal = await _svc().create(
         session,
         company_id=body.company_id,
@@ -134,10 +176,10 @@ async def create_goal(
 async def get_goal(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> GoalResponse:
-    goal = await _svc().get(session, goal_id)
-    if goal is None:
-        raise HTTPException(status_code=404, detail="Goal not found")
+    goal = await _load_authorized_goal(goal_id, session, ctx)
     return GoalResponse.model_validate(goal)
 
 
@@ -146,7 +188,10 @@ async def update_goal(
     goal_id: uuid.UUID,
     body: GoalUpdate,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> GoalResponse:
+    await _load_authorized_goal(goal_id, session, ctx)
     updates = {k: v for k, v in body.model_dump(exclude_unset=True).items()}
     goal = await _svc().update(session, goal_id, **updates)
     if goal is None:
@@ -158,7 +203,10 @@ async def update_goal(
 async def delete_goal(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> None:
+    await _load_authorized_goal(goal_id, session, ctx)
     deleted = await _svc().delete(session, goal_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Goal not found")
@@ -168,10 +216,10 @@ async def delete_goal(
 async def get_ancestors(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[GoalResponse]:
-    goal = await _svc().get(session, goal_id)
-    if goal is None:
-        raise HTTPException(status_code=404, detail="Goal not found")
+    await _load_authorized_goal(goal_id, session, ctx)
     ancestors = await _svc().get_ancestors(session, goal_id)
     return [GoalResponse.model_validate(a) for a in ancestors]
 
@@ -180,11 +228,11 @@ async def get_ancestors(
 async def list_tasks_for_goal(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[WorkItemSummaryResponse]:
     """Return all work items linked to a goal (GH#6469)."""
-    goal = await _svc().get(session, goal_id)
-    if goal is None:
-        raise HTTPException(status_code=404, detail="Goal not found")
+    await _load_authorized_goal(goal_id, session, ctx)
     result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.goal_id == goal_id))
     items = result.scalars().all()
     return [WorkItemSummaryResponse.model_validate(item) for item in items]

--- a/autobot-backend/llc/tests/test_goals_idor.py
+++ b/autobot-backend/llc/tests/test_goals_idor.py
@@ -1,0 +1,228 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Auth + IDOR regression tests for llc/api/goals.py routes (GH#12136).
+
+Before GH#12136 every goals route declared only ``Depends(get_async_session)``
+with no ``get_current_user`` / ``require_org_context`` — an unauthenticated
+caller could CRUD any company's goals (missing-auth + IDOR).
+
+These tests assert:
+  (a) an unauthenticated request is rejected (401), never served (200);
+  (b) an authenticated caller from org A requesting org B's goal → 403 (IDOR);
+  (c) an authenticated same-tenant caller still succeeds (200/201/204).
+
+The unauthenticated cases work by overriding ``get_current_user`` to raise 401
+exactly as the real dependency does when no user is present: if a route did NOT
+declare the dependency the override would be a no-op and the request would
+return 200 — so a passing test proves the dependency is wired on that route.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
+
+
+def _make_goal(company_id: str) -> MagicMock:
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.company_id = company_id
+    m.parent_goal_id = None
+    m.title = "Test Goal"
+    m.description = None
+    m.level = "vision"
+    m.status = "draft"
+    m.owner_agent_id = None
+    m.due_date = None
+    m.created_at = datetime.now(timezone.utc)
+    m.updated_at = datetime.now(timezone.utc)
+    return m
+
+
+def _make_app(
+    *,
+    authenticated: bool = True,
+    caller_org_id: str,
+    goal_company_id: str = None,
+    goal_exists: bool = True,
+) -> TestClient:
+    """Build a FastAPI test client for goals auth/IDOR tests."""
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.goals import router as goals_router  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(goals_router)
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    goal_cid = goal_company_id if goal_company_id is not None else caller_org_id
+    mock_goal = _make_goal(goal_cid) if goal_exists else None
+
+    async def _fake_session():
+        yield mock_session
+
+    async def _execute(stmt, *args, **kwargs):
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=mock_goal)
+        result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+        return result
+
+    mock_session.execute = _execute
+
+    app.dependency_overrides[get_async_session] = _fake_session
+
+    def _fake_user() -> dict:
+        if not authenticated:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        return {"id": str(_FIXED_USER_ID), "user_id": str(_FIXED_USER_ID)}
+
+    def _fake_tenant() -> TenantContext:
+        if not authenticated:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        return TenantContext(org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=False)
+
+    app.dependency_overrides[get_current_user] = _fake_user
+    app.dependency_overrides[require_org_context] = _fake_tenant
+
+    # GoalService.get returns the mock goal (used by goal_id-keyed routes).
+    patch("llc.services.goal.GoalService.get", new=AsyncMock(return_value=mock_goal)).start()
+    patch("llc.services.goal.GoalService.list_by_company", new=AsyncMock(return_value=[])).start()
+    patch("llc.services.goal.GoalService.get_ancestors", new=AsyncMock(return_value=[])).start()
+    patch("llc.services.goal.GoalService.delete", new=AsyncMock(return_value=True)).start()
+    patch("llc.services.goal.GoalService.update", new=AsyncMock(return_value=mock_goal)).start()
+    patch("llc.services.goal.GoalService.create", new=AsyncMock(return_value=mock_goal)).start()
+
+    return TestClient(app, raise_server_exceptions=True)
+
+
+class TestGoalsUnauthenticated:
+    """(a) No credentials → 401, never 200."""
+
+    def teardown_method(self, _m):
+        patch.stopall()
+
+    def test_list_unauth_rejected(self):
+        org = str(uuid.uuid4())
+        client = _make_app(authenticated=False, caller_org_id=org)
+        resp = client.get(f"/goals?company_id={org}")
+        assert resp.status_code == 401
+
+    def test_create_unauth_rejected(self):
+        org = str(uuid.uuid4())
+        client = _make_app(authenticated=False, caller_org_id=org)
+        resp = client.post("/goals", json={"company_id": org, "title": "X", "level": "vision"})
+        assert resp.status_code == 401
+
+    def test_get_goal_unauth_rejected(self):
+        org = str(uuid.uuid4())
+        client = _make_app(authenticated=False, caller_org_id=org)
+        resp = client.get(f"/goals/{uuid.uuid4()}")
+        assert resp.status_code == 401
+
+    def test_delete_goal_unauth_rejected(self):
+        org = str(uuid.uuid4())
+        client = _make_app(authenticated=False, caller_org_id=org)
+        resp = client.delete(f"/goals/{uuid.uuid4()}")
+        assert resp.status_code == 401
+
+
+class TestGoalsCrossTenantIdor:
+    """(b) org A caller against org B's goal → 403."""
+
+    def teardown_method(self, _m):
+        patch.stopall()
+
+    def test_get_cross_tenant_403(self):
+        caller, other = str(uuid.uuid4()), str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller, goal_company_id=other)
+        resp = client.get(f"/goals/{uuid.uuid4()}")
+        assert resp.status_code == 403
+
+    def test_patch_cross_tenant_403(self):
+        caller, other = str(uuid.uuid4()), str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller, goal_company_id=other)
+        resp = client.patch(f"/goals/{uuid.uuid4()}", json={"title": "Hacked"})
+        assert resp.status_code == 403
+
+    def test_delete_cross_tenant_403(self):
+        caller, other = str(uuid.uuid4()), str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller, goal_company_id=other)
+        resp = client.delete(f"/goals/{uuid.uuid4()}")
+        assert resp.status_code == 403
+
+    def test_ancestors_cross_tenant_403(self):
+        caller, other = str(uuid.uuid4()), str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller, goal_company_id=other)
+        resp = client.get(f"/goals/{uuid.uuid4()}/ancestors")
+        assert resp.status_code == 403
+
+    def test_tasks_cross_tenant_403(self):
+        caller, other = str(uuid.uuid4()), str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller, goal_company_id=other)
+        resp = client.get(f"/goals/{uuid.uuid4()}/tasks")
+        assert resp.status_code == 403
+
+    def test_list_cross_tenant_403(self):
+        caller, other = str(uuid.uuid4()), str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller)
+        resp = client.get(f"/goals?company_id={other}")
+        assert resp.status_code == 403
+
+    def test_create_cross_tenant_403(self):
+        caller, other = str(uuid.uuid4()), str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller)
+        resp = client.post("/goals", json={"company_id": other, "title": "X", "level": "vision"})
+        assert resp.status_code == 403
+
+    def test_get_missing_goal_404(self):
+        caller = str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller, goal_exists=False)
+        resp = client.get(f"/goals/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+
+class TestGoalsSameTenantAllowed:
+    """(c) Authorized same-tenant caller still works."""
+
+    def teardown_method(self, _m):
+        patch.stopall()
+
+    def test_get_same_tenant_200(self):
+        org = str(uuid.uuid4())
+        client = _make_app(caller_org_id=org, goal_company_id=org)
+        resp = client.get(f"/goals/{uuid.uuid4()}")
+        assert resp.status_code == 200
+
+    def test_list_same_tenant_200(self):
+        org = str(uuid.uuid4())
+        client = _make_app(caller_org_id=org)
+        resp = client.get(f"/goals?company_id={org}")
+        assert resp.status_code == 200
+
+    def test_create_same_tenant_201(self):
+        org = str(uuid.uuid4())
+        client = _make_app(caller_org_id=org)
+        resp = client.post("/goals", json={"company_id": org, "title": "X", "level": "vision"})
+        assert resp.status_code == 201
+
+    def test_delete_same_tenant_204(self):
+        org = str(uuid.uuid4())
+        client = _make_app(caller_org_id=org, goal_company_id=org)
+        resp = client.delete(f"/goals/{uuid.uuid4()}")
+        assert resp.status_code == 204
+
+    def test_ancestors_same_tenant_200(self):
+        org = str(uuid.uuid4())
+        client = _make_app(caller_org_id=org, goal_company_id=org)
+        resp = client.get(f"/goals/{uuid.uuid4()}/ancestors")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Thinking Path
`llc/api/goals.py` (`/api/llc/goals`) had NO auth — every handler declared only `Depends(get_async_session)`. Unauthenticated callers could CRUD goals in any company (missing-auth + IDOR). Fixed to match the sibling `companies.py` pattern.

## What Changed
- All **7 handlers** now declare `get_current_user` + `require_org_context` (per-handler, matching companies.py — no llc router uses router-level auth).
- Company-keyed handlers (list/create): `_assert_same_tenant(ctx, company_id)` → 403 on mismatch (unless platform admin).
- Goal-keyed handlers (get/patch/delete/ancestors/tasks): `_load_authorized_goal()` loads the goal, 404 if missing, derives `company_id`, applies the tenant check → 403 cross-tenant (IDOR fix). Ownership check runs BEFORE any mutation.
- Authorized same-tenant behavior unchanged.

Closes #12136

## Verification
- New `test_goals_idor.py` 17/17: unauth→401 (×4), cross-tenant→403 (×7), same-tenant→200/201/204 (×5), missing→404. Existing `test_goals.py` 22/22 (no regression). py_compile+black clean.

## ⚠️ Audit (report-only, follow-ups filed)
Same missing-auth pattern found in ~12 other LLC routers + a spoofable header check in `secrets.py` — see the linked security issues. This PR fixes goals.py only.

## Model Used
Opus 4.8 (subagent: security-auditor). 403-vs-404 cross-tenant convention noted as a pre-existing codebase inconsistency.