### PR TITLE
feat(deploy): standalone autobot_shared ansible role (#12094)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy_role.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy_role.yml
@@ -69,6 +69,17 @@
       when: deploy_role == 'ai-stack'
       tags: ['ai-stack']
 
+    # autobot_shared (#12094): standalone role extracted from the embedded #3649
+    # sync block in roles/backend/tasks/main.yml. Syncing the shared python
+    # package as its OWN role lets per-role Migrate refresh it first, fixing the
+    # staleness class of bugs in #11611. role_registry.py points this role at
+    # deploy_role.yml just like backend/frontend after #12083.
+    - name: "Apply autobot_shared Role"
+      include_role:
+        name: autobot_shared
+      when: deploy_role == 'autobot_shared'
+      tags: ['autobot_shared']
+
     # celery/scheduler (#12083): role_registry.py's celery/scheduler roles share
     # the SAME source (autobot-backend/) and the SAME ansible role — the backend
     # role's tasks (ansible/roles/backend/tasks/main.yml) already deploy the

--- a/autobot-slm-backend/ansible/roles/autobot_shared/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/autobot_shared/defaults/main.yml
@@ -1,0 +1,21 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# autobot_shared Role - Default Variables (#12094)
+# Standalone extraction of the embedded #3649 sync block that previously lived
+# inside roles/backend/tasks/main.yml. Variable names/values intentionally match
+# the backend role so both roles converge on the SAME standalone PYTHONPATH dir.
+
+# Service account owning the synced package (matches common/backend roles).
+backend_user: autobot
+backend_group: autobot
+
+# Canonical git checkout on the box that the deployer pulls into (#3649).
+code_source_dir: /opt/autobot/code_source
+
+# Standalone PYTHONPATH copy imported by backend, Celery, and MCP-bridge
+# services. The backend's embedded autobot_shared path is a symlink here
+# (#10020), so syncing this one directory covers every consumer.
+backend_shared_standalone_dir: /opt/autobot/autobot_shared

--- a/autobot-slm-backend/ansible/roles/autobot_shared/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/autobot_shared/handlers/main.yml
@@ -1,0 +1,17 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# autobot_shared Role - Handlers (#12094)
+# Mirror the notify targets of the extracted #3649 block: consumers of the
+# shared package must reload it after a sync. Handlers only fire on change.
+- name: restart backend
+  ansible.builtin.systemd:
+    name: autobot-backend
+    state: restarted
+
+- name: restart celery
+  ansible.builtin.systemd:
+    name: autobot-celery
+    state: restarted

--- a/autobot-slm-backend/ansible/roles/autobot_shared/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/autobot_shared/tasks/main.yml
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# autobot_shared Role - Main Tasks (#12094)
+# Syncs the single canonical autobot_shared package from code_source to the
+# standalone PYTHONPATH dir imported by backend/Celery/MCP-bridge. Extracted
+# from the embedded #3649 block in roles/backend/tasks/main.yml so per-role
+# Migrate/Redeploy (/api/roles/autobot_shared/migrate) can sync it FIRST as its
+# own step, fixing the staleness class of bugs in #11611.
+
+# Issue #3649: Sync the single canonical autobot_shared to the standalone
+# PYTHONPATH dir. The backend's embedded path is a symlink here (#10020), so
+# syncing this directory is sufficient for all consumers. The .env / *.env
+# excludes protect the deployed systemd EnvironmentFile from --delete (#9970).
+- name: "Shared | Sync autobot_shared to standalone PYTHONPATH dir (#3649, #12094)"
+  ansible.posix.synchronize:
+    src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot_shared/"
+    dest: "{{ backend_shared_standalone_dir }}/"
+    rsync_opts:
+      - "--exclude=__pycache__"
+      - "--exclude=*.pyc"
+      - "--exclude=*.egg-info"
+      - "--exclude=.git"
+      - "--exclude=.env"
+      - "--exclude=*.env"
+      - "--delete"
+  notify:
+    - restart backend
+    - restart celery
+  tags: ['autobot_shared', 'deploy']
+
+- name: "Shared | Fix ownership of standalone autobot_shared (#3649)"
+  ansible.builtin.file:
+    path: "{{ backend_shared_standalone_dir }}"
+    owner: "{{ backend_user }}"
+    group: "{{ backend_group }}"
+    recurse: true
+  tags: ['autobot_shared', 'deploy']

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -388,18 +388,14 @@ _INFRA_ROLES = [
         "post_sync_cmd": (f"cd {_BASE_DIR}/autobot_shared && pip install -e ."),
         "required": True,
         "degraded_without": [],
-        # #12083: "deploy-shared.yml" never existed anywhere under ansible/, and
-        # unlike backend/frontend there is no standalone ansible role for
-        # autobot_shared to repoint at either — its sync is embedded as tasks
-        # INSIDE ansible/roles/backend/tasks/main.yml ("Sync autobot_shared to
-        # standalone PYTHONPATH dir", #3649), not a role of its own. Extracting a
-        # dedicated autobot_shared role/playbook is out of scope here (creating a
-        # new playbook, not a rename) — filed as a follow-up. None matches the
-        # existing postgres precedent (api/roles.py returns HTTP 422 for None)
-        # instead of silently raising FileNotFoundError on every Migrate attempt.
-        # The rsync-based _ensure_autobot_shared_synced path (#11611) remains the
-        # working, correct way this role's content actually gets deployed.
-        "ansible_playbook": None,
+        # #12094: the standalone ansible/roles/autobot_shared/ role now exists
+        # (extracted from the embedded #3649 sync block in roles/backend), and
+        # playbooks/deploy_role.yml dispatches role_name == 'autobot_shared' to
+        # it. Repointing at the generic dispatcher (like backend/frontend after
+        # #12083) makes /api/roles/autobot_shared/migrate sync the shared package
+        # as its OWN first-class step, fixing the staleness class of bugs in
+        # #11611. The rsync-based _ensure_autobot_shared_synced path also remains.
+        "ansible_playbook": "playbooks/deploy_role.yml",
     },
     {
         "name": "slm-agent",


### PR DESCRIPTION
## Thinking Path
`/api/roles/autobot_shared/migrate` failed fast (HTTP 422) because the role's `ansible_playbook` was `None` (interim fix from #12083) — there was no standalone deployable ansible role for `autobot_shared`. Its real deployment logic lived embedded inside `roles/backend/tasks/main.yml` (the #3649 "Sync autobot_shared to standalone PYTHONPATH dir" block), so nothing synced the shared package as its own first-class step, causing the staleness class of bugs in #11611. This PR extracts that block into a standalone role and wires it into the generic `deploy_role.yml` dispatcher, matching the backend/frontend pattern established in #12083.

## What Changed
- **New role `ansible/roles/autobot_shared/`** — faithful extraction of the embedded #3649 block:
  - `tasks/main.yml` — `ansible.posix.synchronize` from `code_source/autobot_shared/` to `backend_shared_standalone_dir`, plus ownership fix. Every rsync carries `--exclude=.env` and `--exclude=*.env` (protects the deployed EnvironmentFile from `--delete`, #9970), alongside the original `__pycache__`/`*.pyc`/`*.egg-info`/`.git` excludes.
  - `defaults/main.yml` — reuses the exact backend-role variable names/values (`backend_user`, `backend_group`, `code_source_dir`, `backend_shared_standalone_dir`) so both roles converge on the same target dir.
  - `handlers/main.yml` — `restart backend` / `restart celery`, mirroring the embedded block's `notify`.
- **`playbooks/deploy_role.yml`** — added an `include_role: autobot_shared` dispatch task `when: deploy_role == 'autobot_shared'`.
- **`services/role_registry.py`** — `autobot_shared.ansible_playbook`: `None` → `"playbooks/deploy_role.yml"` (comment updated to reflect the now-existing role).

The embedded backend block is intentionally left in place (repo rule: never delete code, wire it in). See Verification for the double-sync analysis — it is idempotent and harmless; deduping it is noted as a safe follow-up.

## Verification
- YAML parse (all new/edited): `python3 -c "import yaml; yaml.safe_load(open(f))"` → OK for `defaults/main.yml`, `tasks/main.yml`, `handlers/main.yml`, `deploy_role.yml`.
- Python AST: `python3 -c "import ast; ast.parse(open('services/role_registry.py').read())"` → OK.
- `tools/lint/check_canonical_role_names.py` → clean; `tools/lint/check_spdx_header.py` on the 3 new files → exit 0.
- Pre-commit hooks passed on commit (no `--no-verify`).
- ansible-lint not installed in this environment (`which ansible-lint` → none), so it was not run.
- Double-sync risk: `autobot_shared`-only Migrate runs this role; a `backend` Migrate still runs the embedded block. Both are the same idempotent rsync to the same dir — running either or both leaves identical state (no harm). Live `POST /api/roles/autobot_shared/migrate` against a node was not executed here (no box access); to be validated by the reviewer on a live node per the issue's final acceptance box.

## Model Used
Sonnet

Closes #12094
