### PR TITLE
fix(codebase-analytics): wire _get_bug_prediction to async analyze path (#12406)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -1688,7 +1688,12 @@ async def _get_bug_prediction(
     """
     Get bug prediction data for the project (Issue #505).
 
-    Runs the analysis in a thread pool to avoid blocking the async event loop.
+    Issue #12406: Calls the async analysis path directly (this function is
+    already async, so no thread-pool wrapper is needed). The async path is
+    what exercises the source_id-scoped ``bug_pattern_vectors`` ChromaDB
+    collection when use_semantic=True; with use_semantic=False (the
+    pipeline default) it degrades to the same synchronous per-file
+    analysis as the old sync path, so this is a safe default baseline.
 
     Issue #554: Enhanced with optional semantic analysis:
     - use_semantic=True enables LLM-based bug pattern matching
@@ -1713,18 +1718,16 @@ async def _get_bug_prediction(
         # the project root, causing FileNotFoundError in git subprocess calls.
         root = project_root or str(PATH.PROJECT_ROOT)
 
-        # Issue #1233: Use dedicated analytics executor to prevent
-        # default thread pool starvation
-
         # Issue #554: Pass semantic analysis flag
         # Issue #12384: Pass source_id for ChromaDB metadata/query scoping
         predictor = BugPredictor(project_root=root, use_semantic_analysis=use_semantic, source_id=source_id)
 
+        # Issue #12406: analyze_directory_async is the path that writes/reads
+        # the source_id-scoped bug_pattern_vectors collection; the previous
+        # sync analyze_directory() call never reached it, making the #12384
+        # scoping dead code. Already async here, so no run_in_executor needed.
         result = await asyncio.wait_for(
-            asyncio.get_running_loop().run_in_executor(
-                get_analytics_executor(),
-                lambda: predictor.analyze_directory(pattern="*.py", limit=limit),
-            ),
+            predictor.analyze_directory_async(pattern="*.py", limit=limit),
             timeout=BUG_PREDICTION_TIMEOUT,
         )
 

--- a/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report_scoping_test.py
@@ -304,3 +304,49 @@ class TestPatternAnalysisNoGlobalWrite:
         # The report consumes the returned object directly and never reads the
         # ChromaDB cache, so persistence must be OFF to avoid a cross-source write.
         assert captured.get("enable_embedding_storage") is False
+
+
+# ---------------------------------------------------------------------------
+# _get_bug_prediction must call the async analysis path so the source_id-
+# scoped `bug_pattern_vectors` ChromaDB collection (#12384) is actually
+# reachable -- the previous sync `analyze_directory()` call never learned or
+# queried it, making the #12384 scoping defensive dead code (#12406).
+# ---------------------------------------------------------------------------
+class TestGetBugPredictionUsesAsyncPath:
+    """Issue #12406: wire _get_bug_prediction to BugPredictor.analyze_directory_async."""
+
+    async def test_calls_analyze_directory_async_not_sync(self):
+        from api.codebase_analytics.endpoints import report as report_mod
+
+        fake_result = MagicMock(analyzed_files=3, high_risk_count=0)
+        fake_predictor = MagicMock()
+        fake_predictor.analyze_directory = MagicMock(side_effect=AssertionError("sync path must not be called"))
+        fake_predictor.analyze_directory_async = AsyncMock(return_value=fake_result)
+
+        with patch.object(report_mod, "BugPredictor", return_value=fake_predictor):
+            result = await report_mod._get_bug_prediction(
+                project_root="/srv/sources/b",
+                use_semantic=False,
+                source_id="B",
+            )
+
+        fake_predictor.analyze_directory_async.assert_awaited_once_with(
+            pattern="*.py", limit=report_mod.BUG_PREDICTION_FILE_LIMIT
+        )
+        fake_predictor.analyze_directory.assert_not_called()
+        assert result is fake_result
+
+    async def test_constructs_predictor_with_semantic_flag_and_source_id(self):
+        from api.codebase_analytics.endpoints import report as report_mod
+
+        with patch.object(report_mod, "BugPredictor") as fake_cls:
+            fake_predictor = fake_cls.return_value
+            fake_predictor.analyze_directory_async = AsyncMock(return_value=None)
+
+            await report_mod._get_bug_prediction(
+                project_root="/srv/sources/b",
+                use_semantic=True,
+                source_id="B",
+            )
+
+        fake_cls.assert_called_once_with(project_root="/srv/sources/b", use_semantic_analysis=True, source_id="B")

--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -1323,7 +1323,10 @@ class BugPredictor(_BaseClass):
 
         await self._learn_bug_patterns_async()
 
-        all_files = list(root.rglob(pattern))
+        # #12406: offload the recursive tree walk too — with an unlimited file
+        # limit rglob() traverses the whole source tree, and this runs in an
+        # async request handler, so keep it off the event loop.
+        all_files = await asyncio.to_thread(lambda: list(root.rglob(pattern)))
         total_files = len(all_files)
         files = all_files[:limit] if limit > 0 else all_files
 

--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -1077,7 +1077,10 @@ class BugPredictor(_BaseClass):
             and time.monotonic() - self._bug_history_cache_time > _BUG_HISTORY_CACHE_TTL
         ):
             self._bug_history_cache = None
