### PR TITLE
fix(security): guard SSRF sinks in provider_auth + external_importer via ssrf_guard (#12278)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -351,7 +351,10 @@ async def oauth_callback(
 
     try:
         # Public-client PKCE: the verifier (server-stored) replaces a client secret.
-        resp = await exchange_code(
+        # SSRF mitigated: token_url passed _validate_outbound_url() (https + host
+        # allowlist + port pin) and _pinned_connector() pins the pre-resolved public
+        # IP (defeats DNS-rebind); redirects disabled in exchange_code. (#12278)
+        resp = await exchange_code(  # codeql[py/full-ssrf]
             provider_cfg,
             stored["client_id"],
             "",  # nosec B106 - PKCE public client: no client_secret
@@ -419,7 +422,10 @@ async def device_initiate(
     payload = {"client_id": req.client_id, "scope": req.scope}
     try:
         async with aiohttp.ClientSession(timeout=timeout, connector=connector) as http:
-            async with http.post(
+            # SSRF mitigated: device_authorization_url passed _validate_outbound_url()
+            # (https + host allowlist + port pin) and connector pins the pre-resolved
+            # public IP (defeats DNS-rebind); redirects disabled. (#12278)
+            async with http.post(  # codeql[py/full-ssrf]
                 req.device_authorization_url,
                 data=payload,
                 headers={"Accept": "application/json"},
@@ -493,7 +499,10 @@ async def device_poll(
     timeout = aiohttp.ClientTimeout(total=30.0)
     try:
         async with aiohttp.ClientSession(timeout=timeout, connector=connector) as http:
-            async with http.post(
+            # SSRF mitigated: token_url passed _validate_outbound_url() (https + host
+            # allowlist + port pin) and connector pins the pre-resolved public IP
+            # (defeats DNS-rebind); redirects disabled. (#12278)
+            async with http.post(  # codeql[py/full-ssrf]
                 req.token_url,
                 data=payload,
                 headers={"Accept": "application/json"},

--- a/autobot-backend/api/tests/test_provider_auth_ssrf.py
+++ b/autobot-backend/api/tests/test_provider_auth_ssrf.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""SSRF guards on provider-auth outbound token/device endpoints (#12278).
+
+Proves the guards protecting the CodeQL ``py/full-ssrf`` sinks in
+``api/provider_auth.py`` (exchange_code + device POSTs):
+- ``_validate_outbound_url`` rejects non-https, IP-literal (loopback / RFC1918 /
+  link-local metadata) and non-allowlisted hosts, and accepts allowlisted https.
+- ``_pinned_connector`` rejects an allowlisted host that RESOLVES to a private
+  address (DNS-rebind), and pins the public IP otherwise.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from api import provider_auth as mod
+
+
+def _allow(monkeypatch):
+    monkeypatch.setattr(mod, "get_oauth_allowed_hosts", lambda: {"token.example.com"})
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "https://169.254.169.254/token",  # AWS/Azure/GCP metadata (link-local)
+        "https://127.0.0.1/token",  # loopback
+        "https://10.0.0.1/token",  # RFC1918
+        "http://token.example.com/token",  # not https
+        "https://evil.example.com/token",  # not allowlisted
+    ],
+)
+def test_validate_outbound_url_blocks_unsafe(monkeypatch, bad_url):
+    _allow(monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        mod._validate_outbound_url(bad_url)
+    assert exc.value.status_code == 400
+
+
+def test_validate_outbound_url_allows_allowlisted_https(monkeypatch):
+    _allow(monkeypatch)
+    mod._validate_outbound_url("https://token.example.com/token")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_pinned_connector_blocks_dns_rebind_to_private(monkeypatch):
+    """Allowlisted host resolving to a private IP must be blocked (rebind)."""
+    fake_infos = [(2, 1, 6, "", ("10.0.0.1", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        with pytest.raises(HTTPException) as exc:
+            await mod._pinned_connector("https://token.example.com/token")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_pinned_connector_blocks_metadata_ip(monkeypatch):
+    fake_infos = [(2, 1, 6, "", ("169.254.169.254", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        with pytest.raises(HTTPException):
+            await mod._pinned_connector("https://token.example.com/token")
+
+
+@pytest.mark.asyncio
+async def test_pinned_connector_pins_public_ip(monkeypatch):
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        connector = await mod._pinned_connector("https://token.example.com/token")
+    try:
+        results = await connector._resolver.resolve("token.example.com", 443)
+        assert results[0]["host"] == "93.184.216.34"
+    finally:
+        await connector.close()

--- a/autobot-backend/skills/external_importer.py
+++ b/autobot-backend/skills/external_importer.py
@@ -100,6 +100,25 @@ def _validate_git_ref(ref: str) -> None:
         )
 
 
+async def _validate_catalog_url(url: str) -> None:
+    """SSRF guard for HTTP skill-catalog URLs (#12278).
+
+    Enforces an http/https scheme, a present hostname, and a publicly routable
+    resolved IP (rejects loopback, RFC1918, link-local/metadata). Delegates the
+    IP-range checks to the shared ``is_public_url_async`` guard so the SSRF rules
+    live in one module. Raises ``RuntimeError`` on any violation.
+    """
+    from autobot_shared.url_safety import is_public_url_async  # noqa: PLC0415
+
+    parsed = urlparse(url)
+    if (parsed.scheme or "").lower() not in ("http", "https"):
+        raise RuntimeError(f"Catalog URL must use http or https scheme: {url!r}")
+    if not parsed.hostname:
+        raise RuntimeError(f"Catalog URL missing hostname: {url!r}")
+    if not await is_public_url_async(url):
+        raise RuntimeError(f"Catalog URL blocked by SSRF guard: {url}")
+
+
 def _ensure_cache_dir() -> str:
     """Create skill cache directory if it does not exist.
 
@@ -293,15 +312,23 @@ class ExternalSkillImporter:
         Raises:
             RuntimeError: On HTTP error, SSRF guard rejection, or unexpected response shape.
         """
-        from autobot_shared.url_safety import is_public_url_async
+        from autobot_shared.security.ssrf_guard import SSRFError, pinned_connector  # noqa: PLC0415
 
-        if not await is_public_url_async(url):
-            raise RuntimeError(f"Catalog URL blocked by SSRF guard: {url}")
+        await _validate_catalog_url(url)
+        # Resolve-once + IP-pin so DNS cannot rebind to a private address between
+        # the public-IP check and the socket connect (DNS-rebind TOCTOU).
+        try:
+            connector = await pinned_connector(url)
+        except SSRFError as exc:
+            raise RuntimeError(f"Catalog URL blocked by SSRF guard: {url} ({exc})") from exc
 
         params = {"page": page, "page_size": page_size}
         timeout = aiohttp.ClientTimeout(total=30)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(url, params=params) as response:
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+            # SSRF mitigated: _validate_catalog_url() enforces scheme+public host and
+            # the connector pins the pre-resolved public IP (defeats DNS-rebind);
+            # redirects disabled. codeql[py/full-ssrf] (#12278)
+            async with session.get(url, params=params, allow_redirects=False) as response:  # codeql[py/full-ssrf]
                 if response.status != 200:
                     raise RuntimeError(f"Catalog fetch failed: HTTP {response.status} from {url}")
                 data = await response.json()

--- a/autobot-backend/skills/test_external_importer_ssrf.py
+++ b/autobot-backend/skills/test_external_importer_ssrf.py
@@ -81,3 +81,50 @@ async def test_import_git_repo_rejects_private_ips():
 
     with pytest.raises(RuntimeError, match="blocked by SSRF guard"):
         await importer.import_git_repo("https://10.0.0.1/repo.git")
+
+
+@pytest.mark.asyncio
+async def test_import_http_catalog_public_url_passes_and_pins_ip():
+    """A valid public catalog URL is fetched via an IP-pinned connector (#12278)."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    importer = ExternalSkillImporter()
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"skills": [{"name": "demo"}]})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_get = MagicMock(return_value=mock_response)
+    mock_session = MagicMock()
+    mock_session.get = mock_get
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        with patch("aiohttp.ClientSession", return_value=mock_session) as mk_session:
+            skills = await importer.import_http_catalog("https://catalog.example.com/skills")
+
+    assert skills == [{"name": "demo"}]
+    # A pinned connector must be supplied to the session (DNS-rebind defence).
+    assert mk_session.call_args.kwargs.get("connector") is not None
+    # Redirects must be disabled so a 3xx cannot bypass the SSRF check.
+    assert mock_get.call_args.kwargs.get("allow_redirects") is False
+
+
+@pytest.mark.asyncio
+async def test_import_http_catalog_blocks_dns_rebind_to_private():
+    """is_public passes on check, but the pinned resolve sees a private IP → blocked."""
+    from unittest.mock import AsyncMock, patch
+
+    importer = ExternalSkillImporter()
+
+    fake_private = [(2, 1, 6, "", ("10.0.0.1", 0))]
+    # First-stage is_public check is forced True; the pinned resolve then sees a
+    # private IP and must reject (defence-in-depth against DNS-rebind).
+    with patch("autobot_shared.url_safety.is_public_url_async", AsyncMock(return_value=True)):
+        with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_private):
+            with pytest.raises(RuntimeError, match="blocked by SSRF guard"):
+                await importer.import_http_catalog("https://rebind.example.com/skills")


### PR DESCRIPTION
## Thinking Path

CodeQL `py/full-ssrf` (#12278) flagged 4 outbound-request sinks where a
user-controlled URL reaches an HTTP call. The canonical
`autobot_shared/security/ssrf_guard.py` already provides scheme validation,
public-IP resolution and a DNS-rebind-defeating pinned connector. Rather than
add ad-hoc checks, each flagged sink now routes through that guard, and the two
genuinely-mitigated sinks carry the repo's inline `# codeql[py/full-ssrf]`
annotation with justification.

## What Changed

- **`skills/external_importer.py` — alert #565 (`import_http_catalog`, real gap).**
  Previously did a `is_public_url_async()` *check* then a fresh `session.get()`
  that re-resolved DNS (DNS-rebind TOCTOU). Now a new `_validate_catalog_url()`
  helper enforces http/https scheme + present hostname + public IP, and the
  fetch uses `ssrf_guard.pinned_connector()` (resolve-once + IP pin) with
  `allow_redirects=False`. Also fixes 2 pre-existing failing tests that expected
  distinct `must use http or https scheme` / `missing hostname` messages.
- **`api/provider_auth.py` — alerts #965 & #968 (false positives, already guarded).**
  The `exchange_code` and device-flow `http.post` sinks are already protected by
  `_validate_outbound_url()` (https + host allowlist + port pin) **and**
  `_pinned_connector()` (IP pin defeating DNS-rebind, redirects disabled). Added
  `# codeql[py/full-ssrf]` inline suppressions with justification on all three
  outbound calls (both flagged + the equivalent `device_poll` sink).
- **`autobot_shared/security/ssrf_guard.py` — alert #578 (false positive).** The
  flagged `fetch_safe_url` sink IS the guard (scheme-validated, public-IP
  resolved, pinned resolver, `allow_redirects=False`) and already carries an
  inline `# codeql[py/full-ssrf]` annotation on the sink line. No change needed;
  the stale alert line (164) maps to the annotated sink on re-scan.

## Verification

- `ast.parse` clean on all 4 changed files.
- `python3 -m pytest skills/test_external_importer_ssrf.py skills/external_importer_test.py api/tests/test_provider_auth_ssrf.py api/tests/test_provider_auth_oauth_state.py api/tests/test_provider_auth_device_poll_limit.py` → **61 passed**.
- New tests prove private/loopback/metadata (`169.254.169.254`, `127.0.0.1`, `10.x`) URLs are **blocked** and valid public URLs pass, for both the catalog fetch and the provider-auth guards; a DNS-rebind case (check passes, resolve sees private IP) is rejected.
- `black --check --line-length 120 --target-version py310` clean; `flake8 --max-line-length 120` clean.

## Model Used

claude-opus-4-8

Closes #12278
