### PR TITLE
fix(audit): persist unfileable audit findings instead of dropping them (#12319)

### DIFF
--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -17,6 +17,7 @@ Beat pidfile MUST NOT reside on tmpfs (/run/autobot/ is wiped on reboot).
 """
 
 import json
+import os
 import re
 import subprocess  # nosec B404 — internal git/gh CLI calls only
 import sys
@@ -33,6 +34,18 @@ logger = get_logger(__name__)
 _TESTGAPS_LAST_RUN_KEY = "audit:testgaps:last_run"
 _DEAD_CODE_INVENTORY_KEY = "audit:dead_code:last_inventory"
 _CLAIMS_LAST_RUN_KEY = "audit:claims:last_run"
+
+# Dead-letter queue: findings that could not be filed (e.g. gh unauthenticated)
+# are persisted here for retry on the next run instead of being discarded (#12319).
+_DEFERRED_FINDINGS_KEY = "audit:deferred_findings"
+
+# Upper bound on the dead-letter queue so it cannot grow without limit while
+# filing is broken. Overflow is logged in full (never silently truncated); the
+# oldest findings are shed first. Overridable via env for large backlogs.
+try:
+    _MAX_DEFERRED = max(1, int(os.getenv("AUTOBOT_AUDIT_MAX_DEFERRED", "10000")))
+except ValueError:
+    _MAX_DEFERRED = 10000
 
 # GitHub repo used for filing issues
 _GH_REPO = "mrveiss/AutoBot-AI"
@@ -126,6 +139,16 @@ def _list_open_issues(label: str | None = None) -> list[str]:
         return []
 
 
+def _gh_available() -> bool:
+    """Return True if the gh CLI is authenticated and can file issues.
+
+    Checked once per task run so a missing credential produces a single CRITICAL
+    log instead of one ERROR per lost finding (#12319).
+    """
+    code, _, _ = _run(["gh", "auth", "status"])
+    return code == 0
+
+
 def _file_issue(title: str, body: str, labels: str = _AUDIT_LABELS) -> bool:
     """Create a GitHub issue. Returns True on success."""
     code, _, err = _run(
@@ -149,20 +172,88 @@ def _file_issue(title: str, body: str, labels: str = _AUDIT_LABELS) -> bool:
     return True
 
 
-def _dedupe_and_file(findings: list[dict], existing_titles: set[str], label: str) -> int:
-    """File GitHub issues for findings whose title is not in *existing_titles*.
+def _load_deferred(redis) -> list[dict]:
+    """Return the dead-letter queue of findings awaiting a retry."""
+    queued = _redis_get(redis, _DEFERRED_FINDINGS_KEY)
+    return queued if isinstance(queued, list) else []
 
-    Returns the number of newly filed issues.
+
+def _persist_deferred(redis, deferred: list[dict]) -> int:
+    """Persist unfileable findings for retry, deduped by title. Returns queue size.
+
+    Enforces ``_MAX_DEFERRED`` by shedding the oldest findings first, logging the
+    exact titles dropped and why — never a silent truncation (#12319).
     """
+    by_title: dict[str, dict] = {}
+    for finding in deferred:
+        by_title[finding["title"]] = finding
+    unique = list(by_title.values())
+
+    if len(unique) > _MAX_DEFERRED:
+        dropped = unique[: len(unique) - _MAX_DEFERRED]
+        unique = unique[len(unique) - _MAX_DEFERRED :]
+        logger.error(
+            "audit dead-letter queue exceeded cap %d — shedding %d oldest finding(s) "
+            "(set AUTOBOT_AUDIT_MAX_DEFERRED higher to retain them). Dropped titles: %s",
+            _MAX_DEFERRED,
+            len(dropped),
+            [f["title"] for f in dropped],
+        )
+
+    _redis_set(redis, _DEFERRED_FINDINGS_KEY, unique)
+    return len(unique)
+
+
+def _dedupe_and_file(
+    findings: list[dict],
+    existing_titles: set[str],
+    label: str,
+    redis=None,
+) -> tuple[int, int]:
+    """File GitHub issues for new findings; persist any that cannot be filed.
+
+    Drains the dead-letter queue first (retrying previously deferred findings),
+    then processes *findings*. A finding is *filed* when ``gh issue create``
+    succeeds, *skipped* when its title already exists, and *deferred* to the
+    Redis dead-letter queue when filing is impossible (unauthenticated gh) or
+    fails. No finding is ever silently discarded (#12319).
+
+    Returns ``(filed, deferred)`` where ``filed + deferred`` accounts for every
+    non-duplicate finding drawn from both the queue and *findings*.
+    """
+    gh_ok = _gh_available()
+    pending = _load_deferred(redis)
+
     filed = 0
-    for finding in findings:
-        title = finding["title"]
+    still_deferred: list[dict] = []
+
+    def _attempt(title: str, body: str, lbl: str) -> None:
+        nonlocal filed
         if title in existing_titles:
-            continue
-        if _file_issue(title, finding["body"], label):
+            return
+        if gh_ok and _file_issue(title, body, lbl):
             existing_titles.add(title)
             filed += 1
-    return filed
+        else:
+            still_deferred.append({"title": title, "body": body, "label": lbl})
+
+    for item in pending:
+        _attempt(item["title"], item["body"], item.get("label", label))
+    for finding in findings:
+        _attempt(finding["title"], finding["body"], label)
+
+    if not gh_ok and still_deferred:
+        logger.critical(
+            "gh CLI unauthenticated — %d audit finding(s) deferred to the Redis "
+            "dead-letter queue (%s) instead of being filed or lost. Configure a "
+            "GH_TOKEN for the worker to restore issue filing; deferred findings "
+            "are retried automatically once it is available.",
+            len(still_deferred),
+            _DEFERRED_FINDINGS_KEY,
+        )
+
+    deferred_count = _persist_deferred(redis, still_deferred)
+    return filed, deferred_count
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +355,7 @@ def audit_testgaps(self) -> dict:
 
     findings = _testgap_findings(modules, repo_root)
     existing_titles = set(_list_open_issues(label="observability"))
-    filed = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS)
+    filed, deferred = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
 
     _redis_set(redis, _TESTGAPS_LAST_RUN_KEY, run_at)
 
@@ -274,12 +365,14 @@ def audit_testgaps(self) -> dict:
         "modules_checked": len(modules),
         "gaps_found": len(findings),
         "issues_filed": filed,
+        "issues_deferred": deferred,
     }
     logger.info(
-        "audit_testgaps complete: modules_checked=%d gaps_found=%d issues_filed=%d",
+        "audit_testgaps complete: modules_checked=%d gaps_found=%d " "issues_filed=%d issues_deferred=%d",
         len(modules),
         len(findings),
         filed,
+        deferred,
     )
     return result
 
