### PR TITLE
fix(chat): count hard-truncation in ToolOutputFilter savings metric (#12239)

### DIFF
--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -395,9 +395,12 @@ def classify_tool(command: str) -> str:
     return categories.get(cmd, "other")
 
 
-async def record_filter_savings(command: str, original: str, filtered: str) -> None:
-    """Track bytes saved by filter category in Redis analytics (fire-and-forget)."""
-    savings = len(original) - len(filtered)
+async def record_filter_savings(command: str, savings: int) -> None:
+    """Track *savings* bytes for *command*'s category in Redis analytics (fire-and-forget).
+
+    ``savings`` must be the total bytes removed across every reduction stage
+    (soft filter + terminal hard cap) — see :meth:`ToolOutputFilter.filter`.
+    """
     if savings <= 0:
         return
     category = classify_tool(command)
@@ -463,26 +466,39 @@ class ToolOutputFilter:
 
         rule = self._match_rule(command)
         if rule is None:
-            return cap_unmatched_output(command, output, exit_code)
+            result = cap_unmatched_output(command, output, exit_code)
+            self._schedule_savings(command, len(output) - len(result))
+            return result
 
         filtered = self._apply(rule, output, exit_code)
-        pre_hint_filtered = filtered  # snapshot before tee hint for accurate savings
-
-        savings = len(output) - len(pre_hint_filtered)
-        if savings > 200:
+        # Content-level savings, pre-hint (#5895) — the tee-hint pointer is
+        # navigational overhead, not filtered-away content, so it isn't
+        # counted against the metric.
+        content_savings = len(output) - len(filtered)
+        if content_savings > 200:
             hint = tee_and_hint(output, command.strip().split()[0], exit_code)
             if hint and filtered:
                 filtered = filtered + "\n" + hint
 
-        try:
-            asyncio.get_running_loop().create_task(record_filter_savings(command, output, pre_hint_filtered))
-        except RuntimeError:
-            pass
-
         # Issue #11543: terminal guard — a matched rule can still leave output
         # above the ceiling (huge diff, hundreds of failures). Cap the final
         # result regardless of match so nothing above the cap reaches history.
-        return _hard_cap(command, filtered, output, exit_code)
+        pre_cap_len = len(filtered)
+        result = _hard_cap(command, filtered, output, exit_code)
+
+        # Issue #12239: the hard cap can trim a matched rule's own output
+        # further — that delta was previously dropped from the metric,
+        # under-counting the true savings whenever the cap fired on a match.
+        hard_cap_savings = max(pre_cap_len - len(result), 0)
+        self._schedule_savings(command, content_savings + hard_cap_savings)
+        return result
+
+    def _schedule_savings(self, command: str, savings: int) -> None:
+        """Fire-and-forget savings recording; no-op outside a running event loop."""
+        try:
+            asyncio.get_running_loop().create_task(record_filter_savings(command, savings))
+        except RuntimeError:
+            pass
 
     def filter_blocks(self, output: str, handler: BlockHandler, exit_code: int = 0) -> str:
         """Filter structured block output using *handler* (ESLint, mypy, docker build, etc.)."""

--- a/autobot-backend/tests/services/test_tool_output_filter.py
+++ b/autobot-backend/tests/services/test_tool_output_filter.py
@@ -696,25 +696,27 @@ def test_get_tool_output_filter_same_object_on_repeated_calls():
 
 
 # ---------------------------------------------------------------------------
-# record_filter_savings uses pre-hint bytes (#5895)
+# record_filter_savings: content-level savings excludes the tee hint (#5895),
+# but the terminal hard cap's own delta must still be counted in full (#12239)
 # ---------------------------------------------------------------------------
 
 
 def test_filter_savings_not_inflated_by_tee_hint(tmp_path, monkeypatch):
+    """The tee-hint pointer text isn't counted against the savings metric."""
+    import asyncio
+
     import services.tool_output_filter as mod
+    from services.tool_output_filter import _tail_lines
 
     # Override tee dir to tmp so tee_and_hint actually writes
     monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
-    saved_args: list = []
+    saved: list[int] = []
 
-    import asyncio
-
-    async def _capture(command, original, filtered):
-        saved_args.append((len(original), len(filtered)))
+    async def _capture(command, savings):
+        saved.append(savings)
 
     monkeypatch.setattr(mod, "record_filter_savings", _capture)
 
-    ToolOutputFilter()
     # Build output that will trigger savings > 200 so tee_and_hint fires.
     # Use a rule with max_lines=1 to compress heavily.
     big_output = "\n".join(["x" * 40] * 30)  # ~1200 bytes
@@ -725,11 +727,102 @@ def test_filter_savings_not_inflated_by_tee_hint(tmp_path, monkeypatch):
         return f2.filter("cmd", big_output)
 
     result = asyncio.get_event_loop().run_until_complete(_run())
-    # If savings were tracked, verify filtered length does NOT include tee hint
-    if saved_args:
-        orig_len, filt_len = saved_args[0]
-        # filt_len must NOT include "[full output saved: ...]" line
-        assert "[full output saved:" not in result[:filt_len] or filt_len < len(result)
+
+    assert "[full output saved:" in result  # tee hint fired
+    expected_pre_hint = _tail_lines(big_output, 1)
+    assert saved == [len(big_output) - len(expected_pre_hint)]
+
+
+def test_filter_savings_includes_hard_cap_delta_on_matched_rule(tmp_path, monkeypatch):
+    """#12239: a rule that barely reduces output still leaves the hard cap's
+    truncation uncounted unless the cap's own delta is added to savings."""
+    import asyncio
+
+    import services.tool_output_filter as mod
+
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "_MAX_UNMATCHED_OUTPUT_CHARS", 100)
+    monkeypatch.setattr(mod, "tee_and_hint", lambda *a, **k: None)  # isolate byte math
+    saved: list[int] = []
+
+    async def _capture(command, savings):
+        saved.append(savings)
+
+    monkeypatch.setattr(mod, "record_filter_savings", _capture)
+
+    # strip_ansi on ansi-free text: zero content-level savings, so the OLD
+    # code recorded nothing even though the hard cap trims ~4900 bytes.
+    rule_cfg = {"r": {"match_command": "^huge", "strip_ansi": True}}
+    filt = _make_filter(rule_cfg)
+    output = "y" * 5000
+
+    async def _run():
+        return filt.filter("huge", output)
+
+    result = asyncio.get_event_loop().run_until_complete(_run())
+
+    assert "chars omitted" in result  # hard cap fired
+    assert saved == [len(output) - len(result)]
+    assert saved[0] > 4000
+
+
+def test_filter_savings_combines_soft_and_hard_reductions(tmp_path, monkeypatch):
+    """#12239: soft-filter AND hard-cap reductions must both land in the
+    recorded total for a single call — neither dropped nor double-counted."""
+    import asyncio
+
+    import services.tool_output_filter as mod
+
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "_MAX_UNMATCHED_OUTPUT_CHARS", 500)
+    monkeypatch.setattr(mod, "tee_and_hint", lambda *a, **k: None)  # isolate byte math
+    saved: list[int] = []
+
+    async def _capture(command, savings):
+        saved.append(savings)
+
+    monkeypatch.setattr(mod, "record_filter_savings", _capture)
+
+    lines = [f"line-{n:04d} some noisy repeated diagnostic text" for n in range(400)]
+    output = "\n".join(lines)  # ~18KB, far above the 500-char test cap
+    rule_cfg = {"r": {"match_command": "^huge", "max_lines": 300}}
+    filt = _make_filter(rule_cfg)
+
+    async def _run():
+        return filt.filter("huge", output)
+
+    result = asyncio.get_event_loop().run_until_complete(_run())
+
+    assert "lines omitted" in result  # soft filter (max_lines) trimmed content
+    assert "chars omitted" in result  # hard cap trimmed further
+    assert saved == [len(output) - len(result)]
+
+
+def test_filter_savings_recorded_for_unmatched_hard_cap(tmp_path, monkeypatch):
+    """#12239: unmatched output that only hits the hard cap previously
+    recorded no savings at all; it must now record the actual bytes trimmed."""
+    import asyncio
+
+    import services.tool_output_filter as mod
+
+    monkeypatch.setattr(mod, "_TEE_DIR", tmp_path)
+    saved: list[int] = []
+
+    async def _capture(command, savings):
+        saved.append(savings)
+
+    monkeypatch.setattr(mod, "record_filter_savings", _capture)
+
+    filt = _make_filter({})  # no rules → always unmatched
+    output = "z" * (mod._MAX_UNMATCHED_OUTPUT_CHARS * 3)
+
+    async def _run():
+        return filt.filter("no-such-command", output)
+
+    result = asyncio.get_event_loop().run_until_complete(_run())
+
+    assert saved == [len(output) - len(result)]
+    assert saved[0] > 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

