### PR TITLE
fix(celery): explicit logged reconciliation of persisted Beat schedule (#12354)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from celery import Celery
 from celery.schedules import crontab
-from celery.signals import worker_process_init
+from celery.signals import beat_init, worker_process_init
 from kombu import Queue
 
 from autobot_shared.logging_manager import get_logger as _get_logger
@@ -315,6 +315,39 @@ def _assert_beat_tasks_registered() -> None:
 
 
 _assert_beat_tasks_registered()
+
+
+# GH#12354: complement to _assert_beat_tasks_registered() (#12353, which guards
+# the forward direction — every scheduled task is registered). This guards the
+# reverse: prune any entry the on-disk PersistentScheduler store is still
+# carrying whose task is no longer declared in beat_schedule, e.g. a
+# renamed/removed task lingering in the shelve file. Celery's own
+# PersistentScheduler already does an equivalent merge by entry NAME on every
+# clean startup, but silently; this makes it explicit, task-name-based (not
+# just key-based), and loud, running on the beat_init signal — i.e. only in
+# the actual `celery beat` process, after Celery has finished setting up its
+# scheduler (celery.beat.Service.start() accesses self.scheduler, which runs
+# setup_schedule(), before it sends beat_init).
+@beat_init.connect
+def _reconcile_persisted_beat_schedule(sender=None, **kwargs) -> None:
+    scheduler = getattr(sender, "scheduler", None)
+    if scheduler is None:
+        logger.warning("beat_init: no scheduler on sender %r — skipping reconciliation (#12354)", sender)
+        return
+
+    from utils.celery_beat_reconcile import reconcile_schedule
+
+    valid_tasks = {entry["task"] for entry in celery_app.conf.beat_schedule.values()}
+    pruned = reconcile_schedule(scheduler.schedule, valid_tasks)
+    if pruned:
+        scheduler.sync()
+    logger.info(
+        "beat_init: %d schedule entries active after reconciliation (%d pruned: %s) — GH#12354",
+        len(scheduler.schedule),
+        len(pruned),
+        pruned,
+    )
+
 
 # GH#4459: Register web-push task_success signal so tasks that pass user_id
 # in their kwargs trigger a browser push notification on completion.

--- a/autobot-backend/utils/celery_beat_reconcile.py
+++ b/autobot-backend/utils/celery_beat_reconcile.py
@@ -59,7 +59,17 @@ def reconcile_schedule(
         The sorted list of entry names that were pruned (empty when the
         persisted schedule already matches ``beat_schedule``).
     """
-    stale = sorted(name for name, entry in schedule.items() if entry.task not in valid_tasks)
+    # Never prune Celery's own internal periodic entries (e.g.
+    # ``celery.backend_cleanup``): ``install_default_entries()`` injects those
+    # straight into the scheduler under non-autoexpire result backends and they
+    # are never present in ``app.conf.beat_schedule``, so they must not count as
+    # stale — otherwise a backend change would silently disable result-expiry
+    # cleanup (#12354 review).
+    stale = sorted(
+        name
+        for name, entry in schedule.items()
+        if entry.task not in valid_tasks and not entry.task.startswith("celery.")
+    )
     for name in stale:
         logger.warning(
             "Beat startup reconciliation: pruning stale persisted schedule entry "

--- a/autobot-backend/utils/celery_beat_reconcile.py
+++ b/autobot-backend/utils/celery_beat_reconcile.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Explicit, logged reconciliation of the persisted Beat scheduler state (#12354).
+
+Background
+----------
+Celery's default ``PersistentScheduler`` already merges ``app.conf.beat_schedule``
+into its on-disk shelve store on every clean process startup
+(``celery.beat.Scheduler.merge_inplace``), popping any persisted entry whose
+*name* is no longer a key in ``beat_schedule``. That merge is silent
+(debug-level logging only), so when a renamed/removed task keeps firing in
+production — e.g. #10337->#10666 renamed the ``reconcile-unified-credentials-
+hourly`` entry (task ``tasks.reconcile_unified_credentials``) to
+``reconcile-credentials-hourly`` (task ``tasks.reconcile_credentials``), yet
+workers kept logging "Received unregistered task of type
+tasks.reconcile_unified_credentials" (#12354) — there is no log evidence of
+whether the running Beat process ever actually re-merged, and nothing catches
+the case where a scheduler entry's *task* string alone drifts from
+``beat_schedule`` while its *name*/key is reused.
+
+``reconcile_schedule`` makes that reconciliation explicit, loud, and testable:
+given the live scheduler's ``schedule`` mapping and the set of task names
+declared in ``celery_app.conf.beat_schedule``, prune (and return) every entry
+whose ``task`` is not in that set. Wired into celery_app.py's ``beat_init``
+signal handler so it runs — and logs — on every Beat startup, self-healing a
+stale persisted entry even if the process that produced it never restarts
+cleanly.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Mapping, MutableMapping, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class _ScheduleEntryLike(Protocol):
+    task: str
+
+
+def reconcile_schedule(
+    schedule: MutableMapping[str, _ScheduleEntryLike],
+    valid_tasks: Mapping[str, object] | set,
+) -> list[str]:
+    """Prune persisted schedule entries whose task is not in ``valid_tasks``.
+
+    Args:
+        schedule: A live, mutable mapping of entry name -> object exposing a
+            ``.task`` attribute (a Celery ``ScheduleEntry``, or any stand-in
+            with the same shape for testing). Mutated in place.
+        valid_tasks: The set of task names ``celery_app.conf.beat_schedule``
+            currently declares. Accepts a set or any container supporting
+            ``in`` (a dict of task->entry works too).
+
+    Returns:
+        The sorted list of entry names that were pruned (empty when the
+        persisted schedule already matches ``beat_schedule``).
+    """
+    stale = sorted(name for name, entry in schedule.items() if entry.task not in valid_tasks)
+    for name in stale:
+        logger.warning(
+            "Beat startup reconciliation: pruning stale persisted schedule entry "
+            "%r (task=%r not in current beat_schedule) — GH#12354",
+            name,
+            schedule[name].task,
+        )
+        del schedule[name]
+    return stale

--- a/autobot-backend/utils/celery_beat_reconcile_test.py
+++ b/autobot-backend/utils/celery_beat_reconcile_test.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the Beat schedule reconciliation guard (#12354).
+
+Pure/testable: uses simple stand-in entries (any object exposing ``.task``)
+instead of real ``celery.beat.ScheduleEntry``/scheduler objects, so it runs
+without importing the heavy, pytest-stubbed ``celery_app`` module (#7766),
+the same approach as ``utils/celery_schedules.py``'s extraction (#11606).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from utils.celery_beat_reconcile import reconcile_schedule
+
+
+@dataclass
+class _FakeEntry:
+    task: str
+
+
+def test_stale_entry_is_pruned():
+    """A persisted entry whose task is not in beat_schedule is removed."""
+    schedule = {
+        "reconcile-unified-credentials-hourly": _FakeEntry(task="tasks.reconcile_unified_credentials"),
+        "reconcile-credentials-hourly": _FakeEntry(task="tasks.reconcile_credentials"),
+    }
+    valid_tasks = {"tasks.reconcile_credentials"}
+
+    pruned = reconcile_schedule(schedule, valid_tasks)
+
+    assert pruned == ["reconcile-unified-credentials-hourly"]
+    assert "reconcile-unified-credentials-hourly" not in schedule
+    assert "reconcile-credentials-hourly" in schedule
+
+
+def test_valid_entries_are_kept_untouched():
+    """When every persisted entry matches beat_schedule, nothing is pruned."""
+    schedule = {
+        "knowledge-cleanup-orphan-documents": _FakeEntry(task="tasks.cleanup_orphan_documents"),
+        "pricing-refresh-daily": _FakeEntry(task="pricing.refresh_daily"),
+    }
+    valid_tasks = {"tasks.cleanup_orphan_documents", "pricing.refresh_daily"}
+
+    pruned = reconcile_schedule(schedule, valid_tasks)
+
+    assert pruned == []
+    assert set(schedule) == {"knowledge-cleanup-orphan-documents", "pricing-refresh-daily"}
+
+
+def test_multiple_stale_entries_pruned_sorted():
+    """Several stale entries are all removed and returned in sorted order."""
+    schedule = {
+        "z-stale-task": _FakeEntry(task="tasks.long_gone_z"),
+        "a-stale-task": _FakeEntry(task="tasks.long_gone_a"),
+        "current-task": _FakeEntry(task="tasks.current"),
+    }
+    valid_tasks = {"tasks.current"}
+
+    pruned = reconcile_schedule(schedule, valid_tasks)
+
+    assert pruned == ["a-stale-task", "z-stale-task"]
+    assert set(schedule) == {"current-task"}
+
+
+def test_empty_schedule_is_a_no_op():
+    """An empty persisted schedule reconciles cleanly with no pruning."""
+    schedule: dict = {}
+
+    pruned = reconcile_schedule(schedule, {"tasks.anything"})
+
+    assert pruned == []
+    assert schedule == {}

--- a/autobot-backend/utils/celery_beat_reconcile_test.py
+++ b/autobot-backend/utils/celery_beat_reconcile_test.py
@@ -74,3 +74,21 @@ def test_empty_schedule_is_a_no_op():
 
     assert pruned == []
     assert schedule == {}
+
+
+def test_celery_internal_entries_are_never_pruned():
+    """#12354 review: Celery's own default entries (e.g. celery.backend_cleanup,
+    injected by install_default_entries under non-autoexpire result backends and
+    absent from beat_schedule) must be kept, not pruned."""
+    schedule = {
+        "celery.backend_cleanup": _FakeEntry(task="celery.backend_cleanup"),
+        "stale-app-task": _FakeEntry(task="tasks.long_gone"),
+        "current-task": _FakeEntry(task="tasks.current"),
+    }
+    valid_tasks = {"tasks.current"}  # neither celery.* nor the stale task
+
+    pruned = reconcile_schedule(schedule, valid_tasks)
+
+    # Only the app-declared stale task is pruned; the celery.* internal stays.
+    assert pruned == ["stale-app-task"]
+    assert set(schedule) == {"celery.backend_cleanup", "current-task"}


### PR DESCRIPTION
## Thinking Path

Investigated the scheduler backend first: `celery_app.py` configures no custom scheduler (`--scheduler` flag absent from the systemd unit, no `beat_scheduler`/`DatabaseScheduler` in code), so Beat runs Celery's default `celery.beat.PersistentScheduler`, a `shelve`-backed file at `/var/lib/autobot/celerybeat-schedule` (see `autobot-slm-backend/ansible/roles/backend/templates/autobot-celery-beat.service.j2`).

Root cause: reading the installed Celery 5.6.3 source (`celery/beat.py`), `PersistentScheduler.setup_schedule()` already calls `Scheduler.merge_inplace(app.conf.beat_schedule)` on **every clean Beat process startup** — this pops any persisted entry whose *name* is no longer a key in `beat_schedule` and writes the pruned store back via `self.sync()`. Confirmed the rename that produced the phantom (commit `a8970713c`, #10337→#10666, merged 2026-06-29) changed **both** the beat_schedule dict key (`reconcile-unified-credentials-hourly` → `reconcile-credentials-hourly`) and the task string — exactly the case `merge_inplace` is built to prune. `autobot-celery-beat` is also in `code_sync.py`'s `_COMPONENT_SERVICES` restart set, so ordinary deploys should restart Beat and trigger that merge.

Since Celery's own scheduler already self-heals this class of staleness by design, and the repo has no bug in the scheduler-sync path itself, the persistence of `tasks.reconcile_unified_credentials` for ~175 rejections over ~a month points to an **operational** condition on the deployed host (most likely an orphaned/duplicate `celery beat` process that never received a clean restart since before the rename — it would keep ticking its own stale in-memory schedule and periodically `sync()` it back into the shared shelve file, undoing any correctly-restarted process's prune). No in-repo code change can affect an already-running process's in-memory state, so I did not force a code "fix" for that specific instance.

What I *could* do at the code level, per the issue's own guidance: the built-in `merge_inplace` prune is silent (debug-level only) and only matches by entry *name*, not by *task* string under a reused name. There was no log evidence anywhere of Beat's reconciliation happening, so a stale-schedule bug like this could recur invisibly. Added an explicit, loud, `beat_init`-driven reconciliation as defense-in-depth and observability.

## What Changed

- `autobot-backend/utils/celery_beat_reconcile.py` (new): pure `reconcile_schedule(schedule, valid_tasks)` — prunes any schedule entry whose `.task` is not in the current `beat_schedule` task set, logging each pruned entry at WARNING.
- `autobot-backend/celery_app.py`: wires a `beat_init` signal handler (`_reconcile_persisted_beat_schedule`) that runs the reconciliation against the live scheduler's `schedule` mapping on every Beat startup, syncs the store if anything was pruned, and logs an INFO summary either way — direct complement to #12353's `_assert_beat_tasks_registered()` (forward: every scheduled task is registered) with the reverse guard (no persisted entry dispatches a task no longer scheduled).
- `autobot-backend/utils/celery_beat_reconcile_test.py` (new): unit tests — stale entry pruned, valid entries kept untouched, multiple stale entries pruned in sorted order, empty schedule is a no-op.

No deploy-side/ad-hoc script was added — per repo policy, updates go through the builtin code-sync/self-update path only. Clearing the currently-affected host's stale persisted state (if the reconciliation above doesn't already resolve it on the next Beat restart) is an operational action for the owner via a normal Beat service restart.

## Verification

```
$ python3 -m pytest utils/celery_beat_reconcile_test.py celery_beat_registration_test.py \
    celery_priority_test.py celery_queue_coverage_test.py \
    tests/integration/test_celery_reliability.py tests/initialization/test_health_celery_dead_letter.py \
    -p no:xdist -q
======================= 30 passed, 75 warnings in 10.66s =======================
```

`python3 -m py_compile celery_app.py utils/celery_beat_reconcile.py utils/celery_beat_reconcile_test.py` — compiles cleanly.

Closes #12354

## Model Used

Claude Opus 4.8