@@ -341,7 +434,7 @@ def audit_dead_code(self) -> dict:
         findings.append({"title": title, "body": body})
 
     existing_titles = set(_list_open_issues(label="observability"))
-    filed = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS)
+    filed, deferred = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
 
     # Persist current full inventory for next run's diff
     _redis_set(redis, _DEAD_CODE_INVENTORY_KEY, list(current_fps.keys()))
@@ -352,12 +445,14 @@ def audit_dead_code(self) -> dict:
         "total_findings": len(current_lines),
         "new_findings": len(new_findings_raw),
         "issues_filed": filed,
+        "issues_deferred": deferred,
     }
     logger.info(
-        "audit_dead_code complete: total_findings=%d new_findings=%d issues_filed=%d",
+        "audit_dead_code complete: total_findings=%d new_findings=%d " "issues_filed=%d issues_deferred=%d",
         len(current_lines),
         len(new_findings_raw),
         filed,
+        deferred,
     )
     return result
 
@@ -379,10 +474,13 @@ def _extract_capability_claims(repo_root: Path) -> list[dict]:
         re.IGNORECASE,
     )
     claims = []
+    # Exclude the audit's own generated report so it does not re-audit its own
+    # output — that self-reference inflated findings into five figures (#12319).
+    self_report = (repo_root / "docs" / "verification.md").resolve()
     search_paths = [repo_root / "README.md"] + list((repo_root / "docs").glob("**/*.md"))
 
     for src in search_paths:
