### PR TITLE
feat(frontend): Advanced Control admin panel — Stage 1: shell + takeover approval queue (#12162)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useAdvancedControl.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useAdvancedControl.test.ts
@@ -1,0 +1,193 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Unit tests for useAdvancedControl (#12162, #12102, #11506 T1 — Stage 1).
+ *
+ * Covers: loadTakeovers populates pending/active/status from the client,
+ * approve/pause/resume/complete call the right client methods and refresh
+ * state on success, and failures (success:false or thrown) surface via the
+ * `error` ref without throwing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { effectScope } from 'vue'
+
+const mockGetPendingTakeovers = vi.fn()
+const mockGetActiveTakeovers = vi.fn()
+const mockGetTakeoverStatus = vi.fn()
+const mockApproveTakeover = vi.fn()
+const mockPauseTakeoverSession = vi.fn()
+const mockResumeTakeoverSession = vi.fn()
+const mockCompleteTakeoverSession = vi.fn()
+const mockExecuteTakeoverAction = vi.fn()
+
+vi.mock('@/utils/AdvancedControlApiClient', () => ({
+  advancedControlApiClient: {
+    getPendingTakeovers: (...args: unknown[]) => mockGetPendingTakeovers(...args),
+    getActiveTakeovers: (...args: unknown[]) => mockGetActiveTakeovers(...args),
+    getTakeoverStatus: (...args: unknown[]) => mockGetTakeoverStatus(...args),
+    approveTakeover: (...args: unknown[]) => mockApproveTakeover(...args),
+    pauseTakeoverSession: (...args: unknown[]) => mockPauseTakeoverSession(...args),
+    resumeTakeoverSession: (...args: unknown[]) => mockResumeTakeoverSession(...args),
+    completeTakeoverSession: (...args: unknown[]) => mockCompleteTakeoverSession(...args),
+    executeTakeoverAction: (...args: unknown[]) => mockExecuteTakeoverAction(...args),
+  },
+}))
+
+import { useAdvancedControl } from '../useAdvancedControl'
+import { useUserStore } from '@/stores/useUserStore'
+
+const okEmpty = { success: true, data: { pending_requests: [], count: 0 } }
+const okEmptyActive = { success: true, data: { active_sessions: [], count: 0 } }
+const okStatus = {
+  success: true,
+  data: {
+    pending_requests_count: 0,
+    active_sessions_count: 0,
+    paused_tasks_count: 0,
+    total_completed_sessions: 0,
+    system_status: 'normal' as const,
+  },
+}
+
+function resetMocks(): void {
+  mockGetPendingTakeovers.mockReset().mockResolvedValue(okEmpty)
+  mockGetActiveTakeovers.mockReset().mockResolvedValue(okEmptyActive)
+  mockGetTakeoverStatus.mockReset().mockResolvedValue(okStatus)
+  mockApproveTakeover.mockReset()
+  mockPauseTakeoverSession.mockReset()
+  mockResumeTakeoverSession.mockReset()
+  mockCompleteTakeoverSession.mockReset()
+  mockExecuteTakeoverAction.mockReset()
+}
+
+describe('useAdvancedControl', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    resetMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts with empty state', () => {
+    const { pendingTakeovers, activeTakeovers, takeoverStatus, loading, error } = useAdvancedControl()
+    expect(pendingTakeovers.value).toEqual([])
+    expect(activeTakeovers.value).toEqual([])
+    expect(takeoverStatus.value).toBeNull()
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('loadTakeovers populates pending/active/status from the client', async () => {
+    const pendingReq = {
+      request_id: 'r1',
+      trigger: 'MANUAL_REQUEST' as const,
+      reason: 'needs a human',
+      requesting_agent: 'agent-1',
+      affected_tasks: [],
+      priority: 'HIGH' as const,
+      created_at: '2026-07-23T00:00:00Z',
+      timeout_at: null,
+      auto_approve: false,
+    }
+    const activeSession = {
+      session_id: 's1',
+      request_id: 'r1',
+      human_operator: 'alice',
+      status: 'active' as const,
+      started_at: '2026-07-23T00:00:00Z',
+      paused_at: null,
+      actions_executed: 2,
+      takeover_scope: {},
+    }
+    mockGetPendingTakeovers.mockResolvedValueOnce({ success: true, data: { pending_requests: [pendingReq], count: 1 } })
+    mockGetActiveTakeovers.mockResolvedValueOnce({ success: true, data: { active_sessions: [activeSession], count: 1 } })
+    mockGetTakeoverStatus.mockResolvedValueOnce({
+      success: true,
+      data: { pending_requests_count: 1, active_sessions_count: 1, paused_tasks_count: 0, total_completed_sessions: 5, system_status: 'takeover_active' },
+    })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { loadTakeovers, pendingTakeovers, activeTakeovers, takeoverStatus, loading, error } = useAdvancedControl()
+      const promise = loadTakeovers()
+      expect(loading.value).toBe(true)
+      await promise
+
+      expect(loading.value).toBe(false)
+      expect(error.value).toBeNull()
+      expect(pendingTakeovers.value).toEqual([pendingReq])
+      expect(activeTakeovers.value).toEqual([activeSession])
+      expect(takeoverStatus.value?.system_status).toBe('takeover_active')
+    })
+    scope.stop()
+  })
+
+  it('approve calls approveTakeover with the current username and reloads', async () => {
+    const userStore = useUserStore()
+    userStore.currentUser = { id: 'u1', username: 'alice' } as never
+    mockApproveTakeover.mockResolvedValueOnce({ success: true, data: { success: true, session_id: 's1' } })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { approve } = useAdvancedControl()
+      const result = await approve('r1')
+      expect(result).toBe(true)
+    })
+    scope.stop()
+
+    expect(mockApproveTakeover).toHaveBeenCalledWith('r1', { human_operator: 'alice' })
+    expect(mockGetPendingTakeovers).toHaveBeenCalled()
+  })
+
+  it('pause/resume/complete call the matching client methods and reload on success', async () => {
+    mockPauseTakeoverSession.mockResolvedValueOnce({ success: true, data: { success: true, session_id: 's1', status: 'paused' } })
+    mockResumeTakeoverSession.mockResolvedValueOnce({ success: true, data: { success: true, session_id: 's1', status: 'active' } })
+    mockCompleteTakeoverSession.mockResolvedValueOnce({ success: true, data: { success: true, session_id: 's1', status: 'completed' } })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { pause, resume, complete } = useAdvancedControl()
+      expect(await pause('s1')).toBe(true)
+      expect(await resume('s1')).toBe(true)
+      expect(await complete('s1')).toBe(true)
+    })
+    scope.stop()
+
+    expect(mockPauseTakeoverSession).toHaveBeenCalledWith('s1')
+    expect(mockResumeTakeoverSession).toHaveBeenCalledWith('s1')
+    expect(mockCompleteTakeoverSession).toHaveBeenCalledWith('s1', {})
+  })
+
+  it('surfaces a client success:false error without throwing', async () => {
+    mockApproveTakeover.mockResolvedValueOnce({ success: false, error: 'already approved' })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { approve, error } = useAdvancedControl()
+      const result = await approve('r1')
+      expect(result).toBe(false)
+      expect(error.value).toBe('already approved')
+    })
+    scope.stop()
+  })
+
+  it('surfaces a thrown error (network failure) via the error ref', async () => {
+    mockGetPendingTakeovers.mockRejectedValueOnce(new Error('network down'))
+    mockGetActiveTakeovers.mockRejectedValueOnce(new Error('network down'))
+    mockGetTakeoverStatus.mockRejectedValueOnce(new Error('network down'))
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { loadTakeovers, error } = useAdvancedControl()
+      await loadTakeovers()
+      expect(error.value).toBe('network down')
+    })
+    scope.stop()
+  })
+})

