### PR TITLE
fix(security): incomplete URL substring sanitization — reddit host parse + test FP suppressions (#12281)

### DIFF
--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+from urllib.parse import urlparse
 
 import httpx
 
@@ -28,6 +29,17 @@ logger = logging.getLogger(__name__)
 
 # Reddit API user-agent string.
 _USER_AGENT = "autobot-content-reach/1.0"
+
+
+def _is_reddit_url(url: str) -> bool:
+    """Return True only if *url*'s parsed hostname is reddit.com or a reddit.com subdomain.
+
+    Uses urlparse so a hostname boundary is enforced: a substring check like
+    ``"reddit.com" in url`` would wrongly match ``https://reddit.com.evil.com/``
+    or ``https://evil.com/?x=reddit.com`` (CodeQL py/incomplete-url-substring-sanitization).
+    """
+    host = (urlparse(url).hostname or "").lower()
+    return host == "reddit.com" or host.endswith(".reddit.com")
 
 
 class RedditJsonBackend(ContentBackend):
@@ -54,7 +66,7 @@ class RedditJsonBackend(ContentBackend):
         """Fetch Reddit posts; raise BackendError on network, HTTP, or parse failure."""
         headers = {"User-Agent": _USER_AGENT}
 
-        if request.url and "reddit.com" in request.url:
+        if request.url and _is_reddit_url(request.url):
             await ensure_public_url(request.url)
             url = request.url if request.url.endswith(".json") else request.url + ".json"
             try:

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -886,10 +886,10 @@ class TestGetOauthAllowedHosts:
         old = os.environ.pop(env_key, None)
         try:
             hosts = get_oauth_allowed_hosts()
-            assert "accounts.google.com" in hosts
-            assert "github.com" in hosts
-            assert "api.anthropic.com" in hosts
-            assert "login.microsoftonline.com" in hosts
+            assert "accounts.google.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
+            assert "github.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
+            assert "api.anthropic.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
+            assert "login.microsoftonline.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
         finally:
             if old is not None:
                 os.environ[env_key] = old
@@ -904,8 +904,8 @@ class TestGetOauthAllowedHosts:
         os.environ[env_key] = "custom.provider.com, other.example.com"
         try:
             hosts = get_oauth_allowed_hosts()
-            assert "custom.provider.com" in hosts
-            assert "other.example.com" in hosts
+            assert "custom.provider.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
+            assert "other.example.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
             assert "accounts.google.com" not in hosts
         finally:
             if old is None:

--- a/autobot-backend/tests/api/test_marketplace.py
+++ b/autobot-backend/tests/api/test_marketplace.py
@@ -125,7 +125,7 @@ class TestPluginSourceUrl:
 
     def test_contains_github(self):
         url = _plugin_source_url("test")
-        assert "github.com" in url or "http" in url
+        assert "github.com" in url or "http" in url  # codeql[py/incomplete-url-substring-sanitization]
 
     def test_different_slugs_differ(self):
         assert _plugin_source_url("a") != _plugin_source_url("b")

--- a/autobot-backend/tests/content_reach/backends/test_browser.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser.py
@@ -133,7 +133,7 @@ async def test_browser_search_builds_ddg_url(monkeypatch):
 
     # The URL passed to research_url must be the DDG search URL with encoded query
     assert stub_manager.last_url is not None
-    assert "duckduckgo.com" in stub_manager.last_url
+    assert "duckduckgo.com" in stub_manager.last_url  # codeql[py/incomplete-url-substring-sanitization]
     # Accept both + and %20 encoding — urllib.parse.quote_plus uses +
     assert "cats" in stub_manager.last_url
     assert "dogs" in stub_manager.last_url

--- a/autobot-backend/tests/content_reach/sources/test_reddit.py
+++ b/autobot-backend/tests/content_reach/sources/test_reddit.py
@@ -140,6 +140,61 @@ async def test_reddit_url_mode_no_double_json():
 
 
 # ---------------------------------------------------------------------------
+# RedditJsonBackend — reddit host detection (#12281 incomplete-url-substring)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://reddit.com/r/python",
+        "https://www.reddit.com/r/python",
+        "https://old.reddit.com/r/python",
+        "https://REDDIT.COM/r/python",
+    ],
+)
+def test_is_reddit_url_accepts_genuine_reddit_hosts(url):
+    """Exact host and reddit.com subdomains are recognised as reddit URLs."""
+    from content_reach.sources.reddit import _is_reddit_url
+
+    assert _is_reddit_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://reddit.com.evil.com/r/python",  # suffix-attached lookalike
+        "https://evil.com/?redirect=reddit.com",  # substring in query
+        "https://notreddit.com/r/python",  # missing dot boundary
+        "https://reddit.com.attacker.net/",
+        "https://evilreddit.com/",
+    ],
+)
+def test_is_reddit_url_rejects_bypass_payloads(url):
+    """Lookalike hosts that a substring check would accept are rejected."""
+    from content_reach.sources.reddit import _is_reddit_url
+
+    assert _is_reddit_url(url) is False
+
+
+@pytest.mark.asyncio
+async def test_reddit_spoofed_host_falls_back_to_search(monkeypatch):
+    """A reddit.com-lookalike URL is NOT fetched directly; it uses the search endpoint."""
+    import content_reach.sources.reddit as reddit_mod
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    monkeypatch.setattr(reddit_mod, "ensure_public_url", AsyncMock())
+    mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(url="https://reddit.com.evil.com/r/python", query="python")
+    await backend.fetch(request)
+
+    called_url = mock_client.get.call_args.args[0]
+    # Spoofed host must not be fetched directly; falls back to the reddit search endpoint.
+    assert called_url == "https://www.reddit.com/search.json"
+
+
+# ---------------------------------------------------------------------------
 # RedditJsonBackend — error cases
 # ---------------------------------------------------------------------------
 

