### PR TITLE
fix(transcriber): cleanup partial upload on client disconnect (#12417)

### DIFF
--- a/autobot-backend/transcriber/routes/recordings.py
+++ b/autobot-backend/transcriber/routes/recordings.py
@@ -69,7 +69,11 @@ async def upload_recording(
     # GH#12331: enforce MAX_FILE_SIZE during streaming (never buffer the whole
     # upload in memory) — abort and delete the partial file the instant the
     # cumulative byte count crosses the cap, regardless of proxy limits.
+    # GH#12417: `finally` (not `except Exception`) so a client disconnect mid-upload
+    # — which raises asyncio.CancelledError, a BaseException, not an Exception —
+    # still triggers cleanup instead of orphaning the partial file.
     total_bytes = 0
+    upload_complete = False
     try:
         async with aiofiles.open(dest, "wb") as f:
             while chunk := await file.read(_CHUNK_SIZE):
@@ -80,9 +84,10 @@ async def upload_recording(
                         f"File exceeds maximum upload size of {MAX_FILE_SIZE // (1024 * 1024)}MB",
                     )
                 await f.write(chunk)
-    except Exception:
-        dest.unlink(missing_ok=True)
-        raise
+        upload_complete = True
+    finally:
+        if not upload_complete:
+            dest.unlink(missing_ok=True)
     # The file is on disk before the DB row exists; unlink the partial upload
     # if the insert fails so a rejected recording never leaks an orphan (GH#12310).
     try:

--- a/autobot-backend/transcriber/tests/test_recordings_api.py
+++ b/autobot-backend/transcriber/tests/test_recordings_api.py
@@ -3,7 +3,9 @@
 # autobot-backend/transcriber/tests/test_recordings_api.py
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
+import asyncio
 import io
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +14,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from transcriber.database import Database
-from transcriber.deps import get_db
+from transcriber.deps import DEFAULT_USER, get_db
 from transcriber.routes.projects import router as projects_router
 from transcriber.routes.recordings import router as recordings_router
 
@@ -185,6 +187,43 @@ async def test_upload_recording_at_limit_succeeds(client, tmp_path, monkeypatch)
     files = list(upload_dir.iterdir())
     assert len(files) == 1
     assert len(files[0].read_bytes()) == 104
+
+
+@pytest.mark.asyncio
+async def test_upload_recording_cancelled_mid_write_cleans_up(tmp_path):
+    """GH#12417: a client disconnect mid-upload raises asyncio.CancelledError,
+    a BaseException (not Exception) — the partial file must still be unlinked
+    and the CancelledError must still propagate (never swallowed)."""
+    import transcriber.routes.recordings as rec_mod
+
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    db = Database(str(tmp_path / "test.db"))
+    await db.connect()
+    pid = await db.create_project("P", "", user_id=DEFAULT_USER)
+
+    class FlakyFile:
+        filename = "cancelled.wav"
+
+        def __init__(self):
+            self._reads = 0
+
+        async def read(self, n):
+            self._reads += 1
+            if self._reads == 1:
+                return b"RIFF" + b"\x00" * 10
+            raise asyncio.CancelledError()
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(transcriber_upload_dir=str(upload_dir))),
+        state=SimpleNamespace(),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await rec_mod.upload_recording(pid, request, FlakyFile(), db)
+
+    # No orphan left behind — cleanup ran despite the BaseException.
+    assert list(upload_dir.iterdir()) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #12417

## Thinking Path
`upload_recording` (hardened in #12415/#12331) used `except Exception: dest.unlink(missing_ok=True); raise` to clean up the partial file on abort. `asyncio.CancelledError` has been a `BaseException` (not `Exception`) since Python 3.8, so it is not caught by `except Exception`. When a client disconnects mid-upload, FastAPI/Starlette cancels the request task, raising `CancelledError` through the streaming write loop — the cleanup never ran and the partial file was orphaned on disk.

## What Changed
- `autobot-backend/transcriber/routes/recordings.py`: replaced `except Exception: ... ; raise` with a `success`-flag (`upload_complete`) + `finally: if not upload_complete: dest.unlink(missing_ok=True)`. This covers every abort path in the write loop (413 size-guard, CancelledError, any other mid-write error) without ever swallowing the exception — `finally` re-raises automatically, so `CancelledError` still propagates and the request is properly cancelled. The success path sets `upload_complete = True` only after the write loop finishes, before the DB insert, so it never deletes a completed upload. The separate GH#12310 cleanup (unlink on DB-insert failure) is untouched.
- `autobot-backend/transcriber/tests/test_recordings_api.py`: added `test_upload_recording_cancelled_mid_write_cleans_up`, which calls the route handler directly with a fake `UploadFile` whose `.read()` raises `asyncio.CancelledError` after the first chunk, asserting the partial file is removed and `CancelledError` still propagates.

## Verification
```
cd autobot-backend && python3 -m pytest transcriber/tests/test_recordings_api.py -p no:xdist -q
...
transcriber/tests/test_recordings_api.py ........                        [100%]
========================= 8 passed, 1 warning in 3.58s =========================
```
All 8 tests pass, including the pre-existing oversize→413+cleanup and at-limit→202 tests plus the new CancelledError test.

## Model Used
Claude Opus 4.8