### PR TITLE
fix(security_workflow_manager): guard None redis client in create_assessment (#12442)

### DIFF
--- a/autobot-backend/services/security_workflow_manager.py
+++ b/autobot-backend/services/security_workflow_manager.py
@@ -391,6 +391,9 @@ class SecurityWorkflowManager(AsyncRedisClientMixin):
         """Save assessment to Redis."""
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot save assessment %s", assessment.id)
+                raise RuntimeError("Redis unavailable: cannot save assessment")
             key = self._assessment_key(assessment.id)
 
             # Update timestamp
@@ -424,6 +427,9 @@ class SecurityWorkflowManager(AsyncRedisClientMixin):
         """
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot get assessment %s", assessment_id)
+                raise RuntimeError("Redis unavailable: cannot get assessment")
             key = self._assessment_key(assessment_id)
 
             data = await redis.get(key)
@@ -439,6 +445,9 @@ class SecurityWorkflowManager(AsyncRedisClientMixin):
         """List all active (non-complete) assessments."""
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot list active assessments")
+                raise RuntimeError("Redis unavailable: cannot list active assessments")
             assessment_ids = await redis.smembers(self.REDIS_ACTIVE_INDEX)
 
             if not assessment_ids:
@@ -1185,6 +1194,9 @@ class SecurityWorkflowManager(AsyncRedisClientMixin):
         """
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot delete assessment %s", assessment_id)
+                raise RuntimeError("Redis unavailable: cannot delete assessment")
             key = self._assessment_key(assessment_id)
 
             deleted = await redis.delete(key)

--- a/autobot-backend/services/security_workflow_manager_test.py
+++ b/autobot-backend/services/security_workflow_manager_test.py
@@ -15,7 +15,7 @@ Tests the security assessment workflow functionality including:
 Issue: #260
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -229,7 +229,7 @@ class TestSecurityWorkflowManager:
         return mgr
 
     @pytest.mark.asyncio
-    async def test_create_assessment(self, manager) -> None:
+    async def test_create_assessment(self, manager, mock_redis) -> None:
         """Test assessment creation."""
         assessment = await manager.create_assessment(
             name="Test Scan",
@@ -243,6 +243,7 @@ class TestSecurityWorkflowManager:
         assert assessment.target == "192.168.1.0/24"
         assert assessment.phase == AssessmentPhase.INIT
         assert len(assessment.id) == 36  # UUID format
+        mock_redis.set.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_create_training_assessment(self, manager) -> None:
@@ -394,6 +395,37 @@ class TestSecurityWorkflowManager:
         assert summary["stats"]["ports"] == 1
         assert summary["stats"]["services"] == 1
         assert summary["stats"]["vulnerabilities"] == 1
+
+
+class TestSecurityWorkflowManagerRedisUnavailable:
+    """Issue #12442: redis unavailable (circuit breaker open) must raise a
+    clear RuntimeError, not crash with AttributeError on a None client.
+
+    ``_get_redis()`` is patched directly (rather than left to fall through
+    to the real connection manager) so these tests stay fast and don't
+    trigger the 5-attempt retry/circuit-breaker backoff.
+    """
+
+    @pytest.fixture
+    def manager_no_redis(self):
+        """Create a manager whose ``_get_redis()`` always returns None."""
+        mgr = SecurityWorkflowManager()
+        mgr._redis = None
+        return mgr
+
+    @pytest.mark.asyncio
+    async def test_create_assessment_raises_when_redis_none(self, manager_no_redis) -> None:
+        """Write path: create_assessment -> _save_assessment must raise, not crash."""
+        with patch.object(manager_no_redis, "_get_redis", AsyncMock(return_value=None)):
+            with pytest.raises(RuntimeError, match="Redis unavailable"):
+                await manager_no_redis.create_assessment(name="Test", target="192.168.1.1")
+
+    @pytest.mark.asyncio
+    async def test_get_assessment_raises_when_redis_none(self, manager_no_redis) -> None:
+        """Read path: get_assessment must raise, not crash."""
+        with patch.object(manager_no_redis, "_get_redis", AsyncMock(return_value=None)):
+            with pytest.raises(RuntimeError, match="Redis unavailable"):
+                await manager_no_redis.get_assessment("some-assessment-id")
 
 
 class TestPhaseDescriptions:

--- a/autobot-backend/services/security_workflow_manager_test.py
+++ b/autobot-backend/services/security_workflow_manager_test.py
@@ -220,7 +220,12 @@ class TestSecurityWorkflowManager:
     def manager(self, mock_redis):
         """Create manager with mocked Redis."""
         mgr = SecurityWorkflowManager()
-        mgr._redis_client = mock_redis
+        # Issue #12442: the mixin's lazy-init client attribute is `_redis`
+        # (see AsyncRedisClientMixin), not `_redis_client`. This fixture was
+        # stale after the migration to AsyncRedisClientMixin (#5946/#6061)
+        # and silently injected the mock into an attribute nobody read,
+        # which conftest previously masked (#12441).
+        mgr._redis = mock_redis
         return mgr
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path
`create_assessment` -> `_save_assessment` -> `redis.set(...)` crashed with `AttributeError: 'NoneType' object has no attribute 'set'`. Traced `SecurityWorkflowManager`'s redis accessor: it uses `AsyncRedisClientMixin` (migrated in #5946/#6061), which lazily caches the client on `self._redis` via `_get_redis()`. The unit test fixture, however, still assigned the mock to `self._redis_client` — a dead attribute left over from the pre-migration hand-rolled `_get_redis()` implementation this class used to have. With the mock never wired in, `_get_redis()` fell through to the real connection manager, which legitimately returns `None` once its circuit breaker opens (5 failed connection attempts against an unreachable dev-env Redis, ~150s retry-backoff) — and the very next line called `.set()` on that `None`.

## What Changed
- `autobot-backend/services/security_workflow_manager_test.py`: fixed the stale `manager` fixture to set `mgr._redis` (the mixin's real attribute) instead of the unread `mgr._redis_client`, with a comment explaining the history so it doesn't regress.
- `autobot-backend/services/security_workflow_manager.py`: `_get_async_redis_client()`/`_get_redis()` can legitimately return `None` (Redis disabled or circuit breaker open) — that's a real production crash path, not just a test artifact. Added explicit `if redis is None:` guards with a clear `logger.error` + `RuntimeError` domain error at every direct `_get_redis()` call site in this class (`_save_assessment`, `get_assessment`, `list_active_assessments`, `delete_assessment`), matching this file's existing fail-closed handling of `RedisError` and the same guard pattern already used in `services/skill_management/skill_metrics.py`.

No test assertions were weakened — the fixture fix makes the mock actually take effect (as originally intended); the source guards make the failure mode a clear domain error instead of an `AttributeError` crash.

## Verification
```
$ python3 -m pytest services/security_workflow_manager_test.py -p no:xdist -q
services/security_workflow_manager_test.py ..........................    [100%]
============================== 26 passed in 0.35s ==============================
```
Before the fix: `9 failed, 17 passed in 152.28s` (the 9 failures were all `AttributeError: 'NoneType' object has no attribute 'set'`, plus ~150s of retry-backoff against the circuit-broken Redis connection).

```
$ python3 -m black --check services/security_workflow_manager.py services/security_workflow_manager_test.py
All done! 2 files would be left unchanged.
$ python3 -m flake8 services/security_workflow_manager.py services/security_workflow_manager_test.py
(no output)
```

## Model Used
Sonnet 5

Closes #12442