### PR TITLE
fix(security): cross-project analytics data leakage — scope source_id in call-graph/endpoint-coverage/deps/import-tree/env (#12330)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/api_endpoints.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/api_endpoints.py
@@ -14,6 +14,7 @@ Provides endpoints to:
 """
 
 import asyncio
+from pathlib import Path
 from typing import Dict
 
 from fastapi import APIRouter, Query
@@ -24,20 +25,54 @@ from autobot_shared.logging_manager import get_logger
 
 from ..api_endpoint_scanner import APIEndpointChecker
 from ..models import APIEndpointAnalysis
+from .shared import resolve_scan_root
 
 logger = get_logger(__name__)
 
 router = APIRouter()
 
-# Cache for analysis results (simple in-memory cache)
+# Cache for analysis results (simple in-memory cache).
+# Issue #12330: Keyed by source_id (or "default") to prevent cross-project
+# leakage -- a single global "latest" entry returned one project's endpoint
+# coverage for every other selected source.
 _analysis_cache: Dict[str, APIEndpointAnalysis] = {}
 # Lock for thread-safe access to _analysis_cache (Issue #559)
 _analysis_cache_lock = asyncio.Lock()
 
 
-def _get_checker() -> APIEndpointChecker:
-    """Get or create the API endpoint checker instance."""
-    return APIEndpointChecker()
+def _cache_key(source_id: str | None) -> str:
+    """Cache key for a source. Issue #12330: scope per project, not global."""
+    return source_id or "default"
+
+
+def _get_checker(project_root: Path | None = None) -> APIEndpointChecker:
+    """Get or create the API endpoint checker instance.
+
+    Issue #12330: Bind the checker to the requested source's root so it scans
+    the selected project rather than AutoBot's own root.
+    """
+    return APIEndpointChecker(project_root=project_root)
+
+
+async def _get_or_run_analysis(source_id: str | None) -> APIEndpointAnalysis:
+    """Return cached analysis for a source, or run it scoped to that source.
+
+    Issue #12330: Both the cache lookup and a cache-miss analysis are scoped to
+    the resolved source root so no two projects share results.
+    """
+    key = _cache_key(source_id)
+    async with _analysis_cache_lock:
+        cached = _analysis_cache.get(key)
+    if cached is not None:
+        return cached
+
+    root = await resolve_scan_root(source_id)
+    checker = _get_checker(root)
+    analysis = await asyncio.to_thread(checker.run_full_analysis)
+
+    async with _analysis_cache_lock:
+        _analysis_cache[key] = analysis
+    return analysis
 
 
 @router.get("/api-endpoints")
@@ -46,13 +81,17 @@ def _get_checker() -> APIEndpointChecker:
     operation="get_api_endpoints",
     error_code_prefix="CODEBASE",
 )
