### PR TITLE
feat(code-sync): surface per-component deployed-vs-source staleness in /status (#12191)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -15,6 +15,7 @@ import hashlib
 import logging
 import os
 import shutil
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -529,6 +530,50 @@ async def _get_tracker_for_db(db: AsyncSession):
     return get_git_tracker(repo_path=repo_path, branch=branch)
 
 
+# #11820: TTL for the per-component staleness scan surfaced by GET /status.
+# Never hard-code a cache TTL — read it from the environment so a frequently
+# polled status endpoint doesn't re-checksum every deployed component per call.
+_STALE_COMPONENTS_TTL_SECONDS = int(os.getenv("SLM_STALE_COMPONENTS_TTL_SECONDS", "60"))
+_stale_components_cache: dict = {"ts": -_STALE_COMPONENTS_TTL_SECONDS - 1.0, "value": []}
+
+
+async def _compute_stale_components() -> list[str]:
+    """Return ALLOWED_COMPONENTS deployed on this box whose files drift from source.
+
+    Surfaces the #11820 gap: a co-located managed component can be stale (its
+    deployed files differ from code_source) even when a node's code_version
+    matches latest, so /status must not read "up to date" while this is set.
+    Only components actually deployed here (deployed dir present) are checked,
+    and the result is cached for _STALE_COMPONENTS_TTL_SECONDS to bound cost on
+    the polled status path. Defensive: a failing component is logged and skipped,
+    never breaking the status response.
+    """
+    now = time.monotonic()
+    if now - _stale_components_cache["ts"] < _STALE_COMPONENTS_TTL_SECONDS:
+        return _stale_components_cache["value"]
+
+    stale: list[str] = []
+    loop = asyncio.get_running_loop()
+    for component in sorted(ALLOWED_COMPONENTS):
+        try:
+            deployed_dir = get_default_deployed_dir(component)
+            if not os.path.isdir(deployed_dir):
+                continue  # not deployed on this box — nothing to compare
+            source_dir = get_default_source_dir(component)
+            report = await loop.run_in_executor(
+                None,
+                functools.partial(build_drift_report, source_dir, deployed_dir, component),
+            )
+            if report["drifted_files"]:
+                stale.append(component)
+        except Exception:  # noqa: BLE001 - a bad component must not break /status
+            logger.exception("stale-components scan failed for %s", component)
+
+    _stale_components_cache["ts"] = now
+    _stale_components_cache["value"] = stale
+    return stale
+
+
 @router.get("/status", response_model=CodeSyncStatusResponse)
 async def get_sync_status(
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -584,6 +629,10 @@ async def get_sync_status(
     # Check if local repo has updates
     has_update = local_version is not None and latest_version is not None and local_version != latest_version
 
+    # #11820: surface deployed-vs-source drift for co-located managed components
+    # so the endpoint never reads "up to date" while a managed component is stale.
+    stale_components = await _compute_stale_components()
+
     return CodeSyncStatusResponse(
         latest_version=latest_version,
         local_version=local_version,
@@ -591,6 +640,7 @@ async def get_sync_status(
         has_update=has_update,
         outdated_nodes=outdated_nodes,
         total_nodes=total_nodes,
+        stale_components=stale_components,
     )
 
 

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -1609,6 +1609,10 @@ class CodeSyncStatusResponse(BaseModel):
     has_update: bool = False
     outdated_nodes: int = 0
     total_nodes: int = 0
+    # #11820: components deployed on this box whose files drift from code_source.
+    # Non-empty means a managed component is stale even if node code_version
+    # matches latest — so consumers must not report "up to date" while this is set.
+    stale_components: list[str] = []
 
 
 class CodeSyncRefreshResponse(BaseModel):

--- a/autobot-slm-backend/tests/api/test_status_stale_components_11820.py
+++ b/autobot-slm-backend/tests/api/test_status_stale_components_11820.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11820: GET /code-sync/status must surface deployed-vs-source drift for
+co-located managed components (stale_components) so it never reads "up to date"
+while a managed component is stale. Tests the _compute_stale_components helper:
+detection, TTL caching, and defensive per-component isolation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+import ast  # noqa: E402
+import types  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+# Same shims as test_sync_status_outdated_signal.py: stub the conflicting
+# multipart package and swap benign dicts in for MagicMock schema names so
+# api.code_sync imports under the conftest stub regime.
+if "multipart" in sys.modules and not hasattr(sys.modules["multipart"], "multipart"):
+    sys.modules.pop("multipart", None)
+_mp_stub = types.ModuleType("multipart")
+_mp_stub.multipart = types.ModuleType("multipart.multipart")  # type: ignore[attr-defined]
+sys.modules.setdefault("multipart", _mp_stub)
+sys.modules.setdefault("multipart.multipart", _mp_stub.multipart)  # type: ignore[attr-defined]
+
+_code_sync_src = (_BACKEND_ROOT / "api" / "code_sync.py").read_text(encoding="utf-8")
+_SCHEMA_NAMES = tuple(
+    sorted(
+        alias.name
+        for node in ast.walk(ast.parse(_code_sync_src))
+        if isinstance(node, ast.ImportFrom) and node.module == "models.schemas"
+        for alias in node.names
+    )
+)
+_schemas_stub = sys.modules.get("models.schemas")
+if isinstance(_schemas_stub, MagicMock):
+    for _name in _SCHEMA_NAMES:
+        setattr(_schemas_stub, _name, dict)
+
+
+def _reset_cache(cs) -> None:
+    cs._stale_components_cache["ts"] = -1.0e9
+    cs._stale_components_cache["value"] = []
+
+
+async def test_flags_only_drifted_deployed_components(monkeypatch, tmp_path):
+    import api.code_sync as cs
+
+    _reset_cache(cs)
+    monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot-slm-backend", "autobot_shared"})
+    monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))  # exists → checked
+    monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
+
+    def fake_report(src, dep, comp):
+        return {"drifted_files": ["x.py"] if comp == "autobot_shared" else [], "total_compared": 1}
+
+    monkeypatch.setattr(cs, "build_drift_report", fake_report)
+
+    assert await cs._compute_stale_components() == ["autobot_shared"]
+
+
+async def test_skips_components_not_deployed_here(monkeypatch):
+    import api.code_sync as cs
+
+    _reset_cache(cs)
+    monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot-backend"})
+    monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: "/nonexistent/deployed/dir")
+
+    def _boom(*_a, **_k):  # must never be called when the dir is absent
+        raise AssertionError("build_drift_report called for a non-deployed component")
+
+    monkeypatch.setattr(cs, "build_drift_report", _boom)
+
+    assert await cs._compute_stale_components() == []
+
+
+async def test_result_is_ttl_cached(monkeypatch, tmp_path):
+    import api.code_sync as cs
+
+    _reset_cache(cs)
+    monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot_shared"})
+    monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
+    monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
+    monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": ["x"], "total_compared": 1})
+
+    first = await cs._compute_stale_components()
+    assert first == ["autobot_shared"]
+
+    # Within the TTL the cached value is returned even though the checker now
+    # reports clean — proving /status is not re-checksumming on every poll.
+    monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": [], "total_compared": 1})
+    assert await cs._compute_stale_components() == ["autobot_shared"]
+
+
+async def test_failing_component_is_isolated(monkeypatch, tmp_path):
+    import api.code_sync as cs
+
+    _reset_cache(cs)
+    monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot-slm-backend", "autobot_shared"})
+    monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
+    monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
+
+    def flaky(src, dep, comp):
+        if comp == "autobot-slm-backend":
+            raise RuntimeError("checksum walk exploded")
+        return {"drifted_files": ["y.py"], "total_compared": 1}
+
+    monkeypatch.setattr(cs, "build_drift_report", flaky)
+
+    # The exploding component is skipped, the healthy one still surfaces.
+    assert await cs._compute_stale_components() == ["autobot_shared"]


### PR DESCRIPTION
## Thinking Path
Child of #11820. `/code-sync/status` tracked repo-level (`has_update`) and node-level (`outdated_nodes`) currency but was blind to whether a co-located managed component's **deployed files** drift from `code_source` — the exact staleness class that drove the #11820 deploy work (a managed component stale while 'update all' reports done). The drift machinery already exists (`drift_checker.build_drift_report`, the /drift endpoint); it just wasn't surfaced in status.

## What Changed
- `models/schemas.py`: `CodeSyncStatusResponse.stale_components: list[str]`.
- `api/code_sync.py`: `_compute_stale_components()` — reuses `build_drift_report` over the `ALLOWED_COMPONENTS` actually deployed here (deployed dir present), returns those with drifted files. TTL-cached via `SLM_STALE_COMPONENTS_TTL_SECONDS` (default 60s, env-driven per repo convention) so the polled status path doesn't re-checksum every call; per-component try/except so one bad scan never breaks /status. `get_sync_status` populates the field.
- `tests/api/test_status_stale_components_11820.py`: detection, not-deployed skip, TTL caching, failure isolation.

## Verification
```
tests/api/test_status_stale_components_11820.py ....  (4 passed)
tests/api/test_sync_status_outdated_signal.py .      (1 passed, no regression)
```
flake8 clean; isort + black clean. Read-only status enrichment — no write path, no schema/DB change.

## Model Used
Opus 4.8

Closes #12191