### PR TITLE
fix(code-sync): advance node code_version on successful drift-resolve so status stops falsely reporting outdated (#11512)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -316,6 +316,11 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
         steps2: List[str] = []
         await _restart_component_services(component, steps2)
 
+        # #11512: reached only when the restart above did NOT kill this
+        # process (self-restarting components never return from the call
+        # above) — a genuine successful resolve, so advance code_version.
+        await _advance_node_version_if_fully_synced(component)
+
     except Exception as exc:
         logger.error("component resolve job %s: unexpected error: %s", job_id, exc, exc_info=True)
         try:
@@ -537,7 +542,7 @@ _STALE_COMPONENTS_TTL_SECONDS = int(os.getenv("SLM_STALE_COMPONENTS_TTL_SECONDS"
 _stale_components_cache: dict = {"ts": -_STALE_COMPONENTS_TTL_SECONDS - 1.0, "value": []}
 
 
-async def _compute_stale_components() -> list[str]:
+async def _compute_stale_components(force: bool = False) -> list[str]:
     """Return ALLOWED_COMPONENTS deployed on this box whose files drift from source.
 
     Surfaces the #11820 gap: a co-located managed component can be stale (its
@@ -547,9 +552,13 @@ async def _compute_stale_components() -> list[str]:
     and the result is cached for _STALE_COMPONENTS_TTL_SECONDS to bound cost on
     the polled status path. Defensive: a failing component is logged and skipped,
     never breaking the status response.
+
+    force=True bypasses the cache and re-scans immediately (#11512): callers
+    that just resynced a component need the FRESH drift state, not a stale
+    cached snapshot that could still list the component they just fixed.
     """
     now = time.monotonic()
-    if now - _stale_components_cache["ts"] < _STALE_COMPONENTS_TTL_SECONDS:
+    if not force and now - _stale_components_cache["ts"] < _STALE_COMPONENTS_TTL_SECONDS:
         return _stale_components_cache["value"]
 
     stale: list[str] = []
@@ -788,6 +797,11 @@ async def resolve_drift(
             deps_changed=deps_changed,
             post_steps=post_steps,
         )
+
+    # #11512: rsync + restart + health check all succeeded — this is a
+    # genuine successful drift-resolve, so advance the node's code_version
+    # marker (guarded: only when NO deployed component is still stale).
+    await _advance_node_version_if_fully_synced(request.component)
 
     return DriftResolveResponse(
         success=True,
@@ -3149,6 +3163,63 @@ async def _update_fleet_node_version(node_id: str) -> None:
         logger.warning("Fleet sync: could not update %s version: %s", node_id, db_err)
 
 
+async def _get_local_slm_node_id() -> str | None:
+    """Resolve this SLM's own Node row by matching external_url's host IP.
+
+    Same lookup used by /self-update and /nodes/{id}/sync (Issue #921):
+    IP match, not hostname, since hostnames are user-editable.
+    """
+    from services.database import db_service
+
+    slm_own_ip = urlparse(settings.external_url).hostname or ""
+    if not slm_own_ip:
+        return None
+
+    async with db_service.session() as db:
+        result = await db.execute(select(Node).where(Node.ip_address == slm_own_ip))
+        node = result.scalar_one_or_none()
+        return node.node_id if node else None
+
+
+async def _advance_node_version_if_fully_synced(component: str) -> None:
+    """Advance this node's code_version after a successful drift-resolve (#11512).
+
+    Root cause: Node.code_version was only advanced on a completed Ansible
+    self-update, never on drift-resolve/component-resync + restart, so a
+    node that is actually current stayed permanently flagged "outdated".
+
+    Safety: a single component resolving clean does NOT prove the whole node
+    is current — a sibling component could still be stale. Force a fresh
+    (uncached) scan across every deployed component and only advance when
+    NONE are stale, so a partially-synced node is never falsely marked
+    up to date.
+
+    Defensive by design (matches the rest of this module): this is a
+    best-effort side effect of a resolve/restart that already succeeded, so
+    any failure here (DB hiccup, unresolvable SLM IP, ...) is logged and
+    swallowed rather than turning an otherwise-successful resolve into a
+    reported failure.
+    """
+    try:
+        stale = await _compute_stale_components(force=True)
+        if stale:
+            logger.info(
+                "drift resolve %s: node still has stale components %s — not advancing code_version",
+                component,
+                stale,
+            )
+            return
+
+        node_id = await _get_local_slm_node_id()
+        if not node_id:
+            logger.debug("drift resolve %s: local SLM node not found — skipping version advance", component)
+            return
+
+        await _update_fleet_node_version(node_id)
+    except Exception as exc:  # noqa: BLE001 - best-effort side effect, never break the caller
+        logger.warning("drift resolve %s: could not advance node code_version: %s", component, exc)
+
+
 class MarkSyncedRequest(BaseModel):
     """Request to mark a node as synced without running rsync."""
 
@@ -4491,6 +4562,11 @@ async def _run_slm_stage(
             # procedure here so the one-click update actually brings the whole
             # co-located box current.
             await _resolve_colocated_managed_services(stage, slm_node.node_id)
+            # #11512: the SLM control plane was already at the deployed-commit
+            # marker's target and co-located roles were just resynced — same
+            # "resync succeeded but code_version never advanced" gap as
+            # drift-resolve. Guarded the same way (only when nothing is stale).
+            await _advance_node_version_if_fully_synced("autobot-slm-backend")
             stage.completed_at = _now_iso()
             _stage_log(stage, stage.message)
             return False

--- a/autobot-slm-backend/tests/api/test_drift_resolve_advances_node_version_11512.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve_advances_node_version_11512.py
@@ -1,0 +1,390 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for #11512: node code_version marker stays stale while the
+node runs the latest code, because drift-resolve/component-resync + restart
+never advanced ``Node.code_version`` (only a completed Ansible self-update
+did).
+
+Covers the new ``_advance_node_version_if_fully_synced`` helper:
+  - Advances the node marker when a fresh, forced stale-components scan
+    shows nothing stale (the node is genuinely fully current).
+  - Does NOT advance when a sibling component is still stale — a single
+    component resolving clean must not falsely mark a partially-stale node
+    current (the safer variant called for by the issue).
+  - Does NOT advance when the local SLM node cannot be resolved.
+  - Never raises — a failure here must not turn an otherwise-successful
+    resolve into a reported failure.
+  - ``_get_local_slm_node_id`` resolves via IP match against
+    ``settings.external_url`` (the same pattern used by /self-update).
+
+And the two call sites that were the actual root cause:
+  - POST /drift/resolve (``resolve_drift``): advances on success, not on
+    rsync/pip failure.
+  - The async job (``_run_component_resolve_job``): advances AFTER the
+    deferred restart, not on rsync failure.
+
+Real-load prologue mirrors tests/api/test_drift_resolve.py: the root
+conftest stubs ``models.schemas`` / ``services.drift_checker`` as
+MagicMocks, so this module swaps in the REAL sqlalchemy/models/drift
+modules, execs a PRIVATE copy of api/code_sync.py against them, restores
+the stubs, and pins that private module into ``sys.modules["api.code_sync"]``
+per-test so ``patch("api.code_sync.…")`` targets resolve to it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(_BACKEND_ROOT), str(_BACKEND_ROOT.parent)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SWAP_KEYS = (
+    "models.database",
+    "models.schemas",
+    "services.deploy_artifacts",
+    "services.drift_checker",
+)
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+def _load_real_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+for _name in list(_orig_modules):
+    del sys.modules[_name]
+try:
+    for _name in ("sqlalchemy", "sqlalchemy.ext.asyncio", "sqlalchemy.orm"):
+        importlib.import_module(_name)
+
+    _load_real_module("models.database", _BACKEND_ROOT / "models" / "database.py")
+    _real_schemas = _load_real_module("models.schemas", _BACKEND_ROOT / "models" / "schemas.py")
+    _load_real_module("services.deploy_artifacts", _BACKEND_ROOT / "services" / "deploy_artifacts.py")
+    _real_dc = _load_real_module("services.drift_checker", _BACKEND_ROOT / "services" / "drift_checker.py")
+
+    _cs_spec = importlib.util.spec_from_file_location("_code_sync_advance_test", _BACKEND_ROOT / "api" / "code_sync.py")
+    _CS = importlib.util.module_from_spec(_cs_spec)  # type: ignore[arg-type]
+    _cs_spec.loader.exec_module(_CS)  # type: ignore[union-attr]
+
+    DriftResolveRequest = _real_schemas.DriftResolveRequest
+finally:
+    for _name in [name for name in sys.modules if _is_swap_key(name)]:
+        del sys.modules[_name]
+    for _name, _mod in _orig_modules.items():
+        sys.modules[_name] = _mod
+
+
+@pytest.fixture(autouse=True)
+def _pin_private_code_sync():
+    """Resolve patch("api.code_sync.…") / in-test imports to the private module."""
+    saved = {
+        "api.code_sync": sys.modules.get("api.code_sync"),
+        "services.drift_checker": sys.modules.get("services.drift_checker"),
+    }
+    sys.modules["api.code_sync"] = _CS
+    sys.modules["services.drift_checker"] = _real_dc
+    saved_attrs = {}
+    for _parent, _child, _mod in (("api", "code_sync", _CS), ("services", "drift_checker", _real_dc)):
+        _pkg = sys.modules.get(_parent)
+        if _pkg is not None:
+            saved_attrs[(_parent, _child)] = getattr(_pkg, _child, None)
+            setattr(_pkg, _child, _mod)
+    try:
+        yield
+    finally:
+        for _k, _m in saved.items():
+            if _m is None:
+                sys.modules.pop(_k, None)
+            else:
+                sys.modules[_k] = _m
+        for (_parent, _child), _prev_attr in saved_attrs.items():
+            _pkg = sys.modules.get(_parent)
+            if _pkg is None:
+                continue
+            if _prev_attr is None:
+                with contextlib.suppress(AttributeError):
+                    delattr(_pkg, _child)
+            else:
+                setattr(_pkg, _child, _prev_attr)
+
+
+_FAKE_USER = {"username": "tester", "is_admin": True}
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class _FakeJobRow:
+    """Mutable stand-in for a ComponentSyncJob DB row."""
+
+    def __init__(self):
+        self.status = "running"
+        self.success = None
+        self.deps_changed = False
+        self.post_steps = None
+        self.message = None
+        self.completed_at = None
+
+
+def _make_db_service_mock(row):
+    """db_service mock whose session().execute() always resolves to *row*."""
+    db_service_mock = MagicMock()
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+        async def execute(self, _stmt):
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = row
+            return result
+
+        async def commit(self):
+            pass
+
+        def add(self, _obj):
+            pass
+
+    db_service_mock.session.return_value = _FakeSession()
+    return db_service_mock
+
+
+# ---------------------------------------------------------------------------
+# _advance_node_version_if_fully_synced — guard logic
+# ---------------------------------------------------------------------------
+
+
+def test_advances_when_fully_synced():
+    """stale=[] + node found -> _update_fleet_node_version IS called."""
+    with (
+        patch.object(_CS, "_compute_stale_components", AsyncMock(return_value=[])),
+        patch.object(_CS, "_get_local_slm_node_id", AsyncMock(return_value="slm-node-1")),
+        patch.object(_CS, "_update_fleet_node_version", AsyncMock()) as update_mock,
+    ):
+        _run(_CS._advance_node_version_if_fully_synced("autobot-slm-backend"))
+
+    update_mock.assert_awaited_once_with("slm-node-1")
+
+
+def test_does_not_advance_when_sibling_component_still_stale():
+    """A single component resolving clean must NOT mark a partially-stale
+    node current — the safer variant required by #11512 (a sibling component,
+    e.g. autobot_shared, could still be drifted).
+    """
+    with (
+        patch.object(_CS, "_compute_stale_components", AsyncMock(return_value=["autobot_shared"])),
+        patch.object(_CS, "_get_local_slm_node_id", AsyncMock()) as node_id_mock,
+        patch.object(_CS, "_update_fleet_node_version", AsyncMock()) as update_mock,
+    ):
+        _run(_CS._advance_node_version_if_fully_synced("autobot-slm-backend"))
+
+    update_mock.assert_not_called()
+    node_id_mock.assert_not_called()
+
+
+def test_does_not_advance_when_local_node_not_found():
+    """stale=[] but the local SLM node can't be resolved -> no advance, no crash."""
+    with (
+        patch.object(_CS, "_compute_stale_components", AsyncMock(return_value=[])),
+        patch.object(_CS, "_get_local_slm_node_id", AsyncMock(return_value=None)),
+        patch.object(_CS, "_update_fleet_node_version", AsyncMock()) as update_mock,
+    ):
+        _run(_CS._advance_node_version_if_fully_synced("autobot-slm-backend"))
+
+    update_mock.assert_not_called()
+
+
+def test_swallows_exceptions_without_propagating():
+    """A failure inside the guard (DB hiccup, bad settings, ...) must never
+    turn an otherwise-successful resolve into a reported failure.
+    """
+    with patch.object(_CS, "_compute_stale_components", AsyncMock(side_effect=RuntimeError("boom"))):
+        _run(_CS._advance_node_version_if_fully_synced("autobot-slm-backend"))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _get_local_slm_node_id — IP-match lookup (same pattern as /self-update)
+# ---------------------------------------------------------------------------
+
+
+def test_get_local_slm_node_id_resolves_via_ip_match():
+    fake_node = MagicMock()
+    fake_node.node_id = "slm-node-42"
+    db_mock = _make_db_service_mock(fake_node)
+
+    with patch.object(_CS, "settings") as mock_settings:
+        mock_settings.external_url = "http://10.0.0.5:8000"
+        with patch.dict(sys.modules, {"services.database": MagicMock(db_service=db_mock)}):
+            node_id = _run(_CS._get_local_slm_node_id())
+
+    assert node_id == "slm-node-42"
+
+
+def test_get_local_slm_node_id_returns_none_without_external_url():
+    with patch.object(_CS, "settings") as mock_settings:
+        mock_settings.external_url = ""
+        node_id = _run(_CS._get_local_slm_node_id())
+
+    assert node_id is None
+
+
+def test_get_local_slm_node_id_returns_none_when_node_not_found():
+    db_mock = _make_db_service_mock(None)
+
+    with patch.object(_CS, "settings") as mock_settings:
+        mock_settings.external_url = "http://10.0.0.5:8000"
+        with patch.dict(sys.modules, {"services.database": MagicMock(db_service=db_mock)}):
+            node_id = _run(_CS._get_local_slm_node_id())
+
+    assert node_id is None
+
+
+# ---------------------------------------------------------------------------
+# POST /drift/resolve wiring — resolve_drift advances on success only
+# ---------------------------------------------------------------------------
+
+
+def _setup_dir_mocks(component="autobot-slm-backend"):
+    return (
+        patch.object(_CS, "get_default_source_dir", return_value=f"/opt/autobot/code_source/{component}"),
+        patch.object(_CS, "get_default_deployed_dir", return_value=f"/opt/autobot/{component}"),
+    )
+
+
+def test_resolve_drift_success_advances_node_version():
+    src_patch, dep_patch = _setup_dir_mocks()
+    rsync_patch = patch.object(_CS, "_rsync_component_local", AsyncMock(return_value=(True, "")))
+    post_sync_patch = patch.object(
+        _CS,
+        "_run_post_sync_steps",
+        AsyncMock(return_value=(False, [], True)),
+    )
+    advance_patch = patch.object(_CS, "_advance_node_version_if_fully_synced", AsyncMock())
+
+    with src_patch, dep_patch, rsync_patch, post_sync_patch, advance_patch as advance_mock:
+        req = DriftResolveRequest(component="autobot-slm-backend")
+        resp = _run(_CS.resolve_drift(req, _FAKE_USER))
+
+    assert resp.success is True
+    advance_mock.assert_awaited_once_with("autobot-slm-backend")
+
+
+def test_resolve_drift_pip_failure_does_not_advance_node_version():
+    src_patch, dep_patch = _setup_dir_mocks()
+    rsync_patch = patch.object(_CS, "_rsync_component_local", AsyncMock(return_value=(True, "")))
+    post_sync_patch = patch.object(
+        _CS,
+        "_run_post_sync_steps",
+        AsyncMock(return_value=(False, ["pip install: FAILED"], False)),
+    )
+    advance_patch = patch.object(_CS, "_advance_node_version_if_fully_synced", AsyncMock())
+
+    with src_patch, dep_patch, rsync_patch, post_sync_patch, advance_patch as advance_mock:
+        req = DriftResolveRequest(component="autobot-slm-backend")
+        resp = _run(_CS.resolve_drift(req, _FAKE_USER))
+
+    assert resp.success is False
+    advance_mock.assert_not_called()
+
+
+def test_resolve_drift_rsync_failure_does_not_advance_node_version():
+    src_patch, dep_patch = _setup_dir_mocks()
+    rsync_patch = patch.object(_CS, "_rsync_component_local", AsyncMock(return_value=(False, "rsync failed")))
+    advance_patch = patch.object(_CS, "_advance_node_version_if_fully_synced", AsyncMock())
+
+    with src_patch, dep_patch, rsync_patch, advance_patch as advance_mock:
+        req = DriftResolveRequest(component="autobot-slm-backend")
+        resp = _run(_CS.resolve_drift(req, _FAKE_USER))
+
+    assert resp.success is False
+    advance_mock.assert_not_called()
+
+
+def test_invalid_component_never_advances():
+    """Guard: request validation failure (400) happens before any advance call."""
+    advance_patch = patch.object(_CS, "_advance_node_version_if_fully_synced", AsyncMock())
+    with advance_patch as advance_mock:
+        req = DriftResolveRequest(component="../../etc/passwd")
+        with pytest.raises(HTTPException):
+            _run(_CS.resolve_drift(req, _FAKE_USER))
+    advance_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Async job wiring — _run_component_resolve_job advances AFTER the restart
+# ---------------------------------------------------------------------------
+
+
+def test_component_resolve_job_advances_after_restart():
+    row = _FakeJobRow()
+    db_mock = _make_db_service_mock(row)
+    call_order: list[str] = []
+
+    async def _fake_restart(component, steps):
+        call_order.append("restarted")
+
+    async def _fake_advance(component):
+        call_order.append("advanced")
+
+    with (
+        patch.object(_CS, "get_default_source_dir", return_value="/src/autobot-slm-backend"),
+        patch.object(_CS, "get_default_deployed_dir", return_value="/opt/autobot/autobot-slm-backend"),
+        patch.object(_CS, "_rsync_component_local", AsyncMock(return_value=(True, ""))),
+        patch.object(
+            _CS,
+            "_run_post_sync_steps",
+            AsyncMock(return_value=(False, ["post-sync: restart deferred"], True)),
+        ),
+        patch.object(_CS, "_restart_component_services", side_effect=_fake_restart),
+        patch.object(_CS, "_advance_node_version_if_fully_synced", side_effect=_fake_advance),
+        patch.object(_CS, "_running_tasks", {}),
+    ):
+        with patch.dict(sys.modules, {"services.database": MagicMock(db_service=db_mock)}):
+            _run(_CS._run_component_resolve_job("job-11512", "autobot-slm-backend"))
+
+    assert call_order == ["restarted", "advanced"], f"expected restart before advance, got {call_order}"
+    assert row.status == "completed"
+
+
+def test_component_resolve_job_rsync_failure_does_not_advance():
+    row = _FakeJobRow()
+    db_mock = _make_db_service_mock(row)
+    advance_mock = AsyncMock()
+
+    with (
+        patch.object(_CS, "get_default_source_dir", return_value="/src/autobot-slm-backend"),
+        patch.object(_CS, "get_default_deployed_dir", return_value="/opt/autobot/autobot-slm-backend"),
+        patch.object(_CS, "_rsync_component_local", AsyncMock(return_value=(False, "rsync boom"))),
+        patch.object(_CS, "_advance_node_version_if_fully_synced", advance_mock),
+        patch.object(_CS, "_running_tasks", {}),
+    ):
+        with patch.dict(sys.modules, {"services.database": MagicMock(db_service=db_mock)}):
+            _run(_CS._run_component_resolve_job("job-11512-fail", "autobot-slm-backend"))
+
+    assert row.status == "failed"
+    advance_mock.assert_not_called()


### PR DESCRIPTION
## Thinking Path

Root cause confirmed: `Node.code_version` was only advanced by `_update_fleet_node_version()` on paths that culminate in a completed Ansible run (`_ansible_self_update`, `_sync_single_node`) or the SLM self-sync helper (`_mark_slm_node_up_to_date`). The per-component drift-resolve endpoints — `POST /drift/resolve` (`resolve_drift`, `autobot-slm-backend/api/code_sync.py:695`) and its async counterpart (`resolve_drift_async` → `_run_component_resolve_job`, line 201) — rsync files from `code_source`, run post-sync steps, and call `_restart_component_services` (line 1928), but never touched `Node.code_version`. So a node deployed entirely via drift-resolve (or a scheduled sync that lands through it) stays permanently flagged "outdated" even though files/DB/process are all current — exactly the symptom in #11512 (484 commits behind on a fully-current node).

Chosen approach: the **safer variant** — advance the local SLM node's `code_version` only when a *fresh, forced* rescan across every deployed component (`_compute_stale_components(force=True)`, reusing the #11820 per-component drift scanner) shows **zero** stale components, not just the one component that was just resolved. A single component resolving clean does not prove the whole node is current — a sibling component could still be drifted — so gating on the single component's success would risk falsely marking a partially-stale node "up to date". This reuses the existing `_update_fleet_node_version()` helper (unchanged) to actually write the commit, so the self-update path's marker-advance logic is untouched.

The `_compute_stale_components` TTL cache previously had no bypass, so a caller right after a resolve could read a stale cached list (including the component it just fixed). Added a `force: bool = False` param that skips the TTL check but still refreshes the cache — a useful side effect: `/status`'s `stale_components` field is now warmed with the accurate post-resolve state immediately instead of waiting up to `SLM_STALE_COMPONENTS_TTL_SECONDS`.

While in this file, found the exact same gap in the update-all pipeline's "SLM already current" fast path (`_run_slm_stage`, line ~4517): when the deployed-commit marker already equals the target, no Ansible self-update fires, `_resolve_colocated_managed_services` resyncs co-located roles, but `Node.code_version` was never advanced there either — same root cause, same file, same new helper. Fixed in this PR (Rule 6: fix pre-existing issues discovered along the way, same PR when in-scope) rather than filing a separate discovery issue, since it's a 3-line wire-in of the exact helper this PR introduces.

## What Changed

`autobot-slm-backend/api/code_sync.py`:
- `_compute_stale_components(force: bool = False)` — new `force` param bypasses the TTL cache for a guaranteed-fresh scan; cache is still refreshed either way.
- New `_get_local_slm_node_id()` — resolves this SLM's own `Node` row via IP match against `settings.external_url` (same lookup pattern already used by `/self-update` and `/nodes/{id}/sync`, Issue #921).
- New `_advance_node_version_if_fully_synced(component)` — forces a fresh stale-components scan; only when it comes back empty does it resolve the local node and call `_update_fleet_node_version()`. Wrapped in its own try/except (best-effort side effect, matches this module's existing defensive style) so a DB hiccup or unresolvable IP never turns an otherwise-successful resolve into a reported failure.
- Wired into three call sites:
  - `resolve_drift` (sync `POST /drift/resolve`) — called right before the `success=True` response, i.e. only after rsync + post-sync steps (incl. restart + health check) all succeeded.
  - `_run_component_resolve_job` (async `POST /drift/resolve-async` background job) — called immediately after the deferred `_restart_component_services()` call, which only returns for non-self-killing components (a self-restarting component's process dies mid-call and never reaches this line — acceptable, matches the file's existing self-restart risk model).
  - `_run_slm_stage`'s CURRENT branch — called after `_resolve_colocated_managed_services`, closing the same gap for the update-all "already current" fast path.

## Verification

```
$ python3 -c "import ast; ast.parse(open('autobot-slm-backend/api/code_sync.py', encoding='utf-8').read())"
ast OK

$ python3 -m black --check autobot-slm-backend/api/code_sync.py autobot-slm-backend/tests/api/test_drift_resolve_advances_node_version_11512.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.

$ python3 -m flake8 autobot-slm-backend/api/code_sync.py autobot-slm-backend/tests/api/test_drift_resolve_advances_node_version_11512.py --max-line-length=120
(no output — clean)

$ python3 -m pytest autobot-slm-backend/tests/api/ -q
315 passed, 4 warnings in 623.40s
```

New regression tests (`tests/api/test_drift_resolve_advances_node_version_11512.py`, 12 tests, all passing):
- `_advance_node_version_if_fully_synced`: advances when fully synced; **does NOT advance when a sibling component is still stale** (the core safety guard); does not advance when the local node can't be resolved; never raises on internal failure.
- `_get_local_slm_node_id`: resolves via IP match; returns `None` without an `external_url`; returns `None` when no node matches.
- `resolve_drift` wiring: advances on success; does NOT advance on pip failure, rsync failure, or invalid-component 400.
- `_run_component_resolve_job` wiring: advances AFTER the restart call (verified ordering); does NOT advance on rsync failure.

All 315 pre-existing `tests/api/` tests still pass (no regressions in `test_drift_resolve.py`, `test_component_resolve_job.py`, `test_status_stale_components_11820.py`, `test_slm_deployed_commit_marker_12202.py`).

## Model Used

Sonnet 5 (claude-sonnet-5-20251101)

Closes #11512