-        if not src.is_file():
+        if not src.is_file() or src.resolve() == self_report:
             continue
         rel = src.relative_to(repo_root)
         for lineno, line in enumerate(src.read_text(errors="ignore").splitlines(), 1):
@@ -489,7 +587,7 @@ def audit_claims(self) -> dict:
         findings.append({"title": title, "body": body})
 
     existing_titles = set(_list_open_issues(label="observability"))
-    filed = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS)
+    filed, deferred = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
 
     _redis_set(redis, _CLAIMS_LAST_RUN_KEY, run_at)
     _redis_set(
@@ -505,13 +603,15 @@ def audit_claims(self) -> dict:
         "verified": len(verified),
         "unverified": len(unverified),
         "issues_filed": filed,
+        "issues_deferred": deferred,
         "verification_doc": str(doc_path.relative_to(repo_root)),
     }
     logger.info(
-        "audit_claims complete: claims_checked=%d verified=%d unverified=%d issues_filed=%d",
+        "audit_claims complete: claims_checked=%d verified=%d unverified=%d " "issues_filed=%d issues_deferred=%d",
         len(claims),
         len(verified),
         len(unverified),
         filed,
+        deferred,
     )
     return result

--- a/autobot-backend/workers/audit_tasks_test.py
+++ b/autobot-backend/workers/audit_tasks_test.py
@@ -11,9 +11,11 @@ duplicate issues when an audit task runs multiple times without new findings.
 from unittest.mock import MagicMock, patch
 
 from workers.audit_tasks import (
+    _DEFERRED_FINDINGS_KEY,
     _dead_code_fingerprint,
     _dedupe_and_file,
     _find_test_file,
+    _persist_deferred,
     audit_claims,
     audit_dead_code,
     audit_testgaps,
@@ -31,10 +33,15 @@ class TestDedupeAndFile:
             {"title": "discovery: old issue", "body": "body1"},
             {"title": "discovery: new issue", "body": "body2"},
         ]
-        with patch("workers.audit_tasks._file_issue", return_value=True) as mock_file:
-            filed = _dedupe_and_file(findings, existing, "enhancement")
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._persist_deferred", return_value=0),
+            patch("workers.audit_tasks._file_issue", return_value=True) as mock_file,
+        ):
+            filed, deferred = _dedupe_and_file(findings, existing, "enhancement")
 
-        assert filed == 1
+        assert (filed, deferred) == (1, 0)
         mock_file.assert_called_once_with("discovery: new issue", "body2", "enhancement")
 
     def test_no_filing_when_all_duplicates(self):
@@ -43,10 +50,15 @@ class TestDedupeAndFile:
             {"title": "discovery: gap A", "body": "body"},
             {"title": "discovery: gap B", "body": "body"},
         ]
-        with patch("workers.audit_tasks._file_issue") as mock_file:
-            filed = _dedupe_and_file(findings, existing, "enhancement")
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._persist_deferred", return_value=0),
+            patch("workers.audit_tasks._file_issue") as mock_file,
+        ):
+            filed, deferred = _dedupe_and_file(findings, existing, "enhancement")
 
-        assert filed == 0
+        assert (filed, deferred) == (0, 0)
         mock_file.assert_not_called()
 
     def test_updates_existing_titles_set_to_prevent_double_filing(self):
@@ -55,17 +67,160 @@ class TestDedupeAndFile:
             {"title": "discovery: gap X", "body": "body"},
             {"title": "discovery: gap X", "body": "body"},  # exact duplicate in batch
         ]
-        with patch("workers.audit_tasks._file_issue", return_value=True):
-            filed = _dedupe_and_file(findings, existing, "enhancement")
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._persist_deferred", return_value=0),
+            patch("workers.audit_tasks._file_issue", return_value=True),
+        ):
+            filed, deferred = _dedupe_and_file(findings, existing, "enhancement")
 
         assert filed == 1  # second identical title skipped because first added it to set
 
     def test_zero_findings_files_nothing(self):
