### PR TITLE
fix(security): broaden redact_text KV regex to mask client_secret= in free-text logs (#12333)

### DIFF
--- a/autobot_shared/security/redaction.py
+++ b/autobot_shared/security/redaction.py
@@ -31,7 +31,14 @@ from typing import Dict, Mapping
 _AUTH_HEADER_RE = re.compile(r"(?i)(authorization\s*[:=]\s*).+")
 
 # ``api_key=…`` / ``token: …`` / ``secret=…`` / ``password=…`` key/value pairs.
-_SECRET_KV_RE = re.compile(r"(?i)\b(api[_-]?key|token|secret|password|passwd)\b(\s*[:=]\s*)([^\s,;\"']+)")
+# The optional ``[a-z0-9_]*[_-]?`` prefix also matches prefixed keys such as
+# ``client_secret=``, ``access_token:``, ``db_password=`` (#12333) — anchored
+# so the secret word must sit immediately before the ``[:=]``, so ordinary
+# prose (``the password reset flow``) and near-miss keys
+# (``password_hash_algorithm=``) are never matched.
+_SECRET_KV_RE = re.compile(
+    r"(?i)\b([a-z0-9_]*[_-]?(?:api[_-]?key|token|secret|password|passwd))\b(\s*[:=]\s*)([^\s,;\"']+)"
+)
 
 # ---------------------------------------------------------------------------
 # Mapping redaction (union of the former code_sync._mask_secret_extra_vars)

--- a/autobot_shared/security/redaction_test.py
+++ b/autobot_shared/security/redaction_test.py
@@ -77,6 +77,33 @@ class TestRedactText:
         line = "2026-07-23 10:00:00,123 INFO worker started successfully"
         assert redact_text(line) == line
 
+    @pytest.mark.parametrize(
+        "key",
+        ["client_secret", "access_token", "refresh_token", "db_password", "vault_token"],
+    )
+    def test_prefixed_secret_kv_is_redacted(self, key):
+        # #12333 — prefixed keys (client_secret=, access_token:, etc.) must be
+        # masked in free-text logs, not just via redact_mapping.
+        line = f"OAUTH {key}=SUPER-SECRET-VALUE issued"
+        redacted = redact_text(line)
+        assert "SUPER-SECRET-VALUE" not in redacted
+        assert f"{key}=***" in redacted
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "The password reset flow succeeded for user bob",
+            "we issued new tokens today for the demo",
+            "password_hash_algorithm=bcrypt",
+            "topsecret999 was mentioned but not assigned",
+            "the secret sauce recipe is great",
+        ],
+    )
+    def test_broadened_regex_does_not_over_redact(self, line):
+        # #12333 — the broadened prefix must not mask ordinary prose or
+        # near-miss keys that merely contain (but don't end in) a secret word.
+        assert redact_text(line) == line
+
 
 # ---------------------------------------------------------------------------
 # redact_mapping — kv/dict level (former _mask_secret_extra_vars)


### PR DESCRIPTION
Closes #12333

## Thinking Path
`_SECRET_KV_RE` used `\b(api[_-]?key|token|secret|password|passwd)\b` — the leading `\b` requires a non-word char immediately before the secret word, but `_` (as in `client_secret=`) is a word char, so no boundary exists there. `redact_mapping` already catches these keys via substring/prefix matching on the key set, but the free-text `redact_text` path (used for raw log lines, e.g. OAuth client_secret in a log message) missed them entirely.

Considered two fixes: (1) explicitly enumerate `client_secret`, `access_token`, `refresh_token` in the alternation, or (2) allow a generic `[a-z0-9_]*[_-]?` prefix before the secret word. Chose (2): the regex is suffix-anchored — the secret word must sit immediately before the `:`/`=` separator — so prose (`the password reset flow`) and near-miss keys (`password_hash_algorithm=`) never match regardless of the prefix. Empirically verified no over-redaction across a set of realistic log lines and no ReDoS risk (linear timing on a 5000-char adversarial input). The generic prefix also catches future unforeseen variants (`consumer_secret`, `oauth_client_secret`, `vendor_api_key`) that an enumerated list would keep missing — better fit for a security control where false negatives are the real risk.

## What Changed
- `autobot_shared/security/redaction.py`: broadened `_SECRET_KV_RE` to `\b([a-z0-9_]*[_-]?(?:api[_-]?key|token|secret|password|passwd))\b(\s*[:=]\s*)([^\s,;\"']+)`.
- `autobot_shared/security/redaction_test.py`: added tests for prefixed keys (`client_secret`, `access_token`, `refresh_token`, `db_password`, `vault_token`) being masked, and for ordinary prose / near-miss keys NOT being over-redacted.
- `redact_mapping` unchanged (already correct).

## Verification
```
$ python3 -m pytest autobot_shared/security/redaction_test.py -p no:xdist -q
39 passed in 0.19s

$ python3 -m pytest autobot-slm-backend/api/monitoring_applogs_test.py -p no:xdist -q
38 passed, 1 warning in 1.21s
```
Before: `redact_text("OAUTH client_secret=SUPER-SECRET-VALUE issued")` → unchanged (leaked).
After: `redact_text("OAUTH client_secret=SUPER-SECRET-VALUE issued")` → `OAUTH client_secret=*** issued`.

## Model Used
Claude Opus 4.8