### PR TITLE
fix(security): resolve clear-text storage code-scanning alerts (#12283)

### DIFF
--- a/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_secrets_ownership.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_secrets_ownership.py
@@ -325,7 +325,10 @@ class SecretsMigrator:
 
         # Save rollback SQL
         if not self.dry_run:
-            rollback_file = Path("/tmp/secrets_migration_rollback.sql")
+            # FP: rollback SQL contains only identifiers/metadata
+            # (secret_id, owner_id, scope) — never the secret value itself
+            # (see rollback_sql.append above). No sensitive material is stored.
+            rollback_file = Path("/tmp/secrets_migration_rollback.sql")  # codeql[py/clear-text-storage-sensitive-data]
             rollback_file.write_text("\n".join(self.rollback_sql))
             logger.info("Rollback SQL saved to: %s", rollback_file)
 

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
@@ -546,7 +546,9 @@ class MigrationValidator:
         logger.info("\n%s", report)
 
         # Save to file
-        report_file = Path("/tmp/migration_validation_report.txt")
+        # FP: report contains only counts, secret IDs and validation
+        # messages — never secret values (see generate_report / issues[]).
+        report_file = Path("/tmp/migration_validation_report.txt")  # codeql[py/clear-text-storage-sensitive-data]
         report_file.write_text(report)
         logger.info("\nReport saved to: %s", report_file)
 

--- a/autobot-infrastructure/shared/scripts/security/mtls-migrate.py
+++ b/autobot-infrastructure/shared/scripts/security/mtls-migrate.py
@@ -85,9 +85,11 @@ class MTLSMigration:
             f"REDIS_ADMIN_USER={username}\n"
             f"REDIS_ADMIN_PASSWORD={password}\n"  # noqa: S105
         )
-        with open(self.ADMIN_CREDS_FILE, "w", encoding="utf-8") as f:
-            # Emergency recovery credentials, secured by 0o600 perms
-            f.write(creds_content)  # lgtm[py/clear-text-storage-sensitive-data]
+        # Intentional, accepted-risk storage: emergency recovery credentials
+        # written to a gitignored file with 0o600 perms (chmod below). Not a
+        # false positive — deliberately suppressed with justification.
+        with open(self.ADMIN_CREDS_FILE, "w", encoding="utf-8") as f:  # codeql[py/clear-text-storage-sensitive-data]
+            f.write(creds_content)  # codeql[py/clear-text-storage-sensitive-data]
         # Secure file permissions (owner read/write only)
         os.chmod(self.ADMIN_CREDS_FILE, 0o600)
         logger.info(
@@ -313,7 +315,7 @@ class MTLSMigration:
         try:
             r = redis.Redis(host=redis_ip, port=6379, socket_timeout=5)
             r.ping()
-            logger.info(f"  Plain connection (6379): OK")
+            logger.info("  Plain connection (6379): OK")
             r.close()
         except Exception as e:
             logger.error(f"  Plain connection (6379): FAILED - {e}")

--- a/autobot-infrastructure/shared/scripts/security_scan.py
+++ b/autobot-infrastructure/shared/scripts/security_scan.py
@@ -385,8 +385,10 @@ class SecurityScanner:
             json.dump(self.scan_results, f, indent=2)
 
         # Save markdown summary
+        # FP: the markdown report is a summary of counts/status only
+        # (see generate_markdown_report) — no secret values are written.
         md_report_path = self.reports_dir / f"security_summary_{timestamp}.md"
-        with open(md_report_path, "w") as f:
+        with open(md_report_path, "w") as f:  # codeql[py/clear-text-storage-sensitive-data]
             f.write(self.generate_markdown_report())
 
         logger.info("📄 Reports saved to:")

--- a/autobot-slm-backend/services/replication.py
+++ b/autobot-slm-backend/services/replication.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Tuple
@@ -526,7 +527,11 @@ class ReplicationService:
         redis_password: str,
     ) -> bool:
         """Run Ansible playbook to configure Redis replication."""
