### PR TITLE
refactor(deploy): TLS cert-gen one-of-a-kind — extract triplicated block to shared task (#12181)

### DIFF
--- a/autobot-slm-backend/ansible/_shared/tasks/generate_self_signed_cert.yml
+++ b/autobot-slm-backend/ansible/_shared/tasks/generate_self_signed_cert.yml
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# Shared: generate a self-signed TLS cert and lock down its private key (#12181).
+#
+# Extracted from the byte-identical slm/backend/frontend blocks in
+# playbooks/rotate-certs.yml so cert generation lives in ONE place, mirroring the
+# _shared/tasks/stat_tls_certs.yml convention (#7272).
+#
+# Consumers set these before include_tasks (the rotate-certs plays already do):
+#   _cert_days     - validity in days
+#   _key_file      - private key output path
+#   _cert_file     - certificate output path
+#   _cert_subject  - openssl -subj string
+#   cert_label     - optional log label (slm/backend/frontend); defaults to 'node'
+#
+# Discoverable: grep -rn "generate_self_signed_cert.yml" lists all consumers.
+
+- name: "Certs [{{ cert_label | default('node') }}] | Generate new self-signed cert"
+  ansible.builtin.command:
+    cmd: >-
+      openssl req -x509 -nodes
+      -days {{ _cert_days }}
+      -newkey rsa:2048
+      -keyout {{ _key_file }}
+      -out {{ _cert_file }}
+      -subj '{{ _cert_subject }}'
+  changed_when: true
+
+- name: "Certs [{{ cert_label | default('node') }}] | Set key permissions"
+  ansible.builtin.file:
+    path: "{{ _key_file }}"
+    mode: "0600"
+    owner: root
+    group: root

--- a/autobot-slm-backend/ansible/playbooks/rotate-certs.yml
+++ b/autobot-slm-backend/ansible/playbooks/rotate-certs.yml
@@ -97,23 +97,10 @@
         mode: "0644"
       failed_when: false
 
-    - name: "Certs [slm] | Generate new self-signed cert"
-      ansible.builtin.command:
-        cmd: >-
-          openssl req -x509 -nodes
-          -days {{ _cert_days }}
-          -newkey rsa:2048
-          -keyout {{ _key_file }}
-          -out {{ _cert_file }}
-          -subj '{{ _cert_subject }}'
-      changed_when: true
-
-    - name: "Certs [slm] | Set key permissions"
-      ansible.builtin.file:
-        path: "{{ _key_file }}"
-        mode: "0600"
-        owner: root
-        group: root
+    - name: "Certs [slm] | Generate self-signed cert + lock key (shared, #12181)"
+      ansible.builtin.include_tasks: ../_shared/tasks/generate_self_signed_cert.yml
+      vars:
+        cert_label: slm
 
     - name: "Certs [slm] | Test nginx config"
       ansible.builtin.command:
@@ -187,23 +174,10 @@
         mode: "0644"
       failed_when: false
 
-    - name: "Certs [backend] | Generate new self-signed cert"
-      ansible.builtin.command:
-        cmd: >-
-          openssl req -x509 -nodes
-          -days {{ _cert_days }}
-          -newkey rsa:2048
-          -keyout {{ _key_file }}
-          -out {{ _cert_file }}
-          -subj '{{ _cert_subject }}'
-      changed_when: true
-
-    - name: "Certs [backend] | Set key permissions"
-      ansible.builtin.file:
-        path: "{{ _key_file }}"
-        mode: "0600"
-        owner: root
-        group: root
+    - name: "Certs [backend] | Generate self-signed cert + lock key (shared, #12181)"
+      ansible.builtin.include_tasks: ../_shared/tasks/generate_self_signed_cert.yml
+      vars:
+        cert_label: backend
 
     - name: "Certs [backend] | Restart backend service"
       ansible.builtin.systemd:
@@ -265,23 +239,10 @@
         mode: "0644"
       failed_when: false
 
-    - name: "Certs [frontend] | Generate new self-signed cert"
-      ansible.builtin.command:
-        cmd: >-
-          openssl req -x509 -nodes
-          -days {{ _cert_days }}
-          -newkey rsa:2048
-          -keyout {{ _key_file }}
-          -out {{ _cert_file }}
-          -subj '{{ _cert_subject }}'
-      changed_when: true
-
-    - name: "Certs [frontend] | Set key permissions"
-      ansible.builtin.file:
-        path: "{{ _key_file }}"
-        mode: "0600"
-        owner: root
-        group: root
+    - name: "Certs [frontend] | Generate self-signed cert + lock key (shared, #12181)"
+      ansible.builtin.include_tasks: ../_shared/tasks/generate_self_signed_cert.yml
+      vars:
+        cert_label: frontend
 
     - name: "Certs [frontend] | Test nginx config"
       ansible.builtin.command:


### PR DESCRIPTION
## Thinking Path
TLS cert-generation was not "one of a kind": `playbooks/rotate-certs.yml` copy-pasted a byte-identical `openssl req -x509 -nodes … -newkey rsa:2048` task + its `0600 root:root` key-permissions task three times (slm/backend/frontend plays). Audited the other TLS playbooks first — `enable-tls.yml` (verify+configure), `deploy-certificate.yml` (place a cert), `distribute-tls-certs.yml` (mTLS client certs) — these are distinct lifecycle ops, NOT duplicates, so they stay as-is.

## What Changed
- New `ansible/_shared/tasks/generate_self_signed_cert.yml` — the single canonical self-signed cert generate + key-lockdown, parameterized by the `_cert_days`/`_key_file`/`_cert_file`/`_cert_subject` vars the plays already set (+ optional `cert_label` for log readability). Mirrors the existing `_shared/tasks/stat_tls_certs.yml` convention (#7272).
- `playbooks/rotate-certs.yml` — replaced the three inline copies with `include_tasks` of the shared file. Net −39 lines; zero inline `openssl req -x509` remain.

## Verification
- `yaml.safe_load` OK for both files.
- `ansible-playbook --syntax-check` on rotate-certs.yml passes.
- Behavior-preserving: identical openssl invocation per node, same per-node vars, same key permissions — only relocated.
- Include path verified: `../_shared/tasks/generate_self_signed_cert.yml` resolves from `ansible/playbooks/`.

## Model Used
Opus 4.8

Closes #12181