### PR TITLE
fix(ci): dependabot uv entry + release notes range on guard-fire (#11829, #11861)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -466,3 +466,20 @@ updates:
       - dependency-name: "websockets"
         # #10474: cap <16 — langgraph-sdk 0.4.2 requires websockets >=14,<16.
         update-types: ["version-update:semver-major"]
+
+  # #11829: knowledge-base-mcp is a uv project (uv.lock); without a "uv"
+  # ecosystem entry dependabot cannot rebase/raise grouped lock updates for it.
+  - package-ecosystem: "uv"
+    directory: "/autobot-infrastructure/shared/mcp/tools/knowledge-base-mcp"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,15 +93,23 @@ jobs:
           # or collides. Never release a version <= any existing tag: fall back
           # to patch-bump of the highest existing tag instead.
           HIGHEST_TAG="$(git tag --list 'v[0-9]*' | sort -V | tail -1)"
+          # When the guard rewrites the version, the notes step's `--latest`
+          # range is computed from git-cliff's OWN version view and no longer
+          # matches the guard-overridden tag. Pin the notes range to
+          # <highest_tag>..HEAD so the published notes cover exactly what the
+          # new tag ships (#11861). Empty when the guard is inert -> `--latest`.
+          NOTES_RANGE=""
           if [[ -n "$HIGHEST_TAG" ]] && \
              [[ "$(printf '%s\n%s\n' "$NEXT_VERSION" "$HIGHEST_TAG" | sort -V | tail -1)" == "$HIGHEST_TAG" ]]; then
             IFS=. read -r MAJ MIN PAT <<<"${HIGHEST_TAG#v}"
             NEXT_VERSION="v${MAJ}.${MIN}.$((PAT + 1))"
-            echo "Monotonic guard: git-cliff bump not above existing ${HIGHEST_TAG}; releasing ${NEXT_VERSION}"
+            NOTES_RANGE="${HIGHEST_TAG}..HEAD"
+            echo "Monotonic guard: git-cliff bump not above existing ${HIGHEST_TAG}; releasing ${NEXT_VERSION} (notes range ${NOTES_RANGE})"
           fi
           echo "Next version: $NEXT_VERSION"
           echo "release_needed=true" >> "$GITHUB_OUTPUT"
           echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "notes_range=$NOTES_RANGE" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes (git-cliff)
         if: steps.check.outputs.release_needed == 'true'
@@ -109,7 +117,9 @@ jobs:
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5  # v4
         with:
           config: cliff.toml
-          args: --latest --strip header
+          # Guard-fire pins an explicit <highest_tag>..HEAD range so notes match
+          # the published version; inert guard keeps git-cliff's --latest (#11861).
+          args: ${{ steps.check.outputs.notes_range != '' && format('{0} --strip header', steps.check.outputs.notes_range) || '--latest --strip header' }}
         env:
           OUTPUT: RELEASE_NOTES.md
           GITHUB_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,11 @@ jobs:
             echo "Monotonic guard: git-cliff bump not above existing ${HIGHEST_TAG}; releasing ${NEXT_VERSION} (notes range ${NOTES_RANGE})"
           fi
           echo "Next version: $NEXT_VERSION"
-          echo "release_needed=true" >> "$GITHUB_OUTPUT"
-          echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "notes_range=$NOTES_RANGE" >> "$GITHUB_OUTPUT"
+          {
+            echo "release_needed=true"
+            echo "version=$NEXT_VERSION"
+            echo "notes_range=$NOTES_RANGE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes (git-cliff)
         if: steps.check.outputs.release_needed == 'true'


### PR DESCRIPTION
## Thinking Path
Two latent CI-config gaps found during release work, same-scope (`.github/`), low-risk → batched.

- **#11829** — `knowledge-base-mcp/uv.lock` exists but `dependabot.yml` had no `uv` ecosystem entry, so dependabot can't rebase/raise grouped lock PRs for it (orphaned #11800).
- **#11861** — when the monotonic guard rewrites the version, the notes step's `--latest` range is computed from git-cliff's own version view, so `changelog/<version>.md` could be *named* with the guard's version but *bodied* with git-cliff's range.

## What Changed
- `.github/dependabot.yml`: add a `uv` ecosystem entry for `/autobot-infrastructure/shared/mcp/tools/knowledge-base-mcp`, mirroring the pip entries (weekly, Dev_new_gui, grouped all-dependencies).
- `.github/workflows/release.yml`: emit a `notes_range` output — set to `<highest_tag>..HEAD` only when the guard fires; the notes step uses it in place of `--latest` so published notes always match the released tag. Inert guard is unchanged (`--latest`).

Implemented option 1 from #11861 (regenerate notes for the correct range) rather than option 2 (fail the release loudly), since option 1 restores correctness with no behavior loss on legitimate releases.

## Verification
- `python3 -c 'import yaml; yaml.safe_load(...)'` — both files valid YAML.
- `uv` now in ecosystem set; `uv.lock` path confirmed present.
- git-cliff accepts a positional `<range>` arg alongside `--strip header`; notes_range only ever holds `v[0-9]*..HEAD` (no untrusted input).

## Model Used
Opus 4.8

Closes #11829, #11861