### PR TITLE
docs(build): correct stale Python 3.11 comment on black target-version (#12468)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [tool.black]
 line-length = 120
-# Stays py312 (NOT py314): the NPU/OpenVINO worker runs Python 3.11, and py314
-# target makes black emit PEP 758 unparenthesized `except A, B:` which is a
-# SyntaxError on 3.11 shared code. Bump only when the worker leaves 3.11 (#10877).
+# Stays py312 (NOT py314): the backend runs Python 3.14, but the NPU/OpenVINO
+# worker runs an older Python (its requirements pin 3.12+ — OpenVINO ships no
+# 3.14 wheels). A py314 target makes black emit PEP 758 unparenthesized
+# `except A, B:`, a SyntaxError on that worker's cross-imported shared code.
+# Bump only when the worker gains 3.14 support (#10877).
 target-version = ["py312"]
 
 [tool.isort]


### PR DESCRIPTION
Closes #12468

## Thinking Path
User flagged formatting seemingly targeting an old Python while the stack runs 3.14. Investigation: the whole stack IS on 3.14 (.python-version, Dockerfiles, CI, mypy, requires-python). The only sub-3.14 target is black `target-version = ["py312"]`, which is DELIBERATE (#10877) to keep shared code parseable on the NPU/OpenVINO worker. Owner confirmed the worker is still <3.14 (no OpenVINO 3.14 wheels), so py312 must stay. Only the comment was stale (cited 3.11; worker requirements now say 3.12+).

## What Changed
- `pyproject.toml` [tool.black] comment updated to the current 3.12+ worker floor + enduring OpenVINO-no-3.14-wheels reason. **No change to `target-version` (stays py312); no code reformatted.**

## Verification
- Diff is comment-only (verified: the `target-version` line is unchanged). No formatter/target change, zero code impact.

## Model Used
Opus 4.8.