### PR TITLE
fix(security): tenant-scope agent_api context/peers reads to stop cross-tenant leak (#12156)

### DIFF
--- a/autobot-backend/llc/api/agent_api.py
+++ b/autobot-backend/llc/api/agent_api.py
@@ -40,6 +40,25 @@ def _agent_context(request: Request) -> tuple[str, str]:
     return agent_id, company_id
 
 
+async def _assert_item_in_company(item_id: str, company_id: str) -> None:
+    """GH#12156: 404 unless the work item belongs to the caller's company.
+
+    KB collections are keyed by work_item_id alone, so tenant isolation must be
+    enforced at the handler by verifying ownership before any KB read.
+    """
+    from autobot_shared.singleton_factory import lazy_singleton
+    from user_management.database import get_async_session_factory
+
+    from ..services.work_item_service import WorkItemService
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        svc = lazy_singleton(WorkItemService)()
+        item = await svc.get(session, item_id)
+    if item is None or str(item.company_id) != str(company_id):
+        raise HTTPException(status_code=404, detail="Work item not found")
+
+
 @router.get("/work-items/next")
 async def get_next_work_item(request: Request) -> Dict[str, Any]:
     agent_id, company_id = _agent_context(request)
@@ -187,7 +206,8 @@ async def agent_upload_attachment(
 @router.get("/context/{item_id}")
 async def get_item_context(item_id: uuid.UUID, request: Request) -> Dict[str, Any]:
     """Return agent context for a work item, including any human handoff KB notes (GH#8232)."""
-    _agent_context(request)  # GH#12148: enforce authenticated agent context (defense-in-depth)
+    _, company_id = _agent_context(request)  # GH#12148: authenticated agent context
+    await _assert_item_in_company(str(item_id), company_id)  # GH#12156: tenant scope
     from ..kb.work_item_kb import WorkItemKB
 
     kb = WorkItemKB()

--- a/autobot-backend/llc/tests/test_agent_context_tenant_scope.py
+++ b/autobot-backend/llc/tests/test_agent_context_tenant_scope.py
@@ -1,0 +1,95 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Cross-tenant isolation for agent_api context + peers reads (GH#12156).
+
+The KB context collection is keyed by ``work_item_id`` alone, so an authenticated
+agent for company A could read company B's handoff notes by UUID. These tests
+prove the handler now verifies work-item ownership (cross-tenant -> 404, own ->
+data) and that peer search only ever queries the caller's own company index.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from llc.api import agent_api
+
+_COMPANY_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_COMPANY_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+_ITEM_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+_DB = "user_management.database"
+_WIS = "llc.services.work_item_service"
+
+
+def _request(company_id: str) -> MagicMock:
+    req = MagicMock()
+    req.state.agent_id = "agent-1"
+    req.state.company_id = company_id
+    return req
+
+
+def _patched_factory():
+    """Stand-in for get_async_session_factory yielding a throwaway session."""
+
+    @asynccontextmanager
+    async def _cm():
+        yield MagicMock()
+
+    return lambda: _cm()
+
+
+def _patch_work_item(item_company_id):  # noqa: ANN001, ANN202
+    item = None if item_company_id is None else MagicMock(company_id=item_company_id)
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=item)
+    return (
+        patch(f"{_DB}.get_async_session_factory", new=_patched_factory),
+        patch(f"{_WIS}.WorkItemService", return_value=svc),
+    )
+
+
+@pytest.mark.asyncio
+class TestContextTenantScope:
+    async def test_cross_tenant_context_404(self):
+        fac_p, svc_p = _patch_work_item(_COMPANY_B)  # item owned by B
+        with fac_p, svc_p:
+            with pytest.raises(HTTPException) as exc:
+                await agent_api.get_item_context(_ITEM_ID, _request(_COMPANY_A))
+        assert exc.value.status_code == 404
+
+    async def test_missing_item_404(self):
+        fac_p, svc_p = _patch_work_item(None)  # no such item
+        with fac_p, svc_p:
+            with pytest.raises(HTTPException) as exc:
+                await agent_api.get_item_context(_ITEM_ID, _request(_COMPANY_A))
+        assert exc.value.status_code == 404
+
+    async def test_same_tenant_context_ok(self):
+        fac_p, svc_p = _patch_work_item(_COMPANY_A)  # item owned by caller
+        kb = MagicMock()
+        kb.get_context = AsyncMock(return_value=[{"id": "notes:1", "document": "hi", "metadata": {}}])
+        with fac_p, svc_p, patch("llc.kb.work_item_kb.WorkItemKB", return_value=kb):
+            result = await agent_api.get_item_context(_ITEM_ID, _request(_COMPANY_A))
+        assert result["has_human_handoff_context"] is True
+        assert result["handoff_notes"][0]["document"] == "hi"
+        kb.get_context.assert_awaited_once_with(_ITEM_ID)
+
+
+@pytest.mark.asyncio
+class TestPeersTenantScope:
+    async def test_peers_query_scoped_to_caller_company(self):
+        collection = MagicMock()
+        collection.query = AsyncMock(return_value={"ids": [[]]})
+        kb = MagicMock()
+        kb._async_chroma_client.get_collection = AsyncMock(return_value=collection)
+        with patch("knowledge.get_knowledge_base", new=AsyncMock(return_value=kb)):
+            out = await agent_api.search_peer_agents(q="devops", request=_request(_COMPANY_A))
+        assert out["count"] == 0
+        called_name = kb._async_chroma_client.get_collection.await_args.args[0]
+        assert called_name == f"company:{_COMPANY_A}:agents"
+        assert _COMPANY_B not in called_name


### PR DESCRIPTION
## Thinking Path
Follow-up to the #12148 auth campaign (PR #12155). Those handlers are now authenticated by `LLCAgentAuthMiddleware` (per-agent LLC bearer, injecting `request.state.agent_id`/`company_id`), but `get_item_context` only *authenticated* the caller — it never verified the requested work item belongs to that caller's company. WorkItemKB collections are keyed by `work_item:{work_item_id}` alone (no company prefix), so an agent for company A could read company B's handoff notes just by passing B's item UUID. Traced the KB keying + how siblings (`agent_hires`, work-item CRUD) enforce tenant scope before touching auth. `peers/search` was audited too: it already scopes via `company:{company_id}:agents` built from the caller's own `company_id`, so it does not leak — this PR locks that in with a regression test rather than changing behaviour.

## What Changed
- **agent_api.py** — new `_assert_item_in_company(item_id, company_id)` helper: loads the work item via `WorkItemService.get` and raises **404** ("Work item not found") when the item is missing OR its `company_id` differs from the caller's. `get_item_context` now calls it (after `_agent_context` auth) before any KB read. 404 (not 403) matches the issue's requested convention and avoids existence disclosure across tenants. Auth unchanged; still async; helper ≤30 lines.
- **test_agent_context_tenant_scope.py** (new) — regression coverage:
  - `test_cross_tenant_context_404` — agent-of-A reading a B-owned item → 404, no KB read.
  - `test_missing_item_404` — unknown item → 404.
  - `test_same_tenant_context_ok` — agent-of-A reading its own item → handoff notes returned.
  - `test_peers_query_scoped_to_caller_company` — peer search only ever queries `company:{A}:agents`, never company B's collection.

## Verification
- `python3 -m pytest llc/tests/test_agent_context_tenant_scope.py` → **4 passed**.
- Sibling suites green: `test_agent_auth_middleware.py`, `test_agent_hires_auth.py`, `test_heartbeat_context.py` → **18 passed**.
- `ast.parse` OK on both changed files; `black --check` clean; `flake8` clean (RC=0).
- No commit trailers; author `mrveiss`.

## Model Used
Opus 4.8

Closes #12156
