### PR TITLE
test(conftest): real-load services.npu_client to end inert-patch order-dependence (#12114)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -263,6 +263,20 @@ if "services.npu_profile_suggester" not in sys.modules:
         "services.npu_profile_suggester",
         backend_root / "services" / "npu_profile_suggester.py",
     )
+# services.npu_client (#12114 / demonstrated by #12407) — the embedding client is
+# imported almost exclusively via lazy, function-level ``from services.npu_client
+# import ...`` calls in production code, so it is essentially never bound on the
+# ``services`` package stub at collection time.  Any test that is the first to do
+# ``patch("services.npu_client.<name>")`` therefore silently patches the stub's
+# catch-all MagicMock (an INERT patch) unless some earlier-collected module happened
+# to import it — making test outcomes depend on collection ORDER (#12407 had to work
+# around this with ``patch.object(npu_client_module, ...)``).  Real-load and bind it
+# here — light deps only (stdlib + aiohttp + autobot_shared; prometheus_client is
+# stubbed) — so the real module is always present and string-form patch() targets
+# the real globals.  Mirrors the #11248 tool_output_filter / #11731 npu_profile_suggester
+# pattern the module docstring recommends.
+if "services.npu_client" not in sys.modules:
+    _real_load_and_bind("services.npu_client", backend_root / "services" / "npu_client.py")
 # Provide the SUPPORTED_LANGUAGES symbol consumed by api.schemas_agent
 if not hasattr(sys.modules.get("services.personality_service", object()), "SUPPORTED_LANGUAGES"):
     sys.modules["services.personality_service"].SUPPORTED_LANGUAGES = {}  # type: ignore[attr-defined]

--- a/autobot-backend/services/npu_client_conftest_binding_test.py
+++ b/autobot-backend/services/npu_client_conftest_binding_test.py
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guard for #12114 / #12407 — the conftest ``services`` MagicMock
+package stub used to leave ``services.npu_client`` unbound at collection time,
+so the FIRST test to do ``patch("services.npu_client.<name>")`` silently patched
+a throwaway MagicMock (an INERT patch) and test outcomes depended on collection
+ORDER.  conftest now real-loads and binds ``services.npu_client`` unconditionally,
+so string-form ``patch()`` always targets the real module globals.
+
+These assertions must hold with NO other npu_client test having run first — that
+is exactly the order-dependence this guards against.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+
+def test_npu_client_is_real_module_not_stub():
+    mod = sys.modules.get("services.npu_client")
+    assert isinstance(mod, types.ModuleType), "services.npu_client must be in sys.modules"
+    assert not isinstance(mod, MagicMock)
+    # A real load exposes real callables, not MagicMock attributes.
+    assert not isinstance(mod.generate_embedding_with_fallback, MagicMock)
+
+
+def test_npu_client_bound_on_services_parent_stub():
+    """patch() resolves ``"services.npu_client.X"`` via getattr(services, "npu_client");
+    the parent bind must return the real module, not the stub's catch-all mock."""
+    services_pkg = sys.modules["services"]
+    bound = getattr(services_pkg, "npu_client")
+    assert bound is sys.modules["services.npu_client"]
+    assert not isinstance(bound, MagicMock)
+
+
+def test_string_form_patch_targets_real_symbol():
+    """The trap: without the conftest bind, this patch would hit a throwaway mock
+    and ``from services.npu_client import get_npu_client`` would still see the real
+    (unpatched) function.  With the bind, both resolve to the same patched object."""
+    with patch("services.npu_client.get_npu_client") as patched:
+        from services.npu_client import get_npu_client
+
+        assert get_npu_client is patched


### PR DESCRIPTION
Closes #12114

## Thinking Path
`autobot-backend/conftest.py` stubs the `services` package as a MagicMock whose catch-all `__getattr__` returns a mock singleton. `unittest.mock.patch("services.<mod>.<name>")` resolves its target via `getattr(sys.modules["services"], "<mod>")`, which hits that catch-all and silently patches a throwaway mock (an INERT patch) — **unless** some earlier-collected module already imported `services.<mod>` (Python then binds the real submodule onto the parent). So a patch's effect, and therefore a test's pass/fail, depends on collection ORDER. The repo already carries `_real_load_and_bind` for exactly this trap, but it was applied to only a few submodules. #12407 hit this exact trap for `services.npu_client` and had to work around it with `patch.object(npu_client_module, ...)`.

Scope was kept deliberately bounded (NOT the risky "auto-bind every services submodule" change): I probed every `patch("services.*")` target at collection time and confirmed all ~46 resolve to a MagicMock, but `services.npu_client` is the one with a *demonstrated* order-dependence problem (#12407) — it is imported almost exclusively via lazy, function-level `from services.npu_client import ...` in production, so it is essentially never bound at collection time by production import chains. Its deps are light (stdlib + aiohttp + autobot_shared; prometheus_client is stubbed), so a real-load is low-blast.

## What Changed
- **conftest.py**: real-load + parent-bind `services.npu_client` via the existing `_real_load_and_bind` helper, mirroring the #11248 `tool_output_filter` / #11731 `npu_profile_suggester` pattern the helper docstring recommends. No change to the global stub behaviour for other submodules.
- **services/npu_client_conftest_binding_test.py** (new): regression guard asserting (1) `services.npu_client` is a real module, not a MagicMock; (2) it is bound on the `services` parent stub; (3) string-form `patch("services.npu_client.get_npu_client")` now targets the real symbol (`from services.npu_client import get_npu_client is patched`).
- **Surfaced failures**: none. Real-loading `services.npu_client` surfaced no previously-hidden failures, so no module needed reverting and no discovery issue was filed.

## Verification
- New regression test in isolation (proves order-independence with no other npu_client test first): `3 passed`.
- npu_client-related suite (`npu_client_embedding_fallback_test`, binding test, pattern_analysis/`embedding_test`): `17 passed`.
- **Collection diff, full backend suite, change vs HEAD baseline**: identical `51` collection errors (all pre-existing environmental — missing deps `sklearn`/`scripts.utilities`, nonexistent modules `api.slm.nodes` etc.) — **0 new, 0 fixed**.
- **Runtime failure diff on the affected-directory slice** (`services knowledge code_intelligence autobot_memory_graph tests/knowledge tests/services` — every dir that lazily imports npu_client), change vs baseline: identical `635 failed / 3953 passed` (the 635 are pre-existing: no Redis + missing deps) — **0 new failures introduced, 0 removed**. The change is behaviourally neutral on the runnable set while eliminating the latent order-dependence.

## Model Used
Claude Opus 4.8
