### PR TITLE
test(conftest): real-load code_intelligence.bug_predictor to fix standalone failures (#12421)

### DIFF
--- a/autobot-backend/code_intelligence/conftest.py
+++ b/autobot-backend/code_intelligence/conftest.py
@@ -108,3 +108,25 @@ _load_real(
 _real_sa = sys.modules.get("code_intelligence.security_analyzer")
 if _real_sa is not None:
     setattr(sys.modules["code_intelligence"], "security_analyzer", _real_sa)
+
+# Replace the code_intelligence.bug_predictor stub with the real module (#12421).
+# The top-level conftest stubs it as a MagicMock (heavy __init__ chain avoidance),
+# so STANDALONE `from code_intelligence.bug_predictor import BugPredictor` in
+# bug_predictor_test.py otherwise resolves mock attributes and every test errors.
+# It only real-loaded incidentally when bug_predictor_source_scoping_test.py's
+# private synthetic-alias load ran first — an order-dependent trap (same class as
+# #12114). Real-load here (after __path__ is repaired above) so bug_predictor.py's
+# `from code_intelligence.analytics_infrastructure import SemanticAnalysisMixin`
+# resolves the real (import-light) module and BugPredictor inherits the mixin.
+# Mirrors the security_analyzer real-load above.
+_load_real(
+    "code_intelligence.bug_predictor",
+    _backend_root / "code_intelligence" / "bug_predictor.py",
+)
+
+# Expose the real bug_predictor on the code_intelligence namespace so that
+# `from code_intelligence.bug_predictor import X` and `patch("code_intelligence.
+# bug_predictor.Y")` resolve the real module (getattr(parent, child)).
+_real_bp = sys.modules.get("code_intelligence.bug_predictor")
+if _real_bp is not None:
+    setattr(sys.modules["code_intelligence"], "bug_predictor", _real_bp)


### PR DESCRIPTION
Closes #12421

## Thinking Path
`code_intelligence/bug_predictor_test.py` failed STANDALONE (47 errors): the top-level `conftest.py` stubs `code_intelligence.bug_predictor` as a MagicMock (to avoid the heavy `code_intelligence/__init__.py` chain), so `from code_intelligence.bug_predictor import BugPredictor` resolved mock attributes. It only passed incidentally when `bug_predictor_source_scoping_test.py` ran first and real-loaded the module via a private synthetic-alias trick — an order-dependent trap, same class of bug as #12114 (`services.npu_client`).

Two options were considered: (a) real-load in the top-level `conftest.py` via `_real_load_and_bind`, or (b) real-load in the LOCAL `code_intelligence/conftest.py` which already repairs the `code_intelligence` stub `__path__` and real-loads `security_analyzer` the same way. Chose (b): more scoped (only affects the code_intelligence slice), mirrors the established `security_analyzer` pattern in that file, and — critically — runs AFTER `__path__` is repaired so `bug_predictor.py`'s `from code_intelligence.analytics_infrastructure import SemanticAnalysisMixin` resolves the real (import-light) module and `BugPredictor` inherits the mixin.

Import chain confirmed light: `bug_predictor.py` top-level imports are stdlib + `autobot_shared.logging_manager` / `time_utils` / `status_enums` + `constants.threshold_constants`, plus a try/except import of `analytics_infrastructure` (itself stdlib + `autobot_shared` at module level; torch/numpy/chromadb/npu_client are all lazy function-level). No heavy import surfaced.

## What Changed
- `autobot-backend/code_intelligence/conftest.py`: real-load `code_intelligence.bug_predictor` from disk (replacing the top-level MagicMock stub) and bind it on the `code_intelligence` namespace, mirroring the existing `security_analyzer` real-load.

## Verification
From `autobot-backend/`:

Standalone (previously 47 failed / 4 passed):
```
python3 -m pytest code_intelligence/bug_predictor_test.py -p no:xdist -q
============================== 51 passed in 0.52s ==============================
```

Combined with the scoping test (no interference):
```
python3 -m pytest code_intelligence/bug_predictor_test.py code_intelligence/bug_predictor_source_scoping_test.py -p no:xdist -q
============================== 56 passed in 0.57s ==============================
```

Broad slice `code_intelligence/` (order-dependent full-directory run, with 2 pre-existing broken collectors ignored) — strictly improved, zero regressions:
- base: 503 failed / 114 passed
- this PR: 456 failed / 161 passed (delta = exactly the 47 bug_predictor tests moving from fail→pass)

The 2 ignored collection errors (`anti_pattern_detector_test.py` FileNotFoundError, `test_pattern_analyzer.py` MagicMock-mark) are pre-existing on the base branch, unrelated to this change.

## Model Used
Claude Opus 4.8