### PR TITLE
fix(tests): repoint stale singleton/subpackage imports in dead test collectors (Category B+D)

### DIFF
--- a/autobot-backend/computer_vision/multimodal_ai_test.py
+++ b/autobot-backend/computer_vision/multimodal_ai_test.py
@@ -30,10 +30,12 @@ from multimodal_processor import (  # noqa: E402
     ModalInput,
     ModalityType,
     ProcessingIntent,
-    multimodal_processor,
 )
+from multimodal_processor import processor as multimodal_processor  # noqa: E402
 from tests.test_helpers import get_test_backend_url  # noqa: E402
-from voice_processing_system import AudioInput, voice_processing_system  # noqa: E402
+from voice_processing_system import AudioInput, get_voice_processing_system  # noqa: E402
+
+voice_processing_system = get_voice_processing_system()
 
 
 def test_api_connectivity():

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -492,6 +492,39 @@ if "llm_shared" not in sys.modules:
         if hasattr(_hw_mod, "TORCH_AVAILABLE"):
             _llm_stub.TORCH_AVAILABLE = _hw_mod.TORCH_AVAILABLE  # type: ignore[attr-defined]
 
+    # #12438: Real-load llm_shared.pricing — auto-refresh pricing sources (GH#6480).
+    # Self-contained aside from autobot_shared.logging_manager (already patched)
+    # and autobot_shared.redis_client (real module); the llm_shared stub's empty
+    # __path__ otherwise breaks every provider-source import and its colocated
+    # services/pricing_refresh_test.py. Dependency order: sources → redis_store
+    # → per-provider sources → package __init__.
+    _real_load_and_bind("llm_shared.pricing.sources", _llm_root / "pricing" / "sources.py")
+    _real_load_and_bind("llm_shared.pricing.redis_store", _llm_root / "pricing" / "redis_store.py")
+    _real_load_and_bind("llm_shared.pricing.anthropic_source", _llm_root / "pricing" / "anthropic_source.py")
+    _real_load_and_bind("llm_shared.pricing.openai_source", _llm_root / "pricing" / "openai_source.py")
+    _real_load_and_bind("llm_shared.pricing.google_source", _llm_root / "pricing" / "google_source.py")
+    _real_load_and_bind("llm_shared.pricing.deepseek_source", _llm_root / "pricing" / "deepseek_source.py")
+    _real_load_and_bind("llm_shared.pricing.vertexai_source", _llm_root / "pricing" / "vertexai_source.py")
+    _real_load_and_bind("llm_shared.pricing", _llm_root / "pricing" / "__init__.py")
+    # The submodule real-loads above ran before "llm_shared.pricing" existed in
+    # sys.modules, so _real_load_and_bind's own parent-bind was a no-op for them
+    # (and __init__.py's "from llm_shared.pricing.X import Y" doesn't re-trigger
+    # it either, since those submodules were already sys.modules-cached). Bind
+    # them explicitly now so patch("llm_shared.pricing.redis_store.X") resolves
+    # via getattr(llm_shared.pricing, "redis_store") instead of raising
+    # AttributeError.
+    _pricing_pkg = sys.modules["llm_shared.pricing"]
+    for _pricing_sub in (
+        "sources",
+        "redis_store",
+        "anthropic_source",
+        "openai_source",
+        "google_source",
+        "deepseek_source",
+        "vertexai_source",
+    ):
+        setattr(_pricing_pkg, _pricing_sub, sys.modules[f"llm_shared.pricing.{_pricing_sub}"])
+
     # llm_shared.cache — provide symbols consumed by services.llm_service
     _cache_stub = sys.modules["llm_shared.cache"]
     _cache_stub.CachedResponse = MagicMock()  # type: ignore[attr-defined]

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -639,10 +639,10 @@ except Exception:
 
 # orchestration.causal_error_recovery / causal_error_analyzer stubs (#7431).
 # orchestration/__init__.py imports CausalErrorRecovery from causal_error_recovery,
-# which cascades through agent_loop → tools → code_intelligence — a chain of
+# which cascades through agent_loop → code_intelligence — a chain of
 # modules with Python-3.10-incompatible annotations or missing config keys.
