### PR TITLE
fix(analytics): anti-pattern/cached 500 on cache-miss/retrieval error → graceful no_data 200 (#12382)

### DIFF
--- a/autobot-backend/api/anti_pattern.py
+++ b/autobot-backend/api/anti_pattern.py
@@ -236,8 +236,11 @@ async def get_cached_analysis():
     response (Issue #12365) if no cached results exist or cache retrieval
     fails — consistent with the other analytics `/cached` endpoints.
     """
+    # Detector construction (an importlib load) is infra, not cache state: let a
+    # broken detector propagate to @with_error_handling rather than masking it as
+    # "no data". Only the cache READ degrades to no_data (#12365 review item b).
+    detector = await _get_detector()
     try:
-        detector = await _get_detector()
         cached = await detector.get_cached_report()
     except Exception as e:
         logger.warning("Anti-pattern cache retrieval failed, returning no_data: %s", e)
@@ -246,9 +249,9 @@ async def get_cached_analysis():
     if cached:
         return JSONResponse(content={"success": True, "cached": True, "data": cached})
 
+    # Bare status=no_data matches the sibling analytics /cached convention.
     return JSONResponse(
         content={
-            "success": False,
             "status": "no_data",
             "message": "No cached analysis available. Run /analyze first.",
         },

--- a/autobot-backend/api/anti_pattern.py
+++ b/autobot-backend/api/anti_pattern.py
@@ -232,26 +232,27 @@ async def get_cached_analysis():
     """
     Get the most recent cached analysis results.
 
-    Returns the last analysis if available, or 404 if no cached results exist.
+    Returns the last analysis if available, or a graceful "no_data" 200
+    response (Issue #12365) if no cached results exist or cache retrieval
+    fails — consistent with the other analytics `/cached` endpoints.
     """
     try:
         detector = await _get_detector()
         cached = await detector.get_cached_report()
-
-        if cached:
-            return JSONResponse(content={"success": True, "cached": True, "data": cached})
-        else:
-            return JSONResponse(
-                status_code=404,
-                content={
-                    "success": False,
-                    "message": "No cached analysis available. Run /analyze first.",
-                },
-            )
-
     except Exception as e:
-        logger.error("Failed to retrieve cached analysis: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to retrieve cache")
+        logger.warning("Anti-pattern cache retrieval failed, returning no_data: %s", e)
+        cached = None
+
+    if cached:
+        return JSONResponse(content={"success": True, "cached": True, "data": cached})
+
+    return JSONResponse(
+        content={
+            "success": False,
+            "status": "no_data",
+            "message": "No cached analysis available. Run /analyze first.",
+        },
+    )
 
 
 @router.post("/god-classes", response_model=DataResponse[AntiPatternGodClassesResultResponse])

--- a/autobot-backend/api/anti_pattern_cached_test.py
+++ b/autobot-backend/api/anti_pattern_cached_test.py
@@ -35,11 +35,10 @@ class TestGetCachedAnalysis:
 
         assert resp.status_code == 200
         body = resp.json()
-        assert body["success"] is False
         assert body["status"] == "no_data"
 
     def test_retrieval_exception_returns_no_data_not_500(self, client):
-        """Cache retrieval error degrades to 200 no_data instead of 500."""
+        """A cache READ error degrades to 200 no_data instead of 500."""
         mock_detector = AsyncMock()
         mock_detector.get_cached_report.side_effect = RuntimeError("redis unavailable")
 
@@ -48,8 +47,19 @@ class TestGetCachedAnalysis:
 
         assert resp.status_code == 200
         body = resp.json()
-        assert body["success"] is False
         assert body["status"] == "no_data"
+
+    def test_detector_construction_fault_is_not_masked(self, client):
+        """#12365 review item b: a broken detector (infra fault) must surface,
+        not be reported as an empty cache. Only the cache READ degrades."""
+        with patch(
+            "api.anti_pattern._get_detector",
+            AsyncMock(side_effect=RuntimeError("detector import failed")),
+        ):
+            resp = client.get("/api/anti-pattern/cached")
+
+        # Whatever the error envelope, it must NOT be a 200 no_data.
+        assert not (resp.status_code == 200 and resp.json().get("status") == "no_data")
 
     def test_cache_hit_returns_data(self, client):
         """Cached results still return normally when present."""

--- a/autobot-backend/api/anti_pattern_cached_test.py
+++ b/autobot-backend/api/anti_pattern_cached_test.py
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for GET /api/anti-pattern/cached graceful no_data handling (Issue #12365)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.anti_pattern import router
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/anti-pattern")
+    return app
+
+
+@pytest.fixture
+def client():
+    return TestClient(_make_app())
+
+
+class TestGetCachedAnalysis:
+    def test_cache_miss_returns_no_data_not_404(self, client):
+        """Empty cache (detector returns None) degrades to 200 no_data."""
+        mock_detector = AsyncMock()
+        mock_detector.get_cached_report.return_value = None
+
+        with patch("api.anti_pattern._get_detector", AsyncMock(return_value=mock_detector)):
+            resp = client.get("/api/anti-pattern/cached")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["status"] == "no_data"
+
+    def test_retrieval_exception_returns_no_data_not_500(self, client):
+        """Cache retrieval error degrades to 200 no_data instead of 500."""
+        mock_detector = AsyncMock()
+        mock_detector.get_cached_report.side_effect = RuntimeError("redis unavailable")
+
+        with patch("api.anti_pattern._get_detector", AsyncMock(return_value=mock_detector)):
+            resp = client.get("/api/anti-pattern/cached")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["status"] == "no_data"
+
+    def test_cache_hit_returns_data(self, client):
+        """Cached results still return normally when present."""
+        mock_detector = AsyncMock()
+        mock_detector.get_cached_report.return_value = {"total_issues": 3}
+
+        with patch("api.anti_pattern._get_detector", AsyncMock(return_value=mock_detector)):
+            resp = client.get("/api/anti-pattern/cached")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["cached"] is True
+        assert body["data"] == {"total_issues": 3}

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -37653,7 +37653,9 @@ export interface paths {
          * Get Cached Analysis
          * @description Get the most recent cached analysis results.
          *
-         *     Returns the last analysis if available, or 404 if no cached results exist.
+         *     Returns the last analysis if available, or a graceful "no_data" 200
+         *     response (Issue #12365) if no cached results exist or cache retrieval
+         *     fails — consistent with the other analytics `/cached` endpoints.
          */
         get: operations["get_cached_analysis_api_anti_pattern_cached_get"];
         put?: never;


### PR DESCRIPTION
Closes #12382
Refs #12365

## Thinking Path

Issue #12365 documents a systemic empty-cache design issue across 6 analytics modules — that redesign is an owner decision tracked under #12364 and out of scope here. Within it, one distinct, independently-fixable sub-bug stood out: `GET /api/anti-pattern/cached` raised a hard `HTTPException(500)` whenever `detector.get_cached_report()` threw, instead of degrading gracefully like its sibling `/cached` endpoints. I grepped `autobot-backend/api/` for the `no_data` convention used by `analytics_bug_prediction.py::get_cached_bug_prediction` and `codebase_analytics/endpoints/{dependencies,duplicates,import_tree}.py`, all of which return a 200 `{"status": "no_data", ...}` payload rather than 404/500 on an empty or failed cache lookup. I also checked the frontend for any consumer of `/api/anti-pattern/cached` (only the generated `api.ts` OpenAPI types reference it — no composable/component currently calls it), so there was no existing response-shape contract to preserve, and I was free to align with the sibling convention.

## What Changed

- `autobot-backend/api/anti_pattern.py` — `get_cached_analysis()`: both the cache-miss (`cached is None`) and the `except Exception` retrieval-failure path now return a graceful `200` with `{"success": false, "status": "no_data", "message": "No cached analysis available. Run /analyze first."}`, instead of a `404` for the miss and a `500 HTTPException` for the exception. The exception is still logged (downgraded `logger.error` → `logger.warning` since it's now a handled, non-fatal condition), not swallowed. Handler stays at 21 lines.
- `autobot-backend/api/anti_pattern_cached_test.py` (new) — 3 tests: cache-miss → 200 no_data, retrieval exception → 200 no_data (not 500), and the existing cache-hit success path still works.

## Verification

```
$ python3 -m pytest api/anti_pattern_cached_test.py -p no:xdist -q
api/anti_pattern_cached_test.py ...                                      [100%]
========================= 3 passed, 1 warning in 1.19s =========================
```

## Model Used

Claude Opus 4.8