### PR TITLE
fix(backend): LLC relation N+1 + terminal tool-output size cap (#11686, #11543)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -52,7 +52,7 @@ from ..models.enums import (
     WorkItemStatus,
     WorkItemType,
 )
-from ..models.work_item import LLCWorkItemComment
+from ..models.work_item import LLCWorkItem, LLCWorkItemComment
 from ..scheduler.heartbeat_scheduler import HeartbeatScheduler
 from ..services.activity_log import ActivityLogQuery, LLCActivityLogService
 from ..services.attachment_service import (
@@ -306,7 +306,7 @@ def _coworker_display(item: Any) -> Optional[Dict[str, Any]]:
     return None
 
 
-async def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
+async def _relations_to_list(item: Any, session: AsyncSession) -> List[Dict[str, Any]]:
     """Serialize outgoing relations for the response (GH#8252).
 
     #11684: use ``awaitable_attrs`` so relationship access is async-safe. Items
@@ -316,14 +316,33 @@ async def _relations_to_list(item: Any) -> List[Dict[str, Any]]:
     not-yet-loaded relationship raises ``MissingGreenlet`` (sync IO in an async
     context) → the endpoint 500s even though the row exists. ``awaitable_attrs``
     returns the cached value when already loaded and awaits a load otherwise, so
-    every path serializes correctly. (``outgoing_relations`` is ``lazy=selectin``;
-    each relation's ``target`` is lazy=select — an N+1 when an item has many
-    relations, tracked as a fast-follow.)
+    every path serializes correctly.
+
+    #11686: fetch the referenced targets' three serialized columns
+    (``identifier``/``title``/``status``) in a single bulk query keyed by
+    ``target_id`` instead of lazy-loading each ``rel.target`` (N+1). Selecting
+    columns rather than the ``LLCWorkItem`` entity also avoids eager-loading each
+    target's ``children``/``comments``/``work_products``/relations subtree (all
+    ``lazy=selectin``) — only the fields actually serialized are read.
     """
-    rows = []
     outgoing = await item.awaitable_attrs.outgoing_relations
-    for rel in outgoing or []:
-        tgt = await rel.awaitable_attrs.target
+    if not outgoing:
+        return []
+
+    target_ids = {rel.target_id for rel in outgoing}
+    result = await session.execute(
+        select(
+            LLCWorkItem.id,
+            LLCWorkItem.identifier,
+            LLCWorkItem.title,
+            LLCWorkItem.status,
+        ).where(LLCWorkItem.id.in_(target_ids))
+    )
+    targets = {row.id: row for row in result}
+
+    rows = []
+    for rel in outgoing:
+        tgt = targets.get(rel.target_id)
         rows.append(
             {
                 "id": str(rel.id),
@@ -378,7 +397,7 @@ async def _item_to_dict(item: Any, session: AsyncSession) -> Dict[str, Any]:
         "has_human_handoff_context": bool(getattr(item, "review_brief", None)),
         "created_at": item.created_at.isoformat() if item.created_at else None,
         "updated_at": item.updated_at.isoformat() if item.updated_at else None,
-        "relations": await _relations_to_list(item),
+        "relations": await _relations_to_list(item, session),
     }
 
 

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -257,6 +257,9 @@ class LLCWorkItemRelation(Base):
         "LLCWorkItem",
         foreign_keys=[target_id],
         back_populates="incoming_relations",
+        # Issue #11686: batch-load targets to avoid an N+1 when serializing an
+        # item's outgoing relations (_relations_to_list reads each rel.target).
+        lazy="selectin",
     )
 
     __table_args__ = (

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -257,9 +257,6 @@ class LLCWorkItemRelation(Base):
         "LLCWorkItem",
         foreign_keys=[target_id],
         back_populates="incoming_relations",
-        # Issue #11686: batch-load targets to avoid an N+1 when serializing an
-        # item's outgoing relations (_relations_to_list reads each rel.target).
-        lazy="selectin",
     )
 
     __table_args__ = (

--- a/autobot-backend/llc/tests/test_work_item_relations_async.py
+++ b/autobot-backend/llc/tests/test_work_item_relations_async.py
@@ -29,23 +29,33 @@ class _Awaitable:
         return _coro()
 
 
-def _rel(rid, target):
-    return SimpleNamespace(
-        id=rid,
-        relation_type="blocks",
-        target_id="t-1",
-        awaitable_attrs=_Awaitable(target=target),
-    )
+def _rel(rid, target_id="t-1"):
+    return SimpleNamespace(id=rid, relation_type="blocks", target_id=target_id)
+
+
+class _FakeSession:
+    """Session whose execute() returns the given target column-rows (#11686:
+    _relations_to_list bulk-fetches target identifier/title/status by id)."""
+
+    def __init__(self, *target_rows):
+        self._rows = list(target_rows)
+
+    async def execute(self, *_args, **_kwargs):
+        return list(self._rows)
+
+
+def _target_row(tid, identifier, title, status):
+    return SimpleNamespace(id=tid, identifier=identifier, title=title, status=status)
 
 
 @pytest.mark.asyncio
-async def test_relations_to_list_awaits_unloaded_relationship():
+async def test_relations_to_list_serializes_target_fields():
     from llc.api import work_items
 
-    tgt = SimpleNamespace(identifier="MVT-9", title="Target", status="open")
-    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[_rel("r-1", tgt)]))
+    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[_rel("r-1")]))
+    session = _FakeSession(_target_row("t-1", "MVT-9", "Target", "open"))
 
