### PR TITLE
fix(enterprise): read config.port.redis not config.redis_port (default 0 trap) (#12470)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -1550,7 +1550,7 @@ async def get_redis_checkpointer() -> "AsyncRedisSaver":  # type: ignore[return]
         ttl_minutes = ssot.redis.checkpoint_ttl_minutes
     except Exception:
         redis_host = _ssot_config.redis_host
-        redis_port = _ssot_config.redis_port
+        redis_port = _ssot_config.port.redis
         _REDIS_URI = f"redis://{redis_host}:{redis_port}"
         logger.warning(
             "SSOT config unavailable, using fallback Redis URI: %s",

--- a/autobot-backend/config/__init__.py
+++ b/autobot-backend/config/__init__.py
@@ -86,7 +86,7 @@ class _ConfigStub:
         return {
             "enabled": config.redis_enabled.lower() == "true",
             "host": config.redis_host,
-            "port": int(config.redis_port),
+            "port": int(config.port.redis),
             "db": int(config.redis_db_main),
         }
 

--- a/autobot-backend/enterprise_feature_manager.py
+++ b/autobot-backend/enterprise_feature_manager.py
@@ -88,7 +88,7 @@ class EnterpriseFeatureManager:
             "npu_worker_host": config.npu_worker_host,
             "npu_worker_port": config.npu_worker_port,
             "redis_host": config.redis_host,
-            "redis_port": config.redis_port,
+            "redis_port": config.port.redis,
             "ai_stack_host": config.vm.aistack,
             "ai_stack_port": config.port.aistack,
             "browser_host": config.vm.browser,

--- a/autobot-backend/enterprise_feature_manager_test.py
+++ b/autobot-backend/enterprise_feature_manager_test.py
@@ -12,7 +12,7 @@ no-__init__ instance so they fail loudly if any attribute regresses.
 """
 
 import enterprise_feature_manager as efm
-from autobot_shared.ssot_config import config
+from autobot_shared.ssot_config import MiscConfig, PortConfig, config
 
 
 def _instance() -> efm.EnterpriseFeatureManager:
@@ -31,6 +31,44 @@ def test_get_vm_env_config_uses_canonical_subconfig_attrs() -> None:
     assert cfg["ai_stack_port"] == config.port.aistack
     assert cfg["browser_host"] == config.vm.browser
     assert cfg["browser_port"] == config.port.browser
+
+
+class TestRedisPortCanonicalAccessor:
+    """Regression coverage for #12470.
+
+    `config.redis_port` resolves (via AutoBotConfig.__getattr__ sub-config
+    fallback) to the legacy `MiscConfig.redis_port` field (alias REDIS_PORT,
+    default 0) rather than the canonical `PortConfig.redis` field (alias
+    AUTOBOT_REDIS_PORT, default 6379). On any box that doesn't explicitly
+    export REDIS_PORT -- every single-node/dev/local install -- the legacy
+    field is falsy 0, which alone trips `_validate_vm_env_config`'s
+    `all(cfg.values())` check even though every other topology value has a
+    perfectly good default.
+    """
+
+    def test_misc_redis_port_is_legacy_trap_defaults_to_zero(self, monkeypatch: object) -> None:
+        """Document the trap: MiscConfig.redis_port defaults to 0 when unset."""
+        monkeypatch.delenv("REDIS_PORT", raising=False)
+        misc = MiscConfig(_env_file=None)
+        assert misc.redis_port == 0
+
+    def test_port_config_redis_defaults_to_6379_when_unset(self, monkeypatch: object) -> None:
+        """The canonical accessor keeps the correct default even with no env set."""
+        monkeypatch.delenv("AUTOBOT_REDIS_PORT", raising=False)
+        port = PortConfig(_env_file=None)
+        assert port.redis == 6379
+
+    def test_get_vm_env_config_reads_canonical_redis_port(self) -> None:
+        """`_get_vm_env_config` must read `config.port.redis`, not `config.redis_port`."""
+        cfg = _instance()._get_vm_env_config()
+        assert cfg["redis_port"] == config.port.redis
+        assert cfg["redis_port"] != 0
+
+    def test_validate_vm_env_config_does_not_trip_on_default_single_node_config(self) -> None:
+        """REDIS_PORT unset must not falsely fail topology validation (#12470)."""
+        instance = _instance()
+        cfg = instance._get_vm_env_config()
+        instance._validate_vm_env_config(cfg)  # must not raise
 
 
 def test_get_fallback_endpoints_builds_without_attribute_error() -> None:

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -62964,7 +62964,7 @@ export interface components {
              * Status
              * @enum {string}
              */
-            status: "ok" | "degraded" | "down";
+            status: "ok" | "degraded" | "down" | "not_applicable" | "idle";
             /** Detail */
             detail?: string | null;
             /** Latency Ms */
@@ -94638,7 +94638,7 @@ export interface components {
              * Status
              * @enum {string}
              */
-            status: "ok" | "degraded" | "down";
+            status: "ok" | "degraded" | "down" | "not_applicable" | "idle";
             /** Timestamp */
             timestamp: string;
         } & {


### PR DESCRIPTION
## Thinking Path

`config.redis_port` doesn't exist as a top-level field on `AutoBotConfig` — it resolves through `AutoBotConfig.__getattr__`'s sub-config fallback, which walks `llm, timeout, vm, port, redis, cache, tls, feature, permission, database_pool, auth, path, misc` in order looking for a matching attribute name. `PortConfig` names its field `redis` (not `redis_port`), so the lookup skips past `port` and lands on `MiscConfig.redis_port` — a legacy catch-all field (GH#7437 migration) aliased to env var `REDIS_PORT` with default `0`.

Every other VM topology value read by `EnterpriseFeatureManager._get_vm_env_config()` already has a correct non-empty default (`VMConfig` hosts default to `127.0.0.1` per #2953; ports default to real numbers like `8001`, `6080`, `9001`). `redis_port` was the sole exception, defaulting to falsy `0`, which alone trips `_validate_vm_env_config`'s `all(cfg.values())` check on every box that doesn't explicitly export the legacy `REDIS_PORT` var — i.e. every default single-node/dev/local install, since production Ansible templates set `REDIS_PORT` explicitly and happened to mask the bug there.

Confirmed via `grep -rn "config.port.redis\|config.redis_port\|\.port\.redis"` that `config.port.redis` (alias `AUTOBOT_REDIS_PORT`, default `6379`) is the canonical accessor used elsewhere (`chat_history/base.py`, `knowledge/base.py`, `config/service_config.py`, `redis_url` property itself).

## What Changed

Repointed all 3 SSOT call sites identified in the issue from `config.redis_port` / `_ssot_config.redis_port` to `config.port.redis` / `_ssot_config.port.redis`:

- `autobot-backend/enterprise_feature_manager.py:91` — `_get_vm_env_config()`
- `autobot-backend/chat_workflow/graph.py:1553` — `get_redis_checkpointer()` SSOT-unavailable fallback branch
- `autobot-backend/config/__init__.py:89` — `_ConfigStub.get_redis_config()`

Grepped the full repo for other `.redis_port` readers of the SSOT config singleton — none found. The remaining `self.redis_port` / `self.config.redis_port` hits across the codebase are unrelated local dataclass/instance attributes with their own correct `6379` defaults (e.g. `TestSuiteConfig` in `comprehensive_test_suite.py`), not readers of `MiscConfig.redis_port`.

Left `MiscConfig.redis_port` (the field itself) in place — it's part of the documented GH#7437 bulk-migration catch-all and no readers remain after this fix, so removing it is a separate field-lifecycle decision, not required to close this bug (per issue's own suggested-fix framing, changing/removing the field is a bigger scope than repointing call sites).

Added regression tests in `enterprise_feature_manager_test.py` (`TestRedisPortCanonicalAccessor`) that:
- construct isolated `MiscConfig`/`PortConfig` instances (bypassing the cached singleton and any `.env`) to document the `0` vs `6379` default split directly
- assert `_get_vm_env_config()["redis_port"]` matches `config.port.redis` and is non-zero
- assert `_validate_vm_env_config` no longer raises on a default single-node config

## Verification

```
$ python3 -m pytest enterprise_feature_manager_test.py api/system_health_classification_test.py -p no:xdist -q
======================= 25 passed, 37 warnings in 3.91s ========================

$ python3 -m black --check enterprise_feature_manager.py enterprise_feature_manager_test.py chat_workflow/graph.py config/__init__.py
All done! 4 files would be left unchanged.

$ python3 -m flake8 enterprise_feature_manager.py enterprise_feature_manager_test.py chat_workflow/graph.py config/__init__.py
(no output — 0 findings)
```

Isolated reproduction of the trap (no ambient `.env`):
```
>>> MiscConfig(_env_file=None).redis_port   # legacy, REDIS_PORT unset
0
>>> PortConfig(_env_file=None).redis        # canonical, AUTOBOT_REDIS_PORT unset
6379
```

**Interaction with #12471's health-probe classifier** (`api/enterprise_features.py:_probe_enterprise_features`): since every other topology field already has a valid non-empty default, this fix means `_validate_vm_env_config` will now genuinely succeed on a default single-node box (all hosts `127.0.0.1`, all ports non-zero) — flipping the probe from `not_applicable` (masking the bug) to `ok` (correct: topology construction now genuinely succeeds). A box with a real missing host/port (e.g. legitimate multi-VM misconfiguration, or `AUTOBOT_*_HOST` explicitly set to empty) still trips the same `ValueError` and still correctly classifies as `not_applicable`/`down` per #12471's existing logic — unaffected by this change, verified by the passing `TestEnterpriseFeaturesProbe` cases in `api/system_health_classification_test.py`.

## Model Used

Sonnet 5

Closes #12470