### PR TITLE
perf(knowledge): drop full_content from facts/by_category browse list (#12370)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -2161,8 +2161,9 @@ def _process_fact_data(fact_data: dict, cat: str, fact_key: str) -> dict | None:
         return {
             "key": fact_key,
             "title": fact_title,
+            # Issue #12370: browse list ships only the snippet; the full
+            # document is lazy-loaded per fact via GET /fact/{fact_key}.
             "content": content[:500] + "..." if len(content) > 500 else content,
-            "full_content": content,
             "category": cat,
             "type": fact_type,
             "metadata": metadata,
@@ -2346,8 +2347,9 @@ async def _get_facts_by_category_legacy(kb, category: str | None, limit: int):
             {
                 "key": fact_key,
                 "title": title,
+                # Issue #12370: snippet only; full document lazy-loaded via
+                # GET /fact/{fact_key}.
                 "content": content[:500] + "..." if len(content) > 500 else content,
-                "full_content": content,
                 "category": fact_cat,
                 "type": fact_type,
                 "metadata": metadata,

--- a/autobot-backend/api/knowledge_by_category_payload_test.py
+++ b/autobot-backend/api/knowledge_by_category_payload_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Issue #12370: the ``GET /api/knowledge_base/facts/by_category`` browse list
+must ship only a snippet (``content``), never the entire document
+(``full_content``). The full text is lazy-loaded per fact via
+``GET /api/knowledge_base/fact/{fact_key}``.
+
+These tests pin the payload contract:
+    * the list-item builder omits ``full_content`` and truncates ``content``;
+    * the list response model no longer declares ``full_content``;
+    * the detail endpoint's content extractor still returns the full text.
+"""
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def large_fact_data():
+    """Redis ``hgetall`` shape (bytes keys/values) for a >500-char document."""
+    content = "x" * 1200
+    return content, {
+        b"content": content.encode("utf-8"),
+        b"metadata": json.dumps({"title": "Big Doc", "type": "note"}).encode("utf-8"),
+    }
+
+
+class TestBrowseListOmitsFullContent:
+    """The browse list ships a snippet only — never full_content."""
+
+    def test_process_fact_data_omits_full_content(self, large_fact_data):
+        from api.knowledge import _process_fact_data
+
+        content, fact_data = large_fact_data
+        result = _process_fact_data(fact_data, "tools", "fact:abc")
+
+        assert result is not None
+        # Issue #12370: the entire document must NOT be in the list item.
+        assert "full_content" not in result
+        # Snippet is truncated to 500 chars + ellipsis.
+        assert result["content"].endswith("...")
+        assert len(result["content"]) == 503
+        assert result["content"][:-3] == content[:500]
+        # The fields a browse list actually needs are present.
+        assert result["key"] == "fact:abc"
+        assert result["title"] == "Big Doc"
+        assert result["category"] == "tools"
+        assert result["type"] == "note"
+        assert isinstance(result["metadata"], dict)
+
+    def test_short_fact_content_not_ellipsised(self):
+        from api.knowledge import _process_fact_data
+
+        short = "nmap is a network scanner"
+        fact_data = {
+            b"content": short.encode("utf-8"),
+            b"metadata": json.dumps({"title": "nmap"}).encode("utf-8"),
+        }
+        result = _process_fact_data(fact_data, "tools", "fact:xyz")
+
+        assert result is not None
+        assert "full_content" not in result
+        # Short facts arrive whole (no trailing ellipsis) so the client
+        # renders them without a detail round-trip.
+        assert result["content"] == short
+
+    def test_response_model_no_longer_declares_full_content(self):
+        from knowledge.schemas.entries import FactByCategoryEntry
+
+        # Issue #12370: contract (OpenAPI/api.ts) must not advertise the field.
+        assert "full_content" not in FactByCategoryEntry.model_fields
+        assert "content" in FactByCategoryEntry.model_fields
+
+
+class TestDetailEndpointCarriesFullContent:
+    """The per-fact detail endpoint remains the lazy-load source of truth."""
+
+    def test_extract_fact_content_returns_full_untruncated_text(self, large_fact_data):
+        from api.knowledge import _extract_fact_content
+
+        content, _ = large_fact_data
+        # Detail endpoint returns the whole document, untruncated, in `content`.
+        extracted = _extract_fact_content({"content": content})
+
+        assert extracted == content
+        assert len(extracted) == 1200
+        assert not extracted.endswith("...")
+
+    def test_detail_response_model_exposes_content(self):
+        from knowledge.schemas.entries import FactByKeyResponse
+
+        # The detail response carries the full document under `content`.
+        assert "content" in FactByKeyResponse.model_fields
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/autobot-backend/knowledge/schemas/entries.py
+++ b/autobot-backend/knowledge/schemas/entries.py
@@ -59,7 +59,8 @@ class FactByCategoryEntry(BaseModel):
     key: str
     title: str = "Untitled"
     content: str = Field("", description="Truncated to 500 chars + ellipsis")
-    full_content: str = ""
+    # Issue #12370: full_content intentionally omitted from the browse list —
+    # the entire document is lazy-loaded per fact via GET /fact/{fact_key}.
     category: str = ""
     type: str = "unknown"
     metadata: Dict[str, Any] = Field(default_factory=dict)

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -318,7 +318,8 @@ interface KnowledgeFactLike {
   title?: string
   source?: string
   content?: string
-  full_content?: string
+  // Issue #12370: full_content removed from the browse list — lazy-loaded
+  // per fact via GET /fact/{fact_key}.
   timestamp?: string
   created_at?: string
   category?: string
@@ -565,19 +566,21 @@ const buildNestedTree = (facts: Record<string, unknown>[], category: string): Tr
         if (!current._files) current._files = []
         // Extract the actual fact ID from the Redis key (e.g., "fact:UUID" -> "UUID")
         const factId = fact.key ? fact.key.replace('fact:', '') : `fact-${category}-${factIdx}`
-        const fileContent = (fact.full_content || fact.content || '') as string
+        // Issue #12370: the browse list carries only the snippet (content).
+        // The full document is lazy-loaded on open via GET /fact/{fact_key}
+        // (see loadFileContent), so we never ship full_content in the list.
+        const snippet = (fact.content || '') as string
         current._files.push({
           id: factId, // Use actual fact ID from Redis, not synthetic ID
           name: part,
           type: 'file' as const,
           path: `/${category}/${filename}`,
           category: category,
-          size: fileContent.length,
-          content: fileContent,
+          size: snippet.length,
+          content: snippet,
           metadata: {
             ...fact.metadata,
-            key: fact.key,
-            full_content: fact.full_content
+            key: fact.key
           }
         })
       } else {
@@ -1067,11 +1070,11 @@ const loadFolderContents = async (folder: TreeNode) => {
 const loadFileContent = async (file: TreeNode) => {
   contentError.value = null
   await loadFileContentOp(async () => {
-    // First check if we have full_content in metadata
-    if (file.metadata?.full_content) {
-      fileContent.value = file.metadata.full_content
-    } else if (file.content && !file.content.endsWith('...')) {
-      // Use content if it's not truncated
+    // Issue #12370: the browse list no longer carries full_content. Short
+    // facts arrive whole in the snippet (no trailing ellipsis); anything
+    // truncated is lazy-loaded in full from the per-fact detail endpoint.
+    if (file.content && !file.content.endsWith('...')) {
+      // Snippet is the complete fact — use it directly.
       fileContent.value = file.content
     } else {
       // Need to fetch full content from Redis
@@ -1079,7 +1082,7 @@ const loadFileContent = async (file: TreeNode) => {
       const factKey = file.metadata?.key || file.path?.split('/').pop()
 
       if (factKey) {
-        // Fetch full fact data from backend
+        // Fetch full fact data from backend (GET /fact/{fact_key})
         const response = await fetchFactContent(factKey)
 
         if (response && response.content) {

--- a/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
+++ b/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
@@ -117,7 +117,7 @@ export interface TreeNodeMetadata {
   title?: string
   source?: string
   content?: string
-  full_content?: string
+  // Issue #12370: full_content removed — lazy-loaded via GET /fact/{fact_key}.
   timestamp?: string
   created_at?: string
   category?: string

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -72320,11 +72320,6 @@ export interface components {
              */
             content: string;
             /**
-             * Full Content
-             * @default
-             */
-            full_content: string;
-            /**
              * Category
              * @default
              */

--- a/autobot-frontend/src/types/knowledgeBase.ts
+++ b/autobot-frontend/src/types/knowledgeBase.ts
@@ -221,7 +221,8 @@ export interface CategorizedFact {
   key: string
   title: string
   content: string
-  full_content?: string
+  // Issue #12370: full_content removed from the browse list — the full
+  // document is lazy-loaded per fact via GET /knowledge_base/fact/{fact_key}.
   category: string
   type: string
   metadata: Record<string, unknown>


### PR DESCRIPTION
Closes #12370

## Thinking Path

`GET /api/knowledge_base/facts/by_category` powers the Knowledge browse tree, which renders only a title + ~500-char snippet per fact. Yet the endpoint returned every fact's `full_content` — the entire document (measured 107KB for one fact; 3.06MB for just 43 facts, growing linearly). ~98% of the payload was text the list never shows. A per-fact detail endpoint (`GET /fact/{fact_key}`) already existed and already returned the full text, and the frontend already had a lazy-load path (`fetchFactContent`) wired into `loadFileContent`. So the fix is to stop shipping `full_content` in the list and let the existing detail endpoint serve the full document on open/edit. Pagination of the unbounded list is a larger, separate change — filed as #12394.

## What Changed

**Backend**
- `knowledge/schemas/entries.py` — removed `full_content` from `FactByCategoryEntry` (list response model). Detail model `FactByKeyResponse` unchanged.
- `api/knowledge.py` — `_process_fact_data` (indexed path) and `_get_facts_by_category_legacy` (SCAN fallback) no longer emit `full_content`; both still emit the truncated `content` snippet. Detail handler `get_fact_by_key` unchanged — still returns the full document as `content` (knowledge.py:2452-2457 via `_extract_fact_content`).

**Frontend** (every `.full_content` browse-list consumer traced)
- `KnowledgeBrowser.vue` `buildNestedTree` — tree nodes now built from the snippet (`fact.content`), no `full_content` stored on node metadata. `loadFileContent` drops the dead `metadata.full_content` branch; short (un-truncated) snippets render directly, truncated ones lazy-load in full via `fetchFactContent` → `GET /fact/{fact_key}`. Open/edit/copy-full-text all flow through this path unchanged.
- Removed the now-unused `full_content` field from the `KnowledgeFactLike` (KnowledgeBrowser), `TreeNodeMetadata` (TreeNodeComponent), and `CategorizedFact` (knowledgeBase.ts) types.
- `types/generated/api.ts` — dropped `full_content` from the `FactByCategoryEntry` schema to match the backend contract (surgical edit; WSL has no npm to run openapi-typescript).

Unrelated `full_content` refs left intact: chat `SessionFact`/`FactPreview`/`ShareConversationDialog` and the `prompts` store's `full_content_available` flag — none consume the by_category list.

## Verification

- New `api/knowledge_by_category_payload_test.py` pins the contract: list builder omits `full_content` + truncates to 503 chars, short facts keep whole content, response model no longer declares `full_content`, and the detail extractor returns the full untruncated text. **5 passed.**
- Existing `api/knowledge_categories_test.py` — **25 passed** (no regression).
- Ran `python3 -m pytest api/knowledge_by_category_payload_test.py api/knowledge_categories_test.py -p no:xdist -q`.
- Detail-endpoint full_content confirmed at `autobot-backend/api/knowledge.py:2452-2457`.

Follow-up: pagination of the unbounded `facts/by_category` list tracked in #12394 (`priority: medium`).

## Model Used

Claude Opus 4.8
