### PR TITLE
fix(security): suppress semgrep autobot-sql-string-format FPs on validated-identifier SQL (#12284 follow-up)

### DIFF
--- a/autobot-backend/utils/sql_injection_hardening_test.py
+++ b/autobot-backend/utils/sql_injection_hardening_test.py
@@ -90,8 +90,11 @@ def test_quote_sqlite_identifier_neutralises_injection():
     conn = sqlite3.connect(":memory:")
     try:
         conn.execute("CREATE TABLE t (id INTEGER)")
-        conn.execute(f"CREATE VIEW {quoted} AS SELECT 1")
-        conn.execute(f"DROP VIEW IF EXISTS {quoted}")
+        # `quoted` is the escaped output of the function under test; the identifier
+        # is safely double-quoted (metacharacters inert) and can't be bind-parameterized. (#12284)
+        conn.execute(f"CREATE VIEW {quoted} AS SELECT 1")  # nosemgrep: autobot-sql-string-format
+        # Same quoted identifier; the assertion below proves the payload never executed. (#12284)
+        conn.execute(f"DROP VIEW IF EXISTS {quoted}")  # nosemgrep: autobot-sql-string-format
         conn.commit()
         # Table t survived: the injected drop never executed.
         assert conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='t'").fetchone() is not None


### PR DESCRIPTION
## Thinking Path
The SAST check (`semgrep.autobot-sql-string-format`, CWE-89) reds on every PR. Investigating the exact CI command locally (`semgrep 1.163.0`, same as CI) against the current `Dev_new_gui` tip showed the 4 source-code lines flagged historically (utils/common.py, services/nl_database_service.py, database/migrations/001_create_conversation_files.py) are **already resolved** by #12284/#12291: each was restructured to bare-assign the SQL to a variable before `execute()`, which no longer matches the rule pattern `$DB.execute(f"...")`, and the interpolated value is a SQL **identifier** (allowlist-validated / double-quote-escaped / backtick-escaped) that cannot be bind-parameterized.

The only remaining SAST ERRORs were 2 lines **inside the #12284 regression test itself** (`utils/sql_injection_hardening_test.py:93-94`), which deliberately call `conn.execute(f"CREATE VIEW {quoted} ...")` / `DROP VIEW` to prove the quoting neutralises an injection payload. `quoted` is the escaped output of `_quote_sqlite_identifier` (the function under test); the test asserts the payload never executes (table `t` survives). Safe by construction — same validated-identifier category as #12284.

## What Changed
- `utils/sql_injection_hardening_test.py:93,94` — added `# nosemgrep: autobot-sql-string-format` with a per-line justification comment (identifier is safely double-quoted, metacharacters inert, can't be bind-parameterized; ref #12284), matching the repo's existing `# nosemgrep` style.
- SQL safety unchanged; no `# nosec` markers touched. The 4 previously-cited source lines already carry their `# nosec B608` + justification from #12291 and are not currently flagged, so they are left untouched.

## Verification
- `semgrep --config=.semgrep/rules.yaml --severity ERROR --error autobot-backend/ autobot-slm-backend/ autobot_shared/` → **exit 0**, `Findings: 0 (0 blocking)`, `Ran 11 rules on 3169 files: 0 findings.`
- `python3 -m black --check --line-length 120` → unchanged.
- `python3 -m flake8 --max-line-length 120` → clean.
- `ast.parse` → clean.
- `pytest utils/sql_injection_hardening_test.py` → **4 passed**.

Refs #12284

## Model Used
claude-opus-4-8
