### PR TITLE
fix(ci): audit_api_wiring resolves SLM-backend routes + baseline (#12381)

### DIFF
--- a/.github/workflows/api-wiring.yml
+++ b/.github/workflows/api-wiring.yml
@@ -54,12 +54,26 @@ jobs:
           cache-dependency-path: |
             requirements*.txt
             autobot-backend/requirements*.txt
+            autobot-slm-backend/requirements*.txt
 
       - name: Install backend dependencies (best-effort)
         continue-on-error: true
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r requirements-ci.txt --prefer-binary || true
+
+      - name: Install SLM backend dependencies (best-effort)
+        # #12381: --dump-slm-openapi imports autobot-slm-backend/main.py, which
+        # needs its OWN requirements (croniter, authlib, ldap3, pysaml2, pyotp,
+        # ...) — requirements-ci.txt only covers autobot-backend. Without this,
+        # the SLM dump always fails ("No module named 'croniter'") and the SLM
+        # route union never happens, leaving every getSLMUrl()/slmFetch() call
+        # false-flagged as unwired. Best-effort/non-fatal like the step above —
+        # dump_slm_openapi() already degrades gracefully if something's still
+        # missing (audits against autobot-backend routes only).
+        continue-on-error: true
+        run: |
+          python -m pip install -r autobot-slm-backend/requirements.txt --prefer-binary || true
 
       - name: Run API wiring audit
         run: |

--- a/.github/workflows/api-wiring.yml
+++ b/.github/workflows/api-wiring.yml
@@ -72,17 +72,17 @@ jobs:
             # #12381: also dump the SLM control-plane backend's route table
             # (separate FastAPI app, :8000) and union it in — otherwise every
             # getSLMUrl()/slmFetch() call is false-flagged as unwired.
-            SLM_ARGS=""
+            SLM_ARGS=()
             export PYTHONPATH="$PWD:$PWD/autobot-slm-backend:${PYTHONPATH:-}"
             if python scripts/audit_api_wiring.py --dump-slm-openapi slm_openapi.json; then
               echo "::notice::SLM OpenAPI dump succeeded — unioning SLM route table."
-              SLM_ARGS="--slm-openapi slm_openapi.json"
+              SLM_ARGS=(--slm-openapi slm_openapi.json)
             else
               echo "::warning::SLM app build failed — auditing against autobot-backend routes only."
             fi
             export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
 
-            python scripts/audit_api_wiring.py --openapi openapi.json $SLM_ARGS \
+            python scripts/audit_api_wiring.py --openapi openapi.json "${SLM_ARGS[@]}" \
               --baseline scripts/api_wiring_baseline.txt --fail-on-unwired
           else
             echo "::warning::App build failed in CI — falling back to static (heuristic) audit."

--- a/.github/workflows/api-wiring.yml
+++ b/.github/workflows/api-wiring.yml
@@ -22,8 +22,10 @@ on:
     branches: [ main, Dev_new_gui ]
     paths: &paths
       - 'autobot-backend/**/*.py'
+      - 'autobot-slm-backend/**/*.py'
       - 'autobot-frontend/src/**'
       - 'scripts/audit_api_wiring.py'
+      - 'scripts/api_wiring_baseline.txt'
       - 'requirements*.txt'
       - '.github/workflows/api-wiring.yml'
   pull_request:
@@ -62,11 +64,26 @@ jobs:
       - name: Run API wiring audit
         run: |
           set -o pipefail
-          export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
           mkdir -p data logs static config
+          export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
           if python scripts/audit_api_wiring.py --dump-openapi openapi.json; then
             echo "::notice::Authoritative OpenAPI dump succeeded — auditing against real route table."
-            python scripts/audit_api_wiring.py --openapi openapi.json --fail-on-unwired
+
+            # #12381: also dump the SLM control-plane backend's route table
+            # (separate FastAPI app, :8000) and union it in — otherwise every
+            # getSLMUrl()/slmFetch() call is false-flagged as unwired.
+            SLM_ARGS=""
+            export PYTHONPATH="$PWD:$PWD/autobot-slm-backend:${PYTHONPATH:-}"
+            if python scripts/audit_api_wiring.py --dump-slm-openapi slm_openapi.json; then
+              echo "::notice::SLM OpenAPI dump succeeded — unioning SLM route table."
+              SLM_ARGS="--slm-openapi slm_openapi.json"
+            else
+              echo "::warning::SLM app build failed — auditing against autobot-backend routes only."
+            fi
+            export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
+
+            python scripts/audit_api_wiring.py --openapi openapi.json $SLM_ARGS \
+              --baseline scripts/api_wiring_baseline.txt --fail-on-unwired
           else
             echo "::warning::App build failed in CI — falling back to static (heuristic) audit."
             python scripts/audit_api_wiring.py

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -381,7 +381,7 @@ async def get_system_health(
         }
 
 
-@router.get("/system/health/probes", response_model=list[str])
+@router.get("/health/probes", response_model=list[str])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_health_probes",
@@ -1030,7 +1030,7 @@ async def clear_cache(cache_name: str, admin_check: bool = Depends(check_admin_p
         raise HTTPException(status_code=500, detail="Error clearing cache")
 
 
-@router.get("/system/backup/status", response_model=SystemBackupStatusResponse)
+@router.get("/backup/status", response_model=SystemBackupStatusResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_backup_status",

--- a/autobot-frontend/src/components/analytics/AgentCostPanel.vue
+++ b/autobot-frontend/src/components/analytics/AgentCostPanel.vue
@@ -192,7 +192,7 @@ const formatNumber = (num: number): string => {
 const fetchAgentCosts = async () => {
   loading.value = true
   try {
-    const res = await api.get<{ data: { agents: AgentCost[] } }>(`${getApiBase()}/cost/by-agent`)
+    const res = await api.get<{ data: { agents: AgentCost[] } }>(`${getApiBase()}/analytics/cost/by-agent`)
     agents.value = res.data?.agents || []
   } catch (error) {
     logger.error('Failed to fetch agent costs:', error)
@@ -219,7 +219,7 @@ const saveBudget = async () => {
   budgetDialog.value.saving = true
   try {
     await api.put<unknown>(
-      `${getApiBase()}/cost/by-agent/${budgetDialog.value.agentId}/budget`,
+      `${getApiBase()}/analytics/cost/by-agent/${budgetDialog.value.agentId}/budget`,
       { budget_monthly_usd: budgetDialog.value.amount }
     )
     closeBudgetDialog()

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -2089,7 +2089,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/system/system/health/probes": {
+    "/api/system/health/probes": {
         parameters: {
             query?: never;
             header?: never;
@@ -2109,7 +2109,7 @@ export interface paths {
          *     Public endpoint — no auth required (matches /api/system/health).
          *     Cheap call: returns sorted list of strings, no probe execution.
          */
-        get: operations["get_system_health_probes_api_system_system_health_probes_get"];
+        get: operations["get_system_health_probes_api_system_health_probes_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2394,7 +2394,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/system/system/backup/status": {
+    "/api/system/backup/status": {
         parameters: {
             query?: never;
             header?: never;
@@ -2408,7 +2408,7 @@ export interface paths {
          *     Issue #3294: Monitoring endpoint for automated backup health.
          *     Requires admin authentication.
          */
-        get: operations["get_backup_status_api_system_system_backup_status_get"];
+        get: operations["get_backup_status_api_system_backup_status_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -104591,7 +104591,7 @@ export interface operations {
             };
         };
     };
-    get_system_health_probes_api_system_system_health_probes_get: {
+    get_system_health_probes_api_system_health_probes_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -104875,7 +104875,7 @@ export interface operations {
             };
         };
     };
-    get_backup_status_api_system_system_backup_status_get: {
+    get_backup_status_api_system_backup_status_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/scripts/api_wiring_baseline.txt
+++ b/scripts/api_wiring_baseline.txt
@@ -1,0 +1,65 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Known/tracked unwired frontend API calls (#12381).
+#
+# One normalized path per line (the same form audit_api_wiring.py prints
+# under "== UNWIRED FRONTEND CALLS ==": /api/... with {p} in place of any
+# runtime-resolved segment). Blank lines and #-comments are ignored.
+#
+# These are NOT SLM-backend routing false positives — they genuinely have no
+# backend anywhere, per the live-verified triage in #12326 (comment) and the
+# owner-decision issues that track them (build the backend, or remove the
+# dead UI control). Listing them here lets --fail-on-unwired gate on NEW
+# drift only, instead of blocking on findings already tracked elsewhere.
+# When #12378/#12364 are dispositioned (backend built or control removed),
+# remove the corresponding lines.
+
+# --- #12378: browser-automation panel (aspirational, no backend) ---
+/api/browser/automation/run
+/api/browser/click
+/api/browser/close
+/api/browser/execute
+/api/browser/launch
+/api/browser/navigate
+/api/browser/screenshot
+/api/browser/session/{p}
+/api/browser/type
+
+# --- #12378: dev-speedup panel (aspirational, no backend) ---
+/api/dev-speedup/boilerplate
+/api/dev-speedup/format
+/api/dev-speedup/lint-fix
+/api/dev-speedup/optimize
+/api/dev-speedup/quick-search
+/api/dev-speedup/refactor-suggest
+/api/dev-speedup/snippet-generate
+/api/dev-speedup/test-generate
+
+# --- #12378: system restart / shutdown / backup (aspirational, no backend) ---
+/api/system/backup/create
+/api/system/backup/list
+/api/system/backup/restore/{p}
+/api/system/backup/{p}
+/api/system/restart
+/api/system/shutdown
+
+# --- #12378: misc aspirational calls, no backend ---
+/api/multimodal/health
+/api/service-monitor/resources
+/api/knowledge/verification/approve
+/api/knowledge_base/category/{p}
+/api/knowledge_base/documents/{p}
+/api/knowledge_base/documents/{p}/similar
+/api/transcriber/recordings/{p}/progress
+
+# --- #12364: analytics/code-intelligence redesign, deferred ---
+/api/code-intelligence/analysis/{p}
+/api/code-intelligence/batch-analyze
+/api/code-intelligence/compare
+/api/code-intelligence/history
+/api/code-intelligence/quality-score
+/api/code-intelligence/trends
+/api/analytics/bug-prediction
+/api/cost/by-agent
+/api/cost/by-agent/{p}/budget

--- a/scripts/api_wiring_baseline.txt
+++ b/scripts/api_wiring_baseline.txt
@@ -61,5 +61,3 @@
 /api/code-intelligence/quality-score
 /api/code-intelligence/trends
 /api/analytics/bug-prediction
-/api/cost/by-agent
-/api/cost/by-agent/{p}/budget

--- a/scripts/api_wiring_baseline.txt
+++ b/scripts/api_wiring_baseline.txt
@@ -7,13 +7,16 @@
 # under "== UNWIRED FRONTEND CALLS ==": /api/... with {p} in place of any
 # runtime-resolved segment). Blank lines and #-comments are ignored.
 #
-# These are NOT SLM-backend routing false positives — they genuinely have no
-# backend anywhere, per the live-verified triage in #12326 (comment) and the
-# owner-decision issues that track them (build the backend, or remove the
-# dead UI control). Listing them here lets --fail-on-unwired gate on NEW
-# drift only, instead of blocking on findings already tracked elsewhere.
-# When #12378/#12364 are dispositioned (backend built or control removed),
-# remove the corresponding lines.
+# These are NOT SLM-backend routing false positives (those are fixed by
+# unioning --slm-openapi, no baseline needed) — each line here is either a
+# call that genuinely has no backend anywhere (per the live-verified triage
+# in #12326 comment + the owner-decision issues that track it: build the
+# backend, or remove the dead UI control) or a documented extraction false
+# positive (e.g. a cache-key config map, not a real call — see the #12381
+# section below). Listing them here lets --fail-on-unwired gate on NEW drift
+# only, instead of blocking on findings already tracked elsewhere. When
+# #12378/#12364 are dispositioned (backend built or control removed), remove
+# the corresponding lines.
 
 # --- #12378: browser-automation panel (aspirational, no backend) ---
 /api/browser/automation/run
@@ -61,3 +64,11 @@
 /api/code-intelligence/quality-score
 /api/code-intelligence/trends
 /api/analytics/bug-prediction
+
+# --- #12381: extraction false positive, not a live call ---
+# autobot-frontend/src/services/CacheService.ts:49 — `/api/user/profile` is a
+# key in the cache-TTL `strategies` lookup map (`getTTLForEndpoint()` does
+# `endpoint.includes(pattern)` against the REAL fetch URL elsewhere), not an
+# actual fetch call itself. Matches the "base-URL constants and cache-key
+# maps" false-positive class documented in the #12326 comment thread.
+/api/user/profile

--- a/scripts/api_wiring_baseline.txt
+++ b/scripts/api_wiring_baseline.txt
@@ -72,3 +72,9 @@
 # actual fetch call itself. Matches the "base-URL constants and cache-key
 # maps" false-positive class documented in the #12326 comment thread.
 /api/user/profile
+# Real WebSocket handlers the audit's WS-route enumeration doesn't yet resolve
+# (sub-router parametrized WS routes) — wired to real handlers, not dead. Tracked
+# for enumeration improvement in #12432.
+/api/advanced-control/ws/desktop/{p}
+/api/advanced-control/ws/monitoring
+/api/overseer/ws/{p}

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -22,6 +22,19 @@ Two modes for obtaining the backend route table:
      Regex-scans @router/@app decorators and include_router(prefix=...) calls.
      Prefix resolution is heuristic; treat results as triage, not gospel.
 
+SLM control-plane backend (#12381): some frontend calls (getSLMUrl()/
+slmFetch()) target autobot-slm-backend (:8000), not autobot-backend (:8001).
+Union its route table in with --slm-openapi, produced the same way:
+    python scripts/audit_api_wiring.py --dump-slm-openapi slm_openapi.json
+    python scripts/audit_api_wiring.py --openapi openapi.json \
+        --slm-openapi slm_openapi.json --fail-on-unwired
+
+Baseline (#12381): calls with no backend anywhere yet (tracked product
+decisions, e.g. #12378/#12364) can be excluded from --fail-on-unwired without
+hiding them from the report:
+    python scripts/audit_api_wiring.py --openapi openapi.json \
+        --baseline scripts/api_wiring_baseline.txt --fail-on-unwired
+
 Exit codes: 0 = clean, 1 = unwired frontend calls found, 2 = unmounted routers
 found (combinable: 3 = both). Suitable as a CI gate.
 
@@ -42,6 +55,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKEND = REPO_ROOT / "autobot-backend"
+# #12381: the SLM control-plane backend (autobot-slm-backend, :8000) mounts
+# its own '/api'-prefixed route table, entirely separate from autobot-backend
+# (:8001). Frontend calls made via getSLMUrl()/slmFetch() resolve against
+# THIS app, not the one BACKEND builds — see dump_slm_openapi().
+SLM_BACKEND = REPO_ROOT / "autobot-slm-backend"
 FRONTEND_SRC = REPO_ROOT / "autobot-frontend" / "src"
 
 # Frontend files we never treat as real consumers
@@ -111,6 +129,39 @@ def dump_openapi(out_path: str) -> int:
     out.write_text(json.dumps(spec, indent=1))
     print(
         f"[dump-openapi] wrote {len(spec.get('paths', {}))} paths "
+        f"(+{len(spec.get('x-websocket-paths', []))} websocket) to {out}"
+    )
+    return 0
+
+
+def dump_slm_openapi(out_path: str) -> int:
+    """Import the SLM backend app and dump app.openapi() (#12381).
+
+    Mirrors dump_openapi() but imports the module-level ``app`` from
+    autobot-slm-backend/main.py instead of calling autobot-backend's
+    app_factory.create_app(). Both backends mount their routers under the
+    same ``/api`` prefix (verified: autobot-slm-backend/main.py:617-677 all
+    use ``prefix="/api"``), so the resulting path sets are directly unionable
+    with backend_paths_from_openapi() output — no extra prefix normalization
+    needed.
+    """
+    out = Path(out_path).resolve()
+    sys.path.insert(0, str(SLM_BACKEND))
+    os.chdir(SLM_BACKEND)
+    try:
+        from main import app  # type: ignore
+        spec = app.openapi()
+        # Same WebSocket-route workaround as dump_openapi() (GH#9864).
+        from starlette.routing import WebSocketRoute  # type: ignore
+        spec["x-websocket-paths"] = sorted(
+            {r.path for r in app.routes if isinstance(r, WebSocketRoute)}
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"[dump-slm-openapi] FAILED to build app: {e}", file=sys.stderr)
+        return 1
+    out.write_text(json.dumps(spec, indent=1))
+    print(
+        f"[dump-slm-openapi] wrote {len(spec.get('paths', {}))} paths "
         f"(+{len(spec.get('x-websocket-paths', []))} websocket) to {out}"
     )
     return 0
@@ -327,12 +378,58 @@ def matches(fe: str, backend: set[str]) -> bool:
     return False
 
 
+# ---------------------------------------------------------------- baseline ----
+
+def load_baseline(path: str | None) -> set[str]:
+    """Load a committed list of known/tracked-unwired frontend paths (#12381).
+
+    One normalized path per line (the same ``/api/...`` form printed under
+    ``== UNWIRED FRONTEND CALLS ==``); blank lines and ``#``-comments ignored.
+    Calls in the baseline are still *reported* (as tracked) but excluded from
+    the ``--fail-on-unwired`` exit code — the standard gradually-fixed-lint
+    baseline pattern, so the gate only fails on NEW drift.
+    """
+    if not path:
+        return set()
+    p = Path(path)
+    if not p.exists():
+        return set()
+    baseline: set[str] = set()
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        baseline.add(line)
+    return baseline
+
+
+def partition_baseline(
+    unwired: dict[str, set[str]], baseline: set[str]
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Split unwired calls into (tracked, new) by baseline membership."""
+    tracked = {p: files for p, files in unwired.items() if p in baseline}
+    new = {p: files for p, files in unwired.items() if p not in baseline}
+    return tracked, new
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--openapi", help="openapi.json path or URL (authoritative mode)")
     ap.add_argument("--dump-openapi", metavar="OUT",
                     help="import app_factory.create_app() and dump spec, then exit")
+    ap.add_argument("--slm-openapi", metavar="FILE",
+                    help="second openapi.json (SLM control-plane backend, "
+                         "autobot-slm-backend) whose paths are UNIONed into the known "
+                         "backend route table (#12381) — produce it with "
+                         "--dump-slm-openapi first")
+    ap.add_argument("--dump-slm-openapi", metavar="OUT",
+                    help="import autobot-slm-backend/main.py's app and dump spec, "
+                         "then exit")
+    ap.add_argument("--baseline", metavar="FILE",
+                    help="file of known/tracked unwired frontend paths (one per line) "
+                         "excluded from the --fail-on-unwired exit code (#12381) — "
+                         "still reported, just not gated")
     ap.add_argument("--dead-surface", action="store_true",
                     help="also report backend paths with no frontend consumer")
     ap.add_argument("--fail-on-unwired", action="store_true",
@@ -346,9 +443,16 @@ def main() -> int:
     if args.dump_openapi:
         return dump_openapi(args.dump_openapi)
 
+    if args.dump_slm_openapi:
+        return dump_slm_openapi(args.dump_slm_openapi)
+
     if args.openapi:
         backend = backend_paths_from_openapi(args.openapi)
         mode = "AUTHORITATIVE (openapi)"
+        if args.slm_openapi:
+            slm_backend = backend_paths_from_openapi(args.slm_openapi)
+            backend |= slm_backend
+            mode += f" + SLM ({len(slm_backend)} paths unioned)"
     else:
         backend, _ = backend_paths_static()
         mode = "STATIC (regex, heuristic — prefer --openapi)"
@@ -357,10 +461,19 @@ def main() -> int:
     print(f"mode: {mode}")
     print(f"backend paths: {len(backend)} | frontend distinct /api/ paths: {len(fe)}\n")
 
-    unwired = {p: files for p, files in sorted(fe.items()) if not matches(p, backend)}
+    unwired_all = {p: files for p, files in sorted(fe.items()) if not matches(p, backend)}
     if args.only_prefix:
-        unwired = {p: files for p, files in unwired.items() if p.startswith(args.only_prefix)}
+        unwired_all = {p: files for p, files in unwired_all.items()
+                       if p.startswith(args.only_prefix)}
         print(f"(scoped to {args.only_prefix})")
+    baseline = load_baseline(args.baseline)
+    tracked, unwired = partition_baseline(unwired_all, baseline)
+    if tracked:
+        print(f"== TRACKED UNWIRED CALLS (baselined, non-gating): {len(tracked)} ==")
+        for p, files in tracked.items():
+            print(f"  {p}")
+            for f in sorted(files)[:3]:
+                print(f"      <- {f}")
     print(f"== UNWIRED FRONTEND CALLS: {len(unwired)} ==")
     for p, files in unwired.items():
         print(f"  {p}")

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -104,6 +104,17 @@ def norm_path(p: str) -> str:
 
 # ---------------------------------------------------------------- backend ----
 
+def _runtime_websocket_paths(app) -> set[str]:  # noqa: ANN001
+    """Best-effort runtime WebSocketRoute walk of ``app.routes``.
+
+    Works when the installed FastAPI/Starlette flattens included sub-router
+    routes onto ``app.routes`` (true through fastapi<0.139). It is NOT relied
+    on alone — see static_websocket_paths() for why (#12381).
+    """
+    from starlette.routing import WebSocketRoute  # type: ignore
+    return {r.path for r in app.routes if isinstance(r, WebSocketRoute)}
+
+
 def dump_openapi(out_path: str) -> int:
     """Import the app and dump app.openapi() — authoritative route table."""
     # Resolve BEFORE chdir: a relative out_path must land where the caller
@@ -119,10 +130,15 @@ def dump_openapi(out_path: str) -> int:
         # FastAPI omits WebSocket routes from OpenAPI — record them in a
         # custom key so the audit can verify /api/ws* style frontend calls
         # against the real route table instead of flagging them (GH#9864).
-        from starlette.routing import WebSocketRoute  # type: ignore
-        spec["x-websocket-paths"] = sorted(
-            {r.path for r in app.routes if isinstance(r, WebSocketRoute)}
-        )
+        # Union runtime introspection with a static source scan (#12381):
+        # fastapi>=0.139's lazy ``_IncludedRouter`` wrapping means
+        # include_router()'d routes are no longer flattened onto app.routes,
+        # so the runtime walk alone silently returns zero WS routes on newer
+        # FastAPI (confirmed in CI: "+0 websocket" despite 25 real handlers).
+        # The static scan is version-independent and is the source of truth;
+        # the runtime walk is kept as a supplementary safety net.
+        ws = _runtime_websocket_paths(app) | static_websocket_paths(BACKEND)
+        spec["x-websocket-paths"] = sorted(ws)
     except Exception as e:  # noqa: BLE001
         print(f"[dump-openapi] FAILED to build app: {e}", file=sys.stderr)
         return 1
@@ -151,11 +167,9 @@ def dump_slm_openapi(out_path: str) -> int:
     try:
         from main import app  # type: ignore
         spec = app.openapi()
-        # Same WebSocket-route workaround as dump_openapi() (GH#9864).
-        from starlette.routing import WebSocketRoute  # type: ignore
-        spec["x-websocket-paths"] = sorted(
-            {r.path for r in app.routes if isinstance(r, WebSocketRoute)}
-        )
+        # Same runtime+static WebSocket union as dump_openapi() (GH#9864, #12381).
+        ws = _runtime_websocket_paths(app) | static_websocket_paths(SLM_BACKEND)
+        spec["x-websocket-paths"] = sorted(ws)
     except Exception as e:  # noqa: BLE001
         print(f"[dump-slm-openapi] FAILED to build app: {e}", file=sys.stderr)
         return 1
@@ -182,12 +196,17 @@ def backend_paths_from_openapi(src: str) -> set[str]:
 ROUTER_PREFIX_RE = re.compile(r"APIRouter\([^)]*?prefix\s*=\s*[\'\"]([^\'\"]+)", re.S)
 
 
-def backend_paths_static() -> tuple[set[str], dict[str, list[str]]]:
-    """Best-effort static scan. Returns (normalized paths, module->raw routes)."""
-    raw_routes: dict[str, list[str]] = defaultdict(list)
+def _scan_route_decorators(
+    root: Path,
+) -> tuple[dict[str, list[tuple[str, str]]], dict[str, str], set[str]]:
+    """Regex-scan `root` for @router.<method>(...) decorators, APIRouter
+    prefixes, and include_router() mount prefixes. Returns
+    (module -> [(method, path), ...], module -> own prefix, mount prefixes).
+    """
+    raw: dict[str, list[tuple[str, str]]] = defaultdict(list)
     module_prefix: dict[str, str] = {}
     prefixes: set[str] = set()
-    for py in BACKEND.rglob("*.py"):
+    for py in root.rglob("*.py"):
         sp = str(py)
         if "__pycache__" in sp or "/tests/" in sp or sp.endswith("_test.py") or "/test_" in sp:
             continue
@@ -195,11 +214,19 @@ def backend_paths_static() -> tuple[set[str], dict[str, list[str]]]:
         mp = ROUTER_PREFIX_RE.search(txt)
         if mp:
             module_prefix[sp] = mp.group(1).rstrip("/")
-        for _m, path in ROUTE_DECORATOR_RE.findall(txt):
-            raw_routes[sp].append(path)
+        for method, path in ROUTE_DECORATOR_RE.findall(txt):
+            raw[sp].append((method, path))
         for _var, prefix in INCLUDE_ROUTER_RE.findall(txt):
             prefixes.add(prefix.rstrip("/"))
+    return raw, module_prefix, prefixes
 
+
+def _combine_prefixed_paths(
+    raw_routes: dict[str, list[str]], module_prefix: dict[str, str], prefixes: set[str]
+) -> set[str]:
+    """Combine each module's raw route strings with its own APIRouter prefix
+    and every known mount prefix (loose — mount-prefix combos aren't scoped
+    per-module, matching the pre-existing heuristic)."""
     paths: set[str] = set()
     for sp, routes in raw_routes.items():
         own = module_prefix.get(sp, "")
@@ -207,10 +234,40 @@ def backend_paths_static() -> tuple[set[str], dict[str, list[str]]]:
             base = own + ("" if (r.startswith("/") or not r) else "/") + r
             for candidate in {r, base}:
                 paths.add(norm_path(candidate) if candidate else norm_path(own or "/"))
-                for pre in prefixes:       # mount-prefix combinations (loose)
+                for pre in prefixes:
                     paths.add(norm_path(pre + (candidate if candidate.startswith("/")
                                                else "/" + candidate if candidate else "")))
-    return paths, raw_routes
+    return paths
+
+
+def backend_paths_static(root: Path = BACKEND) -> tuple[set[str], dict[str, list[str]]]:
+    """Best-effort static scan. Returns (normalized paths, module->raw routes)."""
+    raw, module_prefix, prefixes = _scan_route_decorators(root)
+    raw_routes = {sp: [path for _method, path in entries] for sp, entries in raw.items()}
+    return _combine_prefixed_paths(raw_routes, module_prefix, prefixes), raw_routes
+
+
+def static_websocket_paths(root: Path) -> set[str]:
+    """Static-scan websocket-only paths under `root` (#12381).
+
+    Runtime WebSocketRoute introspection of a live app is unreliable across
+    FastAPI versions: fastapi>=0.139's lazy ``_IncludedRouter`` wrapping means
+    ``app.routes`` no longer flattens include_router()'d routes, so a naive
+    ``isinstance(r, WebSocketRoute)`` walk silently finds nothing. Websocket
+    declarations are structurally simple (one ``@router.websocket(...)`` per
+    handler + static string prefixes), so a source scan — reusing the same
+    prefix-combination algorithm as backend_paths_static() — is both simpler
+    and version-independent. No `add_websocket_route()`/programmatic
+    registrations exist in this codebase (verified by grep), so decorator
+    scanning has full coverage.
+    """
+    raw, module_prefix, prefixes = _scan_route_decorators(root)
+    ws_routes = {
+        sp: [path for method, path in entries if method == "websocket"]
+        for sp, entries in raw.items()
+    }
+    ws_routes = {sp: paths for sp, paths in ws_routes.items() if paths}
+    return _combine_prefixed_paths(ws_routes, module_prefix, prefixes)
 
 
 def _module_served_by_openapi(txt: str, backend: set[str]) -> bool:

--- a/scripts/audit_api_wiring_test.py
+++ b/scripts/audit_api_wiring_test.py
@@ -1,0 +1,177 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the SLM-backend union + baseline logic in audit_api_wiring.py (#12381).
+
+Real-repo authoritative mode requires backend deps that aren't installed in
+this dev environment (WSL missing autobot_shared/deps), so these tests
+exercise the union + baseline LOGIC directly against small mock openapi.json
+fixtures rather than importing app_factory.create_app() / the SLM app. CI
+verifies the real route tables when the workflow runs --dump-openapi and
+--dump-slm-openapi against the built apps.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "audit_api_wiring.py"
+_spec = importlib.util.spec_from_file_location("audit_api_wiring", SCRIPT)
+audit = importlib.util.module_from_spec(_spec)
+sys.modules["audit_api_wiring"] = audit
+_spec.loader.exec_module(audit)  # type: ignore[union-attr]
+
+
+def _write_openapi(path: Path, paths: list[str]) -> Path:
+    path.write_text(json.dumps({"paths": {p: {} for p in paths}}), encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------- SLM union ----
+
+def test_slm_only_route_is_wired_after_union(tmp_path):
+    """A frontend call matching ONLY the SLM backend's route table is not
+    unwired once --slm-openapi is unioned in (the #12381 bug)."""
+    backend_json = _write_openapi(tmp_path / "backend.json", ["/api/foo"])
+    slm_json = _write_openapi(tmp_path / "slm.json", ["/api/nodes"])
+
+    backend = audit.backend_paths_from_openapi(str(backend_json))
+    assert not audit.matches("/api/nodes", backend), "sanity: SLM-only route absent pre-union"
+
+    backend |= audit.backend_paths_from_openapi(str(slm_json))
+    assert audit.matches("/api/nodes", backend)
+    assert audit.matches("/api/foo", backend)
+    assert not audit.matches("/api/bar", backend)
+
+
+def test_slm_union_preserves_single_backend_behavior(tmp_path):
+    """Absent --slm-openapi, behavior is unchanged (single-backend set)."""
+    backend_json = _write_openapi(tmp_path / "backend.json", ["/api/foo"])
+    backend = audit.backend_paths_from_openapi(str(backend_json))
+    assert backend == {"/api/foo"}
+
+
+# --------------------------------------------------------- baseline ----
+
+def test_load_baseline_skips_blanks_and_comments(tmp_path):
+    baseline_file = tmp_path / "baseline.txt"
+    baseline_file.write_text(
+        "# comment\n\n/api/browser/launch\n  \n/api/dev-speedup/format\n# another\n",
+        encoding="utf-8",
+    )
+    assert audit.load_baseline(str(baseline_file)) == {
+        "/api/browser/launch",
+        "/api/dev-speedup/format",
+    }
+
+
+def test_load_baseline_none_and_missing_file_return_empty_set(tmp_path):
+    assert audit.load_baseline(None) == set()
+    assert audit.load_baseline(str(tmp_path / "does-not-exist.txt")) == set()
+
+
+def test_partition_baseline_splits_tracked_from_new():
+    unwired = {
+        "/api/tracked": {"file_a.ts"},
+        "/api/new": {"file_b.ts"},
+    }
+    tracked, new = audit.partition_baseline(unwired, {"/api/tracked"})
+    assert tracked == {"/api/tracked": {"file_a.ts"}}
+    assert new == {"/api/new": {"file_b.ts"}}
+
+
+def test_partition_baseline_empty_baseline_is_noop():
+    unwired = {"/api/x": {"f.ts"}}
+    tracked, new = audit.partition_baseline(unwired, set())
+    assert tracked == {}
+    assert new == unwired
+
+
+# --------------------------------------------------------- main() gating ----
+
+def test_baselined_call_does_not_fail_but_new_unwired_call_does(tmp_path, monkeypatch, capsys):
+    """End-to-end through main(): a call matching an SLM-only route is wired,
+    a baselined dead call is reported but non-gating, and a genuinely-new
+    unwired call still trips --fail-on-unwired."""
+    backend_json = _write_openapi(tmp_path / "backend.json", ["/api/wired"])
+    slm_json = _write_openapi(tmp_path / "slm.json", ["/api/slm_only"])
+    baseline_file = tmp_path / "baseline.txt"
+    baseline_file.write_text("/api/tracked_dead\n", encoding="utf-8")
+
+    fake_calls = {
+        "/api/wired": {"file_wired.ts"},
+        "/api/slm_only": {"file_slm.ts"},
+        "/api/tracked_dead": {"file_tracked.ts"},
+        "/api/new_dead": {"file_new.ts"},
+    }
+    monkeypatch.setattr(audit, "frontend_calls", lambda: fake_calls)
+    monkeypatch.setattr(audit, "find_missing_api_prefix", lambda backend: {})
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "audit_api_wiring.py",
+            "--openapi", str(backend_json),
+            "--slm-openapi", str(slm_json),
+            "--baseline", str(baseline_file),
+            "--only-prefix", "/api",  # skip real-repo unmounted-router scan noise
+            "--fail-on-unwired",
+        ],
+    )
+    rc = audit.main()
+    out = capsys.readouterr().out
+
+    assert rc & 1 == 1, "genuinely-new unwired call must still fail the gate"
+    assert "/api/new_dead" in out
+    assert "/api/wired" not in out.split("== UNWIRED FRONTEND CALLS")[1]
+    assert "/api/slm_only" not in out.split("== UNWIRED FRONTEND CALLS")[1]
+    assert "TRACKED UNWIRED CALLS" in out
+    assert "/api/tracked_dead" in out
+
+
+def test_no_new_unwired_calls_passes_gate(tmp_path, monkeypatch, capsys):
+    backend_json = _write_openapi(tmp_path / "backend.json", ["/api/wired"])
+    slm_json = _write_openapi(tmp_path / "slm.json", ["/api/slm_only"])
+    baseline_file = tmp_path / "baseline.txt"
+    baseline_file.write_text("/api/tracked_dead\n", encoding="utf-8")
+
+    fake_calls = {
+        "/api/wired": {"file_wired.ts"},
+        "/api/slm_only": {"file_slm.ts"},
+        "/api/tracked_dead": {"file_tracked.ts"},
+    }
+    monkeypatch.setattr(audit, "frontend_calls", lambda: fake_calls)
+    monkeypatch.setattr(audit, "find_missing_api_prefix", lambda backend: {})
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "audit_api_wiring.py",
+            "--openapi", str(backend_json),
+            "--slm-openapi", str(slm_json),
+            "--baseline", str(baseline_file),
+            "--only-prefix", "/api",
+            "--fail-on-unwired",
+        ],
+    )
+    rc = audit.main()
+    assert rc == 0
+
+
+# --------------------------------------------------------- CLI wiring ----
+
+def test_dump_slm_openapi_flag_dispatches(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(audit, "dump_slm_openapi", lambda out: calls.append(out) or 0)
+    monkeypatch.setattr(
+        sys, "argv", ["audit_api_wiring.py", "--dump-slm-openapi", str(tmp_path / "out.json")]
+    )
+    rc = audit.main()
+    assert rc == 0
+    assert calls == [str(tmp_path / "out.json")]

--- a/scripts/audit_api_wiring_test.py
+++ b/scripts/audit_api_wiring_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -53,6 +54,93 @@ def test_slm_union_preserves_single_backend_behavior(tmp_path):
     backend_json = _write_openapi(tmp_path / "backend.json", ["/api/foo"])
     backend = audit.backend_paths_from_openapi(str(backend_json))
     assert backend == {"/api/foo"}
+
+
+# --------------------------------------------------------- websocket scan ----
+
+def test_static_websocket_paths_finds_prefixed_websocket_route(tmp_path_factory):
+    """A source-level scan finds @router.websocket() routes and combines them
+    with the router's own prefix AND any include_router() mount prefix — the
+    fix for CI's "+0 websocket" bug (fastapi>=0.139's lazy _IncludedRouter
+    wrapping breaks the old isinstance(r, WebSocketRoute) runtime walk, #12381).
+    """
+    # tmp_path_factory (not the function-scoped tmp_path fixture): tmp_path's
+    # own directory is named "test_<function-name>0", which would trip the
+    # "/test_" source-exclusion filter (correctly, for real repo paths like
+    # "api/test_foo.py") regardless of nesting depth beneath it.
+    src = tmp_path_factory.mktemp("ws_scan_fixture")
+    module = src / "advanced_control.py"
+    module.write_text(
+        'router = APIRouter(prefix="/advanced-control")\n'
+        '@router.websocket("/ws/desktop/{session_id}")\n'
+        "async def ws_desktop(websocket): ...\n"
+        '@router.get("/status")\n'
+        "async def status(): ...\n",
+        encoding="utf-8",
+    )
+    mount = src / "app_factory.py"
+    mount.write_text('app.include_router(advanced_control_router, prefix="/api")\n', encoding="utf-8")
+
+    ws_paths = audit.static_websocket_paths(src)
+    assert "/api/advanced-control/ws/desktop/{p}" in ws_paths
+    # The GET /status route must NOT be picked up by the websocket-only scan.
+    assert not any(p.endswith("/status") for p in ws_paths)
+
+
+def test_static_websocket_paths_ignores_test_files(tmp_path_factory):
+    src = tmp_path_factory.mktemp("ws_scan_fixture")
+    (src / "foo_test.py").write_text(
+        'router = APIRouter()\n@router.websocket("/ws")\nasync def h(websocket): ...\n',
+        encoding="utf-8",
+    )
+    assert audit.static_websocket_paths(src) == set()
+
+
+def test_dump_openapi_websocket_union_survives_empty_runtime_walk(monkeypatch, tmp_path, tmp_path_factory):
+    """Simulates the exact CI failure mode: a fake `app` whose .routes yields
+    zero WebSocketRoute instances (the fastapi>=0.139 _IncludedRouter case) —
+    x-websocket-paths must still be populated from the static scan."""
+    # tmp_path_factory — see comment in
+    # test_static_websocket_paths_finds_prefixed_websocket_route for why.
+    src = tmp_path_factory.mktemp("ws_scan_fixture")
+    ws_module = src / "ws_router.py"
+    ws_module.write_text(
+        'router = APIRouter()\n@router.websocket("/ws")\nasync def h(websocket): ...\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(audit, "BACKEND", src)
+
+    class _FakeApp:
+        routes = []  # simulates app.routes with everything hidden in _IncludedRouter
+
+        def openapi(self):
+            return {"paths": {"/api/foo": {}}}
+
+    fake_app = _FakeApp()
+
+    class _FakeAppFactoryModule:
+        @staticmethod
+        def create_app():
+            return fake_app
+
+    monkeypatch.setitem(sys.modules, "app_factory", _FakeAppFactoryModule)
+    monkeypatch.setattr(os, "chdir", lambda *_a, **_k: None)
+
+    out = tmp_path / "openapi.json"
+    rc = audit.dump_openapi(str(out))
+    assert rc == 0
+    spec = json.loads(out.read_text(encoding="utf-8"))
+    # No include_router(prefix="/api") mount in this fixture tree, so the
+    # static scan yields the bare route ("/ws") rather than a prefixed one —
+    # prefix combination itself is covered by
+    # test_static_websocket_paths_finds_prefixed_websocket_route above. The
+    # point here is that the union is non-empty despite the empty runtime walk.
+    assert "/ws" in spec["x-websocket-paths"]
+    assert _runtime_websocket_paths_returns_empty(fake_app)
+
+
+def _runtime_websocket_paths_returns_empty(fake_app) -> bool:
+    return audit._runtime_websocket_paths(fake_app) == set()
 
 
 # --------------------------------------------------------- baseline ----


### PR DESCRIPTION
Closes #12381

## Thinking Path
`scripts/audit_api_wiring.py` built its authoritative route table from `app_factory.create_app()` (autobot-backend, :8001) only. Frontend calls composed via `getSLMUrl()`/`slmFetch()` target the SLM control-plane backend (`autobot-slm-backend/main.py`, :8000) — a separate FastAPI app with its own `/api`-prefixed route table (`main.py:617-677`, all `app.include_router(..., prefix="/api")`). Those calls hit a real route but the audit had no way to see it, so it false-flagged them as unwired (per #12326's comment thread: 5 `tls`/`nodes` calls verified as SLM-backend, not dead). Separately, #12378 (aspirational browser-automation/dev-speedup/system panels) and #12364 (analytics/code-intelligence redesign) are genuinely-tracked no-backend calls with no fix yet — those need a baseline, not a code fix, so `--fail-on-unwired` can gate on new drift instead of pre-existing tracked findings.

## What Changed
- `scripts/audit_api_wiring.py`: added `dump_slm_openapi()` (mirrors `dump_openapi()`, imports the module-level `app` from `autobot-slm-backend/main.py`) behind `--dump-slm-openapi OUT`, and `--slm-openapi FILE` to union a second openapi.json's paths into the known backend route set — both backends share the `/api` prefix convention so no extra normalization was needed.
- Added `load_baseline()` / `partition_baseline()` and `--baseline FILE`: known/tracked unwired frontend paths are still reported (`== TRACKED UNWIRED CALLS ==`) but excluded from the `--fail-on-unwired` exit code.
- `scripts/api_wiring_baseline.txt`: seeded with the calls I can justify from live-verified triage (#12326 comment) — the #12378 aspirational panels (browser-automation 9, dev-speedup 8, system restart/shutdown/backup 6, misc 7) and the #12364 deferred analytics/code-intelligence calls (9). Did **not** guess entries I can't evidence — anything not covered here that CI's authoritative run reveals as still-unwired needs a fast-follow add.
- `.github/workflows/api-wiring.yml`: dumps both openapis (SLM dump best-effort, degrades gracefully like the existing autobot-backend dump does) and runs the audit with `--openapi ... --slm-openapi ... --baseline scripts/api_wiring_baseline.txt --fail-on-unwired`. Added `autobot-slm-backend/**/*.py` and `scripts/api_wiring_baseline.txt` to the trigger paths.

## Verification
```
$ python3 -m pytest scripts/audit_api_wiring_test.py -p no:xdist -q
============================= test session starts ==============================
collected 9 items

scripts/audit_api_wiring_test.py .........                               [100%]

============================== 9 passed in 10.82s ==============================
```
Tests cover: an SLM-only route becomes wired after union (and is NOT wired pre-union — the bug this PR fixes), single-backend behavior is preserved when `--slm-openapi` is absent, baseline file parsing (comments/blanks skipped), `partition_baseline` splits tracked vs new, and an end-to-end `main()` run (mocked `frontend_calls()`) proving a baselined dead call does **not** fail the gate while a genuinely-new unwired call **does** (`rc & 1 == 1`).

Static mode sanity check (no deps, syntax-only): `python3 scripts/audit_api_wiring.py` runs clean, no exceptions.

**Could not run authoritative mode locally** — this WSL environment is missing `autobot_shared`/backend deps (`--dump-openapi` fails here, matches prior known limitation). CI builds both apps and will show the real counts; if SLM-awareness + this baseline don't fully clear `api-wiring` to green, the residual will need a fast-follow baseline addition (I'll be watching the run).

## Model Used
Claude Opus 4.8