### PR TITLE
docs(license): drop stale mcp-task-manager-server references (#9791)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,7 +341,6 @@ code-index-mcp/
 mcp-github-project-manager/
 mcp-tools/context7/
 mcp-tools/mcp-structured-thinking/
-mcp-tools/mcp-task-manager-server/
 
 # Large log and analysis files
 *.log.bak

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -621,9 +621,8 @@ External (standalone MCP servers):
 1. **context7** - Code documentation/reference
 2. **mcp-structured-thinking** - Structured reasoning
 3. **mcp-github-project-manager** - GitHub integration
-4. **mcp-task-manager-server** - Task management
-5. **mcp-autobot-tracker** - AutoBot tracking
-6. **code-index-mcp** - Code indexing
+4. **mcp-autobot-tracker** - AutoBot tracking
+5. **code-index-mcp** - Code indexing
 
 Backend bridges (verified from `autobot-backend/api/*_mcp.py`):
 


### PR DESCRIPTION
## Thinking Path
The GPL-3.0 `mcp-task-manager-server` was removed (PR #12171) to unblock the Apache-2.0 relicense (#9826), but two docs still referenced it as live — misleading, and advertising a removed GPLv3 component.

## What Changed
- `docs/ROADMAP.md`: removed `mcp-task-manager-server` from the 'External standalone MCP servers' list (renumbered the remaining entries).
- `.gitignore`: removed the now-absent `mcp-tools/mcp-task-manager-server/` ignore rule.

(Left as-is: historical `CHANGELOG.md` + audit-report entries — accurate as history.)

## Verification
`git ls-tree -r HEAD | grep mcp-task-manager` = 0 (component fully gone from tree). Text-only change, no code impact.

## Model Used
Opus 4.8

Closes #12196
Refs #9791