### PR TITLE
fix(llc-security): auth + tenant authz on costs/decisions/labels/templates (#12148)

### DIFF
--- a/autobot-backend/llc/api/costs.py
+++ b/autobot-backend/llc/api/costs.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
 from llc.services.model_tiers import get_model_tier_service
 from user_management.database import get_async_session
@@ -127,6 +128,22 @@ class QuotaWindow(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Auth / tenant isolation (GH#12148)
+# ---------------------------------------------------------------------------
+
+
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access to a company-scoped cost request (GH#12148).
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches goals.py/budget.py (GH#12136). Platform
+    admins are exempt.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
+# ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
 
@@ -135,7 +152,8 @@ class QuotaWindow(BaseModel):
 async def costs_by_agent_model(
     company_id: Optional[str] = Query(None, description="Filter by company UUID"),
     session: AsyncSession = Depends(get_async_session),
-    ctx: TenantContext = Depends(lambda: None),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[AgentModelCost]:
     """Return normalised token usage per agent/model pair.
 
@@ -143,7 +161,9 @@ async def costs_by_agent_model(
     across Anthropic, OpenAI, and Google so callers receive a consistent schema.
     ``cachedInputTokens`` is ``0`` for providers without cache hit reporting.
     """
-    effective_company_id = company_id or (str(ctx.org_id) if ctx else None)
+    if company_id:
+        _assert_company_match(ctx, company_id)
+    effective_company_id = company_id or str(ctx.org_id)
     if not effective_company_id:
         return []
 
@@ -201,7 +221,8 @@ async def costs_by_agent_model(
 async def quota_windows(
     company_id: Optional[str] = Query(None, description="Filter by company UUID"),
     session: AsyncSession = Depends(get_async_session),
-    ctx: TenantContext = Depends(lambda: None),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[QuotaWindow]:
     """Return provider quota window structures for all configured providers.
 
@@ -210,7 +231,9 @@ async def quota_windows(
     Anthropic).  Actual headroom values require provider API key configuration
     and are populated by the quota monitor (phase 3).
     """
-    effective_company_id = company_id or (str(ctx.org_id) if ctx else None)
+    if company_id:
+        _assert_company_match(ctx, company_id)
+    effective_company_id = company_id or str(ctx.org_id)
     svc = get_model_tier_service()
 
     # Determine which providers are actively used by looking at cost events

--- a/autobot-backend/llc/api/decisions.py
+++ b/autobot-backend/llc/api/decisions.py
@@ -13,7 +13,10 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from api.user_management.dependencies import get_current_user, require_org_context
+from user_management.services import TenantContext
 
 from ..kb.decision_log import DecisionLogReader
 
@@ -21,16 +24,30 @@ router = APIRouter()
 _reader = DecisionLogReader()
 
 
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access to a company-scoped decision request (GH#12148).
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches goals.py/budget.py (GH#12136). Platform
+    admins are exempt.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
 @router.get("/companies/{company_id}/decisions/search")
 async def search_decisions(
     company_id: str,
     q: str = Query(..., description="Free-text search query"),
     n: int = Query(10, ge=1, le=50, description="Maximum results to return"),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
     """RAG search over the company decisions knowledge base.
 
     Returns ranked results with text, metadata, and similarity distance.
     """
+    _assert_company_match(ctx, company_id)
     try:
         cid = uuid.UUID(company_id)
     except ValueError:
@@ -48,11 +65,14 @@ async def list_decisions(
     until: Optional[datetime] = Query(None, description="Filter decisions before this timestamp (ISO 8601)"),
     limit: int = Query(50, ge=1, le=200, description="Page size"),
     offset: int = Query(0, ge=0, description="Page offset"),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
     """List board decisions for a company, newest-first.
 
     Filterable by approval type and date range.
     """
+    _assert_company_match(ctx, company_id)
     try:
         cid = uuid.UUID(company_id)
     except ValueError:

--- a/autobot-backend/llc/api/labels.py
+++ b/autobot-backend/llc/api/labels.py
@@ -11,16 +11,27 @@ Routes:
   DELETE /api/llc/companies/{company_id}/labels/{label_id}
   POST   /api/llc/companies/{company_id}/labels/work-items/{work_item_id}/labels
   DELETE /api/llc/companies/{company_id}/labels/work-items/{work_item_id}/labels/{label_id}
+
+Auth / tenant isolation (GH#12148): every handler requires an authenticated
+user and an organization context matching the ``{company_id}`` path segment.
+Object-keyed operations additionally verify that the label / work item / label
+set belongs to that company (IDOR guard).
 """
 
+import uuid
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from llc.deps import get_session, service_dep
+from user_management.services import TenantContext
 
+from ..models.label import LLCLabel
+from ..models.work_item import LLCWorkItem
 from ..services.label_service import (
     LabelNameConflict,
     LabelNotFound,
@@ -31,6 +42,51 @@ from ..services.label_service import (
 
 router = APIRouter(prefix="/companies/{company_id}/labels", tags=["llc-labels"])
 _service = service_dep(LLCLabelService)
+
+
+# ------------------------------------------------------------------
+# Auth / tenant isolation (GH#12148)
+# ------------------------------------------------------------------
+
+
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access to a company-scoped label request (GH#12148).
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches goals.py/budget.py (GH#12136). Platform
+    admins are exempt.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
+async def _assert_label_in_company(session: AsyncSession, label_id: str, company_id: str) -> None:
+    """404 unless *label_id* exists and belongs to *company_id* (IDOR guard)."""
+    label = await _service().get(session, label_id)
+    if label is None or str(label.company_id) != company_id:
+        raise HTTPException(status_code=404, detail="Label not found")
+
+
+async def _assert_work_item_in_company(session: AsyncSession, work_item_id: str, company_id: str) -> None:
+    """404 unless *work_item_id* exists and belongs to *company_id* (IDOR guard)."""
+    result = await session.execute(select(LLCWorkItem).where(LLCWorkItem.id == uuid.UUID(work_item_id)))
+    work_item = result.scalar_one_or_none()
+    if work_item is None or str(work_item.company_id) != company_id:
+        raise HTTPException(status_code=404, detail="Work item not found")
+
+
+async def _assert_labels_in_company(session: AsyncSession, label_ids: List[str], company_id: str) -> None:
+    """404 unless every id in *label_ids* is a label owned by *company_id* (IDOR guard)."""
+    wanted = {uuid.UUID(lid) for lid in label_ids}
+    if not wanted:
+        return
+    result = await session.execute(
+        select(func.count())
+        .select_from(LLCLabel)
+        .where(LLCLabel.id.in_(wanted), LLCLabel.company_id == uuid.UUID(company_id))
+    )
+    if int(result.scalar_one()) != len(wanted):
+        raise HTTPException(status_code=404, detail="Label not found")
 
 
 # ------------------------------------------------------------------
@@ -66,7 +122,10 @@ async def create_label(
     company_id: str,
     body: LabelCreate,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
+    _assert_company_match(ctx, company_id)
     try:
         label = await _service().create(
             session,
@@ -86,7 +145,10 @@ async def create_label(
 async def list_labels(
     company_id: str,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
+    _assert_company_match(ctx, company_id)
     return await _service().list_labels(session, company_id=company_id)
 
 
@@ -96,7 +158,11 @@ async def update_label(
     label_id: str,
     body: LabelUpdate,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
+    _assert_company_match(ctx, company_id)
+    await _assert_label_in_company(session, label_id, company_id)
     try:
         label = await _service().update(
             session,
@@ -118,7 +184,11 @@ async def delete_label(
     company_id: str,
     label_id: str,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> None:
+    _assert_company_match(ctx, company_id)
+    await _assert_label_in_company(session, label_id, company_id)
     try:
         await _service().delete(session, label_id=label_id)
         await session.commit()
@@ -137,7 +207,12 @@ async def assign_labels(
     work_item_id: str,
     body: LabelAssign,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
+    _assert_company_match(ctx, company_id)
+    await _assert_work_item_in_company(session, work_item_id, company_id)
+    await _assert_labels_in_company(session, body.label_ids, company_id)
     try:
         assigned = await _service().assign_labels(
             session,
@@ -160,7 +235,11 @@ async def remove_label(
     work_item_id: str,
     label_id: str,
     session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> None:
+    _assert_company_match(ctx, company_id)
+    await _assert_work_item_in_company(session, work_item_id, company_id)
     try:
         await _service().remove_label(
             session,

--- a/autobot-backend/llc/api/templates.py
+++ b/autobot-backend/llc/api/templates.py
@@ -11,6 +11,13 @@ Route group: /llc/templates
   GET    /{template_id}        — fetch full template JSON
   POST   /{template_id}/import — import template into target company
   DELETE /{template_id}        — delete template + remove from ChromaDB
+
+Auth / tenant isolation (GH#12148): every handler requires an authenticated
+user. Company-scoped operations bind the requesting/owning company to the
+caller's authenticated organization context rather than trusting a
+caller-supplied ``company_id`` — a caller can no longer read, publish into,
+import into, or delete templates on behalf of an arbitrary company. DELETE
+additionally requires the caller's org to own the template (or platform admin).
 """
 
 import uuid
@@ -19,6 +26,7 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from llc.models.template import (
     TemplateCategory,
     TemplateDetail,
@@ -38,6 +46,7 @@ from llc.services.template import (
     TemplateService,
 )
 from user_management.database import get_async_session
+from user_management.services import TenantContext
 
 router = APIRouter(prefix="/templates", tags=["llc-templates"])
 
@@ -47,15 +56,34 @@ def _get_service(session: AsyncSession = Depends(get_async_session)) -> Template
     return TemplateService(session=session)
 
 
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject a caller-supplied company that isn't the caller's own org (GH#12148).
+
+    Platform admins are exempt. 403 (not 404) here because the caller is
+    asserting a company identity that isn't theirs — an authorization failure,
+    not a lookup miss.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+
 @router.post("/", response_model=TemplateDetail, status_code=status.HTTP_201_CREATED)
 async def publish_template(
     req: TemplatePublishRequest,
     company_id: Optional[uuid.UUID] = Query(None, description="Owning company ID"),
     svc: TemplateService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> TemplateDetail:
-    """Publish a scrubbed company export as a reusable template (GH#8260)."""
+    """Publish a scrubbed company export as a reusable template (GH#8260).
+
+    The template is owned by the caller's authenticated organization; a
+    caller-supplied ``company_id`` must match it (GH#12148).
+    """
+    if company_id is not None:
+        _assert_company_match(ctx, str(company_id))
     try:
-        result = await svc.publish(req, company_id=company_id)
+        result = await svc.publish(req, company_id=ctx.org_id)
         await svc.session.commit()
         return result
     except ValueError:
@@ -66,8 +94,13 @@ async def publish_template(
 async def search_templates(
     q: str = Query(..., min_length=1, description="Semantic search query"),
     svc: TemplateService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
 ) -> TemplateSearchResponse:
-    """RAG search over platform:template_kb ChromaDB collection (GH#8260)."""
+    """RAG search over platform:template_kb ChromaDB collection (GH#8260).
+
+    Returns platform-level template metadata only; requires authentication
+    (GH#12148).
+    """
     results: List[TemplateSearchResult] = await svc.search(q)
     return TemplateSearchResponse(query=q, results=results, total=len(results))
 
@@ -81,8 +114,16 @@ async def list_templates(
     page_size: int = Query(default=20, ge=1, le=100),
     company_id: Optional[uuid.UUID] = Query(None, description="Requesting company ID"),
     svc: TemplateService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[TemplateRead]:
-    """List templates visible to the requesting company (GH#8260)."""
+    """List templates visible to the caller's organization (GH#8260).
+
+    Private-template visibility is scoped to the authenticated org; a
+    caller-supplied ``company_id`` must match it (GH#12148).
+    """
+    if company_id is not None:
+        _assert_company_match(ctx, str(company_id))
     params = TemplateListParams(
         category=category,
         tag=tag,
@@ -90,24 +131,29 @@ async def list_templates(
         page=page,
         page_size=page_size,
     )
-    return await svc.list_templates(params, requesting_company_id=company_id)
+    return await svc.list_templates(params, requesting_company_id=ctx.org_id)
 
 
 # Static /built-in routes MUST be declared before the dynamic /{template_id}
 # route: FastAPI matches in definition order, so a {template_id: uuid} above
 # would swallow GET /built-in and 422 on UUID parsing of "built-in" (GH#9042).
 @router.get("/built-in", response_model=List[Dict])
-async def list_built_in_templates() -> List[Dict]:
+async def list_built_in_templates(
+    _current_user: dict = Depends(get_current_user),
+) -> List[Dict]:
     """List all built-in company templates (GH#9042).
 
     Returns template metadata only (name, description, category, tags).
-    Does not require authentication or database access.
+    Requires authentication (GH#12148).
     """
     return TemplateService.list_built_in_templates()
 
 
 @router.get("/built-in/{template_key}", response_model=Dict)
-async def get_built_in_template(template_key: str) -> Dict:
+async def get_built_in_template(
+    template_key: str,
+    _current_user: dict = Depends(get_current_user),
+) -> Dict:
     """Fetch a specific built-in template by key (GH#9042).
 
     Args:
@@ -127,10 +173,18 @@ async def get_template(
     template_id: uuid.UUID,
     company_id: Optional[uuid.UUID] = Query(None, description="Requesting company ID"),
     svc: TemplateService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> TemplateDetail:
-    """Fetch full template JSON by ID (GH#8260)."""
+    """Fetch full template JSON by ID (GH#8260).
+
+    Access is evaluated against the caller's authenticated org; a
+    caller-supplied ``company_id`` must match it (GH#12148).
+    """
+    if company_id is not None:
+        _assert_company_match(ctx, str(company_id))
     try:
-        return await svc.get(template_id, requesting_company_id=company_id)
+        return await svc.get(template_id, requesting_company_id=ctx.org_id)
     except TemplateNotFoundError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
     except TemplateAccessError:
@@ -142,8 +196,14 @@ async def import_template(
     template_id: uuid.UUID,
     req: TemplateImportRequest,
     svc: TemplateService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> TemplateImportResult:
-    """Import template into target company; resolves {{SECRET}} placeholders (GH#8260)."""
+    """Import template into target company; resolves {{SECRET}} placeholders (GH#8260).
+
+    The import target must be the caller's authenticated org (GH#12148).
+    """
+    _assert_company_match(ctx, str(req.target_company_id))
     try:
         result = await svc.import_template(template_id, req)
         await svc.session.commit()
@@ -163,8 +223,24 @@ async def import_template(
 async def delete_template(
     template_id: uuid.UUID,
     svc: TemplateService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> None:
-    """Delete template from DB and ChromaDB collection (GH#8260)."""
+    """Delete template from DB and ChromaDB collection (GH#8260).
+
+    Only the owning organization (or a platform admin) may delete a template
+    (GH#12148).
+    """
+    try:
+        detail = await svc.get(template_id, requesting_company_id=ctx.org_id)
+    except TemplateNotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    except TemplateAccessError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    if not ctx.is_platform_admin and str(detail.created_by_company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
     try:
         await svc.delete(template_id)
         await svc.session.commit()

--- a/autobot-backend/llc/tests/test_labels.py
+++ b/autobot-backend/llc/tests/test_labels.py
@@ -225,7 +225,10 @@ def test_list_labels_route(app_client):
 def test_update_label_not_found(app_client):
     client, company_id, label_id, *_ = app_client
 
-    with patch("llc.api.labels._service") as mock_svc:
+    with (
+        patch("llc.api.labels._service") as mock_svc,
+        patch("llc.api.labels._assert_label_in_company", new=AsyncMock()),
+    ):
         svc = AsyncMock()
         svc.update = AsyncMock(side_effect=LabelNotFound(label_id))
         mock_svc.return_value = svc
@@ -241,7 +244,10 @@ def test_update_label_not_found(app_client):
 def test_delete_label_not_found(app_client):
     client, company_id, label_id, *_ = app_client
 
-    with patch("llc.api.labels._service") as mock_svc:
+    with (
+        patch("llc.api.labels._service") as mock_svc,
+        patch("llc.api.labels._assert_label_in_company", new=AsyncMock()),
+    ):
         svc = AsyncMock()
         svc.delete = AsyncMock(side_effect=LabelNotFound(label_id))
         mock_svc.return_value = svc
@@ -255,7 +261,11 @@ def test_assign_labels_work_item_not_found(app_client):
     client, company_id, label_id, *_ = app_client
     work_item_id = str(uuid.uuid4())
 
-    with patch("llc.api.labels._service") as mock_svc:
+    with (
+        patch("llc.api.labels._service") as mock_svc,
+        patch("llc.api.labels._assert_work_item_in_company", new=AsyncMock()),
+        patch("llc.api.labels._assert_labels_in_company", new=AsyncMock()),
+    ):
         svc = AsyncMock()
         svc.assign_labels = AsyncMock(side_effect=WorkItemNotFound(work_item_id))
         mock_svc.return_value = svc
@@ -272,7 +282,10 @@ def test_remove_label_work_item_not_found(app_client):
     client, company_id, label_id, *_ = app_client
     work_item_id = str(uuid.uuid4())
 
-    with patch("llc.api.labels._service") as mock_svc:
+    with (
+        patch("llc.api.labels._service") as mock_svc,
+        patch("llc.api.labels._assert_work_item_in_company", new=AsyncMock()),
+    ):
         svc = AsyncMock()
         svc.remove_label = AsyncMock(side_effect=WorkItemNotFound(work_item_id))
         mock_svc.return_value = svc

--- a/autobot-backend/llc/tests/test_llc_crud_authz.py
+++ b/autobot-backend/llc/tests/test_llc_crud_authz.py
@@ -1,0 +1,335 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Auth + tenant-isolation tests for LLC CRUD/config routers (GH#12148).
+
+costs.py / decisions.py / labels.py / templates.py previously depended only on
+``get_async_session`` / ``get_session`` — no authentication and no tenant
+authorization — allowing an unauthenticated caller to read/mutate ANY company's
+data by supplying an arbitrary ``company_id`` (missing-authentication + IDOR).
+
+Each router is exercised for: unauthenticated -> 401, cross-tenant -> 403/404,
+same-tenant -> success. Labels use the real in-memory ORM harness so the
+IDOR guards run against real rows; decisions/templates mock their KB/DB layer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.models.enums import WorkItemStatus, WorkItemType
+from llc.models.label import LLCLabel
+from llc.models.work_item import LLCWorkItem
+from llc.tests import _e2e_harness as harness
+
+_FIXED_USER_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+_OTHER_ORG = str(uuid.uuid4())
+
+
+@pytest_asyncio.fixture
+async def engine():  # noqa: ANN201
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")  # canonical: ignore py-adhoc-db-engine
+    await harness.create_loop_schema(eng)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )  # canonical: ignore py-adhoc-db-engine
+
+
+def _make_app(
+    session_factory,
+    caller_org_id: str,
+    *,
+    is_platform_admin: bool = False,
+    unauth: bool = False,
+    template_svc: Optional[object] = None,
+) -> FastAPI:  # noqa: ANN001
+    """Build a FastAPI app wiring the 4 CRUD routers with a fixed tenant ctx."""
+    from api.user_management.dependencies import get_current_user, require_org_context
+    from llc.api import costs as costs_api
+    from llc.api import decisions as decisions_api
+    from llc.api import labels as labels_api
+    from llc.api import templates as templates_api
+    from llc.deps import get_session
+    from user_management.database import get_async_session
+    from user_management.services import TenantContext
+
+    app = FastAPI()
+    app.include_router(costs_api.router, prefix="/api/llc")
+    app.include_router(decisions_api.router, prefix="/api/llc")
+    app.include_router(labels_api.router, prefix="/api/llc")
+    app.include_router(templates_api.router, prefix="/api/llc")
+
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    app.dependency_overrides[get_async_session] = _override_session
+    app.dependency_overrides[get_session] = _override_session
+
+    def _override_current_user() -> dict:
+        if unauth:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        return {"id": str(_FIXED_USER_ID), "user_id": str(_FIXED_USER_ID)}
+
+    def _override_tenant() -> TenantContext:
+        return TenantContext(
+            org_id=uuid.UUID(caller_org_id),
+            user_id=_FIXED_USER_ID,
+            is_platform_admin=is_platform_admin,
+        )
+
+    app.dependency_overrides[get_current_user] = _override_current_user
+    app.dependency_overrides[require_org_context] = _override_tenant
+
+    if template_svc is not None:
+        app.dependency_overrides[templates_api._get_service] = lambda: template_svc
+
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def _insert_label(session_factory, company_id: str, name: str = "bug") -> str:  # noqa: ANN001
+    label_id = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(LLCLabel(id=label_id, company_id=uuid.UUID(company_id), name=name, color="#ef4444"))
+        await session.commit()
+    return str(label_id)
+
+
+async def _insert_work_item(session_factory, company_id: str) -> str:  # noqa: ANN001
+    wi_id = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            LLCWorkItem(
+                id=wi_id,
+                company_id=uuid.UUID(company_id),
+                identifier=f"WI-{uuid.uuid4().hex[:8]}",
+                type=WorkItemType.TASK.value,
+                title="Item",
+                status=WorkItemStatus.BACKLOG.value,
+                priority="medium",
+                version=1,
+                labels=[],
+            )
+        )
+        await session.commit()
+    return str(wi_id)
+
+
+# ---------------------------------------------------------------------------
+# labels.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_labels_unauth_returns_401(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, company_id, unauth=True)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/labels")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_labels_same_tenant_update_and_list(session_factory) -> None:  # noqa: ANN001
+    """Same-tenant caller can mutate and list a label owned by their company.
+
+    Uses a pre-seeded label with an explicit id because the SQLite harness has
+    no ``gen_random_uuid()`` server default (Postgres-only); label creation via
+    the service is covered by the service unit tests in test_labels.py.
+    """
+    company_id = str(uuid.uuid4())
+    label_id = await _insert_label(session_factory, company_id)
+    async with _client(_make_app(session_factory, company_id)) as client:
+        patched = await client.patch(f"/api/llc/companies/{company_id}/labels/{label_id}", json={"name": "renamed"})
+        assert patched.status_code == 200, patched.text
+        assert patched.json()["name"] == "renamed"
+        listing = await client.get(f"/api/llc/companies/{company_id}/labels")
+    assert listing.status_code == 200, listing.text
+    assert len(listing.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_labels_cross_tenant_create_returns_404(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, _OTHER_ORG)) as client:
+        resp = await client.post(f"/api/llc/companies/{company_id}/labels", json={"name": "bug"})
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_labels_cross_company_label_idor_returns_404(session_factory) -> None:  # noqa: ANN001
+    """Caller owns company A but references a label that belongs to company B."""
+    company_a = str(uuid.uuid4())
+    company_b = str(uuid.uuid4())
+    label_b = await _insert_label(session_factory, company_b)
+    async with _client(_make_app(session_factory, company_a)) as client:
+        resp = await client.patch(f"/api/llc/companies/{company_a}/labels/{label_b}", json={"name": "hijack"})
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_labels_cross_company_work_item_idor_returns_404(session_factory) -> None:  # noqa: ANN001
+    company_a = str(uuid.uuid4())
+    company_b = str(uuid.uuid4())
+    wi_b = await _insert_work_item(session_factory, company_b)
+    label_a = await _insert_label(session_factory, company_a)
+    async with _client(_make_app(session_factory, company_a)) as client:
+        resp = await client.post(
+            f"/api/llc/companies/{company_a}/labels/work-items/{wi_b}/labels",
+            json={"label_ids": [label_a]},
+        )
+    assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# costs.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_costs_unauth_returns_401(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, company_id, unauth=True)) as client:
+        resp = await client.get("/api/llc/costs/by-agent-model", params={"company_id": company_id})
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_costs_cross_tenant_returns_404(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, _OTHER_ORG)) as client:
+        resp = await client.get("/api/llc/costs/by-agent-model", params={"company_id": company_id})
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_costs_same_tenant_returns_200(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, company_id)) as client:
+        resp = await client.get("/api/llc/costs/by-agent-model", params={"company_id": company_id})
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# decisions.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_decisions_unauth_returns_401(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, company_id, unauth=True)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/decisions")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_decisions_cross_tenant_returns_404(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, _OTHER_ORG)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/decisions")
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_decisions_same_tenant_returns_200(session_factory, monkeypatch) -> None:  # noqa: ANN001
+    from llc.api import decisions as decisions_api
+
+    monkeypatch.setattr(decisions_api._reader, "list_decisions", AsyncMock(return_value=[]))
+    company_id = str(uuid.uuid4())
+    async with _client(_make_app(session_factory, company_id)) as client:
+        resp = await client.get(f"/api/llc/companies/{company_id}/decisions")
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# templates.py
+# ---------------------------------------------------------------------------
+
+
+def _fake_template_service() -> MagicMock:
+    svc = MagicMock()
+    svc.session = AsyncMock()
+    svc.list_templates = AsyncMock(return_value=[])
+    svc.import_template = AsyncMock()
+    svc.delete = AsyncMock()
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_templates_unauth_returns_401(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    app = _make_app(session_factory, company_id, unauth=True, template_svc=_fake_template_service())
+    async with _client(app) as client:
+        resp = await client.get("/api/llc/templates/built-in")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_templates_cross_tenant_list_returns_403(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    app = _make_app(session_factory, _OTHER_ORG, template_svc=_fake_template_service())
+    async with _client(app) as client:
+        resp = await client.get("/api/llc/templates/", params={"company_id": company_id})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_templates_import_cross_tenant_returns_403(session_factory) -> None:  # noqa: ANN001
+    target = str(uuid.uuid4())
+    template_id = str(uuid.uuid4())
+    app = _make_app(session_factory, _OTHER_ORG, template_svc=_fake_template_service())
+    async with _client(app) as client:
+        resp = await client.post(
+            f"/api/llc/templates/{template_id}/import",
+            json={"target_company_id": target, "secrets": {}},
+        )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_templates_delete_non_owner_returns_403(session_factory) -> None:  # noqa: ANN001
+    caller_org = str(uuid.uuid4())
+    template_id = str(uuid.uuid4())
+    svc = _fake_template_service()
+    detail = MagicMock()
+    detail.created_by_company_id = uuid.uuid4()  # owned by a different company
+    svc.get = AsyncMock(return_value=detail)
+    app = _make_app(session_factory, caller_org, template_svc=svc)
+    async with _client(app) as client:
+        resp = await client.delete(f"/api/llc/templates/{template_id}")
+    assert resp.status_code == 403, resp.text
+    svc.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_templates_same_tenant_list_returns_200(session_factory) -> None:  # noqa: ANN001
+    company_id = str(uuid.uuid4())
+    app = _make_app(session_factory, company_id, template_svc=_fake_template_service())
+    async with _client(app) as client:
+        resp = await client.get("/api/llc/templates/", params={"company_id": company_id})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -51200,13 +51200,19 @@ export interface paths {
         };
         /**
          * List Templates
-         * @description List templates visible to the requesting company (GH#8260).
+         * @description List templates visible to the caller's organization (GH#8260).
+         *
+         *     Private-template visibility is scoped to the authenticated org; a
+         *     caller-supplied ``company_id`` must match it (GH#12148).
          */
         get: operations["list_templates_api_llc_templates__get"];
         put?: never;
         /**
          * Publish Template
          * @description Publish a scrubbed company export as a reusable template (GH#8260).
+         *
+         *     The template is owned by the caller's authenticated organization; a
+         *     caller-supplied ``company_id`` must match it (GH#12148).
          */
         post: operations["publish_template_api_llc_templates__post"];
         delete?: never;
@@ -51225,6 +51231,9 @@ export interface paths {
         /**
          * Search Templates
          * @description RAG search over platform:template_kb ChromaDB collection (GH#8260).
+         *
+         *     Returns platform-level template metadata only; requires authentication
+         *     (GH#12148).
          */
         get: operations["search_templates_api_llc_templates_search_get"];
         put?: never;
@@ -51247,7 +51256,7 @@ export interface paths {
          * @description List all built-in company templates (GH#9042).
          *
          *     Returns template metadata only (name, description, category, tags).
-         *     Does not require authentication or database access.
+         *     Requires authentication (GH#12148).
          */
         get: operations["list_built_in_templates_api_llc_templates_built_in_get"];
         put?: never;
@@ -51294,6 +51303,9 @@ export interface paths {
         /**
          * Get Template
          * @description Fetch full template JSON by ID (GH#8260).
+         *
+         *     Access is evaluated against the caller's authenticated org; a
+         *     caller-supplied ``company_id`` must match it (GH#12148).
          */
         get: operations["get_template_api_llc_templates__template_id__get"];
         put?: never;
@@ -51301,6 +51313,9 @@ export interface paths {
         /**
          * Delete Template
          * @description Delete template from DB and ChromaDB collection (GH#8260).
+         *
+         *     Only the owning organization (or a platform admin) may delete a template
+         *     (GH#12148).
          */
         delete: operations["delete_template_api_llc_templates__template_id__delete"];
         options?: never;
@@ -51320,6 +51335,8 @@ export interface paths {
         /**
          * Import Template
          * @description Import template into target company; resolves {{SECRET}} placeholders (GH#8260).
+         *
+         *     The import target must be the caller's authenticated org (GH#12148).
          */
         post: operations["import_template_api_llc_templates__template_id__import_post"];
         delete?: never;


### PR DESCRIPTION
## Thinking Path
Part of the #12148 systemic LLC missing-auth campaign. All four are user-facing CRUD/config routers with handlers guarded only by `Depends(get_async_session)` (or a `lambda: None` no-op TenantContext). Applied the goals.py/budget.py pattern per router.

## What Changed
- **costs.py** (2) — replaced placeholder `ctx = Depends(lambda: None)` (disabled auth) with `get_current_user` + `require_org_context` + `_assert_company_match` (404 cross-tenant, admin exempt); query fallback bound to `ctx.org_id`.
- **decisions.py** (2) — added auth + `_assert_company_match(ctx, company_id)` on both routes.
- **labels.py** (6) — auth + `_assert_company_match` on all handlers, plus 3 IDOR helpers (`_assert_label_in_company`, `_assert_work_item_in_company`, `_assert_labels_in_company`) that load the object and verify its company. Closes a real IDOR where a same-company caller could mutate another company's label/work-item, or assign another company's labels, via the shared path.
- **templates.py** (8) — platform-shared library where `company_id` was a trusted caller-supplied param. Bound requesting/owning company to `ctx.org_id`; `_assert_company_match` (403) on mismatch. **DELETE previously had no scoping (anyone could delete any template)** → now requires caller org to own the template (or platform admin). The 3 previously-public routes (`/search`, `/built-in`, `/built-in/{key}`) now require `get_current_user` (deny-by-default; no tenant behavior changed).

## Verification
- New `test_llc_crud_authz.py` + updated `test_labels.py`: 60 passed across the 4 affected files; **1184 passed / 2 skipped across full `llc/tests/`, 0 regressions**. (unauth→401, cross-tenant→404/403, same-tenant→works.)
- Follow-up noted: in-memory SQLite harness can't create `LLCLabel` via the service (PK relies on PG `gen_random_uuid()` server default) — label test seeds an explicit id + exercises PATCH/LIST; service-create already covered by existing unit tests.

## Model Used
Opus 4.8

Part of #12148.
