### PR TITLE
test(frontend): cover #12376 repointed API methods (#12386)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useBatchProcessing.toggleSchedule.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/useBatchProcessing.toggleSchedule.spec.ts
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Coverage for #12386 — the #12376 repoint of useBatchProcessingApi.toggleSchedule.
+ *
+ * PR #12376 corrected the prefix to /api/batch-jobs/schedules/{id} and issues a
+ * PATCH with body `{ enabled }`. The backend route is still missing (tracked in
+ * #12380), so these tests assert the *intended* request shape the method sends,
+ * not a live round-trip.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useBatchProcessingApi } from '../useBatchProcessing'
+
+const mockPatch = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: mockPatch
+  })
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api'
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() })
+}))
+
+vi.mock('@/utils/cacheManagement', () => ({
+  showSubtleErrorNotification: vi.fn()
+}))
+
+describe('useBatchProcessingApi.toggleSchedule (#12386)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('PATCHes /api/batch-jobs/schedules/{id} with { enabled: true }', async () => {
+    mockPatch.mockResolvedValue({ id: 'sched-1', enabled: true })
+    const { toggleSchedule } = useBatchProcessingApi()
+
+    await toggleSchedule('sched-1', true)
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/batch-jobs/schedules/sched-1', {
+      enabled: true
+    })
+  })
+
+  it('forwards enabled=false in the PATCH body', async () => {
+    mockPatch.mockResolvedValue({ id: 'sched-2', enabled: false })
+    const { toggleSchedule } = useBatchProcessingApi()
+
+    await toggleSchedule('sched-2', false)
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/batch-jobs/schedules/sched-2', {
+      enabled: false
+    })
+  })
+
+  it('returns null and does not throw when the PATCH rejects (route missing, #12380)', async () => {
+    mockPatch.mockRejectedValue(new Error('405 Method Not Allowed'))
+    const { toggleSchedule } = useBatchProcessingApi()
+
+    const result = await toggleSchedule('sched-3', true)
+
+    expect(result).toBeNull()
+  })
+})

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.updateDocument.spec.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.updateDocument.spec.ts
@@ -1,0 +1,80 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Coverage for #12386 — the #12376 repoint of KnowledgeRepository.updateDocument.
+ *
+ * PR #12376 moved fact updates to PUT /api/knowledge-maintenance/fact/{id} and
+ * changed the body to match UpdateFactRequest: `content` and `category` stay
+ * top-level, while `title`/`source`/`tags` are folded into `metadata` (merged,
+ * not clobbering caller-supplied metadata) so they actually persist.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeRepository } from '../KnowledgeRepository'
+import type { KnowledgeDocument } from '../KnowledgeRepository'
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api'
+}))
+
+describe('KnowledgeRepository.updateDocument (#12386)', () => {
+  let repo: KnowledgeRepository
+  let putSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    repo = new KnowledgeRepository()
+    putSpy = vi.fn().mockResolvedValue({ data: {} as KnowledgeDocument })
+    // @ts-expect-error - override inherited method for unit test isolation
+    repo.put = putSpy
+  })
+
+  it('PUTs to /api/knowledge-maintenance/fact/{id} with content/category top-level and title/source/tags under metadata', async () => {
+    await repo.updateDocument('id1', {
+      title: 'T',
+      source: 'S',
+      tags: ['x'],
+      content: 'C',
+      category: 'K'
+    } as Partial<KnowledgeDocument>)
+
+    expect(putSpy).toHaveBeenCalledWith('/api/knowledge-maintenance/fact/id1', {
+      content: 'C',
+      category: 'K',
+      metadata: {
+        title: 'T',
+        source: 'S',
+        tags: ['x']
+      }
+    })
+  })
+
+  it('merges title/source/tags into caller-supplied metadata without clobbering it', async () => {
+    await repo.updateDocument('id2', {
+      title: 'T',
+      metadata: { existing: 'keep', title: 'old' }
+    } as Partial<KnowledgeDocument>)
+
+    const [, body] = putSpy.mock.calls[0] as [string, Record<string, unknown>]
+    expect(body.metadata).toEqual({ existing: 'keep', title: 'T' })
+    // content/category omitted when not supplied
+    expect(body).not.toHaveProperty('content')
+    expect(body).not.toHaveProperty('category')
+  })
+
+  it('keeps title/source/tags out of the top-level body', async () => {
+    await repo.updateDocument('id3', {
+      title: 'T',
+      source: 'S',
+      tags: ['a', 'b'],
+      content: 'C'
+    } as Partial<KnowledgeDocument>)
+
+    const [, body] = putSpy.mock.calls[0] as [string, Record<string, unknown>]
+    expect(body).not.toHaveProperty('title')
+    expect(body).not.toHaveProperty('source')
+    expect(body).not.toHaveProperty('tags')
+    expect(body.content).toBe('C')
+  })
+})

