### PR TITLE
fix(deploy): CRITICAL — stop db-credentials.env clobber desyncing slm_app password (#12224)

### DIFF
--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
@@ -88,13 +88,35 @@
   become_user: postgres
   loop: "{{ databases }}"
 
-- name: Save credentials to file
-  ansible.builtin.template:
-    src: db-credentials.env.j2
-    dest: "{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}"
+# #12224: db-credentials.env is SHARED between the SLM phase (SLM_*) and the
+# managed-backend phase (AUTOBOT_*). The previous `template` module rewrote the
+# WHOLE file with only the current prefix, so on a co-located box the second
+# phase erased the first phase's keys (e.g. SLM_DATABASE_URL) — the SLM control
+# plane then lost its creds and crash-looped on the next restart. Write each
+# prefix as its own marked block so both coexist and neither clobbers the other;
+# this also lets "Reuse existing database password" find the prior password, so
+# a redeploy no longer regenerates it and env/Postgres never diverge.
+- name: "Save credentials to file (per-prefix block, #12224)"
+  ansible.builtin.blockinfile:
+    path: "{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}"
+    marker: "# {mark} {{ db_env_prefix }} DB CREDENTIALS (managed by postgresql role)"
+    create: true
     owner: "{{ autobot_user }}"
     group: "{{ autobot_group }}"
     mode: '0600'
+    block: |
+      {{ db_env_prefix }}_DB_HOST={{ db_host | default('127.0.0.1') }}
+      {{ db_env_prefix }}_DB_PORT={{ postgresql_port }}
+      {{ db_env_prefix }}_DB_USER={{ db_user }}
+      {{ db_env_prefix }}_DB_PASSWORD={{ db_password }}
+      {{ db_env_prefix }}_DB_NAME={{ databases | first }}
+      {% for db in databases %}
+      {{ db_env_prefix }}_DB_{{ db | upper | replace('-', '_') }}={{ db }}
+      {% endfor %}
+      {{ db_env_prefix }}_DATABASE_URL=postgresql+asyncpg://{{ db_user }}:{{ db_password }}@{{ db_host | default('127.0.0.1') }}:{{ postgresql_port }}/{{ databases | first }}
+      {% for db in databases[1:] %}
+      {{ db | upper | replace('-', '_') }}_DATABASE_URL=postgresql+asyncpg://{{ db_user }}:{{ db_password }}@{{ db_host | default('127.0.0.1') }}:{{ postgresql_port }}/{{ db }}
+      {% endfor %}
   become: true
   no_log: true
 


### PR DESCRIPTION
## Thinking Path
A routine code-sync update crash-looped the SLM control plane (`InvalidPasswordError: slm_app`). Root cause (confirmed live on the box — db-credentials.env had ONLY `AUTOBOT_*` keys, `SLM_DATABASE_URL` absent): the postgres role's `Save credentials to file` used the `template` module, which **overwrites the whole file** with only the current phase's prefix. On a co-located box both phases share `/etc/autobot/db-credentials.env`, so Phase 2 (`AUTOBOT_*`) erased Phase 1's `SLM_*` keys. With its prior password gone from the file, each phase then **regenerated** the password, diverging env ↔ Postgres.

## What Changed
`roles/postgresql/tasks/databases.yml` — replaced the file-overwriting `template` with a per-prefix `blockinfile` (marker `# {mark} {{ db_env_prefix }} DB CREDENTIALS ...`). Each phase now manages only its own block, so `SLM_*` and `AUTOBOT_*` coexist. This also lets "Reuse existing database password" find the prior password → no regeneration → env and Postgres never diverge. The now-unused `templates/db-credentials.env.j2` is left in place (no-delete policy; orphaned).

## Verification
- YAML valid; `ansible-playbook --syntax-check` passes.
- Rendered both prefixes: SLM block + AUTOBOT block are distinct and complete (HOST/USER/PASSWORD/NAME/DATABASE_URL each).
- Idempotency: blockinfile updates only the marked block; the sibling block is untouched.
- Recovery: deploying this + running the postgres deploy restores the missing `SLM_*` block in sync with the role (self-heals the current box state).

## Note
The live box currently has `SLM_*` erased (latent — the running SLM process still holds the old env, but a restart would crash-loop). Safe remediation once this merges: deploy + run the postgres deploy (restores `SLM_*` in sync), or the manual ALTER ROLE steps in #12224.

## Model Used
Opus 4.8

Closes #12224