### PR TITLE
fix(frontend): correct composable state-contracts (share module-level refs where consumed cross-component) (#11658)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeHealthAnalytics.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeHealthAnalytics.vue
@@ -311,8 +311,8 @@ const capitalize = (str: string): string => {
   return str && str.length > 0 ? str.charAt(0).toUpperCase() + str.slice(1) : str || ''
 }
 
-// Load stats on mount (category fact counts are fetched by VectorStatsSection
-// on its own useKnowledgeStats instance — the composable state is per-instance)
+// Load stats on mount. Category fact counts are fetched by VectorStatsSection;
+// useKnowledgeStats is a shared-singleton (#11658) so that state is shared.
 onMounted(async () => {
   await refreshStats()
 })

--- a/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
+++ b/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
@@ -50,9 +50,9 @@ import { createLogger } from '@/utils/debugUtils'
 const logger = createLogger('VectorStatsSection')
 
 const { vectorStats } = useVectorStats()
-// useKnowledgeStats is per-instance state: the fetch must happen on the SAME
-// instance this section reads from (a parent-side refresh populates a
-// different ref and the chart renders 0% bars).
+// useKnowledgeStats is a shared-singleton (#11658): every call returns the
+// same module-level refs, so this section fetches its own category facts and
+// any other consumer observes the same `categoryFactCounts`.
 const { categoryFactCounts, refreshCategoryFacts } = useKnowledgeStats()
 
 onMounted(async () => {

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeStats.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeStats.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { KnowledgeStats } from '@/types/knowledgeBase'
-import { useKnowledgeStats } from '../knowledge/useKnowledgeStats'
+import { useKnowledgeStats, resetKnowledgeStats } from '../knowledge/useKnowledgeStats'
 
 vi.mock('@/utils/ApiClient', () => ({
   default: {
@@ -26,6 +26,9 @@ import apiClient from '@/utils/ApiClient'
 describe('useKnowledgeStats', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // useKnowledgeStats is a module-level singleton (#11658); clear its shared
+    // state so per-test assertions on the initial (empty) values hold.
+    resetKnowledgeStats()
   })
 
   describe('fetchStats', () => {
@@ -128,6 +131,53 @@ describe('useKnowledgeStats', () => {
 
       expect(data).toEqual(mockStats)
       expect(basicStats.value).toEqual(mockStats)
+    })
+  })
+
+  describe('shared-singleton state contract (#11658)', () => {
+    it('two consumers share the same refresh/refreshCategoryFacts state', async () => {
+      // Consumer A (e.g. a parent) and consumer B (e.g. a child section) each
+      // call useKnowledgeStats() independently, as real components do.
+      const consumerA = useKnowledgeStats()
+      const consumerB = useKnowledgeStats()
+
+      const mockStats: KnowledgeStats = { total_facts: 7, total_documents: 2 }
+      vi.mocked(apiClient.get).mockResolvedValueOnce(mockStats)
+
+      // A performs the fetch...
+      await consumerA.refresh()
+
+      // ...and B observes the same shared `stats` ref.
+      expect(consumerB.stats.value).toEqual(mockStats)
+      expect(consumerA.stats.value).toBe(consumerB.stats.value)
+    })
+
+    it('category fact counts fetched by one consumer are read by another (#11619 guard)', async () => {
+      const parent = useKnowledgeStats()
+      const child = useKnowledgeStats()
+
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        categories: { docs: [1, 2, 3], notes: [1] },
+      })
+
+      // The reader/child triggers the fetch; a sibling/parent reads the counts.
+      await child.refreshCategoryFacts()
+
+      expect(parent.categoryFactCounts.value).toEqual({ docs: 3, notes: 1 })
+      expect(child.categoryFactCounts.value).toBe(parent.categoryFactCounts.value)
+    })
+
+    it('reset() clears shared state for all consumers', async () => {
+      const a = useKnowledgeStats()
+      const b = useKnowledgeStats()
+
+      const mockStats: KnowledgeStats = { total_facts: 1, total_documents: 1 }
+      vi.mocked(apiClient.get).mockResolvedValueOnce(mockStats)
+      await a.refresh()
+      expect(b.stats.value).toEqual(mockStats)
+
+      a.reset()
+      expect(b.stats.value).toBe(null)
     })
   })
 })

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
@@ -10,13 +10,25 @@
  * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
  * ApiClient already logs retries + final failure and never returns null.
  *
- * Reactive refs layer (#5149): the composable now owns loading/error state
- * via `ref`s and exposes a `refresh` action. The bare imperative functions
- * are still exported at module scope so non-reactive consumers (and the
- * `useKnowledgeBase` BC shim) keep working unchanged.
+ * Reactive refs layer (#5149): the composable owns loading/error state and a
+ * `refresh` action. The bare imperative functions are still exported at module
+ * scope so non-reactive consumers (and the `useKnowledgeBase` BC shim) keep
+ * working unchanged.
  *
  * Category facts extraction (#6052): fetchCategoryFacts / refreshCategoryFacts
  * extracted from KnowledgeStats.vue inline apiClient call.
+ *
+ * SHARED-SINGLETON STATE CONTRACT (#11658): the reactive refs below
+ * (`stats`, `basicStats`, `categoryFactCounts`, `isLoading`, `error`) are
+ * declared at MODULE scope, so every `useKnowledgeStats()` call returns the
+ * SAME refs. This is intentional — knowledge-base stats are global (there is
+ * one knowledge base, not one-per-component), so a refresh triggered by any
+ * consumer is observed by all readers. Previously these refs were per-call,
+ * which produced the #11619 bug: a parent fetched `refreshCategoryFacts()`
+ * into instance A while a child read `categoryFactCounts` from instance B, so
+ * the distribution chart rendered 0% bars. Do NOT move this state back inside
+ * the function. Use `resetKnowledgeStats()` to clear it (logout / KB switch /
+ * test teardown).
  */
 
 import { ref, readonly, type Ref } from 'vue'
@@ -66,6 +78,59 @@ export const fetchCategoryFacts = async (): Promise<Record<string, number> | nul
   }
 }
 
+// ==================== Shared-singleton reactive state (#11658) ====================
+// Declared at module scope so all consumers share one instance — see the
+// SHARED-SINGLETON STATE CONTRACT note in the file header.
+
+const stats = ref<KnowledgeStats | null>(null)
+const basicStats = ref<KnowledgeStats | null>(null)
+const categoryFactCounts = ref<Record<string, number>>({})
+const error = ref<Error | null>(null)
+const { isLoading, wrap } = useLoadingState()
+
+const refresh = async (): Promise<KnowledgeStats | null> => {
+  error.value = null
+  return wrap(async () => {
+    try {
+      const data = await fetchStats()
+      stats.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    }
+  })
+}
+
+const refreshBasic = async (): Promise<KnowledgeStats | null> => {
+  error.value = null
+  return wrap(async () => {
+    const data = await fetchBasicStats()
+    basicStats.value = data
+    return data
+  })
+}
+
+const refreshCategoryFacts = async (): Promise<Record<string, number> | null> => {
+  const data = await fetchCategoryFacts()
+  if (data !== null) {
+    categoryFactCounts.value = data
+  }
+  return data
+}
+
+/**
+ * Clear all shared knowledge-stats state back to its initial (empty) values.
+ * Call on logout, when switching knowledge bases, or in test teardown so the
+ * module-level singleton does not leak state across contexts.
+ */
+export function resetKnowledgeStats(): void {
+  stats.value = null
+  basicStats.value = null
+  categoryFactCounts.value = {}
+  error.value = null
+}
+
 // ==================== Reactive composable ====================
 
 export interface UseKnowledgeStatsReturn {
@@ -85,6 +150,8 @@ export interface UseKnowledgeStatsReturn {
   refreshBasic: () => Promise<KnowledgeStats | null>
   /** Fetch category fact counts, update `categoryFactCounts`, return the payload. */
   refreshCategoryFacts: () => Promise<Record<string, number> | null>
+  /** Clear all shared state (logout / KB switch / test teardown). */
+  reset: () => void
   // Imperative passthroughs — BC with pre-#5149 callers
   fetchStats: typeof fetchStats
   fetchBasicStats: typeof fetchBasicStats
@@ -92,43 +159,6 @@ export interface UseKnowledgeStatsReturn {
 }
 
 export function useKnowledgeStats(): UseKnowledgeStatsReturn {
-  const stats = ref<KnowledgeStats | null>(null)
-  const basicStats = ref<KnowledgeStats | null>(null)
-  const categoryFactCounts = ref<Record<string, number>>({})
-  const { isLoading, wrap } = useLoadingState()
-  const error = ref<Error | null>(null)
-
-  const refresh = async (): Promise<KnowledgeStats | null> => {
-    error.value = null
-    return wrap(async () => {
-      try {
-        const data = await fetchStats()
-        stats.value = data
-        return data
-      } catch (err) {
-        error.value = err instanceof Error ? err : new Error(String(err))
-        throw err
-      }
-    })
-  }
-
-  const refreshBasic = async (): Promise<KnowledgeStats | null> => {
-    error.value = null
-    return wrap(async () => {
-      const data = await fetchBasicStats()
-      basicStats.value = data
-      return data
-    })
-  }
-
-  const refreshCategoryFacts = async (): Promise<Record<string, number> | null> => {
-    const data = await fetchCategoryFacts()
-    if (data !== null) {
-      categoryFactCounts.value = data
-    }
-    return data
-  }
-
   return {
     stats: readonly(stats) as Readonly<Ref<KnowledgeStats | null>>,
     basicStats: readonly(basicStats) as Readonly<Ref<KnowledgeStats | null>>,
@@ -138,6 +168,7 @@ export function useKnowledgeStats(): UseKnowledgeStatsReturn {
     refresh,
     refreshBasic,
     refreshCategoryFacts,
+    reset: resetKnowledgeStats,
     fetchStats,
     fetchBasicStats,
     fetchCategoryFacts,


### PR DESCRIPTION
Closes #12289
## Thinking Path

Issue #11658 asks for a **state-contract audit** of `src/composables/`: find per-instance composables (fresh `ref()`s per call) consumed by ≥2 components that assume **shared** state (component A writes → component B reads a different, isolated ref). The named exemplar is `useKnowledgeStats` (#11619: parent fetched into instance A, child read `categoryFactCounts` from instance B → chart rendered 0% bars).

I enumerated ~250 composables and classified each as module-scope (shared) vs per-call (per-instance), then mapped consumers and inspected every multi-consumer per-instance holder for genuine shared-state intent.

## Audit result

Nearly all multi-consumer per-instance composables are **correctly scoped**:

| Composable | Consumers | Verdict |
|---|---|---|
| `useKnowledgeSearch` | KnowledgeBrowser + SearchBar + SearchResults | OK — parent instantiates once, passes the `search` object down as a **prop** |
| `useTerminalStore` | Terminal + HostSelector | OK — Pinia `defineStore` (singleton by design) |
| `useSourceRegistry` | CodebaseAnalytics (+3) | OK — only 1 real `useSourceRegistry()` call; others import bare module-level fns |
| `useMachineKnowledge` / `useManPages` | 3 each | OK — KnowledgeBrowser uses the module-level imperative fns by **return value**; the two managers are independent UIs |
| `useKnowledgeOrphans` | Session/Memory managers | OK — different orphan types, independent state |
| `useMultiModelCompare`, `useCompanyPeople`, `useWorkflowTemplates`, `useReasoningTrace`, `useThumbnailWorker`, `useNavOverflow`, `useModal`, `useDebounce`, `useExpansion`, `useLoadingState`, `useBatchSelection`, `useNotificationBus`, … | many | OK — utilities / param-driven / prop-shared / return-value usage |
| **`useKnowledgeStats`** | **VectorStatsSection + KnowledgeHealthAnalytics** | **FIXED — genuine shared-state contract, see below** |

## What Changed

`useKnowledgeStats` holds **global** knowledge-base data (no per-instance parameter — there is exactly one knowledge base). It was per-instance only as an artifact of the #5149 extraction, and #11619 papered over the isolation with a fragile "fetch-in-the-reader" workaround in the consumers. That footgun re-arms for any future consumer.

- Moved `stats`, `basicStats`, `categoryFactCounts`, `error`, and the loading state to **module scope**, so every `useKnowledgeStats()` returns the same refs (matches the `useVectorStats` store-backed reference pattern). `refresh*` actions unchanged; bare imperative exports (`fetchStats`/`fetchBasicStats`/`fetchCategoryFacts`) preserved.
- Added `resetKnowledgeStats()` (exported + on the return object) to clear shared state on logout / KB switch / test teardown.
- Documented the **shared-singleton state contract** in the file header JSDoc so the state is never moved back inside the function.
- Updated the now-inaccurate `// per-instance` comments in `VectorStatsSection.vue` and `KnowledgeHealthAnalytics.vue` (behaviour of the consumers is unchanged — fetch-in-reader still works, and now siblings observe it).

Deliberately **not** blanket-converted — only the one composable whose state is genuinely global and consumed cross-component.

## Verification

- `vitest run src/composables/__tests__/useKnowledgeStats.test.ts` → **10 passed** (7 original + 3 new share-state guards: two consumers share `refresh` state, category-fact counts fetched by one consumer read by another (#11619 guard), `reset()` clears for all consumers).
- `vue-tsc --noEmit -p tsconfig.app.json` → no errors on touched files.
- `eslint` on all 4 touched files → clean (exit 0).

## Model Used

claude-opus-4-8

Refs #11658