### PR TITLE
fix(security): authorize source_id against caller in analytics scoping (#12358)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/indexing.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/indexing.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -193,7 +193,7 @@ def _create_cleanup_callback(task_id: str):
     operation="index_codebase",
     error_code_prefix="CODEBASE",
 )
-async def index_codebase(request: IndexCodebaseRequest | None = None):
+async def index_codebase(http_request: Request, request: IndexCodebaseRequest | None = None):
     """
     Start background indexing of a codebase path (Issue #398: refactored, #1133: queued).
 
@@ -201,6 +201,17 @@ async def index_codebase(request: IndexCodebaseRequest | None = None):
     Returns immediately with a task_id. If another job is running, queues the request.
     """
     global _current_indexing_task_id
+
+    # Issue #12358: the source_id here arrives in the request body, so the
+    # router-level require_source_access dependency (path/query only) cannot see
+    # it. Authorize it explicitly before resolving the source's clone path.
+    if request and request.source_id:
+        from auth_middleware import get_current_user  # noqa: PLC0415
+
+        from .shared import authorize_source_access  # noqa: PLC0415
+
+        user = await get_current_user(http_request)
+        await authorize_source_access(request.source_id, user)
 
     path_or_sync = await _validate_and_get_path(request)
 

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -14,7 +14,7 @@ import json
 from typing import Any, Dict, List
 
 from celery.result import AsyncResult
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from autobot_shared.logging_manager import get_logger
@@ -138,8 +138,22 @@ async def _clear_checkpoint(task_id: str) -> None:
 
 
 @router.post("/patterns/analyze", response_model=PatternAnalysisStatus)
-async def start_pattern_analysis(request: PatternAnalysisRequest) -> PatternAnalysisStatus:
+async def start_pattern_analysis(
+    request: PatternAnalysisRequest, http_request: Request
+) -> PatternAnalysisStatus:
     """Enqueue code pattern analysis as a Celery task (GH#6505, GH#8436)."""
+    # #12375: source_id arrives in the request BODY here, so the router-level
+    # require_source_access dependency (which reads path/query params only)
+    # cannot gate it. Authorize the caller against it in-handler, mirroring the
+    # index endpoint, so one admin cannot scope a task to another's private source.
+    if request.source_id:
+        from auth_middleware import get_current_user  # noqa: PLC0415
+
+        from .shared import authorize_source_access  # noqa: PLC0415
+
+        user = await get_current_user(http_request)
+        await authorize_source_access(request.source_id, user)
+
     celery_result = run_pattern_analysis.delay(request.model_dump())
     prefix = f"{_REDIS_PREFIX}{request.source_id}:" if request.source_id else _REDIS_PREFIX
     await store_latest_task_id(prefix, celery_result.id)

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -138,9 +138,7 @@ async def _clear_checkpoint(task_id: str) -> None:
 
 
 @router.post("/patterns/analyze", response_model=PatternAnalysisStatus)
-async def start_pattern_analysis(
-    request: PatternAnalysisRequest, http_request: Request
-) -> PatternAnalysisStatus:
+async def start_pattern_analysis(request: PatternAnalysisRequest, http_request: Request) -> PatternAnalysisStatus:
     """Enqueue code pattern analysis as a Celery task (GH#6505, GH#8436)."""
     # #12375: source_id arrives in the request BODY here, so the router-level
     # require_source_access dependency (which reads path/query params only)

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -8,6 +8,8 @@ Shared utilities and constants for codebase analytics endpoints
 
 from pathlib import Path
 
+from fastapi import HTTPException, Request, status
+
 from autobot_shared.logging_manager import get_logger
 
 # Logger
@@ -209,6 +211,62 @@ async def resolve_scan_root(source_id: "str | None", use_default: bool = True) -
     if source_root:
         return source_root
     return get_project_root()
