### PR TITLE
fix(transcriber): scope nginx 500m upload cap to /api/transcriber/ (#12311)

### DIFF
--- a/autobot-infrastructure/autobot-slm-frontend/templates/autobot-slm.conf
+++ b/autobot-infrastructure/autobot-slm-frontend/templates/autobot-slm.conf
@@ -69,6 +69,27 @@ server {
         proxy_read_timeout 300s;
     }
 
+    # Transcriber media uploads — must be before /api/ to take priority.
+    # #12311: the server-level 10m cap (sized for SLM agent event sync, #1090)
+    # rejected realistic audio/video uploads (.wav/.mp3/.mp4/.m4a/.ogg/.flac/.webm)
+    # with 413 before they reached the app. Scoped here so agent-sync keeps 10m.
+    # 500m matches the app's documented ceiling (transcriber/upload_security.py
+    # MAX_FILE_SIZE = 500 * 1024 * 1024). proxy_request_buffering off streams the
+    # upload to the backend instead of spooling the whole body to a temp file.
+    location /api/transcriber/ {
+        proxy_pass http://127.0.0.1:8000/api/transcriber/;
+        proxy_http_version 1.1;
+        client_max_body_size 500m;
+        proxy_request_buffering off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+    }
+
     # API reverse proxy
     location /api/ {
         proxy_pass http://127.0.0.1:8000/api/;


### PR DESCRIPTION
## Thinking Path

Issue #12311: nginx caps request bodies at `10m` site-wide, so realistic transcriber audio uploads (`.wav/.mp3/.mp4/.m4a/.ogg/.flac/.webm` — typically tens of MB) are rejected with **413** at the proxy before reaching the app, and nginx returns HTML the frontend can't surface.

The issue's evidence points at the active config `/etc/nginx/sites-enabled/autobot-slm`. Traced it to `autobot-slm-frontend/templates/autobot-slm.conf`, deployed by `bootstrap-slm.sh:491` — this template still had the server-level `10m` and no transcriber scope. The two sibling templates (`slm_manager` colocated `/api/`, `frontend` role `/api/`) already received the `#10565` upload fix; this bootstrap template was the one that got missed.

The server-level `10m` is intentional — it was sized for SLM agent event sync (#1090) — so raising it globally is wrong. I scoped the larger cap to the upload path only.

## What Changed

`autobot-infrastructure/autobot-slm-frontend/templates/autobot-slm.conf`: added a dedicated `location /api/transcriber/` block (placed before `location /api/` so the longer prefix wins) that:
- Raises `client_max_body_size` from the inherited `10m` to **`500m`** — matching the app's documented ceiling `MAX_FILE_SIZE = 500 * 1024 * 1024` in `transcriber/upload_security.py:23`, so proxy and app agree on one number.
- Adds `proxy_request_buffering off` to stream large uploads to the backend instead of spooling the whole body to a temp file.
- Proxies to the same `http://127.0.0.1:8000/api/transcriber/` upstream with the standard headers + timeouts.

The server-level `10m` is untouched, so SLM agent event sync (#1090) and every other path keep the original limit. Least surface area, applied in the provisioning template so a deploy picks it up — no hand edit on the box.

**App-side agreement note:** the app declares `MAX_FILE_SIZE = 500 MB`, but the recordings upload route (`transcriber/routes/recordings.py:50`) does not actually call `upload_security` — it streams chunks with no size check. So 500 MB is the *documented* app ceiling, not yet actively enforced on this route. The proxy now agrees with that documented number; wiring the app to enforce it is a separate follow-up.

Complementary to #12310 (PR #12328), which fixes the app-side relative-path 500. Together: small files no longer 500, realistic files no longer 413.

## Verification

`nginx -t` against the rendered template (self-signed cert, scratch paths):
```
nginx: the configuration file ... syntax is ok
```
All remaining `nginx -t` errors are privilege-only (`bind() to :80` needs root, default `/var/log/nginx` log path) — none relate to the config content. Brace balance verified (10 open / 10 close). New directives (`location /api/transcriber/`, `client_max_body_size 500m`, `proxy_request_buffering off`) are valid and in the correct `location` context.

## Model Used

claude-opus-4-8

Closes #12311