-async def get_api_endpoints() -> JSONResponse:
+async def get_api_endpoints(
+    source_id: str | None = Query(None, description="#12330: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get all backend API endpoints.
 
     Returns list of all FastAPI route definitions found in the backend.
+    Issue #12330: Scoped to the selected source's clone path.
     """
-    checker = _get_checker()
+    root = await resolve_scan_root(source_id)
+    checker = _get_checker(root)
     endpoints = await asyncio.to_thread(checker.get_backend_endpoints)
 
     return JSONResponse(
@@ -70,13 +109,17 @@ async def get_api_endpoints() -> JSONResponse:
     operation="get_frontend_api_calls",
     error_code_prefix="CODEBASE",
 )
-async def get_frontend_api_calls() -> JSONResponse:
+async def get_frontend_api_calls(
+    source_id: str | None = Query(None, description="#12330: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get all frontend API calls.
 
     Returns list of all API calls found in frontend TypeScript/Vue files.
+    Issue #12330: Scoped to the selected source's clone path.
     """
-    checker = _get_checker()
+    root = await resolve_scan_root(source_id)
+    checker = _get_checker(root)
     calls = await asyncio.to_thread(checker.get_frontend_calls)
 
     return JSONResponse(
@@ -95,7 +138,7 @@ async def get_frontend_api_calls() -> JSONResponse:
     error_code_prefix="CODEBASE",
 )
 async def get_endpoint_coverage(
-    source_id: str | None = Query(None, description="#1772: source_id for API consistency"),
+    source_id: str | None = Query(None, description="#12330: scope coverage to the selected code source"),
 ) -> JSONResponse:
     """
     Get full API endpoint coverage analysis.
@@ -107,13 +150,11 @@ async def get_endpoint_coverage(
     - Orphaned endpoints (unused)
     - Missing endpoints (called but not defined)
     - Coverage percentage
-    """
-    checker = _get_checker()
-    analysis = await asyncio.to_thread(checker.run_full_analysis)
 
-    # Cache the result (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        _analysis_cache["latest"] = analysis
+    Issue #12330: Analysis is scoped to the selected source's clone path and
+    cached per-source so one project's coverage never leaks into another's.
+    """
+    analysis = await _get_or_run_analysis(source_id)
 
     return JSONResponse(
         {
@@ -137,19 +178,17 @@ async def get_endpoint_coverage(
     operation="get_endpoint_analysis_full",
     error_code_prefix="CODEBASE",
 )
-async def get_endpoint_analysis_full() -> JSONResponse:
+async def get_endpoint_analysis_full(
+    source_id: str | None = Query(None, description="#12330: scope analysis to the selected code source"),
+) -> JSONResponse:
     """
     Get complete API endpoint analysis with all details.
 
     Returns full analysis including all endpoints, calls, and mismatches.
     Use /endpoint-coverage for a summary only.
+    Issue #12330: Scoped and cached per source.
     """
-    checker = _get_checker()
-    analysis = await asyncio.to_thread(checker.run_full_analysis)
-
-    # Cache the result (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        _analysis_cache["latest"] = analysis
+    analysis = await _get_or_run_analysis(source_id)
 
     return JSONResponse(
         {
@@ -165,21 +204,17 @@ async def get_endpoint_analysis_full() -> JSONResponse:
     operation="get_orphaned_endpoints",
     error_code_prefix="CODEBASE",
 )
-async def get_orphaned_endpoints() -> JSONResponse:
+async def get_orphaned_endpoints(
+    source_id: str | None = Query(None, description="#12330: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get orphaned endpoints (defined but never called).
 
     These are backend endpoints that have no matching frontend calls.
     They may be unused code that can be removed.
+    Issue #12330: Scoped and cached per source.
     """
-    # Check cache first (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" in _analysis_cache:
-            analysis = _analysis_cache["latest"]
-        else:
-            checker = _get_checker()
-            analysis = await asyncio.to_thread(checker.run_full_analysis)
-            _analysis_cache["latest"] = analysis
+    analysis = await _get_or_run_analysis(source_id)
 
     return JSONResponse(
         {
@@ -196,21 +231,17 @@ async def get_orphaned_endpoints() -> JSONResponse:
     operation="get_missing_endpoints",
     error_code_prefix="CODEBASE",
 )
-async def get_missing_endpoints() -> JSONResponse:
+async def get_missing_endpoints(
+    source_id: str | None = Query(None, description="#12330: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get missing endpoints (called but not defined).
 
     These are frontend API calls that have no matching backend endpoint.
     They may indicate bugs or deprecated endpoint usage.
+    Issue #12330: Scoped and cached per source.
     """
-    # Check cache first (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" in _analysis_cache:
-            analysis = _analysis_cache["latest"]
-        else:
-            checker = _get_checker()
-            analysis = await asyncio.to_thread(checker.run_full_analysis)
-            _analysis_cache["latest"] = analysis
+    analysis = await _get_or_run_analysis(source_id)
 
     return JSONResponse(
         {
@@ -227,20 +258,16 @@ async def get_missing_endpoints() -> JSONResponse:
     operation="get_used_endpoints",
     error_code_prefix="CODEBASE",
 )
-async def get_used_endpoints() -> JSONResponse:
+async def get_used_endpoints(
+    source_id: str | None = Query(None, description="#12330: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get actively used endpoints with their call counts.
 
     Returns endpoints that are both defined in backend and called from frontend.
+    Issue #12330: Scoped and cached per source.
     """
-    # Check cache first (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" in _analysis_cache:
-            analysis = _analysis_cache["latest"]
-        else:
-            checker = _get_checker()
-            analysis = await asyncio.to_thread(checker.run_full_analysis)
-            _analysis_cache["latest"] = analysis
+    analysis = await _get_or_run_analysis(source_id)
 
     # Sort by call count (most used first)
     sorted_used = sorted(
@@ -271,21 +298,24 @@ async def get_used_endpoints() -> JSONResponse:
     operation="refresh_endpoint_cache",
     error_code_prefix="CODEBASE",
 )
-async def refresh_endpoint_cache() -> JSONResponse:
+async def refresh_endpoint_cache(
+    source_id: str | None = Query(None, description="#12330: refresh the selected source's cache entry"),
+) -> JSONResponse:
     """
-    Force refresh the endpoint analysis cache.
+    Force refresh the endpoint analysis cache for a source.
 
     Call this after making code changes to get updated results.
+    Issue #12330: Rebuilds only the requested source's entry, scoped to that
+    source's clone path, so refreshing one project does not evict or overwrite
+    another project's cached analysis.
     """
-    global _analysis_cache
-
-    checker = _get_checker()
-    analysis = checker.run_full_analysis()
+    root = await resolve_scan_root(source_id)
+    checker = _get_checker(root)
+    analysis = await asyncio.to_thread(checker.run_full_analysis)
 
     # Update cache (thread-safe, Issue #559)
     async with _analysis_cache_lock:
-        _analysis_cache = {}
-        _analysis_cache["latest"] = analysis
+        _analysis_cache[_cache_key(source_id)] = analysis
 
     return JSONResponse(
         {

--- a/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/call_graph.py
@@ -22,7 +22,7 @@ from autobot_shared.redis_client import get_redis_client
 from constants.ttl_constants import TTL_5_MINUTES
 from utils.io_executor import get_analytics_executor
 
-from .shared import COMMON_THIRD_PARTY, STDLIB_MODULES, ImportContext, get_project_root
+from .shared import COMMON_THIRD_PARTY, STDLIB_MODULES, ImportContext, resolve_scan_root
 
 logger = get_logger(__name__)
 
@@ -724,14 +724,17 @@ def _build_call_graph_response(
 )
 async def get_call_graph(
     refresh: bool = Query(False, description="Force refresh, bypass cache"),
-    source_id: str | None = Query(None, description="#1772: source_id for API consistency"),
+    source_id: str | None = Query(None, description="#12330: scope call graph to the selected code source"),
 ):
     """Get function call graph.
 
     Issue #281/#665/#711: Refactored with caching.
     Issue #713: Enhanced with import-aware cross-module resolution.
+    Issue #12330: Scope the scan to the requested source's clone path so one
+    project cannot see another's call graph. The cache key is derived from the
+    resolved root (path-hashed) so each source keeps a distinct cache entry.
     """
-    project_root = get_project_root()
+    project_root = await resolve_scan_root(source_id)
 
     if not refresh:
         cached_data = await _get_cached_call_graph(str(project_root))

--- a/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
@@ -87,8 +87,7 @@ class TestCallGraphIsolation:
     """End-to-end: the call graph returned for A must not contain B's code."""
 
     async def test_call_graph_scoped_to_source(self, tmp_path):
-        from api.codebase_analytics.endpoints import call_graph
-        from api.codebase_analytics.endpoints import shared
+        from api.codebase_analytics.endpoints import call_graph, shared
 
         root_a = tmp_path / "proj_a"
         root_b = tmp_path / "proj_b"
@@ -143,9 +142,7 @@ class TestEndpointCoverageCacheScoping:
 
         def fake_checker(project_root=None):
             checker = MagicMock()
-            checker.run_full_analysis = MagicMock(
-                return_value=analysis_a if project_root == root_a else analysis_b
-            )
+            checker.run_full_analysis = MagicMock(return_value=analysis_a if project_root == root_a else analysis_b)
             return checker
 
         api_endpoints._analysis_cache.clear()

--- a/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
@@ -1,0 +1,175 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for cross-project analytics data leakage (Issue #12330).
+
+Several Codebase Analytics endpoints accepted a ``source_id`` "for API
+consistency" but ignored it, scanning AutoBot's own project root regardless of
+the selected code source. As a result opening one project's analytics could
+show another project's call graph / endpoint coverage / dependency graph.
+
+These tests assert the scoping fix: a request for project A can never see
+project B's data, while a same-project request still works.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _write_module(directory: Path, filename: str, body: str) -> None:
+    (directory / filename).write_text(body, encoding="utf-8")
+
+
+class TestResolveScanRoot:
+    """Unit tests for the shared source-scoping helper."""
+
+    async def test_scopes_to_requested_source(self, tmp_path):
+        """Different source_ids resolve to their own clone paths (no shared root)."""
+        from api.codebase_analytics.endpoints import shared
+
+        root_a = tmp_path / "proj_a"
+        root_b = tmp_path / "proj_b"
+        root_a.mkdir()
+        root_b.mkdir()
+
+        async def fake_resolve(source_id):
+            return {"A": root_a, "B": root_b}.get(source_id)
+
+        with patch.object(shared, "resolve_source_root", side_effect=fake_resolve):
+            resolved_a = await shared.resolve_scan_root("A")
+            resolved_b = await shared.resolve_scan_root("B")
+
+        assert resolved_a == root_a
+        assert resolved_b == root_b
+        assert resolved_a != resolved_b
+
+    async def test_falls_back_to_project_root_when_unresolved(self):
+        """No source and no default → AutoBot project root (legacy behavior)."""
+        from api.codebase_analytics.endpoints import shared
+
+        with (
+            patch.object(shared, "resolve_source_root", AsyncMock(return_value=None)),
+            patch(
+                "api.codebase_analytics.source_storage.get_default_source_id",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            resolved = await shared.resolve_scan_root(None)
+
+        assert resolved == shared.get_project_root()
+
+    async def test_uses_default_source_when_source_id_missing(self, tmp_path):
+        """When no source_id is given the default source is scoped, not the global root."""
+        from api.codebase_analytics.endpoints import shared
+
+        default_root = tmp_path / "default_proj"
+        default_root.mkdir()
+
+        async def fake_resolve(source_id):
+            return default_root if source_id == "DEFAULT" else None
+
+        with (
+            patch.object(shared, "resolve_source_root", side_effect=fake_resolve),
+            patch(
+                "api.codebase_analytics.source_storage.get_default_source_id",
+                AsyncMock(return_value="DEFAULT"),
+            ),
+        ):
+            resolved = await shared.resolve_scan_root(None)
+
+        assert resolved == default_root
+
+
+class TestCallGraphIsolation:
+    """End-to-end: the call graph returned for A must not contain B's code."""
+
+    async def test_call_graph_scoped_to_source(self, tmp_path):
+        from api.codebase_analytics.endpoints import call_graph
+        from api.codebase_analytics.endpoints import shared
+
+        root_a = tmp_path / "proj_a"
+        root_b = tmp_path / "proj_b"
+        root_a.mkdir()
+        root_b.mkdir()
+        _write_module(root_a, "mod_a.py", "def alpha_unique_fn():\n    return 1\n")
+        _write_module(root_b, "mod_b.py", "def beta_unique_fn():\n    return 2\n")
+
+        async def fake_resolve(source_id):
+            return {"A": root_a, "B": root_b}.get(source_id)
+
+        # Scope resolution to our temp sources; cache writes are best-effort and
+        # swallowed if Redis is unavailable, so no Redis is required.
+        with patch.object(shared, "resolve_source_root", side_effect=fake_resolve):
+            resp_a = await call_graph.get_call_graph(refresh=True, source_id="A")
+            resp_b = await call_graph.get_call_graph(refresh=True, source_id="B")
+
+        names_a = _all_function_names(resp_a)
+        names_b = _all_function_names(resp_b)
+
+        # Same-project data is present...
+        assert "alpha_unique_fn" in names_a
+        assert "beta_unique_fn" in names_b
+        # ...and cross-project data never leaks across the boundary.
+        assert "beta_unique_fn" not in names_a
+        assert "alpha_unique_fn" not in names_b
+
+
+class TestEndpointCoverageCacheScoping:
+    """The endpoint-coverage in-memory cache must be keyed per source."""
+
+    async def test_cache_key_is_per_source(self):
+        from api.codebase_analytics.endpoints.api_endpoints import _cache_key
+
+        assert _cache_key(None) == "default"
+        assert _cache_key("A") == "A"
+        assert _cache_key("A") != _cache_key("B")
+
+    async def test_analysis_cached_and_not_shared_between_sources(self, tmp_path):
+        from api.codebase_analytics.endpoints import api_endpoints
+
+        root_a = tmp_path / "cov_a"
+        root_b = tmp_path / "cov_b"
+        root_a.mkdir()
+        root_b.mkdir()
+
+        async def fake_resolve(source_id, use_default=True):
+            return {"A": root_a, "B": root_b}.get(source_id, api_endpoints.Path("/tmp"))
+
+        analysis_a = MagicMock(name="analysis_A")
+        analysis_b = MagicMock(name="analysis_B")
+
+        def fake_checker(project_root=None):
+            checker = MagicMock()
+            checker.run_full_analysis = MagicMock(
+                return_value=analysis_a if project_root == root_a else analysis_b
+            )
+            return checker
+
+        api_endpoints._analysis_cache.clear()
+        with (
+            patch.object(api_endpoints, "resolve_scan_root", side_effect=fake_resolve),
+            patch.object(api_endpoints, "_get_checker", side_effect=fake_checker),
+        ):
+            result_a = await api_endpoints._get_or_run_analysis("A")
+            result_b = await api_endpoints._get_or_run_analysis("B")
+            # Second call for A must hit the per-source cache (no re-scan).
+            cached_a = await api_endpoints._get_or_run_analysis("A")
+
+        assert result_a is analysis_a
+        assert result_b is analysis_b
+        assert result_a is not result_b
+        assert cached_a is analysis_a
+        assert api_endpoints._analysis_cache["A"] is analysis_a
+        assert api_endpoints._analysis_cache["B"] is analysis_b
+
+
+def _all_function_names(response) -> set:
+    """Collect every function name from a call-graph JSONResponse."""
+    data = json.loads(response.body)
+    graph = data.get("call_graph", {})
+    names = {node.get("name") for node in graph.get("nodes", [])}
+    names |= {node.get("name") for node in data.get("orphaned_functions", [])}
+    return names

--- a/autobot-backend/api/codebase_analytics/endpoints/dependencies.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/dependencies.py
@@ -23,7 +23,7 @@ from utils.celery_task_status import celery_result_to_status, get_latest_task_re
 from utils.chromadb_client import get_all_paginated
 
 from ..storage import get_code_collection
-from .shared import COMMON_THIRD_PARTY, STDLIB_MODULES, get_project_root
+from .shared import COMMON_THIRD_PARTY, STDLIB_MODULES, resolve_scan_root
 
 logger = get_logger(__name__)
 
@@ -382,12 +382,19 @@ def _build_visualization_graph(
 async def _load_modules_from_chromadb(
     code_collection,
     modules: Dict[str, Dict],
+    source_id: str | None = None,
 ) -> None:
-    """Helper for get_dependencies. Load module map from ChromaDB. Ref: #1088."""
+    """Helper for get_dependencies. Load module map from ChromaDB. Ref: #1088.
+
+    Issue #12330: Filter by source_id to prevent cross-project leakage; without
+    it the query returns modules indexed for every registered source.
+    """
     try:
+        type_filter = {"type": {"$in": ["function", "class"]}}
+        where = {"$and": [type_filter, {"source_id": source_id}]} if source_id else type_filter
         results = get_all_paginated(
             code_collection,
-            where={"type": {"$in": ["function", "class"]}},
+            where=where,
             include=["metadatas"],
         )
         seen_files: set = set()
@@ -444,13 +451,17 @@ async def _scan_filesystem_imports(
     operation="get_dependencies",
     error_code_prefix="CODEBASE",
 )
-async def get_dependencies():
+async def get_dependencies(
+    source_id: str | None = Query(None, description="#12330: scope dependency scan to the selected code source"),
+):
     """
     Get file dependency analysis showing imports and module relationships.
 
     Issue #281: Refactored from 146 lines to use extracted helper methods.
     Issue #1088: Further refactored with _load_modules_from_chromadb and
     _scan_filesystem_imports helpers.
+    Issue #12330: Scope the filesystem scan to the requested source's clone path
+    so one project cannot see another's dependency graph.
 
     Returns:
     - modules: List of all modules/files in the codebase
@@ -459,6 +470,13 @@ async def get_dependencies():
     - circular_dependencies: Detected circular import issues
     - external_dependencies: Third-party package dependencies
     """
+    # Issue #12330: Resolve the default source once so both the ChromaDB module
+    # load and the filesystem scan below are scoped to the same project.
+    if not source_id:
+        from api.codebase_analytics.source_storage import get_default_source_id
+
+        source_id = await get_default_source_id()
+
     code_collection = await asyncio.to_thread(get_code_collection)
     modules: Dict[str, Dict] = {}
     import_relationships: List[Dict] = []
@@ -466,9 +484,9 @@ async def get_dependencies():
     runtime_rels: List[Dict] = []
 
     if code_collection:
-        await _load_modules_from_chromadb(code_collection, modules)
+        await _load_modules_from_chromadb(code_collection, modules, source_id=source_id)
 
-    project_root = get_project_root()
+    project_root = await resolve_scan_root(source_id, use_default=False)
     await _scan_filesystem_imports(
         project_root,
         modules,

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -29,12 +29,33 @@ logger = get_logger(__name__)
 
 router = APIRouter()
 
-# Cache for environment analysis (in-memory, refreshed on demand)
-_env_analysis_cache: dict | None = None
-# Full analysis cache for export (Issue #631)
-_env_analysis_full_cache: dict | None = None
+# Cache for environment analysis (in-memory, refreshed on demand).
+# Issue #12330: Keyed by source_id (or "default") to prevent cross-project
+# leakage -- a single global cache returned one project's hardcoded-value
+# analysis for every other selected source.
+_env_analysis_cache: dict[str, dict] = {}
+# Full analysis cache for export (Issue #631), keyed by source (Issue #12330)
+_env_analysis_full_cache: dict[str, dict] = {}
 # Lock for thread-safe access to _env_analysis_cache (Issue #559)
 _env_analysis_cache_lock = asyncio.Lock()
+
+
+def _env_cache_key(source_id: str | None) -> str:
+    """Cache key for a source. Issue #12330: scope per project, not global."""
+    return source_id or "default"
+
+
+async def _resolve_env_scan_root(source_id: str | None) -> str:
+    """Resolve the filesystem root to analyze for a source (Issue #12330).
+
+    Uses the selected source's clone path when available, otherwise falls back
+    to the AutoBot project root (resolve_project_root, deployed-layout aware) to
+    preserve existing behavior when no source is selected.
+    """
+    from .shared import resolve_source_root
+
+    source_root = await resolve_source_root(source_id)
+    return str(source_root) if source_root else _get_project_root()
 
 
 def _get_project_root() -> str:
@@ -255,11 +276,14 @@ def _build_error_response(message: str, status: str = "error") -> dict:
     }
 
 
-async def _check_env_analysis_cache(use_llm_filter: bool, refresh: bool) -> JSONResponse | None:
+async def _check_env_analysis_cache(
+    use_llm_filter: bool, refresh: bool, source_id: str | None = None
+) -> JSONResponse | None:
     """
     Check if cached environment analysis is available and valid.
 
     Issue #665: Extracted from get_environment_analysis to reduce function length.
+    Issue #12330: Scoped by source_id to prevent cross-project cache leakage.
 
     Returns:
         JSONResponse with cached data if valid, None if cache miss or refresh needed.
@@ -268,12 +292,13 @@ async def _check_env_analysis_cache(use_llm_filter: bool, refresh: bool) -> JSON
     cache_valid = not use_llm_filter
 
     async with _env_analysis_cache_lock:
-        if _env_analysis_cache and not refresh and cache_valid:
+        cached = _env_analysis_cache.get(_env_cache_key(source_id))
+        if cached and not refresh and cache_valid:
             logger.info(
                 "Returning cached environment analysis (%d hardcoded values)",
-                _env_analysis_cache.get("total_hardcoded_values", 0),
+                cached.get("total_hardcoded_values", 0),
             )
-            return JSONResponse(_env_analysis_cache)
+            return JSONResponse(cached)
 
     return None
 
@@ -302,19 +327,21 @@ async def _execute_env_analysis(
         return await _run_environment_analysis(analyzer, path, pattern_list)
 
 
-async def _cache_env_analysis_results(result: dict, full_result: dict, use_llm_filter: bool) -> None:
+async def _cache_env_analysis_results(
+    result: dict, full_result: dict, use_llm_filter: bool, source_id: str | None = None
+) -> None:
     """
     Cache environment analysis results (thread-safe).
 
     Issue #665: Extracted from get_environment_analysis to reduce function length.
     Issue #633: Only cache non-LLM-filtered results (LLM filtering is dynamic).
+    Issue #12330: Scoped by source_id to prevent cross-project cache leakage.
     """
-    global _env_analysis_cache, _env_analysis_full_cache
-
     if not use_llm_filter:
+        key = _env_cache_key(source_id)
         async with _env_analysis_cache_lock:
-            _env_analysis_cache = result
-            _env_analysis_full_cache = full_result
+            _env_analysis_cache[key] = result
+            _env_analysis_full_cache[key] = full_result
 
 
 def _add_llm_filtering_metadata(result: dict, analysis: dict, use_llm_filter: bool) -> None:
@@ -334,8 +361,9 @@ async def _analyze_and_return_env_result(
     use_llm_filter: bool,
     llm_model: str,
     filter_priority: str,
+    source_id: str | None = None,
 ) -> JSONResponse:
-    """Helper for get_environment_analysis. Ref: #1088."""
+    """Helper for get_environment_analysis. Ref: #1088. Issue #12330: per-source cache."""
     analysis = await _execute_env_analysis(analyzer, path, pattern_list, use_llm_filter, llm_model, filter_priority)
     if analysis is None:
         return JSONResponse(
@@ -348,7 +376,7 @@ async def _analyze_and_return_env_result(
     full_result = _build_environment_result(analysis, path, for_display=False)
     _add_llm_filtering_metadata(result, analysis, use_llm_filter)
     _add_llm_filtering_metadata(full_result, analysis, use_llm_filter)
-    await _cache_env_analysis_results(result, full_result, use_llm_filter)
+    await _cache_env_analysis_results(result, full_result, use_llm_filter, source_id=source_id)
     logger.info(
         "Environment analysis complete: %d hardcoded values, %d recommendations%s",
         result["total_hardcoded_values"],
@@ -374,23 +402,25 @@ async def get_environment_analysis(
         "high",
         description="Priority level to filter: 'high', 'medium', 'low', or 'all'",
     ),
-    source_id: str | None = Query(None, description="#1772: source_id for API consistency"),
+    source_id: str | None = Query(None, description="#12330: scope analysis to the selected code source"),
 ):
     """
     Analyze codebase for hardcoded values and environment variable opportunities (Issue #538).
     Issue #665: Refactored to use extracted helpers for cache, analysis, and result building.
+    Issue #12330: Scope the scan to the selected source's clone path so one project
+    cannot see another's hardcoded-value analysis.
     """
     # Check cache first (Issue #559: thread-safe, Issue #633: LLM filter bypass)
-    cached = await _check_env_analysis_cache(use_llm_filter, refresh)
+    cached = await _check_env_analysis_cache(use_llm_filter, refresh, source_id=source_id)
     if cached:
         return cached
 
-    # Setup path and validate security
-    project_root = _get_project_root()
+    # Setup path and validate security (Issue #12330: scoped to the source root)
+    scan_root = await _resolve_env_scan_root(source_id)
     if not path:
-        path = project_root
+        path = scan_root
 
-    error_response = _validate_env_path_security(path, project_root)
+    error_response = _validate_env_path_security(path, scan_root)
     if error_response:
         return error_response
 
@@ -401,7 +431,7 @@ async def get_environment_analysis(
         if not analyzer:
             return JSONResponse(_build_error_response("EnvironmentAnalyzer not available. Check tools installation."))
         return await _analyze_and_return_env_result(
-            analyzer, path, pattern_list, use_llm_filter, llm_model, filter_priority
+            analyzer, path, pattern_list, use_llm_filter, llm_model, filter_priority, source_id=source_id
         )
     except Exception as e:
         logger.error("Environment analysis failed: %s", e, exc_info=True)
@@ -416,13 +446,14 @@ async def get_environment_analysis(
 )
 async def get_env_recommendations(
     path: str = Query(None, description="Root path to analyze (defaults to project root)"),
-    source_id: str | None = Query(None, description="#1772: source_id for API consistency"),
+    source_id: str | None = Query(None, description="#12330: scope recommendations to the selected code source"),
 ):
     """
     Get environment variable recommendations for a codebase (Issue #538).
 
     Returns actionable recommendations for creating/updating .env files
     based on detected hardcoded values.
+    Issue #12330: Scoped to the selected source's clone path.
 
     Args:
         path: Root path to analyze
@@ -430,24 +461,25 @@ async def get_env_recommendations(
     Returns:
         JSON with prioritized recommendations
     """
-    # Check cache first (thread-safe, Issue #559)
+    # Check cache first (thread-safe, Issue #559; Issue #12330: per-source)
     async with _env_analysis_cache_lock:
-        if _env_analysis_cache and _env_analysis_cache.get("recommendations"):
+        cached = _env_analysis_cache.get(_env_cache_key(source_id))
+        if cached and cached.get("recommendations"):
             return JSONResponse(
                 {
                     "status": "success",
-                    "recommendations": _env_analysis_cache["recommendations"],
-                    "total": len(_env_analysis_cache["recommendations"]),
+                    "recommendations": cached["recommendations"],
+                    "total": len(cached["recommendations"]),
                     "source": "cache",
                 }
             )
 
-    # Run fresh analysis if no cache
-    project_root = _get_project_root()
+    # Run fresh analysis if no cache (Issue #12330: scoped to the source root)
+    scan_root = await _resolve_env_scan_root(source_id)
     if not path:
-        path = project_root
+        path = scan_root
 
-    error_response = _validate_env_path_security(path, project_root)
+    error_response = _validate_env_path_security(path, scan_root)
     if error_response:
         return error_response
 
@@ -572,15 +604,17 @@ def _build_export_response_json(
     )
 
 
-async def _load_env_analysis_cache() -> tuple:
+async def _load_env_analysis_cache(source_id: str | None = None) -> tuple:
     """Thread-safe cache read for export_env_analysis. Returns (full_data, error_response).
 
     Issue #2735: Extracted from export_env_analysis for length compliance.
     Issue #559: Thread-safe access to _env_analysis_full_cache.
+    Issue #12330: Scoped by source_id to prevent cross-project cache leakage.
     Returns (full_data, None) on success or (None, JSONResponse) when cache is empty.
     """
     async with _env_analysis_cache_lock:
-        if not _env_analysis_full_cache:
+        full_data = _env_analysis_full_cache.get(_env_cache_key(source_id))
+        if not full_data:
             return None, JSONResponse(
                 {
                     "status": "error",
@@ -591,7 +625,7 @@ async def _load_env_analysis_cache() -> tuple:
                 },
                 status_code=404,
             )
-        return _env_analysis_full_cache.copy(), None
+        return full_data.copy(), None
 
 
 def _validate_export_severity(severity: str | None) -> JSONResponse | None:
@@ -621,14 +655,15 @@ async def export_env_analysis(
     severity: str = Query(None, description="Filter by severity ('high', 'medium', 'low')"),
     limit: int = Query(None, description="Limit number of results (default: all)"),
     include_recommendations: bool = Query(True, description="Include recommendations in export"),
-    source_id: str | None = Query(None, description="#1772: source_id for API consistency"),
+    source_id: str | None = Query(None, description="#12330: export the selected code source's analysis"),
 ):
     """
     Export full environment analysis results without truncation (Issue #631).
     Issue #665: Refactored to use extracted helpers for filtering and sorting.
     Issue #2735: Cache load and severity validation extracted to helpers.
+    Issue #12330: Scoped to the selected source's cached analysis.
     """
-    full_data, cache_error = await _load_env_analysis_cache()
+    full_data, cache_error = await _load_env_analysis_cache(source_id=source_id)
     if cache_error is not None:
         return cache_error
 

--- a/autobot-backend/api/codebase_analytics/endpoints/import_tree.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/import_tree.py
@@ -21,7 +21,7 @@ from autobot_shared.logging_manager import get_logger
 from tasks.analytics_tasks import run_import_tree_analysis
 from utils.celery_task_status import celery_result_to_status, get_latest_task_result, store_latest_task_id
 
-from .shared import INTERNAL_MODULE_PREFIXES, STDLIB_MODULES, get_project_root
+from .shared import INTERNAL_MODULE_PREFIXES, STDLIB_MODULES, resolve_scan_root
 
 logger = get_logger(__name__)
 
@@ -121,7 +121,9 @@ def _deduplicate_imports(imports: List[Dict]) -> List[Dict]:
     operation="get_import_tree",
     error_code_prefix="CODEBASE",
 )
-async def get_import_tree():
+async def get_import_tree(
+    source_id: str | None = Query(None, description="#12330: scope import tree to the selected code source"),
+):
     """
     Get bidirectional file import relationships for tree visualization.
 
@@ -131,8 +133,10 @@ async def get_import_tree():
 
     This enables bidirectional navigation in the import tree UI.
     (Issue #315 - refactored to reduce nesting)
+    Issue #12330: Scope the scan to the requested source's clone path so one
+    project cannot see another's import tree.
     """
-    project_root = get_project_root()
+    project_root = await resolve_scan_root(source_id)
     # Issue #358 - avoid blocking (use lambda to defer rglob to thread)
     python_files = await asyncio.to_thread(lambda: list(project_root.rglob("*.py")))
 

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -175,6 +175,42 @@ async def resolve_source_root(source_id: "str | None") -> "Path | None":
     return None
 
 
+async def resolve_scan_root(source_id: "str | None", use_default: bool = True) -> Path:
+    """Resolve the filesystem root a source-scoped analytics scan must read.
+
+    Issue #12330: Several filesystem-scanning analytics endpoints accepted a
+    ``source_id`` "for API consistency" but ignored it, scanning AutoBot's own
+    project root regardless of the selected code source -- cross-project data
+    leakage. This resolves the requested source's clone path so scans are scoped
+    to the caller's project.
+
+    When ``source_id`` is falsy and ``use_default`` is True, the default (most
+    recently indexed) source is resolved first to avoid silently mixing projects
+    (matches the stats.py/report.py pattern, #2653). Falls back to the AutoBot
+    project root only when no source can be resolved (e.g. dev checkout with no
+    registered sources).
+
+    Args:
+        source_id: The requested source identifier, or None.
+        use_default: When True, resolve the default source if source_id is None.
+
+    Returns:
+        Path to the resolved source clone directory, or the AutoBot project root.
+    """
+    if not source_id and use_default:
+        try:
+            from api.codebase_analytics.source_storage import get_default_source_id
+
+            source_id = await get_default_source_id()
+        except Exception as exc:
+            logger.debug("resolve_scan_root: default source lookup failed: %s", exc)
+
+    source_root = await resolve_source_root(source_id)
+    if source_root:
+        return source_root
+    return get_project_root()
+
+
 # Project root helper
 def get_project_root() -> Path:
     """

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -20134,6 +20134,8 @@ export interface paths {
          *     Issue #281: Refactored from 146 lines to use extracted helper methods.
          *     Issue #1088: Further refactored with _load_modules_from_chromadb and
          *     _scan_filesystem_imports helpers.
+         *     Issue #12330: Scope the filesystem scan to the requested source's clone path
+         *     so one project cannot see another's dependency graph.
          *
          *     Returns:
          *     - modules: List of all modules/files in the codebase
@@ -20248,6 +20250,8 @@ export interface paths {
          *
          *     This enables bidirectional navigation in the import tree UI.
          *     (Issue #315 - refactored to reduce nesting)
+         *     Issue #12330: Scope the scan to the requested source's clone path so one
+         *     project cannot see another's import tree.
          */
         get: operations["get_import_tree_api_analytics_codebase_analytics_import_tree_get"];
         put?: never;
@@ -20351,6 +20355,9 @@ export interface paths {
          *
          *     Issue #281/#665/#711: Refactored with caching.
          *     Issue #713: Enhanced with import-aware cross-module resolution.
+         *     Issue #12330: Scope the scan to the requested source's clone path so one
+         *     project cannot see another's call graph. The cache key is derived from the
+         *     resolved root (path-hashed) so each source keeps a distinct cache entry.
          */
         get: operations["get_call_graph_api_analytics_codebase_analytics_call_graph_get"];
         put?: never;
@@ -20594,6 +20601,7 @@ export interface paths {
          * @description Get all backend API endpoints.
          *
          *     Returns list of all FastAPI route definitions found in the backend.
+         *     Issue #12330: Scoped to the selected source's clone path.
          */
         get: operations["get_api_endpoints_api_analytics_codebase_api_endpoints_get"];
         put?: never;
@@ -20616,6 +20624,7 @@ export interface paths {
          * @description Get all frontend API calls.
          *
          *     Returns list of all API calls found in frontend TypeScript/Vue files.
+         *     Issue #12330: Scoped to the selected source's clone path.
          */
         get: operations["get_frontend_api_calls_api_analytics_codebase_api_calls_get"];
         put?: never;
@@ -20644,6 +20653,9 @@ export interface paths {
          *     - Orphaned endpoints (unused)
          *     - Missing endpoints (called but not defined)
          *     - Coverage percentage
+         *
+         *     Issue #12330: Analysis is scoped to the selected source's clone path and
+         *     cached per-source so one project's coverage never leaks into another's.
          */
         get: operations["get_endpoint_coverage_api_analytics_codebase_endpoint_coverage_get"];
         put?: never;
@@ -20667,6 +20679,7 @@ export interface paths {
          *
          *     Returns full analysis including all endpoints, calls, and mismatches.
          *     Use /endpoint-coverage for a summary only.
+         *     Issue #12330: Scoped and cached per source.
          */
         get: operations["get_endpoint_analysis_full_api_analytics_codebase_endpoint_analysis_get"];
         put?: never;
@@ -20690,6 +20703,7 @@ export interface paths {
          *
          *     These are backend endpoints that have no matching frontend calls.
          *     They may be unused code that can be removed.
+         *     Issue #12330: Scoped and cached per source.
          */
         get: operations["get_orphaned_endpoints_api_analytics_codebase_orphaned_endpoints_get"];
         put?: never;
@@ -20713,6 +20727,7 @@ export interface paths {
          *
          *     These are frontend API calls that have no matching backend endpoint.
          *     They may indicate bugs or deprecated endpoint usage.
+         *     Issue #12330: Scoped and cached per source.
          */
         get: operations["get_missing_endpoints_api_analytics_codebase_missing_endpoints_get"];
         put?: never;
@@ -20735,6 +20750,7 @@ export interface paths {
          * @description Get actively used endpoints with their call counts.
          *
          *     Returns endpoints that are both defined in backend and called from frontend.
+         *     Issue #12330: Scoped and cached per source.
          */
         get: operations["get_used_endpoints_api_analytics_codebase_used_endpoints_get"];
         put?: never;
@@ -20756,9 +20772,12 @@ export interface paths {
         put?: never;
         /**
          * Refresh Endpoint Cache
-         * @description Force refresh the endpoint analysis cache.
+         * @description Force refresh the endpoint analysis cache for a source.
          *
          *     Call this after making code changes to get updated results.
+         *     Issue #12330: Rebuilds only the requested source's entry, scoped to that
+         *     source's clone path, so refreshing one project does not evict or overwrite
+         *     another project's cached analysis.
          */
         post: operations["refresh_endpoint_cache_api_analytics_codebase_refresh_endpoint_cache_post"];
         delete?: never;
@@ -20778,6 +20797,8 @@ export interface paths {
          * Get Environment Analysis
          * @description Analyze codebase for hardcoded values and environment variable opportunities (Issue #538).
          *     Issue #665: Refactored to use extracted helpers for cache, analysis, and result building.
+         *     Issue #12330: Scope the scan to the selected source's clone path so one project
+         *     cannot see another's hardcoded-value analysis.
          */
         get: operations["get_environment_analysis_api_analytics_codebase_env_analysis_get"];
         put?: never;
@@ -20801,6 +20822,7 @@ export interface paths {
          *
          *     Returns actionable recommendations for creating/updating .env files
          *     based on detected hardcoded values.
+         *     Issue #12330: Scoped to the selected source's clone path.
          *
          *     Args:
          *         path: Root path to analyze
@@ -20829,6 +20851,7 @@ export interface paths {
          * @description Export full environment analysis results without truncation (Issue #631).
          *     Issue #665: Refactored to use extracted helpers for filtering and sorting.
          *     Issue #2735: Cache load and severity validation extracted to helpers.
+         *     Issue #12330: Scoped to the selected source's cached analysis.
          */
         get: operations["export_env_analysis_api_analytics_codebase_env_analysis_export_get"];
         put?: never;
@@ -127559,7 +127582,10 @@ export interface operations {
     };
     get_dependencies_api_analytics_codebase_analytics_dependencies_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope dependency scan to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -127573,6 +127599,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -127693,7 +127728,10 @@ export interface operations {
     };
     get_import_tree_api_analytics_codebase_analytics_import_tree_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope import tree to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -127707,6 +127745,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -127830,7 +127877,7 @@ export interface operations {
             query?: {
                 /** @description Force refresh, bypass cache */
                 refresh?: boolean;
-                /** @description #1772: source_id for API consistency */
+                /** @description #12330: scope call graph to the selected code source */
                 source_id?: string | null;
             };
             header?: never;
@@ -128150,7 +128197,10 @@ export interface operations {
     };
     get_api_endpoints_api_analytics_codebase_api_endpoints_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128166,11 +128216,23 @@ export interface operations {
                     "application/json": unknown;
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     get_frontend_api_calls_api_analytics_codebase_api_calls_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128184,6 +128246,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -128191,7 +128262,7 @@ export interface operations {
     get_endpoint_coverage_api_analytics_codebase_endpoint_coverage_get: {
         parameters: {
             query?: {
-                /** @description #1772: source_id for API consistency */
+                /** @description #12330: scope coverage to the selected code source */
                 source_id?: string | null;
             };
             header?: never;
@@ -128222,7 +128293,10 @@ export interface operations {
     };
     get_endpoint_analysis_full_api_analytics_codebase_endpoint_analysis_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope analysis to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128236,13 +128310,25 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
     get_orphaned_endpoints_api_analytics_codebase_orphaned_endpoints_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128256,13 +128342,25 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
     get_missing_endpoints_api_analytics_codebase_missing_endpoints_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128276,13 +128374,25 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
     get_used_endpoints_api_analytics_codebase_used_endpoints_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128298,11 +128408,23 @@ export interface operations {
                     "application/json": unknown;
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     refresh_endpoint_cache_api_analytics_codebase_refresh_endpoint_cache_post: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12330: refresh the selected source's cache entry */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128316,6 +128438,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -128335,7 +128466,7 @@ export interface operations {
                 llm_model?: string;
                 /** @description Priority level to filter: 'high', 'medium', 'low', or 'all' */
                 filter_priority?: string;
-                /** @description #1772: source_id for API consistency */
+                /** @description #12330: scope analysis to the selected code source */
                 source_id?: string | null;
             };
             header?: never;
@@ -128369,7 +128500,7 @@ export interface operations {
             query?: {
                 /** @description Root path to analyze (defaults to project root) */
                 path?: string;
-                /** @description #1772: source_id for API consistency */
+                /** @description #12330: scope recommendations to the selected code source */
                 source_id?: string | null;
             };
             header?: never;
@@ -128409,7 +128540,7 @@ export interface operations {
                 limit?: number;
                 /** @description Include recommendations in export */
                 include_recommendations?: boolean;
-                /** @description #1772: source_id for API consistency */
+                /** @description #12330: export the selected code source's analysis */
                 source_id?: string | null;
             };
             header?: never;


### PR DESCRIPTION
## Thinking Path

Issue #12330 reports cross-project data leakage in Codebase Analytics: several endpoints accept a `source_id` query param "for API consistency" (added by #1772) but never use it, scanning AutoBot's own project root regardless of the selected code source. Opening `/analytics/codebase/<source-id>` then shows another codebase's data in some panels.

Root cause is a half-finished `source_id` migration. The proven leaks (call-graph, endpoint-coverage) plus their siblings share two mechanisms:
1. **Wrong scan root** — handlers call `get_project_root()` / `Path.cwd()` instead of the requested source's clone path, so every source is analysed as AutoBot itself.
2. **Global module caches** — `_analysis_cache["latest"]`, `_env_analysis_cache`, and an unscoped ChromaDB query return one project's results for every other selected source.

Audited all 20 analytics endpoint modules. `sources/stats/duplicates/ownership/charts/report/pattern_analysis/declarations` already scope correctly (they resolve `clone_path` and key caches/where-filters by `source_id`). The unscoped/accepted-but-ignored ones are fixed here.

## What Changed

Added `resolve_scan_root(source_id)` to `endpoints/shared.py` — resolves the requested source's clone path (falling back to the default source, then the project root), mirroring the existing `stats.py`/`report.py` pattern.

Wired real scoping into every leaking endpoint:
- **`call_graph.py`** `get_call_graph` — scans the resolved source root; path-hashed cache key is now per-source.
- **`api_endpoints.py`** — `get_endpoint_coverage`, `get_api_endpoints`, `get_api_calls`, `get_endpoint_analysis_full`, `orphaned/missing/used`, `refresh-endpoint-cache`: the `APIEndpointChecker` is bound to the resolved source root and the in-memory `_analysis_cache` is keyed per source (was a single global `"latest"` entry).
- **`dependencies.py`** `get_dependencies` — added `source_id`; both the filesystem scan **and** the previously-unfiltered ChromaDB module query (`_load_modules_from_chromadb`) are now scoped by `source_id`.
- **`import_tree.py`** `get_import_tree` — added `source_id`; scans the resolved source root.
- **`environment.py`** `env-analysis`, `env-recommendations`, `env-analysis/export` — scan the resolved source root, validate the path against that root, and the `_env_analysis_cache` / `_env_analysis_full_cache` are keyed per source.

No existing check was weakened; unresolvable sources still fall back to the project root exactly as before.

### Known follow-up (not in this PR)
`cross_language_patterns.py` has the same `source_id`-ignored + global `_analysis_cache["latest"]` pattern, but its `CrossLanguagePatternDetector` couples `project_root` to its ChromaDB/embedding-cache location, so scoping it is a behaviourally riskier change that belongs in a separate PR.

## Verification

- `python3 -m black --check --line-length 120` — clean (6 files)
- `python3 -m flake8 --max-line-length 120` — 0 findings
- `ast.parse` — clean on all changed files
- New `endpoints/cross_project_scoping_test.py` — **6 passed**, including an end-to-end test that runs the real `get_call_graph` against two temp source dirs and asserts project A's response contains A's function and **never** B's (and vice versa), plus per-source cache-keying assertions:

```
6 passed, 1 warning in 1.41s
```

Two pre-existing failures in adjacent test files are unrelated to this change (confirmed my diff does not touch the exercised code): `call_graph_resolution_test::test_extract_multiple_imports` (the test asserts an `Optional` import its own source never declares) and `analytics_evolution_test::test_explicit_dates_are_parsed` (timezone-dependent timestamp).

## Model Used

claude-opus-4-8

Closes #12330
