### PR TITLE
feat(llm): canonical PROVIDER_FALLBACK event + read API, reclaim dead llm:fallback:active write (#11995)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -367,6 +367,10 @@ if "llm_shared" not in sys.modules:
     # #11519: provider degradation store — load real BEFORE model_fallback_coordinator
     # and provider_registry which import it at module level.
     _real_load_and_bind("llm_shared.provider_degradation", _llm_root / "provider_degradation.py")
+    # #11995: PROVIDER_FALLBACK event emission helper — load real BEFORE
+    # model_fallback_coordinator, which imports it at module level. events.bus
+    # / events.event_types are unstubbed lightweight modules, safe to import here.
+    _real_load_and_bind("llm_shared.fallback_events", _llm_root / "fallback_events.py")
     _real_load_and_bind("llm_shared.model_fallback_coordinator", _llm_root / "model_fallback_coordinator.py")
     # #9017: reasoning_effort utility is imported by chat_workflow.manager at module level;
     # load the real file so tests that import manager don't hit the providers MagicMock stub.

--- a/autobot-backend/events/event_types.py
+++ b/autobot-backend/events/event_types.py
@@ -48,3 +48,10 @@ HUMAN_ANSWER_RECEIVED = "human_answer_received"
 # Emitted when the verifier completes a pass; shown to the human at the
 # approval gate so the operator sees "verifier flagged X" before approving.
 VERIFIER_VERDICT = "verifier_verdict"
+
+# LLM provider routing — fallback/degradation decision (#11995, GH#8998)
+# Emitted from llm_shared.fallback_events.emit_fallback_event(), called from
+# BOTH ModelFallbackCoordinator.execute_with_fallback() (llm_shared/
+# model_fallback_coordinator.py) and services/llm_service.py's inline
+# chat()/stream() fallback loops, so neither call site is inert.
+PROVIDER_FALLBACK = "provider_fallback"

--- a/autobot-backend/llm_shared/fallback_events.py
+++ b/autobot-backend/llm_shared/fallback_events.py
@@ -1,0 +1,98 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical PROVIDER_FALLBACK event emission (#11995, GH#8998).
+
+Single shared seam called from BOTH divergent fallback paths —
+``model_fallback_coordinator.ModelFallbackCoordinator.execute_with_fallback``
+and ``services.llm_service.LLMService``'s inline ``chat()``/``stream()``
+fallback loops — so neither call site is inert (cf. the
+agentloop_inert_in_production doctrine: features wired into only one path
+are effectively hidden).
+
+This module intentionally does NOT touch Redis persistence: the existing
+``llm:fallback:active:*`` write in ``services/llm_service.py`` and its reader
+(``GET /api/llm/fallback-status`` in ``api/llm_providers.py``, added by
+PR #9421 / MVA-2999) are left as-is. This helper adds the missing real-time
+signal on top of that already-wired read path.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+from autobot_shared.logging_manager import get_logger
+from events.bus import publish_event
+from events.event_types import PROVIDER_FALLBACK
+
+logger = get_logger(__name__)
+
+
+def _build_fallback_payload(
+    *,
+    conversation_id: Optional[str],
+    primary_model: str,
+    fallback_model: Optional[str],
+    primary_provider: Optional[str],
+    fallback_provider: Optional[str],
+    reason: str,
+    chain_tried: Optional[List[str]],
+    degraded_skipped: Optional[List[str]],
+    exhausted: bool,
+    request_id: Optional[str],
+) -> Dict[str, Any]:
+    """Assemble the canonical PROVIDER_FALLBACK payload shape (#11995)."""
+    return {
+        "conversation_id": conversation_id or "system",
+        "request_id": request_id,
+        "primary_model": primary_model,
+        "primary_provider": primary_provider,
+        "fallback_model": fallback_model,
+        "fallback_provider": fallback_provider,
+        "reason": reason,
+        "chain_tried": chain_tried or [],
+        "degraded_skipped": degraded_skipped or [],
+        "exhausted": exhausted,
+        "timestamp": time.time(),
+    }
+
+
+async def emit_fallback_event(
+    *,
+    conversation_id: Optional[str],
+    primary_model: str,
+    fallback_model: Optional[str],
+    primary_provider: Optional[str] = None,
+    fallback_provider: Optional[str] = None,
+    reason: str = "rate_limit_429",
+    chain_tried: Optional[List[str]] = None,
+    degraded_skipped: Optional[List[str]] = None,
+    exhausted: bool = False,
+    request_id: Optional[str] = None,
+) -> None:
+    """Publish a PROVIDER_FALLBACK event to the "global" channel.
+
+    Non-fatal on failure (same pattern as rag_service._emit_retrieval_feedback):
+    observability must never break the request it is describing.
+    """
+    payload = _build_fallback_payload(
+        conversation_id=conversation_id,
+        primary_model=primary_model,
+        fallback_model=fallback_model,
+        primary_provider=primary_provider,
+        fallback_provider=fallback_provider,
+        reason=reason,
+        chain_tried=chain_tried,
+        degraded_skipped=degraded_skipped,
+        exhausted=exhausted,
+        request_id=request_id,
+    )
+    try:
+        await publish_event("global", PROVIDER_FALLBACK, payload)
+    except Exception as exc:
+        logger.debug("PROVIDER_FALLBACK publish failed (non-fatal): %s", exc)
+
+
+__all__ = ["emit_fallback_event"]

--- a/autobot-backend/llm_shared/fallback_events_test.py
+++ b/autobot-backend/llm_shared/fallback_events_test.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the canonical PROVIDER_FALLBACK event helper (#11995)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from events.event_types import PROVIDER_FALLBACK
+from llm_shared.fallback_events import emit_fallback_event
+
+
+@pytest.mark.asyncio
+async def test_emit_fallback_event_publishes_canonical_payload():
+    """Publishes PROVIDER_FALLBACK on the "global" channel with full payload."""
+    with patch("llm_shared.fallback_events.publish_event", new=AsyncMock()) as mock_publish:
+        await emit_fallback_event(
+            conversation_id="conv-1",
+            primary_model="claude-opus-4",
+            fallback_model="claude-sonnet-4",
+            primary_provider="anthropic",
+            fallback_provider="anthropic",
+            reason="rate_limit_429",
+            chain_tried=["claude-opus-4", "claude-sonnet-4"],
+            degraded_skipped=["claude-haiku-4"],
+            request_id="req-1",
+        )
+
+    mock_publish.assert_awaited_once()
+    channel, event_type, payload = mock_publish.await_args.args
+    assert channel == "global"
+    assert event_type == PROVIDER_FALLBACK
+    assert payload["conversation_id"] == "conv-1"
+    assert payload["request_id"] == "req-1"
+    assert payload["primary_model"] == "claude-opus-4"
+    assert payload["fallback_model"] == "claude-sonnet-4"
+    assert payload["reason"] == "rate_limit_429"
+    assert payload["chain_tried"] == ["claude-opus-4", "claude-sonnet-4"]
+    assert payload["degraded_skipped"] == ["claude-haiku-4"]
+    assert payload["exhausted"] is False
+    assert isinstance(payload["timestamp"], float)
+
+
+@pytest.mark.asyncio
+async def test_emit_fallback_event_defaults_conversation_id_to_system():
+    """No conversation_id → "system", matching the existing Redis write convention."""
+    with patch("llm_shared.fallback_events.publish_event", new=AsyncMock()) as mock_publish:
+        await emit_fallback_event(
+            conversation_id=None,
+            primary_model="claude-opus-4",
+            fallback_model=None,
+            exhausted=True,
+        )
+
+    payload = mock_publish.await_args.args[2]
+    assert payload["conversation_id"] == "system"
+    assert payload["exhausted"] is True
+    assert payload["chain_tried"] == []
+    assert payload["degraded_skipped"] == []
+
+
+@pytest.mark.asyncio
+async def test_emit_fallback_event_publish_failure_is_non_fatal():
+    """A broken event bus must never break the fallback request it describes."""
+    with patch(
+        "llm_shared.fallback_events.publish_event",
+        new=AsyncMock(side_effect=RuntimeError("bus down")),
+    ):
+        await emit_fallback_event(
+            conversation_id="conv-1",
+            primary_model="claude-opus-4",
+            fallback_model="claude-sonnet-4",
+        )  # must not raise

--- a/autobot-backend/llm_shared/model_fallback_coordinator.py
+++ b/autobot-backend/llm_shared/model_fallback_coordinator.py
@@ -31,6 +31,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 
 from .fallback_chain import get_fallback_chain_manager
+from .fallback_events import emit_fallback_event
 from .models import LLMRequest, LLMResponse
 from .optimization.rate_limiter import RateLimitError
 from .provider_degradation import get_degradation_store
@@ -114,6 +115,16 @@ class ModelFallbackCoordinator:
                         primary_model,
                         chain_tried,
                     )
+                    await emit_fallback_event(
+                        conversation_id=request.metadata.get("conversation_id"),
+                        primary_model=primary_model,
+                        fallback_model=current_model,
+                        primary_provider=primary_provider,
+                        fallback_provider=current_provider,
+                        chain_tried=chain_tried,
+                        degraded_skipped=request.metadata.get("degraded_skipped"),
+                        request_id=request.request_id,
+                    )
                 return response
 
             except RateLimitError as exc:
@@ -179,6 +190,17 @@ class ModelFallbackCoordinator:
             chain_tried=chain_tried,
             exhausted=True,
             degraded_skipped=request.metadata.get("degraded_skipped"),
+        )
+        await emit_fallback_event(
+            conversation_id=request.metadata.get("conversation_id"),
+            primary_model=primary_model,
+            fallback_model=current_model,
+            primary_provider=primary_provider,
+            fallback_provider=current_provider,
+            chain_tried=chain_tried,
+            degraded_skipped=request.metadata.get("degraded_skipped"),
+            exhausted=True,
+            request_id=request.request_id,
         )
         return last_error_response
 

--- a/autobot-backend/llm_shared/model_fallback_coordinator_test.py
+++ b/autobot-backend/llm_shared/model_fallback_coordinator_test.py
@@ -223,3 +223,59 @@ async def test_provider_none_returns_error_response():
     result = await coordinator.execute_with_fallback(_make_request(), registry)
 
     assert result.error == "All providers unavailable"
+
+
+# ---------------------------------------------------------------------------
+# #11995: PROVIDER_FALLBACK event emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emits_provider_fallback_event_on_success():
+    """A successful fallback hop emits PROVIDER_FALLBACK with the audit payload."""
+    coordinator = ModelFallbackCoordinator()
+    fallback_response = _ok_response("claude-sonnet-4")
+    registry = _make_registry([RateLimitError("quota hit"), fallback_response])
+    mgr = _chain_manager_with("claude-opus-4", ["claude-sonnet-4"])
+
+    with (
+        patch("llm_shared.model_fallback_coordinator.get_fallback_chain_manager", return_value=mgr),
+        patch("llm_shared.model_fallback_coordinator.emit_fallback_event", new=AsyncMock()) as mock_emit,
+    ):
+        await coordinator.execute_with_fallback(_make_request("claude-opus-4"), registry)
+
+    mock_emit.assert_awaited_once()
+    kwargs = mock_emit.await_args.kwargs
+    assert kwargs["primary_model"] == "claude-opus-4"
+    assert kwargs["fallback_model"] == "claude-sonnet-4"
+    assert kwargs["chain_tried"] == ["claude-opus-4", "claude-sonnet-4"]
+    assert kwargs.get("exhausted", False) is False
+
+
+@pytest.mark.asyncio
+async def test_emits_provider_fallback_event_on_exhaustion():
+    """Exhausting the fallback chain still emits PROVIDER_FALLBACK(exhausted=True)."""
+    coordinator = ModelFallbackCoordinator()
+    registry = _make_registry([RateLimitError("quota")] * 10)
+    mgr = _chain_manager_with("claude-opus-4", ["claude-sonnet-4"])
+
+    with (
+        patch("llm_shared.model_fallback_coordinator.get_fallback_chain_manager", return_value=mgr),
+        patch("llm_shared.model_fallback_coordinator.emit_fallback_event", new=AsyncMock()) as mock_emit,
+    ):
+        await coordinator.execute_with_fallback(_make_request("claude-opus-4"), registry, max_attempts=2)
+
+    mock_emit.assert_awaited_once()
+    assert mock_emit.await_args.kwargs["exhausted"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_provider_fallback_event_when_primary_succeeds():
+    """No fallback hop → no PROVIDER_FALLBACK event."""
+    coordinator = ModelFallbackCoordinator()
+    registry = _make_registry([_ok_response()])
+
+    with patch("llm_shared.model_fallback_coordinator.emit_fallback_event", new=AsyncMock()) as mock_emit:
+        await coordinator.execute_with_fallback(_make_request(), registry)
+
+    mock_emit.assert_not_awaited()

--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -50,6 +50,7 @@ from autobot_shared.tracing import get_tracer
 from llm_shared import ProviderRegistry, get_provider_registry
 from llm_shared.cache import CachedResponse, get_llm_cache
 from llm_shared.fallback_chain import get_fallback_chain_manager
+from llm_shared.fallback_events import emit_fallback_event
 from llm_shared.models import LLMRequest, LLMResponse
 from llm_shared.rate_limit_backoff import extract_rate_limit_info
 from llm_shared.tiered_routing import TierConfig, TieredModelRouter
@@ -314,6 +315,15 @@ class LLMService:
                         primary_provider=primary_provider_name,
                         fallback_provider=provider.provider_name,
                     )
+                    await emit_fallback_event(
+                        conversation_id=conversation_id,
+                        primary_model=primary_model_name,
+                        fallback_model=current_model,
+                        primary_provider=primary_provider_name,
+                        fallback_provider=provider.provider_name,
+                        chain_tried=list(attempted_models),
+                        request_id=request.request_id,
+                    )
                 # #10597: cache successful responses for identical future requests.
                 if cache_key and response.content:
                     await self._optimized_store_cache(cache_key, response, request.request_id)
@@ -362,6 +372,10 @@ class LLMService:
                 response.error,
                 " → ".join(attempted_models),
             )
+            if len(attempted_models) > 1:
+                await self._emit_exhausted_fallback(
+                    conversation_id, attempted_models, current_model, request.request_id
+                )
             self._track_usage(response, conversation_id)
             return response
 
@@ -372,6 +386,8 @@ class LLMService:
             len(attempted_models),
             " → ".join(attempted_models),
         )
