### PR TITLE
fix(backend): fail fast on permanent DB credential misconfig, bounded retry on transient (#12293)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -268,34 +268,34 @@ async def _init_security_layer(app: FastAPI) -> None:
 async def _init_database() -> None:
     """Helper for initialize_critical_services. Ref: #1088.
 
-    Issue #898: Initialize PostgreSQL async engine. Raises RuntimeError on failure.
+    Issue #898: Initialize PostgreSQL async engine.
+    Issue #12293: ``init_database()`` now distinguishes a permanent credential
+    misconfiguration (fail fast with a loud CRITICAL diagnosis) from transient
+    DB unavailability (bounded, clearly-logged retry). Both raise a clear
+    ``RuntimeError``; surface it unchanged rather than re-wrapping into a
+    generic "Database initialization failed" that would bury the root cause.
     """
     logger.info("✅ [ 16%] Database: Initializing PostgreSQL async engine...")
-    logger.info("🔍 DEBUG: About to call get_deployment_config()")
     try:
         from user_management.config import get_deployment_config
 
         config = get_deployment_config()
         logger.info(
-            "🔍 DEBUG: Deployment config loaded - mode=%s, postgres_enabled=%s",
+            "Database: mode=%s postgres_enabled=%s target=%s:%s/%s",
             config.mode.value,
             config.postgres_enabled,
-        )
-        logger.info(
-            "🔍 DEBUG: PostgreSQL - host=%s, port=%s, db=%s",
             config.postgres_host,
             config.postgres_port,
             config.postgres_db,
         )
-        logger.info("🔍 DEBUG: About to call init_database()")
         await init_database()
         logger.info("✅ [ 16%] Database: PostgreSQL async engine initialized")
     except Exception as db_error:
-        logger.error("❌ CRITICAL: Database initialization failed: %s", db_error)
-        import traceback
-
-        logger.error("❌ TRACEBACK: %s", traceback.format_exc())
-        raise RuntimeError(f"Database initialization failed: {db_error}")
+        # init_database() has already logged a CRITICAL fail-fast / bounded-retry
+        # diagnosis (#12293). Re-raise its clear RuntimeError unchanged so the
+        # root cause (e.g. stale autobot_app password) is not hidden.
+        logger.error("❌ CRITICAL: Database initialization aborted: %s", db_error)
+        raise
 
 
 async def _init_telemetry_and_redis() -> None:

--- a/autobot-backend/tests/user_management/test_init_database_crashloop.py
+++ b/autobot-backend/tests/user_management/test_init_database_crashloop.py
@@ -1,0 +1,144 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Issue #12293: backend must not silently crash-loop on DB credential misconfig.
+
+Pins init_database()'s fail-fast vs bounded-retry behaviour:
+
+* A *permanent* credential/authorization error (bad password, missing role,
+  missing database) fails fast with ZERO retries and a clear RuntimeError —
+  retrying can never help, so the process exits with a distinct signal instead
+  of looping forever.
+* A *transient* error (DB still coming up) is retried a BOUNDED number of times
+  and then either succeeds or gives up with a clear RuntimeError.
+"""
+
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+import user_management.database as db
+
+
+def _fake_config():
+    """Minimal stand-in for DeploymentConfig with postgres enabled."""
+    return types.SimpleNamespace(
+        mode=types.SimpleNamespace(value="single_company"),
+        postgres_enabled=True,
+        postgres_host="db-host",
+        postgres_port=5432,
+        postgres_db="autobot",
+        postgres_user="autobot_app",
+    )
+
+
+class _AuthError(Exception):
+    """Stand-in for asyncpg.InvalidPasswordError (SQLSTATE 28P01)."""
+
+    sqlstate = "28P01"
+
+
+class TestPermanentErrorClassification:
+    def test_auth_sqlstate_is_permanent(self):
+        assert db._is_permanent_db_error(_AuthError("password authentication failed")) is True
+
+    def test_wrapped_auth_error_is_permanent(self):
+        # SQLAlchemy-style wrapping: OperationalError -> asyncpg error via __cause__.
+        try:
+            try:
+                raise _AuthError("password authentication failed for user")
+            except _AuthError as inner:
+                raise RuntimeError("(sqlalchemy) connect failed") from inner
+        except RuntimeError as wrapped:
+            assert db._is_permanent_db_error(wrapped) is True
+
+    def test_invalid_catalog_is_permanent(self):
+        class _NoDb(Exception):
+            sqlstate = "3D000"
+
+        assert db._is_permanent_db_error(_NoDb("database does not exist")) is True
+
+    def test_connection_refused_is_transient(self):
+        assert db._is_permanent_db_error(ConnectionRefusedError("connection refused")) is False
+
+    def test_timeout_is_transient(self):
+        assert db._is_permanent_db_error(TimeoutError("timed out")) is False
+
+
+class TestInitDatabaseFailFast:
+    @pytest.mark.asyncio
+    async def test_permanent_error_fails_fast_no_retry(self, monkeypatch):
+        monkeypatch.setattr(db, "get_deployment_config", _fake_config)
+        monkeypatch.setattr(db, "_DB_INIT_MAX_ATTEMPTS", 5)
+        monkeypatch.setattr(db, "_DB_INIT_RETRY_DELAY_SECONDS", 0.0)
+
+        verify = AsyncMock(side_effect=_AuthError("password authentication failed for user"))
+        monkeypatch.setattr(db, "_verify_postgres_connection", verify)
+        sleep = AsyncMock()
+        monkeypatch.setattr(db.asyncio, "sleep", sleep)
+
+        with pytest.raises(RuntimeError) as exc:
+            await db.init_database()
+
+        # Fail fast: exactly one attempt, no sleeps, and a credential-naming message.
+        assert verify.await_count == 1
+        assert sleep.await_count == 0
+        msg = str(exc.value).lower()
+        assert "credential" in msg or "authorization" in msg
+        assert "autobot_app" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_transient_error_retries_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr(db, "get_deployment_config", _fake_config)
+        monkeypatch.setattr(db, "_DB_INIT_MAX_ATTEMPTS", 5)
+        monkeypatch.setattr(db, "_DB_INIT_RETRY_DELAY_SECONDS", 0.0)
+
+        # Fail transiently twice, then succeed on the third attempt.
+        verify = AsyncMock(
+            side_effect=[
+                ConnectionRefusedError("connection refused"),
+                ConnectionRefusedError("connection refused"),
+                None,
+            ]
+        )
+        monkeypatch.setattr(db, "_verify_postgres_connection", verify)
+        sleep = AsyncMock()
+        monkeypatch.setattr(db.asyncio, "sleep", sleep)
+
+        await db.init_database()  # must NOT raise
+
+        assert verify.await_count == 3
+        assert sleep.await_count == 2  # one sleep between each of the two failures
+
+    @pytest.mark.asyncio
+    async def test_transient_error_bounded_then_gives_up(self, monkeypatch):
+        monkeypatch.setattr(db, "get_deployment_config", _fake_config)
+        monkeypatch.setattr(db, "_DB_INIT_MAX_ATTEMPTS", 3)
+        monkeypatch.setattr(db, "_DB_INIT_RETRY_DELAY_SECONDS", 0.0)
+
+        verify = AsyncMock(side_effect=ConnectionRefusedError("connection refused"))
+        monkeypatch.setattr(db, "_verify_postgres_connection", verify)
+        sleep = AsyncMock()
+        monkeypatch.setattr(db.asyncio, "sleep", sleep)
+
+        with pytest.raises(RuntimeError) as exc:
+            await db.init_database()
+
+        # Bounded: exactly MAX attempts, not infinite; clear "unreachable" signal.
+        assert verify.await_count == 3
+        assert sleep.await_count == 2  # no sleep after the final failing attempt
+        assert "unreachable" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_postgres_disabled_is_noop(self, monkeypatch):
+        cfg = _fake_config()
+        cfg.postgres_enabled = False
+        monkeypatch.setattr(db, "get_deployment_config", lambda: cfg)
+
+        verify = AsyncMock()
+        monkeypatch.setattr(db, "_verify_postgres_connection", verify)
+
+        await db.init_database()  # returns immediately
+        assert verify.await_count == 0

--- a/autobot-backend/user_management/database.py
+++ b/autobot-backend/user_management/database.py
@@ -10,6 +10,8 @@ Follows the canonical client pattern established by Redis utilities.
 Pool sizes are coordinated via SSOT config (#2860).
 """
 
+import asyncio
+import os
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
@@ -28,6 +30,70 @@ logger = get_logger(__name__)
 # Singleton engine instance
 _async_engine: AsyncEngine | None = None
 _async_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def _env_int(name: str, default: int, minimum: int) -> int:
+    """Parse a positive-integer env var, falling back safely on garbage (#12293)."""
+    try:
+        return max(minimum, int(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s — using default %d", name, default)
+        return default
+
+
+def _env_float(name: str, default: float, minimum: float) -> float:
+    """Parse a non-negative-float env var, falling back safely on garbage (#12293)."""
+    try:
+        return max(minimum, float(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s — using default %s", name, default)
+        return default
+
+
+# Issue #12293: Bounded startup retry for *transient* DB unavailability (e.g. the
+# database container is still coming up). Permanent credential/authorization
+# faults fail fast with zero retries. Tunable via env — never hardcoded.
+_DB_INIT_MAX_ATTEMPTS = _env_int("AUTOBOT_DB_INIT_MAX_ATTEMPTS", 5, minimum=1)
+_DB_INIT_RETRY_DELAY_SECONDS = _env_float("AUTOBOT_DB_INIT_RETRY_DELAY_SECONDS", 3.0, minimum=0.0)
+
+# PostgreSQL SQLSTATEs that signal a permanent credential / config fault where
+# retrying can never succeed (#12293):
+#   Class 28  — invalid authorization specification (28P01 = invalid_password)
+#   3D000     — invalid_catalog_name (target database does not exist)
+_PERMANENT_PG_SQLSTATES = frozenset({"3D000"})
+_PERMANENT_PG_SQLSTATE_CLASSES = ("28",)
+_PERMANENT_PG_ERROR_NAMES = frozenset(
+    {
+        "InvalidPasswordError",
+        "InvalidAuthorizationSpecificationError",
+        "InvalidCatalogNameError",
+    }
+)
+
+
+def _is_permanent_db_error(exc: BaseException) -> bool:
+    """Return True when a DB connection error is a permanent credential /
+    authorization / missing-database fault that retrying cannot fix (#12293).
+
+    Walks the full exception chain (``__cause__`` / ``__context__`` / SQLAlchemy
+    ``orig``) to reach the underlying asyncpg error and inspects its SQLSTATE.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        sqlstate = getattr(current, "sqlstate", None) or getattr(current, "pgcode", None)
+        if isinstance(sqlstate, str) and (
+            sqlstate in _PERMANENT_PG_SQLSTATES or sqlstate.startswith(_PERMANENT_PG_SQLSTATE_CLASSES)
+        ):
+            return True
+        if type(current).__name__ in _PERMANENT_PG_ERROR_NAMES:
+            return True
+        stack.extend((current.__cause__, current.__context__, getattr(current, "orig", None)))
+    return False
 
 
 def _get_pool_config() -> dict:
@@ -168,11 +234,29 @@ async def db_session_context() -> AsyncGenerator[AsyncSession, None]:
             await session.close()
 
 
+async def _verify_postgres_connection() -> None:
+    """Open one connection and run ``SELECT 1`` to confirm reachability and
+    credentials. Raises the underlying driver error on failure (#12293)."""
+    from sqlalchemy import text
+
+    engine = get_async_engine()
+    async with engine.begin() as conn:
+        await conn.execute(text("SELECT 1"))
+
+
 async def init_database() -> None:
     """
     Initialize the database connection and verify connectivity.
 
     Call this during application startup.
+
+    Issue #12293: distinguishes a *permanent* credential / authorization
+    misconfiguration (bad password, missing role, missing database) from
+    *transient* unavailability (the database is still coming up). Permanent
+    faults fail fast with a single loud CRITICAL diagnosis — retrying can never
+    help — so a stale password no longer produces an unbounded, silent crash
+    loop. Transient faults get a bounded, clearly-logged retry then give up
+    with a clear signal. Both raise ``RuntimeError`` so startup aborts loudly.
     """
     logger.info("init_database() called")
     config = get_deployment_config()
@@ -189,18 +273,58 @@ async def init_database() -> None:
         return
 
     logger.info("PostgreSQL enabled, proceeding with initialization")
+    # Password-free target string — safe to log; never interpolate the password.
+    safe_target = f"{config.postgres_user}@{config.postgres_host}:{config.postgres_port}/{config.postgres_db}"
 
-    try:
-        from sqlalchemy import text
-
-        engine = get_async_engine()
-
-        async with engine.begin() as conn:
-            await conn.execute(text("SELECT 1"))
-        logger.info("PostgreSQL connection verified successfully")
-    except Exception as e:
-        logger.error("Failed to connect to PostgreSQL: %s", e)
-        raise
+    for attempt in range(1, _DB_INIT_MAX_ATTEMPTS + 1):
+        try:
+            await _verify_postgres_connection()
+            logger.info("PostgreSQL connection verified successfully (attempt %d)", attempt)
+            return
+        except Exception as e:
+            if _is_permanent_db_error(e):
+                logger.critical(
+                    "❌ FATAL: PostgreSQL rejected the backend's credentials — permanent "
+                    "misconfiguration, retrying will NOT help. Target: postgresql://%s "
+                    "(asyncpg). Underlying error: %s: %s. Likely fix: the password for DB "
+                    "role '%s' is stale or wrong — update the backend's POSTGRES_PASSWORD "
+                    "(or its service-keys env) to match the database, then restart "
+                    "(see #12293, #12297).",
+                    safe_target,
+                    type(e).__name__,
+                    e,
+                    config.postgres_user,
+                )
+                raise RuntimeError(
+                    f"PostgreSQL credential/authorization misconfiguration for role "
+                    f"'{config.postgres_user}' at {safe_target}: {type(e).__name__}"
+                ) from e
+            if attempt >= _DB_INIT_MAX_ATTEMPTS:
+                logger.critical(
+                    "❌ FATAL: PostgreSQL unreachable at %s after %d bounded attempt(s) "
+                    "~%.1fs apart. Giving up with a clear signal instead of looping "
+                    "silently (#12293). Last error: %s: %s. Likely fix: ensure PostgreSQL "
+                    "is running and reachable, then restart.",
+                    safe_target,
+                    _DB_INIT_MAX_ATTEMPTS,
+                    _DB_INIT_RETRY_DELAY_SECONDS,
+                    type(e).__name__,
+                    e,
+                )
+                raise RuntimeError(
+                    f"PostgreSQL unreachable at {safe_target} after "
+                    f"{_DB_INIT_MAX_ATTEMPTS} attempt(s): {type(e).__name__}"
+                ) from e
+            logger.warning(
+                "PostgreSQL not ready at %s (attempt %d/%d) — transient, retrying in " "%.1fs: %s: %s",
+                safe_target,
+                attempt,
+                _DB_INIT_MAX_ATTEMPTS,
+                _DB_INIT_RETRY_DELAY_SECONDS,
+                type(e).__name__,
+                e,
+            )
+            await asyncio.sleep(_DB_INIT_RETRY_DELAY_SECONDS)
 
 
 async def close_database() -> None:


### PR DESCRIPTION
## Thinking Path

A stale `autobot_app` password put `autobot-backend.service` into an unbounded, silent crash loop (restart counter reached 1365, API 502 for hours). The backend's startup path treated **every** DB failure the same: `init_database()` raised a generic error, `_init_database` re-wrapped it into `RuntimeError("Database initialization failed: ...")`, the process exited, systemd restarted, forever — with the real cause (`password authentication failed for user "autobot_app"`) buried under `🔍 DEBUG` noise and never surfaced as a distinct fatal signal.

This PR fixes the **backend crash-loop behavior** (#12293). It does not touch the systemd unit (`StartLimitBurst`) or secret provisioning — those deploy-side gaps are #12297.

Key insight: a bad password is **permanent** — retrying can never succeed — while "DB container still coming up" is **transient**. Conflating the two is what produced the silent infinite loop. So we classify by PostgreSQL SQLSTATE and treat them differently.

## What Changed

`autobot-backend/user_management/database.py`
- `_is_permanent_db_error()` — walks the full exception chain (`__cause__` / `__context__` / SQLAlchemy `.orig`) to the underlying asyncpg error and inspects its SQLSTATE. Permanent = class `28` (invalid authorization / `28P01` invalid_password) and `3D000` (invalid_catalog_name / missing database); also matches by asyncpg error class name as a fallback.
- `init_database()` rewritten as a bounded loop:
  - **Permanent credential/authorization fault → fail fast, zero retries**, one loud `logger.critical` naming the failing role, the password-free target (`user@host:port/db`, never the password), the underlying error, and the likely fix (stale `POSTGRES_PASSWORD` / service-keys env), then `raise RuntimeError(...)`.
  - **Transient fault → bounded retry** (`AUTOBOT_DB_INIT_MAX_ATTEMPTS`, default 5; `AUTOBOT_DB_INIT_RETRY_DELAY_SECONDS`, default 3.0 — module-level constants read from env via safe parse helpers, never hardcoded), each attempt warned; on exhaustion a loud `critical` "unreachable after N attempts" + `RuntimeError`.
  - `_verify_postgres_connection()` extracted (single `SELECT 1` probe).
- `init_database()` no longer swallows or masks — it always raises a clear `RuntimeError`.

`autobot-backend/initialization/lifespan.py`
- `_init_database` no longer re-wraps into a generic message or emits `🔍 DEBUG`/traceback noise; it surfaces `init_database()`'s clear `RuntimeError` unchanged so the root cause is visible in the log and in the persisted `startup-error.json` (still `RuntimeError` type-name only — no credential leakage).

`autobot-backend/tests/user_management/test_init_database_crashloop.py` (new)
- Classifier: auth SQLSTATE / wrapped auth error / `3D000` → permanent; `ConnectionRefusedError` / `TimeoutError` → transient.
- Permanent error fails fast (exactly 1 attempt, 0 sleeps, message names role + credential/authorization).
- Transient error retries then succeeds (fail x2 → success on 3rd).
- Transient error is bounded then gives up (exactly MAX attempts, "unreachable" signal — not infinite).
- Postgres-disabled is a no-op.

## Verification

```
$ python3 -m pytest autobot-backend/tests/user_management/test_init_database_crashloop.py -q
9 passed in 0.51s

$ python3 -m pytest .../test_shutdown_symmetry.py .../test_startup_error_sanitize.py -q
26 passed   # (incl. new file — no regression)

$ python3 -m pytest autobot-backend/tests/test_startup_imports.py -q
345 passed in 81.76s

$ python3 -m black --check --line-length 120 <changed .py>   # All done ✨
$ python3 -m flake8 --max-line-length 120 <changed .py>       # exit 0
$ python3 -c "import ast; ..."                                # AST OK
```

Behavior chosen: **fail fast on permanent, bounded retry on transient**, each with a distinct loud `critical` signal. Rationale — retrying a wrong password can never succeed, so retrying only prolongs the invisible outage; failing fast with a named diagnosis turns a multi-hour silent loop into an immediate, actionable log line. Transient unavailability (DB still starting) is the one case where a short bounded retry legitimately helps, so it is the only case that retries — and even that is bounded and loud, never infinite or silent.

## Model Used

claude-opus-4-8

Closes #12293