--- a/autobot-frontend/src/services/__tests__/api.performResearch.spec.ts
+++ b/autobot-frontend/src/services/__tests__/api.performResearch.spec.ts
@@ -14,7 +14,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { apiService } from '../api'
 
-vi.mock('@/config/ssot-config', () => ({
+// Keep the real module (ApiService also imports getConfig etc. from it) and
+// only pin getApiBase to '/api' so the asserted path is deterministic.
+vi.mock('@/config/ssot-config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/config/ssot-config')>()),
   getApiBase: () => '/api'
 }))
 

--- a/autobot-frontend/src/services/__tests__/api.performResearch.spec.ts
+++ b/autobot-frontend/src/services/__tests__/api.performResearch.spec.ts
@@ -1,0 +1,45 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Coverage for #12386 — the #12376 repoint of ApiService.performResearch.
+ *
+ * PR #12376 moved this call to POST /api/agent/research/comprehensive and
+ * replaced the legacy `{ query, focus, max_results }` body with the backend
+ * ResearchTaskRequest field `{ research_query }`. These tests pin the path and
+ * body so the request shape can't silently regress.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { apiService } from '../api'
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api'
+}))
+
+describe('ApiService.performResearch (#12386)', () => {
+  let postSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    postSpy = vi.spyOn(apiService, 'post').mockResolvedValue({ success: true } as never)
+  })
+
+  it('POSTs to /api/agent/research/comprehensive with { research_query }', async () => {
+    await apiService.performResearch('hi')
+
+    expect(postSpy).toHaveBeenCalledWith('/api/agent/research/comprehensive', {
+      research_query: 'hi'
+    })
+  })
+
+  it('does not send the legacy query/focus/max_results fields', async () => {
+    await apiService.performResearch('hi')
+
+    const body = postSpy.mock.calls[0][1] as Record<string, unknown>
+    expect(body).toEqual({ research_query: 'hi' })
+    expect(body).not.toHaveProperty('query')
+    expect(body).not.toHaveProperty('focus')
+    expect(body).not.toHaveProperty('max_results')
+  })
+})


### PR DESCRIPTION
Closes #12386

## Thinking Path
PR #12376 (merged) repointed three frontend API methods; codecov/patch flagged the changed lines as uncovered. I read the merged source for each method to capture its exact current path + body, matched the project's existing Vitest idioms (per-area), and added focused specs that pin the request shapes so they can't silently regress.

## What Changed
Added three Vitest specs (no source changes):
- `autobot-frontend/src/services/__tests__/api.performResearch.spec.ts` — asserts `performResearch('hi')` POSTs `/api/agent/research/comprehensive` with `{ research_query: 'hi' }` and sends none of the legacy `query`/`focus`/`max_results` fields. Mirrors the singleton-spy style: `vi.spyOn(apiService, 'post')` + mocked `getApiBase`.
- `autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.updateDocument.spec.ts` — asserts `updateDocument` PUTs `/api/knowledge-maintenance/fact/{id}` with `content`/`category` top-level and `title`/`source`/`tags` folded under `metadata`, merging (not clobbering) caller-supplied metadata, and keeping those three keys out of the top-level body. Mirrors `KnowledgeRepository.connectors.test.ts` (`new KnowledgeRepository()` + overridden inherited `put`).
- `autobot-frontend/src/composables/__tests__/useBatchProcessing.toggleSchedule.spec.ts` — asserts `toggleSchedule` PATCHes `/api/batch-jobs/schedules/{id}` with `{ enabled }` (both true/false) and returns `null` on rejection (route still missing, #12380). Mirrors `useProviderFallbackApi.spec.ts` (mocked `@/plugins/api` `useApiClient`).

## Verification
WSL has no npm — I could NOT run vitest/vue-tsc locally; CI runs them. Verified by inspection: each spec imports the real module under test, mocks `@/config/ssot-config` `getApiBase` → `/api` (matching every neighbouring spec), and asserts `toHaveBeenCalledWith(path, body)` shapes cross-checked against the merged source:
- `api.ts:149-153` `performResearch` → `post('/api/agent/research/comprehensive', { research_query: query })`.
- `KnowledgeRepository.ts:457-479` `updateDocument` → merges `title`/`source`/`tags` into `metadata`, `content`/`category` top-level, `put('/api/knowledge-maintenance/fact/{id}', body)`.
- `useBatchProcessing.ts:160-172` `toggleSchedule` → `patch('/api/batch-jobs/schedules/{id}', { enabled })`, catch → `null`.

## Model Used
Claude Opus 4.8