### PR TITLE
fix(test): browser-VM fallback assertion drift for session_id arg (#12305)

### DIFF
--- a/autobot-backend/tests/unit/test_search_web_fetch_full.py
+++ b/autobot-backend/tests/unit/test_search_web_fetch_full.py
@@ -273,7 +273,9 @@ class TestExecuteWebSearchFull:
         ):
             result = await mixin._execute_web_search_full("no results query", max_pages=5)
 
-        mock_fallback.assert_called_once_with("no results query")
+        # #11539 threads session_id into the browser-VM fallback; with no
+        # session_id supplied to _execute_web_search_full it defaults to "".
+        mock_fallback.assert_called_once_with("no results query", "")
         assert result == "Fallback results"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path
`test_full_search_falls_back_when_no_entries` failed on pristine `origin/Dev_new_gui` (issue #12305). Reproduced the failure, then traced the fallback path: `_execute_web_search_full(query, max_pages, session_id="")` → on empty entries calls `_web_search_final_fallback(query, session_id)` → calls `_web_search_via_browser_vm(query, session_id)`. The `session_id` argument was threaded into the browser-VM fallback by #11539 (documented in the method docstrings), but the test's `assert_called_once_with` was never updated, so it still expected a single-arg call.

Root cause: **test drift, not a code defect.** The implementation correctly threads `session_id` (defaulting to `""`). The `#7478` regression guarantee — the fallback must NOT route through `_execute_web_search` — is unaffected and is still separately asserted by the patched `_execute_web_search` side-effect.

## What Changed
- `autobot-backend/tests/unit/test_search_web_fetch_full.py`: updated the fallback assertion from `assert_called_once_with("no results query")` to `assert_called_once_with("no results query", "")` to match the current 2-arg signature, with a comment explaining the `#11539` `session_id` default. No production code touched; the test still proves the empty-entries path falls back directly to the browser VM and never re-enters `_execute_web_search`.

## Verification
Before:
```
E   AssertionError: expected call not found.
E   Expected: _web_search_via_browser_vm('no results query')
E   Actual: _web_search_via_browser_vm('no results query', '')
FAILED tests/unit/test_search_web_fetch_full.py::TestExecuteWebSearchFull::test_full_search_falls_back_when_no_entries
```
After:
```
tests/unit/test_search_web_fetch_full.py .                               [100%]
1 passed
```
Whole file: `18 passed`. `black --check --line-length 120` → unchanged; `flake8 --max-line-length 120` → clean; `ast.parse` → ok.

## Model Used
claude-opus-4-8

Closes #12305
