### PR TITLE
fix(http-client): migrate remaining raw get_session() callers to tracked_session() (#12119)

### DIFF
--- a/autobot-backend/api/http_client_mcp.py
+++ b/autobot-backend/api/http_client_mcp.py
@@ -612,25 +612,27 @@ async def execute_http_request(
 
         # Build request kwargs (Issue #665: uses extracted helper)
         http_client = get_http_client()
-        session = await http_client.get_session()
-        request_kwargs = _build_request_kwargs(url, request_headers, timeout, params, json_body, form_data)
+        # Issue #12119: tracked_session() so this MCP HTTP request counts as
+        # in-flight; a concurrent pool resize cannot close the session mid-request.
+        async with http_client.tracked_session() as session:
+            request_kwargs = _build_request_kwargs(url, request_headers, timeout, params, json_body, form_data)
 
-        # Execute the request
-        async with session.request(method, **request_kwargs) as response:
-            # Check response size before reading (if Content-Length provided)
-            content_length = response.headers.get("Content-Length")
-            if content_length and int(content_length) > MAX_RESPONSE_SIZE:
-                raise HTTPException(
-                    status_code=413,
-                    detail=f"Response too large: {content_length} bytes (max: {MAX_RESPONSE_SIZE})",
-                )
+            # Execute the request
+            async with session.request(method, **request_kwargs) as response:
+                # Check response size before reading (if Content-Length provided)
+                content_length = response.headers.get("Content-Length")
+                if content_length and int(content_length) > MAX_RESPONSE_SIZE:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"Response too large: {content_length} bytes (max: {MAX_RESPONSE_SIZE})",
+                    )
 
-            # Read response body (Issue #315 - uses helper)
-            body = None if method.upper() == "HEAD" else await _read_response_body_chunked(response)
-            json_response = _try_parse_json(body)
+                # Read response body (Issue #315 - uses helper)
+                body = None if method.upper() == "HEAD" else await _read_response_body_chunked(response)
+                json_response = _try_parse_json(body)
 
-            # Build response (Issue #665: uses extracted helper)
-            return _build_http_response(response, method, body, json_response)
+                # Build response (Issue #665: uses extracted helper)
+                return _build_http_response(response, method, body, json_response)
 
     except asyncio.TimeoutError:
         logger.error("HTTP request timed out after %s seconds: %s", timeout, url)

--- a/autobot-backend/api/vnc_proxy.py
+++ b/autobot-backend/api/vnc_proxy.py
@@ -412,14 +412,17 @@ async def websocket_proxy(websocket: WebSocket, vnc_type: str):
 
     try:
         http_client = get_http_client()
-        session = await http_client.get_session()
-        async with session.ws_connect(ws_url) as vnc_ws:
-            # Run both forwarding tasks concurrently using extracted helpers (Issue #315)
-            await asyncio.gather(
-                _forward_client_to_vnc(websocket, vnc_ws, vnc_type),
-                _forward_vnc_to_client(websocket, vnc_ws, vnc_type),
-                return_exceptions=True,
-            )
+        # Issue #12119: tracked_session() keeps this VNC WebSocket counted as an
+        # in-flight request for its full (potentially hours-long) lifetime, so a
+        # concurrent pool resize defers recreation instead of closing it mid-stream.
+        async with http_client.tracked_session() as session:
+            async with session.ws_connect(ws_url) as vnc_ws:
+                # Run both forwarding tasks concurrently using extracted helpers (Issue #315)
+                await asyncio.gather(
+                    _forward_client_to_vnc(websocket, vnc_ws, vnc_type),
+                    _forward_vnc_to_client(websocket, vnc_ws, vnc_type),
+                    return_exceptions=True,
+                )
 
     except aiohttp.ClientError as e:
         logger.error("[%s] Failed to connect to VNC WebSocket: %s", vnc_type, e)

--- a/autobot-backend/llm_shared/providers/ollama.py
+++ b/autobot-backend/llm_shared/providers/ollama.py
@@ -72,9 +72,14 @@ class OllamaProvider:
 
     @asynccontextmanager
     async def _get_session(self) -> AsyncGenerator[aiohttp.ClientSession, None]:
-        """Get HTTP session using singleton HTTPClient."""
-        session = await self._http_client.get_session()
-        yield session
+        """Get HTTP session using singleton HTTPClient.
+
+        Issue #12119: delegates to ``tracked_session()`` so hot LLM streaming
+        requests count as in-flight and a concurrent pool resize cannot close
+        the shared session mid-stream.
+        """
+        async with self._http_client.tracked_session() as session:
+            yield session
 
     def get_host_from_env(self) -> str:
         """

--- a/autobot-backend/llm_shared/providers/ollama_test.py
+++ b/autobot-backend/llm_shared/providers/ollama_test.py
@@ -9,8 +9,9 @@ GH#7911
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from autobot_shared.http_client import get_http_client
 from llm_shared.models import LLMRequest, LLMSettings, ToolCall, ToolDefinition
 from llm_shared.providers.ollama import OllamaProvider, _model_supports_tools
 
@@ -273,3 +274,30 @@ class TestPrepareCharRequestToolAwareness:
 
         assert data["format"] == "json"
         assert "tools" not in data
+
+
+# ---------------------------------------------------------------------------
+# Session tracking — _get_session() must delegate to tracked_session() (#12119)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionTracking:
+    """OllamaProvider._get_session() participates in HTTPClientManager
+    active-request tracking so a concurrent pool resize cannot close the shared
+    session mid-stream (#12119). Uses the real singleton (only ``get_session``
+    patched) so the true ``tracked_session()`` increment/decrement path runs.
+    """
+
+    async def test_get_session_delegates_to_tracked_session(self):
+        provider = _make_provider()
+        manager = get_http_client()
+        provider._http_client = manager
+        sentinel = MagicMock(closed=False)
+        baseline = manager._active_requests
+
+        with patch.object(manager, "get_session", new=AsyncMock(return_value=sentinel)):
+            async with provider._get_session() as session:
+                assert session is sentinel
+                assert manager._active_requests == baseline + 1
+
+        assert manager._active_requests == baseline, "counter must return to baseline after the CM exits"

--- a/autobot-backend/utils/ollama_connection_pool.py
+++ b/autobot-backend/utils/ollama_connection_pool.py
@@ -222,15 +222,18 @@ class OllamaConnectionPool:
             logger.debug("[%s] Acquired connection (waited %.2fs)", request_id, wait_time)
 
             http_client = get_http_client()
-            session = await http_client.get_session()
-            execution_start = time.time()
+            # Issue #12119: tracked_session() so the borrowed session counts as
+            # in-flight for the yield's duration; a concurrent pool resize defers
+            # recreation until the connection slot is returned.
+            async with http_client.tracked_session() as session:
+                execution_start = time.time()
 
-            try:
-                yield session
-                await self._record_execution_success(request_id, time.time() - execution_start)
-            except Exception as e:
-                await self._record_execution_failure(request_id, e)
-                raise
+                try:
+                    yield session
+                    await self._record_execution_success(request_id, time.time() - execution_start)
+                except Exception as e:
+                    await self._record_execution_failure(request_id, e)
+                    raise
 
         except asyncio.TimeoutError:
             await self._handle_queue_timeout(request_id)

--- a/autobot-backend/utils/ollama_connection_pool_test.py
+++ b/autobot-backend/utils/ollama_connection_pool_test.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for OllamaConnectionPool session tracking (#12119).
+
+acquire_connection() borrows the shared HTTPClientManager session via
+tracked_session(), so an in-flight pooled request keeps the active-request
+counter above zero and a concurrent pool resize defers recreation instead of
+closing the session mid-request.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from autobot_shared.http_client import get_http_client
+from utils.ollama_connection_pool import OllamaConnectionPool
+
+
+class TestAcquireConnectionSessionTracking:
+    async def test_acquire_connection_delegates_to_tracked_session(self):
+        """acquire_connection() yields the shared session through tracked_session()
+        so the active-request counter is incremented for the borrow's duration and
+        restored afterwards (real singleton, only ``get_session`` patched)."""
+        pool = OllamaConnectionPool()
+        manager = get_http_client()
+        sentinel = MagicMock(closed=False)
+        baseline = manager._active_requests
+
+        with patch.object(manager, "get_session", new=AsyncMock(return_value=sentinel)):
+            async with pool.acquire_connection() as session:
+                assert session is sentinel
+                assert manager._active_requests == baseline + 1
+
+        assert manager._active_requests == baseline, "counter must return to baseline after release"


### PR DESCRIPTION
## Thinking Path
Follow-up to #11656. Raw `HTTPClientManager.get_session()` callers bypass `_active_requests` tracking, so the deferred pool-recreation guard (`_handle_pool_recreation`, which closes the shared session when `_active_requests == 0`) can close their session mid-flight. Migrated the four remaining sites to `tracked_session()`; left the private self-owned `aiohttp.ClientSession` implementations untouched (they don't use HTTPClientManager).

## What Changed
- **`api/vnc_proxy.py` (highest severity)** — the long-lived VNC WebSocket now runs inside `async with http_client.tracked_session()`, so it stays counted in-flight for its full (hours-long) lifetime and a concurrent pool resize defers recreation instead of dropping it mid-stream.
- **`llm_shared/providers/ollama.py`** — `_get_session()` delegates to `tracked_session()` (hot LLM streaming path).
- **`utils/ollama_connection_pool.py`** — `acquire_connection()` borrows the shared session via `tracked_session()`, nested inside its existing semaphore machinery.
- **`api/http_client_mcp.py`** — the MCP HTTP execution is wrapped in `tracked_session()`.

## Verification
- `py_compile` clean on all four sites.
- Grep audit: **0** raw `get_session()` calls remain across the four files; repo-wide audit finds no other HTTPClientManager `get_session` callers.
- New delegation tests (patch only `get_session` on the real singleton, exercise the true `tracked_session()` increment/decrement):
  - `ollama_test.py::TestSessionTracking` and `ollama_connection_pool_test.py` — assert `_active_requests` is +1 during the borrow and back to baseline after. **2 passed.**
  - Inline sites (vnc_proxy, http_client_mcp) are covered by the central `http_client_test.py::test_tracked_session_defers_pool_recreation_while_in_flight`.

## Model Used
Opus 4.8

Closes #12119