### PR TITLE
ci(precommit): run enforce-precommit on every PR so it can be a required check (#12174)

### DIFF
--- a/.github/workflows/enforce-precommit.yml
+++ b/.github/workflows/enforce-precommit.yml
@@ -7,13 +7,12 @@ name: Enforce Pre-commit Hooks
 on:
   pull_request:
     branches: [ main, Dev_new_gui, develop ]
-    paths:
-      - '**/*.py'
-      - '**/*.ts'
-      - '**/*.vue'
-      - '**/*.yml'
-      - '**/*.yaml'
-      - '.pre-commit-config.yaml'
+    # No `paths:` filter — this workflow is a REQUIRED status check (#12174), and
+    # a required check that is path-filtered out never reports, wedging any PR
+    # that touches only non-matching files (docs, .sh, .css, .json). Running on
+    # every PR guarantees it always reports, and also closes the SPDX coverage
+    # gap: the header check covers .sh/.css/.js/.mjs/.tsx, which the old filter
+    # (.py/.ts/.vue/.yml only) never triggered on.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #12174

## Thinking Path
#9840 found SPDX headers had drifted despite enforcement existing (checker + pre-commit hook + CI job). Root cause: the CI job wasn't a *required* branch-protection check. But making it required as-is would wedge PRs — the workflow was path-filtered to `.py/.ts/.vue/.yml`, and a required check that's filtered out never reports (pending forever). The same filter also never triggered on `.sh/.css/.js/.mjs/.tsx`, which the SPDX checker *does* cover — the actual drift hole.

## What Changed
- **`.github/workflows/enforce-precommit.yml`** — removed the `paths:` filter so the workflow runs on every PR to `main`/`Dev_new_gui`/`develop`. Both jobs are GitHub-hosted (`ubuntu-latest`), so this adds no load to the self-hosted runner. No untrusted-input usage introduced.

## Follow-up (this same task)
After merge I'll add `verify-precommit-config` to `Dev_new_gui`'s required status checks, so SPDX/pre-commit drift blocks merges going forward.

## Verification
YAML validated (`yaml.safe_load`). The workflow will now report on all PRs including docs/css/sh-only ones.

## Model Used
Claude Opus 4.8