### PR TITLE
fix(chat): keep chat on failed backend delete instead of removing locally (#12327)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "تعذّر حذف المحادثة. يُرجى المحاولة مرة أخرى."
+    }
   },
   "settings": {
     "title": "الإعدادات",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "Der Chat konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
+    }
   },
   "settings": {
     "title": "Einstellungen",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "Couldn't delete the chat. Please try again."
+    }
   },
   "settings": {
     "title": "Settings",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "No se pudo eliminar el chat. Inténtalo de nuevo."
+    }
   },
   "settings": {
     "title": "Ajustes",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -5552,7 +5552,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "حذف گفتگو ممکن نشد. لطفاً دوباره تلاش کنید."
+    }
   },
   "serviceMessages": {
     "metadata": "Metadata",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "Impossible de supprimer la conversation. Veuillez réessayer."
+    }
   },
   "settings": {
     "title": "Paramètres",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -5552,7 +5552,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "לא ניתן היה למחוק את הצ'אט. אנא נסה שוב."
+    }
   },
   "serviceMessages": {
     "metadata": "Metadata",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "Neizdevās izdzēst sarunu. Lūdzu, mēģiniet vēlreiz."
+    }
   },
   "settings": {
     "title": "Iestatījumi",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "Nie udało się usunąć czatu. Spróbuj ponownie."
+    }
   },
   "settings": {
     "title": "Ustawienia",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -732,7 +732,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "Não foi possível excluir o chat. Tente novamente."
+    }
   },
   "settings": {
     "title": "Configurações",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -5552,7 +5552,10 @@
       "contentRequired": "Content is required"
     },
     "lightweightMode": "Lightweight mode",
