### PR TITLE
feat(llc): company status controls (activate/suspend/offboard/archive) in the UI (#12231)

### DIFF
--- a/autobot-frontend/src/components/llc/CompanyStatusControl.vue
+++ b/autobot-frontend/src/components/llc/CompanyStatusControl.vue
@@ -1,0 +1,168 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Author: mrveiss -->
+<!--
+  GH#12231: company status control — a status badge plus the transition
+  actions valid for the company's current llc_status (activate / suspend /
+  offboard / archive). Wires the #12211/#12234 endpoints via
+  useCompanyStatusApi; destructive transitions (offboard/archive) require a
+  confirmation, and a rejected transition (HTTP 409) surfaces its message.
+  Emits `updated` with the refreshed company so the parent can refresh.
+-->
+<template>
+  <div class="company-status-control">
+    <BaseBadge :variant="badgeVariant" size="sm">
+      {{ t(`llcCompanyStatus.${status}`) }}
+    </BaseBadge>
+
+    <div v-if="actions.length" class="company-status-actions">
+      <BaseButton
+        v-for="action in actions"
+        :key="action"
+        :variant="actionVariant(action)"
+        size="sm"
+        :disabled="isBusy"
+        @click="onAction(action)"
+      >
+        {{ t(`llcCompanyStatus.${action}`) }}
+      </BaseButton>
+    </div>
+
+    <p v-if="errorMessage" class="company-status-error" role="alert">
+      {{ errorMessage }}
+    </p>
+
+    <BaseModal
+      v-if="pendingAction"
+      :model-value="true"
+      :title="t('llcCompanyStatus.confirmTitle')"
+      :close-label="t('common.cancel')"
+      size="sm"
+      @close="cancelConfirm"
+    >
+      <p class="company-status-confirm">
+        {{
+          t(
+            pendingAction === 'archive'
+              ? 'llcCompanyStatus.confirmArchive'
+              : 'llcCompanyStatus.confirmOffboard',
+            { name: company.name },
+          )
+        }}
+      </p>
+      <template #actions>
+        <BaseButton variant="ghost" :disabled="isBusy" @click="cancelConfirm">
+          {{ t('common.cancel') }}
+        </BaseButton>
+        <BaseButton variant="danger" :disabled="isBusy" @click="runPending">
+          {{ t('llcCompanyStatus.confirm') }}
+        </BaseButton>
+      </template>
+    </BaseModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { BaseBadge, BaseButton, BaseModal, type BadgeVariant, type ButtonVariant } from '@autobot/ui'
+import {
+  useCompanyStatusApi,
+  transitionsFor,
+  DESTRUCTIVE_ACTIONS,
+  type CompanyStatus,
+  type CompanyStatusAction,
+  type CompanyStatusResult,
+} from '@/composables/llc/useCompanyStatusApi'
+
+const props = defineProps<{
+  company: { id: string; name: string; llc_status?: string | null }
+}>()
+
+const emit = defineEmits<{ updated: [CompanyStatusResult] }>()
+
+const { t } = useI18n()
+const statusApi = useCompanyStatusApi()
+
+const isBusy = ref(false)
+const errorMessage = ref('')
+const pendingAction = ref<CompanyStatusAction | null>(null)
+
+const status = computed<CompanyStatus>(() => (props.company.llc_status ?? 'onboarding') as CompanyStatus)
+const actions = computed(() => transitionsFor(props.company.llc_status))
+
+const BADGE_VARIANTS: Record<CompanyStatus, BadgeVariant> = {
+  onboarding: 'neutral',
+  active: 'success',
+  paused: 'warning',
+  offboarding: 'warning',
+  archived: 'danger',
+}
+const badgeVariant = computed<BadgeVariant>(() => BADGE_VARIANTS[status.value] ?? 'neutral')
+
+function actionVariant(action: CompanyStatusAction): ButtonVariant {
+  if (action === 'activate') return 'primary'
+  if (DESTRUCTIVE_ACTIONS.has(action)) return 'danger'
+  return 'secondary'
+}
+
+function onAction(action: CompanyStatusAction): void {
+  errorMessage.value = ''
+  if (DESTRUCTIVE_ACTIONS.has(action)) {
+    pendingAction.value = action
+    return
+  }
+  void apply(action)
+}
+
+function cancelConfirm(): void {
+  pendingAction.value = null
+}
+
+async function runPending(): Promise<void> {
+  const action = pendingAction.value
+  if (action) await apply(action)
+}
+
+async function apply(action: CompanyStatusAction): Promise<void> {
+  isBusy.value = true
+  errorMessage.value = ''
+  try {
+    const updated = await statusApi.transition(props.company.id, action)
+    emit('updated', updated)
+    pendingAction.value = null
+  } catch (err) {
+    errorMessage.value = err instanceof Error ? err.message : t('llcCompanyStatus.updateError')
+  } finally {
+    isBusy.value = false
+  }
+}
+</script>
+
+<style scoped>
+.company-status-control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.company-status-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.company-status-error {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-danger);
+}
+
+.company-status-confirm {
+  margin: 0;
+  color: var(--text-primary);
+}
+</style>

