### PR TITLE
refactor(advanced-control): direct enum-name lookup instead of hand-maintained maps (#12208)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -161,30 +161,19 @@ async def request_takeover(
 
     Issue #744: Requires admin authentication.
     """
-    # Convert string enum to TakeoverTrigger
-    trigger_mapping = {
-        "MANUAL_REQUEST": TakeoverTrigger.MANUAL_REQUEST,
-        "CRITICAL_ERROR": TakeoverTrigger.CRITICAL_ERROR,
-        "SECURITY_CONCERN": TakeoverTrigger.SECURITY_CONCERN,
-        "USER_INTERVENTION_REQUIRED": TakeoverTrigger.USER_INTERVENTION_REQUIRED,
-        "SYSTEM_OVERLOAD": TakeoverTrigger.SYSTEM_OVERLOAD,
-        "APPROVAL_REQUIRED": TakeoverTrigger.APPROVAL_REQUIRED,
-        "TIMEOUT_EXCEEDED": TakeoverTrigger.TIMEOUT_EXCEEDED,
-    }
+    # Convert request strings to enums via direct name lookup so each enum is the
+    # single source of truth (#12208 — the old hand-maintained maps mirrored every
+    # member by hand and silently dropped any new one, rejecting a valid trigger
+    # with a 400). Enum member names are the UPPER strings the client sends.
+    try:
+        trigger = TakeoverTrigger[request.trigger.upper()]
+    except KeyError:
+        raise HTTPException(status_code=400, detail=f"Invalid trigger: {request.trigger}") from None
 
-    trigger = trigger_mapping.get(request.trigger.upper())
-    if not trigger:
-        raise HTTPException(status_code=400, detail=f"Invalid trigger: {request.trigger}")
-
-    # Convert priority string to TaskPriority
-    priority_mapping = {
-        "LOW": TaskPriority.LOW,
-        "MEDIUM": TaskPriority.MEDIUM,
-        "HIGH": TaskPriority.HIGH,
-        "CRITICAL": TaskPriority.CRITICAL,
-    }
-
-    priority = priority_mapping.get(request.priority.upper(), TaskPriority.HIGH)
+    try:
+        priority = TaskPriority[request.priority.upper()]
+    except KeyError:
+        priority = TaskPriority.HIGH  # preserve current default-on-unknown behaviour
 
     request_id = await get_takeover_manager().request_takeover(
         trigger=trigger,

--- a/autobot-backend/tests/api/test_advanced_control_takeover_enum_12208.py
+++ b/autobot-backend/tests/api/test_advanced_control_takeover_enum_12208.py
@@ -1,0 +1,81 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for #12208.
+
+``request_takeover`` used two hand-maintained dicts to map request strings to
+``TakeoverTrigger`` / ``TaskPriority`` enums. Each dict was a manual mirror of
+its enum, so any member the dict forgot was silently unusable (a valid trigger
+rejected with 400; a valid priority defaulted to HIGH). The endpoint now uses
+direct ``Enum[name]`` lookups so the enum is the single source of truth.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.advanced_control import request_takeover
+from api.schemas_system import TakeoverRequest
+from memory import TaskPriority
+from takeover_manager import TakeoverTrigger
+
+
+def _req(trigger: str, priority: str = "HIGH") -> TakeoverRequest:
+    return TakeoverRequest(trigger=trigger, reason="r", priority=priority, affected_tasks=[])
+
+
+async def _call(req: TakeoverRequest):
+    manager = MagicMock()
+    manager.request_takeover = AsyncMock(return_value="req-123")
+    with patch("api.advanced_control.get_takeover_manager", return_value=manager):
+        result = await request_takeover(req, admin_check=True)
+    return result, manager.request_takeover
+
+
+@pytest.mark.asyncio
+async def test_valid_trigger_and_priority_map_to_enums():
+    result, called = await _call(_req("MANUAL_REQUEST", "CRITICAL"))
+    assert result["success"] is True
+    kwargs = called.call_args.kwargs
+    assert kwargs["trigger"] is TakeoverTrigger.MANUAL_REQUEST
+    assert kwargs["priority"] is TaskPriority.CRITICAL
+
+
+@pytest.mark.asyncio
+async def test_trigger_lookup_is_case_insensitive():
+    _result, called = await _call(_req("security_concern", "low"))
+    assert called.call_args.kwargs["trigger"] is TakeoverTrigger.SECURITY_CONCERN
+    assert called.call_args.kwargs["priority"] is TaskPriority.LOW
+
+
+@pytest.mark.asyncio
+async def test_invalid_trigger_raises_400():
+    with pytest.raises(HTTPException) as exc:
+        await _call(_req("NOT_A_TRIGGER"))
+    assert exc.value.status_code == 400
+    assert "NOT_A_TRIGGER" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_unknown_priority_defaults_to_high():
+    _result, called = await _call(_req("MANUAL_REQUEST", "BOGUS"))
+    assert called.call_args.kwargs["priority"] is TaskPriority.HIGH
+
+
+@pytest.mark.asyncio
+async def test_priority_member_absent_from_old_map_now_resolves():
+    # NORMAL is a real TaskPriority member the old hand-map omitted -> it used to
+    # silently default to HIGH; the direct lookup now resolves it correctly.
+    _result, called = await _call(_req("MANUAL_REQUEST", "NORMAL"))
+    assert called.call_args.kwargs["priority"] is TaskPriority.NORMAL
+
+
+@pytest.mark.asyncio
+async def test_every_trigger_member_is_accepted():
+    # The whole point of #12208: the enum is the source of truth, so *every*
+    # member resolves without a hand-maintained map to keep in sync.
+    for member in TakeoverTrigger:
+        _result, called = await _call(_req(member.name))
+        assert called.call_args.kwargs["trigger"] is member


### PR DESCRIPTION
## Thinking Path
`request_takeover()` mapped request strings → `TakeoverTrigger`/`TaskPriority` with two dicts that re-listed every enum member by hand. That is a drift class: any member the dict forgets is silently unusable — a valid trigger rejected with 400, a valid priority defaulted to HIGH. (Confirmed live: `TaskPriority` actually has 6 members — the old priority map listed only 4, so NORMAL/URGENT silently defaulted to HIGH.)

## What Changed
- `api/advanced_control.py`: replaced both maps with direct `Enum[name.upper()]` lookups so each enum is the single source of truth. Invalid trigger → 400 (unchanged); unknown priority → HIGH default (unchanged). Enum member names are the UPPER strings the client sends.
- Behavior for the real client is unchanged: the frontend `TakeoverPriority` union is only LOW/MEDIUM/HIGH/CRITICAL, all of which mapped identically before/after. NORMAL/URGENT (previously silently → HIGH) now resolve correctly if sent via the API directly.

## Verification
- `pytest tests/api/test_advanced_control_takeover_enum_12208.py` → **6 passed**: valid mapping, case-insensitivity, invalid-trigger 400, unknown-priority→HIGH default, NORMAL-now-resolves (drift guard), and every-`TakeoverTrigger`-member accepted.
- Confirmed `with_error_handling` re-raises `HTTPException` (preserves the 400).

## Model Used
Opus 4.8

Closes #12208