### PR TITLE
fix(transcriber): resolve TRANSCRIBER_DATA_DIR absolute + unlink orphaned uploads (#12310)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -390,7 +390,10 @@ async def _init_transcriber_db(app: FastAPI) -> None:
     try:
         from transcriber.database import Database
 
-        data_dir = _Path(os.getenv("TRANSCRIBER_DATA_DIR", "data/transcriber"))
+        # Resolve to an absolute path: ``create_recording`` rejects relative
+        # filepaths, and relying on cwd is fragile across launch contexts
+        # (GH#12310 — every upload 500'd because the default was relative).
+        data_dir = _Path(os.getenv("TRANSCRIBER_DATA_DIR", "data/transcriber")).resolve()
         data_dir.mkdir(parents=True, exist_ok=True)
         (data_dir / "uploads").mkdir(exist_ok=True)
         (data_dir / "processed").mkdir(exist_ok=True)

--- a/autobot-backend/transcriber/routes/recordings.py
+++ b/autobot-backend/transcriber/routes/recordings.py
@@ -39,7 +39,9 @@ _ALLOWED_EXTENSIONS = {".wav", ".mp3", ".mp4", ".m4a", ".ogg", ".flac", ".webm"}
 
 
 def _upload_dir(request: Request) -> Path:
-    return Path(request.app.state.transcriber_upload_dir)
+    # Resolve to absolute: create_recording rejects relative filepaths and the
+    # configured dir may be relative under some launch contexts (GH#12310).
+    return Path(request.app.state.transcriber_upload_dir).resolve()
 
 
 def _user_id(request: Request) -> str:
@@ -65,7 +67,13 @@ async def upload_recording(
     async with aiofiles.open(dest, "wb") as f:
         while chunk := await file.read(65536):
             await f.write(chunk)
-    rid = await db.create_recording(project_id, file.filename or safe_name, str(dest), user_id=_user_id(request))
+    # The file is on disk before the DB row exists; unlink the partial upload
+    # if the insert fails so a rejected recording never leaks an orphan (GH#12310).
+    try:
+        rid = await db.create_recording(project_id, file.filename or safe_name, str(dest), user_id=_user_id(request))
+    except Exception:
+        dest.unlink(missing_ok=True)
+        raise
     logger.info(
         "Recording uploaded: recording_id=%s project_id=%s filename=%s",
         rid,

--- a/autobot-backend/transcriber/tests/test_recordings_api.py
+++ b/autobot-backend/transcriber/tests/test_recordings_api.py
@@ -4,6 +4,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 import io
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -62,6 +63,81 @@ async def test_list_recordings(client, tmp_path):
     r2 = await client.get(f"/api/transcriber/projects/{pid}/recordings")
     assert r2.status_code == 200
     assert len(r2.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_upload_recording_with_relative_upload_dir(tmp_path, monkeypatch):
+    """GH#12310: a *relative* upload dir (the shipped default) must still yield 202.
+
+    Production set ``transcriber_upload_dir`` to a cwd-relative path, but
+    ``create_recording`` rejects non-absolute filepaths, so every upload 500'd
+    and left an orphaned file behind. The route now resolves the dir to an
+    absolute path before writing/inserting.
+    """
+    monkeypatch.chdir(tmp_path)
+    rel_upload = "data/transcriber/uploads"
+    (tmp_path / rel_upload).mkdir(parents=True)
+
+    a = FastAPI()
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+
+    async def override_db():
+        return db
+
+    a.dependency_overrides[get_db] = override_db
+    a.state.transcriber_upload_dir = rel_upload  # relative, exactly as shipped
+    a.include_router(projects_router, prefix="/api/transcriber")
+    a.include_router(recordings_router, prefix="/api/transcriber")
+
+    async with AsyncClient(transport=ASGITransport(app=a), base_url="http://test") as c:
+        r = await c.post("/api/transcriber/projects", json={"name": "P", "description": ""})
+        pid = r.json()["id"]
+        # Deferred `from tasks.transcriber_tasks import transcribe_recording`
+        # in the handler — patch the source module to skip the Celery broker.
+        with patch("tasks.transcriber_tasks.transcribe_recording", MagicMock()):
+            r2 = await c.post(
+                f"/api/transcriber/projects/{pid}/recordings",
+                files={"file": ("rel.wav", io.BytesIO(b"RIFF" + b"\x00" * 100), "audio/wav")},
+            )
+
+    assert r2.status_code == 202, r2.text
+    rid = r2.json()["id"]
+    rec = await db.get_recording(rid)
+    # Stored filepath is absolute and the audio landed under the resolved dir.
+    assert rec is not None
+    stored = rec["filepath"]
+    assert stored.startswith("/"), stored
+    saved = tmp_path / rel_upload
+    files = list(saved.iterdir())
+    assert len(files) == 1, files
+    assert files[0].read_bytes().startswith(b"RIFF")
+
+
+@pytest.mark.asyncio
+async def test_failed_insert_unlinks_orphan(client, tmp_path, monkeypatch):
+    """GH#12310: a DB insert failure must not leak the partial upload file."""
+    import transcriber.routes.recordings as rec_mod
+
+    # Locate the resolved upload dir the fixture wired up.
+    r = await client.post("/api/transcriber/projects", json={"name": "P", "description": ""})
+    pid = r.json()["id"]
+
+    async def boom(*args, **kwargs):
+        raise ValueError("filepath must be absolute, got: 'x'")
+
+    monkeypatch.setattr(rec_mod.Database, "create_recording", boom, raising=True)
+    # The ASGI test transport re-raises the handler exception (no server-side
+    # 500 wrapper); in production this surfaces as HTTP 500. Either way the
+    # partial upload must be cleaned up.
+    with pytest.raises(ValueError):
+        await client.post(
+            f"/api/transcriber/projects/{pid}/recordings",
+            files={"file": ("orphan.wav", io.BytesIO(b"RIFF" + b"\x00" * 10), "audio/wav")},
+        )
+    # No orphan left behind in the upload dir.
+    upload_dir = tmp_path / "uploads"
+    assert list(upload_dir.iterdir()) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path

`POST /api/transcriber/projects/{id}/recordings` returned HTTP 500 for **every** upload on a stock install. Traced the path: `initialization/lifespan.py` set `app.state.transcriber_upload_dir` from `TRANSCRIBER_DATA_DIR` whose default (`data/transcriber`) is **relative**; the route wrote the audio file, then `Database.create_recording()` hard-rejected the non-absolute filepath (`raise ValueError(...)`) → opaque 500. Worse, the file was written **before** the failing insert, so each attempt leaked an orphaned upload. Tests never caught it because every fixture injects an absolute `tmp_path`, so the shipped relative default was untested.

## What Changed

- **`initialization/lifespan.py`** — resolve the data dir to an absolute path at startup: `_Path(os.getenv("TRANSCRIBER_DATA_DIR", "data/transcriber")).resolve()`. Primary fix — makes the shipped default satisfy `create_recording`'s absolute-path invariant.
- **`transcriber/routes/recordings.py`** — `_upload_dir()` now returns `.resolve()`d (belt-and-suspenders for any relative state), and the `create_recording` call is wrapped so a failed insert `unlink(missing_ok=True)`s the partial upload → no more orphaned files.
- **`transcriber/tests/test_recordings_api.py`** — two tests: (1) upload through a **relative** upload dir (the shipped config) now returns 202 and stores an absolute filepath with the audio landing under the resolved dir; (2) a failing insert leaves no orphan behind.

## Verification

Before: `ValueError: filepath must be absolute, got: 'data/transcriber/uploads/….wav'` → HTTP 500 on every upload, orphan left on disk.

After (single clean process, machine idle):
```
$ pytest transcriber/tests/test_recordings_api.py -q
.....                                                                    [100%]
5 passed, 1 warning in 2.04s
```
New tests alone: `2 passed in 0.86s`. Lint: `black --check --line-length 120` clean, `flake8 --max-line-length 120` = 0, `ast.parse` clean on all three files.

Note: a companion nginx `client_max_body_size 10m` limit (called out in the issue) blocks large audio at the proxy before it reaches this code — an infra config change outside the repo; this PR fixes the application-side defect so uploads succeed once the payload reaches the app.

## Model Used

claude-opus-4-8

Closes #12310