--- a/autobot-frontend/src/composables/llc/__tests__/useCompanyStatusApi.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/useCompanyStatusApi.test.ts
@@ -1,0 +1,92 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * GH#12231: unit tests for the LLC company status-transition composable.
+ * Asserts each transition POSTs the right endpoint, that the valid-transition
+ * map mirrors the backend guards, and that a rejected (409) transition
+ * propagates the error.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const post = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ post }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+import {
+  useCompanyStatusApi,
+  transitionsFor,
+  VALID_TRANSITIONS,
+  DESTRUCTIVE_ACTIONS,
+} from '../useCompanyStatusApi'
+
+describe('useCompanyStatusApi', () => {
+  beforeEach(() => {
+    post.mockReset()
+  })
+
+  it('activate() POSTs /activate and returns the parsed company', async () => {
+    const company = { id: 'c1', name: 'Acme', llc_status: 'active' }
+    post.mockResolvedValueOnce(company)
+    const result = await useCompanyStatusApi().activate('c1')
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/activate', undefined)
+    expect(result).toEqual(company)
+  })
+
+  it('suspend() POSTs /suspend, omitting the body when no reason given', async () => {
+    post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'paused' })
+    await useCompanyStatusApi().suspend('c1')
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/suspend', undefined)
+  })
+
+  it('suspend() forwards the reason as the request body', async () => {
+    post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'paused' })
+    await useCompanyStatusApi().suspend('c1', 'budget freeze')
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/suspend', { reason: 'budget freeze' })
+  })
+
+  it('offboard() POSTs /offboard', async () => {
+    post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'offboarding' })
+    await useCompanyStatusApi().offboard('c1')
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/offboard', undefined)
+  })
+
+  it('archive() POSTs /archive', async () => {
+    post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'archived' })
+    await useCompanyStatusApi().archive('c1')
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/archive', undefined)
+  })
+
+  it('propagates a rejected (e.g. HTTP 409) transition', async () => {
+    post.mockRejectedValueOnce(new Error('HTTP 409'))
+    await expect(useCompanyStatusApi().archive('c1')).rejects.toThrow('HTTP 409')
+  })
+
+  it('valid-transition map mirrors the backend guards', () => {
+    expect(VALID_TRANSITIONS).toEqual({
+      onboarding: ['activate', 'suspend'],
+      active: ['suspend', 'offboard'],
+      paused: ['activate', 'archive'],
+      offboarding: ['archive'],
+      archived: [],
+    })
+    expect(DESTRUCTIVE_ACTIONS.has('archive')).toBe(true)
+    expect(DESTRUCTIVE_ACTIONS.has('offboard')).toBe(true)
+    expect(DESTRUCTIVE_ACTIONS.has('activate')).toBe(false)
+  })
+
+  it('transitionsFor() returns valid actions and [] for unknown/terminal states', () => {
+    expect(transitionsFor('active')).toEqual(['suspend', 'offboard'])
+    expect(transitionsFor('archived')).toEqual([])
+    expect(transitionsFor(undefined)).toEqual([])
+    expect(transitionsFor('bogus')).toEqual([])
+  })
+})

