### PR TITLE
fix(agent_analytics): wire redis stub + stop swallowing None-redis in analytics writes (#12446)

### DIFF
--- a/autobot-backend/api/agent_usage_test.py
+++ b/autobot-backend/api/agent_usage_test.py
@@ -14,7 +14,7 @@ Covers:
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -56,7 +56,12 @@ def _make_analytics_with_stub():
     """Return (analytics, redis_stub) with Redis injected."""
     analytics = AgentAnalytics()
     stub = _make_redis_stub()
-    analytics._redis_client = stub
+    # Issue #12446: the mixin's lazy-init client attribute is `_redis`
+    # (see AsyncRedisClientMixin), not `_redis_client`. This fixture was
+    # stale after the migration to AsyncRedisClientMixin and silently
+    # injected the mock into an attribute nobody read, which conftest
+    # previously masked (#12441). Same shape as the sister fix #12442.
+    analytics._redis = stub
     return analytics, stub
 
 
@@ -265,6 +270,9 @@ async def test_execute_with_tracking_calls_analytics():
         def get_capabilities(self):
             return []
 
+        async def is_available(self) -> bool:
+            return True
+
     dummy = _DummyAgent()
     mock_analytics = AsyncMock()
     mock_analytics.track_task_start = AsyncMock(return_value=MagicMock())
@@ -300,6 +308,9 @@ async def test_execute_with_tracking_records_failure():
 
         def get_capabilities(self):
             return []
+
+        async def is_available(self) -> bool:
+            return True
 
     broken = _BrokenAgent()
     request = AgentRequest(
@@ -415,17 +426,21 @@ async def test_usage_endpoint_returns_structure():
 @pytest.mark.asyncio
 async def test_usage_endpoint_outcome_filter():
     """outcome= query param filters the daily_trends to matching tasks only."""
+    # Issue #12446: use dates relative to "now" (not a hardcoded past date)
+    # so the endpoint's `days` lookback window doesn't filter these tasks
+    # out as the calendar advances — a hardcoded absolute date rots.
+    now = datetime.now(tz=timezone.utc)
     mock_tasks = [
         {
             "agent_id": "chat",
             "status": "completed",
-            "started_at": "2026-01-01T10:00:00+00:00",
+            "started_at": (now - timedelta(hours=2)).isoformat(),
             "duration_ms": 100.0,
         },
         {
             "agent_id": "chat",
             "status": "failed",
-            "started_at": "2026-01-01T11:00:00+00:00",
+            "started_at": (now - timedelta(hours=1)).isoformat(),
             "duration_ms": 50.0,
         },
     ]

--- a/autobot-backend/services/agent_analytics.py
+++ b/autobot-backend/services/agent_analytics.py
@@ -240,6 +240,9 @@ class AgentAnalytics(AsyncRedisClientMixin):
         # Store running task
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot track task start for %s", task_id)
+                raise RuntimeError("Redis unavailable: cannot track task start")
             running_key = f"{self.REDIS_KEY_PREFIX}running:{task_id}"
             await redis.set(running_key, json.dumps(record.to_dict()), ex=TTL_1_HOUR)
         except Exception as e:
@@ -270,6 +273,9 @@ class AgentAnalytics(AsyncRedisClientMixin):
         """
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot track task completion for %s", task_id)
+                raise RuntimeError("Redis unavailable: cannot track task completion")
             running_key = f"{self.REDIS_KEY_PREFIX}running:{task_id}"
 
             # Get running task
@@ -312,6 +318,9 @@ class AgentAnalytics(AsyncRedisClientMixin):
         """Store completed task record"""
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot store completed task %s", record.task_id)
+                raise RuntimeError("Redis unavailable: cannot store completed task")
 
             # Add to task list (keep last 50k tasks)
             await redis.lpush(self.TASK_LIST_KEY, json.dumps(record.to_dict()))
@@ -330,6 +339,9 @@ class AgentAnalytics(AsyncRedisClientMixin):
         """Update aggregated metrics for an agent"""
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: cannot update agent metrics for %s", record.agent_id)
+                raise RuntimeError("Redis unavailable: cannot update agent metrics")
             metrics_key = f"{self.AGENT_METRICS_KEY}:{record.agent_id}"
 
             # Increment counters - use dispatch table to flatten if/elif chain (Issue #315)
@@ -360,6 +372,12 @@ class AgentAnalytics(AsyncRedisClientMixin):
         """Get aggregated metrics for an agent"""
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error(
+                    "Redis unavailable: agent metrics for %s degraded to empty (not genuinely no data)",
+                    agent_id,
+                )
+                return None
             metrics_key = f"{self.AGENT_METRICS_KEY}:{agent_id}"
 
             data = await redis.hgetall(metrics_key)
@@ -450,6 +468,9 @@ class AgentAnalytics(AsyncRedisClientMixin):
         """Get metrics for all agents"""
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: all-agents metrics degraded to empty list (not genuinely no data)")
+                return []
             pattern = f"{self.AGENT_METRICS_KEY}:*"
             keys = await redis.keys(pattern)
             if not keys:
@@ -476,6 +497,12 @@ class AgentAnalytics(AsyncRedisClientMixin):
         """Get task history for an agent"""
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error(
+                    "Redis unavailable: agent history for %s degraded to empty (not genuinely no data)",
+                    agent_id,
+                )
+                return []
             agent_key = f"{self.AGENT_HISTORY_KEY}:{agent_id}"
             records = await redis.lrange(agent_key, 0, limit - 1)
 
@@ -489,6 +516,9 @@ class AgentAnalytics(AsyncRedisClientMixin):
         """Get recent tasks across all agents"""
         try:
             redis = await self.get_redis()
+            if redis is None:
+                logger.error("Redis unavailable: recent tasks degraded to empty list (not genuinely no data)")
+                return []
             records = await redis.lrange(self.TASK_LIST_KEY, 0, limit - 1)
             return [json.loads(r) for r in records]
 


### PR DESCRIPTION
## Thinking Path

Same shape as the just-merged sister bug #12442 (`security_workflow_manager`). `AgentAnalytics` migrated to `AsyncRedisClientMixin`, whose lazy client is cached on `self._redis`, but the test fixture `_make_analytics_with_stub` in `agent_usage_test.py` still injected the mock into the dead `_redis_client` attribute left over from before the migration. With no mock wired, `_get_redis()` hit the real connection manager, which returns `None` once its circuit breaker opens (5 failed attempts). Every redis call then raised `AttributeError` on `NoneType`, caught by a broad `except Exception`, and logged at ERROR — but `track_task_start` still unconditionally returned a constructed `AgentTaskRecord` regardless of whether the write ever persisted, i.e. silent data loss: the caller sees a normal-looking success while nothing was stored.

## What Changed

- **Fixture:** `analytics._redis_client = stub` -> `analytics._redis = stub` (matches the `AsyncRedisClientMixin` contract, verified against `autobot_shared/redis_mixin.py`).
- **Write paths** (`track_task_start`, `track_task_complete`, `_store_completed_task`, `_update_agent_metrics`): added `if redis is None: logger.error(...); raise RuntimeError(...)` guards mirroring #12442's idiom, replacing an opaque `NoneType` `AttributeError` with a clear domain error. These are still caught by each method's existing outer `except Exception` (unchanged control flow — analytics stays best-effort telemetry, consistent with how `agents/base_agent.py` already treats analytics failures as non-fatal), but the log line now clearly identifies "Redis unavailable" instead of a generic attribute error.
- **Read paths** (`get_agent_metrics`, `get_all_agents_metrics`, `get_agent_history`, `get_recent_tasks`): kept the existing graceful degrade to `None`/`[]` (required by existing tests/callers expecting a legitimate empty result), but added a distinct `logger.error("Redis unavailable: ... degraded to empty (not genuinely no data)")` so a Redis outage is now distinguishable in logs from a genuine "no data yet" case, instead of looking identical to it.
- **Stale test doubles:** `_DummyAgent`/`_BrokenAgent` in `agent_usage_test.py` were missing the abstract `BaseAgent.is_available` method (promoted to the abstract contract by #6659), so they failed to instantiate.
- **Adjacent stale-date bug (in-file, trivial):** `test_usage_endpoint_outcome_filter` hardcoded an absolute `2026-01-01` timestamp for its mock tasks, which rotted outside the endpoint's `days` lookback window as the calendar advanced past that date. Switched to dates relative to `datetime.now(timezone.utc)`.

## Verification

```
$ python3 -m pytest api/agent_usage_test.py -p no:xdist -q
collected 12 items
api/agent_usage_test.py ............                                     [100%]
======================== 12 passed in 121.23s (0:02:01) ========================

$ python3 -m black --check services/agent_analytics.py api/agent_usage_test.py
All done! (2 files would be left unchanged)

$ python3 -m flake8 services/agent_analytics.py api/agent_usage_test.py
(no output / exit 0)
```

Before this fix: 7 of 12 tests failing (`test_track_task_start_stores_record`, `test_track_task_complete_updates_and_cleans`, `test_get_agent_metrics_populated`, `test_track_agent_usage_success`, `test_usage_endpoint_outcome_filter`, `test_execute_with_tracking_calls_analytics`, `test_execute_with_tracking_records_failure`). After: 12/12 passing.

Closes #12446

## Model Used

Sonnet 5