### PR TITLE
fix(llc): eager-load goal relations to stop MissingGreenlet 500 on goal update (#12209)

### DIFF
--- a/autobot-backend/llc/services/goal.py
+++ b/autobot-backend/llc/services/goal.py
@@ -178,6 +178,15 @@ class GoalService(LLCServiceBase):
                 else:
                     setattr(goal, key, value)
         await session.flush()
+        # GH#12209: SQLAlchemy's default eager_defaults="auto" only fetches
+        # onupdate-computed columns (updated_at) via RETURNING on INSERT, not
+        # UPDATE (see Mapper._prefer_eager_defaults vs the strict `is True`
+        # check gating UPDATE RETURNING in orm/persistence.py). Without this
+        # refresh, `updated_at` stays expired after flush(); the first sync
+        # attribute access outside a greenlet context (Pydantic's
+        # `GoalResponse.model_validate` in the router) raises MissingGreenlet.
+        # Refresh it here, inside the awaited/greenlet-safe scope.
+        await session.refresh(goal, attribute_names=["updated_at"])
         # Fix #2: Index after commit, not after flush
         self._schedule_post_commit_index(session, goal)
         return goal

--- a/autobot-backend/llc/tests/test_goals.py
+++ b/autobot-backend/llc/tests/test_goals.py
@@ -133,12 +133,17 @@ async def test_update_goal(svc: GoalService) -> None:
     goal = _make_goal(title="Old Title")
     session = AsyncMock()
     session.flush = AsyncMock()
+    session.refresh = AsyncMock()
 
     with patch.object(svc, "get", new=AsyncMock(return_value=goal)), patch.object(svc, "_schedule_post_commit_index"):
         updated = await svc.update(session, goal.id, title="New Title")
 
     assert updated is goal
     assert goal.title == "New Title"
+    # GH#12209: updated_at must be refreshed inside the awaited/greenlet-safe
+    # scope, else the router's synchronous GoalResponse.model_validate() call
+    # trips MissingGreenlet on the still-expired onupdate column.
+    session.refresh.assert_awaited_once_with(goal, attribute_names=["updated_at"])
 
 
 @pytest.mark.asyncio
@@ -195,6 +200,53 @@ async def test_update_goal_invalid_level_hierarchy(svc: GoalService) -> None:
             await svc.update(session, goal.id, level=GoalLevel.KEY_RESULT)
 
     assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_goal_response_survives_sync_serialization() -> None:
+    """GH#12209 regression: PATCH /llc/goals/{id} must not 500 with
+    MissingGreenlet when the returned ORM object is synchronously serialized
+    by ``GoalResponse.model_validate`` right after ``GoalService.update()``
+    — the exact sequence in ``llc/api/goals.py::update_goal``.
+
+    Uses a real in-memory SQLite (aiosqlite) AsyncSession rather than mocks
+    so SQLAlchemy's actual attribute-expiry/RETURNING behavior on UPDATE is
+    exercised: ``eager_defaults="auto"`` (the mapper default) only fetches
+    onupdate-computed columns via RETURNING on INSERT, not UPDATE, so without
+    the ``session.refresh(goal, ["updated_at"])`` fix, ``updated_at`` stays
+    expired post-flush and this test fails with MissingGreenlet.
+    """
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from llc.api.goals import GoalResponse
+    from user_management.models.base import Base
+
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=[LLCGoal.__table__])
+
+    session_factory = async_sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+    svc = GoalService()
+
+    async with session_factory() as session:
+        with patch.object(svc, "_schedule_post_commit_index"):
+            goal = await svc.create(session, company_id="co1", title="Vision", level=GoalLevel.VISION)
+            await session.commit()
+            goal_id = goal.id
+
+    async with session_factory() as session:
+        with patch.object(svc, "_schedule_post_commit_index"):
+            updated = await svc.update(session, goal_id, status=GoalStatus.ACTIVE)
+        await session.commit()
+
+        # This is the exact call `update_goal` makes right after `svc.update()`
+        # (llc/api/goals.py:180) — no MissingGreenlet, correct field values.
+        response = GoalResponse.model_validate(updated)
+
+    await engine.dispose()
+
+    assert response.status == GoalStatus.ACTIVE.value
+    assert response.updated_at is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path
`PATCH /api/llc/goals/{goal_id}` 500'd with SQLAlchemy `MissingGreenlet` at `llc/api/goals.py:180`, inside `GoalResponse.model_validate(goal)`. I traced this to SQLAlchemy 2.0's mapper default `eager_defaults="auto"`: `Mapper._prefer_eager_defaults()` enables automatic RETURNING-fetch of server-computed columns for **INSERT** (which is why `create_goal`/POST never hit this), but the UPDATE path in `orm/persistence.py` gates the same behavior behind a strict `mapper.base_mapper.eager_defaults is True` check — `"auto"` never satisfies `is True`. So after `GoalService.update()`'s `await session.flush()`, the `onupdate=func.now()` column `updated_at` (defined on the shared `Base` in `user_management/models/base.py`) is left "expired." Pydantic's `model_validate(..., from_attributes=True)` then reads `goal.updated_at` synchronously in the router — outside any `await`/greenlet-spawn context — which SQLAlchemy's async engine can't service, raising `MissingGreenlet`.

I reproduced this end-to-end with a real in-memory SQLite (`aiosqlite`) `AsyncSession` (not mocks) to exercise SQLAlchemy's actual expiry/RETURNING logic, confirmed the failure matches the reported traceback exactly, then confirmed the fix resolves it.

## What Changed
- `autobot-backend/llc/services/goal.py`: `GoalService.update()` now calls `await session.refresh(goal, attribute_names=["updated_at"])` immediately after `flush()`, inside the awaited/greenlet-safe scope, so `updated_at` is loaded before the router ever touches the object synchronously. Scoped to the one column that's actually left expired — `created_at` and all edited fields are already in memory (set directly or eager-fetched via INSERT RETURNING).
- `autobot-backend/llc/tests/test_goals.py`:
  - Extended `test_update_goal` to assert `session.refresh(goal, attribute_names=["updated_at"])` is awaited.
  - Added `test_update_goal_response_survives_sync_serialization` — a real-DB (SQLite/aiosqlite) regression test that creates a goal, updates it via `GoalService.update()`, then calls `GoalResponse.model_validate()` exactly as the router does. Verified this test **fails with the reported `MissingGreenlet` error** when the fix is reverted, and passes with it applied.

## Verification
```
$ python3 -m pytest autobot-backend/llc/tests/test_goals.py autobot-backend/llc/tests/test_goals_idor.py -v
...
======================== 41 passed, 4 warnings in 5.89s ========================
```

Pre-fix repro (temporarily reverted the service change) — confirms the new test reproduces the exact reported bug:
```
$ python3 -m pytest autobot-backend/llc/tests/test_goals.py::test_update_goal_response_survives_sync_serialization -v
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for GoalResponse
E   updated_at
E     Error extracting attribute: MissingGreenlet: greenlet_spawn has not been called;
E     can't call await_only() here. ... [input_type=LLCGoal]
FAILED
```

- `black --check` / `flake8` clean on both touched files.
- `ast.parse` clean on both touched files.

## Model Used
Claude Opus 4.8

Closes #12209