### PR TITLE
fix(frontend): wire System Docs page to backend endpoints (#12314)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -70,6 +70,9 @@ from knowledge.schemas.documents import (
     DocsStatsResponse,
     DocsWatcherControlResponse,
     DocsWatcherStatusResponse,
+    SystemDocContentResponse,
+    SystemDocsCategoriesResponse,
+    SystemDocsCategoryResponse,
 )
 from knowledge.schemas.facts import (
     AddFactResponse,
@@ -2764,6 +2767,79 @@ async def get_documentation_stats(
             "categories_count": len(set(doc.get("category", "general") for doc in all_docs)),
         },
     }
+
+
+# =============================================================================
+# System Docs viewer (Issue #12314)
+#
+# Powers the Knowledge -> System Docs page. Serves the on-disk ``docs/`` tree
+# directly (no ChromaDB/Redis dependency) so the page is always populated.
+# Declaration order matters: the literal ``categories`` and ``category/...``
+# routes MUST precede the ``{doc_id}`` catch-all so they are not shadowed.
+# =============================================================================
+
+
+@router.get("/system-docs/categories", response_model=SystemDocsCategoriesResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_system_doc_categories",
+    error_code_prefix="KNOWLEDGE",
+)
+async def list_system_doc_categories(
+    current_user: dict = Depends(get_current_user),
+):
+    """List system documentation categories with per-category counts.
+
+    Issue #12314: backs ``fetchDocCategories`` in the System Docs viewer.
+    """
+    from services.knowledge.system_docs_service import list_categories
+
+    categories = await asyncio.to_thread(list_categories)
+    return {"categories": categories}
+
+
+@router.get("/system-docs/category/{category_path}", response_model=SystemDocsCategoryResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_system_doc_category",
+    error_code_prefix="KNOWLEDGE",
+)
+async def list_system_doc_category(
+    category_path: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """List documents in a system-docs category (metadata only, no content).
+
+    Issue #12314: backs ``fetchCategoryDocs``. Unknown/invalid categories
+    resolve to an empty list rather than an error.
+    """
+    from services.knowledge.system_docs_service import list_category_docs
+
+    docs = await asyncio.to_thread(list_category_docs, category_path)
+    return {"docs": docs}
+
+
+@router.get("/system-docs/{doc_id}", response_model=SystemDocContentResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_system_doc",
+    error_code_prefix="KNOWLEDGE",
+)
+async def get_system_doc(
+    doc_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Return a single system document with its full markdown content.
+
+    Issue #12314: backs ``fetchDocContent``. ``doc_id`` is the opaque hash
+    id emitted by the list endpoints, so no client path reaches the disk.
+    """
+    from services.knowledge.system_docs_service import get_doc
+
+    doc = await asyncio.to_thread(get_doc, doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="System document not found")
+    return {"doc": doc}
 
 
 @router.get("/docs/watcher/status", response_model=DocsWatcherStatusResponse)

--- a/autobot-backend/knowledge/schemas/documents.py
+++ b/autobot-backend/knowledge/schemas/documents.py
@@ -139,3 +139,74 @@ class DocsWatcherControlResponse(BaseModel):
     success: bool = False
     message: str | None = None
     watcher: Dict[str, Any] | None = None
+
+
+class SystemDocMetadata(BaseModel):
+    """Optional per-document metadata for the System Docs viewer (#12314)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    wordCount: int | None = None
+    lastModified: str | None = None
+    author: str | None = None
+
+
+class SystemDoc(BaseModel):
+    """A single system documentation file (#12314).
+
+    Field names mirror the frontend ``SystemDoc`` interface
+    (``useKnowledgeSystemDocs.ts``) so the contract is explicit in
+    ``/openapi.json``. ``content`` is empty in list responses and
+    populated only by the single-document endpoint.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    title: str
+    path: str
+    content: str = ""
+    type: str = "markdown"
+    category: str = ""
+    metadata: SystemDocMetadata | None = None
+
+
+class SystemDocCategory(BaseModel):
+    """A documentation category node for the System Docs tree (#12314)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    path: str
+    icon: str = "folder"
+    children: List["SystemDocCategory"] = Field(default_factory=list)
+    docs: List[SystemDoc] = Field(default_factory=list)
+    docCount: int = 0
+
+
+class SystemDocsCategoriesResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/system-docs/categories`` (#12314)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    categories: List[SystemDocCategory] = Field(default_factory=list)
+
+
+class SystemDocsCategoryResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/system-docs/category/{path}`` (#12314)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    docs: List[SystemDoc] = Field(default_factory=list)
+
+
+class SystemDocContentResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/system-docs/{doc_id}`` (#12314)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    doc: SystemDoc
+
+
+SystemDocCategory.model_rebuild()

--- a/autobot-backend/services/knowledge/system_docs_service.py
+++ b/autobot-backend/services/knowledge/system_docs_service.py
@@ -1,0 +1,177 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""System Docs filesystem service (Issue #12314).
+
+Backs the ``/api/knowledge_base/system-docs/*`` endpoints that power the
+Knowledge -> System Docs viewer. Reads the on-disk documentation tree
+(``PATH.DOCS_DIR``) directly so the page is always populated without
+depending on the ChromaDB/Redis indexing pipeline.
+
+Categories are derived from the ``docs/`` directory structure: each
+top-level sub-directory is a category, and loose top-level ``*.md`` files
+are grouped under a synthetic ``general`` category. Document ids are an
+opaque hash of the repo-relative path, so no client-supplied path ever
+reaches the filesystem (guards against traversal).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from autobot_shared.logging_manager import get_logger
+from constants.path_constants import PATH
+
+logger = get_logger(__name__)
+
+DOC_TYPE = "markdown"
+GENERAL_CATEGORY = "general"
+_TITLE_SCAN_LINES = 50
+
+
+def _docs_root() -> Path:
+    """Return the on-disk documentation root (``<project>/docs``)."""
+    return Path(PATH.DOCS_DIR)
+
+
+def _humanize(name: str) -> str:
+    """Turn a directory/file stem into a human-readable label."""
+    label = name.replace("_", " ").replace("-", " ").strip().title()
+    return label or name
+
+
+def _doc_id(rel_path: str) -> str:
+    """Deterministic, slash-free id for a repo-relative doc path."""
+    # Non-cryptographic identifier only (usedforsecurity=False).
+    return hashlib.sha1(rel_path.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+
+def _within(path: Path, root: Path) -> bool:
+    """True when ``path`` resolves inside ``root`` (traversal guard)."""
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _iter_markdown(base: Path) -> Iterator[Path]:
+    """Yield markdown files under ``base`` in stable sorted order."""
+    for path in sorted(base.rglob("*.md")):
+        if path.is_file():
+            yield path
+
+
+def _category_dirs(root: Path) -> List[Path]:
+    """Return visible top-level sub-directories of the docs root."""
+    return sorted(p for p in root.iterdir() if p.is_dir() and not p.name.startswith("."))
+
+
+def _loose_docs(root: Path) -> List[Path]:
+    """Return markdown files sitting directly in the docs root."""
+    return sorted(p for p in root.glob("*.md") if p.is_file())
+
+
+def _extract_title(path: Path, fallback: str) -> str:
+    """Use the first markdown H1 as the title, else a humanized stem."""
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for _ in range(_TITLE_SCAN_LINES):
+                line = handle.readline()
+                if not line:
+                    break
+                stripped = line.strip()
+                if stripped.startswith("# "):
+                    return stripped[2:].strip()
+    except OSError as exc:
+        logger.debug("Title scan failed for %s: %s", path, exc)
+    return _humanize(fallback)
+
+
+def _build_doc(path: Path, root: Path, category: str, include_content: bool) -> Dict[str, Any]:
+    """Assemble a SystemDoc dict matching the frontend contract."""
+    rel = path.relative_to(root).as_posix()
+    content = ""
+    if include_content:
+        content = path.read_text(encoding="utf-8")
+    metadata: Dict[str, Any] = {}
+    try:
+        mtime = path.stat().st_mtime
+        metadata["lastModified"] = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        pass
+    return {
+        "id": _doc_id(rel),
+        "title": _extract_title(path, path.stem),
+        "path": rel,
+        "content": content,
+        "type": DOC_TYPE,
+        "category": category,
+        "metadata": metadata,
+    }
+
+
+def _category_entry(cat_id: str, name: str, doc_count: int) -> Dict[str, Any]:
+    """Build a DocCategory dict (docs loaded lazily by the category route)."""
+    return {
+        "id": cat_id,
+        "name": name,
+        "path": cat_id,
+        "icon": "folder",
+        "children": [],
+        "docs": [],
+        "docCount": doc_count,
+    }
+
+
+def list_categories() -> List[Dict[str, Any]]:
+    """List documentation categories with per-category document counts."""
+    root = _docs_root()
+    if not root.is_dir():
+        logger.warning("System docs root missing: %s", root)
+        return []
+    categories: List[Dict[str, Any]] = []
+    loose = _loose_docs(root)
+    if loose:
+        categories.append(_category_entry(GENERAL_CATEGORY, _humanize(GENERAL_CATEGORY), len(loose)))
+    for cat_dir in _category_dirs(root):
+        docs = list(_iter_markdown(cat_dir))
+        if docs:
+            categories.append(_category_entry(cat_dir.name, _humanize(cat_dir.name), len(docs)))
+    return categories
+
+
+def _category_files(root: Path, category_path: str) -> List[Path]:
+    """Resolve the markdown files belonging to a category (traversal-safe)."""
+    if category_path == GENERAL_CATEGORY:
+        return _loose_docs(root)
+    base = root / category_path
+    if not _within(base, root) or not base.is_dir():
+        return []
+    return list(_iter_markdown(base))
+
+
+def list_category_docs(category_path: str) -> List[Dict[str, Any]]:
+    """List documents in a category (metadata only, no content)."""
+    root = _docs_root()
+    if not root.is_dir():
+        return []
+    files = _category_files(root, category_path)
+    return [_build_doc(path, root, category_path, include_content=False) for path in files]
+
+
+def get_doc(doc_id: str) -> Optional[Dict[str, Any]]:
+    """Return a single document (with full content) by its opaque id."""
+    root = _docs_root()
+    if not root.is_dir():
+        return None
+    for path in _iter_markdown(root):
+        rel = path.relative_to(root).as_posix()
+        if _doc_id(rel) == doc_id:
+            category = rel.split("/", 1)[0] if "/" in rel else GENERAL_CATEGORY
+            return _build_doc(path, root, category, include_content=True)
+    return None

--- a/autobot-backend/services/knowledge/test_system_docs_service.py
+++ b/autobot-backend/services/knowledge/test_system_docs_service.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the System Docs filesystem service (Issue #12314)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import services.knowledge.system_docs_service as svc
+
+
+@pytest.fixture()
+def docs_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Build a small on-disk docs tree and point the service at it."""
+    root = tmp_path / "docs"
+    (root / "developer").mkdir(parents=True)
+    (root / "api").mkdir()
+    (root / "README.md").write_text("# Read Me\n\nTop-level doc.\n", encoding="utf-8")
+    (root / "developer" / "setup.md").write_text("# Dev Setup\n\nSteps.\n", encoding="utf-8")
+    (root / "developer" / "nested" / "deep.md").parent.mkdir()
+    (root / "developer" / "nested" / "deep.md").write_text("no heading here\n", encoding="utf-8")
+    (root / "api" / "routes.md").write_text("# Routes\n", encoding="utf-8")
+    monkeypatch.setattr(svc, "_docs_root", lambda: root)
+    return root
+
+
+def test_list_categories_counts_and_general_bucket(docs_tree: Path) -> None:
+    cats = {c["id"]: c for c in svc.list_categories()}
+    assert cats["general"]["docCount"] == 1  # README.md
+    assert cats["developer"]["docCount"] == 2  # setup.md + nested/deep.md
+    assert cats["api"]["docCount"] == 1
+    assert cats["developer"]["name"] == "Developer"
+    assert cats["general"]["path"] == "general"
+
+
+def test_list_category_docs_metadata_only(docs_tree: Path) -> None:
+    docs = svc.list_category_docs("developer")
+    assert len(docs) == 2
+    for doc in docs:
+        assert doc["content"] == ""  # list responses omit content
+        assert doc["category"] == "developer"
+        assert doc["type"] == "markdown"
+    titles = {d["title"] for d in docs}
+    assert "Dev Setup" in titles  # H1 extracted
+    assert "Deep" in titles  # humanized stem fallback (no H1)
+
+
+def test_general_category_lists_loose_docs(docs_tree: Path) -> None:
+    docs = svc.list_category_docs("general")
+    assert [d["path"] for d in docs] == ["README.md"]
+
+
+def test_get_doc_returns_full_content(docs_tree: Path) -> None:
+    doc_id = svc.list_category_docs("api")[0]["id"]
+    full = svc.get_doc(doc_id)
+    assert full is not None
+    assert full["path"] == "api/routes.md"
+    assert full["content"] == "# Routes\n"
+    assert full["title"] == "Routes"
+
+
+def test_get_doc_unknown_id_returns_none(docs_tree: Path) -> None:
+    assert svc.get_doc("deadbeef") is None
+
+
+def test_unknown_category_is_empty(docs_tree: Path) -> None:
+    assert svc.list_category_docs("does-not-exist") == []
+
+
+def test_traversal_category_rejected(docs_tree: Path) -> None:
+    assert svc.list_category_docs("../../etc") == []
+
+
+def test_missing_root_is_safe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(svc, "_docs_root", lambda: tmp_path / "nope")
+    assert svc.list_categories() == []
+    assert svc.list_category_docs("general") == []
+    assert svc.get_doc("anything") is None

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -4979,6 +4979,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/knowledge_base/system-docs/categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List System Doc Categories
+         * @description List system documentation categories with per-category counts.
+         *
+         *     Issue #12314: backs ``fetchDocCategories`` in the System Docs viewer.
+         */
+        get: operations["list_system_doc_categories_api_knowledge_base_system_docs_categories_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/knowledge_base/system-docs/category/{category_path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List System Doc Category
+         * @description List documents in a system-docs category (metadata only, no content).
+         *
+         *     Issue #12314: backs ``fetchCategoryDocs``. Unknown/invalid categories
+         *     resolve to an empty list rather than an error.
+         */
+        get: operations["list_system_doc_category_api_knowledge_base_system_docs_category__category_path__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/knowledge_base/system-docs/{doc_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get System Doc
+         * @description Return a single system document with its full markdown content.
+         *
+         *     Issue #12314: backs ``fetchDocContent``. ``doc_id`` is the opaque hash
+         *     id emitted by the list endpoints, so no client path reaches the disk.
+         */
+        get: operations["get_system_doc_api_knowledge_base_system_docs__doc_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/knowledge_base/docs/watcher/status": {
         parameters: {
             query?: never;
@@ -94290,6 +94358,112 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * SystemDoc
+         * @description A single system documentation file (#12314).
+         *
+         *     Field names mirror the frontend ``SystemDoc`` interface
+         *     (``useKnowledgeSystemDocs.ts``) so the contract is explicit in
+         *     ``/openapi.json``. ``content`` is empty in list responses and
+         *     populated only by the single-document endpoint.
+         */
+        SystemDoc: {
+            /** Id */
+            id: string;
+            /** Title */
+            title: string;
+            /** Path */
+            path: string;
+            /**
+             * Content
+             * @default
+             */
+            content: string;
+            /**
+             * Type
+             * @default markdown
+             */
+            type: string;
+            /**
+             * Category
+             * @default
+             */
+            category: string;
+            metadata?: components["schemas"]["SystemDocMetadata"] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemDocCategory
+         * @description A documentation category node for the System Docs tree (#12314).
+         */
+        SystemDocCategory: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Path */
+            path: string;
+            /**
+             * Icon
+             * @default folder
+             */
+            icon: string;
+            /** Children */
+            children?: components["schemas"]["SystemDocCategory"][];
+            /** Docs */
+            docs?: components["schemas"]["SystemDoc"][];
+            /**
+             * Doccount
+             * @default 0
+             */
+            docCount: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemDocContentResponse
+         * @description Shape of ``GET /api/knowledge_base/system-docs/{doc_id}`` (#12314).
+         */
+        SystemDocContentResponse: {
+            doc: components["schemas"]["SystemDoc"];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemDocMetadata
+         * @description Optional per-document metadata for the System Docs viewer (#12314).
+         */
+        SystemDocMetadata: {
+            /** Wordcount */
+            wordCount?: number | null;
+            /** Lastmodified */
+            lastModified?: string | null;
+            /** Author */
+            author?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemDocsCategoriesResponse
+         * @description Shape of ``GET /api/knowledge_base/system-docs/categories`` (#12314).
+         */
+        SystemDocsCategoriesResponse: {
+            /** Categories */
+            categories?: components["schemas"]["SystemDocCategory"][];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemDocsCategoryResponse
+         * @description Shape of ``GET /api/knowledge_base/system-docs/category/{path}`` (#12314).
+         */
+        SystemDocsCategoryResponse: {
+            /** Docs */
+            docs?: components["schemas"]["SystemDoc"][];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * SystemDynamicImportResponse
          * @description Response for POST /dynamic_import.
          */
@@ -108263,6 +108437,88 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DocsStatsResponse"];
+                };
+            };
+        };
+    };
+    list_system_doc_categories_api_knowledge_base_system_docs_categories_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemDocsCategoriesResponse"];
+                };
+            };
+        };
+    };
+    list_system_doc_category_api_knowledge_base_system_docs_category__category_path__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                category_path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemDocsCategoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_system_doc_api_knowledge_base_system_docs__doc_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                doc_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemDocContentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Thinking Path

Issue #12314 was filed as a frontend "unwired" bug, but forensics showed the **frontend is fully wired and reachable** — the router entry (`system-docs` / `knowledge-system-docs`), the `KnowledgeView.vue` nav link (`to="/knowledge/system-docs"`, `$t('knowledge.views.systemDocs')`), the component `KnowledgeSystemDocs.vue`, and its `knowledge.systemDocs.*` i18n keys all exist across all 11 locales. The real gap was the **backend**: the three endpoints the component calls via `useKnowledgeSystemDocs.ts` did not exist, so the page 404'd and could never populate.

Missing endpoints (all under the `knowledge` router, prefix `/api/knowledge_base`):
- `GET /system-docs/categories`
- `GET /system-docs/category/{category_path}`
- `GET /system-docs/{doc_id}`

Design: serve the on-disk `docs/` tree directly (via canonical `PATH.DOCS_DIR`) so the viewer is always populated with zero dependency on the ChromaDB/Redis indexing pipeline (the sibling `docs/*` endpoints require an initialized KB and otherwise 503). Categories are derived from the `docs/` directory structure; loose top-level `*.md` files fall into a synthetic `general` category. Document ids are an opaque SHA1 of the repo-relative path, so **no client-supplied path ever reaches the filesystem** (traversal-safe); category paths are validated with a `relative_to` containment guard.

## What Changed

- **New** `autobot-backend/services/knowledge/system_docs_service.py` — filesystem-backed docs reader (`list_categories`, `list_category_docs`, `get_doc`), all helpers ≤30 lines, H1-title extraction with humanized-stem fallback, traversal guard.
- **New** `autobot-backend/services/knowledge/test_system_docs_service.py` — 8 unit tests (counts, general bucket, metadata-only listing, full-content fetch, unknown id → None, unknown/traversal category → empty, missing root safe).
- `autobot-backend/api/knowledge.py` — 3 new endpoints gated by `get_current_user` (matching the route's `requiresAuth`, not admin), wrapped in `@with_error_handling`, blocking file IO offloaded via `asyncio.to_thread` (async-first). Declared **before** the `{doc_id}` catch-all so the literal routes are not shadowed.
- `autobot-backend/knowledge/schemas/documents.py` — `SystemDoc`, `SystemDocCategory`, and the three response models; field names mirror the frontend TS interface exactly (`docCount`, `wordCount`, `lastModified`) so the contract is explicit in `/openapi.json`.

No frontend changes and **no new i18n keys** — the frontend was already complete in all 11 locales.

## Verification

- `python -m py_compile` on all 3 edited/new backend files: OK.
- Schema + service import cleanly; smoke-test against the real repo `docs/` tree: 52 categories, content fetch (4406 chars, H1 title), Pydantic validation OK, bogus id → None.
- `pytest services/knowledge/test_system_docs_service.py`: **8 passed**.
- Route declaration order confirmed: `categories` → `category/{path}` → `{doc_id}`.
- Frontend audit: router entry + nav link + component + `systemDocs` i18n key present in all 11 locales (`ar de en es fa fr he lv pl pt ur`).
- WSL has no npm; frontend was not rebuilt. New endpoints add to `/openapi.json`; CI auto-fix may regenerate `api.ts` (the composable uses its own interfaces, so no runtime dependency). No type risk to the composable.

Follow-up (out of scope, larger): the issue also suggested a CI api-wiring gate that fails when a frontend route's backing endpoint 404s — recommend a separate `api-wiring-audit` tooling issue rather than expanding this focused fix.

## Model Used

claude-opus-4-8

Closes #12314
