### PR TITLE
fix(codebase-analytics): api_endpoint_scanner.py fallback uses deployed-layout-aware root (#12404)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Set
 
 from autobot_shared.logging_manager import get_logger
 
-from .endpoints.shared import get_project_root
+from .endpoints.shared import resolve_project_root
 from .models import (
     APIEndpointAnalysis,
     APIEndpointItem,
@@ -127,7 +127,11 @@ class BackendEndpointScanner:
     API_PREFIX = "/api"
 
     def __init__(self, project_root: Path | None = None):
-        self.project_root = project_root or get_project_root()
+        # Issue #12404: Fall back to resolve_project_root() (deployed-layout-aware,
+        # #10730) rather than get_project_root() (hardcoded parents[4], which
+        # resolves to /opt/autobot -- not the analyzable repo -- in the deployed
+        # standalone rsync layout).
+        self.project_root = project_root or Path(resolve_project_root())
         self.backend_path = self.project_root / "api"
         self._router_prefixes: Dict[str, str] = {}
         # Map module name to router prefix (e.g., "chat" -> "", "system" -> "/system")
@@ -750,7 +754,11 @@ class FrontendAPICallScanner:
     """Scans frontend TypeScript/Vue files for API calls."""
 
     def __init__(self, project_root: Path | None = None):
-        self.project_root = project_root or get_project_root()
+        # Issue #12404: Fall back to resolve_project_root() (deployed-layout-aware,
+        # #10730) rather than get_project_root() (hardcoded parents[4], which
+        # resolves to /opt/autobot -- not the analyzable repo -- in the deployed
+        # standalone rsync layout).
+        self.project_root = project_root or Path(resolve_project_root())
         self.frontend_path = self.project_root / "autobot-frontend" / "src"
 
     def scan_all_calls(self) -> List[FrontendAPICallItem]:
@@ -1088,7 +1096,11 @@ class APIEndpointChecker:
     """
 
     def __init__(self, project_root: Path | None = None):
-        self.project_root = project_root or get_project_root()
+        # Issue #12404: Fall back to resolve_project_root() (deployed-layout-aware,
+        # #10730) rather than get_project_root() (hardcoded parents[4], which
+        # resolves to /opt/autobot -- not the analyzable repo -- in the deployed
+        # standalone rsync layout).
+        self.project_root = project_root or Path(resolve_project_root())
         self.backend_scanner = BackendEndpointScanner(self.project_root)
         self.frontend_scanner = FrontendAPICallScanner(self.project_root)
 

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression test for Issue #12404 (sibling of #12393/#12398/#12399).
+
+``BackendEndpointScanner``, ``FrontendAPICallScanner`` and
+``APIEndpointChecker`` all fall back to ``get_project_root()`` (hardcoded
+``parents[4]``) when no ``project_root`` is supplied. In the deployed
+standalone rsync layout ``parents[4]`` resolves to ``/opt/autobot`` -- not
+the analyzable repo -- so the fallback must instead use
+``resolve_project_root()`` (git-walk-up / deployed ``code_source`` probe,
+#10730).
+"""
+
+from unittest.mock import patch
+
+from api.codebase_analytics import api_endpoint_scanner as scanner_mod
+
+
+class TestProjectRootFallbackUsesResolveProjectRoot:
+    """Issue #12404: sibling of #12398/#12399's resolve_project_root fix."""
+
+    def test_backend_scanner_fallback_uses_deployed_layout_aware_root(self, tmp_path):
+        deployed_root = tmp_path / "opt_autobot" / "code_source"
+        wrong_root = tmp_path / "opt_autobot"
+
+        with patch.object(
+            scanner_mod, "resolve_project_root", return_value=str(deployed_root)
+        ):
+            backend_scanner = scanner_mod.BackendEndpointScanner(project_root=None)
+
+        assert backend_scanner.project_root == deployed_root
+        assert backend_scanner.project_root != wrong_root
+
+    def test_frontend_scanner_fallback_uses_deployed_layout_aware_root(self, tmp_path):
+        deployed_root = tmp_path / "opt_autobot" / "code_source"
+        wrong_root = tmp_path / "opt_autobot"
+
+        with patch.object(
+            scanner_mod, "resolve_project_root", return_value=str(deployed_root)
+        ):
+            frontend_scanner = scanner_mod.FrontendAPICallScanner(project_root=None)
+
+        assert frontend_scanner.project_root == deployed_root
+        assert frontend_scanner.project_root != wrong_root
+
+    def test_api_endpoint_checker_fallback_uses_deployed_layout_aware_root(self, tmp_path):
+        deployed_root = tmp_path / "opt_autobot" / "code_source"
+        wrong_root = tmp_path / "opt_autobot"
+
+        with patch.object(
+            scanner_mod, "resolve_project_root", return_value=str(deployed_root)
+        ):
+            checker = scanner_mod.APIEndpointChecker(project_root=None)
+
+        assert checker.project_root == deployed_root
+        assert checker.project_root != wrong_root
+
+    def test_explicit_project_root_is_not_overridden(self, tmp_path):
+        """When project_root IS supplied, resolve_project_root() must not
+        be consulted at all (the resolved branch is untouched)."""
+        explicit_root = tmp_path / "explicit"
+
+        with patch.object(
+            scanner_mod, "resolve_project_root", side_effect=AssertionError("should not be called")
+        ):
+            backend_scanner = scanner_mod.BackendEndpointScanner(project_root=explicit_root)
+
+        assert backend_scanner.project_root == explicit_root

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -26,9 +26,7 @@ class TestProjectRootFallbackUsesResolveProjectRoot:
         deployed_root = tmp_path / "opt_autobot" / "code_source"
         wrong_root = tmp_path / "opt_autobot"
 
-        with patch.object(
-            scanner_mod, "resolve_project_root", return_value=str(deployed_root)
-        ):
+        with patch.object(scanner_mod, "resolve_project_root", return_value=str(deployed_root)):
             backend_scanner = scanner_mod.BackendEndpointScanner(project_root=None)
 
         assert backend_scanner.project_root == deployed_root
@@ -38,9 +36,7 @@ class TestProjectRootFallbackUsesResolveProjectRoot:
         deployed_root = tmp_path / "opt_autobot" / "code_source"
         wrong_root = tmp_path / "opt_autobot"
 
-        with patch.object(
-            scanner_mod, "resolve_project_root", return_value=str(deployed_root)
-        ):
+        with patch.object(scanner_mod, "resolve_project_root", return_value=str(deployed_root)):
             frontend_scanner = scanner_mod.FrontendAPICallScanner(project_root=None)
 
         assert frontend_scanner.project_root == deployed_root
@@ -50,9 +46,7 @@ class TestProjectRootFallbackUsesResolveProjectRoot:
         deployed_root = tmp_path / "opt_autobot" / "code_source"
         wrong_root = tmp_path / "opt_autobot"
 
-        with patch.object(
-            scanner_mod, "resolve_project_root", return_value=str(deployed_root)
-        ):
+        with patch.object(scanner_mod, "resolve_project_root", return_value=str(deployed_root)):
             checker = scanner_mod.APIEndpointChecker(project_root=None)
 
         assert checker.project_root == deployed_root
@@ -63,9 +57,7 @@ class TestProjectRootFallbackUsesResolveProjectRoot:
         be consulted at all (the resolved branch is untouched)."""
         explicit_root = tmp_path / "explicit"
 
-        with patch.object(
-            scanner_mod, "resolve_project_root", side_effect=AssertionError("should not be called")
-        ):
+        with patch.object(scanner_mod, "resolve_project_root", side_effect=AssertionError("should not be called")):
             backend_scanner = scanner_mod.BackendEndpointScanner(project_root=explicit_root)
 
         assert backend_scanner.project_root == explicit_root

--- a/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
@@ -131,7 +131,6 @@ class TestFetchProblemsFromChromaDBFallback:
             ),
             patch.object(report_mod, "filter_problems_by_file_existence", side_effect=fake_filter),
             patch.object(report_mod, "resolve_project_root", return_value=str(deployed_root)),
-            patch.object(report_mod, "get_project_root", return_value=wrong_root),
         ):
             report_mod._fetch_problems_from_chromadb(source_id=None, source_root=None)
 
@@ -268,7 +267,6 @@ class TestReportPipelineSourceIsolation:
             patch.object(report_mod, "_get_api_endpoint_analysis", new=AsyncMock(return_value=None)),
             patch.object(report_mod, "_get_bug_prediction", new=AsyncMock(return_value=None)),
             patch.object(report_mod, "resolve_project_root", return_value=str(deployed_root)),
-            patch.object(report_mod, "get_project_root", return_value=wrong_root),
         ):
             await report_mod.generate_analysis_report(source_id="unresolvable-source", quick=False)
 


### PR DESCRIPTION
Closes #12404

## Thinking Path

Same bug class as #12393/#12398/#12399: `api_endpoint_scanner.py` used
`project_root or get_project_root()` at three constructor sites
(`BackendEndpointScanner`, `FrontendAPICallScanner`,
`APIEndpointChecker`). `get_project_root()` is a hardcoded `parents[4]`
which resolves to `/opt/autobot` (not the analyzable repo) in the
deployed standalone rsync layout. When driven from the report
pipeline this fallback never fires (an explicit `project_root` is
always passed), but any other instantiation with `project_root=None`
hits the bug. `resolve_project_root()` (git-walk-up / deployed
`code_source` probe, #10730) is the deployed-layout-aware replacement
already adopted by the sibling fixes.

While verifying, discovered a pre-existing regression from #12403's
review commit (#12399): it removed `get_project_root` from
`report.py`'s import list but left two `patch.object(report_mod,
"get_project_root", ...)` calls in `report_scoping_test.py`, which now
`AttributeError`'d on collection. Fixed in the same PR (Rule 6 — small,
directly adjacent, discovered while running the required test suite).

## What Changed

- `autobot-backend/api/codebase_analytics/api_endpoint_scanner.py`:
  - import `resolve_project_root` instead of `get_project_root` from `.endpoints.shared`
  - `BackendEndpointScanner.__init__` (line ~130): `project_root or get_project_root()` → `project_root or Path(resolve_project_root())`
  - `FrontendAPICallScanner.__init__` (line ~753→761): same change
  - `APIEndpointChecker.__init__` (line ~1091→1103): same change
  - resolved (`project_root`-supplied) branches untouched
- `autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py` (new): regression tests for all three fallback sites + a test asserting the resolved-branch is never overridden
- `autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py`: removed two stale `patch.object(report_mod, "get_project_root", ...)` calls left over from #12403's review commit, which no longer has that attribute since report.py's fallback now exclusively uses `resolve_project_root()`

## Verification

```
$ python3 -m pytest api/codebase_analytics/ -p no:xdist -q
================== 175 passed, 11 skipped, 1 warning in 2.85s ==================
```

New tests (`api_endpoint_scanner_test.py`) pass in isolation:
```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -p no:xdist -q
4 passed, 1 warning in 1.09s
```

## Model Used

Claude Opus 4.8