### PR TITLE
fix(knowledge): surface + retry embedding failures instead of silently dropping vectors (#12312)

### DIFF
--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -571,6 +571,41 @@ class FactsMixin:
             # is not initialized
             await asyncio.to_thread(self.redis_client.sadd, "user:facts:%s" % owner_id, fact_id)
 
+    async def _record_failed_vectorization(self, fact_id: str, reason: str) -> None:
+        """Record a vectorization failure as queryable, retriable state (Issue #12312).
+
+        Embedding generation can fail transiently (backend crash-loop, timeout). The
+        fact content is already persisted; only its vector is missing. Rather than
+        silently drop the vector (log-only, unrecoverable), mark the fact so it is:
+
+        * **queryable** — ``vectorization_status=failed`` (plus error + timestamp) on
+          the ``fact:<id>`` hash, so affected records can be found without log forensics;
+        * **retriable / auto-backfilled** — added to the background reconciler's pending
+          set (``kb:vectorize:pending``, #11296) which re-vectorizes it every cycle until
+          it succeeds and is marked ``completed``.
+        """
+        from background_vectorization import PENDING_SET_KEY
+
+        logger.error(
+            "Vectorization FAILED for fact %s — vector NOT stored; marked failed and queued for retry. Reason: %s",
+            fact_id,
+            reason,
+        )
+        try:
+            fact_key = "fact:%s" % fact_id
+            await asyncio.to_thread(
+                self.redis_client.hset,
+                fact_key,
+                mapping={
+                    "vectorization_status": "failed",
+                    "vectorization_error": reason,
+                    "vectorization_failed_at": datetime.now(tz=timezone.utc).isoformat(),
+                },
+            )
+            await asyncio.to_thread(self.redis_client.sadd, PENDING_SET_KEY, fact_id)
+        except Exception as exc:
+            logger.error("Could not record vectorization failure for fact %s: %s", fact_id, exc)
+
     async def _vectorize_fact_in_chromadb(self, fact_id: str, content: str, metadata: Dict[str, Any]) -> None:
         """
         Vectorize and store fact in ChromaDB vector store.
@@ -595,6 +630,14 @@ class FactsMixin:
         # Issue #165: Generate embedding using NPU worker with fallback
         # ChromaVectorStore.add() expects nodes with embeddings already set
         embedding = await _generate_embedding_with_npu_fallback(content)
+
+        # Issue #12312: An empty embedding means generation failed upstream (backend
+        # blip, timeout). Do NOT silently drop the vector and log success — record a
+        # queryable, retriable failure so the background reconciler backfills it once
+        # the backend recovers.
+        if not embedding:
+            await self._record_failed_vectorization(fact_id, "embedding generation returned an empty result")
+            return
 
         # Issue #8391: Route through VectorWriteBuffer when available (LSM-style batching).
         # Falls back to direct LlamaIndex add() when buffer is not yet started.
@@ -867,6 +910,15 @@ class FactsMixin:
 
         # Issue #165: Generate embedding using NPU worker with fallback
         embedding = await _generate_embedding_with_npu_fallback(content)
+
+        # Issue #12312: The stale vector was already deleted above; if embedding
+        # generation failed the fact is now unvectorized. Record a queryable,
+        # retriable failure instead of silently dropping and logging success.
+        if not embedding:
+            await self._record_failed_vectorization(
+                fact_id, "embedding generation returned an empty result (re-vectorize)"
+            )
+            return
 
         # Issue #8405: Route through VectorWriteBuffer when available, like _vectorize_fact_in_chromadb.
         write_buffer = getattr(self, "_write_buffer", None)

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -161,7 +161,7 @@ def get_npu_warmup_status() -> Dict[str, Any]:
     }
 
 
-async def _generate_embedding_with_npu_fallback(text: str) -> List[float]:
+async def _generate_embedding_with_npu_fallback(text: str, max_attempts: int = 1) -> List[float]:
     """Generate a single embedding via the canonical NPU-fallback path.
 
     Issue #5105: Thin shim — delegates to
@@ -176,6 +176,9 @@ async def _generate_embedding_with_npu_fallback(text: str) -> List[float]:
 
     Args:
         text: Text content to embed.
+        max_attempts: Total attempts before giving up. Issue #12312: defaults to 1
+            (fast-fail) so inline user-facing paths never stall behind a downed
+            backend; the background reconcile path passes a higher count to retry.
 
     Returns:
         Embedding vector. Empty list if all backends fail (callers downstream
@@ -183,7 +186,7 @@ async def _generate_embedding_with_npu_fallback(text: str) -> List[float]:
     """
     from services.npu_client import generate_embedding_with_fallback
 
-    embedding = await generate_embedding_with_fallback(text)
+    embedding = await generate_embedding_with_fallback(text, max_attempts=max_attempts)
     return embedding or []
 
 
@@ -606,7 +609,33 @@ class FactsMixin:
         except Exception as exc:
             logger.error("Could not record vectorization failure for fact %s: %s", fact_id, exc)
 
-    async def _vectorize_fact_in_chromadb(self, fact_id: str, content: str, metadata: Dict[str, Any]) -> None:
+    async def _mark_vectorization_succeeded(self, fact_id: str) -> None:
+        """Clear any failed/pending vectorization state after a successful vector write (Issue #12312).
+
+        Keeps the unvectorized-count metric accurate: a fact that previously failed
+        and then succeeds inline is marked ``completed`` and dropped from the pending
+        set immediately, rather than lingering as ``failed`` until the next reconcile
+        cycle. Mirrors ``BackgroundVectorizer._mark_vectorization_complete`` (#11296).
+        """
+        from background_vectorization import PENDING_SET_KEY
+
+        try:
+            fact_key = "fact:%s" % fact_id
+            await asyncio.to_thread(
+                self.redis_client.hset,
+                fact_key,
+                mapping={
+                    "vectorization_status": "completed",
+                    "vectorized_at": datetime.now(tz=timezone.utc).isoformat(),
+                },
+            )
+            await asyncio.to_thread(self.redis_client.srem, PENDING_SET_KEY, fact_id)
+        except Exception as exc:
+            logger.debug("Could not mark vectorization success for fact %s (non-critical): %s", fact_id, exc)
+
+    async def _vectorize_fact_in_chromadb(
+        self, fact_id: str, content: str, metadata: Dict[str, Any], max_attempts: int = 1
+    ) -> None:
         """
         Vectorize and store fact in ChromaDB vector store.
 
@@ -617,6 +646,9 @@ class FactsMixin:
             fact_id: Fact identifier
             content: Fact content text
             metadata: Fact metadata dict
+            max_attempts: Embedding attempts before giving up. Issue #12312: defaults
+                to 1 (fast-fail) for inline user-facing creates; the on-demand /
+                reconcile path (``vectorize_existing_fact``) passes a higher count.
         """
         if not self.vector_store:
             return
@@ -629,7 +661,7 @@ class FactsMixin:
 
         # Issue #165: Generate embedding using NPU worker with fallback
         # ChromaVectorStore.add() expects nodes with embeddings already set
-        embedding = await _generate_embedding_with_npu_fallback(content)
+        embedding = await _generate_embedding_with_npu_fallback(content, max_attempts=max_attempts)
 
         # Issue #12312: An empty embedding means generation failed upstream (backend
         # blip, timeout). Do NOT silently drop the vector and log success — record a
@@ -643,7 +675,11 @@ class FactsMixin:
         # Falls back to direct LlamaIndex add() when buffer is not yet started.
         write_buffer = getattr(self, "_write_buffer", None)
         if write_buffer is not None:
-            await write_buffer.write(fact_id, embedding, content, sanitized_metadata)
+            # Issue #12312: honour the write buffer's drop signal so the empty-embedding
+            # contract self-enforces even if the guard above ever moves.
+            if not await write_buffer.write(fact_id, embedding, content, sanitized_metadata):
+                await self._record_failed_vectorization(fact_id, "write buffer rejected the embedding")
+                return
         else:
             from llama_index.core import Document
 
@@ -651,6 +687,7 @@ class FactsMixin:
             doc.embedding = embedding
             await asyncio.to_thread(self.vector_store.add, [doc])
 
+        await self._mark_vectorization_succeeded(fact_id)
         logger.info("Vectorized fact %s in ChromaDB", fact_id)
 
     def _prepare_fact_metadata(
@@ -742,7 +779,14 @@ class FactsMixin:
             if not self.vector_store:
                 return {"status": "error", "message": "Vector store not available"}
 
-            await self._vectorize_fact_in_chromadb(fact_id, fact_info["content"], fact_info["metadata"])
+            # Issue #12312: This is the on-demand / reconcile retry path (admin batch,
+            # retry jobs, background backfill), not a user-facing create — so retry
+            # transient embedding failures with backoff here where latency is hidden.
+            from services.npu_client import EMBEDDING_MAX_ATTEMPTS
+
+            await self._vectorize_fact_in_chromadb(
+                fact_id, fact_info["content"], fact_info["metadata"], max_attempts=EMBEDDING_MAX_ATTEMPTS
+            )
 
             logger.info("Vectorized existing fact %s", fact_id)
             return {
@@ -923,13 +967,17 @@ class FactsMixin:
         # Issue #8405: Route through VectorWriteBuffer when available, like _vectorize_fact_in_chromadb.
         write_buffer = getattr(self, "_write_buffer", None)
         if write_buffer is not None:
-            await write_buffer.write(fact_id, embedding, content, sanitized_metadata)
+            # Issue #12312: honour the write buffer's drop signal (self-enforcing contract).
+            if not await write_buffer.write(fact_id, embedding, content, sanitized_metadata):
+                await self._record_failed_vectorization(fact_id, "write buffer rejected the embedding (re-vectorize)")
+                return
         else:
             from llama_index.core import Document
 
             doc = Document(text=content, doc_id=fact_id, metadata=sanitized_metadata)
             doc.embedding = embedding
             await asyncio.to_thread(self.vector_store.add, [doc])
+        await self._mark_vectorization_succeeded(fact_id)
         logger.info("Re-vectorized updated fact %s", fact_id)
 
     async def _refresh_content_hash(self, fact_id: str, old_content: str, new_content: str) -> None:

--- a/autobot-backend/knowledge/facts_failed_vectorization_test.py
+++ b/autobot-backend/knowledge/facts_failed_vectorization_test.py
@@ -1,0 +1,86 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for Issue #12312 — embedding failures must not silently drop
+vectors during inline fact vectorization.
+
+Asserts that when embedding generation returns an empty result, the fact is:
+  - NOT reported as a success (no vector write attempted);
+  - marked ``vectorization_status=failed`` on its Redis hash (queryable);
+  - added to the background reconciler's pending set (retriable / auto-backfill);
+  - logged at ERROR level (visible without log forensics).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from background_vectorization import PENDING_SET_KEY
+from knowledge.facts import FactsMixin
+
+# Bind the loaded module via sys.modules so patch.object targets the same dict the
+# FactsMixin methods resolve module-level globals in (conftest stub-trap safe).
+facts_mod = sys.modules["knowledge.facts"]
+
+
+class _KB(FactsMixin):
+    """Minimal FactsMixin host with the collaborators the paths under test touch."""
+
+    def __init__(self):
+        self.redis_client = MagicMock()
+        self.vector_store = MagicMock()  # truthy so vectorization is attempted
+        self._write_buffer = MagicMock()
+        self._write_buffer.write = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_record_failed_vectorization_marks_and_queues(caplog):
+    kb = _KB()
+
+    with caplog.at_level(logging.ERROR):
+        await kb._record_failed_vectorization("fact-1", "embedding generation returned an empty result")
+
+    # Queryable failed-state written to the fact hash.
+    hset_call = kb.redis_client.hset.call_args
+    assert hset_call.args[0] == "fact:fact-1"
+    mapping = hset_call.kwargs["mapping"]
+    assert mapping["vectorization_status"] == "failed"
+    assert "empty" in mapping["vectorization_error"]
+    assert mapping["vectorization_failed_at"]
+
+    # Retriable: added to the reconciler's pending set.
+    kb.redis_client.sadd.assert_called_once_with(PENDING_SET_KEY, "fact-1")
+
+    # Visible: ERROR log names the fact.
+    assert any(r.levelno >= logging.ERROR and "fact-1" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_empty_embedding_records_failure_and_skips_write(caplog):
+    kb = _KB()
+
+    with patch.object(facts_mod, "_generate_embedding_with_npu_fallback", AsyncMock(return_value=[])):
+        with caplog.at_level(logging.ERROR):
+            await kb._vectorize_fact_in_chromadb("fact-2", "some content", {})
+
+    # No vector was written (not a false success).
+    kb._write_buffer.write.assert_not_called()
+    # Failure was recorded as retriable/queryable state.
+    kb.redis_client.sadd.assert_called_once_with(PENDING_SET_KEY, "fact-2")
+    assert kb.redis_client.hset.call_args.kwargs["mapping"]["vectorization_status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_valid_embedding_writes_and_does_not_record_failure():
+    kb = _KB()
+
+    with patch.object(facts_mod, "_generate_embedding_with_npu_fallback", AsyncMock(return_value=[0.1, 0.2, 0.3])):
+        await kb._vectorize_fact_in_chromadb("fact-3", "some content", {})
+
+    # Vector was buffered; no failure recorded.
+    kb._write_buffer.write.assert_awaited_once()
+    kb.redis_client.sadd.assert_not_called()

--- a/autobot-backend/knowledge/facts_failed_vectorization_test.py
+++ b/autobot-backend/knowledge/facts_failed_vectorization_test.py
@@ -34,7 +34,7 @@ class _KB(FactsMixin):
         self.redis_client = MagicMock()
         self.vector_store = MagicMock()  # truthy so vectorization is attempted
         self._write_buffer = MagicMock()
-        self._write_buffer.write = AsyncMock()
+        self._write_buffer.write = AsyncMock(return_value=True)
 
 
 @pytest.mark.asyncio
@@ -75,7 +75,7 @@ async def test_empty_embedding_records_failure_and_skips_write(caplog):
 
 
 @pytest.mark.asyncio
-async def test_valid_embedding_writes_and_does_not_record_failure():
+async def test_valid_embedding_writes_marks_completed_and_srem():
     kb = _KB()
 
     with patch.object(facts_mod, "_generate_embedding_with_npu_fallback", AsyncMock(return_value=[0.1, 0.2, 0.3])):
@@ -84,3 +84,46 @@ async def test_valid_embedding_writes_and_does_not_record_failure():
     # Vector was buffered; no failure recorded.
     kb._write_buffer.write.assert_awaited_once()
     kb.redis_client.sadd.assert_not_called()
+    # nit #3: success clears stale failed/pending state (KB-health accuracy).
+    assert kb.redis_client.hset.call_args.kwargs["mapping"]["vectorization_status"] == "completed"
+    kb.redis_client.srem.assert_called_once_with(PENDING_SET_KEY, "fact-3")
+
+
+@pytest.mark.asyncio
+async def test_inline_vectorize_defaults_to_single_attempt():
+    """Issue #12312: inline create must fast-fail (one embedding attempt), not the N-attempt wait."""
+    kb = _KB()
+    shim = AsyncMock(return_value=[0.1, 0.2, 0.3])
+
+    with patch.object(facts_mod, "_generate_embedding_with_npu_fallback", shim):
+        await kb._vectorize_fact_in_chromadb("fact-4", "some content", {})
+
+    assert shim.await_args.kwargs["max_attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_path_forwards_higher_attempt_count():
+    """The on-demand/reconcile path opts into multi-attempt retry."""
+    kb = _KB()
+    shim = AsyncMock(return_value=[0.1, 0.2, 0.3])
+
+    with patch.object(facts_mod, "_generate_embedding_with_npu_fallback", shim):
+        await kb._vectorize_fact_in_chromadb("fact-5", "some content", {}, max_attempts=3)
+
+    assert shim.await_args.kwargs["max_attempts"] == 3
+
+
+@pytest.mark.asyncio
+async def test_write_buffer_rejection_records_failure(caplog):
+    """nit #2: if the buffer drops a (non-empty) embedding, record a retriable failure."""
+    kb = _KB()
+    kb._write_buffer.write = AsyncMock(return_value=False)
+
+    with patch.object(facts_mod, "_generate_embedding_with_npu_fallback", AsyncMock(return_value=[0.1, 0.2, 0.3])):
+        with caplog.at_level(logging.ERROR):
+            await kb._vectorize_fact_in_chromadb("fact-6", "some content", {})
+
+    kb.redis_client.sadd.assert_called_once_with(PENDING_SET_KEY, "fact-6")
+    assert kb.redis_client.hset.call_args.kwargs["mapping"]["vectorization_status"] == "failed"
+    # No success marker written.
+    kb.redis_client.srem.assert_not_called()

--- a/autobot-backend/knowledge/write_buffer.py
+++ b/autobot-backend/knowledge/write_buffer.py
@@ -108,12 +108,16 @@ class VectorWriteBuffer:
         embedding: List[float],
         document: str,
         metadata: Optional[Dict[str, Any]] = None,
-    ) -> None:
+    ) -> bool:
         """Buffer a vector write. If the buffer is full, flush immediately.
 
         Issue #10941: Reject entries with empty/None embeddings — they cause
         IndexError in chroma normalize_insert_record_set and contaminate the
         entire flush batch, silently dropping all valid vectors alongside them.
+
+        Issue #12312: Returns ``True`` when the entry was buffered and ``False``
+        when it was dropped (empty embedding), so callers can detect the drop and
+        record a retriable failure instead of assuming success.
         """
         if not embedding:
             logger.warning(
@@ -121,7 +125,7 @@ class VectorWriteBuffer:
                 "(embedding generation failed upstream); vector will NOT be stored",
                 id,
             )
-            return
+            return False
         async with self._lock:
             self._buffer[id] = BufferedWrite(
                 id=id,
@@ -134,6 +138,7 @@ class VectorWriteBuffer:
 
         if should_flush:
             await self._flush()
+        return True
 
     async def flush_now(self) -> int:
         """Force an immediate flush. Returns number of entries flushed."""

--- a/autobot-backend/knowledge/write_buffer_test.py
+++ b/autobot-backend/knowledge/write_buffer_test.py
@@ -71,6 +71,25 @@ class TestWriteRejectsEmptyEmbedding:
         # _write_count is incremented only for accepted entries
         assert buf._write_count == 0
 
+    @pytest.mark.asyncio
+    async def test_write_returns_false_on_drop_and_logs(self, caplog):
+        """Issue #12312: a dropped write is reported (return False) and logged, not silent."""
+        import logging
+
+        flush_fn = AsyncMock()
+        buf = VectorWriteBuffer(flush_fn=flush_fn, flush_size=1)
+        with caplog.at_level(logging.WARNING):
+            dropped = await buf.write(id="bad", embedding=[], document="text")
+        assert dropped is False
+        assert any("dropping id=" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_write_returns_true_when_buffered(self):
+        """Issue #12312: a successful write returns True so callers can distinguish."""
+        flush_fn = AsyncMock()
+        buf = VectorWriteBuffer(flush_fn=flush_fn, flush_size=100)
+        assert await buf.write(id="good", embedding=VALID_EMBEDDING, document="text") is True
+
 
 # ---------------------------------------------------------------------------
 # make_chromadb_flush_fn — flush-time guard (Issue #10941)

--- a/autobot-backend/services/npu_client.py
+++ b/autobot-backend/services/npu_client.py
@@ -77,8 +77,15 @@ HEALTH_CHECK_CACHE_TTL = 30  # seconds
 # Embedding retry policy (Issue #12312). A non-200 / timeout / empty result from a
 # busy local backend is a routine, recoverable condition — retry with exponential
 # backoff before giving up so a transient blip does not permanently drop a vector.
-# Env-tunable; never hard-code per-caller (repo rule).
-EMBEDDING_MAX_ATTEMPTS = max(1, int(os.environ.get("EMBEDDING_MAX_RETRIES", "3")))
+#
+# EMBEDDING_MAX_ATTEMPTS is the TOTAL number of attempts (not extra retries): 3 means
+# up to 3 tries. It applies ONLY to the background / on-demand reconcile path
+# (``vectorize_existing_fact``) — callers pass it explicitly. The INLINE user-facing
+# path (fact create, query embedding) uses the fast-fail default of a single attempt
+# so a downed backend cannot stall a request; failures there are recorded to the
+# reconciler's pending set, which retries in the background. Env-tunable; never
+# hard-code per-caller (repo rule).
+EMBEDDING_MAX_ATTEMPTS = max(1, int(os.environ.get("EMBEDDING_MAX_ATTEMPTS", "3")))
 EMBEDDING_RETRY_BASE_DELAY = max(0.0, float(os.environ.get("EMBEDDING_RETRY_BASE_DELAY_SECONDS", "0.5")))
 
 
@@ -382,26 +389,34 @@ async def generate_embedding_with_fallback(
     model_name: str = "nomic-embed-text",
     ollama_host: str = None,
     ollama_port: str = None,
+    max_attempts: int = 1,
 ) -> List[float] | None:
     """
     Generate embedding with automatic fallback.
 
-    Tries NPU worker first, falls back to Ollama if unavailable. Retries the
-    whole NPU→Ollama attempt with exponential backoff before giving up
-    (Issue #12312) — a busy local backend returning non-200/timeout is a routine,
-    recoverable condition. Every failure route is logged with its reason so a
-    dropped vector is never undiagnosable.
+    Tries NPU worker first, falls back to Ollama if unavailable. Every failure
+    route is logged with its reason (Issue #12312) so a dropped vector is never
+    undiagnosable.
+
+    ``max_attempts`` controls in-call retry with exponential backoff. It defaults
+    to ``1`` (fast-fail) so INLINE user-facing callers (fact create, query
+    embedding) never stall behind a downed backend — worst case one
+    ``EMBEDDING_TIMEOUT`` instead of N. The background / on-demand reconcile path
+    passes ``EMBEDDING_MAX_ATTEMPTS`` to retry transient blips in the background
+    where latency is not user-visible.
 
     Args:
         text: Text to embed
         model_name: Model name
         ollama_host: Ollama host for fallback
         ollama_port: Ollama port for fallback
+        max_attempts: Total attempts before giving up (>=1). Inline default is 1.
 
     Returns:
         Embedding vector or None if all methods fail
     """
     client = get_npu_client()
+    max_attempts = max(1, max_attempts)
 
     # Fallback to Ollama - use SSOT config for defaults
     # config.port.ollama is the canonical path for the port (MVA-1454 / 6c0726ec1).
@@ -410,7 +425,7 @@ async def generate_embedding_with_fallback(
     ollama_url = f"http://{ollama_host}:{ollama_port}/api/embeddings"
 
     last_reason = "no attempts made"
-    for attempt in range(1, EMBEDDING_MAX_ATTEMPTS + 1):
+    for attempt in range(1, max_attempts + 1):
         # Try NPU worker first
         if await client.is_available():
             embedding = await client.generate_embedding(text, model_name)
@@ -419,9 +434,7 @@ async def generate_embedding_with_fallback(
                 _embedding_generated.labels(backend="npu", status="success").inc()
                 return embedding
             last_reason = "NPU worker available but returned an empty embedding"
-            logger.warning(
-                "Embedding attempt %d/%d: %s (model=%s)", attempt, EMBEDDING_MAX_ATTEMPTS, last_reason, model_name
-            )
+            logger.warning("Embedding attempt %d/%d: %s (model=%s)", attempt, max_attempts, last_reason, model_name)
 
         # Fallback to Ollama
         embedding, reason = await _try_ollama_embedding(text, model_name, ollama_url)
@@ -430,18 +443,16 @@ async def generate_embedding_with_fallback(
             _embedding_generated.labels(backend="ollama", status="success").inc()
             return embedding
         last_reason = reason
-        logger.warning(
-            "Embedding attempt %d/%d failed: %s (model=%s)", attempt, EMBEDDING_MAX_ATTEMPTS, reason, model_name
-        )
+        logger.warning("Embedding attempt %d/%d failed: %s (model=%s)", attempt, max_attempts, reason, model_name)
 
-        if attempt < EMBEDDING_MAX_ATTEMPTS and EMBEDDING_RETRY_BASE_DELAY > 0:
+        if attempt < max_attempts and EMBEDDING_RETRY_BASE_DELAY > 0:
             await asyncio.sleep(EMBEDDING_RETRY_BASE_DELAY * (2 ** (attempt - 1)))
 
     _embedding_generated.labels(backend="none", status="failure").inc()
     logger.error(
         "Embedding generation FAILED after %d attempt(s) — caller must handle the "
         "missing vector (do NOT silently drop). model=%s, last_reason=%s, text_prefix=%r",
-        EMBEDDING_MAX_ATTEMPTS,
+        max_attempts,
         model_name,
         last_reason,
         text[:80],

--- a/autobot-backend/services/npu_client.py
+++ b/autobot-backend/services/npu_client.py
@@ -18,9 +18,10 @@ Usage:
 """
 
 import asyncio
+import os
 import threading
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import aiohttp
 
@@ -72,6 +73,13 @@ BATCH_TIMEOUT = 60.0
 
 # Cache for health status
 HEALTH_CHECK_CACHE_TTL = 30  # seconds
+
+# Embedding retry policy (Issue #12312). A non-200 / timeout / empty result from a
+# busy local backend is a routine, recoverable condition — retry with exponential
+# backoff before giving up so a transient blip does not permanently drop a vector.
+# Env-tunable; never hard-code per-caller (repo rule).
+EMBEDDING_MAX_ATTEMPTS = max(1, int(os.environ.get("EMBEDDING_MAX_RETRIES", "3")))
+EMBEDDING_RETRY_BASE_DELAY = max(0.0, float(os.environ.get("EMBEDDING_RETRY_BASE_DELAY_SECONDS", "0.5")))
 
 
 @dataclass
@@ -341,6 +349,33 @@ async def cleanup_npu_client() -> None:
         _npu_client = None
 
 
+async def _try_ollama_embedding(text: str, model_name: str, ollama_url: str) -> Tuple[List[float] | None, str]:
+    """Single Ollama embedding attempt.
+
+    Issue #12312: Returns ``(embedding, "")`` on success or ``(None, reason)`` on
+    failure so every non-success route carries a diagnosable reason instead of
+    silently falling through. Distinguishes non-200 (with status + body) from a
+    200-with-empty-result — previously indistinguishable in the logs.
+    """
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                ollama_url,
+                json={"model": model_name, "prompt": text},
+                timeout=aiohttp.ClientTimeout(total=EMBEDDING_TIMEOUT),
+            ) as response:
+                if response.status != 200:
+                    body = (await response.text())[:200]
+                    return None, f"Ollama HTTP {response.status}: {body!r}"
+                data = await response.json()
+                embedding = data.get("embedding")
+                if not embedding:
+                    return None, "Ollama returned HTTP 200 with empty/missing embedding"
+                return embedding, ""
+    except Exception as e:
+        return None, f"Ollama request error: {e}"
+
+
 # Embedding generation with automatic fallback
 async def generate_embedding_with_fallback(
     text: str,
@@ -351,7 +386,11 @@ async def generate_embedding_with_fallback(
     """
     Generate embedding with automatic fallback.
 
-    Tries NPU worker first, falls back to Ollama if unavailable.
+    Tries NPU worker first, falls back to Ollama if unavailable. Retries the
+    whole NPU→Ollama attempt with exponential backoff before giving up
+    (Issue #12312) — a busy local backend returning non-200/timeout is a routine,
+    recoverable condition. Every failure route is logged with its reason so a
+    dropped vector is never undiagnosable.
 
     Args:
         text: Text to embed
@@ -364,38 +403,49 @@ async def generate_embedding_with_fallback(
     """
     client = get_npu_client()
 
-    # Try NPU worker first
-    if await client.is_available():
-        embedding = await client.generate_embedding(text, model_name)
-        if embedding:
-            logger.debug(f"Generated embedding via NPU worker ({model_name})")
-            _embedding_generated.labels(backend="npu", status="success").inc()
-            return embedding
-
     # Fallback to Ollama - use SSOT config for defaults
     # config.port.ollama is the canonical path for the port (MVA-1454 / 6c0726ec1).
     ollama_host = ollama_host or config.ollama_host
     ollama_port = ollama_port or config.port.ollama
     ollama_url = f"http://{ollama_host}:{ollama_port}/api/embeddings"
 
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                ollama_url,
-                json={"model": model_name, "prompt": text},
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as response:
-                if response.status == 200:
-                    data = await response.json()
-                    embedding = data.get("embedding")
-                    if embedding:
-                        logger.debug(f"Generated embedding via Ollama ({model_name})")
-                        _embedding_generated.labels(backend="ollama", status="success").inc()
-                        return embedding
-    except Exception as e:
-        logger.warning(f"Ollama embedding generation failed: {e}")
+    last_reason = "no attempts made"
+    for attempt in range(1, EMBEDDING_MAX_ATTEMPTS + 1):
+        # Try NPU worker first
+        if await client.is_available():
+            embedding = await client.generate_embedding(text, model_name)
+            if embedding:
+                logger.debug(f"Generated embedding via NPU worker ({model_name})")
+                _embedding_generated.labels(backend="npu", status="success").inc()
+                return embedding
+            last_reason = "NPU worker available but returned an empty embedding"
+            logger.warning(
+                "Embedding attempt %d/%d: %s (model=%s)", attempt, EMBEDDING_MAX_ATTEMPTS, last_reason, model_name
+            )
+
+        # Fallback to Ollama
+        embedding, reason = await _try_ollama_embedding(text, model_name, ollama_url)
+        if embedding:
+            logger.debug(f"Generated embedding via Ollama ({model_name})")
+            _embedding_generated.labels(backend="ollama", status="success").inc()
+            return embedding
+        last_reason = reason
+        logger.warning(
+            "Embedding attempt %d/%d failed: %s (model=%s)", attempt, EMBEDDING_MAX_ATTEMPTS, reason, model_name
+        )
+
+        if attempt < EMBEDDING_MAX_ATTEMPTS and EMBEDDING_RETRY_BASE_DELAY > 0:
+            await asyncio.sleep(EMBEDDING_RETRY_BASE_DELAY * (2 ** (attempt - 1)))
 
     _embedding_generated.labels(backend="none", status="failure").inc()
+    logger.error(
+        "Embedding generation FAILED after %d attempt(s) — caller must handle the "
+        "missing vector (do NOT silently drop). model=%s, last_reason=%s, text_prefix=%r",
+        EMBEDDING_MAX_ATTEMPTS,
+        model_name,
+        last_reason,
+        text[:80],
+    )
     return None
 
 

--- a/autobot-backend/services/npu_client_embedding_fallback_test.py
+++ b/autobot-backend/services/npu_client_embedding_fallback_test.py
@@ -29,9 +29,8 @@ VALID_EMBEDDING = [0.1, 0.2, 0.3]
 
 
 @pytest.fixture(autouse=True)
-def _fast_retries(monkeypatch):
-    """Keep tests instant: 3 attempts, zero backoff sleep."""
-    monkeypatch.setattr(npu_client, "EMBEDDING_MAX_ATTEMPTS", 3)
+def _no_backoff_sleep(monkeypatch):
+    """Keep tests instant: zero backoff sleep between attempts."""
     monkeypatch.setattr(npu_client, "EMBEDDING_RETRY_BASE_DELAY", 0.0)
 
 
@@ -50,7 +49,9 @@ def _npu_unavailable(monkeypatch):
 
 class TestFailureIsSurfacedAndRetried:
     @pytest.mark.asyncio
-    async def test_all_attempts_fail_returns_none_and_logs_error(self, monkeypatch, caplog):
+    async def test_inline_default_is_single_attempt_fast_fail(self, monkeypatch, caplog):
+        """Issue #12312 regression: the inline default must NOT retry — one attempt only,
+        so a downed backend cannot stall a user-facing request with an N-attempt wait."""
         _npu_unavailable(monkeypatch)
 
         calls = {"n": 0}
@@ -62,11 +63,31 @@ class TestFailureIsSurfacedAndRetried:
         monkeypatch.setattr(npu_client, "_try_ollama_embedding", _always_fail)
 
         with caplog.at_level(logging.WARNING):
-            result = await generate_embedding_with_fallback("hello")
+            result = await generate_embedding_with_fallback("hello")  # default max_attempts=1
+
+        assert result is None
+        assert calls["n"] == 1  # exactly one attempt — no inline retry wait
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("FAILED after 1 attempt" in r.getMessage() for r in errors)
+
+    @pytest.mark.asyncio
+    async def test_background_all_attempts_fail_returns_none_and_logs_error(self, monkeypatch, caplog):
+        _npu_unavailable(monkeypatch)
+
+        calls = {"n": 0}
+
+        async def _always_fail(_text, _model, _url):
+            calls["n"] += 1
+            return None, "Ollama HTTP 503: b'model is loading'"
+
+        monkeypatch.setattr(npu_client, "_try_ollama_embedding", _always_fail)
+
+        with caplog.at_level(logging.WARNING):
+            result = await generate_embedding_with_fallback("hello", max_attempts=3)
 
         # Failure is surfaced to the caller (None), NOT a silent empty success.
         assert result is None
-        # Retried the configured number of attempts before giving up.
+        # Retried the requested number of attempts before giving up.
         assert calls["n"] == 3
         # Every failed attempt is logged with its reason (no silent fall-through).
         assert sum("attempt" in r.message.lower() for r in caplog.records) >= 3
@@ -90,7 +111,7 @@ class TestFailureIsSurfacedAndRetried:
 
         monkeypatch.setattr(npu_client, "_try_ollama_embedding", _fail_then_succeed)
 
-        result = await generate_embedding_with_fallback("hello")
+        result = await generate_embedding_with_fallback("hello", max_attempts=3)
 
         assert result == VALID_EMBEDDING
         assert calls["n"] == 2  # first attempt failed, second recovered

--- a/autobot-backend/services/npu_client_embedding_fallback_test.py
+++ b/autobot-backend/services/npu_client_embedding_fallback_test.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for embedding-fallback failure visibility and retry — Issue #12312.
+
+Regression guard for the four previously-unlogged failure paths in
+``generate_embedding_with_fallback`` that silently dropped 130 vectors:
+  - every failure route is logged with a diagnosable reason;
+  - the whole NPU->Ollama attempt is retried with backoff before giving up;
+  - the terminal ``return None`` is loud (ERROR with model + reason + text prefix)
+    so a dropped vector is never undiagnosable.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+# The conftest `services` package stub means ``from services import npu_client``
+# yields a stub attribute, not the loaded submodule. Bind the real module via
+# sys.modules so monkeypatch targets the same dict the functions resolve globals in.
+from services.npu_client import _try_ollama_embedding, generate_embedding_with_fallback  # noqa: F401
+
+npu_client = sys.modules["services.npu_client"]
+
+VALID_EMBEDDING = [0.1, 0.2, 0.3]
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch):
+    """Keep tests instant: 3 attempts, zero backoff sleep."""
+    monkeypatch.setattr(npu_client, "EMBEDDING_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(npu_client, "EMBEDDING_RETRY_BASE_DELAY", 0.0)
+
+
+def _npu_unavailable(monkeypatch):
+    """Force the NPU branch to be skipped so Ollama drives the outcome."""
+
+    class _Client:
+        async def is_available(self):
+            return False
+
+        async def generate_embedding(self, *_a, **_k):
+            return None
+
+    monkeypatch.setattr(npu_client, "get_npu_client", lambda: _Client())
+
+
+class TestFailureIsSurfacedAndRetried:
+    @pytest.mark.asyncio
+    async def test_all_attempts_fail_returns_none_and_logs_error(self, monkeypatch, caplog):
+        _npu_unavailable(monkeypatch)
+
+        calls = {"n": 0}
+
+        async def _always_fail(_text, _model, _url):
+            calls["n"] += 1
+            return None, "Ollama HTTP 503: b'model is loading'"
+
+        monkeypatch.setattr(npu_client, "_try_ollama_embedding", _always_fail)
+
+        with caplog.at_level(logging.WARNING):
+            result = await generate_embedding_with_fallback("hello")
+
+        # Failure is surfaced to the caller (None), NOT a silent empty success.
+        assert result is None
+        # Retried the configured number of attempts before giving up.
+        assert calls["n"] == 3
+        # Every failed attempt is logged with its reason (no silent fall-through).
+        assert sum("attempt" in r.message.lower() for r in caplog.records) >= 3
+        assert any("503" in r.getMessage() for r in caplog.records)
+        # Terminal give-up is a loud ERROR naming the model + reason.
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "terminal failure must log at ERROR level"
+        assert any("FAILED after" in r.getMessage() for r in errors)
+
+    @pytest.mark.asyncio
+    async def test_retry_recovers_on_later_attempt(self, monkeypatch, caplog):
+        _npu_unavailable(monkeypatch)
+
+        calls = {"n": 0}
+
+        async def _fail_then_succeed(_text, _model, _url):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                return None, "Ollama request error: timeout"
+            return list(VALID_EMBEDDING), ""
+
+        monkeypatch.setattr(npu_client, "_try_ollama_embedding", _fail_then_succeed)
+
+        result = await generate_embedding_with_fallback("hello")
+
+        assert result == VALID_EMBEDDING
+        assert calls["n"] == 2  # first attempt failed, second recovered
+
+    @pytest.mark.asyncio
+    async def test_success_on_first_attempt_no_error(self, monkeypatch):
+        _npu_unavailable(monkeypatch)
+
+        async def _ok(_text, _model, _url):
+            return list(VALID_EMBEDDING), ""
+
+        monkeypatch.setattr(npu_client, "_try_ollama_embedding", _ok)
+
+        assert await generate_embedding_with_fallback("hello") == VALID_EMBEDDING
+
+
+class TestOllamaAttemptReasons:
+    """_try_ollama_embedding must distinguish each failure route with a reason."""
+
+    @pytest.mark.asyncio
+    async def test_non_200_reports_status_and_body(self, monkeypatch):
+        embedding, reason = await self._run_with_response(monkeypatch, status=503, payload={"error": "loading"})
+        assert embedding is None
+        assert "503" in reason
+
+    @pytest.mark.asyncio
+    async def test_200_empty_embedding_reports_reason(self, monkeypatch):
+        embedding, reason = await self._run_with_response(monkeypatch, status=200, payload={"embedding": []})
+        assert embedding is None
+        assert "empty" in reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_200_valid_embedding_returns_vector(self, monkeypatch):
+        embedding, reason = await self._run_with_response(
+            monkeypatch, status=200, payload={"embedding": VALID_EMBEDDING}
+        )
+        assert embedding == VALID_EMBEDDING
+        assert reason == ""
+
+    async def _run_with_response(self, monkeypatch, status, payload):
+        """Drive _try_ollama_embedding against a fake aiohttp response."""
+
+        class _Resp:
+            def __init__(self):
+                self.status = status
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_a):
+                return False
+
+            async def json(self):
+                return payload
+
+            async def text(self):
+                return str(payload)
+
+        class _Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_a):
+                return False
+
+            def post(self, *_a, **_k):
+                return _Resp()
+
+        monkeypatch.setattr(npu_client.aiohttp, "ClientSession", lambda *a, **k: _Session())
+        return await _try_ollama_embedding("hello", "nomic-embed-text", "http://x/api/embeddings")


### PR DESCRIPTION
## Thinking Path

Issue #12312 reports 130 vectors silently dropped: embedding generation failed transiently (backend crash-loop), the fact was still persisted, but its vector was dropped with only a log line — no queryable failed-state, no retry, no correlation to a cause. Root cause is two-fold:

1. **Undiagnosable failures** — `services/npu_client.py:generate_embedding_with_fallback` had four routes to `return None`, only one of which logged. A non-200 from Ollama was indistinguishable from a 200-with-empty-result.
2. **Silent drop reported as success** — the inline vectorization path (`knowledge/facts.py:_vectorize_fact_in_chromadb` and `_revectorize_fact`) passed the empty embedding to `VectorWriteBuffer.write`, which dropped it (correct #10941 containment), then logged `"Vectorized fact X"` anyway. Nothing marked the fact unvectorized, so it was neither queryable nor retried.

A retriable/queryable substrate already exists — the background reconciler's pending set `kb:vectorize:pending` (#11296) plus the `vectorization_status` hash field. The fix records failures into that existing infrastructure rather than inventing a new dead-letter store.

## What Changed

**`services/npu_client.py`** — every failure route now logs its reason (NPU empty; Ollama non-200 with status+body; 200-with-empty; request error), extracted into `_try_ollama_embedding` returning `(embedding, reason)`. The whole NPU→Ollama attempt is retried with exponential backoff (env-tunable `EMBEDDING_MAX_RETRIES`, `EMBEDDING_RETRY_BASE_DELAY_SECONDS`), and the terminal `return None` is a loud ERROR naming model + last reason + text prefix.

**`knowledge/facts.py`** — new `_record_failed_vectorization(fact_id, reason)` helper: logs ERROR, sets `vectorization_status=failed` + error + timestamp on the `fact:<id>` hash (queryable), and SADDs the fact to `kb:vectorize:pending` (retriable — the reconciler re-vectorizes it every cycle until it succeeds). Both inline paths now call it when the embedding is empty and `return` instead of logging false success.

**`knowledge/write_buffer.py`** — `write()` returns `bool` (`False` when a drop occurs) so callers can detect a drop rather than assume success; drop is still logged.

**Recovery of the existing 130**: they carry no `vectorization_status`, so the reconciler's periodic full `fact:*` scan already re-vectorizes them once a backend is healthy — no manual backfill needed.

**Product note (safe default chosen):** I implemented *surface + record + retry* (do not drop, do not hard-fail ingestion) since the fact content is valuable and should still persist. Whether to additionally hard-fail ingestion when the vector cannot be produced, and whether to surface an operator-facing KB-health count (issue rec #4) in the UI, are UX choices left for the owner as fast-follows.

## Verification

- `python3 -m black --check --line-length 120` + `flake8 --max-line-length 120` + `ast.parse`: clean on all touched files.
- New tests (all green):
  - `services/npu_client_embedding_fallback_test.py` — every failure route carries a reason; failure is surfaced (`None`) not a silent empty success; retried the configured number of attempts; recovers on a later attempt; terminal give-up logs at ERROR (caplog).
  - `knowledge/facts_failed_vectorization_test.py` — empty embedding records `vectorization_status=failed` + SADD to pending set + ERROR log, and does NOT call the write buffer; a valid embedding writes and records no failure.
  - `knowledge/write_buffer_test.py` — `write()` returns `False`+logs on drop, `True` when buffered.
- `python3 -m pytest` on the three files: `22 passed`.

## Model Used

claude-opus-4-8

Closes #12312
