### PR TITLE
fix(test): define _HTML_EXTENSIONS to unblock test_security_verification collection (#12479)

### DIFF
--- a/autobot-backend/code_analysis/auto-tools/test_security_verification.py
+++ b/autobot-backend/code_analysis/auto-tools/test_security_verification.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = get_logger(__name__)
 
 # Issue #380: Module-level constant for HTML extensions (performance optimization)
-_HTML_EXTENSIONS = _HTML_EXTENSIONS
+_HTML_EXTENSIONS = (".html", ".htm")
 
 import os
 import sys


### PR DESCRIPTION
## Thinking Path
Reproduced the collection error: `NameError: name '_HTML_EXTENSIONS' is not defined` at `code_analysis/auto-tools/test_security_verification.py:20`. Read the line: `_HTML_EXTENSIONS = _HTML_EXTENSIONS` — a self-reference, not a real definition. `git log -p -S _HTML_EXTENSIONS` traced this to commit `70ed2a44` (Issue #380/#391 "logging fixes and optimizations"), which added the same "module-level constant for HTML extensions" pattern to 4 sibling fix-agents files but the value assigned here was accidentally `_HTML_EXTENSIONS` itself instead of the actual tuple — a bug introduced at authoring time, never a working constant. Confirmed by grepping the 3 sibling files in the same directory (`security_deep_sanitizer.py`, `playwright_sanitizer.py`, `security_sanitizer.py`), which all correctly define `_HTML_EXTENSIONS = (".html", ".htm")`. Also checked for a leftover `scripts.utilities` import (the #12455 cross-tree concern) — none present in this file, so #12455 does not apply here.

## What Changed
Restored the constant to match the established pattern used by all 3 sibling files in the same directory:
```python
_HTML_EXTENSIONS = (".html", ".htm")
```
This is a restore-to-intended-value, not a new import or a rename — the constant was always meant to be locally defined (per the sibling files) and was simply mis-assigned to itself.

## Verification
- Before: `python3 -m pytest code_analysis/auto-tools/test_security_verification.py --collect-only -p no:xdist` → `NameError: name '_HTML_EXTENSIONS' is not defined`, 1 error, 0 collected.
- After: same command → `4 tests collected in 0.17s`, 0 errors.
- Full-suite collection (`autobot-backend`, `--collect-only -q -p no:xdist`): 19608 tests collected, 5 errors — none of the 5 is `test_security_verification.py`; the 5 are pre-existing, unrelated (`agents/agent_optimizer_test.py`, `api/slm/nodes_api_test.py`, `api/slm/stateful_api_test.py`, `api/slm/websockets_test.py`, `security/enterprise/threat_detection/test_learner.py`) — error count did not increase.
- Ran the file as a real test suite: `pytest code_analysis/auto-tools/test_security_verification.py -p no:xdist -q` — collection now succeeds but the 4 `test_*` functions fail at **setup** (not collection) with `fixture 'file_path' not found`. Root cause: this file is a standalone CLI script (`python test_security_verification.py <html_file_path>`) whose helper functions happen to be named `test_*` and take a positional `file_path` arg, which pytest's discovery mistakes for a fixture request. This is a pre-existing, separate defect (predates this fix — it was simply masked by the collection-time `NameError`). Filed as **#12480**; out of scope here since #12479 only targeted the collection blocker. No optional deps were installed; no test was skipped or weakened.
- `black --check` and `flake8` on the changed file: both clean.

Closes #12479

## Model Used
Claude Sonnet 5