### PR TITLE
fix(slm): bound + fail-fast GET /nodes so a slow DB can't hang it (#10913)

### DIFF
--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -387,15 +387,18 @@ async def _get_service_counts(db: AsyncSession, node_ids: list[str]) -> dict[str
     return counts
 
 
-@router.get("", response_model=NodeListResponse)
-async def list_nodes(
-    db: Annotated[AsyncSession, Depends(get_db)],
-    _: Annotated[dict, Depends(get_current_user)],
-    status_filter: str | None = Query(None, alias="status"),
-    page: int = Query(1, ge=1),
-    per_page: int = Query(20, ge=1, le=100),
-) -> NodeListResponse:
-    """List all nodes with optional status filter."""
+_NODES_LIST_TIMEOUT = 10.0  # seconds; guards against slow/stale DB conn hangs (#10913)
+
+
+async def _query_nodes_page(db: AsyncSession, status_filter: str | None, page: int, per_page: int) -> NodeListResponse:
+    """DB-bound body of list_nodes, run under a bounded timeout (#10913).
+
+    Health is read from the already-stored ``Node`` columns (populated by
+    agent heartbeats — see ``node_heartbeat``/``last_heartbeat``); this never
+    live-probes individual nodes, so a single unreachable node cannot block
+    the response — only a slow/stale DB round-trip can, and that is bounded
+    by the caller's ``asyncio.wait_for``.
+    """
     query = select(Node)
 
     if status_filter:
@@ -426,6 +429,34 @@ async def list_nodes(
         page=page,
         per_page=per_page,
     )
+
+
+@router.get("", response_model=NodeListResponse)
+async def list_nodes(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(get_current_user)],
+    status_filter: str | None = Query(None, alias="status"),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+) -> NodeListResponse:
+    """List all nodes with optional status filter.
+
+    Bounded by ``_NODES_LIST_TIMEOUT`` (#10913) so a stale/hung DB
+    connection (e.g. a silently-dropped WSL2 idle socket, #10491) can't
+    hang the whole endpoint — the request fails fast with 504 instead of
+    the client timing out with an opaque ``000``.
+    """
+    try:
+        return await asyncio.wait_for(
+            _query_nodes_page(db, status_filter, page, per_page),
+            timeout=_NODES_LIST_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("GET /nodes timed out after %.0fs (#10913)", _NODES_LIST_TIMEOUT)
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="Node listing timed out — DB may be under heavy load",
+        )
 
 
 @router.post("", response_model=NodeResponse, status_code=status.HTTP_201_CREATED)

