### PR TITLE
feat(llm): pre-request cumulative token budget gate at the provider service (#11541)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -395,6 +395,11 @@ if "llm_shared" not in sys.modules:
     _real_load_and_bind("llm_shared.cross_worker_rate_limiter", _llm_root / "cross_worker_rate_limiter.py")
     _real_load_and_bind("llm_shared.observability", _llm_root / "observability" / "__init__.py")
     _real_load_and_bind("llm_shared.rate_limit_backoff", _llm_root / "rate_limit_backoff.py")
+    # #11541: pre-request cumulative token budget gate — base_provider imports it
+    # at module level (`from .token_budget import get_token_budget_gate`); light
+    # dep (autobot_shared.env_utils/logging_manager/singleton_factory + .models),
+    # load real before base_provider so the gate isn't a MagicMock stub.
+    _real_load_and_bind("llm_shared.token_budget", _llm_root / "token_budget.py")
     _real_load_and_bind("llm_shared.base_provider", _llm_root / "base_provider.py")
     _real_load_and_bind("llm_shared.model_param_registry", _llm_root / "model_param_registry.py")
     _real_load_and_bind("llm_shared.provider_registry", _llm_root / "provider_registry.py")

--- a/autobot-backend/llm_shared/base_provider.py
+++ b/autobot-backend/llm_shared/base_provider.py
@@ -31,6 +31,7 @@ from .models import LLMRequest, LLMResponse
 from .observability import registry as obs_registry
 from .provider_auth import ApiKeyAuth, ProviderAuthError, ProviderAuthStrategy
 from .rate_limit_backoff import extract_rate_limit_info, get_backoff_handler, raise_if_rate_limited
+from .token_budget import get_token_budget_gate
 
 logger = get_logger(__name__)
 
@@ -182,7 +183,13 @@ class BaseProvider(ABC):
         )
 
     async def _guarded_completion(self, request: LLMRequest) -> LLMResponse:
