### PR TITLE
fix(auth): unify login token field across backends (token + access_token) (#12216)

### DIFF
--- a/autobot-backend/api/login_response_mirror_12216_test.py
+++ b/autobot-backend/api/login_response_mirror_12216_test.py
@@ -1,0 +1,29 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#12216: the core login LoginResponse must expose the JWT under BOTH `token`
+(its native field) and `access_token` (the SLM backend's / OAuth2 field) so a
+client written against either backend reads the token correctly."""
+
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_REPO = _BACKEND.parent
+for _p in (str(_REPO), str(_BACKEND)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from api.schemas_agent import LoginResponse  # noqa: E402
+
+
+def test_access_token_mirrors_token():
+    resp = LoginResponse(success=True, message="ok", token="JWT")
+    assert resp.token == "JWT"
+    assert resp.access_token == "JWT"
+
+
+def test_explicit_access_token_is_preserved():
+    resp = LoginResponse(success=True, message="ok", token="A", access_token="B")
+    assert resp.access_token == "B"

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -9,7 +9,7 @@ Agent config, memory, and LLM schemas.
 import uuid
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from models.session_collaboration import PermissionLevel
 from services.personality_service import SUPPORTED_LANGUAGES
@@ -1416,9 +1416,18 @@ class LoginResponse(BaseModel):
     message: str
     user: dict | None = None
     token: str | None = None
+    # #12216: also expose the JWT under `access_token` (the OAuth2 name and the
+    # SLM backend's field) so a cross-backend client reads it correctly.
+    access_token: str | None = None
     session_id: str | None = None
     password_warning: PasswordWarning | None = None
     """Soft warning when the submitted password is weak (non-blocking, #10199)."""
+
+    @model_validator(mode="after")
+    def _mirror_access_token_field(self) -> "LoginResponse":
+        if self.access_token is None:
+            self.access_token = self.token
+        return self
 
 
 class LogoutRequest(BaseModel):

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -80175,6 +80175,8 @@ export interface components {
             } | null;
             /** Token */
             token?: string | null;
+            /** Access Token */
+            access_token?: string | null;
             /** Session Id */
             session_id?: string | null;
             password_warning?: components["schemas"]["PasswordWarning"] | null;

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -32,8 +32,17 @@ class TokenResponse(BaseModel):
     """JWT token response."""
 
     access_token: str
+    # #12216: also expose the JWT under `token` so a client written against the
+    # core backend (whose login returns `token`) reads the SLM response correctly.
+    token: str | None = None
     token_type: str = "bearer"
     expires_in: int
+
+    @model_validator(mode="after")
+    def _mirror_token_field(self) -> "TokenResponse":
+        if self.token is None:
+            self.token = self.access_token
+        return self
 
 
 class MfaChallengeResponse(BaseModel):

--- a/autobot-slm-backend/tests/test_token_response_mirror_12216.py
+++ b/autobot-slm-backend/tests/test_token_response_mirror_12216.py
@@ -1,0 +1,41 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#12216: the SLM login TokenResponse must expose the JWT under BOTH
+`access_token` (its native field) and `token` (the core backend's field) so a
+client written against either backend reads the token correctly.
+
+The root conftest stubs ``models.schemas`` with a MagicMock and the module uses
+package-relative imports, so the real class cannot be imported standalone here.
+Assert structurally (via AST) that TokenResponse declares a ``token`` field and
+a mirror validator. (Runtime mirror behaviour is covered for the equivalent
+core LoginResponse in autobot-backend/api/login_response_mirror_12216_test.py,
+which the core conftest does not stub.)"""
+
+import ast
+from pathlib import Path
+
+_SCHEMAS = Path(__file__).resolve().parents[1] / "models" / "schemas.py"
+
+
+def _token_response_class() -> ast.ClassDef:
+    tree = ast.parse(_SCHEMAS.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "TokenResponse":
+            return node
+    raise AssertionError("TokenResponse class not found in models/schemas.py")
+
+
+def test_token_response_declares_both_token_fields():
+    cls = _token_response_class()
+    fields = {n.target.id for n in cls.body if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)}
+    assert "access_token" in fields
+    assert "token" in fields, "#12216: TokenResponse must also expose `token`"
+
+
+def test_token_response_has_mirror_validator():
+    cls = _token_response_class()
+    src = ast.get_source_segment(_SCHEMAS.read_text(encoding="utf-8"), cls) or ""
+    assert "model_validator" in src
+    assert "self.token = self.access_token" in src, "#12216: `token` must mirror `access_token`"


### PR DESCRIPTION
## Thinking Path
The two backends returned the JWT under different field names — core (`/api/auth/login`) → `token`, SLM (`:8000/api/auth/login`) → `access_token`. A client written against one reads the wrong field on the other and sees an empty token. Non-breaking fix: each login response now exposes the JWT under BOTH names.

## What Changed
- `autobot-slm-backend/models/schemas.py` — `TokenResponse` gains a `token` field + a `model_validator` mirroring `access_token` → `token`.
- `autobot-backend/api/schemas_agent.py` — `LoginResponse` gains an `access_token` field + a `model_validator` mirroring `token` → `access_token` (imported `model_validator`).
- Both mirror only when the alias is unset, so an explicitly-provided value is preserved.
- Tests: core runtime behaviour (`login_response_mirror_12216_test.py`, both fields populated + explicit preserved); SLM structural guard (AST — conftest stubs `models.schemas`).

## Verification
```
core: 2 passed | slm: 2 passed
```
flake8 clean. Non-breaking: existing clients reading `token` (core) / `access_token` (SLM) are unaffected; cross-backend clients now also work.

## Model Used
Opus 4.8

Closes #12216