### PR TITLE
fix(infra): resolve stale playbook paths in Infrastructure Playbooks catalog (#12095)

### DIFF
--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -108,7 +108,7 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         "and Redis VM. Sets up slm, slm_users, and autobot_users databases "
         "with secure authentication and cross-VM connectivity.",
         category=PlaybookCategory.DATABASE,
-        playbook_file="deploy-user-management-db.yml",
+        playbook_file="playbooks/deploy-user-management-db.yml",
         target_hosts=["slm", "redis"],
         variables={
             "postgresql_version": "16",
@@ -124,7 +124,9 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         "RedisGraph, and RedisTimeSeries modules for high-performance "
         "data operations.",
         category=PlaybookCategory.DATABASE,
-        playbook_file="deploy-redis-stack.yml",
+        # #12095: deploy-redis-stack.yml never existed; setup-redis-stack.yml is the
+        # real Redis Stack provisioning playbook (same file the setup-redis-stack entry uses).
+        playbook_file="setup-redis-stack.yml",
         target_hosts=["redis"],
         variables={
             "redis_port": 6379,
@@ -138,7 +140,7 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         name="Monitoring Stack Setup",
         description="Deploy Prometheus, Grafana, and Alertmanager for " "comprehensive fleet monitoring and alerting.",
         category=PlaybookCategory.MONITORING,
-        playbook_file="deploy-slm-manager.yml",
+        playbook_file="playbooks/deploy-slm-manager.yml",
         target_hosts=["slm_server"],
         variables={
             "prometheus_port": 9090,
@@ -153,7 +155,7 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         name="PostgreSQL Database Setup",
         description="Deploy PostgreSQL 16 database server for SLM " "backend data persistence.",
         category=PlaybookCategory.DATABASE,
-        playbook_file="deploy-slm-manager.yml",
+        playbook_file="playbooks/deploy-slm-manager.yml",
         target_hosts=["slm_server"],
         variables={
             "postgresql_version": "16",
@@ -169,7 +171,9 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         description="Generate and deploy TLS certificates for secure "
         "communication between fleet nodes using internal CA.",
         category=PlaybookCategory.SECURITY,
-        playbook_file="deploy-tls.yml",
+        # #12095: deploy-tls.yml never existed; enable-tls.yml is the canonical
+        # fleet TLS enablement playbook. (Mapping pending owner confirmation.)
+        playbook_file="enable-tls.yml",
         target_hosts=["all"],
         variables={
             "cert_validity_days": 365,
@@ -186,7 +190,7 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         "configuration (redis, backend, frontend, AI, NPU, browser) "
         "in dependency order.",
         category=PlaybookCategory.NETWORKING,
-        playbook_file="provision-fleet-roles.yml",
+        playbook_file="playbooks/provision-fleet-roles.yml",
         target_hosts=["slm_nodes"],
         variables={},
         estimated_duration="20-30 minutes",
@@ -199,7 +203,7 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         "via the REST API. Assigns roles for heartbeat acceptance "
         "and fleet dashboard visibility.",
         category=PlaybookCategory.NETWORKING,
-        playbook_file="seed-fleet-nodes.yml",
+        playbook_file="playbooks/seed-fleet-nodes.yml",
         target_hosts=["localhost"],
         variables={},
         estimated_duration="1-2 minutes",
@@ -212,7 +216,7 @@ AVAILABLE_PLAYBOOKS: list[PlaybookInfo] = [
         "frontend, nginx, TLS, monitoring, seed nodes, and "
         "auto-provision all fleet roles.",
         category=PlaybookCategory.NETWORKING,
-        playbook_file="deploy-slm-manager.yml",
+        playbook_file="playbooks/deploy-slm-manager.yml",
         target_hosts=["slm_server", "slm_nodes"],
         variables={},
         estimated_duration="30-45 minutes",

--- a/autobot-slm-backend/tests/test_infrastructure_playbooks.py
+++ b/autobot-slm-backend/tests/test_infrastructure_playbooks.py
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Smoke test: every Infrastructure Playbooks catalog entry resolves to a real file.
+
+Guards against the #12095 bug class — catalog ``playbook_file`` values that point at
+a path which does not exist under ``ansible/`` (missing ``playbooks/`` prefix or a
+renamed/removed playbook), so clicking the entry raised ``FileNotFoundError`` at
+``os.path.join(PLAYBOOKS_DIR, playbook_file)`` in ``api/infrastructure.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+_ANSIBLE_DIR = _BACKEND_ROOT / "ansible"
+for _p in (str(_BACKEND_ROOT), str(_BACKEND_ROOT.parent)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# api.infrastructure only needs these two light service deps for its pure-data
+# catalog; stub them so the module loads without dragging in auth/jwt machinery,
+# and restore afterwards so other tests still get the real modules.
+_STUB_KEYS = ("services.auth", "services.ansible_utils")
+
+
+def _load_catalog():
+    saved = {k: sys.modules.get(k) for k in _STUB_KEYS}
+    for k in _STUB_KEYS:
+        sys.modules[k] = MagicMock()
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_infra_catalog_test", _BACKEND_ROOT / "api" / "infrastructure.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return list(module.AVAILABLE_PLAYBOOKS)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+_CATALOG = _load_catalog()
+
+
+def test_catalog_is_non_empty():
+    assert _CATALOG, "AVAILABLE_PLAYBOOKS is empty — catalog failed to load"
+
+
+@pytest.mark.parametrize("playbook", _CATALOG, ids=lambda p: p.id)
+def test_playbook_file_resolves_to_real_file(playbook):
+    resolved = _ANSIBLE_DIR / playbook.playbook_file
+    assert resolved.is_file(), (
+        f"Catalog entry {playbook.id!r} points at {playbook.playbook_file!r} "
+        f"which does not exist under {_ANSIBLE_DIR} (resolved: {resolved})"
+    )


### PR DESCRIPTION
## Thinking Path
While implementing #12083 the Infrastructure Playbooks catalog (`api/infrastructure.py` `AVAILABLE_PLAYBOOKS`) was flagged for stale `deploy-slm-manager.yml` paths. `run_infrastructure_playbook` resolves each entry via `os.path.join(PLAYBOOKS_DIR, playbook_file)` (line ~600), so a bare filename that actually lives under `ansible/playbooks/` — or a filename with no backing file at all — raises `FileNotFoundError` when the entry is run. An audit of the full catalog found **8 broken entries**, not just the 3 originally reported.

## What Changed
`api/infrastructure.py` — corrected 8 `playbook_file` values so all 20 entries resolve to a real file under `ansible/`:
- **Missing `playbooks/` prefix** (file is under `ansible/playbooks/`): `deploy-user-management-db`, `monitoring-stack`/`postgresql-db`/`full-slm-deploy` (the 3 `deploy-slm-manager.yml` entries), `provision-fleet-roles`, `seed-fleet-nodes`.
- **Referenced a non-existent file** (semantic remap to the real playbook):
  - `redis-stack`: `deploy-redis-stack.yml` → `setup-redis-stack.yml` (the real Redis Stack provisioning playbook, already used by the sibling `setup-redis-stack` entry).
  - `tls-certificates`: `deploy-tls.yml` → `enable-tls.yml` (canonical fleet TLS enablement playbook). **⚠️ This mapping is a best-guess — candidates were `enable-tls.yml` / `deploy-certificate.yml` / `distribute-tls-certs.yml`; owner confirmation welcome.**

Added `tests/test_infrastructure_playbooks.py` — a parametrized smoke test asserting every catalog `playbook_file` resolves to a real file under `ansible/`, so this bug class can't regress silently.

## Verification
```
21 passed in 0.90s
```
(20 catalog entries + non-empty guard; all resolve.) No behavior change beyond pointing the entries at their real files. Entries already correct (`setup-*`, `update-all-nodes`, maintenance playbooks at the ansible root) were left untouched.

## Model Used
Opus 4.8

Closes #12095