### PR TITLE
ci(hardened-smoke): dump autobot-slm logs + healthcheck probe inline on failure (#11516)

### DIFF
--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -197,6 +197,32 @@ jobs:
           echo ""
           curl -v http://localhost/slm/api/health 2>&1 | head -20 || true
 
+      - name: Dump autobot-slm diagnostics on failure
+        # #11516: the hardened overlay fails with "container autobot-slm is
+        # unhealthy", but the crash cause lives in the SLM container's own
+        # logs + healthcheck probe output — print them INLINE (not just the
+        # uploaded artifact) so the failure is diagnosable from the run page.
+        if: failure()
+        run: |
+          echo "=== autobot-slm container state ==="
+          docker inspect autobot-slm \
+            --format 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+            2>&1 || echo "(autobot-slm container not found)"
+          echo ""
+          echo "=== autobot-slm healthcheck probe log (each attempt: ExitCode + Output) ==="
+          docker inspect autobot-slm --format '{{json .State.Health}}' 2>/dev/null \
+            | python3 -m json.tool 2>/dev/null \
+            || echo "(no healthcheck state on autobot-slm)"
+          echo ""
+          echo "=== autobot-slm logs (last 300 lines) ==="
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.hardened.yml \
+            --env-file docker/.env.docker \
+            logs --no-color --tail 300 autobot-slm 2>&1 \
+            || docker logs --tail 300 autobot-slm 2>&1 \
+            || echo "(no autobot-slm logs available)"
+
       - name: Collect logs on failure
         if: failure()
         run: |


### PR DESCRIPTION
## Thinking Path
#11516 (deliverable 1 of 2). The `hardened-smoke-test` job has been red on `Dev_new_gui` base since 2026-07-10 — `docker compose up` with the hardened overlay fails with `dependency failed to start: container autobot-slm is unhealthy`, but the crash cause lives in the SLM container's own logs + healthcheck probe output, which the run page never shows (the existing "Collect logs on failure" step only dumps a full compose-logs *artifact*, not inline SLM-focused output). Root-causing the unhealthiness (deliverable 2) is impossible until that evidence is visible from CI — so this makes it visible.

## What Changed
- Added a `Dump autobot-slm diagnostics on failure` step (`if: failure()`) to `.github/workflows/hardened-smoke-test.yml`, printing INLINE to the job log:
  - `docker inspect` container state — `Status`, `ExitCode`, `OOMKilled`, `Health` (catches the halved hardened `pids: 256` / `memory: 768M` limits killing SLM at startup).
  - the full healthcheck probe log (`.State.Health` JSON — each attempt's ExitCode + Output).
  - the last 300 lines of `autobot-slm` logs (compose logs, falling back to `docker logs`).
- Runs before the existing artifact upload; purely additive, only executes on failure. Uses only static commands — no `github.event.*` interpolation.

## Verification
- YAML parses (`yaml.safe_load`).
- Grep confirms no untrusted `github.event` interpolation in any `run:` block (no injection surface).
- Non-required check; failure-path-only change → zero risk to other PRs' required checks.

## Deliverable 2 — already resolved on base
Re-checked the current CI history: `hardened-smoke-test` is now **consistently green** (this PR's own run + recent base pushes + all sibling PR runs pass; the only non-successes are concurrency-`cancel-in-progress` cancellations, not failures). The SLM unhealthiness was fixed on base after the issue was filed — the writable-path/tmpfs work referenced in `docker-compose.hardened.yml` (#11574) so read-only `root` no longer EROFS-crashes SLM startup. This PR adds the inline diagnostics so any **future** regression is immediately diagnosable rather than blind.

## Model Used
Opus 4.8

Closes #11516 — deliverable 1 (diagnostics) here; deliverable 2 (SLM unhealthiness) resolved on base, hardened-smoke now consistently green.