### PR TITLE
fix(llc): serialize+KB before commit in create_company, single-query list membership (#12323, #12325)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -34,7 +34,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.user_management.dependencies import get_current_user, require_org_context
+from api.user_management.dependencies import _parse_uuid_safe, get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
 from llc.deps import assert_company_access, get_session, service_dep
 from llc.kb.collections import KbCollectionManager
@@ -146,11 +146,18 @@ def _is_platform_admin(current_user: dict) -> bool:
 
 
 def _current_user_id(current_user: dict) -> str:
-    """Return the caller's user id, or raise 401 when absent (#12233)."""
+    """Return the caller's user id, or raise 401 when absent/malformed (#12233).
+
+    #12325: validate the JWT subject as a UUID the same way ``get_tenant_context``
+    does (``_parse_uuid_safe``) — a non-UUID subject is a bad token and must yield
+    a clean 401, not a 500 later when it reaches a ``uuid.UUID(user_id)`` cast in
+    the membership query.
+    """
     raw = current_user.get("user_id") or current_user.get("id") or current_user.get("sub")
-    if not raw:
+    parsed = _parse_uuid_safe(str(raw)) if raw else None
+    if parsed is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-    return str(raw)
+    return str(parsed)
 
 
 @router.get("/", response_model=List[CompanyRead])
@@ -171,7 +178,11 @@ async def list_companies(
     if _is_platform_admin(current_user):
         return [_to_read(c) for c in companies]
     user_id = _current_user_id(current_user)
-    visible = [c for c in companies if await membership_svc.is_member(svc.session, str(c.id), user_id)]
+    # #12325: one membership query for the caller, then an in-memory filter —
+    # replaces an ``is_member`` round-trip per root (an N+1 that scaled with the
+    # total system-wide tenant count). Non-members still match nothing.
+    member_ids = await membership_svc.list_member_company_ids(svc.session, user_id)
+    visible = [c for c in companies if c.id in member_ids]
     return [_to_read(c) for c in visible]
 
 
@@ -203,10 +214,20 @@ async def create_company(
     try:
         org = await svc.create(body)
         await membership_svc.add_member(svc.session, str(org.id), user_id, MembershipRole.OWNER)
-        await svc.session.commit()
+        # GH#12323: serialize the response AND ensure the KB collections BEFORE
+        # commit — mirroring the #12309/#12321 "serialize before commit" invariant
+        # the transition handlers use. If either step fails the except handler's
+        # rollback undoes the INSERT, so a 500 never leaves a committed-but-
+        # unreported company (previously commit() ran first, stranding the row).
+        # ensure_collection is idempotent (get_or_create), so a rollback after a
+        # partial KB pass — or a commit failure after a full one — leaves only
+        # harmless empty collections that the next create call reuses. create()'s
+        # INSERT populates updated_at via RETURNING, so no refresh is needed here.
+        read = _to_read(org)
         for suffix in (None, KbCollectionManager.AGENTS_SUFFIX, KbCollectionManager.DECISIONS_SUFFIX):
             await _kb_manager.ensure_collection(KbCollectionManager.COMPANY_PREFIX, org.id, suffix)
-        return _to_read(org)
+        await svc.session.commit()
+        return read
     except CompanyIssuePrefixConflictError:
         await svc.session.rollback()
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Internal server error")

--- a/autobot-backend/llc/services/membership_service.py
+++ b/autobot-backend/llc/services/membership_service.py
@@ -140,3 +140,22 @@ class MembershipService(LLCServiceBase):
     ) -> bool:
         m = await self.get_member(session, company_id, user_id)
         return m is not None
+
+    async def list_member_company_ids(
+        self,
+        session: AsyncSession,
+        user_id: str,
+    ) -> set[uuid.UUID]:
+        """Return the set of company ids *user_id* is a member of (#12325).
+
+        A single ``SELECT company_id ... WHERE user_id = :uid`` — the caller
+        filters candidate companies against this set in memory, replacing an
+        ``is_member`` round-trip per company (an N+1 that scaled with the total
+        system-wide tenant count, not the caller's own memberships).
+        """
+        result = await session.execute(
+            select(LLCCompanyMembership.company_id).where(
+                LLCCompanyMembership.user_id == uuid.UUID(user_id),
+            )
+        )
+        return {row[0] for row in result.all()}

--- a/autobot-backend/llc/tests/test_company_create_kb_and_list_n1_12323_12325.py
+++ b/autobot-backend/llc/tests/test_company_create_kb_and_list_n1_12323_12325.py
@@ -1,0 +1,222 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""create_company commit-ordering (#12323) + list_companies N+1 (#12325).
+
+#12323 — ``create_company`` used to ``commit()`` the new company *before*
+serializing the response and creating its KB collections, so a failure in either
+left a committed-but-500 company (the DB and the caller disagreed). The handler
+now serializes + ensures KB collections BEFORE the single commit, mirroring the
+#12309/#12321 "serialize before commit" invariant: any failure rolls the INSERT
+back and no company is persisted.
+
+#12325 — ``list_companies`` used to run one ``is_member`` query per root company
+across *every* tenant (an N+1 scaling with system-wide tenant count). It now
+issues a single ``list_member_company_ids`` query and filters in memory.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from api.user_management.dependencies import get_current_user
+from autobot_shared.datetime_utils import datetime_now
+from llc.api import companies
+
+_ORG_ID = uuid.uuid4()
+_USER_ID = uuid.uuid4()
+
+
+def _org(org_id: uuid.UUID = _ORG_ID) -> SimpleNamespace:
+    now = datetime_now()
+    return SimpleNamespace(
+        id=org_id,
+        name="Acme",
+        slug="acme",
+        description=None,
+        issue_prefix="ACME",
+        issue_counter=0,
+        budget_monthly_cents=0,
+        spent_monthly_cents=0,
+        brand_color=None,
+        require_approval_for_hires=False,
+        parent_org_id=None,
+        llc_status="active",
+        pause_reason=None,
+        paused_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    # raise_app_exceptions=False so a re-raised endpoint error surfaces as a 500
+    # HTTP response (the rollback-on-failure tests assert on that status).
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    )
+
+
+def _app(svc, membership, *, is_platform_admin: bool = False, subject: str = None) -> FastAPI:
+    app = FastAPI()
+    app.include_router(companies.router, prefix="/api/llc")
+    app.dependency_overrides[companies._get_service] = lambda: svc
+    app.dependency_overrides[companies._get_membership_service] = lambda: membership
+
+    def _cur() -> dict:
+        user = {"id": subject or str(_USER_ID), "user_id": subject or str(_USER_ID)}
+        if is_platform_admin:
+            user["role"] = "admin"
+        return user
+
+    app.dependency_overrides[get_current_user] = _cur
+    return app
+
+
+# ===========================================================================
+# #12323 — create commit ordering / rollback on failure
+# ===========================================================================
+
+
+def _create_svc() -> MagicMock:
+    svc = MagicMock()
+    svc.session = AsyncMock()
+    svc.create = AsyncMock(return_value=_org())
+    return svc
+
+
+def _membership() -> MagicMock:
+    m = MagicMock()
+    m.add_member = AsyncMock()
+    m.is_member = AsyncMock(return_value=True)
+    return m
+
+
+@pytest.mark.asyncio
+async def test_create_commits_after_kb_and_serialize(monkeypatch):
+    """Happy path: KB ensured + response serialized, then exactly one commit."""
+    ensure = AsyncMock()
+    monkeypatch.setattr(companies._kb_manager, "ensure_collection", ensure)
+    svc = _create_svc()
+    membership = _membership()
+    async with _client(_app(svc, membership)) as client:
+        resp = await client.post("/api/llc/companies/", json={"name": "NewCo"})
+    assert resp.status_code == 201, resp.text
+    # KB collections created for the 3 canonical suffixes.
+    assert ensure.await_count == 3
+    svc.session.commit.assert_awaited_once()
+    svc.session.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_kb_failure_rolls_back_no_commit(monkeypatch):
+    """A KB failure must roll the INSERT back and never commit (#12323)."""
+    monkeypatch.setattr(
+        companies._kb_manager,
+        "ensure_collection",
+        AsyncMock(side_effect=RuntimeError("chroma down")),
+    )
+    svc = _create_svc()
+    membership = _membership()
+    async with _client(_app(svc, membership)) as client:
+        resp = await client.post("/api/llc/companies/", json={"name": "NewCo"})
+    assert resp.status_code == 500
+    # The company INSERT is rolled back and never committed → no committed-but-500 row.
+    svc.session.commit.assert_not_called()
+    svc.session.rollback.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_serialize_failure_rolls_back_no_commit(monkeypatch):
+    """A serialization failure before commit also rolls back (#12323)."""
+    monkeypatch.setattr(companies._kb_manager, "ensure_collection", AsyncMock())
+    monkeypatch.setattr(
+        companies,
+        "_to_read",
+        MagicMock(side_effect=RuntimeError("serialize boom")),
+    )
+    svc = _create_svc()
+    membership = _membership()
+    async with _client(_app(svc, membership)) as client:
+        resp = await client.post("/api/llc/companies/", json={"name": "NewCo"})
+    assert resp.status_code == 500
+    svc.session.commit.assert_not_called()
+    svc.session.rollback.assert_awaited()
+
+
+# ===========================================================================
+# #12325 — list_companies single membership query (no N+1)
+# ===========================================================================
+
+
+def _list_svc(roots) -> MagicMock:
+    svc = MagicMock()
+    svc.session = AsyncMock()
+    svc.list_root_companies = AsyncMock(return_value=roots)
+    return svc
+
+
+def _list_membership(member_ids: set) -> MagicMock:
+    m = MagicMock()
+    m.list_member_company_ids = AsyncMock(return_value=member_ids)
+    m.is_member = AsyncMock(return_value=False)  # must NOT be used by list
+    return m
+
+
+@pytest.mark.asyncio
+async def test_list_uses_single_membership_query_not_per_root():
+    """Membership is resolved with ONE query, not one is_member per root (#12325)."""
+    roots = [_org(uuid.uuid4()) for _ in range(5)]
+    visible_id = roots[2].id
+    svc = _list_svc(roots)
+    membership = _list_membership({visible_id})
+    async with _client(_app(svc, membership)) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [c["id"] for c in body] == [str(visible_id)]
+    # Exactly one membership round-trip regardless of root count; no per-root N+1.
+    membership.list_member_company_ids.assert_awaited_once()
+    membership.is_member.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_non_member_sees_nothing():
+    roots = [_org(uuid.uuid4()) for _ in range(3)]
+    svc = _list_svc(roots)
+    membership = _list_membership(set())
+    async with _client(_app(svc, membership)) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+    membership.list_member_company_ids.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_admin_sees_all_without_membership_query():
+    roots = [_org(uuid.uuid4()) for _ in range(4)]
+    svc = _list_svc(roots)
+    membership = _list_membership(set())
+    async with _client(_app(svc, membership, is_platform_admin=True)) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 4
+    membership.list_member_company_ids.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_non_uuid_subject_is_401(monkeypatch):
+    """A non-UUID JWT subject yields a clean 401, not a 500 (#12325 nit)."""
+    roots = [_org(uuid.uuid4())]
+    svc = _list_svc(roots)
+    membership = _list_membership(set())
+    async with _client(_app(svc, membership, subject="not-a-uuid")) as client:
+        resp = await client.get("/api/llc/companies/")
+    assert resp.status_code == 401
+    membership.list_member_company_ids.assert_not_called()

--- a/autobot-backend/llc/tests/test_company_crud_authz_12233.py
+++ b/autobot-backend/llc/tests/test_company_crud_authz_12233.py
@@ -189,6 +189,9 @@ def _membership(is_member: bool = True) -> MagicMock:
     m = MagicMock()
     m.is_member = AsyncMock(return_value=is_member)
     m.add_member = AsyncMock()
+    # #12325: list_companies now filters against a single membership-id query
+    # instead of one is_member call per root.
+    m.list_member_company_ids = AsyncMock(return_value=({_ORG_ID} if is_member else set()))
     return m
 
 


### PR DESCRIPTION
## Thinking Path

Both bugs live in `autobot-backend/llc/api/companies.py` and were surfaced while reviewing #12320 (authz) / #12321 (commit-order for transitions). Same file, same "serialize before commit" / query-shape family — one PR.

- **#12323** `create_company` ran `commit()` *before* `_to_read(org)` and before `_kb_manager.ensure_collection(...)`. A failure in serialization or KB-collection creation therefore left a committed-but-500 company — the DB and the caller disagree, violating the invariant #12309/#12321 established for the transition/update handlers.
- **#12325** `list_companies` fetched every tenant's root and ran one `await membership_svc.is_member(...)` per root — sequential DB round-trips scaling with total system-wide tenant count, not the caller's own memberships.

## What Changed

**#12323 — commit ordering (mirrors #12309/#12321):**
- `create_company` now builds the read response and ensures the 3 KB collections **before** the single `commit()`. Any failure (serialize or KB) falls through to the existing `except Exception: rollback; raise`, so the company INSERT is rolled back and no committed-but-unreported row survives.
- `ensure_collection` is already idempotent (`get_or_create_collection`), so a rollback after a partial KB pass — or a commit failure after a full one — leaves only harmless empty collections that the next create reuses. `create()`'s INSERT populates `updated_at` via RETURNING, so no `refresh` is needed before serializing.

**#12325 — single membership query:**
- New `MembershipService.list_member_company_ids(session, user_id)` — one `SELECT company_id WHERE user_id = :uid`.
- `list_companies` filters roots against that set in memory; non-members still match nothing, admins still short-circuit to all roots (no membership query at all). No enumeration leak.
- Folded-in nit: `_current_user_id` now validates the JWT subject via `_parse_uuid_safe` (same as `get_tenant_context`) — a non-UUID subject yields a clean 401 instead of a 500 at the `uuid.UUID(user_id)` cast.

## Verification

- `black --check --line-length 120` — clean; `flake8 --max-line-length 120` — 0; `ast.parse` — clean.
- `pytest` (77 tests) across the new suite + `test_company_crud_authz_12233` (the #12320 authz tests — no regression), `test_company`, `test_membership`, `test_company_transition_greenlet_12309`, `test_company_status_endpoints_12211` — **77 passed**.
- New tests:
  - #12323: happy-path asserts KB ensured (3x) + serialize **then** exactly one `commit`; KB-failure and serialize-failure paths assert `commit` **not** called and `rollback` awaited (no committed company).
  - #12325: asserts `list_member_company_ids` awaited **once** and `is_member` **never** called across 5 roots (single query, not per-root N+1); non-member sees `[]`; admin sees all with **no** membership query; non-UUID subject → 401.

## Model Used

claude-opus-4-8

Closes #12323
Closes #12325