-        with patch("workers.audit_tasks._file_issue") as mock_file:
-            filed = _dedupe_and_file([], set(), "enhancement")
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._load_deferred", return_value=[]),
+            patch("workers.audit_tasks._persist_deferred", return_value=0),
+            patch("workers.audit_tasks._file_issue") as mock_file,
+        ):
+            filed, deferred = _dedupe_and_file([], set(), "enhancement")
+
+        assert (filed, deferred) == (0, 0)
+        mock_file.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# No-drop guarantee (#12319): findings that cannot be filed are persisted to a
+# dead-letter queue and retried — never silently discarded.
+# ---------------------------------------------------------------------------
+
+
+def _fake_redis_backing():
+    """Return (store, get_fn, set_fn) emulating the JSON Redis helpers."""
+    store: dict = {}
+
+    def _get(_redis, key):
+        return store.get(key)
+
+    def _set(_redis, key, value, **_kw):
+        store[key] = value
+
+    return store, _get, _set
+
+
+class TestNoDropGuarantee:
+    def test_unfileable_finding_is_deferred_not_dropped(self):
+        """gh unauthenticated → finding lands in the dead-letter queue, not /dev/null."""
+        store, _get, _set = _fake_redis_backing()
+        findings = [{"title": "discovery: lost me", "body": "body"}]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue") as mock_file,
+        ):
+            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", object())
 
         assert filed == 0
