### PR TITLE
feat(chat): opt-in end-user provider-fallback chip (default off) (#11997)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -586,6 +586,7 @@
   --terminal-text-muted: #888888;         /* metadata labels */
   --terminal-text-dim: #cccccc;           /* secondary body text */
   --terminal-text-dim-strong: #dddddd;    /* emphasis body text */
+  --terminal-text-output: #d4d4d4;        /* default (non-ANSI) command-output text */
 
   /* ANSI content palette — literal, do NOT remap to semantic tokens */
   --terminal-ansi-green: #00ff00;         /* prompt + cursor */

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -74,6 +74,11 @@
                 <i class="fas fa-bolt mr-1"></i>
                 {{ $t('chat.lightweightMode', { default: 'Lightweight' }) }}
               </span>
+              <!-- #11997: opt-in provider-fallback chip (off by default) -->
+              <ProviderFallbackChip
+                v-if="message.sender === 'assistant'"
+                :fallback-info="getFallbackForMessage(message.id)"
+              />
               <!-- Issue #1310: Visible type badge for typed messages -->
               <span
                 v-if="getMessageTypeBadge(message)"
@@ -557,7 +562,7 @@
 <script setup lang="ts">
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, nextTick, watch, onMounted } from 'vue'
+import { ref, computed, nextTick, watch, onMounted, onUnmounted } from 'vue'
 import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
 import { useConfirmDialog } from '@/composables/useConfirmDialog'
@@ -578,6 +583,8 @@ import { BaseModal } from '@autobot/ui'
 import OverseerPlanMessage from '@/components/chat/OverseerPlanMessage.vue'
 import OverseerStepMessage from '@/components/chat/OverseerStepMessage.vue'
 import CitationsDisplay from '@/components/chat/CitationsDisplay.vue'
+import ProviderFallbackChip from '@/components/chat/ProviderFallbackChip.vue'
+import { useProviderFallbackChip } from '@/composables/useProviderFallbackChip'
 import ImageCell from '@/components/artifact-cells/ImageCell.vue'
 import VideoCell from '@/components/artifact-cells/VideoCell.vue'
 import { formatFileSize, formatTime } from '@/utils/formatHelpers'
@@ -608,6 +615,10 @@ const { confirm } = useConfirmDialog()
 const store = useChatStore()
 const controller = useChatController()
 const { displaySettings } = useDisplaySettings()
+
+// #11997: correlate live PROVIDER_FALLBACK events to the assistant message
+// they answered, so the opt-in fallback chip can render on that message.
+const { start: startFallbackTracking, getFallbackForMessage } = useProviderFallbackChip()
 const permissionStore = usePermissionStore()
 
 // Command Approval composable — replaces all inline fetchWithAuth calls
