### PR TITLE
fix(transcriber): enforce MAX_FILE_SIZE cap during streaming upload (#12331)

### DIFF
--- a/autobot-backend/transcriber/routes/recordings.py
+++ b/autobot-backend/transcriber/routes/recordings.py
@@ -30,12 +30,14 @@ from autobot_shared.logging_manager import get_logger
 from transcriber.database import Database
 from transcriber.deps import DEFAULT_USER, can_access, get_db
 from transcriber.models import RecordingOut
+from transcriber.upload_security import MAX_FILE_SIZE
 
 logger = get_logger(__name__)
 
 router = APIRouter(tags=["transcriber-recordings"])
 
 _ALLOWED_EXTENSIONS = {".wav", ".mp3", ".mp4", ".m4a", ".ogg", ".flac", ".webm"}
+_CHUNK_SIZE = 65536
 
 
 def _upload_dir(request: Request) -> Path:
@@ -64,9 +66,23 @@ async def upload_recording(
         raise HTTPException(400, f"Unsupported audio format: {ext}")
     safe_name = f"{uuid.uuid4().hex}{ext}"
     dest = _upload_dir(request) / safe_name
-    async with aiofiles.open(dest, "wb") as f:
-        while chunk := await file.read(65536):
-            await f.write(chunk)
+    # GH#12331: enforce MAX_FILE_SIZE during streaming (never buffer the whole
+    # upload in memory) — abort and delete the partial file the instant the
+    # cumulative byte count crosses the cap, regardless of proxy limits.
+    total_bytes = 0
+    try:
+        async with aiofiles.open(dest, "wb") as f:
+            while chunk := await file.read(_CHUNK_SIZE):
+                total_bytes += len(chunk)
+                if total_bytes > MAX_FILE_SIZE:
+                    raise HTTPException(
+                        413,
+                        f"File exceeds maximum upload size of {MAX_FILE_SIZE // (1024 * 1024)}MB",
+                    )
+                await f.write(chunk)
+    except Exception:
+        dest.unlink(missing_ok=True)
+        raise
     # The file is on disk before the DB row exists; unlink the partial upload
     # if the insert fails so a rejected recording never leaks an orphan (GH#12310).
     try:
@@ -139,8 +155,6 @@ async def delete_recording(recording_id: int, request: Request, db: Database = D
 
 
 # ── Audio path validation ─────────────────────────────────────────────────────
-
-_CHUNK_SIZE = 65536
 
 
 def _resolve_audio_path(filepath: str, upload_dir: Path) -> Path:

--- a/autobot-backend/transcriber/tests/test_recordings_api.py
+++ b/autobot-backend/transcriber/tests/test_recordings_api.py
@@ -141,6 +141,53 @@ async def test_failed_insert_unlinks_orphan(client, tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_upload_recording_rejects_oversized_and_cleans_up(client, tmp_path, monkeypatch):
+    """GH#12331: uploads exceeding MAX_FILE_SIZE are rejected with 413 during
+    streaming (never buffered in memory) and the partial file is deleted."""
+    import transcriber.routes.recordings as rec_mod
+
+    monkeypatch.setattr(rec_mod, "MAX_FILE_SIZE", 10)
+
+    r = await client.post("/api/transcriber/projects", json={"name": "P", "description": ""})
+    pid = r.json()["id"]
+
+    oversized = b"RIFF" + b"\x00" * 100  # 104 bytes > 10-byte patched cap
+    r2 = await client.post(
+        f"/api/transcriber/projects/{pid}/recordings",
+        files={"file": ("too_big.wav", io.BytesIO(oversized), "audio/wav")},
+    )
+    assert r2.status_code == 413, r2.text
+
+    # No partial file left behind in the upload dir.
+    upload_dir = tmp_path / "uploads"
+    assert list(upload_dir.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_upload_recording_at_limit_succeeds(client, tmp_path, monkeypatch):
+    """GH#12331: an upload at or under MAX_FILE_SIZE is written through untouched."""
+    import transcriber.routes.recordings as rec_mod
+
+    monkeypatch.setattr(rec_mod, "MAX_FILE_SIZE", 104)
+
+    r = await client.post("/api/transcriber/projects", json={"name": "P", "description": ""})
+    pid = r.json()["id"]
+
+    exact = b"RIFF" + b"\x00" * 100  # exactly 104 bytes == patched cap
+    with patch("tasks.transcriber_tasks.transcribe_recording", MagicMock()):
+        r2 = await client.post(
+            f"/api/transcriber/projects/{pid}/recordings",
+            files={"file": ("exact.wav", io.BytesIO(exact), "audio/wav")},
+        )
+    assert r2.status_code == 202, r2.text
+
+    upload_dir = tmp_path / "uploads"
+    files = list(upload_dir.iterdir())
+    assert len(files) == 1
+    assert len(files[0].read_bytes()) == 104
+
+
+@pytest.mark.asyncio
 async def test_delete_recording(client, tmp_path):
     r = await client.post("/api/transcriber/projects", json={"name": "P", "description": ""})
     pid = r.json()["id"]


### PR DESCRIPTION
Closes #12331

## Thinking Path
The recordings upload route streamed chunks straight to disk with no size check — the 500MB ceiling documented in `transcriber/upload_security.py` (`MAX_FILE_SIZE`) and enforced by the nginx proxy (500m) was never enforced at the app layer. A client bypassing/ignoring the proxy could write an unbounded file to disk (DoS/disk exhaustion). The fix needed to track cumulative bytes while streaming (never buffer the whole upload in memory), abort and clean up the partial file the instant the cap is crossed, and reuse the existing `MAX_FILE_SIZE` constant rather than hardcoding 500MB again.

## What Changed
- `transcriber/routes/recordings.py`: import `MAX_FILE_SIZE` from `transcriber.upload_security`; the streaming write loop in `upload_recording` now tracks `total_bytes` as each 64KB chunk is written and raises `HTTPException(413, ...)` the instant the cumulative size exceeds `MAX_FILE_SIZE`. The write is wrapped in its own `try/except Exception` that unlinks the partial file on ANY abort path (size cap exceeded or any other mid-stream exception) before re-raising, so no orphaned temp files are left behind. The pre-existing DB-insert cleanup path (GH#12310) is unchanged.
- Consolidated the previously-duplicated `65536` chunk-read magic number and the module-level `_CHUNK_SIZE` constant (used by the download-streaming helper) into a single definition near the top of the file, reused by both the upload and download paths.
- `transcriber/tests/test_recordings_api.py`: added `test_upload_recording_rejects_oversized_and_cleans_up` (patches `MAX_FILE_SIZE` down to 10 bytes, uploads 104 bytes, asserts 413 and an empty upload dir) and `test_upload_recording_at_limit_succeeds` (patches the cap to exactly 104 bytes, uploads exactly 104 bytes, asserts 202 and the file landed on disk intact).

## Verification
```
$ python3 -m pytest transcriber/tests/test_recordings_api.py -p no:xdist -q
collected 7 items
transcriber/tests/test_recordings_api.py .......                         [100%]
7 passed, 1 warning in 3.38s

$ python3 -m pytest transcriber/ -p no:xdist -q
100 passed, 1 skipped, 4 warnings in 33.72s
```
`black --check` and `ruff check` pass clean on both changed files.

## Model Used
Claude Opus 4.8