### PR TITLE
perf(feedback): offload feedback.py sync-DB calls off the event loop (#10601)

### DIFF
--- a/autobot-backend/routers/feedback.py
+++ b/autobot-backend/routers/feedback.py
@@ -8,6 +8,7 @@ Feedback API Router (Issue #905)
 Endpoints for completion feedback tracking and model improvement.
 """
 
+import asyncio
 from typing import Dict, List
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
@@ -151,7 +152,10 @@ async def record_feedback(request: FeedbackRequest):
         )
 
     try:
-        feedback = _get_feedback_tracker().record_feedback(
+        # #10601: FeedbackTracker uses a blocking (sync) SQLAlchemy session, so
+        # offload it to a worker thread instead of stalling the event loop.
+        feedback = await asyncio.to_thread(
+            _get_feedback_tracker().record_feedback,
             context=request.context,
             suggestion=request.suggestion,
             action=request.action,
@@ -197,7 +201,9 @@ async def get_acceptance_metrics(
     - **time_window_days**: Time window for metrics (1-90 days)
     """
     try:
-        metrics = _get_feedback_tracker().get_acceptance_metrics(
+        # #10601: offload the blocking sync-DB query off the event loop.
+        metrics = await asyncio.to_thread(
+            _get_feedback_tracker().get_acceptance_metrics,
             language=language,
             pattern_type=pattern_type,
             time_window_days=time_window_days,
@@ -231,7 +237,8 @@ async def get_recent_feedback(
         )
 
     try:
-        events = _get_feedback_tracker().get_recent_feedback(limit=limit, action=action)
+        # #10601: offload the blocking sync-DB query off the event loop.
+        events = await asyncio.to_thread(_get_feedback_tracker().get_recent_feedback, limit=limit, action=action)
 
         return {
             "events": events,
@@ -307,8 +314,9 @@ async def get_feedback_statistics():
     """
     try:
         # Get 7-day and 30-day metrics
-        metrics_7d = _get_feedback_tracker().get_acceptance_metrics(time_window_days=7)
-        metrics_30d = _get_feedback_tracker().get_acceptance_metrics(time_window_days=30)
+        # #10601: offload the blocking sync-DB queries off the event loop.
+        metrics_7d = await asyncio.to_thread(_get_feedback_tracker().get_acceptance_metrics, time_window_days=7)
+        metrics_30d = await asyncio.to_thread(_get_feedback_tracker().get_acceptance_metrics, time_window_days=30)
 
         return {
             "last_7_days": {

--- a/autobot-backend/routers/feedback_test.py
+++ b/autobot-backend/routers/feedback_test.py
@@ -1,0 +1,39 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#10601: the async feedback endpoints must not call the synchronous
+FeedbackTracker (blocking `with self.SessionLocal()`) directly on the event
+loop. Every blocking tracker call is offloaded via asyncio.to_thread. This guard
+fails if an offload is dropped, re-introducing event-loop blocking."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = (Path(__file__).parent / "feedback.py").read_text(encoding="utf-8")
+
+# Tracker methods that open a blocking sync-DB session — must never run inline
+# on the event loop. mark_retrain_completed runs inside a BackgroundTasks worker
+# (already off-loop), so it is intentionally excluded.
+_BLOCKING = {"record_feedback", "get_acceptance_metrics", "get_recent_feedback"}
+
+
+def test_asyncio_imported():
+    assert "import asyncio" in _SRC
+
+
+def test_blocking_tracker_methods_never_called_inline():
+    # A direct call is `_get_feedback_tracker().<method>(`; an offloaded call
+    # passes the bound method as a reference (`.<method>,`) to to_thread.
+    direct_calls = set(re.findall(r"_get_feedback_tracker\(\)\.(\w+)\(", _SRC))
+    leaked = direct_calls & _BLOCKING
+    assert not leaked, f"blocking tracker methods called inline on the loop: {sorted(leaked)}"
+
+
+def test_each_blocking_method_is_offloaded_via_to_thread():
+    for method in _BLOCKING:
+        assert re.search(
+            rf"to_thread\(\s*_get_feedback_tracker\(\)\.{method}\b", _SRC
+        ), f"{method} is not offloaded via asyncio.to_thread"


### PR DESCRIPTION
## Thinking Path
The #10601 PRD (#12183) found the DB layer is already async except one hot spot: `autobot-backend/routers/feedback.py`. Its 4 async endpoints called synchronous `FeedbackTracker` methods (each opens a blocking `with self.SessionLocal()` sync session) directly on the event loop — stalling all concurrent requests for the query duration. You chose the low-risk `asyncio.to_thread` offload.

## What Changed
- `routers/feedback.py`: added `import asyncio`; wrapped all 5 blocking tracker call sites (`record_feedback`, `get_acceptance_metrics`, `get_recent_feedback`, and the two `get_acceptance_metrics` calls in `get_feedback_statistics`) in `await asyncio.to_thread(...)`. `mark_retrain_completed` is left inline — it runs inside a `BackgroundTasks` worker, already off the loop.
- `routers/feedback_test.py`: regex guard test — no blocking tracker method is called inline, and each is offloaded via to_thread (fails if an offload is dropped).

## Verification
```
routers/feedback_test.py ...  (3 passed)
```
flake8 + isort + black clean. No schema/DB change — pure access-pattern fix, reverts as a clean code revert (zero data-loss vector). FeedbackTracker method correctness stays covered by services/feedback_tracker_test.py.

## Model Used
Opus 4.8

Closes #12194
Refs #10601