### PR TITLE
feat(ui): provider-fallback observability panel for admins (#11996)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useProviderFallbackApi.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/useProviderFallbackApi.spec.ts
@@ -1,0 +1,129 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Tests for useProviderFallbackApi — #11996 (umbrella #11994).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useProviderFallbackApi } from '../useProviderFallbackApi'
+import type { LiveEvent } from '@/services/LiveEventService'
+
+const mockGet = vi.fn()
+const mockSubscribe = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get: mockGet, post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn() }),
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}))
+
+vi.mock('@/services/LiveEventService', () => ({
+  default: { subscribe: (...args: unknown[]) => mockSubscribe(...args) },
+}))
+
+const FAKE_STATUS = {
+  configured_chains: [
+    { primary_model: 'gpt-4o', fallback_chain: 'gpt-4o → claude-3-5-sonnet', provider: 'multi' },
+  ],
+  active_fallbacks: [
+    {
+      conversation_id: 'conv-1',
+      primary_model: 'gpt-4o',
+      fallback_model: 'claude-3-5-sonnet',
+      primary_provider: 'openai',
+      fallback_provider: 'anthropic',
+      timestamp: 1700000000,
+    },
+  ],
+}
+
+describe('useProviderFallbackApi.fetchFallbackStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls the GET /api/llm/fallback-status endpoint', async () => {
+    mockGet.mockResolvedValue(FAKE_STATUS)
+    const { fetchFallbackStatus } = useProviderFallbackApi()
+    await fetchFallbackStatus()
+    expect(mockGet).toHaveBeenCalledWith('/api/llm/fallback-status')
+  })
+
+  it('parses the response into configured_chains + active_fallbacks', async () => {
+    mockGet.mockResolvedValue(FAKE_STATUS)
+    const { fetchFallbackStatus } = useProviderFallbackApi()
+    const result = await fetchFallbackStatus()
+    expect(result.configured_chains).toHaveLength(1)
+    expect(result.active_fallbacks[0].fallback_model).toBe('claude-3-5-sonnet')
+    expect(result.active_fallbacks[0].fallback_provider).toBe('anthropic')
+  })
+
+  it('returns empty arrays (not null) when the API call throws', async () => {
+    mockGet.mockRejectedValue(new Error('network error'))
+    const { fetchFallbackStatus } = useProviderFallbackApi()
+    const result = await fetchFallbackStatus()
+    expect(result.configured_chains).toEqual([])
+    expect(result.active_fallbacks).toEqual([])
+  })
+
+  it('tolerates a response missing the arrays', async () => {
+    mockGet.mockResolvedValue({})
+    const { fetchFallbackStatus } = useProviderFallbackApi()
+    const result = await fetchFallbackStatus()
+    expect(result.configured_chains).toEqual([])
+    expect(result.active_fallbacks).toEqual([])
+  })
+})
+
+describe('useProviderFallbackApi.subscribeToFallbackEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('subscribes to the global channel', () => {
+    mockSubscribe.mockReturnValue(() => {})
+    const { subscribeToFallbackEvents } = useProviderFallbackApi()
+    subscribeToFallbackEvents(() => {})
+    expect(mockSubscribe).toHaveBeenCalledWith('global', expect.any(Function))
+  })
+
+  it('invokes the callback only for PROVIDER_FALLBACK events', () => {
+    let handler: ((e: LiveEvent) => void) | null = null
+    mockSubscribe.mockImplementation((_ch: string, h: (e: LiveEvent) => void) => {
+      handler = h
+      return () => {}
+    })
+    const cb = vi.fn()
+    const { subscribeToFallbackEvents } = useProviderFallbackApi()
+    subscribeToFallbackEvents(cb)
+
+    handler!({
+      type: 'live_event', channel: 'global', event_id: 1,
+      event_type: 'agent_abstained', payload: {},
+    })
+    expect(cb).not.toHaveBeenCalled()
+
+    handler!({
+      type: 'live_event', channel: 'global', event_id: 2,
+      event_type: 'provider_fallback',
+      payload: { conversation_id: 'conv-1', exhausted: false, primary_model: 'gpt-4o' },
+    })
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb.mock.calls[0][0].conversation_id).toBe('conv-1')
+  })
+
+  it('returns the unsubscribe function from the live-event service', () => {
+    const unsub = vi.fn()
+    mockSubscribe.mockReturnValue(unsub)
+    const { subscribeToFallbackEvents } = useProviderFallbackApi()
+    const returned = subscribeToFallbackEvents(() => {})
+    expect(returned).toBe(unsub)
+  })
+})