+
+
+def _caller_owner_id(user: "dict | None") -> "str | None":
+    """Derive the caller's ownership identity from an auth user dict (#12358).
+
+    Mirrors how ``owner_id`` is written when a source is created (see
+    ``llc/api/sprints.py``): the user ``id``, falling back to the legacy
+    ``user_id`` key. Returns None for identity-less callers (e.g. the internal
+    service API key, which yields a synthetic admin with no id) so they retain
+    unscoped access via ``_is_visible``.
+    """
+    if not user:
+        return None
+    caller = str(user.get("id") or user.get("user_id") or "")
+    return caller or None
+
+
+async def authorize_source_access(source_id: "str | None", user: "dict | None") -> None:
+    """Enforce that ``user`` may access the code source ``source_id`` (#12358).
+
+    The codebase-analytics router is admin-gated, but an individual source can be
+    PRIVATE to a specific owner; admin role alone must not expose one admin's
+    private source to another. This reuses ``_is_visible`` — the same
+    owner/shared/public model ``list_sources`` uses — so authorization stays
+    consistent rather than inventing a parallel check.
+
+    No-op when ``source_id`` is falsy (the scan then falls back to the caller's
+    default source or the AutoBot project root). Raises 404 (never 403) on an
+    unknown or unauthorized source so cross-tenant source existence is not
+    disclosed, matching the repository's cross-tenant 404 convention.
+    """
+    if not source_id:
+        return
+    from api.codebase_analytics.source_storage import _is_visible, get_source
+
+    source = await get_source(source_id)
+    if source is None or not _is_visible(source, _caller_owner_id(user)):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Code source not found",
+        )
+
+
+async def require_source_access(request: Request) -> None:
+    """FastAPI dependency: authorize the request's ``source_id`` against the caller.
+
+    Applied at the analytics router level (#12358) so every source-scoped
+    endpoint enforces per-source ownership on top of the admin gate. Reads
+    ``source_id`` from the path or query string; the single body-supplied
+    source_id (the index endpoint) is authorized inside its handler.
+    """
+    from auth_middleware import get_current_user  # noqa: PLC0415
+
+    user = await get_current_user(request)
+    source_id = request.path_params.get("source_id") or request.query_params.get("source_id")
+    await authorize_source_access(source_id, user)
 
 
 # Project root helper

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -213,19 +213,36 @@ async def resolve_scan_root(source_id: "str | None", use_default: bool = True) -
     return get_project_root()
 
 
+# Sentinel ownership id for an authenticated, non-service caller whose token
+# carries no derivable identity. It can never equal a real ``owner_id``, so
+# ``_is_visible`` denies another owner's PRIVATE source while still allowing
+# public/shared/unowned ones — i.e. fail-closed, rather than the see-all that a
+# bare ``None`` would grant (#12375 review item c).
+_NO_OWNER_ID = "\x00::codebase-analytics::no-owner::"
+
+
 def _caller_owner_id(user: "dict | None") -> "str | None":
     """Derive the caller's ownership identity from an auth user dict (#12358).
 
     Mirrors how ``owner_id`` is written when a source is created (see
     ``llc/api/sprints.py``): the user ``id``, falling back to the legacy
-    ``user_id`` key. Returns None for identity-less callers (e.g. the internal
-    service API key, which yields a synthetic admin with no id) so they retain
-    unscoped access via ``_is_visible``.
+    ``user_id`` key.
+
+    Only the internal service API key — which ``auth_middleware`` mints as
+    ``{"service": True}`` with no id — is trusted for unscoped access (returns
+    ``None`` → ``_is_visible`` see-all). Any *other* authenticated caller with no
+    derivable id (e.g. an SLM-minted token carrying identity only in ``sub``)
+    fails closed to ``_NO_OWNER_ID`` so admin role alone cannot expose another
+    owner's PRIVATE source (#12375 review item c).
     """
     if not user:
         return None
     caller = str(user.get("id") or user.get("user_id") or "")
-    return caller or None
+    if caller:
+        return caller
+    if user.get("service"):
+        return None
+    return _NO_OWNER_ID
 
 
 async def authorize_source_access(source_id: "str | None", user: "dict | None") -> None:
