### PR TITLE
fix(frontend): LLC status transitions must scope to target row via X-Organization-Id (#12368)

### DIFF
--- a/autobot-frontend/src/composables/llc/__tests__/useCompanyStatusApi.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/useCompanyStatusApi.test.ts
@@ -8,6 +8,10 @@
  * Asserts each transition POSTs the right endpoint, that the valid-transition
  * map mirrors the backend guards, and that a rejected (409) transition
  * propagates the error.
+ *
+ * GH#12368: each transition must send the TARGET row's id as the
+ * ``X-Organization-Id`` header so the backend authorises the target company
+ * regardless of the currently-selected tenant.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
@@ -28,6 +32,9 @@ import {
   DESTRUCTIVE_ACTIONS,
 } from '../useCompanyStatusApi'
 
+/** #12368: the per-request options that scope the call to the target row. */
+const orgHeader = (id: string) => ({ headers: { 'X-Organization-Id': id } })
+
 describe('useCompanyStatusApi', () => {
   beforeEach(() => {
     post.mockReset()
@@ -37,32 +44,46 @@ describe('useCompanyStatusApi', () => {
     const company = { id: 'c1', name: 'Acme', llc_status: 'active' }
     post.mockResolvedValueOnce(company)
     const result = await useCompanyStatusApi().activate('c1')
-    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/activate', undefined)
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/activate', undefined, orgHeader('c1'))
     expect(result).toEqual(company)
   })
 
   it('suspend() POSTs /suspend, omitting the body when no reason given', async () => {
     post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'paused' })
     await useCompanyStatusApi().suspend('c1')
-    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/suspend', undefined)
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/suspend', undefined, orgHeader('c1'))
   })
 
   it('suspend() forwards the reason as the request body', async () => {
     post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'paused' })
     await useCompanyStatusApi().suspend('c1', 'budget freeze')
-    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/suspend', { reason: 'budget freeze' })
+    expect(post).toHaveBeenCalledWith(
+      '/api/llc/companies/c1/suspend',
+      { reason: 'budget freeze' },
+      orgHeader('c1'),
+    )
   })
 
   it('offboard() POSTs /offboard', async () => {
     post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'offboarding' })
     await useCompanyStatusApi().offboard('c1')
-    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/offboard', undefined)
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/offboard', undefined, orgHeader('c1'))
   })
 
   it('archive() POSTs /archive', async () => {
     post.mockResolvedValueOnce({ id: 'c1', name: 'Acme', llc_status: 'archived' })
     await useCompanyStatusApi().archive('c1')
-    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/archive', undefined)
+    expect(post).toHaveBeenCalledWith('/api/llc/companies/c1/archive', undefined, orgHeader('c1'))
+  })
+
+  it('sends the TARGET row id as X-Organization-Id, not the selected tenant (#12368)', async () => {
+    post.mockResolvedValueOnce({ id: 'other-co', name: 'Other', llc_status: 'archived' })
+    await useCompanyStatusApi().archive('other-co')
+    expect(post).toHaveBeenCalledWith(
+      '/api/llc/companies/other-co/archive',
+      undefined,
+      { headers: { 'X-Organization-Id': 'other-co' } },
+    )
   })
 
   it('propagates a rejected (e.g. HTTP 409) transition', async () => {

--- a/autobot-frontend/src/composables/llc/useCompanyStatusApi.ts
+++ b/autobot-frontend/src/composables/llc/useCompanyStatusApi.ts
@@ -70,9 +70,14 @@ export function useCompanyStatusApi() {
     const api = useApiClient()
     const body = action === 'suspend' && reason ? { reason } : undefined
     try {
+      // #12368: send the TARGET row's id as the ``X-Organization-Id`` tenant
+      // scope so the backend ``assert_company_access`` guard authorises the
+      // transition regardless of which company is currently selected. Mirrors
+      // the archived-company delete path (useLlcCompanyStore.deleteCompany).
       return await api.post<CompanyStatusResult>(
         `/api/llc/companies/${companyId}/${action}`,
         body,
+        { headers: { 'X-Organization-Id': companyId } },
       )
     } catch (err) {
       logger.error(`Company ${action} failed for ${companyId}`, err)


### PR DESCRIPTION
Closes #12368

## Thinking Path
The archived-company DELETE (PR #12367) was hardened by sending the row's own id as the `X-Organization-Id` header (`useLlcCompanyStore.deleteCompany` — `api.delete(..., { headers: { 'X-Organization-Id': id } })`), so the backend `assert_company_access(ctx, company_id)` guard authorises the TARGET company regardless of which tenant is currently selected. The `CompanyStatusControl` status-transition paths (activate / suspend / offboard / archive) did NOT pass this header — they relied on the currently-selected tenant context. Since `CompanyStatusControl` is rendered per-row in `CompanySelectorView` (`v-for="company in companyStore.companies"`), transitioning any company OTHER than the selected one hit the wrong org context (latent cross-company bug). Fix: mirror the delete path's exact mechanism in the shared `transition()` helper so every transition scopes to the target row.

## What Changed
- `autobot-frontend/src/composables/llc/useCompanyStatusApi.ts` — `transition()` now passes the per-request option `{ headers: { 'X-Organization-Id': companyId } }` as the third arg to `api.post(...)`, carrying the TARGET row's id. This covers all four public actions (`activate`, `suspend`, `offboard`, `archive`) since they all route through `transition()`.
- `autobot-frontend/src/composables/llc/__tests__/useCompanyStatusApi.test.ts` — updated each `toHaveBeenCalledWith` assertion to expect the org-header option, plus a new test asserting the header carries the TARGET row id (`other-co`), not the selected tenant.

No new mechanism invented: `ApiClient.post(endpoint, data?, options: RequestOptions)` already accepts `headers?: Record<string,string>` (ApiClient.ts:447, 20), and `orgContext`/ApiClient only inject the selected tenant when `X-Organization-Id` is absent (orgContext.ts:71 `if (headers.has('X-Organization-Id')) return`; ApiClient.ts:330 `if (!orgHdrs['X-Organization-Id'])`), so an explicit header is preserved.

## Verification
- WSL has no npm — verified by inspection.
- Backend header read confirmed: `api/user_management/dependencies.py:112` `request.headers.get("X-Organization-Id")`; all four transition endpoints use `Depends(require_org_context)` + `assert_company_access(ctx, company_id)` (`llc/api/companies.py`: activate 342/352, suspend 377/383, offboard 406/414, archive 437/443). So the row-id header authorises the target company.
- Scanned all `/api/llc/companies/...` frontend mutation sites: the only per-row cross-company mutations are in `CompanySelectorView` (delete — already fixed in #12367; status transitions — fixed here). Every other call uses the route/selected `companyId` or child resources (members, projects, controls, portfolios) and is legitimately tenant-scoped, so left untouched. No frontend caller of the company PUT/update endpoint exists.
- TS validity confirmed by inspection (third positional arg matches `RequestOptions`).

## Model Used
Claude Opus 4.8
