### PR TITLE
fix(celery): autodiscover task packages via related_name=None (#12318)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -172,14 +172,20 @@ celery_app.conf.update(
     task_send_sent_event=True,
 )
 
-# Auto-discover tasks from tasks and workers modules
-celery_app.autodiscover_tasks(["tasks", "workers"])
-# GH#6480: pricing refresh task lives in services/, not tasks/ — import explicitly so
-# workers register it. autodiscover_tasks only scans the listed packages.
+# GH#12318: register every task package. autodiscover_tasks defaults to
+# related_name="tasks", i.e. it imports "<pkg>.tasks" (tasks/tasks.py,
+# workers/tasks.py) — neither exists, so the call was a silent no-op and only
+# explicitly-imported modules registered. Beat then dispatched names (credential
+# reconcile, snapshot cleanup, LLC sprint auto-close, audit daemons) to workers
+# that never registered them ("Received unregistered task of type ...") and the
+# jobs never ran. related_name=None imports each PACKAGE __init__ instead, which
+# re-exports its task modules (tasks/__init__.py, workers/__init__.py,
+# llc/scheduler/__init__.py), so their @celery_app.task / @shared_task
+# decorators all run at worker/beat startup.
+celery_app.autodiscover_tasks(["tasks", "workers", "llc.scheduler"], related_name=None)
+# GH#6480: pricing refresh lives in services/, outside the discovered packages —
+# import explicitly so workers register pricing.refresh_daily.
 import services.pricing_refresh  # noqa: F401
-
-# GH#4463: Mobile device tasks module
-import tasks.mobile_device_tasks  # noqa: F401
 from utils.celery_schedules import crontab_from_string  # noqa: E402
 
 # =========================================================================
@@ -288,13 +294,27 @@ celery_app.conf.beat_schedule = {
     },
 }
 
-import llc.scheduler.project_disposal_sweep  # noqa: F401
-import tasks.audit_log_retention  # noqa: F401
 
-# GH#8995: import retention tasks so Celery registers them at worker startup
-import tasks.chat_retention  # noqa: F401
-import tasks.file_retention  # noqa: F401
-import tasks.knowledge_retention  # noqa: F401
+# GH#12318: fail loudly if Beat is configured to dispatch a task no worker will
+# ever register. Force task discovery (import_default_modules runs the lazy
+# autodiscover callbacks), then assert every beat_schedule entry resolves to a
+# registered task. Previously such mismatches surfaced only as "Received
+# unregistered task of type ..." in a log nobody reads, and four scheduled
+# maintenance jobs silently never ran.
+def _assert_beat_tasks_registered() -> None:
+    celery_app.loader.import_default_modules()
+    registered = set(celery_app.tasks)
+    scheduled = {entry["task"] for entry in celery_app.conf.beat_schedule.values()}
+    missing = sorted(scheduled - registered)
+    if missing:
+        logger.critical(
+            "Beat-scheduled tasks are NOT registered and will be dropped as "
+            "'Received unregistered task of type ...': %s",
+            missing,
+        )
+
+
+_assert_beat_tasks_registered()
 
 # GH#4459: Register web-push task_success signal so tasks that pass user_id
 # in their kwargs trigger a browser push notification on completion.

