### PR TITLE
fix(llc-security): require auth + tenant authz on goals/backlog/budget endpoints — close unauth CRUD + IDOR (#12136)

### DIFF
--- a/autobot-backend/llc/api/backlog.py
+++ b/autobot-backend/llc/api/backlog.py
@@ -13,7 +13,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from llc.deps import get_session, service_dep
+from user_management.services import TenantContext
 
 from ..models.enums import WorkItemStatus, WorkItemType
 from ..models.work_item import LLCWorkItem
@@ -77,6 +79,22 @@ class BulkAssignSprintResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Auth / tenant isolation (GH#12136)
+# ---------------------------------------------------------------------------
+
+
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access to a company-scoped backlog request.
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches boards.py/sprints.py/work_items.py (GH#10296).
+    Platform admins are exempt, matching companies.py's org-chart idiom.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
+# ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
 
@@ -94,8 +112,11 @@ async def get_backlog(
     limit: int = Query(50, ge=1, le=500, description="Page size"),
     offset: int = Query(0, ge=0, description="Page offset"),
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> BacklogResponse:
     """Return backlog items ordered by priority (CRITICAL → HIGH → MEDIUM → LOW), then age."""
+    _assert_company_match(ctx, company_id)
     items, total = await _service().list_backlog(
         session,
         company_id=company_id,
@@ -118,12 +139,15 @@ async def get_backlog(
 async def bulk_assign_sprint(
     body: BulkAssignSprintRequest,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> BulkAssignSprintResponse:
     """Assign multiple backlog items to a sprint in a single DB round-trip.
 
     Items that don't belong to the given company are silently excluded.
     Returns the count of rows actually updated.
     """
+    _assert_company_match(ctx, body.company_id)
     if not body.work_item_ids:
         raise HTTPException(status_code=422, detail="work_item_ids must not be empty")
 

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -4,6 +4,7 @@
 # Author: mrveiss
 """LLC per-agent budget API routes (GH#8215)."""
 
+import uuid
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
@@ -12,11 +13,13 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, get_tenant_context, require_org_context
 from autobot_shared.logging_manager import get_logger
 from llc.exceptions import BudgetExhausted
 from llc.models.budget import LLCAgentBudget
 from llc.services.budget import BudgetService
 from user_management.database import get_async_session
+from user_management.services import TenantContext
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/budget", tags=["llc-budget"])
@@ -120,16 +123,49 @@ def _build_response(row: LLCAgentBudget, remaining: Decimal, is_over: bool, aler
     )
 
 
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access to a company-scoped budget request (GH#12136).
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches boards.py/sprints.py/work_items.py (GH#10296).
+    Platform admins are exempt, matching companies.py's org-chart idiom.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
+async def _assert_agent_tenant(session: AsyncSession, agent_id: str, ctx: TenantContext) -> None:
+    """Verify the budget row for *agent_id* belongs to the caller's org (GH#12136).
+
+    404 if the agent has no budget row or belongs to a different tenant —
+    avoids disclosing agent existence across tenants. Platform admins exempt.
+
+    Callers use ``Depends(get_tenant_context)`` (not ``require_org_context``)
+    since agent_id-keyed routes carry no company_id in path/query for the org
+    to be resolved up front — org_id may legitimately be None here (e.g. a
+    non-admin caller whose JWT lacks an org claim), which this then denies.
+    """
+    if ctx.is_platform_admin:
+        return
+    result = await session.execute(select(LLCAgentBudget.company_id).where(LLCAgentBudget.agent_id == agent_id))
+    row_company_id = result.scalar_one_or_none()
+    if row_company_id is None or str(row_company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail=f"No budget row for agent {agent_id}")
+
+
 @router.post("/{agent_id}", response_model=BudgetResponse, status_code=status.HTTP_201_CREATED)
 async def provision_budget(
     agent_id: str,
     body: ProvisionRequest,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(get_tenant_context),
 ) -> BudgetResponse:
     """Provision a default budget row for an agent (GH#9901).
 
     Returns 201 on creation, 409 if a row already exists.
-    Returns 404 if the agent does not exist in agent_org_nodes.
+    Returns 404 if the agent does not exist in agent_org_nodes, or belongs to
+    a different tenant (GH#12136).
     company_id is derived from agent_org_nodes — callers cannot scope rows
     to arbitrary companies.
     """
@@ -142,7 +178,11 @@ async def provision_budget(
     if agent_record is None:
         raise HTTPException(status_code=404, detail=f"Agent {agent_id!r} not found")
 
-    company_id = str(agent_record[0])
+    # str(uuid.UUID(...)) canonicalises to the dashed lower-case form regardless
+    # of how the raw text() query returns the UUID column across dialects
+    # (GH#12136 — needed for the tenant-match comparison below).
+    company_id = str(uuid.UUID(str(agent_record[0])))
+    _assert_company_match(ctx, company_id)
 
     svc = BudgetService()
     row, created = await svc.provision_budget(session, agent_id, company_id, body.budget_limit)
@@ -160,8 +200,11 @@ async def provision_budget(
 async def list_budgets(
     company_id: str = Query(..., description="Filter by company UUID"),
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
     """List all per-agent budget rows for a company (GH#8551, GH#8997)."""
+    _assert_company_match(ctx, company_id)
     result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.company_id == company_id))
     rows = result.scalars().all()
     svc = BudgetService()
@@ -189,13 +232,15 @@ async def list_budgets(
 async def get_budget(
     agent_id: str,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(get_tenant_context),
 ) -> BudgetResponse:
     # GH#8461: single SELECT — fetch the row directly and compute derived fields
     # here rather than calling check_budget() (which does its own SELECT) then
     # re-fetching the same row.
     result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id))
     row = result.scalar_one_or_none()
-    if row is None:
+    if row is None or (str(row.company_id) != str(ctx.org_id) and not ctx.is_platform_admin):
         raise HTTPException(status_code=404, detail=f"No budget row for agent {agent_id}")
 
     remaining, is_over, alert = _derive_status(row)
@@ -207,7 +252,10 @@ async def ingest_cost(
     agent_id: str,
     body: IngestRequest,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(get_tenant_context),
 ) -> IngestResponse:
+    await _assert_agent_tenant(session, agent_id, ctx)
     svc = BudgetService()
     try:
         cost = await svc.ingest_cost_event(session, agent_id, body.tokens_in, body.tokens_out, body.model)
@@ -222,11 +270,13 @@ async def update_limit(
     agent_id: str,
     body: UpdateLimitRequest,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(get_tenant_context),
 ) -> BudgetResponse:
     """Update budget limits and mode (GH#8215, GH#8997)."""
     result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id))
     row = result.scalar_one_or_none()
-    if row is None:
+    if row is None or (str(row.company_id) != str(ctx.org_id) and not ctx.is_platform_admin):
         raise HTTPException(status_code=404, detail=f"No budget row for agent {agent_id}")
 
     # GH#8462: pass Decimal directly — Pydantic already validates it as Decimal,
@@ -286,6 +336,8 @@ async def list_cost_events(
     company_id: str = Query(..., description="Filter by company UUID"),
     limit: int = Query(100, ge=1, le=500),
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
     """Return per-agent budget spend summary as cost events (GH#8551).
 
@@ -293,6 +345,7 @@ async def list_cost_events(
     A dedicated cost-event store is not yet implemented; this derives the
     data from LLCAgentBudget rows.
     """
+    _assert_company_match(ctx, company_id)
     result = await session.execute(
         select(LLCAgentBudget)
         .where(LLCAgentBudget.company_id == company_id)
@@ -341,6 +394,8 @@ class AgentModelCostRow(BaseModel):
 async def costs_by_agent_model(
     company_id: str,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[AgentModelCostRow]:
     """Return token usage broken down by agent and model for a company.
 
@@ -359,6 +414,7 @@ async def costs_by_agent_model(
     a future migration adds the columns.  The endpoint is intentionally
     available from day one so dashboards can start wiring up immediately.
     """
+    _assert_company_match(ctx, company_id)
     result = await session.execute(
         text("""
             SELECT

--- a/autobot-backend/llc/api/goals.py
+++ b/autobot-backend/llc/api/goals.py
@@ -23,10 +23,12 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session
+from user_management.services import TenantContext
 
-from ..models.goal import GoalLevel, GoalStatus
+from ..models.goal import GoalLevel, GoalStatus, LLCGoal
 from ..models.work_item import LLCWorkItem
 from ..services.goal import GoalService
 
@@ -98,6 +100,31 @@ class WorkItemSummaryResponse(BaseModel):
         from_attributes = True
 
 
+# ------------------------------------------------------------------ Auth / tenant isolation (GH#12136)
+
+
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access to a company-scoped goal request.
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches the established pattern in
+    boards.py/sprints.py/work_items.py (GH#10296, GH#10148, GH#9861). Platform
+    admins are exempt, matching companies.py's org-chart/backlog-reorder idiom.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
+async def _get_authorized_goal(session: AsyncSession, goal_id: uuid.UUID, ctx: TenantContext) -> LLCGoal:
+    """Load a goal and enforce tenant isolation; 404 if missing or cross-tenant (GH#12136)."""
+    goal = await _svc().get(session, goal_id)
+    if goal is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    if str(goal.company_id) != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    return goal
+
+
 # ------------------------------------------------------------------ Routes
 
 
@@ -106,7 +133,10 @@ async def list_goals(
     company_id: str = Query(..., description="Company ID to filter goals"),
     parent_goal_id: Optional[uuid.UUID] = Query(None),
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[GoalResponse]:
+    _assert_company_match(ctx, company_id)
     goals = await _svc().list_by_company(session, company_id, parent_goal_id)
     return [GoalResponse.model_validate(g) for g in goals]
 
@@ -115,7 +145,10 @@ async def list_goals(
 async def create_goal(
     body: GoalCreate,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> GoalResponse:
+    _assert_company_match(ctx, body.company_id)
     goal = await _svc().create(
         session,
         company_id=body.company_id,
@@ -134,10 +167,10 @@ async def create_goal(
 async def get_goal(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> GoalResponse:
-    goal = await _svc().get(session, goal_id)
-    if goal is None:
-        raise HTTPException(status_code=404, detail="Goal not found")
+    goal = await _get_authorized_goal(session, goal_id, ctx)
     return GoalResponse.model_validate(goal)
 
 
@@ -146,7 +179,10 @@ async def update_goal(
     goal_id: uuid.UUID,
     body: GoalUpdate,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> GoalResponse:
+    await _get_authorized_goal(session, goal_id, ctx)
     updates = {k: v for k, v in body.model_dump(exclude_unset=True).items()}
     goal = await _svc().update(session, goal_id, **updates)
     if goal is None:
@@ -158,7 +194,10 @@ async def update_goal(
 async def delete_goal(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> None:
+    await _get_authorized_goal(session, goal_id, ctx)
     deleted = await _svc().delete(session, goal_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Goal not found")
@@ -168,10 +207,10 @@ async def delete_goal(
 async def get_ancestors(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[GoalResponse]:
-    goal = await _svc().get(session, goal_id)
-    if goal is None:
-        raise HTTPException(status_code=404, detail="Goal not found")
+    await _get_authorized_goal(session, goal_id, ctx)
     ancestors = await _svc().get_ancestors(session, goal_id)
     return [GoalResponse.model_validate(a) for a in ancestors]
 
@@ -180,11 +219,11 @@ async def get_ancestors(
 async def list_tasks_for_goal(
     goal_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[WorkItemSummaryResponse]:
     """Return all work items linked to a goal (GH#6469)."""
-    goal = await _svc().get(session, goal_id)
-    if goal is None:
-        raise HTTPException(status_code=404, detail="Goal not found")
+    await _get_authorized_goal(session, goal_id, ctx)
     result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.goal_id == goal_id))
     items = result.scalars().all()
     return [WorkItemSummaryResponse.model_validate(item) for item in items]

--- a/autobot-backend/llc/tests/test_backlog.py
+++ b/autobot-backend/llc/tests/test_backlog.py
@@ -11,6 +11,25 @@ from fastapi.testclient import TestClient
 from llc.models.enums import WorkItemPriority, WorkItemStatus, WorkItemType
 from llc.models.work_item import LLCWorkItem
 from llc.services.backlog import BacklogService
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+
+
+def _override_admin_auth(app) -> None:  # noqa: ANN001
+    """Stub auth as a platform admin so tenant checks don't block these
+    service-layer route tests (GH#12136 added auth to backlog.py)."""
+    from api.user_management.dependencies import get_current_user, require_org_context
+
+    def _fake_user() -> dict:
+        return {"id": str(_FIXED_USER_ID), "user_id": str(_FIXED_USER_ID)}
+
+    def _fake_tenant() -> TenantContext:
+        return TenantContext(org_id=None, user_id=_FIXED_USER_ID, is_platform_admin=True)
+
+    app.dependency_overrides[get_current_user] = _fake_user
+    app.dependency_overrides[require_org_context] = _fake_tenant
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -219,6 +238,7 @@ def app_client():
         yield AsyncMock()
 
     app.dependency_overrides[get_session] = _stub_session
+    _override_admin_auth(app)
     return TestClient(app, raise_server_exceptions=True)
 
 
@@ -248,6 +268,7 @@ class TestBacklogRoute:
 
             app.include_router(router, prefix="/api/llc")
             app.dependency_overrides[get_session] = _fake_session
+            _override_admin_auth(app)
 
             from fastapi.testclient import TestClient as TC
 
@@ -278,6 +299,7 @@ class TestBacklogRoute:
 
         app.include_router(router, prefix="/api/llc")
         app.dependency_overrides[get_session] = _fake_session
+        _override_admin_auth(app)
 
         with patch("llc.api.backlog._service") as mock_svc_factory:
             svc = AsyncMock()

--- a/autobot-backend/llc/tests/test_backlog_idor.py
+++ b/autobot-backend/llc/tests/test_backlog_idor.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Auth + IDOR hardening tests for backlog.py routes (GH#12136).
+
+llc/api/backlog.py previously depended only on ``get_session`` — no
+authentication and no tenant-authorization dependency. Mirrors
+test_goals_idor.py / test_boards_idor.py: no auth -> 401, cross-tenant -> 404,
+same-tenant -> success.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+_OTHER_ORG = "99999999-9999-9999-9999-999999999999"
+
+
+def _make_client(caller_org_id: str, is_platform_admin: bool = False) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.backlog import get_session, router  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/llc")
+
+    async def _fake_session():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=is_platform_admin
+    )
+
+    mock_svc_factory = patch("llc.api.backlog._service").start()
+    mock_svc_factory.return_value.list_backlog = AsyncMock(return_value=([], 0))
+    mock_svc_factory.return_value.bulk_assign_sprint = AsyncMock(return_value=2)
+
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestBacklogNoAuth:
+    def test_get_backlog_no_token_returns_401(self):
+        from llc.api.backlog import get_session, router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/llc")
+
+        async def _fake_session():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_session] = _fake_session
+
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = TestClient(app)
+            resp = client.get("/api/llc/backlog", params={"company_id": str(uuid.uuid4())})
+        assert resp.status_code == 401
+
+
+class TestBacklogIdor:
+    def test_get_backlog_own_company_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get("/api/llc/backlog", params={"company_id": org})
+        assert resp.status_code == 200
+
+    def test_get_backlog_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get("/api/llc/backlog", params={"company_id": _OTHER_ORG})
+        assert resp.status_code == 404
+
+    def test_get_backlog_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.get("/api/llc/backlog", params={"company_id": _OTHER_ORG})
+        assert resp.status_code == 200
+
+    def test_bulk_assign_sprint_own_company_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/backlog/bulk-assign-sprint",
+            json={"company_id": org, "sprint_id": str(uuid.uuid4()), "work_item_ids": [str(uuid.uuid4())]},
+        )
+        assert resp.status_code == 200
+
+    def test_bulk_assign_sprint_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/backlog/bulk-assign-sprint",
+            json={"company_id": _OTHER_ORG, "sprint_id": str(uuid.uuid4()), "work_item_ids": [str(uuid.uuid4())]},
+        )
+        assert resp.status_code == 404

--- a/autobot-backend/llc/tests/test_budget_idor.py
+++ b/autobot-backend/llc/tests/test_budget_idor.py
@@ -1,0 +1,212 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Auth + IDOR hardening tests for budget.py routes (GH#12136).
+
+llc/api/budget.py previously depended only on ``get_async_session`` — no
+authentication and no tenant-authorization dependency — allowing an
+unauthenticated caller to provision/read/mutate ANY agent's budget by
+supplying an arbitrary ``agent_id``/``company_id`` (missing-authentication +
+IDOR). Uses the same in-memory-SQLite harness as test_budget_provision.py so
+the real ORM-derived company_id is exercised (not a mock).
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.tests import _e2e_harness as harness
+from models.agent_org import AgentOrgNode, OrgRole
+
+_FIXED_USER_ID = uuid.UUID("88888888-8888-8888-8888-888888888888")
+_OTHER_ORG = str(uuid.uuid4())
+
+
+@pytest_asyncio.fixture
+async def engine():  # noqa: ANN201
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine
+    await harness.create_loop_schema(eng)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )  # canonical: ignore py-adhoc-db-engine
+
+
+def _make_app(session_factory, caller_org_id: str, is_platform_admin: bool = False):  # noqa: ANN001, ANN201
+    """Build a FastAPI app wiring only the budget routers, with a non-admin
+    tenant context fixed to *caller_org_id* (or a platform-admin bypass)."""
+    from fastapi import FastAPI
+
+    from llc.api import budget as budget_api
+    from user_management.database import get_async_session
+    from user_management.services import TenantContext
+
+    application = FastAPI()
+    application.include_router(budget_api.router, prefix="/api/llc")
+    application.include_router(budget_api.cost_events_router, prefix="/api/llc")
+    application.include_router(budget_api.costs_by_model_router, prefix="/api/llc")
+
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    application.dependency_overrides[get_async_session] = _override_session
+
+    def _override_current_user() -> dict:
+        return {"id": str(_FIXED_USER_ID), "user_id": str(_FIXED_USER_ID)}
+
+    def _override_tenant() -> TenantContext:
+        return TenantContext(
+            org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=is_platform_admin
+        )
+
+    from api.user_management.dependencies import (
+        get_current_user,
+        get_tenant_context,
+        require_org_context,
+    )
+
+    application.dependency_overrides[get_current_user] = _override_current_user
+    application.dependency_overrides[get_tenant_context] = _override_tenant
+    application.dependency_overrides[require_org_context] = _override_tenant
+
+    return application
+
+
+@pytest_asyncio.fixture
+async def client_factory(session_factory):  # noqa: ANN001, ANN201
+    """Return a factory building an httpx client scoped to a given caller org."""
+
+    async def _make(caller_org_id: str, is_platform_admin: bool = False) -> httpx.AsyncClient:
+        app = _make_app(session_factory, caller_org_id, is_platform_admin)
+        transport = httpx.ASGITransport(app=app)
+        return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+    return _make
+
+
+async def _insert_agent(session_factory, company_id: str) -> str:  # noqa: ANN001
+    agent_id = str(uuid.uuid4())
+    async with session_factory() as session:
+        session.add(
+            AgentOrgNode(
+                id=uuid.uuid4(),
+                agent_id=agent_id,
+                name="Test Agent",
+                org_role=OrgRole.WORKER.value,
+                company_id=uuid.UUID(company_id),
+            )
+        )
+        await session.commit()
+    return agent_id
+
+
+@pytest.mark.asyncio
+async def test_provision_own_company_returns_201(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    client = await client_factory(company_id)
+    resp = await client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_provision_cross_tenant_returns_404(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    client = await client_factory(_OTHER_ORG)
+    resp = await client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_budget_own_company_returns_200(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    owner_client = await client_factory(company_id)
+    prov = await owner_client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert prov.status_code == 201, prov.text
+
+    resp = await owner_client.get(f"/api/llc/budget/{agent_id}")
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_budget_cross_tenant_returns_404(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    owner_client = await client_factory(company_id)
+    prov = await owner_client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert prov.status_code == 201, prov.text
+
+    other_client = await client_factory(_OTHER_ORG)
+    resp = await other_client.get(f"/api/llc/budget/{agent_id}")
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_update_limit_cross_tenant_returns_404(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    owner_client = await client_factory(company_id)
+    prov = await owner_client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert prov.status_code == 201, prov.text
+
+    other_client = await client_factory(_OTHER_ORG)
+    resp = await other_client.patch(f"/api/llc/budget/{agent_id}/limit", json={"budget_limit": "5.00"})
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_update_limit_own_company_returns_200(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    owner_client = await client_factory(company_id)
+    prov = await owner_client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert prov.status_code == 201, prov.text
+
+    resp = await owner_client.patch(f"/api/llc/budget/{agent_id}/limit", json={"budget_limit": "5.00"})
+    assert resp.status_code == 200, resp.text
+    assert Decimal(resp.json()["budget_limit"]) == Decimal("5.00")
+
+
+@pytest.mark.asyncio
+async def test_list_budgets_cross_tenant_returns_404(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    owner_client = await client_factory(company_id)
+    prov = await owner_client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert prov.status_code == 201, prov.text
+
+    other_client = await client_factory(_OTHER_ORG)
+    resp = await other_client.get("/api/llc/budget", params={"company_id": company_id})
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_list_budgets_own_company_returns_200(client_factory, session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    agent_id = await _insert_agent(session_factory, company_id)
+    owner_client = await client_factory(company_id)
+    prov = await owner_client.post(f"/api/llc/budget/{agent_id}", json={})
+    assert prov.status_code == 201, prov.text
+
+    resp = await owner_client.get("/api/llc/budget", params={"company_id": company_id})
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()) == 1

--- a/autobot-backend/llc/tests/test_goals_idor.py
+++ b/autobot-backend/llc/tests/test_goals_idor.py
@@ -1,0 +1,242 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Auth + IDOR hardening tests for goals.py routes (GH#12136).
+
+Prior to this fix every handler in llc/api/goals.py depended only on
+``get_async_session`` — no authentication and no tenant-authorization
+dependency — allowing an unauthenticated caller to create/read/update/delete
+goals in ANY company by supplying an arbitrary ``company_id``/``goal_id``
+(missing-authentication + IDOR).
+
+Mirrors test_boards_idor.py / test_sprints_idor.py / test_work_items_idor.py:
+  - no auth at all                     -> 401
+  - authenticated, cross-tenant access -> 404 (existence disclosure avoided)
+  - authenticated, same-tenant access  -> the expected success status
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
+_OTHER_ORG = "99999999-9999-9999-9999-999999999999"
+
+
+def _make_goal(company_id: str) -> MagicMock:
+    goal = MagicMock()
+    goal.id = uuid.uuid4()
+    goal.company_id = company_id
+    goal.parent_goal_id = None
+    goal.title = "Test Goal"
+    goal.description = None
+    goal.level = "vision"
+    goal.status = "draft"
+    goal.owner_agent_id = None
+    goal.due_date = None
+    goal.created_at = datetime.now(timezone.utc)
+    goal.updated_at = datetime.now(timezone.utc)
+    return goal
+
+
+def _make_client(
+    caller_org_id: str,
+    goal_company_id: Optional[str] = None,
+    goal_exists: bool = True,
+    is_platform_admin: bool = False,
+) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.goals import router as goals_router  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(goals_router, prefix="/api/llc")
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=is_platform_admin
+    )
+
+    gcid = goal_company_id if goal_company_id is not None else caller_org_id
+    goal = _make_goal(gcid) if goal_exists else None
+
+    patch("llc.api.goals.GoalService.get", new=AsyncMock(return_value=goal)).start()
+    patch("llc.api.goals.GoalService.list_by_company", new=AsyncMock(return_value=[goal] if goal else [])).start()
+    patch("llc.api.goals.GoalService.create", new=AsyncMock(return_value=goal)).start()
+    patch("llc.api.goals.GoalService.update", new=AsyncMock(return_value=goal)).start()
+    patch("llc.api.goals.GoalService.delete", new=AsyncMock(return_value=True)).start()
+    patch("llc.api.goals.GoalService.get_ancestors", new=AsyncMock(return_value=[])).start()
+
+    items_result = MagicMock()
+    items_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=items_result)
+
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestGoalsNoAuth:
+    """No credentials at all -> 401 (real get_current_user, not overridden)."""
+
+    def _make_unauthenticated_client(self) -> TestClient:
+        from llc.api.goals import router as goals_router
+        from user_management.database import get_async_session
+
+        app = FastAPI()
+        app.include_router(goals_router, prefix="/api/llc")
+
+        async def _fake_session():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_async_session] = _fake_session
+        return TestClient(app)
+
+    def test_list_goals_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.get("/api/llc/goals", params={"company_id": str(uuid.uuid4())})
+        assert resp.status_code == 401
+
+    def test_get_goal_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.get(f"/api/llc/goals/{uuid.uuid4()}")
+        assert resp.status_code == 401
+
+
+class TestGoalsIdor:
+    # --- list ---
+
+    def test_list_goals_own_company_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get("/api/llc/goals", params={"company_id": org})
+        assert resp.status_code == 200
+
+    def test_list_goals_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get("/api/llc/goals", params={"company_id": _OTHER_ORG})
+        assert resp.status_code == 404
+
+    def test_list_goals_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.get("/api/llc/goals", params={"company_id": _OTHER_ORG})
+        assert resp.status_code == 200
+
+    # --- create ---
+
+    def test_create_goal_own_company_returns_201(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/goals",
+            json={"company_id": org, "title": "Vision", "level": "vision"},
+        )
+        assert resp.status_code == 201
+
+    def test_create_goal_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/goals",
+            json={"company_id": _OTHER_ORG, "title": "Hijack", "level": "vision"},
+        )
+        assert resp.status_code == 404
+
+    # --- get by id ---
+
+    def test_get_goal_own_tenant_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=org)
+        resp = client.get(f"/api/llc/goals/{uuid.uuid4()}")
+        assert resp.status_code == 200
+
+    def test_get_goal_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=_OTHER_ORG)
+        resp = client.get(f"/api/llc/goals/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    def test_get_goal_not_found_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_exists=False)
+        resp = client.get(f"/api/llc/goals/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    # --- update ---
+
+    def test_update_goal_own_tenant_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=org)
+        resp = client.patch(f"/api/llc/goals/{uuid.uuid4()}", json={"title": "New"})
+        assert resp.status_code == 200
+
+    def test_update_goal_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=_OTHER_ORG)
+        resp = client.patch(f"/api/llc/goals/{uuid.uuid4()}", json={"title": "Hijack"})
+        assert resp.status_code == 404
+
+    # --- delete ---
+
+    def test_delete_goal_own_tenant_returns_204(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=org)
+        resp = client.delete(f"/api/llc/goals/{uuid.uuid4()}")
+        assert resp.status_code == 204
+
+    def test_delete_goal_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=_OTHER_ORG)
+        resp = client.delete(f"/api/llc/goals/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    # --- ancestors ---
+
+    def test_ancestors_own_tenant_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=org)
+        resp = client.get(f"/api/llc/goals/{uuid.uuid4()}/ancestors")
+        assert resp.status_code == 200
+
+    def test_ancestors_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=_OTHER_ORG)
+        resp = client.get(f"/api/llc/goals/{uuid.uuid4()}/ancestors")
+        assert resp.status_code == 404
+
+    # --- tasks ---
+
+    def test_tasks_own_tenant_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=org)
+        resp = client.get(f"/api/llc/goals/{uuid.uuid4()}/tasks")
+        assert resp.status_code == 200
+
+    def test_tasks_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, goal_company_id=_OTHER_ORG)
+        resp = client.get(f"/api/llc/goals/{uuid.uuid4()}/tasks")
+        assert resp.status_code == 404

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48675,7 +48675,8 @@ export interface paths {
          * @description Provision a default budget row for an agent (GH#9901).
          *
          *     Returns 201 on creation, 409 if a row already exists.
-         *     Returns 404 if the agent does not exist in agent_org_nodes.
+         *     Returns 404 if the agent does not exist in agent_org_nodes, or belongs to
+         *     a different tenant (GH#12136).
          *     company_id is derived from agent_org_nodes — callers cannot scope rows
          *     to arbitrary companies.
          */


### PR DESCRIPTION
## Thinking Path

**Security (High):** `llc/api/goals.py` handlers declared only `Depends(get_async_session)` — no identity, no tenant authz — so an **unauthenticated** caller could CRUD goals in **any** company by supplying `company_id`/`goal_id` (missing-auth + IDOR). The issue also suspected a systemic gap, so this PR audits every LLC router and closes the same hole wherever it exists.

## What Changed

**`goals.py`** — all 7 handlers now require `get_current_user` + `require_org_context`, with two shared helpers:
- `_assert_company_match(ctx, company_id)` — company-scoped routes (list/create).
- `_get_authorized_goal(session, goal_id, ctx)` — loads the goal and enforces its owning tenant **before** returning/mutating (the IDOR-by-id fix), for get/update/delete/ancestors/tasks.
Uses the **404-not-403** idiom (avoids existence disclosure) established by `boards.py`/`sprints.py`/`work_items.py`; platform admins exempt.

**Sibling audit (all 30 `llc/api/*.py` routers grepped for `get_async_session` without an auth dep):**
- `backlog.py` — **FIXED** (`get_backlog`, `bulk_assign_sprint`).
- `budget.py` — **FIXED** (all 7 handlers across its 3 routers; the 4 agent_id-keyed ones derive the owning company from `agent_org_nodes` and tenant-check it; also fixed a latent UUID-canonicalization mismatch in `provision_budget`).
- `work_items.py`/`sprints.py`/`boards.py` — already secured (prior GH#9861/#10148/#10296); all other routers already have auth or are health/webhook endpoints. Nothing deferred.

## Verification

- **Independent adversarial security review: VERDICT SOLID** — every handler gated by identity + tenant deps; every object-id handler loads-then-tenant-checks before acting; lists org-scoped; `is_platform_admin` derived server-side (not spoofable); no fail-open path; UUID canonicalization correct and fail-*closed*.
- 32 new IDOR tests (18 goals + 6 backlog + 8 budget: no-token→401, cross-tenant→404, same-tenant→success, admin bypass); 3 pre-existing backlog tests updated for the new auth dep.
- Full `llc/tests/` suite: **1168 passed, 2 skipped, 0 failed**. flake8/black clean.

## Notes (non-blocking, from the security review)
- On request-param routes the real enforcement is `get_tenant_context`'s membership check (returns 403 first); `_assert_company_match`'s 404 is defense-in-depth there and the primary control on body-`company_id`/id-keyed routes.
- Any pre-existing rows with a non-canonical `company_id` string would fail *closed* (spurious 404 for the legit owner, never a cross-tenant leak) — a data-audit consideration only if such rows exist.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer; independent review via security-auditor)

Closes #12136
