### PR TITLE
chore(license): backfill SPDX headers on 2 drifted first-party files (#9840)

### DIFF
--- a/repo_tests/zero_downtime_deploy_test.py
+++ b/repo_tests/zero_downtime_deploy_test.py
@@ -1,5 +1,6 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
-# Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """Smoke tests for autobot-infrastructure/shared/scripts/zero_downtime_deploy.py (#11779).
 

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
-# Copyright (c) 2025-2026 mrveiss
 # Author: mrveiss
 #
 # install-git-hooks.sh — install AutoBot's git hooks as REAL files (copied),


### PR DESCRIPTION
Closes #9840
Part of #9826

## What Changed
SPDX enforcement already exists (check_spdx_header.py + pre-commit + CI, PR #10127). Backfilled the 2 first-party files that drifted since (landed via #11789/#11914 without headers): `repo_tests/zero_downtime_deploy_test.py`, `scripts/install-git-hooks.sh` — via `check_spdx_header.py --fix` (canonical 4-line header; shebang preserved).

## Verification
Full-repo `check_spdx_header.py` scan now exits 0 (was failing). py_compile + bash -n pass. Negative test: checker returns 1 on a header-less probe.

## Follow-ups filed
- #12174: the enforce-precommit CI job (SPDX check) is NOT a required status check on Dev_new_gui — why these drifted (branch-protection change, owner).
- #12175: 325 `autobot-infrastructure/shared/scripts` files lack SPDX but are deliberately excluded (dev/ops, non-deployed) — scope decision (extend sweep vs keep exclusion).

## Model Used
Claude Sonnet (subagent), reviewed by Opus 4.8