### PR TITLE
fix(security): scope codebase report pipeline sub-analyses by source_id (#12372)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -1556,6 +1556,13 @@ async def _get_pattern_analysis(
             enable_regex_detection=True,
             enable_complexity_analysis=True,
             similarity_threshold=0.8,
+            # #12372: the report consumes the returned PatternAnalysisReport
+            # directly and never reads the ChromaDB cache, so disable embedding
+            # storage. Otherwise Phase 4 would persist THIS source's code into the
+            # global, source-unscoped `code_patterns` collection — re-introducing
+            # a cross-source write on the very path this PR scopes. The read-side
+            # source_id filter for that store is tracked separately in #12384.
+            enable_embedding_storage=False,
         )
 
         report = await asyncio.wait_for(

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -1293,23 +1293,41 @@ def _build_analysis_task_list(
     include_cross_language_analysis: bool,
     include_pattern_analysis: bool,
     use_semantic: bool,
+    source_id: str | None = None,
+    scan_root: Path | None = None,
 ) -> List[Tuple[str, Any]]:
     """
     Build list of analysis tasks to run based on flags.
 
     Issue #620: Extracted from _run_parallel_analyses.
+    Issue #12372: Thread source_id/scan_root into every sub-analysis so a
+    report requested for one source never scans or caches another project's
+    (or AutoBot's own) tree -- mirrors the #12356/#12374 cross-language fix.
     """
     tasks = []
     if include_bug_prediction:
-        tasks.append(("bug_prediction", _get_bug_prediction(use_semantic=use_semantic)))
+        tasks.append(
+            (
+                "bug_prediction",
+                _get_bug_prediction(
+                    project_root=str(scan_root) if scan_root else None,
+                    use_semantic=use_semantic,
+                ),
+            )
+        )
     if include_api_analysis:
-        tasks.append(("api_endpoint", _get_api_endpoint_analysis()))
+        tasks.append(("api_endpoint", _get_api_endpoint_analysis(project_root=scan_root)))
     if include_duplicate_analysis:
-        tasks.append(("duplicate", _get_duplicate_analysis()))
+        tasks.append(("duplicate", _get_duplicate_analysis(project_root=scan_root)))
     if include_cross_language_analysis:
-        tasks.append(("cross_language", _get_cross_language_analysis()))
+        tasks.append(
+            (
+                "cross_language",
+                _get_cross_language_analysis(source_id=source_id, project_root=scan_root),
+            )
+        )
     if include_pattern_analysis:
-        tasks.append(("pattern_analysis", _get_pattern_analysis()))
+        tasks.append(("pattern_analysis", _get_pattern_analysis(project_root=scan_root)))
     return tasks
 
 
@@ -1335,11 +1353,14 @@ async def _run_parallel_analyses(
     include_cross_language_analysis: bool,
     include_pattern_analysis: bool,
     use_semantic: bool,
+    source_id: str | None = None,
+    scan_root: Path | None = None,
 ) -> Dict[str, object | None]:
     """
     Run multiple code analyses in parallel.
 
     Issue #620: Refactored to use extracted helpers.
+    Issue #12372: Thread source_id/scan_root through to every sub-analysis.
     """
     analysis_tasks = _build_analysis_task_list(
         include_bug_prediction,
@@ -1348,6 +1369,8 @@ async def _run_parallel_analyses(
         include_cross_language_analysis,
         include_pattern_analysis,
         use_semantic,
+        source_id=source_id,
+        scan_root=scan_root,
     )
     result = _get_empty_analysis_result()
 
@@ -1449,17 +1472,32 @@ def _generate_empty_report_with_analyses(
     return "\n".join(lines)
 
 
-async def _get_cross_language_analysis() -> CrossLanguageAnalysis | None:
+async def _get_cross_language_analysis(
+    source_id: str | None = None,
+    project_root: Path | None = None,
+) -> CrossLanguageAnalysis | None:
     """
     Get cross-language pattern analysis for the project (Issue #244).
+
+    Issue #12372: Scope the scan and ChromaDB pattern tag to the requested
+    source (mirrors the #12356/#12374 fix already applied to the dedicated
+    cross-language-patterns endpoints) so a report requested for one source
+    never scans or surfaces another project's patterns.
+
+    Args:
+        source_id: Code source this analysis is scoped to (Issue #12372).
+        project_root: Resolved filesystem root to scan for this source.
+            Falls back to AutoBot's own root when None.
 
     Returns:
         CrossLanguageAnalysis or None if analysis fails
     """
     try:
         detector = CrossLanguagePatternDetector(
+            project_root=str(project_root) if project_root else None,
             use_llm=True,
             use_cache=True,
+            source_id=source_id,
         )
 
         analysis = await asyncio.wait_for(
@@ -1482,18 +1520,35 @@ async def _get_cross_language_analysis() -> CrossLanguageAnalysis | None:
         return None
 
 
-async def _get_pattern_analysis() -> PatternAnalysisReport | None:
+async def _get_pattern_analysis(
+    project_root: Path | None = None,
+) -> PatternAnalysisReport | None:
     """
     Get code pattern analysis for the project (Issue #208).
 
     Issue #2655: Scope analysis to autobot-backend/ (PATH.BACKEND_DIR) instead of
-    the full repo root to avoid the 180s timeout on large codebases.
+    the full repo root to avoid the 180s timeout on large codebases -- this
+    optimization only applies to AutoBot's own tree (no distinct source
+    resolved), since other registered sources don't share AutoBot's layout.
+
+    Issue #12372: When a distinct source is resolved, scan that source's root
+    instead of always defaulting to AutoBot's own backend directory --
+    otherwise a report requested for source A returned AutoBot's own
+    pattern-analysis findings for every source.
+
+    Args:
+        project_root: Resolved filesystem root for the requested source.
+            Falls back to AutoBot's own backend dir when None or when it
+            resolves to AutoBot's own project root (default source).
 
     Returns:
         PatternAnalysisReport or None if analysis fails
     """
     try:
-        project_root = str(PATH.BACKEND_DIR)
+        if project_root and Path(project_root).resolve() != get_project_root().resolve():
+            scan_target = str(project_root)
+        else:
+            scan_target = str(PATH.BACKEND_DIR)
 
         analyzer = CodePatternAnalyzer(
             enable_clone_detection=True,
@@ -1504,7 +1559,7 @@ async def _get_pattern_analysis() -> PatternAnalysisReport | None:
         )
 
         report = await asyncio.wait_for(
-            analyzer.analyze_directory(project_root),
+            analyzer.analyze_directory(scan_target),
             timeout=180.0,  # 3 minute timeout for comprehensive analysis
         )
 
@@ -1523,15 +1578,26 @@ async def _get_pattern_analysis() -> PatternAnalysisReport | None:
         return None
 
 
-async def _get_duplicate_analysis() -> DuplicateAnalysis | None:
+async def _get_duplicate_analysis(
+    project_root: Path | None = None,
+) -> DuplicateAnalysis | None:
     """
     Get duplicate code analysis for the project (Issue #528).
+
+    Issue #12372: Scope the scan to the requested source's resolved root
+    instead of always defaulting to AutoBot's own project root -- otherwise a
+    report requested for source A returned AutoBot's own duplicate-code
+    findings for every source.
+
+    Args:
+        project_root: Resolved filesystem root for the requested source.
+            Falls back to AutoBot's own project root when None.
 
     Returns:
         DuplicateAnalysis or None if analysis fails
     """
     try:
-        project_root = str(Path(__file__).resolve().parents[4])
+        scan_target = str(project_root) if project_root else str(Path(__file__).resolve().parents[4])
 
         # Issue #1233: Use dedicated analytics executor to prevent
         # default thread pool starvation
@@ -1540,7 +1606,7 @@ async def _get_duplicate_analysis() -> DuplicateAnalysis | None:
         analysis = await asyncio.wait_for(
             asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
-                lambda: DuplicateCodeDetector(project_root=project_root).run_analysis(),
+                lambda: DuplicateCodeDetector(project_root=scan_target).run_analysis(),
             ),
             timeout=TIMEOUT_HTTP_LONG,  # 120 second timeout for duplicate detection
         )
@@ -1561,15 +1627,27 @@ async def _get_duplicate_analysis() -> DuplicateAnalysis | None:
         return None
 
 
-async def _get_api_endpoint_analysis() -> APIEndpointAnalysis | None:
+async def _get_api_endpoint_analysis(
+    project_root: Path | None = None,
+) -> APIEndpointAnalysis | None:
     """
     Get API endpoint analysis for the project (Issue #527).
+
+    Issue #12372: Scope the scan to the requested source's resolved root
+    instead of always defaulting to AutoBot's own project root -- otherwise a
+    report requested for source A returned AutoBot's own API-endpoint
+    coverage findings for every source.
+
+    Args:
+        project_root: Resolved filesystem root for the requested source.
+            Falls back to AutoBot's own project root (APIEndpointChecker
+            default) when None.
 
     Returns:
         APIEndpointAnalysis or None if analysis fails
     """
     try:
-        checker = APIEndpointChecker()
+        checker = APIEndpointChecker(project_root=project_root)
         # Issue #1233: Use dedicated analytics executor
         analysis = await run_in_analytics_executor(checker.run_full_analysis)
         logger.info(
@@ -1951,8 +2029,15 @@ async def _resolve_analyses(
     include_cross_language_analysis: bool,
     include_pattern_analysis: bool,
     use_semantic: bool,
+    source_id: str | None = None,
+    scan_root: Path | None = None,
 ) -> dict:
-    """Helper for generate_analysis_report. Resolve analysis results or quick-mode blanks. Ref: #1088."""
+    """Helper for generate_analysis_report. Resolve analysis results or quick-mode blanks. Ref: #1088.
+
+    Issue #12372: source_id/scan_root are threaded through to every
+    sub-analysis so report generation never falls back to scanning AutoBot's
+    own tree for a different source.
+    """
     if quick:
         logger.info("Quick mode: Skipping expensive analyses")
         return {
@@ -1969,6 +2054,8 @@ async def _resolve_analyses(
         include_cross_language_analysis=include_cross_language_analysis,
         include_pattern_analysis=include_pattern_analysis,
         use_semantic=use_semantic,
+        source_id=source_id,
+        scan_root=scan_root,
     )
 
 
@@ -2024,6 +2111,9 @@ async def generate_analysis_report(
         include_pattern_analysis: Whether to include code pattern analysis (Issue #208)
         quick: If True, skip expensive analyses for faster export
         use_semantic: Enable LLM-based semantic analysis for bug prediction (Issue #554)
+        source_id: Scope the report and every sub-analysis to this code source
+            (Issue #12372). Falls back to the most recently indexed source, or
+            AutoBot's own root only when no source is resolvable.
 
     Returns:
         Markdown formatted report as plain text
@@ -2037,6 +2127,11 @@ async def generate_analysis_report(
     # Issue #2724 / #2760: Resolve source root via shared helper so _fetch_problems_from_chromadb
     # (which runs in a thread) can validate file paths without blocking the event loop.
     source_root = await resolve_source_root(source_id)
+    # Issue #12372: Sub-analysis scanners need a concrete root even when the
+    # source is unresolvable -- fall back to AutoBot's own project root
+    # (matches resolve_scan_root's fallback behavior) rather than letting each
+    # sub-analysis silently default to its own hard-coded AutoBot path.
+    scan_root = source_root or get_project_root()
 
     problems = await asyncio.to_thread(_fetch_problems_from_chromadb, source_id, source_root)
     analyses = await _resolve_analyses(
@@ -2047,6 +2142,8 @@ async def generate_analysis_report(
         include_cross_language_analysis=include_cross_language_analysis,
         include_pattern_analysis=include_pattern_analysis,
         use_semantic=use_semantic,
+        source_id=source_id,
+        scan_root=scan_root,
     )
     report = _render_report(problems, analyses)
     return PlainTextResponse(

--- a/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
@@ -21,7 +21,7 @@ returns another source's (or AutoBot's own) tree.
 """
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 # ---------------------------------------------------------------------------
@@ -196,3 +196,35 @@ class TestReportPipelineSourceIsolation:
             await report_mod.generate_analysis_report(source_id="unresolvable-source", quick=False)
 
         assert captured["pattern_root"] == get_project_root()
+
+
+# ---------------------------------------------------------------------------
+# Write-side leak: the report path must NOT persist the scanned source's code
+# into the global, source-unscoped `code_patterns` ChromaDB collection (#12372
+# review item c). Now that _get_pattern_analysis scans arbitrary source roots,
+# embedding storage must be disabled so one source's code isn't written into a
+# shared store another source's report could read (read-side filter → #12384).
+# ---------------------------------------------------------------------------
+class TestPatternAnalysisNoGlobalWrite:
+    """Issue #12372: _get_pattern_analysis must disable embedding storage."""
+
+    async def test_get_pattern_analysis_disables_embedding_storage(self):
+        from api.codebase_analytics.endpoints import report as report_mod
+
+        captured: dict = {}
+
+        def fake_analyzer(**kwargs):
+            captured.update(kwargs)
+            analyzer = MagicMock()
+            # Stop right after construction — we only assert the kwargs; a raise
+            # routes through _get_pattern_analysis's except → returns None.
+            analyzer.analyze_directory = AsyncMock(side_effect=RuntimeError("stop"))
+            return analyzer
+
+        with patch.object(report_mod, "CodePatternAnalyzer", side_effect=fake_analyzer):
+            result = await report_mod._get_pattern_analysis(project_root="/srv/sources/b")
+
+        assert result is None  # analyze stopped; no crash
+        # The report consumes the returned object directly and never reads the
+        # ChromaDB cache, so persistence must be OFF to avoid a cross-source write.
+        assert captured.get("enable_embedding_storage") is False

--- a/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
@@ -1,0 +1,198 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for cross-project data leakage in the codebase report
+pipeline (Issue #12372).
+
+``GET /report`` receives ``source_id`` and correctly scopes the *problems*
+fetch (``_fetch_problems_from_chromadb``) to it, but every sub-analysis it
+runs -- bug prediction, API-endpoint coverage, duplicate-code detection,
+cross-language patterns, and code-pattern analysis -- ignored ``source_id``
+and always scanned AutoBot's own project root / a hard-coded backend
+directory. A report requested for source B could therefore surface
+AutoBot's own (or another source's) findings in every analysis section.
+
+This mirrors the #12356/#12374 fix already applied to the dedicated
+cross-language-patterns endpoints: thread ``source_id``/the resolved scan
+root through every sub-analysis so a report for one source never scans or
+returns another source's (or AutoBot's own) tree.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+# ---------------------------------------------------------------------------
+# _build_analysis_task_list: every sub-analysis must receive the resolved
+# source_id / scan_root, not silently default to AutoBot's own root.
+# ---------------------------------------------------------------------------
+class TestBuildAnalysisTaskListScoping:
+    """Issue #12372: task construction must thread source scoping through."""
+
+    async def test_all_sub_analyses_receive_source_id_and_scan_root(self):
+        from api.codebase_analytics.endpoints import report as report_mod
+
+        scan_root = Path("/tmp/proj_b")
+        captured: dict = {}
+
+        # Issue #12372 test note: report._get_* are async functions, so
+        # ``patch.object`` auto-detects them and installs ``AsyncMock``.
+        # AsyncMock only invokes ``side_effect`` when the returned coroutine
+        # is *awaited* -- calling the patched function merely schedules that
+        # execution. The task list must therefore be awaited, not just
+        # constructed, to observe what each sub-analysis was called with.
+        def fake_bug_prediction(project_root=None, use_semantic=False):
+            captured["bug_prediction"] = {"project_root": project_root, "use_semantic": use_semantic}
+            return None
+
+        def fake_api_endpoint(project_root=None):
+            captured["api_endpoint"] = {"project_root": project_root}
+            return None
+
+        def fake_duplicate(project_root=None):
+            captured["duplicate"] = {"project_root": project_root}
+            return None
+
+        def fake_cross_language(source_id=None, project_root=None):
+            captured["cross_language"] = {"source_id": source_id, "project_root": project_root}
+            return None
+
+        def fake_pattern_analysis(project_root=None):
+            captured["pattern_analysis"] = {"project_root": project_root}
+            return None
+
+        with (
+            patch.object(report_mod, "_get_bug_prediction", side_effect=fake_bug_prediction),
+            patch.object(report_mod, "_get_api_endpoint_analysis", side_effect=fake_api_endpoint),
+            patch.object(report_mod, "_get_duplicate_analysis", side_effect=fake_duplicate),
+            patch.object(report_mod, "_get_cross_language_analysis", side_effect=fake_cross_language),
+            patch.object(report_mod, "_get_pattern_analysis", side_effect=fake_pattern_analysis),
+        ):
+            tasks = report_mod._build_analysis_task_list(
+                include_bug_prediction=True,
+                include_api_analysis=True,
+                include_duplicate_analysis=True,
+                include_cross_language_analysis=True,
+                include_pattern_analysis=True,
+                use_semantic=False,
+                source_id="B",
+                scan_root=scan_root,
+            )
+            for _name, coro in tasks:
+                await coro
+
+        # None of the sub-analyses fall back to AutoBot's own root/no source.
+        assert captured["bug_prediction"]["project_root"] == str(scan_root)
+        assert captured["api_endpoint"]["project_root"] == scan_root
+        assert captured["duplicate"]["project_root"] == scan_root
+        assert captured["cross_language"]["project_root"] == scan_root
+        assert captured["cross_language"]["source_id"] == "B"
+        assert captured["pattern_analysis"]["project_root"] == scan_root
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: GET /report for source B must never scan/return source A's
+# (or AutoBot's own) tree.
+# ---------------------------------------------------------------------------
+class TestReportPipelineSourceIsolation:
+    """Issue #12372: a report for source B must not surface source A's data."""
+
+    async def _run_report_for_source(self, source_id, source_roots, captured):
+        from api.codebase_analytics.endpoints import report as report_mod
+
+        async def fake_resolve_source_root(sid):
+            return source_roots.get(sid)
+
+        async def fake_get_cross_language_analysis(source_id=None, project_root=None):
+            captured.setdefault(source_id, {})["cross_language_root"] = project_root
+            return None
+
+        async def fake_get_duplicate_analysis(project_root=None):
+            captured.setdefault(source_id, {})["duplicate_root"] = project_root
+            return None
+
+        async def fake_get_pattern_analysis(project_root=None):
+            captured.setdefault(source_id, {})["pattern_root"] = project_root
+            return None
+
+        async def fake_get_api_endpoint_analysis(project_root=None):
+            captured.setdefault(source_id, {})["api_root"] = project_root
+            return None
+
+        async def fake_get_bug_prediction(project_root=None, use_semantic=False):
+            captured.setdefault(source_id, {})["bug_root"] = project_root
+            return None
+
+        with (
+            patch.object(report_mod, "resolve_source_root", side_effect=fake_resolve_source_root),
+            patch.object(
+                report_mod,
+                "_fetch_problems_from_chromadb",
+                return_value=[],
+            ),
+            patch.object(
+                report_mod,
+                "_get_cross_language_analysis",
+                side_effect=fake_get_cross_language_analysis,
+            ),
+            patch.object(report_mod, "_get_duplicate_analysis", side_effect=fake_get_duplicate_analysis),
+            patch.object(report_mod, "_get_pattern_analysis", side_effect=fake_get_pattern_analysis),
+            patch.object(
+                report_mod,
+                "_get_api_endpoint_analysis",
+                side_effect=fake_get_api_endpoint_analysis,
+            ),
+            patch.object(report_mod, "_get_bug_prediction", side_effect=fake_get_bug_prediction),
+        ):
+            await report_mod.generate_analysis_report(source_id=source_id, quick=False)
+
+    async def test_source_b_report_scans_only_source_b_root(self):
+        """A report for source B must resolve/scan source B's root, never A's."""
+        root_a = Path("/srv/sources/a")
+        root_b = Path("/srv/sources/b")
+        source_roots = {"A": root_a, "B": root_b}
+        captured: dict = {}
+
+        await self._run_report_for_source("A", source_roots, captured)
+        await self._run_report_for_source("B", source_roots, captured)
+
+        # Each source's sub-analyses see only that source's resolved root.
+        assert captured["A"]["cross_language_root"] == root_a
+        assert captured["B"]["cross_language_root"] == root_b
+        assert captured["A"]["cross_language_root"] != captured["B"]["cross_language_root"]
+
+        for key in ("duplicate_root", "pattern_root", "api_root"):
+            assert captured["A"][key] == root_a
+            assert captured["B"][key] == root_b
+
+        # Bug prediction receives the root as a string (its own signature).
+        assert captured["A"]["bug_root"] == str(root_a)
+        assert captured["B"]["bug_root"] == str(root_b)
+
+    async def test_unresolvable_source_falls_back_to_project_root_not_none(self):
+        """No registered source resolves -> fall back to AutoBot's own root,
+        not None (which would crash str(None) downstream / silently point
+        every sub-analysis at an undefined scope)."""
+        from api.codebase_analytics.endpoints import report as report_mod
+        from api.codebase_analytics.endpoints.shared import get_project_root
+
+        captured: dict = {}
+
+        async def fake_get_pattern_analysis(project_root=None):
+            captured["pattern_root"] = project_root
+            return None
+
+        with (
+            patch.object(report_mod, "resolve_source_root", new=AsyncMock(return_value=None)),
+            patch.object(report_mod, "_fetch_problems_from_chromadb", return_value=[]),
+            patch.object(report_mod, "_get_cross_language_analysis", new=AsyncMock(return_value=None)),
+            patch.object(report_mod, "_get_duplicate_analysis", new=AsyncMock(return_value=None)),
+            patch.object(report_mod, "_get_pattern_analysis", side_effect=fake_get_pattern_analysis),
+            patch.object(report_mod, "_get_api_endpoint_analysis", new=AsyncMock(return_value=None)),
+            patch.object(report_mod, "_get_bug_prediction", new=AsyncMock(return_value=None)),
+        ):
+            await report_mod.generate_analysis_report(source_id="unresolvable-source", quick=False)
+
+        assert captured["pattern_root"] == get_project_root()

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -20576,6 +20576,9 @@ export interface paths {
          *         include_pattern_analysis: Whether to include code pattern analysis (Issue #208)
          *         quick: If True, skip expensive analyses for faster export
          *         use_semantic: Enable LLM-based semantic analysis for bug prediction (Issue #554)
+         *         source_id: Scope the report and every sub-analysis to this code source
+         *             (Issue #12372). Falls back to the most recently indexed source, or
+         *             AutoBot's own root only when no source is resolvable.
          *
          *     Returns:
          *         Markdown formatted report as plain text


### PR DESCRIPTION
Closes #12372

## Thinking Path

`report.py`'s `/report` endpoint already resolved `source_id` and scoped the ChromaDB *problems* fetch to it (`_fetch_problems_from_chromadb` + `resolve_source_root`, from earlier issues #1772/#2724/#2760/#2653). But it runs five additional sub-analyses to build the rest of the report, and every one of them ignored `source_id`:

- `_get_bug_prediction()` — called with no `project_root` → defaulted to `PATH.PROJECT_ROOT` (AutoBot's own root).
- `_get_api_endpoint_analysis()` — `APIEndpointChecker()` with no `project_root` → defaulted to AutoBot's own root.
- `_get_duplicate_analysis()` — hard-coded `project_root = str(Path(__file__).resolve().parents[4])` (AutoBot's own root).
- `_get_cross_language_analysis()` — `CrossLanguagePatternDetector(use_llm=True, use_cache=True)` with no `source_id`/`project_root` (the exact leak the #12374 reviewer flagged at report.py ~line 1459).
- `_get_pattern_analysis()` — hard-coded `project_root = str(PATH.BACKEND_DIR)` (AutoBot's own backend dir).

So a report requested for source A's or B's codebase would run four of these five scanners against AutoBot's own tree (or, for duplicate/API/pattern, always AutoBot regardless of source) and merge those findings into the response — the exact leak class already fixed for the standalone `/cross-language/*` endpoints in #12356/#12374 (commit cb7d1db1f).

I mirrored that fix: thread `source_id` and the resolved scan root through the whole pipeline instead of touching only the cross-language call, since all five scanners shared the same root cause.

## What Changed

`autobot-backend/api/codebase_analytics/endpoints/report.py`:
- `generate_analysis_report` (the `/report` handler, ~L2089): resolves `scan_root = source_root or get_project_root()` (mirrors `resolve_scan_root`'s fallback) and passes `source_id`/`scan_root` into `_resolve_analyses`.
- `_resolve_analyses` → `_run_parallel_analyses` → `_build_analysis_task_list` (~L1289-1370): thread `source_id`/`scan_root` down to every sub-analysis call.
- `_get_bug_prediction` (~L1587): now called with `project_root=str(scan_root)` instead of implicitly falling back to `PATH.PROJECT_ROOT` for every request.
- `_get_api_endpoint_analysis` (~L1564): now accepts `project_root` and passes it to `APIEndpointChecker(project_root=project_root)` instead of `APIEndpointChecker()`.
- `_get_duplicate_analysis` (~L1558): now accepts `project_root` and uses it instead of the hard-coded `Path(__file__).resolve().parents[4]`.
- `_get_cross_language_analysis` (~L1452, was ~1459 pre-refactor): now accepts `source_id`/`project_root` and passes both to `CrossLanguagePatternDetector(project_root=..., source_id=..., use_llm=True, use_cache=True)` — before: `CrossLanguagePatternDetector(use_llm=True, use_cache=True)` with neither. The detector class itself already supports both kwargs (merged in cb7d1db1f / #12374).
- `_get_pattern_analysis` (~L1500): now accepts `project_root`; scans it directly when a distinct source is resolved, and only falls back to `PATH.BACKEND_DIR` (the #2655 timeout-avoidance scope) when the resolved root *is* AutoBot's own project root.

Sub-analyses scoped (file:line, before → after):
| Sub-analysis | Location | Before | After |
|---|---|---|---|
| Cross-language patterns | `report.py:1459` (pre-fix line cited in #12374 review) | `CrossLanguagePatternDetector(use_llm=True, use_cache=True)` | `CrossLanguagePatternDetector(project_root=str(project_root) if project_root else None, use_llm=True, use_cache=True, source_id=source_id)` |
| Duplicate code | `report.py:1566` | `project_root = str(Path(__file__).resolve().parents[4])` (always AutoBot) | `scan_target = str(project_root) if project_root else <old fallback>` |
| Code pattern analysis | `report.py:1496` | `project_root = str(PATH.BACKEND_DIR)` (always AutoBot) | resolved source root, falling back to `PATH.BACKEND_DIR` only for AutoBot's own tree |
| API endpoint coverage | `report.py:1572` | `APIEndpointChecker()` (defaults to AutoBot root) | `APIEndpointChecker(project_root=project_root)` |
| Bug prediction | `report.py:1619` (call site `_build_analysis_task_list`) | `_get_bug_prediction(use_semantic=use_semantic)` (defaults to `PATH.PROJECT_ROOT`) | `_get_bug_prediction(project_root=str(scan_root) if scan_root else None, use_semantic=use_semantic)` |

## Remaining leaking path (tracked separately, not fixed here)

Two ChromaDB collections used by these same detectors are shared/global with **no** `source_id` metadata at the storage layer, independent of report.py's scan-root scoping fixed here:
- `bug_pattern_vectors` (`code_intelligence/bug_predictor.py`) — reachable via `/report?use_semantic=true` (default `false`).
- `code_patterns` (`code_intelligence/pattern_analysis/storage.py` + the separate `pattern_analysis.py` endpoint family, e.g. `/patterns/cached-patterns`).

Filed as a fast-follow: #12384 (references #12356/#12374 as the pattern to mirror). Not fixed here because it requires threading `source_id` through two additional modules' storage/query layers — a larger, self-contained change per the task's guidance not to silently leave it unfixed but not to inflate this PR's blast radius either.

## Verification

New regression test file: `autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py`

```
$ python3 -m pytest api/codebase_analytics/endpoints/report_scoping_test.py -p no:xdist -q
collected 3 items

api/codebase_analytics/endpoints/report_scoping_test.py ...              [100%]

3 passed, 1 warning in 1.02s
```

Also re-ran the existing #12374 reference test alongside it to confirm no interference/regression:

```
$ python3 -m pytest api/codebase_analytics/endpoints/report_scoping_test.py api/codebase_analytics/endpoints/cross_language_scoping_test.py -p no:xdist -q
collected 11 items
...........
11 passed, 1 warning in 1.66s
```

`python3 -m pyflakes api/codebase_analytics/endpoints/report.py api/codebase_analytics/endpoints/report_scoping_test.py` — clean, no output.

## Model Used

Claude Opus 4.8