-    "lightweightModeTooltip": "lightweight Mode tooltip"
+    "lightweightModeTooltip": "lightweight Mode tooltip",
+    "errors": {
+      "deleteFailed": "چیٹ حذف نہیں ہو سکی۔ براہ کرم دوبارہ کوشش کریں۔"
+    }
   },
   "serviceMessages": {
     "metadata": "Metadata",

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -7,6 +7,7 @@ import apiClient from '@/utils/ApiClient'
 import type { ChatSession } from '@/stores/useChatStore'
 import { createLogger } from '@/utils/debugUtils'
 import { extractErrorMessage } from '@/utils/errorExtract'
+import i18n from '@/i18n'
 import type { ChatMessage, ChatMessageDisplayType } from '@/types/api'
 import { requestQueue } from '@/composables/useRequestQueue'
 
@@ -815,93 +816,71 @@ export class ChatController {
     fileAction?: 'delete' | 'transfer_kb' | 'transfer_shared',
     fileOptions?: Record<string, unknown>
   ): Promise<void> {
+    // Step 1: Delete from the backend FIRST. Removing the chat locally is only safe
+    // once the server confirms the delete — otherwise the client and server diverge
+    // and the "deleted" chat reappears on reload (#12327).
     try {
-
-      // CRITICAL FIX: Enhanced deletion with proper error handling and persistence
-      let backendDeleteSucceeded = false
-      let storeDeleteSucceeded = false
-
-      // Step 1: Try to delete from backend
-      try {
-        await chatRepository.deleteChat(sessionId, fileAction, fileOptions)
-        if (fileAction) {
-          logger.debug(`File action executed: ${fileAction}`, fileOptions)
-        }
-        backendDeleteSucceeded = true
-        logger.debug('Chat successfully deleted from backend:', sessionId)
-      } catch (error: unknown) {
-        logger.error('Backend deletion failed:', error)
-        // Don't throw yet - we'll handle this based on error type
-
-        // If it's a 404 (chat not found), still proceed with local deletion
-        const errStatus = (error as { status?: number }).status
-        if (errStatus === 404) {
-          logger.warn('Chat not found on backend, proceeding with local deletion')
-          backendDeleteSucceeded = true // Treat as success since it's already gone
-        } else {
-          // For other errors, show user error but still try local deletion
-          logger.warn('Backend deletion failed, but proceeding with local deletion to maintain consistency')
-          this.getAppStore()?.setGlobalError(`Backend deletion failed: ${extractErrorMessage(error, 'Unknown error')}. Chat removed locally.`)
-        }
+      await chatRepository.deleteChat(sessionId, fileAction, fileOptions)
+      if (fileAction) {
+        logger.debug(`File action executed: ${fileAction}`, fileOptions)
       }
-
-      // Step 2: Always try to remove from store for consistency
-      try {
-        // Store current sessions count for verification
-        const beforeCount = this.chatStore.sessions.length
-
-        // Delete from store
-        this.chatStore.deleteSession(sessionId)
-
-        // Verify deletion occurred
-        const afterCount = this.chatStore.sessions.length
-        if (afterCount < beforeCount) {
-          storeDeleteSucceeded = true
-          logger.debug('Chat successfully deleted from store:', sessionId)
-
-          // CRITICAL FIX: Force persistence to ensure localStorage is updated immediately
-          // Since Pinia persistence is automatic, we'll add a small delay to ensure it completes
-          await new Promise(resolve => setTimeout(resolve, 100))
-
-          // Verify persistence by checking localStorage directly
-          try {
-            const persistedData = localStorage.getItem('autobot-chat-store')
-            if (persistedData) {
-              const parsed = JSON.parse(persistedData)
-              const persistedSession = parsed.sessions?.find(
-                (s: { id?: string }) => s.id === sessionId
-              )
-              if (!persistedSession) {
-                logger.debug('Chat deletion confirmed in localStorage')
-              } else {
-                logger.warn('Chat still exists in localStorage - persistence may have failed')
-              }
-            }
-          } catch (persistError) {
-            logger.warn('Could not verify localStorage persistence:', persistError)
-          }
-
-        } else {
-          logger.warn('Store deletion did not reduce session count - session may not have existed')
-          storeDeleteSucceeded = true // If it wasn't there, consider it a success
-        }
-      } catch (error: unknown) {
-        logger.error('Store deletion failed:', error)
-        throw new Error(`Failed to delete chat from local storage: ${extractErrorMessage(error, 'Unknown error')}`)
-      }
-
-      // Step 3: Report final status
-      if (storeDeleteSucceeded) {
-        logger.debug(`Chat session ${sessionId} successfully deleted (Backend: ${backendDeleteSucceeded ? 'Success' : 'Failed'}, Store: Success)`)
-      } else {
-        throw new Error('Failed to delete chat from local storage')
-      }
-
+      logger.debug('Chat successfully deleted from backend:', sessionId)
     } catch (error: unknown) {
-      logger.error('Failed to delete chat session:', error)
-      this.getAppStore()?.setGlobalError(`Failed to delete chat: ${extractErrorMessage(error, 'Unknown error')}`)
-      throw error // Re-throw to let caller handle
-    } finally {
+      const errStatus = (error as { status?: number }).status
+      if (errStatus !== 404) {
+        // #12327: the backend rejected or never received the delete. Do NOT remove
+        // the chat locally — keep it in place and surface an unambiguous failure so
+        // the user can retry, instead of reporting a success that never happened.
+        logger.error('Backend deletion failed; keeping chat locally:', error)
+        this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.deleteFailed'))
+        throw error
+      }
+      // 404 → the chat is already gone on the backend, so reconciling local state is
+      // correct. Fall through to the local removal below.
+      logger.warn('Chat not found on backend, reconciling local deletion:', sessionId)
+    }
+
+    // Step 2: Backend delete confirmed (or the chat was already gone) — remove it from
+    // the local store and persisted state.
+    try {
+      const beforeCount = this.chatStore.sessions.length
+
+      this.chatStore.deleteSession(sessionId)
+
+      const afterCount = this.chatStore.sessions.length
+      if (afterCount < beforeCount) {
+        logger.debug('Chat successfully deleted from store:', sessionId)
+
+        // Pinia persistence is automatic; give it a tick to flush to localStorage
+        // before verifying below.
+        await new Promise(resolve => setTimeout(resolve, 100))
+
+        // Verify persistence by checking localStorage directly
+        try {
+          const persistedData = localStorage.getItem('autobot-chat-store')
+          if (persistedData) {
+            const parsed = JSON.parse(persistedData)
+            const persistedSession = parsed.sessions?.find(
+              (s: { id?: string }) => s.id === sessionId
+            )
+            if (!persistedSession) {
+              logger.debug('Chat deletion confirmed in localStorage')
+            } else {
+              logger.warn('Chat still exists in localStorage - persistence may have failed')
+            }
+          }
+        } catch (persistError) {
+          logger.warn('Could not verify localStorage persistence:', persistError)
+        }
+      } else {
+        logger.warn('Store deletion did not reduce session count - session may not have existed')
+      }
+
+      logger.debug(`Chat session ${sessionId} successfully deleted`)
+    } catch (error: unknown) {
+      logger.error('Store deletion failed:', error)
+      this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.deleteFailed'))
+      throw new Error(`Failed to delete chat from local storage: ${extractErrorMessage(error, 'Unknown error')}`)
     }
   }
 

--- a/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
+++ b/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ChatController } from '../ChatController'
 import * as chatRepository from '@/models/repositories'
 import { useChatStore } from '@/stores/useChatStore'
+import { useAppStore } from '@/stores/useAppStore'
 
 // Mock the repositories
 vi.mock('@/models/repositories', () => ({
@@ -184,6 +185,72 @@ describe('ChatController', () => {
 
       const [, , sentOptions] = vi.mocked(chatRepository.chatRepository.sendMessage).mock.calls[0]
       expect(sentOptions).not.toHaveProperty('company_id')
+    })
+  })
+
+  describe('deleteChatSession backend-failure handling (#12327)', () => {
+    // Build a store exposing a deleteSession spy and a sessions list so the
+    // controller's local-removal step can be observed.
+    function deletableStore() {
+      return {
+        deleteSession: vi.fn(),
+        sessions: [{ id: 's1' }],
+        currentSessionId: 's1'
+      }
+    }
+
+    it('keeps the chat locally and surfaces an error when the backend delete fails', async () => {
+      const store = deletableStore()
+      vi.mocked(useChatStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useChatStore>
+      )
+      const setGlobalError = vi.fn()
+      vi.mocked(useAppStore).mockReturnValue(
+        { setGlobalError } as unknown as ReturnType<typeof useAppStore>
+      )
+      // A network failure has no HTTP status — the mirror of the reported case.
+      vi.mocked(chatRepository.chatRepository.deleteChat).mockRejectedValue(
+        new Error('Network Error')
+      )
+
+      await expect(controller.deleteChatSession('s1')).rejects.toThrow('Network Error')
+
+      // The chat must NOT be removed locally, and the user must be told it failed.
+      expect(store.deleteSession).not.toHaveBeenCalled()
+      expect(setGlobalError).toHaveBeenCalledTimes(1)
+    })
+
+    it('removes the chat locally when the backend delete succeeds', async () => {
+      const store = deletableStore()
+      vi.mocked(useChatStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useChatStore>
+      )
+      vi.mocked(chatRepository.chatRepository.deleteChat).mockResolvedValue(
+        undefined as never
+      )
+
+      await controller.deleteChatSession('s1')
+
+      expect(chatRepository.chatRepository.deleteChat).toHaveBeenCalledWith(
+        's1',
+        undefined,
+        undefined
+      )
+      expect(store.deleteSession).toHaveBeenCalledWith('s1')
+    })
+
+    it('reconciles local state when the backend returns 404 (already gone)', async () => {
+      const store = deletableStore()
+      vi.mocked(useChatStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useChatStore>
+      )
+      vi.mocked(chatRepository.chatRepository.deleteChat).mockRejectedValue(
+        Object.assign(new Error('Not Found'), { status: 404 })
+      )
+
+      await controller.deleteChatSession('s1')
+
+      expect(store.deleteSession).toHaveBeenCalledWith('s1')
     })
   })
 


### PR DESCRIPTION
## Thinking Path

Issue #12327: deleting a chat whose backend `DELETE` fails still removed the chat from local state and told the user "Chat removed locally." Client and server then diverge — the chat reappears on reload — while the message implies success. Root cause in `ChatController.deleteChatSession`: an optimistic/unconditional local removal that ran regardless of whether the backend delete succeeded, treating any non-404 failure as recoverable and proceeding anyway.

## What Changed

- `autobot-frontend/src/models/controllers/ChatController.ts` — reordered `deleteChatSession` so the backend delete must succeed first. On a non-404 failure the chat is now kept in the store, an unambiguous error is surfaced, and the method throws — no local removal. A 404 (already gone) still reconciles local state. Success path removes locally and keeps the existing localStorage persistence verification. Removed the misleading "Chat removed locally" message and the dead `backendDeleteSucceeded`/`storeDeleteSucceeded` bookkeeping.
- i18n: new key `chat.errors.deleteFailed` ("Couldn't delete the chat. Please try again.") added to all 11 locales (en, de, es, fr, pt, pl, lv, ar, fa, he, ur). No hardcoded UI string.
- `ChatController.test.ts` — added `deleteChatSession backend-failure handling (#12327)` describe: backend-fail → chat still present + error surfaced + rejects; backend-success → chat removed; 404 → reconciled/removed.

## Verification

- Inspection + `git diff`. Locale JSON validated (all 11 parse). No leftover `backendDeleteSucceeded`/`storeDeleteSucceeded`/"removed locally" references.
- WSL has no `node_modules` installed (no Linux npm per project constraint), so vitest/vue-tsc were not run locally — CI runs them. `i18n.global.t('chat.errors.deleteFailed')` is type-checked against `MessageSchema` (typeof en.json), and the key was added to en.json, so the typed key resolves. Low CI risk.

## Model Used

claude-opus-4-8

Closes #12327