-    rows = await work_items._relations_to_list(item)
+    rows = await work_items._relations_to_list(item, session)
 
     assert rows == [
         {
@@ -62,20 +72,20 @@ async def test_relations_to_list_awaits_unloaded_relationship():
 @pytest.mark.asyncio
 async def test_relations_to_list_empty_for_freshly_created_item():
     # The create path: a brand-new item has no relations — must return [] without
-    # a MissingGreenlet.
+    # a MissingGreenlet and without hitting the database.
     from llc.api import work_items
 
     item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[]))
-    assert await work_items._relations_to_list(item) == []
+    assert await work_items._relations_to_list(item, _FakeSession()) == []
 
 
 @pytest.mark.asyncio
 async def test_relations_to_list_handles_null_target():
-    # A relation whose target could not be resolved serializes None fields, not a crash.
+    # A relation whose target row is missing serializes None fields, not a crash.
     from llc.api import work_items
 
-    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[_rel("r-2", None)]))
-    rows = await work_items._relations_to_list(item)
+    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=[_rel("r-2")]))
+    rows = await work_items._relations_to_list(item, _FakeSession())  # no target rows
     assert rows == [
         {
             "id": "r-2",
@@ -86,3 +96,29 @@ async def test_relations_to_list_handles_null_target():
             "target_status": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_relations_to_list_single_query_for_many_relations():
+    # #11686: N relations resolve their targets in ONE bulk query, not N (no N+1).
+    from llc.api import work_items
+
+    rels = [_rel(f"r-{i}", target_id=f"t-{i}") for i in range(5)]
+    item = SimpleNamespace(awaitable_attrs=_Awaitable(outgoing_relations=rels))
+
+    class _CountingSession(_FakeSession):
+        def __init__(self, *rows):
+            super().__init__(*rows)
+            self.execute_calls = 0
+
+        async def execute(self, *a, **k):
+            self.execute_calls += 1
+            return await super().execute(*a, **k)
+
+    session = _CountingSession(*[_target_row(f"t-{i}", f"MVT-{i}", f"T{i}", "open") for i in range(5)])
+
+    rows = await work_items._relations_to_list(item, session)
+
+    assert len(rows) == 5
+    assert session.execute_calls == 1, "targets must be batch-fetched in a single query"
+    assert rows[3]["target_identifier"] == "MVT-3"

--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -272,26 +272,31 @@ def tee_and_hint(raw: str, slug: str, exit_code: int, mode: str = "failures") ->
         return None
 
 
-def cap_unmatched_output(command: str, output: str, exit_code: int) -> str:
-    """Enforce a hard character ceiling on output that matched no rule.
+def _hard_cap(command: str, text: str, raw: str, exit_code: int) -> str:
+    """Enforce the hard character ceiling on *text*, teeing *raw* for the full copy.
 
-    The rule pipeline shrinks output whose shape it recognises; anything it does
-    not recognise would otherwise reach conversation history at full length. This
-    is the last-resort ceiling — keep the start and end (where errors and
-    summaries usually sit), drop the middle, and leave a pointer to the full
-    copy via the same tee mechanism the matched path uses.
+    Keep the start and end (where errors and summaries usually sit), drop the
+    middle, and leave a pointer to the full output saved via the same tee
+    mechanism the matched path uses. This is the terminal guard applied to both
+    the unmatched passthrough and matched-rule results (#11543) so no output can
+    reach conversation history above the ceiling, regardless of rule match.
     """
     limit = _MAX_UNMATCHED_OUTPUT_CHARS
-    if len(output) <= limit:
-        return output
+    if len(text) <= limit:
+        return text
 
     keep = limit // 2
-    dropped = len(output) - 2 * keep
-    capped = f"{output[:keep]}\n[... {dropped} chars omitted ...]\n{output[-keep:]}"
+    dropped = len(text) - 2 * keep
+    capped = f"{text[:keep]}\n[... {dropped} chars omitted ...]\n{text[-keep:]}"
 
     words = command.split()
-    hint = tee_and_hint(output, words[0] if words else "unknown", exit_code)
+    hint = tee_and_hint(raw, words[0] if words else "unknown", exit_code)
     return f"{capped}\n{hint}" if hint else capped
+
+
+def cap_unmatched_output(command: str, output: str, exit_code: int) -> str:
+    """Hard-cap output that matched no rule (delegates to :func:`_hard_cap`)."""
+    return _hard_cap(command, output, output, exit_code)
 
 
 def _line_similarity(a: str, b: str) -> float:
@@ -474,7 +479,10 @@ class ToolOutputFilter:
         except RuntimeError:
             pass
 
-        return filtered
+        # Issue #11543: terminal guard — a matched rule can still leave output
+        # above the ceiling (huge diff, hundreds of failures). Cap the final
+        # result regardless of match so nothing above the cap reaches history.
+        return _hard_cap(command, filtered, output, exit_code)
 
     def filter_blocks(self, output: str, handler: BlockHandler, exit_code: int = 0) -> str:
         """Filter structured block output using *handler* (ESLint, mypy, docker build, etc.)."""

--- a/autobot-backend/services/tool_output_filter_test.py
+++ b/autobot-backend/services/tool_output_filter_test.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for the ToolOutputFilter hard-size cap (#11543).
+
+No tool output may enter conversation history above the hard ceiling
+(``_MAX_UNMATCHED_OUTPUT_CHARS``), regardless of whether a filter rule matched.
+Oversized output is head/tail-truncated with a pointer to the teed full copy.
+"""
+
+from __future__ import annotations
+
+from services import tool_output_filter as tof
+from services.tool_output_filter import ToolOutputFilter, cap_unmatched_output
+
+_LIMIT = tof._MAX_UNMATCHED_OUTPUT_CHARS
+
+
+def _huge(n_chars: int) -> str:
+    # Distinct-ish content so the cap can't be mistaken for dedup.
+    return "\n".join(f"line {i} " + "x" * 40 for i in range(n_chars // 48))
+
+
+class TestHardSizeCap:
+    def test_unmatched_multi_mb_output_is_capped(self, tmp_path, monkeypatch):
+        """AC: an unmatched command's multi-MB output is capped below the ceiling
+        with a truncation marker and a pointer to the teed full output."""
+        monkeypatch.setattr(tof, "_TEE_DIR", tmp_path)
+        f = ToolOutputFilter()
+        big = _huge(3_000_000)  # ~3 MB, matches no rule
+        assert len(big) > _LIMIT
+
+        result = f.filter("some_unknown_command --flag", big, exit_code=0)
+
+        assert len(result) < _LIMIT + 500, "result must be bounded by the ceiling"
+        assert "chars omitted" in result
+        assert "full output saved" in result, "must point at the teed full copy"
+        # The full copy was actually written to the tee dir.
+        assert any(p.suffix == ".txt" for p in tmp_path.iterdir())
+
+    def test_matched_rule_output_above_cap_is_also_capped(self, tmp_path, monkeypatch):
+        """AC: cap applies *regardless of rule match* — a matched but near-passthrough
+        rule that leaves output above the ceiling is still hard-capped."""
+        monkeypatch.setattr(tof, "_TEE_DIR", tmp_path)
+        f = ToolOutputFilter()
+        # Inject a matching rule that only strips ANSI (passthrough for clean text).
+        f._rules = [{"match_command": "^bigcmd", "strip_ansi": True}]
+        big = _huge(3_000_000)
+
+        result = f.filter("bigcmd run", big, exit_code=0)
+
+        assert len(result) < _LIMIT + 500, "matched-rule output above cap must be capped too"
+        assert "chars omitted" in result
+
+    def test_output_below_cap_is_unchanged(self):
+        """Existing behavior: unmatched output below the ceiling passes through as-is."""
+        f = ToolOutputFilter()
+        small = "just a little output\nnothing special"
+        assert f.filter("some_unknown_command", small, exit_code=0) == small
+
+    def test_cap_unmatched_output_function(self, tmp_path, monkeypatch):
+        """Direct unit: cap_unmatched_output truncates and keeps head+tail."""
+        monkeypatch.setattr(tof, "_TEE_DIR", tmp_path)
+        big = "HEAD_MARKER\n" + _huge(_LIMIT * 3) + "\nTAIL_MARKER"
+
+        capped = cap_unmatched_output("weird_cmd", big, 0)
+
+        assert len(capped) < _LIMIT + 500
+        assert capped.startswith("HEAD_MARKER")
+        assert "TAIL_MARKER" in capped
+        assert "chars omitted" in capped
+
+    def test_cap_unmatched_output_noop_below_limit(self):
+        """Below the ceiling, cap_unmatched_output returns the output unchanged."""
+        small = "tiny"
+        assert cap_unmatched_output("weird_cmd", small, 0) == small


### PR DESCRIPTION
## Thinking Path
Two independent, low-risk backend fixes batched into one PR.

- **#11686** — `_relations_to_list` read each relation's `target` via lazy load → N+1 when an item has many outgoing relations.
- **#11543** — audit-first finding: the hard-size cap existed but was wired **only** on the unmatched branch; the AC requires capping *regardless of rule match*. No test file existed.

## What Changed
- **#11686** `llc/api/work_items.py`: `_relations_to_list` now **bulk-fetches only the three serialized target columns** (`identifier`/`title`/`status`) in one query keyed by `target_id`, killing the N+1 across all load paths (list/get/create all funnel through this one serializer). Selecting columns (not the `LLCWorkItem` entity) also avoids eager-loading each target's `children`/`comments`/`work_products`/relations subtree.
  - *Note:* an earlier revision used mapper-level `lazy=selectin` on `target`; code review showed that (and an equivalent query-level `selectinload`) over-fetches, because any **entity** load of `target` cascades into its own `selectin` children. The column-scoped bulk fetch is the only approach that fixes the N+1 without that cascade.
- **#11543** `services/tool_output_filter.py`: generalized `cap_unmatched_output` → `_hard_cap(command, text, raw, exit_code)` and applied it as a **terminal guard** on the matched-rule path in `filter()`, so no tool output enters chat history above the ceiling regardless of rule match. New `tool_output_filter_test.py`.

## Verification
- `py_compile` clean.
- `pytest services/tool_output_filter_test.py` → **5 passed**.
- `pytest llc/tests/test_work_item_relations_async.py llc/tests/test_work_item_relations.py` → **14 passed**, incl. a new `test_relations_to_list_single_query_for_many_relations` asserting targets resolve in exactly **one** `execute` call (no N+1).
- Independent code-review: no correctness issues; the over-fetch concern is addressed by this rework.

## Model Used
Opus 4.8

Closes #11686, #11543