### PR TITLE
fix(security): stop stack-trace exposure to HTTP clients (#12286)

### DIFF
--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -614,7 +614,8 @@ async def get_historical_trends(
             historical_data["total_historical_calls"] = len(historical_calls)
 
     except Exception as e:
-        historical_data["redis_error"] = str(e)
+        logger.error("Error retrieving historical analytics from Redis: %s", e)
+        historical_data["redis_error"] = "Failed to retrieve historical analytics data"
 
     return historical_data
 

--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -868,7 +868,7 @@ async def get_git_repo_info() -> Metadata:
 
             except Exception as e:
                 logger.error("Error getting repo info: %s", e)
-                repo_info["error"] = str(e)
+                repo_info["error"] = "Failed to read repository info"
 
         repos_info.append(repo_info)
 

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -3048,7 +3048,7 @@ async def create_watch_folder(
         logger.error("Error creating watch folder: %s", e)
         return {
             "success": False,
-            "message": f"Error: {str(e)}",
+            "message": "Failed to create watch folder due to an internal error",
         }
 
 
@@ -3124,7 +3124,7 @@ async def delete_watch_folder(
         logger.error("Error deleting watch folder: %s", e)
         return {
             "success": False,
-            "message": f"Error: {str(e)}",
+            "message": "Failed to delete watch folder due to an internal error",
         }
 
 
@@ -3164,7 +3164,7 @@ async def control_watch_folder(
         logger.error("Error controlling watch folder: %s", e)
         return {
             "success": False,
-            "message": f"Error: {str(e)}",
+            "message": "Failed to update watch folder due to an internal error",
         }
 
 

--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -210,6 +210,8 @@ async def ingest_response_done(session_id: str, body: ResponseDoneRequest) -> di
         await telemetry.check_caps(session_id)
     except CapBreachError as exc:
         await telemetry.session_end(session_id=session_id, reason=exc.reason)
+        # codeql[py/stack-trace-exposure] CapBreachError carries an intentional, hardcoded
+        # client-facing cap-breach notice (e.g. "session ended: N minute limit reached"), not a stack trace.
         return {"status": "cap_breach", "reason": exc.reason.value, "message": str(exc)}
     return {"status": "ok"}
 

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -428,6 +428,8 @@ async def get_kb_ancestry_collections(
     return [
         KbAncestryCollection(
             collection_name=collection_name,
+            # codeql[py/stack-trace-exposure] False positive: the ValueError above is caught and
+            # re-raised as a generic HTTPException; no exception data flows into this response.
             company_id=collection_name.split(":")[0],
             weight=weight,
         )

--- a/autobot-backend/tests/api/test_stack_trace_exposure.py
+++ b/autobot-backend/tests/api/test_stack_trace_exposure.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Issue #12286: stack-trace / exception-detail must never reach the HTTP client.
+
+CodeQL py/stack-trace-exposure flagged several handlers that returned
+``str(exception)`` in the response body. These tests assert the fixed handlers:
+
+  1. Return a generic, exception-free message to the client, and
+  2. Still log the full exception detail server-side (no swallowed errors).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# A distinctive marker that must never appear in a client-facing response body,
+# standing in for internal paths / exception text a raw str(exc) would leak.
+INTERNAL_MARKER = "INTERNAL-DETAIL-MARKER-at-var-log-autobot-line-42"
+
+
+@pytest.mark.asyncio
+async def test_delete_watch_folder_hides_exception_but_logs_it(caplog):
+    """knowledge.delete_watch_folder: generic client message, full detail logged."""
+    from api import knowledge
+    from services.kb_folder_watcher import get_kb_folder_watcher
+
+    # Patch the singleton the handler will resolve, so remove_watch_folder raises
+    # with an exception carrying an internal marker.
+    watcher = get_kb_folder_watcher()
+    with patch.object(watcher, "remove_watch_folder", AsyncMock(side_effect=RuntimeError(INTERNAL_MARKER))):
+        with caplog.at_level(logging.ERROR):
+            result = await knowledge.delete_watch_folder(folder_id="folder-123")
+
+    assert result["success"] is False
+    # Client body leaks neither the exception message nor its class name.
+    assert INTERNAL_MARKER not in result["message"]
+    assert "RuntimeError" not in result["message"]
+    assert result["message"] == "Failed to delete watch folder due to an internal error"
+    # But the server still records the real detail.
+    assert INTERNAL_MARKER in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_historical_trends_hides_redis_error_but_logs_it(caplog):
+    """analytics.get_historical_trends: Redis failure is logged, not exposed."""
+    from api import analytics
+
+    redis_conn = MagicMock()
+    redis_conn.lrange = AsyncMock(side_effect=RuntimeError(INTERNAL_MARKER))
+
+    with patch.object(analytics.analytics_controller, "detect_trends", AsyncMock(return_value={})):
+        with patch.object(
+            analytics.analytics_controller,
+            "get_redis_connection",
+            AsyncMock(return_value=redis_conn),
+        ):
+            with caplog.at_level(logging.ERROR):
+                result = await analytics.get_historical_trends(hours=24)
+
+    body = str(result)
+    assert INTERNAL_MARKER not in body
+    assert "RuntimeError" not in body
+    assert result["redis_error"] == "Failed to retrieve historical analytics data"
+    assert INTERNAL_MARKER in caplog.text

--- a/autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py
+++ b/autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py
@@ -1283,7 +1283,8 @@ class WindowsNPUWorker:
                     info["available_providers"] = manager_info.get("available_providers", [])
                     info["directml_available"] = manager_info.get("directml_available", False)
                 except Exception as e:
-                    info["model_manager_error"] = str(e)
+                    logger.error("Error getting model manager device info: %s", e)
+                    info["model_manager_error"] = "Failed to retrieve model manager info"
             else:
                 info["model_manager"] = None
                 info["selected_device"] = "MOCK (no model manager)"


### PR DESCRIPTION
## Thinking Path

CodeQL `py/stack-trace-exposure` raised 10 open alerts (#12286) where handlers returned `str(exception)` / exception detail in the HTTP response body. Triaged each: 6 are real exposures (fix by returning a generic client message + logging full detail server-side), 4 are false positives (2 already carried inline suppressions; 2 return controlled/already-sanitized data). No exceptions were swallowed — every fixed path logs via `logging.getLogger(__name__)`.

## What Changed

Real fixes (generic client message, full detail logged server-side):
- `autobot-backend/api/knowledge.py:3049,3125,3165` — watch-folder create/delete/control returned `f"Error: {str(e)}"` → generic messages (already logged).
- `autobot-backend/api/git_mcp.py:871` — per-repo `error` field returned `str(e)` → `"Failed to read repository info"` (already logged).
- `autobot-backend/api/analytics.py:617` — `redis_error` returned `str(e)` and was **not logged** (swallowed) → now `logger.error(...)` + generic message.
- `autobot-npu-worker/.../npu_worker.py:1286` — `/device-info` returned `model_manager_error = str(e)` → now `logger.error(...)` + generic message.

False positives (inline `# codeql[py/stack-trace-exposure]` with justification):
- `autobot-backend/api/realtime_session.py:213` — `str(exc)` is a `CapBreachError` carrying an intentional hardcoded client-facing cap-breach notice, not a stack trace.
- `autobot-backend/llc/api/companies.py:431` — flagged line is a benign string split; the `ValueError` above is already caught and re-raised as a generic `HTTPException`.

Already suppressed inline (no change): `autobot-backend/api/knowledge_mcp.py:759,766` — MCP structured errors to the AI agent, pre-existing justified suppressions (alerts #576/#577).

Tests: `autobot-backend/tests/api/test_stack_trace_exposure.py` — asserts fixed handlers return exception-free bodies (no marker, no `RuntimeError` class name) while the server still logs the full detail.

## Verification

- `python3 -m black --check --line-length 120` — all files unchanged.
- `python3 -m flake8 --max-line-length 120` — exit 0.
- `ast.parse` — clean on all 6 touched Python files.
- `pytest tests/api/test_stack_trace_exposure.py` — 2 passed.
- `pytest tests/api/test_analytics_quality_history.py` — 14 passed (no import regression).

## Model Used

claude-opus-4-8 (Opus 4.8)

Closes #12286
