### PR TITLE
docs(readme): label SLM as service lifecycle management, not fleet management (#12045)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Your data stays on your machines. Your AI stays yours.
 |---|---|
 | Chat interface | Your prompts |
 | RAG knowledge base | Your documents |
-| Fleet management | Your infrastructure |
+| Service lifecycle management (SLM) | Your infrastructure |
 | Module ecosystem | Your data |
 
 ## The Platform Model
@@ -250,7 +250,7 @@ AutoBot runs as a coordinated set of services:
 |---------|------|------|
 | **Frontend** | Vue.js UI, TLS termination | 80, 443 |
 | **Backend** | FastAPI API server | 8001 |
-| **SLM** | Service Lifecycle Manager — fleet deploy/operate/scale | (via dashboard `/slm`) |
+| **SLM** | Service Lifecycle Manager — deploys, operates, and scales AutoBot's own services | (via dashboard `/slm`) |
 | **Redis** | Cache, message queue | 6379 |
 | **PostgreSQL** | Relational database | 5432 |
 | **ChromaDB** | Vector embeddings store | 8100 |


### PR DESCRIPTION
## Thinking Path

The README hero capability table advertised **"Fleet management"** as a headline capability. That phrasing reads as *managing a fleet of agents*, which is the wrong mental model for what the component does.

**SLM = Service Lifecycle Manager**: it manages the services AutoBot itself requires — vector DB, cache, relational DB, inference, background workers — across deploy → operate → scale → self-update.

The Platform Model section (L42–47) already stated this correctly, including the *"never small language model"* note. So this is drift between two tables and the prose that governs them, not a new claim. Fix = align the tables to the prose, changing no meaning anywhere else.

## What Changed

| Location | Before | After |
|---|---|---|
| Hero table (L31) | `Fleet management` | `Service lifecycle management (SLM)` |
| Core Services (L253) | `Service Lifecycle Manager — fleet deploy/operate/scale` | `Service Lifecycle Manager — deploys, operates, and scales AutoBot's own services` |

**Deliberately not changed:** `docs/architecture/NETWORK_TOPOLOGY.md`, `docs/user-guide/01-installation.md`, and `docs/developer/AUTOBOT_REFERENCE.md` also say "fleet management", but there it denotes genuine multi-node operations (SSH to fleet nodes, monitoring) — correct usage, left alone.

## Verification

Docs-only; no code paths touched. Diff is 2 lines in 1 file.

```
$ grep -c "Fleet management" README.md
0

$ git diff origin/Dev_new_gui...HEAD --stat
 README.md | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

All 10 remaining SLM references in README.md now agree on the expansion and the scope of what it manages (L31, 42, 44, 46, 93, 127, 129, 195, 253, 273).

## Model Used

Claude Opus 4.8 (1M context)

---

Closes #12302
Umbrella: #12045 (stays open — wiki pages and ROADMAP metrics still outstanding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