+        if len(attempted_models) > 1:
+            await self._emit_exhausted_fallback(conversation_id, attempted_models, current_model, request.request_id)
         return _build_error_response(
             request,
             f"All fallback models exhausted ({len(attempted_models)} attempts)",
@@ -483,6 +499,15 @@ class LLMService:
                         primary_provider=primary_provider_name,
                         fallback_provider=provider.provider_name,
                     )
+                    await emit_fallback_event(
+                        conversation_id=conversation_id,
+                        primary_model=primary_model_name,
+                        fallback_model=current_model,
+                        primary_provider=primary_provider_name,
+                        fallback_provider=provider.provider_name,
+                        chain_tried=list(attempted_models),
+                        request_id=request.request_id,
+                    )
                 return
 
             except Exception as exc:
@@ -538,6 +563,10 @@ class LLMService:
                     exc,
                     " → ".join(attempted_models),
                 )
+                if len(attempted_models) > 1:
+                    await self._emit_exhausted_fallback(
+                        conversation_id, attempted_models, current_model, request.request_id
+                    )
                 raise
 
         # Max attempts reached
@@ -547,6 +576,8 @@ class LLMService:
             len(attempted_models),
             " → ".join(attempted_models),
         )
+        if len(attempted_models) > 1:
+            await self._emit_exhausted_fallback(conversation_id, attempted_models, current_model, request.request_id)
         raise RuntimeError(f"All fallback models exhausted ({len(attempted_models)} attempts)")
 
     # ------------------------------------------------------------------
