### PR TITLE
fix(deploy): write .deployed_commit marker in the self-update path (#12223)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -262,6 +262,30 @@
         - autobot_shared
       tags: [slm]
 
+    # #12223 (#12202): the self-update path deploys the SLM backend via the
+    # unarchive above and never runs the slm_manager role — where the #12202
+    # marker-write lives — so without this the .deployed_commit marker is never
+    # written and _get_slm_deployed_commit() always returns None (self-update
+    # always fires, never skips-when-current). Record the just-deployed commit
+    # here too, mirroring the slm_manager role, so the skip-check works.
+    - name: "[PLAY 1] SLM | Record deployed commit marker (#12223, #12202)"
+      ansible.builtin.shell:
+        cmd: >-
+          git -C {{ code_source_dir | default('/opt/autobot/code_source') }} rev-parse HEAD
+          > /opt/autobot/autobot-slm-backend/.deployed_commit
+      changed_when: false
+      become: true
+      tags: [slm]
+
+    - name: "[PLAY 1] SLM | Own the deployed-commit marker (#12223)"
+      file:
+        path: /opt/autobot/autobot-slm-backend/.deployed_commit
+        owner: autobot
+        group: autobot
+        mode: "0644"
+      become: true
+      tags: [slm]
+
     # Issue #9225: slm-agent needs autobot_shared in PYTHONPATH
     - name: "[PLAY 1] SLM Agent | Create autobot_shared symlink for agent imports"
       ansible.builtin.file:


### PR DESCRIPTION
## Thinking Path
Verified live (2026-07-24): #12206's fix WORKS — the self-update now fires instead of always skipping (critical bug resolved). But the `.deployed_commit` marker is never written, so `_get_slm_deployed_commit()` always returns None and the self-update ALWAYS fires — it never skips-when-current (every update-all does a full SLM redeploy + restart).

Root cause: #12206 put the marker-write in the `slm_manager` role, but the self-update path (`_ansible_self_update` → `update-all-nodes.yml`) deploys the SLM backend via tarball `unarchive` (line 231) and never runs `slm_manager` (grep: 0 refs). Confirmed on the box: after a completed self-update, `.deployed_commit` was absent.

## What Changed
`ansible/playbooks/update-all-nodes.yml` (slm_server play, right after the SLM-backend unarchive + ownership fix): added the marker-write, mirroring the `slm_manager` role's #12202 task — `git -C {{ code_source_dir }} rev-parse HEAD > /opt/autobot/autobot-slm-backend/.deployed_commit` + own it `autobot:autobot 0644`. The role-based write stays for the role path.

## Verification
- YAML valid; `ansible-playbook --syntax-check` passes.
- Fail-safe preserved: an absent/mismatched marker still fires the self-update; a matching marker now legitimately skips.
- Post-merge on-box: a self-update writes the marker, and a subsequent update-all with no new commits shows `slm_self_update: current`.

## Model Used
Opus 4.8

Closes #12223