### PR TITLE
fix(codebase-analytics): scope destructive pattern-storage clear to source_id (#12408)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -724,15 +724,23 @@ async def get_cached_patterns(
 
 
 @router.post("/patterns/storage/clear")
-async def clear_pattern_storage() -> Dict[str, str]:
-    """Clear all stored patterns from ChromaDB.
+async def clear_pattern_storage(
+    source_id: str | None = Query(default=None, description="Code source to scope the clear to (Issue #12408)"),
+) -> Dict[str, str]:
+    """Clear stored patterns for a single source from ChromaDB.
 
-    WARNING: This is destructive and cannot be undone.
+    Issue #12408: Always scopes the clear to source_id (default sentinel
+    when None, matching every other ``/patterns/*`` endpoint's convention --
+    e.g. ``get_pattern_storage_stats``, ``search_similar_patterns_endpoint``)
+    so clearing one source's patterns can never delete another source's (or
+    AutoBot's own) stored patterns.
+
+    WARNING: This is destructive and cannot be undone for the scoped source.
     """
     try:
         from code_intelligence.pattern_analysis.storage import clear_patterns
 
-        success = await clear_patterns()
+        success = await clear_patterns(source_id=source_id)
 
         if success:
             return {"message": "Pattern storage cleared successfully"}

--- a/autobot-backend/code_intelligence/pattern_analysis/clear_patterns_source_scoping_test.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/clear_patterns_source_scoping_test.py
@@ -1,0 +1,216 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for the destructive cross-source ``clear_patterns()``
+data-loss bug (Issue #12408).
+
+``POST /patterns/storage/clear`` -> ``clear_patterns()`` previously fetched
+and deleted every id in the shared ``code_patterns`` ChromaDB collection with
+NO source filter -- so clearing one source's patterns silently wiped every
+other source's (and AutoBot's own) stored patterns too. This mirrors the
+#12384/#12405 read-side scoping fix, applied here to the destructive
+write-side clear.
+
+These tests assert the fix end-to-end:
+- ``clear_patterns(source_id="A")`` deletes ONLY source A's patterns; source
+  B's patterns remain intact;
+- omitting ``source_id`` resolves to the ``"default"`` sentinel scope (like
+  every other ``/patterns/*`` endpoint), never a full-collection wipe;
+- the endpoint layer (``clear_pattern_storage``) threads ``source_id``
+  through unchanged.
+"""
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Real-module loading -- mirrors source_scoping_test.py's
+# _load_real_pattern_analysis_package() so we exercise real storage.py
+# behavior rather than the top-level conftest's MagicMock stub.
+# ---------------------------------------------------------------------------
+def _load_real_pattern_analysis_package():
+    base = Path(__file__).resolve().parent  # code_intelligence/pattern_analysis/
+    pkg_name = "_real_pattern_analysis_12408"
+
+    if pkg_name not in sys.modules:
+        pkg = ModuleType(pkg_name)
+        pkg.__path__ = [str(base)]
+        pkg.__package__ = pkg_name
+        sys.modules[pkg_name] = pkg
+        for sub in (
+            "types",
+            "complexity_analyzer",
+            "refactoring_generator",
+            "regex_detector",
+            "storage",
+            "analyzer",
+        ):
+            spec = importlib.util.spec_from_file_location(f"{pkg_name}.{sub}", base / f"{sub}.py")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[f"{pkg_name}.{sub}"] = module
+            spec.loader.exec_module(module)
+            setattr(pkg, sub, module)
+
+    return sys.modules[pkg_name]
+
+
+@pytest.fixture
+def pa():
+    return _load_real_pattern_analysis_package()
+
+
+class _FakeChromaCollection:
+    """In-memory ChromaDB stand-in with ``where``-scoped delete support,
+    reproducing the real fail-closed equality-filter behavior: a ``where``
+    condition on a key ABSENT from a record's metadata never matches.
+
+    Extends the style of ``source_scoping_test.py``'s fake with a ``delete``
+    method (not needed by the #12384 read-only tests, required here since
+    #12408 is about the destructive write path).
+    """
+
+    def __init__(self):
+        self.ids: list = []
+        self.embeddings: list = []
+        self.documents: list = []
+        self.metadatas: list = []
+        self.last_delete_where: Dict[str, Any] | None = None
+        self.last_delete_ids: list | None = None
+
+    async def add(self, ids, embeddings, documents, metadatas=None):
+        self.ids.extend(ids)
+        self.embeddings.extend(embeddings)
+        self.documents.extend(documents)
+        self.metadatas.extend(metadatas or [{} for _ in ids])
+
+    @staticmethod
+    def _matches(meta: dict, cond: dict) -> bool:
+        if "$and" in cond:
+            return all(_FakeChromaCollection._matches(meta, c) for c in cond["$and"])
+        ((key, value),) = cond.items()
+        return meta.get(key) == value  # absent key -> None != value -> no match
+
+    def _matched_indices(self, where):
+        return [i for i, m in enumerate(self.metadatas) if where is None or self._matches(m, where)]
+
+    async def get(self, where=None, limit=None, offset=None, include=None):
+        matched = self._matched_indices(where)
+        if offset:
+            matched = matched[offset:]
+        if limit is not None:
+            matched = matched[:limit]
+        result: Dict[str, Any] = {"ids": [self.ids[i] for i in matched]}
+        if include is None or "metadatas" in include:
+            result["metadatas"] = [self.metadatas[i] for i in matched]
+        if include and "documents" in include:
+            result["documents"] = [self.documents[i] for i in matched]
+        return result
+
+    async def delete(self, *, ids=None, where=None):
+        """Mirrors the real adapters (chromadb_adapter/async_chromadb_adapter/
+        memory_adapter): forwards ``where`` straight through to a native
+        where-scoped delete; ``ids`` deletes those exact ids."""
+        self.last_delete_where = where
+        self.last_delete_ids = list(ids) if ids is not None else None
+        if ids is None and where is None:
+            raise ValueError("delete requires ids or where")
+        target_indices = self._matched_indices(where) if where is not None else range(len(self.ids))
+        target_ids = {self.ids[i] for i in target_indices}
+        if ids is not None:
+            target_ids &= set(ids)
+
+        keep = [i for i in range(len(self.ids)) if self.ids[i] not in target_ids]
+        self.ids = [self.ids[i] for i in keep]
+        self.embeddings = [self.embeddings[i] for i in keep]
+        self.documents = [self.documents[i] for i in keep]
+        self.metadatas = [self.metadatas[i] for i in keep]
+
+    async def count(self) -> int:
+        return len(self.ids)
+
+
+async def _seed_two_sources(collection: _FakeChromaCollection) -> None:
+    await collection.add(
+        ids=["a1", "a2"],
+        embeddings=[[0.1], [0.2]],
+        documents=["a1 doc", "a2 doc"],
+        metadatas=[
+            {"pattern_type": "duplicate", "source_id": "A"},
+            {"pattern_type": "regex_opportunity", "source_id": "A"},
+        ],
+    )
+    await collection.add(
+        ids=["b1"],
+        embeddings=[[0.3]],
+        documents=["b1 doc"],
+        metadatas=[{"pattern_type": "duplicate", "source_id": "B"}],
+    )
+
+
+class TestClearPatternsSourceScoping:
+    async def test_clear_scoped_to_source_deletes_only_that_source(self, pa):
+        """Issue #12408: clearing source A must delete ONLY A's patterns --
+        B's must remain intact. This is the core data-loss regression."""
+        collection = _FakeChromaCollection()
+        await _seed_two_sources(collection)
+        assert await collection.count() == 3
+
+        success = await pa.storage.clear_patterns(collection=collection, source_id="A")
+
+        assert success is True
+        assert collection.ids == ["b1"]
+        assert await collection.count() == 1
+        remaining = await collection.get(include=["metadatas"])
+        assert all(m["source_id"] == "B" for m in remaining["metadatas"])
+
+    async def test_clear_missing_source_id_does_not_wipe_all_sources(self, pa):
+        """Issue #12408: omitting source_id must resolve to the "default"
+        sentinel scope (matching build_source_scoped_where / every other
+        /patterns/* endpoint) -- it must NEVER wipe every source."""
+        collection = _FakeChromaCollection()
+        await _seed_two_sources(collection)
+        # Patterns tagged "default" (e.g. a caller that never set a source).
+        await collection.add(
+            ids=["d1"],
+            embeddings=[[0.4]],
+            documents=["d1 doc"],
+            metadatas=[{"pattern_type": "duplicate", "source_id": "default"}],
+        )
+        assert await collection.count() == 4
+
+        success = await pa.storage.clear_patterns(collection=collection)  # no source_id
+
+        assert success is True
+        # Only the "default"-scoped pattern is gone; A and B are untouched.
+        assert set(collection.ids) == {"a1", "a2", "b1"}
+        assert collection.last_delete_where == {"source_id": "default"}
+
+    async def test_clear_uses_where_delete_not_unscoped_ids(self, pa):
+        """The fix must call collection.delete(where=...) scoped by
+        build_source_scoped_where, never an unfiltered ids=[...] wipe."""
+        collection = _FakeChromaCollection()
+        await _seed_two_sources(collection)
+
+        await pa.storage.clear_patterns(collection=collection, source_id="A")
+
+        assert collection.last_delete_where == pa.storage.build_source_scoped_where("A")
+        assert collection.last_delete_where == {"source_id": "A"}
+
+
+class TestClearPatternStorageEndpointThreadsSourceId:
+    def test_endpoint_signature_accepts_source_id_query_param(self):
+        """Issue #12408: the endpoint must accept source_id like every other
+        /patterns/* endpoint, not silently ignore/drop it."""
+        from api.codebase_analytics.endpoints import pattern_analysis as endpoint_module
+
+        sig = inspect.signature(endpoint_module.clear_pattern_storage)
+        assert "source_id" in sig.parameters

--- a/autobot-backend/code_intelligence/pattern_analysis/storage.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/storage.py
@@ -185,9 +185,16 @@ def _build_single_pattern_metadata(pattern_type: str, code_content: str, metadat
     Returns:
         Sanitized metadata dictionary
     """
+    # Issue #12408: default source_id to "default" here too, matching
+    # _build_single_pattern_data's id-hash default -- otherwise a caller
+    # that omits source_id gets a record whose id was hashed with "default"
+    # but whose metadata lacks source_id, so build_source_scoped_where's
+    # equality filter (which matches on the "default" sentinel) never finds
+    # it: fail-closed invisible + id/metadata mismatch.
     full_metadata = {
         "pattern_type": pattern_type,
         "code_length": len(code_content),
+        "source_id": metadata.get("source_id", "default"),
         **metadata,
     }
     return sanitize_metadata(full_metadata)
@@ -265,10 +272,16 @@ def _prepare_pattern_metadata(pattern: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         Sanitized metadata dictionary ready for ChromaDB storage
     """
+    # Issue #12408: default source_id to "default" here too, matching
+    # _prepare_pattern_data's id-hash default -- see _build_single_pattern_metadata
+    # above for why the asymmetry is a fail-closed-invisible + id/metadata
+    # mismatch bug (flagged in the #12405 review).
+    metadata = pattern.get("metadata", {})
     full_metadata = {
         "pattern_type": pattern["pattern_type"],
         "code_length": len(pattern["code_content"]),
-        **pattern.get("metadata", {}),
+        "source_id": metadata.get("source_id", "default"),
+        **metadata,
     }
     return sanitize_metadata(full_metadata)
 
@@ -512,13 +525,29 @@ async def get_pattern_stats(collection=None, source_id: str | None = None) -> Di
         return {"error": "Failed to retrieve pattern stats"}
 
 
-async def clear_patterns(collection=None) -> bool:
-    """Clear all patterns from the collection.
+async def clear_patterns(collection=None, source_id: str | None = None) -> bool:
+    """Clear all patterns for a single source from the collection.
 
-    WARNING: This is destructive and cannot be undone.
+    Issue #12408: Scoped to ``source_id`` (default sentinel when None,
+    mirroring ``build_source_scoped_where``) so a clear for one source can
+    never delete another source's (or AutoBot's own) stored patterns.
+    Previously this had NO source filter at all -- ``collection.get()``/
+    ``collection.delete()`` operated over every id in the shared
+    ``code_patterns`` collection, so clearing one source wiped every source.
+
+    Uses ``collection.delete(where=...)`` directly rather than a get-then-
+    delete-by-ids round trip: all three backend adapters used by this
+    codebase (``chromadb_adapter``, ``async_chromadb_adapter``,
+    ``memory_adapter``) forward ``where`` straight through to the
+    underlying store's native where-delete, so there is no need to first
+    enumerate matching ids (and no SQL-variable-limit concern, since the
+    ``where`` clause itself is bounded, unlike an ``ids=[...]`` IN-list).
+
+    WARNING: This is destructive and cannot be undone for the scoped source.
 
     Args:
         collection: Optional pre-fetched collection
+        source_id: Code source to scope the clear to (Issue #12408).
 
     Returns:
         True if successful, False otherwise
@@ -529,14 +558,10 @@ async def clear_patterns(collection=None) -> bool:
             if collection is None:
                 return False
 
-        # Get all IDs and delete them
-        count = await collection.count()
-        if count > 0:
-            results = await collection.get(limit=count, include=[])
-            if results.get("ids"):
-                await collection.delete(ids=results["ids"])
+        where_filter = build_source_scoped_where(source_id)
+        await collection.delete(where=where_filter)
 
-        logger.info("Cleared %d patterns from collection", count)
+        logger.info("Cleared patterns for source_id=%s", source_id or "default")
         return True
 
     except Exception as e:

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -21496,9 +21496,15 @@ export interface paths {
         put?: never;
         /**
          * Clear Pattern Storage
-         * @description Clear all stored patterns from ChromaDB.
+         * @description Clear stored patterns for a single source from ChromaDB.
          *
-         *     WARNING: This is destructive and cannot be undone.
+         *     Issue #12408: Always scopes the clear to source_id (default sentinel
+         *     when None, matching every other ``/patterns/*`` endpoint's convention --
+         *     e.g. ``get_pattern_storage_stats``, ``search_similar_patterns_endpoint``)
+         *     so clearing one source's patterns can never delete another source's (or
+         *     AutoBot's own) stored patterns.
+         *
+         *     WARNING: This is destructive and cannot be undone for the scoped source.
          */
         post: operations["clear_pattern_storage_api_analytics_codebase_patterns_storage_clear_post"];
         delete?: never;
@@ -129486,7 +129492,10 @@ export interface operations {
     };
     clear_pattern_storage_api_analytics_codebase_patterns_storage_clear_post: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Code source to scope the clear to (Issue #12408) */
+                source_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -129502,6 +129511,15 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
Closes #12408

## Thinking Path
`POST /patterns/storage/clear` → `clear_patterns()` had NO source filter: it fetched every id in the shared `code_patterns` ChromaDB collection (`collection.get(limit=count)`) and deleted all of them (`collection.delete(ids=...)`). One source's "clear" wiped every other source's (and AutoBot's own) stored patterns — a cross-source destructive data-loss bug. #12405 already added `build_source_scoped_where()` and scoped every *read* endpoint (`search_similar_patterns`, `get_pattern_stats`, `get_cached_patterns`, `get_cached_pattern_summary`) to `source_id`; this PR mirrors that same scoping onto the one remaining unscoped, destructive write path.

I verified `collection.delete(where=...)` is natively supported end-to-end by every backend adapter this codebase uses (`chromadb_adapter.py`, `async_chromadb_adapter.py`, `memory_adapter.py` all forward `where` straight to the underlying store's delete), so the fix uses a direct scoped `delete(where=...)` rather than a get-ids-then-delete round trip — simpler, and avoids the SQL-variable-limit concern that only applies to large `ids=[...]` IN-lists (not `where` filters).

## What Changed
- `code_intelligence/pattern_analysis/storage.py` `clear_patterns()` (~L515): now takes `source_id: str | None = None`, builds `where_filter = build_source_scoped_where(source_id)`, and calls `collection.delete(where=where_filter)` — scoped to exactly one source's patterns instead of the whole collection.
- **Missing-`source_id` decision:** omitting `source_id` resolves to the `"default"` sentinel scope via `build_source_scoped_where(None) == {"source_id": "default"}` — identical to every sibling `/patterns/*` endpoint's existing convention (`get_pattern_storage_stats`, `search_similar_patterns_endpoint`, `get_cached_patterns`, `get_cached_pattern_summary`). This is the safe option: a caller that forgets to pass `source_id` clears only the "default"-tagged patterns, **never** every source. Requiring `source_id` (400 without it) would have been inconsistent with every other endpoint in this file, so I matched the established convention instead.
- `api/codebase_analytics/endpoints/pattern_analysis.py` `clear_pattern_storage()` (~L727): now accepts `source_id: str | None = Query(default=None, ...)` like its siblings, and threads it into `clear_patterns(source_id=source_id)`.
- **Sentinel-asymmetry fix (flagged in #12405 review):** `_prepare_pattern_metadata()` and its single-pattern sibling `_build_single_pattern_metadata()` both defaulted `source_id` to `"default"` for the ID hash (via `_prepare_pattern_data`/`_build_single_pattern_data`) but NOT for the stored metadata dict — so a caller that omitted `source_id` produced a record whose id was hashed with `"default"` but whose metadata had no `source_id` key at all, making it invisible to `build_source_scoped_where`'s equality filter (id/metadata mismatch, fail-closed-invisible). Both functions now default `source_id` to `"default"` in the metadata splat too, so id and metadata always agree.

## Verification
```
$ python3 -m pytest code_intelligence/pattern_analysis/source_scoping_test.py code_intelligence/pattern_analysis/clear_patterns_source_scoping_test.py -p no:xdist -q
collected 15 items

code_intelligence/pattern_analysis/source_scoping_test.py ...........    [ 73%]
code_intelligence/pattern_analysis/clear_patterns_source_scoping_test.py . [ 80%]
...                                                                      [100%]

======================== 15 passed, 1 warning in 0.79s =========================
```
New tests (`clear_patterns_source_scoping_test.py`) prove:
- `clear_patterns(source_id="A")` deletes ONLY A's patterns; B's patterns remain intact (the core destructive-isolation regression test).
- Omitting `source_id` resolves to the `"default"` sentinel scope and does NOT wipe A or B's patterns.
- The scoped delete goes through `collection.delete(where=build_source_scoped_where(...))`, never an unfiltered wipe.
- The endpoint signature threads `source_id` through.

All 11 pre-existing #12405 source-scoping tests still pass (no regression).

## Model Used
Claude Opus 4.8