### PR TITLE
fix(backend): advanced-control status/health compute real status not hardcoded healthy (#12243)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -42,12 +42,18 @@ from constants.error_constants import ERR_SESSION_NOT_FOUND
 from constants.threshold_constants import TimingConstants
 from desktop_streaming_manager import get_desktop_streaming
 from memory import TaskPriority  # canonical enum (#10626)
+from metrics.system_monitor import evaluate_resource_thresholds
 from takeover_manager import TakeoverTrigger, get_takeover_manager
 from task_execution_tracker import get_task_tracker
 from type_defs.common import Metadata
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["advanced_control"])
+
+# Map the resource classifier's verdict to this control plane's health vocabulary
+# (#12243). "warning" (approaching a threshold) is a soft degrade; "critical"
+# (over a threshold) is unhealthy.
+_RESOURCE_STATUS_TO_HEALTH = {"ok": "healthy", "warning": "degraded", "critical": "unhealthy"}
 
 
 # Desktop Streaming Endpoints
@@ -415,11 +421,28 @@ async def get_system_status(
     # boot epoch). timestamp is when this snapshot was taken; uptime_seconds is a
     # duration (now - boot).
     now = time.time()
+    # #12243: derive status from the metrics this response actually reports rather
+    # than a hardcoded "healthy". Grade the already-collected resource_usage against
+    # the canonical thresholds; if desktop streaming (this panel's core capability)
+    # is unavailable, that is at least a degraded control plane.
+    resource_verdict = evaluate_resource_thresholds(
+        {
+            "cpu_percent": resource_usage["cpu_percent"],
+            "memory_percent": resource_usage["memory_percent"],
+            "disk_percent": resource_usage["disk_usage"],
+        }
+    )
+    status = _RESOURCE_STATUS_TO_HEALTH[resource_verdict["status"]]
+    streaming_available = bool(get_desktop_streaming().vnc_manager.vnc_available)
+    if not streaming_available and status == "healthy":
+        status = "degraded"
+
     system_status = {
-        "status": "healthy",
+        "status": status,
         "timestamp": now,
         "uptime_seconds": now - psutil.boot_time(),
         "streaming_capabilities": get_desktop_streaming().get_system_capabilities(),
+        "resource_alerts": resource_verdict["critical_alerts"] + resource_verdict["warnings"],
     }
 
     response = SystemMonitoringResponse(
@@ -482,9 +505,13 @@ async def get_system_health(
     try:
         dsm = get_desktop_streaming()
         tm = get_takeover_manager()
+        # #12243: reflect the real subsystem state instead of a constant "healthy".
+        # Desktop streaming (VNC) is this control plane's core capability — when it
+        # is unavailable the panel is degraded, not healthy.
+        streaming_available = dsm.vnc_manager.vnc_available
         health_status = {
-            "status": "healthy",
-            "desktop_streaming_available": dsm.vnc_manager.vnc_available,
+            "status": "healthy" if streaming_available else "degraded",
+            "desktop_streaming_available": streaming_available,
             "novnc_available": dsm.vnc_manager.novnc_available,
             "active_streaming_sessions": len(dsm.vnc_manager.active_sessions),
             "pending_takeovers": len(await tm.get_pending_requests()),

--- a/autobot-backend/metrics/system_monitor.py
+++ b/autobot-backend/metrics/system_monitor.py
@@ -10,7 +10,7 @@ Monitors system performance during workflow execution
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 
 import psutil
 
@@ -18,6 +18,36 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso
 
 logger = get_logger(__name__)
+
+# Canonical resource-saturation thresholds (percent). Single source of truth so
+# every health surface derives the same verdict from cpu/memory/disk load.
+RESOURCE_THRESHOLDS = {"cpu_percent": 80, "memory_percent": 85, "disk_percent": 90}
+
+
+def evaluate_resource_thresholds(metrics: Mapping[str, float]) -> Dict[str, Any]:
+    """Classify an already-collected resource-metrics snapshot.
+
+    Pure helper (no sampling) so callers can grade the exact numbers they report
+    instead of taking a second, divergent psutil reading. Returns a dict with
+    ``status`` (``ok``/``warning``/``critical``) plus the triggering alert lists.
+    """
+    warnings: List[str] = []
+    critical: List[str] = []
+
+    for metric, threshold in RESOURCE_THRESHOLDS.items():
+        if metric not in metrics:
+            continue
+        value = metrics[metric]
+        if value > threshold:
+            critical.append(f"{metric}: {value:.1f}% (threshold: {threshold}%)")
+        elif value > threshold * 0.8:  # 80% of threshold as warning
+            warnings.append(f"{metric}: {value:.1f}% (approaching threshold: {threshold}%)")
+
+    return {
+        "status": "critical" if critical else ("warning" if warnings else "ok"),
+        "critical_alerts": critical,
+        "warnings": warnings,
+    }
 
 
 class SystemResourceMonitor:
@@ -352,26 +382,9 @@ class SystemResourceMonitor:
         """Check if system resources are within acceptable thresholds"""
         try:
             current = self.get_current_metrics()
-
-            # Define thresholds
-            thresholds = {"cpu_percent": 80, "memory_percent": 85, "disk_percent": 90}
-
-            warnings = []
-            critical = []
-
-            # Check each threshold
-            for metric, threshold in thresholds.items():
-                if metric in current:
-                    value = current[metric]
-                    if value > threshold:
-                        critical.append(f"{metric}: {value:.1f}% (threshold: {threshold}%)")
-                    elif value > threshold * 0.8:  # 80% of threshold as warning
-                        warnings.append(f"{metric}: {value:.1f}% " f"(approaching threshold: {threshold}%)")
-
+            verdict = evaluate_resource_thresholds(current)
             return {
-                "status": "critical" if critical else ("warning" if warnings else "ok"),
-                "critical_alerts": critical,
-                "warnings": warnings,
+                **verdict,
                 "current_metrics": current,
                 "check_timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }

--- a/autobot-backend/tests/api/test_advanced_control_status_health_12243.py
+++ b/autobot-backend/tests/api/test_advanced_control_status_health_12243.py
@@ -1,0 +1,125 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression test for #12243.
+
+``GET /api/advanced-control/system/status`` and ``/system/health`` previously
+hardcoded ``status: "healthy"`` regardless of the real resource load or
+capability state they report. The status must now be *derived*:
+
+- ``system/status`` grades the reported cpu/memory/disk usage against the
+  canonical thresholds (:data:`metrics.system_monitor.RESOURCE_THRESHOLDS`) and
+  degrades when desktop streaming (the panel's core capability) is unavailable.
+- ``system/health`` reports ``degraded`` when desktop streaming is unavailable.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _streaming_mock(vnc_available=True, novnc_available=True):
+    streaming = MagicMock()
+    streaming.vnc_manager.vnc_available = vnc_available
+    streaming.vnc_manager.novnc_available = novnc_available
+    streaming.vnc_manager.active_sessions = []
+    streaming.vnc_manager.list_active_sessions.return_value = []
+    streaming.get_system_capabilities.return_value = {}
+    return streaming
+
+
+def _takeover_mock():
+    takeover = MagicMock()
+    takeover.get_pending_requests = AsyncMock(return_value=[])
+    takeover.get_active_sessions = AsyncMock(return_value=[])
+    takeover._paused_count = AsyncMock(return_value=0)
+    return takeover
+
+
+def _patch_resources(cpu, mem, disk):
+    """Force psutil resource sampling used by get_system_status to fixed values."""
+    return (
+        patch("psutil.cpu_percent", return_value=cpu),
+        patch("psutil.virtual_memory", return_value=MagicMock(percent=mem)),
+        patch("psutil.disk_usage", return_value=MagicMock(percent=disk)),
+        patch("psutil.pids", return_value=[]),
+        patch("psutil.boot_time", return_value=1_700_000_000.0),
+    )
+
+
+async def _call_system_status(cpu, mem, disk, vnc_available=True):
+    from api.advanced_control import get_system_status
+
+    streaming = _streaming_mock(vnc_available=vnc_available)
+    takeover = _takeover_mock()
+    cpu_p, vmem_p, disk_p, pids_p, boot_p = _patch_resources(cpu, mem, disk)
+    with (
+        cpu_p,
+        vmem_p,
+        disk_p,
+        pids_p,
+        boot_p,
+        patch("api.advanced_control.get_desktop_streaming", return_value=streaming),
+        patch("api.advanced_control.get_takeover_manager", return_value=takeover),
+    ):
+        resp = await get_system_status(admin_check=True)
+    return resp.system_status
+
+
+@pytest.mark.asyncio
+async def test_system_status_healthy_when_all_nominal():
+    status = await _call_system_status(cpu=5, mem=10, disk=15, vnc_available=True)
+    assert status["status"] == "healthy"
+    assert status["resource_alerts"] == []
+
+
+@pytest.mark.asyncio
+async def test_system_status_unhealthy_when_resource_over_threshold():
+    # CPU 99% is over the 80% critical threshold -> unhealthy (NOT hardcoded healthy).
+    status = await _call_system_status(cpu=99, mem=10, disk=15, vnc_available=True)
+    assert status["status"] == "unhealthy"
+    assert any("cpu_percent" in alert for alert in status["resource_alerts"])
+
+
+@pytest.mark.asyncio
+async def test_system_status_degraded_when_resource_approaching_threshold():
+    # Memory 70% is above 85% * 0.8 == 68% warning band -> degraded.
+    status = await _call_system_status(cpu=5, mem=70, disk=15, vnc_available=True)
+    assert status["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_system_status_degraded_when_streaming_unavailable():
+    # Resources nominal but the core capability is down -> degraded, not healthy.
+    status = await _call_system_status(cpu=5, mem=10, disk=15, vnc_available=False)
+    assert status["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_system_health_healthy_when_streaming_available():
+    from api.advanced_control import get_system_health
+
+    streaming = _streaming_mock(vnc_available=True)
+    takeover = _takeover_mock()
+    with (
+        patch("api.advanced_control.get_desktop_streaming", return_value=streaming),
+        patch("api.advanced_control.get_takeover_manager", return_value=takeover),
+    ):
+        health = await get_system_health(admin_check=True)
+    assert health["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_system_health_degraded_when_streaming_unavailable():
+    from api.advanced_control import get_system_health
+
+    streaming = _streaming_mock(vnc_available=False)
+    takeover = _takeover_mock()
+    with (
+        patch("api.advanced_control.get_desktop_streaming", return_value=streaming),
+        patch("api.advanced_control.get_takeover_manager", return_value=takeover),
+    ):
+        health = await get_system_health(admin_check=True)
+    assert health["status"] == "degraded"
+    assert health["desktop_streaming_available"] is False


### PR DESCRIPTION
## Thinking Path
`/advanced-control/system/status` and `/system/health` both hardcoded `status: "healthy"` (advanced_control.py L419 / L486), so the Monitoring tab (#12173) read "healthy" even on a saturated or streaming-down box. The status must be derived from the same signals the responses already report. Rather than invent a new health model, I reused the canonical resource thresholds that already live in `metrics/system_monitor.py`.

## What Changed
- **`metrics/system_monitor.py`** — extracted the inline cpu/memory/disk thresholds to a module constant `RESOURCE_THRESHOLDS` and a pure classifier `evaluate_resource_thresholds(metrics)` returning `ok`/`warning`/`critical` from an already-collected snapshot (no second psutil sample). `check_resource_thresholds()` now delegates to it — same return contract, single source of truth.
- **`api/advanced_control.py`**
  - `get_system_status`: grades the reported `resource_usage` (cpu/memory/disk) via `evaluate_resource_thresholds`, mapping `ok→healthy`, `warning→degraded`, `critical→unhealthy`; also degrades when desktop streaming (the panel's core capability) is unavailable. Adds a `resource_alerts` list for observability.
  - `get_system_health`: reports `degraded` when desktop streaming (VNC) is unavailable, `healthy` when up — no longer a constant.
- **Test** `tests/api/test_advanced_control_status_health_12243.py` — 6 cases covering nominal→healthy, over-threshold→unhealthy, approaching-threshold→degraded, streaming-down→degraded (status), and streaming up/down→healthy/degraded (health).

## Verification
- `python3 -m black --check --line-length 120` — clean (3 files unchanged)
- `python3 -m flake8 --max-line-length 120` — 0 violations
- `python3 -m pytest` new + sibling advanced-control tests — 13 passed

## Model Used
Claude Opus 4.8

Closes #12243
