### PR TITLE
refactor(llc): standardize + document tenant-context resolution across LLC endpoints (#12215)

### DIFF
--- a/autobot-backend/api/user_management/dependencies.py
+++ b/autobot-backend/api/user_management/dependencies.py
@@ -252,12 +252,21 @@ async def require_org_context(
     """
     Dependency that requires organization context.
 
-    Raises HTTPException if no org context is available.
+    Raises HTTPException if no org context is available (#12215): the detail
+    message names the ``X-Organization-Id`` header explicitly, since routes
+    whose path has no ``company_id``/``id`` param (see
+    ``_extract_request_org_id``) cannot resolve org context from the URL and
+    the caller's JWT carries no ``org_id`` claim. See
+    ``docs/llc/tenant-context.md`` for the full resolution contract.
     """
     if not context.org_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Organization context required",
+            detail=(
+                "Organization context required — supply an 'X-Organization-Id' "
+                "request header (or a company_id path/query param, where the "
+                "route has one). See docs/llc/tenant-context.md."
+            ),
         )
     return context
 

--- a/autobot-backend/llc/api/activity.py
+++ b/autobot-backend/llc/api/activity.py
@@ -3,6 +3,13 @@
 """LLC activity log API (GH#8216).
 
 GET /api/llc/companies/{company_id}/activity — paginated, filterable audit trail.
+
+Tenant isolation (#12215): the caller's authenticated org context
+(``TenantContext.org_id``, resolved by ``require_org_context`` — see
+``docs/llc/tenant-context.md``) must match the ``{company_id}`` path param, or
+platform-admin. Previously this route only required authentication with no
+tenant check at all, letting any authenticated user read any company's
+activity log by supplying an arbitrary ``company_id``.
 """
 
 from datetime import datetime
@@ -12,8 +19,10 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.user_management.dependencies import get_current_user
+from api.user_management.dependencies import get_current_user, require_org_context
+from llc.deps import assert_company_access
 from user_management.database import get_async_session
+from user_management.services import TenantContext
 
 from ..models.activity import ActorType
 from ..services.activity_log import ActivityLogQuery, LLCActivityLogService
@@ -62,12 +71,14 @@ async def get_activity_log(
     page_size: int = Query(50, ge=1, le=200),
     session: AsyncSession = Depends(get_async_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> ActivityLogResponse:
     """Return paginated activity log for a company.
 
     All filters are optional and AND-ed together. Results are ordered by
     occurred_at descending (newest first).
     """
+    assert_company_access(ctx, company_id)
     params = ActivityLogQuery(
         entity_type=entity_type,
         entity_id=entity_id,

--- a/autobot-backend/llc/api/routines.py
+++ b/autobot-backend/llc/api/routines.py
@@ -12,6 +12,14 @@ Routes:
   DELETE /api/llc/routines/{routine_id}
   GET    /api/llc/routines/{routine_id}/runs
   POST   /api/llc/routines/{routine_id}/trigger
+
+Tenant isolation (#12215): every handler requires ``require_org_context`` and
+enforces ``assert_company_access`` — company-scoped routes against the path
+``company_id``, resource-scoped routes against the fetched routine's
+``company_id`` (see ``docs/llc/tenant-context.md``). Previously this router
+had no tenant check at all: any authenticated user could list/create routines
+for an arbitrary company, or read/update/delete/trigger any other company's
+routine by UUID.
 """
 
 import time
@@ -27,9 +35,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.user_management.dependencies import get_current_user
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.redis_client import get_async_redis_client
-from llc.deps import get_session, service_dep
+from llc.deps import assert_company_access, get_session, service_dep
+from user_management.services import TenantContext
 
 from ..models.enums import RoutineProduces, RoutineStatus
 from ..scheduler.routine_scheduler import _SCHEDULE_KEY
@@ -104,6 +113,20 @@ class TriggerResponse(BaseModel):
     message: str = "Routine scheduled for immediate execution"
 
 
+async def _load_owned_routine(session: AsyncSession, routine_id: uuid.UUID, ctx: TenantContext):
+    """Fetch a routine by id; 404 if missing or owned by another company.
+
+    Shared IDOR guard for the resource-level routine routes (#12215), mirrors
+    ``llc.deps.load_authorized`` — 404 (not 403) so a cross-tenant caller
+    can't distinguish "not my routine" from "doesn't exist".
+    """
+    routine = await _service().get(session, routine_id)
+    if routine is None:
+        raise HTTPException(status_code=404, detail="Routine not found")
+    assert_company_access(ctx, routine.company_id)
+    return routine
+
+
 # ------------------------------------------------------------------
 # Company-scoped routes
 # ------------------------------------------------------------------
@@ -117,7 +140,9 @@ async def list_routines(
     offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[RoutineRead]:
+    assert_company_access(ctx, company_id)
     routines = await _service().list(
         session,
         company_id=company_id,
@@ -138,7 +163,9 @@ async def create_routine(
     body: RoutineCreate,
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> RoutineRead:
+    assert_company_access(ctx, company_id)
     if croniter is None:
         raise HTTPException(status_code=503, detail="Routine scheduling unavailable — croniter not installed")
     if not croniter.is_valid(body.cron_schedule):
@@ -179,10 +206,9 @@ async def get_routine(
     routine_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> RoutineRead:
-    routine = await _service().get(session, routine_id)
-    if routine is None:
-        raise HTTPException(status_code=404, detail="Routine not found")
+    routine = await _load_owned_routine(session, routine_id, ctx)
     return RoutineRead.model_validate(routine)
 
 
@@ -192,7 +218,9 @@ async def update_routine(
     body: RoutineUpdate,
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> RoutineRead:
+    await _load_owned_routine(session, routine_id, ctx)
     updates = body.model_dump(exclude_unset=True)
     new_cron = updates.get("cron_schedule")
     if croniter is None and new_cron is not None:
@@ -229,10 +257,9 @@ async def delete_routine(
     routine_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> None:
-    routine = await _service().get(session, routine_id)
-    if routine is None:
-        raise HTTPException(status_code=404, detail="Routine not found")
+    await _load_owned_routine(session, routine_id, ctx)
     await _service().delete(session, routine_id)
     await session.commit()
 
@@ -244,10 +271,9 @@ async def list_routine_runs(
     offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[RoutineRunRead]:
-    routine = await _service().get(session, routine_id)
-    if routine is None:
-        raise HTTPException(status_code=404, detail="Routine not found")
+    await _load_owned_routine(session, routine_id, ctx)
     runs = await _service().list_runs(session, routine_id, limit=limit, offset=offset)
     return [RoutineRunRead.model_validate(r) for r in runs]
 
@@ -261,10 +287,9 @@ async def trigger_routine(
     routine_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> TriggerResponse:
-    routine = await _service().get(session, routine_id)
-    if routine is None:
-        raise HTTPException(status_code=404, detail="Routine not found")
+    routine = await _load_owned_routine(session, routine_id, ctx)
     if routine.status != RoutineStatus.ACTIVE:
         raise HTTPException(status_code=409, detail="Routine is not active")
     # Schedule for immediate dispatch — the scheduler creates the run record when it fires,

--- a/autobot-backend/llc/tests/test_activity_idor.py
+++ b/autobot-backend/llc/tests/test_activity_idor.py
@@ -1,0 +1,68 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""IDOR hardening tests for activity.py routes (#12215).
+
+Mirrors test_boards_idor.py: GET /companies/{company_id}/activity previously
+had no tenant check at all — any authenticated user could read any company's
+activity log by supplying an arbitrary company_id path param. This confirms
+the ``require_org_context`` + ``assert_company_access`` guard rejects a
+mismatched (spoofed) company_id and accepts a matching one.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+_OTHER_ORG = "99999999-9999-9999-9999-999999999999"
+
+
+def _make_client(caller_org_id: str) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.activity import router as activity_router  # noqa: PLC0415
+    from llc.services.activity_log import ActivityLogPage  # noqa: PLC0415
+    from user_management.database import get_async_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(activity_router, prefix="/api/llc")
+
+    async def _fake_session():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=False
+    )
+
+    empty_page = ActivityLogPage(items=[], page=1, page_size=50, total=0)
+    patch("llc.api.activity._service.query", new=AsyncMock(return_value=empty_page)).start()
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestActivityLogIdor:
+    def test_get_activity_own_tenant_ok(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get(f"/api/llc/companies/{org}/activity")
+        assert resp.status_code == 200
+
+    def test_get_activity_cross_tenant_404(self):
+        """Spoofed company_id (not the caller's own org) is rejected, not honoured."""
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get(f"/api/llc/companies/{_OTHER_ORG}/activity")
+        assert resp.status_code == 404

--- a/autobot-backend/llc/tests/test_routine.py
+++ b/autobot-backend/llc/tests/test_routine.py
@@ -337,7 +337,12 @@ async def test_api_trigger() -> None:
 
     with patch.object(mod, "_service", lambda: mock_svc):
         client = TestClient(app, raise_server_exceptions=True)
-        resp = client.post(f"/api/llc/routines/{routine_row.id}/trigger")
+        # #12215: /routines/{routine_id} has no company_id path param, so tenant
+        # context must come from the X-Organization-Id header.
+        resp = client.post(
+            f"/api/llc/routines/{routine_row.id}/trigger",
+            headers={"X-Organization-Id": str(routine_row.company_id)},
+        )
 
     # The trigger endpoint enqueues asynchronously → 202 Accepted.
     assert resp.status_code == 202

--- a/autobot-backend/llc/tests/test_routines_idor.py
+++ b/autobot-backend/llc/tests/test_routines_idor.py
@@ -1,0 +1,151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""IDOR hardening tests for routines.py routes (#12215).
+
+Mirrors test_boards_idor.py / test_sprints_idor.py: routines.py previously
+had NO tenant check at all — any authenticated user could list/create
+routines for an arbitrary company, or read/update/delete/trigger any other
+company's routine by UUID. This confirms every route now enforces
+``require_org_context`` + ``assert_company_access``, so a caller in org A
+cannot act on org B's routines (cross-tenant → 404, own-tenant → success).
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from llc.models.enums import RoutineProduces, RoutineStatus
+from llc.models.routine import LLCRoutine
+from user_management.services import TenantContext
+
+_FIXED_USER_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+_OTHER_ORG = "99999999-9999-9999-9999-999999999999"
+
+
+def _routine(company_id: str) -> MagicMock:
+    row = MagicMock(spec=LLCRoutine)
+    row.id = uuid.uuid4()
+    row.company_id = uuid.UUID(company_id)
+    row.name = "nightly-sync"
+    row.cron_schedule = "*/5 * * * *"
+    row.description = None
+    row.env = {}
+    row.status = RoutineStatus.ACTIVE
+    row.produces = RoutineProduces.NEW_WORK_ITEM
+    row.work_item_template = {}
+    row.assignee_agent_id = None
+    row.recurring_work_item_id = None
+    row.last_fired_at = None
+    row.created_at = datetime.now(tz=timezone.utc)
+    row.updated_at = datetime.now(tz=timezone.utc)
+    return row
+
+
+def _make_client(caller_org_id: str, routine: Optional[MagicMock] = None) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.routines import router as routines_router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(routines_router, prefix="/api/llc")
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def _fake_session():
+        yield mock_session
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_FIXED_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org_id), user_id=_FIXED_USER_ID, is_platform_admin=False
+    )
+
+    patch("llc.services.routine_service.RoutineService.get", new=AsyncMock(return_value=routine)).start()
+    patch("llc.services.routine_service.RoutineService.list", new=AsyncMock(return_value=[])).start()
+    patch(
+        "llc.services.routine_service.RoutineService.create",
+        new=AsyncMock(return_value=_routine(caller_org_id)),
+    ).start()
+    patch("llc.services.routine_service.RoutineService.delete", new=AsyncMock(return_value=None)).start()
+    patch("llc.services.routine_service.RoutineService.list_runs", new=AsyncMock(return_value=[])).start()
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestRoutinesIdor:
+    def test_get_routine_own_tenant_ok(self):
+        org = str(uuid.uuid4())
+        routine = _routine(org)
+        client = _make_client(org, routine=routine)
+        resp = client.get(f"/api/llc/routines/{routine.id}")
+        assert resp.status_code == 200
+
+    def test_get_routine_cross_tenant_404(self):
+        org = str(uuid.uuid4())
+        routine = _routine(_OTHER_ORG)
+        client = _make_client(org, routine=routine)
+        resp = client.get(f"/api/llc/routines/{routine.id}")
+        assert resp.status_code == 404
+
+    def test_delete_routine_cross_tenant_404(self):
+        org = str(uuid.uuid4())
+        routine = _routine(_OTHER_ORG)
+        client = _make_client(org, routine=routine)
+        resp = client.delete(f"/api/llc/routines/{routine.id}")
+        assert resp.status_code == 404
+
+    def test_trigger_routine_cross_tenant_404(self):
+        org = str(uuid.uuid4())
+        routine = _routine(_OTHER_ORG)
+        client = _make_client(org, routine=routine)
+        resp = client.post(f"/api/llc/routines/{routine.id}/trigger")
+        assert resp.status_code == 404
+
+    def test_list_routine_runs_cross_tenant_404(self):
+        org = str(uuid.uuid4())
+        routine = _routine(_OTHER_ORG)
+        client = _make_client(org, routine=routine)
+        resp = client.get(f"/api/llc/routines/{routine.id}/runs")
+        assert resp.status_code == 404
+
+    def test_update_routine_cross_tenant_404(self):
+        org = str(uuid.uuid4())
+        routine = _routine(_OTHER_ORG)
+        client = _make_client(org, routine=routine)
+        resp = client.patch(f"/api/llc/routines/{routine.id}", json={"name": "renamed"})
+        assert resp.status_code == 404
+
+    def test_list_routines_rejects_foreign_company(self):
+        """Spoofed company_id (not the caller's own org) is rejected, not honoured."""
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get(f"/api/llc/companies/{_OTHER_ORG}/routines")
+        assert resp.status_code == 404
+
+    def test_create_routine_rejects_foreign_company(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.post(
+            f"/api/llc/companies/{_OTHER_ORG}/routines",
+            json={"name": "x", "cron_schedule": "*/5 * * * *", "produces": "new_work_item"},
+        )
+        assert resp.status_code == 404
+
+    def test_list_routines_own_company_ok(self):
+        org = str(uuid.uuid4())
+        client = _make_client(org)
+        resp = client.get(f"/api/llc/companies/{org}/routines")
+        assert resp.status_code == 200

--- a/docs/llc/_index.md
+++ b/docs/llc/_index.md
@@ -67,6 +67,7 @@ and leans on the platform for memory, inference, and governance.
 | [Budget token mode](budget-token-mode.md) | Token-based budget accounting for LLC agents |
 | [GitHub PR integration](github-pr-integration.md) | PR ↔ work-item linking, branch naming convention, webhook setup |
 | [Project timeline (Gantt)](project-timeline.md) | Timeline view, scheduled dates, dependency arrows, critical path |
+| [Tenant-context resolution](tenant-context.md) | How LLC API endpoints derive/enforce `X-Organization-Id` and company scoping |
 
 ## Related
 

--- a/docs/llc/tenant-context.md
+++ b/docs/llc/tenant-context.md
@@ -1,0 +1,136 @@
+---
+tags:
+  - llc
+  - api
+  - security
+aliases:
+  - Tenant Context
+  - X-Organization-Id
+status: current
+---
+
+# LLC API tenant-context resolution (#12215)
+
+Every LLC API endpoint that reads or mutates company-scoped data must know
+*which company* (tenant) the request is for. This document is the single
+source of truth for how that tenant context is derived and enforced —
+previously this was undocumented and callers only discovered the contract via
+opaque `400` responses (#12215).
+
+## Canonical mechanism: `TenantContext`
+
+Human-facing LLC routes (i.e. everything under `/api/llc/*` except the
+agent-bearer surface described below) resolve tenant context through a single
+FastAPI dependency chain, defined in
+[`api/user_management/dependencies.py`](../../autobot-backend/api/user_management/dependencies.py):
+
+```
+get_current_user  →  get_tenant_context  →  require_org_context
+```
+
+- **`get_current_user`** — resolves the authenticated user from the session
+  JWT (`Authorization: Bearer ...`). Always required first; there is no
+  tenant context without an authenticated user.
+- **`get_tenant_context`** — builds a `TenantContext(org_id, user_id,
+  is_platform_admin)` from the request, using this precedence for `org_id`
+  (first match wins), per GH#10750 A5:
+  1. `X-Organization-Id` request header.
+  2. `company_id` (or `id`) path parameter — e.g.
+     `/companies/{company_id}/...`.
+  3. `company_id` query parameter (`?company_id=...`).
+  4. `org_id` JWT claim (legacy fallback, no extra DB check).
+- **`require_org_context`** — the dependency routers actually declare; wraps
+  `get_tenant_context` and raises `400` with a message naming the
+  `X-Organization-Id` header if no `org_id` could be resolved from any
+  source.
+
+### Anti-spoofing guarantee
+
+A client **cannot** grant itself access to another company's data merely by
+sending an `X-Organization-Id` header or `company_id` param:
+
+- If the resolved `org_id` came from the header/path/query (sources 1–3) and
+  the caller is **not** a platform admin, `get_tenant_context` performs a
+  membership check against `llc_company_memberships`. Non-members are
+  rejected with `403` before any handler code runs.
+- Individual routers additionally re-validate that the specific resource
+  being read/written belongs to `ctx.org_id` (see below) — the header only
+  ever *selects* which of the caller's own companies is in scope; it can
+  never grant access to a company the caller isn't a member of.
+- Platform admins (`role == "admin"` or `is_platform_admin == True` on the
+  JWT) may address any company without a membership check — this is the only
+  privileged path.
+
+### Per-resource IDOR guard
+
+Once `ctx.org_id` is resolved, routers must additionally confirm the
+*specific row(s)* being accessed belong to that org. The canonical helpers
+(`llc/deps.py`, GH#10148/#12184) are:
+
+| Helper | Use when |
+|---|---|
+| `assert_company_access(ctx, company_id)` | The route already loaded/knows a `company_id` (e.g. from a path param or a fetched row) and just needs the tenant check. |
+| `load_authorized(session, Model, obj_id, ctx, ...)` | Loading a single row by id — fetch + tenant-check in one call. |
+| `load_owned_project(project_id, session, ctx)` | Project-scoped resources specifically (sprints, findings). |
+
+All of these return `404` (not `403`) on a cross-tenant mismatch, so a
+cross-tenant caller can't distinguish "not yours" from "doesn't exist".
+
+## Why some routes need the header and others don't
+
+`_extract_request_org_id` only recognizes path params literally named
+`company_id` or `id`. Routes nested under `/companies/{company_id}/...`
+therefore resolve `org_id` from the URL with **no header required**. Flat
+routes keyed by a different resource id (e.g. `/goals/{goal_id}`,
+`/agents/{agent_id}/heartbeat/trigger`) have no such path param, so the
+caller **must** send `X-Organization-Id` (or rely on the JWT `org_id`
+fallback) — otherwise `require_org_context` returns `400`.
+
+This is expected, not a bug: **when calling any flat-resource LLC endpoint,
+always send `X-Organization-Id`.** It is safe to send it unconditionally on
+every LLC request (nested routes simply ignore it in favour of the path
+value, per the precedence above).
+
+## Legitimate variants (not deviations)
+
+A few LLC routers intentionally use a different mechanism because the caller
+is not a human session:
+
+- **Agent bearer auth** (`/api/llc/agent/*`) — `LLCAgentAuthMiddleware`
+  (`llc/middleware/agent_auth.py`) validates an `Authorization: Bearer
+  <agent-api-key>` token against `llc_agent_api_keys` and injects
+  `request.state.agent_id` / `request.state.company_id` directly. Agents
+  authenticate with a per-agent key scoped to exactly one company at
+  creation time, so there is no header to spoof and no `TenantContext` to
+  resolve.
+- **Board-role checks** (`llc/api/controls.py`, replay.py) — instant-control
+  endpoints (pause/resume/terminate) require a specific `MembershipRole`
+  (`OWNER`/`ADMIN`), not just membership, via `llc.deps.require_board_role`.
+  This is a stricter, not looser, variant of the same DB-backed membership
+  check.
+- **Webhooks** (`llc/api/github_webhooks.py`) — authenticated via GitHub's
+  HMAC webhook signature, not a user session; no `TenantContext` exists to
+  resolve.
+- **Public/global endpoints** (`llc/api/health.py`, `llc/api/adapters.py`) —
+  return no tenant-scoped data (a health probe; the list of registered
+  adapter *types*, not per-company config), so no tenant context is needed.
+
+## Audit history
+
+- **#12215**: documented this contract; standardized error messaging;
+  closed two IDOR gaps found during the audit — `llc/api/activity.py` and
+  `llc/api/routines.py` previously required only authentication with **no**
+  tenant check at all, letting any authenticated user read another
+  company's activity log, or read/update/delete/trigger another company's
+  routines by UUID. Both now use `require_org_context` +
+  `assert_company_access`/an owned-row loader, consistent with every other
+  LLC router.
+- **#12184/#10148**: introduced the shared `assert_company_access` /
+  `load_authorized` / `load_owned_project` helpers, consolidating ~9
+  near-identical per-router IDOR checks.
+- **#12148**: templates.py hardened to bind company-scoped operations to
+  `ctx.org_id` rather than trusting a caller-supplied `company_id`.
+- **#12233**: `companies.py` `GET/PATCH/DELETE /{company_id}` gained the
+  same `ctx.org_id == company_id` guard as other routers.
+- **#10750 A5**: introduced the `TenantContext` precedence + membership-check
+  design described above.


### PR DESCRIPTION
## Thinking Path

Audited every `llc/api/*.py` router for how it derives tenant context. The
canonical mechanism already exists (`TenantContext` via `require_org_context`
/`get_tenant_context` in `api/user_management/dependencies.py`, GH#10750 A5)
and is used by the large majority of routers, with anti-spoofing membership
checks and 404-hiding IDOR guards (`llc/deps.py` `assert_company_access` /
`load_authorized`, GH#12184/#10148). The inconsistency reported in #12215 has
two real causes:

1. **Expected-but-undocumented behaviour**: `_extract_request_org_id` only
   recognizes path params literally named `company_id`/`id`, so nested
   `/companies/{company_id}/...` routes resolve tenant context from the URL
   with no header, while flat routes (`/goals/{goal_id}`,
   `/agents/{agent_id}/heartbeat/trigger`, ...) require
   `X-Organization-Id`. This is by design, just never written down — fixed by
   documenting it and by naming the header in the `400` error.
2. **Two real deviations (security gaps)**: `activity.py` and `routines.py`
   had **no tenant check at all** (only `get_current_user`), letting any
   authenticated user read another company's activity log, or
   read/update/delete/trigger another company's routines by UUID. These are
   migrated to the canonical `require_org_context` + `assert_company_access`
   pattern, matching every other LLC router.

`GET /api/llc/companies/{id}` — reported as "public" in the issue — already
gained the `ctx.org_id == company_id` guard via #12233 (merged before this
audit); verified in `llc/api/companies.py`, no further action needed.

## What Changed

- `api/user_management/dependencies.py`: `require_org_context` 400 detail now
  names the `X-Organization-Id` header explicitly instead of a generic
  "Organization context required".
- `llc/api/activity.py`: `GET /companies/{company_id}/activity` now requires
  `require_org_context` + `assert_company_access(ctx, company_id)` — closes
  an IDOR gap (any authenticated user could read any company's activity log).
- `llc/api/routines.py`: every route (company-scoped list/create,
  resource-scoped get/update/delete/list-runs/trigger) now requires
  `require_org_context` + `assert_company_access` (via a new
  `_load_owned_routine` helper for the resource-level routes) — closes an
  IDOR gap (any authenticated user could act on any company's routines).
- `docs/llc/tenant-context.md` (new, linked from `docs/llc/_index.md`): the
  canonical tenant-context contract — resolution precedence, anti-spoofing
  membership check, per-resource IDOR helpers, why some routes need the
  header and others don't, and the legitimate variants that are *not*
  deviations (agent-bearer auth, board-role checks, webhooks, public probes).

Deliberately **not** changed: agent-bearer auth (`llc/api/agent_api.py` +
`LLCAgentAuthMiddleware`), board-role checks (`controls.py`, `replay.py`),
`github_webhooks.py`, `health.py`/`adapters.py` — these are legitimate,
already-secure variants for non-human or non-tenant-scoped callers, documented
as such rather than force-migrated (see "Legitimate variants" in the new doc).

## Verification

```
$ python3 -m pytest llc/ api/user_management/test_tenant_context_resolution.py -q
1440 passed, 2 skipped

$ python3 -m pytest llc/tests/test_activity_idor.py llc/tests/test_routines_idor.py llc/tests/test_routine.py -q
21 passed
```

New IDOR tests (`test_activity_idor.py`, `test_routines_idor.py`) confirm a
spoofed cross-tenant `company_id`/routine ownership is rejected with `404`
while same-tenant calls succeed — the existing `test_tenant_context_resolution.py`
(GH#10750 A5) already covers header-spoofing at the dependency layer
(non-member header org → `403`) and stays green unmodified.

`black --check` + `flake8` clean on all changed files; `ast.parse` clean.

## Model Used

Sonnet
Closes #12215