### PR TITLE
fix(advanced-control): system/status uptime_seconds must be a duration, not boot epoch (#12177)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -404,6 +404,8 @@ async def get_system_status(
     Issue #744: Requires admin authentication.
     """
     # Get resource usage
+    import time
+
     import psutil
 
     resource_usage = {
@@ -420,10 +422,14 @@ async def get_system_status(
     # Get takeover data
     pending_takeovers = await get_takeover_manager().get_pending_requests()
     active_takeovers = await get_takeover_manager().get_active_sessions()
+    # #12177: both fields were mistakenly set to psutil.boot_time() (an absolute
+    # boot epoch). timestamp is when this snapshot was taken; uptime_seconds is a
+    # duration (now - boot).
+    now = time.time()
     system_status = {
         "status": "healthy",
-        "timestamp": psutil.boot_time(),
-        "uptime_seconds": psutil.boot_time(),
+        "timestamp": now,
+        "uptime_seconds": now - psutil.boot_time(),
         "streaming_capabilities": get_desktop_streaming().get_system_capabilities(),
     }
 

--- a/autobot-backend/tests/api/test_advanced_control_system_status_12177.py
+++ b/autobot-backend/tests/api/test_advanced_control_system_status_12177.py
@@ -1,0 +1,49 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression test for #12177.
+
+``GET /api/advanced-control/system/status`` previously set both ``timestamp``
+and ``uptime_seconds`` to ``psutil.boot_time()`` — an absolute boot epoch
+(~1.7e9), so frontends rendering ``uptime_seconds`` as a duration showed a
+meaningless ~1.7 billion. ``timestamp`` must be the snapshot time (now) and
+``uptime_seconds`` a real duration (now - boot).
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import psutil
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_system_status_uptime_is_duration_not_boot_epoch():
+    from api.advanced_control import get_system_status
+
+    streaming = MagicMock()
+    streaming.vnc_manager.list_active_sessions.return_value = []
+    streaming.get_system_capabilities.return_value = {}
+
+    takeover = MagicMock()
+    takeover.get_pending_requests = AsyncMock(return_value=[])
+    takeover.get_active_sessions = AsyncMock(return_value=[])
+
+    with (
+        patch("api.advanced_control.get_desktop_streaming", return_value=streaming),
+        patch("api.advanced_control.get_takeover_manager", return_value=takeover),
+    ):
+        resp = await get_system_status(admin_check=True)
+
+    status = resp.system_status
+    boot = psutil.boot_time()
+    now = time.time()
+
+    # uptime_seconds is a duration (now - boot), NOT the absolute boot epoch (#12177).
+    assert 0 <= status["uptime_seconds"] < boot
+    assert status["uptime_seconds"] == pytest.approx(now - boot, abs=5)
+
+    # timestamp is the snapshot time (now), NOT the boot epoch.
+    assert status["timestamp"] == pytest.approx(now, abs=5)
+    assert status["timestamp"] > status["uptime_seconds"]


### PR DESCRIPTION
## Thinking Path
Closes #12177. `GET /api/advanced-control/system/status` set BOTH `timestamp` and `uptime_seconds` to `psutil.boot_time()` — an absolute boot epoch (~1.7e9). Frontends (the Advanced Control → Monitoring tab, #12173) rendering `uptime_seconds` as a duration showed a meaningless ~1.7 billion.

## What Changed
- `autobot-backend/api/advanced_control.py` `get_system_status()`:
  - `uptime_seconds` → `time.time() - psutil.boot_time()` (a real duration).
  - `timestamp` → `time.time()` (the snapshot time; it was the same copy-paste boot-epoch bug).
  - Added `import time` (local, next to the existing local `import psutil`).
- Left `status: "healthy"` as-is — per the issue it's intentional (this endpoint aggregates raw data; `/system/health` is the real health-check).

## Verification
- New `tests/api/test_advanced_control_system_status_12177.py`: asserts `uptime_seconds` is a small duration (`< boot_time`, ≈ now−boot) not the epoch, and `timestamp ≈ now` — **1 passed**.
- `py_compile` / `black` / `flake8 -F` clean.

## Model Used
Opus 4.8

Closes #12177.