--- a/autobot-frontend/src/composables/llc/useCompanyStatusApi.ts
+++ b/autobot-frontend/src/composables/llc/useCompanyStatusApi.ts
@@ -1,0 +1,90 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * LLC company status-transition API (GH#12231).
+ *
+ * Wraps the four backend status-transition endpoints added in #12211/#12234:
+ *   POST /api/llc/companies/{id}/activate  -> ACTIVE
+ *   POST /api/llc/companies/{id}/suspend   -> PAUSED   (optional reason)
+ *   POST /api/llc/companies/{id}/offboard  -> OFFBOARDING
+ *   POST /api/llc/companies/{id}/archive   -> ARCHIVED
+ *
+ * Each call returns the full updated CompanyRead (parsed JSON, no envelope).
+ * The valid-transition map mirrors the backend guards in
+ * autobot-backend/llc/services/company.py so the UI only ever offers a
+ * transition the backend will accept (a 409 is still surfaced as an error).
+ */
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useCompanyStatusApi')
+
+/** The five LLC company lifecycle states (LLCCompanyStatus enum). */
+export type CompanyStatus = 'onboarding' | 'active' | 'paused' | 'offboarding' | 'archived'
+
+/** The four status-transition actions an operator can trigger. */
+export type CompanyStatusAction = 'activate' | 'suspend' | 'offboard' | 'archive'
+
+/** Subset of the backend CompanyRead schema a transition returns. */
+export interface CompanyStatusResult {
+  id: string
+  name: string
+  llc_status: CompanyStatus
+  pause_reason?: string | null
+  paused_at?: string | null
+}
+
+/**
+ * Current status -> the transitions valid from it. Mirrors the backend
+ * `_ACTIVATE_FROM` / `_SUSPEND_FROM` / `_OFFBOARD_FROM` / `_ARCHIVE_FROM`
+ * frozensets. ARCHIVED is terminal (no outgoing transitions).
+ */
+export const VALID_TRANSITIONS: Record<CompanyStatus, CompanyStatusAction[]> = {
+  onboarding: ['activate', 'suspend'],
+  active: ['suspend', 'offboard'],
+  paused: ['activate', 'archive'],
+  offboarding: ['archive'],
+  archived: [],
+}
+
+/** Transitions that discard/park a company — the UI must confirm these. */
+export const DESTRUCTIVE_ACTIONS: ReadonlySet<CompanyStatusAction> = new Set([
+  'offboard',
+  'archive',
+])
+
+/** Actions valid from the given status (empty for an unknown/terminal state). */
+export function transitionsFor(status: string | undefined | null): CompanyStatusAction[] {
+  if (!status) return []
+  return VALID_TRANSITIONS[status as CompanyStatus] ?? []
+}
+
+export function useCompanyStatusApi() {
+  async function transition(
+    companyId: string,
+    action: CompanyStatusAction,
+    reason?: string,
+  ): Promise<CompanyStatusResult> {
+    const api = useApiClient()
+    const body = action === 'suspend' && reason ? { reason } : undefined
+    try {
+      return await api.post<CompanyStatusResult>(
+        `/api/llc/companies/${companyId}/${action}`,
+        body,
+      )
+    } catch (err) {
+      logger.error(`Company ${action} failed for ${companyId}`, err)
+      throw err
+    }
+  }
+
+  return {
+    activate: (id: string) => transition(id, 'activate'),
+    suspend: (id: string, reason?: string) => transition(id, 'suspend', reason),
+    offboard: (id: string) => transition(id, 'offboard'),
+    archive: (id: string) => transition(id, 'archive'),
+    transition,
+  }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7652,6 +7652,22 @@
     "systemHealth": "صحة النظام",
     "advancedControl": "التحكم المتقدم"
   },
+  "llcCompanyStatus": {
+    "onboarding": "الإعداد",
+    "active": "نشطة",
+    "paused": "متوقفة مؤقتًا",
+    "offboarding": "الإنهاء",
+    "archived": "مؤرشفة",
+    "activate": "تفعيل",
+    "suspend": "إيقاف مؤقت",
+    "offboard": "إنهاء",
+    "archive": "أرشفة",
+    "confirmTitle": "تأكيد تغيير الحالة",
+    "confirmOffboard": "إنهاء «{name}»؟ يبدأ هذا في إغلاق الشركة.",
+    "confirmArchive": "أرشفة «{name}»؟ هذه حالة نهائية ولا يمكن التراجع عنها.",
+    "confirm": "تأكيد",
+    "updateError": "تعذّر تغيير حالة الشركة."
+  },
   "llcMembers": {
     "title": "الأعضاء",
     "subtitle": "إدارة الأشخاص المنتمين إلى هذه الشركة وأدوارهم.",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7652,6 +7652,22 @@
     "systemHealth": "Systemzustand",
     "advancedControl": "Erweiterte Steuerung"
   },
+  "llcCompanyStatus": {
+    "onboarding": "Einführung",
+    "active": "Aktiv",
+    "paused": "Pausiert",
+    "offboarding": "Abwicklung",
+    "archived": "Archiviert",
+    "activate": "Aktivieren",
+    "suspend": "Pausieren",
+    "offboard": "Abwickeln",
+    "archive": "Archivieren",
+    "confirmTitle": "Statusänderung bestätigen",
+    "confirmOffboard": "„{name}“ abwickeln? Damit wird das Unternehmen heruntergefahren.",
+    "confirmArchive": "„{name}“ archivieren? Dies ist ein Endzustand und kann nicht rückgängig gemacht werden.",
+    "confirm": "Bestätigen",
+    "updateError": "Der Unternehmensstatus konnte nicht geändert werden."
+  },
   "llcMembers": {
     "title": "Mitglieder",
     "subtitle": "Verwalten Sie die Personen dieses Unternehmens und ihre Rollen.",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7701,6 +7701,22 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
+  "llcCompanyStatus": {
+    "onboarding": "Onboarding",
+    "active": "Active",
+    "paused": "Paused",
+    "offboarding": "Offboarding",
+    "archived": "Archived",
+    "activate": "Activate",
+    "suspend": "Suspend",
+    "offboard": "Offboard",
+    "archive": "Archive",
+    "confirmTitle": "Confirm status change",
+    "confirmOffboard": "Offboard \"{name}\"? This starts winding the company down.",
+    "confirmArchive": "Archive \"{name}\"? This is a terminal state and cannot be undone.",
+    "confirm": "Confirm",
+    "updateError": "Could not change the company status."
+  },
   "llcMembers": {
     "title": "Members",
     "subtitle": "Manage the people who belong to this company and their roles.",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7652,6 +7652,22 @@
     "systemHealth": "Salud del sistema",
     "advancedControl": "Control avanzado"
   },
+  "llcCompanyStatus": {
+    "onboarding": "Incorporación",
+    "active": "Activa",
+    "paused": "Pausada",
+    "offboarding": "Baja",
+    "archived": "Archivada",
+    "activate": "Activar",
+    "suspend": "Pausar",
+    "offboard": "Dar de baja",
+    "archive": "Archivar",
+    "confirmTitle": "Confirmar cambio de estado",
+    "confirmOffboard": "¿Dar de baja «{name}»? Esto inicia el cierre de la empresa.",
+    "confirmArchive": "¿Archivar «{name}»? Este es un estado final y no se puede deshacer.",
+    "confirm": "Confirmar",
+    "updateError": "No se pudo cambiar el estado de la empresa."
+  },
   "llcMembers": {
     "title": "Miembros",
     "subtitle": "Gestione las personas que pertenecen a esta empresa y sus roles.",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -197,6 +197,22 @@
     "systemHealth": "سلامت سیستم",
     "advancedControl": "کنترل پیشرفته"
   },
+  "llcCompanyStatus": {
+    "onboarding": "راه‌اندازی",
+    "active": "فعال",
+    "paused": "متوقف‌شده",
+    "offboarding": "خروج",
+    "archived": "بایگانی‌شده",
+    "activate": "فعال‌سازی",
+    "suspend": "توقف موقت",
+    "offboard": "خروج",
+    "archive": "بایگانی",
+    "confirmTitle": "تأیید تغییر وضعیت",
+    "confirmOffboard": "خروج «{name}»؟ این کار تعطیلی شرکت را آغاز می‌کند.",
+    "confirmArchive": "بایگانی «{name}»؟ این یک وضعیت نهایی است و قابل بازگشت نیست.",
+    "confirm": "تأیید",
+    "updateError": "تغییر وضعیت شرکت ممکن نشد."
+  },
   "llcMembers": {
     "title": "اعضا",
     "subtitle": "افراد متعلق به این شرکت و نقش‌های آن‌ها را مدیریت کنید.",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7652,6 +7652,22 @@
     "systemHealth": "Santé du système",
     "advancedControl": "Contrôle avancé"
   },
+  "llcCompanyStatus": {
+    "onboarding": "Intégration",
+    "active": "Active",
+    "paused": "En pause",
+    "offboarding": "Désengagement",
+    "archived": "Archivée",
+    "activate": "Activer",
+    "suspend": "Mettre en pause",
+    "offboard": "Désengager",
+    "archive": "Archiver",
+    "confirmTitle": "Confirmer le changement de statut",
+    "confirmOffboard": "Désengager « {name} » ? Cela lance la fermeture de l'entreprise.",
+    "confirmArchive": "Archiver « {name} » ? Il s'agit d'un état final et irréversible.",
+    "confirm": "Confirmer",
+    "updateError": "Impossible de changer le statut de l'entreprise."
+  },
   "llcMembers": {
     "title": "Membres",
     "subtitle": "Gérez les personnes qui appartiennent à cette entreprise et leurs rôles.",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -197,6 +197,22 @@
     "systemHealth": "בריאות המערכת",
     "advancedControl": "בקרה מתקדמת"
   },
+  "llcCompanyStatus": {
+    "onboarding": "קליטה",
+    "active": "פעילה",
+    "paused": "מושהית",
+    "offboarding": "סגירה",
+    "archived": "בארכיון",
+    "activate": "הפעלה",
+    "suspend": "השהיה",
+    "offboard": "סגירה",
+    "archive": "העברה לארכיון",
+    "confirmTitle": "אישור שינוי סטטוס",
+    "confirmOffboard": "לסגור את \"{name}\"? פעולה זו מתחילה את סגירת החברה.",
+    "confirmArchive": "להעביר את \"{name}\" לארכיון? זהו מצב סופי שלא ניתן לבטלו.",
+    "confirm": "אישור",
+    "updateError": "לא ניתן היה לשנות את סטטוס החברה."
+  },
   "llcMembers": {
     "title": "חברים",
     "subtitle": "נהל את האנשים השייכים לחברה זו ואת התפקידים שלהם.",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7652,6 +7652,22 @@
     "systemHealth": "Sistēmas veselība",
     "advancedControl": "Papildu vadība"
   },
+  "llcCompanyStatus": {
+    "onboarding": "Uzsākšana",
+    "active": "Aktīvs",
+    "paused": "Apturēts",
+    "offboarding": "Slēgšana",
+    "archived": "Arhivēts",
+    "activate": "Aktivizēt",
+    "suspend": "Apturēt",
+    "offboard": "Slēgt",
+    "archive": "Arhivēt",
+    "confirmTitle": "Apstiprināt statusa maiņu",
+    "confirmOffboard": "Slēgt “{name}”? Tas sāk uzņēmuma darbības izbeigšanu.",
+    "confirmArchive": "Arhivēt “{name}”? Šis ir gala stāvoklis, un to nevar atsaukt.",
+    "confirm": "Apstiprināt",
+    "updateError": "Neizdevās mainīt uzņēmuma statusu."
+  },
   "llcMembers": {
     "title": "Dalibnieki",
     "subtitle": "Parvaldiet sis kompanijas dalibniekus un vinu lomas.",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7652,6 +7652,22 @@
     "systemHealth": "Kondycja systemu",
     "advancedControl": "Sterowanie zaawansowane"
   },
+  "llcCompanyStatus": {
+    "onboarding": "Wdrażanie",
+    "active": "Aktywna",
+    "paused": "Wstrzymana",
+    "offboarding": "Wygaszanie",
+    "archived": "Zarchiwizowana",
+    "activate": "Aktywuj",
+    "suspend": "Wstrzymaj",
+    "offboard": "Wygaś",
+    "archive": "Archiwizuj",
+    "confirmTitle": "Potwierdź zmianę statusu",
+    "confirmOffboard": "Wygasić „{name}”? Rozpoczyna to zamykanie firmy.",
+    "confirmArchive": "Zarchiwizować „{name}”? To stan końcowy, którego nie można cofnąć.",
+    "confirm": "Potwierdź",
+    "updateError": "Nie udało się zmienić statusu firmy."
+  },
   "llcMembers": {
     "title": "Czlonkowie",
     "subtitle": "Zarzadzaj osobami nalezacymi do tej firmy i ich rolami.",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7652,6 +7652,22 @@
     "systemHealth": "Saúde do sistema",
     "advancedControl": "Controle avançado"
   },
+  "llcCompanyStatus": {
+    "onboarding": "Integração",
+    "active": "Ativa",
+    "paused": "Pausada",
+    "offboarding": "Encerramento",
+    "archived": "Arquivada",
+    "activate": "Ativar",
+    "suspend": "Pausar",
+    "offboard": "Encerrar",
+    "archive": "Arquivar",
+    "confirmTitle": "Confirmar alteração de estado",
+    "confirmOffboard": "Encerrar \"{name}\"? Isto inicia o encerramento da empresa.",
+    "confirmArchive": "Arquivar \"{name}\"? Este é um estado final e não pode ser desfeito.",
+    "confirm": "Confirmar",
+    "updateError": "Não foi possível alterar o estado da empresa."
+  },
   "llcMembers": {
     "title": "Membros",
     "subtitle": "Gerencie as pessoas que pertencem a esta empresa e suas funções.",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -197,6 +197,22 @@
     "systemHealth": "سسٹم کی صحت",
     "advancedControl": "ایڈوانسڈ کنٹرول"
   },
+  "llcCompanyStatus": {
+    "onboarding": "آن بورڈنگ",
+    "active": "فعال",
+    "paused": "معطل",
+    "offboarding": "اختتام",
+    "archived": "محفوظ شدہ",
+    "activate": "فعال کریں",
+    "suspend": "معطل کریں",
+    "offboard": "اختتام کریں",
+    "archive": "محفوظ کریں",
+    "confirmTitle": "اسٹیٹس کی تبدیلی کی تصدیق کریں",
+    "confirmOffboard": "«{name}» کو اختتام کریں؟ یہ کمپنی کو بند کرنے کا آغاز کرتا ہے۔",
+    "confirmArchive": "«{name}» کو محفوظ کریں؟ یہ ایک حتمی حالت ہے اور اسے واپس نہیں کیا جا سکتا۔",
+    "confirm": "تصدیق کریں",
+    "updateError": "کمپنی کا اسٹیٹس تبدیل نہیں کیا جا سکا۔"
+  },
   "llcMembers": {
     "title": "اراکین",
     "subtitle": "اس کمپنی سے تعلق رکھنے والے افراد اور ان کے کرداروں کا انتظام کریں۔",

--- a/autobot-frontend/src/stores/useLlcCompanyStore.ts
+++ b/autobot-frontend/src/stores/useLlcCompanyStore.ts
@@ -82,6 +82,15 @@ export const useLlcCompanyStore = defineStore('llcCompany', () => {
     selectedCompanyId.value = ''
   }
 
+  /**
+   * Patch a company's llc_status in-place after a status transition (#12231),
+   * so the selector badge reflects the new state without a full refetch.
+   */
+  function applyStatus(id: string, status: string): void {
+    const company = companies.value.find((c) => c.id === id)
+    if (company) company.llc_status = status
+  }
+
   return {
     companies,
     selectedCompanyId,
@@ -93,6 +102,7 @@ export const useLlcCompanyStore = defineStore('llcCompany', () => {
     fetchCompanies,
     selectCompany,
     clearSelection,
+    applyStatus,
   }
 }, {
   persist: {

--- a/autobot-frontend/src/views/llc/CompanySelectorView.vue
+++ b/autobot-frontend/src/views/llc/CompanySelectorView.vue
@@ -7,12 +7,16 @@
   Lists companies from GET /api/llc/companies/, stores the selection in
   the llcCompany Pinia store, then forwards to the company dashboard (or
   the ?redirect= destination set by the llcCompanyParamGuard).
+  GH#12231: each row exposes a CompanyStatusControl (status badge + the
+  valid activate/suspend/offboard/archive transitions for its state).
 -->
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useLlcCompanyStore, type LlcCompany } from '@/stores/useLlcCompanyStore'
 import { useRuntimeFeaturesStore } from '@/stores/useRuntimeFeaturesStore'
+import CompanyStatusControl from '@/components/llc/CompanyStatusControl.vue'
+import type { CompanyStatusResult } from '@/composables/llc/useCompanyStatusApi'
 
 const route = useRoute()
 const router = useRouter()
@@ -35,6 +39,11 @@ async function selectCompany(company: LlcCompany): Promise<void> {
   // Enter the company's PM workspace (LlcCompanyLayout with sidebar → backlog,
   // boards, sprints…), not the sidebar-less standalone /llc/dashboard.
   await router.push(`/llc/companies/${company.id}`)
+}
+
+// #12231: reflect a status transition on the selector badge without a refetch.
+function onStatusUpdated(updated: CompanyStatusResult): void {
+  companyStore.applyStatus(updated.id, updated.llc_status)
 }
 
 onMounted(async () => {
@@ -85,7 +94,7 @@ onMounted(async () => {
     </div>
 
     <ul v-else class="company-list">
-      <li v-for="company in companyStore.companies" :key="company.id">
+      <li v-for="company in companyStore.companies" :key="company.id" class="company-row">
         <button
           type="button"
           class="company-card"
@@ -103,10 +112,12 @@ onMounted(async () => {
               {{ company.description }}
             </span>
           </span>
-          <span v-if="company.llc_status" class="company-status">
-            {{ company.llc_status }}
-          </span>
         </button>
+        <CompanyStatusControl
+          class="company-row-status"
+          :company="company"
+          @updated="onStatusUpdated"
+        />
       </li>
     </ul>
 
@@ -203,27 +214,40 @@ onMounted(async () => {
   gap: 0.5rem;
 }
 
+/* #12231: card + its status control stack together as one row */
+.company-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-default);
+  background: var(--bg-card);
+}
+
 .company-card {
   width: 100%;
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.875rem 1rem;
   text-align: left;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-default);
-  background: var(--bg-card);
+  background: none;
+  border: none;
+  padding: 0;
   cursor: pointer;
 }
 
-.company-card:hover {
+.company-row:hover {
   border-color: var(--color-accent-border, var(--color-accent, var(--coselector-accent)));
   background: var(--bg-hover);
 }
 
 .company-card.active {
-  border-color: var(--color-accent, var(--coselector-accent));
-  background: var(--color-accent-subtle, var(--coselector-accent-subtle));
+  color: var(--color-accent, var(--coselector-accent));
+}
+
+.company-row-status {
+  padding-left: 1.375rem;
 }
 
 .company-dot {
@@ -252,18 +276,6 @@ onMounted(async () => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.company-status {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 0.125rem 0.5rem;
-  border-radius: var(--radius-full);
-  background: var(--color-accent-subtle, var(--coselector-accent-subtle));
-  color: var(--color-accent-text, var(--color-accent, var(--coselector-accent)));
-  flex: none;
 }
 
 .selector-create {


### PR DESCRIPTION
## Thinking Path
The backend added company status-transition endpoints in #12211/#12234 (`POST /api/llc/companies/{id}/{activate|suspend|offboard|archive}`), but the frontend only *displayed* `llc_status` — an operator had no way to move a company out of `onboarding` or to suspend/archive it. I mirrored the backend transition guards into the UI so it only ever offers a transition the backend will accept, and surfaces a rejected (409) transition inline.

Valid transitions (mirrored from `llc/services/company.py` `_ACTIVATE_FROM`/`_SUSPEND_FROM`/`_OFFBOARD_FROM`/`_ARCHIVE_FROM`):
- `onboarding` → activate, suspend
- `active` → suspend, offboard
- `paused` → activate, archive
- `offboarding` → archive
- `archived` → (terminal, none)

## What Changed
- **`useCompanyStatusApi.ts`** (new composable): wraps the 4 transition POSTs (returns parsed `CompanyRead`), exports the `VALID_TRANSITIONS` map, `DESTRUCTIVE_ACTIONS` set (offboard/archive), and `transitionsFor(status)`.
- **`CompanyStatusControl.vue`** (new component): `BaseBadge` status + `BaseButton` per valid transition; destructive transitions confirm via `BaseModal`; a 409/error message renders inline. Emits `updated` with the refreshed company. Uses `@autobot/ui` kit + design tokens only (no hardcoded hex/px), `BaseBadge` `danger` variant.
- **`CompanySelectorView.vue`**: each company row now renders the status control (restructured so the control is a sibling of the select button, not nested).
- **`useLlcCompanyStore.ts`**: added `applyStatus(id, status)` to patch a company's `llc_status` in-place after a transition (no refetch).
- **i18n**: new `llcCompanyStatus` block added to all 11 locales.

## Verification
- `npx vitest run src/composables/llc/__tests__/useCompanyStatusApi.test.ts` → **8 passed** (each transition hits the right endpoint; suspend reason forwarded; 409 propagates; `VALID_TRANSITIONS` mirrors the backend; `transitionsFor` returns `[]` for terminal/unknown).
- `npx vue-tsc --noEmit -p tsconfig.app.json` → **no errors on touched files**.
- `npx eslint` on all touched files → **clean (exit 0)**.

## Model Used
claude-opus-4-8

Closes #12231
