### PR TITLE
docs(governance): forbid exposing internal infra details in outward artifacts (#12430)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 - **Never `--no-verify`** — PostToolUse hook auto-formats `.py`
 - **Protected branches:** `main`/`master` blocked by pre-commit hook → use `issue-*` or `hotfix-*`
 - **PR template headings:** `Thinking Path` · `What Changed` · `Verification` · `Model Used`
+- **No internal info in outward artifacts:** never expose IPs, hostnames, secrets/tokens, or internal filesystem paths in GitHub issues/PRs/comments/logs — redact to generic role/node refs
 - **PR queue limit:** ≥5 open PRs → defer implementation and notify
 - **Codebase is source of truth:** never edit `/opt/autobot/` or `/var/log/autobot/`
 - **System updates (test AND prod):** ONLY via the builtin updater a user reaches at `/slm/maintenance/updates/code-sync` (code-sync API / self-update); if the builtin can't do it, fix that gap (issue + PR) — never side-channel via ad-hoc ansible/shell


### PR DESCRIPTION
## Thinking Path

While monitoring a live deploy, issues were initially filed containing internal IPs and hostnames (later scrubbed). A standing rule in the project instructions prevents this class of leak up front. Kept to the Lean Instructions Principle: one bullet, no rationale prose.

## What Changed

- `CLAUDE.md` (Workflow Quick Rules): added one bullet — never expose IPs, hostnames, secrets/tokens, or internal filesystem paths in GitHub issues/PRs/comments/logs; redact to generic role/node refs.

Single-line docs change; no code touched.

## Verification

- `git diff` = exactly 1 insertion, focused on the intended bullet.
- markdownlint not enforced in repo (no config, not in pre-commit/CI); no new lint introduced.

## Model Used

Opus 4.8

Closes #12430
