### PR TITLE
refactor(memory): async task-write variants own the to_thread offload (#12185)

### DIFF
--- a/autobot-backend/api/task_memory.py
+++ b/autobot-backend/api/task_memory.py
@@ -156,8 +156,7 @@ async def create_task(request: TaskCreateRequest):
         except ValueError:
             raise HTTPException(status_code=400, detail=f"Invalid priority: {request.priority}")
 
-        task_id = await asyncio.to_thread(
-            memory_manager.create_task_record,
+        task_id = await memory_manager.acreate_task_record(
             request.task_name,
             request.description,
             priority=priority_enum,
@@ -199,12 +198,11 @@ async def update_task(task_id: str, request: TaskUpdateRequest):
                 raise HTTPException(status_code=400, detail=f"Invalid status: {request.status}")
 
             if status_enum == TaskStatus.IN_PROGRESS:
-                success = await asyncio.to_thread(memory_manager.start_task, task_id)
+                success = await memory_manager.astart_task(task_id)
             elif status_enum == TaskStatus.COMPLETED:
-                success = await asyncio.to_thread(memory_manager.complete_task, task_id, request.outputs)
+                success = await memory_manager.acomplete_task(task_id, request.outputs)
             elif status_enum == TaskStatus.FAILED:
-                success = await asyncio.to_thread(
-                    memory_manager.fail_task,
+                success = await memory_manager.afail_task(
                     task_id,
                     request.error_message or "Unknown error",
                 )

--- a/autobot-backend/context_aware_decision/system.py
+++ b/autobot-backend/context_aware_decision/system.py
@@ -98,14 +98,15 @@ class ContextAwareDecisionSystem:
         if len(self.decision_history) > self.max_history:
             self.decision_history = self.decision_history[-self.max_history :]
 
-    def _record_decision_in_memory(self, decision: Decision, context: DecisionContext) -> None:
-        """Create, start, and complete the decision's task record (sync).
+    async def _record_decision_in_memory(self, decision: Decision, context: DecisionContext) -> None:
+        """Create, start, and complete the decision's task record.
 
-        Issue #12101: extracted so ``_store_decision_in_memory`` can offload
-        the create->start->complete sequence via a single asyncio.to_thread
-        call instead of three separate event-loop-blocking sync calls.
+        Issue #12101: extracted so ``_store_decision_in_memory`` records the
+        create->start->complete sequence off the event loop.
+        Issue #12185: uses the MemoryManager async task-write variants, which own
+        the sync-SQLite offload internally (no inline asyncio.to_thread needed).
         """
-        task_id = self.memory_manager.create_task_record(
+        task_id = await self.memory_manager.acreate_task_record(
             task_name=f"Decision: {decision.decision_type.value}",
             description=(f"Contextual decision making: " f"{decision.chosen_action.get('action', 'unknown')}"),
             priority=TaskPriority.MEDIUM,
@@ -126,8 +127,8 @@ class ContextAwareDecisionSystem:
             },
         )
 
-        self.memory_manager.start_task(task_id)
-        self.memory_manager.complete_task(
+        await self.memory_manager.astart_task(task_id)
+        await self.memory_manager.acomplete_task(
             task_id,
             outputs={
                 "chosen_action": decision.chosen_action,
@@ -139,11 +140,11 @@ class ContextAwareDecisionSystem:
     async def _store_decision_in_memory(self, decision: Decision, context: DecisionContext) -> None:
         """Store decision and context in enhanced memory system.
 
-        Issue #12101: offloads the sync SQLite MemoryManager writes to a
-        worker thread so they never block the event loop.
+        Issue #12185: the create->start->complete sequence uses the MemoryManager
+        async task-write variants, which own the sync-SQLite offload.
         """
         try:
-            await asyncio.to_thread(self._record_decision_in_memory, decision, context)
+            await self._record_decision_in_memory(decision, context)
         except Exception as e:
             logger.error("Failed to store decision in memory: %s", e)
 

--- a/autobot-backend/context_aware_decision/system.py
+++ b/autobot-backend/context_aware_decision/system.py
@@ -11,7 +11,6 @@ Coordinates context collection and decision making.
 Part of Issue #381 - God Class Refactoring
 """
 
-import asyncio
 from dataclasses import asdict
 from typing import Any, Dict, List
 

--- a/autobot-backend/context_aware_decision/tests/test_system_async_offload.py
+++ b/autobot-backend/context_aware_decision/tests/test_system_async_offload.py
@@ -3,17 +3,16 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Tests for async-path MemoryManager offloading in ContextAwareDecisionSystem
-(#12101).
+Tests for async-path MemoryManager offloading in ContextAwareDecisionSystem.
 
-``MemoryManager.create_task_record/start_task/complete_task`` are sync
-SQLite writes. ``_store_decision_in_memory`` is an async method called on
-the event loop, so the create->start->complete sequence must be offloaded
-via a single ``asyncio.to_thread`` call rather than calling the sync
-MemoryManager methods directly.
+``MemoryManager`` task-write methods are sync SQLite writes that block the
+event loop (#12101). Issue #12185 moved the offload into the MemoryManager
+async task-write variants; ``_store_decision_in_memory`` now awaits those
+variants (``acreate_task_record`` / ``astart_task`` / ``acomplete_task``)
+rather than wrapping the sync methods in an inline ``asyncio.to_thread`` call.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -57,41 +56,40 @@ def _make_context() -> DecisionContext:
     )
 
 
-@pytest.mark.asyncio
-async def test_store_decision_offloads_memory_writes_to_thread():
-    """_store_decision_in_memory must offload the create->start->complete
-    sequence via asyncio.to_thread instead of blocking the event loop."""
-    memory_manager = MagicMock()
-    memory_manager.create_task_record.return_value = "task-1"
-    system = ContextAwareDecisionSystem(memory_manager=memory_manager)
-
-    decision = _make_decision()
-    context = _make_context()
-
-    with patch("context_aware_decision.system.asyncio.to_thread") as mock_to_thread:
-
-        async def _immediate(func, *args, **kwargs):
-            return func(*args, **kwargs)
-
-        mock_to_thread.side_effect = _immediate
-
-        await system._store_decision_in_memory(decision, context)
-
-    mock_to_thread.assert_called_once()
-    assert mock_to_thread.call_args.args[0] == system._record_decision_in_memory
-    memory_manager.create_task_record.assert_called_once()
-    memory_manager.start_task.assert_called_once_with("task-1")
-    memory_manager.complete_task.assert_called_once()
+def _memory_manager_with_async_writes() -> MagicMock:
+    mm = MagicMock()
+    mm.acreate_task_record = AsyncMock(return_value="task-1")
+    mm.astart_task = AsyncMock(return_value=True)
+    mm.acomplete_task = AsyncMock(return_value=True)
+    return mm
 
 
 @pytest.mark.asyncio
-async def test_store_decision_swallows_errors_without_blocking():
-    """Errors during the offloaded write are logged, not raised (matches
-    prior behavior of the inline try/except)."""
-    memory_manager = MagicMock()
-    memory_manager.create_task_record.side_effect = RuntimeError("db locked")
+async def test_store_decision_uses_async_task_write_variants():
+    """_store_decision_in_memory must await the create->start->complete sequence
+    through the async task-write variants (which own the offload), never the
+    loop-blocking sync methods directly."""
+    memory_manager = _memory_manager_with_async_writes()
     system = ContextAwareDecisionSystem(memory_manager=memory_manager)
 
     await system._store_decision_in_memory(_make_decision(), _make_context())
 
-    memory_manager.create_task_record.assert_called_once()
+    memory_manager.acreate_task_record.assert_awaited_once()
+    memory_manager.astart_task.assert_awaited_once_with("task-1")
+    memory_manager.acomplete_task.assert_awaited_once()
+    # The sync (loop-blocking) methods must never be called directly.
+    memory_manager.create_task_record.assert_not_called()
+    memory_manager.start_task.assert_not_called()
+    memory_manager.complete_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_store_decision_swallows_errors_without_blocking():
+    """Errors during the write are logged, not raised (inline try/except)."""
+    memory_manager = _memory_manager_with_async_writes()
+    memory_manager.acreate_task_record = AsyncMock(side_effect=RuntimeError("db locked"))
+    system = ContextAwareDecisionSystem(memory_manager=memory_manager)
+
+    await system._store_decision_in_memory(_make_decision(), _make_context())
+
+    memory_manager.acreate_task_record.assert_awaited_once()

--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -754,6 +754,51 @@ class MemoryManager:
             logger.warning("Task not found for failure: %s", task_id)
         return result
 
+    # ------------------------------------------------------------------
+    # Async task-write variants (#12185)
+    #
+    # The sync task-write methods above perform blocking SQLite I/O and must
+    # never run on the event loop. Rather than have every async caller remember
+    # to wrap them in ``asyncio.to_thread(...)`` (8 hand-rolled sites across 4
+    # files — a forgotten one silently reintroduces the #11679/#11680/#12101
+    # event-loop block), these variants own the offload internally. Async code
+    # calls ``await manager.a<method>(...)`` and cannot forget it.
+    # ------------------------------------------------------------------
+
+    async def acreate_task_record(
+        self,
+        task_name: str,
+        description: str,
+        priority: "TaskPriority | None" = None,
+        agent_type: str | None = None,
+        inputs: Dict | None = None,
+        parent_task_id: str | None = None,
+        metadata: Dict | None = None,
+    ) -> str:
+        """Async variant of :meth:`create_task_record` (offloads the sync write)."""
+        return await asyncio.to_thread(
+            self.create_task_record,
+            task_name,
+            description,
+            priority,
+            agent_type,
+            inputs,
+            parent_task_id,
+            metadata,
+        )
+
+    async def astart_task(self, task_id: str) -> bool:
+        """Async variant of :meth:`start_task` (offloads the sync write)."""
+        return await asyncio.to_thread(self.start_task, task_id)
+
+    async def acomplete_task(self, task_id: str, outputs: Dict | None = None, status=None) -> bool:
+        """Async variant of :meth:`complete_task` (offloads the sync write)."""
+        return await asyncio.to_thread(self.complete_task, task_id, outputs, status)
+
+    async def afail_task(self, task_id: str, error_message: str, retry_count: int = 0) -> bool:
+        """Async variant of :meth:`fail_task` (offloads the sync write)."""
+        return await asyncio.to_thread(self.fail_task, task_id, error_message, retry_count)
+
     def add_markdown_reference(
         self,
         task_id: str,

--- a/autobot-backend/memory/manager_async_task_write_test.py
+++ b/autobot-backend/memory/manager_async_task_write_test.py
@@ -1,0 +1,62 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the MemoryManager async task-write variants (#12185).
+
+The sync task-write methods perform blocking SQLite I/O. The async variants
+(``acreate_task_record`` / ``astart_task`` / ``acomplete_task`` /
+``afail_task``) own the ``asyncio.to_thread`` offload internally so async
+callers never block the event loop and can't forget the offload. These tests
+verify each variant offloads to and delegates to its sync counterpart with the
+forwarded arguments — without touching the database (``__new__`` bypasses
+``__init__``; the sync methods are stubbed and executed through the real
+``asyncio.to_thread``).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from memory.manager import MemoryManager
+
+
+def _manager_with_stubbed_sync_writes() -> MemoryManager:
+    mgr = MemoryManager.__new__(MemoryManager)  # bypass __init__ (no DB)
+    mgr.create_task_record = MagicMock(return_value="tid")
+    mgr.start_task = MagicMock(return_value=True)
+    mgr.complete_task = MagicMock(return_value=True)
+    mgr.fail_task = MagicMock(return_value=True)
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_acreate_task_record_offloads_and_delegates():
+    mgr = _manager_with_stubbed_sync_writes()
+    task_id = await mgr.acreate_task_record("name", "desc", agent_type="a")
+    assert task_id == "tid"
+    mgr.create_task_record.assert_called_once()
+    args = mgr.create_task_record.call_args.args
+    assert args[0] == "name" and args[1] == "desc"
+
+
+@pytest.mark.asyncio
+async def test_astart_task_offloads_and_delegates():
+    mgr = _manager_with_stubbed_sync_writes()
+    assert await mgr.astart_task("tid") is True
+    mgr.start_task.assert_called_once_with("tid")
+
+
+@pytest.mark.asyncio
+async def test_acomplete_task_offloads_and_delegates():
+    mgr = _manager_with_stubbed_sync_writes()
+    assert await mgr.acomplete_task("tid", outputs={"x": 1}) is True
+    mgr.complete_task.assert_called_once_with("tid", {"x": 1}, None)
+
+
+@pytest.mark.asyncio
+async def test_afail_task_offloads_and_delegates():
+    mgr = _manager_with_stubbed_sync_writes()
+    assert await mgr.afail_task("tid", "boom") is True
+    mgr.fail_task.assert_called_once_with("tid", "boom", 0)

--- a/autobot-backend/takeover_manager.py
+++ b/autobot-backend/takeover_manager.py
@@ -676,7 +676,7 @@ class TakeoverManager:
             auto_approve=auto_approve or trigger in self.auto_approve_triggers,
         )
 
-    def _record_takeover_in_memory(
+    async def _record_takeover_in_memory(
         self,
         trigger: TakeoverTrigger,
         reason: str,
@@ -688,10 +688,10 @@ class TakeoverManager:
         Record takeover request in memory system.
 
         Issue #665: Extracted from request_takeover to reduce function length.
-        Issue #11680: Synchronous SQLite MemoryManager calls (called via
-        asyncio.to_thread by request_takeover) — must NOT be awaited directly.
+        Issue #12185: uses the MemoryManager async task-write variants, which own
+        the sync-SQLite offload internally (no inline asyncio.to_thread needed).
         """
-        task_id = self.memory_manager.create_task_record(
+        task_id = await self.memory_manager.acreate_task_record(
             task_name="Takeover Request",
             description=f"Human takeover requested: {reason}",
             priority=priority,
@@ -703,23 +703,24 @@ class TakeoverManager:
                 "requesting_agent": requesting_agent,
             },
         )
-        self.memory_manager.start_task(task_id)
+        await self.memory_manager.astart_task(task_id)
         return task_id
 
-    def _record_completion_in_memory(
+    async def _record_completion_in_memory(
         self,
         session_id: str,
         resolution: str,
         request: TakeoverRequest,
         completion_data: Dict[str, Any],
     ) -> None:
-        """Record takeover-session completion in memory system (sync).
+        """Record takeover-session completion in memory system.
 
-        Issue #11680: extracted so complete_takeover_session can offload the
-        create->start->complete sequence via a single asyncio.to_thread call
-        instead of three separate event-loop-blocking sync calls.
+        Issue #11680: extracted so complete_takeover_session records the
+        create->start->complete sequence off the event loop.
+        Issue #12185: uses the MemoryManager async task-write variants, which own
+        the sync-SQLite offload internally (no inline asyncio.to_thread needed).
         """
-        completion_task_id = self.memory_manager.create_task_record(
+        completion_task_id = await self.memory_manager.acreate_task_record(
             task_name="Takeover Session Completion",
             description=f"Takeover session completed: {resolution}",
             priority=request.priority,
@@ -727,8 +728,8 @@ class TakeoverManager:
             inputs={"session_id": session_id},
             metadata={"original_request": asdict(request)},
         )
-        self.memory_manager.start_task(completion_task_id)
-        self.memory_manager.complete_task(completion_task_id, outputs=completion_data)
+        await self.memory_manager.astart_task(completion_task_id)
+        await self.memory_manager.acomplete_task(completion_task_id, outputs=completion_data)
 
     def _is_critical_trigger(self, trigger: TakeoverTrigger) -> bool:
         """Check if trigger requires immediate task pause. Issue #620."""
@@ -781,10 +782,9 @@ class TakeoverManager:
             auto_approve,
         )
 
-        # Issue #11680: offload sync SQLite MemoryManager writes to a worker
-        # thread so they never block the event loop.
-        memory_task_id = await asyncio.to_thread(
-            self._record_takeover_in_memory, trigger, reason, priority, requesting_agent, affected_tasks
+        # Issue #12185: async task-write variants own the sync-SQLite offload.
+        memory_task_id = await self._record_takeover_in_memory(
+            trigger, reason, priority, requesting_agent, affected_tasks
         )
         await self._req_task_set(request_id, memory_task_id)
         # M3: pass per-request timeout so TTL matches the request's own expiry.
@@ -850,9 +850,8 @@ class TakeoverManager:
 
         task_id = await self._req_task_get(request_id)
         if task_id:
-            # Issue #11680: offload sync SQLite MemoryManager write.
-            await asyncio.to_thread(
-                self.memory_manager.complete_task,
+            # Issue #12185: async task-write variant owns the sync-SQLite offload.
+            await self.memory_manager.acomplete_task(
                 task_id,
                 outputs={
                     "session_id": session.session_id,
@@ -1080,11 +1079,8 @@ class TakeoverManager:
             "handback_notes": handback_notes,
         }
 
-        # Issue #11680: offload the create->start->complete sync SQLite
-        # MemoryManager sequence to a single worker-thread hop.
-        await asyncio.to_thread(
-            self._record_completion_in_memory, session_id, resolution, updated.request, completion_data
-        )
+        # Issue #12185: async task-write variants own the sync-SQLite offload.
+        await self._record_completion_in_memory(session_id, resolution, updated.request, completion_data)
 
         logger.info("Takeover session completed: %s - %s", session_id, resolution)
         await self._notify_state_change("session_completed", session_id)
@@ -1184,7 +1180,7 @@ class TakeoverManager:
         task_id = await self._req_task_get(request_id)
         if task_id:
             # Issue #11680: offload sync SQLite MemoryManager write.
-            await asyncio.to_thread(self.memory_manager.fail_task, task_id, "Takeover request expired")
+            await self.memory_manager.afail_task(task_id, "Takeover request expired")
             await self._req_task_delete(request_id)
 
         if existed:

--- a/autobot-backend/task_execution_tracker.py
+++ b/autobot-backend/task_execution_tracker.py
@@ -55,7 +55,7 @@ class TaskExecutionTracker:
 
         logger.info("Task Execution Tracker initialized")
 
-    def _create_and_start_task(
+    async def _create_and_start_task(
         self,
         task_name: str,
         description: str,
@@ -77,9 +77,10 @@ class TaskExecutionTracker:
             metadata: Additional metadata
 
         Returns:
-            Created task ID. Issue #620.
+            Created task ID. Issue #620. Issue #12185: uses the MemoryManager
+            async task-write variants, which own the sync-SQLite offload.
         """
-        task_id = self.memory_manager.create_task_record(
+        task_id = await self.memory_manager.acreate_task_record(
             task_name=task_name,
             description=description,
             priority=priority,
@@ -88,7 +89,7 @@ class TaskExecutionTracker:
             parent_task_id=parent_task_id,
             metadata=metadata,
         )
-        self.memory_manager.start_task(task_id)
+        await self.memory_manager.astart_task(task_id)
         return task_id
 
     def _register_active_task(
@@ -124,7 +125,7 @@ class TaskExecutionTracker:
         worker thread so it never blocks the event loop.
         """
         if task_id in self.active_tasks:
-            await asyncio.to_thread(self.memory_manager.complete_task, task_id, outputs=task_context.outputs)
+            await self.memory_manager.acomplete_task(task_id, outputs=task_context.outputs)
         self.active_tasks.pop(task_id, None)
         await self._execute_task_callbacks(task_id, "completed")
 
@@ -235,14 +236,13 @@ class TaskExecutionTracker:
                 result = await some_agent_operation()
                 return result
 
-        Issue #12101: the create->start sequence in ``_create_and_start_task``
-        performs sync SQLite MemoryManager writes, so it is offloaded to a
-        worker thread via a single asyncio.to_thread call to avoid blocking
-        the event loop while keeping the sequence atomic.
+        Issue #12185: the create->start sequence in ``_create_and_start_task``
+        performs sync SQLite MemoryManager writes; it now uses the async
+        task-write variants, which own the offload, instead of an inline
+        asyncio.to_thread wrapper.
         """
         # Create and start task (Issue #620: uses helper)
-        task_id = await asyncio.to_thread(
-            self._create_and_start_task,
+        task_id = await self._create_and_start_task(
             task_name,
             description,
             priority,
@@ -261,8 +261,8 @@ class TaskExecutionTracker:
 
         except Exception as e:
             logger.error("Task %s failed: %s", task_id, e)
-            # Issue #12101: offload sync SQLite MemoryManager write.
-            await asyncio.to_thread(self.memory_manager.fail_task, task_id, f"Task failed: {type(e).__name__}")
+            # Issue #12185: async task-write variant owns the sync-SQLite offload.
+            await self.memory_manager.afail_task(task_id, f"Task failed: {type(e).__name__}")
             self.active_tasks.pop(task_id, None)
             await self._execute_task_callbacks(task_id, "completed")
             raise

--- a/autobot-backend/task_execution_tracker_test.py
+++ b/autobot-backend/task_execution_tracker_test.py
@@ -3,98 +3,86 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Tests for async-path MemoryManager offloading in TaskExecutionTracker (#12101).
+Tests for async-path MemoryManager offloading in TaskExecutionTracker.
 
-Sync ``MemoryManager`` methods block the event loop when called directly
-from async code. These tests assert that the async paths (``track_task``
-and ``_finalize_task``) offload the writes via ``asyncio.to_thread`` instead
-of calling the sync MemoryManager methods directly on the loop.
+Sync ``MemoryManager`` task-write methods block the event loop when called
+directly from async code (#12101). Issue #12185 moved the offload into the
+MemoryManager async task-write variants (``acreate_task_record`` /
+``astart_task`` / ``acomplete_task`` / ``afail_task``), which own the
+``asyncio.to_thread`` hop internally. These tests assert the tracker's async
+paths (``track_task`` / ``_finalize_task``) use those async variants and never
+call the loop-blocking sync methods directly.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from task_execution_tracker import TaskExecutionTracker
+from task_execution_tracker import TaskExecutionContext, TaskExecutionTracker
 
 
 def _make_tracker() -> TaskExecutionTracker:
-    """Build a tracker with a mocked, synchronous MemoryManager."""
+    """Build a tracker with a mocked MemoryManager exposing async task-writes."""
     memory_manager = MagicMock()
-    memory_manager.create_task_record.return_value = "task-123"
+    memory_manager.acreate_task_record = AsyncMock(return_value="task-123")
+    memory_manager.astart_task = AsyncMock(return_value=True)
+    memory_manager.acomplete_task = AsyncMock(return_value=True)
+    memory_manager.afail_task = AsyncMock(return_value=True)
     return TaskExecutionTracker(memory_manager=memory_manager)
 
 
 @pytest.mark.asyncio
-async def test_track_task_offloads_create_and_start_to_thread():
-    """track_task's create+start sequence must go through asyncio.to_thread,
-    not call the sync MemoryManager methods directly on the event loop."""
+async def test_track_task_uses_async_task_write_variants():
+    """track_task's create+start+complete sequence must go through the async
+    task-write variants (which own the offload)."""
     tracker = _make_tracker()
 
     async with tracker.track_task("name", "desc") as task_context:
         task_context.set_outputs({"ok": True})
 
-    tracker.memory_manager.create_task_record.assert_called_once()
-    tracker.memory_manager.start_task.assert_called_once_with("task-123")
-    tracker.memory_manager.complete_task.assert_called_once()
+    tracker.memory_manager.acreate_task_record.assert_awaited_once()
+    tracker.memory_manager.astart_task.assert_awaited_once_with("task-123")
+    tracker.memory_manager.acomplete_task.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_track_task_offloads_fail_task_to_thread_on_exception():
-    """On exception, fail_task must be offloaded via asyncio.to_thread."""
+async def test_track_task_fails_via_async_variant_on_exception():
+    """On exception, afail_task must be awaited."""
     tracker = _make_tracker()
 
     with pytest.raises(RuntimeError):
         async with tracker.track_task("name", "desc"):
             raise RuntimeError("boom")
 
-    tracker.memory_manager.fail_task.assert_called_once()
-    assert tracker.memory_manager.fail_task.call_args.args[0] == "task-123"
+    tracker.memory_manager.afail_task.assert_awaited_once()
+    assert tracker.memory_manager.afail_task.await_args.args[0] == "task-123"
 
 
 @pytest.mark.asyncio
-async def test_track_task_uses_to_thread_not_direct_call():
-    """Explicitly assert asyncio.to_thread is the mechanism used to reach
-    the sync MemoryManager API, confirming the event loop is never blocked."""
+async def test_track_task_never_calls_sync_task_writes_directly():
+    """The loop-blocking sync task-write methods must never be called directly;
+    the async variants are used instead so the event loop is never blocked."""
     tracker = _make_tracker()
 
-    with patch("task_execution_tracker.asyncio.to_thread") as mock_to_thread:
-        mock_to_thread.return_value = "task-999"
+    async with tracker.track_task("name", "desc") as task_context:
+        task_context.set_outputs({"ok": True})
 
-        async def _immediate(func, *args, **kwargs):
-            return func(*args, **kwargs)
-
-        mock_to_thread.side_effect = _immediate
-
-        async with tracker.track_task("name", "desc") as task_context:
-            task_context.set_outputs({"ok": True})
-
-    assert mock_to_thread.call_count >= 1
-    called_funcs = [call.args[0] for call in mock_to_thread.call_args_list]
-    assert tracker._create_and_start_task in called_funcs
-    assert tracker.memory_manager.complete_task in called_funcs
+    tracker.memory_manager.create_task_record.assert_not_called()
+    tracker.memory_manager.start_task.assert_not_called()
+    tracker.memory_manager.complete_task.assert_not_called()
+    tracker.memory_manager.acreate_task_record.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_finalize_task_offloads_complete_task_to_thread():
-    """_finalize_task must offload the complete_task write via to_thread."""
+async def test_finalize_task_uses_acomplete_task():
+    """_finalize_task must await acomplete_task (not the sync complete_task)."""
     tracker = _make_tracker()
     tracker.active_tasks["task-123"] = {"task_name": "x", "agent_type": None, "inputs": None}
-
-    from task_execution_tracker import TaskExecutionContext
 
     task_context = TaskExecutionContext(tracker, "task-123")
     task_context.set_outputs({"result": "done"})
 
-    with patch("task_execution_tracker.asyncio.to_thread") as mock_to_thread:
+    await tracker._finalize_task("task-123", task_context)
 
-        async def _immediate(func, *args, **kwargs):
-            return func(*args, **kwargs)
-
-        mock_to_thread.side_effect = _immediate
-
-        await tracker._finalize_task("task-123", task_context)
-
-    mock_to_thread.assert_called_once()
-    assert mock_to_thread.call_args.args[0] == tracker.memory_manager.complete_task
-    tracker.memory_manager.complete_task.assert_called_once_with("task-123", outputs={"result": "done"})
+    tracker.memory_manager.acomplete_task.assert_awaited_once_with("task-123", outputs={"result": "done"})
+    tracker.memory_manager.complete_task.assert_not_called()


### PR DESCRIPTION
## Thinking Path
The #11680/#12101 async-correctness fixes stopped blocking the event loop by wrapping sync SQLite `MemoryManager` task-writes in `asyncio.to_thread(...)` — but that offload is hand-rolled at 8 sites across 4 files. `MemoryManager` exposes only sync methods (+ `_sync` variants); any async caller that forgets `to_thread` silently reintroduces the loop-block bug. Consolidate by giving `MemoryManager` async task-write variants that own the offload.

## What Changed
- **`memory/manager.py`**: added `acreate_task_record` / `astart_task` / `acomplete_task` / `afail_task` — each `await asyncio.to_thread(self.<sync>, ...)`. Sync API + `_sync` variants untouched.
- Migrated all async call sites to the variants (no inline `to_thread(...task-write...)` wrappers remain):
  - `takeover_manager.py`: `_record_takeover_in_memory` + `_record_completion_in_memory` are now `async` (create→start[→complete] via the variants); approve/expire direct sites.
  - `task_execution_tracker.py`: `_create_and_start_task` now `async`; `_finalize_task` complete + track-task fail path.
  - `context_aware_decision/system.py`: `_record_decision_in_memory` now `async`.
  - `api/task_memory.py`: create/start/complete/fail endpoints.
- Out of scope (left as-is): non-task-write `to_thread` calls (`add_markdown_reference`, `cleanup_old_data`, embedding-cache), per the issue's 4-method scope.

Note on the batched helpers: the create→start[→complete] sequences previously ran in one `to_thread` hop; they now issue one hop per variant. This is safe — the fresh `task_id` is not published to any other coroutine until the sequence completes, so there is no interleaving/atomicity concern.

## Verification
- `py_compile` clean; all 4 now-async helpers have exactly one caller each, all `await`ed.
- `pytest memory/manager_async_task_write_test.py task_execution_tracker_test.py context_aware_decision/tests/test_system_async_offload.py` → **10 passed**.
- New `manager_async_task_write_test.py` verifies each variant offloads + delegates with forwarded args; tracker/decision offload tests updated to assert the async variants are awaited and the sync methods are never called directly on the loop.

## Model Used
Opus 4.8

Closes #12185