### PR TITLE
test: fix 4 pre-existing backend test failures (graph-rag mock + analytics expectations) (#12351, #12357)

### DIFF
--- a/autobot-backend/api/analytics_evolution_test.py
+++ b/autobot-backend/api/analytics_evolution_test.py
@@ -15,7 +15,7 @@ Tests the following functionality:
 
 import sys
 import types
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -73,8 +73,10 @@ class TestParseDateRange:
         end = "2025-01-31"
         start_ts, end_ts = _parse_date_range(start, end)
 
-        expected_start = datetime.fromisoformat(start).timestamp()
-        expected_end = datetime.fromisoformat(end).timestamp()
+        # Production parses ISO dates as UTC (parse_utc_iso); anchor expectations
+        # to UTC so the assertion is deterministic regardless of runner timezone.
+        expected_start = datetime.fromisoformat(start).replace(tzinfo=timezone.utc).timestamp()
+        expected_end = datetime.fromisoformat(end).replace(tzinfo=timezone.utc).timestamp()
         assert start_ts == expected_start
         assert end_ts == expected_end
 

--- a/autobot-backend/api/codebase_analytics/call_graph_resolution_test.py
+++ b/autobot-backend/api/codebase_analytics/call_graph_resolution_test.py
@@ -148,7 +148,8 @@ class TestExtractImportContext:
 
         assert ctx.resolve_name("Dict") == "typing.Dict"
         assert ctx.resolve_name("List") == "typing.List"
-        assert ctx.resolve_name("Optional") == "typing.Optional"
+        # Optional is not part of this import statement, so it stays unresolved
+        assert ctx.resolve_name("Optional") is None
 
     def test_skip_star_import(self):
         """Test that star imports are skipped."""

--- a/autobot-backend/services/graph_rag_service_test.py
+++ b/autobot-backend/services/graph_rag_service_test.py
@@ -71,6 +71,8 @@ def mock_rag_service():
             ),
         )
     )
+    # get_metrics is awaited by GraphRAGService.get_metrics(); must be AsyncMock
+    rag.get_metrics = AsyncMock(return_value={"searches": 0})
     return rag
 
 
@@ -192,8 +194,9 @@ async def test_graph_aware_search_with_entity_expansion(graph_rag_service, mock_
         max_results=5,
     )
 
-    # Verify graph traversal was called
-    mock_memory_graph.get_related_entities.assert_called_once()
+    # Verify graph traversal was called (start_entity plus extracted entities
+    # each become a starting point, so it may be called more than once)
+    mock_memory_graph.get_related_entities.assert_called()
 
     # Verify graph metrics
     assert metrics.graph_expansion_enabled is True


### PR DESCRIPTION
Closes #12351
Closes #12357

## Thinking Path
Four pre-existing, test-only backend failures across two issues, batched (same scope, low risk). For each I read the production code being exercised to confirm the production behavior is correct and the *test* was wrong before editing an assertion — no production code changed.

## What Changed
**#12351 — `services/graph_rag_service_test.py`**
- `mock_rag_service` fixture: `rag.get_metrics` was a plain `Mock`, but `GraphRAGService.get_metrics()` does `await self.rag.get_metrics()`. Made it an `AsyncMock(return_value={"searches": 0})`. (`advanced_search`, the only other awaited `self.rag.*` call, was already `AsyncMock`.) Fixes `test_get_metrics`.
- `test_graph_aware_search_with_entity_expansion`: assertion was `assert_called_once()`, but with `start_entity` **and** entity extraction enabled the code legitimately builds multiple graph starting points (start_entity + extracted entities), so `get_related_entities` is awaited once per starting point (4x with the shared mock). This is correct production behavior, not a bug — the assertion was over-strict. Relaxed to `assert_called()`, which still verifies traversal happened without asserting a mock-artifact count.

**#12357 — analytics**
- `api/codebase_analytics/call_graph_resolution_test.py::test_extract_multiple_imports`: input is `from typing import Dict, List` — `Optional` is never imported, so `resolve_name("Optional")` correctly returns `None`. The assertion `== "typing.Optional"` was a buggy expectation. Corrected to `is None` (asserts the real set: Dict/List resolved, Optional not).
- `api/analytics_evolution_test.py::test_explicit_dates_are_parsed`: production `_parse_date_range` uses `parse_utc_iso(...)` (UTC-anchored), while the test computed expected via naive `datetime.fromisoformat(...).timestamp()` (interpreted in runner-local TZ) → TZ-dependent failure. Anchored the expected values to UTC via `.replace(tzinfo=timezone.utc)` so the assertion is deterministic and matches production semantics.

No production bugs found — all four were bad test expectations/mocks; production behavior verified correct in each case.

## Verification
`python3 -m pytest <file> -p no:xdist -q` from `autobot-backend/` (never `-n auto`):

```
services/graph_rag_service_test.py .......................               [100%]
============================== 23 passed in 0.48s ==============================

api/codebase_analytics/call_graph_resolution_test.py ................... [ 47%]
........                                                                 [ 67%]
api/analytics_evolution_test.py .............                            [100%]
======================== 40 passed, 1 warning in 1.86s =========================
```

TZ-independence of the date fix (previously failed depending on runner TZ):
```
TZ=America/Los_Angeles ... 1 passed
TZ=Asia/Tokyo          ... 1 passed
```

## Model Used
Claude Opus 4.8
