### PR TITLE
fix(llc): company transitions 500 + commit-despite-error (MissingGreenlet) (#12309)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -198,8 +198,12 @@ async def update_company(
     assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.update(company_id, body)
+        # GH#12309: serialize BEFORE commit so that if response building ever
+        # fails the except handler's rollback still undoes the change — never
+        # leave a committed-but-500 state where the DB and caller disagree.
+        read = _to_read(org)
         await svc.session.commit()
-        return _to_read(org)
+        return read
     except CompanyNotFoundError:
         await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
@@ -264,8 +268,11 @@ async def activate_company(
     assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.activate(company_id)
+        # GH#12309: serialize BEFORE commit so a failed response never persists
+        # a partial transition (commit only lands on the success path).
+        read = _to_read(org)
         await svc.session.commit()
-        return _to_read(org)
+        return read
     except CompanyNotFoundError:
         await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
@@ -292,8 +299,10 @@ async def suspend_company(
     assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.suspend(company_id, reason=body.reason if body else None)
+        # GH#12309: serialize BEFORE commit (commit only on the success path).
+        read = _to_read(org)
         await svc.session.commit()
-        return _to_read(org)
+        return read
     except CompanyNotFoundError:
         await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
@@ -321,8 +330,10 @@ async def offboard_company(
     assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.offboard(company_id)
+        # GH#12309: serialize BEFORE commit (commit only on the success path).
+        read = _to_read(org)
         await svc.session.commit()
-        return _to_read(org)
+        return read
     except CompanyNotFoundError:
         await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")
@@ -348,8 +359,10 @@ async def archive_company(
     assert_company_access(ctx, company_id)  # shared guard (#12238)
     try:
         org = await svc.archive(company_id)
+        # GH#12309: serialize BEFORE commit (commit only on the success path).
+        read = _to_read(org)
         await svc.session.commit()
-        return _to_read(org)
+        return read
     except CompanyNotFoundError:
         await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Internal server error")

--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -117,6 +117,13 @@ class CompanyService(LLCServiceBase):
                 setattr(org, field, value)
 
         await self.session.flush()
+        # GH#12309 (same class as #12209): SQLAlchemy's eager_defaults="auto"
+        # only RETURNING-fetches the onupdate-computed `updated_at` on INSERT,
+        # not UPDATE, so it stays expired after flush(). The router then reads
+        # it while serializing the response — a sync lazy load outside the
+        # greenlet context that raises MissingGreenlet (HTTP 500). Refresh it
+        # here, inside the awaited/greenlet-safe scope.
+        await self.session.refresh(org, attribute_names=["updated_at"])
         logger.info("LLC company updated: %s (id=%s)", org.name, org.id)
         return org
 
@@ -202,6 +209,13 @@ class CompanyService(LLCServiceBase):
         for field, value in field_updates.items():
             setattr(org, field, value)
         await self.session.flush()
+        # GH#12309 (same class as #12209): the onupdate-computed `updated_at`
+        # stays expired after an UPDATE flush (eager_defaults="auto" fetches it
+        # via RETURNING only on INSERT). Without this refresh the router's
+        # response serialization triggers a sync lazy load outside the greenlet
+        # context -> MissingGreenlet -> HTTP 500 (while the transition has
+        # already been flushed). Refresh inside the greenlet-safe scope.
+        await self.session.refresh(org, attribute_names=["updated_at"])
         logger.info(log_msg, org.name, org.id)
         return org
 

--- a/autobot-backend/llc/tests/test_company_transition_greenlet_12309.py
+++ b/autobot-backend/llc/tests/test_company_transition_greenlet_12309.py
@@ -27,12 +27,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from fastapi import FastAPI
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import MissingGreenlet
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.compiler import compiles
-from fastapi import FastAPI
 
 from api.user_management.dependencies import get_current_user, require_org_context
 from llc.api import companies

--- a/autobot-backend/llc/tests/test_company_transition_greenlet_12309.py
+++ b/autobot-backend/llc/tests/test_company_transition_greenlet_12309.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GH#12309 regression: LLC company transitions must not 500 with
+MissingGreenlet, and a failed response must never leave a committed state.
+
+Two guards:
+
+1. Real-engine tests (``TestTransitionSurvivesSyncSerialization``) drive the
+   *actual* ``CompanyService`` against an in-memory aiosqlite ``AsyncSession``
+   so SQLAlchemy's real attribute-expiry behaviour is exercised. The mapper
+   default ``eager_defaults="auto"`` only RETURNING-fetches the onupdate
+   ``updated_at`` on INSERT, not UPDATE — so post-flush ``updated_at`` stays
+   expired and the router's ``_to_read(org)`` serialization (a sync attribute
+   read) raises ``MissingGreenlet``. Without the ``session.refresh(org,
+   ["updated_at"])`` fix these tests fail exactly as production did.
+
+2. A router ordering test (``test_transition_serializes_before_commit``)
+   proves the response is built *before* ``commit()`` so a serialization
+   failure rolls back instead of persisting a partial transition (the
+   data-integrity half of the bug: caller told 500, DB moved anyway).
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import MissingGreenlet
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+from fastapi import FastAPI
+
+from api.user_management.dependencies import get_current_user, require_org_context
+from llc.api import companies
+from llc.models.company import CompanyUpdate
+from llc.services.company import CompanyService
+from user_management.models.base import Base
+from user_management.models.organization import Organization
+from user_management.services import TenantContext
+
+
+# Organization.settings is postgres JSONB; render it as JSON on sqlite so the
+# real-engine repro can create the table. Scoped to the sqlite dialect only —
+# no effect on the production postgres path.
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_as_json_on_sqlite(element, compiler, **kw):  # noqa: ANN001
+    return "JSON"
+
+
+async def _seed_company(session_factory, llc_status: str = "onboarding") -> uuid.UUID:
+    async with session_factory() as session:
+        org = Organization(
+            name="AutoBot Relations",
+            slug=f"rel-{uuid.uuid4().hex[:8]}",
+            settings={},
+            llc_status=llc_status,
+            issue_counter=0,
+            budget_monthly_cents=0,
+            spent_monthly_cents=0,
+            require_approval_for_hires=False,
+        )
+        session.add(org)
+        await session.commit()
+        return org.id
+
+
+@pytest.fixture()
+async def session_factory():
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=[Organization.__table__])
+    try:
+        yield async_sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+    finally:
+        await engine.dispose()
+
+
+class TestTransitionSurvivesSyncSerialization:
+    """The exact router sequence — ``svc.<verb>()`` then ``_to_read(org)`` — must
+    not raise MissingGreenlet against a real AsyncSession (GH#12309)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "start_status, verb, expected",
+        [
+            ("onboarding", "activate", "active"),
+            ("active", "suspend", "paused"),
+            ("active", "offboard", "offboarding"),
+            ("paused", "archive", "archived"),
+        ],
+    )
+    async def test_transition_then_serialize(self, session_factory, start_status, verb, expected):
+        company_id = await _seed_company(session_factory, llc_status=start_status)
+        async with session_factory() as session:
+            svc = CompanyService(session=session)
+            org = await getattr(svc, verb)(company_id)
+            # Mirrors llc/api/companies.py: serialize BEFORE commit.
+            read = companies._to_read(org)
+            await session.commit()
+
+        assert read.llc_status.value == expected
+        assert read.updated_at is not None
+
+    @pytest.mark.asyncio
+    async def test_patch_update_then_serialize(self, session_factory):
+        company_id = await _seed_company(session_factory, llc_status="active")
+        async with session_factory() as session:
+            svc = CompanyService(session=session)
+            org = await svc.update(company_id, CompanyUpdate(name="Renamed"))
+            read = companies._to_read(org)
+            await session.commit()
+
+        assert read.name == "Renamed"
+        assert read.updated_at is not None
+
+    @pytest.mark.asyncio
+    async def test_updated_at_is_expired_without_refresh(self, session_factory):
+        """Documents the root cause: after an UPDATE flush the onupdate
+        ``updated_at`` is expired, so a *sync* read raises MissingGreenlet.
+        Guards against a future regression that drops the refresh.
+        """
+        company_id = await _seed_company(session_factory, llc_status="onboarding")
+        async with session_factory() as session:
+            org = (await session.execute(select(Organization).where(Organization.id == company_id))).scalar_one()
+            org.llc_status = "active"
+            await session.flush()  # UPDATE, no refresh
+            with pytest.raises(MissingGreenlet):
+                _ = org.updated_at  # noqa: F841 — sync access of expired attr
+
+
+class TestCommitOnlyOnSuccess:
+    """The transition endpoints must build the response before committing so a
+    serialization failure rolls back rather than persisting a partial state."""
+
+    _ORG_ID = uuid.uuid4()
+    _USER_ID = uuid.uuid4()
+
+    def _app(self, svc) -> FastAPI:
+        app = FastAPI()
+        app.include_router(companies.router, prefix="/api/llc")
+        app.dependency_overrides[companies._get_service] = lambda: svc
+        app.dependency_overrides[get_current_user] = lambda: {
+            "id": str(self._USER_ID),
+            "user_id": str(self._USER_ID),
+        }
+        app.dependency_overrides[require_org_context] = lambda: TenantContext(
+            org_id=self._ORG_ID, user_id=self._USER_ID, is_platform_admin=False
+        )
+        return app
+
+    @pytest.mark.asyncio
+    async def test_transition_serializes_before_commit(self, monkeypatch):
+        """If ``_to_read`` fails, ``commit()`` must NOT run and ``rollback()``
+        must — no committed-but-500 state (GH#12309 data-integrity half)."""
+        svc = MagicMock()
+        svc.session = AsyncMock()
+        svc.activate = AsyncMock(return_value=object())
+        monkeypatch.setattr(companies, "_to_read", MagicMock(side_effect=RuntimeError("serialize boom")))
+
+        app = self._app(svc)
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(f"/api/llc/companies/{self._ORG_ID}/activate")
+
+        assert resp.status_code == 500
+        svc.session.commit.assert_not_awaited()
+        svc.session.rollback.assert_awaited_once()


### PR DESCRIPTION
## Thinking Path

Every LLC company status transition (`activate`/`suspend`/`offboard`/`archive`) and `PATCH /companies/{id}` returned HTTP 500 while still committing the state change — the caller was told it failed, retried, and got a `409`; DB and UI disagreed.

Root cause (same class as #12209, already fixed in `goals.py`): the async session factory already sets `expire_on_commit=False`, so the issue's "expired on commit" premise is not the mechanism. The real trigger is `updated_at` (`onupdate=func.now()` on `Base`). SQLAlchemy's mapper default `eager_defaults="auto"` only RETURNING-fetches onupdate-computed columns on INSERT, **not UPDATE**, so after a transition's UPDATE flush `updated_at` stays expired. The router's `_to_read(org)` then reads it — a synchronous lazy load outside the greenlet context → `sqlalchemy.exc.MissingGreenlet` → 500. Because `commit()` ran *before* `_to_read()`, the mutation had already landed.

Verified on the codebase: `sprints.py` already calls `await session.refresh(...)` after every commit that serializes an ORM object, so it is greenlet-safe — the issue's "4 sites in sprints.py" was stale. The genuine defect was confined to `companies.py`.

## What Changed

- `llc/services/company.py` — after the UPDATE flush in `_transition()` (covers activate/suspend/offboard/archive) and in `update()`, `await self.session.refresh(org, attribute_names=["updated_at"])`, inside the awaited/greenlet-safe scope. This is the root-cause async-first fix; no sync calls added to the async path.
- `llc/api/companies.py` — the 5 transition/update handlers now build `read = _to_read(org)` **before** `await svc.session.commit()` and return `read`. A serialization failure now hits the `except` handler's `rollback()` instead of persisting a partial transition, so commit only lands on the success path (closes the data-integrity half).
- `llc/tests/test_company_transition_greenlet_12309.py` — new regression suite.

`create()` is INSERT (RETURNING fetches `updated_at`) and was never affected, so it is untouched. Archived one-way-door (secondary finding) is a separate scope and not addressed here.

## Verification

Real-engine (in-memory aiosqlite `AsyncSession`, JSONB→JSON shim so `organizations` builds on sqlite), exercising SQLAlchemy's real expiry behavior:

- `test_updated_at_is_expired_without_refresh` — reproduces the exact bug: after an UPDATE flush, a sync read of `updated_at` raises `MissingGreenlet`.
- `test_transition_then_serialize[activate|suspend|offboard|archive]` + `test_patch_update_then_serialize` — drive the real `CompanyService` then `_to_read(org)` (the router sequence): no `MissingGreenlet`, correct `llc_status`, `updated_at` populated. These fail pre-fix.
- `test_transition_serializes_before_commit` — when `_to_read` raises, `commit()` is **not** awaited and `rollback()` is → no committed-but-500 state.

```
llc/tests/test_company_transition_greenlet_12309.py .......  [ 14%]
llc/tests/test_company.py .............................      [ 76%]
llc/tests/test_company_status_endpoints_12211.py ...........  [100%]
======================== 47 passed in 4.16s ========================
```

Gates on touched files: `black --check --line-length 120` clean · `flake8 --max-line-length 120` exit 0 · `ast.parse` clean.

## Model Used

claude-opus-4-8

Closes #12309
