### PR TITLE
refactor(frontend): fold Vision + FeatureFlags clients onto shared apiClient (#12152)

### DIFF
--- a/autobot-frontend/src/utils/FeatureFlagsApiClient.ts
+++ b/autobot-frontend/src/utils/FeatureFlagsApiClient.ts
@@ -9,11 +9,9 @@
  * Issue #580: GUI integration for feature flags management
  */
 
-import appConfig from '@/config/AppConfig.js';
-import { NetworkConstants } from '@/constants/network';
+import apiClient from '@/utils/ApiClient';
 import { createLogger } from '@/utils/debugUtils';
 import { getApiBase } from '@/config/ssot-config';
-import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
 
 const logger = createLogger('FeatureFlagsApiClient');
@@ -81,51 +79,17 @@ export type { ApiResponse } from '@/types/api';
  * Communicates with /api/admin/feature-flags and /api/admin/access-control endpoints
  */
 class FeatureFlagsApiClient {
-  private baseUrl: string = '';
-  private baseUrlPromise: Promise<string> | null = null;
-
-  constructor() {
-    this.initializeBaseUrl();
-  }
-
-  private async initializeBaseUrl(): Promise<void> {
-    try {
-      this.baseUrl = await appConfig.getApiUrl('');
-    } catch {
-      logger.warn('AppConfig initialization failed, using NetworkConstants fallback');
-      this.baseUrl = `http://${NetworkConstants.MAIN_MACHINE_IP}:${NetworkConstants.BACKEND_PORT}`;
-    }
-  }
-
-  private async ensureBaseUrl(): Promise<string> {
-    if (this.baseUrl) {
-      return this.baseUrl;
-    }
-
-    if (!this.baseUrlPromise) {
-      this.baseUrlPromise = this.initializeBaseUrl().then(() => this.baseUrl);
-    }
-
-    return await this.baseUrlPromise;
-  }
+  // Base-URL resolution, auth-token injection (with expiry check), 401
+  // auto-logout+redirect, and org-context headers all live on the shared
+  // apiClient singleton (#12152) — this client is a thin typed wrapper
+  // around it, translating raw Response into the local ApiResponse<T> shape.
 
   private async request<T>(
     endpoint: string,
-    options: RequestInit = {}
+    options: { method?: string; body?: unknown } = {}
   ): Promise<ApiResponse<T>> {
-    const baseUrl = await this.ensureBaseUrl();
-    const url = `${baseUrl}${endpoint}`;
-
-    const defaultHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
     try {
-      const response = await fetchWithAuth(url, {
-        ...options,
-        headers: { ...defaultHeaders, ...options.headers },
-      });
-
+      const response = await apiClient.rawRequest(endpoint, options);
       const data = await response.json();
 
       if (!response.ok) {
@@ -169,7 +133,7 @@ class FeatureFlagsApiClient {
   }>> {
     return this.request(`${getApiBase()}/admin/feature-flags/enforcement-mode`, {
       method: 'PUT',
-      body: JSON.stringify({ mode }),
+      body: { mode },
     });
   }
 
@@ -185,7 +149,7 @@ class FeatureFlagsApiClient {
     const encodedEndpoint = encodeURIComponent(endpoint);
     return this.request(`${getApiBase()}/admin/feature-flags/endpoint/${encodedEndpoint}`, {
       method: 'PUT',
-      body: JSON.stringify({ mode }),
+      body: { mode },
     });
   }
 

--- a/autobot-frontend/src/utils/VisionMultimodalApiClient.ts
+++ b/autobot-frontend/src/utils/VisionMultimodalApiClient.ts
@@ -9,10 +9,8 @@
  * Issue #582: GUI integration for Vision & Multimodal Interface
  */
 
-import appConfig from '@/config/AppConfig.js';
-import { NetworkConstants } from '@/constants/network';
+import apiClient from '@/utils/ApiClient';
 import { createLogger } from '@/utils/debugUtils';
-import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { getApiBase } from '@/config/ssot-config';
 import type { ApiResponse } from '@/types/api';
 
@@ -318,51 +316,17 @@ export interface GalleryItem {
  * Communicates with /api/vision and /api/multimodal endpoints
  */
 class VisionMultimodalApiClient {
-  private baseUrl: string = '';
-  private baseUrlPromise: Promise<string> | null = null;
-
-  constructor() {
-    this.initializeBaseUrl();
-  }
-
-  private async initializeBaseUrl(): Promise<void> {
-    try {
-      this.baseUrl = await appConfig.getApiUrl('');
-    } catch {
-      logger.warn('AppConfig initialization failed, using NetworkConstants fallback');
-      this.baseUrl = `http://${NetworkConstants.MAIN_MACHINE_IP}:${NetworkConstants.BACKEND_PORT}`;
-    }
-  }
-
-  private async ensureBaseUrl(): Promise<string> {
-    if (this.baseUrl) {
-      return this.baseUrl;
-    }
-
-    if (!this.baseUrlPromise) {
-      this.baseUrlPromise = this.initializeBaseUrl().then(() => this.baseUrl);
-    }
-
-    return await this.baseUrlPromise;
-  }
+  // Base-URL resolution, auth-token injection (with expiry check), 401
+  // auto-logout+redirect, and org-context headers all live on the shared
+  // apiClient singleton (#12152) — this client is a thin typed wrapper
+  // around it, translating raw Response into the local ApiResponse<T> shape.
 
   private async request<T>(
     endpoint: string,
-    options: RequestInit = {}
+    options: { method?: string; body?: unknown } = {}
   ): Promise<ApiResponse<T>> {
-    const baseUrl = await this.ensureBaseUrl();
-    const url = `${baseUrl}${endpoint}`;
-
-    const defaultHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
     try {
-      const response = await fetchWithAuth(url, {
-        ...options,
-        headers: { ...defaultHeaders, ...options.headers },
-      });
-
+      const response = await apiClient.rawRequest(endpoint, options);
       const data = await response.json();
 
       if (!response.ok) {
@@ -387,16 +351,15 @@ class VisionMultimodalApiClient {
     endpoint: string,
     formData: FormData
   ): Promise<ApiResponse<T>> {
-    const baseUrl = await this.ensureBaseUrl();
-    const url = `${baseUrl}${endpoint}`;
-
     try {
-      const response = await fetchWithAuth(url, {
+      // apiClient.rawRequest already handles FormData bodies generically
+      // (strips Content-Type so the browser sets the multipart boundary),
+      // so it composes multi-field/multi-file payloads exactly like the
+      // previous fetchWithAuth-based implementation.
+      const response = await apiClient.rawRequest(endpoint, {
         method: 'POST',
         body: formData,
-        // Don't set Content-Type - browser will set it with boundary for multipart
       });
-
       const data = await response.json();
 
       if (!response.ok) {
@@ -446,7 +409,7 @@ class VisionMultimodalApiClient {
   ): Promise<ApiResponse<ScreenAnalysisResponse>> {
     return this.request<ScreenAnalysisResponse>(`${getApiBase()}/vision/analyze`, {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: request,
     });
   }
 
@@ -459,7 +422,7 @@ class VisionMultimodalApiClient {
   ): Promise<ApiResponse<ElementDetectionResponse>> {
     return this.request<ElementDetectionResponse>(`${getApiBase()}/vision/elements`, {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: request,
     });
   }
 
@@ -470,7 +433,7 @@ class VisionMultimodalApiClient {
   async extractText(request: OCRRequest = {}): Promise<ApiResponse<OCRResponse>> {
     return this.request<OCRResponse>(`${getApiBase()}/vision/ocr`, {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: request,
     });
   }
 
@@ -581,7 +544,7 @@ class VisionMultimodalApiClient {
   ): Promise<ApiResponse<MultiModalResponse>> {
     return this.request<MultiModalResponse>(`${getApiBase()}/multimodal/process/text`, {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: request,
     });
   }
 
@@ -594,7 +557,7 @@ class VisionMultimodalApiClient {
   ): Promise<ApiResponse<EmbeddingResponse>> {
     return this.request<EmbeddingResponse>(`${getApiBase()}/multimodal/embeddings/generate`, {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: request,
     });
   }
 
@@ -607,7 +570,7 @@ class VisionMultimodalApiClient {
   ): Promise<ApiResponse<CrossModalSearchResponse>> {
     return this.request<CrossModalSearchResponse>(`${getApiBase()}/multimodal/search/cross-modal`, {
       method: 'POST',
-      body: JSON.stringify(request),
+      body: request,
     });
   }
 

--- a/autobot-frontend/src/utils/__tests__/FeatureFlagsApiClient.spec.ts
+++ b/autobot-frontend/src/utils/__tests__/FeatureFlagsApiClient.spec.ts
@@ -1,0 +1,125 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * FeatureFlagsApiClient tests (#12152)
+ *
+ * Verifies the client routes every request through the shared apiClient
+ * singleton (so it inherits expiry-aware auth + 401 auto-logout + retry)
+ * instead of its own fetchWithAuth/base-URL plumbing.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    rawRequest: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+}))
+
+import apiClient from '@/utils/ApiClient'
+import { featureFlagsApiClient } from '../FeatureFlagsApiClient'
+
+function mockResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  }
+}
+
+describe('FeatureFlagsApiClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('getFeatureFlagsStatus issues a GET against apiClient.rawRequest', async () => {
+    const status = {
+      current_mode: 'log_only',
+      history: [],
+      endpoint_overrides: {},
+      total_endpoints_configured: 3,
+    }
+    vi.mocked(apiClient.rawRequest).mockResolvedValue(mockResponse(status))
+
+    const result = await featureFlagsApiClient.getFeatureFlagsStatus()
+
+    expect(apiClient.rawRequest).toHaveBeenCalledWith('/api/admin/feature-flags/status', {})
+    // On success this client returns the backend body directly (pre-existing
+    // shape — the backend response already conforms to ApiResponse<T>).
+    expect(result).toEqual(status)
+  })
+
+  it('updateEnforcementMode PUTs the raw { mode } object (apiClient stringifies it)', async () => {
+    vi.mocked(apiClient.rawRequest).mockResolvedValue(
+      mockResponse({ new_mode: 'enforced', updated_by: 'admin', updated_at: '2026-07-23T00:00:00Z' })
+    )
+
+    await featureFlagsApiClient.updateEnforcementMode('enforced')
+
+    expect(apiClient.rawRequest).toHaveBeenCalledWith('/api/admin/feature-flags/enforcement-mode', {
+      method: 'PUT',
+      body: { mode: 'enforced' },
+    })
+  })
+
+  it('setEndpointEnforcement URL-encodes the endpoint and PUTs { mode }', async () => {
+    vi.mocked(apiClient.rawRequest).mockResolvedValue(
+      mockResponse({ endpoint: '/api/chat', mode: 'log_only' })
+    )
+
+    await featureFlagsApiClient.setEndpointEnforcement('/api/chat', 'log_only')
+
+    expect(apiClient.rawRequest).toHaveBeenCalledWith(
+      '/api/admin/feature-flags/endpoint/%2Fapi%2Fchat',
+      { method: 'PUT', body: { mode: 'log_only' } }
+    )
+  })
+
+  it('removeEndpointEnforcement issues a DELETE with no body', async () => {
+    vi.mocked(apiClient.rawRequest).mockResolvedValue(
+      mockResponse({ endpoint: '/api/chat', reverted_to: 'disabled' })
+    )
+
+    await featureFlagsApiClient.removeEndpointEnforcement('/api/chat')
+
+    expect(apiClient.rawRequest).toHaveBeenCalledWith(
+      '/api/admin/feature-flags/endpoint/%2Fapi%2Fchat',
+      { method: 'DELETE' }
+    )
+  })
+
+  it('translates a non-ok response into ApiResponse.success = false with the backend error', async () => {
+    vi.mocked(apiClient.rawRequest).mockResolvedValue(
+      mockResponse({ detail: 'admin only' }, false, 403)
+    )
+
+    const result = await featureFlagsApiClient.getFeatureFlagsStatus()
+
+    expect(result).toEqual({ success: false, error: 'admin only' })
+  })
+
+  it('translates a thrown/network error into ApiResponse.success = false', async () => {
+    vi.mocked(apiClient.rawRequest).mockRejectedValue(new Error('Request timeout after 30000ms'))
+
+    const result = await featureFlagsApiClient.getFeatureFlagsStatus()
+
+    expect(result).toEqual({ success: false, error: 'Request timeout after 30000ms' })
+  })
+
+  it('getAccessControlMetrics builds the query string and issues a GET', async () => {
+    vi.mocked(apiClient.rawRequest).mockResolvedValue(
+      mockResponse({ total_violations: 0, period_days: 7, by_endpoint: {}, by_user: {}, by_day: {}, current_mode: 'log_only' })
+    )
+
+    await featureFlagsApiClient.getAccessControlMetrics({ days: 14, include_details: true })
+
+    expect(apiClient.rawRequest).toHaveBeenCalledWith(
+      '/api/admin/access-control/metrics?days=14&include_details=true',
+      {}
+    )
+  })
+})

--- a/autobot-frontend/src/utils/__tests__/VisionMultimodalApiClient.spec.ts
+++ b/autobot-frontend/src/utils/__tests__/VisionMultimodalApiClient.spec.ts
@@ -1,0 +1,132 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * VisionMultimodalApiClient tests (#12152)
+ *
+ * Verifies the client routes every request through the shared apiClient
+ * singleton (so it inherits expiry-aware auth + 401 auto-logout + retry)
+ * instead of its own fetchWithAuth/base-URL plumbing, and that the
+ * multi-field FormData composition used by combineModalities is preserved.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    rawRequest: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+}))
+
+import apiClient from '@/utils/ApiClient'
+import { visionMultimodalApiClient } from '../VisionMultimodalApiClient'
+
+function mockResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  }
+}
+
+describe('VisionMultimodalApiClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('JSON requests route through apiClient.rawRequest', () => {
+    it('getVisionHealth issues a GET against apiClient.rawRequest', async () => {
+      vi.mocked(apiClient.rawRequest).mockResolvedValue(
+        mockResponse({ status: 'ok', analyzer_ready: true, capabilities: [], element_types_supported: [], interaction_types_supported: [] })
+      )
+
+      const result = await visionMultimodalApiClient.getVisionHealth()
+
+      expect(apiClient.rawRequest).toHaveBeenCalledWith('/api/vision/health', {})
+      expect(result.success).toBe(true)
+      expect(result.data).toMatchObject({ status: 'ok' })
+    })
+
+    it('analyzeScreen sends the raw request object as body (apiClient stringifies it)', async () => {
+      vi.mocked(apiClient.rawRequest).mockResolvedValue(mockResponse({ timestamp: 1 }))
+
+      await visionMultimodalApiClient.analyzeScreen({ session_id: 'abc' })
+
+      expect(apiClient.rawRequest).toHaveBeenCalledWith('/api/vision/analyze', {
+        method: 'POST',
+        body: { session_id: 'abc' },
+      })
+    })
+
+    it('translates a non-ok response into ApiResponse.success = false with the backend error', async () => {
+      vi.mocked(apiClient.rawRequest).mockResolvedValue(
+        mockResponse({ detail: 'analyzer offline' }, false, 503)
+      )
+
+      const result = await visionMultimodalApiClient.getVisionStatus()
+
+      expect(result).toEqual({ success: false, error: 'analyzer offline' })
+    })
+
+    it('translates a thrown/network error into ApiResponse.success = false', async () => {
+      vi.mocked(apiClient.rawRequest).mockRejectedValue(new Error('Request timeout after 30000ms'))
+
+      const result = await visionMultimodalApiClient.getVisionHealth()
+
+      expect(result).toEqual({ success: false, error: 'Request timeout after 30000ms' })
+    })
+  })
+
+  describe('multi-field FormData composition (combineModalities)', () => {
+    it('composes text + image + audio + intent into one FormData and posts it via apiClient.rawRequest', async () => {
+      vi.mocked(apiClient.rawRequest).mockResolvedValue(mockResponse({ success: true, fusion_result: {} }))
+
+      const imageFile = new File(['img'], 'shot.png', { type: 'image/png' })
+      const audioFile = new File(['aud'], 'clip.wav', { type: 'audio/wav' })
+
+      await visionMultimodalApiClient.combineModalities('describe this', imageFile, audioFile, 'analysis')
+
+      expect(apiClient.rawRequest).toHaveBeenCalledTimes(1)
+      const [endpoint, options] = vi.mocked(apiClient.rawRequest).mock.calls[0]
+      expect(endpoint).toBe('/api/multimodal/fusion/combine')
+      expect(options.method).toBe('POST')
+
+      const formData = options.body as FormData
+      expect(formData).toBeInstanceOf(FormData)
+      expect(formData.get('text')).toBe('describe this')
+      expect(formData.get('image_file')).toBe(imageFile)
+      expect(formData.get('audio_file')).toBe(audioFile)
+      expect(formData.get('intent')).toBe('analysis')
+    })
+
+    it('omits absent optional fields (text/image/audio) but always sends intent', async () => {
+      vi.mocked(apiClient.rawRequest).mockResolvedValue(mockResponse({ success: true, fusion_result: {} }))
+
+      await visionMultimodalApiClient.combineModalities(undefined, undefined, undefined, 'decision_making')
+
+      const [, options] = vi.mocked(apiClient.rawRequest).mock.calls[0]
+      const formData = options.body as FormData
+      expect(formData.get('text')).toBeNull()
+      expect(formData.get('image_file')).toBeNull()
+      expect(formData.get('audio_file')).toBeNull()
+      expect(formData.get('intent')).toBe('decision_making')
+    })
+
+    it('processImage posts a single-field FormData (file + intent + optional question)', async () => {
+      vi.mocked(apiClient.rawRequest).mockResolvedValue(mockResponse({ success: true, result_id: 'r1' }))
+
+      const file = new File(['img'], 'shot.png', { type: 'image/png' })
+      await visionMultimodalApiClient.processImage(file, 'visual_qa', 'what is this?')
+
+      const [endpoint, options] = vi.mocked(apiClient.rawRequest).mock.calls[0]
+      expect(endpoint).toBe('/api/multimodal/process/image')
+      const formData = options.body as FormData
+      expect(formData.get('file')).toBe(file)
+      expect(formData.get('intent')).toBe('visual_qa')
+      expect(formData.get('question')).toBe('what is this?')
+    })
+  })
+})


### PR DESCRIPTION
## Thinking Path

`VisionMultimodalApiClient` and `FeatureFlagsApiClient` each re-implemented their own baseUrl resolution (appConfig + NetworkConstants fallback), auth injection (`fetchWithAuth`), and manual JSON serialization — duplicating what the shared `apiClient` singleton already centralizes (baseUrl, auth-token + expiry check, 401 auto-logout/redirect, org-context headers). Fold both onto the canonical client.

## What Changed

- `utils/VisionMultimodalApiClient.ts` and `utils/FeatureFlagsApiClient.ts`: removed the per-client `baseUrl`/`baseUrlPromise`/`initializeBaseUrl`/`ensureBaseUrl` machinery and the `appConfig`/`NetworkConstants`/`fetchWithAuth` imports; `request<T>()` now delegates to `apiClient.rawRequest(endpoint, options)` and maps the raw `Response` into the local `ApiResponse<T>` shape.
- Call sites pass structured `body: { … }` (apiClient serializes) instead of `JSON.stringify(...)`.

## Verification

- SLM Frontend Check / build + type-check green (27 checks pass).
- Behavior preserved: same endpoints, same `ApiResponse<T>` return shape; auth/baseUrl/org-context now handled uniformly by the shared client.

## Model Used

Claude Opus 4.8