### PR TITLE
chore(cleanup): remove dead single_user postgres_required 503-gate (#10202)

### DIFF
--- a/autobot-backend/api/envelope_secrets.py
+++ b/autobot-backend/api/envelope_secrets.py
@@ -12,7 +12,7 @@ unit-testable in isolation:
 
 - ``principal`` — the caller's ``(user_id, permissions)`` from the auth
   middleware + RBAC; 401 when unauthenticated.
-- ``get_session`` — the Postgres ``AsyncSession`` (gated by ``postgres_required``).
+- ``get_session`` — the Postgres ``AsyncSession`` (always available; #10636).
 - ``get_coordinator`` — the ``SecretsCoordinator``; 503 when the root key is unset.
 
 Coordinator exceptions map to HTTP: ``SecretNotFoundError``→404,

--- a/autobot-backend/api/vnc_proxy.py
+++ b/autobot-backend/api/vnc_proxy.py
@@ -154,10 +154,9 @@ async def _audit_control_lock_change(action: str, session_id: str, current_user:
     """Best-effort audit log for a control-lock acquire/release (#12002).
 
     Uses integrations.desktop_tracking (Issue #873), the existing desktop
-    activity audit hook. Never raises -- PostgreSQL may be disabled entirely
-    in single_user deployments (get_async_session_factory hard-raises in
-    that mode), and a missing/unauthenticated user_id must not block the
-    safety-critical lock operation itself.
+    activity audit hook. Never raises -- a transient PostgreSQL/session-factory
+    error must not block the safety-critical lock operation, and neither must a
+    missing/unauthenticated user_id.
     """
     raw_user_id = current_user.get("user_id")
     if not raw_user_id:
@@ -184,7 +183,7 @@ async def _audit_control_lock_change(action: str, session_id: str, current_user:
             )
             await db.commit()
     except RuntimeError as e:
-        # PostgreSQL not enabled for this deployment mode -- expected in single_user.
+        # Defensive: session factory unavailable (e.g. startup race) -- non-fatal.
         logger.debug("Control-lock audit skipped (PostgreSQL unavailable): %s", e)
     except Exception as e:
         logger.warning("Control-lock audit logging failed for %s (non-fatal): %s", action, e)

--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """LLC API router (GH#8251)."""
 
-from fastapi import APIRouter, Depends
-
-from llc.deps import postgres_required
+from fastapi import APIRouter
 
 from .activity import router as activity_router
 from .adapters import router as adapters_router
@@ -39,10 +37,9 @@ from .sprints import router as sprints_router
 from .templates import router as templates_router
 from .work_items import router as work_items_router
 
-# GH#10010: All LLC routes require Postgres, which AutoBot always provides
-# (#10636).  The postgres_required dependency is retained as a router-level
-# hook for these Postgres-backed routes.
-router = APIRouter(prefix="/llc", tags=["llc"], dependencies=[Depends(postgres_required)])
+# All LLC routes are Postgres-backed, which AutoBot always provides (#10636);
+# single_user mode is retired, so no availability gate is needed (#10202).
+router = APIRouter(prefix="/llc", tags=["llc"])
 router.include_router(activity_router)
 router.include_router(boards_router)
 router.include_router(adapters_router)

--- a/autobot-backend/llc/deps.py
+++ b/autobot-backend/llc/deps.py
@@ -17,7 +17,7 @@ circular import when a router is loaded in isolation via importlib (e.g. tests).
 
 Usage::
 
-    from llc.deps import get_session, postgres_required, service_dep
+    from llc.deps import get_session, service_dep
     from llc.services.my_service import MyService
 
     router = APIRouter(...)
@@ -37,7 +37,7 @@ import functools
 import uuid
 from typing import AsyncGenerator, Callable, Set, Type, TypeVar
 
-from fastapi import Depends, HTTPException
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -49,20 +49,7 @@ from user_management.services import TenantContext
 _T = TypeVar("_T")
 
 
-def postgres_required() -> None:
-    """FastAPI dependency hook for LLC endpoints requiring a Postgres session.
-
-    AutoBot always runs full, Postgres-backed user management (#10636), so this
-    gate always passes.  Retained as a router-level dependency hook so existing
-    router wiring (``APIRouter(dependencies=[Depends(postgres_required)])``)
-    stays in place.
-    """
-    return None
-
-
-async def get_session(
-    _gate: None = Depends(postgres_required),
-) -> AsyncGenerator[AsyncSession, None]:
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
     """Bare async DB session — no auto-commit or auto-rollback.
 
     Callers are responsible for explicit transaction management
@@ -155,7 +142,6 @@ async def load_owned_project(project_id: uuid.UUID, session: AsyncSession, ctx: 
 __all__ = [
     "get_session",
     "load_owned_project",
-    "postgres_required",
     "require_board_role",
     "service_dep",
 ]


### PR DESCRIPTION
## Thinking Path
Closes #10202 (part of #10193). single_user mode was retired (#10636/#10687) and Postgres is now always present, so the `postgres_required` dependency — long since neutered to a `return None` no-op and deliberately retained only as a temporary router-wiring hook — is dead. Removing it completes the single_user 503-gate cleanup. Audited the wider 503 surface: the KB/memory/voice "not available" 503s are legitimate availability checks and were left untouched; the `@requires_postgres` decorator no longer exists.

## What Changed
- **`llc/deps.py`** — removed `postgres_required()` (no-op), its `_gate` param on `get_session`, its `__all__` export, the docstring usage-example ref, and the now-unused `Depends` import.
- **`llc/api/__init__.py`** — dropped `Depends(postgres_required)` from the `/llc` router group + the import; refreshed the explanatory comment. The removed dependency was a no-op, so route registration/behavior is unchanged.
- **`api/envelope_secrets.py`** — freshened a docstring line that referenced `postgres_required`.
- **`api/vnc_proxy.py`** — freshened a stale `single_user` comment on the control-lock audit's defensive `except RuntimeError` (branch kept — it still guards transient session-factory errors during startup races; only the misleading single_user wording removed).

## Verification
- `python3 -m pytest llc/tests/ -q` → **1235 passed, 2 skipped** (LLC routers still load + register `/llc` routes; behavior unchanged since the gate was a no-op).
- `flake8 --select=F` clean, `black --check` clean, `py_compile` clean on all 4 files.
- Grep confirms zero residual `postgres_required` references.

## Model Used
Opus 4.8

Closes #10202. (Issue is labeled `frontend` but the work is backend cleanup.)