--- a/autobot-slm-backend/tests/api/test_nodes_list_timeout_10913.py
+++ b/autobot-slm-backend/tests/api/test_nodes_list_timeout_10913.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression test: GET /api/nodes must not hang on a slow/stale DB (#10913).
+
+Root cause: ``list_nodes`` ran its DB query + service-count lookup inline
+with no bound, so a stale/hung DB connection (e.g. a silently-dropped WSL2
+idle socket, #10491) could block the whole request indefinitely — clients
+observed a curl ``000`` after 45s.
+
+Fix: the DB-bound body was extracted to ``_query_nodes_page`` and wrapped in
+``asyncio.wait_for(..., timeout=_NODES_LIST_TIMEOUT)`` (mirrors the
+``_ROLES_LIST_TIMEOUT`` precedent in ``api/roles.py``, #11360) so a slow
+backend fails fast with ``504 Gateway Timeout`` instead of hanging.
+
+Follows the code_version_test.py real-module-swap pattern (#11737): the
+slm-backend root conftest stubs ``sqlalchemy``/``models.database``/
+``models.schemas`` as MagicMocks for import-time safety, so ``api.nodes``
+is imported inside ``_real_modules_swapped()`` to get the real FastAPI/
+pydantic machinery ``asyncio.wait_for`` and ``HTTPException`` need.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+_SLM_ROOT = Path(__file__).parent.parent.parent
+if str(_SLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SLM_ROOT))
+
+_SQLALCHEMY_MODULES = ("sqlalchemy", "sqlalchemy.ext", "sqlalchemy.ext.asyncio", "sqlalchemy.orm")
+
+
+def _is_sqlalchemy_key(name: str) -> bool:
+    return name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so relative imports work)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _build_real_modules() -> dict:
+    """One-time real sqlalchemy + models.database/models.schemas snapshot.
+
+    Mirrors tests/services/code_version_test.py's module-level setup: the
+    root conftest stubs these as MagicMocks for import-time safety, so the
+    real packages are loaded once here and swapped in on demand.
+    """
+    saved = {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)}
+    saved.update({name: sys.modules.get(name) for name in ("models.database", "models.schemas")})
+    for name in list(saved):
+        sys.modules.pop(name, None)
+    try:
+        for name in _SQLALCHEMY_MODULES:
+            importlib.import_module(name)
+        importlib.import_module("sqlalchemy.dialects.sqlite")
+        _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+        _load_real_module("models.schemas", _SLM_ROOT / "models" / "schemas.py")
+        return {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)} | {
+            "models.database": sys.modules["models.database"],
+            "models.schemas": sys.modules["models.schemas"],
+        }
+    finally:
+        for name in [n for n in sys.modules if _is_sqlalchemy_key(n)]:
+            del sys.modules[name]
+        sys.modules.pop("models.database", None)
+        sys.modules.pop("models.schemas", None)
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
+
+
+_REAL_MODULES = _build_real_modules()
+
+
+@contextlib.contextmanager
+def _real_modules_swapped():
+    """Temporarily put the real sqlalchemy/models modules into sys.modules."""
+    saved = {name: sys.modules.get(name) for name in _REAL_MODULES}
+    sys.modules.update(_REAL_MODULES)
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
+
+
+def _load_nodes_module():
+    """Import the real ``api.nodes`` module under the real-module swap."""
+    with _real_modules_swapped():
+        sys.modules.pop("api.nodes", None)
+        return importlib.import_module("api.nodes")
+
+
+class TestListNodesTimeout:
+    """GET /nodes bounds the DB round-trip so it can't hang (#10913)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_504_promptly_when_db_hangs(self):
+        """A hung db.execute() must not block the endpoint past the timeout."""
+        nodes_module = _load_nodes_module()
+        nodes_module._NODES_LIST_TIMEOUT = 0.05  # keep the test itself fast
+
+        async def _hang(*_args, **_kwargs):
+            await asyncio.sleep(10)  # far longer than _NODES_LIST_TIMEOUT
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = _hang
+
+        start = time.monotonic()
+        with pytest.raises(HTTPException) as exc_info:
+            await nodes_module.list_nodes(
+                db=mock_db,
+                _={"admin": True, "role": "admin"},
+                status_filter=None,
+                page=1,
+                per_page=20,
+            )
+        elapsed = time.monotonic() - start
+
+        assert exc_info.value.status_code == 504
+        # Bounded well under the 10s hang -- proves wait_for actually cancelled it.
+        assert elapsed < 2.0, f"list_nodes took {elapsed:.2f}s -- timeout did not bound it"
+
+    @pytest.mark.asyncio
+    async def test_fast_path_still_returns_page(self):
+        """A normal (fast) DB round-trip is unaffected by the wait_for wrapper."""
+        nodes_module = _load_nodes_module()
+        nodes_module._NODES_LIST_TIMEOUT = 5.0
+
+        expected = nodes_module.NodeListResponse(nodes=[], total=0, page=1, per_page=20)
+
+        async def _fast_query(*_args, **_kwargs):
+            return expected
+
+        nodes_module._query_nodes_page = _fast_query
+
+        result = await nodes_module.list_nodes(
+            db=AsyncMock(),
+            _={"admin": True, "role": "admin"},
+            status_filter=None,
+            page=1,
+            per_page=20,
+        )
+
+        assert result is expected


### PR DESCRIPTION
## Thinking Path

Issue #10913 reports `GET /slm/api/nodes` timing out (curl `000`) while `/slm/api/health` and `/slm/api/fleet/services` stay healthy, and hypothesizes an inline per-node live health probe with no timeout.

Traced the handler to `autobot-slm-backend/api/nodes.py:391` (`list_nodes`). Reading it end-to-end plus its helper `_get_service_counts`, there is **no live per-node network/socket probing** in this endpoint — node health is already served from the `Node` table's stored columns (`last_heartbeat`, `code_status`, etc.), populated asynchronously by `node_heartbeat`/agent heartbeats. So the "per-node probe" premise doesn't match current code.

What the endpoint *does* do is run its DB query (`select(Node)` + a count query + `_get_service_counts`) inline with **no bound at all**. Memory of a near-identical symptom (`GET /slm/api/nodes timed 32s, 32s, 0.026s`) was root-caused in #10491/PR #10496: WSL2 silently drops idle TCP connections, and SQLAlchemy's `pool_pre_ping` `SELECT 1` had no `command_timeout`, so a dead pooled connection blocked ~30s before being discarded. That fix added `command_timeout=10` to `connect_args` (confirmed still present, `services/database.py:59`), bounding a single stale-connection retry to ~10s — but nothing bounds the *endpoint* as a whole (pool-checkout wait + pre_ping-fail + reconnect can still stack past that), and there's no fast-fail path, matching #10913's report of a still-longer (45s) hang.

The exact same class of bug was already fixed for `GET /roles` in #11360 (`api/roles.py:134`, `_ROLES_LIST_TIMEOUT` + `asyncio.wait_for`) — that precedent is the fix applied here.

## What Changed

`autobot-slm-backend/api/nodes.py`:
- Extracted the DB-bound body of `list_nodes` into `_query_nodes_page(db, status_filter, page, per_page)` (no behavior change).
- `list_nodes` now runs it via `asyncio.wait_for(..., timeout=_NODES_LIST_TIMEOUT)` (`_NODES_LIST_TIMEOUT = 10.0`, matching the `_ROLES_LIST_TIMEOUT` convention).
- On `asyncio.TimeoutError`, logs a warning and raises `HTTPException(504, "Node listing timed out — DB may be under heavy load")` instead of hanging — so a stale/slow DB round-trip fails fast with a clear signal instead of an opaque client-side `000`.
- No per-node `gather`/concurrent fan-out was needed: there is no per-node network probe to parallelize — health is already read from stored heartbeat data, which is the "prefer cached over live-probe" outcome the issue asked for.

## Verification

New regression test `autobot-slm-backend/tests/api/test_nodes_list_timeout_10913.py` (follows the `code_version_test.py` real-module-swap pattern, #11737):
- `test_returns_504_promptly_when_db_hangs` — mocks `db.execute` to hang for 10s, patches `_NODES_LIST_TIMEOUT` to 0.05s, asserts `list_nodes()` raises `HTTPException(504)` and returns in well under 2s (proves the timeout actually cancels the hang instead of the request blocking).
- `test_fast_path_still_returns_page` — proves the `wait_for` wrapper is transparent on the normal (fast) path.

```
tests/api/test_nodes_list_timeout_10913.py::TestListNodesTimeout::test_returns_504_promptly_when_db_hangs PASSED
tests/api/test_nodes_list_timeout_10913.py::TestListNodesTimeout::test_fast_path_still_returns_page PASSED
2 passed in 2.70s
```

Affected-area regression check (unchanged, all green):
```
tests/api/test_node_update_availability_11964.py .... (8 passed)
tests/api/test_fleet_health.py .................. (10 passed)
tests/test_portinfo_schema_address.py ... (3 passed)
tests/services/code_version_test.py ..................... (26 passed)
47 passed, 1 warning in 3.42s
```

Full `tests/` collection (868 items) collects and runs clean with no import/collection errors introduced by this change (spot-checked the initial pass before truncating the long-running full suite — no failures observed).

Lint:
```
black --check --target-version py310 api/nodes.py tests/api/test_nodes_list_timeout_10913.py
All done! (2 files would be left unchanged)

flake8 api/nodes.py tests/api/test_nodes_list_timeout_10913.py --max-line-length=120
(no output — clean)
```

`ast.parse()` on both changed files: OK.

## Model Used

Sonnet 5

Closes #10913