### PR TITLE
fix(llc): roll back WorkItemDetail optimistic edits on failed PATCH (#12348)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "View",
       "noActivity": "No activity recorded.",
       "noHandoffBrief": "No handoff brief available.",
-      "loadingBrief": "Loading brief..."
+      "loadingBrief": "Loading brief...",
+      "errors": {
+        "saveFailed": "تعذّر حفظ التغيير. يُرجى المحاولة مرة أخرى."
+      }
     },
     "orgChart": {
       "title": "Org Chart",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "Anzeigen",
       "noActivity": "Keine Aktivität aufgezeichnet.",
       "noHandoffBrief": "Kein Übergabe-Briefing verfügbar.",
-      "loadingBrief": "Briefing wird geladen..."
+      "loadingBrief": "Briefing wird geladen...",
+      "errors": {
+        "saveFailed": "Ihre Änderung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut."
+      }
     },
     "orgChart": {
       "title": "Organigramm",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8122,7 +8122,10 @@
       "viewArtifact": "View",
       "noActivity": "No activity recorded.",
       "noHandoffBrief": "No handoff brief available.",
-      "loadingBrief": "Loading brief..."
+      "loadingBrief": "Loading brief...",
+      "errors": {
+        "saveFailed": "Couldn't save your change. Please try again."
+      }
     },
     "orgChart": {
       "title": "Org Chart",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "Ver",
       "noActivity": "No se ha registrado actividad.",
       "noHandoffBrief": "No hay resumen de traspaso disponible.",
-      "loadingBrief": "Cargando resumen..."
+      "loadingBrief": "Cargando resumen...",
+      "errors": {
+        "saveFailed": "No se pudo guardar el cambio. Inténtalo de nuevo."
+      }
     },
     "orgChart": {
       "title": "Organigrama",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "View",
       "noActivity": "No activity recorded.",
       "noHandoffBrief": "No handoff brief available.",
-      "loadingBrief": "Loading brief..."
+      "loadingBrief": "Loading brief...",
+      "errors": {
+        "saveFailed": "ذخیره تغییر ممکن نشد. لطفاً دوباره تلاش کنید."
+      }
     },
     "orgChart": {
       "title": "Org Chart",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "Voir",
       "noActivity": "Aucune activité enregistrée.",
       "noHandoffBrief": "Aucune note de transfert disponible.",
-      "loadingBrief": "Chargement de la note..."
+      "loadingBrief": "Chargement de la note...",
+      "errors": {
+        "saveFailed": "Impossible d'enregistrer votre modification. Veuillez réessayer."
+      }
     },
     "orgChart": {
       "title": "Organigramme",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "View",
       "noActivity": "No activity recorded.",
       "noHandoffBrief": "No handoff brief available.",
-      "loadingBrief": "Loading brief..."
+      "loadingBrief": "Loading brief...",
+      "errors": {
+        "saveFailed": "לא ניתן היה לשמור את השינוי. אנא נסה שוב."
+      }
     },
     "orgChart": {
       "title": "Org Chart",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "View",
       "noActivity": "No activity recorded.",
       "noHandoffBrief": "No handoff brief available.",
-      "loadingBrief": "Loading brief..."
+      "loadingBrief": "Loading brief...",
+      "errors": {
+        "saveFailed": "Neizdevās saglabāt izmaiņas. Lūdzu, mēģiniet vēlreiz."
+      }
     },
     "orgChart": {
       "title": "Org Chart",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "View",
       "noActivity": "No activity recorded.",
       "noHandoffBrief": "No handoff brief available.",
-      "loadingBrief": "Loading brief..."
+      "loadingBrief": "Loading brief...",
+      "errors": {
+        "saveFailed": "Nie udało się zapisać zmiany. Spróbuj ponownie."
+      }
     },
     "orgChart": {
       "title": "Org Chart",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "Ver",
       "noActivity": "Nenhuma atividade registrada.",
       "noHandoffBrief": "Nenhum resumo de transferência disponível.",
-      "loadingBrief": "Carregando resumo..."
+      "loadingBrief": "Carregando resumo...",
+      "errors": {
+        "saveFailed": "Não foi possível salvar sua alteração. Tente novamente."
+      }
     },
     "orgChart": {
       "title": "Organograma",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8133,7 +8133,10 @@
       "viewArtifact": "View",
       "noActivity": "No activity recorded.",
       "noHandoffBrief": "No handoff brief available.",
-      "loadingBrief": "Loading brief..."
+      "loadingBrief": "Loading brief...",
+      "errors": {
+        "saveFailed": "آپ کی تبدیلی محفوظ نہیں ہو سکی۔ براہ کرم دوبارہ کوشش کریں۔"
+      }
     },
     "orgChart": {
       "title": "Org Chart",

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -18,6 +18,9 @@
         </button>
       </div>
 
+      <!-- Save-failure banner (#12348): an optimistic edit could not be persisted. -->
+      <div v-if="saveError" class="save-error" role="alert">{{ saveError }}</div>
+
       <!-- Goal ancestry breadcrumb -->
       <div v-if="goalAncestry.length > 0" class="goal-breadcrumb">
         <template v-for="(g, i) in goalAncestry" :key="g.id">
@@ -303,6 +306,8 @@ const titleInput = ref<HTMLInputElement | null>(null)
 const descInput = ref<HTMLTextAreaElement | null>(null)
 const origTitle = ref('')
 const origDesc = ref('')
+// #12348: message shown when an optimistic edit could not be persisted.
+const saveError = ref<string | null>(null)
 
 const comments = ref<Comment[]>([])
 const artifacts = ref<Artifact[]>([])
@@ -403,7 +408,10 @@ function cancelTitle() {
 async function saveTitle() {
   editingTitle.value = false
   if (localItem.value.title === origTitle.value) return
-  await patchItem({ title: localItem.value.title })
+  const prev = origTitle.value
+  await patchItem({ title: localItem.value.title }, () => {
+    localItem.value.title = prev
+  })
 }
 
 function startEditDesc() {
@@ -415,23 +423,37 @@ function startEditDesc() {
 async function saveDesc() {
   editingDesc.value = false
   if (localItem.value.description === origDesc.value) return
-  await patchItem({ description: localItem.value.description })
+  const prev = origDesc.value
+  await patchItem({ description: localItem.value.description }, () => {
+    localItem.value.description = prev
+  })
 }
 
 async function saveAC() {
   // GH#10852: persist per-criterion completion (parallel-indexed to
   // acceptance_criteria) so checkbox state survives reload.
+  // #12348: snapshot the last-persisted completion so a rejected save rolls the
+  // checkbox back rather than leaving it visually toggled.
+  const prevDone = localItem.value.acceptance_criteria_done ?? []
   const done = (localItem.value.acceptance_criteria ?? []).map((_, i) => checkedAC.value[i] ?? false)
-  await patchItem({ acceptance_criteria_done: done })
+  await patchItem({ acceptance_criteria_done: done }, () => {
+    checkedAC.value = (localItem.value.acceptance_criteria ?? []).map((_, i) => prevDone[i] ?? false)
+  })
 }
 
-async function patchItem(patch: Partial<WorkItem>) {
+async function patchItem(patch: Partial<WorkItem>, rollback?: () => void) {
   try {
     const updated = await api.patch<WorkItem>(`/api/llc/work-items/${props.item.id}`, patch)
     Object.assign(localItem.value, updated)
+    saveError.value = null
     emit('updated', localItem.value)
   } catch (err) {
+    // #12348: the edit was applied optimistically via v-model before this call.
+    // The backend rejected it, so roll the local state back to its last-persisted
+    // value and surface the failure instead of showing a change that never saved.
     logger.error('Failed to patch item', err)
+    rollback?.()
+    saveError.value = t('llc.workItem.errors.saveFailed')
   }
 }
 
@@ -550,6 +572,15 @@ onMounted(() => {
 </script>
 
 <style scoped>
+.save-error {
+  margin: 0.5rem 1.25rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  font-size: 0.8rem;
+}
+
 .work-item-detail-overlay {
   position: fixed;
   inset: 0;

--- a/autobot-frontend/src/views/llc/__tests__/WorkItemDetail.optimistic.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/WorkItemDetail.optimistic.test.ts
@@ -1,0 +1,146 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #12348: WorkItemDetail edits (title / description / acceptance-criteria) are
+// applied optimistically through v-model before the PATCH lands. These tests
+// assert that a rejected PATCH rolls the local state back to its last-persisted
+// value and surfaces an i18n error, mirroring the chat-delete fix (#12327).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const patch = vi.fn()
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post, patch }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+// The assignee picker fetches org people on mount; keep it inert for these tests.
+vi.mock('@/composables/llc/useCompanyPeople', () => ({
+  useCompanyPeople: () => ({
+    agents: { value: [] },
+    humans: { value: [] },
+    isLoading: { value: false },
+    load: vi.fn(),
+  }),
+}))
+
+import WorkItemDetail from '../WorkItemDetail.vue'
+
+interface DetailVm {
+  localItem: {
+    title: string
+    description: string
+    acceptance_criteria: string[]
+    acceptance_criteria_done?: boolean[]
+  }
+  checkedAC: boolean[]
+  saveError: string | null
+  startEditTitle: () => void
+  saveTitle: () => Promise<void>
+  startEditDesc: () => void
+  saveDesc: () => Promise<void>
+  saveAC: () => Promise<void>
+}
+
+const ITEM = {
+  id: 'w1',
+  identifier: 'WI-1',
+  title: 'Original title',
+  description: 'Original description',
+  type: 'pbi',
+  status: 'new',
+  priority: 'medium',
+  acceptance_criteria: ['Criterion A', 'Criterion B'],
+  acceptance_criteria_done: [false, false],
+}
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+const SAVE_FAILED = en.llc.workItem.errors.saveFailed
+
+async function mountDetail() {
+  const wrapper = mount(WorkItemDetail, {
+    props: { item: { ...ITEM }, companyId: 'c1' },
+    global: {
+      plugins: [i18n],
+      stubs: { HandoffModal: true, WorkItemBadge: true },
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('WorkItemDetail optimistic-edit rollback (#12348)', () => {
+  beforeEach(() => {
+    patch.mockReset()
+    get.mockReset()
+    post.mockReset()
+  })
+
+  it('rolls the title back and surfaces an error when the PATCH fails', async () => {
+    const wrapper = await mountDetail()
+    const vm = wrapper.vm as unknown as DetailVm
+    patch.mockRejectedValueOnce(new Error('boom'))
+
+    vm.startEditTitle() // captures origTitle = 'Original title'
+    vm.localItem.title = 'Edited title' // what v-model would have written
+    await vm.saveTitle()
+    await flushPromises()
+
+    expect(patch).toHaveBeenCalledWith('/api/llc/work-items/w1', { title: 'Edited title' })
+    expect(vm.localItem.title).toBe('Original title')
+    expect(vm.saveError).toBe(SAVE_FAILED)
+  })
+
+  it('keeps the edited title and clears the error when the PATCH succeeds', async () => {
+    const wrapper = await mountDetail()
+    const vm = wrapper.vm as unknown as DetailVm
+    patch.mockResolvedValueOnce({ ...ITEM, title: 'Edited title' })
+
+    vm.startEditTitle()
+    vm.localItem.title = 'Edited title'
+    await vm.saveTitle()
+    await flushPromises()
+
+    expect(vm.localItem.title).toBe('Edited title')
+    expect(vm.saveError).toBeNull()
+  })
+
+  it('rolls the description back when the PATCH fails', async () => {
+    const wrapper = await mountDetail()
+    const vm = wrapper.vm as unknown as DetailVm
+    patch.mockRejectedValueOnce(new Error('boom'))
+
+    vm.startEditDesc() // captures origDesc = 'Original description'
+    vm.localItem.description = 'Edited description'
+    await vm.saveDesc()
+    await flushPromises()
+
+    expect(vm.localItem.description).toBe('Original description')
+    expect(vm.saveError).toBe(SAVE_FAILED)
+  })
+
+  it('rolls the acceptance-criteria checkbox back when the PATCH fails', async () => {
+    const wrapper = await mountDetail()
+    const vm = wrapper.vm as unknown as DetailVm
+    patch.mockRejectedValueOnce(new Error('boom'))
+
+    // Mounted state hydrates checkedAC from acceptance_criteria_done ([false, false]).
+    vm.checkedAC[0] = true // what the checkbox v-model would have written
+    await vm.saveAC()
+    await flushPromises()
+
+    expect(patch).toHaveBeenCalledWith('/api/llc/work-items/w1', {
+      acceptance_criteria_done: [true, false],
+    })
+    expect(vm.checkedAC).toEqual([false, false])
+    expect(vm.saveError).toBe(SAVE_FAILED)
+  })
+})


### PR DESCRIPTION
Closes #12348

## Thinking Path
#12327 fixed a data-integrity UX bug in chat delete: the item was removed from the local Pinia store even when the backend delete FAILED, so a phantom change appeared to persist but did not. Its template: do the backend call FIRST and only mutate local state on success (404 = reconcile), and surface an i18n error (`chat.errors.deleteFailed`) with no rollback needed because nothing was mutated pre-call. This PR audits sibling mutate-then-call flows and fixes the one genuine instance of the same class of bug.

## What Changed
Audited every frontend DELETE/edit/rename flow that mutates a Pinia store / local ref around a backend call. Only **WorkItemDetail** had the bug. Full audit table:

| Flow | Verdict | Notes |
|---|---|---|
| Chat delete (`ChatController.deleteChatSession`) | reference (#12327) | backend-first + i18n error |
| **WorkItemDetail edits — title / description / acceptance-criteria** | **FIXED** | v-model mutates `localItem`/`checkedAC` before PATCH; `patchItem` catch only logged — no rollback. Now rolls back to last-persisted value + surfaces `llc.workItem.errors.saveFailed` |
| Knowledge `deleteDocument` / `bulkDeleteDocuments` / `updateDocument` (`KnowledgeController`) | already-correct | backend `await` first, store mutated only on success |
| Knowledge-fact deletion (DELETE `/fact/{id}` = `deleteDocument`) | already-correct | same path as above |
| Category delete/update (`CategoryEditModal` + `useKnowledgeStore`) | already-correct | emits `deleted` only on success; i18n error on failure |
| `useAIDocument` `deleteDocument` / `updateDocument` | already-correct | backend-first |
| `useFailedVectorizationJobs` `retryJob` / `deleteJob` | already-correct | backend-first |
| Folder store (`create`/`update`/`delete`/`assignSessionToFolder`) | already-correct | backend-first everywhere |
| Chat presets store (`create`/`update`/`delete`) | already-correct | backend-first |
| Kanban/Sprint board `onDrop` (move) | already-correct | rolls back `column_id` in catch |
| Backlog reorder (`onDrop` → `persistBacklogOrder`) | already-correct | reverts to pre-drag order on failure |
| WorkItemDetail `performAction` (transition/claim) | already-correct | no optimistic mutation — assigns only from server response |
| Session rename (`updateSessionTitle`) | N/A | local-only, no backend call (persisted to localStorage) |
| Session collaborators / secrets / activities (#608) | N/A | local-only metadata, no backend |

**Fix detail (WorkItemDetail.vue):** `patchItem(patch, rollback?)` now clears `saveError` on success and, on failure, invokes the caller's `rollback` (restoring the pre-edit title/description or the last-persisted AC completion) and sets `saveError = t('llc.workItem.errors.saveFailed')`. A small `role="alert"` banner renders `saveError`.

**i18n:** added `llc.workItem.errors.saveFailed` to all 11 locales (en/de/es/fr/pt/pl/lv/ar/fa/he/ur).

No deferred flows — the audit surfaced a single clear-cut instance, so no follow-up issue was needed.

## Verification
- Inspection + grep sweep of `components/`, `views/`, `composables/`, `stores/`, `models/` for `.splice`/`.filter`/`.push`/`.value =` mutations preceding an `await api.(post|put|patch|delete)` without a catch-restore. Only WorkItemDetail matched.
- Added `views/llc/__tests__/WorkItemDetail.optimistic.test.ts` (modeled on the existing `BacklogView.reorder.test.ts`): asserts failed PATCH → title/description rolled back + `saveError` set; failed AC PATCH → checkbox rolled back; successful PATCH → edit kept + error cleared.
- All 11 locale JSONs validated (parse + key-resolve). WSL has no npm — vitest/vue-tsc run in CI.

## Model Used
Claude Opus 4.8
