### PR TITLE
fix(frontend): repoint drifted dead API paths + teach audit to see getApiBase() (#12326)

### DIFF
--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -109,7 +109,7 @@ export function useBatchProcessingApi() {
 
     async listTemplates(): Promise<BatchTemplatesListResponse | null> {
       try {
-        return await api.get<BatchTemplatesListResponse>(`${getApiBase()}/batch-templates`)
+        return await api.get<BatchTemplatesListResponse>(`${getApiBase()}/batch-jobs/templates/`)
       } catch (error: unknown) {
         logger.error('Failed to load batch templates', error)
         showSubtleErrorNotification('Error', 'Failed to load batch templates', 'error')
@@ -119,7 +119,7 @@ export function useBatchProcessingApi() {
 
     async createTemplate(request: CreateBatchTemplateRequest): Promise<BatchTemplate | null> {
       try {
-        return await api.post<BatchTemplate>(`${getApiBase()}/batch-templates`, request)
+        return await api.post<BatchTemplate>(`${getApiBase()}/batch-jobs/templates/`, request)
       } catch (error: unknown) {
         logger.error('Failed to create batch template', error)
         showSubtleErrorNotification('Error', 'Failed to create batch template', 'error')
@@ -129,7 +129,7 @@ export function useBatchProcessingApi() {
 
     async deleteTemplate(templateId: string): Promise<{ status: string } | null> {
       try {
-        return await api.delete<{ status: string }>(`${getApiBase()}/batch-templates/${templateId}`)
+        return await api.delete<{ status: string }>(`${getApiBase()}/batch-jobs/templates/${templateId}`)
       } catch (error: unknown) {
         logger.error('Failed to delete batch template', error)
         showSubtleErrorNotification('Error', 'Failed to delete batch template', 'error')
@@ -139,7 +139,7 @@ export function useBatchProcessingApi() {
 
     async listSchedules(): Promise<BatchSchedulesListResponse | null> {
       try {
-        return await api.get<BatchSchedulesListResponse>(`${getApiBase()}/batch-schedules`)
+        return await api.get<BatchSchedulesListResponse>(`${getApiBase()}/batch-jobs/schedules/`)
       } catch (error: unknown) {
         logger.error('Failed to load batch schedules', error)
         showSubtleErrorNotification('Error', 'Failed to load batch schedules', 'error')
@@ -149,7 +149,7 @@ export function useBatchProcessingApi() {
 
     async createSchedule(request: CreateBatchScheduleRequest): Promise<BatchSchedule | null> {
       try {
-        return await api.post<BatchSchedule>(`${getApiBase()}/batch-schedules`, request)
+        return await api.post<BatchSchedule>(`${getApiBase()}/batch-jobs/schedules/`, request)
       } catch (error: unknown) {
         logger.error('Failed to create batch schedule', error)
         showSubtleErrorNotification('Error', 'Failed to create batch schedule', 'error')
@@ -159,7 +159,10 @@ export function useBatchProcessingApi() {
 
     async toggleSchedule(scheduleId: string, enabled: boolean): Promise<BatchSchedule | null> {
       try {
-        return await api.patch(`${getApiBase()}/batch-schedules/${scheduleId}`, { enabled })
+        // #12326: corrected prefix to /batch-jobs/schedules. NOTE: backend does
+        // not yet expose PATCH /api/batch-jobs/schedules/{id} (only GET/POST on
+        // the collection and DELETE on the item) — tracked as a backend gap.
+        return await api.patch(`${getApiBase()}/batch-jobs/schedules/${scheduleId}`, { enabled })
       } catch (error: unknown) {
         logger.error('Failed to update batch schedule', error)
         showSubtleErrorNotification('Error', 'Failed to update batch schedule', 'error')
@@ -169,7 +172,7 @@ export function useBatchProcessingApi() {
 
     async deleteSchedule(scheduleId: string): Promise<{ status: string } | null> {
       try {
-        return await api.delete<{ status: string }>(`${getApiBase()}/batch-schedules/${scheduleId}`)
+        return await api.delete<{ status: string }>(`${getApiBase()}/batch-jobs/schedules/${scheduleId}`)
       } catch (error: unknown) {
         logger.error('Failed to delete batch schedule', error)
         showSubtleErrorNotification('Error', 'Failed to delete batch schedule', 'error')

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -161,7 +161,8 @@ export function useBatchProcessingApi() {
       try {
         // #12326: corrected prefix to /batch-jobs/schedules. NOTE: backend does
         // not yet expose PATCH /api/batch-jobs/schedules/{id} (only GET/POST on
-        // the collection and DELETE on the item) — tracked as a backend gap.
+        // the collection and DELETE on the item) — this toggle 405s until the
+        // backend route lands. Tracked in #12380.
         return await api.patch(`${getApiBase()}/batch-jobs/schedules/${scheduleId}`, { enabled })
       } catch (error: unknown) {
         logger.error('Failed to update batch schedule', error)

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -465,7 +465,7 @@ export class KnowledgeRepository extends ApiRepository {
     // those are silently dropped (200 but never persisted). Fold them into `metadata`
     // so they persist, merging (not clobbering) any metadata the caller supplies.
     const { content, category, metadata, title, source, tags } = updates
-    const mergedMetadata: Record<string, unknown> = { ...(metadata ?? {}) }
+    const mergedMetadata: Record<string, unknown> = { ...metadata }
     if (title !== undefined) mergedMetadata.title = title
     if (source !== undefined) mergedMetadata.source = source
     if (tags !== undefined) mergedMetadata.tags = tags

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -455,8 +455,10 @@ export class KnowledgeRepository extends ApiRepository {
    * Update document by ID
    */
   async updateDocument(documentId: string, updates: Partial<KnowledgeDocument>): Promise<KnowledgeDocument> {
-    // Use facts endpoint for consistency with backend
-    const response = await this.put<KnowledgeDocument>(`${getApiBase()}/knowledge_base/facts/${documentId}`, updates)
+    // #12326: backend serves fact update at PUT /api/knowledge-maintenance/fact/{fact_id}
+    // (autobot-backend/api/knowledge_maintenance.py:1435). The prior
+    // /knowledge_base/facts/{id} path 404'd.
+    const response = await this.put<KnowledgeDocument>(`${getApiBase()}/knowledge-maintenance/fact/${documentId}`, updates)
     return response.data
   }
 
@@ -464,8 +466,10 @@ export class KnowledgeRepository extends ApiRepository {
    * Delete document by ID
    */
   async deleteDocument(documentId: string): Promise<{ success: boolean; message: string }> {
-    // Use facts endpoint for consistency with backend
-    const response = await this.delete<{ success: boolean; message: string }>(`${getApiBase()}/knowledge_base/facts/${documentId}`)
+    // #12326: backend serves fact delete at DELETE /api/knowledge-maintenance/fact/{fact_id}
+    // (autobot-backend/api/knowledge_maintenance.py:1477). The prior
+    // /knowledge_base/facts/{id} path 404'd.
+    const response = await this.delete<{ success: boolean; message: string }>(`${getApiBase()}/knowledge-maintenance/fact/${documentId}`)
     return response.data
   }
 
@@ -522,11 +526,11 @@ export class KnowledgeRepository extends ApiRepository {
 
   /**
    * Reindex knowledge base for improved search performance
-   * Issue #552: Note - Backend uses /api/rebuild_index for global reindex
-   * Consider using vectorize_facts/background for knowledge base specific reindex
+   * #12326: backend serves the global reindex at POST /api/knowledge_base/rebuild_index
+   * (the bare /api/rebuild_index path used previously does not exist and 404'd).
    */
   async reindexKnowledgeBase(): Promise<{ success: boolean; message: string }> {
-    const response = await this.post<{ success: boolean; message: string }>(`${getApiBase()}/rebuild_index`)
+    const response = await this.post<{ success: boolean; message: string }>(`${getApiBase()}/knowledge_base/rebuild_index`)
     return response.data
   }
 
@@ -534,7 +538,9 @@ export class KnowledgeRepository extends ApiRepository {
    * Check knowledge base health status
    */
   async checkKnowledgeBaseHealth(): Promise<{ healthy: boolean; message: string }> {
-    const response = await this.get<{ healthy: boolean; message: string }>(`${getApiBase()}/knowledge_base/health`)
+    // #12326: backend serves KB health at GET /api/knowledge_base/health/status
+    // (the bare /knowledge_base/health path 404'd).
+    const response = await this.get<{ healthy: boolean; message: string }>(`${getApiBase()}/knowledge_base/health/status`)
     return response.data
   }
 

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -458,7 +458,24 @@ export class KnowledgeRepository extends ApiRepository {
     // #12326: backend serves fact update at PUT /api/knowledge-maintenance/fact/{fact_id}
     // (autobot-backend/api/knowledge_maintenance.py:1435). The prior
     // /knowledge_base/facts/{id} path 404'd.
-    const response = await this.put<KnowledgeDocument>(`${getApiBase()}/knowledge-maintenance/fact/${documentId}`, updates)
+    //
+    // The backend binds UpdateFactRequest (autobot-backend/api/schemas_knowledge.py:3006)
+    // which only accepts `content`, `category`, and `metadata` (Metadata = Dict[str, Any]).
+    // Callers also send `title`, `source`, and `tags`; with pydantic `extra=ignore`
+    // those are silently dropped (200 but never persisted). Fold them into `metadata`
+    // so they persist, merging (not clobbering) any metadata the caller supplies.
+    const { content, category, metadata, title, source, tags } = updates
+    const mergedMetadata: Record<string, unknown> = { ...(metadata ?? {}) }
+    if (title !== undefined) mergedMetadata.title = title
+    if (source !== undefined) mergedMetadata.source = source
+    if (tags !== undefined) mergedMetadata.tags = tags
+
+    const body: Record<string, unknown> = {}
+    if (content !== undefined) body.content = content
+    if (category !== undefined) body.category = category
+    if (Object.keys(mergedMetadata).length > 0) body.metadata = mergedMetadata
+
+    const response = await this.put<KnowledgeDocument>(`${getApiBase()}/knowledge-maintenance/fact/${documentId}`, body)
     return response.data
   }
 

--- a/autobot-frontend/src/models/repositories/SystemRepository.ts
+++ b/autobot-frontend/src/models/repositories/SystemRepository.ts
@@ -383,8 +383,9 @@ export class SystemRepository extends ApiRepository {
   }
 
   async checkForUpdates(): Promise<unknown> {
-    // Note: Backend doesn't have update check - this is aspirational
-    const response = await this.get(`${getApiBase()}/system/updates/check`)
+    // #12326: backend serves the update check at POST /api/settings/updates/check
+    // (autobot-backend settings router). The prior GET /system/updates/check 404'd.
+    const response = await this.post(`${getApiBase()}/settings/updates/check`)
     return response.data
   }
 

--- a/autobot-frontend/src/services/api.ts
+++ b/autobot-frontend/src/services/api.ts
@@ -142,11 +142,13 @@ class ApiService {
   // Research Agent API
   // #12326: backend serves this at POST /api/agent/research/comprehensive
   // (autobot-backend/api/agent.py:1126). The bare /research/comprehensive path 404'd.
-  async performResearch(query: string, focus = 'general', maxResults = 5): Promise<ApiResponse> {
+  // Body maps to ResearchTaskRequest (autobot-backend/api/schemas_agent.py:1625):
+  // required field is `research_query`; the backend has no `focus`/`max_results`
+  // concept, so those legacy args are ignored. `include_web`/`include_code_search`
+  // default server-side (True/False).
+  async performResearch(query: string): Promise<ApiResponse> {
     return this.post(`${getApiBase()}/agent/research/comprehensive`, {
-      query,
-      focus,
-      max_results: maxResults
+      research_query: query
     })
   }
 

--- a/autobot-frontend/src/services/api.ts
+++ b/autobot-frontend/src/services/api.ts
@@ -140,8 +140,10 @@ class ApiService {
   }
 
   // Research Agent API
+  // #12326: backend serves this at POST /api/agent/research/comprehensive
+  // (autobot-backend/api/agent.py:1126). The bare /research/comprehensive path 404'd.
   async performResearch(query: string, focus = 'general', maxResults = 5): Promise<ApiResponse> {
-    return this.post(`${getApiBase()}/research/comprehensive`, {
+    return this.post(`${getApiBase()}/agent/research/comprehensive`, {
       query,
       focus,
       max_results: maxResults

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -57,6 +57,15 @@ INCLUDE_ROUTER_RE = re.compile(
     r"include_router\(\s*([A-Za-z_][\w.]*)[^)]*?prefix\s*=\s*[\'\"]([^\'\"]+)", re.S
 )
 FE_API_RE = re.compile(r"[\'\"`](/api/[A-Za-z0-9_/${}():.\-]+)")
+# #12326: the dominant idiom composes the path from a helper —
+# ``apiClient.get(`${getApiBase()}/knowledge_base/health/status`)``. getApiBase()
+# resolves to '/api' (see ssot-config.ts:getApiBase), so the real call target is
+# ``/api`` + the captured suffix. Without this the audit only saw literal
+# ``'/api/...'`` strings (~42% of calls) and reported a clean bill while dozens of
+# ``${getApiBase()}/...`` calls hit non-existent routes.
+GETAPIBASE_CALL_RE = re.compile(
+    r"\$\{getApiBase\(\)\}(/[A-Za-z0-9_/${}():.\-]+)"
+)
 # #10037: ``${getBackendUrl()}/<path>`` calls. getBackendUrl() is host-level
 # (no /api), so any <path> that omits /api hits a path the backend doesn't
 # serve. We only flag the high-confidence case where /api<path> IS a real
@@ -242,7 +251,11 @@ def frontend_calls() -> dict[str, set[str]]:
                 # not real calls — skip them.
                 if line.lstrip()[:2] in ("* ", "//", "/*") or line.strip() == "*":
                     continue
-                for m in FE_API_RE.findall(line):
+                # Literal '/api/...' strings and getApiBase()-composed paths
+                # (#12326). getApiBase() -> '/api', so prepend it to the suffix.
+                matched = list(FE_API_RE.findall(line))
+                matched += ["/api" + s for s in GETAPIBASE_CALL_RE.findall(line)]
+                for m in matched:
                     p = norm_path(m)
                     # Unbalanced braces = extraction artifact (brace-expansion
                     # notation inside comments, e.g. `/api/x/{a,b}/y`), not a call.


### PR DESCRIPTION
Closes #12379
Refs #12326 (parent stays open for the analytics/code-intelligence bucket #12364 + no-backend aspirational panels #12378)

## Thinking Path
The reported "77 dead UI calls" was partly misdiagnosed. I built the authoritative route table from `app.openapi()` (2155 HTTP + 25 WS routes) and checked all 77: **12** were genuinely drifted paths, **~26** were live false-positives (base-URL constants, cache-key maps, SLM-backend `tls`/`nodes` calls), **9** belong to the analytics/code-intelligence redesign (#12364), and the remainder are no-backend "aspirational" panels (owner decision #12378).

## What Changed
- Repointed the **12 genuinely-drifted** frontend API paths to verified-real backend routes: KB update/deleteDocument → `/knowledge-maintenance/fact/{id}` (fixes a wired dead delete button), reindex → `/knowledge_base/rebuild_index`, health → `/knowledge_base/health/status`, `checkForUpdates` → `POST /settings/updates/check`, batch templates/schedules → `/batch-jobs/templates|schedules/`, `performResearch` → `/agent/research/comprehensive`.
- Fixed `scripts/audit_api_wiring.py` to resolve `${getApiBase()}` → `/api` (frontend paths seen 208→691; unwired findings surfaced 0→44).
- **Body-contract fixes (post-review):** repointing the path was necessary but not sufficient for two calls that were still failing at runtime:
  - `performResearch` now sends `research_query` (the required field of `ResearchTaskRequest`) instead of `query`/`focus`/`max_results` — the old body 422'd.
  - `updateDocument` now folds `title`/`source`/`tags` into `metadata` so they persist against `UpdateFactRequest` (which only accepts `content`/`category`/`metadata`) instead of being silently dropped.
- **`toggleSchedule` (batch):** the corrected path `PATCH /api/batch-jobs/schedules/{id}` still 405s because `batch_jobs.py` exposes no PATCH route (only GET/POST on the collection, DELETE on the item). The missing backend route is tracked in **#12380**; the UI toggle is left in place with a comment referencing that issue.

## Verification
- All 12 new paths verified against `app.openapi()` (real route + method). Two of them additionally required body-contract fixes to actually succeed at runtime — `performResearch` body → `ResearchTaskRequest.research_query` (`autobot-backend/api/schemas_agent.py:1625`), and `updateDocument` non-first-class fields → `metadata` per `UpdateFactRequest` (`autobot-backend/api/schemas_knowledge.py:3006`). The `toggleSchedule` PATCH has no backend route and is tracked as a missing-endpoint gap in **#12380** (not fixable frontend-side). `black --check` / repo flake8 clean. Frontend verified by inspection (WSL has no npm; CI runs vitest/vue-tsc).

## Model Used
Claude Opus 4.8