-        """Run ``_chat_completion_impl`` through the provider circuit breaker (GH#11488).
+        """Run ``_chat_completion_impl`` through the token budget gate and the
+        provider circuit breaker (GH#11488, GH#11541).
+
+        GH#11541: a pre-flight cumulative token budget check runs first —
+        over-budget requests short-circuit with an error response and never
+        reach the breaker, so the gate cannot affect breaker failure stats
+        (the breaker contract is untouched).
 
         Error responses count as breaker failures — except rate limits, which
         the backoff handler owns (GH#8502) and which prove the provider is up.
@@ -191,6 +198,12 @@ class BaseProvider(ABC):
         surfaces like any provider error; registry-level avoidance of
         breaker-open providers is tracked separately.)
         """
+        budget_block = await get_token_budget_gate().evaluate(request)
+        if budget_block is not None:
+            self._total_requests += 1
+            self._total_errors += 1
+            return budget_block
+
         breaker = self._completion_circuit_breaker()
         start = time.monotonic()
 
@@ -202,14 +215,17 @@ class BaseProvider(ABC):
             return response
 
         try:
-            return await breaker.call_async(_run)
+            response = await breaker.call_async(_run)
         except _CompletionErrorSignal as signal:
-            return signal.response
+            response = signal.response
         except CircuitBreakerOpenError as exc:
             logger.warning("Provider %s circuit breaker open; failing fast", self.provider_name)
             return self._breaker_error_response(request, f"circuit breaker open: {exc}", start)
         except TimeoutError as exc:
             return self._breaker_error_response(request, str(exc), start)
+
+        await get_token_budget_gate().record(request, response)
+        return response
 
     @abstractmethod
     async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:

--- a/autobot-backend/llm_shared/token_budget.py
+++ b/autobot-backend/llm_shared/token_budget.py
@@ -1,0 +1,170 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Pre-request cumulative token budget gate (Issue #11541).
+
+OpenManus counts tokens per request, accumulates ``total_input_tokens`` and
+refuses to send a request that would exceed ``max_input_tokens`` (adopted
+from ``app/llm.py:240-262`` per the umbrella research issue #11536). This
+module ports that shape to AutoBot: before a provider call is issued, the
+cumulative estimated token spend for the current run is checked against a
+configurable ceiling — a request that would exceed it is short-circuited
+with an error ``LLMResponse`` (never raised, per the must-not-raise contract
+established by #11488/#11499).
+
+Scope: cumulative tokens are tracked per "run" — the caller-supplied
+``request.metadata["session_id"]`` when threaded through, else the
+per-request ``request.request_id`` (no plumbing required from existing
+callers; threading a real session id turns per-request tracking into true
+per-conversation tracking).
+
+Counters are stored in Redis (shared across all uvicorn workers, mirroring
+``LLMCrossWorkerRateLimiter`` / #8170) and fall back to allow-all when Redis
+is unavailable — a Redis outage must never hard-block LLM calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from autobot_shared.env_utils import env_int
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
+
+from .models import LLMRequest, LLMResponse
+
+logger = get_logger(__name__)
+
+# Per-run cumulative token ceiling (input + output). 0 disables the gate —
+# #11541 acceptance: "Ceiling disabled by default or set high enough to be
+# invisible in normal chat".
+TOKEN_BUDGET_PER_RUN: int = env_int("AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN", 0)
+
+# TTL (seconds) for a run's cumulative counter — bounds Redis memory for
+# abandoned sessions. Refreshed on every increment, so an active run's
+# counter never resets mid-conversation. Default: 24h.
+TOKEN_BUDGET_TTL_SECONDS: int = env_int("AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS", 86400)
+
+# Chars-per-token estimate — the same rough approximation already used by
+# chat_workflow/compact_hook.py and context_window_manager.py. Accurate
+# tokenisation is unnecessary for a budget *ceiling* check.
+_CHARS_PER_TOKEN: int = 4
+
+_KEY_PREFIX = "autobot:llm:token_budget"
+
+
+def _estimate_tokens(char_count: int) -> int:
+    """Cheap chars/4 token estimate (matches compact_hook.py convention)."""
+    return max(0, char_count // _CHARS_PER_TOKEN)
+
+
+def _estimate_request_tokens(request: LLMRequest) -> int:
+    """Estimate this request's token cost: input messages + requested output budget."""
+    input_chars = sum(len(str(m.get("content", ""))) for m in request.messages)
+    return _estimate_tokens(input_chars) + (request.max_tokens or 0)
+
+
+def _estimate_response_tokens(response: LLMResponse) -> int:
+    """Estimate a completed response's token cost when the provider didn't report usage."""
+    return _estimate_tokens(len(response.content or ""))
+
+
+def _scope_key(request: LLMRequest) -> str:
+    """Resolve the cumulative-budget scope for *request* (#11541).
+
+    Uses ``metadata['session_id']`` when the caller threads one through
+    (true per-conversation tracking); falls back to ``request_id`` so the
+    gate works unconditionally, degrading to a per-request ceiling.
+    """
+    metadata: Dict[str, Any] = request.metadata or {}
+    session_id = metadata.get("session_id")
+    return str(session_id) if session_id else request.request_id
+
+
+class TokenBudgetGate:
+    """Redis-backed cumulative token budget gate (#11541).
+
+    Shared across all uvicorn workers via Redis, mirroring
+    ``LLMCrossWorkerRateLimiter`` (#8170). Never raises — Redis errors and a
+    disabled budget (``TOKEN_BUDGET_PER_RUN <= 0``) both resolve to
+    allow-all.
+    """
+
+    async def evaluate(self, request: LLMRequest) -> Optional[LLMResponse]:
+        """Return an error ``LLMResponse`` when *request* would exceed the
+        run's budget; ``None`` when the call may proceed."""
+        if TOKEN_BUDGET_PER_RUN <= 0:
+            return None
+
+        scope = _scope_key(request)
+        estimated = _estimate_request_tokens(request)
+
+        try:
+            cumulative = await self._get_cumulative(scope)
+        except Exception:
+            logger.debug("token budget gate: Redis unavailable — allowing request", exc_info=True)
+            return None
+
+        if cumulative + estimated <= TOKEN_BUDGET_PER_RUN:
+            return None
+
+        logger.warning(
+            "token budget gate: run=%s would exceed ceiling (%d + %d > %d) — blocking",
+            scope,
+            cumulative,
+            estimated,
+            TOKEN_BUDGET_PER_RUN,
+        )
+        return LLMResponse(
+            content="",
+            model=request.model_name or "",
+            request_id=request.request_id,
+            error=(f"Token budget exhausted for this run ({cumulative}/{TOKEN_BUDGET_PER_RUN} tokens used)."),
+        )
+
+    async def record(self, request: LLMRequest, response: LLMResponse) -> None:
+        """Add *response*'s actual (or estimated) token usage to the run's cumulative counter."""
+        if TOKEN_BUDGET_PER_RUN <= 0:
+            return
+
+        used = response.tokens_used or _estimate_response_tokens(response)
+        if used <= 0:
+            return
+
+        try:
+            await self._increment(_scope_key(request), used)
+        except Exception:
+            logger.debug("token budget gate: Redis unavailable — usage not recorded", exc_info=True)
+
+    async def _get_cumulative(self, scope: str) -> int:
+        redis = await self._get_redis()
+        raw = await redis.get(f"{_KEY_PREFIX}:{scope}")
+        return int(raw) if raw else 0
+
+    async def _increment(self, scope: str, amount: int) -> None:
+        redis = await self._get_redis()
+        key = f"{_KEY_PREFIX}:{scope}"
+        await redis.incrby(key, amount)
+        await redis.expire(key, TOKEN_BUDGET_TTL_SECONDS)
+
+    async def _get_redis(self):
+        from autobot_shared.redis_client import get_async_redis_client  # noqa: PLC0415
+
+        return await get_async_redis_client()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+get_token_budget_gate = lazy_singleton(TokenBudgetGate)
+
+
+__all__ = [
+    "TOKEN_BUDGET_PER_RUN",
+    "TOKEN_BUDGET_TTL_SECONDS",
+    "TokenBudgetGate",
+    "get_token_budget_gate",
+]

--- a/autobot-backend/tests/llm_shared/test_token_budget.py
+++ b/autobot-backend/tests/llm_shared/test_token_budget.py
@@ -1,0 +1,203 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for the pre-request cumulative token budget gate (Issue #11541).
+
+Covers:
+- Disabled by default (TOKEN_BUDGET_PER_RUN <= 0) -> gate is a no-op
+- Under budget -> request proceeds (no provider call blocked)
+- At/over budget -> gated with an error LLMResponse, never raises
+- Cumulative counting across calls (per scope key)
+- Redis unavailable -> fails open (allow-all), never hard-blocks
+- BaseProvider._guarded_completion integration: budget block short-circuits
+  before the breaker is touched (breaker contract untouched)
+"""
+
+from typing import AsyncIterator, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from llm_shared import token_budget
+from llm_shared.base_provider import BaseProvider
+from llm_shared.models import LLMRequest, LLMResponse
+
+
+class _FakeRedis:
+    """In-memory stand-in for the async Redis client (get/incrby/expire only)."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, int] = {}
+
+    async def get(self, key: str):
+        value = self._store.get(key)
+        return str(value).encode() if value is not None else None
+
+    async def incrby(self, key: str, amount: int) -> int:
+        self._store[key] = self._store.get(key, 0) + amount
+        return self._store[key]
+
+    async def expire(self, key: str, ttl: int) -> None:
+        return None
+
+
+class _EchoProvider(BaseProvider):
+    """Minimal concrete BaseProvider that always succeeds with a fixed response."""
+
+    provider_name = "echo"
+
+    def __init__(self, tokens_used: int | None = 10) -> None:
+        super().__init__(settings={})
+        self._tokens_used = tokens_used
+
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
+        return LLMResponse(content="ok", model="echo-model", tokens_used=self._tokens_used)
+
+    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
+        yield "ok"
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def list_models(self) -> List[str]:
+        return ["echo-model"]
+
+
+def _request(session_id: str = "run-1", max_tokens: int | None = None) -> LLMRequest:
+    return LLMRequest(
+        messages=[{"role": "user", "content": "hello world"}],
+        max_tokens=max_tokens,
+        metadata={"session_id": session_id},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_budget(monkeypatch):
+    """Isolate each test: fresh fake Redis + explicit budget (no env leakage)."""
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(token_budget.TokenBudgetGate, "_get_redis", AsyncMock(return_value=fake_redis))
+    yield fake_redis
+
+
+class TestTokenBudgetGateDisabledByDefault:
+    def test_disabled_by_default(self):
+        """#11541 acceptance: ceiling disabled by default."""
+        assert token_budget.TOKEN_BUDGET_PER_RUN <= 0
+
+    @pytest.mark.asyncio
+    async def test_disabled_gate_is_noop(self, monkeypatch):
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 0)
+        gate = token_budget.TokenBudgetGate()
+        result = await gate.evaluate(_request())
+        assert result is None
+
+
+class TestTokenBudgetGateEnforcement:
+    @pytest.mark.asyncio
+    async def test_under_budget_proceeds(self, monkeypatch):
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 1000)
+        gate = token_budget.TokenBudgetGate()
+        result = await gate.evaluate(_request())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_over_budget_blocks_with_error_response_no_raise(self, monkeypatch):
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 1)
+        gate = token_budget.TokenBudgetGate()
+        result = await gate.evaluate(_request(max_tokens=500))
+        assert isinstance(result, LLMResponse)
+        assert result.error
+        assert "budget" in result.error.lower()
+        assert result.content == ""
+
+    @pytest.mark.asyncio
+    async def test_cumulative_counting_across_calls(self, monkeypatch, _reset_budget):
+        """Two calls whose combined usage exceeds the ceiling: 2nd is gated."""
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 11)
+        gate = token_budget.TokenBudgetGate()
+        req = _request(session_id="cumulative-run")
+        response = LLMResponse(content="x", tokens_used=10)
+
+        first = await gate.evaluate(req)
+        assert first is None
+        await gate.record(req, response)
+
+        second = await gate.evaluate(req)
+        assert isinstance(second, LLMResponse)
+        assert second.error
+
+    @pytest.mark.asyncio
+    async def test_scope_isolation_per_session(self, monkeypatch, _reset_budget):
+        """Different session ids ('runs') track independent cumulative counters."""
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 11)
+        gate = token_budget.TokenBudgetGate()
+        req_a = _request(session_id="run-a")
+        req_b = _request(session_id="run-b")
+
+        await gate.record(req_a, LLMResponse(content="x", tokens_used=10))
+
+        assert await gate.evaluate(req_a) is not None  # run-a near/over ceiling
+        assert await gate.evaluate(req_b) is None  # run-b untouched
+
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_fails_open(self, monkeypatch):
+        """A Redis outage must never hard-block LLM calls."""
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 1)
+        gate = token_budget.TokenBudgetGate()
+
+        async def _boom():
+            raise ConnectionError("redis down")
+
+        monkeypatch.setattr(gate, "_get_redis", _boom)
+        result = await gate.evaluate(_request(max_tokens=500))
+        assert result is None
+
+
+class TestBaseProviderIntegration:
+    """GH#11541: gate lives at BaseProvider._guarded_completion (chat_completion seam)."""
+
+    @pytest.mark.asyncio
+    async def test_under_budget_calls_provider(self, monkeypatch):
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 10_000)
+        provider = _EchoProvider()
+        response = await provider.chat_completion(_request(session_id="under-budget-run"))
+        assert response.error is None
+        assert response.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_over_budget_short_circuits_before_provider_call(self, monkeypatch):
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 1)
+        provider = _EchoProvider()
+        provider._chat_completion_impl = AsyncMock(side_effect=AssertionError("provider must not be called"))
+        response = await provider.chat_completion(_request(session_id="over-budget-run", max_tokens=500))
+        assert response.error is not None
+        assert "budget" in response.error.lower()
+        provider._chat_completion_impl.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_breaker_contract_untouched_by_budget_block(self, monkeypatch):
+        """A budget block must not register as a circuit-breaker failure."""
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 1)
+        provider = _EchoProvider()
+        breaker = provider._completion_circuit_breaker()
+        failures_before = breaker.failure_count
+
+        await provider.chat_completion(_request(session_id="breaker-check-run", max_tokens=500))
+
+        assert breaker.failure_count == failures_before
+
+    @pytest.mark.asyncio
+    async def test_cumulative_usage_recorded_after_success(self, monkeypatch):
+        monkeypatch.setattr(token_budget, "TOKEN_BUDGET_PER_RUN", 15)
+        provider = _EchoProvider(tokens_used=10)
+        session = "record-after-success-run"
+
+        first = await provider.chat_completion(_request(session_id=session))
+        assert first.error is None
+
+        # Second call in the same run now exceeds the 15-token ceiling (10 used + new estimate).
+        second = await provider.chat_completion(_request(session_id=session, max_tokens=100))
+        assert second.error is not None
+        assert "budget" in second.error.lower()


