### PR TITLE
feat(kb): offline mock/replay knowledge connector + fixtures for sync() testing (#10538)

### DIFF
--- a/autobot-backend/knowledge/connectors/__init__.py
+++ b/autobot-backend/knowledge/connectors/__init__.py
@@ -22,12 +22,19 @@ Packages:
 - slack       — SlackConnector (Slack Web API) — Issue #10538, feature-flagged
 - confluence  — ConfluenceConnector (Atlassian Confluence REST API) — Issue #10538, feature-flagged
 - jira        — JiraConnector (Atlassian Jira REST API v3) — Issue #10538, feature-flagged
+- mock        — MockConnector (local JSON fixtures, zero network) — Issue #10538, feature-flagged
 - scheduler  — ConnectorScheduler (asyncio task-based)
 
 Issue #10538: The Slack/Confluence/Jira connectors are registered only when
 ``AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true`` (default disabled — see
 ``autobot_shared/feature_flags.py``). Until enabled, their connector types
 are absent from ``ConnectorRegistry`` and cannot be instantiated.
+
+Issue #10538: MockConnector is registered only when
+``AUTOBOT_FEATURE_KB_MOCK_CONNECTOR=true`` (default disabled). It never
+makes a network call — the gate exists solely to keep a "mock" entry out of
+the production ``GET /knowledge_base/connector_types`` listing by default;
+enable it in dev/CI to exercise the sync() pipeline offline.
 
 Example usage::
 
@@ -79,6 +86,13 @@ if is_feature_enabled("kb_enterprise_connectors"):
     import knowledge.connectors.confluence  # noqa: F401
     import knowledge.connectors.jira  # noqa: F401
     import knowledge.connectors.slack  # noqa: F401
+
+# Issue #10538: MockConnector makes zero network calls (it replays local JSON
+# fixtures), so it does not need the kb_enterprise_connectors gate above.
+# It has its own flag purely to keep "mock" out of the production connector
+# type listing by default — see the module docstring in knowledge/connectors/mock.py.
+if is_feature_enabled("kb_mock_connector"):
+    import knowledge.connectors.mock  # noqa: F401
 
 __all__ = [
     "AbstractConnector",

--- a/autobot-backend/knowledge/connectors/connectors_init_gating_test.py
+++ b/autobot-backend/knowledge/connectors/connectors_init_gating_test.py
@@ -3,20 +3,21 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Tests for the Slack/Confluence/Jira feature-flag gate (Issue #10538).
+Tests for the Slack/Confluence/Jira/Mock feature-flag gates (Issue #10538).
 
 The framework's ``knowledge/connectors/__init__.py`` only imports (and
 therefore registers, via the ``@ConnectorRegistry.register`` decorator) the
 Slack/Confluence/Jira connector modules when the ``kb_enterprise_connectors``
-subsystem flag is enabled. Since import side effects are process-global and
-cached by Python, this is verified two ways:
+subsystem flag is enabled, and the Mock connector module when
+``kb_mock_connector`` is enabled. Since import side effects are process-global
+and cached by Python, this is verified two ways:
 
-1. A static source check that the gate exists and covers all three modules
+1. A static source check that each gate exists and covers its module(s)
    (regression guard against someone dropping the ``if`` and always
    importing them).
-2. A behavioural check, via a subprocess, that a fresh interpreter with the
-   flag left at its default (disabled) never registers "slack", "confluence"
-   or "jira" as connector types.
+2. A behavioural check, via a subprocess, that a fresh interpreter with both
+   flags left at their default (disabled) never registers "slack",
+   "confluence", "jira" or "mock" as connector types.
 """
 
 import os
@@ -50,6 +51,24 @@ class TestFeatureFlagGateSource:
         assert "import knowledge.connectors.jira" not in unconditional_block
 
 
+class TestMockConnectorGateSource:
+    """Static check that __init__.py gates the mock connector on its own flag."""
+
+    def test_gate_covers_mock_connector(self) -> None:
+        source = _CONNECTORS_INIT.read_text(encoding="utf-8")
+        assert 'is_feature_enabled("kb_mock_connector")' in source
+
+        gate_start = source.index('if is_feature_enabled("kb_mock_connector")')
+        gated_block = source[gate_start:]
+        assert "import knowledge.connectors.mock" in gated_block
+
+    def test_gated_import_not_unconditional(self) -> None:
+        source = _CONNECTORS_INIT.read_text(encoding="utf-8")
+        gate_start = source.index('if is_feature_enabled("kb_mock_connector")')
+        unconditional_block = source[:gate_start]
+        assert "import knowledge.connectors.mock" not in unconditional_block
+
+
 class TestFeatureFlagGateBehaviour:
     """Subprocess check: default-disabled flag keeps the types unregistered."""
 
@@ -66,9 +85,40 @@ class TestFeatureFlagGateBehaviour:
             "assert 'slack' not in types, types; "
             "assert 'confluence' not in types, types; "
             "assert 'jira' not in types, types; "
+            "assert 'mock' not in types, types; "
             "print('OK')"
         ) % (str(project_root), str(backend_dir))
         env = os.environ.copy()
+        env.pop("AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS", None)
+        env.pop("AUTOBOT_FEATURE_KB_MOCK_CONNECTOR", None)
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(backend_dir),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "OK" in result.stdout
+
+    def test_mock_registers_when_flag_enabled(self) -> None:
+        """Enabling AUTOBOT_FEATURE_KB_MOCK_CONNECTOR registers 'mock' only."""
+        backend_dir = Path(__file__).parents[2]
+        project_root = backend_dir.parent
+        script = (
+            "import sys; "
+            "sys.path.insert(0, %r); "
+            "sys.path.insert(0, %r); "
+            "from knowledge.connectors.registry import ConnectorRegistry; "
+            "import knowledge.connectors; "
+            "types = ConnectorRegistry.list_types(); "
+            "assert 'mock' in types, types; "
+            "assert 'slack' not in types, types; "
+            "print('OK')"
+        ) % (str(project_root), str(backend_dir))
+        env = os.environ.copy()
+        env["AUTOBOT_FEATURE_KB_MOCK_CONNECTOR"] = "true"
         env.pop("AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS", None)
         result = subprocess.run(
             [sys.executable, "-c", script],

--- a/autobot-backend/knowledge/connectors/fixtures/mock/doc_001_runbook.json
+++ b/autobot-backend/knowledge/connectors/fixtures/mock/doc_001_runbook.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-001",
+  "title": "Runbook: Restarting the Redis Cluster",
+  "category": "engineering",
+  "author": "sre-team",
+  "updated_at": "2026-01-10T09:00:00+00:00",
+  "content": "To restart the Redis cluster safely: 1) drain traffic from the affected node via the load balancer, 2) run `redis-cli -h <node> shutdown nosave`, 3) wait for the systemd unit to relaunch the process, 4) confirm replication has resynced with `INFO replication` before re-adding the node to the pool."
+}

--- a/autobot-backend/knowledge/connectors/fixtures/mock/doc_002_roadmap.json
+++ b/autobot-backend/knowledge/connectors/fixtures/mock/doc_002_roadmap.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-002",
+  "title": "Q3 Product Roadmap",
+  "category": "product",
+  "author": "product-team",
+  "updated_at": "2026-02-14T12:30:00+00:00",
+  "content": "Q3 priorities: ship the connector marketplace beta, finish the mobile companion app onboarding flow, and reduce median first-response latency in the support queue by 20%. Stretch goal: multi-tenant cost attribution dashboard."
+}

--- a/autobot-backend/knowledge/connectors/fixtures/mock/doc_003_onboarding.json
+++ b/autobot-backend/knowledge/connectors/fixtures/mock/doc_003_onboarding.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-003",
+  "title": "Employee Onboarding Checklist",
+  "category": "hr",
+  "author": "people-ops",
+  "updated_at": "2026-03-02T08:15:00+00:00",
+  "content": "New hire checklist: provision laptop and VPN access on day 1, schedule buddy introductions during week 1, complete security awareness training within the first two weeks, and set 30/60/90-day goals with the manager by the end of week 2."
+}

--- a/autobot-backend/knowledge/connectors/fixtures/mock/doc_004_escalation.json
+++ b/autobot-backend/knowledge/connectors/fixtures/mock/doc_004_escalation.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-004",
+  "title": "Customer Support Escalation Policy",
+  "category": "support",
+  "author": "support-lead",
+  "updated_at": "2026-04-18T16:45:00+00:00",
+  "content": "Escalate to on-call engineering when: a customer reports data loss, an outage affects more than one tenant, or a security concern is raised. Tier-1 handles password resets and billing questions directly; everything else routes through the escalation queue with a 15-minute SLA acknowledgement."
+}

--- a/autobot-backend/knowledge/connectors/fixtures/mock/doc_005_postmortem.json
+++ b/autobot-backend/knowledge/connectors/fixtures/mock/doc_005_postmortem.json
@@ -1,0 +1,8 @@
+{
+  "id": "doc-005",
+  "title": "Incident Postmortem: 2026-05-12 Outage",
+  "category": "engineering",
+  "author": "sre-team",
+  "updated_at": "2026-05-13T10:00:00+00:00",
+  "content": "Root cause was an unbounded connection pool on the ingest worker that exhausted Redis connections during a traffic spike. Remediation: added a hard pool ceiling, alerting on pool saturation, and a load test that reproduces the spike before the next release."
+}

--- a/autobot-backend/knowledge/connectors/mock.py
+++ b/autobot-backend/knowledge/connectors/mock.py
@@ -1,0 +1,212 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Mock/Replay Knowledge Connector (Issue #10538)
+
+Offline, credential-free connector that serves documents from local JSON
+fixtures instead of a live third-party API. It implements the exact same
+``AbstractConnector`` interface (``test_connection``/``discover_sources``/
+``fetch_content``/``detect_changes``) that Slack/Confluence/Jira use and does
+NOT override ``sync()``, so a call to ``sync()`` exercises the real inherited
+pipeline end-to-end (change detection -> fetch -> output-schema validation ->
+KB ingest -> Redis checkpoint/job-state) with zero network access. This
+de-risks the eventual credential wiring for the enterprise connectors by
+making the shared framework testable offline.
+
+Config keys (under ``ConnectorConfig.config``):
+    fixtures_dir (str): Directory of ``*.json`` fixture documents. Defaults
+        to the bundled ``fixtures/mock`` directory next to this module.
+        Each fixture is a JSON object with keys: id, title, category,
+        author, updated_at (ISO-8601), content.
+
+Gating: registered only when the ``kb_mock_connector`` feature flag is
+enabled (default disabled — see ``knowledge/connectors/__init__.py`` and
+``autobot_shared/feature_flags.py``). Unlike Slack/Confluence/Jira, which are
+gated because they reach real third-party SaaS APIs, this connector never
+makes a network call — it is gated purely so a "mock" entry never appears in
+the production ``GET /knowledge_base/connector_types`` listing by default.
+Tests import this module directly, bypassing the package-level gate.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
+from knowledge.connectors.base import AbstractConnector
+from knowledge.connectors.models import (
+    ChangeInfo,
+    ConnectorConfig,
+    ContentResult,
+    SourceInfo,
+)
+from knowledge.connectors.registry import ConnectorRegistry
+
+logger = get_logger(__name__)
+
+_DEFAULT_FIXTURES_DIR = Path(__file__).parent / "fixtures" / "mock"
+
+
+@ConnectorRegistry.register("mock")
+class MockConnector(AbstractConnector):
+    """Replays local JSON fixtures through the real connector pipeline.
+
+    Each fixture file becomes one KB fact keyed by
+    ``mock:{connector_id}:doc:{doc_id}``. No network access is made at any
+    point; ``discover_sources``/``fetch_content``/``detect_changes`` all read
+    from disk (or an in-memory override supplied via ``docs`` at construction
+    for unit tests that don't want real files).
+    """
+
+    connector_type = "mock"
+    # Issue #4421: zero-config — reads local fixtures, no credentials needed.
+    tier = 0
+
+    @classmethod
+    def output_schema(cls) -> Dict[str, Any]:
+        """Return JSONSchema for ContentResult.metadata (Issue #8147)."""
+        return {
+            "type": "object",
+            "required": ["category", "title"],
+            "properties": {
+                "category": {"type": "string", "description": "Document category"},
+                "title": {"type": "string", "description": "Document title"},
+                "author": {"type": "string", "description": "Document author"},
+                "doc_id": {"type": "string", "description": "Fixture document ID"},
+            },
+        }
+
+    def __init__(self, config: ConnectorConfig, docs: Optional[List[Dict[str, Any]]] = None) -> None:
+        super().__init__(config)
+        cfg = config.config
+        self._fixtures_dir = Path(cfg.get("fixtures_dir", str(_DEFAULT_FIXTURES_DIR)))
+        self._docs_override = docs
+
+    # ------------------------------------------------------------------
+    # AbstractConnector interface
+    # ------------------------------------------------------------------
+
+    async def test_connection(self) -> bool:
+        """Always reachable offline: True when fixtures are loadable."""
+        return bool(self._load_docs())
+
+    async def discover_sources(self) -> List[SourceInfo]:
+        """Return a SourceInfo for every fixture document."""
+        return [_doc_to_source_info(self.config.connector_id, doc) for doc in self._load_docs()]
+
+    async def fetch_content(self, source_id: str) -> Optional[ContentResult]:
+        """Return the fixture document content for *source_id*."""
+        doc = self._find_doc(source_id)
+        if doc is None:
+            self.logger.warning("Mock source_id not found: %s", source_id)
+            return None
+        return _doc_to_content_result(source_id, doc)
+
+    async def detect_changes(self, since: Optional[datetime] = None) -> List[ChangeInfo]:
+        """Return ChangeInfo for every fixture updated after *since*."""
+        changes: List[ChangeInfo] = []
+        for doc in self._load_docs():
+            updated_at = _parse_updated_at(doc)
+            if since is not None and updated_at <= since:
+                continue
+            change_type = "added" if since is None else "modified"
+            changes.append(
+                ChangeInfo(
+                    source_id=_build_source_id(self.config.connector_id, doc["id"]),
+                    change_type=change_type,
+                    timestamp=updated_at,
+                    details={"category": doc.get("category", ""), "doc_id": doc["id"]},
+                )
+            )
+        return changes
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_docs(self) -> List[Dict[str, Any]]:
+        """Load all fixture documents (or the in-memory override) — no network."""
+        if self._docs_override is not None:
+            return self._docs_override
+        return _load_fixtures_from_dir(self._fixtures_dir, self.logger)
+
+    def _find_doc(self, source_id: str) -> Optional[Dict[str, Any]]:
+        doc_id = _parse_source_id(source_id)
+        if doc_id is None:
+            return None
+        return next((d for d in self._load_docs() if d.get("id") == doc_id), None)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (no state, no network)
+# ---------------------------------------------------------------------------
+
+
+def _load_fixtures_from_dir(fixtures_dir: Path, log) -> List[Dict[str, Any]]:
+    """Read and parse every ``*.json`` fixture in *fixtures_dir*, sorted by name."""
+    docs: List[Dict[str, Any]] = []
+    if not fixtures_dir.is_dir():
+        log.warning("Mock fixtures_dir missing: %s", fixtures_dir)
+        return docs
+    for path in sorted(fixtures_dir.glob("*.json")):
+        try:
+            docs.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning("Failed to load fixture %s: %s", path, exc)
+    return docs
+
+
+def _build_source_id(connector_id: str, doc_id: str) -> str:
+    return "mock:%s:doc:%s" % (connector_id, doc_id)
+
+
+def _parse_source_id(source_id: str) -> Optional[str]:
+    parts = source_id.split(":")
+    # Format: mock:{connector_id}:doc:{doc_id}
+    if len(parts) != 4 or parts[0] != "mock" or parts[2] != "doc":
+        return None
+    return parts[3]
+
+
+def _parse_updated_at(doc: Dict[str, Any]) -> datetime:
+    raw = doc.get("updated_at")
+    if not raw:
+        return now_utc()
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return now_utc()
+
+
+def _doc_to_source_info(connector_id: str, doc: Dict[str, Any]) -> SourceInfo:
+    content = doc.get("content", "")
+    return SourceInfo(
+        source_id=_build_source_id(connector_id, doc["id"]),
+        name=doc.get("title", doc["id"]),
+        path=doc["id"],
+        content_type="text/plain",
+        size_bytes=len(content.encode("utf-8")),
+        last_modified=_parse_updated_at(doc),
+        metadata={"category": doc.get("category", ""), "author": doc.get("author", "")},
+    )
+
+
+def _doc_to_content_result(source_id: str, doc: Dict[str, Any]) -> ContentResult:
+    return ContentResult(
+        source_id=source_id,
+        content=doc.get("content", ""),
+        content_type="text/plain",
+        metadata={
+            "category": doc.get("category", ""),
+            "title": doc.get("title", ""),
+            "author": doc.get("author", ""),
+            "doc_id": doc["id"],
+        },
+    )
+
+
+__all__ = ["MockConnector"]

--- a/autobot-backend/knowledge/connectors/mock_test.py
+++ b/autobot-backend/knowledge/connectors/mock_test.py
@@ -1,0 +1,216 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the Mock/Replay Knowledge Connector (Issue #10538)
+
+Proves the enterprise connectors' sync() path is testable end-to-end OFFLINE:
+  - registration under ConnectorRegistry
+  - discover_sources()/fetch_content()/detect_changes() read local fixtures only
+  - category resolution (CATEGORY_MAP -> "test") works for a live instance
+  - a full sync() run (the real inherited AbstractConnector pipeline, not a
+    stub) normalizes every fixture into a ContentResult and ingests it
+  - zero network sockets are opened at any point
+"""
+
+import socket
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge.connectors.mock import MockConnector, _parse_source_id
+from knowledge.connectors.models import ConnectorConfig
+from knowledge.connectors.registry import CATEGORY_MAP, ConnectorRegistry
+
+_FIXTURE_CATEGORIES = {"engineering", "product", "hr", "support"}
+
+
+@pytest.fixture
+def mock_config():
+    return ConnectorConfig(
+        connector_id="test-mock-1",
+        connector_type="mock",
+        name="Test Mock",
+        config={},
+        enabled=True,
+        verification_mode="collaborative",
+    )
+
+
+class TestMockConnectorRegistration:
+    def test_registered_under_mock_type(self):
+        assert ConnectorRegistry.get_registered_class("mock") is MockConnector
+
+    def test_init(self, mock_config):
+        connector = MockConnector(mock_config)
+        assert connector.connector_type == "mock"
+        assert connector.tier == 0
+
+    def test_output_schema(self):
+        schema = MockConnector.output_schema()
+        assert schema["type"] == "object"
+        assert "category" in schema["required"]
+
+
+class TestMockConnectorFixtures:
+    @pytest.mark.asyncio
+    async def test_discover_sources_reads_bundled_fixtures(self, mock_config):
+        connector = MockConnector(mock_config)
+        sources = await connector.discover_sources()
+        assert len(sources) == 5
+        assert all(s.source_id.startswith("mock:test-mock-1:doc:") for s in sources)
+
+    @pytest.mark.asyncio
+    async def test_discover_sources_exercises_varied_categories(self, mock_config):
+        connector = MockConnector(mock_config)
+        sources = await connector.discover_sources()
+        categories = {s.metadata["category"] for s in sources}
+        assert categories == _FIXTURE_CATEGORIES
+
+    @pytest.mark.asyncio
+    async def test_test_connection_true_when_fixtures_present(self, mock_config):
+        connector = MockConnector(mock_config)
+        assert await connector.test_connection() is True
+
+    @pytest.mark.asyncio
+    async def test_test_connection_false_when_dir_missing(self, mock_config):
+        mock_config.config["fixtures_dir"] = "/nonexistent/mock/fixtures"
+        connector = MockConnector(mock_config)
+        assert await connector.test_connection() is False
+
+
+class TestMockConnectorFetchContent:
+    @pytest.mark.asyncio
+    async def test_fetch_content_normalizes_fixture(self, mock_config):
+        connector = MockConnector(mock_config)
+        source_id = "mock:test-mock-1:doc:doc-001"
+        result = await connector.fetch_content(source_id)
+        assert result is not None
+        assert result.metadata["category"] == "engineering"
+        assert result.metadata["doc_id"] == "doc-001"
+        assert "Redis" in result.content
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_unknown_doc_returns_none(self, mock_config):
+        connector = MockConnector(mock_config)
+        result = await connector.fetch_content("mock:test-mock-1:doc:doc-999")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_malformed_source_id_returns_none(self, mock_config):
+        connector = MockConnector(mock_config)
+        assert await connector.fetch_content("not-a-mock-id") is None
+
+
+class TestMockConnectorDetectChanges:
+    @pytest.mark.asyncio
+    async def test_initial_sync_all_added(self, mock_config):
+        connector = MockConnector(mock_config)
+        changes = await connector.detect_changes(since=None)
+        assert len(changes) == 5
+        assert all(c.change_type == "added" for c in changes)
+
+    @pytest.mark.asyncio
+    async def test_incremental_sync_only_newer_docs(self, mock_config):
+        connector = MockConnector(mock_config)
+        since = datetime(2026, 3, 1, tzinfo=timezone.utc)
+        changes = await connector.detect_changes(since=since)
+        # doc-003/004/005 updated_at are after 2026-03-01; doc-001/002 are not.
+        assert len(changes) == 3
+        assert all(c.change_type == "modified" for c in changes)
+
+
+class TestMockConnectorModuleHelpers:
+    def test_parse_source_id_valid(self):
+        assert _parse_source_id("mock:conn-1:doc:doc-001") == "doc-001"
+
+    def test_parse_source_id_malformed(self):
+        assert _parse_source_id("bad:id") is None
+
+
+class TestMockConnectorCategoryResolution:
+    @pytest.fixture(autouse=True)
+    def _clean_instances(self):
+        original = dict(ConnectorRegistry._instances)
+        ConnectorRegistry._instances.clear()
+        yield
+        ConnectorRegistry._instances.clear()
+        ConnectorRegistry._instances.update(original)
+
+    def test_mock_listed_under_test_category(self):
+        assert CATEGORY_MAP["test"] == ["mock"]
+
+    def test_resolve_by_category_returns_live_mock_instance(self, mock_config):
+        connector = MockConnector(mock_config)
+        ConnectorRegistry.add_instance(connector)
+
+        result = ConnectorRegistry.resolve_by_category("test")
+
+        assert connector in result
+
+
+class TestMockConnectorFullSyncOffline:
+    """Exercises the real (non-overridden) AbstractConnector.sync() pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_full_sync_ingests_all_fixtures_with_zero_network(self, mock_config):
+        connector = MockConnector(mock_config)
+        fake_kb = AsyncMock()
+
+        with (
+            patch("knowledge.get_knowledge_base", AsyncMock(return_value=fake_kb)),
+            patch(
+                "autobot_shared.redis_client.get_async_redis_client",
+                AsyncMock(return_value=None),
+            ),
+            patch.object(socket.socket, "connect") as mock_connect,
+        ):
+            mock_connect.side_effect = AssertionError("MockConnector sync() must not open sockets")
+            result = await connector.sync(incremental=False)
+
+        assert mock_connect.call_count == 0
+        assert result.status == "success"
+        assert result.added == 5
+        assert result.errors == []
+        assert fake_kb.store_fact.call_count == 5
+
+        # store_fact(text, metadata, fact_id=...) — metadata is positional arg 1.
+        ingested_categories = {call.args[1]["category"] for call in fake_kb.store_fact.call_args_list}
+        assert ingested_categories == _FIXTURE_CATEGORIES
+
+    @pytest.mark.asyncio
+    async def test_discover_fetch_detect_never_touch_a_socket(self, mock_config):
+        """Direct proof the connector's own methods make zero network calls."""
+        connector = MockConnector(mock_config)
+
+        with patch.object(socket.socket, "connect") as mock_connect:
+            mock_connect.side_effect = AssertionError("must not open sockets")
+            await connector.discover_sources()
+            await connector.fetch_content("mock:test-mock-1:doc:doc-001")
+            await connector.detect_changes(since=None)
+            await connector.test_connection()
+
+        assert mock_connect.call_count == 0
+
+
+class TestMockConnectorInMemoryDocs:
+    """Unit tests that don't want real fixture files can pass docs= directly."""
+
+    @pytest.mark.asyncio
+    async def test_docs_override_bypasses_filesystem(self, mock_config):
+        docs = [
+            {
+                "id": "custom-1",
+                "title": "Custom Doc",
+                "category": "custom",
+                "author": "tester",
+                "updated_at": "2026-06-01T00:00:00+00:00",
+                "content": "custom content",
+            }
+        ]
+        connector = MockConnector(mock_config, docs=docs)
+        sources = await connector.discover_sources()
+        assert len(sources) == 1
+        assert sources[0].metadata["category"] == "custom"

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -42,11 +42,11 @@ logger = get_logger(__name__)
 # registered connector type strings that satisfy it.  Only connector types
 # that are actually implemented in this codebase are listed here.
 #
-# Issue #10538: "slack"/"confluence"/"jira" are listed for documentation
-# purposes even though registration is feature-flagged (default disabled) —
-# resolve_by_category() only ever returns *live* instances, so listing them
-# here is safe: with the flag off they are never registered/instantiated and
-# simply never match.
+# Issue #10538: "slack"/"confluence"/"jira"/"mock" are listed for
+# documentation purposes even though registration is feature-flagged (default
+# disabled) — resolve_by_category() only ever returns *live* instances, so
+# listing them here is safe: with the flag off they are never
+# registered/instantiated and simply never match.
 CATEGORY_MAP: Dict[str, List[str]] = {
     "cloud storage": ["gdrive", "onedrive", "nextcloud"],
     "source control": ["gitlab", "gitea"],
@@ -59,6 +59,7 @@ CATEGORY_MAP: Dict[str, List[str]] = {
     "external": ["external_adapter"],
     "chat": ["slack"],
     "issue tracker": ["jira"],
+    "test": ["mock"],
 }
 
 

--- a/autobot-backend/knowledge/connectors/tests/test_category_resolution.py
+++ b/autobot-backend/knowledge/connectors/tests/test_category_resolution.py
@@ -111,6 +111,9 @@ class TestCategoryMap:
             "slack",
             "confluence",
             "jira",
+            # Issue #10538: feature-flagged (AUTOBOT_FEATURE_KB_MOCK_CONNECTOR,
+            # default off) — offline fixture-replay connector for dev/CI.
+            "mock",
         }
         for category, types in CATEGORY_MAP.items():
             for t in types:

--- a/autobot_shared/feature_flags.py
+++ b/autobot_shared/feature_flags.py
@@ -24,6 +24,8 @@ Subsystem flags that default ``False`` (opt-in):
 
 * ``kb_enterprise_connectors`` — Slack/Confluence/Jira KB ingestion connectors
   (AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS). Issue #10538.
+* ``kb_mock_connector`` — offline mock/replay KB connector for dev/CI testing
+  of the sync() pipeline (AUTOBOT_FEATURE_KB_MOCK_CONNECTOR). Issue #10538.
 
 Usage::
 
@@ -57,6 +59,7 @@ _SUBSYSTEM_FLAG_MAP: dict[str, str] = {
     "training": "training_enabled",
     "osint": "osint_enabled",
     "kb_enterprise_connectors": "kb_enterprise_connectors",
+    "kb_mock_connector": "kb_mock_connector",
 }
 
 F = TypeVar("F", bound=Callable)

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1740,6 +1740,11 @@ class FeatureConfig(BaseSettings):
     # AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS=true once credentials exist.
     kb_enterprise_connectors: bool = Field(default=False, alias="AUTOBOT_FEATURE_KB_ENTERPRISE_CONNECTORS")
 
+    # Issue #10538: Offline mock/replay KB connector for dev/CI testing.
+    # Disabled by default — it makes zero network calls, but the flag keeps a
+    # "mock" entry out of the production connector_types listing/UI.
+    kb_mock_connector: bool = Field(default=False, alias="AUTOBOT_FEATURE_KB_MOCK_CONNECTOR")
+
 
 class CostModelConfig(BaseSettings):
     """Operator-supplied monthly cost estimates for hardware components.


### PR DESCRIPTION
Closes #12204

## Thinking Path

PR #12189 added feature-flagged Slack/Confluence/Jira KB connectors extending
the existing `AbstractConnector` framework, but they can only be exercised
end-to-end against real credentials — leaving the shared `sync()` pipeline
(change detection -> fetch -> output-schema validation -> KB ingest -> Redis
checkpoint/job-state) untested offline. Audited `knowledge/connectors/` and
its tests first: no existing mock/fake/stub/replay connector or test-double
was found (only per-connector HTTP mocking inside each `*_test.py`, e.g.
`slack_test.py` patches `_slack_post`). So this adds a real, registered
`MockConnector` rather than duplicating anything, following the exact
`AbstractConnector` contract used by `file_server.py` (tier 0, zero-config,
does NOT override `sync()` so the real inherited pipeline runs unmodified).

## What Changed

- `autobot-backend/knowledge/connectors/mock.py` — `MockConnector`
  (`connector_type = "mock"`, `tier = 0`). Reads documents from local JSON
  fixtures (or an in-memory `docs=` override for unit tests), never opens a
  network socket. Implements `test_connection`/`discover_sources`/
  `fetch_content`/`detect_changes`; `sync()` is inherited unmodified from
  `AbstractConnector`, so a `sync()` call exercises the exact same
  detect->fetch->validate->ingest->checkpoint pipeline Slack/Confluence/Jira
  use.
- `autobot-backend/knowledge/connectors/fixtures/mock/*.json` — 5 realistic
  KB documents across 4 categories (engineering runbook + postmortem,
  product roadmap, HR onboarding checklist, support escalation policy) so
  category resolution and metadata normalization are exercised, not just a
  single trivial doc.
- Registration: `@ConnectorRegistry.register("mock")`, plus `"test": ["mock"]`
  added to `CATEGORY_MAP` (`registry.py`) so `resolve_by_category()` — the
  existing Issue #10539 mechanism — resolves it like any other connector.
- Gating decision: Slack/Confluence/Jira are gated behind
  `kb_enterprise_connectors` because they reach real third-party SaaS APIs
  with real credentials. `MockConnector` never makes a network call, so that
  rationale doesn't apply — but it IS gated behind a new `kb_mock_connector`
  flag (default `False`, same pattern as `kb_enterprise_connectors` in
  `autobot_shared/feature_flags.py` + `ssot_config.py`) purely so a "mock"
  entry never appears in the production `GET /knowledge_base/connector_types`
  listing/UI by default. Tests import `knowledge.connectors.mock` directly,
  bypassing the package-level gate (same pattern `slack_test.py` already
  uses).
- `connectors_init_gating_test.py` extended with static + subprocess
  behavioural checks for the new gate (mirrors the existing Slack/Confluence/
  Jira gate tests).
- `tests/test_category_resolution.py` — added `"mock"` to the known-types
  allowlist so the existing `CATEGORY_MAP` contract test still passes.

## Verification

```
$ AUTOBOT_FEATURE_KB_MOCK_CONNECTOR=true python3 -m pytest \
    knowledge/connectors/mock_test.py \
    knowledge/connectors/connectors_init_gating_test.py \
    knowledge/connectors/tests/test_category_resolution.py -v
...
44 passed in 16.45s
```

`mock_test.py` proves, with zero network access (patches `socket.socket.connect`
to raise + asserts `call_count == 0`):
- registration under `ConnectorRegistry`
- `discover_sources()`/`fetch_content()`/`detect_changes()` read only local
  JSON fixtures across all 4 categories
- `resolve_by_category("test")` returns the live mock instance
- a full, non-stubbed `sync(incremental=False)` run ingests all 5 fixtures
  (`result.added == 5`, `result.status == "success"`, `fake_kb.store_fact`
  called 5 times with the expected normalized categories)

Also ran, on touched files: `python3 -c "import ast; ast.parse(...)"` (all
pass), `black --check` (clean), `flake8 --max-line-length=120` (0 findings),
and `tools/lint/check_spdx_header.py` (pass).

**Note for reviewer:** this PR does not close #10538 — real credential
wiring for Slack/Confluence/Jira is still owner-gated pending actual
tokens/tenants. It only de-risks that follow-up by making the shared
`sync()` pipeline testable offline today. A discrete tracking issue is
needed to satisfy the pr-issue-validation link-check's Closes/Fixes
requirement for the branch's issue token — requesting the repo owner file
one, per their instruction.

## Model Used

Sonnet

Refs #10538