### PR TITLE
fix(graph-rag): /health no longer 500s on missing initialized attr (#12316)

### DIFF
--- a/autobot-backend/api/graph_rag.py
+++ b/autobot-backend/api/graph_rag.py
@@ -22,7 +22,7 @@ Endpoints:
 - GET /graph-rag/metrics - Performance metrics
 """
 
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -114,16 +114,32 @@ def _serialize_search_results(results) -> List[Metadata]:
     ]
 
 
+def _probe_component(name: str, check: Callable[[], bool]) -> str:
+    """Run a single component readiness probe, never raising.
+
+    A health probe must degrade gracefully (#12316): any exception is logged
+    and reported as ``"unavailable"`` rather than propagated as a 500.
+    """
+    try:
+        return "healthy" if check() else "unavailable"
+    except Exception:  # noqa: BLE001 — a health probe must never raise
+        logger.warning("Graph-RAG health probe failed for %s", name, exc_info=True)
+        return "unavailable"
+
+
 def _check_component_health(service: GraphRAGService) -> Dict[str, str]:
     """
     Check health status of service components.
 
     Issue #398: Extracted from graph_rag_health to reduce method length.
+    Issue #12316: each probe is guarded so a missing/failing dependency yields
+    ``"unavailable"`` instead of raising (memory_graph readiness lives on the
+    public ``AutoBotMemoryGraph.initialized`` property).
     """
     return {
         "graph_rag_service": "healthy",
-        "rag_service": "healthy" if service.rag else "unavailable",
-        "memory_graph": ("healthy" if service.graph and service.graph.initialized else "unavailable"),
+        "rag_service": _probe_component("rag_service", lambda: bool(service.rag)),
+        "memory_graph": _probe_component("memory_graph", lambda: bool(service.graph) and service.graph.initialized),
     }
 
 

--- a/autobot-backend/api/graph_rag_collection_test.py
+++ b/autobot-backend/api/graph_rag_collection_test.py
@@ -25,9 +25,13 @@ import pytest
 pytest.importorskip("fastapi")
 
 from api.graph_rag import (  # noqa: E402
+    _check_component_health,
     _collect_collection_edges,
+    _determine_overall_status,
+    _probe_component,
     _serialize_graph_nodes,
     collection_graph,
+    graph_rag_health,
 )
 
 
@@ -95,3 +99,95 @@ async def test_collection_graph_returns_nodes_and_edges():
     service.graph.search_entities.assert_awaited_once()
     _, kwargs = service.graph.search_entities.await_args
     assert kwargs.get("tags") == ["col-123"]
+
+
+# ---------------------------------------------------------------------------
+# Graph-RAG /health endpoint — #12316
+#
+# Regression: graph_rag_health 500'd with
+#   AttributeError: 'AutoBotMemoryGraph' object has no attribute 'initialized'
+# A health probe must degrade gracefully — always return a status, never 500.
+# ---------------------------------------------------------------------------
+
+
+class _GraphMissingInitialized:
+    """Stand-in for the pre-fix AutoBotMemoryGraph: truthy but no ``initialized``.
+
+    Accessing ``.initialized`` raises AttributeError — exactly the #12316 crash.
+    """
+
+
+def _health_body(response):
+    return json.loads(bytes(response.body).decode("utf-8"))
+
+
+def test_probe_component_reports_unavailable_on_exception():
+    def _boom() -> bool:
+        raise AttributeError("no attribute 'initialized'")
+
+    assert _probe_component("memory_graph", _boom) == "unavailable"
+
+
+def test_probe_component_healthy_and_unavailable():
+    assert _probe_component("x", lambda: True) == "healthy"
+    assert _probe_component("x", lambda: False) == "unavailable"
+
+
+def test_check_component_health_all_healthy():
+    service = MagicMock()
+    service.rag = MagicMock()
+    service.graph = MagicMock()
+    service.graph.initialized = True
+    components = _check_component_health(service)
+    assert components == {
+        "graph_rag_service": "healthy",
+        "rag_service": "healthy",
+        "memory_graph": "healthy",
+    }
+
+
+def test_check_component_health_degraded_when_graph_uninitialized():
+    service = MagicMock()
+    service.rag = MagicMock()
+    service.graph = MagicMock()
+    service.graph.initialized = False
+    components = _check_component_health(service)
+    assert components["memory_graph"] == "unavailable"
+    assert _determine_overall_status(components) == "degraded"
+
+
+def test_check_component_health_survives_missing_initialized_attr():
+    # The exact #12316 crash: graph object lacks ``initialized``.
+    service = MagicMock()
+    service.rag = MagicMock()
+    service.graph = _GraphMissingInitialized()
+    components = _check_component_health(service)  # must not raise
+    assert components["memory_graph"] == "unavailable"
+
+
+async def test_graph_rag_health_returns_200_when_healthy():
+    service = MagicMock()
+    service.rag = MagicMock()
+    service.graph = MagicMock()
+    service.graph.initialized = True
+
+    response = await graph_rag_health(service=service, current_user={"id": "u1"})
+    assert response.status_code == 200
+    body = _health_body(response)
+    assert body["status"] == "healthy"
+    assert body["components"]["memory_graph"] == "healthy"
+
+
+async def test_graph_rag_health_returns_degraded_not_500_when_subsystem_down():
+    # Subsystem unavailable (graph missing ``initialized``) must yield a usable
+    # status (503 degraded), never the GRAPH_RAG_0310 500 from #12316.
+    service = MagicMock()
+    service.rag = MagicMock()
+    service.graph = _GraphMissingInitialized()
+
+    response = await graph_rag_health(service=service, current_user={"id": "u1"})
+    assert response.status_code == 503
+    body = _health_body(response)
+    assert body["status"] == "degraded"
+    assert "status" in body  # monitoring always gets a status field
+    assert body["components"]["memory_graph"] == "unavailable"

--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -127,6 +127,16 @@ class AutoBotMemoryGraphCore:
         self._lock: asyncio.Lock = asyncio.Lock()
         self.index_name: str = f"{config.index_prefix}:idx"
 
+    @property
+    def initialized(self) -> bool:
+        """Public readiness flag — True once ``initialize()`` has completed.
+
+        Exposes the private ``_initialized`` state so callers (e.g. the
+        Graph-RAG health probe, #12316) can read readiness without touching a
+        private attribute or triggering ``AttributeError``.
+        """
+        return self._initialized
+
     def ensure_initialized(self) -> None:
         """Sync guard — raise if ``initialize()`` has not been awaited.
 


### PR DESCRIPTION
## Thinking Path

`GET /api/graph-rag/health` returned HTTP 500 (`GRAPH_RAG_0310`) with
`AttributeError: 'AutoBotMemoryGraph' object has no attribute 'initialized'`.
A health endpoint must always report a status — healthy or degraded — never
crash before evaluating, or monitoring/dashboards go permanently red for the
wrong reason.

Root cause: `_check_component_health()` in `api/graph_rag.py` read
`service.graph.initialized`, but `AutoBotMemoryGraph` only exposes the private
`_initialized` flag — the public `initialized` attribute never existed, so the
probe raised, and `@with_error_handling` converted it to a 500.

## What Changed

- `autobot_memory_graph/core.py`: added a public read-only `initialized`
  property returning `_initialized`, so callers read readiness without touching
  a private attribute (matches the metrics endpoint's `graph_initialized` intent).
- `api/graph_rag.py`: added `_probe_component()` — each component readiness
  check now runs guarded; any exception is logged (`logging`/`get_logger`) and
  reported as `"unavailable"` instead of propagating. A health probe can no
  longer 500 on a subsystem failure; it reports `degraded`/`unhealthy` (503)
  with a usable `status` field. Real errors are logged with `exc_info`, not
  swallowed silently.

## Verification

- `pytest api/graph_rag_collection_test.py` — 11 passed (4 existing + 7 new).
- New tests assert `/health` returns 200 `healthy` when up, and 503 `degraded`
  (with a `status` field) when the memory-graph subsystem is unavailable —
  including the exact regression: a graph object missing `initialized` yields
  `unavailable`, not a 500.
- `black --check` clean, `flake8` clean, `ast.parse` clean on all 3 files.
- Before: `curl /api/graph-rag/health` → 500 `AttributeError ... 'initialized'`.
  After: returns 200/503 JSON with `status` + per-component health.

Note: 2 pre-existing failures in `services/graph_rag_service_test.py`
(`test_get_metrics`, `test_graph_aware_search_with_entity_expansion`) are
unrelated (plain `Mock` awaited as async for `self.rag`); that file is
byte-identical to base. Filed as a discovery issue.

## Model Used

claude-opus-4-8

Closes #12316
