### PR TITLE
feat(frontend): Advanced Control panel — Stage 2: streaming sessions tab (#12169)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useAdvancedControl.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useAdvancedControl.test.ts
@@ -3,12 +3,14 @@
 // AutoBot - AI-Powered Automation Platform
 // Author: mrveiss
 /**
- * Unit tests for useAdvancedControl (#12162, #12102, #11506 T1 — Stage 1).
+ * Unit tests for useAdvancedControl (#12162, #12102, #11506 T1 — Stage 1;
+ * #12169, #12102 — Stage 2 streaming sessions).
  *
  * Covers: loadTakeovers populates pending/active/status from the client,
  * approve/pause/resume/complete call the right client methods and refresh
- * state on success, and failures (success:false or thrown) surface via the
- * `error` ref without throwing.
+ * state on success, failures (success:false or thrown) surface via the
+ * `error` ref without throwing, and the Stage 2 streaming equivalents
+ * (loadStreaming/createStreaming/terminateStreaming).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -23,6 +25,10 @@ const mockPauseTakeoverSession = vi.fn()
 const mockResumeTakeoverSession = vi.fn()
 const mockCompleteTakeoverSession = vi.fn()
 const mockExecuteTakeoverAction = vi.fn()
+const mockListStreamingSessions = vi.fn()
+const mockGetStreamingCapabilities = vi.fn()
+const mockCreateStreamingSession = vi.fn()
+const mockTerminateStreamingSession = vi.fn()
 
 vi.mock('@/utils/AdvancedControlApiClient', () => ({
   advancedControlApiClient: {
@@ -34,6 +40,10 @@ vi.mock('@/utils/AdvancedControlApiClient', () => ({
     resumeTakeoverSession: (...args: unknown[]) => mockResumeTakeoverSession(...args),
     completeTakeoverSession: (...args: unknown[]) => mockCompleteTakeoverSession(...args),
     executeTakeoverAction: (...args: unknown[]) => mockExecuteTakeoverAction(...args),
+    listStreamingSessions: (...args: unknown[]) => mockListStreamingSessions(...args),
+    getStreamingCapabilities: (...args: unknown[]) => mockGetStreamingCapabilities(...args),
+    createStreamingSession: (...args: unknown[]) => mockCreateStreamingSession(...args),
+    terminateStreamingSession: (...args: unknown[]) => mockTerminateStreamingSession(...args),
   },
 }))
 
@@ -53,6 +63,18 @@ const okStatus = {
   },
 }
 
+const okEmptySessions = { success: true, data: { sessions: [], count: 0 } }
+const okCapabilities = {
+  success: true,
+  data: {
+    vnc_available: true,
+    novnc_available: true,
+    max_sessions: 4,
+    supported_resolutions: ['1920x1080'],
+    supported_depths: [24],
+  },
+}
+
 function resetMocks(): void {
   mockGetPendingTakeovers.mockReset().mockResolvedValue(okEmpty)
   mockGetActiveTakeovers.mockReset().mockResolvedValue(okEmptyActive)
@@ -62,6 +84,10 @@ function resetMocks(): void {
   mockResumeTakeoverSession.mockReset()
   mockCompleteTakeoverSession.mockReset()
   mockExecuteTakeoverAction.mockReset()
+  mockListStreamingSessions.mockReset().mockResolvedValue(okEmptySessions)
+  mockGetStreamingCapabilities.mockReset().mockResolvedValue(okCapabilities)
+  mockCreateStreamingSession.mockReset()
+  mockTerminateStreamingSession.mockReset()
 }
 
 describe('useAdvancedControl', () => {
@@ -75,10 +101,13 @@ describe('useAdvancedControl', () => {
   })
 
   it('starts with empty state', () => {
-    const { pendingTakeovers, activeTakeovers, takeoverStatus, loading, error } = useAdvancedControl()
+    const { pendingTakeovers, activeTakeovers, takeoverStatus, streamingSessions, streamingCapabilities, loading, error } =
+      useAdvancedControl()
     expect(pendingTakeovers.value).toEqual([])
     expect(activeTakeovers.value).toEqual([])
     expect(takeoverStatus.value).toBeNull()
+    expect(streamingSessions.value).toEqual([])
+    expect(streamingCapabilities.value).toBeNull()
     expect(loading.value).toBe(false)
     expect(error.value).toBeNull()
   })
@@ -186,6 +215,111 @@ describe('useAdvancedControl', () => {
     await scope.run(async () => {
       const { loadTakeovers, error } = useAdvancedControl()
       await loadTakeovers()
+      expect(error.value).toBe('network down')
+    })
+    scope.stop()
+  })
+
+  it('loadStreaming populates streamingSessions and streamingCapabilities from the client', async () => {
+    const session = {
+      session_id: 's1',
+      user_id: 'u1',
+      vnc_port: 5901,
+      novnc_port: 6901,
+      display: ':1',
+      created_at: '2026-07-23T00:00:00Z',
+      status: 'active' as const,
+    }
+    mockListStreamingSessions.mockResolvedValueOnce({ success: true, data: { sessions: [session], count: 1 } })
+    mockGetStreamingCapabilities.mockResolvedValueOnce({
+      success: true,
+      data: {
+        vnc_available: true,
+        novnc_available: false,
+        max_sessions: 2,
+        supported_resolutions: ['1280x720'],
+        supported_depths: [16],
+      },
+    })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { loadStreaming, streamingSessions, streamingCapabilities, loading, error } = useAdvancedControl()
+      const promise = loadStreaming()
+      expect(loading.value).toBe(true)
+      await promise
+
+      expect(loading.value).toBe(false)
+      expect(error.value).toBeNull()
+      expect(streamingSessions.value).toEqual([session])
+      expect(streamingCapabilities.value?.max_sessions).toBe(2)
+    })
+    scope.stop()
+  })
+
+  it('createStreaming calls createStreamingSession with the request and reloads on success', async () => {
+    mockCreateStreamingSession.mockResolvedValueOnce({
+      success: true,
+      data: {
+        session_id: 's1',
+        vnc_port: 5901,
+        novnc_port: 6901,
+        display: ':1',
+        vnc_url: 'vnc://host:5901',
+        web_url: 'http://host:6901',
+        websocket_endpoint: '/ws/desktop/s1',
+      },
+    })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { createStreaming } = useAdvancedControl()
+      const result = await createStreaming({ user_id: 'u1', resolution: '1920x1080', depth: 24 })
+      expect(result).toBe(true)
+    })
+    scope.stop()
+
+    expect(mockCreateStreamingSession).toHaveBeenCalledWith({ user_id: 'u1', resolution: '1920x1080', depth: 24 })
+    expect(mockListStreamingSessions).toHaveBeenCalled()
+  })
+
+  it('terminateStreaming calls terminateStreamingSession and reloads on success', async () => {
+    mockTerminateStreamingSession.mockResolvedValueOnce({ success: true, data: { success: true, session_id: 's1' } })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { terminateStreaming } = useAdvancedControl()
+      const result = await terminateStreaming('s1')
+      expect(result).toBe(true)
+    })
+    scope.stop()
+
+    expect(mockTerminateStreamingSession).toHaveBeenCalledWith('s1')
+    expect(mockListStreamingSessions).toHaveBeenCalled()
+  })
+
+  it('surfaces a createStreaming client success:false error without throwing', async () => {
+    mockCreateStreamingSession.mockResolvedValueOnce({ success: false, error: 'max sessions reached' })
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { createStreaming, error } = useAdvancedControl()
+      const result = await createStreaming({ user_id: 'u1' })
+      expect(result).toBe(false)
+      expect(error.value).toBe('max sessions reached')
+    })
+    scope.stop()
+    expect(mockListStreamingSessions).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a terminateStreaming thrown error via the error ref', async () => {
+    mockTerminateStreamingSession.mockRejectedValueOnce(new Error('network down'))
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const { terminateStreaming, error } = useAdvancedControl()
+      const result = await terminateStreaming('s1')
+      expect(result).toBe(false)
       expect(error.value).toBe('network down')
     })
     scope.stop()

--- a/autobot-frontend/src/composables/useAdvancedControl.ts
+++ b/autobot-frontend/src/composables/useAdvancedControl.ts
@@ -4,11 +4,13 @@
 // Author: mrveiss
 
 /**
- * Advanced Control composable (#12162, #12102, #11506 T1 — Stage 1).
+ * Advanced Control composable (#12162, #12102, #11506 T1 — Stage 1;
+ * #12169, #12102 — Stage 2 streaming sessions).
  *
- * Wraps `advancedControlApiClient`'s takeover-management endpoints for the
- * admin-only Advanced Control panel. Streaming/monitoring endpoints are out
- * of scope for Stage 1 (see AdvancedControlView.vue placeholders).
+ * Wraps `advancedControlApiClient`'s takeover-management and desktop
+ * streaming endpoints for the admin-only Advanced Control panel.
+ * Monitoring endpoints are out of scope (see AdvancedControlView.vue
+ * placeholder).
  */
 
 import { ref } from 'vue'
@@ -18,6 +20,9 @@ import type {
   ActiveTakeoverSession,
   TakeoverSystemStatus,
   TakeoverCompletionRequest,
+  StreamingSession,
+  StreamingCapabilities,
+  StreamingSessionRequest,
 } from '@/utils/AdvancedControlApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { useUserStore } from '@/stores/useUserStore'
@@ -30,6 +35,8 @@ export function useAdvancedControl() {
   const pendingTakeovers = ref<PendingTakeoverRequest[]>([])
   const activeTakeovers = ref<ActiveTakeoverSession[]>([])
   const takeoverStatus = ref<TakeoverSystemStatus | null>(null)
+  const streamingSessions = ref<StreamingSession[]>([])
+  const streamingCapabilities = ref<StreamingCapabilities | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
 
@@ -167,10 +174,82 @@ export function useAdvancedControl() {
     }
   }
 
+  /**
+   * Loads active streaming sessions and streaming capabilities in parallel.
+   * Partial failures are tolerated per-call, mirroring loadTakeovers.
+   */
+  async function loadStreaming(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      const [sessionsRes, capsRes] = await Promise.all([
+        advancedControlApiClient.listStreamingSessions(),
+        advancedControlApiClient.getStreamingCapabilities(),
+      ])
+
+      if (sessionsRes.success && sessionsRes.data) {
+        streamingSessions.value = sessionsRes.data.sessions
+      } else if (!sessionsRes.success) {
+        logger.error('Failed to load streaming sessions:', sessionsRes.error)
+      }
+
+      if (capsRes.success && capsRes.data) {
+        streamingCapabilities.value = capsRes.data
+      } else if (!capsRes.success) {
+        logger.error('Failed to load streaming capabilities:', capsRes.error)
+      }
+
+      if (!sessionsRes.success && !capsRes.success) {
+        error.value = sessionsRes.error || capsRes.error || 'Failed to load streaming sessions'
+      }
+    } catch (err) {
+      logger.error('Failed to load streaming sessions:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to load streaming sessions'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createStreaming(request: StreamingSessionRequest): Promise<boolean> {
+    error.value = null
+    try {
+      const res = await advancedControlApiClient.createStreamingSession(request)
+      if (!res.success) {
+        error.value = res.error || 'Failed to create streaming session'
+        return false
+      }
+      await loadStreaming()
+      return true
+    } catch (err) {
+      logger.error('Failed to create streaming session:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to create streaming session'
+      return false
+    }
+  }
+
+  async function terminateStreaming(sessionId: string): Promise<boolean> {
+    error.value = null
+    try {
+      const res = await advancedControlApiClient.terminateStreamingSession(sessionId)
+      if (!res.success) {
+        error.value = res.error || 'Failed to terminate streaming session'
+        return false
+      }
+      await loadStreaming()
+      return true
+    } catch (err) {
+      logger.error('Failed to terminate streaming session:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to terminate streaming session'
+      return false
+    }
+  }
+
   return {
     pendingTakeovers,
     activeTakeovers,
     takeoverStatus,
+    streamingSessions,
+    streamingCapabilities,
     loading,
     error,
     loadTakeovers,
@@ -179,5 +258,8 @@ export function useAdvancedControl() {
     resume,
     complete,
     action,
+    loadStreaming,
+    createStreaming,
+    terminateStreaming,
   }
 }

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8757,6 +8757,27 @@
       "pause": "إيقاف مؤقت",
       "resume": "استئناف",
       "complete": "إكمال"
+    },
+    "streaming": {
+      "title": "جلسات البث",
+      "newSession": "جلسة جديدة",
+      "terminate": "إنهاء",
+      "capVncAvailable": "VNC متاح",
+      "capNovncAvailable": "noVNC متاح",
+      "capMaxSessions": "الحد الأقصى للجلسات",
+      "formUserIdLabel": "معرّف المستخدم",
+      "formUserIdPlaceholder": "مثال: user-123",
+      "formResolutionLabel": "الدقة",
+      "formResolutionPlaceholder": "مثال: 1920x1080",
+      "formDepthLabel": "عمق اللون",
+      "colSessionId": "معرّف الجلسة",
+      "colUser": "المستخدم",
+      "colStatus": "الحالة",
+      "colDisplay": "الشاشة",
+      "colCreatedAt": "تاريخ الإنشاء",
+      "colActions": "الإجراءات",
+      "emptyTitle": "لا توجد جلسات بث نشطة",
+      "emptyMessage": "لا توجد جلسات بث لسطح المكتب نشطة حاليًا."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8757,6 +8757,27 @@
       "pause": "Pausieren",
       "resume": "Fortsetzen",
       "complete": "Abschließen"
+    },
+    "streaming": {
+      "title": "Streaming-Sitzungen",
+      "newSession": "Neue Sitzung",
+      "terminate": "Beenden",
+      "capVncAvailable": "VNC verfügbar",
+      "capNovncAvailable": "noVNC verfügbar",
+      "capMaxSessions": "Max. Sitzungen",
+      "formUserIdLabel": "Benutzer-ID",
+      "formUserIdPlaceholder": "z. B. user-123",
+      "formResolutionLabel": "Auflösung",
+      "formResolutionPlaceholder": "z. B. 1920x1080",
+      "formDepthLabel": "Farbtiefe",
+      "colSessionId": "Sitzungs-ID",
+      "colUser": "Benutzer",
+      "colStatus": "Status",
+      "colDisplay": "Anzeige",
+      "colCreatedAt": "Erstellt",
+      "colActions": "Aktionen",
+      "emptyTitle": "Keine aktiven Streaming-Sitzungen",
+      "emptyMessage": "Derzeit gibt es keine aktiven Desktop-Streaming-Sitzungen."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8757,6 +8757,27 @@
       "pause": "Pause",
       "resume": "Resume",
       "complete": "Complete"
+    },
+    "streaming": {
+      "title": "Streaming Sessions",
+      "newSession": "New Session",
+      "terminate": "Terminate",
+      "capVncAvailable": "VNC Available",
+      "capNovncAvailable": "noVNC Available",
+      "capMaxSessions": "Max Sessions",
+      "formUserIdLabel": "User ID",
+      "formUserIdPlaceholder": "e.g. user-123",
+      "formResolutionLabel": "Resolution",
+      "formResolutionPlaceholder": "e.g. 1920x1080",
+      "formDepthLabel": "Color Depth",
+      "colSessionId": "Session ID",
+      "colUser": "User",
+      "colStatus": "Status",
+      "colDisplay": "Display",
+      "colCreatedAt": "Created",
+      "colActions": "Actions",
+      "emptyTitle": "No active streaming sessions",
+      "emptyMessage": "There are no active desktop streaming sessions right now."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8757,6 +8757,27 @@
       "pause": "Pausar",
       "resume": "Reanudar",
       "complete": "Completar"
+    },
+    "streaming": {
+      "title": "Sesiones de transmisión",
+      "newSession": "Nueva sesión",
+      "terminate": "Finalizar",
+      "capVncAvailable": "VNC disponible",
+      "capNovncAvailable": "noVNC disponible",
+      "capMaxSessions": "Sesiones máximas",
+      "formUserIdLabel": "ID de usuario",
+      "formUserIdPlaceholder": "p. ej., user-123",
+      "formResolutionLabel": "Resolución",
+      "formResolutionPlaceholder": "p. ej., 1920x1080",
+      "formDepthLabel": "Profundidad de color",
+      "colSessionId": "ID de sesión",
+      "colUser": "Usuario",
+      "colStatus": "Estado",
+      "colDisplay": "Pantalla",
+      "colCreatedAt": "Creada",
+      "colActions": "Acciones",
+      "emptyTitle": "No hay sesiones de transmisión activas",
+      "emptyMessage": "No hay sesiones de transmisión de escritorio activas en este momento."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8757,6 +8757,27 @@
       "pause": "توقف",
       "resume": "ازسرگیری",
       "complete": "تکمیل"
+    },
+    "streaming": {
+      "title": "نشست‌های پخش زنده",
+      "newSession": "نشست جدید",
+      "terminate": "پایان دادن",
+      "capVncAvailable": "VNC در دسترس",
+      "capNovncAvailable": "noVNC در دسترس",
+      "capMaxSessions": "حداکثر نشست‌ها",
+      "formUserIdLabel": "شناسه کاربر",
+      "formUserIdPlaceholder": "مثلاً: user-123",
+      "formResolutionLabel": "وضوح تصویر",
+      "formResolutionPlaceholder": "مثلاً: 1920x1080",
+      "formDepthLabel": "عمق رنگ",
+      "colSessionId": "شناسه نشست",
+      "colUser": "کاربر",
+      "colStatus": "وضعیت",
+      "colDisplay": "نمایشگر",
+      "colCreatedAt": "ایجادشده",
+      "colActions": "عملیات",
+      "emptyTitle": "نشست پخش زنده فعالی وجود ندارد",
+      "emptyMessage": "در حال حاضر هیچ نشست پخش زنده دسکتاپ فعالی وجود ندارد."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8757,6 +8757,27 @@
       "pause": "Suspendre",
       "resume": "Reprendre",
       "complete": "Terminer"
+    },
+    "streaming": {
+      "title": "Sessions de diffusion",
+      "newSession": "Nouvelle session",
+      "terminate": "Terminer",
+      "capVncAvailable": "VNC disponible",
+      "capNovncAvailable": "noVNC disponible",
+      "capMaxSessions": "Sessions max.",
+      "formUserIdLabel": "ID utilisateur",
+      "formUserIdPlaceholder": "ex. user-123",
+      "formResolutionLabel": "Résolution",
+      "formResolutionPlaceholder": "ex. 1920x1080",
+      "formDepthLabel": "Profondeur de couleur",
+      "colSessionId": "ID de session",
+      "colUser": "Utilisateur",
+      "colStatus": "Statut",
+      "colDisplay": "Affichage",
+      "colCreatedAt": "Créée",
+      "colActions": "Actions",
+      "emptyTitle": "Aucune session de diffusion active",
+      "emptyMessage": "Aucune session de diffusion du bureau active pour le moment."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8757,6 +8757,27 @@
       "pause": "השהה",
       "resume": "המשך",
       "complete": "השלם"
+    },
+    "streaming": {
+      "title": "הפעלות הזרמה",
+      "newSession": "הפעלה חדשה",
+      "terminate": "סיים",
+      "capVncAvailable": "VNC זמין",
+      "capNovncAvailable": "noVNC זמין",
+      "capMaxSessions": "מספר הפעלות מרבי",
+      "formUserIdLabel": "מזהה משתמש",
+      "formUserIdPlaceholder": "לדוגמה: user-123",
+      "formResolutionLabel": "רזולוציה",
+      "formResolutionPlaceholder": "לדוגמה: 1920x1080",
+      "formDepthLabel": "עומק צבע",
+      "colSessionId": "מזהה הפעלה",
+      "colUser": "משתמש",
+      "colStatus": "סטטוס",
+      "colDisplay": "תצוגה",
+      "colCreatedAt": "נוצרה",
+      "colActions": "פעולות",
+      "emptyTitle": "אין הפעלות הזרמה פעילות",
+      "emptyMessage": "אין כרגע הפעלות הזרמת שולחן עבודה פעילות."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8757,6 +8757,27 @@
       "pause": "Pauzēt",
       "resume": "Atsākt",
       "complete": "Pabeigt"
+    },
+    "streaming": {
+      "title": "Straumēšanas sesijas",
+      "newSession": "Jauna sesija",
+      "terminate": "Pārtraukt",
+      "capVncAvailable": "VNC pieejams",
+      "capNovncAvailable": "noVNC pieejams",
+      "capMaxSessions": "Maks. sesijas",
+      "formUserIdLabel": "Lietotāja ID",
+      "formUserIdPlaceholder": "piem., user-123",
+      "formResolutionLabel": "Izšķirtspēja",
+      "formResolutionPlaceholder": "piem., 1920x1080",
+      "formDepthLabel": "Krāsu dziļums",
+      "colSessionId": "Sesijas ID",
+      "colUser": "Lietotājs",
+      "colStatus": "Statuss",
+      "colDisplay": "Displejs",
+      "colCreatedAt": "Izveidota",
+      "colActions": "Darbības",
+      "emptyTitle": "Nav aktīvu straumēšanas sesiju",
+      "emptyMessage": "Pašlaik nav aktīvu darbvirsmas straumēšanas sesiju."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8757,6 +8757,27 @@
       "pause": "Wstrzymaj",
       "resume": "Wznów",
       "complete": "Zakończ"
+    },
+    "streaming": {
+      "title": "Sesje strumieniowania",
+      "newSession": "Nowa sesja",
+      "terminate": "Zakończ",
+      "capVncAvailable": "VNC dostępne",
+      "capNovncAvailable": "noVNC dostępne",
+      "capMaxSessions": "Maks. liczba sesji",
+      "formUserIdLabel": "ID użytkownika",
+      "formUserIdPlaceholder": "np. user-123",
+      "formResolutionLabel": "Rozdzielczość",
+      "formResolutionPlaceholder": "np. 1920x1080",
+      "formDepthLabel": "Głębia koloru",
+      "colSessionId": "ID sesji",
+      "colUser": "Użytkownik",
+      "colStatus": "Stan",
+      "colDisplay": "Ekran",
+      "colCreatedAt": "Utworzono",
+      "colActions": "Działania",
+      "emptyTitle": "Brak aktywnych sesji strumieniowania",
+      "emptyMessage": "Obecnie nie ma aktywnych sesji strumieniowania pulpitu."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8757,6 +8757,27 @@
       "pause": "Pausar",
       "resume": "Retomar",
       "complete": "Concluir"
+    },
+    "streaming": {
+      "title": "Sessões de transmissão",
+      "newSession": "Nova sessão",
+      "terminate": "Encerrar",
+      "capVncAvailable": "VNC disponível",
+      "capNovncAvailable": "noVNC disponível",
+      "capMaxSessions": "Sessões máximas",
+      "formUserIdLabel": "ID do usuário",
+      "formUserIdPlaceholder": "ex.: user-123",
+      "formResolutionLabel": "Resolução",
+      "formResolutionPlaceholder": "ex.: 1920x1080",
+      "formDepthLabel": "Profundidade de cor",
+      "colSessionId": "ID da sessão",
+      "colUser": "Usuário",
+      "colStatus": "Status",
+      "colDisplay": "Tela",
+      "colCreatedAt": "Criada",
+      "colActions": "Ações",
+      "emptyTitle": "Nenhuma sessão de transmissão ativa",
+      "emptyMessage": "Não há sessões de transmissão de área de trabalho ativas no momento."
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8757,6 +8757,27 @@
       "pause": "موقوف کریں",
       "resume": "دوبارہ شروع کریں",
       "complete": "مکمل کریں"
+    },
+    "streaming": {
+      "title": "اسٹریمنگ سیشنز",
+      "newSession": "نیا سیشن",
+      "terminate": "ختم کریں",
+      "capVncAvailable": "VNC دستیاب ہے",
+      "capNovncAvailable": "noVNC دستیاب ہے",
+      "capMaxSessions": "زیادہ سے زیادہ سیشنز",
+      "formUserIdLabel": "صارف کی شناخت",
+      "formUserIdPlaceholder": "مثلاً: user-123",
+      "formResolutionLabel": "ریزولیوشن",
+      "formResolutionPlaceholder": "مثلاً: 1920x1080",
+      "formDepthLabel": "کلر ڈیپتھ",
+      "colSessionId": "سیشن کی شناخت",
+      "colUser": "صارف",
+      "colStatus": "حالت",
+      "colDisplay": "ڈسپلے",
+      "colCreatedAt": "تخلیق شدہ",
+      "colActions": "اقدامات",
+      "emptyTitle": "کوئی فعال اسٹریمنگ سیشن نہیں",
+      "emptyMessage": "اس وقت کوئی فعال ڈیسک ٹاپ اسٹریمنگ سیشن موجود نہیں ہے۔"
     }
   },
   "adminUsers": {

--- a/autobot-frontend/src/views/AdvancedControlView.vue
+++ b/autobot-frontend/src/views/AdvancedControlView.vue
@@ -186,13 +186,118 @@
       </template>
     </div>
 
-    <!-- Streaming tab placeholder -->
+    <!-- Streaming Sessions tab -->
     <div v-else-if="activeTab === 'streaming'" v-bind="panelAttrs('streaming')" class="acv-content">
-      <EmptyState
-        icon="window-restore"
-        :title="t('advancedControl.tabs.streamingTitle')"
-        :message="t('advancedControl.tabs.comingSoonMessage')"
-      />
+      <div v-if="error" class="error-banner">
+        <Icon name="exclamation-circle" />
+        <span>{{ error }}</span>
+        <button class="btn-dismiss" :aria-label="t('common.dismiss')" @click="clearError"><Icon name="times" /></button>
+      </div>
+
+      <!-- Capabilities summary -->
+      <div v-if="streamingCapabilities" class="status-summary">
+        <div class="status-card">
+          <span class="status-value">{{ streamingCapabilities.vnc_available ? t('common.yes') : t('common.no') }}</span>
+          <span class="status-label">{{ t('advancedControl.streaming.capVncAvailable') }}</span>
+        </div>
+        <div class="status-card">
+          <span class="status-value">{{ streamingCapabilities.novnc_available ? t('common.yes') : t('common.no') }}</span>
+          <span class="status-label">{{ t('advancedControl.streaming.capNovncAvailable') }}</span>
+        </div>
+        <div class="status-card">
+          <span class="status-value">{{ streamingCapabilities.max_sessions }}</span>
+          <span class="status-label">{{ t('advancedControl.streaming.capMaxSessions') }}</span>
+        </div>
+      </div>
+
+      <div v-if="loading && streamingSessions.length === 0" class="loading-state">
+        <Icon name="sync-alt" :spin="true" /> {{ t('advancedControl.loading') }}
+      </div>
+
+      <template v-else>
+        <section class="table-section">
+          <h3 class="section-title section-title--with-action">
+            <span>{{ t('advancedControl.streaming.title') }}</span>
+            <button class="btn-action-secondary" @click="toggleCreateForm">
+              <Icon name="plus-circle" />
+              {{ t('advancedControl.streaming.newSession') }}
+            </button>
+          </h3>
+
+          <form v-if="showCreateForm" class="streaming-create-form" @submit.prevent="onCreateStreaming">
+            <div class="form-field">
+              <label for="streaming-user-id">{{ t('advancedControl.streaming.formUserIdLabel') }}</label>
+              <input
+                id="streaming-user-id"
+                v-model="createForm.userId"
+                type="text"
+                required
+                :placeholder="t('advancedControl.streaming.formUserIdPlaceholder')"
+              />
+            </div>
+            <div class="form-field">
+              <label for="streaming-resolution">{{ t('advancedControl.streaming.formResolutionLabel') }}</label>
+              <input
+                id="streaming-resolution"
+                v-model="createForm.resolution"
+                type="text"
+                :placeholder="t('advancedControl.streaming.formResolutionPlaceholder')"
+              />
+            </div>
+            <div class="form-field">
+              <label for="streaming-depth">{{ t('advancedControl.streaming.formDepthLabel') }}</label>
+              <input id="streaming-depth" v-model.number="createForm.depth" type="number" min="1" />
+            </div>
+            <div class="form-actions">
+              <button type="button" class="btn-action-secondary" @click="toggleCreateForm">
+                {{ t('common.cancel') }}
+              </button>
+              <button type="submit" class="btn-action-primary" :disabled="loading">
+                {{ t('common.create') }}
+              </button>
+            </div>
+          </form>
+
+          <table v-if="streamingSessions.length > 0" class="data-table">
+            <thead>
+              <tr>
+                <th>{{ t('advancedControl.streaming.colSessionId') }}</th>
+                <th>{{ t('advancedControl.streaming.colUser') }}</th>
+                <th>{{ t('advancedControl.streaming.colStatus') }}</th>
+                <th>{{ t('advancedControl.streaming.colDisplay') }}</th>
+                <th>{{ t('advancedControl.streaming.colCreatedAt') }}</th>
+                <th>{{ t('advancedControl.streaming.colActions') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="session in streamingSessions" :key="session.session_id">
+                <td>{{ session.session_id }}</td>
+                <td>{{ session.user_id }}</td>
+                <td><span class="badge" :class="streamingStatusBadgeClass(session.status)">{{ session.status }}</span></td>
+                <td>{{ session.display }}</td>
+                <td>{{ formatDate(session.created_at) }}</td>
+                <td class="actions-cell">
+                  <button
+                    class="btn-icon btn-danger"
+                    :title="t('advancedControl.streaming.terminate')"
+                    :disabled="loading"
+                    @click="onTerminateStreaming(session.session_id)"
+                  >
+                    <Icon name="trash-alt" />
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <EmptyState
+            v-else
+            icon="window-restore"
+            :title="t('advancedControl.streaming.emptyTitle')"
+            :message="t('advancedControl.streaming.emptyMessage')"
+            compact
+          />
+        </section>
+      </template>
     </div>
 
     <!-- Monitoring tab placeholder -->
@@ -207,13 +312,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useTabs } from '@/composables/useTabs'
 import { useAdvancedControl } from '@/composables/useAdvancedControl'
 import Icon from '@/components/ui/Icon.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
-import type { TakeoverPriority, TakeoverStatus } from '@/utils/AdvancedControlApiClient'
+import type {
+  TakeoverPriority,
+  TakeoverStatus,
+  StreamingSession,
+  StreamingSessionRequest,
+} from '@/utils/AdvancedControlApiClient'
 
 const { t } = useI18n()
 
@@ -221,6 +331,8 @@ const {
   pendingTakeovers,
   activeTakeovers,
   takeoverStatus,
+  streamingSessions,
+  streamingCapabilities,
   loading,
   error,
   loadTakeovers,
@@ -228,6 +340,9 @@ const {
   pause,
   resume,
   complete,
+  loadStreaming,
+  createStreaming,
+  terminateStreaming,
 } = useAdvancedControl()
 
 const TAB_IDS = ['takeover', 'streaming', 'monitoring'] as const
@@ -244,9 +359,18 @@ interface TabDef {
 
 const tabs = computed<TabDef[]>(() => [
   { id: 'takeover', label: t('advancedControl.tabs.takeoverQueue'), icon: 'hand-paper', disabled: false },
-  { id: 'streaming', label: t('advancedControl.tabs.streaming'), icon: 'window-restore', disabled: true },
+  { id: 'streaming', label: t('advancedControl.tabs.streaming'), icon: 'window-restore', disabled: false },
   { id: 'monitoring', label: t('advancedControl.tabs.monitoring'), icon: 'tachometer-alt', disabled: true },
 ])
+
+// Load streaming data lazily the first time the tab becomes active, mirroring
+// the eager onMounted(loadTakeovers) call used for the (always-visible)
+// Takeover Queue tab.
+watch(activeTab, (tab) => {
+  if (tab === 'streaming') {
+    void loadStreaming()
+  }
+})
 
 function clearError(): void {
   error.value = null
@@ -313,6 +437,51 @@ async function onResume(sessionId: string): Promise<void> {
 
 async function onComplete(sessionId: string): Promise<void> {
   await complete(sessionId)
+}
+
+const streamingStatusBadgeClasses: Record<StreamingSession['status'], string> = {
+  active: 'badge-active',
+  paused: 'badge-admin',
+  terminated: 'badge-inactive',
+}
+
+function streamingStatusBadgeClass(status: StreamingSession['status']): string {
+  return streamingStatusBadgeClasses[status] ?? 'badge-bundle'
+}
+
+const showCreateForm = ref(false)
+const createForm = reactive<{ userId: string; resolution: string; depth: number | null }>({
+  userId: '',
+  resolution: '',
+  depth: null,
+})
+
+function resetCreateForm(): void {
+  createForm.userId = ''
+  createForm.resolution = ''
+  createForm.depth = null
+}
+
+function toggleCreateForm(): void {
+  showCreateForm.value = !showCreateForm.value
+  if (!showCreateForm.value) resetCreateForm()
+}
+
+async function onCreateStreaming(): Promise<void> {
+  if (!createForm.userId.trim()) return
+  const request: StreamingSessionRequest = { user_id: createForm.userId.trim() }
+  if (createForm.resolution.trim()) request.resolution = createForm.resolution.trim()
+  if (createForm.depth != null) request.depth = createForm.depth
+
+  const success = await createStreaming(request)
+  if (success) {
+    showCreateForm.value = false
+    resetCreateForm()
+  }
+}
+
+async function onTerminateStreaming(sessionId: string): Promise<void> {
+  await terminateStreaming(sessionId)
 }
 
 onMounted(loadTakeovers)
@@ -587,7 +756,8 @@ onMounted(loadTakeovers)
   color: var(--color-error);
 }
 
-.btn-action-secondary {
+.btn-action-secondary,
+.btn-action-primary {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1-5);
@@ -601,8 +771,61 @@ onMounted(loadTakeovers)
   cursor: pointer;
 }
 
-.btn-action-secondary:disabled {
+.btn-action-primary {
+  border-color: transparent;
+  background: var(--color-primary);
+  color: var(--text-on-primary);
+}
+
+.btn-action-secondary:disabled,
+.btn-action-primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* ── Streaming tab ──────────────────────────────────────────────────────── */
+
+.section-title--with-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.streaming-create-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-tertiary);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.form-field label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.form-field input {
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.form-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  margin-left: auto;
 }
 </style>

--- a/autobot-frontend/src/views/__tests__/AdvancedControlView.test.ts
+++ b/autobot-frontend/src/views/__tests__/AdvancedControlView.test.ts
@@ -3,7 +3,8 @@
 // AutoBot - AI-Powered Automation Platform
 // Author: mrveiss
 //
-// Tests for AdvancedControlView.vue (#12162, #12102, #11506 T1 — Stage 1).
+// Tests for AdvancedControlView.vue (#12162, #12102, #11506 T1 — Stage 1;
+// #12169, #12102 — Stage 2 streaming sessions tab).
 // Mocks useAdvancedControl so no real HTTP calls are made, and asserts the
 // /admin/advanced-control route carries the same admin guard meta as its
 // sibling admin routes (router/index.ts requiresAdmin check).
@@ -23,6 +24,8 @@ import { routes } from '@/router'
 const mockPendingTakeovers = ref<unknown[]>([])
 const mockActiveTakeovers = ref<unknown[]>([])
 const mockTakeoverStatus = ref<unknown>(null)
+const mockStreamingSessions = ref<unknown[]>([])
+const mockStreamingCapabilities = ref<unknown>(null)
 const mockLoading = ref(false)
 const mockError = ref<string | null>(null)
 
@@ -31,12 +34,17 @@ const mockApprove = vi.fn().mockResolvedValue(true)
 const mockPause = vi.fn().mockResolvedValue(true)
 const mockResume = vi.fn().mockResolvedValue(true)
 const mockComplete = vi.fn().mockResolvedValue(true)
+const mockLoadStreaming = vi.fn().mockResolvedValue(undefined)
+const mockCreateStreaming = vi.fn().mockResolvedValue(true)
+const mockTerminateStreaming = vi.fn().mockResolvedValue(true)
 
 vi.mock('@/composables/useAdvancedControl', () => ({
   useAdvancedControl: () => ({
     pendingTakeovers: mockPendingTakeovers,
     activeTakeovers: mockActiveTakeovers,
     takeoverStatus: mockTakeoverStatus,
+    streamingSessions: mockStreamingSessions,
+    streamingCapabilities: mockStreamingCapabilities,
     loading: mockLoading,
     error: mockError,
     loadTakeovers: mockLoadTakeovers,
@@ -45,6 +53,9 @@ vi.mock('@/composables/useAdvancedControl', () => ({
     resume: mockResume,
     complete: mockComplete,
     action: vi.fn(),
+    loadStreaming: mockLoadStreaming,
+    createStreaming: mockCreateStreaming,
+    terminateStreaming: mockTerminateStreaming,
   }),
 }))
 
@@ -75,10 +86,15 @@ describe('AdvancedControlView.vue', () => {
     mockPendingTakeovers.value = []
     mockActiveTakeovers.value = []
     mockTakeoverStatus.value = null
+    mockStreamingSessions.value = []
+    mockStreamingCapabilities.value = null
     mockLoading.value = false
     mockError.value = null
     mockLoadTakeovers.mockClear()
     mockApprove.mockClear()
+    mockLoadStreaming.mockClear()
+    mockCreateStreaming.mockClear()
+    mockTerminateStreaming.mockClear()
   })
 
   it('is registered as an admin-gated route (same guard as sibling admin routes)', () => {
@@ -133,5 +149,85 @@ describe('AdvancedControlView.vue', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('Failed to load takeovers')
+  })
+
+  // -------------------------------------------------------------------------
+  // Streaming Sessions tab (#12169, #12102 — Stage 2)
+  // -------------------------------------------------------------------------
+
+  async function selectStreamingTab(wrapper: ReturnType<typeof mountView>) {
+    const tabs = wrapper.findAll('button[role="tab"]')
+    const streamingTab = tabs.find((btn) => btn.text().includes('Streaming'))
+    expect(streamingTab).toBeTruthy()
+    await streamingTab!.trigger('click')
+    await flushPromises()
+  }
+
+  it('enables the Streaming tab, loads sessions on activation, and renders the empty state', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await selectStreamingTab(wrapper)
+
+    expect(mockLoadStreaming).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('No active streaming sessions')
+  })
+
+  it('renders a streaming session row with a terminate action', async () => {
+    mockStreamingSessions.value = [
+      {
+        session_id: 's1',
+        user_id: 'u1',
+        vnc_port: 5901,
+        novnc_port: 6901,
+        display: ':1',
+        created_at: '2026-07-23T00:00:00Z',
+        status: 'active',
+      },
+    ]
+    mockStreamingCapabilities.value = {
+      vnc_available: true,
+      novnc_available: true,
+      max_sessions: 4,
+      supported_resolutions: ['1920x1080'],
+      supported_depths: [24],
+    }
+
+    const wrapper = mountView()
+    await flushPromises()
+    await selectStreamingTab(wrapper)
+
+    expect(wrapper.text()).toContain('s1')
+    expect(wrapper.text()).toContain('u1')
+
+    const terminateBtn = wrapper.find('button.btn-danger')
+    expect(terminateBtn.exists()).toBe(true)
+    await terminateBtn.trigger('click')
+    expect(mockTerminateStreaming).toHaveBeenCalledWith('s1')
+  })
+
+  it('submits the new-session form with the StreamingSessionRequest shape', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    await selectStreamingTab(wrapper)
+
+    const newSessionBtn = wrapper
+      .findAll('button')
+      .find((btn) => btn.text().includes('New Session'))
+    expect(newSessionBtn).toBeTruthy()
+    await newSessionBtn!.trigger('click')
+
+    await wrapper.find('#streaming-user-id').setValue('user-123')
+    await wrapper.find('#streaming-resolution').setValue('1920x1080')
+    await wrapper.find('#streaming-depth').setValue(24)
+
+    await wrapper.find('form.streaming-create-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(mockCreateStreaming).toHaveBeenCalledWith({
+      user_id: 'user-123',
+      resolution: '1920x1080',
+      depth: 24,
+    })
   })
 })


### PR DESCRIPTION
Closes #12169
Part of #12102 / #11506 (Stage 2 of 3)

## What Changed
Enabled the Streaming tab on the merged AdvancedControlView shell: capabilities summary, sessions table (id/user/status/display/created + terminate), inline New-Session form (StreamingSessionRequest `{user_id, resolution?, depth?}`). Extended `useAdvancedControl` with streaming state + loadStreaming/createStreaming/terminateStreaming (same .success/.data pattern as Stage 1). Lazy-loads on tab activation. i18n: 19 `advancedControl.streaming.*` keys × all 11 locales (real translations).

## Verification
vue-tsc `-p tsconfig.app.json` 0 errors; vitest 18/18 (composable +5, view +3); oxlint clean; all 11 locales validated; no hardcoded strings; admin-gating inherited (route untouched).

## Model Used
Claude Sonnet (subagent), reviewed by Opus 4.8