### PR TITLE
refactor(frontend): rename duplicate-name composables + add test-reset seams (#12151)

### DIFF
--- a/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
+++ b/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
@@ -103,7 +103,7 @@ import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { formatDateTime } from '@/utils/formatHelpers'
-import { useKnowledgeVectorization } from '@/composables/knowledge/useKnowledgeVectorization'
+import { useFailedVectorizationJobs } from '@/composables/knowledge/useFailedVectorizationJobs'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 
@@ -119,7 +119,7 @@ const {
   retryJob: retryJobBase,
   deleteJob: deleteJobBase,
   clearAllFailed: clearAllFailedBase,
-} = useKnowledgeVectorization()
+} = useFailedVectorizationJobs()
 
 // Delete a single job — confirm before delegating to composable
 const deleteJob = async (jobId: string) => {

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -395,8 +395,8 @@ import { ref, shallowRef, computed, onMounted, onUnmounted, watch, nextTick, def
 import type cytoscape from 'cytoscape'
 import type { Core, NodeSingular } from 'cytoscape'
 import { useCytoscapeLibrary } from '@/composables/charts/useCytoscapeLibrary'
-import { useKnowledgeGraph } from '@/composables/knowledge/useKnowledgeGraph'
-import type { GraphEntity as Entity, GraphRelation as Relation } from '@/composables/knowledge/useKnowledgeGraph'
+import { useKnowledgeGraphEntities } from '@/composables/knowledge/useKnowledgeGraphEntities'
+import type { GraphEntity as Entity, GraphRelation as Relation } from '@/composables/knowledge/useKnowledgeGraphEntities'
 import { createLogger } from '@/utils/debugUtils'
 import { useTransientError } from '@/composables/useTransientError'
 import { getCssVar } from '@/composables/useCssVars'
@@ -431,7 +431,7 @@ const emit = defineEmits<{
 // Types
 // ============================================================================
 
-// Entity and Relation types are imported from useKnowledgeGraph composable.
+// Entity and Relation types are imported from useKnowledgeGraphEntities composable.
 
 interface NewEntity {
   name: string
@@ -450,7 +450,7 @@ const {
   errorMessage: graphError,
   fetchGraphData,
   createGraphEntity,
-} = useKnowledgeGraph()
+} = useKnowledgeGraphEntities()
 
 const { message: errorMessage, show: showError, clear: clearError } = useTransientError(5000)
 watch(graphError, (msg) => {
@@ -883,7 +883,7 @@ function handleCleanupComplete(): void {
 }
 
 /**
- * Refreshes the knowledge graph by delegating to useKnowledgeGraph.fetchGraphData().
+ * Refreshes the knowledge graph by delegating to useKnowledgeGraphEntities.fetchGraphData().
  * Emits 'graph-refreshed' event on successful load with entity/relation counts.
  */
 async function refreshGraph(): Promise<void> {
@@ -911,7 +911,7 @@ async function refreshGraph(): Promise<void> {
 
 /**
  * Creates a new entity via the composable, updates the graph, and emits events.
- * Validates required fields before delegating to useKnowledgeGraph.createGraphEntity().
+ * Validates required fields before delegating to useKnowledgeGraphEntities.createGraphEntity().
  */
 async function createEntity(): Promise<void> {
   if (!newEntity.value.name || !newEntity.value.type || !newEntity.value.observations) {

--- a/autobot-frontend/src/composables/knowledge/useFailedVectorizationJobs.ts
+++ b/autobot-frontend/src/composables/knowledge/useFailedVectorizationJobs.ts
@@ -4,7 +4,7 @@
 // Author: mrveiss
 
 /**
- * useKnowledgeVectorization Composable
+ * useFailedVectorizationJobs Composable
  *
  * Manages failed vectorization jobs — fetching, retrying, deleting, and
  * clearing all failed jobs. Extracted from FailedVectorizationsManager (#6041).
@@ -19,7 +19,7 @@ import { getApiBase } from '@/config/ssot-config'
 import { useLoadingState } from '@/composables/useLoadingState'
 import { createLogger } from '@/utils/debugUtils'
 
-const logger = createLogger('useKnowledgeVectorization')
+const logger = createLogger('useFailedVectorizationJobs')
 
 // ==================== Types ====================
 
@@ -103,7 +103,7 @@ export const clearAllFailedVectorizationJobs = async (): Promise<number> => {
 
 // ==================== Reactive composable ====================
 
-export interface UseKnowledgeVectorizationReturn {
+export interface UseFailedVectorizationJobsReturn {
   /** Current list of failed vectorization jobs. */
   failedJobs: Readonly<Ref<FailedVectorizationJob[]>>
   /** Set of job IDs currently being retried. */
@@ -127,7 +127,7 @@ export interface UseKnowledgeVectorizationReturn {
   clearAllFailedVectorizationJobs: typeof clearAllFailedVectorizationJobs
 }
 
-export function useKnowledgeVectorization(): UseKnowledgeVectorizationReturn {
+export function useFailedVectorizationJobs(): UseFailedVectorizationJobsReturn {
   const failedJobs = ref<FailedVectorizationJob[]>([])
   const retryingJobs = ref<Set<string>>(new Set())
   const error = ref<string | null>(null)

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeGraphEntities.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeGraphEntities.ts
@@ -4,7 +4,7 @@
 // Author: mrveiss
 
 /**
- * useKnowledgeGraph
+ * useKnowledgeGraphEntities
  *
  * Encapsulates all HTTP fetching for the KnowledgeGraph component (#6040):
  *   - fetchGraphData()  — parallel GET for unified graph + memory entities
@@ -21,7 +21,7 @@ import { getApiBase } from '@/config/ssot-config'
 import { useLoadingState } from '@/composables/useLoadingState'
 import { createLogger } from '@/utils/debugUtils'
 
-const logger = createLogger('useKnowledgeGraph')
+const logger = createLogger('useKnowledgeGraphEntities')
 
 // ============================================================================
 // Types
@@ -59,7 +59,7 @@ export interface GraphData {
 // Composable
 // ============================================================================
 
-export interface UseKnowledgeGraphReturn {
+export interface UseKnowledgeGraphEntitiesReturn {
   /** Current entity list (merged from unified KB + memory endpoints). */
   entities: Readonly<Ref<GraphEntity[]>>
   /** Current relation list (deduplicated). */
@@ -77,7 +77,7 @@ export interface UseKnowledgeGraphReturn {
   createGraphEntity: (payload: NewEntityPayload) => Promise<GraphEntity | null>
 }
 
-export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
+export function useKnowledgeGraphEntities(): UseKnowledgeGraphEntitiesReturn {
   const entities = ref<GraphEntity[]>([])
   const relations = ref<GraphRelation[]>([])
   const errorMessage = ref('')

--- a/autobot-frontend/src/composables/useActionQueue.ts
+++ b/autobot-frontend/src/composables/useActionQueue.ts
@@ -92,6 +92,13 @@ async function _processQueue(): Promise<void> {
   _isProcessing.value = false
 }
 
+/** Test-only: reset module-level state to its initial values. */
+export function _resetForTests(): void {
+  _handlers.clear()
+  _queue.value = []
+  _isProcessing.value = false
+}
+
 export function useActionQueue() {
   const { isOnline } = useNetworkStatus()
 

--- a/autobot-frontend/src/composables/useConfirmDialog.ts
+++ b/autobot-frontend/src/composables/useConfirmDialog.ts
@@ -31,6 +31,13 @@ function _resolve(value: boolean): void {
   resolve?.(value)
 }
 
+/** Test-only: reset module-level state to its initial values. */
+export function _resetForTests(): void {
+  dialogVisible.value = false
+  dialogOptions.value = null
+  resolveRef.value = null
+}
+
 export function useConfirmDialog() {
   return { confirm, dialogVisible, dialogOptions, _resolve }
 }

--- a/autobot-frontend/src/composables/usePushNotifications.ts
+++ b/autobot-frontend/src/composables/usePushNotifications.ts
@@ -53,6 +53,14 @@ if (_getPushSupported()) {
     .catch(() => {})
 }
 
+/** Test-only: reset module-level state to its initial values. */
+export function _resetForTests(): void {
+  _subscribed.value = false
+  _permissionState.value = 'default'
+  _loading.value = false
+  _error.value = null
+}
+
 /**
  * Composable for Web Push Notification lifecycle (GH#4459).
  *

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -698,6 +698,30 @@ function _handleVadSpeechEnd(audio: Float32Array): void {
     })
 }
 
+/** Test-only: reset module-level state to its initial values. */
+export function _resetForTests(): void {
+  state.value = 'idle'
+  mode.value = 'walkie-talkie'
+  currentTranscript.value = ''
+  bubbles.value = []
+  isActive.value = false
+  errorMessage.value = ''
+  silenceThreshold.value = 1500
+  audioLevel.value = 0
+  currentLanguage.value = 'en'
+  _recognition = null
+  _voiceUnsubscribe = null
+  _vadAudioCtx = null
+  _vadNode = null
+  _micStream = null
+  _sileroVad = null
+  _whisperFallback = false
+  _fallbackRecorder = null
+  _fallbackStream = null
+  _transcribeController = null
+  _ttsCooldownTimer = null
+}
+
 // ─── Main composable ────────────────────────────────────
 
 export function useVoiceConversation() {


### PR DESCRIPTION
Closes #12151
Part of #11658 (Tier-2, owner-approved)

## What Changed
**Renames (removes the same-name import landmine — each had exactly 1 consumer):**
- `composables/knowledge/useKnowledgeGraph.ts` → `useKnowledgeGraphEntities.ts` (consumer: KnowledgeGraph.vue). Root singleton `composables/useKnowledgeGraph.ts` + its 9 consumers untouched.
- `composables/knowledge/useKnowledgeVectorization.ts` → `useFailedVectorizationJobs.ts` (consumer: FailedVectorizationsManager.vue). Root document-status tracker + its 5 consumers untouched.
- `useSecretsAuditApi` pair: **genuinely diverges** (root = audit-log entries; `security/` = infra hosts + secrets-usage) — NOT a dupe, left as-is. Follow-up filed to rename the `security/` one to `useSecretsInfraApi`.

**Test-reset seams (additive):** `_resetForTests()` added to useConfirmDialog, useActionQueue, usePushNotifications, useVoiceConversation (resets module-level state only; no browser-cleanup side effects). Matches existing `_resetProbeRegistryForTesting` pattern.

## Verification
`git mv` preserves history; zero stale imports of old paths (verified); vue-tsc `-p tsconfig.app.json` exit 0; oxlint clean. Additive-only for the seams.

## Model Used
Claude Sonnet (subagent), reviewed by Opus 4.8