-# Stub these modules so the lightweight types-only tests (workflow_planning_test,
-# workflow_integration_test) can collect without needing the full backend stack.
+# Stub these modules so the lightweight types-only tests can collect without
+# needing the full backend stack.
 for _causal_mod in [
     "orchestration.causal_error_recovery",
     "orchestration.causal_error_analyzer",
@@ -650,12 +650,24 @@ for _causal_mod in [
     "agent_loop",
     "agent_loop.loop",
     "agent_loop.think_tool",
-    "tools.parallel",
-    "tools.parallel.executor",
     "code_intelligence",
 ]:
     if _causal_mod not in sys.modules:
         sys.modules[_causal_mod] = _make_pkg_stub(_causal_mod)
+
+# code_intelligence.code_generation.diff real-load (#12438) — tools/parallel/executor.py
+# imports the real DiffGenerator (self-contained: stdlib difflib only) to build CODE_DIFF
+# artifacts. code_intelligence itself is stubbed above (its __init__ has Python-3.10-
+# incompatible annotations), so real-load this leaf submodule bypassing that __init__.
+# NOTE: tools.parallel / tools.parallel.executor are intentionally NOT in the stub list
+# above — they are self-contained aside from this one dependency and executor_artifacts_test.py
+# needs the real ParallelToolExecutor/DiffGenerator behaviour.
+if "code_intelligence.code_generation" not in sys.modules:
+    sys.modules["code_intelligence.code_generation"] = _make_pkg_stub("code_intelligence.code_generation")
+_real_load_and_bind(
+    "code_intelligence.code_generation.diff",
+    backend_root / "code_intelligence" / "code_generation" / "diff.py",
+)
 
 # code_intelligence submodule stubs — code_intelligence itself is stubbed above
 # (its __init__ has Python-3.10-incompatible annotations), so submodule imports

--- a/autobot-backend/control_panel_test.py
+++ b/autobot-backend/control_panel_test.py
@@ -15,10 +15,13 @@ import requests
 # Add project root to Python path
 sys.path.append(str(Path(__file__).parent))
 
-from desktop_streaming_manager import VNCServerManager, desktop_streaming
+from desktop_streaming_manager import VNCServerManager, get_desktop_streaming
 from memory import TaskPriority
-from takeover_manager import TakeoverTrigger, takeover_manager
+from takeover_manager import TakeoverTrigger, get_takeover_manager
 from tests.test_helpers import get_test_backend_url
+
+desktop_streaming = get_desktop_streaming()
+takeover_manager = get_takeover_manager()
 
 
 def test_api_connectivity():

--- a/autobot-backend/multimodal_processor/multimodal_integration_test.py
+++ b/autobot-backend/multimodal_processor/multimodal_integration_test.py
@@ -26,9 +26,11 @@ from multimodal_processor import (
     ModalInput,
     ModalityType,
     ProcessingIntent,
-    multimodal_processor,
 )
-from voice_processing_system import AudioInput, voice_processing_system
+from multimodal_processor import processor as multimodal_processor
+from voice_processing_system import AudioInput, get_voice_processing_system
+
+voice_processing_system = get_voice_processing_system()
 
 
 class TestMultiModalWorkflowIntegration:

--- a/autobot-backend/services/pricing_refresh_test.py
+++ b/autobot-backend/services/pricing_refresh_test.py
@@ -187,7 +187,7 @@ async def test_refresh_writes_new_pricing_to_redis():
     mock_store.set_many = fake_set_many
     mock_store.set_refresh_status = fake_set_status
 
-    with patch("services.pricing_refresh.PricingRedisStore", return_value=mock_store):
+    with patch("llm_shared.pricing.redis_store.PricingRedisStore", return_value=mock_store):
         summary = await _refresh_all()
 
     assert "anthropic" in summary
@@ -229,30 +229,21 @@ async def test_cost_tracker_uses_redis_pricing_when_available():
     # 1M input tokens + 1M output tokens at cheap price = 0.01 + 0.02 = 0.03
     # Hardcoded would give 15.00 + 75.00 = 90.00
     with patch.object(tracker, "_store_usage_record", AsyncMock(return_value=True)):
-        cost = None
-
-        async def capture_record(*args, **kwargs):
-            nonlocal cost
-            # intercept at the record-creation step
-            record = await tracker._build_and_persist_record(
-                "anthropic",
-                "claude-opus-4-0",
-                1_000_000,
-                1_000_000,
-                None,
-                None,
-                None,
-                None,
-                None,
-                True,
-                None,
-                None,
-            )
-            cost = record.cost_usd
-            return True
-
-        with patch.object(tracker, "_store_usage_record", capture_record):
-            await capture_record()
+        record = await tracker._build_and_persist_record(
+            "anthropic",
+            "claude-opus-4-0",
+            1_000_000,
+            1_000_000,
+            None,
+            None,
+            None,
+            None,
+            None,
+            True,
+            None,
+            None,
+        )
+        cost = record.cost_usd
 
     assert cost is not None
     assert abs(cost - 0.03) < 1e-5, f"Expected 0.03 but got {cost}"

--- a/autobot-backend/workflow_scheduler_e2e_test.py
+++ b/autobot-backend/workflow_scheduler_e2e_test.py
@@ -14,7 +14,9 @@ from autobot_shared.ssot_config import config
 sys.path.append(config.project_root)
 
 from tests.test_helpers import get_test_backend_url
-from workflow_scheduler import WorkflowPriority, WorkflowStatus, workflow_scheduler
+from workflow_scheduler import WorkflowPriority, WorkflowStatus, get_workflow_scheduler
+
+workflow_scheduler = get_workflow_scheduler()
 
 
 async def test_workflow_scheduling():


### PR DESCRIPTION
Closes #12456
Refs #12438

## Thinking Path
After #12441, remaining collectors failed on moved/renamed symbols and stub-masked namespaces. Repointed each to the current symbol; real-loaded deps the stub was masking.

## What Changed
- `tools/parallel/executor_artifacts_test.py`: un-stub `tools.parallel`, real-load `code_intelligence.code_generation.diff`.
- `computer_vision/multimodal_ai_test.py` + `multimodal_processor/multimodal_integration_test.py`: `multimodal_processor`->`processor` (#10666); `voice_processing_system`->`get_voice_processing_system()`.
- `control_panel_test.py`: `get_desktop_streaming()`/`get_takeover_manager()` factories.
- `workflow_scheduler_e2e_test.py`: `get_workflow_scheduler()`.
- `services/pricing_refresh_test.py` + conftest: real-load `llm_shared.pricing`; fixed 2 pre-existing test bugs incl. a recursive self-patch INFINITE HANG.

## Verification
- Collection errors 33 -> 27 (19221 -> 19266 tests). `llm_shared/` full suite 549 passed (no regression). black/flake8 clean.
- Surfaced real bugs filed separately: #12453 (workflow_scheduler naive/aware datetime), #12454 (MultiModalInput kwarg drift). Owner-decision dead tests: #12455.

## Model Used
Opus 4.8 (implementation + review).