### PR TITLE
fix(llm): provider selection respects circuit-breaker state; no token burn on open breaker (#11498)

### DIFF
--- a/autobot-backend/circuit_breaker.py
+++ b/autobot-backend/circuit_breaker.py
@@ -236,6 +236,21 @@ class CircuitBreaker:
 
         return False
 
+    @property
+    def is_rejecting(self) -> bool:
+        """Read-only: True when the breaker would reject a call WITHOUT probing.
+
+        #11498: callers (provider registry health checks, pre-rate-limit fail-fast)
+        need to know a provider is currently unavailable without triggering the
+        OPEN->HALF_OPEN probe transition that ``_can_execute`` performs. This is
+        only True while OPEN and still inside the recovery cooldown; once the
+        cooldown elapses (OPEN and ready to probe) it returns False so the next
+        real call can transition to HALF_OPEN and recover.
+        """
+        if self.state != CircuitState.OPEN:
+            return False
+        return (time.time() - self.last_failure_time) < self.config.recovery_timeout
+
     def _record_success(self, duration: float):
         """Record a successful call"""
         with self._lock:

--- a/autobot-backend/circuit_breaker_is_rejecting_11498_test.py
+++ b/autobot-backend/circuit_breaker_is_rejecting_11498_test.py
@@ -1,0 +1,59 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11498: a provider whose completion breaker is OPEN and still cooling must be
+treated as unavailable (registry routes to the fallback chain) and must fail
+fast BEFORE burning a shared rate-limit token — without breaking OPEN->HALF_OPEN
+recovery. The read-only ``CircuitBreaker.is_rejecting`` predicate underpins both."""
+
+import time
+
+from circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitState,
+    get_circuit_breaker_manager,
+)
+
+
+def _open_breaker(name: str, *, cooling: bool) -> CircuitBreaker:
+    cb = CircuitBreaker(name, CircuitBreakerConfig(failure_threshold=1, recovery_timeout=30))
+    cb.state = CircuitState.OPEN
+    cb.last_failure_time = time.time() if cooling else (time.time() - 31)
+    return cb
+
+
+def test_is_rejecting_true_only_while_open_and_cooling():
+    assert _open_breaker("a_service", cooling=True).is_rejecting is True
+
+
+def test_is_rejecting_false_when_open_but_ready_to_probe():
+    # Ready to probe -> NOT rejecting, so a real call can transition to HALF_OPEN.
+    assert _open_breaker("b_service", cooling=False).is_rejecting is False
+
+
+def test_is_rejecting_false_for_closed_and_half_open():
+    cb = CircuitBreaker("c_service", CircuitBreakerConfig())
+    assert cb.is_rejecting is False  # CLOSED
+    cb.state = CircuitState.HALF_OPEN
+    assert cb.is_rejecting is False
+
+
+def test_is_rejecting_read_only_does_not_transition_open_to_half_open():
+    cb = _open_breaker("d_service", cooling=False)  # ready to probe
+    _ = cb.is_rejecting
+    # Must NOT have consumed the probe transition — still OPEN until a real call.
+    assert cb.state is CircuitState.OPEN
+
+
+def test_registry_helper_flags_rejecting_provider():
+    from llm_shared.provider_registry import ProviderRegistry
+
+    mgr = get_circuit_breaker_manager()
+    mgr.circuit_breakers["prov9_service"] = _open_breaker("prov9_service", cooling=True)
+    try:
+        assert ProviderRegistry._completion_breaker_is_rejecting("prov9") is True
+        assert ProviderRegistry._completion_breaker_is_rejecting("no_such_provider") is False
+    finally:
+        mgr.circuit_breakers.pop("prov9_service", None)

--- a/autobot-backend/llm_shared/base_provider.py
+++ b/autobot-backend/llm_shared/base_provider.py
@@ -124,10 +124,17 @@ class BaseProvider(ABC):
         handler = get_backoff_handler()
 
         async def _attempt() -> LLMResponse:
+            start = time.monotonic()
+            # #11498: if the completion breaker is OPEN and still cooling, fail
+            # fast BEFORE taking a shared cross-worker rate-limit token so a down
+            # provider doesn't burn tokens other workers could use. OPEN-but-
+            # ready-to-probe is NOT rejecting, so it falls through and
+            # _guarded_completion transitions the breaker to HALF_OPEN to recover.
+            if self._completion_circuit_breaker().is_rejecting:
+                return self._breaker_error_response(request, f"{provider_key} circuit breaker open", start)
             # Issue #8170: acquire a rate-limit token shared across all uvicorn
             # workers via Redis.  Falls back to allow-all when Redis unavailable.
             async with get_llm_rate_limiter().acquire(provider_key):
-                start = time.monotonic()
                 try:
                     response = await self._guarded_completion(request)
                     latency_ms = (time.monotonic() - start) * 1000

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -182,9 +182,24 @@ class ProviderRegistry(CredentialGatedRegistry[BaseProvider]):
         except Exception as exc:
             logger.warning("Health check for %s raised: %s", name, exc)
             available = False
+        # #11498: is_available() is a cheap ping that can pass while completions
+        # consistently fail. If this provider's completion breaker is OPEN and
+        # still cooling, treat it as unavailable so selection routes to the
+        # fallback chain instead of repeatedly picking a fail-fasting provider.
+        if available and self._completion_breaker_is_rejecting(name):
+            available = False
         async with self._health_lock:
             self._health_cache[name] = (available, now)
         return available
+
+    @staticmethod
+    def _completion_breaker_is_rejecting(name: str) -> bool:
+        """True when *name*'s ``{name}_service`` completion breaker is OPEN and
+        cooling (#11498). Read-only lookup — never creates a breaker."""
+        from circuit_breaker import get_circuit_breaker_manager
+
+        breaker = get_circuit_breaker_manager().circuit_breakers.get(f"{name}_service")
+        return breaker is not None and breaker.is_rejecting
 
     async def health_check_all(self) -> Dict[str, bool]:
         """


### PR DESCRIPTION
## Thinking Path
Two scope-cuts from #11488: (1) `ProviderRegistry` health-checks with the cheap `is_available()` ping, which can pass while a provider's completions consistently fail — so a breaker-open provider keeps getting selected and each request fail-fasts instead of routing to the fallback chain; (2) `BaseProvider.chat_completion` acquires a cross-worker Redis rate-limit token BEFORE the breaker check, so an open-breaker fail-fast still burns a token other workers could use.

## What Changed
- `circuit_breaker.py`: new read-only `CircuitBreaker.is_rejecting` — True only while OPEN and inside the recovery cooldown. It does NOT trigger the OPEN→HALF_OPEN probe transition (unlike `_can_execute`), so recovery is preserved: once the cooldown elapses it returns False and the next real call can probe.
- `llm_shared/provider_registry.py`: `_check_health_cached` now also consults the provider's `{name}_service` completion breaker (read-only, never creates one) — an OPEN-and-cooling breaker marks the provider unavailable so selection routes to the fallback chain.
- `llm_shared/base_provider.py`: `chat_completion._attempt` fails fast via `is_rejecting` BEFORE acquiring the rate-limit token (returns the breaker-error response); OPEN-but-ready-to-probe falls through so `_guarded_completion` can transition to HALF_OPEN.

## Verification
```
circuit_breaker_is_rejecting_11498_test.py .....  (5 passed)
```
Covers: is_rejecting True only OPEN+cooling; False when OPEN+ready / CLOSED / HALF_OPEN; read-only (no OPEN→HALF_OPEN side effect); registry helper flags a rejecting provider. flake8 + black clean. Recovery preserved (ready-to-probe is not rejecting).

## Model Used
Opus 4.8

Closes #11498