### PR TITLE
fix(chat): preserve error status/name so 422/network sends show categorized message (#12401)

### DIFF
--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -227,14 +227,27 @@ export class ChatController {
 
       // If it's a 422 validation error, don't retry
       if (errStatus === 422) {
-        throw new Error(i18n.global.t('chat.errors.invalidFormatDetail', { error: errMsg }))
+        // #12401: keep .status on the re-wrapped error so the outer
+        // getUserFriendlyErrorMessage() categorizes it as invalidFormat instead
+        // of falling through to the generic sendFailed (which would double-wrap
+        // this detail message).
+        throw Object.assign(
+          new Error(i18n.global.t('chat.errors.invalidFormatDetail', { error: errMsg })),
+          { status: 422 }
+        )
       }
 
       // If it's a network error, add context
       const errName = (error as { name?: string }).name
       const errCode = (error as { code?: string }).code
       if (errName === 'NetworkError' || errCode === 'NETWORK_ERROR') {
-        throw new Error(i18n.global.t('chat.errors.networkFailedRetry'))
+        // #12401: keep name==='NetworkError' on the re-wrapped error so the outer
+        // getUserFriendlyErrorMessage() surfaces networkFailed instead of the
+        // generic sendFailed.
+        throw Object.assign(
+          new Error(i18n.global.t('chat.errors.networkFailedRetry')),
+          { name: 'NetworkError' }
+        )
       }
 
       throw error

--- a/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
+++ b/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
@@ -5,6 +5,7 @@ import { ChatController } from '../ChatController'
 import * as chatRepository from '@/models/repositories'
 import { useChatStore } from '@/stores/useChatStore'
 import { useAppStore } from '@/stores/useAppStore'
+import i18n from '@/i18n'
 
 // Mock the repositories
 vi.mock('@/models/repositories', () => ({
@@ -251,6 +252,73 @@ describe('ChatController', () => {
       await controller.deleteChatSession('s1')
 
       expect(store.deleteSession).toHaveBeenCalledWith('s1')
+    })
+  })
+
+  describe('sendMessage error categorization (#12401)', () => {
+    // A store with an existing session so the send path goes straight to the
+    // repository call (and its error handling) without minting a new session.
+    function sendReadyStore() {
+      return {
+        createNewSession: vi.fn((title: string, sessionId: string) => sessionId),
+        switchToSession: vi.fn(),
+        addMessage: vi.fn(() => 'user-msg-1'),
+        updateMessage: vi.fn(),
+        setTyping: vi.fn(),
+        sessions: [],
+        currentSession: null,
+        currentSessionId: 'session-1',
+        activeChatContext: {},
+        settings: { autoSave: false, persistHistory: true }
+      }
+    }
+
+    it('surfaces invalidFormat (not the generic sendFailed) for a 422 error', async () => {
+      vi.mocked(useChatStore).mockReturnValue(
+        sendReadyStore() as unknown as ReturnType<typeof useChatStore>
+      )
+      const setGlobalError = vi.fn()
+      vi.mocked(useAppStore).mockReturnValue(
+        { setGlobalError } as unknown as ReturnType<typeof useAppStore>
+      )
+      // A 422 carries an HTTP status; #12401 must preserve it through the
+      // re-wrap so getUserFriendlyErrorMessage() can categorize it.
+      vi.mocked(chatRepository.chatRepository.sendMessage).mockRejectedValue(
+        Object.assign(new Error('field required'), { status: 422 })
+      )
+      // Collapse the inter-retry backoff so the test is fast.
+      ;(controller as unknown as { retryDelay: number }).retryDelay = 0
+
+      await expect(controller.sendMessage('hello')).rejects.toBeTruthy()
+
+      // The categorized message surfaces exactly once — not the double-wrapped
+      // sendFailed that resulted before status was preserved.
+      expect(setGlobalError).toHaveBeenCalledTimes(1)
+      expect(setGlobalError).toHaveBeenCalledWith(
+        i18n.global.t('chat.errors.invalidFormat')
+      )
+    })
+
+    it('surfaces networkFailed (not the generic sendFailed) for a NetworkError', async () => {
+      vi.mocked(useChatStore).mockReturnValue(
+        sendReadyStore() as unknown as ReturnType<typeof useChatStore>
+      )
+      const setGlobalError = vi.fn()
+      vi.mocked(useAppStore).mockReturnValue(
+        { setGlobalError } as unknown as ReturnType<typeof useAppStore>
+      )
+      // A network failure carries name==='NetworkError'; #12401 must preserve it.
+      vi.mocked(chatRepository.chatRepository.sendMessage).mockRejectedValue(
+        Object.assign(new Error('connection refused'), { name: 'NetworkError' })
+      )
+      ;(controller as unknown as { retryDelay: number }).retryDelay = 0
+
+      await expect(controller.sendMessage('hello')).rejects.toBeTruthy()
+
+      expect(setGlobalError).toHaveBeenCalledTimes(1)
+      expect(setGlobalError).toHaveBeenCalledWith(
+        i18n.global.t('chat.errors.networkFailed')
+      )
     })
   })
 


### PR DESCRIPTION
Closes #12401

## Thinking Path
`ChatController.sendMessageWithRetry` re-wrapped ONLY the 422 and NetworkError repository failures into plain `Error`s (throw sites ~L230/L237), discarding the original `.status`/`.name`. The thrown error flows: retry loop catch (`lastError = error`) -> after retries `throw lastError` -> outer `sendMessage` catch -> `getUserFriendlyErrorMessage(error)`. That function categorizes on `status===422` (-> `invalidFormat`) and `name==='NetworkError'` (-> `networkFailed`), but those exact fields had already been stripped, so both branches were unreachable and the failure fell through to the generic `sendFailed` — double-wrapping the detail message. Confirmed real in the #12400 code-review.

## What Changed
- `autobot-frontend/src/models/controllers/ChatController.ts`: the 422 and network re-throws now `Object.assign(new Error(...), { status: 422 })` / `{ name: 'NetworkError' }` (the same error-tagging idiom already used in this file's delete path). `.status`/`.name` survive to the outer catch, so `getUserFriendlyErrorMessage` reaches the `invalidFormat` / `networkFailed` branches. No change to `getUserFriendlyErrorMessage` (it already reads `.status`/`.name`). Retry count/conditions unchanged. No hardcoded strings — existing i18n keys reused.
- `autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts`: added a `sendMessage error categorization (#12401)` suite asserting a 422 send surfaces `chat.errors.invalidFormat` and a NetworkError surfaces `chat.errors.networkFailed` via `setGlobalError` (called exactly once — no double-wrap into `sendFailed`).

## Verification
- Inspection + control-flow trace: tagged Error -> `lastError` (kept, is an `Error`) -> `throw lastError` -> outer catch -> `getUserFriendlyErrorMessage` reads preserved `.status`/`.name` -> returns categorized key.
- i18n keys confirmed present in `src/i18n/locales/en.json` (`invalidFormat`, `networkFailed`, `invalidFormatDetail`, `networkFailedRetry`).
- Brace/paren balance check passed on both files. WSL has no npm; CI runs vitest + vue-tsc.

## Model Used
Claude Opus 4.8