### PR TITLE
fix(db): make onupdate columns eager on ORM Base to kill MissingGreenlet-on-UPDATE class (#12322)

### DIFF
--- a/autobot-backend/llc/services/company.py
+++ b/autobot-backend/llc/services/company.py
@@ -117,13 +117,11 @@ class CompanyService(LLCServiceBase):
                 setattr(org, field, value)
 
         await self.session.flush()
-        # GH#12309 (same class as #12209): SQLAlchemy's eager_defaults="auto"
-        # only RETURNING-fetches the onupdate-computed `updated_at` on INSERT,
-        # not UPDATE, so it stays expired after flush(). The router then reads
-        # it while serializing the response — a sync lazy load outside the
-        # greenlet context that raises MissingGreenlet (HTTP 500). Refresh it
-        # here, inside the awaited/greenlet-safe scope.
-        await self.session.refresh(org, attribute_names=["updated_at"])
+        # #12322: `updated_at` is populated inline by the UPDATE's RETURNING
+        # clause (Base sets ``eager_defaults=True``), so it is never expired
+        # after flush() and the router's sync response serialization is safe.
+        # The previous per-call ``session.refresh(org, ["updated_at"])`` (#12309)
+        # is now redundant and removed.
         logger.info("LLC company updated: %s (id=%s)", org.name, org.id)
         return org
 
@@ -209,13 +207,11 @@ class CompanyService(LLCServiceBase):
         for field, value in field_updates.items():
             setattr(org, field, value)
         await self.session.flush()
-        # GH#12309 (same class as #12209): the onupdate-computed `updated_at`
-        # stays expired after an UPDATE flush (eager_defaults="auto" fetches it
-        # via RETURNING only on INSERT). Without this refresh the router's
-        # response serialization triggers a sync lazy load outside the greenlet
-        # context -> MissingGreenlet -> HTTP 500 (while the transition has
-        # already been flushed). Refresh inside the greenlet-safe scope.
-        await self.session.refresh(org, attribute_names=["updated_at"])
+        # #12322: the onupdate `updated_at` is populated inline by the UPDATE's
+        # RETURNING clause (Base sets ``eager_defaults=True``), so it is never
+        # expired after flush() and the router's sync response serialization is
+        # safe. The previous per-call ``session.refresh(org, ["updated_at"])``
+        # (#12309) is now redundant and removed.
         logger.info(log_msg, org.name, org.id)
         return org
 

--- a/autobot-backend/llc/services/goal.py
+++ b/autobot-backend/llc/services/goal.py
@@ -178,15 +178,12 @@ class GoalService(LLCServiceBase):
                 else:
                     setattr(goal, key, value)
         await session.flush()
-        # GH#12209: SQLAlchemy's default eager_defaults="auto" only fetches
-        # onupdate-computed columns (updated_at) via RETURNING on INSERT, not
-        # UPDATE (see Mapper._prefer_eager_defaults vs the strict `is True`
-        # check gating UPDATE RETURNING in orm/persistence.py). Without this
-        # refresh, `updated_at` stays expired after flush(); the first sync
-        # attribute access outside a greenlet context (Pydantic's
-        # `GoalResponse.model_validate` in the router) raises MissingGreenlet.
-        # Refresh it here, inside the awaited/greenlet-safe scope.
-        await session.refresh(goal, attribute_names=["updated_at"])
+        # #12322: `updated_at` (onupdate) is populated inline by the UPDATE's
+        # RETURNING clause because Base sets ``eager_defaults=True`` — so it is
+        # never left expired after flush() and the router's sync
+        # ``GoalResponse.model_validate`` no longer risks MissingGreenlet. The
+        # previous per-call ``session.refresh(goal, ["updated_at"])`` (#12209)
+        # is now redundant and removed.
         # Fix #2: Index after commit, not after flush
         self._schedule_post_commit_index(session, goal)
         return goal

--- a/autobot-backend/llc/tests/test_company_transition_greenlet_12309.py
+++ b/autobot-backend/llc/tests/test_company_transition_greenlet_12309.py
@@ -9,12 +9,12 @@ Two guards:
 
 1. Real-engine tests (``TestTransitionSurvivesSyncSerialization``) drive the
    *actual* ``CompanyService`` against an in-memory aiosqlite ``AsyncSession``
-   so SQLAlchemy's real attribute-expiry behaviour is exercised. The mapper
-   default ``eager_defaults="auto"`` only RETURNING-fetches the onupdate
-   ``updated_at`` on INSERT, not UPDATE — so post-flush ``updated_at`` stays
-   expired and the router's ``_to_read(org)`` serialization (a sync attribute
-   read) raises ``MissingGreenlet``. Without the ``session.refresh(org,
-   ["updated_at"])`` fix these tests fail exactly as production did.
+   so SQLAlchemy's real attribute-expiry behaviour is exercised. Base sets
+   ``eager_defaults=True`` (#12322), so the onupdate ``updated_at`` is fetched
+   inline via the UPDATE's RETURNING clause and stays fresh post-flush — the
+   router's ``_to_read(org)`` serialization (a sync attribute read) never
+   raises ``MissingGreenlet``. Without that setting these tests fail exactly as
+   production did (#12209/#12309).
 
 2. A router ordering test (``test_transition_serializes_before_commit``)
    proves the response is built *before* ``commit()`` so a serialization
@@ -23,16 +23,17 @@ Two guards:
 """
 
 import uuid
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 from fastapi import FastAPI
-from sqlalchemy import select
+from sqlalchemy import String, event, select
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import MissingGreenlet
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Mapped, mapped_column
 
 from api.user_management.dependencies import get_current_user, require_org_context
 from llc.api import companies
@@ -49,6 +50,22 @@ from user_management.services import TenantContext
 @compiles(JSONB, "sqlite")
 def _compile_jsonb_as_json_on_sqlite(element, compiler, **kw):  # noqa: ANN001
     return "JSON"
+
+
+class _EagerDefaultsProbe(Base):
+    """Dedicated throwaway model for the #12322 durability guard.
+
+    Inherits Base (and therefore ``eager_defaults=True`` plus the shared
+    ``created_at``/``updated_at`` columns) but is NOT registered with the LLC
+    e2e harness, so no other test can mutate its column defaults to client-side
+    Python values. That keeps the guard exercising the *real* server-side
+    onupdate + RETURNING path regardless of test ordering.
+    """
+
+    __tablename__ = "eager_defaults_probe_12322"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
 
 
 async def _seed_company(session_factory, llc_status: str = "onboarding") -> uuid.UUID:
@@ -117,19 +134,55 @@ class TestTransitionSurvivesSyncSerialization:
         assert read.name == "Renamed"
         assert read.updated_at is not None
 
-    @pytest.mark.asyncio
-    async def test_updated_at_is_expired_without_refresh(self, session_factory):
-        """Documents the root cause: after an UPDATE flush the onupdate
-        ``updated_at`` is expired, so a *sync* read raises MissingGreenlet.
-        Guards against a future regression that drops the refresh.
-        """
-        company_id = await _seed_company(session_factory, llc_status="onboarding")
-        async with session_factory() as session:
-            org = (await session.execute(select(Organization).where(Organization.id == company_id))).scalar_one()
-            org.llc_status = "active"
-            await session.flush()  # UPDATE, no refresh
-            with pytest.raises(MissingGreenlet):
-                _ = org.updated_at  # noqa: F841 — sync access of expired attr
+
+@pytest.mark.asyncio
+async def test_eager_defaults_populates_updated_at_on_update_without_refresh():
+    """#12322 durability guard for Base's ``eager_defaults=True``.
+
+    On a dedicated table (immune to cross-test mutation) prove that after an
+    UPDATE ``flush()`` — with NO manual ``session.refresh`` — the onupdate
+    ``updated_at`` is populated (not expired), so a *sync* attribute read does
+    not raise ``MissingGreenlet``. Also asserts the UPDATE actually carried a
+    ``RETURNING updated_at`` clause on the sqlite test dialect, which is the
+    exact mechanism that kills the recurring bug class (#12209/#12309). A
+    regression that drops ``eager_defaults`` fails this test.
+    """
+    engine = create_async_engine("sqlite+aiosqlite://")
+    update_statements: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        if statement.lstrip().upper().startswith("UPDATE"):
+            update_statements.append(statement)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=[_EagerDefaultsProbe.__table__])
+    sf = async_sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+
+    row_id = uuid.uuid4().hex
+    async with sf() as session:
+        session.add(_EagerDefaultsProbe(id=row_id, name="orig"))
+        await session.flush()
+        assert session.get_bind().dialect.update_returning is True
+        await session.commit()
+
+    async with sf() as session:
+        probe = (
+            await session.execute(select(_EagerDefaultsProbe).where(_EagerDefaultsProbe.id == row_id))
+        ).scalar_one()
+        before = probe.updated_at
+        probe.name = "changed"
+        await session.flush()  # UPDATE, no manual refresh
+        fresh = probe.updated_at  # sync access must NOT raise MissingGreenlet
+        await session.commit()
+
+    await engine.dispose()
+
+    assert isinstance(fresh, datetime)
+    assert fresh >= before
+    # The onupdate column was fetched inline with the UPDATE, not via a later
+    # refresh SELECT — that RETURNING is what keeps updated_at unexpired.
+    assert any("RETURNING" in s.upper() and "UPDATED_AT" in s.upper() for s in update_statements)
 
 
 class TestCommitOnlyOnSuccess:

--- a/autobot-backend/llc/tests/test_goals.py
+++ b/autobot-backend/llc/tests/test_goals.py
@@ -140,10 +140,11 @@ async def test_update_goal(svc: GoalService) -> None:
 
     assert updated is goal
     assert goal.title == "New Title"
-    # GH#12209: updated_at must be refreshed inside the awaited/greenlet-safe
-    # scope, else the router's synchronous GoalResponse.model_validate() call
-    # trips MissingGreenlet on the still-expired onupdate column.
-    session.refresh.assert_awaited_once_with(goal, attribute_names=["updated_at"])
+    # #12322: `updated_at` is now populated inline by the UPDATE RETURNING
+    # (Base's ``eager_defaults=True``), so the service no longer issues a
+    # per-call ``session.refresh``. Freshness on a real engine is asserted by
+    # ``test_update_goal_response_survives_sync_serialization`` below.
+    session.refresh.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -211,10 +212,10 @@ async def test_update_goal_response_survives_sync_serialization() -> None:
 
     Uses a real in-memory SQLite (aiosqlite) AsyncSession rather than mocks
     so SQLAlchemy's actual attribute-expiry/RETURNING behavior on UPDATE is
-    exercised: ``eager_defaults="auto"`` (the mapper default) only fetches
-    onupdate-computed columns via RETURNING on INSERT, not UPDATE, so without
-    the ``session.refresh(goal, ["updated_at"])`` fix, ``updated_at`` stays
-    expired post-flush and this test fails with MissingGreenlet.
+    exercised: with Base's ``eager_defaults=True`` (#12322) the onupdate
+    ``updated_at`` is fetched via RETURNING inline with the UPDATE, so it is
+    fresh post-flush and the synchronous ``GoalResponse.model_validate`` never
+    trips MissingGreenlet — without that setting this test would fail.
     """
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 

--- a/autobot-backend/user_management/models/base.py
+++ b/autobot-backend/user_management/models/base.py
@@ -53,6 +53,19 @@ class Base(AsyncAttrs, DeclarativeBase):
         uuid.UUID: Uuid(as_uuid=True),
     }
 
+    # #12322: eagerly fetch server-side default/onupdate columns (e.g.
+    # ``updated_at``) via RETURNING on INSERT *and* UPDATE, for all models.
+    # SQLAlchemy's default ``eager_defaults="auto"`` only does this for INSERT,
+    # leaving onupdate columns expired after an UPDATE flush — a subsequent sync
+    # attribute read (e.g. Pydantic response serialization outside the greenlet
+    # context) then raises MissingGreenlet. This recurred twice (#12209 goals,
+    # #12309 companies), each patched with a per-call ``session.refresh``.
+    # Setting it here kills the whole class in one place and removes the extra
+    # per-write refresh SELECT (RETURNING is fetched inline with the UPDATE).
+    # Dialects without RETURNING (e.g. sqlite < 3.35) transparently fall back to
+    # a post-UPDATE SELECT, so the column is still populated — never expired.
+    __mapper_args__ = {"eager_defaults": True}
+
 
 class TimestampMixin:
     """Backward compatibility alias for TimestampMixin.

--- a/autobot-backend/user_management/models/base.py
+++ b/autobot-backend/user_management/models/base.py
@@ -64,6 +64,10 @@ class Base(AsyncAttrs, DeclarativeBase):
     # per-write refresh SELECT (RETURNING is fetched inline with the UPDATE).
     # Dialects without RETURNING (e.g. sqlite < 3.35) transparently fall back to
     # a post-UPDATE SELECT, so the column is still populated — never expired.
+    # The other declarative bases were evaluated and are NOT susceptible to this
+    # class, so the fix only needs to live here: LLCBase (llc/models/activity.py)
+    # is append-only (no server-side onupdate), and SkillsBase (skills/models.py)
+    # uses a client-side ``onupdate`` assigned in Python (never expired post-flush).
     __mapper_args__ = {"eager_defaults": True}
 
 


### PR DESCRIPTION
## Thinking Path

The MissingGreenlet-on-UPDATE bug recurred twice — goals (#12209) and companies (#12309) — each patched with a per-call `await session.refresh(obj, ["updated_at"])`. Root cause: SQLAlchemy's default `eager_defaults="auto"` only RETURNING-fetches onupdate columns on INSERT, not UPDATE, so `updated_at` stays expired after an UPDATE flush; the router's sync response serialization then triggers a lazy load outside the greenlet context → HTTP 500. The durable one-place fix (#12322) is `__mapper_args__ = {"eager_defaults": True}` on `Base`, fetching onupdate columns via RETURNING on UPDATE for **all** models.

Because this is a repo-wide `Base` change, it was verified rigorously before landing (below).

## What Changed

- `user_management/models/base.py`: `Base.__mapper_args__ = {"eager_defaults": True}` (with rationale comment).
- `llc/services/goal.py`, `llc/services/company.py` (2 sites): removed the now-redundant per-call `session.refresh(obj, ["updated_at"])` — the value is fetched inline by the UPDATE RETURNING, eliminating the extra per-write refresh SELECT.
- `llc/tests/test_company_transition_greenlet_12309.py`: replaced the old "updated_at is expired without refresh" root-cause test with a **positive durability guard** — a dedicated throwaway model (immune to cross-test table mutation) asserting a sync `updated_at` read after an UPDATE flush does not raise MissingGreenlet AND that the UPDATE carried a `RETURNING updated_at` clause on the sqlite dialect. Updated docstrings.
- `llc/tests/test_goals.py`: `test_update_goal` now asserts `session.refresh` is **not** awaited (the mechanism moved to eager RETURNING); real-engine freshness still covered by `test_update_goal_response_survives_sync_serialization`.

## Verification

**RETURNING-on-sqlite (the whole risk):**
- sqlite `3.37.2` (>= 3.35), SQLAlchemy `2.0.49`. Standalone probe confirmed `dialect.update_returning is True` and the emitted UPDATE is `UPDATE ... SET updated_at=CURRENT_TIMESTAMP ... RETURNING updated_at`; sync access of `updated_at` post-flush works with no MissingGreenlet. INSERT RETURNING (`created_at`/`updated_at`) also confirmed.
- **Worst-case fallback:** with `update_returning` force-disabled (simulating sqlite < 3.35), eager_defaults transparently falls back to a post-UPDATE `SELECT updated_at ...`, so the column is still populated — never expired. Safe on any sqlite version.

**Test suites (green):**
- Full LLC suite `llc/tests/` — 1296 passed, 2 skipped. New durability guard passes both in-suite and in isolation.
- `tests/user_management/`, `api/user_management/`, `tests/migrations/test_organizations_pm_columns.py` — pass (aside from 2 pre-existing, unrelated flakes below).
- Targeted model/service run (company transitions, goals, membership, sprints IDOR, board) — 125 passed.

**Pre-existing failures (confirmed identical on base branch with my changes reverted, unrelated to this change):**
- `test_llc_e2e_loop::test_llc_core_loop_end_to_end` — `object MagicMock can't be used in 'await' expression` in `llc/kb/collections.py` (ChromaDB async-client mock leak, order-dependent).
- `api/user_management/.../test_rate_limit_exceeded_returns_429` — rate-limiter returns "Internal server error" (Redis unavailable in local env); fails in isolation, touches no ORM code.

**Lint:** `black --check --line-length 120` clean; `flake8 --max-line-length 120` clean; `ast.parse` clean on all 5 files.

## Model Used

claude-opus-4-8

Closes #12322
