### PR TITLE
fix(services): resolve 12 real-load-unmasked test failures across 6 modules (#12443)

### DIFF
--- a/autobot-backend/services/command_extraction_service.py
+++ b/autobot-backend/services/command_extraction_service.py
@@ -241,7 +241,7 @@ async def _slm_exec(
     node_id: str,
     command: str,
     timeout: int = 30,
-    slm_url: str = "",
+    slm_url: str | None = None,
     auth_token: str = "",
 ) -> Tuple[bool, str, str]:
     """
@@ -253,13 +253,14 @@ async def _slm_exec(
         node_id: SLM node identifier
         command: Shell command to run
         timeout: Command timeout in seconds
-        slm_url: SLM base URL (falls back to SLM_URL env var)
+        slm_url: SLM base URL (falls back to SLM_URL env var when omitted;
+            pass "" explicitly to force the "not configured" error path)
         auth_token: Bearer token (falls back to SLM_AUTH_TOKEN env var)
 
     Returns:
         Tuple of (success, stdout, stderr)
     """
-    base = (slm_url or _DEFAULT_SLM_URL).rstrip("/")
+    base = (slm_url if slm_url is not None else _DEFAULT_SLM_URL).rstrip("/")
     token = auth_token or _DEFAULT_SLM_TOKEN
     if not base:
         logger.error("SLM_URL not configured — cannot exec on node %s", node_id)

--- a/autobot-backend/services/mcp_isolation_config.py
+++ b/autobot-backend/services/mcp_isolation_config.py
@@ -25,7 +25,6 @@ from enum import Enum
 from typing import Dict, List
 
 from autobot_shared.env_utils import env_int
-from autobot_shared.ssot_config import config
 
 
 class IsolationMode(str, Enum):
@@ -54,8 +53,17 @@ _ALWAYS_INPROCESS = frozenset({"knowledge_mcp", "sequential_thinking_mcp", "stru
 
 
 def _global_mode() -> IsolationMode:
-    """Resolve global default isolation mode from env."""
-    raw = config.mcp_isolation_mode.lower()
+    """Resolve global default isolation mode from env.
+
+    Reads os.environ directly (not the cached ssot_config singleton) so
+    that per-test overrides via monkeypatch/patch.dict take effect, per
+    the module docstring's "read lazily so tests can override" contract.
+    Issue #12443: config.mcp_isolation_mode is populated once at process
+    startup and never reacts to later env changes.
+    """
+    raw = os.environ.get(
+        "MCP_ISOLATION_MODE", ""
+    ).lower()  # ssot-config-exempt: must be lazy for test overrides (#12443)
     try:
         return IsolationMode(raw)
     except ValueError:

--- a/autobot-backend/services/notification_suppression.py
+++ b/autobot-backend/services/notification_suppression.py
@@ -88,7 +88,14 @@ class NotificationSuppressionConfig:
         self._filter_map = {f.reason: f for f in self.filters}
 
     def should_suppress(self, reason: NotificationReason, age_days: int) -> bool:
-        """Determine if a notification should be suppressed."""
+        """Determine if a notification should be suppressed.
+
+        Issue #12443: the previous implementation ended with an unconditional
+        ``return filter_config.action == "archive"``, so every "archive"
+        filter suppressed regardless of age — the max_age_days gate only
+        ever fired for the "review" action. Gate "archive" by max_age_days
+        too, per the field's documented "Archive if older than N days".
+        """
         filter_config = self._filter_map.get(reason)
         if not filter_config:
             return False
@@ -96,11 +103,14 @@ class NotificationSuppressionConfig:
         if filter_config.action == "keep":
             return False
 
-        # Archive old notifications even if action is "review"
-        if filter_config.max_age_days and age_days > filter_config.max_age_days:
-            return True
+        if filter_config.action == "archive":
+            if filter_config.max_age_days is None:
+                return True
+            return age_days > filter_config.max_age_days
 
-        return filter_config.action == "archive"
+        # action == "review": archive old notifications even though the
+        # default action is to keep them for manual review.
+        return bool(filter_config.max_age_days and age_days > filter_config.max_age_days)
 
     def get_filter(self, reason: NotificationReason) -> NotificationFilter | None:
         """Get filter configuration for a reason."""

--- a/autobot-backend/services/queue_integration_test.py
+++ b/autobot-backend/services/queue_integration_test.py
@@ -4,17 +4,45 @@
 """
 Quick test to verify Command Execution Queue integration works end-to-end.
 This demonstrates the complete lifecycle: create → approve → execute → complete.
+
+Issue #12443: CommandExecutionQueue talks to a real (sync) Redis client via
+autobot_shared.redis_client.get_redis_client(). This test was previously
+masked by the blanket ``services.*`` MagicMock stub (removed in #12441); it
+now needs its own fakeredis-backed seam to run without live Redis.
 """
 
 import asyncio
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent))
 
+import services.command_execution_queue as command_execution_queue_module
 from models.command_execution import CommandExecution, CommandState, RiskLevel
 from services.command_execution_queue import get_command_queue
+
+try:
+    import fakeredis
+
+    _FAKEREDIS_AVAILABLE = True
+except ImportError:
+    _FAKEREDIS_AVAILABLE = False
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis_queue(monkeypatch):
+    """Patch the queue's Redis seam with an in-memory fakeredis client."""
+    if not _FAKEREDIS_AVAILABLE:
+        pytest.skip("fakeredis not installed — skipping Redis-backed tests")
+
+    client = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(command_execution_queue_module, "get_redis_client", lambda **_kw: client)
+    command_execution_queue_module.get_command_queue.reset()
+    yield
+    command_execution_queue_module.get_command_queue.reset()
 
 
 async def test_queue_integration() -> None:

--- a/autobot-backend/services/redis_service_manager.py
+++ b/autobot-backend/services/redis_service_manager.py
@@ -114,7 +114,7 @@ class RedisServiceManager:
             service_name: Systemd service name (default: 'redis-stack-server')
             enable_audit_logging: Enable audit logging (default: True)
         """
-        self.slm_url = (slm_url or _DEFAULT_SLM_URL).rstrip("/")
+        self.slm_url = (slm_url if slm_url is not None else _DEFAULT_SLM_URL).rstrip("/")
         self.slm_node_id = slm_node_id or _DEFAULT_REDIS_NODE_ID
         self.service_name = service_name
         self.enable_audit_logging = enable_audit_logging

--- a/autobot-backend/services/redis_service_manager_slm_test.py
+++ b/autobot-backend/services/redis_service_manager_slm_test.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import services.redis_service_manager as redis_service_manager_module
 from services.redis_service_manager import RedisConnectionError, RedisServiceManager
 
 
@@ -51,8 +52,12 @@ class TestInit:
         assert mgr is not None
 
     def test_defaults_from_env(self, monkeypatch) -> None:
-        monkeypatch.setenv("SLM_URL", "https://slm.test")
-        monkeypatch.setenv("REDIS_NODE_ID", "04-DBs")
+        # _DEFAULT_SLM_URL / _DEFAULT_REDIS_NODE_ID are resolved once at module
+        # import time from ssot_config (itself an lru_cache'd singleton), so
+        # monkeypatch.setenv() after import has no effect on them. Patch the
+        # module-level constants directly to exercise the actual fallback path.
+        monkeypatch.setattr(redis_service_manager_module, "_DEFAULT_SLM_URL", "https://slm.test")
+        monkeypatch.setattr(redis_service_manager_module, "_DEFAULT_REDIS_NODE_ID", "04-DBs")
         mgr = RedisServiceManager()
         assert mgr.slm_url == "https://slm.test"
         assert mgr.slm_node_id == "04-DBs"
@@ -181,11 +186,14 @@ class TestCheckRedisConnectivity:
 
     @pytest.mark.asyncio
     async def test_returns_true_on_successful_ping(self, manager) -> None:
+        # _check_redis_connectivity imports get_async_redis_client locally from
+        # autobot_shared.redis_client (not a services.redis_service_manager
+        # module attribute), so the patch target must be the source module.
         mock_client = AsyncMock()
         mock_client.ping = AsyncMock()
         with patch(
-            "services.redis_service_manager.get_redis_client",
-            return_value=mock_client,
+            "autobot_shared.redis_client.get_async_redis_client",
+            AsyncMock(return_value=mock_client),
         ):
             connected, response_ms = await manager._check_redis_connectivity()
         assert connected is True
@@ -196,8 +204,8 @@ class TestCheckRedisConnectivity:
         mock_client = AsyncMock()
         mock_client.ping = AsyncMock(side_effect=Exception("connection refused"))
         with patch(
-            "services.redis_service_manager.get_redis_client",
-            return_value=mock_client,
+            "autobot_shared.redis_client.get_async_redis_client",
+            AsyncMock(return_value=mock_client),
         ):
             connected, response_ms = await manager._check_redis_connectivity()
         assert connected is False

--- a/autobot-backend/services/workflow_io_test.py
+++ b/autobot-backend/services/workflow_io_test.py
@@ -48,17 +48,20 @@ def _make_ctx(
         "workflow_id": workflow_id,
         "status": status,
         "success_rate": success_rate,
-        "step_results": step_results
-        or {
-            "step_1": {"success": True, "agent_id": "agent-a", "execution_time": 1.25},
-            "step_2": {
-                "success": False,
-                "agent_id": "agent-b",
-                "error": "timeout",
-                "execution_time": 5.0,
-            },
-        },
-        "agents_involved": agents_involved or ["agent-a", "agent-b"],
+        "step_results": (
+            step_results
+            if step_results is not None
+            else {
+                "step_1": {"success": True, "agent_id": "agent-a", "execution_time": 1.25},
+                "step_2": {
+                    "success": False,
+                    "agent_id": "agent-b",
+                    "error": "timeout",
+                    "execution_time": 5.0,
+                },
+            }
+        ),
+        "agents_involved": agents_involved if agents_involved is not None else ["agent-a", "agent-b"],
     }
 
 


### PR DESCRIPTION
## Thinking Path

#12441 real-loaded `services.*` submodules in conftest instead of a blanket
MagicMock stub, unmasking 12 failing assertions across 6 test modules. For
each, ran it, read the module under test + git blame, and classified as
real code drift vs stale test before fixing the correct side.

## What Changed

**`redis_service_manager.py` / `redis_service_manager_slm_test.py`** (real bug + stale test):
- `__init__` used `(slm_url or _DEFAULT_SLM_URL)`, so an explicit `slm_url=""`
  (meant to simulate "unconfigured") silently fell back to the default —
  `_slm_service_action` never raised `RedisConnectionError`. Switched to an
  `is not None` check.
- `test_defaults_from_env` monkeypatched env vars *after* `_DEFAULT_SLM_URL`/
  `_DEFAULT_REDIS_NODE_ID` were already resolved at module-import time from the
  `ssot_config` singleton — structurally could never pass. Patched the module
  constants directly instead.
- `TestCheckRedisConnectivity` patched `services.redis_service_manager.get_redis_client`,
  which doesn't exist there (the real call is a local import of
  `get_async_redis_client` from `autobot_shared.redis_client`). Fixed the patch target.

**`command_extraction_service.py`** (real bug, same class as above):
- `_slm_exec`'s `slm_url` param defaulted to `""`, so `(slm_url or _DEFAULT_SLM_URL)`
  couldn't distinguish "not passed" from "explicitly empty" — the
  "SLM_URL not configured" error path was unreachable via explicit argument.
  Changed the sentinel to `None`.

**`mcp_isolation_config.py`** (real regression from #7437):
- `_global_mode()` was migrated from `os.environ.get("MCP_ISOLATION_MODE", ...)`
  to `config.mcp_isolation_mode` (an `lru_cache`'d singleton populated once at
  process start), silently breaking the module's documented "read lazily so
  tests can override" contract and the global-default precedence branch of
  `resolve_mode()`. Reverted to a direct `os.environ.get()` read, matching the
  per-bridge override read a few lines below it.

**`workflow_io_test.py`** (stale test fixture, not a `to_csv` bug):
- `_make_ctx`'s `step_results or {default}` / `agents_involved or [default]`
  swallowed explicitly-passed empty overrides. `test_empty_step_results` never
  actually exercised `to_csv()` with an empty dict. Confirmed `to_csv`'s
  actual (and correct) contract is header-only output for empty input; fixed
  the fixture with `is not None` checks.

**`queue_integration_test.py`** (test infra gap, not a queue bug):
- `CommandExecutionQueue` talks to a real sync Redis client. Previously masked
  by the blanket stub, it now hits the unresolvable placeholder Redis host and
  every `add_command()` fails because `self.redis_client` is `None`. Wired a
  `fakeredis.FakeStrictRedis` seam (same pattern as
  `tests/integration/test_task_claim_race.py` / `test_budget_hard_stop.py`)
  and reset the `lazy_singleton` around each run.

**`notification_suppression.py`** (real bug, present since inception #4167):
- `should_suppress()` ended with an unconditional
  `return filter_config.action == "archive"`, so every "archive" filter
  (CI_ACTIVITY, SUBSCRIBED) suppressed regardless of age — the `max_age_days`
  gate only ever fired for the "review" action branch. Recent CI-activity
  notifications were archived immediately instead of honoring the documented
  7/14-day thresholds. Gated the "archive" branch by `max_age_days` too.

No items required escalation — every failure resolved to either a clear code
bug or a clear stale-test bug with unambiguous evidence from the module under
test / git blame.

## Verification

```
services/redis_service_manager_slm_test.py .............. 15 passed
services/command_extraction_service_test.py ........... 11 passed
services/mcp_isolation_config_test.py ......... 9 passed
services/workflow_io_test.py ......................................... 81 passed
services/queue_integration_test.py . 1 passed
services/test_notification_suppression.py ........... 11 passed

$ python3 -m pytest services/redis_service_manager_slm_test.py services/command_extraction_service_test.py services/mcp_isolation_config_test.py services/workflow_io_test.py services/queue_integration_test.py services/test_notification_suppression.py -p no:xdist -q
============================= 128 passed in 0.83s ==============================
```

Before: 12 failing assertions across these 6 files. After: 128/128 passing.

`black --check` and `flake8` clean on all 7 changed files.

Closes #12443

## Model Used

Claude Sonnet 5