### PR TITLE
refactor(frontend): rename misnamed security/useSecretsAuditApi → useSecretsInfraApi (#12160)

### DIFF
--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -796,7 +796,7 @@ import { useChatStore } from '@/stores/useChatStore';
 import { createLogger } from '@/utils/debugUtils';
 import { formatDateTime } from '@/utils/formatHelpers';
 import { useDebounce } from '@/composables/useDebounce';
-import { useSecretsAuditApi } from '@/composables/security/useSecretsAuditApi';
+import { useSecretsInfraApi } from '@/composables/security/useSecretsInfraApi';
 import EmptyState from '@/components/ui/EmptyState.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
 import { BaseModal } from '@autobot/ui'
@@ -804,7 +804,7 @@ import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n();
 const logger = createLogger('SecretsManager');
-const { fetchInfraHosts, fetchSecretsUsage, deleteInfraHost } = useSecretsAuditApi();
+const { fetchInfraHosts, fetchSecretsUsage, deleteInfraHost } = useSecretsInfraApi();
 
 // Infrastructure-host connection metadata stored alongside a secret.
 interface SecretMetadata {

--- a/autobot-frontend/src/composables/security/useSecretsInfraApi.ts
+++ b/autobot-frontend/src/composables/security/useSecretsInfraApi.ts
@@ -1,8 +1,11 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
 /**
- * useSecretsAuditApi — thin fetch wrappers for infrastructure-host and
- * workflow-usage endpoints used by SecretsManager.
+ * useSecretsInfraApi — thin fetch wrappers for infrastructure-host and
+ * secrets-usage endpoints used by SecretsManager. Renamed from
+ * useSecretsAuditApi (#12160): it fetches infra hosts, not audit logs — the
+ * old name collided with the real composables/useSecretsAuditApi (audit-log
+ * entries).
  *
  * Extracted from SecretsManager.vue (issue #6081).
  */
@@ -35,7 +38,7 @@ export interface SecretsUsageResponse {
   secrets_usage: Record<string, unknown[]>;
 }
 
-export function useSecretsAuditApi() {
+export function useSecretsInfraApi() {
   /** Fetch legacy infrastructure hosts from the old API. */
   async function fetchInfraHosts(): Promise<InfraHostsResponse> {
     const backendUrl = getBackendUrl();


### PR DESCRIPTION
## Thinking Path
`composables/security/useSecretsAuditApi.ts` doesn't do audit logs — it fetches infrastructure hosts (`GET /api/infrastructure/hosts`) + secrets-usage for SecretsManager.vue. Its name collided with the real `composables/useSecretsAuditApi.ts` (audit-log entries), which is confusing. Low-risk mechanical rename (part of #11658 naming cleanup).

## What Changed
- `git mv` `composables/security/useSecretsAuditApi.ts` → `composables/security/useSecretsInfraApi.ts`; renamed the export `useSecretsAuditApi` → `useSecretsInfraApi` + updated the header.
- Updated its only consumer, `components/security/SecretsManager.vue` (import + call site).
- The real `composables/useSecretsAuditApi.ts` (audit log, consumed by `components/secrets/SecretAuditLog.vue`) is untouched.

## Verification
- No dangling imports of the old `security/useSecretsAuditApi` path remain anywhere in `autobot-frontend/src`.
- New export wired: SecretsManager.vue imports + calls `useSecretsInfraApi`.

## Model Used
Opus 4.8

Closes #12160