### PR TITLE
fix(codebase_analytics): triage 8 pre-existing analytics test failures + CODEBASE_PARALLEL_MODE default regression (#12392)

### DIFF
--- a/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
+++ b/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
@@ -13,7 +13,7 @@ Tests the following functionality:
 """
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -266,8 +266,8 @@ class TestRecreateChromaDBCollection:
         mock_client.get_or_create_collection = MagicMock(side_effect=async_get_or_create)
 
         with patch(
-            "utils.chromadb_client.get_async_chromadb_client",
-            return_value=mock_client,
+            "knowledge.backends.get_async_default_client",
+            new=AsyncMock(return_value=mock_client),
         ):
             result = await _recreate_chromadb_collection("test-task")
 
@@ -293,8 +293,8 @@ class TestRecreateChromaDBCollection:
         mock_client.get_or_create_collection = MagicMock(side_effect=async_get_or_create)
 
         with patch(
-            "utils.chromadb_client.get_async_chromadb_client",
-            return_value=mock_client,
+            "knowledge.backends.get_async_default_client",
+            new=AsyncMock(return_value=mock_client),
         ):
             result = await _recreate_chromadb_collection("test-task")
 
@@ -307,12 +307,9 @@ class TestRecreateChromaDBCollection:
         """Should return None if ChromaDB client fails entirely."""
         from api.codebase_analytics.scanner import _recreate_chromadb_collection
 
-        async def async_client_fails(*args, **kwargs):
-            raise ConnectionError("ChromaDB unavailable")
-
         with patch(
-            "utils.chromadb_client.get_async_chromadb_client",
-            side_effect=async_client_fails,
+            "knowledge.backends.get_async_default_client",
+            new=AsyncMock(side_effect=ConnectionError("ChromaDB unavailable")),
         ):
             result = await _recreate_chromadb_collection("test-task")
 

--- a/autobot-backend/api/codebase_analytics/parallel_processing_test.py
+++ b/autobot-backend/api/codebase_analytics/parallel_processing_test.py
@@ -518,8 +518,10 @@ class TestProcessFilesParallel:
         from api.codebase_analytics.scanner import _process_files_parallel
 
         # Use actual files from the project
-        project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
-        test_files = list(project_root.glob("backend/api/codebase_analytics/*.py"))[:3]
+        # This test file lives in codebase_analytics/, so its own directory is a
+        # guaranteed source of real .py files to exercise the parallel path (#12392).
+        project_root = Path(__file__).resolve().parent
+        test_files = list(project_root.glob("*.py"))[:3]
 
         if not test_files:
             pytest.skip("No test files found")
@@ -542,8 +544,8 @@ class TestAnalyzeSingleFile:
         """Test _analyze_single_file returns FileAnalysisResult."""
         from api.codebase_analytics.scanner import _analyze_single_file
 
-        project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
-        test_file = project_root / "backend" / "api" / "codebase_analytics" / "types.py"
+        project_root = Path(__file__).resolve().parent
+        test_file = project_root / "types.py"
 
         if not test_file.exists():
             pytest.skip("Test file not found")
@@ -563,7 +565,7 @@ class TestAnalyzeSingleFile:
         """Test nonexistent file returns base result without processing."""
         from api.codebase_analytics.scanner import _analyze_single_file
 
-        project_root = Path("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        project_root = Path(__file__).resolve().parent
         fake_file = project_root / "nonexistent_file_12345.py"
 
         result = await _analyze_single_file(

--- a/autobot-backend/api/codebase_analytics/progress_tracker_test.py
+++ b/autobot-backend/api/codebase_analytics/progress_tracker_test.py
@@ -12,6 +12,7 @@ returns fresh results instead of stale pre-scan values.
 """
 
 import importlib.util
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,9 +20,10 @@ import pytest
 
 def _load_progress_tracker():
     """Load progress_tracker.py without triggering the heavy analyzers import chain."""
+    module_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "progress_tracker.py")
     spec = importlib.util.spec_from_file_location(
         "progress_tracker_under_test",
-        "autobot-backend/api/codebase_analytics/progress_tracker.py",
+        module_path,
     )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1584,7 +1584,8 @@ class MiscConfig(BaseSettings):
     codebase_index_incremental: str = Field(default="", alias="CODEBASE_INDEX_INCREMENTAL")
     codebase_index_parallel_batches: str = Field(default="", alias="CODEBASE_INDEX_PARALLEL_BATCHES")
     codebase_index_parallel_files: str = Field(default="", alias="CODEBASE_INDEX_PARALLEL_FILES")
