### PR TITLE
fix(security): bump vulnerable transitive npm deps in lockfiles (#12295)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -11989,9 +11989,9 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/package-lock.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/package-lock.json
@@ -1549,9 +1549,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3557,9 +3557,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/autobot-slm-frontend/package-lock.json
+++ b/autobot-slm-frontend/package-lock.json
@@ -3940,9 +3940,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4386,9 +4386,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5026,9 +5026,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/libs/autobot-sdk-ts/package-lock.json
+++ b/libs/autobot-sdk-ts/package-lock.json
@@ -1238,9 +1238,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2734,9 +2734,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Thinking Path
Dependabot flagged vulnerable transitive npm deps across six lockfiles. This is a WSL environment with no Linux npm, so `npm audit fix` is unavailable — each lockfile was edited by hand, fetching `resolved` tarball URLs and `integrity` hashes from the npm registry. For every vulnerable package I found all occurrences in the lockfile `packages` map (top-level and nested), bumped only those in a vulnerable range to the lowest patched release that still satisfies each consumer's declared semver range (respecting the existing major), verified the new version's `dependencies` field was unchanged, kept edits surgical (version/resolved/integrity only), and deferred anything that would require a tree restructure npm alone can do.

## What Changed
Surgical `package-lock.json` bumps (version + resolved + integrity):

- `autobot-frontend`: `protobufjs` 7.6.4 -> 7.6.5. (`brace-expansion` already 5.0.7.)
- `autobot-slm-frontend`: `brace-expansion` 5.0.6 -> 5.0.7; `editorconfig/**/brace-expansion` 2.1.1 -> 2.1.2; `glob/**/brace-expansion` 2.1.1 -> 2.1.2.
- `libs/autobot-sdk-ts`: `brace-expansion` 1.1.15 -> 1.1.16; `js-yaml` 3.14.2 -> 3.15.0.
- `autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking`: `brace-expansion` 1.1.15 -> 1.1.16; `filelist/**/brace-expansion` 2.1.1 -> 2.1.2; `js-yaml` 3.14.2 -> 3.15.0.

No change needed (already at/above patched): `.mcp` and `mcp-autobot-tracker` — `body-parser` 2.3.0, `fast-uri` 3.1.4, `hono` 4.12.31.

### Deferred (require npm / transitive-parent update — not surgically fixable)
- `js-yaml` in `autobot-frontend` (-> 4.3.0): sole consumer `@redocly/openapi-core@1.34.17` pins `js-yaml` to exactly `4.2.0`.
- `@hono/node-server` in the three MCP lockfiles (-> 2.0.5): required by `@modelcontextprotocol/sdk` with `^1.19.9` (excludes 2.x); no 1.x patch exists.
- `@babel/core` in `mcp-structured-thinking` (-> 7.29.6): cascades into ~10 coupled `@babel/*` packages plus an `@ampproject/remapping` -> `@jridgewell/remapping` swap.

## Verification
- All four edited lockfiles validate as JSON (`python3 -c "import json;json.load(...)"`).
- `git diff` touches only `version`/`resolved`/`integrity` lines — no reformatting or key reordering.
- Grep confirms no vulnerable versions remain for the surgically bumped packages (`brace-expansion` 1.1.16 / 2.1.2 / 5.0.7, `js-yaml` 3.15.0, `protobufjs` 7.6.5).
- Each new version's registry `dependencies` field matches the prior version's (pure re-pin, no tree changes).

## Model Used
claude-opus-4-8

Refs Dependabot npm alerts (brace-expansion, js-yaml, protobufjs, @hono/node-server, @babel/core, body-parser, fast-uri, hono).
Closes #12295
