### PR TITLE
fix(frontend): gate telemetry consent modal behind auth so it no longer overlays login (#12334)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -488,7 +488,11 @@
     />
 
     <!-- Telemetry Consent Modal (Issue #9035) -->
-    <TelemetryConsentModal />
+    <!-- Gated behind authentication (#12334): the consent prompt persists its
+         choice via authenticated endpoints, so mounting it on the login/
+         unauthenticated route overlaid the Sign In form and 401'd, re-nagging
+         forever. Defer until after successful login. -->
+    <TelemetryConsentModal v-if="userStore.isAuthenticated" />
 
     <!-- System Status Notifications (limit to last 5 to prevent teleport accumulation) -->
     <SystemStatusNotification

--- a/autobot-frontend/src/components/modals/__tests__/TelemetryConsentModal.spec.ts
+++ b/autobot-frontend/src/components/modals/__tests__/TelemetryConsentModal.spec.ts
@@ -1,0 +1,122 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Component tests for the first-run telemetry consent modal.
+ *
+ * Issue #12334: the modal was mounted unconditionally in App.vue, so it rendered
+ * over the login form on the unauthenticated route — intercepting pointer events
+ * (Sign In unclickable) and 401'ing its persistence calls, which re-nagged
+ * forever. The fix gates the mount behind `userStore.isAuthenticated`
+ * (`<TelemetryConsentModal v-if="userStore.isAuthenticated" />`), deferring the
+ * prompt until after successful login where its authenticated endpoints work.
+ *
+ * These tests reproduce that gating contract with a tiny wrapper that mirrors
+ * App.vue's `v-if`, asserting:
+ *   1. Unauthenticated → the modal is never mounted, so no telemetry status
+ *      call fires and nothing can overlay the login form.
+ *   2. Authenticated + server reports "not yet shown" → the consent prompt
+ *      appears at the correct time (the flow still fires, no feature loss).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+// ── Module-level mocks (hoisted) ─────────────────────────────────────────────
+
+const apiGet = vi.fn()
+const apiPost = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get: apiGet, post: apiPost }),
+}))
+
+vi.mock('@/components/ui/Icon.vue', () => ({
+  default: { name: 'Icon', template: '<i class="icon-stub" />', props: ['name'] },
+}))
+
+// Stub BaseModal so its visibility is observable from the DOM: it renders its
+// body slot only when `modelValue` (the modal's `isVisible`) is true.
+vi.mock('@autobot/ui', () => ({
+  BaseModal: {
+    name: 'BaseModal',
+    props: ['modelValue', 'title'],
+    template: '<div v-if="modelValue" class="telemetry-modal-stub"><slot /></div>',
+  },
+}))
+
+// ── Imports after mocks ──────────────────────────────────────────────────────
+
+import TelemetryConsentModal from '../TelemetryConsentModal.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false,
+})
+
+// Wrapper mirroring App.vue's gate: `<TelemetryConsentModal v-if="isAuthenticated" />`.
+function mountGated(isAuthenticated: boolean) {
+  const authed = ref(isAuthenticated)
+  const Wrapper = defineComponent({
+    setup() {
+      return () => (authed.value ? h(TelemetryConsentModal) : null)
+    },
+  })
+  const wrapper = mount(Wrapper, { global: { plugins: [i18n] } })
+  return { wrapper, authed }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  apiPost.mockResolvedValue({})
+})
+
+describe('TelemetryConsentModal gating (#12334)', () => {
+  it('is not mounted while unauthenticated and never calls the telemetry status endpoint', async () => {
+    const { wrapper } = mountGated(false)
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.find('.telemetry-modal-stub').exists()).toBe(false)
+    // The pre-auth 401 storm came from this call — it must not fire on login.
+    expect(apiGet).not.toHaveBeenCalled()
+  })
+
+  it('shows the consent prompt once authenticated when the server reports it has not been shown', async () => {
+    apiGet.mockResolvedValue({
+      enabled: false,
+      anonymous_usage_stats: false,
+      first_run_prompt_shown: false,
+    })
+
+    const { wrapper } = mountGated(true)
+    await nextTick()
+    await nextTick()
+
+    expect(apiGet).toHaveBeenCalledWith('/api/settings/telemetry')
+    expect(wrapper.find('.telemetry-modal-stub').exists()).toBe(true)
+  })
+
+  it('stays hidden once authenticated when the server reports the prompt was already shown', async () => {
+    apiGet.mockResolvedValue({
+      enabled: true,
+      anonymous_usage_stats: true,
+      first_run_prompt_shown: true,
+    })
+
+    const { wrapper } = mountGated(true)
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.find('.telemetry-modal-stub').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Thinking Path

Issue #12334 reports that on first run the telemetry consent modal renders on top of the login form: it intercepts pointer events so **Sign In is unclickable**, and its persistence calls (`POST /api/settings/telemetry`, `.../prompt-shown`) 401 because they run pre-auth — so the choice is never recorded and the prompt re-nags forever.

Root cause: `TelemetryConsentModal` was mounted **unconditionally** in `App.vue` (`<TelemetryConsentModal />`). Its `onMounted` immediately hits the authenticated `/api/settings/telemetry` status endpoint and self-opens, regardless of route or auth state — so on the login/unauthenticated route it overlaid the form and its writes 401'd. The endpoints require an authenticated session by construction, so the prompt cannot function pre-login.

## What Changed

- `autobot-frontend/src/App.vue` — gated the mount behind auth: `<TelemetryConsentModal v-if="userStore.isAuthenticated" />`. This matches how other post-login chrome is gated in the same file (`showAuthChrome = userStore.isAuthenticated && !isPublicRoute`, and existing `v-if="userStore.isAuthenticated"` blocks). The component now mounts — and only then runs its status check and self-opens — after successful login, when its endpoints work. No feature loss: the consent flow still fires, just at the correct onboarding moment.
- `autobot-frontend/src/components/modals/__tests__/TelemetryConsentModal.spec.ts` — new component test covering the gating contract via a wrapper mirroring App.vue's `v-if`:
  - unauthenticated → modal never mounts and the telemetry status endpoint is never called (nothing can overlay login, no pre-auth 401s);
  - authenticated + server "not yet shown" → the prompt appears (flow still fires);
  - authenticated + server "already shown" → stays hidden.

## Verification

- `git diff` inspection: the mount is now tied to `userStore.isAuthenticated`; the modal's self-opening `onMounted` status call can no longer run on the login route.
- Frontend `node_modules` is not installed in this WSL environment, so vitest could not be executed locally; the test follows existing repo patterns (`ChatSettingsModal.spec.ts`, `NpuWorkerPairConfirmDialog.spec.ts`) and will run in CI. **CI risk:** low — one declarative `v-if` on an already-exposed store property plus an isolated new spec; no type/API surface changes.
- No new i18n keys introduced (fix is a mount condition only).

## Model Used

Claude Opus 4.8

Closes #12334