--- a/autobot-backend/celery_beat_registration_test.py
+++ b/autobot-backend/celery_beat_registration_test.py
@@ -1,0 +1,125 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every Celery beat-scheduled task must be registered on a worker (GH#12318).
+
+Background
+----------
+``celery_app.autodiscover_tasks(["tasks", "workers"])`` defaulted to
+``related_name="tasks"``, so Celery tried to import ``tasks/tasks.py`` and
+``workers/tasks.py`` — neither exists — and the call was a silent no-op. Only
+task modules that celery_app.py imported *explicitly* actually registered.
+Beat happily dispatched the other scheduled names (credential reconcile,
+snapshot cleanup, LLC sprint auto-close, audit daemons, trajectory
+consolidation) to workers that had never registered them, so the worker logged
+``Received unregistered task of type ...`` and dropped the job. Four scheduled
+maintenance jobs had never run on the deployment.
+
+The fix switches discovery to ``related_name=None`` (imports each package
+``__init__`` so its re-exported task modules load) over
+``["tasks", "workers", "llc.scheduler"]`` and wires the two ``llc.scheduler``
+task modules into that package's ``__init__``.
+
+What this test does
+-------------------
+It parses every ``"task": "<name>"`` from celery_app.py's ``beat_schedule``,
+imports the exact registration surface celery_app.py loads at startup (the
+autodiscovered packages plus ``services.pricing_refresh``), and asserts every
+scheduled task name is present in the Celery task registry. A scheduled task
+whose module is not wired in fails here loud and immediate, instead of silently
+in production.
+
+Infrastructure stubs (celery_app, redis, logging) come from the top-level
+``conftest.py``; ``sys.modules["celery_app"].celery_app`` is the shared
+in-process Celery app the task decorators register against.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).resolve().parent
+_CELERY_APP_SRC = (_BACKEND_DIR / "celery_app.py").read_text(encoding="utf-8")
+
+# Registration surface celery_app.py loads at worker/beat startup: the packages
+# passed to autodiscover_tasks(..., related_name=None) plus the one task module
+# that lives outside them (services/, GH#6480).
+_REGISTRATION_IMPORTS = ["tasks", "workers", "llc.scheduler", "services.pricing_refresh"]
+
+# GH#12318: the exact names that were silently dropped as unregistered — an
+# explicit floor so the guard is meaningful even if the beat_schedule parse
+# ever regresses.
+_KNOWN_DROPPED = {
+    "tasks.reconcile_credentials",
+    "tasks.cleanup_expired_snapshots",
+    "llc.scheduler.sprint_autoclose.run_daily_check",
+    "workers.audit_testgaps",
+    "workers.audit_dead_code",
+    "workers.audit_claims",
+    "memory.consolidate_trajectories",
+}
+
+
+def _scheduled_task_names() -> set[str]:
+    """Task names celery_app.py's beat_schedule dispatches (parsed from source).
+
+    celery_app.py is heavy and pytest-stubbed (#7766), so the schedule is read
+    from source text rather than by importing the real module — the same
+    approach as celery_queue_coverage_test.py.
+    """
+    names = set(re.findall(r'"task":\s*"([\w.]+)"', _CELERY_APP_SRC))
+    assert names, "no beat_schedule task names parsed from celery_app.py"
+    return names
+
+
+def _registered_task_names() -> set[str]:
+    """Import the startup registration surface and return the Celery registry."""
+    for module in _REGISTRATION_IMPORTS:
+        importlib.import_module(module)
+    celery_app_mod = sys.modules.get("celery_app")
+    assert celery_app_mod is not None, "celery_app stub missing — check conftest.py"
+    return set(celery_app_mod.celery_app.tasks)
+
+
+def test_known_dropped_tasks_are_registered():
+    """The GH#12318 tasks that never ran must now be in the registry."""
+    registered = _registered_task_names()
+    missing = sorted(_KNOWN_DROPPED - registered)
+    assert not missing, f"GH#12318 tasks still unregistered (would be dropped by workers): {missing!r}"
+
+
+def test_autodiscover_imports_task_packages_not_dot_tasks():
+    """celery_app.py must autodiscover with related_name=None over every package.
+
+    Guards the root-cause fix directly: the default related_name="tasks" imports
+    "<pkg>.tasks" (non-existent) and registers nothing. Reverting to that default
+    or dropping a package from the list would silently re-break discovery, so
+    assert the call keeps related_name=None and covers the three task packages.
+    """
+    match = re.search(r"autodiscover_tasks\(\s*(\[[^\]]*\])\s*,\s*related_name=None\s*\)", _CELERY_APP_SRC)
+    assert match, "autodiscover_tasks must be called with related_name=None (GH#12318 root cause)"
+    packages = set(re.findall(r'"([\w.]+)"', match.group(1)))
+    for required in ("tasks", "workers", "llc.scheduler"):
+        assert required in packages, f"autodiscover_tasks must include the {required!r} package; got {packages!r}"
+
+
+def test_every_beat_scheduled_task_is_registered():
+    """Every beat_schedule task must resolve to a registered Celery task.
+
+    Guards the whole schedule: a task added to beat_schedule whose module is not
+    wired into the discovered packages (or services) fails here rather than
+    silently as 'Received unregistered task of type ...' in production.
+    """
+    scheduled = _scheduled_task_names()
+    registered = _registered_task_names()
+    missing = sorted(scheduled - registered)
+    assert not missing, (
+        f"beat_schedule dispatches tasks no worker registers: {missing!r}\n"
+        f"Fix: ensure each task's module is imported at worker startup — add its "
+        f"package to celery_app.autodiscover_tasks (related_name=None) or import "
+        f"it explicitly, and re-export it from that package's __init__.py."
+    )

