### PR TITLE
i18n(chat): convert hardcoded ChatController error strings to i18n keys (#12349)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "تعذّر حذف المحادثة. يُرجى المحاولة مرة أخرى."
+      "deleteFailed": "تعذّر حذف المحادثة. يُرجى المحاولة مرة أخرى.",
+      "createFailed": "تعذّر إنشاء المحادثة: {error}",
+      "loadSessionsFailed": "تعذّر تحميل جلسات المحادثة: {error}",
+      "loadMessagesFailed": "تعذّر تحميل الرسائل: {error}",
+      "saveFailed": "تعذّر حفظ المحادثة: {error}",
+      "resetFailed": "تعذّر إعادة تعيين المحادثة: {error}",
+      "clearFailed": "تعذّر مسح المحادثات: {error}",
+      "invalidFormat": "تنسيق الرسالة غير صالح. يُرجى التحقق من إدخالك والمحاولة مرة أخرى.",
+      "serviceUnavailable": "خدمة المحادثة غير متوفرة. يُرجى تحديث الصفحة والمحاولة مرة أخرى.",
+      "serverError": "حدث خطأ في الخادم. يُرجى المحاولة مرة أخرى بعد لحظة.",
+      "networkFailed": "فشل الاتصال بالشبكة. يُرجى التحقق من اتصالك بالإنترنت.",
+      "timeout": "انتهت مهلة الطلب. يُرجى المحاولة مرة أخرى برسالة أقصر.",
+      "sendFailed": "تعذّر إرسال الرسالة: {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "Der Chat konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
+      "deleteFailed": "Der Chat konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
+      "createFailed": "Chat konnte nicht erstellt werden: {error}",
+      "loadSessionsFailed": "Chatsitzungen konnten nicht geladen werden: {error}",
+      "loadMessagesFailed": "Nachrichten konnten nicht geladen werden: {error}",
+      "saveFailed": "Chat konnte nicht gespeichert werden: {error}",
+      "resetFailed": "Chat konnte nicht zurückgesetzt werden: {error}",
+      "clearFailed": "Chats konnten nicht gelöscht werden: {error}",
+      "invalidFormat": "Ungültiges Nachrichtenformat. Bitte überprüfen Sie Ihre Eingabe und versuchen Sie es erneut.",
+      "serviceUnavailable": "Chat-Dienst nicht verfügbar. Bitte laden Sie die Seite neu und versuchen Sie es erneut.",
+      "serverError": "Ein Serverfehler ist aufgetreten. Bitte versuchen Sie es in einem Moment erneut.",
+      "networkFailed": "Netzwerkverbindung fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung.",
+      "timeout": "Zeitüberschreitung der Anfrage. Bitte versuchen Sie es mit einer kürzeren Nachricht erneut.",
+      "sendFailed": "Nachricht konnte nicht gesendet werden: {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "Couldn't delete the chat. Please try again."
+      "deleteFailed": "Couldn't delete the chat. Please try again.",
+      "createFailed": "Failed to create chat: {error}",
+      "loadSessionsFailed": "Failed to load chat sessions: {error}",
+      "loadMessagesFailed": "Failed to load messages: {error}",
+      "saveFailed": "Failed to save chat: {error}",
+      "resetFailed": "Failed to reset chat: {error}",
+      "clearFailed": "Failed to clear chats: {error}",
+      "invalidFormat": "Invalid message format. Please check your input and try again.",
+      "serviceUnavailable": "Chat service not available. Please refresh the page and try again.",
+      "serverError": "Server error occurred. Please try again in a moment.",
+      "networkFailed": "Network connection failed. Please check your internet connection.",
+      "timeout": "Request timed out. Please try again with a shorter message.",
+      "sendFailed": "Failed to send message: {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "No se pudo eliminar el chat. Inténtalo de nuevo."
+      "deleteFailed": "No se pudo eliminar el chat. Inténtalo de nuevo.",
+      "createFailed": "No se pudo crear el chat: {error}",
+      "loadSessionsFailed": "No se pudieron cargar las sesiones de chat: {error}",
+      "loadMessagesFailed": "No se pudieron cargar los mensajes: {error}",
+      "saveFailed": "No se pudo guardar el chat: {error}",
+      "resetFailed": "No se pudo restablecer el chat: {error}",
+      "clearFailed": "No se pudieron eliminar los chats: {error}",
+      "invalidFormat": "Formato de mensaje no válido. Comprueba tu entrada e inténtalo de nuevo.",
+      "serviceUnavailable": "Servicio de chat no disponible. Actualiza la página e inténtalo de nuevo.",
+      "serverError": "Se produjo un error del servidor. Inténtalo de nuevo en un momento.",
+      "networkFailed": "Error de conexión de red. Comprueba tu conexión a Internet.",
+      "timeout": "Se agotó el tiempo de espera de la solicitud. Inténtalo de nuevo con un mensaje más corto.",
+      "sendFailed": "No se pudo enviar el mensaje: {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -5560,7 +5560,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "حذف گفتگو ممکن نشد. لطفاً دوباره تلاش کنید."
+      "deleteFailed": "حذف گفتگو ممکن نشد. لطفاً دوباره تلاش کنید.",
+      "createFailed": "ایجاد گفتگو ممکن نشد: {error}",
+      "loadSessionsFailed": "بارگذاری جلسات گفتگو ممکن نشد: {error}",
+      "loadMessagesFailed": "بارگذاری پیام‌ها ممکن نشد: {error}",
+      "saveFailed": "ذخیره گفتگو ممکن نشد: {error}",
+      "resetFailed": "بازنشانی گفتگو ممکن نشد: {error}",
+      "clearFailed": "پاک کردن گفتگوها ممکن نشد: {error}",
+      "invalidFormat": "قالب پیام نامعتبر است. لطفاً ورودی خود را بررسی کرده و دوباره تلاش کنید.",
+      "serviceUnavailable": "سرویس گفتگو در دسترس نیست. لطفاً صفحه را تازه‌سازی کرده و دوباره تلاش کنید.",
+      "serverError": "خطای سرور رخ داد. لطفاً لحظه‌ای دیگر دوباره تلاش کنید.",
+      "networkFailed": "اتصال شبکه ناموفق بود. لطفاً اتصال اینترنت خود را بررسی کنید.",
+      "timeout": "زمان درخواست به پایان رسید. لطفاً با پیام کوتاه‌تری دوباره تلاش کنید.",
+      "sendFailed": "ارسال پیام ممکن نشد: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "Impossible de supprimer la conversation. Veuillez réessayer."
+      "deleteFailed": "Impossible de supprimer la conversation. Veuillez réessayer.",
+      "createFailed": "Impossible de créer la conversation : {error}",
+      "loadSessionsFailed": "Impossible de charger les sessions de conversation : {error}",
+      "loadMessagesFailed": "Impossible de charger les messages : {error}",
+      "saveFailed": "Impossible d'enregistrer la conversation : {error}",
+      "resetFailed": "Impossible de réinitialiser la conversation : {error}",
+      "clearFailed": "Impossible de supprimer les conversations : {error}",
+      "invalidFormat": "Format de message invalide. Veuillez vérifier votre saisie et réessayer.",
+      "serviceUnavailable": "Service de conversation indisponible. Veuillez actualiser la page et réessayer.",
+      "serverError": "Une erreur du serveur s'est produite. Veuillez réessayer dans un instant.",
+      "networkFailed": "Échec de la connexion réseau. Veuillez vérifier votre connexion Internet.",
+      "timeout": "La requête a expiré. Veuillez réessayer avec un message plus court.",
+      "sendFailed": "Impossible d'envoyer le message : {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -5560,7 +5560,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "לא ניתן היה למחוק את הצ'אט. אנא נסה שוב."
+      "deleteFailed": "לא ניתן היה למחוק את הצ'אט. אנא נסה שוב.",
+      "createFailed": "לא ניתן היה ליצור את הצ'אט: {error}",
+      "loadSessionsFailed": "לא ניתן היה לטעון את הפעלות הצ'אט: {error}",
+      "loadMessagesFailed": "לא ניתן היה לטעון את ההודעות: {error}",
+      "saveFailed": "לא ניתן היה לשמור את הצ'אט: {error}",
+      "resetFailed": "לא ניתן היה לאפס את הצ'אט: {error}",
+      "clearFailed": "לא ניתן היה לנקות את הצ'אטים: {error}",
+      "invalidFormat": "פורמט הודעה לא חוקי. אנא בדוק את הקלט ונסה שוב.",
+      "serviceUnavailable": "שירות הצ'אט אינו זמין. אנא רענן את הדף ונסה שוב.",
+      "serverError": "אירעה שגיאת שרת. אנא נסה שוב בעוד רגע.",
+      "networkFailed": "החיבור לרשת נכשל. אנא בדוק את חיבור האינטרנט שלך.",
+      "timeout": "תם הזמן הקצוב לבקשה. אנא נסה שוב עם הודעה קצרה יותר.",
+      "sendFailed": "לא ניתן היה לשלוח את ההודעה: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "Neizdevās izdzēst sarunu. Lūdzu, mēģiniet vēlreiz."
+      "deleteFailed": "Neizdevās izdzēst sarunu. Lūdzu, mēģiniet vēlreiz.",
+      "createFailed": "Neizdevās izveidot sarunu: {error}",
+      "loadSessionsFailed": "Neizdevās ielādēt sarunu sesijas: {error}",
+      "loadMessagesFailed": "Neizdevās ielādēt ziņojumus: {error}",
+      "saveFailed": "Neizdevās saglabāt sarunu: {error}",
+      "resetFailed": "Neizdevās atiestatīt sarunu: {error}",
+      "clearFailed": "Neizdevās notīrīt sarunas: {error}",
+      "invalidFormat": "Nederīgs ziņojuma formāts. Lūdzu, pārbaudiet ievadi un mēģiniet vēlreiz.",
+      "serviceUnavailable": "Sarunu pakalpojums nav pieejams. Lūdzu, atsvaidziniet lapu un mēģiniet vēlreiz.",
+      "serverError": "Radās servera kļūda. Lūdzu, mēģiniet vēlreiz pēc brīža.",
+      "networkFailed": "Neizdevās tīkla savienojums. Lūdzu, pārbaudiet interneta savienojumu.",
+      "timeout": "Pieprasījuma noildze. Lūdzu, mēģiniet vēlreiz ar īsāku ziņojumu.",
+      "sendFailed": "Neizdevās nosūtīt ziņojumu: {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "Nie udało się usunąć czatu. Spróbuj ponownie."
+      "deleteFailed": "Nie udało się usunąć czatu. Spróbuj ponownie.",
+      "createFailed": "Nie udało się utworzyć czatu: {error}",
+      "loadSessionsFailed": "Nie udało się załadować sesji czatu: {error}",
+      "loadMessagesFailed": "Nie udało się załadować wiadomości: {error}",
+      "saveFailed": "Nie udało się zapisać czatu: {error}",
+      "resetFailed": "Nie udało się zresetować czatu: {error}",
+      "clearFailed": "Nie udało się wyczyścić czatów: {error}",
+      "invalidFormat": "Nieprawidłowy format wiadomości. Sprawdź swoje dane i spróbuj ponownie.",
+      "serviceUnavailable": "Usługa czatu jest niedostępna. Odśwież stronę i spróbuj ponownie.",
+      "serverError": "Wystąpił błąd serwera. Spróbuj ponownie za chwilę.",
+      "networkFailed": "Połączenie sieciowe nie powiodło się. Sprawdź połączenie z internetem.",
+      "timeout": "Upłynął limit czasu żądania. Spróbuj ponownie z krótszą wiadomością.",
+      "sendFailed": "Nie udało się wysłać wiadomości: {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -734,7 +734,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "Não foi possível excluir o chat. Tente novamente."
+      "deleteFailed": "Não foi possível excluir o chat. Tente novamente.",
+      "createFailed": "Não foi possível criar o chat: {error}",
+      "loadSessionsFailed": "Não foi possível carregar as sessões de chat: {error}",
+      "loadMessagesFailed": "Não foi possível carregar as mensagens: {error}",
+      "saveFailed": "Não foi possível salvar o chat: {error}",
+      "resetFailed": "Não foi possível redefinir o chat: {error}",
+      "clearFailed": "Não foi possível limpar os chats: {error}",
+      "invalidFormat": "Formato de mensagem inválido. Verifique sua entrada e tente novamente.",
+      "serviceUnavailable": "Serviço de chat indisponível. Atualize a página e tente novamente.",
+      "serverError": "Ocorreu um erro no servidor. Tente novamente em um instante.",
+      "networkFailed": "Falha na conexão de rede. Verifique sua conexão com a internet.",
+      "timeout": "A solicitação expirou. Tente novamente com uma mensagem mais curta.",
+      "sendFailed": "Não foi possível enviar a mensagem: {error}"
     }
   },
   "settings": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -5560,7 +5560,19 @@
     "lightweightMode": "Lightweight mode",
     "lightweightModeTooltip": "lightweight Mode tooltip",
     "errors": {
-      "deleteFailed": "چیٹ حذف نہیں ہو سکی۔ براہ کرم دوبارہ کوشش کریں۔"
+      "deleteFailed": "چیٹ حذف نہیں ہو سکی۔ براہ کرم دوبارہ کوشش کریں۔",
+      "createFailed": "چیٹ بنائی نہیں جا سکی: {error}",
+      "loadSessionsFailed": "چیٹ سیشنز لوڈ نہیں ہو سکے: {error}",
+      "loadMessagesFailed": "پیغامات لوڈ نہیں ہو سکے: {error}",
+      "saveFailed": "چیٹ محفوظ نہیں ہو سکی: {error}",
+      "resetFailed": "چیٹ ری سیٹ نہیں ہو سکی: {error}",
+      "clearFailed": "چیٹس صاف نہیں ہو سکیں: {error}",
+      "invalidFormat": "پیغام کی شکل غلط ہے۔ براہ کرم اپنی ان پٹ چیک کریں اور دوبارہ کوشش کریں۔",
+      "serviceUnavailable": "چیٹ سروس دستیاب نہیں ہے۔ براہ کرم صفحہ ریفریش کریں اور دوبارہ کوشش کریں۔",
+      "serverError": "سرور کی خرابی پیش آئی۔ براہ کرم ایک لمحے میں دوبارہ کوشش کریں۔",
+      "networkFailed": "نیٹ ورک کنکشن ناکام ہو گیا۔ براہ کرم اپنا انٹرنیٹ کنکشن چیک کریں۔",
+      "timeout": "درخواست کا وقت ختم ہو گیا۔ براہ کرم مختصر پیغام کے ساتھ دوبارہ کوشش کریں۔",
+      "sendFailed": "پیغام بھیجا نہیں جا سکا: {error}"
     }
   },
   "serviceMessages": {

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -244,22 +244,22 @@ export class ChatController {
     const message = extractErrorMessage(error, 'Unknown error')
 
     if (status === 422) {
-      return 'Invalid message format. Please check your input and try again.'
+      return i18n.global.t('chat.errors.invalidFormat')
     }
     if (status === 404) {
-      return 'Chat service not available. Please refresh the page and try again.'
+      return i18n.global.t('chat.errors.serviceUnavailable')
     }
     if (status === 500) {
-      return 'Server error occurred. Please try again in a moment.'
+      return i18n.global.t('chat.errors.serverError')
     }
     if (name === 'NetworkError') {
-      return 'Network connection failed. Please check your internet connection.'
+      return i18n.global.t('chat.errors.networkFailed')
     }
     if (message.includes('timeout')) {
-      return 'Request timed out. Please try again with a shorter message.'
+      return i18n.global.t('chat.errors.timeout')
     }
 
-    return `Failed to send message: ${message}`
+    return i18n.global.t('chat.errors.sendFailed', { error: message })
   }
 
   /**
@@ -645,7 +645,7 @@ export class ChatController {
     } catch (error) {
       // Backend create failed - don't create local session if backend fails
       logger.error('Failed to create chat session on backend:', error)
-      this.getAppStore()?.setGlobalError(`Failed to create chat: ${extractErrorMessage(error, 'Unknown error')}`)
+      this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.createFailed', { error: extractErrorMessage(error, 'Unknown error') }))
       throw error
     }
 
@@ -690,7 +690,7 @@ export class ChatController {
     } catch (error: unknown) {
       logger.error('Failed to load chat sessions:', error)
       // Don't throw error, allow app to continue with local sessions
-      this.getAppStore()?.setGlobalError(`Failed to load chat sessions: ${extractErrorMessage(error, 'Unknown error')}`)
+      this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.loadSessionsFailed', { error: extractErrorMessage(error, 'Unknown error') }))
     } finally {
     }
   }
@@ -753,7 +753,7 @@ export class ChatController {
 
     } catch (error: unknown) {
       logger.error('Failed to load messages:', error)
-      this.getAppStore()?.setGlobalError(`Failed to load messages: ${extractErrorMessage(error, 'Unknown error')}`)
+      this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.loadMessagesFailed', { error: extractErrorMessage(error, 'Unknown error') }))
     } finally {
     }
   }
@@ -777,7 +777,7 @@ export class ChatController {
 
     } catch (error: unknown) {
       logger.error('Failed to save chat session:', error)
-      this.getAppStore()?.setGlobalError(`Failed to save chat: ${extractErrorMessage(error, 'Unknown error')}`)
+      this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.saveFailed', { error: extractErrorMessage(error, 'Unknown error') }))
     }
   }
 
@@ -919,7 +919,7 @@ export class ChatController {
       }
 
     } catch (error: unknown) {
-      this.getAppStore()?.setGlobalError(`Failed to reset chat: ${extractErrorMessage(error, 'Unknown error')}`)
+      this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.resetFailed', { error: extractErrorMessage(error, 'Unknown error') }))
       throw error
     }
   }
@@ -952,7 +952,7 @@ export class ChatController {
       logger.debug('All chats cleared successfully')
 
     } catch (error: unknown) {
-      this.getAppStore()?.setGlobalError(`Failed to clear chats: ${extractErrorMessage(error, 'Unknown error')}`)
+      this.getAppStore()?.setGlobalError(i18n.global.t('chat.errors.clearFailed', { error: extractErrorMessage(error, 'Unknown error') }))
       throw error
     } finally {
     }


### PR DESCRIPTION
Closes #12349

## Thinking Path
#12327 converted the first ChatController user-facing error (`chat.errors.deleteFailed`) to i18n using `import i18n from '@/i18n'` + `i18n.global.t('chat.errors.deleteFailed')`, adding the key to all 11 locale files under `chat.errors` with real per-language translations (not English placeholders). This PR mirrors that exact mechanism, namespace, and locale set to convert every remaining hardcoded English error string surfaced to the user through `setGlobalError`.

The surfaced strings live in two places: 6 direct `setGlobalError(...)` string literals, plus the `getUserFriendlyErrorMessage()` helper (6 strings) whose return value is passed to `setGlobalError` at the `sendMessage` catch site — so leaving the helper hardcoded would leave that path in English. Both are in the same file and the same user-facing error category, so both are converted (no-hardcoded-UI-strings is a CRITICAL rule).

## What Changed
`ChatController.ts` — 12 hardcoded English error strings replaced with `i18n.global.t(...)` (existing `i18n` import from #12327 reused). Strings that embedded a raw error detail keep it via a `{error}` named param so user-visible behaviour is unchanged:

Direct `setGlobalError` literals:
- `Failed to create chat: ${error}` → `chat.errors.createFailed`
- `Failed to load chat sessions: ${error}` → `chat.errors.loadSessionsFailed`
- `Failed to load messages: ${error}` → `chat.errors.loadMessagesFailed`
- `Failed to save chat: ${error}` → `chat.errors.saveFailed`
- `Failed to reset chat: ${error}` → `chat.errors.resetFailed`
- `Failed to clear chats: ${error}` → `chat.errors.clearFailed`

`getUserFriendlyErrorMessage()` returns (surfaced via `setGlobalError` in `sendMessage`):
- `Invalid message format...` → `chat.errors.invalidFormat`
- `Chat service not available...` → `chat.errors.serviceUnavailable`
- `Server error occurred...` → `chat.errors.serverError`
- `Network connection failed...` → `chat.errors.networkFailed`
- `Request timed out...` → `chat.errors.timeout`
- `Failed to send message: ${message}` → `chat.errors.sendFailed`

All 11 locale files (`ar, de, en, es, fa, fr, he, lv, pl, pt, ur`) received the 12 new keys under `chat.errors`, with real translations per language (English only for `en`), matching #12327's convention and key nesting.

## Verification
- Grep: every `setGlobalError` and every `getUserFriendlyErrorMessage` return now uses `i18n.global.t(...)`; zero hardcoded English literals remain in these paths.
- Parity script (Python, node-free): all 11 locales parse as valid JSON and each contains all 13 `chat.errors` keys (1 pre-existing `deleteFailed` + 12 new) — no key present in `en` but missing elsewhere.
- WSL has no npm; vitest/vue-tsc not run per environment constraint. Verified by inspection + JSON parse + key-parity grep.

## Model Used
Claude Opus 4.8
