### PR TITLE
fix(security): suppress CodeQL FPs on safe torch.load + PKCE SHA-256 (#12279)

### DIFF
--- a/autobot-backend/training/completion_trainer.py
+++ b/autobot-backend/training/completion_trainer.py
@@ -295,7 +295,14 @@ class CompletionTrainer:
         if not checkpoint_path.exists():
             raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
 
-        checkpoint = torch.load(checkpoint_path, map_location=self.device, weights_only=True)
+        # `weights_only=True` restricts unpickling to tensors/plain data and refuses
+        # arbitrary global/reduce execution — the PyTorch-documented mitigation against
+        # pickle-based RCE (CodeQL false positive: its taint model does not treat this
+        # kwarg as a sanitizer). `version` only selects an on-disk filename the app
+        # itself wrote via `torch.save`, so the deserialized bytes are trusted.
+        checkpoint = torch.load(  # codeql[py/unsafe-deserialization]
+            checkpoint_path, map_location=self.device, weights_only=True
+        )
 
         # Restore model
         config = checkpoint["model_config"]

--- a/autobot-backend/training/completion_trainer_test.py
+++ b/autobot-backend/training/completion_trainer_test.py
@@ -8,14 +8,54 @@ Completion Trainer Tests (Issue #904)
 Tests for ML model training infrastructure.
 """
 
+import pickle
 import tempfile
 from pathlib import Path
 
+import pytest
 import torch
 
 from training.completion_model import CompletionModel
 from training.data_loader import Tokenizer
 from training.evaluator import CompletionEvaluator
+
+# Module-level marker used by the malicious-pickle test below. A crafted
+# checkpoint whose __reduce__ targets this function would flip the flag if the
+# payload were ever executed during deserialization.
+_PICKLE_PAYLOAD = {"executed": False}
+
+
+def _record_payload_execution():
+    """Reduce target for the malicious-pickle gadget (harmless side effect)."""
+    _PICKLE_PAYLOAD["executed"] = True
+    return {}
+
+
+class _MaliciousCheckpoint:
+    """Object whose unpickling would invoke ``_record_payload_execution``."""
+
+    def __reduce__(self):
+        return (_record_payload_execution, ())
+
+
+def test_load_checkpoint_rejects_malicious_pickle():
+    """torch.load(weights_only=True) must refuse code-executing checkpoints (CodeQL #983).
+
+    Proves the py/unsafe-deserialization mitigation: the restricted unpickler
+    rejects a crafted checkpoint before any embedded reduce gadget can run.
+    """
+    _PICKLE_PAYLOAD["executed"] = False
+    with tempfile.TemporaryDirectory() as tmpdir:
+        malicious_path = Path(tmpdir) / "malicious.pt"
+        with open(malicious_path, "wb") as f:
+            pickle.dump(_MaliciousCheckpoint(), f)
+
+        # weights_only=True (the sink used in CompletionTrainer.load_checkpoint)
+        # must raise rather than execute the embedded gadget.
+        with pytest.raises(Exception):
+            torch.load(malicious_path, map_location="cpu", weights_only=True)
+
+        assert _PICKLE_PAYLOAD["executed"] is False, "malicious payload was executed"
 
 
 def test_tokenizer_initialization():

--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -106,6 +106,9 @@ def test_pkce_challenge_s256_matches_rfc7636():
     verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
     expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest()).rstrip(b"=").decode("ascii")
     assert _pkce_challenge_s256(verifier) == expected
+    # RFC 7636 Appendix B literal reference value — independent oracle proving the
+    # transform is the spec-mandated SHA-256 S256 method (CodeQL alert #920 FP).
+    assert _pkce_challenge_s256(verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
 
 def test_pkce_challenge_is_url_safe_and_unpadded():

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -72,7 +72,11 @@ def _extract_redirect_url(saml_result: Any) -> str | None:
 
 def _pkce_challenge_s256(verifier: str) -> str:
     """Derive the RFC 7636 S256 code_challenge from a code_verifier."""
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    # RFC 7636 §4.2 mandates SHA-256 for the S256 code_challenge transform. `verifier`
+    # is an ephemeral, high-entropy code_verifier — not a stored password — so a slow
+    # password KDF is inapplicable and would break OAuth PKCE interoperability (CodeQL
+    # false positive: it misclassifies the verifier as password material).
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()  # codeql[py/weak-sensitive-data-hashing]
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 


### PR DESCRIPTION
## Thinking Path

Issue #12279 tracks two CodeQL alerts: **#983 `py/unsafe-deserialization`** (`completion_trainer.py:298`) and **#920 `py/weak-sensitive-data-hashing`** (`sso_service.py:75`). Inspecting the exact alert commit (`0afb93b4`) and current `main`, both flagged lines are **already safe**, so both alerts are false positives:

- **#983** — `torch.load(..., weights_only=True)`. `weights_only=True` (added in #1567) is the PyTorch-documented mitigation that restricts unpickling to tensors/plain data and refuses arbitrary global/reduce execution. CodeQL's taint model treats `torch.load` as a deserialization sink but does not recognize this kwarg as a sanitizer. The only user-influenced input (`version`) selects an on-disk filename the app itself wrote via `torch.save` — trusted bytes.
- **#920** — `hashlib.sha256(verifier.encode("ascii"))` derives the RFC 7636 §4.2 **S256 PKCE `code_challenge`**. The input is an ephemeral, high-entropy `code_verifier`, not a stored password; a slow password KDF is inapplicable and would break OAuth PKCE interoperability. CodeQL misclassifies the verifier as password material. (Same rule is already suppressed on the same grounds in `api_key_service.py`.)

Resolution follows the task's justified-suppression path, matching the repo's existing `# codeql[...]` convention (135 instances).

## What Changed

- `autobot-backend/training/completion_trainer.py` — added `# codeql[py/unsafe-deserialization]` on the `torch.load(` line plus a prose trust-boundary justification.
- `autobot-slm-backend/user_management/services/sso_service.py` — added `# codeql[py/weak-sensitive-data-hashing]` on the SHA-256 line plus RFC 7636 justification.
- `autobot-backend/training/completion_trainer_test.py` — new `test_load_checkpoint_rejects_malicious_pickle`: crafts a checkpoint whose `__reduce__` gadget would run code, asserts `torch.load(weights_only=True)` raises and the gadget never executes.
- `autobot-slm-backend/tests/services/test_sso_service.py` — strengthened `test_pkce_challenge_s256_matches_rfc7636` with the literal RFC 7636 Appendix B reference value (independent oracle).

No behavior change; no serialization-format change, so no backward-compat handling needed (on-disk checkpoints are unaffected).

## Verification

- `black --check --line-length 120 --target-version py310` — all 4 files unchanged.
- `flake8 --max-line-length 120` — exit 0.
- `ast.parse` — clean on all 4 files.
- `pytest tests/services/test_sso_service.py -k pkce` — **10 passed**.
- Malicious-pickle gadget validated offline: unrestricted unpickle executes the payload (real gadget); a restricted unpickler (as `weights_only=True` uses) raises `UnpicklingError` without executing — confirming the new test proves the mitigation. (`torch` is not installed locally; the trainer test runs in CI's backend image.)

## Model Used

claude-opus-4-8

Closes #12279
