### PR TITLE
fix(frontend): add missing /api prefix to un-prefixed API calls (#12317)

### DIFF
--- a/autobot-frontend/src/components/desktop/DesktopContextPanel.vue
+++ b/autobot-frontend/src/components/desktop/DesktopContextPanel.vue
@@ -130,7 +130,7 @@ const { start: startContextPolling } = usePollingJob<DesktopContext | null>(
     loading.value = true
     error.value = null
     try {
-      const data = await ApiClient.get<DesktopContext>('/vnc/desktop/context')
+      const data = await ApiClient.get<DesktopContext>('/api/vnc/desktop/context')
       context.value = data
       return data
     } catch (err: unknown) {

--- a/autobot-frontend/src/components/settings/MemoryPrivacyPanel.vue
+++ b/autobot-frontend/src/components/settings/MemoryPrivacyPanel.vue
@@ -148,7 +148,7 @@ async function loadMemories() {
   loading.value = true
   loaded.value = false
   try {
-    const data = await apiClient.get<{ memories: MemoryItem[] }>('/memory/privacy/list')
+    const data = await apiClient.get<{ memories: MemoryItem[] }>('/api/memory/privacy/list')
     memories.value = data.memories || []
     loaded.value = true
     logger.debug('MemoryPrivacyPanel: loaded %d items', memories.value.length)
@@ -169,7 +169,7 @@ async function forgetItem(item: MemoryItem) {
   if (!ok) return
   deletingIds.value = new Set([...deletingIds.value, item.memory_id])
   try {
-    await apiClient.delete(`/memory/privacy/${item.store}/${encodeURIComponent(item.memory_id)}`)
+    await apiClient.delete(`/api/memory/privacy/${item.store}/${encodeURIComponent(item.memory_id)}`)
     memories.value = memories.value.filter(m => m.memory_id !== item.memory_id)
     showToast(t('settings.memoryPrivacy.forgotten'), 'success')
     logger.info('MemoryPrivacyPanel: forgot %s from %s', item.memory_id, item.store)

--- a/autobot-frontend/src/composables/__tests__/useVncControls.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVncControls.test.ts
@@ -33,25 +33,25 @@ describe('useVncControls session_id threading', () => {
     const { mouseClick } = useVncControls()
     await mouseClick({ x: 1, y: 2 })
 
-    expect(mockPost).toHaveBeenCalledWith('/vnc/click', { x: 1, y: 2, session_id: 'default' })
+    expect(mockPost).toHaveBeenCalledWith('/api/vnc/click', { x: 1, y: 2, session_id: 'default' })
   })
 
   it('threads an explicit session_id through mouseClick/keyboardType/specialKey/scroll/drag', async () => {
     const { mouseClick, keyboardType, specialKey, mouseScroll, mouseDrag } = useVncControls('chat-42')
 
     await mouseClick({ x: 1, y: 2 })
-    expect(mockPost).toHaveBeenLastCalledWith('/vnc/click', { x: 1, y: 2, session_id: 'chat-42' })
+    expect(mockPost).toHaveBeenLastCalledWith('/api/vnc/click', { x: 1, y: 2, session_id: 'chat-42' })
 
     await keyboardType('hello')
-    expect(mockPost).toHaveBeenLastCalledWith('/vnc/type', { text: 'hello', session_id: 'chat-42' })
+    expect(mockPost).toHaveBeenLastCalledWith('/api/vnc/type', { text: 'hello', session_id: 'chat-42' })
 
     await specialKey('Return')
-    expect(mockPost).toHaveBeenLastCalledWith('/vnc/key', { key: 'Return', session_id: 'chat-42' })
+    expect(mockPost).toHaveBeenLastCalledWith('/api/vnc/key', { key: 'Return', session_id: 'chat-42' })
 
     await mouseScroll({ direction: 'up' })
-    expect(mockPost).toHaveBeenLastCalledWith('/vnc/scroll', { direction: 'up', session_id: 'chat-42' })
+    expect(mockPost).toHaveBeenLastCalledWith('/api/vnc/scroll', { direction: 'up', session_id: 'chat-42' })
 
     await mouseDrag({ x1: 0, y1: 0, x2: 5, y2: 5 })
-    expect(mockPost).toHaveBeenLastCalledWith('/vnc/drag', { x1: 0, y1: 0, x2: 5, y2: 5, session_id: 'chat-42' })
+    expect(mockPost).toHaveBeenLastCalledWith('/api/vnc/drag', { x1: 0, y1: 0, x2: 5, y2: 5, session_id: 'chat-42' })
   })
 })

--- a/autobot-frontend/src/composables/chat/useContextOverflowProtection.ts
+++ b/autobot-frontend/src/composables/chat/useContextOverflowProtection.ts
@@ -143,7 +143,7 @@ export function useContextOverflowProtection(
         original_message_count: number
         summary_token_count: number
         timestamp: string
-      }>('/chat/summarize', {
+      }>('/api/chat/summarize', {
         session_id: sessionId,
         message_ids: messageIds,
         target_length: targetSummaryLength,

--- a/autobot-frontend/src/composables/useDevices.ts
+++ b/autobot-frontend/src/composables/useDevices.ts
@@ -47,7 +47,7 @@ export function useDevices() {
     return wrap(async () => {
       try {
         error.value = null
-        const response = await api.get<DeviceListResponse>('/devices')
+        const response = await api.get<DeviceListResponse>('/api/devices')
         devices.value = response.devices || []
         logger.debug('Fetched devices:', devices.value.length)
       } catch (err) {
@@ -63,7 +63,7 @@ export function useDevices() {
     return wrap(async () => {
       try {
         error.value = null
-        await api.delete(`/devices/${deviceId}`)
+        await api.delete(`/api/devices/${deviceId}`)
         devices.value = devices.value.filter(d => d.id !== deviceId)
         logger.info('Device deleted:', deviceId)
       } catch (err) {
@@ -79,7 +79,7 @@ export function useDevices() {
     return wrap(async () => {
       try {
         error.value = null
-        const response = await api.get('/devices/pair-qr')
+        const response = await api.get('/api/devices/pair-qr')
         logger.debug('Got QR challenge')
         return response
       } catch (err) {
@@ -100,7 +100,7 @@ export function useDevices() {
     return wrap(async () => {
       try {
         error.value = null
-        const response = await api.post<{ device_id?: string }>('/devices/pair', payload)
+        const response = await api.post<{ device_id?: string }>('/api/devices/pair', payload)
         // Refresh the device list after successful pairing
         await fetchDevices()
         logger.info('Device paired:', response.device_id)

--- a/autobot-frontend/src/composables/useImageGeneration.ts
+++ b/autobot-frontend/src/composables/useImageGeneration.ts
@@ -46,7 +46,7 @@ export function useImageGeneration() {
     error.value = null
     try {
       const result = await apiClient.post<ImageGenerationResult>(
-        '/image-generation/generate',
+        '/api/image-generation/generate',
         params,
       )
       if (!result.success) {
@@ -64,7 +64,7 @@ export function useImageGeneration() {
 
   async function fetchProviders(): Promise<void> {
     try {
-      const data = await apiClient.get<{ providers: ProviderStatus[] }>('/image-generation/providers')
+      const data = await apiClient.get<{ providers: ProviderStatus[] }>('/api/image-generation/providers')
       providers.value = data.providers ?? []
     } catch {
       providers.value = []

--- a/autobot-frontend/src/composables/useKnowledgeCollaboration.ts
+++ b/autobot-frontend/src/composables/useKnowledgeCollaboration.ts
@@ -255,7 +255,7 @@ export function useKnowledgeCollaboration() {
     error.value = null
     return wrap(async () => {
       try {
-        const response = await apiClient.post<ScopedSearchResult>('/knowledge/search/scoped', {
+        const response = await apiClient.post<ScopedSearchResult>('/api/knowledge/search/scoped', {
           query,
           top_k: options.top_k || 10,
           mode: options.mode || 'hybrid',

--- a/autobot-frontend/src/composables/useSessionActivityLogger.ts
+++ b/autobot-frontend/src/composables/useSessionActivityLogger.ts
@@ -265,7 +265,7 @@ export function useSessionActivityLogger(): UseSessionActivityLoggerReturn {
     if (!activity) return
 
     try {
-      await apiClient.post<unknown>(`/chat/sessions/${sessionId}/activities`, {
+      await apiClient.post<unknown>(`/api/chat/sessions/${sessionId}/activities`, {
         activity_id: activity.id,
         type: activity.type,
         user_id: activity.userId,
@@ -447,7 +447,7 @@ export function useSessionActivityLogger(): UseSessionActivityLoggerReturn {
     let success = true
     for (const [sessionId, activities] of bySession) {
       try {
-        await apiClient.post<unknown>(`/chat/sessions/${sessionId}/activities/batch`, {
+        await apiClient.post<unknown>(`/api/chat/sessions/${sessionId}/activities/batch`, {
           activities: activities.map(a => ({
             activity_id: a.id,
             type: a.type,

--- a/autobot-frontend/src/composables/useVideoGeneration.ts
+++ b/autobot-frontend/src/composables/useVideoGeneration.ts
@@ -53,7 +53,7 @@ export function useVideoGeneration() {
 
   async function submit(params: GenerateVideoParams): Promise<VideoJobResponse | null> {
     try {
-      const result = await apiClient.post<VideoJobResponse>('/video-generation/generate', params)
+      const result = await apiClient.post<VideoJobResponse>('/api/video-generation/generate', params)
       if (!result.success) {
         error.value = result.error ?? 'Video generation failed'
       }
@@ -66,7 +66,7 @@ export function useVideoGeneration() {
 
   async function pollStatus(jobId: string): Promise<VideoStatusResponse | null> {
     try {
-      return await apiClient.get<VideoStatusResponse>(`/video-generation/status/${jobId}`)
+      return await apiClient.get<VideoStatusResponse>(`/api/video-generation/status/${jobId}`)
     } catch (err: unknown) {
       error.value = err instanceof Error ? err.message : String(err)
       return null
@@ -118,7 +118,7 @@ export function useVideoGeneration() {
 
   async function fetchProviders(): Promise<void> {
     try {
-      const data = await apiClient.get<{ providers: VideoProviderStatus[] }>('/video-generation/providers')
+      const data = await apiClient.get<{ providers: VideoProviderStatus[] }>('/api/video-generation/providers')
       providers.value = data.providers ?? []
     } catch {
       providers.value = []

--- a/autobot-frontend/src/composables/useVncConnection.ts
+++ b/autobot-frontend/src/composables/useVncConnection.ts
@@ -50,7 +50,7 @@ export function useVncConnection(sessionId: string = 'default') {
     errors.value = []
     try {
       const data = await wrap(() =>
-        ApiClient.get<ConnectionSettings>(`/vnc/connection/settings?session_id=${sessionId}`)
+        ApiClient.get<ConnectionSettings>(`/api/vnc/connection/settings?session_id=${sessionId}`)
       )
       settings.value = data
     } catch (err: unknown) {
@@ -63,7 +63,7 @@ export function useVncConnection(sessionId: string = 'default') {
     errors.value = []
     try {
       await wrap(() =>
-        ApiClient.post(`/vnc/connection/settings?session_id=${sessionId}`, newSettings)
+        ApiClient.post(`/api/vnc/connection/settings?session_id=${sessionId}`, newSettings)
       )
       settings.value = newSettings
       return true
@@ -76,7 +76,7 @@ export function useVncConnection(sessionId: string = 'default') {
 
   async function loadMetrics(): Promise<void> {
     try {
-      const data = await ApiClient.get<ConnectionMetrics>('/vnc/connection/quality-metrics')
+      const data = await ApiClient.get<ConnectionMetrics>('/api/vnc/connection/quality-metrics')
       metrics.value = data
     } catch (err: unknown) {
       logger.error('Failed to load connection metrics:', err)

--- a/autobot-frontend/src/composables/useVncControls.ts
+++ b/autobot-frontend/src/composables/useVncControls.ts
@@ -60,7 +60,7 @@ export function useVncControls(sessionId: string = 'default') {
   async function mouseClick(params: MouseClickParams): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/click', { ...params, session_id: sessionId }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/api/vnc/click', { ...params, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Mouse click failed:', err)
       error.value = extractErrorMessage(err, 'Mouse click failed')
@@ -71,7 +71,7 @@ export function useVncControls(sessionId: string = 'default') {
   async function keyboardType(text: string): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/type', { text, session_id: sessionId }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/api/vnc/type', { text, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Keyboard type failed:', err)
       error.value = extractErrorMessage(err, 'Keyboard type failed')
@@ -82,7 +82,7 @@ export function useVncControls(sessionId: string = 'default') {
   async function specialKey(key: string): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/key', { key, session_id: sessionId }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/api/vnc/key', { key, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Special key failed:', err)
       error.value = extractErrorMessage(err, 'Special key failed')
@@ -93,7 +93,7 @@ export function useVncControls(sessionId: string = 'default') {
   async function mouseScroll(params: MouseScrollParams): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/scroll', { ...params, session_id: sessionId }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/api/vnc/scroll', { ...params, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Mouse scroll failed:', err)
       error.value = extractErrorMessage(err, 'Mouse scroll failed')
@@ -104,7 +104,7 @@ export function useVncControls(sessionId: string = 'default') {
   async function mouseDrag(params: MouseDragParams): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/drag', { ...params, session_id: sessionId }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/api/vnc/drag', { ...params, session_id: sessionId }))
     } catch (err: unknown) {
       logger.error('Mouse drag failed:', err)
       error.value = extractErrorMessage(err, 'Mouse drag failed')
@@ -115,7 +115,7 @@ export function useVncControls(sessionId: string = 'default') {
   async function captureScreenshot(): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.get<VncActionResponse>('/vnc/screenshot'))
+      return await wrap(() => ApiClient.get<VncActionResponse>('/api/vnc/screenshot'))
     } catch (err: unknown) {
       logger.error('Screenshot capture failed:', err)
       error.value = extractErrorMessage(err, 'Screenshot capture failed')
@@ -126,7 +126,7 @@ export function useVncControls(sessionId: string = 'default') {
   async function syncClipboard(content: string): Promise<VncActionResponse> {
     error.value = null
     try {
-      return await wrap(() => ApiClient.post<VncActionResponse>('/vnc/clipboard', { content }))
+      return await wrap(() => ApiClient.post<VncActionResponse>('/api/vnc/clipboard', { content }))
     } catch (err: unknown) {
       logger.error('Clipboard sync failed:', err)
       error.value = extractErrorMessage(err, 'Clipboard sync failed')


### PR DESCRIPTION
Closes #12317

## Thinking Path
Five ChatInterface-bundle calls hit backend paths without the `/api` prefix. This repo's `ApiClient` (`@/utils/ApiClient`, also wrapped by `@/plugins/api`'s `useApiClient`) resolves `baseUrl` to a **host-level** origin (`http(s)://host:port` or `''` for the Vite/nginx proxy) — never `/api`. So callers must include `/api` themselves. Without it, nginx falls back to the SPA: POSTs return 405 and GETs return `200 text/html`, which the frontend then tries to parse as JSON. `activities/batch` was observed failing 331x in one session.

Convention check: the offending files use plain literal path strings and do **not** import `getApiBase()`, so the internally-consistent minimal fix is a literal `/api` prefix (the other repo convention, `${getApiBase()}`, is used only in files that already import it — not these). No new imports, no refactors.

While sweeping `autobot-frontend/src` for the same bug class, I found 16 more bare-path calls (same host-level clients) across VNC, video-generation, devices, memory-privacy and knowledge-scoped-search. Each was verified to have a matching `/api/...` route in the generated OpenAPI types, so they are the identical bug and are fixed in-scope.

## What Changed
Added the missing `/api` prefix to 21 client calls (prefix-only; 26 symmetric line changes, no structural edits).

The 5 from the issue:
- `useSessionActivityLogger.ts:268` `POST /chat/sessions/${sessionId}/activities` -> `/api/...` (backend `POST /api/chat/sessions/{session_id}/activities`)
- `useSessionActivityLogger.ts:450` `POST /chat/sessions/${sessionId}/activities/batch` -> `/api/...` (backend `POST /api/chat/sessions/{session_id}/activities/batch`)
- `useContextOverflowProtection.ts:146` `POST /chat/summarize` -> `/api/chat/summarize`
- `useImageGeneration.ts:49` `POST /image-generation/generate` -> `/api/image-generation/generate`
- `useImageGeneration.ts:67` `GET /image-generation/providers` -> `/api/image-generation/providers`

Additional same-class fixes (verified against generated `api.ts`):
- `useVncControls.ts` (7): `/vnc/{click,type,key,scroll,drag,screenshot,clipboard}` -> `/api/vnc/...`
- `useVncConnection.ts` (3): `/vnc/connection/settings` (GET+POST), `/vnc/connection/quality-metrics`
- `useVideoGeneration.ts` (3): `/video-generation/{generate,status/${jobId},providers}`
- `useDevices.ts` (4): `/devices`, `/devices/${deviceId}`, `/devices/pair-qr`, `/devices/pair`
- `DesktopContextPanel.vue` (1): `/vnc/desktop/context`
- `MemoryPrivacyPanel.vue` (2): `/memory/privacy/list`, `/memory/privacy/${store}/${memory_id}`
- `useKnowledgeCollaboration.ts` (1): `/knowledge/search/scoped`

## Verification
- WSL has no Linux npm, so no vitest/vue-tsc — verified by inspection + grep against `src/types/generated/api.ts` (the generated OpenAPI route table) and against the ApiClient baseUrl logic.
- Confirmed `ApiClient.baseUrl` is host-level (`_detectBaseUrl()` returns origin or `''`; `initializeBaseUrl()` uses `appConfig.getApiUrl('')`) — so `/api` belongs in every caller.
- Each corrected path + HTTP method matches a route in the generated types (e.g. `add_session_activities_batch_..._post`, `summarize_conversation_api_chat_summarize_post`, `list_providers_api_image_generation_providers_get`, `generate_image_..._post`, plus all vnc/video/devices/memory/knowledge routes).
- Verified every client binding in the touched files resolves to the host-level `ApiClient`/`useApiClient` (not a raw axios with a `/api` baseURL) — no double-prefix risk.
- Post-fix re-scan of `autobot-frontend/src` for bare-path client calls: **0 remaining**.
- `audit_api_wiring.py --dump-openapi` could not run in this env (`No module named 'autobot_shared'` — app build unavailable); relied on the grep-vs-generated-types cross-check instead.

## Model Used
Claude Opus 4.8
