### PR TITLE
fix(security): require admin auth on advanced-control WebSockets (#12178)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -34,7 +34,7 @@ from api.schemas_workflows import (
     AdvancedControlTakeoverSessionStatusResponse,
     AdvancedControlTakeoverSystemStatusResponse,
 )
-from api.ws_security import enforce_ws_origin
+from api.ws_security import enforce_ws_admin, enforce_ws_origin
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -515,6 +515,8 @@ async def monitoring_websocket(websocket: WebSocket):
     """WebSocket endpoint for real-time system monitoring"""
     if not await enforce_ws_origin(websocket):
         return
+    if not await enforce_ws_admin(websocket):
+        return
     await websocket.accept()
     logger.info("Monitoring WebSocket client connected")
 
@@ -554,6 +556,8 @@ async def monitoring_websocket(websocket: WebSocket):
 async def desktop_streaming_websocket(websocket: WebSocket, session_id: str):
     """WebSocket endpoint for desktop streaming control"""
     if not await enforce_ws_origin(websocket):
+        return
+    if not await enforce_ws_admin(websocket):
         return
     await websocket.accept()
 

--- a/autobot-backend/api/task_workspace_ws.py
+++ b/autobot-backend/api/task_workspace_ws.py
@@ -44,12 +44,9 @@ import os
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
 from pydantic import BaseModel
 
+from api.ws_security import authenticate_ws_admin
 from api.ws_security import validate_ws_origin as _validate_ws_origin
