### PR TITLE
fix(security): pin minimum TLS version to 1.2 for log forwarder (#12285)

### DIFF
--- a/autobot-infrastructure/shared/scripts/logging/log_forwarder.py
+++ b/autobot-infrastructure/shared/scripts/logging/log_forwarder.py
@@ -52,6 +52,7 @@ sys.path.insert(0, str(_REPO_ROOT / "autobot_shared"))
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from autobot_shared.time_utils import parse_utc_iso  # noqa: E402
+from autobot_shared.tls import MIN_TLS_VERSION  # noqa: E402
 
 try:
     import docker
@@ -447,7 +448,6 @@ class LokiDestination(LogDestination):
         Groups entries by (source, level) to create efficient streams.
         """
         from collections import defaultdict
-        from datetime import datetime, timezone
 
         # Group entries by stream labels (source + level)
         streams_dict = defaultdict(list)
@@ -664,6 +664,8 @@ class SyslogDestination(LogDestination):
     def _create_ssl_context(self) -> ssl.SSLContext:
         """Create SSL context for TLS connections."""
         context = ssl.create_default_context()
+        # Reject the broken TLSv1/TLSv1_1 protocols (#12285); shared min version.
+        context.minimum_version = MIN_TLS_VERSION
 
         # Configure certificate verification
         if not self.config.ssl_verify:
@@ -1192,7 +1194,7 @@ class LogForwarder:
         # Wait for queue to empty
         try:
             self.log_queue.join()
-        except:
+        except Exception:
             pass
 
         self.logger.info("Log forwarding service stopped")

--- a/autobot-infrastructure/shared/scripts/logging/test_log_forwarder_tls.py
+++ b/autobot-infrastructure/shared/scripts/logging/test_log_forwarder_tls.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for log_forwarder TLS hardening (#12285).
+
+The syslog TCP_TLS destination must reject the broken TLSv1/TLSv1_1 protocols by
+pinning the shared minimum TLS version on the SSL context it wraps sockets with.
+"""
+
+import ssl
+import sys
+from pathlib import Path
+
+# Make ``log_forwarder`` importable regardless of the pytest rootdir.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from log_forwarder import DestinationConfig, DestinationType, SyslogDestination, SyslogProtocol  # noqa: E402
+
+
+def _tls_destination() -> SyslogDestination:
+    config = DestinationConfig(
+        name="test-syslog",
+        type=DestinationType.SYSLOG,
+        syslog_protocol=SyslogProtocol.TCP_TLS,
+    )
+    return SyslogDestination(config)
+
+
+def test_ssl_context_rejects_tls_below_1_2() -> None:
+    """_create_ssl_context enforces TLS >= 1.2 (#12285)."""
+    ctx = _tls_destination()._create_ssl_context()
+    assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
+
+
+def test_ssl_context_min_version_matches_shared_constant() -> None:
+    """The forwarder reuses the canonical autobot_shared.tls minimum version (#12285)."""
+    from autobot_shared.tls import MIN_TLS_VERSION
+
+    ctx = _tls_destination()._create_ssl_context()
+    assert ctx.minimum_version == MIN_TLS_VERSION

--- a/autobot_shared/tls.py
+++ b/autobot_shared/tls.py
@@ -18,6 +18,11 @@ from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
 
+# Canonical minimum TLS version for every AutoBot SSL context (#12285).
+# CodeQL py/insecure-protocol: pinning this rejects the broken TLSv1/TLSv1_1
+# protocols that ssl.create_default_context() is reported to still permit.
+MIN_TLS_VERSION: ssl.TLSVersion = ssl.TLSVersion.TLSv1_2
+
 # Hosts treated as loopback for TLS trust decisions (#6654).
 _LOOPBACK_HOSTS: frozenset = frozenset({"127.0.0.1", "localhost", "::1", "ip6-localhost"})
 
@@ -64,6 +69,8 @@ def get_internal_tls_context(
     For non-loopback production deployments configure ``AUTOBOT_TLS_CA_PATH``.
     """
     ctx = ssl.create_default_context()
+    # Reject the broken TLSv1/TLSv1_1 protocols on every path below (#12285).
+    ctx.minimum_version = MIN_TLS_VERSION
 
     # 1. Explicit CA path (mTLS callers resolve the path before calling)
     if ca_path and os.path.isfile(ca_path):

--- a/autobot_shared/tls_test.py
+++ b/autobot_shared/tls_test.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
-from autobot_shared.tls import _is_loopback_target, get_internal_tls_context
+from autobot_shared.tls import MIN_TLS_VERSION, _is_loopback_target, get_internal_tls_context
 
 
 class TestGetInternalTlsContext:
@@ -26,6 +26,26 @@ class TestGetInternalTlsContext:
         """Default call returns an ssl.SSLContext."""
         ctx = get_internal_tls_context()
         assert isinstance(ctx, ssl.SSLContext)
+
+    def test_minimum_tls_version_is_v1_2(self) -> None:
+        """Canonical constant pins the minimum TLS version to 1.2 (#12285)."""
+        assert MIN_TLS_VERSION == ssl.TLSVersion.TLSv1_2
+
+    def test_default_context_rejects_tls_below_1_2(self) -> None:
+        """Default (strict) context enforces the minimum TLS version (#12285)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = get_internal_tls_context()
+        assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
+
+    def test_loopback_context_still_enforces_min_tls_version(self) -> None:
+        """Even the permissive loopback path keeps TLS >= 1.2 (#12285)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = get_internal_tls_context("https://127.0.0.1:8000")
+        assert ctx.minimum_version == ssl.TLSVersion.TLSv1_2
 
     def test_verification_enabled_by_default(self) -> None:
         """Without any env vars, verification is not disabled."""


### PR DESCRIPTION
## Thinking Path
CodeQL `py/insecure-protocol` alerts #711 (line 711) and #712 (line 792) both point at the `context.wrap_socket(...)` sinks in `SyslogDestination` (`log_forwarder.py`). The context comes from `_create_ssl_context()` which calls `ssl.create_default_context()` without pinning a minimum TLS version, so CodeQL reports the broken TLSv1/TLSv1_1 protocols as still permitted.

The repo already has a canonical TLS factory — `autobot_shared/tls.py::get_internal_tls_context` (#6702) — but it too created contexts without an explicit `minimum_version`. Rather than duplicate any TLS logic, the minimum-version value is defined once and reused. The forwarder keeps its own config-driven context factory (external SIEM shipping needs the `ssl_verify` flag + cert-path allowlisting that the internal service-to-service helper does not provide, so replacing it wholesale would be a feature loss).

## What Changed
- `autobot_shared/tls.py`: added the single canonical constant `MIN_TLS_VERSION = ssl.TLSVersion.TLSv1_2` and pinned `ctx.minimum_version = MIN_TLS_VERSION` in `get_internal_tls_context` (hardens the canonical helper, which shared the same gap).
- `autobot-infrastructure/shared/scripts/logging/log_forwarder.py`: `_create_ssl_context()` now sets `context.minimum_version = MIN_TLS_VERSION`, reusing the canonical constant (imported via the same mechanism the module already uses for `autobot_shared.time_utils`). No second TLS-config implementation introduced.
- Fixed two pre-existing flake8 errors in the same file discovered along the way (Rule 6): redundant unused local `from datetime import datetime, timezone`, and a bare `except:` → `except Exception:`.
- Tests: extended `autobot_shared/tls_test.py` and added `logging/test_log_forwarder_tls.py` asserting both contexts enforce TLS >= 1.2 and reuse the shared constant.

## Verification
- `python -m black --check --line-length 120` — 4 files unchanged.
- `python -m flake8 --max-line-length 120` — clean (0).
- `ast.parse` — clean on all changed files.
- `pytest autobot_shared/tls_test.py logging/test_log_forwarder_tls.py` — 21 passed.
- Runtime probe: `SyslogDestination(...)._create_ssl_context().minimum_version == ssl.TLSVersion.TLSv1_2`.

## Model Used
claude-opus-4-8

Closes #12285
