### PR TITLE
test(backend): importorskip optional ML dep to skip cleanly when absent (#12438)

### DIFF
--- a/autobot-backend/security/enterprise/threat_detection/test_learner.py
+++ b/autobot-backend/security/enterprise/threat_detection/test_learner.py
@@ -17,8 +17,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from autobot_shared.time_utils import now_utc, utc_timestamp
-from security.enterprise.threat_detection.learner import (
+# Optional ML dependency: importing the threat_detection package pulls in
+# engine.py, which imports scikit-learn. Skip cleanly when sklearn is absent.
+pytest.importorskip("sklearn", reason="scikit-learn not installed — optional ML dep")
+
+from autobot_shared.time_utils import now_utc, utc_timestamp  # noqa: E402
+from security.enterprise.threat_detection.learner import (  # noqa: E402
     _EMA_ALPHA,
     _INACTIVE_DAYS,
     _MITIGATION_KEY_PREFIX,

--- a/autobot-backend/security/threat_detection_refactor_test.py
+++ b/autobot-backend/security/threat_detection_refactor_test.py
@@ -14,8 +14,12 @@ from pathlib import Path
 
 import pytest
 
-from autobot_shared.time_utils import now_utc, utc_timestamp
-from security.enterprise.threat_detection import (
+# Optional ML dependency: threat_detection.engine imports scikit-learn.
+# Skip cleanly when absent; run for real when sklearn IS installed.
+pytest.importorskip("sklearn", reason="scikit-learn not installed — optional ML dep")
+
+from autobot_shared.time_utils import now_utc, utc_timestamp  # noqa: E402
+from security.enterprise.threat_detection import (  # noqa: E402
     AnalysisContext,
     EventHistory,
     SecurityEvent,

--- a/autobot-backend/training/completion_trainer_test.py
+++ b/autobot-backend/training/completion_trainer_test.py
@@ -13,11 +13,16 @@ import tempfile
 from pathlib import Path
 
 import pytest
-import torch
 
-from training.completion_model import CompletionModel
-from training.data_loader import Tokenizer
-from training.evaluator import CompletionEvaluator
+# Optional ML dependency (torch is in requirements-gpu.txt, never default reqs).
+# Skip cleanly when absent; run for real when torch IS installed (e.g. GPU CI).
+pytest.importorskip("torch.nn.functional", reason="torch not installed — optional ML dep")
+
+import torch  # noqa: E402 — after importorskip by design
+
+from training.completion_model import CompletionModel  # noqa: E402
+from training.data_loader import Tokenizer  # noqa: E402
+from training.evaluator import CompletionEvaluator  # noqa: E402
 
 # Module-level marker used by the malicious-pickle test below. A crafted
 # checkpoint whose __reduce__ targets this function would flip the flag if the


### PR DESCRIPTION
Closes #12466
Refs #12438

## Thinking Path
Test collectors hard-errored on missing OPTIONAL ML deps (torch/sklearn, not in default reqs) instead of skipping.

## What Changed
- `training/completion_trainer_test.py`: `pytest.importorskip("torch.nn.functional")` (concrete submodule — conftest stubs bare `torch`, so gating on the submodule skips against the stub and runs against real torch).
- `security/threat_detection_refactor_test.py`: `pytest.importorskip("sklearn")`.
- `security/enterprise/threat_detection/test_learner.py`: added the sklearn gate (forward-correct) but it stays blocked by a SEPARATE pre-existing non-ML bug (`PathConstants.get_config_path` AttributeError via `security/enterprise/__init__.py`->compliance_manager) — reported for its own issue, not fixable by importorskip.

## Verification
- Collect errors 25 -> 23; the 2 fixed files now collect-0/skip-1; black/flake8 clean.

## Model Used
Opus 4.8.