@@ -627,6 +658,29 @@ class LLMService:
                 exc,
                 exc_info=True,
             )
+
+    @staticmethod
+    async def _emit_exhausted_fallback(
+        conversation_id: str | None,
+        attempted_models: list,
+        current_model: str | None,
+        request_id: str,
+    ) -> None:
+        """Emit PROVIDER_FALLBACK(exhausted=True). #11995: chat()/stream() never
+        tracked the exhaustion case at all (only successful fallbacks were)."""
+        primary_attempt = attempted_models[0]
+        primary_provider_name = primary_attempt.split(":")[0]
+        primary_model_name = primary_attempt.split(":", 1)[1] if ":" in primary_attempt else ""
+        await emit_fallback_event(
+            conversation_id=conversation_id,
+            primary_model=primary_model_name,
+            fallback_model=current_model,
+            primary_provider=primary_provider_name,
+            fallback_provider=attempted_models[-1].split(":")[0],
+            chain_tried=list(attempted_models),
+            exhausted=True,
+            request_id=request_id,
+        )
 
     def get_stats(self) -> Dict[str, Any]:
         """Return service-level statistics."""

--- a/autobot-backend/tests/services/test_llm_service_fallback_events.py
+++ b/autobot-backend/tests/services/test_llm_service_fallback_events.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""PROVIDER_FALLBACK event emission from LLMService.chat()/stream() (#11995).
+
+LLMService's inline fallback loop (GH#8998) is a divergent path from
+ModelFallbackCoordinator — this suite proves it is NOT inert for the new
+canonical event (cf. llm_shared/model_fallback_coordinator_test.py for the
+coordinator-side equivalent).
+
+Uses the same real-module-load harness as test_llm_service_caching.py so
+``services.llm_service`` (globally stubbed in conftest.py) can be exercised
+directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import pathlib
+import sys
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+_BACKEND = pathlib.Path(__file__).resolve().parents[2]  # autobot-backend/
+
+
+def _load_real_module(private_name: str, relpath: str):
+    """Load a real module file under a private name (no sys.modules clobber)."""
+    spec = _ilu.spec_from_file_location(private_name, str(_BACKEND / relpath))
+    assert spec and spec.loader
+    mod = _ilu.module_from_spec(spec)
+    sys.modules[private_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+if "llm_shared.rate_limit_backoff" not in sys.modules:
+    _load_real_module("llm_shared.rate_limit_backoff", "llm_shared/rate_limit_backoff.py")
+if "llm_shared.fallback_events" not in sys.modules:
+    _load_real_module("llm_shared.fallback_events", "llm_shared/fallback_events.py")
+
+_llm_service_mod = _load_real_module("_real_llm_service_11995", "services/llm_service.py")
+LLMService = _llm_service_mod.LLMService
+
+from llm_shared.models import LLMRequest, LLMResponse  # noqa: E402
+
+
+class _FlakyProvider:
+    """Rate-limited on the first call, succeeds on the second."""
+
+    provider_name = "fake"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        self.calls += 1
+        if self.calls == 1:
+            return LLMResponse(
+                content="", model=request.model_name, provider=self.provider_name, error="429 rate limit exceeded"
+            )
+        return LLMResponse(content="ok", model=request.model_name, provider=self.provider_name)
+
+    async def stream_completion(self, request: LLMRequest):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("429 rate limit exceeded")
+        yield "ok"
+
+
+class _AlwaysLimitedProvider:
+    """Always rate-limited — exhausts the fallback chain."""
+
+    provider_name = "fake"
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        return LLMResponse(
+            content="", model=request.model_name, provider=self.provider_name, error="429 rate limit exceeded"
+        )
+
+    async def stream_completion(self, request: LLMRequest):
+        raise RuntimeError("429 rate limit exceeded")
+        yield  # pragma: no cover — unreachable, makes this an async generator
+
+
+class _FakeRegistry:
+    def __init__(self, provider) -> None:
+        self._provider = provider
+
+    async def get_provider_for_request(self, provider_name=None, conversation_id=None):
+        return self._provider
+
+
+class _FakeFallbackChainManager:
+    """Returns one fallback hop then None (single-hop chain)."""
+
+    def __init__(self, next_model: str = "fallback-model", next_provider: str = "fake") -> None:
+        self._next = (next_model, next_provider)
+        self.calls = 0
+
+    def get_next_fallback(self, current_model, provider_name):
+        self.calls += 1
+        return self._next if self.calls == 1 else None
+
+
+def _make_service(provider) -> Any:
+    svc = LLMService(registry=_FakeRegistry(provider))
+    svc._response_cache = None
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_chat_emits_provider_fallback_event_on_success(monkeypatch):
+    provider = _FlakyProvider()
+    svc = _make_service(provider)
+    monkeypatch.setattr(_llm_service_mod, "get_fallback_chain_manager", lambda: _FakeFallbackChainManager())
+    mock_emit = AsyncMock()
+    monkeypatch.setattr(_llm_service_mod, "emit_fallback_event", mock_emit)
+
+    messages: List[Dict[str, str]] = [{"role": "user", "content": "hi"}]
+    response = await svc.chat(messages, model_name="primary-model", conversation_id="conv-1", use_cache=False)
+
+    assert response.content == "ok"
+    mock_emit.assert_awaited_once()
+    kwargs = mock_emit.await_args.kwargs
+    assert kwargs["conversation_id"] == "conv-1"
+    assert kwargs["primary_model"] == "primary-model"
+    assert kwargs["fallback_model"] == "fallback-model"
+    assert kwargs.get("exhausted", False) is False
+
+
+@pytest.mark.asyncio
+async def test_chat_emits_provider_fallback_event_on_exhaustion(monkeypatch):
+    provider = _AlwaysLimitedProvider()
+    svc = _make_service(provider)
+    monkeypatch.setattr(_llm_service_mod, "get_fallback_chain_manager", lambda: _FakeFallbackChainManager())
+    mock_emit = AsyncMock()
+    monkeypatch.setattr(_llm_service_mod, "emit_fallback_event", mock_emit)
+
+    messages: List[Dict[str, str]] = [{"role": "user", "content": "hi"}]
+    response = await svc.chat(messages, model_name="primary-model", conversation_id="conv-2", use_cache=False)
+
+    assert response.error
+    mock_emit.assert_awaited_once()
+    assert mock_emit.await_args.kwargs["exhausted"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_provider_fallback_event_on_success(monkeypatch):
+    provider = _FlakyProvider()
+    svc = _make_service(provider)
+    monkeypatch.setattr(_llm_service_mod, "get_fallback_chain_manager", lambda: _FakeFallbackChainManager())
+    mock_emit = AsyncMock()
+    monkeypatch.setattr(_llm_service_mod, "emit_fallback_event", mock_emit)
+
+    chunks = [c async for c in svc.stream([{"role": "user", "content": "hi"}], model_name="primary-model")]
+
+    assert chunks == ["ok"]
+    mock_emit.assert_awaited_once()
+    assert mock_emit.await_args.kwargs["fallback_model"] == "fallback-model"
+
+
+@pytest.mark.asyncio
+async def test_chat_no_event_when_primary_succeeds(monkeypatch):
+    """No fallback hop → no PROVIDER_FALLBACK event (existing behavior unchanged)."""
+
+    class _OkProvider:
+        provider_name = "fake"
+
+        async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+            return LLMResponse(content="ok", model=request.model_name, provider=self.provider_name)
+
+    svc = _make_service(_OkProvider())
+    mock_emit = AsyncMock()
+    monkeypatch.setattr(_llm_service_mod, "emit_fallback_event", mock_emit)
+
+    response = await svc.chat([{"role": "user", "content": "hi"}], model_name="primary-model", use_cache=False)
+
+    assert response.content == "ok"
+    mock_emit.assert_not_awaited()


### PR DESCRIPTION
## Thinking Path

Audited the umbrella's premise before implementing: `services/llm_service.py:600` `_track_fallback_event()` writes `llm:fallback:active:{conversation_id}` (1h TTL), and `#9421`/MVA-2999 already added `GET /api/llm/fallback-status` in `api/llm_providers.py` which reads exactly those keys (batched pipeline, tested by `tests/api/test_llm_providers_fallback.py`). **The "no reader exists" premise in #11994/#11995 is stale — that piece is already wired.** What's genuinely missing, confirmed by grep: `events/event_types.py` has no provider-routing event, and neither `llm_shared/model_fallback_coordinator.py`'s `execute_with_fallback()` (used by `openai_compat.py`/`anthropic_compat.py`/`llm_multi_provider.py`) nor `services/llm_service.py`'s inline `chat()`/`stream()` loop publish anything to the event bus — the coordinator path additionally never touches Redis at all, and `llm_service.py`'s exhaustion branches were never tracked anywhere (only successful fallbacks were). Followed the codebase's existing event-bus pattern (`events/bus.py` `publish_event()`, same seam `rag_service.py` uses for `RAG_RETRIEVAL`) rather than inventing a new store.

## What Changed

- **`events/event_types.py`**: added `PROVIDER_FALLBACK` (only-if-actually-published catalog, per file convention).
- **`llm_shared/fallback_events.py`** (new): `emit_fallback_event()` — the single shared seam, publishing to the `"global"` channel via `events.bus.publish_event`. Non-fatal on failure (same pattern as `rag_service._emit_retrieval_feedback`). Payload: `conversation_id`, `request_id`, `primary_model`/`primary_provider`, `fallback_model`/`fallback_provider`, `reason`, `chain_tried`, `degraded_skipped`, `exhausted`, `timestamp`.
- **`llm_shared/model_fallback_coordinator.py`**: `execute_with_fallback()` now emits on successful fallback AND on chain exhaustion — this path previously emitted nothing (neither event nor Redis write).
- **`services/llm_service.py`**: `chat()`/`stream()` now emit on successful fallback (alongside the existing `_track_fallback_event` Redis write, unchanged) AND on both exhaustion exits (`max_fallback_attempts` reached, and "rate-limited but no fallback chain configured") — previously only the success case was tracked anywhere.
- **`conftest.py`**: registered `llm_shared.fallback_events` in the real-load list (before `model_fallback_coordinator`, which imports it at module level) — the pre-existing lightweight `llm_shared` package stub has an empty `__path__`, so without this the new relative import silently fell back to another MagicMock stub and every coordinator test failed with `TypeError: object MagicMock can't be used in 'await' expression`. This surfaced and fixed a latent conftest gap, not a regression in production code.

### Design decision: no duplicate read endpoint

The issue text asks for `GET /api/llm/fallback/active`; since `GET /api/llm/fallback-status` already does exactly that (same Redis keys, same shape, tested), adding a second route would duplicate rather than reclaim. Per repo Core Rule 1 (check before writing / reuse), this PR leaves that endpoint as-is and focuses the "reclaim" on the piece that was actually inert — the missing real-time signal, now covered from both fallback paths.

## Verification

```
$ python3 -m pytest autobot-backend/llm_shared/fallback_events_test.py \
    autobot-backend/llm_shared/model_fallback_coordinator_test.py \
    autobot-backend/tests/services/test_llm_service_fallback_events.py \
    autobot-backend/tests/integration/test_chat_fallback.py \
    autobot-backend/tests/api/test_llm_providers_fallback.py \
    autobot-backend/tests/services/test_llm_service_caching.py -q
======================== 39 passed, 1 warning in ~3s =========================
```

Also ran the full `llm_shared/` + `events/` suite (575 passed, 115 skipped) and `tests/services/` + fallback-adjacent suites (647 passed) with no regressions. Full-repo `--collect-only` shows the same 51 pre-existing collection errors as a fresh `origin/Dev_new_gui` checkout (missing optional deps in this dev venv, e.g. `sklearn`, `scripts.utilities`) — confirmed unrelated to this change by diffing against a throwaway baseline worktree.

`black --check` (py310 target) and `flake8 --max-line-length=120` clean on all changed files. `ast.parse` clean on all changed `.py` files.

## Model Used

Sonnet 5 (implementation).

Closes #11995