### PR TITLE
fix(batch-jobs): add PATCH /batch-jobs/schedules/{id} to toggle enabled (#12380)

### DIFF
--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -35,6 +35,7 @@ from api.schemas_workflows import (
     BatchLogEntry,
     BatchSchedule,
     BatchScheduleDeleteResponse,
+    BatchScheduleUpdate,
     BatchStatusResponse,
     BatchTemplate,
     BatchTemplateDeleteResponse,
@@ -536,6 +537,47 @@ async def create_batch_schedule(
     redis_client.sadd("batch:schedules:all", schedule_id)
 
     logger.info("Created batch schedule %s for job %s", schedule_id, job_id)
+    return schedule
+
+
+@router.patch("/schedules/{schedule_id}", response_model=BatchSchedule)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="update_batch_schedule",
+    error_code_prefix="BATCH_JOBS",
+)
+async def update_batch_schedule(
+    schedule_id: str,
+    update: BatchScheduleUpdate,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Partially update a batch job schedule (e.g. toggle ``enabled``).
+
+    Issue #12380: frontend's ``toggleSchedule`` PATCHes this route with
+    ``{ enabled }`` to flip a schedule on/off; only fields present on the
+    request body are applied, matching PATCH semantics.
+
+    Issue #744: Requires authenticated user.
+    """
+    redis_client = get_redis_client(database="main")
+    if not redis_client:
+        raise HTTPException(status_code=503, detail="Redis service unavailable")
+
+    schedule_key = _get_schedule_key(schedule_id)
+    schedule_data = redis_client.get(schedule_key)
+
+    if not schedule_data:
+        raise HTTPException(status_code=404, detail=f"Schedule {schedule_id} not found")
+
+    schedule = BatchSchedule(**json.loads(schedule_data.decode("utf-8")))
+    updates = update.model_dump(exclude_unset=True)
+    for field, value in updates.items():
+        setattr(schedule, field, value)
+
+    redis_client.set(schedule_key, schedule.model_dump_json())
+
+    logger.info("Updated batch schedule %s: %s", schedule_id, updates)
     return schedule
 
 

--- a/autobot-backend/api/batch_jobs_schedules_test.py
+++ b/autobot-backend/api/batch_jobs_schedules_test.py
@@ -1,0 +1,269 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Issue #12380: PATCH /batch-jobs/schedules/{schedule_id} toggle regression tests.
+
+The frontend's ``useBatchProcessing.toggleSchedule`` PATCHes this route with
+``{ enabled }`` to flip a schedule on/off. These tests lock down that the
+route exists, persists the update to the same Redis-backed store the
+GET/POST/DELETE handlers use, and 404s for an unknown schedule id.
+
+Import notes
+------------
+``api/batch_jobs.py`` pulls in a heavy dependency chain not fully available
+in the dev/CI venv. We pre-stub the same blocking sub-modules used by
+``tests/test_health_probe_data_contract.py`` before importing the module
+under test, then monkeypatch the sync ``get_redis_client`` per-test with an
+in-memory fake.
+"""
+
+import json
+import sys
+import types
+from datetime import datetime, timezone
+from enum import Enum
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+
+class BatchJobStatus(str, Enum):
+    pending = "pending"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
+class BatchJobType(str, Enum):
+    data_processing = "data_processing"
+    ai_task = "ai_task"
+    report = "report"
+
+
+def _pkg_stub(name: str, **attrs) -> types.ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    mod.__package__ = name.rpartition(".")[0]
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    _m = MagicMock()
+    mod.__getattr__ = lambda attr: _m  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
+
+def _leaf_stub(name: str, **attrs) -> types.ModuleType:
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = types.ModuleType(name)
+    mod.__package__ = name.rpartition(".")[0]
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+_leaf_stub("utils.error_catalog", get_error=MagicMock())
+_leaf_stub("utils.catalog_http_exceptions", raise_auth_error=MagicMock(), raise_http_error=MagicMock())
+_pkg_stub("utils")
+
+_leaf_stub("auth_middleware", get_current_user=MagicMock())
+
+_pkg_stub("autobot_shared.redis_management.config", REDIS_DATABASES=MagicMock(), DEFAULT_MAX_CONNECTIONS=20)
+
+if "autobot_shared.redis_client" not in sys.modules:
+    _rc = types.ModuleType("autobot_shared.redis_client")
+    _rc.__package__ = "autobot_shared"
+    from unittest.mock import AsyncMock
+
+    _rc.get_async_redis_client = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+    _rc.get_redis_client = MagicMock(return_value=None)  # type: ignore[attr-defined]
+    sys.modules["autobot_shared.redis_client"] = _rc
+
+if "autobot_shared.error_boundaries" not in sys.modules:
+
+    class _ErrorCategory(Enum):
+        SERVER_ERROR = "server_error"
+        CLIENT_ERROR = "client_error"
+
+    _eb = types.ModuleType("autobot_shared.error_boundaries")
+    _eb.__package__ = "autobot_shared"
+    _eb.ErrorCategory = _ErrorCategory  # type: ignore[attr-defined]
+    _eb.with_error_handling = lambda *a, **k: (lambda f: f)  # type: ignore[attr-defined]
+    sys.modules["autobot_shared.error_boundaries"] = _eb
+
+_pkg_stub("autobot_shared.models")
+_leaf_stub("autobot_shared.models.pagination", PaginationParams=MagicMock())
+
+_pkg_stub("autobot_shared.security")
+_leaf_stub("autobot_shared.security.path_validator", validate_path=MagicMock())
+
+if "api.schemas_workflows" not in sys.modules:
+    from typing import Optional
+
+    class _BatchSchedule(BaseModel):
+        schedule_id: str
+        job_id: str
+        cron_expression: str
+        enabled: bool
+        next_run: datetime
+
+    class _BatchScheduleUpdate(BaseModel):
+        enabled: Optional[bool] = None
+        cron_expression: Optional[str] = None
+
+    def _pydantic_model(name: str) -> type:
+        return type(name, (BaseModel,), {"__annotations__": {}})
+
+    _sw = types.ModuleType("api.schemas_workflows")
+    _sw.__path__ = []
+    _sw.__package__ = "api"
+
+    _sw.BatchJobStatus = BatchJobStatus  # type: ignore[attr-defined]
+    _sw.BatchJobType = BatchJobType  # type: ignore[attr-defined]
+    _sw.BatchSchedule = _BatchSchedule  # type: ignore[attr-defined]
+    _sw.BatchScheduleUpdate = _BatchScheduleUpdate  # type: ignore[attr-defined]
+
+    # NOTE: this list must stay a superset-compatible match with the stub list
+    # in tests/test_health_probe_data_contract.py — both files guard their
+    # sys.modules["api.schemas_workflows"] stub with "if not already present",
+    # so whichever test file's module is collected first wins for the whole
+    # pytest session. Missing names here would break that file's later import
+    # of api.long_running_operations (which shares this schemas module).
+    for _schema_name in [
+        "APIBatchRequest",
+        "APIBatchResponse",
+        "BatchChatInitResponse",
+        "BatchJob",
+        "BatchJobCreate",
+        "BatchJobDeleteResponse",
+        "BatchJobList",
+        "BatchLoadResponse",
+        "BatchLogEntry",
+        "BatchScheduleDeleteResponse",
+        "BatchStatusResponse",
+        "BatchTemplate",
+        "BatchTemplateDeleteResponse",
+        # Names used by api/long_running_operations.py route decorators
+        "CodebaseIndexingRequest",
+        "KnowledgeBaseRequest",
+        "LongRunningOperationCancelResponse",
+        "LongRunningOperationListResponse",
+        "LongRunningOperationMigrateResponse",
+        "LongRunningOperationResumeResponse",
+        "LongRunningOperationStatusResponse",
+        "SecurityScanRequest",
+        "TestSuiteRequest",
+    ]:
+        setattr(_sw, _schema_name, _pydantic_model(_schema_name))
+
+    _sw_mock = MagicMock()
+    _sw.__getattr__ = lambda attr: _sw_mock  # type: ignore[attr-defined]
+    sys.modules["api.schemas_workflows"] = _sw
+
+_pkg_stub("constants")
+_leaf_stub(
+    "constants.path_constants",
+    PATH=types.SimpleNamespace(PROJECT_ROOT="/tmp"),  # nosec B108 - test/controlled code uses tmpdir intentionally
+)
+_leaf_stub("constants.threshold_constants", TimingConstants=MagicMock())
+
+
+class _FakeRedis:
+    """In-memory stand-in for the sync redis client used by api/batch_jobs.py."""
+
+    def __init__(self):
+        self._store: dict[str, bytes] = {}
+
+    def get(self, key):
+        return self._store.get(key)
+
+    def set(self, key, value):
+        self._store[key] = value.encode("utf-8") if isinstance(value, str) else value
+
+    def exists(self, key):
+        return key in self._store
+
+    def delete(self, key):
+        self._store.pop(key, None)
+
+    def sadd(self, *_a, **_k):
+        return 1
+
+    def srem(self, *_a, **_k):
+        return 1
+
+
+import api.batch_jobs as _bj  # noqa: E402  (intentionally after sys.modules setup)
+from api.schemas_workflows import BatchSchedule, BatchScheduleUpdate  # noqa: E402
+
+
+def _seed_schedule(redis, schedule_id="sched-1", enabled=True):
+    schedule = BatchSchedule(
+        schedule_id=schedule_id,
+        job_id="job-1",
+        cron_expression="0 * * * *",
+        enabled=enabled,
+        next_run=datetime.now(tz=timezone.utc),
+    )
+    redis.set(_bj._get_schedule_key(schedule_id), schedule.model_dump_json())
+    return schedule
+
+
+@pytest.mark.asyncio
+async def test_patch_schedule_toggles_enabled_and_persists(monkeypatch):
+    """PATCH {enabled: false} disables a schedule and persists the change."""
+    redis = _FakeRedis()
+    _seed_schedule(redis, schedule_id="sched-1", enabled=True)
+    monkeypatch.setattr(_bj, "get_redis_client", lambda database: redis)
+
+    result = await _bj.update_batch_schedule(
+        "sched-1",
+        BatchScheduleUpdate(enabled=False),
+        current_user={"user_id": "test"},
+    )
+
+    assert result.enabled is False
+    assert result.schedule_id == "sched-1"
+
+    persisted = json.loads(redis.get(_bj._get_schedule_key("sched-1")).decode("utf-8"))
+    assert persisted["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_schedule_unknown_id_404(monkeypatch):
+    """PATCH against a nonexistent schedule id raises 404."""
+    from fastapi import HTTPException
+
+    redis = _FakeRedis()
+    monkeypatch.setattr(_bj, "get_redis_client", lambda database: redis)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _bj.update_batch_schedule(
+            "does-not-exist",
+            BatchScheduleUpdate(enabled=False),
+            current_user={"user_id": "test"},
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_schedule_leaves_unset_fields_untouched(monkeypatch):
+    """Fields absent from the request body (exclude_unset) are not overwritten."""
+    redis = _FakeRedis()
+    _seed_schedule(redis, schedule_id="sched-2", enabled=True)
+    monkeypatch.setattr(_bj, "get_redis_client", lambda database: redis)
+
+    result = await _bj.update_batch_schedule(
+        "sched-2",
+        BatchScheduleUpdate(enabled=False),
+        current_user={"user_id": "test"},
+    )
+
+    assert result.cron_expression == "0 * * * *"

--- a/autobot-backend/api/batch_jobs_schedules_test.py
+++ b/autobot-backend/api/batch_jobs_schedules_test.py
@@ -103,6 +103,7 @@ _leaf_stub("autobot_shared.models.pagination", PaginationParams=MagicMock())
 _pkg_stub("autobot_shared.security")
 _leaf_stub("autobot_shared.security.path_validator", validate_path=MagicMock())
 
+
 def _pydantic_model(name: str) -> type:
     return type(name, (BaseModel,), {"__annotations__": {}})
 

--- a/autobot-backend/api/batch_jobs_schedules_test.py
+++ b/autobot-backend/api/batch_jobs_schedules_test.py
@@ -103,31 +103,17 @@ _leaf_stub("autobot_shared.models.pagination", PaginationParams=MagicMock())
 _pkg_stub("autobot_shared.security")
 _leaf_stub("autobot_shared.security.path_validator", validate_path=MagicMock())
 
+def _pydantic_model(name: str) -> type:
+    return type(name, (BaseModel,), {"__annotations__": {}})
+
+
 if "api.schemas_workflows" not in sys.modules:
-    from typing import Optional
-
-    class _BatchSchedule(BaseModel):
-        schedule_id: str
-        job_id: str
-        cron_expression: str
-        enabled: bool
-        next_run: datetime
-
-    class _BatchScheduleUpdate(BaseModel):
-        enabled: Optional[bool] = None
-        cron_expression: Optional[str] = None
-
-    def _pydantic_model(name: str) -> type:
-        return type(name, (BaseModel,), {"__annotations__": {}})
-
     _sw = types.ModuleType("api.schemas_workflows")
     _sw.__path__ = []
     _sw.__package__ = "api"
 
     _sw.BatchJobStatus = BatchJobStatus  # type: ignore[attr-defined]
     _sw.BatchJobType = BatchJobType  # type: ignore[attr-defined]
-    _sw.BatchSchedule = _BatchSchedule  # type: ignore[attr-defined]
-    _sw.BatchScheduleUpdate = _BatchScheduleUpdate  # type: ignore[attr-defined]
 
     # NOTE: this list must stay a superset-compatible match with the stub list
     # in tests/test_health_probe_data_contract.py — both files guard their
@@ -145,7 +131,9 @@ if "api.schemas_workflows" not in sys.modules:
         "BatchJobList",
         "BatchLoadResponse",
         "BatchLogEntry",
+        "BatchSchedule",
         "BatchScheduleDeleteResponse",
+        "BatchScheduleUpdate",
         "BatchStatusResponse",
         "BatchTemplate",
         "BatchTemplateDeleteResponse",
@@ -165,6 +153,45 @@ if "api.schemas_workflows" not in sys.modules:
     _sw_mock = MagicMock()
     _sw.__getattr__ = lambda attr: _sw_mock  # type: ignore[attr-defined]
     sys.modules["api.schemas_workflows"] = _sw
+
+# Issue #12380 review fix: this file and tests/test_health_probe_data_contract.py
+# both stub sys.modules["api.schemas_workflows"], gated on "not already present"
+# — so whichever test file collects first wins the base stub for the whole
+# session. Neither file's base stub loop builds real-field BatchSchedule /
+# BatchScheduleUpdate (both use the field-less `_pydantic_model` placeholder).
+# This file's tests construct real BatchSchedule/BatchScheduleUpdate instances
+# and read their fields (cron_expression, enabled, ...), so — regardless of
+# which file collected first — force real-field versions onto the *shared*
+# stub module here, before `import api.batch_jobs` below binds names from it.
+# Collection (module import) always completes for every test file before any
+# test *executes*, so this reassignment is visible to api.batch_jobs's own
+# `from api.schemas_workflows import BatchSchedule, BatchScheduleUpdate` no
+# matter which file the pytest run happens to collect first. Guarded by a
+# `__spec__ is None` check so a genuine (non-stub) real module is never
+# clobbered — hand-built `types.ModuleType()` stubs never populate `__spec__`
+# (stays None), while every real import-system-loaded module gets a concrete
+# `ModuleSpec`. NOTE: `hasattr(mod, "__file__")` is NOT a reliable stub-check
+# here — both this file's and the health-probe file's stub set a catch-all
+# `module.__getattr__` fallback (for arbitrary unlisted schema names), which
+# makes `hasattr(mod, "__file__")` always True (returns a MagicMock) even
+# though `__file__` was never actually set.
+_schemas_workflows_mod = sys.modules["api.schemas_workflows"]
+if _schemas_workflows_mod.__spec__ is None:
+    from typing import Optional
+
+    class _BatchSchedule(BaseModel):
+        schedule_id: str
+        job_id: str
+        cron_expression: str
+        enabled: bool
+        next_run: datetime
+
+    class _BatchScheduleUpdate(BaseModel):
+        enabled: Optional[bool] = None
+        cron_expression: Optional[str] = None
+
+    _schemas_workflows_mod.BatchSchedule = _BatchSchedule  # type: ignore[attr-defined]
+    _schemas_workflows_mod.BatchScheduleUpdate = _BatchScheduleUpdate  # type: ignore[attr-defined]
 
 _pkg_stub("constants")
 _leaf_stub(

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2230,6 +2230,17 @@ class BatchSchedule(BaseModel):
     next_run: datetime
 
 
+class BatchScheduleUpdate(BaseModel):
+    """Request body for PATCH /schedules/{schedule_id} — partial update.
+
+    Issue #12380: supports toggling ``enabled`` (frontend's primary use case)
+    plus ``cron_expression`` for trivial general partial-update support.
+    """
+
+    enabled: bool | None = None
+    cron_expression: str | None = None
+
+
 class BatchJobList(BaseModel):
     """Response model for job list."""
 

--- a/autobot-backend/tests/test_health_probe_data_contract.py
+++ b/autobot-backend/tests/test_health_probe_data_contract.py
@@ -168,6 +168,7 @@ if "api.schemas_workflows" not in sys.modules:
         "BatchLogEntry",
         "BatchSchedule",
         "BatchScheduleDeleteResponse",
+        "BatchScheduleUpdate",
         "BatchStatusResponse",
         "BatchTemplate",
         "BatchTemplateDeleteResponse",

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -159,11 +159,9 @@ export function useBatchProcessingApi() {
 
     async toggleSchedule(scheduleId: string, enabled: boolean): Promise<BatchSchedule | null> {
       try {
-        // #12326: corrected prefix to /batch-jobs/schedules. NOTE: backend does
-        // not yet expose PATCH /api/batch-jobs/schedules/{id} (only GET/POST on
-        // the collection and DELETE on the item) — this toggle 405s until the
-        // backend route lands. Tracked in #12380.
-        return await api.patch(`${getApiBase()}/batch-jobs/schedules/${scheduleId}`, { enabled })
+        // #12326: corrected prefix to /batch-jobs/schedules.
+        // #12380: backend PATCH /api/batch-jobs/schedules/{id} added.
+        return await api.patch<BatchSchedule>(`${getApiBase()}/batch-jobs/schedules/${scheduleId}`, { enabled })
       } catch (error: unknown) {
         logger.error('Failed to update batch schedule', error)
         showSubtleErrorNotification('Error', 'Failed to update batch schedule', 'error')

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -30661,7 +30661,17 @@ export interface paths {
         delete: operations["delete_batch_schedule_api_batch_jobs_schedules__schedule_id__delete"];
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update Batch Schedule
+         * @description Partially update a batch job schedule (e.g. toggle ``enabled``).
+         *
+         *     Issue #12380: frontend's ``toggleSchedule`` PATCHes this route with
+         *     ``{ enabled }`` to flip a schedule on/off; only fields present on the
+         *     request body are applied, matching PATCH semantics.
+         *
+         *     Issue #744: Requires authenticated user.
+         */
+        patch: operations["update_batch_schedule_api_batch_jobs_schedules__schedule_id__patch"];
         trace?: never;
     };
     "/api/batch-jobs/status": {
@@ -57690,6 +57700,21 @@ export interface components {
             status: string;
             /** Schedule Id */
             schedule_id: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * BatchScheduleUpdate
+         * @description Request body for PATCH /schedules/{schedule_id} — partial update.
+         *
+         *     Issue #12380: supports toggling ``enabled`` (frontend's primary use case)
+         *     plus ``cron_expression`` for trivial general partial-update support.
+         */
+        BatchScheduleUpdate: {
+            /** Enabled */
+            enabled?: boolean | null;
+            /** Cron Expression */
+            cron_expression?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -141483,6 +141508,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BatchScheduleDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_batch_schedule_api_batch_jobs_schedules__schedule_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                schedule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchScheduleUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchSchedule"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Closes #12380

## Thinking Path
Frontend's `useBatchProcessing.toggleSchedule` (`autobot-frontend/src/composables/useBatchProcessing.ts`) PATCHes `/api/batch-jobs/schedules/{id}` with `{ enabled }` to flip a schedule on/off, but `autobot-backend/api/batch_jobs.py` only exposed GET/POST on the `/schedules/` collection and DELETE on `/schedules/{id}` — no PATCH, so the toggle 405d. Read the existing schedule handlers to match their style (Redis-backed store, `@with_error_handling`, `get_current_user` auth dep), confirmed the frontend request/response shape, and added the missing route.

Also confirmed (and filed #12439 for) a separate pre-existing gap: `BatchSchedule` Redis records (`enabled`, `cron_expression`) are never read by any scheduler/executor — the schedules feature is metadata-only today. Out of scope for this PR; not invented here.

## What Changed
- `autobot-backend/api/batch_jobs.py`: new `PATCH /schedules/{schedule_id}` handler (`update_batch_schedule`) — loads the schedule from the same `batch:schedule:{id}` Redis key the other handlers use, applies only the fields present in the request body (`exclude_unset`), persists, returns the updated `BatchSchedule`, 404s for unknown ids.
- `autobot-backend/api/schemas_workflows.py`: new `BatchScheduleUpdate` request model (`enabled: bool | None`, `cron_expression: str | None`).
- `autobot-frontend/src/composables/useBatchProcessing.ts`: updated the stale comment noting the route was missing, typed the `api.patch` call as `BatchSchedule`.
- `autobot-backend/api/batch_jobs_schedules_test.py` (new): toggle-persists, unknown-id-404, and unset-fields-untouched tests for the new route.
- `autobot-backend/tests/test_health_probe_data_contract.py`: added `BatchScheduleUpdate` to the pre-existing `api.schemas_workflows` stub list (the new import in `batch_jobs.py` would otherwise resolve to a bare `MagicMock` under that file's module stubbing, breaking FastAPI route registration).

## Verification
```
$ python3 -m pytest api/batch_jobs_schedules_test.py tests/test_health_probe_data_contract.py api/api_endpoint_migrations_test.py -p no:xdist -q
====================== 10 passed, 2111 skipped in 12.79s =======================
```

## Model Used
Claude Opus 4.8