### PR TITLE
feat(kb): scaffold Slack/Confluence/Jira knowledge connectors behind feature flag (#10538)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -78,6 +78,12 @@ _SUPPORTED_TYPES = [
     "forgejo",
     "gdrive",
     "onedrive",
+    # Issue #10538: registered only when AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true
+    # (default off) — get_registered_class() returns None otherwise, so the
+    # create_connector() call below still 422s until the flag is enabled.
+    "slack",
+    "confluence",
+    "jira",
 ]
 
 # Marker auth_type for connectors whose bearer credential is an OAuth bundle

--- a/autobot-backend/knowledge/connectors/CONNECTORS.md
+++ b/autobot-backend/knowledge/connectors/CONNECTORS.md
@@ -13,13 +13,15 @@ belongs to that category.  The lookup is case-insensitive.
 |---|---|
 | `cloud storage` | `gdrive`, `onedrive`, `nextcloud` |
 | `source control` | `gitlab`, `gitea` |
-| `wiki` | `notion` |
-| `knowledge base` | `notion`, `file_server`, `web_crawler` |
+| `wiki` | `notion`, `confluence` |
+| `knowledge base` | `notion`, `file_server`, `web_crawler`, `confluence` |
 | `file system` | `file_server` |
 | `database` | `database` |
 | `web` | `web_crawler` |
 | `audio` | `audio` |
 | `external` | `external_adapter` |
+| `chat` | `slack` |
+| `issue tracker` | `jira` |
 
 ## Connector Types
 
@@ -36,6 +38,9 @@ belongs to that category.  The lookup is case-insensitive.
 | `database` | `database.py` | SQLAlchemy-backed databases |
 | `audio` | `audio_connector.py` | Audio file ingestion |
 | `external_adapter` | `external_adapter.py` | Subprocess / stdout-JSON adapters |
+| `slack` | `slack.py` | Slack Web API channel/thread history — Issue #10538, feature-flagged (`AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS`, default off) |
+| `confluence` | `confluence.py` | Atlassian Confluence REST API pages — Issue #10538, feature-flagged (`AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS`, default off) |
+| `jira` | `jira.py` | Atlassian Jira REST API v3 issues + comments — Issue #10538, feature-flagged (`AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS`, default off) |
 
 ## Usage
 

--- a/autobot-backend/knowledge/connectors/__init__.py
+++ b/autobot-backend/knowledge/connectors/__init__.py
@@ -19,7 +19,15 @@ Packages:
 - gdrive     — GoogleDriveConnector (Google Drive API v3)
 - gitlab      — GitLabConnector (GitLab v4 API) / GiteaConnector (Gitea + Forgejo v1 API)
 - nextcloud   — NextcloudConnector (Nextcloud WebDAV)
+- slack       — SlackConnector (Slack Web API) — Issue #10538, feature-flagged
+- confluence  — ConfluenceConnector (Atlassian Confluence REST API) — Issue #10538, feature-flagged
+- jira        — JiraConnector (Atlassian Jira REST API v3) — Issue #10538, feature-flagged
 - scheduler  — ConnectorScheduler (asyncio task-based)
+
+Issue #10538: The Slack/Confluence/Jira connectors are registered only when
+``AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true`` (default disabled — see
+``autobot_shared/feature_flags.py``). Until enabled, their connector types
+are absent from ``ConnectorRegistry`` and cannot be instantiated.
 
 Example usage::
 
@@ -50,6 +58,7 @@ import knowledge.connectors.nextcloud  # noqa: F401
 import knowledge.connectors.notion  # noqa: F401
 import knowledge.connectors.onedrive  # noqa: F401  # GH#9004
 import knowledge.connectors.web_crawler  # noqa: F401