--- a/autobot-frontend/src/composables/useAdvancedControl.ts
+++ b/autobot-frontend/src/composables/useAdvancedControl.ts
@@ -1,0 +1,183 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Advanced Control composable (#12162, #12102, #11506 T1 — Stage 1).
+ *
+ * Wraps `advancedControlApiClient`'s takeover-management endpoints for the
+ * admin-only Advanced Control panel. Streaming/monitoring endpoints are out
+ * of scope for Stage 1 (see AdvancedControlView.vue placeholders).
+ */
+
+import { ref } from 'vue'
+import { advancedControlApiClient } from '@/utils/AdvancedControlApiClient'
+import type {
+  PendingTakeoverRequest,
+  ActiveTakeoverSession,
+  TakeoverSystemStatus,
+  TakeoverCompletionRequest,
+} from '@/utils/AdvancedControlApiClient'
+import { createLogger } from '@/utils/debugUtils'
+import { useUserStore } from '@/stores/useUserStore'
+
+const logger = createLogger('useAdvancedControl')
+
+export function useAdvancedControl() {
+  const userStore = useUserStore()
+
+  const pendingTakeovers = ref<PendingTakeoverRequest[]>([])
+  const activeTakeovers = ref<ActiveTakeoverSession[]>([])
+  const takeoverStatus = ref<TakeoverSystemStatus | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  /**
+   * Loads pending requests, active sessions, and system status in parallel.
+   * Partial failures are tolerated per-call — a failed call logs and leaves
+   * its slice of state unchanged rather than aborting the whole refresh.
+   */
+  async function loadTakeovers(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      const [pendingRes, activeRes, statusRes] = await Promise.all([
+        advancedControlApiClient.getPendingTakeovers(),
+        advancedControlApiClient.getActiveTakeovers(),
+        advancedControlApiClient.getTakeoverStatus(),
+      ])
+
+      if (pendingRes.success && pendingRes.data) {
+        pendingTakeovers.value = pendingRes.data.pending_requests
+      } else if (!pendingRes.success) {
+        logger.error('Failed to load pending takeovers:', pendingRes.error)
+      }
+
+      if (activeRes.success && activeRes.data) {
+        activeTakeovers.value = activeRes.data.active_sessions
+      } else if (!activeRes.success) {
+        logger.error('Failed to load active takeovers:', activeRes.error)
+      }
+
+      if (statusRes.success && statusRes.data) {
+        takeoverStatus.value = statusRes.data
+      } else if (!statusRes.success) {
+        logger.error('Failed to load takeover status:', statusRes.error)
+      }
+
+      if (!pendingRes.success && !activeRes.success && !statusRes.success) {
+        error.value = pendingRes.error || activeRes.error || statusRes.error || 'Failed to load takeovers'
+      }
+    } catch (err) {
+      logger.error('Failed to load takeovers:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to load takeovers'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function approve(requestId: string): Promise<boolean> {
+    error.value = null
+    try {
+      const humanOperator = userStore.currentUser?.username ?? 'unknown'
+      const res = await advancedControlApiClient.approveTakeover(requestId, {
+        human_operator: humanOperator,
+      })
+      if (!res.success) {
+        error.value = res.error || 'Failed to approve takeover'
+        return false
+      }
+      await loadTakeovers()
+      return true
+    } catch (err) {
+      logger.error('Failed to approve takeover:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to approve takeover'
+      return false
+    }
+  }
+
+  async function pause(sessionId: string): Promise<boolean> {
+    error.value = null
+    try {
+      const res = await advancedControlApiClient.pauseTakeoverSession(sessionId)
+      if (!res.success) {
+        error.value = res.error || 'Failed to pause session'
+        return false
+      }
+      await loadTakeovers()
+      return true
+    } catch (err) {
+      logger.error('Failed to pause session:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to pause session'
+      return false
+    }
+  }
+
+  async function resume(sessionId: string): Promise<boolean> {
+    error.value = null
+    try {
+      const res = await advancedControlApiClient.resumeTakeoverSession(sessionId)
+      if (!res.success) {
+        error.value = res.error || 'Failed to resume session'
+        return false
+      }
+      await loadTakeovers()
+      return true
+    } catch (err) {
+      logger.error('Failed to resume session:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to resume session'
+      return false
+    }
+  }
+
+  async function complete(sessionId: string, completion: TakeoverCompletionRequest = {}): Promise<boolean> {
+    error.value = null
+    try {
+      const res = await advancedControlApiClient.completeTakeoverSession(sessionId, completion)
+      if (!res.success) {
+        error.value = res.error || 'Failed to complete session'
+        return false
+      }
+      await loadTakeovers()
+      return true
+    } catch (err) {
+      logger.error('Failed to complete session:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to complete session'
+      return false
+    }
+  }
+
+  async function action(sessionId: string, actionType: string, actionData: Record<string, unknown> = {}): Promise<boolean> {
+    error.value = null
+    try {
+      const res = await advancedControlApiClient.executeTakeoverAction(sessionId, {
+        action_type: actionType,
+        action_data: actionData,
+      })
+      if (!res.success) {
+        error.value = res.error || 'Failed to execute action'
+        return false
+      }
+      return true
+    } catch (err) {
+      logger.error('Failed to execute takeover action:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to execute action'
+      return false
+    }
+  }
+
+  return {
+    pendingTakeovers,
+    activeTakeovers,
+    takeoverStatus,
+    loading,
+    error,
+    loadTakeovers,
+    approve,
+    pause,
+    resume,
+    complete,
+    action,
+  }
+}

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -116,4 +116,6 @@ export const adminMenuItems: NavItem[] = [
   { to: '/admin/budget-policies', labelKey: 'nav.budgetPolicies', icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
   // Issue #10932: System Health panel — CONTENT_REACH probe
   { to: '/admin/system-health', labelKey: 'nav.systemHealth', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
+  // Issue #12162 (#12102/#11506 T1 Stage 1): Advanced Control — takeover approval queue
+  { to: '/admin/advanced-control', labelKey: 'nav.advancedControl', icon: 'M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11', iconStroke: true },
 ];

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7649,7 +7649,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "صحة النظام"
+    "systemHealth": "صحة النظام",
+    "advancedControl": "التحكم المتقدم"
   },
   "llcMembers": {
     "title": "الأعضاء",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapter",
     "hiring": "Hiring…",
     "hire": "Hire"
+  },
+  "advancedControl": {
+    "title": "التحكم المتقدم",
+    "subtitle": "الموافقة على طلبات الاستحواذ وإدارة جلسات التحكم البشري النشطة",
+    "tabListAriaLabel": "علامات تبويب التحكم المتقدم",
+    "loading": "جارٍ تحميل قائمة انتظار الاستحواذ…",
+    "tabs": {
+      "takeoverQueue": "قائمة انتظار الاستحواذ",
+      "streaming": "البث",
+      "monitoring": "المراقبة",
+      "comingSoon": "قريبًا",
+      "comingSoonMessage": "هذه العلامة غير متاحة بعد.",
+      "streamingTitle": "بث سطح المكتب",
+      "monitoringTitle": "مراقبة النظام"
+    },
+    "summary": {
+      "pending": "قيد الانتظار",
+      "active": "نشطة",
+      "paused": "متوقفة مؤقتًا",
+      "completed": "مكتملة",
+      "systemStatus": "حالة النظام",
+      "statusNormal": "طبيعية",
+      "statusTakeoverActive": "الاستحواذ نشط",
+      "statusEmergency": "حالة طارئة"
+    },
+    "pending": {
+      "title": "طلبات الاستحواذ قيد الانتظار",
+      "colTrigger": "المُحفِّز",
+      "colReason": "السبب",
+      "colPriority": "الأولوية",
+      "colRequestedBy": "طلبها",
+      "colCreatedAt": "تاريخ الإنشاء",
+      "colActions": "الإجراءات",
+      "unknownAgent": "وكيل غير معروف",
+      "emptyTitle": "لا توجد طلبات قيد الانتظار",
+      "emptyMessage": "لا توجد طلبات استحواذ بانتظار الموافقة."
+    },
+    "active": {
+      "title": "جلسات الاستحواذ النشطة",
+      "colOperator": "المُشغِّل",
+      "colStatus": "الحالة",
+      "colStartedAt": "بدأت",
+      "colActionsExecuted": "الإجراءات المنفذة",
+      "emptyTitle": "لا توجد جلسات نشطة",
+      "emptyMessage": "لا توجد جلسات تحكم بشري نشطة في الوقت الحالي."
+    },
+    "actions": {
+      "approve": "موافقة",
+      "pause": "إيقاف مؤقت",
+      "resume": "استئناف",
+      "complete": "إكمال"
+    }
   },
   "adminUsers": {
     "title": "User Management",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7649,7 +7649,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "Systemzustand"
+    "systemHealth": "Systemzustand",
+    "advancedControl": "Erweiterte Steuerung"
   },
   "llcMembers": {
     "title": "Mitglieder",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapter",
     "hiring": "Wird eingestellt…",
     "hire": "Einstellen"
+  },
+  "advancedControl": {
+    "title": "Erweiterte Steuerung",
+    "subtitle": "Übernahmeanfragen genehmigen und aktive Sitzungen mit menschlicher Steuerung verwalten",
+    "tabListAriaLabel": "Registerkarten der erweiterten Steuerung",
+    "loading": "Übernahmewarteschlange wird geladen…",
+    "tabs": {
+      "takeoverQueue": "Übernahme-Warteschlange",
+      "streaming": "Streaming",
+      "monitoring": "Überwachung",
+      "comingSoon": "Demnächst verfügbar",
+      "comingSoonMessage": "Diese Registerkarte ist noch nicht verfügbar.",
+      "streamingTitle": "Desktop-Streaming",
+      "monitoringTitle": "Systemüberwachung"
+    },
+    "summary": {
+      "pending": "Ausstehend",
+      "active": "Aktiv",
+      "paused": "Pausiert",
+      "completed": "Abgeschlossen",
+      "systemStatus": "Systemstatus",
+      "statusNormal": "Normal",
+      "statusTakeoverActive": "Übernahme aktiv",
+      "statusEmergency": "Notfall"
+    },
+    "pending": {
+      "title": "Ausstehende Übernahmeanfragen",
+      "colTrigger": "Auslöser",
+      "colReason": "Grund",
+      "colPriority": "Priorität",
+      "colRequestedBy": "Angefordert von",
+      "colCreatedAt": "Erstellt",
+      "colActions": "Aktionen",
+      "unknownAgent": "Unbekannter Agent",
+      "emptyTitle": "Keine ausstehenden Anfragen",
+      "emptyMessage": "Es gibt keine Übernahmeanfragen, die auf Genehmigung warten."
+    },
+    "active": {
+      "title": "Aktive Übernahmesitzungen",
+      "colOperator": "Bediener",
+      "colStatus": "Status",
+      "colStartedAt": "Gestartet",
+      "colActionsExecuted": "Ausgeführte Aktionen",
+      "emptyTitle": "Keine aktiven Sitzungen",
+      "emptyMessage": "Derzeit gibt es keine aktiven Sitzungen mit menschlicher Steuerung."
+    },
+    "actions": {
+      "approve": "Genehmigen",
+      "pause": "Pausieren",
+      "resume": "Fortsetzen",
+      "complete": "Abschließen"
+    }
   },
   "adminUsers": {
     "title": "Benutzerverwaltung",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7657,6 +7657,7 @@
     "adminSandbox": "Sandbox",
     "budgetPolicies": "Budget Policies",
     "systemHealth": "System Health",
+    "advancedControl": "Advanced Control",
     "sharedLinks": "Shared Chat Links",
     "companyOs": "Company OS",
     "llcDashboard": "Dashboard",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapter",
     "hiring": "Hiring…",
     "hire": "Hire"
+  },
+  "advancedControl": {
+    "title": "Advanced Control",
+    "subtitle": "Approve takeover requests and manage active human-control sessions",
+    "tabListAriaLabel": "Advanced Control tabs",
+    "loading": "Loading takeover queue…",
+    "tabs": {
+      "takeoverQueue": "Takeover Queue",
+      "streaming": "Streaming",
+      "monitoring": "Monitoring",
+      "comingSoon": "Coming soon",
+      "comingSoonMessage": "This tab is not yet available.",
+      "streamingTitle": "Desktop Streaming",
+      "monitoringTitle": "System Monitoring"
+    },
+    "summary": {
+      "pending": "Pending",
+      "active": "Active",
+      "paused": "Paused",
+      "completed": "Completed",
+      "systemStatus": "System Status",
+      "statusNormal": "Normal",
+      "statusTakeoverActive": "Takeover Active",
+      "statusEmergency": "Emergency"
+    },
+    "pending": {
+      "title": "Pending Takeover Requests",
+      "colTrigger": "Trigger",
+      "colReason": "Reason",
+      "colPriority": "Priority",
+      "colRequestedBy": "Requested By",
+      "colCreatedAt": "Created",
+      "colActions": "Actions",
+      "unknownAgent": "Unknown agent",
+      "emptyTitle": "No pending requests",
+      "emptyMessage": "There are no takeover requests waiting for approval."
+    },
+    "active": {
+      "title": "Active Takeover Sessions",
+      "colOperator": "Operator",
+      "colStatus": "Status",
+      "colStartedAt": "Started",
+      "colActionsExecuted": "Actions Executed",
+      "emptyTitle": "No active sessions",
+      "emptyMessage": "There are no active human-control sessions right now."
+    },
+    "actions": {
+      "approve": "Approve",
+      "pause": "Pause",
+      "resume": "Resume",
+      "complete": "Complete"
+    }
   },
   "adminUsers": {
     "title": "User Management",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7649,7 +7649,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "Salud del sistema"
+    "systemHealth": "Salud del sistema",
+    "advancedControl": "Control avanzado"
   },
   "llcMembers": {
     "title": "Miembros",
@@ -8705,6 +8706,58 @@
     "adapter": "Adaptador",
     "hiring": "Contratando…",
     "hire": "Contratar"
+  },
+  "advancedControl": {
+    "title": "Control avanzado",
+    "subtitle": "Apruebe solicitudes de control manual y gestione las sesiones activas",
+    "tabListAriaLabel": "Pestañas de control avanzado",
+    "loading": "Cargando cola de solicitudes de control…",
+    "tabs": {
+      "takeoverQueue": "Cola de solicitudes",
+      "streaming": "Transmisión",
+      "monitoring": "Monitorización",
+      "comingSoon": "Próximamente",
+      "comingSoonMessage": "Esta pestaña aún no está disponible.",
+      "streamingTitle": "Transmisión de escritorio",
+      "monitoringTitle": "Monitorización del sistema"
+    },
+    "summary": {
+      "pending": "Pendientes",
+      "active": "Activas",
+      "paused": "En pausa",
+      "completed": "Completadas",
+      "systemStatus": "Estado del sistema",
+      "statusNormal": "Normal",
+      "statusTakeoverActive": "Control activo",
+      "statusEmergency": "Emergencia"
+    },
+    "pending": {
+      "title": "Solicitudes de control pendientes",
+      "colTrigger": "Motivo",
+      "colReason": "Razón",
+      "colPriority": "Prioridad",
+      "colRequestedBy": "Solicitado por",
+      "colCreatedAt": "Creado",
+      "colActions": "Acciones",
+      "unknownAgent": "Agente desconocido",
+      "emptyTitle": "No hay solicitudes pendientes",
+      "emptyMessage": "No hay solicitudes de control esperando aprobación."
+    },
+    "active": {
+      "title": "Sesiones de control activas",
+      "colOperator": "Operador",
+      "colStatus": "Estado",
+      "colStartedAt": "Iniciada",
+      "colActionsExecuted": "Acciones ejecutadas",
+      "emptyTitle": "No hay sesiones activas",
+      "emptyMessage": "No hay sesiones de control manual activas en este momento."
+    },
+    "actions": {
+      "approve": "Aprobar",
+      "pause": "Pausar",
+      "resume": "Reanudar",
+      "complete": "Completar"
+    }
   },
   "adminUsers": {
     "title": "Gestión de usuarios",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -194,7 +194,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "سلامت سیستم"
+    "systemHealth": "سلامت سیستم",
+    "advancedControl": "کنترل پیشرفته"
   },
   "llcMembers": {
     "title": "اعضا",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapter",
     "hiring": "Hiring…",
     "hire": "Hire"
+  },
+  "advancedControl": {
+    "title": "کنترل پیشرفته",
+    "subtitle": "درخواست‌های تصاحب را تأیید کنید و نشست‌های فعال کنترل انسانی را مدیریت کنید",
+    "tabListAriaLabel": "برگه‌های کنترل پیشرفته",
+    "loading": "در حال بارگذاری صف تصاحب…",
+    "tabs": {
+      "takeoverQueue": "صف تصاحب",
+      "streaming": "پخش زنده",
+      "monitoring": "پایش",
+      "comingSoon": "به‌زودی",
+      "comingSoonMessage": "این برگه هنوز در دسترس نیست.",
+      "streamingTitle": "پخش دسکتاپ",
+      "monitoringTitle": "پایش سیستم"
+    },
+    "summary": {
+      "pending": "در انتظار",
+      "active": "فعال",
+      "paused": "متوقف‌شده",
+      "completed": "تکمیل‌شده",
+      "systemStatus": "وضعیت سیستم",
+      "statusNormal": "عادی",
+      "statusTakeoverActive": "تصاحب فعال",
+      "statusEmergency": "اضطراری"
+    },
+    "pending": {
+      "title": "درخواست‌های تصاحب در انتظار",
+      "colTrigger": "محرک",
+      "colReason": "دلیل",
+      "colPriority": "اولویت",
+      "colRequestedBy": "درخواست‌دهنده",
+      "colCreatedAt": "ایجادشده",
+      "colActions": "عملیات",
+      "unknownAgent": "عامل ناشناس",
+      "emptyTitle": "درخواستی در انتظار نیست",
+      "emptyMessage": "هیچ درخواست تصاحبی منتظر تأیید نیست."
+    },
+    "active": {
+      "title": "نشست‌های فعال تصاحب",
+      "colOperator": "اپراتور",
+      "colStatus": "وضعیت",
+      "colStartedAt": "شروع‌شده",
+      "colActionsExecuted": "عملیات اجراشده",
+      "emptyTitle": "نشست فعالی وجود ندارد",
+      "emptyMessage": "در حال حاضر هیچ نشست کنترل انسانی فعالی وجود ندارد."
+    },
+    "actions": {
+      "approve": "تأیید",
+      "pause": "توقف",
+      "resume": "ازسرگیری",
+      "complete": "تکمیل"
+    }
   },
   "adminUsers": {
     "title": "User Management",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7649,7 +7649,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "Santé du système"
+    "systemHealth": "Santé du système",
+    "advancedControl": "Contrôle avancé"
   },
   "llcMembers": {
     "title": "Membres",
@@ -8705,6 +8706,58 @@
     "adapter": "Adaptateur",
     "hiring": "Engagement…",
     "hire": "Engager"
+  },
+  "advancedControl": {
+    "title": "Contrôle avancé",
+    "subtitle": "Approuvez les demandes de prise de contrôle et gérez les sessions actives",
+    "tabListAriaLabel": "Onglets du contrôle avancé",
+    "loading": "Chargement de la file d'attente…",
+    "tabs": {
+      "takeoverQueue": "File de prise de contrôle",
+      "streaming": "Diffusion",
+      "monitoring": "Surveillance",
+      "comingSoon": "Bientôt disponible",
+      "comingSoonMessage": "Cet onglet n'est pas encore disponible.",
+      "streamingTitle": "Diffusion du bureau",
+      "monitoringTitle": "Surveillance du système"
+    },
+    "summary": {
+      "pending": "En attente",
+      "active": "Actives",
+      "paused": "En pause",
+      "completed": "Terminées",
+      "systemStatus": "État du système",
+      "statusNormal": "Normal",
+      "statusTakeoverActive": "Prise de contrôle active",
+      "statusEmergency": "Urgence"
+    },
+    "pending": {
+      "title": "Demandes de prise de contrôle en attente",
+      "colTrigger": "Déclencheur",
+      "colReason": "Raison",
+      "colPriority": "Priorité",
+      "colRequestedBy": "Demandé par",
+      "colCreatedAt": "Créée",
+      "colActions": "Actions",
+      "unknownAgent": "Agent inconnu",
+      "emptyTitle": "Aucune demande en attente",
+      "emptyMessage": "Aucune demande de prise de contrôle en attente d'approbation."
+    },
+    "active": {
+      "title": "Sessions de prise de contrôle actives",
+      "colOperator": "Opérateur",
+      "colStatus": "Statut",
+      "colStartedAt": "Démarrée",
+      "colActionsExecuted": "Actions exécutées",
+      "emptyTitle": "Aucune session active",
+      "emptyMessage": "Aucune session de contrôle manuel active pour le moment."
+    },
+    "actions": {
+      "approve": "Approuver",
+      "pause": "Suspendre",
+      "resume": "Reprendre",
+      "complete": "Terminer"
+    }
   },
   "adminUsers": {
     "title": "Gestion des utilisateurs",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -194,7 +194,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "בריאות המערכת"
+    "systemHealth": "בריאות המערכת",
+    "advancedControl": "בקרה מתקדמת"
   },
   "llcMembers": {
     "title": "חברים",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapter",
     "hiring": "Hiring…",
     "hire": "Hire"
+  },
+  "advancedControl": {
+    "title": "בקרה מתקדמת",
+    "subtitle": "אשר בקשות השתלטות ונהל הפעלות בקרה אנושית פעילות",
+    "tabListAriaLabel": "לשוניות בקרה מתקדמת",
+    "loading": "טוען את תור ההשתלטות…",
+    "tabs": {
+      "takeoverQueue": "תור השתלטות",
+      "streaming": "הזרמה",
+      "monitoring": "ניטור",
+      "comingSoon": "בקרוב",
+      "comingSoonMessage": "לשונית זו עדיין אינה זמינה.",
+      "streamingTitle": "הזרמת שולחן עבודה",
+      "monitoringTitle": "ניטור מערכת"
+    },
+    "summary": {
+      "pending": "ממתינות",
+      "active": "פעילות",
+      "paused": "מושהות",
+      "completed": "הושלמו",
+      "systemStatus": "מצב המערכת",
+      "statusNormal": "תקין",
+      "statusTakeoverActive": "השתלטות פעילה",
+      "statusEmergency": "חירום"
+    },
+    "pending": {
+      "title": "בקשות השתלטות ממתינות",
+      "colTrigger": "טריגר",
+      "colReason": "סיבה",
+      "colPriority": "עדיפות",
+      "colRequestedBy": "התבקש על ידי",
+      "colCreatedAt": "נוצר",
+      "colActions": "פעולות",
+      "unknownAgent": "סוכן לא ידוע",
+      "emptyTitle": "אין בקשות ממתינות",
+      "emptyMessage": "אין בקשות השתלטות הממתינות לאישור."
+    },
+    "active": {
+      "title": "הפעלות השתלטות פעילות",
+      "colOperator": "מפעיל",
+      "colStatus": "סטטוס",
+      "colStartedAt": "התחילה",
+      "colActionsExecuted": "פעולות שבוצעו",
+      "emptyTitle": "אין הפעלות פעילות",
+      "emptyMessage": "אין כרגע הפעלות בקרה אנושית פעילות."
+    },
+    "actions": {
+      "approve": "אשר",
+      "pause": "השהה",
+      "resume": "המשך",
+      "complete": "השלם"
+    }
   },
   "adminUsers": {
     "title": "User Management",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7649,7 +7649,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "Sistēmas veselība"
+    "systemHealth": "Sistēmas veselība",
+    "advancedControl": "Papildu vadība"
   },
   "llcMembers": {
     "title": "Dalibnieki",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapteris",
     "hiring": "Pieņem…",
     "hire": "Pieņemt"
+  },
+  "advancedControl": {
+    "title": "Papildu vadība",
+    "subtitle": "Apstipriniet pārņemšanas pieprasījumus un pārvaldiet aktīvās manuālās vadības sesijas",
+    "tabListAriaLabel": "Papildu vadības cilnes",
+    "loading": "Notiek pārņemšanas rindas ielāde…",
+    "tabs": {
+      "takeoverQueue": "Pārņemšanas rinda",
+      "streaming": "Straumēšana",
+      "monitoring": "Pārraudzība",
+      "comingSoon": "Drīzumā",
+      "comingSoonMessage": "Šī cilne vēl nav pieejama.",
+      "streamingTitle": "Darbvirsmas straumēšana",
+      "monitoringTitle": "Sistēmas pārraudzība"
+    },
+    "summary": {
+      "pending": "Gaida",
+      "active": "Aktīvas",
+      "paused": "Pauzētas",
+      "completed": "Pabeigtas",
+      "systemStatus": "Sistēmas statuss",
+      "statusNormal": "Normāls",
+      "statusTakeoverActive": "Pārņemšana aktīva",
+      "statusEmergency": "Ārkārtas situācija"
+    },
+    "pending": {
+      "title": "Gaidošie pārņemšanas pieprasījumi",
+      "colTrigger": "Trigeris",
+      "colReason": "Iemesls",
+      "colPriority": "Prioritāte",
+      "colRequestedBy": "Pieprasīja",
+      "colCreatedAt": "Izveidots",
+      "colActions": "Darbības",
+      "unknownAgent": "Nezināms aģents",
+      "emptyTitle": "Nav gaidošu pieprasījumu",
+      "emptyMessage": "Nav pārņemšanas pieprasījumu, kas gaida apstiprinājumu."
+    },
+    "active": {
+      "title": "Aktīvās pārņemšanas sesijas",
+      "colOperator": "Operators",
+      "colStatus": "Statuss",
+      "colStartedAt": "Sākta",
+      "colActionsExecuted": "Izpildītās darbības",
+      "emptyTitle": "Nav aktīvu sesiju",
+      "emptyMessage": "Pašlaik nav aktīvu manuālās vadības sesiju."
+    },
+    "actions": {
+      "approve": "Apstiprināt",
+      "pause": "Pauzēt",
+      "resume": "Atsākt",
+      "complete": "Pabeigt"
+    }
   },
   "adminUsers": {
     "title": "Lietotāju pārvaldība",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7649,7 +7649,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "Kondycja systemu"
+    "systemHealth": "Kondycja systemu",
+    "advancedControl": "Sterowanie zaawansowane"
   },
   "llcMembers": {
     "title": "Czlonkowie",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapter",
     "hiring": "Zatrudnianie…",
     "hire": "Zatrudnij"
+  },
+  "advancedControl": {
+    "title": "Sterowanie zaawansowane",
+    "subtitle": "Zatwierdzaj żądania przejęcia i zarządzaj aktywnymi sesjami sterowania ręcznego",
+    "tabListAriaLabel": "Karty sterowania zaawansowanego",
+    "loading": "Wczytywanie kolejki przejęć…",
+    "tabs": {
+      "takeoverQueue": "Kolejka przejęć",
+      "streaming": "Strumieniowanie",
+      "monitoring": "Monitorowanie",
+      "comingSoon": "Wkrótce dostępne",
+      "comingSoonMessage": "Ta karta nie jest jeszcze dostępna.",
+      "streamingTitle": "Strumieniowanie pulpitu",
+      "monitoringTitle": "Monitorowanie systemu"
+    },
+    "summary": {
+      "pending": "Oczekujące",
+      "active": "Aktywne",
+      "paused": "Wstrzymane",
+      "completed": "Zakończone",
+      "systemStatus": "Stan systemu",
+      "statusNormal": "Normalny",
+      "statusTakeoverActive": "Przejęcie aktywne",
+      "statusEmergency": "Awaria"
+    },
+    "pending": {
+      "title": "Oczekujące żądania przejęcia",
+      "colTrigger": "Wyzwalacz",
+      "colReason": "Powód",
+      "colPriority": "Priorytet",
+      "colRequestedBy": "Zgłoszone przez",
+      "colCreatedAt": "Utworzono",
+      "colActions": "Działania",
+      "unknownAgent": "Nieznany agent",
+      "emptyTitle": "Brak oczekujących żądań",
+      "emptyMessage": "Nie ma żądań przejęcia oczekujących na zatwierdzenie."
+    },
+    "active": {
+      "title": "Aktywne sesje przejęcia",
+      "colOperator": "Operator",
+      "colStatus": "Stan",
+      "colStartedAt": "Rozpoczęto",
+      "colActionsExecuted": "Wykonane działania",
+      "emptyTitle": "Brak aktywnych sesji",
+      "emptyMessage": "Obecnie nie ma aktywnych sesji sterowania ręcznego."
+    },
+    "actions": {
+      "approve": "Zatwierdź",
+      "pause": "Wstrzymaj",
+      "resume": "Wznów",
+      "complete": "Zakończ"
+    }
   },
   "adminUsers": {
     "title": "Zarządzanie użytkownikami",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7649,7 +7649,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "Saúde do sistema"
+    "systemHealth": "Saúde do sistema",
+    "advancedControl": "Controle avançado"
   },
   "llcMembers": {
     "title": "Membros",
@@ -8705,6 +8706,58 @@
     "adapter": "Adaptador",
     "hiring": "Contratando…",
     "hire": "Contratar"
+  },
+  "advancedControl": {
+    "title": "Controle avançado",
+    "subtitle": "Aprove solicitações de controle manual e gerencie sessões ativas",
+    "tabListAriaLabel": "Abas de controle avançado",
+    "loading": "Carregando fila de solicitações…",
+    "tabs": {
+      "takeoverQueue": "Fila de solicitações",
+      "streaming": "Transmissão",
+      "monitoring": "Monitoramento",
+      "comingSoon": "Em breve",
+      "comingSoonMessage": "Esta aba ainda não está disponível.",
+      "streamingTitle": "Transmissão de área de trabalho",
+      "monitoringTitle": "Monitoramento do sistema"
+    },
+    "summary": {
+      "pending": "Pendentes",
+      "active": "Ativas",
+      "paused": "Pausadas",
+      "completed": "Concluídas",
+      "systemStatus": "Status do sistema",
+      "statusNormal": "Normal",
+      "statusTakeoverActive": "Controle ativo",
+      "statusEmergency": "Emergência"
+    },
+    "pending": {
+      "title": "Solicitações de controle pendentes",
+      "colTrigger": "Gatilho",
+      "colReason": "Motivo",
+      "colPriority": "Prioridade",
+      "colRequestedBy": "Solicitado por",
+      "colCreatedAt": "Criada",
+      "colActions": "Ações",
+      "unknownAgent": "Agente desconhecido",
+      "emptyTitle": "Nenhuma solicitação pendente",
+      "emptyMessage": "Não há solicitações de controle aguardando aprovação."
+    },
+    "active": {
+      "title": "Sessões de controle ativas",
+      "colOperator": "Operador",
+      "colStatus": "Status",
+      "colStartedAt": "Iniciada",
+      "colActionsExecuted": "Ações executadas",
+      "emptyTitle": "Nenhuma sessão ativa",
+      "emptyMessage": "Não há sessões de controle manual ativas no momento."
+    },
+    "actions": {
+      "approve": "Aprovar",
+      "pause": "Pausar",
+      "resume": "Retomar",
+      "complete": "Concluir"
+    }
   },
   "adminUsers": {
     "title": "Gerenciamento de usuários",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -194,7 +194,8 @@
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
-    "systemHealth": "سسٹم کی صحت"
+    "systemHealth": "سسٹم کی صحت",
+    "advancedControl": "ایڈوانسڈ کنٹرول"
   },
   "llcMembers": {
     "title": "اراکین",
@@ -8705,6 +8706,58 @@
     "adapter": "Adapter",
     "hiring": "Hiring…",
     "hire": "Hire"
+  },
+  "advancedControl": {
+    "title": "ایڈوانسڈ کنٹرول",
+    "subtitle": "قبضے کی درخواستوں کی منظوری دیں اور فعال انسانی کنٹرول سیشنز کا نظم کریں",
+    "tabListAriaLabel": "ایڈوانسڈ کنٹرول ٹیبز",
+    "loading": "قبضے کی قطار لوڈ ہو رہی ہے…",
+    "tabs": {
+      "takeoverQueue": "قبضے کی قطار",
+      "streaming": "اسٹریمنگ",
+      "monitoring": "نگرانی",
+      "comingSoon": "جلد آ رہا ہے",
+      "comingSoonMessage": "یہ ٹیب ابھی دستیاب نہیں ہے۔",
+      "streamingTitle": "ڈیسک ٹاپ اسٹریمنگ",
+      "monitoringTitle": "سسٹم کی نگرانی"
+    },
+    "summary": {
+      "pending": "زیر التوا",
+      "active": "فعال",
+      "paused": "موقوف",
+      "completed": "مکمل",
+      "systemStatus": "سسٹم کی حالت",
+      "statusNormal": "نارمل",
+      "statusTakeoverActive": "قبضہ فعال",
+      "statusEmergency": "ہنگامی"
+    },
+    "pending": {
+      "title": "زیر التوا قبضے کی درخواستیں",
+      "colTrigger": "محرک",
+      "colReason": "وجہ",
+      "colPriority": "ترجیح",
+      "colRequestedBy": "درخواست دہندہ",
+      "colCreatedAt": "تخلیق شدہ",
+      "colActions": "اقدامات",
+      "unknownAgent": "نامعلوم ایجنٹ",
+      "emptyTitle": "کوئی زیر التوا درخواست نہیں",
+      "emptyMessage": "منظوری کے منتظر کوئی قبضے کی درخواست موجود نہیں ہے۔"
+    },
+    "active": {
+      "title": "فعال قبضہ سیشنز",
+      "colOperator": "آپریٹر",
+      "colStatus": "حالت",
+      "colStartedAt": "شروع ہوا",
+      "colActionsExecuted": "انجام شدہ اقدامات",
+      "emptyTitle": "کوئی فعال سیشن نہیں",
+      "emptyMessage": "اس وقت کوئی فعال انسانی کنٹرول سیشن موجود نہیں ہے۔"
+    },
+    "actions": {
+      "approve": "منظور کریں",
+      "pause": "موقوف کریں",
+      "resume": "دوبارہ شروع کریں",
+      "complete": "مکمل کریں"
+    }
   },
   "adminUsers": {
     "title": "User Management",

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -838,6 +838,19 @@ export const routes: RouteRecordRaw[] = [
       hideInNav: true,
     },
   },
+  // Issue #12162 (#12102/#11506 T1 Stage 1): Advanced Control — takeover approval queue
+  {
+    path: '/admin/advanced-control',
+    name: 'admin-advanced-control',
+    component: () => import('@/views/AdvancedControlView.vue'),
+    meta: {
+      title: 'Advanced Control',
+      description: 'Takeover approval queue, streaming, and monitoring',
+      requiresAuth: true,
+      admin: true,
+      hideInNav: true,
+    },
+  },
   // GH#6470: Budget policy management (admin-only)
   {
     path: '/admin/budget-policies',

--- a/autobot-frontend/src/views/AdvancedControlView.vue
+++ b/autobot-frontend/src/views/AdvancedControlView.vue
@@ -1,0 +1,608 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2026 mrveiss -->
+<!-- Author: mrveiss -->
+<!--
+  AdvancedControlView — admin-only Advanced Control panel (#12162, #12102,
+  #11506 T1 — Stage 1). Tabbed shell wired to AdvancedControlApiClient's
+  takeover-management endpoints. Streaming/Monitoring tabs are placeholders
+  for a later stage.
+-->
+<template>
+  <div class="advanced-control-view view-container">
+    <div class="page-header">
+      <div class="page-header-content">
+        <h2 class="page-title">{{ t('advancedControl.title') }}</h2>
+        <p class="page-subtitle">{{ t('advancedControl.subtitle') }}</p>
+      </div>
+      <div class="header-actions">
+        <button class="btn-action-secondary" :disabled="loading" @click="loadTakeovers">
+          <Icon name="sync-alt" :spin="loading" />
+          {{ t('common.refresh') }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Tab bar -->
+    <div
+      ref="tablistRef"
+      class="acv-tabs"
+      role="tablist"
+      :aria-label="t('advancedControl.tabListAriaLabel')"
+    >
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        v-bind="tabAttrs(tab.id)"
+        class="acv-tab"
+        :class="{ 'acv-tab--active': activeTab === tab.id }"
+        :disabled="tab.disabled"
+        @click="!tab.disabled && selectTab(tab.id)"
+        @keydown="handleKeydown"
+      >
+        <Icon :name="tab.icon" />
+        {{ tab.label }}
+        <span v-if="tab.disabled" class="acv-tab__soon">{{ t('advancedControl.tabs.comingSoon') }}</span>
+      </button>
+    </div>
+
+    <!-- Takeover Queue tab -->
+    <div v-if="activeTab === 'takeover'" v-bind="panelAttrs('takeover')" class="acv-content">
+      <div v-if="error" class="error-banner">
+        <Icon name="exclamation-circle" />
+        <span>{{ error }}</span>
+        <button class="btn-dismiss" :aria-label="t('common.dismiss')" @click="clearError"><Icon name="times" /></button>
+      </div>
+
+      <!-- Status summary -->
+      <div v-if="takeoverStatus" class="status-summary">
+        <div class="status-card">
+          <span class="status-value">{{ takeoverStatus.pending_requests_count }}</span>
+          <span class="status-label">{{ t('advancedControl.summary.pending') }}</span>
+        </div>
+        <div class="status-card">
+          <span class="status-value">{{ takeoverStatus.active_sessions_count }}</span>
+          <span class="status-label">{{ t('advancedControl.summary.active') }}</span>
+        </div>
+        <div class="status-card">
+          <span class="status-value">{{ takeoverStatus.paused_tasks_count }}</span>
+          <span class="status-label">{{ t('advancedControl.summary.paused') }}</span>
+        </div>
+        <div class="status-card">
+          <span class="status-value">{{ takeoverStatus.total_completed_sessions }}</span>
+          <span class="status-label">{{ t('advancedControl.summary.completed') }}</span>
+        </div>
+        <div class="status-card status-card--system" :class="`status-card--${takeoverStatus.system_status}`">
+          <span class="status-label">{{ t('advancedControl.summary.systemStatus') }}</span>
+          <span class="badge" :class="systemStatusBadgeClass">{{ systemStatusLabel }}</span>
+        </div>
+      </div>
+
+      <div v-if="loading && pendingTakeovers.length === 0 && activeTakeovers.length === 0" class="loading-state">
+        <Icon name="sync-alt" :spin="true" /> {{ t('advancedControl.loading') }}
+      </div>
+
+      <template v-else>
+        <!-- Pending requests -->
+        <section class="table-section">
+          <h3 class="section-title">{{ t('advancedControl.pending.title') }}</h3>
+          <table v-if="pendingTakeovers.length > 0" class="data-table">
+            <thead>
+              <tr>
+                <th>{{ t('advancedControl.pending.colTrigger') }}</th>
+                <th>{{ t('advancedControl.pending.colReason') }}</th>
+                <th>{{ t('advancedControl.pending.colPriority') }}</th>
+                <th>{{ t('advancedControl.pending.colRequestedBy') }}</th>
+                <th>{{ t('advancedControl.pending.colCreatedAt') }}</th>
+                <th>{{ t('advancedControl.pending.colActions') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="req in pendingTakeovers" :key="req.request_id">
+                <td>{{ req.trigger }}</td>
+                <td class="reason-cell">{{ req.reason }}</td>
+                <td><span class="badge" :class="priorityBadgeClass(req.priority)">{{ req.priority }}</span></td>
+                <td>{{ req.requesting_agent || t('advancedControl.pending.unknownAgent') }}</td>
+                <td>{{ formatDate(req.created_at) }}</td>
+                <td class="actions-cell">
+                  <button
+                    class="btn-icon btn-success"
+                    :title="t('advancedControl.actions.approve')"
+                    :disabled="loading"
+                    @click="onApprove(req.request_id)"
+                  >
+                    <Icon name="check-circle" />
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <EmptyState
+            v-else
+            icon="check-circle"
+            :title="t('advancedControl.pending.emptyTitle')"
+            :message="t('advancedControl.pending.emptyMessage')"
+            compact
+          />
+        </section>
+
+        <!-- Active sessions -->
+        <section class="table-section">
+          <h3 class="section-title">{{ t('advancedControl.active.title') }}</h3>
+          <table v-if="activeTakeovers.length > 0" class="data-table">
+            <thead>
+              <tr>
+                <th>{{ t('advancedControl.active.colOperator') }}</th>
+                <th>{{ t('advancedControl.active.colStatus') }}</th>
+                <th>{{ t('advancedControl.active.colStartedAt') }}</th>
+                <th>{{ t('advancedControl.active.colActionsExecuted') }}</th>
+                <th>{{ t('advancedControl.pending.colActions') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="session in activeTakeovers" :key="session.session_id">
+                <td>{{ session.human_operator }}</td>
+                <td><span class="badge" :class="statusBadgeClass(session.status)">{{ session.status }}</span></td>
+                <td>{{ formatDate(session.started_at) }}</td>
+                <td>{{ session.actions_executed }}</td>
+                <td class="actions-cell">
+                  <button
+                    v-if="session.status === 'active'"
+                    class="btn-icon btn-warning"
+                    :title="t('advancedControl.actions.pause')"
+                    :disabled="loading"
+                    @click="onPause(session.session_id)"
+                  >
+                    <Icon name="pause-circle" />
+                  </button>
+                  <button
+                    v-if="session.status === 'paused'"
+                    class="btn-icon btn-info"
+                    :title="t('advancedControl.actions.resume')"
+                    :disabled="loading"
+                    @click="onResume(session.session_id)"
+                  >
+                    <Icon name="play-circle" />
+                  </button>
+                  <button
+                    class="btn-icon btn-danger"
+                    :title="t('advancedControl.actions.complete')"
+                    :disabled="loading"
+                    @click="onComplete(session.session_id)"
+                  >
+                    <Icon name="stop-circle" />
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <EmptyState
+            v-else
+            icon="hand-paper"
+            :title="t('advancedControl.active.emptyTitle')"
+            :message="t('advancedControl.active.emptyMessage')"
+            compact
+          />
+        </section>
+      </template>
+    </div>
+
+    <!-- Streaming tab placeholder -->
+    <div v-else-if="activeTab === 'streaming'" v-bind="panelAttrs('streaming')" class="acv-content">
+      <EmptyState
+        icon="window-restore"
+        :title="t('advancedControl.tabs.streamingTitle')"
+        :message="t('advancedControl.tabs.comingSoonMessage')"
+      />
+    </div>
+
+    <!-- Monitoring tab placeholder -->
+    <div v-else-if="activeTab === 'monitoring'" v-bind="panelAttrs('monitoring')" class="acv-content">
+      <EmptyState
+        icon="tachometer-alt"
+        :title="t('advancedControl.tabs.monitoringTitle')"
+        :message="t('advancedControl.tabs.comingSoonMessage')"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useTabs } from '@/composables/useTabs'
+import { useAdvancedControl } from '@/composables/useAdvancedControl'
+import Icon from '@/components/ui/Icon.vue'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import type { TakeoverPriority, TakeoverStatus } from '@/utils/AdvancedControlApiClient'
+
+const { t } = useI18n()
+
+const {
+  pendingTakeovers,
+  activeTakeovers,
+  takeoverStatus,
+  loading,
+  error,
+  loadTakeovers,
+  approve,
+  pause,
+  resume,
+  complete,
+} = useAdvancedControl()
+
+const TAB_IDS = ['takeover', 'streaming', 'monitoring'] as const
+type TabId = (typeof TAB_IDS)[number]
+
+const { activeTab, tabAttrs, panelAttrs, handleKeydown, tablistRef, selectTab } = useTabs(TAB_IDS)
+
+interface TabDef {
+  id: TabId
+  label: string
+  icon: 'hand-paper' | 'window-restore' | 'tachometer-alt'
+  disabled: boolean
+}
+
+const tabs = computed<TabDef[]>(() => [
+  { id: 'takeover', label: t('advancedControl.tabs.takeoverQueue'), icon: 'hand-paper', disabled: false },
+  { id: 'streaming', label: t('advancedControl.tabs.streaming'), icon: 'window-restore', disabled: true },
+  { id: 'monitoring', label: t('advancedControl.tabs.monitoring'), icon: 'tachometer-alt', disabled: true },
+])
+
+function clearError(): void {
+  error.value = null
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+const priorityBadgeClasses: Record<TakeoverPriority, string> = {
+  LOW: 'badge-info',
+  MEDIUM: 'badge-bundle',
+  HIGH: 'badge-admin',
+  CRITICAL: 'badge-inactive',
+}
+
+function priorityBadgeClass(priority: TakeoverPriority): string {
+  return priorityBadgeClasses[priority] ?? 'badge-bundle'
+}
+
+const statusBadgeClasses: Record<TakeoverStatus, string> = {
+  pending: 'badge-admin',
+  approved: 'badge-bundle',
+  active: 'badge-active',
+  paused: 'badge-admin',
+  completed: 'badge-active',
+  rejected: 'badge-inactive',
+}
+
+function statusBadgeClass(status: TakeoverStatus): string {
+  return statusBadgeClasses[status] ?? 'badge-bundle'
+}
+
+const systemStatusLabel = computed(() => {
+  const status = takeoverStatus.value?.system_status
+  if (status === 'takeover_active') return t('advancedControl.summary.statusTakeoverActive')
+  if (status === 'emergency') return t('advancedControl.summary.statusEmergency')
+  return t('advancedControl.summary.statusNormal')
+})
+
+const systemStatusBadgeClass = computed(() => {
+  const status = takeoverStatus.value?.system_status
+  if (status === 'emergency') return 'badge-inactive'
+  if (status === 'takeover_active') return 'badge-admin'
+  return 'badge-active'
+})
+
+async function onApprove(requestId: string): Promise<void> {
+  await approve(requestId)
+}
+
+async function onPause(sessionId: string): Promise<void> {
+  await pause(sessionId)
+}
+
+async function onResume(sessionId: string): Promise<void> {
+  await resume(sessionId)
+}
+
+async function onComplete(sessionId: string): Promise<void> {
+  await complete(sessionId)
+}
+
+onMounted(loadTakeovers)
+</script>
+
+<style scoped>
+.advanced-control-view {
+  padding: var(--spacing-6);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-6);
+  gap: var(--spacing-4);
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-1);
+}
+
+.page-subtitle {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: var(--spacing-0);
+}
+
+.header-actions {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+/* ── Tabs ───────────────────────────────────────────────────────────────── */
+
+.acv-tabs {
+  display: flex;
+  gap: var(--spacing-1);
+  border-bottom: 1px solid var(--border-default);
+  margin-bottom: var(--spacing-5);
+}
+
+.acv-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.acv-tab:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.acv-tab--active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.acv-tab__soon {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  background: var(--bg-tertiary);
+  padding: var(--spacing-0-5) var(--spacing-1-5);
+  border-radius: var(--radius-full);
+}
+
+.acv-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+/* ── Status summary ─────────────────────────────────────────────────────── */
+
+.status-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.status-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding: var(--spacing-4);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xl);
+}
+
+.status-card--system {
+  justify-content: center;
+}
+
+.status-value {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.status-label {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ── Error banner ───────────────────────────────────────────────────────── */
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: var(--radius-lg);
+  color: var(--color-error);
+}
+
+.btn-dismiss {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+}
+
+/* ── Tables ─────────────────────────────────────────────────────────────── */
+
+.table-section {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.section-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: var(--spacing-0);
+  padding: var(--spacing-4);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.loading-state {
+  padding: var(--spacing-8);
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th {
+  text-align: left;
+  padding: var(--spacing-3) var(--spacing-4);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.data-table td {
+  padding: var(--spacing-3) var(--spacing-4);
+  border-bottom: 1px solid var(--border-default);
+  font-size: var(--text-sm);
+}
+
+.data-table tr:last-child td {
+  border-bottom: none;
+}
+
+.reason-cell {
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-block;
+  padding: var(--spacing-0-5) var(--spacing-2);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.badge-admin {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.badge-active {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.badge-inactive {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.badge-bundle {
+  background: var(--color-info-bg);
+  color: var(--color-info);
+}
+
+.badge-info {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.actions-cell {
+  display: flex;
+  gap: var(--spacing-1);
+}
+
+.btn-icon {
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-xs);
+}
+
+.btn-icon:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-warning {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.btn-info {
+  background: var(--color-info-bg);
+  color: var(--color-info);
+}
+
+.btn-success {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.btn-danger {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.btn-action-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1-5);
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.btn-action-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/autobot-frontend/src/views/__tests__/AdvancedControlView.test.ts
+++ b/autobot-frontend/src/views/__tests__/AdvancedControlView.test.ts
@@ -1,0 +1,137 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Tests for AdvancedControlView.vue (#12162, #12102, #11506 T1 — Stage 1).
+// Mocks useAdvancedControl so no real HTTP calls are made, and asserts the
+// /admin/advanced-control route carries the same admin guard meta as its
+// sibling admin routes (router/index.ts requiresAdmin check).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
+import en from '@/i18n/locales/en.json'
+import { routes } from '@/router'
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Real Vue refs so template auto-unwrapping works the same as the live composable.
+const mockPendingTakeovers = ref<unknown[]>([])
+const mockActiveTakeovers = ref<unknown[]>([])
+const mockTakeoverStatus = ref<unknown>(null)
+const mockLoading = ref(false)
+const mockError = ref<string | null>(null)
+
+const mockLoadTakeovers = vi.fn().mockResolvedValue(undefined)
+const mockApprove = vi.fn().mockResolvedValue(true)
+const mockPause = vi.fn().mockResolvedValue(true)
+const mockResume = vi.fn().mockResolvedValue(true)
+const mockComplete = vi.fn().mockResolvedValue(true)
+
+vi.mock('@/composables/useAdvancedControl', () => ({
+  useAdvancedControl: () => ({
+    pendingTakeovers: mockPendingTakeovers,
+    activeTakeovers: mockActiveTakeovers,
+    takeoverStatus: mockTakeoverStatus,
+    loading: mockLoading,
+    error: mockError,
+    loadTakeovers: mockLoadTakeovers,
+    approve: mockApprove,
+    pause: mockPause,
+    resume: mockResume,
+    complete: mockComplete,
+    action: vi.fn(),
+  }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+import AdvancedControlView from '../AdvancedControlView.vue'
+
+function mountView() {
+  return mount(AdvancedControlView, {
+    global: { plugins: [i18n] },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AdvancedControlView.vue', () => {
+  beforeEach(() => {
+    mockPendingTakeovers.value = []
+    mockActiveTakeovers.value = []
+    mockTakeoverStatus.value = null
+    mockLoading.value = false
+    mockError.value = null
+    mockLoadTakeovers.mockClear()
+    mockApprove.mockClear()
+  })
+
+  it('is registered as an admin-gated route (same guard as sibling admin routes)', () => {
+    const route = routes.find((r) => r.path === '/admin/advanced-control')
+    expect(route).toBeTruthy()
+    expect(route?.meta?.requiresAuth).toBe(true)
+    expect(route?.meta?.admin).toBe(true)
+  })
+
+  it('renders the tab shell and the empty pending/active queue', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Advanced Control')
+    expect(wrapper.text()).toContain('Takeover Queue')
+    expect(wrapper.text()).toContain('No pending requests')
+    expect(wrapper.text()).toContain('No active sessions')
+    expect(mockLoadTakeovers).toHaveBeenCalled()
+  })
+
+  it('renders a pending request row with an approve action', async () => {
+    mockPendingTakeovers.value = [
+      {
+        request_id: 'r1',
+        trigger: 'MANUAL_REQUEST',
+        reason: 'needs a human',
+        requesting_agent: 'agent-1',
+        affected_tasks: [],
+        priority: 'HIGH',
+        created_at: '2026-07-23T00:00:00Z',
+        timeout_at: null,
+        auto_approve: false,
+      },
+    ]
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('needs a human')
+    expect(wrapper.text()).toContain('agent-1')
+
+    const approveBtn = wrapper.find('button.btn-success')
+    expect(approveBtn.exists()).toBe(true)
+    await approveBtn.trigger('click')
+    expect(mockApprove).toHaveBeenCalledWith('r1')
+  })
+
+  it('surfaces the composable error via the error banner', async () => {
+    mockError.value = 'Failed to load takeovers'
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to load takeovers')
+  })
+})


### PR DESCRIPTION
Closes #12162
Part of #12102 / #11506 (Stage 1 of 3, owner-approved feature)

## What Changed
First slice of the Advanced Control (Phase 8) admin frontend for the live-but-UI-less `api/advanced_control.py` (admin-gated, #744):
- **`useAdvancedControl.ts`** — wraps the existing `advancedControlApiClient`; exposes pending/active takeovers + status, and approve/pause/resume/complete/action.
- **`AdvancedControlView.vue`** — tabbed shell (via existing `useTabs`); **Takeover Approval Queue** tab fully built (pending+active tables, approve + session actions, loading/empty/error states, design tokens). Streaming/Monitoring tabs are disabled "coming soon" placeholders (Stages 2-3).
- **Route** `/admin/advanced-control` — admin-gated (meta copied verbatim from `/admin/sandbox`; global `router.beforeEach` enforces). **navItems** adminMenuItems entry.
- **i18n** — `nav.advancedControl` + `advancedControl.*` in ALL 11 locales with real translations (matched the #10932 systemHealth precedent).

## Verification
vue-tsc `-p tsconfig.app.json` exit 0; vitest 40/40 (composable 6, view 4, locale-parity, nav coverage); eslint + oxlint clean; no hardcoded strings (all via `t()`); additive + admin-gated (no impact on existing flows). Patterns cited: AdminUsersView (styling/tokens), FeatureFlagsSettingsPanel (ApiResponse `.success`/`.data`), useTabs/WebResearchPanel (shell), /admin/sandbox (guard).

## Model Used
Claude Sonnet (subagent), reviewed by Opus 4.8