--- a/autobot-backend/llc/scheduler/__init__.py
+++ b/autobot-backend/llc/scheduler/__init__.py
@@ -5,6 +5,22 @@
 from .base import PollLoopScheduler
 from .budget_watchdog import BudgetWatchdog
 from .liveness_monitor import LivenessMonitor
-from .session_checkpointer import SessionCheckpointer
 
-__all__ = ["PollLoopScheduler", "BudgetWatchdog", "LivenessMonitor", "SessionCheckpointer"]
+# GH#12318: re-export the Celery task modules so Celery's autodiscover_tasks
+# (called with related_name=None in celery_app.py) imports them via this
+# package __init__ and registers their @shared_task decorators. Without these,
+# beat dispatched llc.scheduler.sprint_autoclose.run_daily_check /
+# run_disposal_sweep to a worker that never registered them ("Received
+# unregistered task of type ...").
+from .project_disposal_sweep import run_disposal_sweep
+from .session_checkpointer import SessionCheckpointer
+from .sprint_autoclose import run_daily_check
+
+__all__ = [
+    "PollLoopScheduler",
+    "BudgetWatchdog",
+    "LivenessMonitor",
+    "SessionCheckpointer",
+    "run_disposal_sweep",
+    "run_daily_check",
+]


### PR DESCRIPTION
## Thinking Path

`celery_app.autodiscover_tasks(["tasks", "workers"])` defaults to `related_name="tasks"`, so Celery tries to import `tasks/tasks.py` and `workers/tasks.py` — neither exists — making the call a silent no-op. Only task modules celery_app.py imported *explicitly* registered. Beat kept dispatching the other scheduled names to workers that never registered them, producing `Received unregistered task of type ...` and silently dropping the job. Four scheduled maintenance jobs (credential reconcile, snapshot cleanup, LLC sprint auto-close, audit daemons, trajectory consolidation) had never run.

Verified empirically that `autodiscover_tasks([...], related_name=None)` imports each *package* `__init__` (which re-exports its task modules), registering every decorator at worker/beat startup.

## What Changed

- **`celery_app.py`** — `autodiscover_tasks(["tasks", "workers", "llc.scheduler"], related_name=None)` so each package `__init__` is imported and its `@celery_app.task` / `@shared_task` decorators run. Removed the now-redundant per-module explicit imports (`tasks.mobile_device_tasks`, `tasks.audit_log_retention`, `tasks.chat_retention`, `tasks.file_retention`, `tasks.knowledge_retention`, `llc.scheduler.project_disposal_sweep`) that were papering over the broken discovery one module at a time. Kept `import services.pricing_refresh` (lives outside the discovered packages). Added a startup guard `_assert_beat_tasks_registered()` that forces discovery and logs CRITICAL for any `beat_schedule` entry missing from the registry — the exact silent failure mode, made loud.
- **`llc/scheduler/__init__.py`** — re-export `run_daily_check` (sprint_autoclose) and `run_disposal_sweep` (project_disposal_sweep) so `related_name=None` discovery registers them.
- **`celery_beat_registration_test.py`** (new) — parses every `beat_schedule` `"task"` name from `celery_app.py`, imports the startup registration surface, and asserts each name is registered; a floor test for the 7 GH#12318 names; and a source assertion that `autodiscover_tasks` keeps `related_name=None` over the three packages.

## Verification

Root cause reproduced and fix confirmed under pytest (root conftest provides an in-process Celery app):

- Pre-fix `llc/scheduler/__init__.py` (negative control) — test fails as expected:
  ```
  AssertionError: beat_schedule dispatches tasks no worker registers:
  ['llc.scheduler.project_disposal_sweep.run_disposal_sweep', 'llc.scheduler.sprint_autoclose.run_daily_check']
  ```
- Post-fix — all previously-dropped names now registered: `tasks.reconcile_credentials`, `tasks.cleanup_expired_snapshots`, `llc.scheduler.sprint_autoclose.run_daily_check`, `workers.audit_testgaps/dead_code/claims`, `memory.consolidate_trajectories`.
- `pytest celery_beat_registration_test.py celery_queue_coverage_test.py tasks/test_task_registration.py` → 8 passed.
- `black --check --target-version py310` clean; `flake8` clean; `ast.parse` clean.

Note: the phantom `tasks.reconcile_unified_credentials` (175 rejections) is not in `beat_schedule` and does not exist in code — it originates from persisted Beat scheduler state (renamed/removed task), a separate concern out of scope for this discovery fix.

## Model Used

claude-opus-4-8

Closes #12318