`ToolOutputFilter.filter()` recorded savings from `record_filter_savings(command, output, pre_hint_filtered)` — a snapshot taken **before** the terminal `_hard_cap()` guard (services/tool_output_filter.py:485, added in #11543) runs. When a matched rule's own output still exceeded the character ceiling, `_hard_cap()` truncated it further, but that additional reduction was never folded into the recorded savings — an under-count. Separately, the unmatched-passthrough path (`cap_unmatched_output`) never called `record_filter_savings` at all, so 100% of its hard-cap savings went unrecorded — a second instance of the same class of bug, fixed in the same PR per Rule 6 (in-scope, same file/function).

## What Changed

- `services/tool_output_filter.py`
  - `record_filter_savings()` now takes an explicit `savings: int` instead of recomputing `len(original) - len(filtered)` from two strings — this lets the caller combine multiple reduction stages without reconstructing dummy strings.
  - `ToolOutputFilter.filter()`:
    - Matched-rule path: computes `content_savings` (soft filter, pre-hint — preserving the #5895 design that tee-hint pointer text isn't counted as "saved" content) **plus** `hard_cap_savings` (the additional delta the terminal `_hard_cap()` trims beyond the pre-cap length). Both are summed and recorded — no double counting, since the two deltas are non-overlapping segments of the same pipeline.
    - Unmatched path: now records `len(output) - len(result)` after `cap_unmatched_output()`, closing the second gap.
    - Extracted `_schedule_savings()` helper (fire-and-forget task scheduling) to keep `filter()` at 30 lines.
  - Units unchanged: savings is a character/byte count (`len()` on `str`), matching the existing Redis `tool_filter_savings:<category>` counter semantics — no mixing with token counts.
  - Pure metric fix — filtering/truncation behavior and the text returned to callers is byte-for-byte unchanged.

## Verification

```
$ python3 -m pytest tests/services/test_tool_output_filter.py -q
90 passed in 0.86s

$ python3 -m pytest tests/services/test_tool_output_filter.py -q -k savings -v
test_filter_savings_not_inflated_by_tee_hint PASSED
test_filter_savings_includes_hard_cap_delta_on_matched_rule PASSED
test_filter_savings_combines_soft_and_hard_reductions PASSED
test_filter_savings_recorded_for_unmatched_hard_cap PASSED
4 passed in 0.29s

$ python3 -m pytest tests/services/ -q
634 passed in 19.70s

$ python3 -m black --check services/tool_output_filter.py tests/services/test_tool_output_filter.py
All done! (2 files would be left unchanged)

$ python3 -m flake8 services/tool_output_filter.py tests/services/test_tool_output_filter.py
(clean, no output)
```

New tests added:
- `test_filter_savings_includes_hard_cap_delta_on_matched_rule` — reproduces the exact bug: a rule with zero content-level reduction (`strip_ansi` on ansi-free text) that still gets hard-capped; asserts the recorded savings equals the true `len(output) - len(result)` delta (previously recorded `0`).
- `test_filter_savings_combines_soft_and_hard_reductions` — a rule that trims real content (`max_lines`) **and** still exceeds the hard cap in the same call; asserts both stages contribute and the total is exact (`saved == [len(output) - len(result)]`).
- `test_filter_savings_recorded_for_unmatched_hard_cap` — the no-rule-matched path now records the hard cap's delta instead of nothing.
- `test_filter_savings_not_inflated_by_tee_hint` — updated to the new signature; asserts the #5895 pre-hint exemption still holds when no hard cap fires.

## Model Used

Sonnet 5 (claude-sonnet-5)

Closes #12239