### PR TITLE
feat(chat): extract_content live-page builtin — goal-directed extraction (#11540)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -268,6 +268,34 @@ EXTRACT_STRUCTURED_DATA_SCHEMA: dict = {
     "required": ["url", "schema"],
 }
 
+# Issue #11540: goal-directed extraction from the *current* live page (the
+# session already sitting behind a login / mid-form, reached via navigate +
+# click_index/fill_index) — unlike extract_structured_data above, which
+# always re-fetches the URL from scratch and so can never see that state.
+EXTRACT_CONTENT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "goal": {
+            "type": "string",
+            "description": (
+                "What to extract from the current live page, e.g. 'the order "
+                "confirmation number' or 'all product prices listed here'. "
+                "Extraction is goal-directed — not a raw page dump."
+            ),
+        },
+    },
+    "required": ["goal"],
+}
+
+# Issue #11540: hardcoded, read-only JS for extract_content's live-page
+# snapshot — plain property reads (no assignment), so it can never match a
+# BLOCKED_JS_PATTERNS entry (those all target writes: ``.innerHTML =``,
+# ``window.location =``, cookie/storage access, etc.). Passed straight to the
+# browser VM's existing ``evaluate`` action, not a new browser primitive.
+_EXTRACT_CONTENT_SNAPSHOT_SCRIPT = (
+    "({url: window.location.href, title: document.title, html: document.documentElement.outerHTML})"
+)
+
 # Browser tool schemas — co-located with BROWSER_TOOL_NAMES (Issue #4726).
 NAVIGATE_SCHEMA: dict = {
     "type": "object",
@@ -463,6 +491,8 @@ _BUILTIN_TOOL_SCHEMAS: dict[str, dict] = {
     "crawl_site": CRAWL_SITE_SCHEMA,
     "map_site": MAP_SITE_SCHEMA,
     "extract_structured_data": EXTRACT_STRUCTURED_DATA_SCHEMA,
+    # Issue #11540: goal-directed extraction from the current live page.
+    "extract_content": EXTRACT_CONTENT_SCHEMA,
     # #10932: Unified content_reach gateway (5 source chains).
     "content_reach": CONTENT_REACH_SCHEMA,
     # #11501: LLC board/CEO-chat work-object tools (create_task, update_goal,
@@ -555,12 +585,19 @@ BROWSER_TOOL_NAMES: frozenset[str] = frozenset(
 # Issue #7509: web research tools — direct internal dispatch via web_fetch.
 WEB_RESEARCH_TOOL_NAMES: frozenset[str] = frozenset({"scrape_url", "crawl_site", "map_site", "extract_structured_data"})
 
+# Issue #11540: goal-directed extraction from the browser session's *current*
+# page — reads whatever the live DOM already shows, never re-fetches a URL.
+LIVE_PAGE_EXTRACT_TOOL_NAMES: frozenset[str] = frozenset({"extract_content"})
+
 # GH#11489: builtin tools sharing the uniform dispatch gate (invalid-call
 # counter reset → Issue #4529 schema validation → handler). ``_builtin_route``
 # maps each name to its handler, so adding a tool here needs no new branch at
 # the ``_dispatch_tool_call`` seam.
 _UNIFORM_BUILTIN_TOOLS: frozenset[str] = (
-    BROWSER_TOOL_NAMES | WEB_RESEARCH_TOOL_NAMES | frozenset({"web_search", "execute_command"})
+    BROWSER_TOOL_NAMES
+    | WEB_RESEARCH_TOOL_NAMES
+    | LIVE_PAGE_EXTRACT_TOOL_NAMES
+    | frozenset({"web_search", "execute_command"})
 )
 
 # GH#11160: maps a declared approval category (a work item's
@@ -2541,6 +2578,118 @@ class ToolHandlerMixin:
         json_str = json.dumps(result["data"], indent=2, ensure_ascii=False)
         return f"## Extracted data from {url}\n\n```json\n{json_str}\n```"
 
+    # ------------------------------------------------------------------
+    # Issue #11540: goal-directed extraction from the *current* live page
+    # ------------------------------------------------------------------
+
+    async def _handle_extract_content_tool(
+        self,
+        tool_call: dict[str, Any],
+        execution_results: list[dict[str, Any]],
+        session_id: str = "",
+    ):
+        """Dispatch the extract_content builtin. Issue #11540.
+
+        Unlike WEB_RESEARCH_TOOL_NAMES (always re-fetches a URL), this reads
+        whatever page the browser session is already on — post-login,
+        post-click, post-form-fill — so it works behind auth walls a fresh
+        fetch could never reach.
+        """
+        params = tool_call.get("params", {})
+        goal = params.get("goal", "")
+        logger.info("[Issue #11540] extract_content: goal=%s", goal[:100])
+
+        yield WorkflowMessage(
+            type="tool_execution",
+            content=f"Extracting from the live page: {goal[:100]}",
+            metadata={"tool": "extract_content"},
+        )
+
+        try:
+            result = await self._exec_extract_content(params, session_id)
+            execution_results.append({"tool": "extract_content", "status": "success", "output": result})
+            yield WorkflowMessage(
+                type="command_output",
+                content=result,
+                metadata={"tool": "extract_content", "status": "success"},
+            )
+        except Exception as exc:
+            logger.error("[Issue #11540] extract_content failed: %s", exc)
+            execution_results.append({"tool": "extract_content", "status": "error", "error": str(exc)})
+            yield WorkflowMessage(
+                type="error",
+                content=f"extract_content failed: {exc}",
+                metadata={"tool": "extract_content", "error": True},
+            )
+
+    async def _capture_live_page_snapshot(self, session_id: str) -> tuple[str, str]:
+        """Read (html, url) off the browser session's *current* page. Issue #11540.
+
+        Reuses the existing browser VM ``evaluate`` action — the same one
+        ``evaluate`` tool calls use — with a hardcoded, read-only script (no
+        assignment, so ``is_script_safe()`` is a non-issue). No re-fetch: this
+        sees whatever page the session already reached via navigate/clicks.
+        """
+        from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
+
+        vm_response = await send_to_browser_vm(
+            "evaluate",
+            {"script": _EXTRACT_CONTENT_SNAPSHOT_SCRIPT},
+            session_id=session_id or DEFAULT_BROWSER_SESSION_ID,
+        )
+        inner = vm_response.get("result", vm_response)
+        page = inner.get("result") or {}
+        return page.get("html", ""), page.get("url", "")
+
+    async def _answer_goal_from_markdown(self, markdown: str, url: str, goal: str) -> str:
+        """Run the goal-directed LLM sub-extraction over already-fetched markdown. Issue #11540.
+
+        Reuses the same schema-driven LLM sub-call ``extract_structured_data``
+        uses (``llm_shared.structured_ops.extract``, #11520) with a single
+        free-text ``answer`` field described by the goal instead of a full
+        JSON Schema, and the same content-firewall gate ``extract_url()``
+        applies (#10552) before any web content reaches the LLM. ``extract()``
+        auto-chunks input over ``AUTOBOT_EXTRACT_CHUNK_THRESHOLD`` chars — the
+        context-budget-aware cap in place of OpenManus's fixed 2000-char clip.
+        """
+        from llm_shared.structured_ops import extract
+        from security.content_firewall import ContentSource, get_content_firewall
+
+        fw_verdict = await get_content_firewall().inspect(
+            markdown, source=ContentSource.WEB, context_label=url or "live_page"
+        )
+        if fw_verdict.blocked:
+            return f"extract_content blocked by content firewall (risk={fw_verdict.risk.value})"
+
+        answer_schema = {
+            "type": "object",
+            "properties": {"answer": {"type": "string", "description": goal}},
+            "required": ["answer"],
+        }
+        data = await extract(fw_verdict.content, answer_schema)
+        answer = data.get("answer", "") if isinstance(data, dict) else str(data)
+        header = f"## Extracted from live page{f': {url}' if url else ''}\n\nGoal: {goal}\n\n"
+        return header + (answer or "*(nothing relevant found)*")
+
+    async def _exec_extract_content(self, params: dict, session_id: str = "") -> str:
+        """Goal-directed extraction from the browser session's live page. Issue #11540.
+
+        Orchestrates the two halves above: capture the live DOM snapshot,
+        then run the goal-directed LLM sub-extraction over it.
+        """
+        from web_fetch.extractors import extract_markdown
+
+        goal = (params.get("goal") or "").strip()
+        if not goal:
+            return "extract_content requires a 'goal' describing what to extract."
+
+        html_content, url = await self._capture_live_page_snapshot(session_id)
+        if not html_content:
+            return "extract_content: no live page content — navigate to a page first."
+
+        _title, markdown = extract_markdown(html_content)
+        return await self._answer_goal_from_markdown(markdown, url, goal)
+
     async def _execute_web_search(self, query: str, max_pages: int = 5, session_id: str = "") -> str:
         """Run a web search and return formatted results. Issue #2306.
 
@@ -3045,6 +3194,8 @@ class ToolHandlerMixin:
             return self._handle_web_search_tool(tool_call, execution_results, session_id)
         if tool_name in WEB_RESEARCH_TOOL_NAMES:  # Issue #7509
             return self._handle_web_research_tool(tool_name, tool_call, execution_results, session_id)
+        if tool_name in LIVE_PAGE_EXTRACT_TOOL_NAMES:  # Issue #11540
+            return self._handle_extract_content_tool(tool_call, execution_results, session_id)
         if tool_name == "execute_command":
             return self._dispatch_execute_command(
                 tool_call,

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
@@ -19,6 +19,7 @@ from chat_workflow.tool_handler import (
     _BUILTIN_TOOL_SCHEMAS,
     _UNIFORM_BUILTIN_TOOLS,
     BROWSER_TOOL_NAMES,
+    LIVE_PAGE_EXTRACT_TOOL_NAMES,
     WEB_RESEARCH_TOOL_NAMES,
     ToolHandlerMixin,
 )
@@ -68,8 +69,10 @@ async def _dispatch(mixin: ToolHandlerMixin, tool_call: dict, execution_results:
 
 
 def test_uniform_set_is_union_of_builtin_families() -> None:
-    """Membership SSOT: browser + web research + web_search + execute_command."""
-    assert _UNIFORM_BUILTIN_TOOLS == (BROWSER_TOOL_NAMES | WEB_RESEARCH_TOOL_NAMES | {"web_search", "execute_command"})
+    """Membership SSOT: browser + web research + live-page extract + web_search + execute_command."""
+    assert _UNIFORM_BUILTIN_TOOLS == (
+        BROWSER_TOOL_NAMES | WEB_RESEARCH_TOOL_NAMES | LIVE_PAGE_EXTRACT_TOOL_NAMES | {"web_search", "execute_command"}
+    )
     # respond/delegate are non-uniform (special return shapes) and must stay out.
     assert "respond" not in _UNIFORM_BUILTIN_TOOLS
     assert "delegate" not in _UNIFORM_BUILTIN_TOOLS
@@ -84,6 +87,7 @@ def test_every_uniform_tool_has_a_schema() -> None:
 _ROUTE_EXPECTATIONS = [
     *[(name, "_handle_browser_tool") for name in sorted(BROWSER_TOOL_NAMES)],
     *[(name, "_handle_web_research_tool") for name in sorted(WEB_RESEARCH_TOOL_NAMES)],
+    *[(name, "_handle_extract_content_tool") for name in sorted(LIVE_PAGE_EXTRACT_TOOL_NAMES)],
     ("web_search", "_handle_web_search_tool"),
     ("execute_command", "_dispatch_execute_command"),
 ]

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_extract_content.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_extract_content.py
@@ -1,0 +1,233 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the extract_content builtin in chat_workflow/tool_handler.py.
+
+Issue #11540: goal-directed extraction from the browser session's *current*
+live page (post-login/post-click), as opposed to WEB_RESEARCH_TOOL_NAMES'
+extract_structured_data which always re-fetches a URL from scratch. Exercises
+the real prod dispatch seam (_dispatch_tool_call -> _builtin_route ->
+_handle_extract_content_tool), offline: the browser VM and LLM calls are
+mocked, never a real browser/network hop.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_LIVE_HTML = "<html><head><title>Checkout</title></head><body><p>Order #A1B2C3</p></body></html>"
+
+
+def test_extract_content_schema_registered() -> None:
+    """EXTRACT_CONTENT_SCHEMA is present in _BUILTIN_TOOL_SCHEMAS and requires 'goal'."""
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS, EXTRACT_CONTENT_SCHEMA
+
+    assert "extract_content" in _BUILTIN_TOOL_SCHEMAS
+    assert _BUILTIN_TOOL_SCHEMAS["extract_content"] is EXTRACT_CONTENT_SCHEMA
+    assert "goal" in EXTRACT_CONTENT_SCHEMA.get("required", [])
+
+
+def test_extract_content_in_uniform_builtin_tools() -> None:
+    """extract_content shares the uniform builtin dispatch gate (GH#11489)."""
+    from chat_workflow.tool_handler import _UNIFORM_BUILTIN_TOOLS, LIVE_PAGE_EXTRACT_TOOL_NAMES
+
+    assert "extract_content" in LIVE_PAGE_EXTRACT_TOOL_NAMES
+    assert "extract_content" in _UNIFORM_BUILTIN_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_exec_extract_content_returns_goal_relevant_answer() -> None:
+    """_exec_extract_content reads the live DOM (not a re-fetch) and answers the goal."""
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+    vm_response = {
+        "success": True,
+        "action": "evaluate",
+        "result": {
+            "result": {"url": "https://shop.example.com/checkout", "title": "Checkout", "html": _LIVE_HTML},
+            "page_state": {},
+        },
+    }
+
+    with (
+        patch(
+            "api.browser_mcp.send_to_browser_vm",
+            new_callable=AsyncMock,
+            return_value=vm_response,
+        ) as mock_vm,
+        patch(
+            "llm_shared.structured_ops.extract",
+            new_callable=AsyncMock,
+            return_value={"answer": "Order #A1B2C3"},
+        ) as mock_extract,
+    ):
+        output = await mixin._exec_extract_content({"goal": "the order confirmation number"}, session_id="sess-1")
+
+    # Browser VM was asked to read the live page, not to navigate/re-fetch a URL.
+    mock_vm.assert_awaited_once()
+    assert mock_vm.await_args.args[0] == "evaluate"
+    assert mock_vm.await_args.kwargs["session_id"] == "sess-1"
+
+    # LLM sub-call ran against the live-page markdown with a goal-described schema.
+    mock_extract.assert_awaited_once()
+    schema_arg = mock_extract.await_args.args[1]
+    assert schema_arg["properties"]["answer"]["description"] == "the order confirmation number"
+
+    assert "Order #A1B2C3" in output
+    assert "https://shop.example.com/checkout" in output
+
+
+@pytest.mark.asyncio
+async def test_exec_extract_content_no_live_page_content() -> None:
+    """Empty live page (no navigation yet) returns a friendly notice, not a crash."""
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+    vm_response = {"success": True, "action": "evaluate", "result": {"result": {"url": "", "html": ""}}}
+
+    with patch("api.browser_mcp.send_to_browser_vm", new_callable=AsyncMock, return_value=vm_response):
+        output = await mixin._exec_extract_content({"goal": "anything"}, session_id="sess-1")
+
+    assert "navigate to a page first" in output
+
+
+@pytest.mark.asyncio
+async def test_exec_extract_content_requires_goal() -> None:
+    """A missing/blank goal is rejected before any browser VM call."""
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+    with patch("api.browser_mcp.send_to_browser_vm", new_callable=AsyncMock) as mock_vm:
+        output = await mixin._exec_extract_content({"goal": "   "}, session_id="sess-1")
+
+    mock_vm.assert_not_awaited()
+    assert "requires a 'goal'" in output
+
+
+# ---------------------------------------------------------------------------
+# Chat dispatch verification — the real prod seam (_dispatch_tool_call)
+# ---------------------------------------------------------------------------
+
+_DISPATCH_ARGS = {
+    "session_id": "sess-ec",
+    "terminal_session_id": "term-ec",
+    "ollama_endpoint": "http://127.0.0.1:11434",
+    "selected_model": "test-model",
+}
+
+
+def _dispatch_mixin():
+    """ToolHandlerMixin with governance gates quieted (covered by own suites)."""
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+    mixin._enforce_forbidden_work = lambda *a, **k: None
+    mixin._enforce_config_protection = lambda *a, **k: None
+    mixin._enforce_fact_forcing = lambda *a, **k: None
+    mixin._enforce_work_item_approval = lambda *a, **k: None
+    return mixin
+
+
+async def _drain_dispatch(mixin, tool_call: dict, execution_results: list) -> list:
+    return [
+        msg
+        async for msg in mixin._dispatch_tool_call(
+            tool_call,
+            execution_results=execution_results,
+            additional_response_parts=[],
+            **_DISPATCH_ARGS,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_extract_content_returns_goal_relevant_content() -> None:
+    """extract_content, routed through the real _dispatch_tool_call seam, is
+    registered/dispatchable and yields goal-relevant content in the expected
+    tool-result shape (#11540)."""
+    mixin = _dispatch_mixin()
+
+    vm_response = {
+        "success": True,
+        "action": "evaluate",
+        "result": {
+            "result": {"url": "https://shop.example.com/checkout", "title": "Checkout", "html": _LIVE_HTML},
+        },
+    }
+
+    execution_results: list = []
+    with (
+        patch("api.browser_mcp.send_to_browser_vm", new_callable=AsyncMock, return_value=vm_response),
+        patch(
+            "llm_shared.structured_ops.extract",
+            new_callable=AsyncMock,
+            return_value={"answer": "Order #A1B2C3"},
+        ),
+    ):
+        messages = await _drain_dispatch(
+            mixin,
+            {"name": "extract_content", "params": {"goal": "the order confirmation number"}},
+            execution_results,
+        )
+
+    outputs = [m for m in messages if getattr(m, "type", "") == "command_output"]
+    assert outputs, f"no command_output yielded; got: {[getattr(m, 'type', m) for m in messages]}"
+    assert "Order #A1B2C3" in outputs[0].content
+    assert execution_results[-1] == {
+        "tool": "extract_content",
+        "status": "success",
+        "output": outputs[0].content,
+    }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_extract_content_schema_validation_rejects_missing_goal() -> None:
+    """Issue #4529 schema validation runs before the handler — a missing 'goal'
+    is a schema_error, not a browser VM call."""
+    mixin = _dispatch_mixin()
+    execution_results: list = []
+
+    with patch("api.browser_mcp.send_to_browser_vm", new_callable=AsyncMock) as mock_vm:
+        messages = await _drain_dispatch(
+            mixin,
+            {"name": "extract_content", "params": {}},
+            execution_results,
+        )
+
+    mock_vm.assert_not_awaited()
+    assert execution_results[-1]["status"] == "schema_error"
+    assert any(getattr(m, "type", "") == "tool_result" for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_extract_content_firewall_blocked() -> None:
+    """A content-firewall block surfaces as a success-shaped notice (mirrors extract_url)."""
+    mixin = _dispatch_mixin()
+
+    vm_response = {
+        "success": True,
+        "action": "evaluate",
+        "result": {"result": {"url": "https://x", "html": "<p>x</p>"}},
+    }
+    blocked_verdict = MagicMock(blocked=True, risk=MagicMock(value="critical"), content="")
+
+    execution_results: list = []
+    with (
+        patch("api.browser_mcp.send_to_browser_vm", new_callable=AsyncMock, return_value=vm_response),
+        patch("security.content_firewall.get_content_firewall") as mock_fw,
+    ):
+        mock_fw.return_value.inspect = AsyncMock(return_value=blocked_verdict)
+        messages = await _drain_dispatch(
+            mixin,
+            {"name": "extract_content", "params": {"goal": "anything"}},
+            execution_results,
+        )
+
+    outputs = [m for m in messages if getattr(m, "type", "") == "command_output"]
+    assert outputs
+    assert "blocked by content firewall" in outputs[0].content


### PR DESCRIPTION
## Thinking Path

Audited the seam first per the task brief. `chat_workflow/tool_handler.py`'s
`_dispatch_tool_call` (autobot-backend/chat_workflow/tool_handler.py:2893) is
confirmed the real prod dispatch seam — every chat tool call funnels through
it, and `_UNIFORM_BUILTIN_TOOLS` → `_builtin_route` (line 3025) is the
established extension point every builtin family (browser #1368, web_search
#2306, web research #7509) already uses (NOT the AgentLoop, which repo memory
confirms has no prod caller).

For live-page access, the browser worker (`autobot-browser-worker/playwright-server.js`)
has no dedicated "get HTML" action, but its existing `evaluate` action (already
registered as a browser tool, `is_script_safe`-gated) runs arbitrary read
JS and returns the value — reusing it with a hardcoded, read-only script
(`document.documentElement.outerHTML` + `location.href` + `document.title`)
avoids adding any new browser primitive. `web_fetch.extractors.extract_markdown()`
converts that HTML the same way `scrape_url`/`extract_url` already do, and
`llm_shared.structured_ops.extract()` (the exact schema-driven LLM sub-call
`extract_structured_data` uses, #11520) runs the goal-directed extraction —
built as a single free-text `answer` field described by the caller's goal
instead of inventing a new extraction algorithm.

## What Changed

- `chat_workflow/tool_handler.py`:
  - `EXTRACT_CONTENT_SCHEMA` + `_EXTRACT_CONTENT_SNAPSHOT_SCRIPT` constants
  - `LIVE_PAGE_EXTRACT_TOOL_NAMES` frozenset (SSOT, mirrors `BROWSER_TOOL_NAMES`/`WEB_RESEARCH_TOOL_NAMES`), folded into `_UNIFORM_BUILTIN_TOOLS`
  - Route row in `_builtin_route`
  - `_handle_extract_content_tool` (dispatch wrapper, WorkflowMessage/execution_results shape identical to every other builtin)
  - `_capture_live_page_snapshot` (reads html+url off the live page via the existing `evaluate` browser-VM action — no re-fetch)
  - `_answer_goal_from_markdown` (content-firewall gate reused from `extract_url`, then `structured_ops.extract()` with a goal-described single-field schema)
  - `_exec_extract_content` (orchestrator, ≤30 lines per function)
- `tests/unit/chat_workflow/test_tool_handler_builtin_route.py`: updated the pre-existing exact-membership assertions (`_UNIFORM_BUILTIN_TOOLS` union, route-table parametrization) to include the new tool family — these would otherwise fail after this change.
- `tests/unit/chat_workflow/test_tool_handler_extract_content.py` (new): schema registration, uniform-gate membership, `_exec_extract_content` unit tests (goal-relevant answer, no-page notice, missing-goal guard), and dispatch-path tests through the real `_dispatch_tool_call` seam (success shape, schema-validation rejection, firewall-blocked notice) — all offline, browser VM + LLM mocked.

## Verification

```
$ python3 -m pytest tests/unit/chat_workflow/test_tool_handler_extract_content.py \
    tests/unit/chat_workflow/test_tool_handler_builtin_route.py \
    tests/unit/chat_workflow/test_tool_handler_web_research.py -q
56 passed, 1 warning in 4.71s

$ python3 -m pytest tests/unit/chat_workflow/ -q
296 passed, 2 warnings in 8.72s

$ python3 -m black --check chat_workflow/tool_handler.py tests/unit/chat_workflow/test_tool_handler_extract_content.py tests/unit/chat_workflow/test_tool_handler_builtin_route.py
All done! (3 files would be left unchanged)

$ python3 -m flake8 chat_workflow/tool_handler.py tests/unit/chat_workflow/test_tool_handler_extract_content.py tests/unit/chat_workflow/test_tool_handler_builtin_route.py
(clean, exit 0)
```

`ast.parse()` clean on all three changed/added `.py` files.

## Model Used

Sonnet 5

Closes #11540