--- a/autobot-frontend/src/composables/useProviderFallbackApi.ts
+++ b/autobot-frontend/src/composables/useProviderFallbackApi.ts
@@ -1,0 +1,83 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Provider Fallback Observability Composable (#11996 / umbrella #11994)
+ *
+ * Surfaces the provider-routing decision path for the always-on admin panel:
+ *   - `fetchFallbackStatus()` reads `GET /api/llm/fallback-status` (#9421 /
+ *     #11995) for the reload-safe current state (configured chains + active
+ *     fallbacks reclaimed from the `llm:fallback:active:*` Redis write).
+ *   - `subscribeToFallbackEvents()` consumes live PROVIDER_FALLBACK events on
+ *     the "global" channel (#11995) — mirrors `useAgentEvents.ts`.
+ *
+ * No new backend API is introduced: both a live stream and a read API already
+ * exist, so the panel is "always on" (live) AND reload-safe (status endpoint).
+ *
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ */
+
+import { useApiClient } from '@/plugins/api'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+import liveEventService, { type LiveEvent } from '@/services/LiveEventService'
+import {
+  PROVIDER_FALLBACK,
+  type FallbackStatusResponse,
+  type ProviderFallbackPayload,
+} from '@/constants/providerFallbackEvents'
+
+const logger = createLogger('useProviderFallbackApi')
+
+const EMPTY_STATUS: FallbackStatusResponse = {
+  configured_chains: [],
+  active_fallbacks: [],
+}
+
+export interface UseProviderFallbackApiReturn {
+  /** Fetch current fallback state (reload-safe) from the read API. */
+  fetchFallbackStatus: () => Promise<FallbackStatusResponse>
+  /**
+   * Subscribe to live PROVIDER_FALLBACK events on the global channel.
+   * Returns an unsubscribe function.
+   */
+  subscribeToFallbackEvents: (
+    callback: (payload: ProviderFallbackPayload) => void,
+  ) => () => void
+}
+
+export function useProviderFallbackApi(): UseProviderFallbackApiReturn {
+  const api = useApiClient()
+
+  async function fetchFallbackStatus(): Promise<FallbackStatusResponse> {
+    try {
+      const data = await api.get<FallbackStatusResponse>(
+        `${getApiBase()}/llm/fallback-status`,
+      )
+      return {
+        configured_chains: data?.configured_chains ?? [],
+        active_fallbacks: data?.active_fallbacks ?? [],
+      }
+    } catch (error: unknown) {
+      logger.error('Failed to load provider fallback status', error)
+      return { ...EMPTY_STATUS }
+    }
+  }
+
+  function subscribeToFallbackEvents(
+    callback: (payload: ProviderFallbackPayload) => void,
+  ): () => void {
+    const handler = (event: LiveEvent): void => {
+      if (event.event_type !== PROVIDER_FALLBACK) return
+      const payload = event.payload as ProviderFallbackPayload
+      logger.debug('PROVIDER_FALLBACK received', {
+        conversation_id: payload.conversation_id,
+        exhausted: payload.exhausted,
+      })
+      callback(payload)
+    }
+    return liveEventService.subscribe('global', handler)
+  }
+
+  return { fetchFallbackStatus, subscribeToFallbackEvents }
+}

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -116,6 +116,8 @@ export const adminMenuItems: NavItem[] = [
   { to: '/admin/budget-policies', labelKey: 'nav.budgetPolicies', icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
   // Issue #10932: System Health panel — CONTENT_REACH probe
   { to: '/admin/system-health', labelKey: 'nav.systemHealth', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
+  // Issue #11996 (#11994): Provider-fallback observability panel
+  { to: '/admin/provider-fallback', labelKey: 'nav.providerFallback', icon: 'M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4', iconStroke: true },
   // Issue #12162 (#12102/#11506 T1 Stage 1): Advanced Control — takeover approval queue
   { to: '/admin/advanced-control', labelKey: 'nav.advancedControl', icon: 'M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11', iconStroke: true },
 ];

--- a/autobot-frontend/src/constants/providerFallbackEvents.ts
+++ b/autobot-frontend/src/constants/providerFallbackEvents.ts
@@ -1,0 +1,73 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Provider Fallback Event Constants (#11996 / umbrella #11994)
+ *
+ * Canonical real-time event emitted by the backend when the LLM router falls
+ * back from a primary model/provider to a secondary one (rate limit, error,
+ * or full-chain exhaustion). Emitted on the "global" live-event channel by
+ * `llm_shared/fallback_events.emit_fallback_event` (#11995).
+ *
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ */
+
+/**
+ * Live-event type string for a provider/model fallback decision (#11995).
+ * Matches `events.event_types.PROVIDER_FALLBACK` on the backend.
+ */
+export const PROVIDER_FALLBACK = 'provider_fallback' as const
+
+/**
+ * Payload shape of a PROVIDER_FALLBACK live event (built by
+ * `_build_fallback_payload` in `llm_shared/fallback_events.py`).
+ */
+export interface ProviderFallbackPayload {
+  conversation_id: string
+  request_id: string | null
+  primary_model: string
+  primary_provider: string | null
+  fallback_model: string | null
+  fallback_provider: string | null
+  reason: string
+  chain_tried: string[]
+  degraded_skipped: string[]
+  exhausted: boolean
+  /** Seconds since epoch (float), as emitted by `time.time()`. */
+  timestamp: number
+  // Payloads arrive as plain JSON records — extra fields pass through, and the
+  // index signature keeps Record<string, unknown> casts valid.
+  [key: string]: unknown
+}
+
+/**
+ * One entry of the `active_fallbacks` array returned by
+ * `GET /api/llm/fallback-status` — the reclaimed `llm:fallback:active:*`
+ * Redis write (GH#8998 / #11995). Note this is a NARROWER shape than the live
+ * event payload (only successful hops are persisted, with an int timestamp).
+ */
+export interface ActiveFallbackEntry {
+  conversation_id: string
+  primary_model: string
+  fallback_model: string
+  primary_provider: string
+  fallback_provider: string
+  /** Seconds since epoch (int). */
+  timestamp: number
+  [key: string]: unknown
+}
+
+/** One configured fallback chain from `GET /api/llm/fallback-status`. */
+export interface ConfiguredFallbackChain {
+  primary_model: string
+  /** Human-readable chain, e.g. "gpt-4o → claude-3-5-sonnet". */
+  fallback_chain: string
+  provider: string
+  [key: string]: unknown
+}
+
+/** Full response shape of `GET /api/llm/fallback-status` (#9421 / #11995). */
+export interface FallbackStatusResponse {
+  configured_chains: ConfiguredFallbackChain[]
+  active_fallbacks: ActiveFallbackEntry[]
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7650,6 +7650,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "صحة النظام",
+    "providerFallback": "احتياطي المزود",
     "advancedControl": "التحكم المتقدم"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "فشل تحميل صحة النظام",
       "refresh": "تحديث",
       "noSources": "لا توجد مصادر محتوى مهيأة"
+    },
+    "providerFallback": {
+      "title": "احتياطي المزود",
+      "subtitle": "نشاط مباشر لاحتياطي مزودي ونماذج LLM",
+      "status": "الحالة",
+      "stateHealthy": "لا توجد احتياطيات نشطة",
+      "stateDegraded": "الاحتياطي نشط",
+      "active": "الاحتياطيات النشطة",
+      "chains": "السلاسل المُهيأة",
+      "timeline": "النشاط المباشر",
+      "switched": "تم التبديل",
+      "exhausted": "استُنفد",
+      "refresh": "تحديث",
+      "loading": "جارٍ تحميل حالة الاحتياطي…",
+      "noData": "لا يوجد نشاط احتياطي للمزود",
+      "none": "لا شيء"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7650,6 +7650,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Systemzustand",
+    "providerFallback": "Anbieter-Fallback",
     "advancedControl": "Erweiterte Steuerung"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "Systemzustand konnte nicht geladen werden",
       "refresh": "Aktualisieren",
       "noSources": "Keine Inhaltsquellen konfiguriert"
+    },
+    "providerFallback": {
+      "title": "Anbieter-Fallback",
+      "subtitle": "Live-Aktivität von LLM-Anbieter- und Modell-Fallbacks",
+      "status": "Status",
+      "stateHealthy": "Keine aktiven Fallbacks",
+      "stateDegraded": "Fallback aktiv",
+      "active": "Aktive Fallbacks",
+      "chains": "Konfigurierte Ketten",
+      "timeline": "Live-Aktivität",
+      "switched": "Umgeschaltet",
+      "exhausted": "Erschöpft",
+      "refresh": "Aktualisieren",
+      "loading": "Fallback-Status wird geladen…",
+      "noData": "Keine Anbieter-Fallback-Aktivität",
+      "none": "keine"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7657,6 +7657,7 @@
     "adminSandbox": "Sandbox",
     "budgetPolicies": "Budget Policies",
     "systemHealth": "System Health",
+    "providerFallback": "Provider Fallback",
     "advancedControl": "Advanced Control",
     "sharedLinks": "Shared Chat Links",
     "companyOs": "Company OS",
@@ -8623,6 +8624,22 @@
       "error": "Failed to load system health",
       "refresh": "Refresh",
       "noSources": "No content sources configured"
+    },
+    "providerFallback": {
+      "title": "Provider Fallback",
+      "subtitle": "Live LLM provider and model fallback activity",
+      "status": "Status",
+      "stateHealthy": "No active fallbacks",
+      "stateDegraded": "Fallback active",
+      "active": "Active fallbacks",
+      "chains": "Configured chains",
+      "timeline": "Live activity",
+      "switched": "Switched",
+      "exhausted": "Exhausted",
+      "refresh": "Refresh",
+      "loading": "Loading fallback status…",
+      "noData": "No provider fallback activity",
+      "none": "none"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7650,6 +7650,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Salud del sistema",
+    "providerFallback": "Respaldo de proveedor",
     "advancedControl": "Control avanzado"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "Error al cargar la salud del sistema",
       "refresh": "Actualizar",
       "noSources": "No hay fuentes de contenido configuradas"
+    },
+    "providerFallback": {
+      "title": "Respaldo de proveedor",
+      "subtitle": "Actividad en vivo de respaldo de proveedores y modelos LLM",
+      "status": "Estado",
+      "stateHealthy": "Sin respaldos activos",
+      "stateDegraded": "Respaldo activo",
+      "active": "Respaldos activos",
+      "chains": "Cadenas configuradas",
+      "timeline": "Actividad en vivo",
+      "switched": "Cambiado",
+      "exhausted": "Agotado",
+      "refresh": "Actualizar",
+      "loading": "Cargando estado de respaldo…",
+      "noData": "Sin actividad de respaldo de proveedor",
+      "none": "ninguno"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -195,6 +195,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "سلامت سیستم",
+    "providerFallback": "جایگزینی ارائه‌دهنده",
     "advancedControl": "کنترل پیشرفته"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "بارگذاری سلامت سیستم ناموفق بود",
       "refresh": "بازنشانی",
       "noSources": "هیچ منبع محتوایی پیکربندی نشده است"
+    },
+    "providerFallback": {
+      "title": "جایگزینی ارائه‌دهنده",
+      "subtitle": "فعالیت زندهٔ جایگزینی ارائه‌دهندگان و مدل‌های LLM",
+      "status": "وضعیت",
+      "stateHealthy": "بدون جایگزینی فعال",
+      "stateDegraded": "جایگزینی فعال",
+      "active": "جایگزینی‌های فعال",
+      "chains": "زنجیره‌های پیکربندی‌شده",
+      "timeline": "فعالیت زنده",
+      "switched": "تغییر یافت",
+      "exhausted": "تمام‌شده",
+      "refresh": "تازه‌سازی",
+      "loading": "در حال بارگیری وضعیت جایگزینی…",
+      "noData": "هیچ فعالیت جایگزینی ارائه‌دهنده‌ای نیست",
+      "none": "هیچ"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7650,6 +7650,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Santé du système",
+    "providerFallback": "Basculement de fournisseur",
     "advancedControl": "Contrôle avancé"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "Échec du chargement de la santé du système",
       "refresh": "Actualiser",
       "noSources": "Aucune source de contenu configurée"
+    },
+    "providerFallback": {
+      "title": "Basculement de fournisseur",
+      "subtitle": "Activité en direct des basculements de fournisseurs et modèles LLM",
+      "status": "Statut",
+      "stateHealthy": "Aucun basculement actif",
+      "stateDegraded": "Basculement actif",
+      "active": "Basculements actifs",
+      "chains": "Chaînes configurées",
+      "timeline": "Activité en direct",
+      "switched": "Basculé",
+      "exhausted": "Épuisé",
+      "refresh": "Actualiser",
+      "loading": "Chargement de l'état de basculement…",
+      "noData": "Aucune activité de basculement de fournisseur",
+      "none": "aucun"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -195,6 +195,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "בריאות המערכת",
+    "providerFallback": "גיבוי ספק",
     "advancedControl": "בקרה מתקדמת"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "טעינת בריאות המערכת נכשלה",
       "refresh": "רענן",
       "noSources": "לא הוגדרו מקורות תוכן"
+    },
+    "providerFallback": {
+      "title": "גיבוי ספק",
+      "subtitle": "פעילות חיה של גיבוי ספקים ומודלים של LLM",
+      "status": "סטטוס",
+      "stateHealthy": "אין גיבויים פעילים",
+      "stateDegraded": "גיבוי פעיל",
+      "active": "גיבויים פעילים",
+      "chains": "שרשראות מוגדרות",
+      "timeline": "פעילות חיה",
+      "switched": "הוחלף",
+      "exhausted": "מוצה",
+      "refresh": "רענן",
+      "loading": "טוען את מצב הגיבוי…",
+      "noData": "אין פעילות גיבוי ספק",
+      "none": "ללא"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7650,6 +7650,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Sistēmas veselība",
+    "providerFallback": "Nodrošinātāja rezerve",
     "advancedControl": "Papildu vadība"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "Neizdevās ielādēt sistēmas veselību",
       "refresh": "Atsvaidzināt",
       "noSources": "Nav konfigurētu satura avotu"
+    },
+    "providerFallback": {
+      "title": "Nodrošinātāja rezerve",
+      "subtitle": "Tiešraides LLM nodrošinātāju un modeļu rezerves aktivitāte",
+      "status": "Statuss",
+      "stateHealthy": "Nav aktīvu rezervju",
+      "stateDegraded": "Rezerve aktīva",
+      "active": "Aktīvās rezerves",
+      "chains": "Konfigurētās ķēdes",
+      "timeline": "Tiešraides aktivitāte",
+      "switched": "Pārslēgts",
+      "exhausted": "Izsmelts",
+      "refresh": "Atsvaidzināt",
+      "loading": "Ielādē rezerves statusu…",
+      "noData": "Nav nodrošinātāja rezerves aktivitātes",
+      "none": "nav"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7650,6 +7650,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Kondycja systemu",
+    "providerFallback": "Przełączanie dostawcy",
     "advancedControl": "Sterowanie zaawansowane"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "Nie udało się załadować kondycji systemu",
       "refresh": "Odśwież",
       "noSources": "Brak skonfigurowanych źródeł treści"
+    },
+    "providerFallback": {
+      "title": "Przełączanie dostawcy",
+      "subtitle": "Aktywność przełączania dostawców i modeli LLM na żywo",
+      "status": "Status",
+      "stateHealthy": "Brak aktywnych przełączeń",
+      "stateDegraded": "Przełączenie aktywne",
+      "active": "Aktywne przełączenia",
+      "chains": "Skonfigurowane łańcuchy",
+      "timeline": "Aktywność na żywo",
+      "switched": "Przełączono",
+      "exhausted": "Wyczerpano",
+      "refresh": "Odśwież",
+      "loading": "Ładowanie stanu przełączania…",
+      "noData": "Brak aktywności przełączania dostawcy",
+      "none": "brak"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7650,6 +7650,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "Saúde do sistema",
+    "providerFallback": "Fallback de provedor",
     "advancedControl": "Controle avançado"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "Falha ao carregar a saúde do sistema",
       "refresh": "Atualizar",
       "noSources": "Nenhuma fonte de conteúdo configurada"
+    },
+    "providerFallback": {
+      "title": "Fallback de provedor",
+      "subtitle": "Atividade ao vivo de fallback de provedores e modelos LLM",
+      "status": "Estado",
+      "stateHealthy": "Nenhum fallback ativo",
+      "stateDegraded": "Fallback ativo",
+      "active": "Fallbacks ativos",
+      "chains": "Cadeias configuradas",
+      "timeline": "Atividade ao vivo",
+      "switched": "Alternado",
+      "exhausted": "Esgotado",
+      "refresh": "Atualizar",
+      "loading": "Carregando estado de fallback…",
+      "noData": "Nenhuma atividade de fallback de provedor",
+      "none": "nenhum"
     }
   },
   "components": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -195,6 +195,7 @@
     "companyOsUnavailableTitle": "Company OS is not available",
     "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
     "systemHealth": "سسٹم کی صحت",
+    "providerFallback": "فراہم کنندہ فال بیک",
     "advancedControl": "ایڈوانسڈ کنٹرول"
   },
   "llcCompanyStatus": {
@@ -8623,6 +8624,22 @@
       "error": "سسٹم کی صحت لوڈ کرنے میں ناکامی",
       "refresh": "تازہ کریں",
       "noSources": "کوئی مواد کا ذریعہ ترتیب نہیں دیا گیا"
+    },
+    "providerFallback": {
+      "title": "فراہم کنندہ فال بیک",
+      "subtitle": "LLM فراہم کنندگان اور ماڈلز کے فال بیک کی براہ راست سرگرمی",
+      "status": "حیثیت",
+      "stateHealthy": "کوئی فعال فال بیک نہیں",
+      "stateDegraded": "فال بیک فعال",
+      "active": "فعال فال بیکس",
+      "chains": "ترتیب شدہ زنجیریں",
+      "timeline": "براہ راست سرگرمی",
+      "switched": "تبدیل ہو گیا",
+      "exhausted": "ختم ہو گیا",
+      "refresh": "تازہ کریں",
+      "loading": "فال بیک حیثیت لوڈ ہو رہی ہے…",
+      "noData": "کوئی فراہم کنندہ فال بیک سرگرمی نہیں",
+      "none": "کوئی نہیں"
     }
   },
   "components": {

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -876,6 +876,18 @@ export const routes: RouteRecordRaw[] = [
       admin: true,
     },
   },
+  // Issue #11996 (#11994): Always-on provider-fallback observability panel
+  {
+    path: '/admin/provider-fallback',
+    name: 'admin-provider-fallback',
+    component: () => import('@/views/ProviderFallbackView.vue'),
+    meta: {
+      title: 'Provider Fallback',
+      hideInNav: true,
+      requiresAuth: true,
+      admin: true,
+    },
+  },
   // /desktop removed from nav — noVNC is accessible via the Chat tab's noVNC tab.
   // Redirect any bookmarked /desktop URLs to /chat.
   { path: '/desktop', redirect: '/chat' },

--- a/autobot-frontend/src/views/ProviderFallbackView.vue
+++ b/autobot-frontend/src/views/ProviderFallbackView.vue
@@ -1,0 +1,361 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+  AutoBot - AI-Powered Automation Platform
+  Author: mrveiss
+
+  Always-on provider-fallback observability panel (admin) — #11996 / #11994.
+
+  Surfaces the provider-routing decision path AutoBot previously hid:
+    - Current state (reload-safe) from GET /api/llm/fallback-status: which
+      conversations are on a fallback model, and the configured chains.
+    - Live PROVIDER_FALLBACK events (#11995) on the global channel, appended to
+      a capped timeline so ops sees fallback/exhaustion the moment it happens.
+-->
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import BaseBadge from '@/components/base/BaseBadge.vue'
+import { useProviderFallbackApi } from '@/composables/useProviderFallbackApi'
+import type {
+  ActiveFallbackEntry,
+  ConfiguredFallbackChain,
+  ProviderFallbackPayload,
+} from '@/constants/providerFallbackEvents'
+
+const { fetchFallbackStatus, subscribeToFallbackEvents } = useProviderFallbackApi()
+
+// Cap the live timeline so a busy fallback storm can't grow the DOM unbounded.
+const MAX_TIMELINE = 50
+
+const loading = ref(false)
+const configuredChains = ref<ConfiguredFallbackChain[]>([])
+const activeFallbacks = ref<ActiveFallbackEntry[]>([])
+const timeline = ref<ProviderFallbackPayload[]>([])
+
+const hasActive = computed(() => activeFallbacks.value.length > 0)
+const noData = computed(
+  () =>
+    !loading.value &&
+    activeFallbacks.value.length === 0 &&
+    configuredChains.value.length === 0 &&
+    timeline.value.length === 0,
+)
+
+function formatTimestamp(seconds: number): string {
+  if (!Number.isFinite(seconds)) return '—'
+  return new Date(seconds * 1000).toLocaleString()
+}
+
+async function refresh(): Promise<void> {
+  loading.value = true
+  const status = await fetchFallbackStatus()
+  configuredChains.value = status.configured_chains
+  activeFallbacks.value = status.active_fallbacks
+  loading.value = false
+}
+
+let unsubscribe: (() => void) | null = null
+
+onMounted(() => {
+  refresh()
+  unsubscribe = subscribeToFallbackEvents((payload) => {
+    timeline.value = [payload, ...timeline.value].slice(0, MAX_TIMELINE)
+    // A live event means state changed — refresh the reload-safe view too.
+    refresh()
+  })
+})
+
+onUnmounted(() => {
+  if (unsubscribe) unsubscribe()
+  unsubscribe = null
+})
+</script>
+
+<template>
+  <div class="provider-fallback">
+    <!-- Header -->
+    <div class="pf-header">
+      <div>
+        <h1 class="pf-title">{{ $t('admin.providerFallback.title') }}</h1>
+        <p class="pf-subtitle">{{ $t('admin.providerFallback.subtitle') }}</p>
+      </div>
+      <button class="pf-refresh" :disabled="loading" @click="refresh">
+        {{ $t('admin.providerFallback.refresh') }}
+      </button>
+    </div>
+
+    <!-- Overall state -->
+    <div class="pf-state">
+      <span class="pf-label">{{ $t('admin.providerFallback.status') }}</span>
+      <BaseBadge :variant="hasActive ? 'warning' : 'success'" size="md">
+        {{
+          hasActive
+            ? $t('admin.providerFallback.stateDegraded')
+            : $t('admin.providerFallback.stateHealthy')
+        }}
+      </BaseBadge>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="pf-empty">
+      {{ $t('admin.providerFallback.loading') }}
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="noData" class="pf-empty">
+      {{ $t('admin.providerFallback.noData') }}
+    </div>
+
+    <template v-else>
+      <!-- Active fallbacks (reload-safe, from the read API) -->
+      <section v-if="hasActive" class="pf-section">
+        <h2 class="pf-section-title">{{ $t('admin.providerFallback.active') }}</h2>
+        <div class="pf-cards">
+          <div
+            v-for="entry in activeFallbacks"
+            :key="entry.conversation_id"
+            class="pf-card"
+          >
+            <div class="pf-card-head">
+              <span class="pf-conv">{{ entry.conversation_id }}</span>
+              <span class="pf-time">{{ formatTimestamp(entry.timestamp) }}</span>
+            </div>
+            <div class="pf-hop">
+              <BaseBadge variant="neutral" size="sm" monospace>
+                {{ entry.primary_provider }}/{{ entry.primary_model }}
+              </BaseBadge>
+              <span class="pf-arrow" aria-hidden="true">→</span>
+              <BaseBadge variant="warning" size="sm" monospace>
+                {{ entry.fallback_provider }}/{{ entry.fallback_model }}
+              </BaseBadge>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Configured chains -->
+      <section v-if="configuredChains.length" class="pf-section">
+        <h2 class="pf-section-title">{{ $t('admin.providerFallback.chains') }}</h2>
+        <div class="pf-cards">
+          <div
+            v-for="chain in configuredChains"
+            :key="chain.primary_model"
+            class="pf-card"
+          >
+            <div class="pf-card-head">
+              <BaseBadge variant="primary" size="sm" monospace>
+                {{ chain.primary_model }}
+              </BaseBadge>
+              <span class="pf-provider">{{ chain.provider }}</span>
+            </div>
+            <div class="pf-chain">{{ chain.fallback_chain }}</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Live timeline (PROVIDER_FALLBACK events) -->
+      <section v-if="timeline.length" class="pf-section">
+        <h2 class="pf-section-title">{{ $t('admin.providerFallback.timeline') }}</h2>
+        <ul class="pf-timeline">
+          <li v-for="(ev, idx) in timeline" :key="`${ev.conversation_id}-${idx}`" class="pf-event">
+            <BaseBadge :variant="ev.exhausted ? 'danger' : 'warning'" size="sm">
+              {{
+                ev.exhausted
+                  ? $t('admin.providerFallback.exhausted')
+                  : $t('admin.providerFallback.switched')
+              }}
+            </BaseBadge>
+            <span class="pf-event-body">
+              <span class="pf-conv">{{ ev.conversation_id }}</span>
+              <span class="pf-event-hop">
+                {{ ev.primary_model }} → {{ ev.fallback_model || $t('admin.providerFallback.none') }}
+              </span>
+              <span class="pf-reason">{{ ev.reason }}</span>
+            </span>
+            <span class="pf-time">{{ formatTimestamp(ev.timestamp) }}</span>
+          </li>
+        </ul>
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.provider-fallback {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: var(--spacing-6);
+}
+
+.pf-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.pf-title {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+}
+
+.pf-subtitle {
+  margin-top: var(--spacing-1);
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+}
+
+.pf-refresh {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--duration-150) var(--ease-out);
+}
+
+.pf-refresh:hover:not(:disabled) {
+  background-color: var(--bg-tertiary);
+}
+
+.pf-refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.pf-state {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+}
+
+.pf-label {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-secondary);
+}
+
+.pf-empty {
+  padding: var(--spacing-12) var(--spacing-4);
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.pf-section {
+  margin-bottom: var(--spacing-6);
+}
+
+.pf-section-title {
+  margin-bottom: var(--spacing-3);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-tertiary);
+}
+
+.pf-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.pf-card {
+  padding: var(--spacing-4);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+}
+
+.pf-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.pf-conv {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.pf-time {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.pf-provider {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.pf-hop {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+.pf-arrow {
+  color: var(--text-tertiary);
+}
+
+.pf-chain {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.pf-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pf-event {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+.pf-event-body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex: 1;
+  min-width: 0;
+}
+
+.pf-event-hop {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.pf-reason {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+</style>

--- a/autobot-frontend/src/views/__tests__/ProviderFallbackView.spec.ts
+++ b/autobot-frontend/src/views/__tests__/ProviderFallbackView.spec.ts
@@ -1,0 +1,111 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Tests for ProviderFallbackView.vue (#11996 / umbrella #11994).
+// Mocks useProviderFallbackApi so no real HTTP / WebSocket calls are made.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const mockFetch = vi.fn()
+const mockSubscribe = vi.fn(() => () => {})
+
+vi.mock('@/composables/useProviderFallbackApi', () => ({
+  useProviderFallbackApi: () => ({
+    fetchFallbackStatus: mockFetch,
+    subscribeToFallbackEvents: mockSubscribe,
+  }),
+}))
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+import ProviderFallbackView from '../ProviderFallbackView.vue'
+
+function mountView() {
+  return mount(ProviderFallbackView, { global: { plugins: [i18n] } })
+}
+
+describe('ProviderFallbackView.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSubscribe.mockReturnValue(() => {})
+  })
+
+  it('renders the active fallback state from the read API', async () => {
+    mockFetch.mockResolvedValue({
+      configured_chains: [
+        { primary_model: 'gpt-4o', fallback_chain: 'gpt-4o → claude-3-5-sonnet', provider: 'multi' },
+      ],
+      active_fallbacks: [
+        {
+          conversation_id: 'conv-42',
+          primary_model: 'gpt-4o',
+          fallback_model: 'claude-3-5-sonnet',
+          primary_provider: 'openai',
+          fallback_provider: 'anthropic',
+          timestamp: 1700000000,
+        },
+      ],
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    // Degraded state badge shown because an active fallback exists
+    expect(wrapper.text()).toContain('Fallback active')
+    // Active fallback card surfaces the conversation + hop models
+    expect(wrapper.text()).toContain('conv-42')
+    expect(wrapper.text()).toContain('anthropic/claude-3-5-sonnet')
+    // Configured chain surfaced
+    expect(wrapper.text()).toContain('gpt-4o → claude-3-5-sonnet')
+  })
+
+  it('renders the healthy state and empty message when there is no activity', async () => {
+    mockFetch.mockResolvedValue({ configured_chains: [], active_fallbacks: [] })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No active fallbacks')
+    expect(wrapper.text()).toContain('No provider fallback activity')
+  })
+
+  it('subscribes to live PROVIDER_FALLBACK events on mount', async () => {
+    mockFetch.mockResolvedValue({ configured_chains: [], active_fallbacks: [] })
+
+    mountView()
+    await flushPromises()
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1)
+    expect(mockSubscribe).toHaveBeenCalledWith(expect.any(Function))
+  })
+
+  it('appends a live event to the timeline', async () => {
+    mockFetch.mockResolvedValue({ configured_chains: [], active_fallbacks: [] })
+    let liveCb: ((p: Record<string, unknown>) => void) | null = null
+    mockSubscribe.mockImplementation((cb: (p: Record<string, unknown>) => void) => {
+      liveCb = cb
+      return () => {}
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    liveCb!({
+      conversation_id: 'conv-live',
+      primary_model: 'gpt-4o',
+      fallback_model: 'claude-3-5-sonnet',
+      reason: 'rate_limit_429',
+      exhausted: true,
+      timestamp: 1700000001,
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('conv-live')
+    expect(wrapper.text()).toContain('Exhausted')
+  })
+})


### PR DESCRIPTION
## Thinking Path

Umbrella #11994 Child B. Backend Child A (#11995, merged) already landed both a live signal and a read API, so no new backend endpoint was needed:

- **Read API (reload-safe):** `GET /api/llm/fallback-status` (`autobot-backend/api/llm_providers.py`, mounted at `/api/llm`) returns `{ configured_chains[], active_fallbacks[] }` — `active_fallbacks` is the reclaimed `llm:fallback:active:*` Redis write.
- **Live signal:** the canonical `PROVIDER_FALLBACK` (`provider_fallback`) event is published on the `global` channel by `llm_shared/fallback_events.emit_fallback_event`, reachable in the frontend via the existing `LiveEventService` (same seam `useAgentEvents.ts` uses for `AGENT_ABSTAINED`).

So the panel is **always-on**: live via WS + reload-safe via the status endpoint. No new backend metric invented.

## What Changed

- **`constants/providerFallbackEvents.ts`** — `PROVIDER_FALLBACK` event constant + typed payload/response shapes (`ProviderFallbackPayload`, `FallbackStatusResponse`, `ActiveFallbackEntry`, `ConfiguredFallbackChain`).
- **`composables/useProviderFallbackApi.ts`** — `fetchFallbackStatus()` (GETs `/api/llm/fallback-status`, parsed JSON) + `subscribeToFallbackEvents()` (filters `global`-channel live events for `provider_fallback`, returns unsubscribe).
- **`views/ProviderFallbackView.vue`** — admin panel: current state badge, active-fallback cards, configured chains, and a capped live timeline. Reuses `BaseBadge` (canonical `danger`/`warning`/`success`); scoped styles use design tokens only (no hardcoded hex/px).
- **Routing + nav (both, manual):** `/admin/provider-fallback` route (`admin: true`, `hideInNav: true`) in `router/index.ts` + `adminMenuItems` entry (`nav.providerFallback`) in `config/navItems.ts`.
- **i18n:** `admin.providerFallback.*` (14 keys) + `nav.providerFallback` across all 11 locales.
- **Tests:** `useProviderFallbackApi.spec.ts` (7) + `ProviderFallbackView.spec.ts` (4).

## Verification

- `npx vitest run` new specs → **11 passed** (2 files).
- `npx vitest run src/__tests__/nav-items-coverage.test.ts` → **9 passed** (admin nav item covered).
- `npx vue-tsc --noEmit -p tsconfig.app.json` → **exit 0, 0 errors**.
- `npx eslint` on all touched files → **clean (0 errors, 0 warnings)**.

## Model Used

Opus 4.8

Closes #11996