### PR DESCRIPTION
## Thinking Path

Issue #11541 pins the seam (`BaseProvider._guarded_completion`), the scope (cumulative estimated input+output tokens per conversation/run), the config source (env-tunable module-level constant, following the cache-TTL convention), and the enforcement (over-budget short-circuits with an error `LLMResponse`, never raises — the must-not-raise contract from #11488/#11499). The gate must not affect breaker failure stats ("breaker contract untouched") and must be disabled by default.

`LLMRequest` has no `session_id` field today, so "per conversation/run" resolves to `request.metadata["session_id"]` when a caller threads one through, falling back to `request.request_id` (per-request ceiling) so the gate works unconditionally with zero call-site plumbing changes. Cumulative counters live in Redis (`autobot:llm:token_budget:{scope}`), mirroring the existing `LLMCrossWorkerRateLimiter` (#8170) cross-worker pattern, and fail open (allow-all) on any Redis error — a Redis outage must never hard-block LLM calls. Token counting reuses the codebase's existing chars/4 estimate convention (`chat_workflow/compact_hook.py`, `context_window_manager.py`) rather than adding a new tokenizer; actual `response.tokens_used` is preferred when a provider reports it.

## What Changed

- `autobot-backend/llm_shared/token_budget.py` (new): `TokenBudgetGate` — `evaluate()` returns an error `LLMResponse` when the run's cumulative usage + this request's estimate would exceed `TOKEN_BUDGET_PER_RUN` (env `AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN`, default `0` = disabled); `record()` adds a completed call's actual/estimated usage to the run's Redis counter (`AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS`, default 24h, refreshed on every increment).
- `autobot-backend/llm_shared/base_provider.py`: `_guarded_completion` calls `get_token_budget_gate().evaluate(request)` **before** the circuit breaker — an over-budget request never reaches `breaker.call_async`, so breaker failure stats are untouched. On success/error paths that do reach the provider, `get_token_budget_gate().record(request, response)` updates the run's cumulative counter.
- `autobot-backend/conftest.py`: real-loads `llm_shared.token_budget` (light dep — `.models` + `autobot_shared` seams only) ahead of `llm_shared.base_provider` in the existing light-module real-load chain, so the gate isn't silently replaced by the test suite's `llm_shared` `MagicMock` stub.
- `autobot-backend/tests/llm_shared/test_token_budget.py` (new): disabled-by-default, under/over-budget gating, cumulative counting across calls, per-scope isolation, Redis-unavailable fail-open, and `BaseProvider.chat_completion` integration (budget block short-circuits before the provider call and leaves `CircuitBreaker.failure_count` untouched).

## Verification

```
$ python3 -m pytest autobot-backend/tests/llm_shared/test_token_budget.py -q
11 passed in 0.28s

$ python3 -m pytest autobot-backend/tests/llm_shared/ autobot-backend/tests/test_provider_registry.py autobot-backend/tests/llm_interface_pkg/ -q
429 passed in 10.91s

$ python3 -m black --check autobot-backend/llm_shared/token_budget.py autobot-backend/llm_shared/base_provider.py autobot-backend/tests/llm_shared/test_token_budget.py autobot-backend/conftest.py
All done! ✨ 🍰 ✨ — 4 files would be left unchanged.

$ python3 -m flake8 autobot-backend/llm_shared/token_budget.py autobot-backend/llm_shared/base_provider.py autobot-backend/tests/llm_shared/test_token_budget.py autobot-backend/conftest.py
(clean, 0 findings)
```

## Model Used

Sonnet 5

Closes #11541