--- a/autobot-backend/tests/content_reach/test_url_guard.py
+++ b/autobot-backend/tests/content_reach/test_url_guard.py
@@ -283,8 +283,9 @@ async def test_reddit_url_mode_ssrf_block_no_fetch(monkeypatch):
 
     mock_client = AsyncMock()
     backend = RedditJsonBackend(client=mock_client)
-    # reddit.com URL so the url-mode branch is taken
-    request = ContentRequest(url="http://10.0.0.1/reddit.com/r/test")
+    # Genuine reddit.com host so the url-mode branch is taken; the SSRF guard
+    # (_is_public_url_async stubbed False) must then block before any fetch.
+    request = ContentRequest(url="https://www.reddit.com/r/test")
 
     with pytest.raises(BackendError):
         await backend.fetch(request)
@@ -559,7 +560,7 @@ async def test_robots_cache_cleared_when_max_reached(monkeypatch):
 
     # After clear + add new, cache should contain exactly 1 entry.
     assert len(guard_mod._robots_cache) == 1
-    assert "http://new-domain.com" in guard_mod._robots_cache
+    assert "http://new-domain.com" in guard_mod._robots_cache  # codeql[py/incomplete-url-substring-sanitization]
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_web_research.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_web_research.py
@@ -140,9 +140,9 @@ def test_format_map_results() -> None:
 
     output = _format_map_results(site_result)
     assert "Mapped 2 URLs" in output
-    assert "example.com" in output
+    assert "example.com" in output  # codeql[py/incomplete-url-substring-sanitization]
     assert "sitemap" in output
-    assert "https://example.com/" in output
+    assert "https://example.com/" in output  # codeql[py/incomplete-url-substring-sanitization]
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +168,7 @@ async def test_exec_scrape_url_success() -> None:
     with patch("web_fetch.WebFetcher.fetch", new_callable=AsyncMock, return_value=mock_result):
         output = await mixin._exec_scrape_url({"url": "https://example.com", "render": "auto"})
 
-    assert "https://example.com" in output
+    assert "https://example.com" in output  # codeql[py/incomplete-url-substring-sanitization]
     assert "Hello world" in output
 
 

--- a/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
@@ -214,7 +214,7 @@ class TestCrawlDepth:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=1))
         results = await connector.crawl(["https://example.com"], max_depth=1, ingest=False, same_origin=True)
         fetched_urls = [r.url for r in results]
-        assert "https://example.com" in fetched_urls
+        assert "https://example.com" in fetched_urls  # codeql[py/incomplete-url-substring-sanitization]
         # With max_depth=1, only the seed (depth=0) is emitted; depth=1 links are
         # added to the frontier but rejected by add_links since depth > max_depth.
         assert "https://example.com/about" not in fetched_urls
@@ -224,7 +224,7 @@ class TestCrawlDepth:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=2))
         results = await connector.crawl(["https://example.com"], max_depth=2, ingest=False, same_origin=True)
         fetched_urls = {r.url for r in results}
-        assert "https://example.com" in fetched_urls
+        assert "https://example.com" in fetched_urls  # codeql[py/incomplete-url-substring-sanitization]
         assert "https://example.com/about" in fetched_urls
         assert "https://example.com/blog" in fetched_urls
         # /contact is linked from /about at depth=2; adding it would require
@@ -251,7 +251,7 @@ class TestSameOrigin:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=2))
         results = await connector.crawl(["https://example.com"], max_depth=2, ingest=False, same_origin=True)
         fetched_urls = {r.url for r in results}
-        assert not any("external.com" in u for u in fetched_urls)
+        assert not any("external.com" in u for u in fetched_urls)  # codeql[py/incomplete-url-substring-sanitization]
 
     async def test_same_origin_false_allows_external(self, mock_bs4, mock_robots_none) -> None:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=2, same_origin=False))

--- a/autobot-backend/tests/unit/test_search_web_fetch_full.py
+++ b/autobot-backend/tests/unit/test_search_web_fetch_full.py
@@ -186,7 +186,7 @@ class TestFormatFullSearchResults:
         ]
         output = _format_full_search_results("test query", entries)
         assert "Example" in output
-        assert "https://example.com" in output
+        assert "https://example.com" in output  # codeql[py/incomplete-url-substring-sanitization]
         assert "# Hello" in output
 
     def test_failed_entry_shows_fetch_error(self) -> None:

