### PR TITLE
feat(deploy): postgres per-role Migrate playbook (delegating wrapper) (#12170)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-postgres-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-postgres-role.yml
@@ -1,0 +1,25 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# postgres per-role Migrate/Redeploy entry point (#12170, umbrella #11820)
+#
+# The `postgres` role had ansible_playbook: None, so /api/roles/postgres/migrate
+# returned HTTP 422 — postgres was the one managed role with no deployable
+# playbook. This gives it a dedicated entry point.
+#
+# It DELEGATES to the complete, tested deploy-user-management-db.yml rather than
+# re-authoring the per-host DB / user / listen-address / pg_hba / firewall /
+# verification logic — keeping that logic one-of-a-kind (no duplication).
+#
+# run_role_full_procedure (api/roles.py) invokes this with
+# `--limit <target_node_id>`, so only the phase whose `hosts:` matches the
+# migrated node runs, with that phase's correct per-host vars:
+#   - SLM node  -> Phase 1 (slm, slm_users databases, listen localhost)
+#   - DB VM     -> Phase 2 (autobot_users database, remote access + firewall)
+# The extra `role_name=postgres` var passed by the caller is unused here (harmless).
+---
+
+- name: "postgres role Migrate — delegate to the full user-management DB deploy (#12170)"
+  ansible.builtin.import_playbook: deploy-user-management-db.yml

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -226,10 +226,11 @@ _DATABASE_ROLES = [
         "auto_restart": True,
         "required": True,
         "degraded_without": [],
-        # No AutoBot-owned playbook provisions postgres; deploy-database.yml
-        # provisions Redis Stack only.  api/roles.py:338-341 returns HTTP 422
-        # for None — correct behaviour for an externally managed service.
-        "ansible_playbook": None,
+        # #12170: postgres now has a dedicated deploy entry point.
+        # playbooks/deploy-postgres-role.yml delegates to the full, tested
+        # deploy-user-management-db.yml; run_role_full_procedure's --limit runs
+        # only the phase matching the migrated node. Was None (HTTP 422).
+        "ansible_playbook": "playbooks/deploy-postgres-role.yml",
     },
 ]
 

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -142,8 +142,8 @@ def test_postgres_role_present():
     assert role["systemd_service"] == "postgresql"
     assert role["required"] is True
     assert role["auto_restart"] is True
-    # No AutoBot playbook owns postgres provisioning; api/roles.py returns 422.
-    assert role["ansible_playbook"] is None
+    # #12170: postgres now has a dedicated deploy playbook (was None → 422).
+    assert role["ansible_playbook"] == "playbooks/deploy-postgres-role.yml"
     assert role["sync_type"] is None
     # Non-empty target_path ensures role_detector activates path + systemd checks.
     assert role["target_path"] == "/var/lib/postgresql"
@@ -365,3 +365,30 @@ def test_build_filtered_requirements_script_rewrites_root_requirements_not_strip
     assert "-c /opt/autobot/code_source/constraints/shared.txt" in output
     assert "-r /opt/autobot/code_source/requirements.txt" in output
     assert "fastapi>=0.139.2" in output
+
+
+# ---------------------------------------------------------------------------
+# Ansible playbook resolution (#12170 gave postgres a real playbook; guards the
+# #12083/#12095 bug class where an ansible_playbook points at a non-existent
+# file, making per-role Migrate raise FileNotFoundError / return HTTP 422).
+# ---------------------------------------------------------------------------
+
+_ANSIBLE_DIR = _Path(__file__).parent.parent.parent / "ansible"
+
+
+def test_postgres_has_deploy_playbook():
+    """#12170: postgres must have a real deploy playbook (was None -> HTTP 422)."""
+    assert _role("postgres")["ansible_playbook"] == "playbooks/deploy-postgres-role.yml"
+
+
+def test_all_role_ansible_playbooks_resolve():
+    """Every configured ansible_playbook resolves to a real file under ansible/,
+    so per-role Migrate/Redeploy can never FileNotFoundError."""
+    missing = []
+    for role in DEFAULT_ROLES:
+        pb = role.get("ansible_playbook")
+        if not pb:
+            continue
+        if not (_ANSIBLE_DIR / pb).is_file():
+            missing.append(f"{role['name']} -> {pb}")
+    assert not missing, f"role ansible_playbook(s) missing under {_ANSIBLE_DIR}: {missing}"


### PR DESCRIPTION
## Thinking Path
`postgres` was the one managed role with `ansible_playbook: None`, so `/api/roles/postgres/migrate` returned HTTP 422 (#11820 child). A complete, data-safe postgres deployment already exists — the `postgresql` role driven by `playbooks/deploy-user-management-db.yml` (per-host: slm→slm+slm_users; DB VM→autobot_users, with listen-addresses, pg_hba remote access, UFW firewall, cross-VM verify). Re-authoring that in a fresh wrapper would **duplicate** ~130 lines of DB/user/firewall logic — the opposite of one-of-a-kind. So the wrapper **delegates**.

`run_role_full_procedure` (api/roles.py) runs each role playbook with `--limit <target_node_id>`, so importing the multi-phase playbook runs **only the phase whose `hosts:` matches the migrated node**, with that phase's correct per-host vars — exactly right for a single-node postgres Migrate.

## What Changed
- New `ansible/playbooks/deploy-postgres-role.yml` — thin dedicated entry point that `import_playbook`s the tested `deploy-user-management-db.yml` (no logic duplication).
- `services/role_registry.py` — postgres `ansible_playbook`: `None` → `playbooks/deploy-postgres-role.yml` (+ replaced the now-stale 'no playbook owns postgres' comment).
- `tests/services/test_role_registry.py` — updated the stale `ansible_playbook is None` assertion; added `test_postgres_has_deploy_playbook` + `test_all_role_ansible_playbooks_resolve` (guards the #12083/#12095 FileNotFoundError class across every role).

## Verification
```
20 passed in 0.22s
```
- `ansible-playbook --syntax-check playbooks/deploy-postgres-role.yml` passes (from the ansible/ dir so ansible.cfg roles_path applies).
- All 10 distinct role_registry `ansible_playbook` values resolve to real files under ansible/.
- Data-safety: the delegated role is idempotent (`postgresql_db`/`postgresql_user` state:present, passwords read-and-reused, #10636 anti-clobber) — no schema drop, no data-loss vector.
- **Live acceptance** (POST /api/roles/postgres/migrate against the box) needs box access — left for on-box validation per the issue.

## Model Used
Opus 4.8

Closes #12170