-            self._build_bug_history_cache()
+            # Issue #12406: _build_bug_history_cache shells out to `git log`
+            # (subprocess.run) -- offload so this reachable-again async path
+            # doesn't block the event loop on cache-miss.
+            await asyncio.to_thread(self._build_bug_history_cache)
 
         bug_patterns = self._collect_bug_patterns_from_cache()
         if not bug_patterns:
@@ -1219,8 +1222,13 @@ class BugPredictor(_BaseClass):
         Returns:
             FileRiskAssessment with complete risk analysis
         """
-        # Get base assessment using synchronous method
-        assessment = self.analyze_file(file_path)
+        # Issue #12406: was a direct sync call blocking the event loop --
+        # analyze_file() reads file contents and (on cache miss) shells out to
+        # `git log` (see _build_bug_history_cache/_build_change_frequency_cache).
+        # Offload to a thread so analyze_directory_async is genuinely safe to
+        # await directly from an async request handler (mirrors the #7467
+        # to_thread fix for path.read_text just below in this file).
+        assessment = await asyncio.to_thread(self.analyze_file, file_path)
 
         # Add semantic analysis if enabled
         if self.use_semantic_analysis:


### PR DESCRIPTION
Closes #12406

## Thinking Path
`_get_bug_prediction()` in `api/codebase_analytics/endpoints/report.py` is already `async`, but called the **synchronous** `BugPredictor.analyze_directory()` via `run_in_executor`. The semantic bug-pattern learning/query that reads/writes the `bug_pattern_vectors` ChromaDB collection (source_id-scoped in #12384) lives only in `analyze_directory_async()` -- the sync call never reaches it, making the #12384 scoping defensive dead code.

Switching the call to `analyze_directory_async()` directly is correct (no `run_in_executor` needed, the caller is already async) -- but doing that naively reintroduces exactly the problem `run_in_executor`/the dedicated analytics executor (#1233) existed to prevent: `analyze_directory_async()`'s per-file work (`analyze_file_async`) called the sync `self.analyze_file()` -- which does `path.read_text()` and (on cache miss) shells out to `git log` via `subprocess.run` -- directly on the event loop, with no thread offload. `BUG_PREDICTION_FILE_LIMIT=0` (unlimited) means a report request would synchronously block the event loop while reading/scoring every `*.py` file in the scanned project.

## What Changed
- `api/codebase_analytics/endpoints/report.py`: `_get_bug_prediction()` now `await`s `predictor.analyze_directory_async(...)` directly instead of `run_in_executor(analyze_directory)`. The `asyncio.wait_for(..., timeout=BUG_PREDICTION_TIMEOUT)` wrapper is preserved.
- `code_intelligence/bug_predictor.py`:
  - `analyze_file_async()`: offload the sync `self.analyze_file(file_path)` call via `asyncio.to_thread` (mirrors the existing `#7467` `asyncio.to_thread(path.read_text, ...)` pattern a few lines below in the same file), so `analyze_directory_async` no longer blocks the event loop per-file.
  - `_learn_bug_patterns_async()`: offload the sync `self._build_bug_history_cache()` call (git subprocess) the same way, so the `use_semantic=True` path (opt-in, now reachable for the first time via this fix) doesn't block the loop on a cache-miss `git log`.

## Safety assessment (enabling the async path)
- `use_semantic` defaults to `False` throughout the report pipeline (`_get_bug_prediction`, `_resolve_analyses`, `generate_analysis_report` query param) -- this PR does **not** force-enable semantic analysis on the default report path.
- With `use_semantic=False`, `analyze_directory_async` degrades to the same per-file analysis as the old sync `analyze_directory`: `_learn_bug_patterns_async`/`_check_cached_prediction`/`_cache_prediction_result` all early-return, and `analyze_file_async` calls the exact same `self.analyze_file()` used by the old sync path -- just now off the event loop via `asyncio.to_thread` instead of inside `run_in_executor`'s dedicated analytics thread pool. Functionally equivalent, same thread-pool-offload guarantee, no behavior change for the default (non-semantic) case.
- With `use_semantic=True` (explicit opt-in via the `/report?use_semantic=true` query param), the source_id-scoped `bug_pattern_vectors` collection (#12384) is now actually written/read for the first time, and the git-subprocess cache-build no longer blocks the loop either (second fix above).
- Net effect: no regression on the default path, and the scoped semantic path becomes safely reachable when requested.

## Verification
```
$ python3 -m pytest code_intelligence/bug_predictor_source_scoping_test.py api/codebase_analytics/endpoints/report_scoping_test.py -p no:xdist -q
...
code_intelligence/bug_predictor_source_scoping_test.py .....             [ 38%]
api/codebase_analytics/endpoints/report_scoping_test.py ........         [100%]
======================== 13 passed, 1 warning in 2.22s =========================
```
Added `TestGetBugPredictionUsesAsyncPath` (2 new tests) to `report_scoping_test.py`, asserting `_get_bug_prediction` awaits `BugPredictor.analyze_directory_async` (and never calls the sync `analyze_directory`), and that `use_semantic`/`source_id` are still threaded into the `BugPredictor` constructor.

Filed #12421 for an unrelated, pre-existing test-infra gap discovered while verifying (`bug_predictor_test.py` fails when run standalone because `code_intelligence.bug_predictor`'s top-level conftest stub is never replaced with the real module outside the source-scoping test's private-alias trick) -- confirmed unrelated to this diff, out of scope here.

## Model Used
Claude Opus 4.8