### PR TITLE
fix(health): correct llm_awareness + single-node/dev-only/idle probe misclassification

### DIFF
--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -781,7 +781,13 @@ async def get_chat_context(chat_id: str):
 async def probe_chat_knowledge(
     request: Request | None = None,
 ) -> ComponentHealth:
-    """Issue #3333: probe registration for the chat-knowledge manager."""
+    """Issue #3333 / #12459: probe registration for the chat-knowledge manager.
+
+    ``chat_knowledge_manager`` is a lazy singleton created on first use
+    (``get_chat_knowledge_manager_instance``) — "not initialized" simply
+    means no chat has touched it yet, not a failure. Report ``idle`` so it
+    does not count toward the down/degraded rollup.
+    """
     try:
         app_manager = None
         if request is not None:
@@ -790,8 +796,8 @@ async def probe_chat_knowledge(
         if manager is None:
             return ComponentHealth(
                 name="chat_knowledge",
-                status="degraded",
-                detail="chat_knowledge_manager not initialized",
+                status="idle",
+                detail="chat_knowledge_manager not initialized (lazy singleton, not yet used)",
             )
         return ComponentHealth(name="chat_knowledge", status="ok")
     except Exception as exc:

--- a/autobot-backend/api/enterprise_features.py
+++ b/autobot-backend/api/enterprise_features.py
@@ -27,7 +27,7 @@ from api.schemas_workflows import (
     FeatureEnableRequest,
     PerformanceOptimizationRequest,
 )
-from api.system_health import register_singleton_probe
+from api.system_health import ComponentHealth, register_health_probe
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -481,7 +481,41 @@ async def bulk_enable_features(request: BulkFeatureRequest):
         raise HTTPException(status_code=500, detail="Bulk enablement failed")
 
 
-register_singleton_probe("enterprise_features", get_enterprise_manager)
+@register_health_probe("enterprise_features")
+async def _probe_enterprise_features(request=None) -> ComponentHealth:
+    """Issue #3333 / #12459: probe registration for the enterprise-feature manager.
+
+    ``EnterpriseFeatureManager`` requires a full 6-VM topology
+    (``AUTOBOT_*_HOST``/``AUTOBOT_*_PORT``) to build its VM map. On a
+    single-node/co-located install that topology is intentionally absent —
+    this is expected, not a failure, and must not force overall
+    system-health to ``down``. A genuinely broken manager (any error other
+    than the topology ``ValueError``) still reports ``down``.
+    """
+    try:
+        instance = get_enterprise_manager()
+        if instance is None:
+            return ComponentHealth(name="enterprise_features", status="down", detail="singleton returned None")
+        return ComponentHealth(name="enterprise_features", status="ok")
+    except ValueError as exc:
+        if "VM topology configuration missing" in str(exc):
+            return ComponentHealth(
+                name="enterprise_features",
+                status="not_applicable",
+                detail="multi-VM topology not configured (expected on single-node)",
+            )
+        return ComponentHealth(
+            name="enterprise_features",
+            status="down",
+            detail=f"probe error: ValueError: {str(exc).strip()[:160]}",
+        )
+    except Exception as exc:
+        reason = str(exc).strip() or "no detail"
+        return ComponentHealth(
+            name="enterprise_features",
+            status="down",
+            detail=f"probe error: {type(exc).__name__}: {reason[:160]}",
+        )
 
 
 @router.post("/performance/optimize", response_model=DataResponse[EnterprisePerformanceOptimizeResponse])

--- a/autobot-backend/api/hot_reload.py
+++ b/autobot-backend/api/hot_reload.py
@@ -188,7 +188,15 @@ async def stop_hot_reload():
 async def probe_hot_reload(
     request: Request | None = None,
 ) -> ComponentHealth:
-    """Issue #3333: probe registration for hot-reload file watcher."""
+    """Issue #3333 / #12459: probe registration for the hot-reload file watcher.
+
+    The watcher is dev-only tooling — nothing starts it automatically at
+    boot (only the admin-only ``POST /hot-reload/start`` endpoint does), so
+    "not running" is the expected steady state in every deployment,
+    including production. Report ``not_applicable`` rather than
+    ``degraded`` so this opt-in dev feature never drags overall
+    system-health down.
+    """
     try:
         from utils.hot_reload_manager import hot_reload_manager
 
@@ -197,8 +205,8 @@ async def probe_hot_reload(
             return ComponentHealth(name="hot_reload", status="ok")
         return ComponentHealth(
             name="hot_reload",
-            status="degraded",
-            detail="watcher not running",
+            status="not_applicable",
+            detail="watcher not running (dev-only, off by default — start via POST /hot-reload/start)",
         )
     except Exception as exc:
         return ComponentHealth(

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -206,18 +206,18 @@ async def get_system_info(
 async def probe_intelligent_agent(
     request: Request | None = None,
 ) -> ComponentHealth:
-    """Issue #3333: probe registration for intelligent_agent module.
+    """Issue #3333 / #12459: probe registration for intelligent_agent module.
 
     Lightweight check: inspect the module-level lazy singleton without forcing
-    initialization. ``ok`` if already initialized; ``degraded`` if not yet
-    initialized (legitimate cold-start state).
+    initialization. ``ok`` if already initialized; ``idle`` if not yet
+    initialized — a legitimate cold-start/not-yet-used state, not a failure.
     """
     try:
         if _agent_instance is None:
             return ComponentHealth(
                 name="intelligent_agent",
-                status="degraded",
-                detail="agent not yet initialized",
+                status="idle",
+                detail="agent not yet initialized (lazy singleton, not yet used)",
             )
         return ComponentHealth(name="intelligent_agent", status="ok")
     except Exception as exc:

--- a/autobot-backend/api/llm_awareness.py
+++ b/autobot-backend/api/llm_awareness.py
@@ -25,7 +25,7 @@ from api.schemas_agent import (
     PromptInjectionRequest,
     QueryAnalysisRequest,
 )
-from api.system_health import register_singleton_probe
+from api.system_health import ComponentHealth, register_health_probe
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from llm_self_awareness import get_llm_self_awareness
@@ -347,4 +347,32 @@ async def export_awareness_data(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-register_singleton_probe("llm_awareness", get_llm_self_awareness)
+@register_health_probe("llm_awareness")
+async def _probe_llm_awareness(request=None) -> ComponentHealth:
+    """Issue #3333 / #12458: probe registration for the LLM self-awareness singleton.
+
+    The optional ``PhaseValidator`` dependency (``autobot-infrastructure``) is
+    not deployed to ``autobot-backend`` — its absence is expected and must
+    not force this probe (and therefore the overall system-health rollup) to
+    ``down``. Report ``ok`` either way; surface a detail note when the
+    optional validation sub-component is unavailable so operators can see
+    it without it counting as a failure.
+    """
+    try:
+        awareness = get_llm_self_awareness()
+        if awareness is None:
+            return ComponentHealth(name="llm_awareness", status="down", detail="singleton returned None")
+        if getattr(awareness.state_tracker, "validator", None) is None:
+            return ComponentHealth(
+                name="llm_awareness",
+                status="ok",
+                detail="llm_awareness validation unavailable (optional component not installed)",
+            )
+        return ComponentHealth(name="llm_awareness", status="ok")
+    except Exception as exc:
+        reason = str(exc).strip() or "no detail"
+        return ComponentHealth(
+            name="llm_awareness",
+            status="down",
+            detail=f"probe error: {type(exc).__name__}: {reason[:160]}",
+        )

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -85,11 +85,14 @@ async def get_playwright_status():
 async def probe_playwright(
     request: Request | None = None,
 ) -> ComponentHealth:
-    """Issue #3333: probe registration for playwright module.
+    """Issue #3333 / #12459: probe registration for playwright module.
 
     Lightweight check: inspect the module-level singleton without forcing
     creation (which would require env-var resolution and a network probe).
-    ``ok`` if already initialized; ``degraded`` if not yet initialized.
+    ``ok`` if already initialized; ``idle`` if not yet initialized — the
+    browser-automation worker is opt-in (used only when a research/browser
+    task runs) so a fresh boot with no such task yet is expected, not a
+    failure.
     """
     try:
         from services import playwright_service as _ps_mod
@@ -97,8 +100,8 @@ async def probe_playwright(
         if getattr(_ps_mod, "_playwright_service", None) is None:
             return ComponentHealth(
                 name="playwright",
-                status="degraded",
-                detail="service not yet initialized",
+                status="idle",
+                detail="service not yet initialized (lazy singleton, not yet used)",
             )
         return ComponentHealth(name="playwright", status="ok")
     except Exception as exc:

--- a/autobot-backend/api/redis_service.py
+++ b/autobot-backend/api/redis_service.py
@@ -275,23 +275,32 @@ async def get_redis_status(manager: RedisServiceManager = Depends(get_service_ma
 async def probe_redis_service(
     request: Request | None = None,
 ) -> ComponentHealth:
-    """Issue #3333: probe registration for Redis service-manager health."""
+    """Issue #3333 / #12459: probe registration for Redis service-manager health.
+
+    #12459: ``detail`` previously echoed the bare ``overall_status`` word
+    ("degraded"), which is not diagnosable when Redis itself pings fine —
+    the real cause (SLM couldn't confirm systemd state, connectivity down,
+    slow response, ...) lives in ``HealthStatus.recommendations`` but was
+    never surfaced. Join it into ``detail`` so a "degraded" result always
+    says *which* check failed.
+    """
     try:
         manager = await get_service_manager()
         health = await manager.get_health()
         overall = (health.overall_status or "").lower()
+        reasons = "; ".join(health.recommendations or []) or None
         if overall in ("healthy", "ok"):
             return ComponentHealth(name="redis_service", status="ok")
         if overall in ("degraded", "warning"):
             return ComponentHealth(
                 name="redis_service",
                 status="degraded",
-                detail=health.overall_status,
+                detail=reasons or health.overall_status,
             )
         return ComponentHealth(
             name="redis_service",
             status="down",
-            detail=health.overall_status or "service unhealthy",
+            detail=reasons or health.overall_status or "service unhealthy",
         )
     except Exception as exc:
         return ComponentHealth(

--- a/autobot-backend/api/system_health.py
+++ b/autobot-backend/api/system_health.py
@@ -58,7 +58,17 @@ class KnownProbes(str, enum.Enum):
 # component cannot hold the aggregator hostage.
 _PROBE_TIMEOUT_S = 2.0
 
-HealthStatus = Literal["ok", "degraded", "down"]
+# Issue #12459: "ok"/"degraded"/"down" alone cannot express an EXPECTED
+# absence (single-node topology, dev-only tooling intentionally off,
+# lazy singleton not yet touched). Forcing those into "degraded"/"down"
+# trains operators to ignore a noisy health page and can mask a real
+# failure. Two additional states are excluded from the aggregate rollup
+# (see ``_aggregate_status``) but are still visible per-component:
+#   not_applicable — the check genuinely does not apply here (single-node
+#                    multi-VM config, a dev-only feature intentionally off).
+#   idle           — a lazy singleton that will initialize on first use;
+#                    "not yet used" is not a failure.
+HealthStatus = Literal["ok", "degraded", "down", "not_applicable", "idle"]
 
 
 class ComponentHealth(BaseModel):
@@ -144,6 +154,9 @@ async def _run_probe(name: str, fn: ProbeFn, request: Request | None) -> Compone
 
 
 def _aggregate_status(components: list[ComponentHealth]) -> HealthStatus:
+    # Issue #12459: "not_applicable" and "idle" are deliberately excluded from
+    # both branches below — an expected-absent or not-yet-used component must
+    # not drag a healthy single-node deployment's overall status down.
     if any(c.status == "down" for c in components):
         return "down"
     if any(c.status == "degraded" for c in components):

--- a/autobot-backend/api/system_health_classification_test.py
+++ b/autobot-backend/api/system_health_classification_test.py
@@ -21,8 +21,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from api.system_health import (
-    ComponentHealth,
     _PROBES,
+    ComponentHealth,
     _aggregate_status,
     collect_system_health,
     register_health_probe,

--- a/autobot-backend/api/system_health_classification_test.py
+++ b/autobot-backend/api/system_health_classification_test.py
@@ -1,0 +1,311 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for the single-node/dev-only/idle probe reclassification (#12459)
+and the ``llm_awareness`` optional-dependency fix (#12458).
+
+Each probe test asserts BOTH sides of the fix:
+  - the EXPECTED-absent condition now reports a non-blocking status
+    (``not_applicable`` / ``idle`` / informational ``ok``), and
+  - a genuine failure still reports ``down`` (no blanket suppression).
+
+A final scenario runs the real aggregator (``collect_system_health``) with a
+representative single-node probe set to prove overall status is ``ok``, and
+with one genuine failure mixed in to prove overall status is still ``down``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.system_health import (
+    ComponentHealth,
+    _PROBES,
+    _aggregate_status,
+    collect_system_health,
+    register_health_probe,
+)
+
+
+class TestAggregateStatusExcludesExpectedStates:
+    """Pure-function coverage for the not_applicable/idle rollup exclusion."""
+
+    def test_not_applicable_and_idle_alone_roll_up_to_ok(self):
+        components = [
+            ComponentHealth(name="a", status="not_applicable"),
+            ComponentHealth(name="b", status="idle"),
+            ComponentHealth(name="c", status="ok"),
+        ]
+        assert _aggregate_status(components) == "ok"
+
+    def test_down_still_wins_even_alongside_not_applicable(self):
+        components = [
+            ComponentHealth(name="a", status="not_applicable"),
+            ComponentHealth(name="b", status="down"),
+        ]
+        assert _aggregate_status(components) == "down"
+
+    def test_degraded_still_wins_even_alongside_idle(self):
+        components = [
+            ComponentHealth(name="a", status="idle"),
+            ComponentHealth(name="b", status="degraded"),
+        ]
+        assert _aggregate_status(components) == "degraded"
+
+
+class TestEnterpriseFeaturesProbe:
+    """Issue #12459: single-node (no multi-VM topology) must not be 'down'."""
+
+    @pytest.mark.asyncio
+    async def test_missing_vm_topology_is_not_applicable(self, monkeypatch: pytest.MonkeyPatch):
+        import api.enterprise_features as mod
+
+        def _raise_topology_missing():
+            raise ValueError(
+                "VM topology configuration missing: All AUTOBOT_*_HOST and AUTOBOT_*_PORT environment variables must be set"
+            )
+
+        monkeypatch.setattr(mod, "get_enterprise_manager", _raise_topology_missing)
+
+        result = await mod._probe_enterprise_features()
+
+        assert result.status == "not_applicable"
+        assert "single-node" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_genuine_failure_still_down(self, monkeypatch: pytest.MonkeyPatch):
+        import api.enterprise_features as mod
+
+        def _raise_other():
+            raise RuntimeError("config file corrupted")
+
+        monkeypatch.setattr(mod, "get_enterprise_manager", _raise_other)
+
+        result = await mod._probe_enterprise_features()
+
+        assert result.status == "down"
+
+    @pytest.mark.asyncio
+    async def test_configured_topology_is_ok(self, monkeypatch: pytest.MonkeyPatch):
+        import api.enterprise_features as mod
+
+        monkeypatch.setattr(mod, "get_enterprise_manager", lambda: MagicMock())
+
+        result = await mod._probe_enterprise_features()
+
+        assert result.status == "ok"
+
+
+class TestHotReloadProbe:
+    """Issue #12459: dev-only watcher off is expected in every environment."""
+
+    @pytest.mark.asyncio
+    async def test_watcher_not_running_is_not_applicable(self, monkeypatch: pytest.MonkeyPatch):
+        import utils.hot_reload_manager as hrm_mod
+        from api.hot_reload import probe_hot_reload
+
+        monkeypatch.setattr(hrm_mod.hot_reload_manager, "get_status", AsyncMock(return_value={"running": False}))
+
+        result = await probe_hot_reload()
+
+        assert result.status == "not_applicable"
+
+    @pytest.mark.asyncio
+    async def test_probe_error_still_down(self, monkeypatch: pytest.MonkeyPatch):
+        import utils.hot_reload_manager as hrm_mod
+        from api.hot_reload import probe_hot_reload
+
+        monkeypatch.setattr(
+            hrm_mod.hot_reload_manager, "get_status", AsyncMock(side_effect=RuntimeError("watcher crashed"))
+        )
+
+        result = await probe_hot_reload()
+
+        assert result.status == "down"
+
+
+class TestLazySingletonProbesReportIdle:
+    """Issue #12459: not-yet-used lazy singletons are idle, not degraded."""
+
+    @pytest.mark.asyncio
+    async def test_chat_knowledge_not_initialized_is_idle(self, monkeypatch: pytest.MonkeyPatch):
+        import api.chat_knowledge as mod
+
+        monkeypatch.setattr(mod, "chat_knowledge_manager", None)
+
+        result = await mod.probe_chat_knowledge(request=None)
+
+        assert result.status == "idle"
+
+    @pytest.mark.asyncio
+    async def test_intelligent_agent_not_initialized_is_idle(self, monkeypatch: pytest.MonkeyPatch):
+        import api.intelligent_agent as mod
+
+        monkeypatch.setattr(mod, "_agent_instance", None)
+
+        result = await mod.probe_intelligent_agent()
+
+        assert result.status == "idle"
+
+    @pytest.mark.asyncio
+    async def test_playwright_not_initialized_is_idle(self, monkeypatch: pytest.MonkeyPatch):
+        import services.playwright_service as ps_mod
+        from api.playwright import probe_playwright
+
+        monkeypatch.setattr(ps_mod, "_playwright_service", None, raising=False)
+
+        result = await probe_playwright()
+
+        assert result.status == "idle"
+
+
+class TestRedisServiceProbeDetail:
+    """Issue #12459: 'degraded' must carry an actionable reason."""
+
+    @pytest.mark.asyncio
+    async def test_degraded_detail_is_actionable_not_bare_status_word(self, monkeypatch: pytest.MonkeyPatch):
+        import api.redis_service as mod
+
+        fake_health = MagicMock(
+            overall_status="degraded",
+            recommendations=[
+                "Service manager (SLM) could not confirm systemd status for "
+                "redis-stack-server, but Redis itself responded to a direct "
+                "ping — this is a service-management visibility gap, not a "
+                "Redis outage"
+            ],
+        )
+        fake_manager = MagicMock()
+        fake_manager.get_health = AsyncMock(return_value=fake_health)
+        monkeypatch.setattr(mod, "get_service_manager", AsyncMock(return_value=fake_manager))
+
+        result = await mod.probe_redis_service()
+
+        assert result.status == "degraded"
+        assert result.detail != "degraded"
+        assert "visibility gap" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_healthy_redis_is_ok(self, monkeypatch: pytest.MonkeyPatch):
+        import api.redis_service as mod
+
+        fake_health = MagicMock(overall_status="healthy", recommendations=[])
+        fake_manager = MagicMock()
+        fake_manager.get_health = AsyncMock(return_value=fake_health)
+        monkeypatch.setattr(mod, "get_service_manager", AsyncMock(return_value=fake_manager))
+
+        result = await mod.probe_redis_service()
+
+        assert result.status == "ok"
+
+    @pytest.mark.asyncio
+    async def test_critical_redis_is_still_down(self, monkeypatch: pytest.MonkeyPatch):
+        import api.redis_service as mod
+
+        fake_health = MagicMock(overall_status="critical", recommendations=["Redis process is not reachable"])
+        fake_manager = MagicMock()
+        fake_manager.get_health = AsyncMock(return_value=fake_health)
+        monkeypatch.setattr(mod, "get_service_manager", AsyncMock(return_value=fake_manager))
+
+        result = await mod.probe_redis_service()
+
+        assert result.status == "down"
+        assert "not reachable" in result.detail
+
+
+class TestLlmAwarenessProbe:
+    """Issue #12458: optional PhaseValidator absence must not force 'down'."""
+
+    @pytest.mark.asyncio
+    async def test_missing_optional_validator_is_ok_with_detail(self, monkeypatch: pytest.MonkeyPatch):
+        import api.llm_awareness as mod
+
+        fake_awareness = MagicMock()
+        fake_awareness.state_tracker.validator = None
+        monkeypatch.setattr(mod, "get_llm_self_awareness", lambda: fake_awareness)
+
+        result = await mod._probe_llm_awareness()
+
+        assert result.status == "ok"
+        assert "optional component not installed" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_available_validator_is_ok_no_detail(self, monkeypatch: pytest.MonkeyPatch):
+        import api.llm_awareness as mod
+
+        fake_awareness = MagicMock()
+        fake_awareness.state_tracker.validator = MagicMock()
+        monkeypatch.setattr(mod, "get_llm_self_awareness", lambda: fake_awareness)
+
+        result = await mod._probe_llm_awareness()
+
+        assert result.status == "ok"
+        assert result.detail is None
+
+    @pytest.mark.asyncio
+    async def test_genuine_construction_failure_is_still_down(self, monkeypatch: pytest.MonkeyPatch):
+        import api.llm_awareness as mod
+
+        def _raise():
+            raise RuntimeError("redis unreachable")
+
+        monkeypatch.setattr(mod, "get_llm_self_awareness", _raise)
+
+        result = await mod._probe_llm_awareness()
+
+        assert result.status == "down"
+
+
+class TestSingleNodeAggregateHealthy:
+    """End-to-end: a representative single-node probe set rolls up to 'ok',
+    and a genuine failure mixed into the same set still rolls up to 'down'.
+
+    ``_PROBES`` is process-global — other already-imported modules may have
+    registered real probes (e.g. a real ``redis_service`` probe that could
+    itself fail in a sandboxed test environment with no reachable Redis).
+    Snapshot/restore it so this test exercises ONLY the representative
+    single-node set, not whatever else happens to be registered.
+    """
+
+    def setup_method(self):
+        self._saved_probes = dict(_PROBES)
+        _PROBES.clear()
+
+    def teardown_method(self):
+        _PROBES.clear()
+        _PROBES.update(self._saved_probes)
+
+    @pytest.mark.asyncio
+    async def test_single_node_scenario_is_overall_ok(self):
+        @register_health_probe("t12459_enterprise")
+        async def _p1(request=None):
+            return ComponentHealth(name="t12459_enterprise", status="not_applicable", detail="single-node")
+
+        @register_health_probe("t12459_hot_reload")
+        async def _p2(request=None):
+            return ComponentHealth(name="t12459_hot_reload", status="not_applicable", detail="dev-only, off")
+
+        @register_health_probe("t12459_lazy")
+        async def _p3(request=None):
+            return ComponentHealth(name="t12459_lazy", status="idle", detail="not yet used")
+
+        health = await collect_system_health()
+
+        assert health.status == "ok"
+        assert {c.name for c in health.components} == {"t12459_enterprise", "t12459_hot_reload", "t12459_lazy"}
+
+    @pytest.mark.asyncio
+    async def test_genuine_failure_amongst_expected_states_is_still_down(self):
+        @register_health_probe("t12459_enterprise")
+        async def _p1(request=None):
+            return ComponentHealth(name="t12459_enterprise", status="not_applicable", detail="single-node")
+
+        @register_health_probe("t12459_real_failure")
+        async def _p2(request=None):
+            return ComponentHealth(name="t12459_real_failure", status="down", detail="database connection refused")
+
+        health = await collect_system_health()
+
+        assert health.status == "down"

--- a/autobot-backend/project_state_tracking/tracker.py
+++ b/autobot-backend/project_state_tracking/tracker.py
@@ -88,7 +88,16 @@ class ProjectStateTracker:
         # Core components
         self.progression_manager = get_progression_manager()
         self.legacy_state_manager = ProjectStateManager()
-        self.validator = PhaseValidator(self.project_root)
+        # PhaseValidator lives in autobot-infrastructure — guard against MissingDep
+        # so the tracker (and the llm_awareness singleton that depends on it via
+        # get_state_tracker()) can be constructed even when the infrastructure
+        # repo is not on PYTHONPATH. Mirrors the same guard in
+        # PhaseProgressionManager.__init__ (#10466). Issue #12458.
+        try:
+            self.validator = PhaseValidator(self.project_root)
+        except Exception:
+            logger.debug("PhaseValidator unavailable; phase-validation snapshots disabled")
+            self.validator = None
 
         # State tracking
         self.state_history: List[StateSnapshot] = []
@@ -196,8 +205,14 @@ class ProjectStateTracker:
         Issue #620: Further refactored to extract snapshot creation and history.
         """
         try:
-            # Get phase validation results and capabilities
-            validation_results = await self.validator.validate_all_phases()
+            # Get phase validation results and capabilities. #12458: validator
+            # is None when the optional PhaseValidator dependency is absent —
+            # fall back to an empty validation result instead of failing the
+            # snapshot outright.
+            if self.validator is None:
+                validation_results = {"phases": {}, "overall_assessment": {"system_maturity_score": 0}}
+            else:
+                validation_results = await self.validator.validate_all_phases()
             capabilities = self.progression_manager.get_current_system_capabilities()
 
             # Extract phase states and calculate metrics (Issue #665: uses helpers)

--- a/autobot-backend/project_state_tracking/tracker_test.py
+++ b/autobot-backend/project_state_tracking/tracker_test.py
@@ -1,0 +1,93 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for the PhaseValidator absent-optional-dependency guard (#12458).
+
+``ProjectStateTracker.__init__`` used to call ``PhaseValidator(project_root)``
+unguarded. On any backend deployment where ``autobot-infrastructure`` is not
+on ``PYTHONPATH`` (every autobot-backend deploy, per #12458), ``PhaseValidator``
+is a ``MissingDep`` sentinel and calling it raises ``ImportError`` — which
+propagated out of ``__init__`` and made the ``llm_awareness`` health probe
+permanently ``down`` (``get_llm_self_awareness -> get_state_tracker ->
+ProjectStateTracker()``).
+
+These tests isolate the guard from the tracker's heavy collaborators
+(Redis, SQLite, background asyncio task) via monkeypatching, matching the
+already-tested guard pattern in ``PhaseProgressionManager.__init__`` (#10466).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import project_state_tracking.tracker as tracker_module
+from autobot_shared.missing_dep import MissingDep
+
+
+def _patch_heavy_collaborators(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize every non-validator side effect of ``ProjectStateTracker.__init__``."""
+    monkeypatch.setattr(tracker_module, "get_progression_manager", lambda: MagicMock())
+    monkeypatch.setattr(tracker_module, "ProjectStateManager", MagicMock)
+    monkeypatch.setattr(tracker_module, "get_redis_client", lambda: MagicMock())
+    monkeypatch.setattr(tracker_module, "get_error_boundary_manager", lambda: None)
+    monkeypatch.setattr(tracker_module, "init_database", lambda *_a, **_k: None)
+    monkeypatch.setattr(tracker_module.ProjectStateTracker, "_define_milestones", lambda self: None)
+    monkeypatch.setattr(tracker_module.ProjectStateTracker, "_load_state", lambda self: None)
+    monkeypatch.setattr(tracker_module.ProjectStateTracker, "_start_background_tracking", lambda self: None)
+
+
+class TestPhaseValidatorGuard:
+    """Issue #12458: absent optional PhaseValidator must not raise."""
+
+    def test_missing_phase_validator_yields_none_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MissingDep sentinel (the real production state) -> validator is None, no raise."""
+        _patch_heavy_collaborators(monkeypatch)
+        sentinel = MissingDep("PhaseValidator", ImportError("No module named 'scripts.phase_validation_system'"))
+        monkeypatch.setattr(tracker_module, "PhaseValidator", sentinel)
+
+        tracker = tracker_module.ProjectStateTracker(db_path="unused.db")
+
+        assert tracker.validator is None
+
+    def test_available_phase_validator_is_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When PhaseValidator IS importable (infra repo on path), it is still wired up."""
+        _patch_heavy_collaborators(monkeypatch)
+        fake_validator_instance = MagicMock()
+        fake_validator_cls = MagicMock(return_value=fake_validator_instance)
+        monkeypatch.setattr(tracker_module, "PhaseValidator", fake_validator_cls)
+
+        tracker = tracker_module.ProjectStateTracker(db_path="unused.db")
+
+        assert tracker.validator is fake_validator_instance
+
+    @pytest.mark.asyncio
+    async def test_capture_state_snapshot_degrades_gracefully_without_validator(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing validator must not blow up capture_state_snapshot either."""
+        _patch_heavy_collaborators(monkeypatch)
+        sentinel = MissingDep("PhaseValidator", ImportError("No module named 'scripts.phase_validation_system'"))
+        monkeypatch.setattr(tracker_module, "PhaseValidator", sentinel)
+
+        tracker = tracker_module.ProjectStateTracker(db_path="unused.db")
+        assert tracker.validator is None
+
+        # progression_manager is a MagicMock — give it real dict-shaped returns
+        # so the snapshot-building helpers (which index into the result) work.
+        tracker.progression_manager.get_current_system_capabilities.return_value = {
+            "active_capabilities": [],
+            "system_maturity": 0,
+        }
+        tracker.progression_manager.config = {}
+
+        async def _noop(*_a, **_k):
+            return None
+
+        monkeypatch.setattr(tracker, "_save_snapshot", _noop)
+        monkeypatch.setattr(tracker, "_check_milestones", _noop)
+
+        snapshot = await tracker.capture_state_snapshot()
+
+        assert snapshot.phase_states == {}

--- a/autobot-backend/services/redis_service_manager.py
+++ b/autobot-backend/services/redis_service_manager.py
@@ -551,15 +551,32 @@ class RedisServiceManager:
         return "critical"
 
     def _generate_health_recommendations(
-        self, service_running: bool, connectivity: bool, response_time_ms: float
+        self,
+        service_running: bool,
+        connectivity: bool,
+        response_time_ms: float,
+        service_status: str = "unknown",
     ) -> List[str]:
         """
         Generate health recommendations based on current state.
 
         (Issue #398: extracted helper)
+        Issue #12459: ``service_running`` collapses "confirmed stopped" and
+        "SLM couldn't confirm systemd state" (``service_status == "unknown"``)
+        into the same falsy value, so this used to claim the service "is not
+        running" even when direct Redis connectivity proved it clearly was.
+        Distinguish the SLM-unreachable-but-reachable case so the message is
+        accurate instead of misleading (#12459 health-probe audit).
         """
         recommendations = []
-        if not service_running:
+        if service_status == "unknown" and connectivity:
+            recommendations.append(
+                "Service manager (SLM) could not confirm systemd status for "
+                "redis-stack-server, but Redis itself responded to a direct "
+                "ping — this is a service-management visibility gap, not a "
+                "Redis outage"
+            )
+        elif not service_running:
             recommendations.append("Redis Stack service is not running - consider starting it")
         if not connectivity and service_running:
             recommendations.append("Redis Stack service running but not responding - check logs")
@@ -582,7 +599,9 @@ class RedisServiceManager:
 
             connectivity, response_time_ms = await self._check_redis_connectivity()
             overall_status = self._determine_health_status(service_running, connectivity, status.status)
-            recommendations = self._generate_health_recommendations(service_running, connectivity, response_time_ms)
+            recommendations = self._generate_health_recommendations(
+                service_running, connectivity, response_time_ms, status.status
+            )
 
             return HealthStatus(
                 overall_status=overall_status,

--- a/autobot-frontend/src/models/repositories/SystemRepository.ts
+++ b/autobot-frontend/src/models/repositories/SystemRepository.ts
@@ -9,14 +9,20 @@ import type { BackendSettings as BackendConfig } from '@/types/settings'
 import { getApiBase } from '@/config/ssot-config'
 
 /**
- * Backend `/api/system/health` response shape (#5212, updated #6909).
+ * Backend `/api/system/health` response shape (#5212, updated #6909, #12459).
  *
  * Issue #6909: status and component values use probe vocabulary
  * ("ok" | "degraded" | "down") — the legacy "healthy"/"unhealthy" mapping
  * was retired on the backend. Frontend callers that previously checked
  * `status === 'healthy'` must now check `status === 'ok'`.
+ *
+ * Issue #12459: individual probes can also report `not_applicable`
+ * (expected-absent on this deployment, e.g. single-node/dev-only) or
+ * `idle` (lazy singleton not yet used) — neither counts toward the
+ * aggregate `HealthCheckResponse.status`, which stays `ok | degraded | down`.
  */
 export type HealthStatus = 'ok' | 'degraded' | 'down'
+export type ComponentHealthStatus = HealthStatus | 'not_applicable' | 'idle'
 
 export interface HealthCheckResponse {
   status: HealthStatus
@@ -25,7 +31,7 @@ export interface HealthCheckResponse {
     status: string
     message?: string
   }
-  components?: Record<string, HealthStatus>
+  components?: Record<string, ComponentHealthStatus>
 }
 
 /**


### PR DESCRIPTION
## Thinking Path

Traced `llm_awareness` (#12458) to `ProjectStateTracker.__init__` calling `PhaseValidator(project_root)` **unguarded** — unlike `PhaseProgressionManager.__init__`, which already guards the same optional `autobot-infrastructure` dependency (#10466). That inconsistency, not a missing status vocabulary, was the actual root cause: the singleton construction raised `ImportError` on every probe run.

For #12459, read each cited probe's implementation:
- `enterprise_features` raises `ValueError` when `EnterpriseFeatureManager` can't build a full 6-VM topology — expected on single-node.
- `hot_reload` reports "watcher not running" — nothing starts this dev-only watcher automatically at boot in ANY environment (only an admin-only `POST /hot-reload/start` does), so "not running" is the universal steady state.
- `chat_knowledge` / `intelligent_agent` / `playwright` all follow the same "module-level lazy singleton, not yet constructed" pattern — a legitimate not-yet-used state, not a failure.
- `redis_service` already computed a `recommendations` list with the actual diagnosis but never surfaced it — `detail` just echoed the bare word `"degraded"`. Deeper look: the `service_status == "unknown"` (SLM couldn't confirm systemd state) + `connectivity=True` (Redis pings fine) branch produced a **misleading** recommendation claiming "service is not running," which is false when Redis is directly reachable.

None of `ok`/`degraded`/`down` can express "expected absent" vs. "not yet used" without lying either way, so I added two states (`not_applicable`, `idle`) to the existing `HealthStatus` vocabulary in `api/system_health.py` and excluded both from `_aggregate_status`'s down/degraded rollup — genuine failures still count.

## What Changed

**#12458**
- `autobot-backend/project_state_tracking/tracker.py`: guard `PhaseValidator(project_root)` in `ProjectStateTracker.__init__` (mirrors the existing `PhaseProgressionManager` guard, #10466); guard the same call in `capture_state_snapshot`.
- `autobot-backend/api/llm_awareness.py`: replaced the generic `register_singleton_probe` with a custom probe — `ok` either way, with an informational detail (`"llm_awareness validation unavailable (optional component not installed)"`) when the optional validator is absent.

**#12459** (per-probe classification — see file for rationale on each)
- `api/enterprise_features.py`: VM-topology-missing `ValueError` → `not_applicable`; any other error still `down`.
- `api/hot_reload.py`: watcher-not-running → `not_applicable` (dev-only, never auto-started).
- `api/chat_knowledge.py`, `api/intelligent_agent.py`, `api/playwright.py`: not-yet-initialized lazy singleton → `idle` instead of `degraded`.
- `api/redis_service.py` + `services/redis_service_manager.py`: probe now surfaces `HealthStatus.recommendations` as `detail` instead of the bare status word; fixed the recommendation text itself, which falsely claimed "not running" when SLM merely couldn't confirm systemd state and Redis was directly reachable.
- `api/system_health.py`: `HealthStatus` gains `not_applicable` / `idle`; `_aggregate_status` excludes both from the down/degraded rollup (only `ok`/`degraded`/`down` ever appear in the aggregate `status` field).
- `autobot-frontend/.../SystemRepository.ts`: widened the `components` dict's per-entry type to include the two new states; the aggregate `status` field type is unchanged (`ok | degraded | down`).

**Left unchanged (reasoning below):** `content_reach` ("5 sources; dead: ['social']") is a genuine partial failure (1/6 providers down) — real, actionable information, correctly `degraded`. Not touched.

**Discovered, filed separately (#12470, not fixed here — 3-call-site blast radius, a config-semantics decision beyond a probe fix):** `EnterpriseFeatureManager` reads `config.redis_port` (`MiscConfig`, legacy `REDIS_PORT` alias, default `0`) instead of `config.port.redis` (`PortConfig`, default `6379`) — on any box where `REDIS_PORT` isn't explicitly set (every single-node/dev install; production Ansible templates do set it), this alone used to trip the "VM topology missing" error. The #12459 fix classifies the resulting error correctly regardless of root cause, so this is a latent-bug cleanup, not a blocker.

## Verification

```
$ python3 -m pytest autobot-backend/api/system_health_classification_test.py \
    autobot-backend/api/system_health_test.py \
    autobot-backend/project_state_tracking/tracker_test.py \
    autobot-backend/services/redis_service_manager_test.py -p no:xdist -q
======================= 49 passed, 37 warnings in 3.63s ========================
```

New coverage includes:
- Per-probe expected-state-vs-genuine-failure pairs (enterprise_features, hot_reload, chat_knowledge, intelligent_agent, playwright, redis_service, llm_awareness).
- `_aggregate_status` unit tests: `not_applicable`/`idle` alone → `ok`; `down`/`degraded` still win when present alongside them.
- End-to-end `collect_system_health()` scenario (probe registry snapshotted/restored to avoid cross-test global-state leakage): a representative single-node probe set (`not_applicable` × 2, `idle` × 1) → overall `ok`; the same set plus one genuine `down` probe → overall `down`.
- `tracker_test.py`: `PhaseValidator` absent → `validator is None`, construction does not raise; present → still wired up; `capture_state_snapshot` degrades gracefully without a validator.

```
$ python3 -m black --check <all touched .py files>
All done! ✨ 🍰 ✨  (12 files unchanged)
$ python3 -m flake8 <all touched .py files>
(clean, 0 issues)
```

Manually exercised every fixed probe against this real (non-mocked) environment to confirm the classification end-to-end:
```
llm_awareness -> down | probe error: OperationalError: unable to open database file   (see note below)
enterprise_features -> ok | None      (this box's .env sets REDIS_PORT — matches production)
hot_reload -> not_applicable | watcher not running (dev-only, off by default — start via POST /hot-reload/start)
chat_knowledge -> idle | chat_knowledge_manager not initialized (lazy singleton, not yet used)
intelligent_agent -> idle | agent not yet initialized (lazy singleton, not yet used)
playwright -> idle | service not yet initialized (lazy singleton, not yet used)
```
The `llm_awareness` local repro hit a *different*, pre-existing, environment-only wall: `ProjectStateManager`'s DB path defaults to `/opt/autobot/data/project_state.db`, and I ran the repro as `martins` (no write access) rather than the `autobot` service user that actually runs the backend. Confirmed `autobot` **does** have write access to `/opt/autobot/data` (`sudo -u autobot touch` succeeded); this path was previously unreachable entirely (masked by the `ImportError` this PR fixes), so it isn't a regression — it's newly-reachable code that already works under the real runtime identity. Did not run a live in-place repro as `autobot` to avoid writing a fresh DB file into the production data directory as a side effect of manual verification. Unit test coverage exercises the guard in isolation instead (see `tracker_test.py`).

## Model Used

Claude Opus 4.8 (claude-opus-4-8-20260101)

Closes #12458, #12459