-        # Create ad-hoc playbook for replication
+        # Create ad-hoc playbook for replication.
+        # The credential is NOT written into the playbook file; it is resolved
+        # at run time from the controller environment via Ansible's `env`
+        # lookup, so no clear-text credential is ever persisted to disk.
+        auth = "{{ lookup('env', 'AUTOBOT_REDIS_REPL_AUTH') }}"
         playbook_content = f"""---
 - name: Configure Redis Replication
   hosts: all
@@ -538,11 +543,11 @@ class ReplicationService:
         redis_replication_mode: replica
         redis_master_host: "{master_ip}"
         redis_master_port: 6379
-        redis_master_auth: "{redis_password}"
-        redis_password: "{redis_password}"
+        redis_master_auth: "{auth}"
+        redis_password: "{auth}"
 """
 
-        # Write temporary playbook
+        # Write temporary playbook (contains no secrets)
         playbook_path = self.ansible_dir / "temp_replication.yml"
         playbook_path.write_text(playbook_content, encoding="utf-8")
 
@@ -560,11 +565,14 @@ class ReplicationService:
                 "ansible_ssh_common_args='-o StrictHostKeyChecking=accept-new'",
             ]
 
+            # Pass the credential via the environment (never persisted to disk).
+            playbook_env = {**os.environ, "AUTOBOT_REDIS_REPL_AUTH": redis_password}
             process = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=str(self.ansible_dir),
+                env=playbook_env,
             )
 
             stdout, _ = await asyncio.wait_for(process.communicate(), timeout=300)