--- a/autobot-backend/tests/unit/web_fetch/test_frontier.py
+++ b/autobot-backend/tests/unit/web_fetch/test_frontier.py
@@ -117,7 +117,7 @@ class TestFrontier:
         f.add_links(["https://other.com/page", "https://example.com/about"], depth=1)
         item = f.next()
         assert item is not None
-        assert "example.com" in item[0]
+        assert "example.com" in item[0]  # codeql[py/incomplete-url-substring-sanitization]
         assert f.next() is None  # other.com was filtered
 
     def test_exhausted(self) -> None:

--- a/autobot-slm-backend/tests/api/test_auth_logout.py
+++ b/autobot-slm-backend/tests/api/test_auth_logout.py
@@ -185,7 +185,7 @@ class TestBuildEndSessionUrl:
         assert result is not None
         # urlencode percent-encodes the value; check the key is present and value is encoded
         assert "post_logout_redirect_uri=" in result
-        assert "app.example.com" in result
+        assert "app.example.com" in result  # codeql[py/incomplete-url-substring-sanitization]
 
     def test_appends_id_token_hint_when_present(self):
         link = _mock_sso_link(

--- a/autobot-slm-backend/tests/services/test_sso_logout.py
+++ b/autobot-slm-backend/tests/services/test_sso_logout.py
@@ -125,8 +125,9 @@ class TestOktaEndSessionEndpoint:
 
     def test_okta_end_session_uses_domain(self):
         template = _get_template("okta", domain="example.okta.com")
-        assert "example.okta.com" in template["end_session_endpoint"]
-        assert "/oauth2/v1/logout" in template["end_session_endpoint"]
+        endpoint = template["end_session_endpoint"]
+        assert "example.okta.com" in endpoint  # codeql[py/incomplete-url-substring-sanitization]
+        assert "/oauth2/v1/logout" in endpoint
 
 
 class TestMicrosoftEntraEndSessionEndpoint:
@@ -137,7 +138,7 @@ class TestMicrosoftEntraEndSessionEndpoint:
     def test_entra_end_session_uses_common_tenant(self):
         template = _get_template("microsoft_entra", domain="common")
         url = template["end_session_endpoint"]
-        assert "login.microsoftonline.com" in url
+        assert "login.microsoftonline.com" in url  # codeql[py/incomplete-url-substring-sanitization]
         assert "common" in url
         assert "oauth2/v2.0/logout" in url
 


### PR DESCRIPTION
## Thinking Path
Issue #12281 tracked 21 open CodeQL `py/incomplete-url-substring-sanitization` alerts (all high, tool=CodeQL — none semgrep). I checked the tool for each alert, read every flagged line in its surrounding context, and split them into one real source-code finding and 20 test-file false positives.

- **1 real finding** — `content_reach/sources/reddit.py:57` used `"reddit.com" in request.url` to decide reddit url-mode routing. That substring check matches lookalikes (`https://reddit.com.evil.com/`, `https://evil.com/?x=reddit.com`).
- **20 false positives** — all in test files, where the substring runs on a **parsed allowlist list** (`assert "github.com" in hosts`), a **dict key** (`in guard_mod._robots_cache`), a **rendered output string**, or a **recorded test URL** — none is a security sanitization.

I reused the repo's canonical URL-safety layer for the SSRF path (`ensure_public_url` → `autobot_shared.url_safety`, already called immediately after the routing check), so only the host-detection routing needed tightening — no new URL parser.

## What Changed
- `reddit.py`: added `_is_reddit_url()` that parses `urlparse(url).hostname` and accepts only exact `reddit.com` or `*.reddit.com` (leading-dot boundary), replacing the substring check.
- `tests/content_reach/sources/test_reddit.py`: added parametrized accept/reject tests proving bypass payloads (`reddit.com.evil.com`, `evil.com/?redirect=reddit.com`, `notreddit.com`, `evilreddit.com`) are rejected while genuine reddit hosts pass, plus an integration test that a spoofed host falls back to the search endpoint.
- `tests/content_reach/test_url_guard.py`: updated the url-mode SSRF-block test to use a genuine reddit host (its old `http://10.0.0.1/reddit.com/r/test` URL relied on the substring bug being fixed).
- 20 test-file alerts: added the repo's established inline `# codeql[py/incomplete-url-substring-sanitization]` suppression (matching the existing style for this rule) on each flagged line, with justification in commit messages. Extracted an `endpoint` variable in `test_sso_logout.py` to keep the suppressed line within the 120-char limit.

## Verification
- `black --check --line-length 120` — all 12 files clean.
- `flake8 --max-line-length 120` — 0 findings; no changed line exceeds 120.
- `pytest tests/content_reach/sources/test_reddit.py tests/content_reach/test_url_guard.py` — **45 passed** (includes new bypass-rejection tests).
- `pytest` across all suppressed test files — 199 passed, 1 pre-existing failure (`test_full_search_falls_back_when_no_entries`) that reproduces on pristine `origin/Dev_new_gui` and is comment-only-unrelated to this PR, filed as #12305.

## Model Used
claude-opus-4-8

Closes #12281
