### PR TITLE
fix(security): scope cross_language_patterns analytics by source_id (#12356)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/cross_language_patterns.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_language_patterns.py
@@ -14,31 +14,65 @@ Provides endpoints to:
 """
 
 import asyncio
+from pathlib import Path
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from code_intelligence.cross_language_patterns import CrossLanguagePatternDetector
 
+from .shared import resolve_scan_root
+
 logger = get_logger(__name__)
 
 router = APIRouter()
 
-# Cache for analysis results
+# Cache for analysis results.
+# Issue #12356: Keyed by source_id (or "default") to prevent cross-project
+# leakage -- a single global "latest" entry returned one project's cross-language
+# patterns for every other selected source.
 _analysis_cache: dict = {}
 # Lock for thread-safe access to _analysis_cache (Issue #559)
 _analysis_cache_lock = asyncio.Lock()
 
 
-def _get_detector() -> CrossLanguagePatternDetector:
-    """Get or create the pattern detector instance."""
+def _cache_key(source_id: str | None) -> str:
+    """Cache key for a source. Issue #12356: scope per project, not global."""
+    return source_id or "default"
+
+
+def _get_detector(
+    project_root: Path | None = None,
+    source_id: str | None = None,
+    use_llm: bool = True,
+    use_cache: bool = True,
+) -> CrossLanguagePatternDetector:
+    """Get or create the pattern detector instance.
+
+    Issue #12356: Bind the detector to the requested source's clone path and
+    scope tag so it scans the selected project and keys its ChromaDB pattern
+    collection/query + embedding cache per source, rather than defaulting to
+    AutoBot's own root and a shared, unscoped collection.
+    """
     return CrossLanguagePatternDetector(
-        use_llm=True,
-        use_cache=True,
+        project_root=str(project_root) if project_root else None,
+        use_llm=use_llm,
+        use_cache=use_cache,
         embedding_model="nomic-embed-text",
+        source_id=source_id,
     )
+
+
+async def _get_cached_analysis(source_id: str | None):
+    """Return the cached analysis for a source, or None (Issue #12356).
+
+    Reads only the requested source's entry so one project's cached patterns
+    are never returned for another selected source.
+    """
+    async with _analysis_cache_lock:
+        return _analysis_cache.get(_cache_key(source_id))
 
 
 @router.post("/cross-language/analyze")
@@ -50,7 +84,7 @@ def _get_detector() -> CrossLanguagePatternDetector:
 async def run_cross_language_analysis(
     use_llm: bool = True,
     use_cache: bool = True,
-    source_id: str | None = None,
+    source_id: str | None = Query(None, description="#12356: scope analysis to the selected code source"),
 ) -> JSONResponse:
     """
     Run full cross-language pattern analysis.
@@ -64,20 +98,28 @@ async def run_cross_language_analysis(
     Args:
         use_llm: Whether to use LLM for semantic analysis (default: True)
         use_cache: Whether to cache results (default: True)
+        source_id: Scope the scan and cache to the selected code source
+            (Issue #12356). Falls back to AutoBot's own root only when no source
+            is resolvable.
 
     Returns:
         Complete analysis results with all detected patterns
     """
-    detector = CrossLanguagePatternDetector(
+    # Issue #12356: scan the requested source's clone path (not AutoBot's own
+    # root) and key both the detector and this cache entry per source.
+    scan_root = await resolve_scan_root(source_id)
+    detector = _get_detector(
+        project_root=scan_root,
+        source_id=source_id,
         use_llm=use_llm,
         use_cache=use_cache,
     )
 
     analysis = await detector.run_analysis()
 
-    # Cache the result (thread-safe, Issue #559)
+    # Cache the result per source (thread-safe, Issue #559 / #12356)
     async with _analysis_cache_lock:
-        _analysis_cache["latest"] = analysis
+        _analysis_cache[_cache_key(source_id)] = analysis
 
     return JSONResponse(
         {
@@ -93,27 +135,29 @@ async def run_cross_language_analysis(
     operation="get_cross_language_summary",
     error_code_prefix="CODEBASE",
 )
-async def get_cross_language_summary() -> JSONResponse:
+async def get_cross_language_summary(
+    source_id: str | None = Query(None, description="#12356: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get summary of latest cross-language analysis.
 
     Returns cached results if available, otherwise returns empty status.
     Use POST /cross-language/analyze to trigger a new analysis.
+    Issue #12356: Reads only the selected source's cached analysis.
     """
-    # Check cache first (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" not in _analysis_cache:
-            # Return empty status instead of auto-running full analysis
-            # Full analysis can take minutes and should only be triggered
-            # via POST /analyze endpoint explicitly
-            return JSONResponse(
-                {
-                    "status": "empty",
-                    "message": "No analysis available. Click 'Full Scan' to run analysis.",
-                    "has_cached_data": False,
-                }
-            )
-        analysis = _analysis_cache["latest"]
+    # Check cache first (thread-safe, Issue #559 / #12356: per-source)
+    analysis = await _get_cached_analysis(source_id)
+    if analysis is None:
+        # Return empty status instead of auto-running full analysis
+        # Full analysis can take minutes and should only be triggered
+        # via POST /analyze endpoint explicitly
+        return JSONResponse(
+            {
+                "status": "empty",
+                "message": "No analysis available. Click 'Full Scan' to run analysis.",
+                "has_cached_data": False,
+            }
+        )
 
     return JSONResponse(
         {
@@ -162,23 +206,25 @@ async def get_cross_language_summary() -> JSONResponse:
     operation="get_dto_mismatches",
     error_code_prefix="CODEBASE",
 )
-async def get_dto_mismatches() -> JSONResponse:
+async def get_dto_mismatches(
+    source_id: str | None = Query(None, description="#12356: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get DTO/type mismatches between backend and frontend.
 
     Returns mismatches where Python models and TypeScript interfaces differ.
+    Issue #12356: Reads only the selected source's cached analysis.
     """
-    # Check cache (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" not in _analysis_cache:
-            return JSONResponse(
-                {
-                    "status": "error",
-                    "message": "No analysis available. Run /cross-language/analyze first.",
-                },
-                status_code=400,
-            )
-        analysis = _analysis_cache["latest"]
+    # Check cache (thread-safe, Issue #559 / #12356: per-source)
+    analysis = await _get_cached_analysis(source_id)
+    if analysis is None:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": "No analysis available. Run /cross-language/analyze first.",
+            },
+            status_code=400,
+        )
 
     return JSONResponse(
         {
@@ -195,23 +241,25 @@ async def get_dto_mismatches() -> JSONResponse:
     operation="get_validation_duplications",
     error_code_prefix="CODEBASE",
 )
-async def get_validation_duplications() -> JSONResponse:
+async def get_validation_duplications(
+    source_id: str | None = Query(None, description="#12356: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get duplicated validation logic across languages.
 
     Returns validation rules that exist in both Python and TypeScript.
+    Issue #12356: Reads only the selected source's cached analysis.
     """
-    # Check cache (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" not in _analysis_cache:
-            return JSONResponse(
-                {
-                    "status": "error",
-                    "message": "No analysis available. Run /cross-language/analyze first.",
-                },
-                status_code=400,
-            )
-        analysis = _analysis_cache["latest"]
+    # Check cache (thread-safe, Issue #559 / #12356: per-source)
+    analysis = await _get_cached_analysis(source_id)
+    if analysis is None:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": "No analysis available. Run /cross-language/analyze first.",
+            },
+            status_code=400,
+        )
 
     return JSONResponse(
         {
@@ -228,25 +276,28 @@ async def get_validation_duplications() -> JSONResponse:
     operation="get_api_contract_mismatches",
     error_code_prefix="CODEBASE",
 )
-async def get_api_contract_mismatches() -> JSONResponse:
+async def get_api_contract_mismatches(
+    source_id: str | None = Query(None, description="#12356: scope to the selected code source"),
+) -> JSONResponse:
     """
     Get API contract mismatches between backend and frontend.
 
     Returns endpoints that are:
     - Orphaned (backend has, frontend doesn't call)
     - Missing (frontend calls, backend doesn't have)
+
+    Issue #12356: Reads only the selected source's cached analysis.
     """
-    # Check cache (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" not in _analysis_cache:
-            return JSONResponse(
-                {
-                    "status": "error",
-                    "message": "No analysis available. Run /cross-language/analyze first.",
-                },
-                status_code=400,
-            )
-        analysis = _analysis_cache["latest"]
+    # Check cache (thread-safe, Issue #559 / #12356: per-source)
+    analysis = await _get_cached_analysis(source_id)
+    if analysis is None:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": "No analysis available. Run /cross-language/analyze first.",
+            },
+            status_code=400,
+        )
 
     orphaned = [m for m in analysis.api_contract_mismatches if m.mismatch_type == "orphaned_endpoint"]
     missing = [m for m in analysis.api_contract_mismatches if m.mismatch_type == "missing_endpoint"]
@@ -272,6 +323,7 @@ async def get_api_contract_mismatches() -> JSONResponse:
 async def get_semantic_matches(
     min_similarity: float = 0.7,
     limit: int = 50,
+    source_id: str | None = Query(None, description="#12356: scope to the selected code source"),
 ) -> JSONResponse:
     """
     Get semantically similar patterns across languages.
@@ -282,18 +334,18 @@ async def get_semantic_matches(
     Args:
         min_similarity: Minimum similarity score (0.0-1.0, default: 0.7)
         limit: Maximum number of matches to return (default: 50)
+        source_id: Scope to the selected code source (Issue #12356)
     """
-    # Check cache (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" not in _analysis_cache:
-            return JSONResponse(
-                {
-                    "status": "error",
-                    "message": "No analysis available. Run /cross-language/analyze first.",
-                },
-                status_code=400,
-            )
-        analysis = _analysis_cache["latest"]
+    # Check cache (thread-safe, Issue #559 / #12356: per-source)
+    analysis = await _get_cached_analysis(source_id)
+    if analysis is None:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": "No analysis available. Run /cross-language/analyze first.",
+            },
+            status_code=400,
+        )
 
     # Filter by similarity threshold
     filtered_matches = [m for m in analysis.pattern_matches if m.similarity_score >= min_similarity]
@@ -324,6 +376,7 @@ async def get_patterns_by_category(
     category: str | None = None,
     severity: str | None = None,
     limit: int = 100,
+    source_id: str | None = Query(None, description="#12356: scope to the selected code source"),
 ) -> JSONResponse:
     """
     Get detected patterns filtered by category and/or severity.
@@ -332,18 +385,18 @@ async def get_patterns_by_category(
         category: Filter by category (api_contract, data_types, validation, etc.)
         severity: Filter by severity (critical, high, medium, low, info)
         limit: Maximum patterns to return (default: 100)
+        source_id: Scope to the selected code source (Issue #12356)
     """
-    # Check cache (thread-safe, Issue #559)
-    async with _analysis_cache_lock:
-        if "latest" not in _analysis_cache:
-            return JSONResponse(
-                {
-                    "status": "error",
-                    "message": "No analysis available. Run /cross-language/analyze first.",
-                },
-                status_code=400,
-            )
-        analysis = _analysis_cache["latest"]
+    # Check cache (thread-safe, Issue #559 / #12356: per-source)
+    analysis = await _get_cached_analysis(source_id)
+    if analysis is None:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": "No analysis available. Run /cross-language/analyze first.",
+            },
+            status_code=400,
+        )
 
     patterns = analysis.patterns
 
@@ -376,17 +429,19 @@ async def get_patterns_by_category(
     operation="clear_cross_language_cache",
     error_code_prefix="CODEBASE",
 )
-async def clear_cross_language_cache() -> JSONResponse:
+async def clear_cross_language_cache(
+    source_id: str | None = Query(None, description="#12356: clear only this source's cache entry"),
+) -> JSONResponse:
     """
     Clear the cross-language analysis cache.
 
     Call this after making code changes to get fresh results.
+    Issue #12356: Clears only the requested source's entry so clearing one
+    project's cache does not evict another project's cached analysis.
     """
-    global _analysis_cache
-
-    # Clear cache (thread-safe, Issue #559)
+    # Clear cache (thread-safe, Issue #559 / #12356: per-source)
     async with _analysis_cache_lock:
-        _analysis_cache = {}
+        _analysis_cache.pop(_cache_key(source_id), None)
 
     return JSONResponse(
         {

--- a/autobot-backend/api/codebase_analytics/endpoints/cross_language_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_language_scoping_test.py
@@ -1,0 +1,192 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for cross-project cross-language-pattern leakage (Issue #12356).
+
+The ``/cross-language/*`` analytics endpoints accepted a ``source_id`` but
+ignored it: the detector defaulted to AutoBot's own root and a single global
+``_analysis_cache["latest"]`` entry, so opening one project's cross-language
+analysis could return another project's patterns. The
+``CrossLanguagePatternDetector`` also stored/queried its ChromaDB pattern
+collection with no source scoping, so two projects sharing a fallback ChromaDB
+path could cross-match.
+
+These tests assert the fix end-to-end:
+- the endpoint scopes both the scan root and the per-source cache to the caller;
+- one source can never read another source's cached analysis;
+- the detector tags every stored pattern with ``source_id``, filters queries by
+  it, and keys its embedding cache per source.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-level isolation
+# ---------------------------------------------------------------------------
+class TestCrossLanguageCacheScoping:
+    """The analysis cache and detector must be keyed per source, not global."""
+
+    def test_cache_key_is_per_source(self):
+        from api.codebase_analytics.endpoints.cross_language_patterns import _cache_key
+
+        assert _cache_key(None) == "default"
+        assert _cache_key("A") == "A"
+        assert _cache_key("A") != _cache_key("B")
+
+    async def test_analyze_scopes_detector_and_caches_per_source(self, tmp_path, monkeypatch):
+        """POST /analyze binds the detector to the source root/tag and caches per source."""
+        from api.codebase_analytics.endpoints import cross_language_patterns as clp
+
+        root_a = tmp_path / "proj_a"
+        root_a.mkdir()
+
+        async def fake_scan_root(source_id, use_default=True):
+            return {"A": root_a}.get(source_id, clp.Path("/tmp"))
+
+        captured: dict = {}
+        analysis_a = MagicMock(name="analysis_A")
+        analysis_a.to_dict.return_value = {"marker": "A"}
+
+        def fake_get_detector(project_root=None, source_id=None, use_llm=True, use_cache=True):
+            captured["project_root"] = project_root
+            captured["source_id"] = source_id
+            detector = MagicMock()
+            detector.run_analysis = AsyncMock(return_value=analysis_a)
+            return detector
+
+        clp._analysis_cache.clear()
+        monkeypatch.setattr(clp, "resolve_scan_root", fake_scan_root)
+        monkeypatch.setattr(clp, "_get_detector", fake_get_detector)
+
+        await clp.run_cross_language_analysis(source_id="A")
+
+        # Detector bound to the requested source's clone path and scope tag.
+        assert captured["project_root"] == root_a
+        assert captured["source_id"] == "A"
+        # Cached under the per-source key, never the old global "latest".
+        assert clp._analysis_cache["A"] is analysis_a
+        assert "latest" not in clp._analysis_cache
+
+    async def test_one_source_never_reads_anothers_analysis(self, tmp_path):
+        """Project A's cached patterns are invisible to a project-B request."""
+        from api.codebase_analytics.endpoints import cross_language_patterns as clp
+
+        # Seed only source A.
+        a_only = MagicMock()
+        a_only.dto_mismatches = [MagicMock(to_dict=MagicMock(return_value={"owner": "A"}))]
+        clp._analysis_cache.clear()
+        clp._analysis_cache["A"] = a_only
+
+        # B has no cached analysis → error, and A's data never leaks across.
+        resp_b = await clp.get_dto_mismatches(source_id="B")
+        assert resp_b.status_code == 400
+        assert b"owner" not in resp_b.body
+
+        # A still sees its own data.
+        resp_a = await clp.get_dto_mismatches(source_id="A")
+        data_a = json.loads(resp_a.body)
+        assert data_a["status"] == "success"
+        assert data_a["total"] == 1
+        assert data_a["mismatches"] == [{"owner": "A"}]
+
+    async def test_summary_scoped_to_source(self, tmp_path):
+        """/summary returns 'empty' for an unseeded source rather than another's summary."""
+        from api.codebase_analytics.endpoints import cross_language_patterns as clp
+
+        clp._analysis_cache.clear()
+        clp._analysis_cache["A"] = MagicMock()  # A seeded, B not
+
+        resp_b = await clp.get_cross_language_summary(source_id="B")
+        data_b = json.loads(resp_b.body)
+        assert data_b["status"] == "empty"
+        assert data_b["has_cached_data"] is False
+
+    async def test_clear_cache_scoped_to_source(self):
+        """Clearing one source's cache leaves other sources' entries intact."""
+        from api.codebase_analytics.endpoints import cross_language_patterns as clp
+
+        clp._analysis_cache.clear()
+        clp._analysis_cache["A"] = MagicMock(name="A")
+        clp._analysis_cache["B"] = MagicMock(name="B")
+
+        await clp.clear_cross_language_cache(source_id="A")
+
+        assert "A" not in clp._analysis_cache
+        assert "B" in clp._analysis_cache
+
+
+# ---------------------------------------------------------------------------
+# Detector-level source scoping (real module, loaded under a synthetic package
+# so the conftest ``code_intelligence`` stub is left untouched).
+# ---------------------------------------------------------------------------
+def _load_real_detector_class():
+    """Load the real CrossLanguagePatternDetector without importing the heavy
+    ``code_intelligence`` package __init__ (which the conftest stubs)."""
+    base = Path(__file__).resolve().parents[3] / "code_intelligence" / "cross_language_patterns"
+    pkg_name = "_real_clp_12356"
+
+    if pkg_name not in sys.modules:
+        pkg = types.ModuleType(pkg_name)
+        pkg.__path__ = [str(base)]
+        pkg.__package__ = pkg_name
+        sys.modules[pkg_name] = pkg
+        # Load submodules in dependency order so relative imports resolve.
+        for sub in ("models", "extractors", "detector"):
+            spec = importlib.util.spec_from_file_location(f"{pkg_name}.{sub}", base / f"{sub}.py")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[f"{pkg_name}.{sub}"] = module
+            spec.loader.exec_module(module)
+
+    return sys.modules[f"{pkg_name}.detector"].CrossLanguagePatternDetector
+
+
+class TestDetectorSourceScoping:
+    """The detector must scope its ChromaDB metadata/query and embedding cache."""
+
+    def test_stored_pattern_metadata_tagged_with_source(self):
+        detector_cls = _load_real_detector_class()
+
+        det_a = detector_cls(source_id="A")
+        meta = det_a._build_pattern_metadata({"language": "python", "pattern": {"type": "DTO", "name": "User"}})
+        assert meta["source_id"] == "A"
+
+        det_default = detector_cls()  # no source_id → "default", never another source's tag
+        meta_default = det_default._build_pattern_metadata({"language": "python", "pattern": {}})
+        assert meta_default["source_id"] == "default"
+
+    async def test_query_filters_matches_by_source(self):
+        detector_cls = _load_real_detector_class()
+        det_a = detector_cls(source_id="A")
+
+        captured: dict = {}
+
+        class _FakeCollection:
+            async def query(self, query_embeddings, n_results, where):
+                captured["where"] = where
+                return {"distances": [[]], "ids": [[]]}
+
+        await det_a._query_cross_language_matches(
+            _FakeCollection(),
+            [{"id": "py1", "embedding": [0.1, 0.2]}],
+            [],
+        )
+
+        assert captured["where"] == {"$and": [{"language": "typescript"}, {"source_id": "A"}]}
+
+    def test_embedding_cache_key_is_per_source(self):
+        detector_cls = _load_real_detector_class()
+
+        det_a = detector_cls(source_id="A")
+        det_b = detector_cls(source_id="B")
+
+        assert det_a._embedding_cache_model != det_b._embedding_cache_model
+        assert det_a._embedding_cache_model.startswith("nomic-embed-text")
+        assert det_a._embedding_cache_model.endswith("A")

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -106,6 +106,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
         use_llm: bool = True,
         use_cache: bool = True,
         embedding_model: str = "nomic-embed-text",
+        source_id: str | None = None,
     ):
         """
         Initialize the detector.
@@ -115,11 +116,24 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
             use_llm: Whether to use LLM for semantic analysis
             use_cache: Whether to use Redis caching
             embedding_model: Model to use for embeddings (Ollama)
+            source_id: Code source this analysis is scoped to (Issue #12356).
+                Folded into the ChromaDB pattern metadata/query filter and the
+                embedding-cache key so one project can never read another
+                project's cross-language patterns when they share a fallback
+                ChromaDB path (e.g. AutoBot's own root).
         """
         self.project_root = Path(project_root) if project_root else Path.cwd()
         self.use_llm = use_llm
         self.use_cache = use_cache
         self.embedding_model = embedding_model
+        # Issue #12356: scope tag for chroma metadata/query and embedding cache.
+        self.source_id = source_id
+        self._source_tag = source_id or "default"
+        # Fold the source tag into the embedding-cache model id (mirrors the
+        # #12251 model-folding trick) so cache reads never cross project
+        # boundaries even if a detector instance is reused across sources. The
+        # real embedding request below still uses ``self.embedding_model``.
+        self._embedding_cache_model = f"{embedding_model}::src::{self._source_tag}"
 
         # Initialize extractors
         self.python_extractor = PythonPatternExtractor()
@@ -189,10 +203,10 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
         if not self.use_llm or not text.strip():
             return None
 
-        # Check cache first
+        # Check cache first (Issue #12356: source-scoped cache key)
         cache = await self._get_embedding_cache()
         if cache:
-            cached = await cache.get(text, model=self.embedding_model)
+            cached = await cache.get(text, model=self._embedding_cache_model)
             if cached:
                 self._cache_hits += 1
                 return cached
@@ -205,7 +219,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
             if embedding:
                 self._embeddings_generated += 1
                 if cache:
-                    await cache.put(text, embedding, model=self.embedding_model)
+                    await cache.put(text, embedding, model=self._embedding_cache_model)
                 return embedding
         except Exception as e:
             logger.warning("Failed to generate embedding: %s", e)
@@ -249,7 +263,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
             if not text or not text.strip():
                 continue
             if cache:
-                cached = await cache.get(text, model=self.embedding_model)
+                cached = await cache.get(text, model=self._embedding_cache_model)
                 if cached:
                     self._cache_hits += 1
                     results[idx] = cached
@@ -278,7 +292,7 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
                     results[idx] = embedding
                     self._embeddings_generated += 1
                     if cache:
-                        await cache.put(text, embedding, model=self.embedding_model)
+                        await cache.put(text, embedding, model=self._embedding_cache_model)
 
         logger.info(
             "Batch generated %d embeddings (%d concurrent)",
@@ -831,11 +845,15 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
         Build metadata dictionary for a single pattern.
 
         Issue #620.
+        Issue #12356: Tag every stored pattern with ``source_id`` so the query
+        filter can scope matches to a single project — without it, patterns from
+        different sources sharing a fallback ChromaDB path would cross-match.
         """
         return {
             "language": pattern["language"],
             "type": str(pattern["pattern"].get("type", "unknown")),
             "name": pattern["pattern"].get("name", ""),
+            "source_id": self._source_tag,
         }
 
     async def _batch_insert_patterns(self, collection, patterns: List[Dict]) -> bool:
@@ -980,12 +998,16 @@ class CrossLanguagePatternDetector(AsyncRedisClientLockedMixin):
         matches = []
         ts_pattern_lookup = {p["id"]: p for p in typescript_patterns}
 
+        # Issue #12356: constrain matches to this project's stored patterns so
+        # a shared/fallback ChromaDB path can never surface another source's
+        # patterns (mirrors the dependencies.py source_id where-filter).
+        match_where = {"$and": [{"language": "typescript"}, {"source_id": self._source_tag}]}
         for py_p in python_patterns[:50]:
             try:
                 results = await collection.query(
                     query_embeddings=[py_p["embedding"]],
                     n_results=5,
-                    where={"language": "typescript"},
+                    where=match_where,
                 )
                 matches.extend(self._process_query_results(results, py_p, ts_pattern_lookup))
             except Exception as e:

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -20884,6 +20884,9 @@ export interface paths {
          *     Args:
          *         use_llm: Whether to use LLM for semantic analysis (default: True)
          *         use_cache: Whether to cache results (default: True)
+         *         source_id: Scope the scan and cache to the selected code source
+         *             (Issue #12356). Falls back to AutoBot's own root only when no source
+         *             is resolvable.
          *
          *     Returns:
          *         Complete analysis results with all detected patterns
@@ -20908,6 +20911,7 @@ export interface paths {
          *
          *     Returns cached results if available, otherwise returns empty status.
          *     Use POST /cross-language/analyze to trigger a new analysis.
+         *     Issue #12356: Reads only the selected source's cached analysis.
          */
         get: operations["get_cross_language_summary_api_analytics_codebase_cross_language_summary_get"];
         put?: never;
@@ -20930,6 +20934,7 @@ export interface paths {
          * @description Get DTO/type mismatches between backend and frontend.
          *
          *     Returns mismatches where Python models and TypeScript interfaces differ.
+         *     Issue #12356: Reads only the selected source's cached analysis.
          */
         get: operations["get_dto_mismatches_api_analytics_codebase_cross_language_dto_mismatches_get"];
         put?: never;
@@ -20952,6 +20957,7 @@ export interface paths {
          * @description Get duplicated validation logic across languages.
          *
          *     Returns validation rules that exist in both Python and TypeScript.
+         *     Issue #12356: Reads only the selected source's cached analysis.
          */
         get: operations["get_validation_duplications_api_analytics_codebase_cross_language_validation_duplications_get"];
         put?: never;
@@ -20976,6 +20982,8 @@ export interface paths {
          *     Returns endpoints that are:
          *     - Orphaned (backend has, frontend doesn't call)
          *     - Missing (frontend calls, backend doesn't have)
+         *
+         *     Issue #12356: Reads only the selected source's cached analysis.
          */
         get: operations["get_api_contract_mismatches_api_analytics_codebase_cross_language_api_mismatches_get"];
         put?: never;
@@ -21003,6 +21011,7 @@ export interface paths {
          *     Args:
          *         min_similarity: Minimum similarity score (0.0-1.0, default: 0.7)
          *         limit: Maximum number of matches to return (default: 50)
+         *         source_id: Scope to the selected code source (Issue #12356)
          */
         get: operations["get_semantic_matches_api_analytics_codebase_cross_language_semantic_matches_get"];
         put?: never;
@@ -21028,6 +21037,7 @@ export interface paths {
          *         category: Filter by category (api_contract, data_types, validation, etc.)
          *         severity: Filter by severity (critical, high, medium, low, info)
          *         limit: Maximum patterns to return (default: 100)
+         *         source_id: Scope to the selected code source (Issue #12356)
          */
         get: operations["get_patterns_by_category_api_analytics_codebase_cross_language_patterns_get"];
         put?: never;
@@ -21052,6 +21062,8 @@ export interface paths {
          * @description Clear the cross-language analysis cache.
          *
          *     Call this after making code changes to get fresh results.
+         *     Issue #12356: Clears only the requested source's entry so clearing one
+         *     project's cache does not evict another project's cached analysis.
          */
         post: operations["clear_cross_language_cache_api_analytics_codebase_cross_language_clear_cache_post"];
         delete?: never;
@@ -128578,6 +128590,7 @@ export interface operations {
             query?: {
                 use_llm?: boolean;
                 use_cache?: boolean;
+                /** @description #12356: scope analysis to the selected code source */
                 source_id?: string | null;
             };
             header?: never;
@@ -128608,7 +128621,10 @@ export interface operations {
     };
     get_cross_language_summary_api_analytics_codebase_cross_language_summary_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12356: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128622,13 +128638,25 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
     get_dto_mismatches_api_analytics_codebase_cross_language_dto_mismatches_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12356: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128642,13 +128670,25 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
     get_validation_duplications_api_analytics_codebase_cross_language_validation_duplications_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12356: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128664,11 +128704,23 @@ export interface operations {
                     "application/json": unknown;
                 };
             };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
     };
     get_api_contract_mismatches_api_analytics_codebase_cross_language_api_mismatches_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12356: scope to the selected code source */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128682,6 +128734,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -128691,6 +128752,8 @@ export interface operations {
             query?: {
                 min_similarity?: number;
                 limit?: number;
+                /** @description #12356: scope to the selected code source */
+                source_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -128724,6 +128787,8 @@ export interface operations {
                 category?: string | null;
                 severity?: string | null;
                 limit?: number;
+                /** @description #12356: scope to the selected code source */
+                source_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -128753,7 +128818,10 @@ export interface operations {
     };
     clear_cross_language_cache_api_analytics_codebase_cross_language_clear_cache_post: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description #12356: clear only this source's cache entry */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -128767,6 +128835,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Thinking Path

#12355 scoped 5 leaking Codebase Analytics endpoints for #12330 but deliberately left `cross_language_patterns.py` out: its `CrossLanguagePatternDetector` couples `project_root` to its ChromaDB/embedding-cache path, so a scoped fix was flagged as behaviorally risky. This PR closes that remaining leak, mirroring #12355's pattern exactly and extending it into the detector.

The leak: every `/cross-language/*` request built the detector with **no `project_root`** (→ `Path.cwd()`, AutoBot's own root) and cached results under a single global `_analysis_cache["latest"]`. The detector also stored/queried its ChromaDB pattern collection with only a `language` filter. So opening project A's cross-language analysis could return project B's DTO/API/validation/semantic patterns.

## What Changed

**Endpoint — `api/codebase_analytics/endpoints/cross_language_patterns.py`**
- All 8 routes now accept `source_id` (`analyze`, `summary`, `dto-mismatches`, `validation-duplications`, `api-mismatches`, `semantic-matches`, `patterns`, `clear-cache`).
- `run_cross_language_analysis` resolves the scan root via `await resolve_scan_root(source_id)` (shared helper added by #12355) and binds the detector to it; falls back to AutoBot's own root only when no source resolves — never another source's.
- `_analysis_cache` is keyed per source via `_cache_key(source_id)` (mirrors `api_endpoints.py`); the global `"latest"` entry and the `global` full-cache wipe are gone. GET routes read only their source's entry through a shared `_get_cached_analysis` helper; `clear-cache` evicts only the requested source.

**Detector — `code_intelligence/cross_language_patterns/detector.py`**
- New optional `source_id` param (backward-compatible; other callers unaffected).
- `_build_pattern_metadata` tags every stored ChromaDB record with `source_id` (confirmed the code indexer uses the same `source_id` metadata convention — `chromadb_storage.py`, `dependencies.py`).
- `_query_cross_language_matches` now filters `where={"$and": [{"language": "typescript"}, {"source_id": <tag>}]}` (mirrors `dependencies.py`).
- Embedding-cache reads/writes fold the source tag into the cache-model key (`nomic-embed-text::src::<tag>`, mirroring the #12251 model-folding trick) so no cross-project cache read is possible even if a detector instance is reused. The real embedding request still uses the plain model id.
- The per-source `project_root` also makes the detector's ChromaDB path (`project_root/data/chromadb`) per-source, physically isolating collections; the `source_id` tag additionally protects the shared fallback-root case.

No check was weakened. `report.py`'s report pipeline has the same class of leak across all its sub-analyses — larger blast radius, filed as fast-follow **#12372** (my detector change is backward-compatible, no regression there).

## Verification

- `python -m py_compile`, `black --check`, `flake8` (repo `.flake8`): all clean on both changed source files.
- New isolation test `cross_language_scoping_test.py` (mirrors #12355's `cross_project_scoping_test.py`) — **8 passed**:
  - endpoint: per-source cache key; `analyze` binds detector to the source's clone path + tag and caches under the per-source key (never `"latest"`); project A's cached analysis is invisible to a project-B request (`dto-mismatches` 400 + `summary` empty, no A bytes in B's body); `clear-cache` scoped to one source.
  - detector (real module, loaded under a synthetic package so the conftest `code_intelligence` stub is untouched): stored-pattern metadata carries `source_id`; query `where` filters by `source_id`; embedding-cache key differs per source.
- Sibling `cross_project_scoping_test.py` + new test run together: **14 passed**.

Adding `source_id` query params changes the OpenAPI schema, so `autobot-frontend/src/types/generated/api.ts` will be regenerated by the CI auto-fix (same as #12355).

## Model Used

claude-opus-4-8

Closes #12356
Refs #12330 #12364 #12372