-        mock_file.assert_not_called()
+        assert deferred == 1
+        mock_file.assert_not_called()  # never even attempted while unauthenticated
+        queued = store[_DEFERRED_FINDINGS_KEY]
+        assert [f["title"] for f in queued] == ["discovery: lost me"]
+
+    def test_file_failure_defers_finding(self):
+        """gh authenticated but the create call fails → finding is still preserved."""
+        store, _get, _set = _fake_redis_backing()
+        findings = [{"title": "discovery: flaky", "body": "body"}]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue", return_value=False),
+        ):
+            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", object())
+
+        assert (filed, deferred) == (0, 1)
+        assert store[_DEFERRED_FINDINGS_KEY][0]["title"] == "discovery: flaky"
+
+    def test_processed_plus_deferred_equals_input(self):
+        """Every non-duplicate finding is accounted for: filed + deferred == input."""
+        store, _get, _set = _fake_redis_backing()
+        findings = [{"title": f"discovery: {i}", "body": "b"} for i in range(5)]
+
+        # Fail filing for odd indices, succeed for even.
+        def _file(title, _body, _labels=None):
+            return int(title.rsplit(" ", 1)[1]) % 2 == 0
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue", side_effect=_file),
+        ):
+            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", object())
+
+        assert filed + deferred == len(findings)
+        assert (filed, deferred) == (3, 2)
+
+    def test_deferred_findings_retried_and_drained_when_gh_recovers(self):
+        """Once gh is available again, queued findings file and leave the queue."""
+        store, _get, _set = _fake_redis_backing()
+
+        # Run 1: gh down — finding is deferred.
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            _dedupe_and_file([{"title": "discovery: retry me", "body": "b"}], set(), "enh", object())
+        assert len(store[_DEFERRED_FINDINGS_KEY]) == 1
+
+        # Run 2: gh restored, no new findings — the queued one is filed and drained.
+        filed_titles = []
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch(
+                "workers.audit_tasks._file_issue",
+                side_effect=lambda t, b, lbl: filed_titles.append(t) or True,
+            ),
+        ):
+            filed, deferred = _dedupe_and_file([], set(), "enh", object())
+
+        assert filed_titles == ["discovery: retry me"]
+        assert (filed, deferred) == (1, 0)
+        assert store[_DEFERRED_FINDINGS_KEY] == []
+
+    def test_persist_deferred_dedupes_by_title(self):
+        store, _get, _set = _fake_redis_backing()
+        deferred = [
+            {"title": "dup", "body": "a", "label": "l"},
+            {"title": "dup", "body": "b", "label": "l"},
+            {"title": "uniq", "body": "c", "label": "l"},
+        ]
+        with patch("workers.audit_tasks._redis_set", side_effect=_set):
+            size = _persist_deferred(object(), deferred)
+        assert size == 2
+
+    def test_persist_deferred_cap_logs_dropped_titles(self):
+        """Overflow sheds the oldest findings and logs their exact titles — no silent loss."""
+        store, _get, _set = _fake_redis_backing()
+        deferred = [{"title": f"t{i}", "body": "b", "label": "l"} for i in range(12)]
+        with (
+            patch("workers.audit_tasks._MAX_DEFERRED", 10),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks.logger.error") as mock_err,
+        ):
+            size = _persist_deferred(object(), deferred)
+        assert size == 10
+        mock_err.assert_called_once()
+        dropped_arg = mock_err.call_args.args[-1]
+        assert dropped_arg == ["t0", "t1"]  # oldest two shed and logged verbatim
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +304,7 @@ class TestAuditTestgaps:
 
         with (
             patch("workers.audit_tasks._get_redis", return_value=MagicMock()),
+            patch("workers.audit_tasks._gh_available", return_value=True),
             patch("workers.audit_tasks._redis_get", side_effect=fake_redis_get),
             patch("workers.audit_tasks._redis_set", side_effect=fake_redis_set),
             patch("workers.audit_tasks._changed_python_modules", return_value=[mod]),
@@ -166,6 +322,7 @@ class TestAuditTestgaps:
     def test_no_modules_changed_files_nothing(self, tmp_path):
         with (
             patch("workers.audit_tasks._get_redis", return_value=None),
+            patch("workers.audit_tasks._gh_available", return_value=True),
             patch("workers.audit_tasks._redis_get", return_value=None),
             patch("workers.audit_tasks._redis_set"),
             patch("workers.audit_tasks._changed_python_modules", return_value=[]),
@@ -197,6 +354,7 @@ class TestAuditDeadCode:
 
         with (
             patch("workers.audit_tasks._get_redis", return_value=MagicMock()),
+            patch("workers.audit_tasks._gh_available", return_value=True),
             patch(
                 "workers.audit_tasks._redis_get",
                 side_effect=lambda _, k: inventory.get(k),
@@ -221,6 +379,7 @@ class TestAuditDeadCode:
 
         with (
             patch("workers.audit_tasks._get_redis", return_value=MagicMock()),
+            patch("workers.audit_tasks._gh_available", return_value=True),
             patch("workers.audit_tasks._redis_get", return_value=[]),  # empty prior inventory
             patch("workers.audit_tasks._redis_set"),
             patch("workers.audit_tasks._run_vulture", return_value=[finding]),
@@ -243,6 +402,7 @@ class TestAuditDeadCode:
 
         with (
             patch("workers.audit_tasks._get_redis", return_value=MagicMock()),
+            patch("workers.audit_tasks._gh_available", return_value=True),
             patch("workers.audit_tasks._redis_get", side_effect=lambda _, k: stored.get(k)),
             patch(
                 "workers.audit_tasks._redis_set",
@@ -280,6 +440,7 @@ class TestAuditClaims:
 
         with (
             patch("workers.audit_tasks._get_redis", return_value=MagicMock()),
+            patch("workers.audit_tasks._gh_available", return_value=True),
             patch("workers.audit_tasks._redis_get", side_effect=lambda _, k: stored.get(k)),
             patch("workers.audit_tasks._redis_set"),
             patch("workers.audit_tasks._repo_root", return_value=tmp_path),
@@ -299,6 +460,7 @@ class TestAuditClaims:
 
         with (
             patch("workers.audit_tasks._get_redis", return_value=MagicMock()),
+            patch("workers.audit_tasks._gh_available", return_value=True),
             patch("workers.audit_tasks._redis_get", return_value=[]),  # no prior unverified
             patch("workers.audit_tasks._redis_set"),
             patch("workers.audit_tasks._repo_root", return_value=tmp_path),
@@ -310,3 +472,21 @@ class TestAuditClaims:
 
         assert result["issues_filed"] == 1
         mock_file.assert_called_once()
+
+    def test_own_verification_report_is_not_re_audited(self, tmp_path):
+        """The audit must not treat its own generated docs/verification.md as a claim
+        source — that self-reference is what inflated findings to five figures (#12319)."""
+        from workers.audit_tasks import _extract_capability_claims
+
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (tmp_path / "README.md").write_text("# AutoBot\n")
+        # Simulate the audit's own output: full of endpoint-shaped list items.
+        (docs / "verification.md").write_text("- `README.md:1` — GET /api/ghost — returns data\n" * 50)
+        (docs / "guide.md").write_text("- GET /api/real — documented here\n")
+
+        claims = _extract_capability_claims(tmp_path)
+        sources = {c["source"] for c in claims}
+
+        assert "docs/verification.md" not in sources
+        assert "docs/guide.md" in sources


### PR DESCRIPTION
## Thinking Path

Issue #12319 reports **12,252 audit findings silently dropped**. The audit worker (`workers/audit_tasks.py`) files discoveries by shelling out to `gh issue create`, but the `autobot` service user has no GitHub credential, so every call hits `gh`'s interactive `Welcome to GitHub CLI!` prompt and fails. `_dedupe_and_file` treated a `False` from `_file_issue` as "move on" — no retry, no persistence — so every finding vanished. Because `audit_testgaps` deduplicates only against *open GitHub issues* (which never existed), the same findings were rediscovered and re-dropped on every run, inflating the count into five figures.

A second compounding cause: `audit_claims` writes `docs/verification.md` and then, on the next run, scans `docs/**/*.md` — **including its own generated report** — turning each report line into a fresh "unverified claim" finding (the issue's example was `docs/verification.md:28054`).

Safe default chosen (flagged for owner below): **do not drop — record + report**, rather than mass-creating 12k GitHub issues.

## What Changed

`workers/audit_tasks.py`
- **Dead-letter queue (`audit:deferred_findings`)** — `_dedupe_and_file` now persists any finding it cannot file (unauthenticated `gh` *or* a failed create) to Redis instead of discarding it, and **drains/retries the queue first on every run**, so findings self-heal once a credential is available. Returns `(filed, deferred)`.
- **Fail loud once, not per-finding** — `_gh_available()` checks `gh auth status` a single time per run; when unauthenticated it logs one `CRITICAL` (with remediation) instead of one `ERROR` per lost finding.
- **Bounded, non-silent cap** — `_persist_deferred` dedupes by title and enforces `_MAX_DEFERRED` (env `AUTOBOT_AUDIT_MAX_DEFERRED`, default 10000), shedding oldest-first and **logging the exact dropped titles** — no silent truncation.
- **Stop self-auditing** — `_extract_capability_claims` now excludes the audit's own `docs/verification.md`, killing the self-referential finding explosion.
- All three tasks (`audit_testgaps`, `audit_dead_code`, `audit_claims`) now surface `issues_deferred` in their result dict and log line.

`workers/audit_tasks_test.py`
- New `TestNoDropGuarantee`: unfileable finding is deferred not dropped; a failed create still preserves the finding; `filed + deferred == input` invariant; deferred findings are retried and drained when `gh` recovers; cap sheds oldest and logs dropped titles; persist dedupes by title.
- New `audit_claims` test: the generated `verification.md` is not re-audited.
- Existing tests updated for the `(filed, deferred)` contract and the `_gh_available` gate.

## Verification

```
$ python3 -m pytest workers/audit_tasks_test.py -q
23 passed in 0.75s

$ python3 -m black --check --fast workers/audit_tasks.py workers/audit_tasks_test.py
2 files would be left unchanged.

$ python3 -m flake8 workers/audit_tasks.py workers/audit_tasks_test.py
(no output)
```

The drop point was `workers/audit_tasks.py:152-165` (old `_dedupe_and_file` — `if _file_issue(...)` with no `else`). Findings are now persisted + retried + counted.

**Owner decision flagged:** this implements the safe default (persist + report an aggregate `issues_deferred` count) rather than creating a GitHub issue per finding. If you prefer the worker to actually file them, the fix is operational — set `GH_TOKEN` in the worker unit environment; the queued findings will drain automatically on the next run. Filing 12k issues at once is intentionally *not* done here.

## Model Used

Claude Opus 4.8

Closes #12319