--- a/autobot-slm-backend/tests/services/test_replication_no_plaintext_secret_12283.py
+++ b/autobot-slm-backend/tests/services/test_replication_no_plaintext_secret_12283.py
@@ -1,0 +1,104 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression guard for clear-text storage of the Redis replication password.
+
+Issue #12283 / CodeQL alert #993 (py/clear-text-storage-sensitive-data):
+``_run_ansible_replication`` previously embedded the Redis password directly
+into the ad-hoc Ansible playbook written to disk. These tests prove the
+plaintext credential is NEVER written to the playbook file and is instead
+passed to the ansible-playbook subprocess through the environment.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── Load the REAL services.replication (#12283) ──────────────────────────────
+# The slm-backend root conftest stubs ``services.replication`` as a MagicMock
+# (it is an api import); pop the stub, import the real module through the
+# hollow ``services`` package, then restore the stub for sibling tests.
+_REPL_KEY = "services.replication"
+_orig_repl = sys.modules.get(_REPL_KEY)
+sys.modules.pop(_REPL_KEY, None)
+try:
+    _repl_mod = importlib.import_module(_REPL_KEY)
+finally:
+    if _orig_repl is not None:
+        sys.modules[_REPL_KEY] = _orig_repl
+    else:
+        sys.modules.pop(_REPL_KEY, None)
+
+ReplicationService = _repl_mod.ReplicationService
+
+_SECRET_PW = "S3cr3t-Replica-Pw-12283"
+
+
+def _service(tmp_path: Path) -> "ReplicationService":
+    # __new__ skips __init__ (which only builds ansible_dir from settings);
+    # the ansible runner does not touch other instance state.
+    svc = ReplicationService.__new__(ReplicationService)
+    svc.ansible_dir = tmp_path
+    return svc
+
+
+async def _run_capture(tmp_path: Path) -> dict:
+    """Invoke _run_ansible_replication with a mocked subprocess and capture
+    the playbook-file content (while it exists) plus the subprocess env."""
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        # args: ("ansible-playbook", "<playbook_path>", "-i", ...)
+        playbook_path = Path(args[1])
+        captured["content"] = playbook_path.read_text(encoding="utf-8")
+        captured["env"] = kwargs.get("env")
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", None))
+        proc.returncode = 0
+        return proc
+
+    with patch.object(_repl_mod.asyncio, "create_subprocess_exec", new=fake_exec):
+        captured["result"] = await _service(tmp_path)._run_ansible_replication(
+            target_ip="10.0.0.5",
+            ssh_user="autobot",
+            ssh_port=22,
+            master_ip="10.0.0.1",
+            redis_password=_SECRET_PW,
+        )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_password_not_written_to_playbook_file(tmp_path):
+    """The plaintext Redis password must never appear in the on-disk playbook."""
+    captured = await _run_capture(tmp_path)
+    assert _SECRET_PW not in captured["content"], "plaintext password leaked into playbook file"
+    # Indirection marker: the file references the env var, not the value.
+    assert "lookup('env', 'AUTOBOT_REDIS_REPL_AUTH')" in captured["content"]
+
+
+@pytest.mark.asyncio
+async def test_password_passed_via_environment(tmp_path):
+    """The credential must reach ansible via the subprocess environment."""
+    captured = await _run_capture(tmp_path)
+    assert captured["env"] is not None, "subprocess env not supplied"
+    assert captured["env"]["AUTOBOT_REDIS_REPL_AUTH"] == _SECRET_PW
+    assert captured["result"] is True
+
+
+@pytest.mark.asyncio
+async def test_nonsensitive_master_ip_still_templated(tmp_path):
+    """Non-sensitive master IP is still interpolated into the playbook."""
+    captured = await _run_capture(tmp_path)
+    assert "10.0.0.1" in captured["content"]
+
+
+@pytest.mark.asyncio
+async def test_temp_playbook_is_cleaned_up(tmp_path):
+    """The temp playbook must be removed after the run (no lingering file)."""
+    await _run_capture(tmp_path)
+    assert not (tmp_path / "temp_replication.yml").exists()


### PR DESCRIPTION
## Thinking Path

Issue #12283 tracks 5 open CodeQL `py/clear-text-storage-sensitive-data` alerts (#41, #762, #763, #764, #993). Established ground truth first: read each flagged sink and traced what data actually reaches disk. Only one alert stores real credential material; the rest store identifiers/counts/metadata or are intentional, mitigated storage.

## What Changed

**Real fix — #993 `autobot-slm-backend/services/replication.py:547`**
The ad-hoc Ansible replication playbook embedded the Redis password in clear text before writing it to `temp_replication.yml`. Now the playbook references the credential via `lookup('env', 'AUTOBOT_REDIS_REPL_AUTH')` and the value is passed through the subprocess environment — no plaintext is ever persisted to disk. This breaks the CodeQL taint path (the written content no longer contains the password) rather than merely suppressing it.

**False positives — inline `# codeql[...]` suppression with justification**
- #762 `migrate_secrets_ownership.py:328` — rollback SQL contains only `secret_id`/`owner_id`/`scope` (identifiers/metadata), never the secret value.
- #764 `validate_migration.py:549` — report contains only counts, secret IDs and validation messages.
- #41 `security_scan.py:389` — markdown report is status/count summary only (template is not even an f-string).

**Intentional, accepted-risk storage — #763 `mtls-migrate.py:89`**
Emergency-recovery Redis admin credentials written to a gitignored file with `0o600` perms (chmod immediately after). Replaced the deprecated `lgtm[]` marker with the repo-standard `# codeql[...]` suppression.

**In-scope cleanup**: fixed a pre-existing F541 (f-string without placeholder) in `mtls-migrate.py`.

## Verification

- `black --check --line-length 120` — 6 files unchanged.
- `flake8 --max-line-length 120` — exit 0.
- `ast.parse` clean on all touched Python.
- New regression test `test_replication_no_plaintext_secret_12283.py` (4 tests, all pass): asserts the plaintext password is absent from the on-disk playbook, that the file references the env lookup, that the credential is passed via the subprocess env, and that the temp playbook is cleaned up.

## Model Used

claude-opus-4-8

Closes #12283
