### PR TITLE
fix(knowledge): key EmbeddingCache on (model, text) to stop cross-model collisions (#12251)

### DIFF
--- a/autobot-backend/code_embedding_generator.py
+++ b/autobot-backend/code_embedding_generator.py
@@ -236,7 +236,7 @@ class CodeEmbeddingGenerator:
         start_time = time.time()
         cache_key = self._get_cache_key(code, language)
 
-        cached = await self.embedding_cache.get(cache_key)
+        cached = await self.embedding_cache.get(cache_key, model=self.model_name)
         if cached is not None:
             return CodeEmbeddingResult(
                 embedding=np.array(cached),
@@ -248,7 +248,7 @@ class CodeEmbeddingGenerator:
 
         embedding, device_used = await self._compute_embedding(code, language)
 
-        await self.embedding_cache.put(cache_key, embedding.tolist())
+        await self.embedding_cache.put(cache_key, embedding.tolist(), model=self.model_name)
 
         return CodeEmbeddingResult(
             embedding=embedding,
@@ -424,7 +424,7 @@ class CodeEmbeddingGenerator:
                 for j, (embedding, device_used) in enumerate(raw_pairs):
                     code, lang = batch[j]
                     cache_key = self._get_cache_key(code, lang)
-                    await self.embedding_cache.put(cache_key, embedding.tolist())
+                    await self.embedding_cache.put(cache_key, embedding.tolist(), model=self.model_name)
                     results.append(
                         CodeEmbeddingResult(
                             embedding=embedding,

--- a/autobot-backend/code_intelligence/analytics_infrastructure.py
+++ b/autobot-backend/code_intelligence/analytics_infrastructure.py
@@ -269,7 +269,7 @@ class AnalyticsInfrastructureMixin:
 
         cache = await self._get_embedding_cache()
         if cache:
-            cached = await cache.get(text)
+            cached = await cache.get(text, model=self._embedding_model)
             if cached:
                 self._metrics.cache_hits += 1
                 return cached
@@ -288,7 +288,7 @@ class AnalyticsInfrastructureMixin:
             self._metrics.embeddings_generated += 1
             self._metrics.llm_requests += 1
             if cache:
-                await cache.put(text, embedding)
+                await cache.put(text, embedding, model=self._embedding_model)
             return embedding
 
         return None

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -192,7 +192,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
         # Check cache first
         cache = await self._get_embedding_cache()
         if cache:
-            cached = await cache.get(text)
+            cached = await cache.get(text, model=self.embedding_model)
             if cached:
                 self._cache_hits += 1
                 return cached
@@ -205,7 +205,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
             if embedding:
                 self._embeddings_generated += 1
                 if cache:
-                    await cache.put(text, embedding)
+                    await cache.put(text, embedding, model=self.embedding_model)
                 return embedding
         except Exception as e:
             logger.warning("Failed to generate embedding: %s", e)
@@ -249,7 +249,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
             if not text or not text.strip():
                 continue
             if cache:
-                cached = await cache.get(text)
+                cached = await cache.get(text, model=self.embedding_model)
                 if cached:
                     self._cache_hits += 1
                     results[idx] = cached
@@ -278,7 +278,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
                     results[idx] = embedding
                     self._embeddings_generated += 1
                     if cache:
-                        await cache.put(text, embedding)
+                        await cache.put(text, embedding, model=self.embedding_model)
 
         logger.info(
             "Batch generated %d embeddings (%d concurrent)",

--- a/autobot-backend/knowledge/embedding_cache.py
+++ b/autobot-backend/knowledge/embedding_cache.py
@@ -103,9 +103,16 @@ class EmbeddingCache:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _make_key(self, query: str) -> str:
-        """Create cache key from query text using SHA-256 hash."""
-        return hashlib.sha256(query.encode("utf-8")).hexdigest()
+    def _make_key(self, model: str, query: str) -> str:
+        """Create cache key from (model, query) using SHA-256 hash.
+
+        Issue #12251: the embedding model id is folded into the key so the
+        same text embedded by two different models never collides — a
+        cross-model read would otherwise return a wrong-space vector. The
+        NUL separator keeps ``model``/``query`` boundaries unambiguous.
+        """
+        payload = f"{model}\x00{query}".encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
 
     def _is_expired(self, key: str) -> bool:
         """Return True if the cached entry has exceeded its TTL."""
@@ -162,7 +169,7 @@ class EmbeddingCache:
     # Public interface
     # ------------------------------------------------------------------
 
-    async def get(self, query: str) -> Optional[List[float]]:
+    async def get(self, query: str, model: str) -> Optional[List[float]]:
         """
         Get embedding from cache if available and not expired.
 
@@ -171,11 +178,12 @@ class EmbeddingCache:
 
         Args:
             query: Query text
+            model: Embedding model id (part of the cache key — Issue #12251)
 
         Returns:
             Cached embedding or None if not found/expired
         """
-        key = self._make_key(query)
+        key = self._make_key(model, query)
 
         async with self._lock:
             # --- Check T1 ---
@@ -209,7 +217,7 @@ class EmbeddingCache:
             self._misses += 1
             return None
 
-    async def put(self, query: str, embedding: List[float]) -> None:
+    async def put(self, query: str, embedding: List[float], model: str) -> None:
         """
         Store embedding in cache using ARC insertion policy.
 
@@ -220,8 +228,9 @@ class EmbeddingCache:
         Args:
             query: Query text
             embedding: Computed embedding vector
+            model: Embedding model id (part of the cache key — Issue #12251)
         """
-        key = self._make_key(query)
+        key = self._make_key(model, query)
 
         async with self._lock:
             # If already live, update value and timestamp (update in place)

--- a/autobot-backend/knowledge/embedding_cache_test.py
+++ b/autobot-backend/knowledge/embedding_cache_test.py
@@ -3,6 +3,9 @@
 """
 Unit tests for Embedding Cache - Issue #65 P0 Optimization / Issue #8156 ARC
 Tests the ARC cache with TTL for ChromaDB query embeddings.
+
+Issue #12251: cache key is (model, text); tests pass an explicit model id
+and cover cross-model isolation (same text, different models → no collision).
 """
 
 import asyncio
@@ -11,6 +14,10 @@ import pytest
 import pytest_asyncio
 
 from knowledge_base import EmbeddingCache, get_embedding_cache
+
+# Single model id used by the ARC-mechanics tests below. The cross-model
+# isolation tests use two distinct model ids explicitly.
+_MODEL = "test-embed-model"
 
 
 @pytest.fixture
@@ -33,7 +40,7 @@ class TestEmbeddingCache:
     @pytest.mark.asyncio
     async def test_cache_miss_returns_none(self, cache):
         """Test that cache miss returns None"""
-        result = await cache.get("unknown query")
+        result = await cache.get("unknown query", model=_MODEL)
         assert result is None
 
     @pytest.mark.asyncio
@@ -42,8 +49,8 @@ class TestEmbeddingCache:
         query = "test query"
         embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
 
-        await cache.put(query, embedding)
-        result = await cache.get(query)
+        await cache.put(query, embedding, model=_MODEL)
+        result = await cache.get(query, model=_MODEL)
 
         assert result == embedding
 
@@ -59,15 +66,15 @@ class TestEmbeddingCache:
         assert stats["misses"] == 0
 
         # Cache miss
-        await cache.get(query)
+        await cache.get(query, model=_MODEL)
         stats = cache.get_stats()
         assert stats["misses"] == 1
 
         # Add to cache
-        await cache.put(query, embedding)
+        await cache.put(query, embedding, model=_MODEL)
 
         # Cache hit
-        await cache.get(query)
+        await cache.get(query, model=_MODEL)
         stats = cache.get_stats()
         assert stats["hits"] == 1
         assert stats["hit_rate_percent"] == 50.0
@@ -76,42 +83,42 @@ class TestEmbeddingCache:
     async def test_lru_eviction(self, cache):
         """Test eviction when cache is full (cold-miss path uses T1)"""
         # Fill cache to capacity (maxsize=3)
-        await cache.put("query1", [0.1])
-        await cache.put("query2", [0.2])
-        await cache.put("query3", [0.3])
+        await cache.put("query1", [0.1], model=_MODEL)
+        await cache.put("query2", [0.2], model=_MODEL)
+        await cache.put("query3", [0.3], model=_MODEL)
 
         stats = cache.get_stats()
         assert stats["cache_size"] == 3
 
         # Add fourth entry - should evict one of the existing entries
-        await cache.put("query4", [0.4])
+        await cache.put("query4", [0.4], model=_MODEL)
 
         stats = cache.get_stats()
         assert stats["cache_size"] == 3
 
         # query1 should be evicted (oldest T1 entry, p starts at 0 so T1 evicted first)
-        result1 = await cache.get("query1")
+        result1 = await cache.get("query1", model=_MODEL)
         assert result1 is None
 
         # Others should still be present
-        result2 = await cache.get("query2")
+        result2 = await cache.get("query2", model=_MODEL)
         assert result2 == [0.2]
 
-        result4 = await cache.get("query4")
+        result4 = await cache.get("query4", model=_MODEL)
         assert result4 == [0.4]
 
     @pytest.mark.asyncio
     async def test_promotion_t1_to_t2_on_second_hit(self, cache):
         """ARC-specific: second access promotes entry from T1 to T2"""
-        await cache.put("query1", [0.1])
-        await cache.put("query2", [0.2])
+        await cache.put("query1", [0.1], model=_MODEL)
+        await cache.put("query2", [0.2], model=_MODEL)
 
         stats = cache.get_stats()
         assert stats["t1_size"] == 2
         assert stats["t2_size"] == 0
 
         # First hit on query1: still in T1 initially, promoted to T2 on get
-        result = await cache.get("query1")
+        result = await cache.get("query1", model=_MODEL)
         assert result == [0.1]
 
         stats = cache.get_stats()
@@ -129,9 +136,9 @@ class TestEmbeddingCache:
 
         # Warm up hot set — put then get to promote into T2
         for q in hot_queries:
-            await big_cache.put(q, hot_embeddings[q])
+            await big_cache.put(q, hot_embeddings[q], model=_MODEL)
         for q in hot_queries:
-            await big_cache.get(q)  # promotes to T2
+            await big_cache.get(q, model=_MODEL)  # promotes to T2
 
         stats = big_cache.get_stats()
         assert stats["t2_size"] == 5
@@ -139,11 +146,11 @@ class TestEmbeddingCache:
         # Scan 1001 unique queries to fill cache many times over
         for i in range(1001):
             scan_q = f"scan_unique_{i}"
-            await big_cache.put(scan_q, [float(i)])
+            await big_cache.put(scan_q, [float(i)], model=_MODEL)
 
         # Hot set should still be retrievable (ARC protects T2 from scans)
         for q in hot_queries:
-            result = await big_cache.get(q)
+            result = await big_cache.get(q, model=_MODEL)
             assert result == hot_embeddings[q], f"Hot entry {q!r} was evicted by scan workload"
 
     @pytest.mark.asyncio
@@ -153,9 +160,9 @@ class TestEmbeddingCache:
 
         # Put 4 entries and promote 2 into T2
         for i in range(4):
-            await big_cache.put(f"q{i}", [float(i)])
-        await big_cache.get("q0")  # promotes q0 to T2
-        await big_cache.get("q1")  # promotes q1 to T2
+            await big_cache.put(f"q{i}", [float(i)], model=_MODEL)
+        await big_cache.get("q0", model=_MODEL)  # promotes q0 to T2
+        await big_cache.get("q1", model=_MODEL)  # promotes q1 to T2
 
         stats = big_cache.get_stats()
         assert stats["t2_size"] == 2
@@ -184,24 +191,24 @@ class TestEmbeddingCache:
         query = "expiring query"
         embedding = [0.1, 0.2, 0.3]
 
-        await cache.put(query, embedding)
+        await cache.put(query, embedding, model=_MODEL)
 
         # Immediately should be available
-        result = await cache.get(query)
+        result = await cache.get(query, model=_MODEL)
         assert result == embedding
 
         # Wait for TTL to expire (2 seconds) - Issue #479: Use async sleep
         await asyncio.sleep(2.1)
 
         # Should be expired now
-        result = await cache.get(query)
+        result = await cache.get(query, model=_MODEL)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_cache_clear(self, cache):
         """Test that clearing cache removes all entries"""
-        await cache.put("query1", [0.1])
-        await cache.put("query2", [0.2])
+        await cache.put("query1", [0.1], model=_MODEL)
+        await cache.put("query2", [0.2], model=_MODEL)
 
         stats = cache.get_stats()
         assert stats["cache_size"] == 2
@@ -217,19 +224,19 @@ class TestEmbeddingCache:
         assert stats["t2_size"] == 0
 
         # Entries should be gone
-        result = await cache.get("query1")
+        result = await cache.get("query1", model=_MODEL)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_case_sensitive_keys(self, cache):
         """Test that query keys are case sensitive"""
-        await cache.put("Query", [0.1])
-        await cache.put("query", [0.2])
-        await cache.put("QUERY", [0.3])
+        await cache.put("Query", [0.1], model=_MODEL)
+        await cache.put("query", [0.2], model=_MODEL)
+        await cache.put("QUERY", [0.3], model=_MODEL)
 
-        result1 = await cache.get("Query")
-        result2 = await cache.get("query")
-        result3 = await cache.get("QUERY")
+        result1 = await cache.get("Query", model=_MODEL)
+        result2 = await cache.get("query", model=_MODEL)
+        result3 = await cache.get("QUERY", model=_MODEL)
 
         assert result1 == [0.1]
         assert result2 == [0.2]
@@ -250,12 +257,12 @@ class TestEmbeddingCache:
     async def test_stats_hit_rate_calculation(self, cache):
         """Test hit rate percentage calculation"""
         # 3 hits, 1 miss = 75% hit rate
-        await cache.put("query", [0.1])
+        await cache.put("query", [0.1], model=_MODEL)
 
-        await cache.get("nonexistent")  # miss
-        await cache.get("query")  # hit
-        await cache.get("query")  # hit
-        await cache.get("query")  # hit
+        await cache.get("nonexistent", model=_MODEL)  # miss
+        await cache.get("query", model=_MODEL)  # hit
+        await cache.get("query", model=_MODEL)  # hit
+        await cache.get("query", model=_MODEL)  # hit
 
         stats = cache.get_stats()
         assert stats["hits"] == 3
@@ -265,10 +272,10 @@ class TestEmbeddingCache:
     @pytest.mark.asyncio
     async def test_update_existing_entry(self, cache):
         """Test that putting an existing key updates its value"""
-        await cache.put("query", [0.1])
-        await cache.put("query", [0.2])
+        await cache.put("query", [0.1], model=_MODEL)
+        await cache.put("query", [0.2], model=_MODEL)
 
-        result = await cache.get("query")
+        result = await cache.get("query", model=_MODEL)
         assert result == [0.2]
 
         # Should not increase cache size
@@ -280,8 +287,8 @@ class TestEmbeddingCache:
         """Test caching of large embedding vectors (typical 384-1536 dimensions)"""
         large_embedding = [0.01 * i for i in range(1536)]
 
-        await cache.put("large query", large_embedding)
-        result = await cache.get("large query")
+        await cache.put("large query", large_embedding, model=_MODEL)
+        result = await cache.get("large query", model=_MODEL)
 
         assert result == large_embedding
         assert len(result) == 1536
@@ -291,9 +298,9 @@ class TestEmbeddingCache:
         """Test cache handles concurrent access correctly"""
 
         async def put_then_get(query, embedding):
-            await cache.put(query, embedding)
+            await cache.put(query, embedding, model=_MODEL)
             await asyncio.sleep(0.01)
-            return await cache.get(query)
+            return await cache.get(query, model=_MODEL)
 
         # Run concurrent operations
         tasks = [put_then_get(f"query{i}", [float(i)]) for i in range(3)]
@@ -306,6 +313,54 @@ class TestEmbeddingCache:
         assert results[2] == [2.0]
 
 
+class TestEmbeddingCacheModelKeying:
+    """Issue #12251: cache key is (model, text) — no cross-model collision."""
+
+    @pytest.mark.asyncio
+    async def test_same_text_different_models_no_collision(self, cache):
+        """Same text under two models must yield two independent entries."""
+        text = "identical query text"
+        vec_a = [0.1, 0.2, 0.3]  # model A embedding space
+        vec_b = [0.9, 0.8, 0.7, 0.6]  # model B embedding space (different dim)
+
+        await cache.put(text, vec_a, model="model-a")
+        await cache.put(text, vec_b, model="model-b")
+
+        # Each model reads back ITS OWN vector — no cross-space bleed.
+        assert await cache.get(text, model="model-a") == vec_a
+        assert await cache.get(text, model="model-b") == vec_b
+
+        # Two distinct entries, not one overwritten slot.
+        stats = cache.get_stats()
+        assert stats["cache_size"] == 2
+
+    @pytest.mark.asyncio
+    async def test_same_model_same_text_is_one_hit(self, cache):
+        """Same (model, text) collapses to a single cached entry (a hit)."""
+        text = "reused query"
+        vec = [0.5, 0.5]
+
+        await cache.put(text, vec, model="model-a")
+        first = await cache.get(text, model="model-a")
+        second = await cache.get(text, model="model-a")
+
+        assert first == vec
+        assert second == vec
+
+        stats = cache.get_stats()
+        assert stats["cache_size"] == 1
+        assert stats["hits"] == 2
+
+    @pytest.mark.asyncio
+    async def test_other_model_miss_does_not_return_first_vector(self, cache):
+        """A read under a different model than the writer must MISS, not bleed."""
+        text = "wrong space guard"
+        await cache.put(text, [1.0, 2.0], model="writer-model")
+
+        # The exact pre-fix bug: reader-model must NOT get writer-model's vector.
+        assert await cache.get(text, model="reader-model") is None
+
+
 class TestEmbeddingCacheIntegration:
     """Integration tests for embedding cache with knowledge base"""
 
@@ -313,9 +368,9 @@ class TestEmbeddingCacheIntegration:
     async def test_cache_stats_in_knowledge_base(self, global_cache):
         """Test that cache stats appear in knowledge base stats"""
         # Simulate some cache activity
-        await global_cache.put("test", [0.1, 0.2])
-        await global_cache.get("test")
-        await global_cache.get("miss")
+        await global_cache.put("test", [0.1, 0.2], model=_MODEL)
+        await global_cache.get("test", model=_MODEL)
+        await global_cache.get("miss", model=_MODEL)
 
         stats = global_cache.get_stats()
 

--- a/autobot-backend/knowledge/search.py
+++ b/autobot-backend/knowledge/search.py
@@ -345,16 +345,20 @@ class SearchMixin:
         Issue #281: Extracted helper.
         Issue #165: Uses NPU worker for hardware-accelerated embedding generation.
         """
+        from autobot_shared.ssot_config import config
         from knowledge.embedding_cache import get_embedding_cache
         from knowledge.facts import _generate_embedding_with_npu_fallback
 
+        # Issue #12251: cache key is (model, text). The NPU-fallback helper
+        # embeds with the configured default model, so key on that name.
+        model = config.llm.embedding_model
         _embedding_cache = get_embedding_cache()
-        query_embedding = await _embedding_cache.get(query)
+        query_embedding = await _embedding_cache.get(query, model=model)
 
         if query_embedding is None:
             # Cache miss - compute embedding using NPU worker with fallback
             query_embedding = await _generate_embedding_with_npu_fallback(query)
-            await _embedding_cache.put(query, query_embedding)
+            await _embedding_cache.put(query, query_embedding, model=model)
 
         return query_embedding
 

--- a/autobot-backend/npu_semantic_search.py
+++ b/autobot-backend/npu_semantic_search.py
@@ -194,6 +194,9 @@ class NPUSemanticSearch:
         self.ai_accelerator = None
         # Use Issue #65 P0 optimized EmbeddingCache (60-80% improvement for repeated queries)
         self.embedding_cache = get_embedding_cache()
+        # Issue #12251: cache key is (model, text); this engine embeds with the
+        # configured default embedding model via the NPU/Ollama fallback path.
+        self._embedding_model = config.llm.embedding_model
         self.search_results_cache = {}  # Cache for complete search results
         self.cache_max_size = _SEARCH_CACHE_MAX_SIZE
         self.cache_ttl_seconds = _SEARCH_CACHE_TTL
@@ -566,7 +569,7 @@ class NPUSemanticSearch:
     ) -> Tuple[np.ndarray, str]:
         """Generate embedding using optimal hardware with L1+L2 caching. Issue #65 P0, #8159."""
         # L1: in-process cache (fastest)
-        cached_embedding = await self.embedding_cache.get(text)
+        cached_embedding = await self.embedding_cache.get(text, model=self._embedding_model)
         if cached_embedding is not None:
             self._l1_hits += 1
             logger.debug("L1 cache hit for query: %s...", text[:50])
@@ -577,7 +580,7 @@ class NPUSemanticSearch:
         if l2_result is not None:
             self._l2_hits += 1
             logger.debug("L2 cache hit for query: %s...", text[:50])
-            await self.embedding_cache.put(text, l2_result.tolist())  # warm L1
+            await self.embedding_cache.put(text, l2_result.tolist(), model=self._embedding_model)  # warm L1
             return l2_result, "l2_cached"
 
         # Miss: generate via NPU/GPU/CPU
@@ -588,7 +591,7 @@ class NPUSemanticSearch:
             logger.warning("Optimized embedding generation failed: %s, using fallback", e)
             embedding, device_name = await self._generate_fallback_embedding(text)
 
-        await self.embedding_cache.put(text, embedding.tolist())
+        await self.embedding_cache.put(text, embedding.tolist(), model=self._embedding_model)
         await self._l2_cache_set(text, embedding)
         return embedding, device_name
 

--- a/autobot-backend/tests/test_npu_redis_cache.py
+++ b/autobot-backend/tests/test_npu_redis_cache.py
@@ -27,6 +27,8 @@ def _make_search_instance():
     obj._l1_hits = 0
     obj._l2_hits = 0
     obj._cache_misses = 0
+    # Issue #12251: cache key is (model, text); the engine keys on this id.
+    obj._embedding_model = "test-embed-model"
 
     # Minimal embedding_cache stub
     cache = MagicMock()


### PR DESCRIPTION
## Thinking Path
`knowledge/embedding_cache.py` is a repo-wide shared ARC singleton (`get_embedding_cache()`). `_make_key` hashed the TEXT only (`sha256(text)`), so if two embedding models embed the same text, the second reader silently gets the FIRST model's vector — a wrong-space / wrong-dimensionality correctness bug (issue #12251, found in the #10987 audit). Fix folds the model id into the key; every caller now passes the model it actually embeds with.

## What Changed
- `_make_key(model, query)` → `sha256(f"{model}\x00{query}")` (NUL-separated, explicit utf-8). `get`/`put` take a required `model: str`.
- Callers pass their real model id:
  - `code_embedding_generator.py` → `self.model_name` (`microsoft/codebert-base`)
  - `code_intelligence/analytics_infrastructure.py` → `self._embedding_model`
  - `code_intelligence/cross_language_patterns/detector.py` → `self.embedding_model`
  - `npu_semantic_search.py` → new `self._embedding_model = config.llm.embedding_model` (this engine embeds via the NPU/Ollama default-model fallback path)
  - `knowledge/search.py` → `config.llm.embedding_model` (NPU-fallback helper embeds with the configured default; sourced from config, not a literal)
- No change to eviction / TTL / sizing — pure key-scheme fix.

## Cold-cache note (blast radius)
Changing the key scheme means a one-time COLD cache after deploy: all reads miss until re-populated, correct thereafter. This is expected and correct — flagged in the issue.

## Verification
- New tests in `knowledge/embedding_cache_test.py` (`TestEmbeddingCacheModelKeying`): same text + two models → 2 distinct entries each returning its own vector; same (model, text) → one entry / hit; cross-model read MISSES (does not bleed the first vector). Offline, fake vectors.
- `pytest knowledge/embedding_cache_test.py` → 20 passed. Affected suite (`code_embedding_generator_test.py`, `tests/test_npu_redis_cache.py`, `knowledge/code_semantic_search_test.py`) → 52 passed total.
- `black --check` + `flake8` clean on all 8 changed files; `ast.parse` clean.

## Model Used
claude-opus-4-8

Closes #12251
