### PR TITLE
fix(code-intelligence): CodePatternAnalyzer generates real embeddings (#12407)

### DIFF
--- a/autobot-backend/code_intelligence/pattern_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/analyzer.py
@@ -59,6 +59,12 @@ try:
 except ImportError:
     EMBEDDING_CACHE_AVAILABLE = False
 
+# Issue #12407: Real embedding model used by the canonical
+# ``services.npu_client.generate_embedding_with_fallback`` helper. Mirrors
+# ``DEFAULT_EMBEDDING_MODEL`` in analytics_infrastructure.py / the
+# ``embedding_model`` default in cross_language_patterns/detector.py.
+EMBEDDING_MODEL = "nomic-embed-text"
+
 
 class CodePatternAnalyzer:
     """Main orchestrator for code pattern detection and optimization.
@@ -174,6 +180,11 @@ class CodePatternAnalyzer:
         # Issue #12384: scope tag for chroma metadata written by this instance.
         self.source_id = source_id
         self._source_tag = source_id or "default"
+        # Issue #12407: single reused EmbeddingCache instance (mirrors
+        # SemanticAnalysisMixin / CrossLanguagePatternDetector) so repeated
+        # calls to ``_generate_embedding`` actually benefit from the cache
+        # instead of instantiating a throwaway cache every call.
+        self._embedding_cache = EmbeddingCache(maxsize=500, ttl_seconds=3600) if EMBEDDING_CACHE_AVAILABLE else None
 
     # Batch size for per-file analysis (tunable)
     BATCH_SIZE = 50
@@ -975,26 +986,48 @@ class CodePatternAnalyzer:
             logger.error("Failed to store patterns: %s", e)
 
     async def _generate_embedding(self, code: str) -> List[float]:
-        """Generate embedding for code content.
+        """Generate a semantic embedding for code content.
+
+        Issue #12407: Uses the canonical NPU/Ollama fallback helper
+        (``services.npu_client.generate_embedding_with_fallback``) via the
+        reused ``self._embedding_cache`` instance, mirroring
+        ``SemanticAnalysisMixin._get_embedding``
+        (code_intelligence/analytics_infrastructure.py) and
+        ``CrossLanguagePatternDetector._get_embedding``
+        (code_intelligence/cross_language_patterns/detector.py, #12374). The
+        previous implementation called a nonexistent
+        ``EmbeddingCache.get_embedding()`` method, which raised
+        ``AttributeError`` on every call and was silently swallowed, so every
+        pattern was actually stored under a hash-based pseudo-embedding.
 
         Args:
             code: Code content to embed
 
         Returns:
-            Embedding vector
+            Embedding vector (real if embedding infra is available, hash-based
+            pseudo-embedding only as a last-resort fallback).
         """
-        # Use existing embedding infrastructure if available
-        if EMBEDDING_CACHE_AVAILABLE:
+        if EMBEDDING_CACHE_AVAILABLE and self._embedding_cache is not None:
             try:
-                cache = EmbeddingCache()
-                embedding = await cache.get_embedding(code)
-                if embedding:
-                    return embedding
-            except Exception:  # nosec B110 - cache miss handled by fallback
-                logger.debug("Suppressed exception in try block", exc_info=True)
+                cached = await self._embedding_cache.get(code, model=EMBEDDING_MODEL)
+                if cached:
+                    return cached
+            except Exception as e:
+                logger.warning("Embedding cache read failed, generating fresh: %s", e)
 
-        # Fallback: Simple hash-based pseudo-embedding for testing
-        # In production, this should use actual embeddings
+            try:
+                from services.npu_client import generate_embedding_with_fallback
+
+                embedding = await generate_embedding_with_fallback(code, model_name=EMBEDDING_MODEL)
+                if embedding:
+                    await self._embedding_cache.put(code, embedding, model=EMBEDDING_MODEL)
+                    return embedding
+                logger.warning("Embedding generation returned no vector, using hash fallback")
+            except Exception as e:
+                logger.warning("Embedding generation failed, using hash fallback: %s", e)
+
+        # Last-resort fallback: hash-based pseudo-embedding, ONLY reached when
+        # the real embedding infrastructure is genuinely unavailable/failed.
         import hashlib
 
         hash_bytes = hashlib.sha256(code.encode()).digest()

--- a/autobot-backend/code_intelligence/pattern_analysis/embedding_test.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/embedding_test.py
@@ -1,0 +1,192 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for ``CodePatternAnalyzer._generate_embedding`` (Issue #12407).
+
+Prior to this fix, ``_generate_embedding`` called
+``EmbeddingCache().get_embedding(code)`` -- a method that does not exist on
+``EmbeddingCache`` (only ``get(query, model)``/``put(query, embedding,
+model)``). Every call raised ``AttributeError``, was swallowed by a broad
+``except Exception``, and silently fell through to a SHA-256 hash-based
+pseudo-embedding, so ``code_patterns`` similarity search never actually did
+semantic matching.
+
+These tests assert the real fix:
+- the canonical ``services.npu_client.generate_embedding_with_fallback``
+  helper is called with the code and the real embedding model name (not the
+  hash fallback);
+- a single ``EmbeddingCache`` instance created in ``__init__`` is reused
+  across calls (get -> miss -> generate -> put), instead of a fresh
+  ``EmbeddingCache()`` per call;
+- a cache hit skips the embedding-generation call entirely;
+- the hash-based pseudo-embedding is reached ONLY when the real embedding
+  call genuinely fails -- never on a successful real embedding.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Issue #12407: ``services`` is stubbed in conftest.py as a MagicMock package
+# with a catch-all ``__getattr__`` (see ``_make_pkg_stub``/``_real_load_and_bind``
+# docstring). ``unittest.mock.patch("services.npu_client.X")`` resolves its
+# target via a ``getattr`` chain starting at the parent package, which hits
+# that catch-all and silently patches a throwaway mock instead of the real
+# ``services.npu_client`` module (inert patch). Importing the real submodule
+# directly and patching via ``patch.object`` sidesteps the parent-stub lookup
+# entirely, matching the module ``analyzer.py``'s local
+# ``from services.npu_client import ...`` actually resolves via sys.modules.
+import services.npu_client as npu_client_module  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Real-module loading (bypasses the top-level conftest's
+# ``code_intelligence.pattern_analysis`` MagicMock stub so we exercise real
+# behavior) -- mirrors ``_load_real_pattern_analysis_package`` in
+# source_scoping_test.py.
+# ---------------------------------------------------------------------------
+def _load_real_pattern_analysis_package():
+    base = Path(__file__).resolve().parent  # code_intelligence/pattern_analysis/
+    pkg_name = "_real_pattern_analysis_12407"
+
+    if pkg_name not in sys.modules:
+        pkg = ModuleType(pkg_name)
+        pkg.__path__ = [str(base)]
+        pkg.__package__ = pkg_name
+        sys.modules[pkg_name] = pkg
+        for sub in (
+            "types",
+            "complexity_analyzer",
+            "refactoring_generator",
+            "regex_detector",
+            "storage",
+            "analyzer",
+        ):
+            spec = importlib.util.spec_from_file_location(f"{pkg_name}.{sub}", base / f"{sub}.py")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[f"{pkg_name}.{sub}"] = module
+            spec.loader.exec_module(module)
+            setattr(pkg, sub, module)
+
+    return sys.modules[pkg_name]
+
+
+@pytest.fixture
+def pa():
+    return _load_real_pattern_analysis_package()
+
+
+@pytest.fixture
+def analyzer(pa):
+    return pa.analyzer.CodePatternAnalyzer(enable_embedding_storage=False)
+
+
+FAKE_EMBEDDING = [0.1, 0.2, 0.3]
+
+
+class TestGenerateEmbeddingUsesCanonicalHelper:
+    async def test_calls_generate_embedding_with_fallback_with_real_model(self, pa, analyzer):
+        code = "def foo(): return 1"
+        with patch.object(
+            npu_client_module,
+            "generate_embedding_with_fallback",
+            new=AsyncMock(return_value=FAKE_EMBEDDING),
+        ) as mocked:
+            result = await analyzer._generate_embedding(code)
+
+        mocked.assert_awaited_once_with(code, model_name=pa.analyzer.EMBEDDING_MODEL)
+        assert pa.analyzer.EMBEDDING_MODEL == "nomic-embed-text"
+        assert result == FAKE_EMBEDDING
+
+    async def test_does_not_fall_through_to_hash_embedding_on_success(self, pa, analyzer):
+        code = "def bar(): return 2"
+        with patch.object(
+            npu_client_module,
+            "generate_embedding_with_fallback",
+            new=AsyncMock(return_value=FAKE_EMBEDDING),
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        # Hash-based pseudo-embedding is always 768 floats derived from
+        # sha256(code) -- assert we got the short real embedding instead.
+        assert result == FAKE_EMBEDDING
+        assert len(result) != 768
+
+
+class TestGenerateEmbeddingReusesCache:
+    async def test_uses_single_cache_instance_created_in_init(self, pa, analyzer):
+        assert analyzer._embedding_cache is not None
+        assert isinstance(analyzer._embedding_cache, pa.analyzer.EmbeddingCache)
+
+        code = "def baz(): return 3"
+        cache = analyzer._embedding_cache
+        with (
+            patch.object(cache, "get", new=AsyncMock(return_value=None)) as mock_get,
+            patch.object(cache, "put", new=AsyncMock()) as mock_put,
+            patch.object(
+                npu_client_module,
+                "generate_embedding_with_fallback",
+                new=AsyncMock(return_value=FAKE_EMBEDDING),
+            ),
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        mock_get.assert_awaited_once_with(code, model=pa.analyzer.EMBEDDING_MODEL)
+        mock_put.assert_awaited_once_with(code, FAKE_EMBEDDING, model=pa.analyzer.EMBEDDING_MODEL)
+        assert result == FAKE_EMBEDDING
+
+    async def test_cache_hit_skips_generation_call(self, pa, analyzer):
+        code = "def qux(): return 4"
+        with (
+            patch.object(analyzer._embedding_cache, "get", new=AsyncMock(return_value=FAKE_EMBEDDING)),
+            patch.object(
+                npu_client_module,
+                "generate_embedding_with_fallback",
+                new=AsyncMock(),
+            ) as mock_generate,
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        mock_generate.assert_not_awaited()
+        assert result == FAKE_EMBEDDING
+
+    def test_instance_attribute_reused_not_reinstantiated_per_call(self, pa):
+        analyzer_a = pa.analyzer.CodePatternAnalyzer(enable_embedding_storage=False)
+        analyzer_b = pa.analyzer.CodePatternAnalyzer(enable_embedding_storage=False)
+        # Each analyzer instance gets its own cache (created once in
+        # __init__), but repeated calls on the SAME instance must reuse it.
+        assert analyzer_a._embedding_cache is not None
+        assert analyzer_a._embedding_cache is analyzer_a._embedding_cache
+        assert analyzer_a._embedding_cache is not analyzer_b._embedding_cache
+
+
+class TestGenerateEmbeddingHashFallback:
+    async def test_hash_fallback_only_when_real_embedding_fails(self, pa, analyzer):
+        code = "def quux(): return 5"
+        with patch.object(
+            npu_client_module,
+            "generate_embedding_with_fallback",
+            new=AsyncMock(side_effect=RuntimeError("embedding infra unavailable")),
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        # Hash-based pseudo-embedding: 768 floats in [-1, 1].
+        assert len(result) == 768
+        assert all(-1.0 <= v <= 1.0 for v in result)
+
+    async def test_hash_fallback_when_generation_returns_none(self, pa, analyzer):
+        code = "def corge(): return 6"
+        with patch.object(
+            npu_client_module,
+            "generate_embedding_with_fallback",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await analyzer._generate_embedding(code)
+
+        assert len(result) == 768


### PR DESCRIPTION
Closes #12407

## Thinking Path
`CodePatternAnalyzer._generate_embedding()` called `EmbeddingCache().get_embedding(code)` -- but `EmbeddingCache` (`knowledge/embedding_cache.py`) has no `get_embedding()` method, only `async def get(self, query, model)` / `async def put(self, query, embedding, model)`. Every call raised `AttributeError`, which was swallowed by a broad `except Exception`, so every pattern silently fell through to a SHA-256 hash-based pseudo-embedding. Result: `code_patterns` similarity search (`/patterns/similar`) only ever matched near-byte-identical code, not semantically similar code -- the vector feature (#208) was not actually working. `EmbeddingCache()` was also re-instantiated every call, so its cache never helped even on the hash path.

Read the canonical reference implementations before writing the fix:
- `code_intelligence/analytics_infrastructure.py` `SemanticAnalysisMixin._get_embedding` (line 246) -- calls `services.npu_client.generate_embedding_with_fallback(text, model_name=self._embedding_model)`, uses `cache.get(text, model=...)` / `cache.put(text, embedding, model=...)`.
- `code_intelligence/cross_language_patterns/detector.py` `CrossLanguagePatternDetector._get_embedding` (line 197, #12374) -- same pattern, single `EmbeddingCache` instance held on `self`, real model name used for the actual embedding call.
- `knowledge/embedding_cache.py` -- confirmed exact `get(query, model)` / `put(query, embedding, model)` signatures.

## What Changed
`autobot-backend/code_intelligence/pattern_analysis/analyzer.py`:
- Added module-level `EMBEDDING_MODEL = "nomic-embed-text"` (mirrors `DEFAULT_EMBEDDING_MODEL` in `analytics_infrastructure.py`).
- `CodePatternAnalyzer.__init__` now creates a single reused `self._embedding_cache = EmbeddingCache(maxsize=500, ttl_seconds=3600)` instance instead of instantiating a fresh `EmbeddingCache()` inside `_generate_embedding` on every call.
- `_generate_embedding` now: cache `get(code, model=EMBEDDING_MODEL)` -> on miss, `services.npu_client.generate_embedding_with_fallback(code, model_name=EMBEDDING_MODEL)` -> on success, cache `put(code, embedding, model=EMBEDDING_MODEL)` and return the real embedding. The SHA-256 hash-based pseudo-embedding is now a genuine last-resort fallback only, reached when the real embedding call raises or returns nothing -- logged at `warning`, never silently swallowed at `debug`.

Added `autobot-backend/code_intelligence/pattern_analysis/embedding_test.py` (7 new tests, real-module-loaded like `source_scoping_test.py`) asserting: the canonical helper is called with the code + real model name; the reused cache instance is used (get -> miss -> generate -> put); a cache hit skips generation entirely; the hash fallback is reached ONLY on real-embedding failure/None, never on success.

Interaction with #12384 (source-scoped `code_patterns` storage, merged): stored embeddings feed `search_similar_patterns`. Switching from hash-based to real embeddings means pre-existing hash-embedding records won't semantically match new real-embedding queries -- same reindex-needed note as #12384's fail-closed scoping; no data-loss risk since nothing is deleted.

## Verification
WSL/light test env has no sentence-transformers/NPU worker reachable, but the real Ollama fallback in `services.npu_client.generate_embedding_with_fallback` was actually exercised live during manual debugging (confirmed via log: `Generated embedding via Ollama (nomic-embed-text)`), proving the real code path executes end-to-end, not just the hash fallback.

`python3 -m pytest code_intelligence/pattern_analysis/ -p no:xdist -q`:
```
code_intelligence/pattern_analysis/embedding_test.py .......             [ 38%]
code_intelligence/pattern_analysis/source_scoping_test.py ...........    [100%]
======================== 18 passed, 1 warning in 1.04s =========================
```
(11 pre-existing #12384 source-scoping tests unaffected; 7 new embedding tests pass.)

`flake8`/`black --check` clean on both changed files.

Gotcha discovered while writing the test (documented in the test file's header comment): `services` is stubbed in `conftest.py` as a `MagicMock` package with a catch-all `__getattr__`. `unittest.mock.patch("services.npu_client.X")` resolves its target via a `getattr` chain starting at that parent stub, silently patching a throwaway mock instead of the real `services.npu_client` module (an inert patch) -- confirmed this is the exact trap `conftest.py`'s own `_real_load_and_bind` docstring warns about. Worked around it in the test by importing `services.npu_client` directly and using `patch.object` on the real module object, which is what `analyzer.py`'s local `from services.npu_client import ...` actually resolves via `sys.modules`.

## Model Used
Claude Opus 4.8