### PR TITLE
fix(frontend): register useVoiceConversation watchers once, not per-call (#12153)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useVoiceConversation.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceConversation.test.ts
@@ -1,0 +1,152 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// useVoiceConversation watcher single-registration (#12153): this composable
+// is a MODULE-SINGLETON (state declared at module scope, #1037) but is
+// invoked once per mounted caller (VoiceConversationPanel,
+// VoiceConversationOverlay, ChatInterface). Registering `watch(isSpeaking,
+// ...)` / `watch(prefLanguage, ...)` inside the exported function body meant
+// every mounted caller registered ANOTHER watcher on the same module-level
+// refs, so a single TTS-completion or language-preference change fired
+// `_resumeAutoListening` (and the language handler) once PER mounted
+// caller. The fix hoists both watch() registrations to module scope
+// (immediately after `_handleVadSpeechEnd`, before `useVoiceConversation()`)
+// so they run exactly once, no matter how many times the composable is
+// called.
+//
+// isSpeaking/language are themselves module-singleton refs (see
+// useVoiceOutput.ts / usePreferences.ts) — the mocks below replicate that by
+// creating each ref ONCE inside the mock factory closure, so every call to
+// useVoiceOutput()/usePreferences() (production or test) observes the same
+// instance, exactly like the real composables.
+
+import { describe, it, expect, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+
+vi.mock('@/composables/useVoiceOutput', () => {
+  const isSpeaking = ref(false)
+  return {
+    useVoiceOutput: () => ({
+      isSpeaking,
+      wsConnected: ref(false),
+      unlockAudio: vi.fn(),
+      stopSpeaking: vi.fn(),
+      speakStreaming: vi.fn(),
+      flushStreaming: vi.fn(),
+      subscribeVoiceMessages: vi.fn(() => vi.fn()),
+      sendVoiceFrame: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('@/composables/usePreferences', () => {
+  const language = ref('en')
+  return {
+    usePreferences: () => ({ language }),
+  }
+})
+
+vi.mock('@/composables/useVoiceProfiles', () => ({
+  useVoiceProfiles: () => ({ effectiveVoiceId: ref('') }),
+}))
+
+vi.mock('@/composables/useRealtimeVoice', () => ({
+  useRealtimeVoice: () => ({
+    connectionState: ref('idle'),
+    errorMessage: ref(''),
+    disconnectReason: ref(''),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+}))
+
+vi.mock('@/models/controllers', () => ({
+  useChatController: () => ({ sendMessage: vi.fn().mockResolvedValue(undefined) }),
+}))
+
+vi.mock('@/stores/useChatStore', () => ({
+  useChatStore: () => ({ sessions: [], currentSessionId: null }),
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+}))
+
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: vi.fn(),
+}))
+
+// createLogger is called ONCE by production (module scope, `const logger =
+// createLogger(...)`); the `debug` fn is defined inside this factory's
+// closure (not the returned arrow fn) so every createLogger() call — in
+// production or in the test below — shares the SAME spy instance.
+vi.mock('@/utils/debugUtils', () => {
+  const debug = vi.fn()
+  return {
+    createLogger: () => ({ debug, warn: vi.fn(), error: vi.fn() }),
+  }
+})
+
+import { useVoiceConversation } from '../useVoiceConversation'
+import { useVoiceOutput } from '@/composables/useVoiceOutput'
+import { usePreferences } from '@/composables/usePreferences'
+import { createLogger } from '@/utils/debugUtils'
+
+// Same singleton instances the module-scope watch() calls in
+// useVoiceConversation.ts observe.
+const { isSpeaking: mockIsSpeaking } = useVoiceOutput()
+const { language: mockLanguage } = usePreferences()
+const { debug: debugSpy } = createLogger('test')
+
+describe('useVoiceConversation — watcher single-registration (#12153)', () => {
+  it('fires the language-change watcher exactly once per preference change, regardless of how many callers are mounted', async () => {
+    // Simulate 3 mounted callers (VoiceConversationPanel,
+    // VoiceConversationOverlay, ChatInterface) all invoking the composable.
+    // Pre-fix, each call registered its OWN `watch(prefLanguage, ...)` on
+    // this same module-singleton ref, so a single language change would
+    // have logged 3 times instead of 1.
+    useVoiceConversation()
+    useVoiceConversation()
+    useVoiceConversation()
+
+    debugSpy.mockClear()
+    mockLanguage.value = 'de'
+    await nextTick()
+
+    const langChangeCalls = debugSpy.mock.calls.filter(
+      (args) => args[0] === 'Language preference changed:',
+    )
+    expect(langChangeCalls).toHaveLength(1)
+    expect(langChangeCalls[0][1]).toBe('de')
+
+    mockLanguage.value = 'en' // reset for isolation from other tests
+    await nextTick()
+    debugSpy.mockClear()
+  })
+
+  it('single-caller trace: isSpeaking flip still resumes listening exactly as before the hoist', async () => {
+    // With a single mounted caller, behavior must be identical to pre-fix:
+    // TTS completion (isSpeaking true→false) while state === 'speaking' in
+    // full-duplex mode resumes listening via _resumeAutoListening.
+    const conversation = useVoiceConversation()
+    conversation.mode.value = 'full-duplex'
+    conversation.isActive.value = true
+    conversation.state.value = 'speaking'
+    conversation.errorMessage.value = ''
+
+    mockIsSpeaking.value = true
+    await nextTick()
+    mockIsSpeaking.value = false
+    await nextTick()
+
+    // _resumeAutoListening → _startListeningInternal; jsdom has no
+    // SpeechRecognition, so the browser-unsupported error surfaces and
+    // state settles at 'idle' — same as pre-fix single-caller behavior.
+    expect(conversation.state.value).toBe('idle')
+    expect(conversation.errorMessage.value).toContain('Chrome, Edge, or Safari 15+')
+
+    conversation.isActive.value = false
+  })
+})

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -538,12 +538,12 @@ function _dispatchTranscript(text: string): void {
       speakStreaming(speechText)
       flushStreaming()
       // #6823: removed local one-shot `watch(isSpeaking, ...)` here.
-      // The factory-level watcher (below) is the single source of truth
-      // for TTS-completion handling — pre-fix this duplicate caused
-      // both `_resumeAutoListening` AND `_onSpeakingDone` to fire on
-      // every walkie-talkie/hands-free TTS burst, double-triggering
-      // the hands-free TTS cooldown timer and bouncing state through
-      // 'idle' → 'listening' → 'idle' → 'listening'.
+      // The module-level watcher (#12153, defined above this function) is
+      // the single source of truth for TTS-completion handling — pre-fix
+      // this duplicate caused both `_resumeAutoListening` AND
+      // `_onSpeakingDone` to fire on every walkie-talkie/hands-free TTS
+      // burst, double-triggering the hands-free TTS cooldown timer and
+      // bouncing state through 'idle' → 'listening' → 'idle' → 'listening'.
     }
   }).catch((err) => {
     logger.error('Failed to send voice transcript:', err)
@@ -722,10 +722,45 @@ export function _resetForTests(): void {
   _ttsCooldownTimer = null
 }
 
+// ─── Module-level watchers (#12153) ──────────────────────
+// Registered ONCE at module load — NOT inside useVoiceConversation(). That
+// function is invoked once per mounted caller (VoiceConversationPanel,
+// VoiceConversationOverlay, ChatInterface); a watch() registered in its body
+// added ANOTHER watcher on these module-singleton refs per mounted caller,
+// so `_resumeAutoListening` (and the language handler) fired once PER
+// mounted caller on every TTS-completion / language-preference change
+// instead of once. `isSpeaking` / `language` are themselves module-singleton
+// refs (useVoiceOutput.ts / usePreferences.ts), so resolving them here —
+// like the `_realtimeVoice` singleton above (#7345) — is safe and stable
+// for the app's lifetime.
+const { isSpeaking } = useVoiceOutput()
+const { language: prefLanguage } = usePreferences()
+
+// #6823: single source of truth for TTS-completion handling. Routes
+// through `_resumeAutoListening` (not the redundant `_onSpeakingDone`)
+// so the hands-free TTS cooldown timer is set exactly once per burst
+// — was previously fired by both the inner `_dispatchTranscript`
+// watcher AND this outer one.
+watch(isSpeaking, (speaking) => {
+  if (!speaking && state.value === 'speaking') {
+    _resumeAutoListening()
+  }
+})
+
+// #1334: Update STT language when preference changes mid-conversation
+watch(prefLanguage, (newLang) => {
+  currentLanguage.value = newLang || 'en'
+  if (_recognition && state.value === 'listening') {
+    const bcp47 = _LANG_TO_BCP47[newLang] || newLang
+    _recognition.lang = bcp47
+  }
+  logger.debug('Language preference changed:', newLang)
+})
+
 // ─── Main composable ────────────────────────────────────
 
 export function useVoiceConversation() {
-  const { isSpeaking, unlockAudio, stopSpeaking } = useVoiceOutput()
+  const { unlockAudio, stopSpeaking } = useVoiceOutput()
 
   const isListening = computed(() => state.value === 'listening')
   const isProcessing = computed(() => state.value === 'processing')
@@ -857,28 +892,6 @@ export function useVoiceConversation() {
     }
     logger.debug('Mode switched to:', newMode)
   }
-
-  // #6823: single source of truth for TTS-completion handling. Routes
-  // through `_resumeAutoListening` (not the redundant `_onSpeakingDone`)
-  // so the hands-free TTS cooldown timer is set exactly once per burst
-  // — was previously fired by both the inner `_dispatchTranscript`
-  // watcher AND this outer one.
-  watch(isSpeaking, (speaking) => {
-    if (!speaking && state.value === 'speaking') {
-      _resumeAutoListening()
-    }
-  })
-
-  // #1334: Update STT language when preference changes mid-conversation
-  const { language: prefLanguage } = usePreferences()
-  watch(prefLanguage, (newLang) => {
-    currentLanguage.value = newLang || 'en'
-    if (_recognition && state.value === 'listening') {
-      const bcp47 = _LANG_TO_BCP47[newLang] || newLang
-      _recognition.lang = bcp47
-    }
-    logger.debug('Language preference changed:', newLang)
-  })
 
   function cleanup(): void {
     deactivate()


### PR DESCRIPTION
## Thinking Path

`useVoiceConversation` is a module-singleton (state at module scope, #1037) but is invoked once per mounted caller (VoiceConversationPanel, VoiceConversationOverlay, ChatInterface). Registering `watch(isSpeaking, …)` / `watch(prefLanguage, …)` inside the exported function body meant every caller added ANOTHER watcher on the same module-level refs — so one TTS-completion or language change fired `_resumeAutoListening` / the language handler once PER mounted caller.

## What Changed

- `composables/useVoiceConversation.ts`: hoisted both `watch()` registrations to module scope (after `_handleVadSpeechEnd`, before the exported `useVoiceConversation()`), so they run exactly once regardless of caller count.
- Added `composables/__tests__/useVoiceConversation.test.ts` (152 lines) proving the language-change watcher fires exactly once with 3 mounted callers, and that single-caller isSpeaking→resume behavior is unchanged.

## Verification

- New vitest test green; SLM Frontend Check / build green (27 checks pass).
- No behavior change for a single caller; eliminates duplicate handler firing for multiple callers.

## Model Used

Claude Opus 4.8


Closes #12153