-from auth_middleware import (
-    check_admin_permission,
-    get_auth_middleware,
-    verify_internal_api_key,
-)
+from auth_middleware import check_admin_permission
 from autobot_shared.logging_manager import get_logger
 from services.docker_task_workspace import (
     WorkspaceInfo,
@@ -392,26 +389,10 @@ async def _ws_error(websocket: WebSocket, content: str) -> None:
 
 
 def _authenticate_ws_admin(websocket: WebSocket) -> bool:
-    """Fail-closed auth+authz for the shell WS: a valid user (JWT/session/cookie)
-    or the internal-service key, AND admin role — matching the REST endpoints.
-
-    A WebSocket exposes the same ``headers``/``cookies`` interface as a Request,
-    so the standard auth middleware resolves the caller. Any error → deny.
+    """Fail-closed auth+authz for the shell WS — delegates to the shared,
+    audited implementation in :mod:`api.ws_security` (#12178).
     """
-    # Dev/test escape hatch: when WS auth is explicitly disabled, allow the
-    # connection. Production defaults to "1", so full auth is required.
-    if os.environ.get("AUTOBOT_REQUIRE_WS_AUTH", "1") != "1":
-        return True
-    try:
-        if verify_internal_api_key(websocket.headers.get("X-Internal-API-Key")):
-            return True
-        user = get_auth_middleware().get_user_from_request(websocket)  # type: ignore[arg-type]
-        if not user:
-            return False
-        return user.get("role") == "admin"
-    except Exception:
-        logger.warning("workspace_shell: WS auth error — denying", exc_info=True)
-        return False
+    return authenticate_ws_admin(websocket)
 
 
 def _info_to_response(info: WorkspaceInfo) -> WorkspaceInfoResponse:

--- a/autobot-backend/api/ws_security.py
+++ b/autobot-backend/api/ws_security.py
@@ -17,6 +17,7 @@ so every authenticated WS endpoint can reuse one audited implementation (#11088)
 from __future__ import annotations
 
 import logging
+import os
 
 from fastapi import WebSocket
 
@@ -67,3 +68,53 @@ async def enforce_ws_origin(websocket: WebSocket) -> bool:
         except Exception:  # already closed / handshake not completed
             pass
         return False
+
+
+def authenticate_ws_admin(websocket: WebSocket) -> bool:
+    """Fail-closed auth+authz for admin WS endpoints: a valid user (JWT/session/
+    cookie) or the internal-service key, AND admin role — matching the REST
+    endpoints' ``Depends(check_admin_permission)``.
+
+    A WebSocket exposes the same ``headers``/``cookies`` interface as a Request,
+    so the standard auth middleware resolves the caller. Any error → deny.
+
+    Originally added inline to ``api/task_workspace_ws.py`` (#11051); extracted
+    here so every admin WS endpoint reuses one audited implementation (#12178).
+    """
+    # Dev/test escape hatch: when WS auth is explicitly disabled, allow the
+    # connection. Production defaults to "1", so full auth is required.
+    if os.environ.get("AUTOBOT_REQUIRE_WS_AUTH", "1") != "1":
+        return True
+    try:
+        from auth_middleware import (  # noqa: PLC0415
+            get_auth_middleware,
+            verify_internal_api_key,
+        )
+
+        if verify_internal_api_key(websocket.headers.get("X-Internal-API-Key")):
+            return True
+        user = get_auth_middleware().get_user_from_request(websocket)  # type: ignore[arg-type]
+        if not user:
+            return False
+        return user.get("role") == "admin"
+    except Exception:
+        logger.warning("WS admin auth error — denying", exc_info=True)
+        return False
+
+
+async def enforce_ws_admin(websocket: WebSocket) -> bool:
+    """Enforce admin auth and, on rejection, close the socket with ``4001``.
+
+    Convenience wrapper mirroring :func:`enforce_ws_origin`: call before
+    ``websocket.accept()`` and ``return`` when it yields ``False``.
+
+    Returns ``True`` when the caller is an authenticated admin (or WS auth is
+    disabled for dev/test), ``False`` after having closed the socket ``4001``.
+    """
+    if authenticate_ws_admin(websocket):
+        return True
+    try:
+        await websocket.close(code=4001, reason="Authentication required (admin)")
+    except Exception:  # already closed / handshake not completed
+        pass
+    return False

--- a/autobot-backend/tests/test_task_workspace.py
+++ b/autobot-backend/tests/test_task_workspace.py
@@ -543,7 +543,12 @@ def test_checkpoint_name_rejects_slash():
 
 
 def test_authenticate_ws_admin_denies_unauthenticated():
-    """Fail-closed: no user + no internal key → deny (no shell)."""
+    """Fail-closed: no user + no internal key → deny (no shell).
+
+    ``_authenticate_ws_admin`` delegates to the shared ``ws_security`` helper
+    (#12178), which lazy-imports its auth deps from ``auth_middleware`` — so the
+    patch targets are the source module, not this one.
+    """
     from types import SimpleNamespace
     from unittest.mock import patch
 
@@ -552,8 +557,8 @@ def test_authenticate_ws_admin_denies_unauthenticated():
     ws = SimpleNamespace(headers={})
     with (
         patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
-        patch.object(mod, "get_auth_middleware") as gam,
-        patch.object(mod, "verify_internal_api_key", return_value=False),
+        patch("auth_middleware.get_auth_middleware") as gam,
+        patch("auth_middleware.verify_internal_api_key", return_value=False),
     ):
         gam.return_value.get_user_from_request.return_value = None
         assert mod._authenticate_ws_admin(ws) is False
@@ -569,8 +574,8 @@ def test_authenticate_ws_admin_denies_non_admin():
     ws = SimpleNamespace(headers={})
     with (
         patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
-        patch.object(mod, "get_auth_middleware") as gam,
-        patch.object(mod, "verify_internal_api_key", return_value=False),
+        patch("auth_middleware.get_auth_middleware") as gam,
+        patch("auth_middleware.verify_internal_api_key", return_value=False),
     ):
         gam.return_value.get_user_from_request.return_value = {"role": "user"}
         assert mod._authenticate_ws_admin(ws) is False
@@ -587,8 +592,8 @@ def test_authenticate_ws_admin_allows_admin_and_internal_key():
 
     with (
         patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
-        patch.object(mod, "get_auth_middleware") as gam,
-        patch.object(mod, "verify_internal_api_key", side_effect=lambda key: key == "k"),
+        patch("auth_middleware.get_auth_middleware") as gam,
+        patch("auth_middleware.verify_internal_api_key", side_effect=lambda key: key == "k"),
     ):
         gam.return_value.get_user_from_request.return_value = {"role": "admin"}
         # cookie/JWT-resolved admin, NO Authorization header

--- a/autobot-backend/tests/test_ws_security_admin.py
+++ b/autobot-backend/tests/test_ws_security_admin.py
@@ -1,0 +1,90 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the shared admin WebSocket auth helpers (#12178).
+
+``authenticate_ws_admin`` / ``enforce_ws_admin`` gate admin-only WS endpoints
+(``/ws/monitoring``, ``/ws/desktop``) with the same fail-closed auth+authz the
+REST siblings enforce via ``Depends(check_admin_permission)``. Before #12178
+those two sockets did Origin validation only — an authenticated non-admin (or,
+with a permissive Origin, any caller) could open them.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.ws_security import authenticate_ws_admin, enforce_ws_admin
+
+
+def _ws(headers=None):
+    return SimpleNamespace(headers=headers or {})
+
+
+def test_authenticate_ws_admin_denies_unauthenticated():
+    with (
+        patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
+        patch("auth_middleware.get_auth_middleware") as gam,
+        patch("auth_middleware.verify_internal_api_key", return_value=False),
+    ):
+        gam.return_value.get_user_from_request.return_value = None
+        assert authenticate_ws_admin(_ws()) is False
+
+
+def test_authenticate_ws_admin_denies_non_admin():
+    with (
+        patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
+        patch("auth_middleware.get_auth_middleware") as gam,
+        patch("auth_middleware.verify_internal_api_key", return_value=False),
+    ):
+        gam.return_value.get_user_from_request.return_value = {"role": "user"}
+        assert authenticate_ws_admin(_ws()) is False
+
+
+def test_authenticate_ws_admin_allows_admin_and_internal_key():
+    with (
+        patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
+        patch("auth_middleware.get_auth_middleware") as gam,
+        patch("auth_middleware.verify_internal_api_key", side_effect=lambda key: key == "k"),
+    ):
+        gam.return_value.get_user_from_request.return_value = {"role": "admin"}
+        assert authenticate_ws_admin(_ws()) is True
+        assert authenticate_ws_admin(_ws({"X-Internal-API-Key": "k"})) is True
+
+
+def test_authenticate_ws_admin_dev_bypass_when_disabled():
+    with patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "0"}):
+        assert authenticate_ws_admin(_ws()) is True
+
+
+def test_authenticate_ws_admin_fail_closed_on_error():
+    """Any exception in the auth path denies (never leaks an open socket)."""
+    with (
+        patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
+        patch("auth_middleware.verify_internal_api_key", side_effect=RuntimeError("boom")),
+    ):
+        assert authenticate_ws_admin(_ws()) is False
+
+
+@pytest.mark.asyncio
+async def test_enforce_ws_admin_closes_4001_when_denied():
+    ws = SimpleNamespace(headers={}, close=AsyncMock())
+    with (
+        patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
+        patch("auth_middleware.get_auth_middleware") as gam,
+        patch("auth_middleware.verify_internal_api_key", return_value=False),
+    ):
+        gam.return_value.get_user_from_request.return_value = {"role": "user"}
+        assert await enforce_ws_admin(ws) is False
+    ws.close.assert_awaited_once()
+    assert ws.close.await_args.kwargs.get("code") == 4001
+
+
+@pytest.mark.asyncio
+async def test_enforce_ws_admin_allows_admin_without_closing():
+    ws = SimpleNamespace(headers={}, close=AsyncMock())
+    with patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "0"}):
+        assert await enforce_ws_admin(ws) is True
+    ws.close.assert_not_awaited()


### PR DESCRIPTION
Closes #12178

## Thinking Path
Discovered while wiring the Stage 3 monitoring UI (#12173): `/ws/monitoring` — and its neighbour `/ws/desktop/{session_id}` (desktop *control*) — enforced only `enforce_ws_origin`, while all 14 REST siblings in the same router gate on `Depends(check_admin_permission)`. Origin validation stops CSWSH but is not authz: an authenticated non-admin (or, on any permissive/absent Origin, an unauthenticated caller) could open these admin sockets. This is why Stage 3 deliberately polls instead of consuming the WS.

## What Changed
- **`api/ws_security.py`** — promoted the fail-closed WS admin auth helper (JWT/session/cookie **or** internal-service key, AND `role == admin`; `AUTOBOT_REQUIRE_WS_AUTH` dev bypass) from `task_workspace_ws.py` into the shared module as `authenticate_ws_admin`, plus an `enforce_ws_admin` wrapper that closes `4001` on denial — mirroring the existing `enforce_ws_origin` pattern. Same precedent as `enforce_ws_origin` itself (extracted #11088).
- **`api/advanced_control.py`** — both WS endpoints now call `enforce_ws_admin` after the Origin check, before `accept()`.
- **`api/task_workspace_ws.py`** — the original private `_authenticate_ws_admin` now delegates to the shared helper (no duplication; identical behaviour); dropped its now-unused `get_auth_middleware`/`verify_internal_api_key` imports.

## Verification
- `tests/test_ws_security_admin.py` (new, 7): deny unauth / deny non-admin / allow admin+internal-key / dev-bypass / fail-closed-on-error / `enforce_ws_admin` closes 4001 on denial / allows admin without closing — **7 passed**.
- `tests/test_task_workspace.py` delegated auth tests repointed to the source patch targets (lazy import) — **4 passed**.
- `ruff check` on all changed files — clean. AST parse OK.

## Discovered (filed, out of scope)
Sibling `/ws/desktop` shared the same gap — fixed here in the same change since same file + same fix. #12177 (uptime) remains a separate low-pri backend issue.

## Model Used
Claude Opus 4.8