### PR TITLE
fix(knowledge): paginate GET /facts/by_category (#12394)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -2085,37 +2085,57 @@ async def query_knowledge(
 # =============================================================================
 
 
-async def _check_facts_cache(kb, category: str | None, limit: int) -> tuple:
+async def _check_facts_cache(kb, category: str | None, limit: int, offset: int = 0) -> tuple:
     """Check cache for facts_by_category result (Issue #281: extracted)."""
     import json
 
-    cache_key = f"kb:cache:facts_by_category:{category or 'all'}:{limit}"
+    cache_key = f"kb:cache:facts_by_category:{category or 'all'}:{limit}:{offset}"
     cached_result = await asyncio.to_thread(kb.redis_client.get, cache_key)
 
     if cached_result:
-        logger.debug(f"Cache HIT for facts_by_category (category={category}, limit={limit})")
+        logger.debug(f"Cache HIT for facts_by_category (category={category}, limit={limit}, offset={offset})")
         return (
             json.loads(cached_result.decode("utf-8") if isinstance(cached_result, bytes) else cached_result),
             cache_key,
         )
 
     logger.info(
-        f"Cache MISS for facts_by_category - using category index lookup " f"(category={category}, limit={limit})"
+        f"Cache MISS for facts_by_category - using category index lookup "
+        f"(category={category}, limit={limit}, offset={offset})"
     )
     return None, cache_key
 
 
-async def _fetch_category_fact_ids(kb, categories_to_fetch: list, limit: int) -> dict:
-    """Fetch fact IDs from category indexes (Issue #281: extracted)."""
-    category_fact_ids = {}
+async def _fetch_category_fact_ids(kb, categories_to_fetch: list, limit: int, offset: int = 0) -> tuple:
+    """Fetch a deterministic page of fact IDs per category index (Issue #12394).
+
+    Uses SMEMBERS + a sorted slice instead of SRANDMEMBER: SRANDMEMBER draws a
+    fresh random sample on every call, so it cannot support stable offset/limit
+    windows across pages (page 2 could re-show page 1's items or skip others).
+    This mirrors ``KnowledgeCategoryManager.get_facts_in_category``
+    (knowledge/categories.py) which paginates the same way over Redis sets.
+
+    Returns:
+        (category_fact_ids, category_totals) where ``category_totals`` holds
+        the full per-category set size (independent of the requested page),
+        used to compute ``has_more``/``total_count`` and to distinguish "index
+        exists but this page is empty" from "no index at all" (legacy-scan
+        fallback trigger).
+    """
+    category_fact_ids: dict = {}
+    category_totals: dict = {}
     for cat in categories_to_fetch:
         index_key = f"category:index:{cat}"
-        fact_ids = await asyncio.to_thread(kb.redis_client.srandmember, index_key, limit)
-        if fact_ids:
-            decoded_ids = [fid.decode("utf-8") if isinstance(fid, bytes) else fid for fid in fact_ids]
-            category_fact_ids[cat] = decoded_ids
-            logger.debug(f"Category index {cat}: fetched {len(decoded_ids)} fact IDs")
-    return category_fact_ids
+        fact_ids = await asyncio.to_thread(kb.redis_client.smembers, index_key)
+        if not fact_ids:
+            continue
+        decoded_ids = sorted(fid.decode("utf-8") if isinstance(fid, bytes) else fid for fid in fact_ids)
+        category_totals[cat] = len(decoded_ids)
+        page = decoded_ids[offset : offset + limit]
+        if page:
+            category_fact_ids[cat] = page
+            logger.debug(f"Category index {cat}: page [{offset}:{offset + limit}] of {len(decoded_ids)} fact IDs")
+    return category_fact_ids, category_totals
 
 
 async def _batch_fetch_facts(kb, category_fact_ids: dict) -> tuple:
@@ -2219,11 +2239,14 @@ async def get_facts_by_category(
     admin_check: bool = Depends(check_admin_permission),
     req: Request = None,
     category: str | None = None,
-    limit: int = 100,
+    limit: int = Query(default=QueryDefaults.KNOWLEDGE_DEFAULT_LIMIT, ge=1, le=QueryDefaults.MAX_PAGE_SIZE),
+    offset: int = Query(default=QueryDefaults.DEFAULT_OFFSET, ge=0),
 ):
     """Get facts grouped by category for browsing with caching.
 
     Issue #744: Requires admin authentication.
+    Issue #12394: paginated via ``limit``/``offset`` (applied per category) —
+    the response was previously unbounded across all categories.
     """
     kb = await get_or_create_knowledge_base(req.app)
     if kb is None:
@@ -2234,7 +2257,7 @@ async def get_facts_by_category(
         autobot_kb_degradation_total.labels(endpoint="facts_by_category", reason="kb_uninit").inc()
         _raise_kb_unavailable()
 
-    cached_result, cache_key = await _check_facts_cache(kb, category, limit)
+    cached_result, cache_key = await _check_facts_cache(kb, category, limit, offset)
     if cached_result:
         return cached_result
 
@@ -2243,14 +2266,29 @@ async def get_facts_by_category(
     categories_to_fetch = [category] if category else [c.value for c in KnowledgeCategory]
 
     try:
-        category_fact_ids = await _fetch_category_fact_ids(kb, categories_to_fetch, limit)
-        if not category_fact_ids:
+        category_fact_ids, category_totals = await _fetch_category_fact_ids(kb, categories_to_fetch, limit, offset)
+        if not category_totals:
+            # Issue #12394: fall back only when NO category index exists at all.
+            # (Previously this checked `category_fact_ids`, which is also empty
+            # for a legitimate out-of-range page on an existing index, wrongly
+            # triggering the expensive full-keyspace SCAN fallback.)
             logger.warning("No category indexes - falling back to SCAN method")
-            return await _get_facts_by_category_legacy(kb, category, limit)
+            return await _get_facts_by_category_legacy(kb, category, limit, offset)
+
+        total_count = sum(category_totals.values())
+        has_more = any(offset + limit < category_totals.get(cat, 0) for cat in categories_to_fetch)
 
         all_fact_keys, fact_results = await _batch_fetch_facts(kb, category_fact_ids)
         if not all_fact_keys:
-            return {"categories": {}, "total_facts": 0}
+            return {
+                "categories": {},
+                "total_facts": 0,
+                "total_count": total_count,
+                "limit": limit,
+                "offset": offset,
+                "has_more": has_more,
+                "category_filter": category,
+            }
 
         categories_dict = _build_categories_dict(all_fact_keys, fact_results)
     except Exception as e:
@@ -2260,6 +2298,10 @@ async def get_facts_by_category(
     result = {
         "categories": categories_dict,
         "total_facts": sum(len(v) for v in categories_dict.values()),
+        "total_count": total_count,
+        "limit": limit,
+        "offset": offset,
+        "has_more": has_more,
         "category_filter": category,
     }
     await _cache_facts_result(kb, cache_key, result)
@@ -2321,16 +2363,29 @@ def _parse_fact_entry(fact_key_bytes, fact_data, get_category_for_source) -> tup
         return None
 
 
-async def _get_facts_by_category_legacy(kb, category: str | None, limit: int):
-    """Legacy fallback: Get facts by scanning all keys (Issue #398: refactored)."""
+async def _get_facts_by_category_legacy(kb, category: str | None, limit: int, offset: int = 0):
+    """Legacy fallback: Get facts by scanning all keys (Issue #398: refactored).
+
+    Issue #12394: honors offset/limit per category (windowed on SCAN order,
+    which — unlike the indexed path — is not sorted; "good enough" for this
+    already-degraded fallback that only runs when a category has no index).
+    """
     from knowledge_categories import get_category_for_source
 
     all_fact_keys = await _scan_all_fact_keys(kb)
     if not all_fact_keys:
-        return {"categories": {}, "total_facts": 0}
+        return {
+            "categories": {},
+            "total_facts": 0,
+            "total_count": 0,
+            "limit": limit,
+            "offset": offset,
+            "has_more": False,
+        }
 
     all_facts_data = await _batch_fetch_facts_legacy(kb, all_fact_keys)
     categories_dict: dict = {}
+    category_counts: dict = {}
 
     for fact_key_bytes, fact_data in all_facts_data:
         parsed = _parse_fact_entry(fact_key_bytes, fact_data, get_category_for_source)
@@ -2339,10 +2394,12 @@ async def _get_facts_by_category_legacy(kb, category: str | None, limit: int):
         fact_key, fact_cat, title, content, fact_type, metadata = parsed
         if category and fact_cat != category:
             continue
+        seen_index = category_counts.get(fact_cat, 0)
+        category_counts[fact_cat] = seen_index + 1
+        if seen_index < offset or seen_index >= offset + limit:
+            continue
         if fact_cat not in categories_dict:
             categories_dict[fact_cat] = []
-        if len(categories_dict[fact_cat]) >= limit:
-            continue
         categories_dict[fact_cat].append(
             {
                 "key": fact_key,
@@ -2356,9 +2413,16 @@ async def _get_facts_by_category_legacy(kb, category: str | None, limit: int):
             }
         )
 
+    total_count = sum(category_counts.values())
+    has_more = any(offset + limit < category_counts.get(cat, 0) for cat in category_counts)
+
     return {
         "categories": categories_dict,
         "total_facts": sum(len(v) for v in categories_dict.values()),
+        "total_count": total_count,
+        "limit": limit,
+        "offset": offset,
+        "has_more": has_more,
         "category_filter": category,
     }
 

--- a/autobot-backend/api/knowledge_by_category_payload_test.py
+++ b/autobot-backend/api/knowledge_by_category_payload_test.py
@@ -13,9 +13,21 @@ These tests pin the payload contract:
     * the list-item builder omits ``full_content`` and truncates ``content``;
     * the list response model no longer declares ``full_content``;
     * the detail endpoint's content extractor still returns the full text.
+
+Issue #12394: the same endpoint was unbounded (every fact in every category,
+every call). These tests pin the pagination contract:
+    * ``limit``/``offset`` window each category's fact index deterministically
+      (SMEMBERS + sorted slice, not SRANDMEMBER — see ``_fetch_category_fact_ids``);
+    * ``total_count``/``has_more`` reflect the true per-category size, not just
+      what was returned on this page;
+    * an out-of-range ``offset`` on an existing category index returns an
+      empty page WITHOUT falling back to the expensive full-keyspace SCAN
+      (that fallback is reserved for "no index at all").
 """
 
 import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -96,6 +108,187 @@ class TestDetailEndpointCarriesFullContent:
 
         # The detail response carries the full document under `content`.
         assert "content" in FactByKeyResponse.model_fields
+
+
+class _FakePipeline:
+    """Minimal sync pipeline stand-in for ``redis_client.pipeline()``."""
+
+    def __init__(self, facts: dict):
+        self._facts = facts
+        self._ops: list[str] = []
+
+    def hgetall(self, key: str):
+        self._ops.append(key)
+        return self
+
+    def execute(self):
+        results = [self._facts.get(key, {}) for key in self._ops]
+        self._ops = []
+        return results
+
+
+class _FakeRedisClient:
+    """Minimal sync Redis stand-in exercising SMEMBERS + pipeline hgetall."""
+
+    def __init__(self, category_sets: dict, facts: dict):
+        self._category_sets = category_sets
+        self._facts = facts
+        self._cache: dict = {}
+
+    def smembers(self, key: str):
+        category = key.split(":", 2)[-1]
+        return self._category_sets.get(category, set())
+
+    def pipeline(self):
+        return _FakePipeline(self._facts)
+
+    def get(self, key: str):
+        return self._cache.get(key)
+
+    def setex(self, key: str, _ttl: int, value):
+        self._cache[key] = value
+
+
+def _make_fake_kb(category_sets: dict, fact_ids: list[str]):
+    facts = {
+        f"fact:{fid}": {
+            b"content": f"content for {fid}".encode("utf-8"),
+            b"metadata": json.dumps({"title": f"Title {fid}"}).encode("utf-8"),
+        }
+        for fid in fact_ids
+    }
+    kb = MagicMock()
+    kb.redis_client = _FakeRedisClient(category_sets, facts)
+    return kb
+
+
+class TestFetchCategoryFactIdsPagination:
+    """Issue #12394: ``_fetch_category_fact_ids`` windows deterministically."""
+
+    @pytest.mark.asyncio
+    async def test_page_is_deterministic_sorted_slice(self):
+        from api.knowledge import _fetch_category_fact_ids
+
+        kb = _make_fake_kb(
+            {"tools": {b"3", b"1", b"5", b"2", b"4"}},
+            fact_ids=["1", "2", "3", "4", "5"],
+        )
+
+        category_fact_ids, category_totals = await _fetch_category_fact_ids(kb, ["tools"], limit=2, offset=1)
+
+        assert category_fact_ids == {"tools": ["2", "3"]}
+        assert category_totals == {"tools": 5}
+
+    @pytest.mark.asyncio
+    async def test_repeated_calls_return_identical_page(self):
+        """SRANDMEMBER would re-sample randomly; SMEMBERS+sort must not."""
+        from api.knowledge import _fetch_category_fact_ids
+
+        kb = _make_fake_kb(
+            {"tools": {b"3", b"1", b"5", b"2", b"4"}},
+            fact_ids=["1", "2", "3", "4", "5"],
+        )
+
+        first, _ = await _fetch_category_fact_ids(kb, ["tools"], limit=2, offset=1)
+        second, _ = await _fetch_category_fact_ids(kb, ["tools"], limit=2, offset=1)
+
+        assert first == second == {"tools": ["2", "3"]}
+
+    @pytest.mark.asyncio
+    async def test_offset_beyond_total_returns_empty_page_with_correct_total(self):
+        from api.knowledge import _fetch_category_fact_ids
+
+        kb = _make_fake_kb(
+            {"tools": {b"1", b"2", b"3"}},
+            fact_ids=["1", "2", "3"],
+        )
+
+        category_fact_ids, category_totals = await _fetch_category_fact_ids(kb, ["tools"], limit=2, offset=10)
+
+        assert category_fact_ids == {}
+        assert category_totals == {"tools": 3}
+
+
+class TestGetFactsByCategoryRoutePagination:
+    """Issue #12394: end-to-end pagination contract of the route handler."""
+
+    @pytest.mark.asyncio
+    async def test_response_carries_limit_offset_total_count_has_more(self, monkeypatch):
+        from api import knowledge as knowledge_module
+
+        kb = _make_fake_kb(
+            {"tools": {b"1", b"2", b"3", b"4", b"5"}},
+            fact_ids=["1", "2", "3", "4", "5"],
+        )
+
+        async def _fake_get_or_create_knowledge_base(_app, **_kwargs):
+            return kb
+
+        monkeypatch.setattr(knowledge_module, "get_or_create_knowledge_base", _fake_get_or_create_knowledge_base)
+
+        req = SimpleNamespace(app=MagicMock())
+        result = await knowledge_module.get_facts_by_category(
+            admin_check=True, req=req, category="tools", limit=2, offset=1
+        )
+
+        assert result["limit"] == 2
+        assert result["offset"] == 1
+        assert result["total_count"] == 5
+        assert result["total_facts"] == 2
+        assert result["has_more"] is True
+        assert [f["key"] for f in result["categories"]["tools"]] == ["fact:2", "fact:3"]
+
+    @pytest.mark.asyncio
+    async def test_last_page_reports_has_more_false(self, monkeypatch):
+        from api import knowledge as knowledge_module
+
+        kb = _make_fake_kb(
+            {"tools": {b"1", b"2", b"3", b"4", b"5"}},
+            fact_ids=["1", "2", "3", "4", "5"],
+        )
+
+        async def _fake_get_or_create_knowledge_base(_app, **_kwargs):
+            return kb
+
+        monkeypatch.setattr(knowledge_module, "get_or_create_knowledge_base", _fake_get_or_create_knowledge_base)
+
+        req = SimpleNamespace(app=MagicMock())
+        result = await knowledge_module.get_facts_by_category(
+            admin_check=True, req=req, category="tools", limit=2, offset=4
+        )
+
+        assert result["total_count"] == 5
+        assert result["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_offset_does_not_trigger_legacy_scan_fallback(self, monkeypatch):
+        """Issue #12394 fix: an empty PAGE on an existing index must not be
+        mistaken for a MISSING index (which would trigger the expensive
+        full-keyspace SCAN fallback)."""
+        from api import knowledge as knowledge_module
+
+        kb = _make_fake_kb(
+            {"tools": {b"1", b"2", b"3"}},
+            fact_ids=["1", "2", "3"],
+        )
+
+        async def _fake_get_or_create_knowledge_base(_app, **_kwargs):
+            return kb
+
+        async def _fail_if_called(*_args, **_kwargs):
+            raise AssertionError("legacy SCAN fallback must not run when a category index exists")
+
+        monkeypatch.setattr(knowledge_module, "get_or_create_knowledge_base", _fake_get_or_create_knowledge_base)
+        monkeypatch.setattr(knowledge_module, "_get_facts_by_category_legacy", _fail_if_called)
+
+        req = SimpleNamespace(app=MagicMock())
+        result = await knowledge_module.get_facts_by_category(
+            admin_check=True, req=req, category="tools", limit=2, offset=10
+        )
+
+        assert result["categories"] == {}
+        assert result["total_count"] == 3
+        assert result["has_more"] is False
 
 
 if __name__ == "__main__":

--- a/autobot-backend/knowledge/schemas/entries.py
+++ b/autobot-backend/knowledge/schemas/entries.py
@@ -71,12 +71,23 @@ class FactsByCategoryResponse(BaseModel):
 
     Grouped facts keyed by category name. ``category_filter`` echoes the
     optional ``?category=`` query param for client-side confirmation.
+
+    Issue #12394: ``limit``/``offset`` are applied per category (each
+    category's fact index is paginated independently). ``total_facts`` is
+    the count actually returned in this page (sum across categories);
+    ``total_count`` is the true sum across all matching categories,
+    independent of pagination. ``has_more`` is True when at least one
+    category has additional facts beyond this page.
     """
 
     model_config = ConfigDict(extra="allow")
 
     categories: Dict[str, List[FactByCategoryEntry]] = Field(default_factory=dict)
     total_facts: int = 0
+    total_count: int = 0
+    limit: int = 0
+    offset: int = 0
+    has_more: bool = False
     category_filter: str | None = None
     # Error branch returns this + empty categories/total_facts.
     error: str | None = None

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -170,11 +170,12 @@
             @vectorize-folder="handleVectorizeFolder"
           />
 
-          <!-- Load More button for cursor-based pagination (only for user knowledge modes) -->
-          <div v-if="(props.mode === 'user' || props.mode === 'user-knowledge') && hasMoreEntries && !isLoadingMore" class="load-more-container">
+          <!-- Load More button for the categorized (by_category) browse tree
+               (Issue #12394: the endpoint is now paginated per category). -->
+          <div v-if="hasMoreCategoryFacts && !isLoadingMoreCategoryFacts" class="load-more-container">
             <BaseButton
               variant="primary"
-              @click="loadMoreEntries"
+              @click="loadMoreCategoryFacts"
               class="load-more-btn"
             >
               <Icon name="chevron-down" />
@@ -182,7 +183,7 @@
             </BaseButton>
           </div>
 
-          <div v-if="(props.mode === 'user' || props.mode === 'user-knowledge') && isLoadingMore" class="loading-more">
+          <div v-if="isLoadingMoreCategoryFacts" class="loading-more">
             <Icon name="spinner" class="animate-spin" />
             <span>{{ $t('knowledge.browser.loadingMoreEntries') }}</span>
           </div>
@@ -401,6 +402,18 @@ const allLoadedEntries = ref<Record<string, unknown>[]>([])
 const entriesCursor = ref<string>('0')
 const hasMoreEntries = ref<boolean>(true)
 const isLoadingMore = ref<boolean>(false)
+
+// Offset-based pagination for the categorized (by_category) browse tree
+// (Issue #12394: the endpoint was previously unbounded). `limit`/`offset`
+// are applied per category by the backend; page size matches the prior
+// unbounded default of 100 so the initial tree looks the same as before.
+const CATEGORY_FACTS_PAGE_SIZE = 100
+const categoryFactsOffset = ref<number>(0)
+const hasMoreCategoryFacts = ref<boolean>(false)
+const isLoadingMoreCategoryFacts = ref<boolean>(false)
+// Accumulated raw facts per category across all loaded pages — the tree is
+// rebuilt from this on every page (mirrors loadMoreEntries/buildTreeFromEntries).
+const accumulatedFactsByCategory = ref<Record<string, Record<string, unknown>[]>>({})
 
 // Fetch function for cursor-based pagination — delegates to useKnowledgeBrowser
 const fetchEntries = fetchEntriesPage
@@ -765,40 +778,84 @@ const retryLoadKnowledgeTree = () => {
   })
 }
 
+// Rebuild treeData from the accumulated per-category facts (Issue #12394).
+// Called after both the initial page and every "load more" page.
+const buildTreeFromCategoryFacts = () => {
+  const categories = Object.keys(accumulatedFactsByCategory.value)
+
+  // Update category counts
+  const counts: Record<string, number> = {}
+  categories.forEach(cat => {
+    counts[cat] = accumulatedFactsByCategory.value[cat].length
+  })
+  categoryCounts.value = counts
+
+  treeData.value = categories.map((category: string, idx: number) => {
+    const facts = accumulatedFactsByCategory.value[category] || []
+
+    // Build nested folder structure based on file paths
+    const children = buildNestedTree(facts, category)
+
+    return {
+      id: `folder-${idx}`,
+      name: formatCategoryName(category),
+      type: 'folder' as const,
+      path: `/${category}`,
+      category: category,
+      children: children
+    }
+  })
+}
+
 const loadKnowledgeTreeFn = async () => {
-  // Load facts from knowledge base by category
-  const data = await fetchFactsByCategory()
+  // Load the first page of facts from knowledge base by category
+  // (Issue #12394: bounded — previously fetched every fact unconditionally).
+  categoryFactsOffset.value = 0
+  const data = await fetchFactsByCategory({ limit: CATEGORY_FACTS_PAGE_SIZE, offset: 0 })
 
   if (data && data.categories) {
-    // Build tree structure from categories
-    const categoriesByName = data.categories as Record<string, Record<string, unknown>[]>
-    const categories = Object.keys(categoriesByName)
+    accumulatedFactsByCategory.value = data.categories as Record<string, Record<string, unknown>[]>
+    hasMoreCategoryFacts.value = Boolean(data.has_more)
+    categoryFactsOffset.value = CATEGORY_FACTS_PAGE_SIZE
 
-    // Update category counts
-    const counts: Record<string, number> = {}
-    categories.forEach(cat => {
-      counts[cat] = categoriesByName[cat].length
-    })
-    categoryCounts.value = counts
-
-    treeData.value = categories.map((category: string, idx: number) => {
-      const facts = categoriesByName[category] || []
-
-      // Build nested folder structure based on file paths
-      const children = buildNestedTree(facts, category)
-
-      return {
-        id: `folder-${idx}`,
-        name: formatCategoryName(category),
-        type: 'folder' as const,
-        path: `/${category}`,
-        category: category,
-        children: children
-      }
-    })
+    buildTreeFromCategoryFacts()
 
     // Issue #162: Fetch vectorization status for all files after tree is built
     await fetchVectorizationStatuses(treeData.value)
+  }
+}
+
+// Fetch the next page of categorized facts and merge into the existing tree,
+// preserving expanded folders (Issue #12394).
+const loadMoreCategoryFacts = async () => {
+  if (isLoadingMoreCategoryFacts.value || !hasMoreCategoryFacts.value) return
+
+  const expandedPaths = getExpandedPaths(treeData.value, expandedNodes.value)
+  isLoadingMoreCategoryFacts.value = true
+  try {
+    const data = await fetchFactsByCategory({
+      limit: CATEGORY_FACTS_PAGE_SIZE,
+      offset: categoryFactsOffset.value
+    })
+
+    if (data && data.categories) {
+      const newCategories = data.categories as Record<string, Record<string, unknown>[]>
+      const merged = { ...accumulatedFactsByCategory.value }
+      Object.keys(newCategories).forEach(cat => {
+        merged[cat] = [...(merged[cat] || []), ...newCategories[cat]]
+      })
+      accumulatedFactsByCategory.value = merged
+      hasMoreCategoryFacts.value = Boolean(data.has_more)
+      categoryFactsOffset.value += CATEGORY_FACTS_PAGE_SIZE
+
+      buildTreeFromCategoryFacts()
+      restoreExpandedState(treeData.value, expandedPaths)
+      await fetchVectorizationStatuses(treeData.value)
+    }
+  } catch (err) {
+    logger.error('Failed to load more categorized facts:', err)
+  } finally {
+    isLoadingMoreCategoryFacts.value = false
   }
 }
 
@@ -810,7 +867,12 @@ const _loadUserKnowledge = async () => {
   buildTreeFromEntries(allLoadedEntries.value)
 }
 
-const loadMoreEntries = async () => {
+// Issue #12394: the "Load More" button now drives loadMoreCategoryFacts
+// (the by_category tree actually shown for every mode). This cursor-based
+// /entries pagination is kept as deferred wire-in scaffolding — same
+// pattern as `_loadUserKnowledge` above — not currently reachable from the
+// template.
+const _loadMoreEntries = async () => {
   // Save expanded paths before rebuild to preserve tree state
   const expandedPaths = getExpandedPaths(treeData.value, expandedNodes.value)
 

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeBrowser.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeBrowser.ts
@@ -52,6 +52,15 @@ export interface FactContentResponse {
   [key: string]: unknown
 }
 
+/**
+ * Options for a paginated `fetchFactsByCategory` page request.
+ * `limit`/`offset` are applied per category by the backend (Issue #12394).
+ */
+export interface FactsByCategoryPageOptions {
+  limit?: number
+  offset?: number
+}
+
 // ==================== Bare imperative API ====================
 
 /**
@@ -61,10 +70,22 @@ export const fetchMainCategories = (): Promise<MainCategoriesResponse> =>
   apiClient.get<MainCategoriesResponse>(`${getApiBase()}/knowledge_base/categories/main`)
 
 /**
- * Fetch all knowledge facts grouped by category for the browser tree.
+ * Fetch a page of knowledge facts grouped by category, for the browser tree.
+ *
+ * Issue #12394: paginated via `limit`/`offset` (applied per category by the
+ * backend, default page size matches the prior unbounded-default of 100).
+ * The response also carries `has_more` so callers can page further on demand.
  */
-export const fetchFactsByCategory = (): Promise<Record<string, unknown>> =>
-  apiClient.get<Record<string, unknown>>(`${getApiBase()}/knowledge_base/facts/by_category`)
+export const fetchFactsByCategory = (
+  options: FactsByCategoryPageOptions = {}
+): Promise<Record<string, unknown>> => {
+  const params = new URLSearchParams()
+  if (options.limit !== undefined) params.append('limit', String(options.limit))
+  if (options.offset !== undefined) params.append('offset', String(options.offset))
+  const query = params.toString()
+  const url = `${getApiBase()}/knowledge_base/facts/by_category${query ? `?${query}` : ''}`
+  return apiClient.get<Record<string, unknown>>(url)
+}
 
 /**
  * Fetch a paginated page of user knowledge entries.

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
@@ -134,16 +134,19 @@ export const fetchCategory = (category: string): Promise<CategoryResponse> =>
  * Uses GET /api/knowledge_base/facts/by_category endpoint.
  * @param category - Optional category filter (null for all categories)
  * @param limit - Maximum number of facts per category (default: 100)
+ * @param offset - Pagination offset applied per category (Issue #12394, default: 0)
  */
 export const getCategorizedFacts = async (
   category: string | null = null,
-  limit: number = 100
+  limit: number = 100,
+  offset: number = 0
 ): Promise<CategorizedFactsResponse> => {
   const params = new URLSearchParams()
   if (category) {
     params.append('category', category)
   }
   params.append('limit', String(limit))
+  params.append('offset', String(offset))
 
   const url = `${getApiBase()}/knowledge_base/facts/by_category?${params.toString()}`
   const data = await apiClient.get<CategorizedFactsResponse>(url)
@@ -251,7 +254,8 @@ export interface UseKnowledgeCategoriesReturn {
   /** Fetch categorized facts, update `categorizedFacts` + state refs. */
   refreshCategorizedFacts: (
     category?: string | null,
-    limit?: number
+    limit?: number,
+    offset?: number
   ) => Promise<CategorizedFactsResponse>
   // Imperative passthroughs — BC with pre-#5149 callers
   fetchCategories: typeof fetchCategories
@@ -289,12 +293,13 @@ export function useKnowledgeCategories(): UseKnowledgeCategoriesReturn {
 
   const refreshCategorizedFacts = async (
     category: string | null = null,
-    limit: number = 100
+    limit: number = 100,
+    offset: number = 0
   ): Promise<CategorizedFactsResponse> => {
     error.value = null
     return wrap(async () => {
       try {
-        const data = await getCategorizedFacts(category, limit)
+        const data = await getCategorizedFacts(category, limit, offset)
         categorizedFacts.value = data
         return data
       } catch (err) {

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -72401,6 +72401,13 @@ export interface components {
          *
          *     Grouped facts keyed by category name. ``category_filter`` echoes the
          *     optional ``?category=`` query param for client-side confirmation.
+         *
+         *     Issue #12394: ``limit``/``offset`` are applied per category (each
+         *     category's fact index is paginated independently). ``total_facts`` is
+         *     the count actually returned in this page (sum across categories);
+         *     ``total_count`` is the true sum across all matching categories,
+         *     independent of pagination. ``has_more`` is True when at least one
+         *     category has additional facts beyond this page.
          */
         FactsByCategoryResponse: {
             /** Categories */
@@ -72412,6 +72419,26 @@ export interface components {
              * @default 0
              */
             total_facts: number;
+            /**
+             * Total Count
+             * @default 0
+             */
+            total_count: number;
+            /**
+             * Limit
+             * @default 0
+             */
+            limit: number;
+            /**
+             * Offset
+             * @default 0
+             */
+            offset: number;
+            /**
+             * Has More
+             * @default false
+             */
+            has_more: boolean;
             /** Category Filter */
             category_filter?: string | null;
             /** Error */
@@ -108332,6 +108359,7 @@ export interface operations {
             query?: {
                 category?: string | null;
                 limit?: number;
+                offset?: number;
             };
             header?: never;
             path?: never;

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -4824,6 +4824,8 @@ export interface paths {
          * @description Get facts grouped by category for browsing with caching.
          *
          *     Issue #744: Requires admin authentication.
+         *     Issue #12394: paginated via ``limit``/``offset`` (applied per category) —
+         *     the response was previously unbounded across all categories.
          */
         get: operations["get_facts_by_category_api_knowledge_base_facts_by_category_get"];
         put?: never;

--- a/autobot-frontend/src/types/knowledgeBase.ts
+++ b/autobot-frontend/src/types/knowledgeBase.ts
@@ -230,10 +230,19 @@ export interface CategorizedFact {
 
 /**
  * Response from /api/knowledge_base/facts/by_category endpoint
+ *
+ * Issue #12394: `limit`/`offset` are applied per category. `total_facts` is
+ * the count returned in this page (sum across categories); `total_count` is
+ * the true sum across all matching categories. `has_more` is true when at
+ * least one category has additional facts beyond this page.
  */
 export interface CategorizedFactsResponse {
   categories: Record<string, CategorizedFact[]>
   total_facts: number
+  total_count?: number
+  limit?: number
+  offset?: number
+  has_more?: boolean
   category_filter?: string | null
 }
 


### PR DESCRIPTION
Closes #12394

## Thinking Path
Follow-up to #12370/#12395: the browse-list endpoint dropped `full_content` from list items but stayed unbounded — `GET /facts/by_category` fetched every fact per category on every call via Redis `SRANDMEMBER`, a latency/memory cliff as the KB grows. I grepped sibling endpoints in this exact module (`/categories/{id}/facts` in `knowledge_categories.py`, plus `knowledge_tags.py`/`knowledge_collections.py`/`knowledge_ownership.py`) and found the established convention: `limit`/`offset` query params (from `QueryDefaults`) with a `total_count`/`has_more` response contract. `knowledge/categories.py`'s `get_facts_in_category` already solves the exact same problem (paginating a Redis SET of fact IDs) via `SMEMBERS` + a sorted Python slice — `SRANDMEMBER` can't support stable offset windows since it draws a fresh random sample every call (page 2 could re-show page 1 or skip items entirely). I mirrored that pattern.

## What Changed
**Backend** (`autobot-backend/api/knowledge.py`, `knowledge/schemas/entries.py`):
- `_fetch_category_fact_ids`: `SRANDMEMBER(limit)` → `SMEMBERS` + sorted slice `[offset:offset+limit]`, returning both the page and each category's true total (needed for `has_more`/`total_count` and to distinguish "index exists, page is empty" from "no index at all").
- `get_facts_by_category`: added `limit`/`offset` query params (`Query(default=QueryDefaults.KNOWLEDGE_DEFAULT_LIMIT, ...)` / `Query(default=QueryDefaults.DEFAULT_OFFSET, ...)` — same default as before, so the first page is unchanged). Response gains `total_count`, `limit`, `offset`, `has_more`; `total_facts` keeps its old meaning (count returned in this page).
- **Fixed a bug this change exposed**: the legacy full-keyspace-SCAN fallback previously triggered whenever `category_fact_ids` was empty — which is also true for a legitimate out-of-range page on an *existing* index. Now it only fires when no index exists at all (`category_totals` empty).
- `_get_facts_by_category_legacy` (SCAN fallback): also honors `limit`/`offset` per category for contract consistency.
- Cache key now includes `offset`.

Response shape, before → after:
```jsonc
// before
{ "categories": {...}, "total_facts": 42, "category_filter": null }
// after
{ "categories": {...}, "total_facts": 42, "total_count": 217, "limit": 100, "offset": 0, "has_more": true, "category_filter": null }
```

**Frontend** (`KnowledgeBrowser.vue`, `useKnowledgeBrowser.ts`, `useKnowledgeCategories.ts`, `knowledgeBase.ts`, `types/generated/api.ts`):
- `fetchFactsByCategory()` now takes `{ limit, offset }` and builds the querystring (backward compatible — `{}` default).
- `KnowledgeBrowser.vue`'s `loadKnowledgeTreeFn` (the sole reachable tree-builder for every `mode`) now requests page size 100 (same as the old default) and accumulates pages in `accumulatedFactsByCategory`; a new `loadMoreCategoryFacts()` fetches the next page, merges it in, rebuilds the tree, and restores expanded-folder state — mirroring the file's existing `loadMoreEntries`/`buildTreeFromEntries` merge pattern.
- **Discovered + fixed in-scope**: the pre-existing "Load More" button/refs (`hasMoreEntries`/`loadMoreEntries`) were mode-gated to `user`/`user-knowledge` and wired to a *different*, cursor-based `/entries` endpoint via `_loadUserKnowledge` — which is never called from any reachable code path (`onMounted`/`watch` only ever call `loadKnowledgeTreeFn`). So that button rendered immediately (its `hasMoreEntries` ref defaults `true`) for the default `mode='user'`, and clicking it would silently swap the visible by_category tree for an unrelated, empty entries-based one. I repurposed the button to drive `loadMoreCategoryFacts` (removing the mode gate, since by_category is the actual tree source for every mode) and renamed the now-unreachable `loadMoreEntries` → `_loadMoreEntries`, matching this file's existing `_loadUserKnowledge` "deferred wire-in" convention for dead-but-not-deleted scaffolding.
- Regenerated `api.ts` types by hand (dumped `FactsByCategoryResponse.model_json_schema()` via Python — no npm in this WSL environment) for the new response fields + `offset` query param.

## Verification
Backend (from `autobot-backend/`):
```
python3 -m pytest api/knowledge_by_category_payload_test.py api/knowledge_categories_test.py -p no:xdist -q
======================= 36 passed, 72 warnings in 3.64s ========================
```
Added `TestFetchCategoryFactIdsPagination` (deterministic sorted-slice paging, repeated-call stability, out-of-range offset) and `TestGetFactsByCategoryRoutePagination` (route-level `limit`/`offset`/`total_count`/`has_more` contract, last-page `has_more=false`, and a regression test that asserts the legacy SCAN fallback is NOT invoked for an out-of-range offset on an existing index).

`git log`:
```
8cbd1ff60 fix(knowledge): wire by_category browse tree to paginated backend (#12394)
e22c76dac fix(knowledge): paginate GET /facts/by_category with limit/offset (#12394)
```

Frontend: verified by inspection (no npm in WSL) — traced `loadKnowledgeTreeFn`/`loadMoreCategoryFacts` call sites, confirmed `getExpandedPaths`/`restoreExpandedState`/`buildNestedTree` reuse matches the file's existing merge pattern, and confirmed no other caller of `fetchFactsByCategory`/`getCategorizedFacts`/`refreshCategorizedFacts` breaks (checked `useKnowledgeBase.ts` BC shim + `useKnowledgeCategories.test.ts`, which only asserts on `category=` substring, unaffected by the added `offset=0` param).

## Model Used
Claude Opus 4.8