@@ -1212,7 +1223,24 @@ watch(() => store.isTyping, (isTyping) => {
 // }, { deep: true })
 
 // Initialize permission store on mount (scroll handled by useVirtualChatScroll)
+// #11997: resolve a fallback event's conversation id to the last assistant
+// message of that conversation (the response the fallback produced).
+function resolveFallbackTargetMessage(conversationId: string): string | null {
+  const session =
+    store.sessions.find((s) => s.id === conversationId) ?? store.currentSession
+  const msgs = session?.messages ?? []
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    if (msgs[i].sender === 'assistant') return msgs[i].id
+  }
+  return null
+}
+
+let stopFallbackTracking: (() => void) | null = null
+
 onMounted(async () => {
+  // #11997: start correlating provider-fallback events to chat messages.
+  stopFallbackTracking = startFallbackTracking(resolveFallbackTargetMessage)
+
   // Permission v2: Initialize permission store
   try {
     await permissionStore.initialize()
@@ -1223,6 +1251,11 @@ onMounted(async () => {
   } catch (error) {
     logger.warn('Failed to initialize permission store:', error)
   }
+})
+
+onUnmounted(() => {
+  stopFallbackTracking?.()
+  stopFallbackTracking = null
 })
 </script>
 

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1499,7 +1499,7 @@ onUnmounted(() => {
 
 .message-wrapper.type-terminal_output .message-text {
   @apply font-mono text-sm leading-relaxed whitespace-pre-wrap;
-  color: #d4d4d4;
+  color: var(--terminal-text-output);
 }
 
 .message-wrapper.type-terminal_output .message-content {

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1226,9 +1226,12 @@ watch(() => store.isTyping, (isTyping) => {
 // #11997: resolve a fallback event's conversation id to the last assistant
 // message of that conversation (the response the fallback produced).
 function resolveFallbackTargetMessage(conversationId: string): string | null {
-  const session =
-    store.sessions.find((s) => s.id === conversationId) ?? store.currentSession
-  const msgs = session?.messages ?? []
+  // #11994: correlate ONLY to the event's own conversation — never fall back to
+  // the current session, or a fallback from another conversation would be
+  // mis-attributed to the message being viewed (cross-conversation leak).
+  const session = store.sessions.find((s) => s.id === conversationId)
+  if (!session) return null
+  const msgs = session.messages ?? []
   for (let i = msgs.length - 1; i >= 0; i--) {
     if (msgs[i].sender === 'assistant') return msgs[i].id
   }

--- a/autobot-frontend/src/components/chat/ChatSettingsModal.vue
+++ b/autobot-frontend/src/components/chat/ChatSettingsModal.vue
@@ -105,6 +105,8 @@ const displaySettingsConfig = computed<{ key: keyof DisplaySettings; label: stri
   { key: 'showDebug', label: t('chat.sidebar.showDebug') },
   { key: 'showSources', label: t('chat.sidebar.showSources') },
   { key: 'autoScroll', label: t('chat.sidebar.autoScroll') },
+  // #11997: opt-in provider-fallback chip (default OFF)
+  { key: 'showFallbackChip', label: t('chat.sidebar.showFallbackChip') },
 ])
 const localMode = ref(contextOverflowMode.value)
 const localEffort = ref(reasoningEffort.value)

--- a/autobot-frontend/src/components/chat/ProviderFallbackChip.vue
+++ b/autobot-frontend/src/components/chat/ProviderFallbackChip.vue
@@ -1,0 +1,65 @@
+<template>
+  <BaseBadge
+    v-if="visible"
+    variant="warning"
+    size="sm"
+    class="provider-fallback-chip"
+    :title="tooltip"
+  >
+    <Icon name="exclamation-triangle" class="chip-icon" />
+    {{ t('chat.message.fallback.badge') }}
+  </BaseBadge>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Provider Fallback Chip (#11997 / umbrella #11994)
+ *
+ * Opt-in, off-by-default inline chip shown on an assistant message when the
+ * primary LLM provider was unavailable and a fallback provider answered.
+ * Gated behind the `showFallbackChip` display setting (default OFF), preserving
+ * the platform's "invisible by default" fallback design intent (#11994).
+ */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { BaseBadge } from '@autobot/ui'
+import Icon from '@/components/ui/Icon.vue'
+import { useDisplaySettings } from '@/composables/useDisplaySettings'
+import type { ProviderFallbackPayload } from '@/constants/providerFallbackEvents'
+
+interface Props {
+  /** Fallback decision that produced this message, or `null` when none. */
+  fallbackInfo?: ProviderFallbackPayload | null
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  fallbackInfo: null,
+})
+
+const { t } = useI18n()
+const { getSetting } = useDisplaySettings()
+
+/** Opt-in + present-fallback gate. Default OFF → chip hidden unless enabled. */
+const visible = computed<boolean>(() => getSetting('showFallbackChip') && props.fallbackInfo != null)
+
+const tooltip = computed<string>(() => {
+  const info = props.fallbackInfo
+  const primary = info?.primary_provider || info?.primary_model || t('common.unknown')
+  const fallback = info?.fallback_provider || info?.fallback_model || t('common.unknown')
+  return t('chat.message.fallback.tooltip', { primary, fallback })
+})
+</script>
+
+<style scoped>
+.provider-fallback-chip {
+  margin-inline-start: var(--spacing-1-5);
+  vertical-align: middle;
+}
+
+.chip-icon {
+  margin-inline-end: var(--spacing-1);
+}
+</style>

--- a/autobot-frontend/src/components/chat/__tests__/ProviderFallbackChip.spec.ts
+++ b/autobot-frontend/src/components/chat/__tests__/ProviderFallbackChip.spec.ts
@@ -1,0 +1,139 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Component tests for the opt-in provider-fallback chip (#11997 / umbrella
+ * #11994).
+ *
+ * Scenarios:
+ *  1. The `showFallbackChip` display setting defaults to OFF.
+ *  2. Setting OFF (default) → chip hidden even when a fallback matched.
+ *  3. Setting ON + a matching fallback → chip renders with primary/fallback
+ *     tooltip context.
+ *  4. Setting ON + no fallback → chip hidden.
+ *
+ * useDisplaySettings is mocked so the test drives the opt-in gate directly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+// ── Module-level mocks (hoisted) ─────────────────────────────────────────────
+
+vi.mock('@/composables/useDisplaySettings', () => ({
+  useDisplaySettings: vi.fn(),
+}))
+
+vi.mock('@/components/ui/Icon.vue', () => ({
+  default: { name: 'Icon', template: '<i class="icon-stub" />', props: ['name'] },
+}))
+
+vi.mock('@autobot/ui', () => ({
+  BaseBadge: {
+    name: 'BaseBadge',
+    props: ['variant', 'size', 'title'],
+    template:
+      '<span class="base-badge-stub" :data-variant="variant" :title="title">' +
+      '<slot name="icon" /><slot /></span>',
+  },
+}))
+
+// ── Imports after mocks ──────────────────────────────────────────────────────
+
+import { useDisplaySettings } from '@/composables/useDisplaySettings'
+import ProviderFallbackChip from '../ProviderFallbackChip.vue'
+import type { ProviderFallbackPayload } from '@/constants/providerFallbackEvents'
+
+// ── i18n (real messages so tooltip interpolation is asserted) ────────────────
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    en: {
+      common: { unknown: 'Unknown' },
+      chat: {
+        message: {
+          fallback: {
+            badge: 'Via fallback',
+            tooltip:
+              'Primary provider unavailable — answered via a fallback provider ({primary} → {fallback}).',
+          },
+        },
+      },
+    },
+  },
+})
+
+const FALLBACK: ProviderFallbackPayload = {
+  conversation_id: 'conv-1',
+  request_id: null,
+  primary_model: 'gpt-4o',
+  primary_provider: 'openai',
+  fallback_model: 'claude-3-5-sonnet',
+  fallback_provider: 'anthropic',
+  reason: 'rate_limit',
+  chain_tried: ['gpt-4o', 'claude-3-5-sonnet'],
+  degraded_skipped: [],
+  exhausted: false,
+  timestamp: 1_700_000_000,
+}
+
+let settingEnabled = false
+
+function mountChip(fallbackInfo: ProviderFallbackPayload | null): VueWrapper {
+  return mount(ProviderFallbackChip, {
+    props: { fallbackInfo },
+    global: { plugins: [i18n] },
+  })
+}
+
+beforeEach(() => {
+  settingEnabled = false
+  vi.mocked(useDisplaySettings).mockReturnValue({
+    getSetting: (key: string) => (key === 'showFallbackChip' ? settingEnabled : false),
+  } as unknown as ReturnType<typeof useDisplaySettings>)
+})
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ProviderFallbackChip (opt-in, default OFF)', () => {
+  it('defaults the showFallbackChip setting to OFF', async () => {
+    // Assert against the real defaults, not the mock, to prove default-OFF.
+    const actual = await vi.importActual<typeof import('@/composables/useDisplaySettings')>(
+      '@/composables/useDisplaySettings',
+    )
+    const { getSetting } = actual.useDisplaySettings()
+    expect(getSetting('showFallbackChip')).toBe(false)
+  })
+
+  it('hides the chip when the setting is OFF (default) even with a fallback', () => {
+    settingEnabled = false
+    const wrapper = mountChip(FALLBACK)
+    expect(wrapper.find('.base-badge-stub').exists()).toBe(false)
+  })
+
+  it('renders the chip when the setting is ON and a fallback matched the message', () => {
+    settingEnabled = true
+    const wrapper = mountChip(FALLBACK)
+    const badge = wrapper.find('.base-badge-stub')
+    expect(badge.exists()).toBe(true)
+    expect(badge.attributes('data-variant')).toBe('warning')
+    expect(badge.text()).toContain('Via fallback')
+    expect(badge.attributes('title')).toBe(
+      'Primary provider unavailable — answered via a fallback provider (openai → anthropic).',
+    )
+  })
+
+  it('hides the chip when the setting is ON but no fallback matched', () => {
+    settingEnabled = true
+    const wrapper = mountChip(null)
+    expect(wrapper.find('.base-badge-stub').exists()).toBe(false)
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useProviderFallbackChip.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useProviderFallbackChip.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Correlation tests for the provider-fallback chip composable (#11997 /
+ * umbrella #11994).
+ *
+ * Focus: the conversation-id → assistant-message-id mapping. The live event
+ * seam is global (all conversations), so the composable must pin a fallback
+ * ONLY to the message the caller's resolver returns — and must NOT attribute a
+ * fallback whose conversation the resolver does not recognise (the
+ * cross-conversation leak guarded by ChatMessages.resolveFallbackTargetMessage
+ * returning null for unloaded conversations).
+ *
+ * useProviderFallbackApi is mocked so the test drives the subscribe callback
+ * directly. The composable's map is module-level, so each test resets modules
+ * and re-imports for isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ProviderFallbackPayload } from '@/constants/providerFallbackEvents'
+
+vi.mock('@/composables/useProviderFallbackApi', () => ({
+  useProviderFallbackApi: vi.fn(),
+}))
+
+function makePayload(conversationId: string): ProviderFallbackPayload {
+  return {
+    conversation_id: conversationId,
+    request_id: null,
+    primary_model: 'gpt-4',
+    primary_provider: 'openai',
+    fallback_model: 'claude',
+    fallback_provider: 'anthropic',
+    reason: 'rate_limit',
+    chain_tried: ['openai', 'anthropic'],
+    degraded_skipped: [],
+    exhausted: false,
+    timestamp: 0,
+  }
+}
+
+describe('useProviderFallbackChip', () => {
+  let captured: ((p: ProviderFallbackPayload) => void) | null
+  let unsubscribe: ReturnType<typeof vi.fn>
+  let useProviderFallbackChip: typeof import('../useProviderFallbackChip').useProviderFallbackChip
+
+  beforeEach(async () => {
+    vi.resetModules()
+    captured = null
+    unsubscribe = vi.fn()
+    const api = await import('@/composables/useProviderFallbackApi')
+    vi.mocked(api.useProviderFallbackApi).mockReturnValue({
+      subscribeToFallbackEvents: vi.fn((cb: (p: ProviderFallbackPayload) => void) => {
+        captured = cb
+        return unsubscribe
+      }),
+    } as unknown as ReturnType<typeof api.useProviderFallbackApi>)
+    ;({ useProviderFallbackChip } = await import('../useProviderFallbackChip'))
+  })
+
+  it('pins a fallback to the resolved message of its own conversation', () => {
+    const { start, getFallbackForMessage } = useProviderFallbackChip()
+    const resolve = vi.fn((cid: string) => (cid === 'conv-A' ? 'msg-A' : null))
+    start(resolve)
+
+    const payload = makePayload('conv-A')
+    captured?.(payload)
+
+    expect(resolve).toHaveBeenCalledWith('conv-A')
+    expect(getFallbackForMessage('msg-A')).toEqual(payload)
+  })
+
+  it('does NOT attribute a fallback from an unrecognised conversation (no cross-conversation leak)', () => {
+    const { start, getFallbackForMessage, fallbackByMessageId } = useProviderFallbackChip()
+    // Resolver only knows conv-A (the loaded conversation); conv-B is elsewhere.
+    const resolve = vi.fn((cid: string) => (cid === 'conv-A' ? 'msg-A' : null))
+    start(resolve)
+
+    captured?.(makePayload('conv-B'))
+
+    expect(resolve).toHaveBeenCalledWith('conv-B')
+    expect(fallbackByMessageId.size).toBe(0)
+    expect(getFallbackForMessage('msg-A')).toBeNull()
+  })
+
+  it('stops correlating after the returned unsubscribe is called', () => {
+    const { start } = useProviderFallbackChip()
+    const stop = start(vi.fn(() => 'msg-A'))
+
+    stop()
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('getFallbackForMessage returns null for a message with no fallback', () => {
+    const { getFallbackForMessage } = useProviderFallbackChip()
+    expect(getFallbackForMessage('never-set')).toBeNull()
+  })
+})

--- a/autobot-frontend/src/composables/useDisplaySettings.ts
+++ b/autobot-frontend/src/composables/useDisplaySettings.ts
@@ -16,6 +16,9 @@ export interface DisplaySettings {
   showDebug: boolean
   showSources: boolean
   autoScroll: boolean
+  // #11997: opt-in end-user provider-fallback chip (default OFF, preserving the
+  // 'invisible by default' design intent of umbrella #11994).
+  showFallbackChip: boolean
 }
 
 const getDefaultSettings = (): DisplaySettings => ({
@@ -25,7 +28,8 @@ const getDefaultSettings = (): DisplaySettings => ({
   showPlanning: true, // Issue #352: Enable by default for multi-step task visibility
   showDebug: false,   // Keep debug hidden by default (verbose)
   showSources: true,  // Changed: Show sources by default for transparency
-  autoScroll: true
+  autoScroll: true,
+  showFallbackChip: false // #11997: opt-in, off by default (invisible unless enabled)
 })
 
 const loadDisplaySettings = (): DisplaySettings => {

--- a/autobot-frontend/src/composables/useProviderFallbackChip.ts
+++ b/autobot-frontend/src/composables/useProviderFallbackChip.ts
@@ -1,0 +1,75 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Provider-fallback chat-chip correlation composable (#11997 / umbrella #11994)
+ *
+ * Consumes the canonical PROVIDER_FALLBACK live event (#11995) and correlates
+ * each fallback decision to the specific assistant chat message it produced, so
+ * the chat view can render an opt-in inline chip on that message.
+ *
+ * Reuses the same live-event seam as the admin observability panel (#11996):
+ * `useProviderFallbackApi().subscribeToFallbackEvents` — no duplicate
+ * subscription, no new backend.
+ *
+ * Correlation key: `payload.conversation_id` (the frontend chat/session id is
+ * propagated to the backend as the conversation id — see ChatController). The
+ * caller supplies a resolver that maps a conversation id to the id of the
+ * assistant message the fallback answered (typically the last assistant message
+ * of that conversation), so the chip stays pinned to that message even after
+ * later successful (non-fallback) responses arrive.
+ *
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ */
+
+import { reactive } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+import { useProviderFallbackApi } from '@/composables/useProviderFallbackApi'
+import type { ProviderFallbackPayload } from '@/constants/providerFallbackEvents'
+
+const logger = createLogger('useProviderFallbackChip')
+
+/**
+ * Shared reactive map of assistant message id → the fallback decision that
+ * produced it. Module-level so every chat message renders from one source of
+ * truth regardless of which component instance started the subscription.
+ */
+const fallbackByMessageId = reactive(new Map<string, ProviderFallbackPayload>())
+
+/** Maps a fallback event's conversation id to the target assistant message id. */
+export type ResolveTargetMessageId = (conversationId: string) => string | null
+
+export interface UseProviderFallbackChipReturn {
+  /**
+   * Start correlating live PROVIDER_FALLBACK events to chat messages.
+   * @param resolve - resolves a conversation id to the assistant message id the
+   *   fallback answered (return `null` to skip messages not currently rendered).
+   * @returns an unsubscribe function.
+   */
+  start: (resolve: ResolveTargetMessageId) => () => void
+  /** Fallback decision that produced a message, or `null` if none. */
+  getFallbackForMessage: (messageId: string) => ProviderFallbackPayload | null
+  /** Reactive map of message id → fallback payload (read-only usage). */
+  fallbackByMessageId: Map<string, ProviderFallbackPayload>
+}
+
+export function useProviderFallbackChip(): UseProviderFallbackChipReturn {
+  const { subscribeToFallbackEvents } = useProviderFallbackApi()
+
+  function start(resolve: ResolveTargetMessageId): () => void {
+    return subscribeToFallbackEvents((payload: ProviderFallbackPayload) => {
+      const messageId = resolve(payload.conversation_id)
+      if (!messageId) {
+        logger.debug('PROVIDER_FALLBACK: no target message for conversation', payload.conversation_id)
+        return
+      }
+      fallbackByMessageId.set(messageId, payload)
+    })
+  }
+
+  function getFallbackForMessage(messageId: string): ProviderFallbackPayload | null {
+    return fallbackByMessageId.get(messageId) ?? null
+  }
+
+  return { start, getFallbackForMessage, fallbackByMessageId }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -136,6 +136,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "عبر الاحتياطي",
+        "tooltip": "المزود الأساسي غير متوفر — تمت الإجابة عبر مزود احتياطي ({primary} → {fallback})."
       }
     },
     "response": "استجابة",
@@ -210,7 +214,8 @@
       "deleteFailed": "Failed to delete some chats",
       "sharedSuccess": "Chat shared successfully",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "إظهار شارة الاحتياطي"
     },
     "interface": {
       "loadFailed": "Failed to load chat interface",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -136,6 +136,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "Über Fallback",
+        "tooltip": "Primärer Anbieter nicht verfügbar – über einen Fallback-Anbieter beantwortet ({primary} → {fallback})."
       }
     },
     "response": "Antwort",
@@ -210,7 +214,8 @@
       "deleteFailed": "Einige Chats konnten nicht gelöscht werden",
       "sharedSuccess": "Chat erfolgreich geteilt",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "Fallback-Badge anzeigen"
     },
     "interface": {
       "loadFailed": "Die Chat-Oberfläche konnte nicht geladen werden",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -160,6 +160,10 @@
         "overseer": "Overseer",
         "tool-code": "Code",
         "tool-output": "Output"
+      },
+      "fallback": {
+        "badge": "Via fallback",
+        "tooltip": "Primary provider unavailable — answered via a fallback provider ({primary} → {fallback})."
       }
     },
     "response": "response",
@@ -234,7 +238,8 @@
       "deleteFailed": "Failed to delete some chats",
       "sharedSuccess": "Chat shared successfully",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "Show fallback badge"
     },
     "folders": {
       "folders": "Folders",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -136,6 +136,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "Vía alternativa",
+        "tooltip": "Proveedor principal no disponible: respondido por un proveedor alternativo ({primary} → {fallback})."
       }
     },
     "response": "respuesta",
@@ -210,7 +214,8 @@
       "deleteFailed": "No se pudieron eliminar algunos chats",
       "sharedSuccess": "Chat compartido exitosamente",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "Mostrar insignia de reserva"
     },
     "interface": {
       "loadFailed": "No se pudo cargar la interfaz de chat",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -4986,7 +4986,8 @@
       "deletedWithFactsRemoved": "Deleted {count} chats and removed associated facts",
       "deletedSuccess": "Deleted {count} chats",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "نمایش نشان جایگزین"
     },
     "overseer": {
       "copyCommand": "Copy command",
@@ -5418,6 +5419,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "از طریق جایگزین",
+        "tooltip": "ارائه‌دهنده اصلی در دسترس نیست — پاسخ از طریق ارائه‌دهنده جایگزین ({primary} → {fallback})."
       }
     },
     "docResult": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -136,6 +136,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "Via secours",
+        "tooltip": "Fournisseur principal indisponible — réponse fournie par un fournisseur de secours ({primary} → {fallback})."
       }
     },
     "response": "réponse",
@@ -210,7 +214,8 @@
       "deleteFailed": "Échec de la suppression de certaines discussions",
       "sharedSuccess": "Chat partagé avec succès",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "Afficher le badge de secours"
     },
     "interface": {
       "loadFailed": "Échec du chargement de l'interface de discussion",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -4986,7 +4986,8 @@
       "deletedWithFactsRemoved": "Deleted {count} chats and removed associated facts",
       "deletedSuccess": "Deleted {count} chats",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "הצג תג גיבוי"
     },
     "overseer": {
       "copyCommand": "Copy command",
@@ -5418,6 +5419,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "דרך גיבוי",
+        "tooltip": "הספק הראשי אינו זמין — נענה על ידי ספק גיבוי ({primary} → {fallback})."
       }
     },
     "docResult": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -136,6 +136,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "Caur rezerves",
+        "tooltip": "Galvenais nodrošinātājs nav pieejams — atbildēja rezerves nodrošinātājs ({primary} → {fallback})."
       }
     },
     "response": "atbildi",
@@ -210,7 +214,8 @@
       "deleteFailed": "Neizdevās izdzēst dažas tērzēšanas sarunas",
       "sharedSuccess": "Tērzēšana veiksmīgi kopīgota",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "Rādīt rezerves atzīmi"
     },
     "interface": {
       "loadFailed": "Neizdevās ielādēt tērzēšanas saskarni",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -136,6 +136,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "Przez zapasowy",
+        "tooltip": "Główny dostawca niedostępny — odpowiedź udzielona przez dostawcę zapasowego ({primary} → {fallback})."
       }
     },
     "response": "odpowiedź",
