### PR TITLE
fix(test): repair 2 broken collectors — code_intelligence test_pattern_analyzer + anti_pattern_detector_test

### DIFF
--- a/autobot-backend/code_intelligence/anti_pattern_detector_test.py
+++ b/autobot-backend/code_intelligence/anti_pattern_detector_test.py
@@ -33,11 +33,18 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 # Import using sys.path manipulation since directory has dashes
 import importlib.util
 
+# #12436: tools/code-analysis-suite/src/anti_pattern_detector.py was deleted
+# during the Phase 1/2 repo restructuring (#781, #926); the directory-level
+# analyzer (whole-codebase class index: `.classes`/`.modules`, cycle
+# detection) now lives at autobot-backend/code_analysis/src/anti_pattern_detector.py
+# — same lineage/Issue #221, confirmed production-canonical for cross-file
+# rules (see code_intelligence/anti_pattern_detector.py facade docstring,
+# GH#6757).
 spec = importlib.util.spec_from_file_location(
     "anti_pattern_detector",
     os.path.join(
         os.path.dirname(__file__),
-        "../../tools/code-analysis-suite/src/anti_pattern_detector.py",
+        "../code_analysis/src/anti_pattern_detector.py",
     ),
 )
 anti_pattern_module = importlib.util.module_from_spec(spec)
@@ -51,6 +58,11 @@ AntiPatternType = anti_pattern_module.AntiPatternType
 ClassInfo = anti_pattern_module.ClassInfo
 ModuleInfo = anti_pattern_module.ModuleInfo
 Severity = anti_pattern_module.Severity
+# #7414 consolidated the local `Severity.score()` method onto the canonical
+# `autobot_shared.status_enums.Severity` enum, extracting the int 0-100 score
+# into this module-level helper (canonical `Severity.to_score()` keeps a
+# separate 0.0-0.9 float contract). Tests below use the helper accordingly.
+anti_pattern_score = anti_pattern_module.anti_pattern_score
 
 
 class TestSeverity:
@@ -65,16 +77,16 @@ class TestSeverity:
 
     def test_severity_scores(self):
         """Test severity score ordering."""
-        assert Severity.CRITICAL.score() > Severity.HIGH.score()
-        assert Severity.HIGH.score() > Severity.MEDIUM.score()
-        assert Severity.MEDIUM.score() > Severity.LOW.score()
+        assert anti_pattern_score(Severity.CRITICAL) > anti_pattern_score(Severity.HIGH)
+        assert anti_pattern_score(Severity.HIGH) > anti_pattern_score(Severity.MEDIUM)
+        assert anti_pattern_score(Severity.MEDIUM) > anti_pattern_score(Severity.LOW)
 
     def test_severity_score_values(self):
         """Test specific severity score values."""
-        assert Severity.CRITICAL.score() == 100
-        assert Severity.HIGH.score() == 75
-        assert Severity.MEDIUM.score() == 50
-        assert Severity.LOW.score() == 25
+        assert anti_pattern_score(Severity.CRITICAL) == 100
+        assert anti_pattern_score(Severity.HIGH) == 75
+        assert anti_pattern_score(Severity.MEDIUM) == 50
+        assert anti_pattern_score(Severity.LOW) == 25
 
 
 class TestAntiPatternType:

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -720,6 +720,17 @@ _ci_merge_stub.ResolutionStrategy = MagicMock()  # type: ignore[attr-defined]
 _ci_merge_stub.analyze_repository = MagicMock()  # type: ignore[attr-defined]
 sys.modules["code_intelligence.merge_conflict_resolver"] = _ci_merge_stub
 
