### PR TITLE
fix(llc-security): auth+tenant on approvals/portability/agent_hires — batch 1 of #12148 (#12163)

### DIFF
--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -75,7 +75,6 @@ router.include_router(context_router)
 router.include_router(controls_router)
 router.include_router(labels_router)
 router.include_router(templates_router)
-router.include_router(agent_hires_router)
 router.include_router(costs_router)
 
 

--- a/autobot-backend/llc/api/agent_hires.py
+++ b/autobot-backend/llc/api/agent_hires.py
@@ -8,6 +8,13 @@ Routes:
   POST /agent-hires                           — create assistant agent, auto-resolves cheap model
   GET  /agent-hires                           — list hire records for the org
   POST /companies/{company_id}/agent-hires    — hire Sonnet or Haiku agent, generates AGENTS.md stub
+
+Access control: every route requires an authenticated session whose tenant
+(``TenantContext.org_id``) matches the target company — either an explicit
+``company_id`` (body or path) or, when omitted, the caller's own org
+(GH#12163). Platform admins are exempt. 404 (not 403) on mismatch so a
+cross-tenant caller can't distinguish "not my company" from "doesn't exist" —
+matches goals.py/secrets.py (GH#12136, GH#12147).
 """
 
 from __future__ import annotations
@@ -21,6 +28,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
 from llc.adapters import registered_adapter_types
 from llc.services.budget import BudgetService
@@ -212,6 +220,22 @@ async def _fetch_company_model_overrides(
 
 
 # ---------------------------------------------------------------------------
+# Auth / tenant isolation (GH#12163)
+# ---------------------------------------------------------------------------
+
+
+def _assert_company_match(ctx: TenantContext, company_id: str) -> None:
+    """Reject cross-tenant access to a company-scoped hire request.
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches goals.py/secrets.py (GH#12136, GH#12147).
+    Platform admins are exempt.
+    """
+    if company_id != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
+# ---------------------------------------------------------------------------
 # GH#8487 — general auto-resolve routes
 # ---------------------------------------------------------------------------
 
@@ -220,12 +244,12 @@ async def _fetch_company_model_overrides(
 async def create_agent_hire(
     body: AgentHireCreate,
     session: AsyncSession = Depends(get_async_session),
-    ctx: TenantContext = Depends(lambda: None),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> AgentHireRead:
     """Create an assistant agent with auto-resolved cheap model (GH#8487)."""
-    effective_company_id = str(body.company_id) if body.company_id else (str(ctx.org_id) if ctx else None)
-    if not effective_company_id:
-        raise HTTPException(status_code=400, detail="company_id is required")
+    effective_company_id = str(body.company_id) if body.company_id else str(ctx.org_id)
+    _assert_company_match(ctx, effective_company_id)
 
     svc = get_model_tier_service()
     senior_adapter_cfg: Optional[Dict[str, Any]] = None
@@ -296,11 +320,10 @@ async def create_agent_hire(
 @router.get("/agent-hires", response_model=List[AgentHireRead])
 async def list_agent_hires(
     session: AsyncSession = Depends(get_async_session),
-    ctx: TenantContext = Depends(lambda: None),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[AgentHireRead]:
     """List agent hire records for the caller's org (GH#8487)."""
-    if not ctx:
-        return []
     try:
         result = await session.execute(
             text(
@@ -345,8 +368,11 @@ async def hire_agent(
     company_id: uuid.UUID,
     body: AgentHireRequest,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> AgentHireResponse:
     """Hire a new LLC agent with explicit model selection and AGENTS.md generation."""
+    _assert_company_match(ctx, str(company_id))
     resolved_model = body.model or SONNET_MODEL
     if resolved_model not in _VALID_MODELS:
         raise HTTPException(

--- a/autobot-backend/llc/api/approvals.py
+++ b/autobot-backend/llc/api/approvals.py
@@ -8,6 +8,13 @@ Routes:
   POST   /api/llc/approvals               — request approval
   GET    /api/llc/approvals               — list pending (company_id required)
   POST   /api/llc/approvals/{id}/decide   — approve or reject
+
+Access control: every route requires an authenticated session whose tenant
+(``TenantContext.org_id``) matches the target company — either the
+``company_id`` supplied directly, or the company owning the requested
+``approval_id`` (GH#12163). Platform admins are exempt. 404 (not 403) is used
+on mismatch so a cross-tenant caller can't distinguish "not my company" from
+"doesn't exist" — matches the goals.py/secrets.py idiom (GH#12136, GH#12147).
 """
 
 import uuid
@@ -15,11 +22,15 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
 from llc.deps import get_session, service_dep
+from user_management.services import TenantContext
 
+from ..models.approval import LLCApproval
 from ..models.enums import ApprovalStatus, ApprovalType
 from ..services.approval import (
     ApprovalNotFoundError,
@@ -72,6 +83,32 @@ class ApprovalResponse(BaseModel):
 
 
 # ------------------------------------------------------------------
+# Auth / tenant isolation (GH#12163)
+# ------------------------------------------------------------------
+
+
+def _assert_company_match(ctx: TenantContext, company_id: Any) -> None:
+    """Reject cross-tenant access to a company-scoped approval request.
+
+    404 (not 403) so a cross-tenant caller can't distinguish "not my company"
+    from "doesn't exist" — matches goals.py/secrets.py (GH#12136, GH#12147).
+    Platform admins are exempt.
+    """
+    if str(company_id) != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+
+async def _get_authorized_approval(session: AsyncSession, approval_id: uuid.UUID, ctx: TenantContext) -> LLCApproval:
+    """Load an approval and enforce tenant isolation; 404 if missing or cross-tenant."""
+    result = await session.execute(select(LLCApproval).where(LLCApproval.id == approval_id))
+    approval = result.scalar_one_or_none()
+    if approval is None:
+        raise HTTPException(status_code=404, detail="Approval not found")
+    _assert_company_match(ctx, approval.company_id)
+    return approval
+
+
+# ------------------------------------------------------------------
 # Endpoints
 # ------------------------------------------------------------------
 
@@ -81,8 +118,11 @@ async def request_approval(
     body: ApprovalRequest,
     session: AsyncSession = Depends(get_session),
     svc: ApprovalService = Depends(_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> ApprovalResponse:
     """Create a pending approval gate record."""
+    _assert_company_match(ctx, body.company_id)
     async with session.begin():
         approval = await svc.request_approval(
             session,
@@ -101,6 +141,8 @@ async def list_pending(
     type: Optional[ApprovalType] = Query(None, description="Filter by gate type"),
     session: AsyncSession = Depends(get_session),
     svc: ApprovalService = Depends(_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[ApprovalResponse]:
     """List pending approvals for a company."""
     try:
@@ -108,6 +150,7 @@ async def list_pending(
     except ValueError:
         raise HTTPException(status_code=422, detail="Invalid company_id UUID")
 
+    _assert_company_match(ctx, cid)
     approvals = await svc.get_pending(session, cid, gate_type=type)
     return [_to_response(a) for a in approvals]
 
@@ -118,12 +161,16 @@ async def decide_approval(
     body: ApprovalDecision,
     session: AsyncSession = Depends(get_session),
     svc: ApprovalService = Depends(_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> ApprovalResponse:
     """Approve or reject a pending approval."""
     try:
         aid = uuid.UUID(approval_id)
     except ValueError:
         raise HTTPException(status_code=422, detail="Invalid approval_id UUID")
+
+    await _get_authorized_approval(session, aid, ctx)
 
     try:
         async with session.begin():

--- a/autobot-backend/llc/api/portability.py
+++ b/autobot-backend/llc/api/portability.py
@@ -7,6 +7,14 @@
 Route group: /llc/import
   POST /preview  — collision-detection preview (no writes)
   POST /execute  — transactional import
+
+Access control: both routes require an authenticated session. When
+``target_company_id`` names an existing company, the caller's tenant
+(``TenantContext.org_id``) must match it — platform admins are exempt — so an
+authenticated caller of one company can't import agents/goals/secrets into a
+different company (GH#12163, the IDOR fix). When ``target_company_id`` is
+omitted the import creates a brand-new top-level company (there is no
+existing tenant to check against), matching companies.py's ``create_company``.
 """
 
 import uuid
@@ -16,9 +24,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from llc.services.portability import PortabilityService
 from llc.services.portability import TemplateImportError as LLCImportError
 from user_management.database import get_async_session
+from user_management.services import TenantContext
 
 router = APIRouter(prefix="/import", tags=["llc-import"])
 
@@ -58,6 +68,26 @@ class ImportExecuteResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Auth / tenant isolation (GH#12163)
+# ---------------------------------------------------------------------------
+
+
+def _assert_import_target_access(ctx: TenantContext, target_company_id: Optional[uuid.UUID]) -> None:
+    """Reject importing into a company the caller doesn't belong to.
+
+    No-op when ``target_company_id`` is omitted (new-company import) — there
+    is no existing tenant to check against. 404 (not 403) on mismatch, so a
+    cross-tenant caller can't distinguish "not my company" from "doesn't
+    exist" — matches goals.py/secrets.py (GH#12136, GH#12147). Platform
+    admins are exempt.
+    """
+    if target_company_id is None:
+        return
+    if str(target_company_id) != str(ctx.org_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+
+
+# ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
 
@@ -70,7 +100,10 @@ class ImportExecuteResponse(BaseModel):
 async def preview_import(
     body: ImportPreviewRequest,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> ImportPreviewResponse:
+    _assert_import_target_access(ctx, body.target_company_id)
     svc = PortabilityService(session=session)
     try:
         result = await svc.preview_import(body.template, target_company_id=body.target_company_id)
@@ -88,7 +121,10 @@ async def preview_import(
 async def execute_import(
     body: ImportExecuteRequest,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> ImportExecuteResponse:
+    _assert_import_target_access(ctx, body.target_company_id)
     remapping = body.remapping_options.model_dump(exclude_none=True) if body.remapping_options else {}
     svc = PortabilityService(session=session)
     try:

--- a/autobot-backend/llc/tests/test_agent_hires_idor.py
+++ b/autobot-backend/llc/tests/test_agent_hires_idor.py
@@ -1,0 +1,165 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Auth + IDOR hardening tests for agent_hires.py routes (GH#12163).
+
+Prior to this fix ``hire_agent`` (POST /companies/{company_id}/agent-hires)
+depended only on ``get_async_session`` — no authentication and no
+tenant-authorization dependency — allowing an unauthenticated caller to hire
+an agent into ANY company. ``create_agent_hire`` / ``list_agent_hires`` used a
+vestigial ``Depends(lambda: None)`` in place of real auth, which always
+resolved to ``None`` and silently skipped all tenant checks.
+
+Mirrors test_goals_idor.py / test_secrets_idor.py (GH#12136, GH#12147):
+  - no auth at all                     -> 401
+  - authenticated, cross-tenant access -> 404 (existence disclosure avoided)
+  - authenticated, same-tenant access  -> the expected success status
+  - platform admin                    -> cross-tenant allowed
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+_OTHER_ORG = "99999999-9999-9999-9999-999999999999"
+
+
+def _make_client(caller_org_id: str, is_platform_admin: bool = False) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.agent_hires import router as agent_hires_router  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(agent_hires_router, prefix="/api/llc")
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session.rollback = AsyncMock()
+    execute_result = MagicMock()
+    execute_result.fetchone.return_value = None
+    execute_result.fetchall.return_value = []
+    mock_session.execute = AsyncMock(return_value=execute_result)
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=is_platform_admin
+    )
+
+    patch("llc.api.agent_hires.registered_adapter_types", return_value=["claude_code"]).start()
+    patch("llc.api.agent_hires.BudgetService.provision_budget", new=AsyncMock()).start()
+
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestAgentHiresNoAuth:
+    """No credentials at all -> 401 (real get_current_user, not overridden)."""
+
+    def _make_unauthenticated_client(self) -> TestClient:
+        from llc.api.agent_hires import router as agent_hires_router
+        from user_management.database import get_async_session
+
+        app = FastAPI()
+        app.include_router(agent_hires_router, prefix="/api/llc")
+
+        async def _fake_session():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_async_session] = _fake_session
+        return TestClient(app)
+
+    def test_create_agent_hire_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.post("/api/llc/agent-hires", json={})
+        assert resp.status_code == 401
+
+    def test_list_agent_hires_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.get("/api/llc/agent-hires")
+        assert resp.status_code == 401
+
+    def test_hire_agent_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.post(
+                f"/api/llc/companies/{uuid.uuid4()}/agent-hires",
+                json={"agent_name": "Bot"},
+            )
+        assert resp.status_code == 401
+
+
+class TestAgentHiresIdor:
+    # --- create_agent_hire (POST /agent-hires) ---
+
+    def test_create_agent_hire_own_company_returns_201(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post("/api/llc/agent-hires", json={"company_id": org})
+        assert resp.status_code == 201
+
+    def test_create_agent_hire_no_company_id_defaults_to_caller_org(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post("/api/llc/agent-hires", json={})
+        assert resp.status_code == 201
+        assert resp.json()["company_id"] == org
+
+    def test_create_agent_hire_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post("/api/llc/agent-hires", json={"company_id": _OTHER_ORG})
+        assert resp.status_code == 404
+
+    def test_create_agent_hire_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.post("/api/llc/agent-hires", json={"company_id": _OTHER_ORG})
+        assert resp.status_code == 201
+
+    # --- list_agent_hires (GET /agent-hires) ---
+
+    def test_list_agent_hires_authenticated_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get("/api/llc/agent-hires")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    # --- hire_agent (POST /companies/{company_id}/agent-hires) ---
+
+    def test_hire_agent_own_company_returns_201(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(f"/api/llc/companies/{org}/agent-hires", json={"agent_name": "Bot"})
+        assert resp.status_code == 201
+
+    def test_hire_agent_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(f"/api/llc/companies/{_OTHER_ORG}/agent-hires", json={"agent_name": "Bot"})
+        assert resp.status_code == 404
+
+    def test_hire_agent_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.post(f"/api/llc/companies/{_OTHER_ORG}/agent-hires", json={"agent_name": "Bot"})
+        assert resp.status_code == 201

--- a/autobot-backend/llc/tests/test_approvals_idor.py
+++ b/autobot-backend/llc/tests/test_approvals_idor.py
@@ -1,0 +1,219 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Auth + IDOR hardening tests for approvals.py routes (GH#12163).
+
+Prior to this fix every handler in llc/api/approvals.py depended only on
+``get_session`` — no authentication and no tenant-authorization dependency —
+allowing an unauthenticated caller to request/list/decide board approvals for
+ANY company by supplying an arbitrary ``company_id``/``approval_id`` (missing
+authentication + IDOR).
+
+Mirrors test_goals_idor.py / test_secrets_idor.py (GH#12136, GH#12147):
+  - no auth at all                     -> 401
+  - authenticated, cross-tenant access -> 404 (existence disclosure avoided)
+  - authenticated, same-tenant access  -> the expected success status
+  - platform admin                    -> cross-tenant allowed
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("88888888-8888-8888-8888-888888888888")
+_OTHER_ORG = "99999999-9999-9999-9999-999999999999"
+
+
+def _make_approval(company_id: str) -> MagicMock:
+    approval = MagicMock()
+    approval.id = uuid.uuid4()
+    approval.company_id = uuid.UUID(company_id)
+    approval.type = "hire"
+    approval.status = "pending"
+    approval.requested_by_agent_id = uuid.uuid4()
+    approval.payload = {}
+    approval.decided_by_agent_id = None
+    approval.decided_at = None
+    approval.created_at = datetime.now(timezone.utc)
+    approval.updated_at = datetime.now(timezone.utc)
+    return approval
+
+
+def _make_client(
+    caller_org_id: str,
+    approval_company_id: str | None = None,
+    approval_exists: bool = True,
+    is_platform_admin: bool = False,
+) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.approvals import router as approvals_router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(approvals_router, prefix="/api/llc")
+
+    acid = approval_company_id if approval_company_id is not None else caller_org_id
+    approval = _make_approval(acid) if approval_exists else None
+
+    mock_session = AsyncMock()
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none.return_value = approval
+    mock_session.execute = AsyncMock(return_value=execute_result)
+    mock_session.begin = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(), __aexit__=AsyncMock()))
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=is_platform_admin
+    )
+
+    patch("llc.api.approvals.ApprovalService.request_approval", new=AsyncMock(return_value=approval)).start()
+    patch("llc.api.approvals.ApprovalService.publish_requested", new=AsyncMock()).start()
+    patch(
+        "llc.api.approvals.ApprovalService.get_pending",
+        new=AsyncMock(return_value=[approval] if approval else []),
+    ).start()
+    patch("llc.api.approvals.ApprovalService.decide", new=AsyncMock(return_value=approval)).start()
+    patch("llc.api.approvals.ApprovalService.publish_decided", new=AsyncMock()).start()
+    patch("llc.api.approvals.ApprovalService.log_decision_to_kb", new=AsyncMock()).start()
+
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestApprovalsNoAuth:
+    """No credentials at all -> 401 (real get_current_user, not overridden)."""
+
+    def _make_unauthenticated_client(self) -> TestClient:
+        from llc.api.approvals import router as approvals_router
+        from llc.deps import get_session
+
+        app = FastAPI()
+        app.include_router(approvals_router, prefix="/api/llc")
+
+        async def _fake_session():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_session] = _fake_session
+        return TestClient(app)
+
+    def test_request_approval_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.post(
+                "/api/llc/approvals",
+                json={
+                    "company_id": str(uuid.uuid4()),
+                    "type": "hire",
+                    "requested_by_agent_id": str(uuid.uuid4()),
+                },
+            )
+        assert resp.status_code == 401
+
+    def test_list_pending_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.get("/api/llc/approvals", params={"company_id": str(uuid.uuid4())})
+        assert resp.status_code == 401
+
+    def test_decide_approval_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.post(
+                f"/api/llc/approvals/{uuid.uuid4()}/decide",
+                json={"decision": "approved"},
+            )
+        assert resp.status_code == 401
+
+
+class TestApprovalsIdor:
+    # --- request ---
+
+    def test_request_approval_own_company_returns_201(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/approvals",
+            json={"company_id": org, "type": "hire", "requested_by_agent_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 201
+
+    def test_request_approval_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/approvals",
+            json={"company_id": _OTHER_ORG, "type": "hire", "requested_by_agent_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 404
+
+    def test_request_approval_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.post(
+            "/api/llc/approvals",
+            json={"company_id": _OTHER_ORG, "type": "hire", "requested_by_agent_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 201
+
+    # --- list ---
+
+    def test_list_pending_own_company_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get("/api/llc/approvals", params={"company_id": org})
+        assert resp.status_code == 200
+
+    def test_list_pending_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get("/api/llc/approvals", params={"company_id": _OTHER_ORG})
+        assert resp.status_code == 404
+
+    def test_list_pending_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.get("/api/llc/approvals", params={"company_id": _OTHER_ORG})
+        assert resp.status_code == 200
+
+    # --- decide ---
+
+    def test_decide_approval_own_tenant_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, approval_company_id=org)
+        resp = client.post(f"/api/llc/approvals/{uuid.uuid4()}/decide", json={"decision": "approved"})
+        assert resp.status_code == 200
+
+    def test_decide_approval_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, approval_company_id=_OTHER_ORG)
+        resp = client.post(f"/api/llc/approvals/{uuid.uuid4()}/decide", json={"decision": "approved"})
+        assert resp.status_code == 404
+
+    def test_decide_approval_not_found_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, approval_exists=False)
+        resp = client.post(f"/api/llc/approvals/{uuid.uuid4()}/decide", json={"decision": "approved"})
+        assert resp.status_code == 404
+
+    def test_decide_approval_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, approval_company_id=_OTHER_ORG, is_platform_admin=True)
+        resp = client.post(f"/api/llc/approvals/{uuid.uuid4()}/decide", json={"decision": "approved"})
+        assert resp.status_code == 200

--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -138,6 +138,7 @@ class TestHireAgentNamedBindDict:
     async def test_hire_agent_insert_binds_match_named_params(self) -> None:
         mod = _get_agent_hires_mod()
         from sqlalchemy.dialects import postgresql
+
         from user_management.services import TenantContext
 
         session = AsyncMock()
@@ -170,6 +171,7 @@ class TestHireAgentNamedBindDict:
     async def test_create_agent_hire_insert_binds_match_named_params(self) -> None:
         mod = _get_agent_hires_mod()
         from sqlalchemy.dialects import postgresql
+
         from user_management.services import TenantContext
 
         session = AsyncMock()

--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -138,6 +138,7 @@ class TestHireAgentNamedBindDict:
     async def test_hire_agent_insert_binds_match_named_params(self) -> None:
         mod = _get_agent_hires_mod()
         from sqlalchemy.dialects import postgresql
+        from user_management.services import TenantContext
 
         session = AsyncMock()
         session.execute = AsyncMock()
@@ -145,12 +146,13 @@ class TestHireAgentNamedBindDict:
 
         body = mod.AgentHireRequest(agent_name="ABR CEO", org_role="manager", title="Chief Executive")
         company_id = uuid.uuid4()
+        ctx = TenantContext(org_id=company_id, user_id=uuid.uuid4())
 
         with (
             patch.object(mod, "registered_adapter_types", return_value=["claude_code"]),
             patch.object(mod.BudgetService, "provision_budget", new=AsyncMock()),
         ):
-            await mod.hire_agent(company_id=company_id, body=body, session=session)
+            await mod.hire_agent(company_id=company_id, body=body, session=session, _current_user={}, ctx=ctx)
 
         stmt, params = session.execute.call_args_list[0].args
         assert isinstance(params, dict), "params must be a named-bind dict, not a positional tuple"
@@ -168,6 +170,7 @@ class TestHireAgentNamedBindDict:
     async def test_create_agent_hire_insert_binds_match_named_params(self) -> None:
         mod = _get_agent_hires_mod()
         from sqlalchemy.dialects import postgresql
+        from user_management.services import TenantContext
 
         session = AsyncMock()
         session.execute = AsyncMock()
@@ -175,7 +178,8 @@ class TestHireAgentNamedBindDict:
         session.rollback = AsyncMock()
 
         body = mod.AgentHireCreate(company_id=uuid.uuid4())
-        await mod.create_agent_hire(body=body, session=session, ctx=None)
+        ctx = TenantContext(org_id=body.company_id, user_id=uuid.uuid4())
+        await mod.create_agent_hire(body=body, session=session, _current_user={}, ctx=ctx)
 
         stmt, params = session.execute.call_args_list[0].args
         assert isinstance(params, dict), "params must be a named-bind dict, not a positional tuple"

--- a/autobot-backend/llc/tests/test_portability_idor.py
+++ b/autobot-backend/llc/tests/test_portability_idor.py
@@ -1,0 +1,177 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Auth + IDOR hardening tests for portability.py routes (GH#12163).
+
+Prior to this fix both handlers in llc/api/portability.py depended only on
+``get_async_session`` — no authentication and no tenant-authorization
+dependency — allowing an unauthenticated caller to import a template into
+ANY existing company by supplying its ``target_company_id`` (missing
+authentication + IDOR).
+
+Mirrors test_goals_idor.py / test_secrets_idor.py (GH#12136, GH#12147):
+  - no auth at all                                -> 401
+  - authenticated, cross-tenant target_company_id  -> 404
+  - authenticated, same-tenant target_company_id   -> the expected success status
+  - target_company_id omitted (new-company import) -> allowed for any authenticated caller
+  - platform admin                                 -> cross-tenant allowed
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_OTHER_ORG = "99999999-9999-9999-9999-999999999999"
+
+_PREVIEW_RESULT = {"collisions": [], "will_create": {}, "warnings": []}
+_EXECUTE_RESULT = {"company_id": str(uuid.uuid4()), "created_entities": {}, "skipped": {}, "warnings": []}
+
+_TEMPLATE = {"schema_version": "1.0", "company": {"name": "Acme"}}
+
+
+def _make_client(caller_org_id: str, is_platform_admin: bool = False) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.portability import router as portability_router  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(portability_router, prefix="/api/llc")
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=is_platform_admin
+    )
+
+    patch("llc.api.portability.PortabilityService.preview_import", new=AsyncMock(return_value=_PREVIEW_RESULT)).start()
+    patch("llc.api.portability.PortabilityService.execute_import", new=AsyncMock(return_value=_EXECUTE_RESULT)).start()
+
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestPortabilityNoAuth:
+    """No credentials at all -> 401 (real get_current_user, not overridden)."""
+
+    def _make_unauthenticated_client(self) -> TestClient:
+        from llc.api.portability import router as portability_router
+        from user_management.database import get_async_session
+
+        app = FastAPI()
+        app.include_router(portability_router, prefix="/api/llc")
+
+        async def _fake_session():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_async_session] = _fake_session
+        return TestClient(app)
+
+    def test_preview_import_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.post(
+                "/api/llc/import/preview",
+                json={"template": _TEMPLATE, "target_company_id": _OTHER_ORG},
+            )
+        assert resp.status_code == 401
+
+    def test_execute_import_no_token_returns_401(self):
+        with patch("api.user_management.dependencies.get_auth_middleware") as mock_mw:
+            mock_mw.return_value.get_user_from_request.return_value = None
+            client = self._make_unauthenticated_client()
+            resp = client.post(
+                "/api/llc/import/execute",
+                json={"template": _TEMPLATE, "target_company_id": _OTHER_ORG},
+            )
+        assert resp.status_code == 401
+
+
+class TestPortabilityIdor:
+    # --- preview ---
+
+    def test_preview_import_own_company_returns_200(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/import/preview",
+            json={"template": _TEMPLATE, "target_company_id": org},
+        )
+        assert resp.status_code == 200
+
+    def test_preview_import_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/import/preview",
+            json={"template": _TEMPLATE, "target_company_id": _OTHER_ORG},
+        )
+        assert resp.status_code == 404
+
+    def test_preview_import_no_target_company_allowed(self):
+        """Omitting target_company_id previews a brand-new company — any authenticated caller."""
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post("/api/llc/import/preview", json={"template": _TEMPLATE})
+        assert resp.status_code == 200
+
+    def test_preview_import_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.post(
+            "/api/llc/import/preview",
+            json={"template": _TEMPLATE, "target_company_id": _OTHER_ORG},
+        )
+        assert resp.status_code == 200
+
+    # --- execute ---
+
+    def test_execute_import_own_company_returns_201(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/import/execute",
+            json={"template": _TEMPLATE, "target_company_id": org},
+        )
+        assert resp.status_code == 201
+
+    def test_execute_import_cross_tenant_returns_404(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            "/api/llc/import/execute",
+            json={"template": _TEMPLATE, "target_company_id": _OTHER_ORG},
+        )
+        assert resp.status_code == 404
+
+    def test_execute_import_no_target_company_allowed(self):
+        """Omitting target_company_id creates a brand-new company — any authenticated caller."""
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post("/api/llc/import/execute", json={"template": _TEMPLATE})
+        assert resp.status_code == 201
+
+    def test_execute_import_platform_admin_cross_tenant_allowed(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org, is_platform_admin=True)
+        resp = client.post(
+            "/api/llc/import/execute",
+            json={"template": _TEMPLATE, "target_company_id": _OTHER_ORG},
+        )
+        assert resp.status_code == 201


### PR DESCRIPTION
## Thinking Path

Batch 1 of the #12148 systemic LLC missing-auth remediation — the most sensitive routers first. Applies the independently-security-audited #12136/#12147 pattern (`get_current_user` + `require_org_context` + server-side tenant check, 404-not-403, platform-admin exempt).

## What Changed

- **`approvals.py`** (3 routes, HITL — sensitive): all gated. `request_approval`/`list_pending` company-check; `POST /{approval_id}/decide` uses object-load-check (`_get_authorized_approval` loads by id, tenant-checks before `svc.decide()`) — IDOR fix.
- **`portability.py`** (2 `/import` routes): `_assert_import_target_access` tenant-checks when `target_company_id` is supplied; new-company import (no target) is any-authenticated, mirroring `companies.py::create_company` (no existing tenant to check).
- **`agent_hires.py`** (3 routes): `create_agent_hire` and `list_agent_hires` had **fake `ctx: Depends(lambda: None)`** — always None, so their tenant branches were dead security theater; replaced with real auth + `_assert_company_match`. `hire_agent` (POST /companies/{company_id}/agent-hires) had **zero** auth — now gated.
- **`llc/api/__init__.py`**: removed a pre-existing duplicate `agent_hires_router` mount (in-scope, trivial, non-security).

## Verification

- 34 new IDOR tests (13 approvals + 10 portability + 11 agent_hires): no-token→401, cross-tenant→404, same-tenant→success, platform-admin bypass, every route.
- Full `llc/tests/` suite: **1217 passed, 2 skipped, 0 failed**. flake8/black clean.
- Independent security-auditor review pending before merge.
- Caller audit per router: only the standard LLC mount + (for agent_hires) unit tests — no internal/agent M2M caller needs the removed bypass.

## Model Used

Claude Opus 4.8 (implementation via senior-backend-engineer; independent security-auditor review before merge)

Closes #12163
Refs #12148