@@ -259,8 +276,9 @@ async def require_source_access(request: Request) -> None:
 
     Applied at the analytics router level (#12358) so every source-scoped
     endpoint enforces per-source ownership on top of the admin gate. Reads
-    ``source_id`` from the path or query string; the single body-supplied
-    source_id (the index endpoint) is authorized inside its handler.
+    ``source_id`` from the path or query string; endpoints that take source_id
+    in the request body (the index and pattern-analyze endpoints) authorize it
+    inside their own handlers via ``authorize_source_access`` (#12375).
     """
     from auth_middleware import get_current_user  # noqa: PLC0415
 

--- a/autobot-backend/api/codebase_analytics/endpoints/source_authorization_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/source_authorization_test.py
@@ -36,12 +36,18 @@ class TestCallerOwnerId:
         assert _caller_owner_id({"id": "alice", "user_id": "ignored"}) == "alice"
         assert _caller_owner_id({"user_id": "bob"}) == "bob"
 
-    def test_none_for_identityless_caller(self):
-        """Internal service key yields a synthetic admin with no id -> unscoped."""
-        from api.codebase_analytics.endpoints.shared import _caller_owner_id
+    def test_none_only_for_service_key_not_other_identityless(self):
+        """Only the internal service key ({"service": True}) is unscoped; any other
+        identity-less authenticated caller (e.g. a sub-only token) fails closed."""
+        from api.codebase_analytics.endpoints.shared import _NO_OWNER_ID, _caller_owner_id
 
         assert _caller_owner_id(None) is None
-        assert _caller_owner_id({"username": "service:slm", "role": "admin"}) is None
+        # Real internal-service dict (auth_middleware.py: minted with service=True).
+        assert _caller_owner_id({"username": "service:slm", "role": "admin", "service": True}) is None
+        # #12375 item c: an SLM-minted token carrying identity only in sub/username
+        # (no id/user_id and NOT the service key) must NOT get unscoped see-all.
+        assert _caller_owner_id({"sub": "carol", "role": "admin"}) == _NO_OWNER_ID
+        assert _caller_owner_id({"username": "dave", "role": "admin"}) == _NO_OWNER_ID
 
 
 class TestAuthorizeSourceAccess:
@@ -90,7 +96,7 @@ class TestAuthorizeSourceAccess:
             await shared.authorize_source_access(src.id, {"id": "bob"})
 
     async def test_service_caller_allowed(self):
-        """Internal service key (no id) keeps unscoped access to any source."""
+        """Internal service key (service=True, no id) keeps unscoped access to any source."""
         from api.codebase_analytics.endpoints import shared
 
         src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
@@ -98,7 +104,31 @@ class TestAuthorizeSourceAccess:
             "api.codebase_analytics.source_storage.get_source",
             AsyncMock(return_value=src),
         ):
-            await shared.authorize_source_access(src.id, {"username": "service:slm", "role": "admin"})
+            await shared.authorize_source_access(
+                src.id, {"username": "service:slm", "role": "admin", "service": True}
+            )
+
+    async def test_subonly_token_denied_on_foreign_private(self):
+        """#12375 item c: an authenticated admin whose token carries only sub/username
+        (no id, not the service key) must be denied a foreign PRIVATE source, not
+        granted unscoped see-all. Non-disclosing 404."""
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await shared.authorize_source_access(src.id, {"sub": "mallory", "role": "admin"})
+            assert exc.value.status_code == 404
+            # But a PUBLIC source is still reachable by the same identity-less caller.
+            pub = _source(owner_id="alice", access=SourceAccess.PUBLIC)
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=pub),
+        ):
+            await shared.authorize_source_access(pub.id, {"sub": "mallory", "role": "admin"})
 
     async def test_foreign_private_source_returns_404(self):
         """The bug: another admin's PRIVATE source must 404, not return data."""
@@ -204,3 +234,53 @@ class TestRequireSourceAccessDependency:
         ):
             await shared.require_source_access(req)
         get_source.assert_not_called()
+
+
+class TestPatternAnalyzeBodyAuthz:
+    """#12375 item a: /patterns/analyze takes source_id in the BODY, so the
+    router-level require_source_access (path/query only) cannot gate it; the
+    handler must authorize it before enqueuing the Celery task."""
+
+    async def _call(self, user, src):
+        from api.codebase_analytics.endpoints import pattern_analysis as pa
+
+        req = pa.PatternAnalysisRequest(source_id="s1", path="/tmp/proj")
+        delay = _FakeDelay()
+        with patch.object(pa.run_pattern_analysis, "delay", delay), patch.object(
+            pa, "store_latest_task_id", AsyncMock()
+        ), patch(
+            "auth_middleware.get_current_user", AsyncMock(return_value=user)
+        ), patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            result = await pa.start_pattern_analysis(req, _FakeRequest())
+        return result, delay
+
+    async def test_foreign_private_source_blocks_before_enqueue(self):
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        with pytest.raises(HTTPException) as exc:
+            await self._call({"id": "bob"}, src)
+        assert exc.value.status_code == 404
+
+    async def test_owner_may_enqueue(self):
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        result, delay = await self._call({"id": "alice"}, src)
+        assert delay.called
+        assert result.status == "pending"
+
+
+class _FakeDelay:
+    called = False
+
+    def __call__(self, *a, **k):
+        self.called = True
+
+        class _R:
+            id = "task-123"
+
+        return _R()
+
+
+class _FakeRequest:
+    """Minimal stand-in; get_current_user is patched so its internals are unused."""

--- a/autobot-backend/api/codebase_analytics/endpoints/source_authorization_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/source_authorization_test.py
@@ -104,9 +104,7 @@ class TestAuthorizeSourceAccess:
             "api.codebase_analytics.source_storage.get_source",
             AsyncMock(return_value=src),
         ):
