### PR TITLE
fix(kb): align connector credential reads with declared auth_schema (#12221)

### DIFF
--- a/autobot-backend/api/knowledge_connectors_auth_schema_test.py
+++ b/autobot-backend/api/knowledge_connectors_auth_schema_test.py
@@ -1,0 +1,249 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Guard tests for Issue #12221: connector credential keys must match auth_schema().
+
+Two layers:
+  1. Structural guard — for every real (network-backed) KB enterprise connector,
+     assert the private attributes it reads from ``ConnectorConfig.config`` map
+     1:1 onto the field names its own ``auth_schema()`` declares, so a
+     schema-valid request can never leave the connector's real credential
+     unset (the original #12221 bug).
+  2. End-to-end guard — drive the real ``POST /knowledge_base/connectors``
+     handler with ONLY auth_schema-declared credential keys, through the real
+     ``ConnectorCredentialStore`` (encrypt -> sanitize -> persist -> decrypt ->
+     merge) backed by an in-memory fake secrets backend, and assert the
+     decrypted value that reaches the outbound HTTP call is the exact
+     credential supplied — proving authentication actually works end-to-end
+     without any network access (aiohttp is fully replaced).
+"""
+
+import dataclasses
+from unittest.mock import patch
+
+import pytest
+
+import knowledge.connectors.confluence  # noqa: F401 — register confluence
+import knowledge.connectors.jira  # noqa: F401 — register jira
+import knowledge.connectors.slack  # noqa: F401 — register slack
+from api import knowledge_connectors as mod
+from knowledge.connectors.confluence import ConfluenceConnector
+from knowledge.connectors.credential_store import ConnectorCredentialStore
+from knowledge.connectors.jira import JiraConnector
+from knowledge.connectors.models import ConnectorConfig
+from knowledge.connectors.registry import ConnectorRegistry
+from knowledge.connectors.slack import SlackConnector
+from knowledge.schemas.connectors import CreateConnectorRequest
+
+# ---------------------------------------------------------------------------
+# Structural guard: connector-read attrs <-> auth_schema() declared fields
+# ---------------------------------------------------------------------------
+
+# Maps each real connector class to {auth_schema field name: private attr it
+# must populate}. Kept explicit (not derived) so a future rename of either
+# side makes this test fail loudly instead of silently agreeing with itself.
+_CONNECTOR_AUTH_ATTR_MAP = {
+    SlackConnector: {"token": "_token"},
+    ConfluenceConnector: {"username": "_email", "password": "_api_token"},
+    JiraConnector: {"username": "_email", "password": "_api_token"},
+}
+
+_NON_AUTH_CONFIG = {
+    SlackConnector: {"channel_ids": ["C1"]},
+    ConfluenceConnector: {"base_url": "https://x.atlassian.net/wiki", "space_keys": ["ENG"]},
+    JiraConnector: {"base_url": "https://x.atlassian.net", "project_keys": ["ABC"]},
+}
+
+
+@pytest.mark.parametrize("connector_cls", [SlackConnector, ConfluenceConnector, JiraConnector])
+def test_connector_reads_declared_auth_schema_keys(connector_cls):
+    """Guard against #12221 regressing: connector reads == auth_schema() keys.
+
+    Builds a config containing ONLY the auth_schema()-declared field names
+    (plus the connector's required non-auth config) and asserts every
+    declared field lands on the attribute the connector's outbound HTTP
+    calls actually use.
+    """
+    auth_cls = connector_cls.auth_schema()
+    declared_fields = {f.name for f in dataclasses.fields(auth_cls)}
+    attr_map = _CONNECTOR_AUTH_ATTR_MAP[connector_cls]
+
+    assert declared_fields == set(attr_map), (
+        "%s auth_schema() fields %s no longer match the expected credential "
+        "keys %s — the connector's __init__ and its auth_schema() have "
+        "drifted apart again (Issue #12221)." % (connector_cls.__name__, declared_fields, set(attr_map))
+    )
+
+    config = dict(_NON_AUTH_CONFIG[connector_cls])
+    for field_name in declared_fields:
+        config[field_name] = "value-for-%s" % field_name
+
+    cfg = ConnectorConfig(
+        connector_id="guard-1",
+        connector_type=connector_cls.connector_type,
+        name="Guard",
+        config=config,
+    )
+    connector = connector_cls(cfg)
+    for field_name, attr_name in attr_map.items():
+        assert getattr(connector, attr_name) == "value-for-%s" % field_name
+
+
+# ---------------------------------------------------------------------------
+# End-to-end guard: create() -> encrypt -> decrypt -> real authenticated call
+# ---------------------------------------------------------------------------
+
+# Placeholder credential values only — never real tokens (Issue #12221 tests).
+_FAKE_BOT_CREDENTIAL = "test-fake-bot-credential"
+_FAKE_API_CREDENTIAL = "test-fake-api-credential"
+_FAKE_USERNAME = "bot@example.com"
+
+
+class _FakeSecretsService:
+    """In-memory stand-in for SecretsService — no SQLite, no encryption keys."""
+
+    def __init__(self) -> None:
+        self._by_id: dict = {}
+        self._next_id = 0
+
+    def create_secret(self, name, secret_type, value, scope="general", created_by=None, **_kwargs):
+        self._next_id += 1
+        secret_id = "fake-secret-%d" % self._next_id
+        self._by_id[secret_id] = {"value": value, "created_by": created_by}
+        return {"id": secret_id}
+
+    def get_secret(self, secret_id=None, include_value=True, accessed_by=None, **_kwargs):
+        return self._by_id.get(secret_id)
+
+
+class _FakeAsyncResponse:
+    """Minimal async-context-manager response compatible with aiohttp usage."""
+
+    def __init__(self, status: int, body: dict) -> None:
+        self.status = status
+        self._body = body
+
+    async def json(self, content_type=None):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class _FakeAiohttpSession:
+    """Replaces aiohttp.ClientSession — records auth material, never dials out."""
+
+    def __init__(self, capture: dict, body: dict, status: int = 200) -> None:
+        self._capture = capture
+        self._body = body
+        self._status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    def post(self, url, headers=None, json=None, **kwargs):
+        self._capture["headers"] = headers
+        return _FakeAsyncResponse(self._status, self._body)
+
+    def get(self, url, auth=None, **kwargs):
+        self._capture["auth"] = auth
+        return _FakeAsyncResponse(self._status, self._body)
+
+    def request(self, method, url, auth=None, json=None, **kwargs):
+        self._capture["auth"] = auth
+        return _FakeAsyncResponse(self._status, self._body)
+
+
+async def _create_via_api(request: CreateConnectorRequest, aiohttp_patch_target: str, fake_session):
+    """Drive the real create_connector() handler with a stubbed secrets backend."""
+    store = ConnectorCredentialStore(_FakeSecretsService())
+    saved = {}
+
+    async def _fake_save(cfg):
+        saved["cfg"] = cfg
+
+    with (
+        patch.object(mod, "get_credential_store", return_value=store),
+        patch.object(mod, "_save_connector", _fake_save),
+        patch(aiohttp_patch_target, return_value=fake_session),
+    ):
+        result = await mod.create_connector(request)
+    return result, saved["cfg"]
+
+
+@pytest.mark.asyncio
+async def test_create_slack_schema_valid_credentials_authenticate():
+    """A #12221-compliant Slack request round-trips the token through auth.test."""
+    capture: dict = {}
+    fake_session = _FakeAiohttpSession(capture, {"ok": True}, 200)
+    req = CreateConnectorRequest(
+        connector_type="slack",
+        name="Guard Slack",
+        config={"token": _FAKE_BOT_CREDENTIAL, "channel_ids": ["C1"]},
+    )
+    try:
+        result, cfg = await _create_via_api(req, "knowledge.connectors.slack.aiohttp.ClientSession", fake_session)
+        assert result["connector_id"] == cfg.connector_id
+        assert capture["headers"]["Authorization"] == "Bearer %s" % _FAKE_BOT_CREDENTIAL
+        # The credential is encrypted at rest — never echoed in the public config.
+        assert "token" not in result["config"]
+    finally:
+        ConnectorRegistry.remove_instance(cfg.connector_id)
+
+
+@pytest.mark.asyncio
+async def test_create_confluence_schema_valid_credentials_authenticate():
+    """A #12221-compliant Confluence request authenticates via BasicAuth(username, password)."""
+    capture: dict = {}
+    fake_session = _FakeAiohttpSession(capture, {"results": []}, 200)
+    req = CreateConnectorRequest(
+        connector_type="confluence",
+        name="Guard Confluence",
+        config={
+            "base_url": "https://guard.atlassian.net/wiki",
+            "username": _FAKE_USERNAME,
+            "password": _FAKE_API_CREDENTIAL,
+            "space_keys": ["ENG"],
+        },
+    )
+    try:
+        result, cfg = await _create_via_api(req, "knowledge.connectors.confluence.aiohttp.ClientSession", fake_session)
+        assert result["connector_id"] == cfg.connector_id
+        assert capture["auth"].login == _FAKE_USERNAME
+        assert capture["auth"].password == _FAKE_API_CREDENTIAL
+        assert "password" not in result["config"]
+    finally:
+        ConnectorRegistry.remove_instance(cfg.connector_id)
+
+
+@pytest.mark.asyncio
+async def test_create_jira_schema_valid_credentials_authenticate():
+    """A #12221-compliant Jira request authenticates via BasicAuth(username, password)."""
+    capture: dict = {}
+    fake_session = _FakeAiohttpSession(capture, {"accountId": "u1"}, 200)
+    req = CreateConnectorRequest(
+        connector_type="jira",
+        name="Guard Jira",
+        config={
+            "base_url": "https://guard.atlassian.net",
+            "username": _FAKE_USERNAME,
+            "password": _FAKE_API_CREDENTIAL,
+            "project_keys": ["ABC"],
+        },
+    )
+    try:
+        result, cfg = await _create_via_api(req, "knowledge.connectors.jira.aiohttp.ClientSession", fake_session)
+        assert result["connector_id"] == cfg.connector_id
+        assert capture["auth"].login == _FAKE_USERNAME
+        assert capture["auth"].password == _FAKE_API_CREDENTIAL
+        assert "password" not in result["config"]
+    finally:
+        ConnectorRegistry.remove_instance(cfg.connector_id)

--- a/autobot-backend/knowledge/connectors/confluence.py
+++ b/autobot-backend/knowledge/connectors/confluence.py
@@ -17,8 +17,13 @@ values below are documentation placeholders only.
 Config keys (under ``ConnectorConfig.config``):
     base_url (str): Confluence site base URL, e.g.
         "https://your-domain.atlassian.net/wiki". Required.
-    email (str): Atlassian account email used for basic auth. Required.
-    api_token (str): Atlassian API token. Required.
+    username (str): Atlassian account email used for basic auth. Required.
+        Canonical ``BasicAuth`` field (Issue #12221) — matches
+        ``auth_schema()`` below so the auth-schema validation and
+        credential-store encryption path actually secures the field the
+        connector reads.
+    password (str): Atlassian API token, used as the HTTP Basic password.
+        Required. Canonical ``BasicAuth`` field (Issue #12221).
     space_keys (list[str]): Confluence space keys to sync. Required.
     page_size (int): Pages per query batch. Default 25.
 """
@@ -84,8 +89,8 @@ class ConfluenceConnector(AbstractConnector):
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)
         cfg = config.config
-        self._email: str = cfg.get("email", "")
-        self._api_token: str = cfg.get("api_token", "")
+        self._email: str = cfg.get("username", "")
+        self._api_token: str = cfg.get("password", "")
         self._base_url: str = cfg.get("base_url", "").rstrip("/")
         self._space_keys: List[str] = cfg.get("space_keys", [])
         self._page_size: int = int(cfg.get("page_size", 25))

--- a/autobot-backend/knowledge/connectors/confluence_test.py
+++ b/autobot-backend/knowledge/connectors/confluence_test.py
@@ -25,8 +25,8 @@ def confluence_config():
         name="Test Confluence",
         config={
             "base_url": "https://example.atlassian.net/wiki",
-            "email": "bot@example.com",
-            "api_token": "test-fake-api-credential",
+            "username": "bot@example.com",
+            "password": "test-fake-api-credential",
             "space_keys": ["ENG"],
         },
         enabled=True,

--- a/autobot-backend/knowledge/connectors/jira.py
+++ b/autobot-backend/knowledge/connectors/jira.py
@@ -17,8 +17,13 @@ values below are documentation placeholders only.
 Config keys (under ``ConnectorConfig.config``):
     base_url (str): Jira site base URL, e.g.
         "https://your-domain.atlassian.net". Required.
-    email (str): Atlassian account email used for basic auth. Required.
-    api_token (str): Atlassian API token. Required.
+    username (str): Atlassian account email used for basic auth. Required.
+        Canonical ``BasicAuth`` field (Issue #12221) — matches
+        ``auth_schema()`` below so the auth-schema validation and
+        credential-store encryption path actually secures the field the
+        connector reads.
+    password (str): Atlassian API token, used as the HTTP Basic password.
+        Required. Canonical ``BasicAuth`` field (Issue #12221).
     project_keys (list[str]): Jira project keys to sync. Required.
     jql (str): Optional JQL override; when set, replaces the
         project-key-derived query entirely.
@@ -88,8 +93,8 @@ class JiraConnector(AbstractConnector):
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)
         cfg = config.config
-        self._email: str = cfg.get("email", "")
-        self._api_token: str = cfg.get("api_token", "")
+        self._email: str = cfg.get("username", "")
+        self._api_token: str = cfg.get("password", "")
         self._base_url: str = cfg.get("base_url", "").rstrip("/")
         self._project_keys: List[str] = cfg.get("project_keys", [])
         self._jql_override: str = cfg.get("jql", "")

--- a/autobot-backend/knowledge/connectors/jira_test.py
+++ b/autobot-backend/knowledge/connectors/jira_test.py
@@ -25,8 +25,8 @@ def jira_config():
         name="Test Jira",
         config={
             "base_url": "https://example.atlassian.net",
-            "email": "bot@example.com",
-            "api_token": "test-fake-api-credential",
+            "username": "bot@example.com",
+            "password": "test-fake-api-credential",
             "project_keys": ["ABC"],
         },
         enabled=True,

--- a/autobot-backend/knowledge/connectors/slack.py
+++ b/autobot-backend/knowledge/connectors/slack.py
@@ -17,9 +17,12 @@ SCAFFOLD NOTE: This connector is registered only when the
 values below are documentation placeholders only.
 
 Config keys (under ``ConnectorConfig.config``):
-    bot_token (str): Slack bot token (``xoxb-...``) with
+    token (str): Slack bot token (``xoxb-...``) with
         ``channels:history``, ``groups:history`` and ``channels:read``
-        scopes. Required.
+        scopes. Required. Canonical ``BearerAuth`` field (Issue #12221) —
+        matches ``auth_schema()`` below so the auth-schema validation and
+        credential-store encryption path actually secures the field the
+        connector reads.
     channel_ids (list[str]): Slack channel IDs to sync. Required.
     sync_threads (bool): Also ingest thread replies. Default True.
     oldest (str): Slack ``ts`` lower bound for the initial sync. Default "0".
@@ -92,7 +95,7 @@ class SlackConnector(AbstractConnector):
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)
         cfg = config.config
-        self._token: str = cfg.get("bot_token", "")
+        self._token: str = cfg.get("token", "")
         self._channel_ids: List[str] = cfg.get("channel_ids", [])
         self._sync_threads: bool = cfg.get("sync_threads", True)
         self._oldest: str = cfg.get("oldest", "0")

--- a/autobot-backend/knowledge/connectors/slack_test.py
+++ b/autobot-backend/knowledge/connectors/slack_test.py
@@ -24,7 +24,7 @@ def slack_config():
         connector_type="slack",
         name="Test Slack",
         config={
-            "bot_token": "test-fake-bot-credential",
+            "token": "test-fake-bot-credential",
             "channel_ids": ["C123"],
             "sync_threads": True,
         },


### PR DESCRIPTION
## Thinking Path
`api/knowledge_connectors.py` validates and encrypts credentials using each connector's declared `auth_schema()` (`BearerAuth.token` for Slack, `BasicAuth.username`/`password` for Confluence/Jira), then decrypts and merges those exact keys back into `ConnectorConfig.config` before instantiation. But `SlackConnector.__init__` read `bot_token`, and `ConfluenceConnector`/`JiraConnector.__init__` read `email`/`api_token` — keys the schema neither validates nor stores. Net effect: a schema-valid request always left the connector's real credential field empty (silent auth failure), while a request satisfying the connector's own docstring 422'd at schema validation.

Reconciled by making the three real connectors read the canonical `auth_schema()`-declared field names directly (Slack: `token`; Confluence/Jira: `username`=account email, `password`=API token used as the HTTP Basic password) rather than adding a translation layer in the API. This keeps the credential-store's sensitive-field extraction (`BearerAuth.__sensitive_fields__`, `BasicAuth.__sensitive_fields__`) working unmodified and matches the pattern already used by `MockConnector`/gdrive/onedrive (no auth_schema mismatch there). `MockConnector` declares no `auth_schema()` (tier 0, no credentials) so it needed no change.

## What Changed
- `autobot-backend/knowledge/connectors/slack.py`: `__init__` reads `cfg.get("token", "")` instead of `cfg.get("bot_token", "")`; docstring updated to document `token` as the canonical `BearerAuth` field.
- `autobot-backend/knowledge/connectors/confluence.py`: `__init__` reads `cfg.get("username", "")` / `cfg.get("password", "")` instead of `cfg.get("email", "")` / `cfg.get("api_token", "")`; docstring updated.
- `autobot-backend/knowledge/connectors/jira.py`: same `username`/`password` reconciliation as Confluence; docstring updated.
- `autobot-backend/knowledge/connectors/{slack,confluence,jira}_test.py`: existing fixtures updated to the new canonical keys (`token` / `username`+`password`).
- `autobot-backend/api/knowledge_connectors_auth_schema_test.py` (new): guard tests —
  - `test_connector_reads_declared_auth_schema_keys` (parametrized over Slack/Confluence/Jira): asserts each connector's `auth_schema()` field set equals the keys its `__init__` actually reads, and that those keys land on the correct private attribute.
  - `test_create_{slack,confluence,jira}_schema_valid_credentials_authenticate`: drives the real `create_connector()` handler with ONLY auth_schema-declared credential keys through the real `ConnectorCredentialStore` (encrypt → sanitize → persist → decrypt → merge), backed by an in-memory fake secrets service, with `aiohttp.ClientSession` fully replaced (no network). Asserts the exact supplied credential reaches the outbound authenticated call (`Authorization: Bearer <token>` for Slack; `BasicAuth(login, password)` for Confluence/Jira) and is never echoed back in the sanitized public config.

## Verification
```
$ python3 -m pytest knowledge/connectors/slack_test.py knowledge/connectors/confluence_test.py \
    knowledge/connectors/jira_test.py api/knowledge_connectors_auth_schema_test.py \
    knowledge/connectors/mock_test.py knowledge/connectors/tests/test_credential_store.py -q
89 passed in 1.27s
```
- `python3 -c "import ast; ast.parse(...)"` — clean on all 7 touched files.
- `black --check --target-version py310` — clean on all 7 touched files.
- `flake8` — 0 issues on all 7 touched files.
- Broader `knowledge/connectors/` package run (344 tests) shows exactly one pre-existing, unrelated failure — `TestWebCrawlerSyncCheckpoint::test_crawled_seeds_written_to_checkpoint` — reproduced identically on a clean `Dev_new_gui` checkout before this branch existed, confirming it's not a regression from this change.

## Model Used
Claude Sonnet 5

Closes #12221