### PR TITLE
fix(codebase-analytics): unresolved-source fallback uses deployed-layout-aware root (#12393)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py
@@ -61,6 +61,30 @@ class TestResolveScanRoot:
 
         assert resolved == shared.get_project_root()
 
+    async def test_unresolved_fallback_uses_deployed_layout_aware_root(self, tmp_path):
+        """Issue #12393: unresolved-source fallback must use resolve_project_root()
+        (git-walk-up / deployed code_source probe, #10730), not the plain
+        parents[4] get_project_root() -- which resolves to /opt/autobot (not the
+        analyzable repo) in the deployed standalone rsync layout."""
+        from api.codebase_analytics.endpoints import shared
+
+        deployed_root = tmp_path / "opt_autobot" / "code_source"
+        wrong_root = tmp_path / "opt_autobot"
+
+        with (
+            patch.object(shared, "resolve_source_root", AsyncMock(return_value=None)),
+            patch(
+                "api.codebase_analytics.source_storage.get_default_source_id",
+                AsyncMock(return_value=None),
+            ),
+            patch.object(shared, "resolve_project_root", return_value=str(deployed_root)),
+            patch.object(shared, "get_project_root", return_value=wrong_root),
+        ):
+            resolved = await shared.resolve_scan_root(None)
+
+        assert resolved == deployed_root
+        assert resolved != wrong_root
+
     async def test_uses_default_source_when_source_id_missing(self, tmp_path):
         """When no source_id is given the default source is scoped, not the global root."""
         from api.codebase_analytics.endpoints import shared

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -188,16 +188,24 @@ async def resolve_scan_root(source_id: "str | None", use_default: bool = True) -
 
     When ``source_id`` is falsy and ``use_default`` is True, the default (most
     recently indexed) source is resolved first to avoid silently mixing projects
-    (matches the stats.py/report.py pattern, #2653). Falls back to the AutoBot
-    project root only when no source can be resolved (e.g. dev checkout with no
-    registered sources).
+    (matches the stats.py/report.py pattern, #2653). Falls back to the resolved
+    AutoBot project root only when no source can be resolved (e.g. dev checkout
+    with no registered sources).
+
+    Issue #12393: The fallback uses ``resolve_project_root()`` (the git-walk-up /
+    deployed ``code_source`` probe, #10730) rather than the plain
+    ``get_project_root()`` (hardcoded ``parents[4]``). In the deployed standalone
+    rsync layout ``parents[4]`` resolves to ``/opt/autobot`` -- not a git repo --
+    so the plain helper silently scanned the wrong tree in production. In a dev
+    checkout the two are equivalent, so this fallback is unchanged there.
 
     Args:
         source_id: The requested source identifier, or None.
         use_default: When True, resolve the default source if source_id is None.
 
     Returns:
-        Path to the resolved source clone directory, or the AutoBot project root.
+        Path to the resolved source clone directory, or the resolved AutoBot
+        project root.
     """
     if not source_id and use_default:
         try:
@@ -210,7 +218,7 @@ async def resolve_scan_root(source_id: "str | None", use_default: bool = True) -
     source_root = await resolve_source_root(source_id)
     if source_root:
         return source_root
-    return get_project_root()
+    return Path(resolve_project_root())
 
 
 # Sentinel ownership id for an authenticated, non-service caller whose token


### PR DESCRIPTION
Closes #12393

## Thinking Path
`resolve_scan_root(source_id)` scopes analytics scans (call_graph, import_tree, dependencies, api_endpoints, cross_language_patterns, environment) to a resolved source's clone path. When NO source resolves (no `source_id` and no registered default, or an unresolvable id), it fell back to `get_project_root()` -- a plain `Path(__file__).resolve().parents[4]`. In a dev checkout `parents[4]` happens to equal the git root, but in the deployed standalone rsync layout (`/opt/autobot`) `parents[4]` is `/opt/autobot` itself, which is NOT the analyzable repo -- the real tree lives in the sibling `code_source/` dir. `resolve_project_root()` (added in #10730) already handles this correctly via a git-walk-up plus a deployed `code_source/.git` probe, with a `parents[4]` final fallback for dev checkouts. Since `resolve_scan_root`'s fallback is exactly the scenario #10730 was built for, swapping it in is a straight correctness fix with no new logic.

## What Changed
- `autobot-backend/api/codebase_analytics/endpoints/shared.py`: `resolve_scan_root`'s unresolvable-source fallback now returns `Path(resolve_project_root())` instead of `get_project_root()`. `resolve_project_root()` is sync (returns `str`), so it's called directly (not awaited) and wrapped in `Path(...)` to match the function's `Path` return type.
- Only the fallback branch inside `resolve_scan_root` was touched. Other `get_project_root()` call sites (`report.py`, `stats.py`, `api_endpoint_scanner.py`, `filter_problems_by_file_existence` in `shared.py` itself) are untouched -- they're either already using `resolve_project_root()` or are a different code path outside this issue's scope.
- Docstring updated to explain the deployed-layout rationale and note dev-checkout behavior is unchanged.
- `autobot-backend/api/codebase_analytics/endpoints/cross_project_scoping_test.py`: added `test_unresolved_fallback_uses_deployed_layout_aware_root`, which mocks `resolve_project_root` and `get_project_root` to return two different sentinel paths and asserts the fallback returns the former, not the latter.

Dev-checkout behavior is unchanged: in this worktree `resolve_project_root()`'s git-walk-up finds `.git` at exactly `parents[4]`, so it returns the identical path `get_project_root()` would -- confirmed by the pre-existing `test_falls_back_to_project_root_when_unresolved` test still passing unmodified. Only the deployed layout (`/opt/autobot` standalone rsync) is corrected by this change.

## Verification
```
$ python3 -m pytest api/codebase_analytics/endpoints/cross_project_scoping_test.py api/codebase_analytics/endpoints/cross_language_scoping_test.py api/codebase_analytics/endpoints/source_authorization_test.py api/codebase_analytics/endpoints/report_scoping_test.py -p no:xdist -q
...
collected 36 items
api/codebase_analytics/endpoints/cross_project_scoping_test.py .......   [ 19%]
api/codebase_analytics/endpoints/cross_language_scoping_test.py ........ [ 41%]
api/codebase_analytics/endpoints/source_authorization_test.py .......... [ 69%]
                                                                          [ 88%]
api/codebase_analytics/endpoints/report_scoping_test.py ....            [100%]
======================== 36 passed, 1 warning in 1.26s =========================
```

## Model Used
Claude Opus 4.8