### PR TITLE
fix(analytics): align env scan-root on resolve_scan_root + isolation tests (#12359)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
@@ -187,9 +187,7 @@ class TestDependencyModuleLoadIsolation:
         with patch.object(deps, "get_all_paginated", side_effect=fake_get_all_paginated):
             await deps._load_modules_from_chromadb(MagicMock(), {}, source_id="A")
 
-        assert captured["where"] == {
-            "$and": [{"type": {"$in": ["function", "class"]}}, {"source_id": "A"}]
-        }
+        assert captured["where"] == {"$and": [{"type": {"$in": ["function", "class"]}}, {"source_id": "A"}]}
 
     async def test_source_b_load_never_returns_source_a_modules(self):
         """Simulates real ChromaDB filtering to prove no cross-source bleed."""

--- a/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
@@ -267,9 +267,12 @@ class TestEnvironmentCacheScoping:
         assert resolved == str(default_root)
 
     async def test_explicit_source_id_unchanged_by_alignment(self, tmp_path):
-        """A real source_id resolves identically whether via resolve_source_root
-        directly (pre-fix) or via resolve_scan_root (post-fix) -- only the
-        None/default case differs."""
+        """A real, resolvable source_id resolves identically whether via
+        resolve_source_root directly (pre-fix) or via resolve_scan_root
+        (post-fix). Behavior differs only in two cases: source_id=None (now
+        resolves the DEFAULT source), and an UNRESOLVABLE source (fallback root
+        is now get_project_root() vs the old resolve_project_root(); identical
+        in a dev checkout, differs in the deployed layout -- tracked in #12393)."""
         from api.codebase_analytics.endpoints import environment, shared
 
         root_a = tmp_path / "proj_a"

--- a/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
@@ -12,6 +12,13 @@ show another project's call graph / endpoint coverage / dependency graph.
 
 These tests assert the scoping fix: a request for project A can never see
 project B's data, while a same-project request still works.
+
+Issue #12359 extends this coverage to the dependency graph's ChromaDB module
+load (``_load_modules_from_chromadb``) and the environment/hardcode-analysis
+per-source cache, and asserts the env scan-root helper is aligned with
+``resolve_scan_root`` (used by call-graph/import-tree/dependencies) so a
+``source_id=None`` request resolves the caller's DEFAULT source rather than
+falling straight through to the AutoBot project root.
 """
 
 import json
@@ -161,6 +168,122 @@ class TestEndpointCoverageCacheScoping:
         assert cached_a is analysis_a
         assert api_endpoints._analysis_cache["A"] is analysis_a
         assert api_endpoints._analysis_cache["B"] is analysis_b
+
+
+class TestDependencyModuleLoadIsolation:
+    """_load_modules_from_chromadb must scope its ChromaDB where-filter by
+    source_id so one project's ChromaDB-indexed modules never appear in
+    another project's dependency graph (Issue #12359)."""
+
+    async def test_where_filter_includes_source_id(self):
+        from api.codebase_analytics.endpoints import dependencies as deps
+
+        captured: dict = {}
+
+        def fake_get_all_paginated(collection, where=None, include=None):
+            captured["where"] = where
+            return {"metadatas": []}
+
+        with patch.object(deps, "get_all_paginated", side_effect=fake_get_all_paginated):
+            await deps._load_modules_from_chromadb(MagicMock(), {}, source_id="A")
+
+        assert captured["where"] == {
+            "$and": [{"type": {"$in": ["function", "class"]}}, {"source_id": "A"}]
+        }
+
+    async def test_source_b_load_never_returns_source_a_modules(self):
+        """Simulates real ChromaDB filtering to prove no cross-source bleed."""
+        from api.codebase_analytics.endpoints import dependencies as deps
+
+        all_metadatas = [
+            {"type": "function", "file_path": "a/mod_a.py", "source_id": "A"},
+            {"type": "function", "file_path": "b/mod_b.py", "source_id": "B"},
+        ]
+
+        def fake_get_all_paginated(collection, where=None, include=None):
+            wanted = where["$and"][1]["source_id"]
+            return {"metadatas": [m for m in all_metadatas if m["source_id"] == wanted]}
+
+        modules_a: dict = {}
+        modules_b: dict = {}
+        with patch.object(deps, "get_all_paginated", side_effect=fake_get_all_paginated):
+            await deps._load_modules_from_chromadb(MagicMock(), modules_a, source_id="A")
+            await deps._load_modules_from_chromadb(MagicMock(), modules_b, source_id="B")
+
+        assert "a/mod_a.py" in modules_a
+        assert "b/mod_b.py" not in modules_a
+        assert "b/mod_b.py" in modules_b
+        assert "a/mod_a.py" not in modules_b
+
+
+class TestEnvironmentCacheScoping:
+    """The env-analysis cache must be keyed per source, and the scan root
+    helper must be aligned with the sibling scan-root-scoped endpoints
+    (Issue #12359)."""
+
+    def test_cache_key_is_per_source(self):
+        from api.codebase_analytics.endpoints.environment import _env_cache_key
+
+        assert _env_cache_key(None) == "default"
+        assert _env_cache_key("A") == "A"
+        assert _env_cache_key("A") != _env_cache_key("B")
+
+    async def test_two_sources_use_distinct_cache_entries(self):
+        """Analysis cached for source A must never surface under source B's key."""
+        from api.codebase_analytics.endpoints import environment
+
+        environment._env_analysis_cache.clear()
+        environment._env_analysis_cache["A"] = {"total_hardcoded_values": 1, "marker": "A"}
+        environment._env_analysis_cache["B"] = {"total_hardcoded_values": 2, "marker": "B"}
+
+        cached_a = await environment._check_env_analysis_cache(use_llm_filter=False, refresh=False, source_id="A")
+        cached_b = await environment._check_env_analysis_cache(use_llm_filter=False, refresh=False, source_id="B")
+
+        data_a = json.loads(cached_a.body)
+        data_b = json.loads(cached_b.body)
+        assert data_a["marker"] == "A"
+        assert data_b["marker"] == "B"
+
+    async def test_scan_root_resolves_default_source_for_none(self, tmp_path):
+        """Issue #12359: _resolve_env_scan_root now delegates to the shared
+        resolve_scan_root (used by call-graph/import-tree/dependencies), so a
+        source_id=None request resolves the caller's DEFAULT registered
+        source instead of jumping straight to the AutoBot project root."""
+        from api.codebase_analytics.endpoints import environment, shared
+
+        default_root = tmp_path / "default_proj"
+        default_root.mkdir()
+
+        async def fake_resolve_source_root(source_id):
+            return default_root if source_id == "DEFAULT" else None
+
+        with (
+            patch.object(shared, "resolve_source_root", side_effect=fake_resolve_source_root),
+            patch(
+                "api.codebase_analytics.source_storage.get_default_source_id",
+                AsyncMock(return_value="DEFAULT"),
+            ),
+        ):
+            resolved = await environment._resolve_env_scan_root(None)
+
+        assert resolved == str(default_root)
+
+    async def test_explicit_source_id_unchanged_by_alignment(self, tmp_path):
+        """A real source_id resolves identically whether via resolve_source_root
+        directly (pre-fix) or via resolve_scan_root (post-fix) -- only the
+        None/default case differs."""
+        from api.codebase_analytics.endpoints import environment, shared
+
+        root_a = tmp_path / "proj_a"
+        root_a.mkdir()
+
+        async def fake_resolve_source_root(source_id):
+            return root_a if source_id == "A" else None
+
+        with patch.object(shared, "resolve_source_root", side_effect=fake_resolve_source_root):
+            resolved = await environment._resolve_env_scan_root("A")
+
+        assert resolved == str(root_a)
 
 
 def _all_function_names(response) -> set:

--- a/autobot-backend/api/codebase_analytics/endpoints/dependencies.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/dependencies.py
@@ -388,6 +388,12 @@ async def _load_modules_from_chromadb(
 
     Issue #12330: Filter by source_id to prevent cross-project leakage; without
     it the query returns modules indexed for every registered source.
+
+    Migration note (#12359): records indexed BEFORE this source-scoping fix
+    landed have no ``source_id`` metadata field, so this filter silently
+    drops them from the dependency graph rather than surfacing under the
+    wrong project (fail-closed -- the safe direction). Those pre-scoping
+    records don't reappear until their source is reindexed.
     """
     try:
         type_filter = {"type": {"$in": ["function", "class"]}}

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -23,7 +23,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import QUALITY_MODEL
 
 from ..analyzers import normalize_hardcode_record
-from .shared import resolve_project_root
+from .shared import resolve_scan_root
 
 logger = get_logger(__name__)
 
@@ -48,19 +48,13 @@ def _env_cache_key(source_id: str | None) -> str:
 async def _resolve_env_scan_root(source_id: str | None) -> str:
     """Resolve the filesystem root to analyze for a source (Issue #12330).
 
-    Uses the selected source's clone path when available, otherwise falls back
-    to the AutoBot project root (resolve_project_root, deployed-layout aware) to
-    preserve existing behavior when no source is selected.
+    Issue #12359: Delegates to the shared ``resolve_scan_root`` used by
+    call-graph/import-tree/dependencies so a ``source_id=None`` request
+    resolves the caller's DEFAULT registered source first, instead of
+    falling straight through to AutoBot's own project root. Keeps env
+    analysis consistent with the sibling scan-root-scoped endpoints.
     """
-    from .shared import resolve_source_root
-
-    source_root = await resolve_source_root(source_id)
-    return str(source_root) if source_root else _get_project_root()
-
-
-def _get_project_root() -> str:
-    """Get project root path — delegates to shared resolver (#10730)."""
-    return resolve_project_root()
+    return str(await resolve_scan_root(source_id))
 
 
 def _validate_env_path_security(path: str, project_root: str) -> JSONResponse | None:


### PR DESCRIPTION
Closes #12359

## Thinking Path
#12355's review flagged three should-fix items. First I read `shared.py`'s `resolve_source_root` vs `resolve_scan_root` side by side, and confirmed how call-graph/import-tree/dependencies already call `resolve_scan_root(source_id)`: for a real `source_id` both helpers resolve identically (the default-lookup branch is skipped entirely), so the only behavior difference is the `source_id=None` case -- `resolve_scan_root` resolves the caller's DEFAULT registered source first, whereas `resolve_source_root` returns `None` immediately and env's own fallback kicked in. That confirmed this is a genuine inconsistency, not a leak, and safe to fix by delegating. I also checked whether env's fallback (`resolve_project_root`, deployed-layout git-aware) differed materially from `resolve_scan_root`'s fallback (`get_project_root`, plain `parents[4]`) -- that dual convention already exists pre-change (`report.py`/`stats.py`/`api_endpoint_scanner.py` all use the plain `get_project_root` fallback via `resolve_scan_root`), so aligning env onto it matches the established codebase-wide pattern rather than introducing a new discrepancy.

For the tests, I matched `cross_project_scoping_test.py`'s existing style (it already covers call-graph + endpoint-coverage-cache isolation for this same #12330 leakage class) and added new test classes there rather than a new file, since dependencies/environment are the same #12330 family. Mirrored `cross_language_scoping_test.py`'s pattern of asserting the exact ChromaDB `where` clause and simulating real filtering with a fake collection.

## What Changed
- `autobot-backend/api/codebase_analytics/endpoints/environment.py`: `_resolve_env_scan_root` now delegates to the shared `resolve_scan_root` (imported from `.shared`) instead of calling `resolve_source_root` directly, matching call-graph/import-tree/dependencies. Removed the now-dead `_get_project_root` delegate and its `resolve_project_root` import (no longer referenced after the alignment).
- `autobot-backend/api/codebase_analytics/endpoints/dependencies.py`: added a migration-note code comment on `_load_modules_from_chromadb` -- dependency records indexed **before** source-scoping (#12330) have no `source_id` metadata, so the `where`-filter silently drops them from the graph rather than surfacing under the wrong project. This is the safe, fail-closed direction; those pre-scoping records simply don't reappear until their source is reindexed. No migration code required.
- `autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py`: new test classes --
  - `TestDependencyModuleLoadIsolation`: asserts the ChromaDB `where`-filter includes `source_id`, and that a source-B load never returns source-A's modules (simulated real filtering via a fake collection).
  - `TestEnvironmentCacheScoping`: asserts `_env_cache_key` produces distinct keys per source, that two sources' cached analyses never bleed into each other, that `_resolve_env_scan_root(None)` now resolves the DEFAULT source (post-fix), and that an explicit `source_id` resolves identically to the pre-fix behavior (no regression for the explicit case).

## Verification
New/changed test file:
```
$ python3 -m pytest api/codebase_analytics/endpoints/cross_project_scoping_test.py -p no:xdist -q
collected 12 items
api/codebase_analytics/endpoints/cross_project_scoping_test.py ......... [ 75%]
...                                                                      [100%]
12 passed, 1 warning in 1.22s
```

Existing #12355 analytics tests (no regression from the helper alignment):
```
$ python3 -m pytest api/codebase_analytics/endpoints/cross_language_scoping_test.py api/codebase_analytics/endpoints/source_authorization_test.py api/codebase_analytics/endpoints/report_scoping_test.py -p no:xdist -q
collected 29 items
api/codebase_analytics/endpoints/cross_language_scoping_test.py ........
api/codebase_analytics/endpoints/source_authorization_test.py ..........
.......
api/codebase_analytics/endpoints/report_scoping_test.py ....
29 passed, 1 warning in 1.09s
```

Full `codebase_analytics` suite (157 passed, 13 skipped, 8 pre-existing failures unrelated to this change -- `progress_tracker_test.py`/`codebase_stats_endpoint_test.py`/`parallel_processing_test.py`, none of which touch scan-root/source_id and reproduce identically on an unmodified checkout).

## Model Used
Claude Opus 4.8