-    codebase_parallel_mode: str = Field(default="", alias="CODEBASE_PARALLEL_MODE")
+    # #12392: restore pre-#7437 default (True) — "" silently disabled parallel indexing
+    codebase_parallel_mode: str = Field(default="true", alias="CODEBASE_PARALLEL_MODE")
     codebase_scan_parallel_files: str = Field(default="", alias="CODEBASE_SCAN_PARALLEL_FILES")
     config: str = Field(default="", alias="CONFIG")
     # #11681: restore pre-#7437 default (500) — 0 silently disabled the content cache


### PR DESCRIPTION
Closes #12392

## Thinking Path
The 8 pre-existing failures in `api/codebase_analytics/` (surfaced during #12359) fell into three distinct groups. For each I read both the test and the production code it exercises to decide whether the test was wrong or whether it was correctly catching a real production bug. One turned out to be a genuine production regression; the other two were stale tests.

## What Changed

**parallel_processing_test.py::test_parallel_mode_enabled_default — REAL PRODUCTION BUG (fixed production)**
`PARALLEL_MODE_ENABLED = config.codebase_parallel_mode.lower() == "true"`. The config field `codebase_parallel_mode` defaulted to `""`, so parallel indexing was silently disabled by default. Git history shows the original code was `os.getenv("CODEBASE_PARALLEL_MODE", "true")` (default True); the #7437 os.getenv→ssot_config migration dropped the `"true"` default to `""`, flipping the documented default from True to False. The file_analyzer comment still reads "Default: True (parallel mode enabled)". Fixed by restoring the config default to `"true"` — same remediation pattern already applied at `content_cache_max_size` (`# #11681: restore pre-#7437 default`). Blast radius is contained: `codebase_parallel_mode` has runtime consumers `file_pipeline.py:302` (parallel dispatch) + `scanner.py:304` (stats guard); `file_analyzer.py` only defines the flag. Blast radius confined to codebase-analytics indexing, no .env override.

**progress_tracker_test.py (4 tests) — BAD TEST (stale, cwd-dependent path)**
`_load_progress_tracker()` loaded the module from the hardcoded cwd-relative path `"autobot-backend/api/codebase_analytics/progress_tracker.py"`. Running from `autobot-backend/` doubled the prefix → `FileNotFoundError`. Fixed to resolve the module path relative to the test file's own location (`__file__`), so it passes regardless of cwd. Real behavior asserted is unchanged.

**codebase_stats_endpoint_test.py::TestRecreateChromaDBCollection (3 tests) — BAD TEST (stale mock target)**
Tests patched `utils.chromadb_client.get_async_chromadb_client`, but production `_recreate_chromadb_collection` was refactored to use `from knowledge.backends import get_async_default_client`. The patch never took effect, so a real `AsyncChromaDBCollection` was returned instead of the mock. Fixed to patch `knowledge.backends.get_async_default_client` with an `AsyncMock` (the client is awaited). The drop+recreate assertions still validate the true production behavior via `_drop_and_create_collection`.

No failures were deferred; production behavior for the drop/recreate path was already correct.

## Verification
```
$ python3 -m pytest api/codebase_analytics/progress_tracker_test.py api/codebase_analytics/codebase_stats_endpoint_test.py api/codebase_analytics/parallel_processing_test.py -p no:xdist -q
62 passed, 2 skipped, 1 warning in 0.85s

$ python3 -m pytest api/codebase_analytics/ -p no:xdist -q
165 passed, 13 skipped, 1 warning in 2.28s
```

## Model Used
Claude Opus 4.8

**Update:** the parallel-path e2e tests (previously silently skipping on a broken `${AUTOBOT_PROJECT_ROOT:-...}` literal) now run against real files and pass (33 passed), so this restore ships with actual functional coverage of the re-enabled parallel path.