-            await shared.authorize_source_access(
-                src.id, {"username": "service:slm", "role": "admin", "service": True}
-            )
+            await shared.authorize_source_access(src.id, {"username": "service:slm", "role": "admin", "service": True})
 
     async def test_subonly_token_denied_on_foreign_private(self):
         """#12375 item c: an authenticated admin whose token carries only sub/username
@@ -246,13 +244,14 @@ class TestPatternAnalyzeBodyAuthz:
 
         req = pa.PatternAnalysisRequest(source_id="s1", path="/tmp/proj")
         delay = _FakeDelay()
-        with patch.object(pa.run_pattern_analysis, "delay", delay), patch.object(
-            pa, "store_latest_task_id", AsyncMock()
-        ), patch(
-            "auth_middleware.get_current_user", AsyncMock(return_value=user)
-        ), patch(
-            "api.codebase_analytics.source_storage.get_source",
-            AsyncMock(return_value=src),
+        with (
+            patch.object(pa.run_pattern_analysis, "delay", delay),
+            patch.object(pa, "store_latest_task_id", AsyncMock()),
+            patch("auth_middleware.get_current_user", AsyncMock(return_value=user)),
+            patch(
+                "api.codebase_analytics.source_storage.get_source",
+                AsyncMock(return_value=src),
+            ),
         ):
             result = await pa.start_pattern_analysis(req, _FakeRequest())
         return result, delay

--- a/autobot-backend/api/codebase_analytics/endpoints/source_authorization_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/source_authorization_test.py
@@ -1,0 +1,206 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Authorization tests for source-scoped codebase analytics (Issue #12358).
+
+The codebase-analytics router is admin-gated, but ``resolve_scan_root`` /
+``get_source`` previously scoped to ANY ``source_id`` with no owner check, so one
+admin could read another admin's PRIVATE source analytics. These tests assert the
+per-source authorization layer: a caller may only reach a source they OWN, one
+SHARED with them, a PUBLIC source, or an unowned/legacy source. An owned PRIVATE
+source belonging to someone else returns 404 (non-disclosing), never the data.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.codebase_analytics.source_models import CodeSource, SourceAccess
+
+
+def _source(**kwargs) -> CodeSource:
+    defaults = {"name": "proj", "clone_path": "/tmp/proj"}
+    defaults.update(kwargs)
+    return CodeSource(**defaults)
+
+
+class TestCallerOwnerId:
+    """The caller identity must match how owner_id is written on create."""
+
+    def test_prefers_id_then_user_id(self):
+        from api.codebase_analytics.endpoints.shared import _caller_owner_id
+
+        assert _caller_owner_id({"id": "alice", "user_id": "ignored"}) == "alice"
+        assert _caller_owner_id({"user_id": "bob"}) == "bob"
+
+    def test_none_for_identityless_caller(self):
+        """Internal service key yields a synthetic admin with no id -> unscoped."""
+        from api.codebase_analytics.endpoints.shared import _caller_owner_id
+
+        assert _caller_owner_id(None) is None
+        assert _caller_owner_id({"username": "service:slm", "role": "admin"}) is None
+
+
+class TestAuthorizeSourceAccess:
+    """authorize_source_access enforces _is_visible for the calling user."""
+
+    async def test_owner_allowed(self):
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            # Owner reaching their own PRIVATE source: no exception raised.
+            await shared.authorize_source_access(src.id, {"id": "alice"})
+
+    async def test_shared_with_allowed(self):
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.SHARED, shared_with=["bob"])
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            await shared.authorize_source_access(src.id, {"id": "bob"})
+
+    async def test_public_allowed(self):
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.PUBLIC)
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            await shared.authorize_source_access(src.id, {"id": "bob"})
+
+    async def test_unowned_source_allowed(self):
+        """Legacy/service-created source (owner_id None) stays admin-accessible."""
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id=None, access=SourceAccess.PRIVATE)
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            await shared.authorize_source_access(src.id, {"id": "bob"})
+
+    async def test_service_caller_allowed(self):
+        """Internal service key (no id) keeps unscoped access to any source."""
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            await shared.authorize_source_access(src.id, {"username": "service:slm", "role": "admin"})
+
+    async def test_foreign_private_source_returns_404(self):
+        """The bug: another admin's PRIVATE source must 404, not return data."""
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await shared.authorize_source_access(src.id, {"id": "bob"})
+        assert exc.value.status_code == 404
+
+    async def test_shared_source_but_not_shared_with_caller_returns_404(self):
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.SHARED, shared_with=["carol"])
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=src),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await shared.authorize_source_access(src.id, {"id": "bob"})
+        assert exc.value.status_code == 404
+
+    async def test_unknown_source_returns_404(self):
+        """A source_id that does not exist is non-disclosing (404)."""
+        from api.codebase_analytics.endpoints import shared
+
+        with patch(
+            "api.codebase_analytics.source_storage.get_source",
+            AsyncMock(return_value=None),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await shared.authorize_source_access("ghost", {"id": "bob"})
+        assert exc.value.status_code == 404
+
+    async def test_falsy_source_id_is_noop(self):
+        """No source_id -> scan falls back to default/project root; no authz call."""
+        from api.codebase_analytics.endpoints import shared
+
+        get_source = AsyncMock(return_value=None)
+        with patch("api.codebase_analytics.source_storage.get_source", get_source):
+            await shared.authorize_source_access(None, {"id": "bob"})
+            await shared.authorize_source_access("", {"id": "bob"})
+        get_source.assert_not_called()
+
+
+class TestRequireSourceAccessDependency:
+    """The router dependency reads source_id from path/query and enforces authz."""
+
+    def _request(self, *, path_params=None, query_params=None):
+        from starlette.datastructures import QueryParams
+
+        class _Req:
+            pass
+
+        req = _Req()
+        req.path_params = path_params or {}
+        req.query_params = QueryParams(query_params or {})
+        return req
+
+    async def test_query_source_id_authorized(self):
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        req = self._request(query_params={"source_id": src.id})
+        with (
+            patch("auth_middleware.get_current_user", AsyncMock(return_value={"id": "bob"})),
+            patch(
+                "api.codebase_analytics.source_storage.get_source",
+                AsyncMock(return_value=src),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await shared.require_source_access(req)
+        assert exc.value.status_code == 404
+
+    async def test_path_source_id_authorized(self):
+        from api.codebase_analytics.endpoints import shared
+
+        src = _source(owner_id="alice", access=SourceAccess.PRIVATE)
+        req = self._request(path_params={"source_id": src.id})
+        with (
+            patch("auth_middleware.get_current_user", AsyncMock(return_value={"id": "alice"})),
+            patch(
+                "api.codebase_analytics.source_storage.get_source",
+                AsyncMock(return_value=src),
+            ),
+        ):
+            # Owner via path param: allowed, no exception.
+            await shared.require_source_access(req)
+
+    async def test_no_source_id_is_noop(self):
+        from api.codebase_analytics.endpoints import shared
+
+        req = self._request()
+        get_source = AsyncMock(return_value=None)
+        with (
+            patch("auth_middleware.get_current_user", AsyncMock(return_value={"id": "bob"})),
+            patch("api.codebase_analytics.source_storage.get_source", get_source),
+        ):
+            await shared.require_source_access(req)
+        get_source.assert_not_called()

--- a/autobot-backend/api/codebase_analytics/router.py
+++ b/autobot-backend/api/codebase_analytics/router.py
@@ -33,11 +33,14 @@ from .endpoints import (
     sources,
     stats,
 )
+from .endpoints.shared import require_source_access  # Issue #12358: per-source authz
 
 # Create main router — prefix provided by analytics_routers.py registry (#1027)
+# Issue #12358: check_admin_permission gates the router; require_source_access adds
+# per-source ownership so one admin cannot read another admin's PRIVATE source.
 router = APIRouter(
     tags=["codebase-analytics"],
-    dependencies=[Depends(check_admin_permission)],
+    dependencies=[Depends(check_admin_permission), Depends(require_source_access)],
 )
 
 # Include all endpoint routers

--- a/autobot-backend/api/codebase_analytics/source_storage.py
+++ b/autobot-backend/api/codebase_analytics/source_storage.py
@@ -59,6 +59,11 @@ def _is_visible(source: CodeSource, owner_id: str | None) -> bool:
     """Return True if the source should appear in the list for owner_id."""
     if owner_id is None:
         return True
+    if source.owner_id is None:
+        # Unowned/legacy or service-created source — there is no owner to gate
+        # against, so access is controlled solely by the caller's admin role
+        # (#12358). Prevents the ownership check from hiding pre-ownership sources.
+        return True
     if source.owner_id == owner_id:
         return True
     if source.access == SourceAccess.PUBLIC:


### PR DESCRIPTION
## Thinking Path
`#12355` fixed cross-project analytics *data* leakage (scoping scans to the passed `source_id`). This closes the *authorization* gap it surfaced: `source_storage.get_source(source_id)` / `resolve_scan_root(source_id)` scoped to ANY `source_id` with no owner check, so — inside the admin-gated analytics router — one admin could read another admin's **PRIVATE** source analytics. The `owner_id`/`SourceAccess`/`shared_with` model (`_is_visible`) was only ever consulted by `list_sources`.

The fix reuses the existing `_is_visible` model rather than inventing new authz, and threads the caller in one place (a router-level FastAPI dependency) so the change stays minimal and does not touch the ~9 endpoint files (avoids conflict with the in-flight `#12356`, which touches `cross_language_patterns.py`).

## What Changed
- **`source_storage.py::_is_visible`** — exempt unowned/legacy sources (`owner_id is None`, e.g. HTTP- or service-created) so the new check never hides pre-ownership sources. Owned PRIVATE sources stay gated.
- **`endpoints/shared.py`** — new `authorize_source_access(source_id, user)` guard: resolves the source and enforces `_is_visible(source, caller)`, raising **404** (non-disclosing, per the repo's cross-tenant convention) on an unknown *or* unauthorized source; no-op on a falsy `source_id`. `_caller_owner_id(user)` derives the caller identity the same way `owner_id` is written on create (`id` → `user_id`; `None` for the identity-less internal service key → unscoped). `require_source_access(request)` is the FastAPI dependency (single `Request` param → no signature-inspection issues) that reads `source_id` from path **or** query and calls the guard.
- **`router.py`** — added `Depends(require_source_access)` alongside `check_admin_permission`, giving blanket per-source authz to every source-scoped analytics endpoint (all take `source_id` as a query/path param).
- **`endpoints/indexing.py`** — the index endpoint's `source_id` arrives in the request body (invisible to the router dependency), so it is authorized explicitly in the handler.
- **`endpoints/source_authorization_test.py`** — new regression tests.

Where enforced: router-level dependency `require_source_access` for all query/path `source_id` endpoints (call-graph, dependencies, import-tree, api-endpoints, duplicates, ownership, env, stats, report, and the `sources/{source_id}` CRUD routes); explicit guard in `index_codebase` for the body `source_id`. Caller threaded via `get_current_user(request)` inside the dependency.

The admin gate is untouched — this ADDS per-source ownership on top. The internal service key keeps unscoped access. `list_sources` (source registry listing) is intentionally left unchanged; this PR scopes the analytics data path per the issue.

## Verification
- `black` + repo `.flake8` (ignores E402): clean on all 5 files.
- `python -m pytest source_authorization_test.py cross_project_scoping_test.py` → **20 passed** (14 new + 6 `#12355` regression, no regression).
- New tests assert: unauthorized foreign PRIVATE source → **404** (not the data); owner → allowed; shared-with → allowed; public → allowed; unowned/service → allowed; unknown `source_id` → 404; falsy `source_id` → no-op; dependency enforces both path- and query-supplied `source_id`.
- Full `api/codebase_analytics/` suite: 135 passed; 9 pre-existing failures are environmental (Redis unavailable + a doubled-path artifact) and reference none of the changed modules.

Discovered (not changed here — behavior/product decision): HTTP `POST /sources` (`create_code_source`) does not capture `owner_id`, so HTTP-created sources are unowned and thus visible to all admins; only the LLC path (`sprints.py`) sets `owner_id`. This PR protects owned PRIVATE sources; capturing owner on HTTP create would extend protection and can be a fast-follow.

## Model Used
claude-opus-4-8

Closes #12358
Refs #12330 #12355 #12364
