### PR TITLE
fix(frontend): route metrics WS URL through SSOT, drop dead :8443 hardcode (Refs #12313)

### DIFF
--- a/autobot-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-frontend/src/composables/usePrometheusMetrics.ts
@@ -16,7 +16,7 @@ import { ref, computed, onMounted, getCurrentInstance } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
-import { getApiBase } from '@/config/ssot-config'
+import { getApiBase, getBackendWsUrl } from '@/config/ssot-config'
 import { useWebSocket } from '@/composables/useWebSocket'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useLoadingState } from './useLoadingState'
@@ -255,12 +255,15 @@ export function usePrometheusMetrics(
   const lastUpdate = ref<Date | null>(null)
   const isConnected = ref(false)
 
-  // Build the monitoring WebSocket URL
+  // Build the monitoring WebSocket URL.
+  // #12313: derive the base from the SSOT (getBackendWsUrl) instead of composing
+  // an absolute `host:VITE_BACKEND_PORT` origin. The old inline fallback baked in
+  // the dead port 8443 — nothing listens there behind nginx, and any absolute
+  // backend origin is blocked by CSP `connect-src 'self'` (see defaults #10348).
+  // getBackendWsUrl() returns a same-origin `wss://<page-host>` in proxy mode, so
+  // the socket inherits whatever scheme/host/port nginx actually serves.
   const _buildWsUrl = (): string => {
-    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const wsHost = import.meta.env.VITE_API_BASE_URL?.replace(/^https?:\/\//, '') ||
-                   `${import.meta.env.VITE_BACKEND_HOST || window.location.hostname}:${import.meta.env.VITE_BACKEND_PORT || '8443'}`
-    return `${wsProtocol}//${wsHost}/api/monitoring/realtime`
+    return `${getBackendWsUrl()}/api/monitoring/realtime`
   }
 
   // WebSocket managed via useWebSocket composable


### PR DESCRIPTION
## Thinking Path

`.env.production` is **not** in git — it is generated at deploy time by the ansible
template `autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2`
(`VITE_BACKEND_PORT={{ backend_port | default(8443) }}`). The in-repo carriers of the
dead `:8443` browser origin are `autobot-frontend/.env.example` and the inline
fallback in `usePrometheusMetrics.ts`.

Per the documented design (`frontend/defaults/main.yml` #10348) the browser must use
**same-origin proxy mode** — nginx serves the SPA on 443 and proxies `/api` + `/ws`.
An absolute backend origin (any `:PORT`) is blocked by CSP `connect-src 'self'` and is
unreachable behind the reverse proxy. `8443` is only the internal nginx→backend
upstream (`nginx-frontend.conf.j2:7`), never a browser target; the SSOT default backend
port is `8001` (`ssot-config.ts`).

## What Changed

- `usePrometheusMetrics.ts`: the monitoring WebSocket URL now derives from the SSOT
  `getBackendWsUrl()` instead of composing `${host}:${VITE_BACKEND_PORT || '8443'}`.
  Removes the dead-`8443` inline fallback; in proxy mode it yields a same-origin
  `wss://<page-host>` that inherits whatever nginx serves. No new hardcode, cannot drift.

## Verification

- `grep -rn 8443 autobot-frontend/src --include=*.ts --include=*.vue` → only an
  explanatory comment remains; no code hardcode.
- TS-only change reusing an existing SSOT export (`getBackendWsUrl`, already used by
  `SSHTerminal` et al.); WSL has no npm so build/type checked by inspection — CI
  `code-quality` / vue-tsc to confirm.

## Model Used

claude-opus-4-8

Refs #12313

> NOTE (not auto-closing): two of the issue's four recommendations remain and one is
> the actual cause of the reported **onboarding** failure — see PR discussion /
> subagent report. Summary: (1) `.env.example` alignment is blocked by the repo's
> `.env`-edit guardrail (canonical value already lives in `ssot-config.ts`);
> (2) the eslint port-guard is deferred (unverifiable without eslint runtime here);
> (3) the onboarding `:8443` failure is caused by `getBackendUrl()` returning an
> absolute origin whenever `frontend.env.j2` bakes `VITE_BACKEND_HOST`+`VITE_BACKEND_PORT`
> — this contradicts the #10348 proxy-mode design and affects all 68 `getBackendUrl`
> callers, so it needs an owner decision (risky blast radius) before change.
