### PR TITLE
fix(llc): make OFFBOARDING company status reachable via a status transition (#12234)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -12,6 +12,10 @@ Route group: /llc/companies
   DELETE /{id}                     — soft-delete a company
   GET    /{id}/tree                — recursive sub-company tree
   GET    /{id}/ancestry            — ancestors from root to this company
+  POST   /{id}/activate            — status transition -> ACTIVE (GH#12211)
+  POST   /{id}/suspend             — status transition -> PAUSED (GH#12211)
+  POST   /{id}/offboard            — status transition -> OFFBOARDING (GH#12234)
+  POST   /{id}/archive             — status transition -> ARCHIVED (GH#12211)
   POST   /{id}/members             — add a member (GH#8223)
   DELETE /{id}/members/{user_id}   — remove a member (GH#8223)
   GET    /{id}/members             — list members (GH#8223)
@@ -293,6 +297,36 @@ async def suspend_company(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     try:
         org = await svc.suspend(company_id, reason=body.reason if body else None)
+        await svc.session.commit()
+        return _to_read(org)
+    except CompanyNotFoundError:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
+    except ValueError as exc:
+        await svc.session.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from None
+    except Exception:
+        await svc.session.rollback()
+        raise
+
+
+@router.post("/{company_id}/offboard", response_model=CompanyRead)
+async def offboard_company(
+    company_id: uuid.UUID,
+    svc: CompanyService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> CompanyRead:
+    """Transition a company to OFFBOARDING (from ACTIVE). Issue #12234.
+
+    Completes the lifecycle started in #12211: OFFBOARDING was already a
+    valid archive() source but nothing ever transitioned a company into it.
+    Tenant-scoped: caller's org must match *company_id* unless platform admin.
+    """
+    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    try:
+        org = await svc.offboard(company_id)
         await svc.session.commit()
         return _to_read(org)
     except CompanyNotFoundError:

--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -167,6 +167,10 @@ class CompanyService(LLCServiceBase):
     _ACTIVATE_FROM: frozenset[str] = frozenset({LLCCompanyStatus.ONBOARDING.value, LLCCompanyStatus.PAUSED.value})
     # Valid states from which suspend() is allowed
     _SUSPEND_FROM: frozenset[str] = frozenset({LLCCompanyStatus.ONBOARDING.value, LLCCompanyStatus.ACTIVE.value})
+    # Valid states from which offboard() is allowed. Issue #12234: OFFBOARDING
+    # was defined and included in _ARCHIVE_FROM (below) but nothing ever
+    # transitioned a company into it, making the state unreachable.
+    _OFFBOARD_FROM: frozenset[str] = frozenset({LLCCompanyStatus.ACTIVE.value})
     # Valid states from which archive() is allowed
     _ARCHIVE_FROM: frozenset[str] = frozenset({LLCCompanyStatus.PAUSED.value, LLCCompanyStatus.OFFBOARDING.value})
 
@@ -206,6 +210,25 @@ class CompanyService(LLCServiceBase):
         org.paused_at = now_utc()
         await self.session.flush()
         logger.info("LLC company suspended: %s (id=%s)", org.name, org.id)
+        return org
+
+    async def offboard(self, company_id: uuid.UUID) -> Organization:
+        """Transition company to OFFBOARDING status.
+
+        Only allowed from ACTIVE — raises ValueError otherwise. This is the
+        step before archive() (#12234): OFFBOARDING was already a valid
+        ``_ARCHIVE_FROM`` source but no transition ever set it, leaving it
+        unreachable.
+        """
+        org = await self._get_or_404(company_id)
+        if org.llc_status not in self._OFFBOARD_FROM:
+            raise ValueError(
+                f"Cannot offboard company in '{org.llc_status}' state "
+                f"(allowed from: {', '.join(sorted(self._OFFBOARD_FROM))})"
+            )
+        org.llc_status = LLCCompanyStatus.OFFBOARDING.value
+        await self.session.flush()
+        logger.info("LLC company offboarding started: %s (id=%s)", org.name, org.id)
         return org
 
     async def archive(self, company_id: uuid.UUID) -> Organization:

--- a/autobot-backend/llc/tests/test_company.py
+++ b/autobot-backend/llc/tests/test_company.py
@@ -141,6 +141,40 @@ class TestCompanyStatusTransitions:
         assert result.llc_status == LLCCompanyStatus.ARCHIVED.value
 
     @pytest.mark.asyncio
+    async def test_offboard_from_active(self):
+        # Issue #12234: OFFBOARDING was in _ARCHIVE_FROM but no transition ever
+        # set it, making the state unreachable.
+        org = _make_org(llc_status="active")
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        result = await svc.offboard(org.id)
+
+        assert result.llc_status == LLCCompanyStatus.OFFBOARDING.value
+
+    @pytest.mark.asyncio
+    async def test_offboard_rejects_invalid_state(self):
+        org = _make_org(llc_status="paused")
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        with pytest.raises(ValueError):
+            await svc.offboard(org.id)
+
+    @pytest.mark.asyncio
+    async def test_archive_reachable_via_offboard(self):
+        # Full lifecycle leg #12234 completes: ACTIVE -> OFFBOARDING -> ARCHIVED.
+        org = _make_org(llc_status="active")
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        offboarded = await svc.offboard(org.id)
+        assert offboarded.llc_status == LLCCompanyStatus.OFFBOARDING.value
+
+        archived = await svc.archive(org.id)
+        assert archived.llc_status == LLCCompanyStatus.ARCHIVED.value
+
+    @pytest.mark.asyncio
     async def test_activate_from_onboarding(self):
         # Issue #12211: onboarding -> active is the transition that was missing.
         org = _make_org(llc_status="onboarding")

--- a/autobot-backend/llc/tests/test_company_status_endpoints_12211.py
+++ b/autobot-backend/llc/tests/test_company_status_endpoints_12211.py
@@ -123,6 +123,45 @@ async def test_archive_endpoint_returns_archived():
 
 
 # ---------------------------------------------------------------------------
+# Offboard transition (#12234) — OFFBOARDING was previously unreachable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_offboard_endpoint_returns_offboarding_and_commits():
+    svc = _svc()
+    svc.offboard = AsyncMock(return_value=_org(llc_status="offboarding"))
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/offboard")
+    assert resp.status_code == 200
+    assert resp.json()["llc_status"] == "offboarding"
+    svc.offboard.assert_awaited_once()
+    svc.session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_offboard_endpoint_invalid_transition_maps_to_409():
+    svc = _svc()
+    svc.offboard = AsyncMock(side_effect=ValueError("Cannot offboard company in 'paused' state"))
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/offboard")
+    assert resp.status_code == 409
+    assert "Cannot offboard" in resp.json()["detail"]
+    svc.session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_offboard_cross_tenant_is_404_and_does_not_touch_service():
+    svc = _svc()
+    svc.offboard = AsyncMock(return_value=_org(llc_status="offboarding"))
+    other_company = uuid.uuid4()
+    async with _client(_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{other_company}/offboard")
+    assert resp.status_code == 404
+    svc.offboard.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Authn / tenant authz on the mutating transition routes (#12211)
 # ---------------------------------------------------------------------------
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48891,6 +48891,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/companies/{company_id}/offboard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Offboard Company
+         * @description Transition a company to OFFBOARDING (from ACTIVE). Issue #12234.
+         *
+         *     Completes the lifecycle started in #12211: OFFBOARDING was already a
+         *     valid archive() source but nothing ever transitioned a company into it.
+         *     Tenant-scoped: caller's org must match *company_id* unless platform admin.
+         */
+        post: operations["offboard_company_api_llc_companies__company_id__offboard_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/companies/{company_id}/archive": {
         parameters: {
             query?: never;
@@ -165755,6 +165779,37 @@ export interface operations {
                 "application/json": components["schemas"]["CompanyStatusTransitionRequest"] | null;
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CompanyRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    offboard_company_api_llc_companies__company_id__offboard_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {


### PR DESCRIPTION
## Thinking Path

`LLCCompanyStatus.OFFBOARDING` was already a valid source state in `CompanyService._ARCHIVE_FROM` (`llc/services/company.py`), so `OFFBOARDING -> ARCHIVED` worked — but no code path ever set `llc_status = OFFBOARDING`. Only `_ARCHIVE_FROM`'s frozenset membership and docstrings referenced it; grepping the whole repo confirmed no `offboard`-style transition existed. That made OFFBOARDING dead state, and `ARCHIVED` was only reachable via `PAUSED -> ARCHIVED`.

The issue itself proposes the fix: add an `offboard()` transition (`ACTIVE -> OFFBOARDING`) to complete the lifecycle rather than dropping the enum member. The enum ordering (`ONBOARDING, ACTIVE, PAUSED, OFFBOARDING, ARCHIVED`) and the #12211 pattern (dedicated `POST /{id}/<verb>` transition endpoints, not a PATCH-able `llc_status` field) both support this reading — OFFBOARDING is the step immediately before archival for a company that's actively winding down (as opposed to `PAUSED`, which already has its own direct path to `ARCHIVED`). No product-decision ambiguity remained once the issue's own suggested transition was cross-checked against the enum order and the existing `_ARCHIVE_FROM`/`_ACTIVATE_FROM`/`_SUSPEND_FROM` guards, so no owner escalation was needed.

## What Changed

- `llc/services/company.py`: added `_OFFBOARD_FROM = {ACTIVE}` guard + `offboard()` method (same shape as `suspend()`/`archive()` — `_get_or_404`, guard check raising `ValueError`, set `llc_status`, `flush()`, log).
- `llc/api/companies.py`: added `POST /{company_id}/offboard` route, same tenant-authz (`require_org_context` + 404-on-cross-tenant) and error-mapping (`CompanyNotFoundError` -> 404, `ValueError` -> 409) as `activate`/`suspend`/`archive`. Also filled in the module-level route-list docstring, which never listed the #12211 transition routes.
- Tests: service-level `test_offboard_from_active`, `test_offboard_rejects_invalid_state`, and a full-lifecycle `test_archive_reachable_via_offboard` (`ACTIVE -> OFFBOARDING -> ARCHIVED`) in `llc/tests/test_company.py`; endpoint-level `test_offboard_endpoint_returns_offboarding_and_commits`, `test_offboard_endpoint_invalid_transition_maps_to_409`, `test_offboard_cross_tenant_is_404_and_does_not_touch_service` in `llc/tests/test_company_status_endpoints_12211.py`.

## Verification

```
$ python3 -m pytest llc/tests/test_company.py llc/tests/test_company_status_endpoints_12211.py -q
37 passed, 2 warnings in 7.19s

$ python3 -m pytest llc/tests/ -q
1259 passed, 2 skipped, 14 warnings in 99.39s

$ python3 -m black --check llc/services/company.py llc/api/companies.py llc/tests/test_company.py llc/tests/test_company_status_endpoints_12211.py
All done! (4 files would be left unchanged)

$ python3 -m flake8 llc/services/company.py llc/api/companies.py llc/tests/test_company.py llc/tests/test_company_status_endpoints_12211.py
(clean, exit 0)
```

`ast.parse()` passed on all 4 changed `.py` files.

## Model Used

Claude Sonnet 5

Closes #12234