+# NOTE: "code_intelligence.test_pattern_analyzer" is intentionally NOT in this
+# list (#12437). Stubbing it here would poison sys.modules before pytest ever
+# collects code_intelligence/test_pattern_analyzer.py itself: with
+# --import-mode=importlib, pytest's import_path() returns whatever is already
+# in sys.modules[module_name] rather than re-importing, so the real test file
+# would never execute — pytest would instead try to treat the MagicMock-backed
+# stub module as the test module, and accessing its (mocked) `pytestmark`
+# attribute raises TypeError during collection. Nothing else in the codebase
+# imports this submodule (code_intelligence/__init__.py does, but that package
+# is itself fully stubbed above and never executes its real __init__), so
+# leaving it unstubbed is safe.
 for _ci_sub in [
     "code_intelligence.performance_analyzer",
     "code_intelligence.redis_optimizer",
@@ -733,7 +744,6 @@ for _ci_sub in [
     "code_intelligence.pattern_analysis",
     "code_intelligence.precommit_analyzer",
     "code_intelligence.shell_analyzer",
-    "code_intelligence.test_pattern_analyzer",
     "code_intelligence.typescript_analyzer",
     "code_intelligence.vue_analyzer",
     "code_intelligence.doc_generator",


### PR DESCRIPTION
## Thinking Path

Both files failed pytest **collection**, not just execution:

- **#12437** `code_intelligence/test_pattern_analyzer.py` — `TypeError: got <MagicMock ...> instead of Mark`. Traced the traceback into `_pytest.mark.structures.get_unpacked_marks` → `getattr(obj, "pytestmark", [])`. `pytest.ini` sets `--import-mode=importlib`, and `_pytest.pathlib.import_path()` returns `sys.modules[module_name]` if already present rather than re-importing. The root `autobot-backend/conftest.py` unconditionally stubbed `code_intelligence.test_pattern_analyzer` as a `MagicMock`-backed package stub (in the generic `code_intelligence.*` submodule stub loop) — this poisoned `sys.modules` *before* pytest ever tried to collect the real test file. Collection then got the stub instead, and any attribute access (including `pytestmark`) fell through the stub's catch-all `__getattr__` to a `MagicMock`, which fails `pytest`'s `isinstance(mark_obj, Mark)` check. Confirmed nothing else in the codebase imports this submodule (the only importer, `code_intelligence/__init__.py`, never executes — `code_intelligence` itself is fully stubbed above), so it's safe to drop from the stub list.
- **#12436** `code_intelligence/anti_pattern_detector_test.py` — `FileNotFoundError` spec-loading `code_intelligence/../../tools/code-analysis-suite/src/anti_pattern_detector.py`. That path was deleted in the Phase 1/2 repo restructuring (`#781`/`#926`, Feb 2026); the test was never updated. Git-blamed the module through its history (`Issue: #221` matches the test's own header) and, per prior memory, confirmed `autobot-backend/code_analysis/src/anti_pattern_detector.py` is the directory-level descendant with the exact API the test exercises (`.classes`/`.modules` class index, `AntiPatternType`/`AntiPatternInstance`/`ClassInfo`/`ModuleInfo`/`AntiPatternReport`/`AntiPatternDetector`, `GOD_CLASS_*_THRESHOLD`, `_find_all_cycles`, etc.) — repointed the spec path there. This exposed a second latent bug: `Severity.score()` was removed in `#7414` (May 2026) when the local `Severity` enum was consolidated onto the canonical `autobot_shared.status_enums.Severity`, with the int score extracted into a module-level `anti_pattern_score()` helper. Updated the 3 affected assertions to call the helper — same invariant, current API (not weakening the test).

**7-file "pollution" claim**: reproduced the task's exact combined-collect command both before and after the #12437 fix. In both cases only `test_pattern_analyzer.py` itself errored — the 7 named files (`mcp/mcp_security_test.py`, `system_integration_test.py`, `security/security_integration_test.py`, `performance_benchmarks_test.py`, `services/slm_client_test.py`, `services/documentation_watcher_staleness_test.py`, `tests/agents/test_subagent_spawning.py`) already collected cleanly in that exact scenario, so the fix doesn't need to (and doesn't) touch them. Separately, in a **full-repo** `--collect-only` these same 7 filenames *do* error, but for unrelated reasons entirely (`ImportError: cannot import name 'load_core_routers' from 'initialization'`, `ModuleNotFoundError: No module named 'services.mesh_brain'`, etc.) — this is Python's own partial-module-caching behavior: unrelated earlier collectors (`initialization/lifespan_test.py`, `agents/agent_optimizer_test.py`, and others already failing pre-existing with `fastapi.exceptions.FastAPIError` on unrelated `MagicMock` response models) leave a half-executed `initialization`/`services.*` package cached in `sys.modules`, and later imports of those names get the broken cache instead of a fresh import. This is a distinct, pre-existing, much larger-scope bug unrelated to #12436/#12437 — filed as **#12463** rather than expanding this PR's blast radius.

## What Changed

- `autobot-backend/conftest.py`: removed `"code_intelligence.test_pattern_analyzer"` from the generic `code_intelligence.*` submodule stub loop (with an explanatory comment for future maintainers).
- `autobot-backend/code_intelligence/anti_pattern_detector_test.py`: repointed the `spec_from_file_location` path from the deleted `tools/code-analysis-suite/src/anti_pattern_detector.py` to the existing `code_analysis/src/anti_pattern_detector.py`; updated 3 `Severity.score()` calls to the current `anti_pattern_score()` helper.

## Verification

Full-repo `--collect-only` error count dropped from **27 → 25** (only the two targeted files' errors disappeared; diffed the full error-file lists before/after — identical except for the 2 removed entries, confirming zero regressions):

```
$ python3 -m pytest --collect-only -p no:xdist -q   # before
================== 19266 tests collected, 27 errors in 42.62s ==================
ERROR code_intelligence/anti_pattern_detector_test.py - FileNotFoundError: [E...
ERROR code_intelligence/test_pattern_analyzer.py - TypeError: got <MagicMock ...
...(25 other pre-existing, unrelated errors)

$ python3 -m pytest --collect-only -p no:xdist -q   # after
================== 19292 tests collected, 25 errors in 45.61s ==================
...(same 25 pre-existing, unrelated errors — the 2 targeted files no longer appear)
```

Targeted 8-file combined-collect (task's exact repro command), before and after:

```
# before (conftest.py at HEAD)
ERROR code_intelligence/test_pattern_analyzer.py - TypeError: got <MagicMock ...
==================== 147 tests collected, 1 error in 11.07s ====================

# after
======================== 147 tests collected in 11.54s =========================
```

`code_intelligence/test_pattern_analyzer.py --collect-only` standalone: `0 errors` (it's a production module misnamed with a `test_` prefix — 0 collectible tests, just harmless `PytestCollectionWarning`s for its `Enum`/`dataclass` classes).

`code_intelligence/anti_pattern_detector_test.py` full run:

```
$ python3 -m pytest code_intelligence/anti_pattern_detector_test.py -p no:xdist -v
...
============================== 26 passed in 0.54s ==============================
```

`black --check` + `flake8` clean on both changed files.

## Model Used

Claude Sonnet 5

Closes #12436, #12437