### PR TITLE
fix(llc): wire company status transitions + add activate (#12211)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -233,13 +233,19 @@ class CompanyStatusTransitionRequest(BaseModel):
 async def activate_company(
     company_id: uuid.UUID,
     svc: CompanyService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> CompanyRead:
     """Transition a company to ACTIVE (from ONBOARDING or PAUSED).
 
     Issue #12211: this is the dedicated transition the CompanyUpdate schema
     defers to (``llc_status`` is intentionally not PATCH-able) — without it a
-    company was stuck in ONBOARDING forever.
+    company was stuck in ONBOARDING forever. Tenant access is enforced the same
+    way as ``get_org_chart``/``reorder_backlog``: the caller's org must match
+    *company_id* unless they are a platform admin.
     """
+    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     try:
         org = await svc.activate(company_id)
         await svc.session.commit()
@@ -260,8 +266,15 @@ async def suspend_company(
     company_id: uuid.UUID,
     body: Optional[CompanyStatusTransitionRequest] = None,
     svc: CompanyService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> CompanyRead:
-    """Transition a company to PAUSED (from ONBOARDING or ACTIVE). Issue #12211."""
+    """Transition a company to PAUSED (from ONBOARDING or ACTIVE). Issue #12211.
+
+    Tenant-scoped: caller's org must match *company_id* unless platform admin.
+    """
+    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     try:
         org = await svc.suspend(company_id, reason=body.reason if body else None)
         await svc.session.commit()
@@ -281,8 +294,15 @@ async def suspend_company(
 async def archive_company(
     company_id: uuid.UUID,
     svc: CompanyService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> CompanyRead:
-    """Transition a company to ARCHIVED (from PAUSED or OFFBOARDING). Issue #12211."""
+    """Transition a company to ARCHIVED (from PAUSED or OFFBOARDING). Issue #12211.
+
+    Tenant-scoped: caller's org must match *company_id* unless platform admin.
+    """
+    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     try:
         org = await svc.archive(company_id)
         await svc.session.commit()

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -223,6 +223,81 @@ async def delete_company(
         raise
 
 
+class CompanyStatusTransitionRequest(BaseModel):
+    """Optional payload for a status transition (e.g. a suspend reason)."""
+
+    reason: Optional[str] = None
+
+
+@router.post("/{company_id}/activate", response_model=CompanyRead)
+async def activate_company(
+    company_id: uuid.UUID,
+    svc: CompanyService = Depends(_get_service),
+) -> CompanyRead:
+    """Transition a company to ACTIVE (from ONBOARDING or PAUSED).
+
+    Issue #12211: this is the dedicated transition the CompanyUpdate schema
+    defers to (``llc_status`` is intentionally not PATCH-able) — without it a
+    company was stuck in ONBOARDING forever.
+    """
+    try:
+        org = await svc.activate(company_id)
+        await svc.session.commit()
+        return _to_read(org)
+    except CompanyNotFoundError:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
+    except ValueError as exc:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from None
+    except Exception:
+        await svc.session.rollback()
+        raise
+
+
+@router.post("/{company_id}/suspend", response_model=CompanyRead)
+async def suspend_company(
+    company_id: uuid.UUID,
+    body: Optional[CompanyStatusTransitionRequest] = None,
+    svc: CompanyService = Depends(_get_service),
+) -> CompanyRead:
+    """Transition a company to PAUSED (from ONBOARDING or ACTIVE). Issue #12211."""
+    try:
+        org = await svc.suspend(company_id, reason=body.reason if body else None)
+        await svc.session.commit()
+        return _to_read(org)
+    except CompanyNotFoundError:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
+    except ValueError as exc:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from None
+    except Exception:
+        await svc.session.rollback()
+        raise
+
+
+@router.post("/{company_id}/archive", response_model=CompanyRead)
+async def archive_company(
+    company_id: uuid.UUID,
+    svc: CompanyService = Depends(_get_service),
+) -> CompanyRead:
+    """Transition a company to ARCHIVED (from PAUSED or OFFBOARDING). Issue #12211."""
+    try:
+        org = await svc.archive(company_id)
+        await svc.session.commit()
+        return _to_read(org)
+    except CompanyNotFoundError:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
+    except ValueError as exc:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from None
+    except Exception:
+        await svc.session.rollback()
+        raise
+
+
 @router.get("/{company_id}/tree", response_model=CompanyTreeNode)
 async def get_company_tree(
     company_id: uuid.UUID,

--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -161,10 +161,34 @@ class CompanyService(LLCServiceBase):
     # Status transitions
     # ------------------------------------------------------------------
 
+    # Valid states from which activate() is allowed (ONBOARDING -> ACTIVE, or
+    # PAUSED -> ACTIVE as a resume). Issue #12211: without this, a company can
+    # never leave ONBOARDING.
+    _ACTIVATE_FROM: frozenset[str] = frozenset({LLCCompanyStatus.ONBOARDING.value, LLCCompanyStatus.PAUSED.value})
     # Valid states from which suspend() is allowed
     _SUSPEND_FROM: frozenset[str] = frozenset({LLCCompanyStatus.ONBOARDING.value, LLCCompanyStatus.ACTIVE.value})
     # Valid states from which archive() is allowed
     _ARCHIVE_FROM: frozenset[str] = frozenset({LLCCompanyStatus.PAUSED.value, LLCCompanyStatus.OFFBOARDING.value})
+
+    async def activate(self, company_id: uuid.UUID) -> Organization:
+        """Transition company to ACTIVE status.
+
+        Allowed from ONBOARDING (finish onboarding) or PAUSED (resume) — raises
+        ValueError otherwise. Clears any pause state so a resumed company is no
+        longer marked paused (#12211).
+        """
+        org = await self._get_or_404(company_id)
+        if org.llc_status not in self._ACTIVATE_FROM:
+            raise ValueError(
+                f"Cannot activate company in '{org.llc_status}' state "
+                f"(allowed from: {', '.join(sorted(self._ACTIVATE_FROM))})"
+            )
+        org.llc_status = LLCCompanyStatus.ACTIVE.value
+        org.pause_reason = None
+        org.paused_at = None
+        await self.session.flush()
+        logger.info("LLC company activated: %s (id=%s)", org.name, org.id)
+        return org
 
     async def suspend(self, company_id: uuid.UUID, reason: Optional[str] = None) -> Organization:
         """Transition company to PAUSED status.

--- a/autobot-backend/llc/tests/test_company.py
+++ b/autobot-backend/llc/tests/test_company.py
@@ -141,6 +141,40 @@ class TestCompanyStatusTransitions:
         assert result.llc_status == LLCCompanyStatus.ARCHIVED.value
 
     @pytest.mark.asyncio
+    async def test_activate_from_onboarding(self):
+        # Issue #12211: onboarding -> active is the transition that was missing.
+        org = _make_org(llc_status="onboarding")
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        result = await svc.activate(org.id)
+
+        assert result.llc_status == LLCCompanyStatus.ACTIVE.value
+
+    @pytest.mark.asyncio
+    async def test_activate_from_paused_clears_pause_state(self):
+        org = _make_org(llc_status="paused")
+        org.pause_reason = "was paused"
+        org.paused_at = datetime_now()
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        result = await svc.activate(org.id)
+
+        assert result.llc_status == LLCCompanyStatus.ACTIVE.value
+        assert result.pause_reason is None
+        assert result.paused_at is None
+
+    @pytest.mark.asyncio
+    async def test_activate_rejects_invalid_state(self):
+        org = _make_org(llc_status="archived")
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        with pytest.raises(ValueError):
+            await svc.activate(org.id)
+
+    @pytest.mark.asyncio
     async def test_not_found_raises(self):
         svc = _make_service()
         svc._get_or_404 = AsyncMock(side_effect=CompanyNotFoundError("not found"))

--- a/autobot-backend/llc/tests/test_company_status_endpoints_12211.py
+++ b/autobot-backend/llc/tests/test_company_status_endpoints_12211.py
@@ -1,0 +1,106 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Endpoint wiring tests for the company status-transition routes (#12211).
+
+Companies were stuck in ONBOARDING because the CompanyService transitions
+(suspend/archive) were never exposed and no activate() existed. These tests
+assert the new POST /activate|/suspend|/archive routes are wired, delegate to
+the service, map an invalid-transition ValueError to 409, and commit/rollback.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from autobot_shared.datetime_utils import datetime_now
+from llc.api import companies
+
+
+def _org(llc_status: str = "active", pause_reason=None) -> SimpleNamespace:
+    now = datetime_now()
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug="acme",
+        description=None,
+        issue_prefix="ACME",
+        issue_counter=0,
+        budget_monthly_cents=0,
+        spent_monthly_cents=0,
+        brand_color=None,
+        require_approval_for_hires=False,
+        parent_org_id=None,
+        llc_status=llc_status,
+        pause_reason=pause_reason,
+        paused_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _app(svc) -> FastAPI:
+    app = FastAPI()
+    app.include_router(companies.router, prefix="/api/llc")
+    app.dependency_overrides[companies._get_service] = lambda: svc
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+def _svc() -> MagicMock:
+    svc = MagicMock()
+    svc.session = AsyncMock()
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_activate_endpoint_returns_active_and_commits():
+    svc = _svc()
+    svc.activate = AsyncMock(return_value=_org(llc_status="active"))
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/activate")
+    assert resp.status_code == 200
+    assert resp.json()["llc_status"] == "active"
+    svc.activate.assert_awaited_once()
+    svc.session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_activate_endpoint_invalid_transition_maps_to_409():
+    svc = _svc()
+    svc.activate = AsyncMock(side_effect=ValueError("Cannot activate company in 'archived' state"))
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/activate")
+    assert resp.status_code == 409
+    assert "Cannot activate" in resp.json()["detail"]
+    svc.session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_suspend_endpoint_forwards_reason():
+    svc = _svc()
+    svc.suspend = AsyncMock(return_value=_org(llc_status="paused", pause_reason="audit"))
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/suspend", json={"reason": "audit"})
+    assert resp.status_code == 200
+    assert resp.json()["llc_status"] == "paused"
+    assert svc.suspend.await_args.kwargs["reason"] == "audit"
+
+
+@pytest.mark.asyncio
+async def test_archive_endpoint_returns_archived():
+    svc = _svc()
+    svc.archive = AsyncMock(return_value=_org(llc_status="archived"))
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/archive")
+    assert resp.status_code == 200
+    assert resp.json()["llc_status"] == "archived"
+    svc.archive.assert_awaited_once()

--- a/autobot-backend/llc/tests/test_company_status_endpoints_12211.py
+++ b/autobot-backend/llc/tests/test_company_status_endpoints_12211.py
@@ -16,10 +16,15 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.datetime_utils import datetime_now
 from llc.api import companies
+from user_management.services import TenantContext
+
+_ORG_ID = uuid.uuid4()
+_USER_ID = uuid.uuid4()
 
 
 def _org(llc_status: str = "active", pause_reason=None) -> SimpleNamespace:
@@ -44,10 +49,21 @@ def _org(llc_status: str = "active", pause_reason=None) -> SimpleNamespace:
     )
 
 
-def _app(svc) -> FastAPI:
+def _app(svc, *, org_id: uuid.UUID = _ORG_ID, is_platform_admin: bool = False, unauth: bool = False) -> FastAPI:
     app = FastAPI()
     app.include_router(companies.router, prefix="/api/llc")
     app.dependency_overrides[companies._get_service] = lambda: svc
+
+    def _override_current_user() -> dict:
+        if unauth:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        return {"id": str(_USER_ID), "user_id": str(_USER_ID)}
+
+    def _override_tenant() -> TenantContext:
+        return TenantContext(org_id=org_id, user_id=_USER_ID, is_platform_admin=is_platform_admin)
+
+    app.dependency_overrides[get_current_user] = _override_current_user
+    app.dependency_overrides[require_org_context] = _override_tenant
     return app
 
 
@@ -66,7 +82,7 @@ async def test_activate_endpoint_returns_active_and_commits():
     svc = _svc()
     svc.activate = AsyncMock(return_value=_org(llc_status="active"))
     async with _client(_app(svc)) as client:
-        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/activate")
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/activate")
     assert resp.status_code == 200
     assert resp.json()["llc_status"] == "active"
     svc.activate.assert_awaited_once()
@@ -78,7 +94,7 @@ async def test_activate_endpoint_invalid_transition_maps_to_409():
     svc = _svc()
     svc.activate = AsyncMock(side_effect=ValueError("Cannot activate company in 'archived' state"))
     async with _client(_app(svc)) as client:
-        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/activate")
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/activate")
     assert resp.status_code == 409
     assert "Cannot activate" in resp.json()["detail"]
     svc.session.rollback.assert_awaited_once()
@@ -89,7 +105,7 @@ async def test_suspend_endpoint_forwards_reason():
     svc = _svc()
     svc.suspend = AsyncMock(return_value=_org(llc_status="paused", pause_reason="audit"))
     async with _client(_app(svc)) as client:
-        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/suspend", json={"reason": "audit"})
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/suspend", json={"reason": "audit"})
     assert resp.status_code == 200
     assert resp.json()["llc_status"] == "paused"
     assert svc.suspend.await_args.kwargs["reason"] == "audit"
@@ -100,7 +116,56 @@ async def test_archive_endpoint_returns_archived():
     svc = _svc()
     svc.archive = AsyncMock(return_value=_org(llc_status="archived"))
     async with _client(_app(svc)) as client:
-        resp = await client.post(f"/api/llc/companies/{uuid.uuid4()}/archive")
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/archive")
     assert resp.status_code == 200
     assert resp.json()["llc_status"] == "archived"
     svc.archive.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Authn / tenant authz on the mutating transition routes (#12211)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activate_requires_authentication():
+    svc = _svc()
+    svc.activate = AsyncMock(return_value=_org())
+    async with _client(_app(svc, unauth=True)) as client:
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/activate")
+    assert resp.status_code == 401
+    svc.activate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_activate_cross_tenant_is_404_and_does_not_touch_service():
+    svc = _svc()
+    svc.activate = AsyncMock(return_value=_org())
+    other_company = uuid.uuid4()  # caller's org is _ORG_ID, target is a different company
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{other_company}/activate")
+    assert resp.status_code == 404
+    svc.activate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_platform_admin_may_transition_any_company():
+    svc = _svc()
+    svc.archive = AsyncMock(return_value=_org(llc_status="archived"))
+    other_company = uuid.uuid4()
+    async with _client(_app(svc, is_platform_admin=True)) as client:
+        resp = await client.post(f"/api/llc/companies/{other_company}/archive")
+    assert resp.status_code == 200
+    svc.archive.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_suspend_not_found_maps_to_404():
+    from llc.services.company import CompanyNotFoundError
+
+    svc = _svc()
+    svc.suspend = AsyncMock(side_effect=CompanyNotFoundError("not found"))
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/suspend")
+    assert resp.status_code == 404
+    svc.session.rollback.assert_awaited_once()

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48843,6 +48843,70 @@ export interface paths {
         patch: operations["update_company_api_llc_companies__company_id__patch"];
         trace?: never;
     };
+    "/api/llc/companies/{company_id}/activate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Activate Company
+         * @description Transition a company to ACTIVE (from ONBOARDING or PAUSED).
+         *
+         *     Issue #12211: this is the dedicated transition the CompanyUpdate schema
+         *     defers to (``llc_status`` is intentionally not PATCH-able) — without it a
+         *     company was stuck in ONBOARDING forever.
+         */
+        post: operations["activate_company_api_llc_companies__company_id__activate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/companies/{company_id}/suspend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Suspend Company
+         * @description Transition a company to PAUSED (from ONBOARDING or ACTIVE). Issue #12211.
+         */
+        post: operations["suspend_company_api_llc_companies__company_id__suspend_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/companies/{company_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Archive Company
+         * @description Transition a company to ARCHIVED (from PAUSED or OFFBOARDING). Issue #12211.
+         */
+        post: operations["archive_company_api_llc_companies__company_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/companies/{company_id}/tree": {
         parameters: {
             query?: never;
@@ -62400,6 +62464,16 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * CompanyStatusTransitionRequest
+         * @description Optional payload for a status transition (e.g. a suspend reason).
+         */
+        CompanyStatusTransitionRequest: {
+            /** Reason */
+            reason?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -165607,6 +165681,103 @@ export interface operations {
                 "application/json": components["schemas"]["CompanyUpdate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CompanyRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    activate_company_api_llc_companies__company_id__activate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CompanyRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    suspend_company_api_llc_companies__company_id__suspend_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CompanyStatusTransitionRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CompanyRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_company_api_llc_companies__company_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48858,7 +48858,9 @@ export interface paths {
          *
          *     Issue #12211: this is the dedicated transition the CompanyUpdate schema
          *     defers to (``llc_status`` is intentionally not PATCH-able) — without it a
-         *     company was stuck in ONBOARDING forever.
+         *     company was stuck in ONBOARDING forever. Tenant access is enforced the same
+         *     way as ``get_org_chart``/``reorder_backlog``: the caller's org must match
+         *     *company_id* unless they are a platform admin.
          */
         post: operations["activate_company_api_llc_companies__company_id__activate_post"];
         delete?: never;
@@ -48879,6 +48881,8 @@ export interface paths {
         /**
          * Suspend Company
          * @description Transition a company to PAUSED (from ONBOARDING or ACTIVE). Issue #12211.
+         *
+         *     Tenant-scoped: caller's org must match *company_id* unless platform admin.
          */
         post: operations["suspend_company_api_llc_companies__company_id__suspend_post"];
         delete?: never;
@@ -48899,6 +48903,8 @@ export interface paths {
         /**
          * Archive Company
          * @description Transition a company to ARCHIVED (from PAUSED or OFFBOARDING). Issue #12211.
+         *
+         *     Tenant-scoped: caller's org must match *company_id* unless platform admin.
          */
         post: operations["archive_company_api_llc_companies__company_id__archive_post"];
         delete?: never;


### PR DESCRIPTION
## Thinking Path
Companies were stuck in `onboarding` forever. `CompanyUpdate` intentionally excludes `llc_status` (comment: *use the dedicated transition methods*), but audit showed `CompanyService.suspend()`/`archive()` were **never exposed** via any endpoint, and no `activate()` (ONBOARDING→ACTIVE) existed at all. So there was no working way to leave onboarding, and PATCH silently dropped `llc_status`.

## What Changed
- **`llc/services/company.py`**: added `activate()` — ONBOARDING or PAUSED → ACTIVE (resume clears `pause_reason`/`paused_at`), guarded via `_ACTIVATE_FROM` like the existing suspend/archive guards.
- **`llc/api/companies.py`**: wired `POST /companies/{id}/activate | /suspend | /archive` (mirroring the existing update/delete pattern). Invalid transition → **409** with the guard's allowed-states message; not found → **404**. Adds a small `CompanyStatusTransitionRequest` (optional suspend `reason`).
- This wires the previously-orphaned `suspend()`/`archive()` service methods and fills the missing `activate()`.

`PATCH` still (by design) does not accept `llc_status` — the dedicated endpoints are now the working path the schema comment referred to.

## Verification
- `pytest llc/tests/test_company.py::TestCompanyStatusTransitions` (6) + `test_company_status_endpoints_12211.py` (4) → **10 passed**: service activate (onboarding, resume-from-paused clears pause state, invalid→ValueError) + endpoint wiring (delegation, commit/rollback, 409 mapping, suspend-reason forwarding).
- `py_compile` clean.

## Discoveries
- **#12231** — frontend has no UI control to trigger these transitions (only displays status); filed as a follow-up (needs i18n across 11 locales).

## Model Used
Opus 4.8

Closes #12211

---
**Update (code review):** the 3 new mutating endpoints initially lacked authn/tenant authz (unauthenticated cross-tenant IDOR — same class as GH#12148). Added `get_current_user` + `require_org_context` + org-match guard (404 on mismatch, platform-admin bypass), mirroring `reorder_backlog`/`get_org_chart`; added authz tests (unauth→401, cross-tenant→404, admin bypass, not-found→404). **14 tests pass.**

**Additional discoveries filed:** #12233 (the *pre-existing* company CRUD endpoints — create/get/update/delete/list — share the same unauth IDOR gap; high-priority security fast-follow) and #12234 (OFFBOARDING is an unreachable state).