@@ -210,7 +214,8 @@
       "deleteFailed": "Nie udało się usunąć niektórych czatów",
       "sharedSuccess": "Czat został udostępniony",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "Pokaż odznakę awaryjną"
     },
     "interface": {
       "loadFailed": "Nie udało się załadować interfejsu czatu",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -136,6 +136,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "Via alternativa",
+        "tooltip": "Provedor principal indisponível — respondido por um provedor alternativo ({primary} → {fallback})."
       }
     },
     "response": "resposta",
@@ -210,7 +214,8 @@
       "deleteFailed": "Falha ao excluir alguns bate-papos",
       "sharedSuccess": "Bate-papo compartilhado com sucesso",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "Mostrar selo de reserva"
     },
     "interface": {
       "loadFailed": "Falha ao carregar a interface de bate-papo",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -4986,7 +4986,8 @@
       "deletedWithFactsRemoved": "Deleted {count} chats and removed associated facts",
       "deletedSuccess": "Deleted {count} chats",
       "searchChats": "Search chats",
-      "noSearchResults": "No chats match your search"
+      "noSearchResults": "No chats match your search",
+      "showFallbackChip": "متبادل بیج دکھائیں"
     },
     "overseer": {
       "copyCommand": "Copy command",
@@ -5418,6 +5419,10 @@
       "thinking": {
         "badge": "🧠 Extended thinking ({count} tokens)",
         "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      },
+      "fallback": {
+        "badge": "متبادل کے ذریعے",
+        "tooltip": "بنیادی فراہم کنندہ دستیاب نہیں — متبادل فراہم کنندہ کے ذریعے جواب دیا گیا ({primary} → {fallback})."
       }
     },
     "docResult": {


### PR DESCRIPTION
## Thinking Path

Child C of umbrella #11994 (provider-routing observability). Backend event + read API landed in #11995; the always-on admin panel is #11996 (PR #12287). This PR adds the **opt-in, off-by-default end-user chip** in the chat UI, preserving the platform's "invisible by default" fallback design intent.

- **How the chip learns of a fallback:** reuses the exact same live-event seam as the admin panel — `useProviderFallbackApi().subscribeToFallbackEvents` (from #11996), which subscribes to the canonical `PROVIDER_FALLBACK` live event on the `global` channel (#11995). No duplicate subscription, no new backend.
- **Correlation key:** `payload.conversation_id`. The frontend chat/session id is propagated to the backend as the conversation id (see `ChatController`), so a new `useProviderFallbackChip` composable maps each fallback event to the last assistant message of the matching conversation and pins the chip to that specific message id.
- **Opt-in + default OFF:** gated behind a new `showFallbackChip` display setting in the existing `useDisplaySettings` opt-in chat-preference pattern, defaulting to `false`. Surfaced as a toggle in `ChatSettingsModal` alongside the other message-display toggles.

> **Depends on #11996 (PR #12287)** — imports `useProviderFallbackApi` / `constants/providerFallbackEvents` introduced there (reused, not duplicated). CI type/build checks go green once #12287 merges; merge this after it.

## What Changed

- `components/chat/ProviderFallbackChip.vue` (new) — `@autobot/ui` BaseBadge (`variant="warning"`), i18n label + primary→fallback tooltip; renders only when opt-in ON **and** a fallback matched the message.
- `composables/useProviderFallbackChip.ts` (new) — correlates `PROVIDER_FALLBACK` events to assistant message ids via the reused subscribe seam.
- `composables/useDisplaySettings.ts` — new `showFallbackChip: boolean`, default `false`.
- `components/chat/ChatMessages.vue` — renders the chip on assistant messages; starts/stops correlation on mount/unmount.
- `components/chat/ChatSettingsModal.vue` — adds the opt-in toggle.
- `i18n/locales/*.json` (11 locales) — `chat.message.fallback.badge`, `chat.message.fallback.tooltip`, `chat.sidebar.showFallbackChip`.

## Verification

- `vitest run ProviderFallbackChip.spec.ts` → **4 passed** (default-OFF; hidden when OFF even with fallback; renders warning badge + tooltip when ON + matched; hidden when ON + no fallback).
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors**.
- `eslint` on all touched files → **clean**.

## Model Used

claude-opus-4-8

Closes #11997
