### PR TITLE
refactor(llc): extract shared tenant-authz ownership guard used across LLC endpoints (#12238)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -36,7 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
-from llc.deps import get_session, service_dep
+from llc.deps import assert_company_access, get_session, service_dep
 from llc.kb.collections import KbCollectionManager
 from llc.models.company import (
     CompanyAncestor,
@@ -177,9 +177,8 @@ async def get_company(
     ctx: TenantContext = Depends(require_org_context),
 ) -> CompanyRead:
     # Issue #12233: tenant authz — caller's org must match company_id unless
-    # platform admin (same guard as get_org_chart / the status transitions).
-    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    # platform admin. Shared guard (#12238), identical 404 semantics.
+    assert_company_access(ctx, company_id)
     try:
         org = await svc.get(company_id)
         return _to_read(org)
@@ -196,8 +195,7 @@ async def update_company(
     ctx: TenantContext = Depends(require_org_context),
 ) -> CompanyRead:
     # Issue #12233: tenant authz — caller's org must match company_id unless admin.
-    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.update(company_id, body)
         await svc.session.commit()
@@ -227,8 +225,7 @@ async def delete_company(
     ctx: TenantContext = Depends(require_org_context),
 ) -> None:
     # Issue #12233: tenant authz — caller's org must match company_id unless admin.
-    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         await svc.delete(company_id)
         await svc.session.commit()
@@ -264,8 +261,7 @@ async def activate_company(
     way as ``get_org_chart``/``reorder_backlog``: the caller's org must match
     *company_id* unless they are a platform admin.
     """
-    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.activate(company_id)
         await svc.session.commit()
@@ -293,8 +289,7 @@ async def suspend_company(
 
     Tenant-scoped: caller's org must match *company_id* unless platform admin.
     """
-    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.suspend(company_id, reason=body.reason if body else None)
         await svc.session.commit()
@@ -323,8 +318,7 @@ async def offboard_company(
     valid archive() source but nothing ever transitioned a company into it.
     Tenant-scoped: caller's org must match *company_id* unless platform admin.
     """
-    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.offboard(company_id)
         await svc.session.commit()
@@ -351,8 +345,7 @@ async def archive_company(
 
     Tenant-scoped: caller's org must match *company_id* unless platform admin.
     """
-    if str(ctx.org_id) != str(company_id) and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.archive(company_id)
         await svc.session.commit()
@@ -675,9 +668,8 @@ async def reorder_backlog(
     backlog can still submit a reorder without receiving a 400).  A 400 is only
     raised when the entire list is empty (caught by pydantic min_length=1).
     """
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     cid = str(company_id)
-    if str(ctx.org_id) != cid and not ctx.is_platform_admin:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     result = await _backlog_svc().bulk_reorder(
         session,
         company_id=cid,

--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -174,6 +174,37 @@ class CompanyService(LLCServiceBase):
     # Valid states from which archive() is allowed
     _ARCHIVE_FROM: frozenset[str] = frozenset({LLCCompanyStatus.PAUSED.value, LLCCompanyStatus.OFFBOARDING.value})
 
+    async def _transition(
+        self,
+        company_id: uuid.UUID,
+        *,
+        verb: str,
+        allowed_from: frozenset[str],
+        target: LLCCompanyStatus,
+        log_msg: str,
+        **field_updates: object,
+    ) -> Organization:
+        """Shared status-transition primitive (#12238): guard + set + flush + log.
+
+        Loads the company, rejects an out-of-range current ``llc_status`` with
+        the canonical ``Cannot {verb} company in '<state>' state`` ValueError,
+        applies ``llc_status=target`` plus any *field_updates* (in order), then
+        flushes and logs *log_msg*. The public activate/suspend/offboard/archive
+        methods are thin wrappers so guard + messages live in one place.
+        """
+        org = await self._get_or_404(company_id)
+        if org.llc_status not in allowed_from:
+            raise ValueError(
+                f"Cannot {verb} company in '{org.llc_status}' state "
+                f"(allowed from: {', '.join(sorted(allowed_from))})"
+            )
+        org.llc_status = target.value
+        for field, value in field_updates.items():
+            setattr(org, field, value)
+        await self.session.flush()
+        logger.info(log_msg, org.name, org.id)
+        return org
+
     async def activate(self, company_id: uuid.UUID) -> Organization:
         """Transition company to ACTIVE status.
 
@@ -181,36 +212,30 @@ class CompanyService(LLCServiceBase):
         ValueError otherwise. Clears any pause state so a resumed company is no
         longer marked paused (#12211).
         """
-        org = await self._get_or_404(company_id)
-        if org.llc_status not in self._ACTIVATE_FROM:
-            raise ValueError(
-                f"Cannot activate company in '{org.llc_status}' state "
-                f"(allowed from: {', '.join(sorted(self._ACTIVATE_FROM))})"
-            )
-        org.llc_status = LLCCompanyStatus.ACTIVE.value
-        org.pause_reason = None
-        org.paused_at = None
-        await self.session.flush()
-        logger.info("LLC company activated: %s (id=%s)", org.name, org.id)
-        return org
+        return await self._transition(
+            company_id,
+            verb="activate",
+            allowed_from=self._ACTIVATE_FROM,
+            target=LLCCompanyStatus.ACTIVE,
+            log_msg="LLC company activated: %s (id=%s)",
+            pause_reason=None,
+            paused_at=None,
+        )
 
     async def suspend(self, company_id: uuid.UUID, reason: Optional[str] = None) -> Organization:
         """Transition company to PAUSED status.
 
         Only allowed from ONBOARDING or ACTIVE — raises ValueError otherwise.
         """
-        org = await self._get_or_404(company_id)
-        if org.llc_status not in self._SUSPEND_FROM:
-            raise ValueError(
-                f"Cannot suspend company in '{org.llc_status}' state "
-                f"(allowed from: {', '.join(sorted(self._SUSPEND_FROM))})"
-            )
-        org.llc_status = LLCCompanyStatus.PAUSED.value
-        org.pause_reason = reason
-        org.paused_at = now_utc()
-        await self.session.flush()
-        logger.info("LLC company suspended: %s (id=%s)", org.name, org.id)
-        return org
+        return await self._transition(
+            company_id,
+            verb="suspend",
+            allowed_from=self._SUSPEND_FROM,
+            target=LLCCompanyStatus.PAUSED,
+            log_msg="LLC company suspended: %s (id=%s)",
+            pause_reason=reason,
+            paused_at=now_utc(),
+        )
 
     async def offboard(self, company_id: uuid.UUID) -> Organization:
         """Transition company to OFFBOARDING status.
@@ -220,32 +245,26 @@ class CompanyService(LLCServiceBase):
         ``_ARCHIVE_FROM`` source but no transition ever set it, leaving it
         unreachable.
         """
-        org = await self._get_or_404(company_id)
-        if org.llc_status not in self._OFFBOARD_FROM:
-            raise ValueError(
-                f"Cannot offboard company in '{org.llc_status}' state "
-                f"(allowed from: {', '.join(sorted(self._OFFBOARD_FROM))})"
-            )
-        org.llc_status = LLCCompanyStatus.OFFBOARDING.value
-        await self.session.flush()
-        logger.info("LLC company offboarding started: %s (id=%s)", org.name, org.id)
-        return org
+        return await self._transition(
+            company_id,
+            verb="offboard",
+            allowed_from=self._OFFBOARD_FROM,
+            target=LLCCompanyStatus.OFFBOARDING,
+            log_msg="LLC company offboarding started: %s (id=%s)",
+        )
 
     async def archive(self, company_id: uuid.UUID) -> Organization:
         """Transition company to ARCHIVED status.
 
         Only allowed from PAUSED or OFFBOARDING — raises ValueError otherwise.
         """
-        org = await self._get_or_404(company_id)
-        if org.llc_status not in self._ARCHIVE_FROM:
-            raise ValueError(
-                f"Cannot archive company in '{org.llc_status}' state "
-                f"(allowed from: {', '.join(sorted(self._ARCHIVE_FROM))})"
-            )
-        org.llc_status = LLCCompanyStatus.ARCHIVED.value
-        await self.session.flush()
-        logger.info("LLC company archived: %s (id=%s)", org.name, org.id)
-        return org
+        return await self._transition(
+            company_id,
+            verb="archive",
+            allowed_from=self._ARCHIVE_FROM,
+            target=LLCCompanyStatus.ARCHIVED,
+            log_msg="LLC company archived: %s (id=%s)",
+        )
 
     # ------------------------------------------------------------------
     # Tree / ancestry

--- a/autobot-backend/llc/tests/test_company.py
+++ b/autobot-backend/llc/tests/test_company.py
@@ -217,6 +217,68 @@ class TestCompanyStatusTransitions:
             await svc.suspend(uuid.uuid4())
 
 
+class TestTransitionHelper:
+    """Focused tests for the shared ``_transition`` primitive (#12238).
+
+    The activate/suspend/offboard/archive wrappers are covered above; these
+    exercise the extracted helper directly to lock its behavior: in-range ->
+    applies target + field updates + flush; out-of-range -> canonical
+    ``Cannot <verb>`` ValueError; missing -> CompanyNotFoundError.
+    """
+
+    @pytest.mark.asyncio
+    async def test_in_range_applies_target_field_updates_and_flushes(self):
+        org = _make_org(llc_status="active")
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        result = await svc._transition(
+            org.id,
+            verb="suspend",
+            allowed_from=svc._SUSPEND_FROM,
+            target=LLCCompanyStatus.PAUSED,
+            log_msg="LLC company suspended: %s (id=%s)",
+            pause_reason="cause",
+            paused_at=None,
+        )
+
+        assert result.llc_status == LLCCompanyStatus.PAUSED.value
+        assert result.pause_reason == "cause"
+        svc.session.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_raises_canonical_value_error(self):
+        org = _make_org(llc_status="archived")
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(return_value=org)
+
+        with pytest.raises(ValueError) as exc:
+            await svc._transition(
+                org.id,
+                verb="activate",
+                allowed_from=svc._ACTIVATE_FROM,
+                target=LLCCompanyStatus.ACTIVE,
+                log_msg="LLC company activated: %s (id=%s)",
+            )
+
+        assert "Cannot activate company in 'archived' state" in str(exc.value)
+        svc.session.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_company_raises_not_found(self):
+        svc = _make_service()
+        svc._get_or_404 = AsyncMock(side_effect=CompanyNotFoundError("not found"))
+
+        with pytest.raises(CompanyNotFoundError):
+            await svc._transition(
+                uuid.uuid4(),
+                verb="archive",
+                allowed_from=svc._ARCHIVE_FROM,
+                target=LLCCompanyStatus.ARCHIVED,
+                log_msg="LLC company archived: %s (id=%s)",
+            )
+
+
 class TestSubCompanyTree:
     @pytest.mark.asyncio
     async def test_tree_single_node(self):


### PR DESCRIPTION
## Thinking Path
#12233/#12211/#12234 left the same tenant-authz id-match guard inlined in 8 `companies.py` endpoints and the same guard+set+flush+log repeated in 4 `CompanyService` status transitions. A canonical `assert_company_access(ctx, company_id)` (404 "Company not found", platform-admin exempt) already lives in `llc/deps.py` — this DRYs the call-sites onto it and extracts one `_transition` primitive. Pure refactor: no behavior/message/status-code changes.

## What Changed
- `llc/api/companies.py`: replaced 8 identical inline `404 "Company not found"` tenant guards (get/update/delete/activate/suspend/offboard/archive + reorder_backlog) with the existing shared `assert_company_access(ctx, company_id)`. `get_org_chart` (403 "Forbidden") and the pm-config existence checks are intentionally left — genuinely different semantics, not forced together.
- `llc/services/company.py`: extracted `_transition(company_id, *, verb, allowed_from, target, log_msg, **field_updates)`; activate/suspend/offboard/archive are now thin wrappers. Error messages, target states, field updates, flush, and log lines are byte-identical to before.
- `llc/tests/test_company.py`: added `TestTransitionHelper` (in-range applies target+fields+flush; out-of-range → canonical `Cannot <verb>` ValueError; missing → CompanyNotFoundError).

The agent_api `_assert_item_in_company` guard was reviewed and deliberately NOT merged: it uses a different tenant key (`request.state.company_id` vs `TenantContext.org_id`), a different message ("Work item not found"), no admin exemption, and has a single call-site.

## Verification
- `llc/tests/test_company_crud_authz_12233.py`, `test_company_status_endpoints_12211.py`, `test_company.py`, `test_llc_crud_authz.py`: 61 passed (58 pre-existing unchanged + 3 new helper tests).
- `ast.parse` OK on both changed modules; `black --check` clean; `flake8` clean (0).

## Model Used
claude-opus-4-8

Closes #12238
