### PR TITLE
fix(llc): register hired agent so trigger/heartbeat resolves it (#12210)

### DIFF
--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -383,8 +383,14 @@ class HeartbeatScheduler:
         the DB commit is visible to other connections (avoids the race where
         _run_adapter's RUNNING UPDATE matches 0 rows because the INSERT is
         still uncommitted).
+
+        Looks up the agent with ``require_enabled=False`` (GH#12210): a manual
+        trigger is an explicit one-off run request, independent of the periodic
+        cron toggle. ``AgentHireRequest.heartbeat_enabled`` defaults to False,
+        so a freshly hired agent that never opted into periodic dispatch would
+        otherwise be invisible here and every manual trigger would raise.
         """
-        agent = await self._get_agent_config(session, agent_id)
+        agent = await self._get_agent_config(session, agent_id, require_enabled=False)
         if agent is None:
             raise ValueError(f"Agent {agent_id!r} not found or not configured")
 
@@ -413,18 +419,27 @@ class HeartbeatScheduler:
     # Shared helpers
     # ------------------------------------------------------------------
 
-    async def _get_agent_config(self, session: AsyncSession, agent_id: str) -> Optional[Dict[str, Any]]:
-        result = await session.execute(
-            text("""
-                SELECT aon.agent_id, aon.name, aon.heartbeat_cron, aon.heartbeat_enabled,
-                       aon.adapter_type, aon.adapter_config, aon.context_mode,
-                       aon.company_id
-                FROM agent_org_nodes aon
-                WHERE aon.agent_id = :agent_id
-                  AND aon.heartbeat_enabled = true
-                """),
-            {"agent_id": agent_id},
-        )
+    async def _get_agent_config(
+        self, session: AsyncSession, agent_id: str, require_enabled: bool = True
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve adapter config for *agent_id* from ``agent_org_nodes``.
+
+        ``require_enabled`` gates on the periodic ``heartbeat_enabled`` cron
+        toggle. It stays True for the scheduler's own dispatch path (its Redis
+        schedule is populated exclusively from enabled agents — see
+        ``_load_enabled_agents``), but manual triggers (GH#12210) pass False so
+        a hired-but-not-yet-cron-enabled agent still resolves.
+        """
+        query = """
+            SELECT aon.agent_id, aon.name, aon.heartbeat_cron, aon.heartbeat_enabled,
+                   aon.adapter_type, aon.adapter_config, aon.context_mode,
+                   aon.company_id
+            FROM agent_org_nodes aon
+            WHERE aon.agent_id = :agent_id
+        """
+        if require_enabled:
+            query += " AND aon.heartbeat_enabled = true"
+        result = await session.execute(text(query), {"agent_id": agent_id})
         row = result.mappings().first()
         return dict(row) if row else None
 

--- a/autobot-backend/llc/tests/test_agent_hire_trigger_12210.py
+++ b/autobot-backend/llc/tests/test_agent_hire_trigger_12210.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression test for GH#12210 — hired agent can't run (heartbeat/trigger).
+
+Repro: ``POST /companies/{id}/agent-hires`` never sets ``heartbeat_enabled``
+(``AgentHireRequest.heartbeat_enabled`` defaults False, see
+``llc/api/agent_hires.py``), then ``POST /agents/{agent_id}/heartbeat/trigger``
+raised ``ValueError: Agent '<id>' not found or not configured`` from
+``HeartbeatScheduler._get_agent_config`` — it filtered on
+``heartbeat_enabled = true`` unconditionally, so a freshly hired agent that
+never opted into the periodic cron was invisible to a manual trigger.
+
+The org node is seeded directly via the ``AgentOrgNode`` ORM model against an
+in-memory SQLite DB (the shared LLC loop harness — see ``_e2e_harness.py`` and
+``test_llc_e2e_loop.py``'s own documented direct-seed pattern; hitting the real
+hire *HTTP* route here is not viable because its raw ``text()`` INSERT omits
+``created_at``/``updated_at``, relying on a Postgres-only server default that
+the SQLite harness intentionally strips for ORM-issued inserts). The seeded
+row mirrors exactly what the hire endpoint persists by default:
+``heartbeat_enabled=False``, ``adapter_type="claude_code"``, a resolved model
+in ``adapter_config``. The test then calls the scheduler's real
+``trigger_manual`` — the exact code path ``llc/api/agents.py``'s trigger
+endpoint invokes — and asserts it resolves the agent and queues a run instead
+of raising "not found or not configured".
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.models.enums import LLCRunStatus
+from llc.scheduler.heartbeat_scheduler import HeartbeatScheduler
+
+# Importing the harness registers the SQLite compile shims and loop models
+# (including AgentOrgNode) on Base.metadata before create_all runs.
+from llc.tests import _e2e_harness as harness
+from models.agent_org import AgentOrgNode, OrgRole
+
+_ORG = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+
+@pytest_asyncio.fixture
+async def engine():  # noqa: ANN201
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
+    await harness.create_loop_schema(eng)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+
+async def _hire_agent(session_factory, *, heartbeat_enabled: bool = False) -> str:  # noqa: ANN001
+    """Seed an ``AgentOrgNode`` matching what ``POST /agent-hires`` persists.
+
+    ``heartbeat_enabled`` defaults False here to mirror
+    ``AgentHireRequest.heartbeat_enabled``'s default (GH#12210 repro: the caller
+    never sets it).
+    """
+    agent_id = str(uuid.uuid4())
+    async with session_factory() as session:
+        session.add(
+            AgentOrgNode(
+                id=uuid.uuid4(),
+                agent_id=agent_id,
+                name="ABR CEO",
+                org_role=OrgRole.MANAGER.value,
+                company_id=_ORG,
+                heartbeat_enabled=heartbeat_enabled,
+                adapter_type="claude_code",
+                adapter_config={"model": "claude-sonnet-4-6"},
+                model="claude-sonnet-4-6",
+            )
+        )
+        await session.commit()
+    return agent_id
+
+
+@pytest.mark.asyncio
+async def test_hired_agent_can_be_manually_triggered(session_factory) -> None:  # noqa: ANN001
+    """Hire (heartbeat_enabled defaults False) then trigger_manual must resolve it."""
+    agent_id = await _hire_agent(session_factory)
+
+    scheduler = HeartbeatScheduler()
+    async with session_factory() as session:
+        run, agent_cfg = await scheduler.trigger_manual(session, agent_id)
+        await session.commit()
+
+    assert agent_cfg["agent_id"] == agent_id
+    assert not agent_cfg["heartbeat_enabled"]  # hire default, unchanged (GH#12210)
+    assert run.status == LLCRunStatus.QUEUED.value
+
+
+@pytest.mark.asyncio
+async def test_unhired_agent_still_raises_not_found(session_factory) -> None:  # noqa: ANN001
+    """No org node at all still fails fast — the fix must not open a blanket bypass."""
+    scheduler = HeartbeatScheduler()
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="not found"):
+            await scheduler.trigger_manual(session, "agent-does-not-exist")


### PR DESCRIPTION
## Thinking Path
Traced the issue's repro: `POST /companies/{id}/agent-hires` inserts an `agent_org_nodes` row via `llc/api/agent_hires.py` — `AgentHireRequest.heartbeat_enabled` defaults to `False` and the repro never overrides it. `POST /agents/{agent_id}/heartbeat/trigger` (`llc/api/agents.py`) calls `HeartbeatScheduler.trigger_manual`, which resolves the agent via `_get_agent_config` (`llc/scheduler/heartbeat_scheduler.py:416`). That lookup filtered `WHERE aon.heartbeat_enabled = true` unconditionally, so a freshly hired agent with `heartbeat_enabled=False` (the default) is invisible to the query and `trigger_manual` raises `ValueError: Agent '<id>' not found or not configured` (line 389) — surfaced as a 404 by the API. This is an ID/state mismatch: the hire sets a state (`heartbeat_enabled=False`) that the trigger's lookup requires to be `True`, even though "trigger" is an explicit one-off run request, not a request to enroll in the periodic cron.

The scheduler's own periodic dispatch path (`_handle_due_agent`) also calls `_get_agent_config`, but correctly requires `heartbeat_enabled=true` there — its Redis schedule is populated exclusively from enabled agents (`_load_enabled_agents`), so that filter is intentional and must stay.

## What Changed
- `llc/scheduler/heartbeat_scheduler.py`: added a `require_enabled: bool = True` parameter to `_get_agent_config`. `trigger_manual` now calls it with `require_enabled=False` — a manual trigger resolves any configured agent for the caller's org regardless of the periodic cron toggle. The scheduler's own dispatch path (`_handle_due_agent`) keeps the default `True`, so periodic behavior is unchanged. No broad `except` added; tenant isolation is unaffected (the post-lookup company-id check in `llc/api/agents.py` is untouched, still 404s on cross-tenant IDs).
- `llc/tests/test_agent_hire_trigger_12210.py` (new): regression test. Seeds an `AgentOrgNode` matching exactly what the hire endpoint persists by default (`heartbeat_enabled=False`, `adapter_type="claude_code"`, resolved model in `adapter_config`) against the shared in-memory SQLite LLC-loop harness (`llc/tests/_e2e_harness.py`), then calls the real `HeartbeatScheduler.trigger_manual` — the exact code path the trigger endpoint invokes — and asserts it queues a run instead of raising. A second test asserts a genuinely nonexistent agent still raises "not found" (the fix does not open a blanket bypass).

## Verification
- Confirmed the new test reproduces the bug: temporarily reverted the fix and re-ran `test_hired_agent_can_be_manually_triggered` — it failed with the exact reported error (`ValueError: Agent '<id>' not found or not configured`); re-applying the fix makes it pass.
- `python3 -m pytest llc/tests/test_agent_hire_trigger_12210.py llc/tests/test_heartbeat_scheduler.py llc/tests/test_llc_e2e_loop.py llc/tests/test_agent_hires_auth.py -q` → 48 passed.
- Full `llc/tests/` suite: `python3 -m pytest llc/tests/ -q` → 1255 passed, 2 skipped (pre-existing, unrelated skips).
- `python3 -m black --check llc/scheduler/heartbeat_scheduler.py llc/tests/test_agent_hire_trigger_12210.py` → unchanged.
- `python3 -m flake8 llc/scheduler/heartbeat_scheduler.py llc/tests/test_agent_hire_trigger_12210.py` → clean.
- `ast.parse` on both changed `.py` files → OK.

## Model Used
Sonnet

Closes #12210