### PR TITLE
fix(security): authn + tenant authz on remaining LLC company endpoints (#12233)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -134,20 +134,75 @@ def _get_service(session: AsyncSession = Depends(get_async_session)) -> CompanyS
     return CompanyService(session=session)
 
 
+def _is_platform_admin(current_user: dict) -> bool:
+    """Platform-admin detection mirroring ``get_tenant_context`` (#12233).
+
+    The collection routes (list/create) carry no ``company_id`` path param, so
+    they authenticate with ``get_current_user`` (not ``require_org_context``)
+    and derive admin status from the JWT the same way the tenant-context
+    dependency does: an explicit ``is_platform_admin`` flag or ``role == "admin"``.
+    """
+    return bool(current_user.get("is_platform_admin")) or current_user.get("role") == "admin"
+
+
+def _current_user_id(current_user: dict) -> str:
+    """Return the caller's user id, or raise 401 when absent (#12233)."""
+    raw = current_user.get("user_id") or current_user.get("id") or current_user.get("sub")
+    if not raw:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    return str(raw)
+
+
 @router.get("/", response_model=List[CompanyRead])
-async def list_companies(svc: CompanyService = Depends(_get_service)) -> List[CompanyRead]:
-    """List top-level companies (parent_org_id IS NULL)."""
+async def list_companies(
+    svc: CompanyService = Depends(_get_service),
+    current_user: dict = Depends(get_current_user),
+    membership_svc: MembershipService = Depends(_get_membership_service),
+) -> List[CompanyRead]:
+    """List top-level companies (parent_org_id IS NULL) visible to the caller.
+
+    Tenant scope (#12233): previously unauthenticated and returned *every*
+    tenant's root company — cross-tenant enumeration of names/budgets. Now
+    authenticated; non-admins see only companies they are a member of, while
+    platform admins still see all roots. Membership is the same tenant
+    primitive ``get_tenant_context`` uses to authorise ``X-Organization-Id``.
+    """
     companies = await svc.list_root_companies()
-    return [_to_read(c) for c in companies]
+    if _is_platform_admin(current_user):
+        return [_to_read(c) for c in companies]
+    user_id = _current_user_id(current_user)
+    visible = [c for c in companies if await membership_svc.is_member(svc.session, str(c.id), user_id)]
+    return [_to_read(c) for c in visible]
 
 
 @router.post("/", response_model=CompanyRead, status_code=status.HTTP_201_CREATED)
 async def create_company(
     body: CompanyCreate,
     svc: CompanyService = Depends(_get_service),
+    current_user: dict = Depends(get_current_user),
+    membership_svc: MembershipService = Depends(_get_membership_service),
 ) -> CompanyRead:
+    """Create a company (root, or a sub-company under an owned parent).
+
+    Tenant scope (#12233): previously unauthenticated — any caller could create
+    a company and, by supplying ``parent_org_id``, graft one under *another*
+    tenant's company. Now authenticated; a non-admin may only create a
+    sub-company under a parent they belong to (cross-tenant parent → 404, so the
+    parent's existence is not disclosed). Root creation (no ``parent_org_id``,
+    the creation-wizard flow) is open to any authenticated user. The creator is
+    recorded as the company ``OWNER`` so they can immediately access it and it
+    surfaces in their tenant-scoped ``list_companies``.
+    """
+    user_id = _current_user_id(current_user)
+    if body.parent_org_id is not None and not _is_platform_admin(current_user):
+        if not await membership_svc.is_member(svc.session, str(body.parent_org_id), user_id):
+            # 404 (not 403): a cross-tenant caller must not distinguish "not my
+            # company" from "doesn't exist" — identical semantics to
+            # assert_company_access (#12238).
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     try:
         org = await svc.create(body)
+        await membership_svc.add_member(svc.session, str(org.id), user_id, MembershipRole.OWNER)
         await svc.session.commit()
         for suffix in (None, KbCollectionManager.AGENTS_SUFFIX, KbCollectionManager.DECISIONS_SUFFIX):
             await _kb_manager.ensure_collection(KbCollectionManager.COMPANY_PREFIX, org.id, suffix)
@@ -365,7 +420,11 @@ async def archive_company(
 async def get_company_tree(
     company_id: uuid.UUID,
     svc: CompanyService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> CompanyTreeNode:
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         return await svc.get_sub_company_tree(company_id)
     except CompanyNotFoundError:
@@ -376,7 +435,11 @@ async def get_company_tree(
 async def get_company_ancestry(
     company_id: uuid.UUID,
     svc: CompanyService = Depends(_get_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[CompanyAncestor]:
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         ancestors = await svc.get_ancestry(company_id)
         return [
@@ -409,6 +472,8 @@ class KbAncestryCollection(BaseModel):
 async def get_kb_ancestry_collections(
     company_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[KbAncestryCollection]:
     """Return the resolved KB collection chain for a company (GH#8241).
 
@@ -416,6 +481,8 @@ async def get_kb_ancestry_collections(
     be applied when merging search results. Useful for inspecting what context
     a sub-company agent inherits.
     """
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     from llc.kb.inheritance import KbInheritanceResolver
 
     # get_query_collections only needs the session; no RAG assembler required (GH#8570).
@@ -447,7 +514,11 @@ async def list_members(
     company_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
     svc: MembershipService = Depends(_get_membership_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     from sqlalchemy import select  # noqa: PLC0415
 
     from user_management.models.user import User  # noqa: PLC0415
@@ -470,7 +541,11 @@ async def add_member(
     body: MemberAddRequest,
     session: AsyncSession = Depends(get_async_session),
     svc: MembershipService = Depends(_get_membership_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         membership = await svc.add_member(session, str(company_id), str(body.user_id), body.role)
         await session.commit()
@@ -486,7 +561,11 @@ async def remove_member(
     user_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
     svc: MembershipService = Depends(_get_membership_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> None:
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         await svc.remove_member(session, str(company_id), str(user_id))
         await session.commit()
@@ -513,8 +592,13 @@ async def set_pm_config(
     company_id: uuid.UUID,
     body: PMConfigSetRequest,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> PMConfigRead:
     """Store encrypted PM credentials for a company (GH#8257)."""
+    # Issue #12233: tenant authz — writing another tenant's PM credentials is a
+    # cross-tenant compromise; caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     import json
 
     from sqlalchemy import select, update
@@ -538,8 +622,12 @@ async def set_pm_config(
 async def test_pm_config(
     company_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
     """Test connectivity to the configured external PM system (GH#8257)."""
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     import json
 
     from sqlalchemy import select
@@ -883,6 +971,8 @@ async def search_agents(
     company_id: uuid.UUID,
     q: str = Query(..., min_length=1, description="Search query for agent capabilities"),
     limit: int = Query(10, ge=1, le=100, description="Max results"),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> Dict[str, Any]:
     """Search agents in company by capabilities using RAG.
 
@@ -897,6 +987,8 @@ async def search_agents(
     Returns:
         List of matching agents with capability metadata.
     """
+    # Issue #12233: tenant authz — caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         from knowledge import get_knowledge_base
         from llc.kb import AgentCapabilityIndexer
@@ -949,6 +1041,8 @@ def _get_portability_service(session: AsyncSession = Depends(get_async_session))
 async def export_template(
     company_id: uuid.UUID,
     svc: PortabilityService = Depends(_get_portability_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> JSONResponse:
     """Export a portable structural template for the company.
 
@@ -956,6 +1050,9 @@ async def export_template(
     goals, active routines, projects, portfolios, and up to 20 seed work items.
     Secret values are never exported — only ``{{SECRET_NAME}}`` placeholders.
     """
+    # Issue #12233: tenant authz — exporting another tenant's structure is a
+    # cross-tenant data leak; caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     payload = await svc.export_template(company_id)
     filename = f"company_{company_id}_template.json"
     return JSONResponse(
@@ -968,12 +1065,17 @@ async def export_template(
 async def export_snapshot(
     company_id: uuid.UUID,
     svc: PortabilityService = Depends(_get_portability_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
 ) -> JSONResponse:
     """Export a full-state snapshot for backup/migration.
 
     Extends the template export with all work items, sprint history, and KB
     collection names (not content).
     """
+    # Issue #12233: tenant authz — a full-state snapshot of another tenant is a
+    # cross-tenant data leak; caller's org must match company_id unless admin.
+    assert_company_access(ctx, company_id)  # shared guard (#12238)
     payload = await svc.export_snapshot(company_id)
     filename = f"company_{company_id}_snapshot.json"
     return JSONResponse(

--- a/autobot-backend/llc/tests/test_company_crud_authz_12233.py
+++ b/autobot-backend/llc/tests/test_company_crud_authz_12233.py
@@ -133,3 +133,229 @@ async def test_delete_cross_tenant_is_404_and_untouched():
         resp = await client.delete(f"/api/llc/companies/{other}")
     assert resp.status_code == 404
     svc.delete.assert_not_called()
+
+
+# ===========================================================================
+# Collection routes: list / create (#12233).
+#
+# These carry no ``company_id`` path param, so they authenticate with
+# ``get_current_user`` and scope by membership (not ``require_org_context``):
+#   - list   → non-admins see only companies they are a member of.
+#   - create → a sub-company may only be grafted under an owned parent; the
+#              creator is recorded as OWNER. Root creation is open to any
+#              authenticated user (the creation-wizard flow).
+# ===========================================================================
+
+
+def _collection_app(
+    svc,
+    membership_svc,
+    *,
+    is_platform_admin: bool = False,
+    unauth: bool = False,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(companies.router, prefix="/api/llc")
+    app.dependency_overrides[companies._get_service] = lambda: svc
+    app.dependency_overrides[companies._get_membership_service] = lambda: membership_svc
+
+    def _cur() -> dict:
+        if unauth:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        user = {"id": str(_USER_ID), "user_id": str(_USER_ID)}
+        if is_platform_admin:
+            user["role"] = "admin"
+        return user
+
+    app.dependency_overrides[get_current_user] = _cur
+    return app
+
+
+def _list_svc() -> MagicMock:
+    svc = MagicMock()
+    svc.session = AsyncMock()
+    svc.list_root_companies = AsyncMock(return_value=[_org()])
+    return svc
+
+
+def _create_svc() -> MagicMock:
+    svc = MagicMock()
+    svc.session = AsyncMock()
+    svc.create = AsyncMock(return_value=_org())
+    return svc
+
+
+def _membership(is_member: bool = True) -> MagicMock:
+    m = MagicMock()
+    m.is_member = AsyncMock(return_value=is_member)
+    m.add_member = AsyncMock()
+    return m
+
+
+# --- list_companies ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_requires_authentication():
+    svc = _list_svc()
+    app = _collection_app(svc, _membership(), unauth=True)
+    async with _client(app) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 401
+    svc.list_root_companies.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_member_sees_own_company():
+    svc = _list_svc()
+    app = _collection_app(svc, _membership(is_member=True))
+    async with _client(app) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_non_member_sees_nothing():
+    """Cross-tenant enumeration is closed: a non-member gets an empty list."""
+    svc = _list_svc()
+    app = _collection_app(svc, _membership(is_member=False))
+    async with _client(app) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_platform_admin_sees_all():
+    svc = _list_svc()
+    membership = _membership(is_member=False)  # admin bypasses membership entirely
+    app = _collection_app(svc, membership, is_platform_admin=True)
+    async with _client(app) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+    membership.is_member.assert_not_called()
+
+
+# --- create_company ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_requires_authentication():
+    svc = _create_svc()
+    app = _collection_app(svc, _membership(), unauth=True)
+    async with _client(app) as client:
+        resp = await client.post("/api/llc/companies/", json={"name": "NewCo"})
+    assert resp.status_code == 401
+    svc.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_root_records_creator_as_owner(monkeypatch):
+    from llc.models.enums import MembershipRole
+
+    monkeypatch.setattr(companies._kb_manager, "ensure_collection", AsyncMock())
+    svc = _create_svc()
+    membership = _membership()
+    app = _collection_app(svc, membership)
+    async with _client(app) as client:
+        resp = await client.post("/api/llc/companies/", json={"name": "NewCo"})
+    assert resp.status_code == 201, resp.text
+    svc.create.assert_awaited_once()
+    membership.add_member.assert_awaited_once()
+    # creator is added to the just-created company as OWNER
+    args = membership.add_member.await_args.args
+    assert args[1] == str(_ORG_ID)
+    assert args[2] == str(_USER_ID)
+    assert args[3] == MembershipRole.OWNER
+
+
+@pytest.mark.asyncio
+async def test_create_sub_company_cross_tenant_parent_is_404():
+    """A non-member cannot graft a sub-company under another tenant's company."""
+    svc = _create_svc()
+    membership = _membership(is_member=False)
+    app = _collection_app(svc, membership)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/llc/companies/",
+            json={"name": "Sub", "parent_org_id": str(uuid.uuid4())},
+        )
+    assert resp.status_code == 404
+    svc.create.assert_not_called()
+    membership.add_member.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_sub_company_owned_parent_ok(monkeypatch):
+    monkeypatch.setattr(companies._kb_manager, "ensure_collection", AsyncMock())
+    svc = _create_svc()
+    membership = _membership(is_member=True)
+    app = _collection_app(svc, membership)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/llc/companies/",
+            json={"name": "Sub", "parent_org_id": str(uuid.uuid4())},
+        )
+    assert resp.status_code == 201, resp.text
+    svc.create.assert_awaited_once()
+
+
+# ===========================================================================
+# Path-scoped route guard — export_snapshot as a representative (#12233).
+# Every {company_id} route now enforces get_current_user + require_org_context
+# + assert_company_access; the export routes leak a full tenant snapshot.
+# ===========================================================================
+
+
+def _export_svc() -> MagicMock:
+    svc = MagicMock()
+    svc.export_snapshot = AsyncMock(return_value={"company_id": str(_ORG_ID)})
+    return svc
+
+
+def _export_app(svc, *, org_id: uuid.UUID = _ORG_ID, unauth: bool = False) -> FastAPI:
+    app = FastAPI()
+    app.include_router(companies.router, prefix="/api/llc")
+    app.dependency_overrides[companies._get_portability_service] = lambda: svc
+
+    def _cur() -> dict:
+        if unauth:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        return {"id": str(_USER_ID), "user_id": str(_USER_ID)}
+
+    def _ctx() -> TenantContext:
+        return TenantContext(org_id=org_id, user_id=_USER_ID, is_platform_admin=False)
+
+    app.dependency_overrides[get_current_user] = _cur
+    app.dependency_overrides[require_org_context] = _ctx
+    return app
+
+
+@pytest.mark.asyncio
+async def test_export_snapshot_requires_authentication():
+    svc = _export_svc()
+    async with _client(_export_app(svc, unauth=True)) as client:
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/export/snapshot")
+    assert resp.status_code == 401
+    svc.export_snapshot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_export_snapshot_cross_tenant_is_404_and_untouched():
+    svc = _export_svc()
+    other = uuid.uuid4()
+    async with _client(_export_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{other}/export/snapshot")
+    assert resp.status_code == 404
+    svc.export_snapshot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_export_snapshot_same_tenant_ok():
+    svc = _export_svc()
+    async with _client(_export_app(svc)) as client:
+        resp = await client.post(f"/api/llc/companies/{_ORG_ID}/export/snapshot")
+    assert resp.status_code == 200
+    svc.export_snapshot.assert_awaited_once()

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48812,11 +48812,29 @@ export interface paths {
         };
         /**
          * List Companies
-         * @description List top-level companies (parent_org_id IS NULL).
+         * @description List top-level companies (parent_org_id IS NULL) visible to the caller.
+         *
+         *     Tenant scope (#12233): previously unauthenticated and returned *every*
+         *     tenant's root company — cross-tenant enumeration of names/budgets. Now
+         *     authenticated; non-admins see only companies they are a member of, while
+         *     platform admins still see all roots. Membership is the same tenant
+         *     primitive ``get_tenant_context`` uses to authorise ``X-Organization-Id``.
          */
         get: operations["list_companies_api_llc_companies__get"];
         put?: never;
-        /** Create Company */
+        /**
+         * Create Company
+         * @description Create a company (root, or a sub-company under an owned parent).
+         *
+         *     Tenant scope (#12233): previously unauthenticated — any caller could create
+         *     a company and, by supplying ``parent_org_id``, graft one under *another*
+         *     tenant's company. Now authenticated; a non-admin may only create a
+         *     sub-company under a parent they belong to (cross-tenant parent → 404, so the
+         *     parent's existence is not disclosed). Root creation (no ``parent_org_id``,
+         *     the creation-wizard flow) is open to any authenticated user. The creator is
+         *     recorded as the company ``OWNER`` so they can immediately access it and it
+         *     surfaces in their tenant-scoped ``list_companies``.
+         */
         post: operations["create_company_api_llc_companies__post"];
         delete?: never;
         options?: never;


### PR DESCRIPTION
## Thinking Path

Issue #12233 reported the LLC company CRUD endpoints as an **unauthenticated IDOR**. PR #12235 already fixed `get`/`update`/`delete` (and the status transitions), which is why the issue stayed open as PARTIAL — the collection routes and the rest of the company-scoped endpoints in `companies.py` were still reachable **without authentication**, allowing cross-tenant read/write/exfiltration by supplying an arbitrary `company_id`.

I audited every route handler in `llc/api/companies.py` and closed the gaps, mirroring the canonical LLC tenant-authz pattern established in #12184 / #12215 (`activity.py`, `routines.py`) and the shared guard extracted in #12238 (`assert_company_access`).

A key constraint drove the list/create design: the frontend (`orgContext.ts`) only sends `X-Organization-Id` once a company is **selected**. The company selector (GET `/companies/`) and creation wizard (POST `/companies/`) run with no org header, so applying `require_org_context` there would 400 and break both flows. Those two collection routes therefore use `get_current_user` + **membership-based** scoping instead — the same tenant primitive `get_tenant_context` already uses.

## What Changed

`autobot-backend/llc/api/companies.py` — guards added:

Path-scoped (`get_current_user` + `require_org_context` + `assert_company_access(ctx, company_id)`, 404 on cross-tenant):
- `get_company_tree`, `get_company_ancestry`, `get_kb_ancestry_collections`
- `list_members`, `add_member`, `remove_member`
- `set_pm_config`, `test_pm_config` (write/read of encrypted PM credentials)
- `search_agents`
- `export_template`, `export_snapshot` (full-tenant data exfiltration)

Collection routes (tenant-scoped variant, `get_current_user` + membership):
- `list_companies` — authenticated; non-admins see only companies they are a member of; platform admins see all roots. Closes cross-tenant enumeration.
- `create_company` — authenticated; a sub-company may only be created under a parent the caller belongs to (cross-tenant parent → 404); the creator is recorded as `OWNER` so the wizard→workspace→selector flow stays intact. Root creation remains open to any authenticated user.

Result: all 22 route handlers in the file now authenticate (audited via AST).

## Verification

- `python3 -m black --check --line-length 120` — clean (companies.py + test)
- `python3 -m flake8 --max-line-length 120` — 0 findings
- `ast.parse` — clean; AST audit confirms every `@router` handler has an auth dependency
- New tests in `test_company_crud_authz_12233.py` (10 added):
  - unauth → **401** (list, create, export)
  - cross-tenant → **404**/empty (create sub-company under foreign parent → 404; non-member list → empty; export foreign snapshot → 404)
  - same-tenant → **200/201** (member list, root create records OWNER, owned-parent sub-create, own-tenant export)
- `pytest llc/tests/test_company_crud_authz_12233.py` → **16 passed**
- Regression: `test_llc_crud_authz test_membership test_company test_company_status_endpoints_12211 test_export test_portability_idor` → **83 passed**

## Model Used

claude-opus-4-8

Closes #12233