+from autobot_shared.feature_flags import is_feature_enabled
 from knowledge.connectors.base import AbstractConnector
 from knowledge.connectors.models import (
     ChangeInfo,
@@ -60,6 +69,16 @@ from knowledge.connectors.models import (
     SyncResult,
 )
 from knowledge.connectors.registry import CATEGORY_MAP, ConnectorRegistry
+
+# Issue #10538: Slack/Confluence/Jira ship disabled by default — these
+# connectors reach third-party SaaS APIs and no credentials are configured
+# out of the box. Gate their import (and therefore their
+# @ConnectorRegistry.register side effect) behind the subsystem flag so
+# nothing in this module makes them creatable unless explicitly enabled.
+if is_feature_enabled("kb_enterprise_connectors"):
+    import knowledge.connectors.confluence  # noqa: F401
+    import knowledge.connectors.jira  # noqa: F401
+    import knowledge.connectors.slack  # noqa: F401
 
 __all__ = [
     "AbstractConnector",

--- a/autobot-backend/knowledge/connectors/confluence.py
+++ b/autobot-backend/knowledge/connectors/confluence.py
@@ -1,0 +1,328 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Confluence Knowledge Connector (Issue #10538)
+
+Ingests Atlassian Confluence pages into the AutoBot knowledge base so wiki
+content becomes searchable via ``kb.search``.
+
+SCAFFOLD NOTE: This connector is registered only when the
+``kb_enterprise_connectors`` feature flag is enabled
+(``AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true`` — see
+``knowledge/connectors/__init__.py``). No credentials are hardcoded; the
+values below are documentation placeholders only.
+
+Config keys (under ``ConnectorConfig.config``):
+    base_url (str): Confluence site base URL, e.g.
+        "https://your-domain.atlassian.net/wiki". Required.
+    email (str): Atlassian account email used for basic auth. Required.
+    api_token (str): Atlassian API token. Required.
+    space_keys (list[str]): Confluence space keys to sync. Required.
+    page_size (int): Pages per query batch. Default 25.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from autobot_shared.auth import BasicAuth
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc, parse_utc_iso
+from knowledge.connectors.base import AbstractConnector, RetryableError
+from knowledge.connectors.models import (
+    ChangeInfo,
+    ConnectorConfig,
+    ContentResult,
+    SourceInfo,
+)
+from knowledge.connectors.registry import ConnectorRegistry
+
+logger = get_logger(__name__)
+
+_REDIS_TS_PREFIX = "connector:confluence:ts:"
+_REDIS_TS_TTL = 86400 * 30  # 30 days
+
+
+@ConnectorRegistry.register("confluence")
+class ConfluenceConnector(AbstractConnector):
+    """Knowledge connector that pulls pages from Confluence spaces.
+
+    Each page becomes one KB fact keyed by
+    ``confluence:{connector_id}:page:{page_id}``. Change detection compares
+    the page's ``version.when`` timestamp against a Redis-cached value so
+    only edited pages are re-fetched.
+    """
+
+    connector_type = "confluence"
+    # Issue #4421: needs an Atlassian API token — tier 2 (credentialed).
+    tier = 2
+    max_concurrency = 4
+
+    @classmethod
+    def auth_schema(cls) -> type:
+        """Confluence Cloud uses HTTP Basic auth (email + API token) — Issue #8145."""
+        return BasicAuth
+
+    @classmethod
+    def output_schema(cls) -> Dict[str, Any]:
+        """Return JSONSchema for ContentResult.metadata (Issue #8147)."""
+        return {
+            "type": "object",
+            "required": ["confluence_page_id", "confluence_space_key"],
+            "properties": {
+                "confluence_page_id": {"type": "string", "description": "Confluence page ID"},
+                "confluence_space_key": {"type": "string", "description": "Confluence space key"},
+                "confluence_title": {"type": "string", "description": "Page title"},
+                "confluence_url": {"type": "string", "description": "Web URL to the page"},
+                "version_when": {"type": "string", "description": "ISO-8601 timestamp of the last edit"},
+            },
+        }
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        cfg = config.config
+        self._email: str = cfg.get("email", "")
+        self._api_token: str = cfg.get("api_token", "")
+        self._base_url: str = cfg.get("base_url", "").rstrip("/")
+        self._space_keys: List[str] = cfg.get("space_keys", [])
+        self._page_size: int = int(cfg.get("page_size", 25))
+
+    # ------------------------------------------------------------------
+    # AbstractConnector interface
+    # ------------------------------------------------------------------
+
+    async def test_connection(self) -> bool:
+        """Verify credentials by fetching the accessible spaces list."""
+        result = await self._get("/rest/api/space?limit=1")
+        healthy = result.get("status_code") == 200
+        if not healthy:
+            self.logger.warning("Confluence test_connection failed: HTTP %s", result.get("status_code"))
+        return healthy
+
+    async def discover_sources(self) -> List[SourceInfo]:
+        """Return a SourceInfo for every page across all configured spaces."""
+        sources: List[SourceInfo] = []
+        for space_key in self._space_keys:
+            pages = await self._list_pages(space_key)
+            for page in pages:
+                sources.append(_page_to_source_info(self.config.connector_id, page, space_key))
+        return sources
+
+    async def fetch_content(self, source_id: str) -> Optional[ContentResult]:
+        """Fetch storage-format body text for the Confluence page in *source_id*."""
+        page_id = _parse_page_id(source_id)
+        if page_id is None:
+            self.logger.error("Malformed Confluence source_id: %s", source_id)
+            return None
+
+        result = await self._get("/rest/api/content/%s?expand=body.storage,space,version" % page_id)
+        if result.get("status_code") != 200:
+            self.logger.error("Failed to fetch Confluence page %s: HTTP %s", page_id, result.get("status_code"))
+            return None
+
+        page = result.get("body", {})
+        title = page.get("title", "")
+        html = page.get("body", {}).get("storage", {}).get("value", "")
+        text = _html_to_text(html)
+        if title:
+            text = "%s\n\n%s" % (title, text)
+
+        version_when = page.get("version", {}).get("when", "")
+        if version_when:
+            await _store_ts(self.config.connector_id, page_id, version_when)
+
+        return ContentResult(
+            source_id=source_id,
+            content=text,
+            content_type="text/plain",
+            metadata={
+                "confluence_page_id": page_id,
+                "confluence_space_key": page.get("space", {}).get("key", ""),
+                "confluence_title": title,
+                "confluence_url": _page_web_url(self._base_url, page),
+                "version_when": version_when,
+                "connector_type": self.connector_type,
+            },
+        )
+
+    async def detect_changes(self, since: Optional[datetime] = None) -> List[ChangeInfo]:
+        """Return ChangeInfo for pages created/edited since *since*."""
+        changes: List[ChangeInfo] = []
+        for space_key in self._space_keys:
+            pages = await self._list_pages(space_key)
+            for page in pages:
+                page_id = page.get("id", "")
+                change = await self._classify_change(page_id, since)
+                if change:
+                    changes.append(change)
+        return changes
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _list_pages(self, space_key: str) -> List[Dict[str, Any]]:
+        """Fetch all pages in a space (handles pagination via ``start``)."""
+        pages: List[Dict[str, Any]] = []
+        start = 0
+        while True:
+            path = "/rest/api/content?spaceKey=%s&type=page&limit=%d&start=%d&expand=version" % (
+                space_key,
+                self._page_size,
+                start,
+            )
+            result = await self.fetch_with_retry(lambda p=path: self._get(p))
+            if result.get("status_code") != 200:
+                self.logger.error(
+                    "Failed to list Confluence pages for space %s: HTTP %s",
+                    space_key,
+                    result.get("status_code"),
+                )
+                break
+            body = result.get("body", {})
+            batch = body.get("results", [])
+            pages.extend(batch)
+            if len(batch) < self._page_size:
+                break
+            start += self._page_size
+        return pages
+
+    async def _classify_change(self, page_id: str, since: Optional[datetime]) -> Optional[ChangeInfo]:
+        """Return ChangeInfo when the page is new or has a newer version than stored."""
+        if since is None:
+            return ChangeInfo(
+                source_id=_build_source_id(self.config.connector_id, page_id),
+                change_type="added",
+                timestamp=now_utc(),
+                details={"page_id": page_id},
+            )
+
+        result = await self._get("/rest/api/content/%s?expand=version" % page_id)
+        if result.get("status_code") != 200:
+            return None
+        version_when = result.get("body", {}).get("version", {}).get("when", "")
+
+        stored = await _load_ts(self.config.connector_id, page_id)
+        if stored is None or version_when > stored:
+            change_type = "added" if stored is None else "modified"
+            await _store_ts(self.config.connector_id, page_id, version_when)
+            return ChangeInfo(
+                source_id=_build_source_id(self.config.connector_id, page_id),
+                change_type=change_type,
+                timestamp=now_utc(),
+                details={"page_id": page_id, "version_when": version_when},
+            )
+        return None
+
+    async def _get(self, path: str) -> Dict[str, Any]:
+        """Make an authenticated GET request to the Confluence REST API."""
+        url = "%s%s" % (self._base_url, path)
+        auth = aiohttp.BasicAuth(login=self._email, password=self._api_token)
+        try:
+            timeout = aiohttp.ClientTimeout(total=30.0)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url, auth=auth) as resp:
+                    if resp.status == 429:
+                        raise RetryableError("Confluence rate-limited", status_code=429)
+                    if resp.status >= 500:
+                        raise RetryableError("Confluence server error %d" % resp.status, status_code=resp.status)
+                    body = await resp.json(content_type=None)
+                    return {"status_code": resp.status, "body": body}
+        except RetryableError:
+            raise
+        except aiohttp.ClientError as exc:
+            self.logger.warning("Confluence request to %s failed: %s", url, exc)
+            return {"status_code": 0, "error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Redis checkpoint helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_ts(connector_id: str, page_id: str) -> Optional[str]:
+    """Load the stored ``version.when`` timestamp for *page_id* from Redis."""
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="knowledge")
+        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, page_id)
+        value = redis.get(key)
+        if hasattr(value, "__await__"):
+            value = await value
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
+    except Exception as exc:
+        logger.warning("Redis load_ts failed for page %s: %s", page_id, exc)
+        return None
+
+
+async def _store_ts(connector_id: str, page_id: str, version_when: str) -> None:
+    """Persist the ``version.when`` timestamp for *page_id* in Redis."""
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="knowledge")
+        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, page_id)
+        result = redis.set(key, version_when, ex=_REDIS_TS_TTL)
+        if hasattr(result, "__await__"):
+            await result
+    except Exception as exc:
+        logger.warning("Redis store_ts failed for page %s: %s", page_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (no state)
+# ---------------------------------------------------------------------------
+
+
+def _build_source_id(connector_id: str, page_id: str) -> str:
+    return "confluence:%s:page:%s" % (connector_id, page_id)
+
+
+def _parse_page_id(source_id: str) -> Optional[str]:
+    parts = source_id.split(":")
+    # Format: confluence:{connector_id}:page:{page_id}
+    if len(parts) != 4 or parts[2] != "page":
+        return None
+    return parts[3]
+
+
+def _page_to_source_info(connector_id: str, page: Dict[str, Any], space_key: str) -> SourceInfo:
+    page_id = page.get("id", "")
+    version = page.get("version", {})
+    updated_raw = version.get("when", "")
+    try:
+        last_modified = parse_utc_iso(updated_raw)
+    except (ValueError, AttributeError):
+        last_modified = now_utc()
+    return SourceInfo(
+        source_id=_build_source_id(connector_id, page_id),
+        name=page.get("title", ""),
+        path="",
+        content_type="text/plain",
+        size_bytes=0,
+        last_modified=last_modified,
+        metadata={"space_key": space_key, "page_id": page_id, "version_when": updated_raw},
+    )
+
+
+def _page_web_url(base_url: str, page: Dict[str, Any]) -> str:
+    webui = page.get("_links", {}).get("webui", "")
+    return "%s%s" % (base_url, webui) if webui else ""
+
+
+def _html_to_text(html: str) -> str:
+    """Strip Confluence storage-format HTML/XML markup down to plain text."""
+    import re
+
+    text = re.sub(r"<[^>]+>", " ", html or "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+__all__ = ["ConfluenceConnector"]

--- a/autobot-backend/knowledge/connectors/confluence_test.py
+++ b/autobot-backend/knowledge/connectors/confluence_test.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for Confluence Knowledge Connector (Issue #10538)
+
+All HTTP calls are mocked — no network access, and the module never makes a
+live request just from being imported or instantiated.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.connectors.confluence import ConfluenceConnector
+from knowledge.connectors.models import ConnectorConfig
+
+
+@pytest.fixture
+def confluence_config():
+    return ConnectorConfig(
+        connector_id="test-confluence-1",
+        connector_type="confluence",
+        name="Test Confluence",
+        config={
+            "base_url": "https://example.atlassian.net/wiki",
+            "email": "bot@example.com",
+            "api_token": "test-fake-api-credential",
+            "space_keys": ["ENG"],
+        },
+        enabled=True,
+        verification_mode="collaborative",
+    )
+
+
+class TestConfluenceConnectorInit:
+    def test_init(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        assert connector.connector_type == "confluence"
+        assert connector.tier == 2
+        assert connector._email == "bot@example.com"
+        assert connector._base_url == "https://example.atlassian.net/wiki"
+        assert connector._space_keys == ["ENG"]
+        assert connector.max_concurrency == 4
+
+    def test_auth_schema(self):
+        from autobot_shared.auth import BasicAuth
+
+        assert ConfluenceConnector.auth_schema() == BasicAuth
+
+    def test_output_schema(self):
+        schema = ConfluenceConnector.output_schema()
+        assert schema["type"] == "object"
+        assert "confluence_page_id" in schema["required"]
+        assert "confluence_space_key" in schema["required"]
+
+
+class TestConfluenceConnectorConnection:
+    @pytest.mark.asyncio
+    async def test_test_connection_success(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 200, "body": {"results": []}}
+            assert await connector.test_connection() is True
+
+    @pytest.mark.asyncio
+    async def test_test_connection_failure(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 401, "body": {}}
+            assert await connector.test_connection() is False
+
+
+class TestConfluenceConnectorDiscovery:
+    @pytest.mark.asyncio
+    async def test_discover_sources(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        list_body = {
+            "results": [
+                {"id": "111", "title": "Runbook", "version": {"when": "2026-01-01T00:00:00.000Z"}},
+            ]
+        }
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 200, "body": list_body}
+            sources = await connector.discover_sources()
+
+        assert len(sources) == 1
+        assert sources[0].source_id == "confluence:test-confluence-1:page:111"
+        assert sources[0].name == "Runbook"
+
+
+class TestConfluenceConnectorFetchContent:
+    @pytest.mark.asyncio
+    async def test_fetch_content(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        source_id = "confluence:test-confluence-1:page:111"
+        page_body = {
+            "title": "Runbook",
+            "body": {"storage": {"value": "<p>Restart the <b>service</b>.</p>"}},
+            "space": {"key": "ENG"},
+            "version": {"when": "2026-01-01T00:00:00.000Z"},
+            "_links": {"webui": "/spaces/ENG/pages/111"},
+        }
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 200, "body": page_body}
+            result = await connector.fetch_content(source_id)
+
+        assert result is not None
+        assert "Runbook" in result.content
+        assert "Restart the service" in result.content
+        assert result.metadata["confluence_page_id"] == "111"
+        assert result.metadata["confluence_space_key"] == "ENG"
+        assert result.metadata["confluence_url"] == "https://example.atlassian.net/wiki/spaces/ENG/pages/111"
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_malformed_source_id(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        assert await connector.fetch_content("not-a-confluence-id") is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_not_found(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        source_id = "confluence:test-confluence-1:page:999"
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 404, "body": {}}
+            assert await connector.fetch_content(source_id) is None
+
+
+class TestConfluenceConnectorChangeDetection:
+    @pytest.mark.asyncio
+    async def test_detect_changes_initial_sync(self, confluence_config):
+        connector = ConfluenceConnector(confluence_config)
+        list_body = {"results": [{"id": "111", "title": "Runbook", "version": {"when": "2026-01-01T00:00:00.000Z"}}]}
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 200, "body": list_body}
+            changes = await connector.detect_changes(since=None)
+
+        assert len(changes) == 1
+        assert changes[0].change_type == "added"
+        assert changes[0].source_id == "confluence:test-confluence-1:page:111"
+
+
+class TestConfluenceModuleHelpers:
+    def test_html_to_text_strips_markup(self):
+        from knowledge.connectors.confluence import _html_to_text
+
+        assert _html_to_text("<p>Hello <b>World</b></p>") == "Hello World"
+
+    def test_html_to_text_empty(self):
+        from knowledge.connectors.confluence import _html_to_text
+
+        assert _html_to_text("") == ""
+
+    def test_parse_page_id_valid(self):
+        from knowledge.connectors.confluence import _parse_page_id
+
+        assert _parse_page_id("confluence:conn-1:page:111") == "111"
+
+    def test_parse_page_id_malformed(self):
+        from knowledge.connectors.confluence import _parse_page_id
+
+        assert _parse_page_id("bad:id") is None

--- a/autobot-backend/knowledge/connectors/connectors_init_gating_test.py
+++ b/autobot-backend/knowledge/connectors/connectors_init_gating_test.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the Slack/Confluence/Jira feature-flag gate (Issue #10538).
+
+The framework's ``knowledge/connectors/__init__.py`` only imports (and
+therefore registers, via the ``@ConnectorRegistry.register`` decorator) the
+Slack/Confluence/Jira connector modules when the ``kb_enterprise_connectors``
+subsystem flag is enabled. Since import side effects are process-global and
+cached by Python, this is verified two ways:
+
+1. A static source check that the gate exists and covers all three modules
+   (regression guard against someone dropping the ``if`` and always
+   importing them).
+2. A behavioural check, via a subprocess, that a fresh interpreter with the
+   flag left at its default (disabled) never registers "slack", "confluence"
+   or "jira" as connector types.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_CONNECTORS_INIT = Path(__file__).parent / "__init__.py"
+
+
+class TestFeatureFlagGateSource:
+    """Static check that __init__.py gates the three connectors on the flag."""
+
+    def test_gate_covers_all_three_connectors(self) -> None:
+        source = _CONNECTORS_INIT.read_text(encoding="utf-8")
+        assert 'is_feature_enabled("kb_enterprise_connectors")' in source
+
+        gate_start = source.index('if is_feature_enabled("kb_enterprise_connectors")')
+        gated_block = source[gate_start:]
+        assert "import knowledge.connectors.slack" in gated_block
+        assert "import knowledge.connectors.confluence" in gated_block
+        assert "import knowledge.connectors.jira" in gated_block
+
+    def test_gated_imports_not_unconditional(self) -> None:
+        """The gated imports must not also appear in the unconditional block above the gate."""
+        source = _CONNECTORS_INIT.read_text(encoding="utf-8")
+        gate_start = source.index('if is_feature_enabled("kb_enterprise_connectors")')
+        unconditional_block = source[:gate_start]
+        assert "import knowledge.connectors.slack" not in unconditional_block
+        assert "import knowledge.connectors.confluence" not in unconditional_block
+        assert "import knowledge.connectors.jira" not in unconditional_block
+
+
+class TestFeatureFlagGateBehaviour:
+    """Subprocess check: default-disabled flag keeps the types unregistered."""
+
+    def test_disabled_by_default_no_registration(self) -> None:
+        backend_dir = Path(__file__).parents[2]
+        project_root = backend_dir.parent
+        script = (
+            "import sys; "
+            "sys.path.insert(0, %r); "
+            "sys.path.insert(0, %r); "
+            "from knowledge.connectors.registry import ConnectorRegistry; "
+            "import knowledge.connectors; "
+            "types = ConnectorRegistry.list_types(); "
+            "assert 'slack' not in types, types; "
+            "assert 'confluence' not in types, types; "
+            "assert 'jira' not in types, types; "
+            "print('OK')"
+        ) % (str(project_root), str(backend_dir))
+        env = os.environ.copy()
+        env.pop("AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS", None)
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(backend_dir),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "OK" in result.stdout

--- a/autobot-backend/knowledge/connectors/jira.py
+++ b/autobot-backend/knowledge/connectors/jira.py
@@ -1,0 +1,369 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Jira Knowledge Connector (Issue #10538)
+
+Ingests Jira issues (with comments) into the AutoBot knowledge base so
+tracker content becomes searchable via ``kb.search``.
+
+SCAFFOLD NOTE: This connector is registered only when the
+``kb_enterprise_connectors`` feature flag is enabled
+(``AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true`` — see
+``knowledge/connectors/__init__.py``). No credentials are hardcoded; the
+values below are documentation placeholders only.
+
+Config keys (under ``ConnectorConfig.config``):
+    base_url (str): Jira site base URL, e.g.
+        "https://your-domain.atlassian.net". Required.
+    email (str): Atlassian account email used for basic auth. Required.
+    api_token (str): Atlassian API token. Required.
+    project_keys (list[str]): Jira project keys to sync. Required.
+    jql (str): Optional JQL override; when set, replaces the
+        project-key-derived query entirely.
+    page_size (int): Issues per search batch. Default 50.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from autobot_shared.auth import BasicAuth
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc, parse_utc_iso
+from knowledge.connectors.base import AbstractConnector, RetryableError
+from knowledge.connectors.models import (
+    ChangeInfo,
+    ConnectorConfig,
+    ContentResult,
+    SourceInfo,
+)
+from knowledge.connectors.registry import ConnectorRegistry
+
+logger = get_logger(__name__)
+
+_REDIS_TS_PREFIX = "connector:jira:ts:"
+_REDIS_TS_TTL = 86400 * 30  # 30 days
+
+
+@ConnectorRegistry.register("jira")
+class JiraConnector(AbstractConnector):
+    """Knowledge connector that pulls issues (and comments) from Jira projects.
+
+    Each issue becomes one KB fact keyed by
+    ``jira:{connector_id}:issue:{issue_key}``, with comments concatenated
+    into the issue body. Change detection uses JQL ``updated >=`` filtering
+    plus a Redis-cached ``updated`` timestamp per issue.
+    """
+
+    connector_type = "jira"
+    # Issue #4421: needs an Atlassian API token — tier 2 (credentialed).
+    tier = 2
+    max_concurrency = 4
+
+    @classmethod
+    def auth_schema(cls) -> type:
+        """Jira Cloud uses HTTP Basic auth (email + API token) — Issue #8145."""
+        return BasicAuth
+
+    @classmethod
+    def output_schema(cls) -> Dict[str, Any]:
+        """Return JSONSchema for ContentResult.metadata (Issue #8147)."""
+        return {
+            "type": "object",
+            "required": ["jira_issue_key", "jira_project_key"],
+            "properties": {
+                "jira_issue_key": {"type": "string", "description": "Jira issue key, e.g. ABC-123"},
+                "jira_project_key": {"type": "string", "description": "Jira project key"},
+                "jira_summary": {"type": "string", "description": "Issue summary/title"},
+                "jira_status": {"type": "string", "description": "Current workflow status"},
+                "jira_url": {"type": "string", "description": "Web URL to the issue"},
+                "updated": {"type": "string", "description": "ISO-8601 last-updated timestamp"},
+                "comment_count": {"type": "integer", "description": "Number of comments included"},
+            },
+        }
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        cfg = config.config
+        self._email: str = cfg.get("email", "")
+        self._api_token: str = cfg.get("api_token", "")
+        self._base_url: str = cfg.get("base_url", "").rstrip("/")
+        self._project_keys: List[str] = cfg.get("project_keys", [])
+        self._jql_override: str = cfg.get("jql", "")
+        self._page_size: int = int(cfg.get("page_size", 50))
+
+    # ------------------------------------------------------------------
+    # AbstractConnector interface
+    # ------------------------------------------------------------------
+
+    async def test_connection(self) -> bool:
+        """Verify credentials via ``/rest/api/3/myself``."""
+        result = await self._get("/rest/api/3/myself")
+        healthy = result.get("status_code") == 200
+        if not healthy:
+            self.logger.warning("Jira test_connection failed: HTTP %s", result.get("status_code"))
+        return healthy
+
+    async def discover_sources(self) -> List[SourceInfo]:
+        """Return a SourceInfo for every issue matching the configured JQL."""
+        issues = await self._search(self._build_jql())
+        return [_issue_to_source_info(self.config.connector_id, issue) for issue in issues]
+
+    async def fetch_content(self, source_id: str) -> Optional[ContentResult]:
+        """Fetch issue fields and comments for the Jira issue in *source_id*."""
+        issue_key = _parse_issue_key(source_id)
+        if issue_key is None:
+            self.logger.error("Malformed Jira source_id: %s", source_id)
+            return None
+
+        result = await self._get("/rest/api/3/issue/%s" % issue_key)
+        if result.get("status_code") != 200:
+            self.logger.error("Failed to fetch Jira issue %s: HTTP %s", issue_key, result.get("status_code"))
+            return None
+
+        issue = result.get("body", {})
+        fields = issue.get("fields", {})
+        comments = fields.get("comment", {}).get("comments", [])
+        text = _issue_to_text(issue_key, fields, comments)
+
+        updated = fields.get("updated", "")
+        if updated:
+            await _store_ts(self.config.connector_id, issue_key, updated)
+
+        return ContentResult(
+            source_id=source_id,
+            content=text,
+            content_type="text/plain",
+            metadata={
+                "jira_issue_key": issue_key,
+                "jira_project_key": fields.get("project", {}).get("key", ""),
+                "jira_summary": fields.get("summary", ""),
+                "jira_status": fields.get("status", {}).get("name", ""),
+                "jira_url": "%s/browse/%s" % (self._base_url, issue_key),
+                "updated": updated,
+                "comment_count": len(comments),
+                "connector_type": self.connector_type,
+            },
+        )
+
+    async def detect_changes(self, since: Optional[datetime] = None) -> List[ChangeInfo]:
+        """Return ChangeInfo for issues created/updated since *since*."""
+        jql = self._build_jql(since=since)
+        issues = await self._search(jql)
+        changes: List[ChangeInfo] = []
+        for issue in issues:
+            issue_key = issue.get("key", "")
+            updated = issue.get("fields", {}).get("updated", "")
+            change = await self._classify_change(issue_key, updated, since)
+            if change:
+                changes.append(change)
+        return changes
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_jql(self, since: Optional[datetime] = None) -> str:
+        """Build the JQL query for discovery/change-detection searches."""
+        if self._jql_override:
+            return self._jql_override
+        keys = ",".join(self._project_keys)
+        jql = "project in (%s)" % keys if keys else "order by updated desc"
+        if since is not None:
+            jql += ' AND updated >= "%s"' % since.strftime("%Y-%m-%d %H:%M")
+        return jql
+
+    async def _classify_change(self, issue_key: str, updated: str, since: Optional[datetime]) -> Optional[ChangeInfo]:
+        """Return ChangeInfo when the issue is new or newer than its stored checkpoint."""
+        if since is None:
+            return ChangeInfo(
+                source_id=_build_source_id(self.config.connector_id, issue_key),
+                change_type="added",
+                timestamp=now_utc(),
+                details={"issue_key": issue_key, "updated": updated},
+            )
+
+        stored = await _load_ts(self.config.connector_id, issue_key)
+        if stored is None or updated > stored:
+            change_type = "added" if stored is None else "modified"
+            await _store_ts(self.config.connector_id, issue_key, updated)
+            return ChangeInfo(
+                source_id=_build_source_id(self.config.connector_id, issue_key),
+                change_type=change_type,
+                timestamp=now_utc(),
+                details={"issue_key": issue_key, "updated": updated},
+            )
+        return None
+
+    async def _search(self, jql: str) -> List[Dict[str, Any]]:
+        """Run a JQL search, handling pagination via ``startAt``."""
+        issues: List[Dict[str, Any]] = []
+        start_at = 0
+        while True:
+            payload = {
+                "jql": jql,
+                "startAt": start_at,
+                "maxResults": self._page_size,
+                "fields": ["summary", "status", "project", "updated", "comment"],
+            }
+            result = await self.fetch_with_retry(lambda p=payload: self._post("/rest/api/3/search", p))
+            if result.get("status_code") != 200:
+                self.logger.error("Jira search failed: HTTP %s", result.get("status_code"))
+                break
+            body = result.get("body", {})
+            batch = body.get("issues", [])
+            issues.extend(batch)
+            total = body.get("total", len(issues))
+            start_at += len(batch)
+            if not batch or start_at >= total:
+                break
+        return issues
+
+    async def _get(self, path: str) -> Dict[str, Any]:
+        return await self._request("GET", path)
+
+    async def _post(self, path: str, json_data: Dict[str, Any]) -> Dict[str, Any]:
+        return await self._request("POST", path, json_data=json_data)
+
+    async def _request(self, method: str, path: str, json_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Make an authenticated request to the Jira REST API."""
+        url = "%s%s" % (self._base_url, path)
+        auth = aiohttp.BasicAuth(login=self._email, password=self._api_token)
+        try:
+            timeout = aiohttp.ClientTimeout(total=30.0)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.request(method, url, auth=auth, json=json_data) as resp:
+                    if resp.status == 429:
+                        raise RetryableError("Jira rate-limited", status_code=429)
+                    if resp.status >= 500:
+                        raise RetryableError("Jira server error %d" % resp.status, status_code=resp.status)
+                    body = await resp.json(content_type=None)
+                    return {"status_code": resp.status, "body": body}
+        except RetryableError:
+            raise
+        except aiohttp.ClientError as exc:
+            self.logger.warning("Jira request to %s failed: %s", url, exc)
+            return {"status_code": 0, "error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Redis checkpoint helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_ts(connector_id: str, issue_key: str) -> Optional[str]:
+    """Load the stored ``updated`` timestamp for *issue_key* from Redis."""
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="knowledge")
+        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, issue_key)
+        value = redis.get(key)
+        if hasattr(value, "__await__"):
+            value = await value
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
+    except Exception as exc:
+        logger.warning("Redis load_ts failed for issue %s: %s", issue_key, exc)
+        return None
+
+
+async def _store_ts(connector_id: str, issue_key: str, updated: str) -> None:
+    """Persist the ``updated`` timestamp for *issue_key* in Redis."""
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="knowledge")
+        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, issue_key)
+        result = redis.set(key, updated, ex=_REDIS_TS_TTL)
+        if hasattr(result, "__await__"):
+            await result
+    except Exception as exc:
+        logger.warning("Redis store_ts failed for issue %s: %s", issue_key, exc)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (no state)
+# ---------------------------------------------------------------------------
+
+
+def _build_source_id(connector_id: str, issue_key: str) -> str:
+    return "jira:%s:issue:%s" % (connector_id, issue_key)
+
+
+def _parse_issue_key(source_id: str) -> Optional[str]:
+    parts = source_id.split(":")
+    # Format: jira:{connector_id}:issue:{issue_key}
+    if len(parts) != 4 or parts[2] != "issue":
+        return None
+    return parts[3]
+
+
+def _issue_to_source_info(connector_id: str, issue: Dict[str, Any]) -> SourceInfo:
+    issue_key = issue.get("key", "")
+    fields = issue.get("fields", {})
+    updated_raw = fields.get("updated", "")
+    try:
+        last_modified = parse_utc_iso(updated_raw)
+    except (ValueError, AttributeError):
+        last_modified = now_utc()
+    return SourceInfo(
+        source_id=_build_source_id(connector_id, issue_key),
+        name=fields.get("summary", ""),
+        path="",
+        content_type="text/plain",
+        size_bytes=0,
+        last_modified=last_modified,
+        metadata={
+            "project_key": fields.get("project", {}).get("key", ""),
+            "issue_key": issue_key,
+            "updated": updated_raw,
+        },
+    )
+
+
+def _issue_to_text(issue_key: str, fields: Dict[str, Any], comments: List[Dict[str, Any]]) -> str:
+    parts = [
+        "Issue %s: %s" % (issue_key, fields.get("summary", "")),
+        "Status: %s" % fields.get("status", {}).get("name", ""),
+        "Project: %s" % fields.get("project", {}).get("key", ""),
+        "Updated: %s" % fields.get("updated", ""),
+    ]
+    description = _adf_to_text(fields.get("description"))
+    if description.strip():
+        parts.append("")
+        parts.append(description.strip())
+    for comment in comments:
+        body = _adf_to_text(comment.get("body"))
+        if body.strip():
+            author = comment.get("author", {}).get("displayName", "unknown")
+            parts.append("")
+            parts.append("Comment by %s: %s" % (author, body.strip()))
+    return "\n".join(parts)
+
+
+def _adf_to_text(node: Any) -> str:
+    """Extract plain text from a Jira Atlassian Document Format (ADF) node.
+
+    Falls back to str() for legacy plain-text description/comment bodies.
+    """
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if not isinstance(node, dict):
+        return str(node)
+
+    parts: List[str] = []
+    if node.get("type") == "text":
+        parts.append(node.get("text", ""))
+    for child in node.get("content", []) or []:
+        parts.append(_adf_to_text(child))
+    return " ".join(p for p in parts if p)
+
+
+__all__ = ["JiraConnector"]

--- a/autobot-backend/knowledge/connectors/jira_test.py
+++ b/autobot-backend/knowledge/connectors/jira_test.py
@@ -1,0 +1,202 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for Jira Knowledge Connector (Issue #10538)
+
+All HTTP calls are mocked — no network access, and the module never makes a
+live request just from being imported or instantiated.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.connectors.jira import JiraConnector
+from knowledge.connectors.models import ConnectorConfig
+
+
+@pytest.fixture
+def jira_config():
+    return ConnectorConfig(
+        connector_id="test-jira-1",
+        connector_type="jira",
+        name="Test Jira",
+        config={
+            "base_url": "https://example.atlassian.net",
+            "email": "bot@example.com",
+            "api_token": "test-fake-api-credential",
+            "project_keys": ["ABC"],
+        },
+        enabled=True,
+        verification_mode="collaborative",
+    )
+
+
+class TestJiraConnectorInit:
+    def test_init(self, jira_config):
+        connector = JiraConnector(jira_config)
+        assert connector.connector_type == "jira"
+        assert connector.tier == 2
+        assert connector._email == "bot@example.com"
+        assert connector._project_keys == ["ABC"]
+        assert connector.max_concurrency == 4
+
+    def test_auth_schema(self):
+        from autobot_shared.auth import BasicAuth
+
+        assert JiraConnector.auth_schema() == BasicAuth
+
+    def test_output_schema(self):
+        schema = JiraConnector.output_schema()
+        assert schema["type"] == "object"
+        assert "jira_issue_key" in schema["required"]
+        assert "jira_project_key" in schema["required"]
+
+    def test_build_jql_default(self, jira_config):
+        connector = JiraConnector(jira_config)
+        assert connector._build_jql() == "project in (ABC)"
+
+    def test_build_jql_override(self, jira_config):
+        jira_config.config["jql"] = "assignee = currentUser()"
+        connector = JiraConnector(jira_config)
+        assert connector._build_jql() == "assignee = currentUser()"
+
+
+class TestJiraConnectorConnection:
+    @pytest.mark.asyncio
+    async def test_test_connection_success(self, jira_config):
+        connector = JiraConnector(jira_config)
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 200, "body": {"accountId": "u1"}}
+            assert await connector.test_connection() is True
+
+    @pytest.mark.asyncio
+    async def test_test_connection_failure(self, jira_config):
+        connector = JiraConnector(jira_config)
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 401, "body": {}}
+            assert await connector.test_connection() is False
+
+
+class TestJiraConnectorDiscovery:
+    @pytest.mark.asyncio
+    async def test_discover_sources(self, jira_config):
+        connector = JiraConnector(jira_config)
+        search_body = {
+            "total": 1,
+            "issues": [
+                {
+                    "key": "ABC-1",
+                    "fields": {
+                        "summary": "Fix the bug",
+                        "project": {"key": "ABC"},
+                        "updated": "2026-01-01T00:00:00.000+0000",
+                    },
+                }
+            ],
+        }
+        with patch.object(connector, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status_code": 200, "body": search_body}
+            sources = await connector.discover_sources()
+
+        assert len(sources) == 1
+        assert sources[0].source_id == "jira:test-jira-1:issue:ABC-1"
+        assert sources[0].name == "Fix the bug"
+
+
+class TestJiraConnectorFetchContent:
+    @pytest.mark.asyncio
+    async def test_fetch_content(self, jira_config):
+        connector = JiraConnector(jira_config)
+        source_id = "jira:test-jira-1:issue:ABC-1"
+        issue_body = {
+            "key": "ABC-1",
+            "fields": {
+                "summary": "Fix the bug",
+                "status": {"name": "Open"},
+                "project": {"key": "ABC"},
+                "updated": "2026-01-01T00:00:00.000+0000",
+                "description": {"type": "doc", "content": [{"type": "text", "text": "Steps to reproduce"}]},
+                "comment": {
+                    "comments": [
+                        {
+                            "author": {"displayName": "Alice"},
+                            "body": {"type": "doc", "content": [{"type": "text", "text": "Looking into it"}]},
+                        }
+                    ]
+                },
+            },
+        }
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 200, "body": issue_body}
+            result = await connector.fetch_content(source_id)
+
+        assert result is not None
+        assert "Fix the bug" in result.content
+        assert "Steps to reproduce" in result.content
+        assert "Alice" in result.content
+        assert result.metadata["jira_issue_key"] == "ABC-1"
+        assert result.metadata["jira_project_key"] == "ABC"
+        assert result.metadata["comment_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_malformed_source_id(self, jira_config):
+        connector = JiraConnector(jira_config)
+        assert await connector.fetch_content("not-a-jira-id") is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_not_found(self, jira_config):
+        connector = JiraConnector(jira_config)
+        source_id = "jira:test-jira-1:issue:ABC-999"
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"status_code": 404, "body": {}}
+            assert await connector.fetch_content(source_id) is None
+
+
+class TestJiraConnectorChangeDetection:
+    @pytest.mark.asyncio
+    async def test_detect_changes_initial_sync(self, jira_config):
+        connector = JiraConnector(jira_config)
+        search_body = {
+            "total": 1,
+            "issues": [
+                {"key": "ABC-1", "fields": {"updated": "2026-01-01T00:00:00.000+0000"}},
+            ],
+        }
+        with patch.object(connector, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status_code": 200, "body": search_body}
+            changes = await connector.detect_changes(since=None)
+
+        assert len(changes) == 1
+        assert changes[0].change_type == "added"
+        assert changes[0].source_id == "jira:test-jira-1:issue:ABC-1"
+
+
+class TestJiraModuleHelpers:
+    def test_adf_to_text_plain_paragraph(self):
+        from knowledge.connectors.jira import _adf_to_text
+
+        node = {"type": "doc", "content": [{"type": "text", "text": "hello"}]}
+        assert _adf_to_text(node) == "hello"
+
+    def test_adf_to_text_none(self):
+        from knowledge.connectors.jira import _adf_to_text
+
+        assert _adf_to_text(None) == ""
+
+    def test_adf_to_text_legacy_string(self):
+        from knowledge.connectors.jira import _adf_to_text
+
+        assert _adf_to_text("plain text body") == "plain text body"
+
+    def test_parse_issue_key_valid(self):
+        from knowledge.connectors.jira import _parse_issue_key
+
+        assert _parse_issue_key("jira:conn-1:issue:ABC-1") == "ABC-1"
+
+    def test_parse_issue_key_malformed(self):
+        from knowledge.connectors.jira import _parse_issue_key
+
+        assert _parse_issue_key("bad:id") is None

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -41,16 +41,24 @@ logger = get_logger(__name__)
 # Maps a logical capability category (lowercase, normalised) to the list of
 # registered connector type strings that satisfy it.  Only connector types
 # that are actually implemented in this codebase are listed here.
+#
+# Issue #10538: "slack"/"confluence"/"jira" are listed for documentation
+# purposes even though registration is feature-flagged (default disabled) —
+# resolve_by_category() only ever returns *live* instances, so listing them
+# here is safe: with the flag off they are never registered/instantiated and
+# simply never match.
 CATEGORY_MAP: Dict[str, List[str]] = {
     "cloud storage": ["gdrive", "onedrive", "nextcloud"],
     "source control": ["gitlab", "gitea"],
-    "wiki": ["notion"],
-    "knowledge base": ["notion", "file_server", "web_crawler"],
+    "wiki": ["notion", "confluence"],
+    "knowledge base": ["notion", "file_server", "web_crawler", "confluence"],
     "file system": ["file_server"],
     "database": ["database"],
     "web": ["web_crawler"],
     "audio": ["audio"],
     "external": ["external_adapter"],
+    "chat": ["slack"],
+    "issue tracker": ["jira"],
 }
 
 

--- a/autobot-backend/knowledge/connectors/slack.py
+++ b/autobot-backend/knowledge/connectors/slack.py
@@ -1,0 +1,352 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Slack Knowledge Connector (Issue #10538)
+
+Ingests Slack channel/thread history into the AutoBot knowledge base so chat
+discussions become searchable via ``kb.search``. Complements
+``integrations/slack_integration.py``, which only pushes outbound
+notifications/approvals and does not ingest history.
+
+SCAFFOLD NOTE: This connector is registered only when the
+``kb_enterprise_connectors`` feature flag is enabled
+(``AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true`` — see
+``knowledge/connectors/__init__.py``). No credentials are hardcoded; the
+values below are documentation placeholders only.
+
+Config keys (under ``ConnectorConfig.config``):
+    bot_token (str): Slack bot token (``xoxb-...``) with
+        ``channels:history``, ``groups:history`` and ``channels:read``
+        scopes. Required.
+    channel_ids (list[str]): Slack channel IDs to sync. Required.
+    sync_threads (bool): Also ingest thread replies. Default True.
+    oldest (str): Slack ``ts`` lower bound for the initial sync. Default "0".
+    page_size (int): Messages per page (Slack API ``limit``). Default 200.
+    slack_api_base (str): Override API base URL (optional; for testing).
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from autobot_shared.auth import BearerAuth
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
+from knowledge.connectors.base import AbstractConnector, RetryableError
+from knowledge.connectors.models import (
+    ChangeInfo,
+    ConnectorConfig,
+    ContentResult,
+    SourceInfo,
+)
+from knowledge.connectors.registry import ConnectorRegistry
+
+logger = get_logger(__name__)
+
+_SLACK_API_BASE = "https://slack.com/api"
+_REDIS_TS_PREFIX = "connector:slack:ts:"
+_REDIS_TS_TTL = 86400 * 30  # 30 days
+
+
+@ConnectorRegistry.register("slack")
+class SlackConnector(AbstractConnector):
+    """Knowledge connector that ingests Slack channel/thread history.
+
+    Each top-level message becomes one KB fact keyed by
+    ``slack:{connector_id}:channel:{channel_id}:ts:{message_ts}``. Thread
+    replies are appended to the parent message's content when
+    ``sync_threads`` is enabled, so a thread ingests as a single fact.
+
+    Change detection compares each channel's newest message ``ts`` against a
+    Redis-cached checkpoint so only new/updated messages are re-fetched.
+    """
+
+    connector_type = "slack"
+    # Issue #4421: needs a Slack bot token — free to create, so tier 1.
+    tier = 1
+    max_concurrency = 4
+
+    @classmethod
+    def auth_schema(cls) -> type:
+        """Slack requires a bearer bot token — Issue #8145."""
+        return BearerAuth
+
+    @classmethod
+    def output_schema(cls) -> Dict[str, Any]:
+        """Return JSONSchema for ContentResult.metadata (Issue #8147)."""
+        return {
+            "type": "object",
+            "required": ["slack_channel_id", "slack_message_ts"],
+            "properties": {
+                "slack_channel_id": {"type": "string", "description": "Slack channel ID"},
+                "slack_message_ts": {"type": "string", "description": "Message timestamp (Slack ts)"},
+                "slack_permalink": {"type": "string", "description": "Permalink to the message"},
+                "slack_author": {"type": "string", "description": "Author user ID"},
+                "thread_reply_count": {"type": "integer", "description": "Number of thread replies included"},
+            },
+        }
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        cfg = config.config
+        self._token: str = cfg.get("bot_token", "")
+        self._channel_ids: List[str] = cfg.get("channel_ids", [])
+        self._sync_threads: bool = cfg.get("sync_threads", True)
+        self._oldest: str = cfg.get("oldest", "0")
+        self._page_size: int = int(cfg.get("page_size", 200))
+        self._base_url: str = cfg.get("slack_api_base", _SLACK_API_BASE).rstrip("/")
+
+    # ------------------------------------------------------------------
+    # AbstractConnector interface
+    # ------------------------------------------------------------------
+
+    async def test_connection(self) -> bool:
+        """Verify the bot token via ``auth.test``."""
+        result = await self._slack_post("/auth.test")
+        healthy = result.get("status_code") == 200 and result.get("body", {}).get("ok") is True
+        if not healthy:
+            self.logger.warning("Slack test_connection failed: %s", result.get("body", {}).get("error"))
+        return healthy
+
+    async def discover_sources(self) -> List[SourceInfo]:
+        """Return a SourceInfo for every top-level message in every configured channel."""
+        sources: List[SourceInfo] = []
+        for channel_id in self._channel_ids:
+            messages = await self._history(channel_id, oldest=self._oldest)
+            for message in messages:
+                sources.append(_message_to_source_info(self.config.connector_id, channel_id, message))
+        return sources
+
+    async def fetch_content(self, source_id: str) -> Optional[ContentResult]:
+        """Fetch a message (and optionally its thread) for *source_id*."""
+        channel_id, ts = _parse_source_id(source_id)
+        if channel_id is None:
+            self.logger.error("Malformed Slack source_id: %s", source_id)
+            return None
+
+        messages = await self._history(channel_id, oldest=ts, latest=ts, inclusive=True, limit=1)
+        if not messages:
+            self.logger.error("Slack message not found: channel=%s ts=%s", channel_id, ts)
+            return None
+
+        message = messages[0]
+        reply_count = 0
+        text_parts = [_message_to_text(message)]
+        if self._sync_threads and message.get("thread_ts") == ts and message.get("reply_count", 0) > 0:
+            replies = await self._replies(channel_id, ts)
+            reply_count = len(replies)
+            text_parts.extend(_message_to_text(r) for r in replies)
+
+        await _store_ts(self.config.connector_id, channel_id, ts)
+        return ContentResult(
+            source_id=source_id,
+            content="\n\n".join(p for p in text_parts if p.strip()),
+            content_type="text/plain",
+            metadata={
+                "slack_channel_id": channel_id,
+                "slack_message_ts": ts,
+                "slack_permalink": message.get("permalink", ""),
+                "slack_author": message.get("user", ""),
+                "thread_reply_count": reply_count,
+                "connector_type": self.connector_type,
+            },
+        )
+
+    async def detect_changes(self, since: Optional[datetime] = None) -> List[ChangeInfo]:
+        """Return ChangeInfo for messages posted/updated after *since*."""
+        changes: List[ChangeInfo] = []
+        for channel_id in self._channel_ids:
+            oldest = self._since_to_ts(since)
+            stored = await _load_ts(self.config.connector_id, channel_id)
+            messages = await self._history(channel_id, oldest=oldest)
+            newest_ts = stored
+            for message in messages:
+                ts = message.get("ts", "")
+                change_type = "added" if stored is None or ts > stored else "modified"
+                changes.append(
+                    ChangeInfo(
+                        source_id=_build_source_id(self.config.connector_id, channel_id, ts),
+                        change_type=change_type,
+                        timestamp=now_utc(),
+                        details={"channel_id": channel_id, "ts": ts},
+                    )
+                )
+                if newest_ts is None or ts > newest_ts:
+                    newest_ts = ts
+            if newest_ts is not None and newest_ts != stored:
+                await _store_ts(self.config.connector_id, channel_id, newest_ts)
+        return changes
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _since_to_ts(since: Optional[datetime]) -> str:
+        """Convert a datetime to a Slack ``ts`` lower bound string."""
+        if since is None:
+            return "0"
+        return "%f" % since.timestamp()
+
+    async def _history(
+        self,
+        channel_id: str,
+        oldest: str = "0",
+        latest: Optional[str] = None,
+        inclusive: bool = False,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Fetch messages from ``conversations.history``, handling pagination."""
+        messages: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        page_limit = limit or self._page_size
+
+        while True:
+            payload: Dict[str, Any] = {
+                "channel": channel_id,
+                "oldest": oldest,
+                "limit": page_limit,
+            }
+            if latest is not None:
+                payload["latest"] = latest
+            if inclusive:
+                payload["inclusive"] = "true"
+            if cursor:
+                payload["cursor"] = cursor
+
+            result = await self.fetch_with_retry(lambda p=payload: self._slack_post("/conversations.history", p))
+            body = result.get("body", {})
+            if result.get("status_code") != 200 or not body.get("ok"):
+                self.logger.error(
+                    "Slack conversations.history failed for %s: %s",
+                    channel_id,
+                    body.get("error"),
+                )
+                break
+
+            messages.extend(body.get("messages", []))
+            if limit is not None:
+                break
+            cursor = body.get("response_metadata", {}).get("next_cursor", "")
+            if not cursor:
+                break
+
+        return messages
+
+    async def _replies(self, channel_id: str, thread_ts: str) -> List[Dict[str, Any]]:
+        """Fetch thread replies (excluding the parent) via ``conversations.replies``."""
+        result = await self._slack_post(
+            "/conversations.replies",
+            {"channel": channel_id, "ts": thread_ts, "limit": self._page_size},
+        )
+        body = result.get("body", {})
+        if result.get("status_code") != 200 or not body.get("ok"):
+            self.logger.warning("Slack conversations.replies failed for %s/%s", channel_id, thread_ts)
+            return []
+        return [m for m in body.get("messages", []) if m.get("ts") != thread_ts]
+
+    async def _slack_post(self, endpoint: str, json_data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Make an authenticated POST request to the Slack Web API."""
+        url = "%s%s" % (self._base_url, endpoint)
+        headers = {
+            "Authorization": "Bearer %s" % self._token,
+            "Content-Type": "application/json; charset=utf-8",
+        }
+        try:
+            timeout = aiohttp.ClientTimeout(total=30.0)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(url, headers=headers, json=json_data or {}) as resp:
+                    if resp.status == 429:
+                        raise RetryableError("Slack rate-limited", status_code=429)
+                    if resp.status >= 500:
+                        raise RetryableError("Slack server error %d" % resp.status, status_code=resp.status)
+                    body = await resp.json(content_type=None)
+                    return {"status_code": resp.status, "body": body}
+        except RetryableError:
+            raise
+        except aiohttp.ClientError as exc:
+            self.logger.warning("Slack request to %s failed: %s", url, exc)
+            return {"status_code": 0, "body": {"ok": False, "error": str(exc)}}
+
+
+# ---------------------------------------------------------------------------
+# Redis checkpoint helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_ts(connector_id: str, channel_id: str) -> Optional[str]:
+    """Load the newest processed message ``ts`` for *channel_id* from Redis."""
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="knowledge")
+        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, channel_id)
+        value = redis.get(key)
+        if hasattr(value, "__await__"):
+            value = await value
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
+    except Exception as exc:
+        logger.warning("Redis load_ts failed for channel %s: %s", channel_id, exc)
+        return None
+
+
+async def _store_ts(connector_id: str, channel_id: str, ts: str) -> None:
+    """Persist the newest processed message ``ts`` for *channel_id* in Redis."""
+    try:
+        from autobot_shared.redis_client import get_redis_client
+
+        redis = get_redis_client(database="knowledge")
+        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, channel_id)
+        result = redis.set(key, ts, ex=_REDIS_TS_TTL)
+        if hasattr(result, "__await__"):
+            await result
+    except Exception as exc:
+        logger.warning("Redis store_ts failed for channel %s: %s", channel_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (no state)
+# ---------------------------------------------------------------------------
+
+
+def _build_source_id(connector_id: str, channel_id: str, ts: str) -> str:
+    return "slack:%s:channel:%s:ts:%s" % (connector_id, channel_id, ts)
+
+
+def _parse_source_id(source_id: str) -> tuple:
+    parts = source_id.split(":")
+    # Format: slack:{connector_id}:channel:{channel_id}:ts:{ts}
+    if len(parts) != 6 or parts[2] != "channel" or parts[4] != "ts":
+        return None, None
+    return parts[3], parts[5]
+
+
+def _message_to_source_info(connector_id: str, channel_id: str, message: Dict[str, Any]) -> SourceInfo:
+    ts = message.get("ts", "")
+    try:
+        last_modified = datetime.fromtimestamp(float(ts), tz=now_utc().tzinfo)
+    except (ValueError, TypeError):
+        last_modified = now_utc()
+    return SourceInfo(
+        source_id=_build_source_id(connector_id, channel_id, ts),
+        name=_message_to_text(message)[:80],
+        path=message.get("permalink", ""),
+        content_type="text/plain",
+        size_bytes=0,
+        last_modified=last_modified,
+        metadata={"channel_id": channel_id, "ts": ts, "user": message.get("user", "")},
+    )
+
+
+def _message_to_text(message: Dict[str, Any]) -> str:
+    author = message.get("user", "unknown")
+    text = message.get("text", "")
+    return "[%s] %s" % (author, text)
+
+
+__all__ = ["SlackConnector"]

--- a/autobot-backend/knowledge/connectors/slack_test.py
+++ b/autobot-backend/knowledge/connectors/slack_test.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for Slack Knowledge Connector (Issue #10538)
+
+All HTTP calls are mocked — no network access, and the module never makes a
+live request just from being imported or instantiated.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.connectors.models import ConnectorConfig
+from knowledge.connectors.slack import SlackConnector
+
+
+@pytest.fixture
+def slack_config():
+    return ConnectorConfig(
+        connector_id="test-slack-1",
+        connector_type="slack",
+        name="Test Slack",
+        config={
+            "bot_token": "test-fake-bot-credential",
+            "channel_ids": ["C123"],
+            "sync_threads": True,
+        },
+        enabled=True,
+        verification_mode="collaborative",
+    )
+
+
+class TestSlackConnectorInit:
+    def test_init(self, slack_config):
+        connector = SlackConnector(slack_config)
+        assert connector.connector_type == "slack"
+        assert connector.tier == 1
+        assert connector._token == "test-fake-bot-credential"
+        assert connector._channel_ids == ["C123"]
+        assert connector._sync_threads is True
+        assert connector.max_concurrency == 4
+
+    def test_auth_schema(self):
+        from autobot_shared.auth import BearerAuth
+
+        assert SlackConnector.auth_schema() == BearerAuth
+
+    def test_output_schema(self):
+        schema = SlackConnector.output_schema()
+        assert schema["type"] == "object"
+        assert "slack_channel_id" in schema["required"]
+        assert "slack_message_ts" in schema["required"]
+
+
+class TestSlackConnectorConnection:
+    @pytest.mark.asyncio
+    async def test_test_connection_success(self, slack_config):
+        connector = SlackConnector(slack_config)
+        with patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status_code": 200, "body": {"ok": True}}
+            assert await connector.test_connection() is True
+
+    @pytest.mark.asyncio
+    async def test_test_connection_failure(self, slack_config):
+        connector = SlackConnector(slack_config)
+        with patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status_code": 200, "body": {"ok": False, "error": "invalid_auth"}}
+            assert await connector.test_connection() is False
+
+
+class TestSlackConnectorDiscovery:
+    @pytest.mark.asyncio
+    async def test_discover_sources(self, slack_config):
+        connector = SlackConnector(slack_config)
+        history_body = {
+            "ok": True,
+            "messages": [{"ts": "1000.001", "user": "U1", "text": "hello"}],
+        }
+        with patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status_code": 200, "body": history_body}
+            sources = await connector.discover_sources()
+
+        assert len(sources) == 1
+        assert sources[0].source_id == "slack:test-slack-1:channel:C123:ts:1000.001"
+        assert "hello" in sources[0].name
+
+
+class TestSlackConnectorFetchContent:
+    @pytest.mark.asyncio
+    async def test_fetch_content_no_thread(self, slack_config):
+        connector = SlackConnector(slack_config)
+        source_id = "slack:test-slack-1:channel:C123:ts:1000.001"
+        history_body = {
+            "ok": True,
+            "messages": [{"ts": "1000.001", "user": "U1", "text": "hello world", "reply_count": 0}],
+        }
+        with patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status_code": 200, "body": history_body}
+            result = await connector.fetch_content(source_id)
+
+        assert result is not None
+        assert "hello world" in result.content
+        assert result.metadata["slack_channel_id"] == "C123"
+        assert result.metadata["slack_message_ts"] == "1000.001"
+        assert result.metadata["thread_reply_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_malformed_source_id(self, slack_config):
+        connector = SlackConnector(slack_config)
+        assert await connector.fetch_content("not-a-slack-id") is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_not_found(self, slack_config):
+        connector = SlackConnector(slack_config)
+        source_id = "slack:test-slack-1:channel:C123:ts:9999.001"
+        with patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"status_code": 200, "body": {"ok": True, "messages": []}}
+            assert await connector.fetch_content(source_id) is None
+
+
+class TestSlackConnectorChangeDetection:
+    @pytest.mark.asyncio
+    async def test_detect_changes_initial_sync(self, slack_config):
+        connector = SlackConnector(slack_config)
+        history_body = {"ok": True, "messages": [{"ts": "1000.001", "user": "U1", "text": "hi"}]}
+        with (
+            patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post,
+            patch("knowledge.connectors.slack._load_ts", new=AsyncMock(return_value=None)),
+            patch("knowledge.connectors.slack._store_ts", new=AsyncMock()),
+        ):
+            mock_post.return_value = {"status_code": 200, "body": history_body}
+            changes = await connector.detect_changes(since=None)
+
+        assert len(changes) == 1
+        assert changes[0].change_type == "added"
+        assert changes[0].source_id == "slack:test-slack-1:channel:C123:ts:1000.001"
+
+
+class TestSlackModuleHelpers:
+    def test_message_to_text(self):
+        from knowledge.connectors.slack import _message_to_text
+
+        assert _message_to_text({"user": "U1", "text": "hi there"}) == "[U1] hi there"
+
+    def test_parse_source_id_valid(self):
+        from knowledge.connectors.slack import _parse_source_id
+
+        channel, ts = _parse_source_id("slack:conn-1:channel:C1:ts:100.5")
+        assert channel == "C1"
+        assert ts == "100.5"
+
+    def test_parse_source_id_malformed(self):
+        from knowledge.connectors.slack import _parse_source_id
+
+        channel, ts = _parse_source_id("bad:id")
+        assert channel is None
+        assert ts is None

--- a/autobot-backend/knowledge/connectors/tests/test_category_resolution.py
+++ b/autobot-backend/knowledge/connectors/tests/test_category_resolution.py
@@ -106,6 +106,11 @@ class TestCategoryMap:
             "database",
             "audio",
             "external_adapter",
+            # Issue #10538: feature-flagged (AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS,
+            # default off) — still valid canonical types, just not always registered.
+            "slack",
+            "confluence",
+            "jira",
         }
         for category, types in CATEGORY_MAP.items():
             for t in types:

--- a/autobot_shared/feature_flags.py
+++ b/autobot_shared/feature_flags.py
@@ -20,6 +20,11 @@ Subsystem flags (all default ``True``):
 * ``training``         — model training / fine-tuning (AUTOBOT_FEATURE_TRAINING)
 * ``osint``            — OSINT sweep engine (AUTOBOT_FEATURE_OSINT)
 
+Subsystem flags that default ``False`` (opt-in):
+
+* ``kb_enterprise_connectors`` — Slack/Confluence/Jira KB ingestion connectors
+  (AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS). Issue #10538.
+
 Usage::
 
     from autobot_shared.feature_flags import is_feature_enabled, require_feature
@@ -51,6 +56,7 @@ _SUBSYSTEM_FLAG_MAP: dict[str, str] = {
     "computer_vision": "computer_vision_enabled",
     "training": "training_enabled",
     "osint": "osint_enabled",
+    "kb_enterprise_connectors": "kb_enterprise_connectors",
 }
 
 F = TypeVar("F", bound=Callable)

--- a/autobot_shared/feature_flags_test.py
+++ b/autobot_shared/feature_flags_test.py
@@ -64,6 +64,11 @@ class TestFeatureConfigSubsystemDefaults:
         cfg = _fresh_feature_config()
         assert cfg.osint_enabled is True
 
+    def test_kb_enterprise_connectors_disabled_default(self) -> None:
+        """Issue #10538: Slack/Confluence/Jira connectors default OFF."""
+        cfg = _fresh_feature_config()
+        assert cfg.kb_enterprise_connectors is False
+
 
 # ---------------------------------------------------------------------------
 # FeatureConfig env-var overrides
@@ -101,6 +106,11 @@ class TestFeatureConfigEnvVarOverrides:
         cfg = _fresh_feature_config(AUTOBOT_FEATURE_NPU="true")
         assert cfg.npu_enabled is True
 
+    def test_kb_enterprise_connectors_enabled_via_env(self) -> None:
+        """Issue #10538: opt-in via AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS."""
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS="true")
+        assert cfg.kb_enterprise_connectors is True
+
 
 # ---------------------------------------------------------------------------
 # is_feature_enabled
@@ -123,6 +133,7 @@ class TestIsFeatureEnabled:
             "computer_vision_enabled": True,
             "training_enabled": True,
             "osint_enabled": True,
+            "kb_enterprise_connectors": False,
         }
         defaults.update(kwargs)
         for attr, val in defaults.items():

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1734,6 +1734,12 @@ class FeatureConfig(BaseSettings):
     graph_rag: bool = Field(default=True, alias="AUTOBOT_FEATURE_GRAPH_RAG")
     mcp: bool = Field(default=True, alias="AUTOBOT_FEATURE_MCP")
 
+    # Issue #10538: Slack/Confluence/Jira KB ingestion connectors.
+    # Disabled by default — no credentials are configured out of the box and
+    # these connectors make outbound calls to third-party SaaS APIs. Set
+    # AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true once credentials exist.
+    kb_enterprise_connectors: bool = Field(default=False, alias="AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS")
+
 
 class CostModelConfig(BaseSettings):
     """Operator-supplied monthly cost estimates for hardware components.


### PR DESCRIPTION
Closes #12190

## Thinking Path

Audited first per repo policy: AutoBot already has a mature, pluggable KB connector framework (`autobot-backend/knowledge/connectors/`) — `AbstractConnector` (base.py), `ConnectorRegistry` (registry.py, with `@ConnectorRegistry.register(type)` decorator + `CATEGORY_MAP`), and 11 concrete connectors (notion, gitlab/gitea, gdrive, onedrive, nextcloud, file_server, web_crawler, database, audio, external_adapter). Notion and GitLab were the closest structural templates (typed `auth_schema()`, Redis-backed incremental-sync checkpoints, `output_schema()` for metadata validation, `source_id` encoding scheme). Slack/Confluence/Jira did not exist as ingestion connectors — Slack only exists as an outbound notification integration (`integrations/slack_integration.py`), confirmed by the issue body itself.

Sibling issue #10539 (tool-agnostic category abstraction) is already merged, so I extended its `CATEGORY_MAP` (`wiki`/`knowledge base` + new `chat`/`issue tracker` categories) rather than inventing a parallel mechanism.

For the feature flag, `autobot_shared/feature_flags.py` + `FeatureConfig` (SSOT) already implement a subsystem-flag pattern with precedent for default-`False` heavy/optional subsystems (`computer_vision`, `training`). Added `kb_enterprise_connectors` (env `AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS`, default `False`) following that exact pattern — no new mechanism invented.

## What Changed

**Feature flag (default disabled):**
- `autobot_shared/ssot_config.py` — `FeatureConfig.kb_enterprise_connectors: bool = False`
- `autobot_shared/feature_flags.py` — registered in `_SUBSYSTEM_FLAG_MAP` as `"kb_enterprise_connectors"`

**Connectors (new files, mirror `notion.py`/`gitlab.py` structure):**
- `autobot-backend/knowledge/connectors/slack.py` — `SlackConnector` (`BearerAuth`, tier 1). Ingests channel history + optional thread replies via Slack Web API (`conversations.history`/`conversations.replies`), Redis-cached per-channel `ts` checkpoint for incremental sync.
- `autobot-backend/knowledge/connectors/confluence.py` — `ConfluenceConnector` (`BasicAuth`, tier 2). Ingests pages per configured space via Confluence REST API, storage-format HTML stripped to plain text, `version.when` checkpoint.
- `autobot-backend/knowledge/connectors/jira.py` — `JiraConnector` (`BasicAuth`, tier 2). Ingests issues + comments per configured project via Jira REST API v3 (JQL search), Atlassian Document Format (ADF) → plain text, `updated` checkpoint.
- All three: `test_connection()`, `discover_sources()`, `fetch_content()`, `detect_changes()`, `output_schema()`, `auth_schema()`. No live network call happens on import or `__init__` — only inside the explicit interface methods (called by `sync()`, which nothing invokes until a connector instance is created).

**Flag gate (registration, not just usage):**
- `autobot-backend/knowledge/connectors/__init__.py` — the three modules are imported (triggering `@ConnectorRegistry.register`) only `if is_feature_enabled("kb_enterprise_connectors")`. With the flag off (default), `ConnectorRegistry.list_types()` never contains `"slack"`/`"confluence"`/`"jira"` and `ConnectorRegistry.create()` raises `ValueError` for them — there's no path to instantiate, let alone call, these connectors until the flag is explicitly enabled.
- `autobot-backend/api/knowledge_connectors.py` — added the three types to `_SUPPORTED_TYPES` so `POST /knowledge_base/connectors` accepts them once the flag is on (it still 422s via `get_registered_class() is None` while disabled).

**Docs:**
- `autobot-backend/knowledge/connectors/CONNECTORS.md` — new connector-type rows + two new categories (`chat`, `issue tracker`).
- `autobot-backend/knowledge/connectors/registry.py` — `CATEGORY_MAP` extended (`wiki`/`knowledge base` now include `confluence`; new `chat`→`slack`, `issue tracker`→`jira`).

**No credentials hardcoded anywhere** — config is documented per-module docstring as placeholders (`bot_token`, `email`/`api_token`, `base_url`, etc.), consumed only via `ConnectorConfig.config` at instance-creation time, same as every other connector in this framework.

**Pre-existing test fixed (discovered along the way):** `knowledge/connectors/tests/test_category_resolution.py::TestCategoryMap::test_all_types_are_real` hardcodes a `known_types` allowlist that every `CATEGORY_MAP` entry must belong to — added `slack`/`confluence`/`jira` to keep it in sync with the extended map (same maintenance pattern used when `gitea`/`forgejo` were added).

## Verification

```
$ python3 -c "import ast; ast.parse(open(f, encoding='utf-8').read())"   # for every new/modified .py — all OK

$ cd autobot-backend && python3 -m pytest \
    knowledge/connectors/slack_test.py \
    knowledge/connectors/confluence_test.py \
    knowledge/connectors/jira_test.py \
    knowledge/connectors/connectors_init_gating_test.py \
    knowledge/connectors/tests/test_category_resolution.py \
    knowledge/connectors/registry_public_api_test.py \
    knowledge/connectors/registry_health_test.py \
    api/knowledge_connectors_create_test.py \
    api/knowledge_connectors_health_test.py \
    ../autobot_shared/feature_flags_test.py -q
...
127 passed in 4.76s
```

Full `knowledge/connectors/` + `feature_flags_test.py` suite (355 tests) also run: 353 passed, 1 pre-existing unrelated failure (`connector_resilience_test.py::TestWebCrawlerSyncCheckpoint` — fails identically in isolation on unmodified `web_crawler.py`; this sandbox has no reachable Redis, `.env` is unset/`.env.example` only — infra gap, not a code defect, not touched by this PR).

All new tests are fully offline — HTTP calls mocked via `patch.object(connector, "_slack_post"/"_get"/"_post", new_callable=AsyncMock)`, Redis checkpoint calls mocked via module-level `_load_ts`/`_store_ts` patches. No network access in the test path. `black --check` and `flake8` (repo config) both clean on every touched file.

Subprocess-based behavioural test (`connectors_init_gating_test.py::test_disabled_by_default_no_registration`) confirms a fresh interpreter with the flag unset never registers `slack`/`confluence`/`jira` as connector types.

## Model Used

Claude Sonnet 5

---

This PR delivers the **connector scaffold**: interfaces, concrete classes, registry wiring, feature flag, docs, and offline tests — all disabled by default. It does **not** include live credential wiring or end-to-end validation against real Slack/Confluence/Jira instances, since no credentials exist yet (per task scope, the user will supply these later). Remaining before full closure: obtain and configure real credentials, flip `AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true` in a target environment, and run a live `sync()` to confirm end-to-end ChromaDB ingestion + `kb.search` retrieval.

Refs #10538