### PR TITLE
fix(code-sync): invalidate stale_components cache on pull so status reflects real drift (#12451)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -584,6 +584,19 @@ async def _compute_stale_components(force: bool = False) -> list[str]:
     return stale
 
 
+def _invalidate_stale_components_cache() -> None:
+    """Bust the stale_components cache (#12451).
+
+    POST /code-sync/pull advances code_source/local_version but never told
+    this TTL cache, so /status could keep serving a pre-pull drift snapshot
+    ("up to date") for up to _STALE_COMPONENTS_TTL_SECONDS right after an
+    operator pull actually drifted a component. Resetting ts (not eagerly
+    recomputing) keeps pull() fast; the next /status call pays the
+    recompute cost exactly once — no thundering herd on repeated polls.
+    """
+    _stale_components_cache["ts"] = -_STALE_COMPONENTS_TTL_SECONDS - 1.0
+
+
 @router.get("/status", response_model=CodeSyncStatusResponse)
 async def get_sync_status(
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -3857,6 +3870,7 @@ async def pull_from_source(
     if success and commit:
         await _update_version_setting(db, commit)
         await db.commit()
+        _invalidate_stale_components_cache()
 
     return {
         "success": success,

--- a/autobot-slm-backend/tests/api/test_status_stale_components_11820.py
+++ b/autobot-slm-backend/tests/api/test_status_stale_components_11820.py
@@ -16,8 +16,9 @@ _BACKEND_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_BACKEND_ROOT))
 
 import ast  # noqa: E402
+import time  # noqa: E402
 import types  # noqa: E402
-from unittest.mock import MagicMock  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
 
 # Same shims as test_sync_status_outdated_signal.py: stub the conflicting
 # multipart package and swap benign dicts in for MagicMock schema names so
@@ -115,3 +116,63 @@ async def test_failing_component_is_isolated(monkeypatch, tmp_path):
 
     # The exploding component is skipped, the healthy one still surfaces.
     assert await cs._compute_stale_components() == ["autobot_shared"]
+
+
+async def test_pull_invalidates_stale_components_cache(monkeypatch, tmp_path):
+    """#12451: POST /code-sync/pull must bust the TTL cache so the very next
+    GET /status recomputes drift, instead of serving the pre-pull snapshot
+    for up to _STALE_COMPONENTS_TTL_SECONDS."""
+    import api.code_sync as cs
+
+    monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot_shared"})
+    monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
+    monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
+    monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": ["x"], "total_compared": 1})
+
+    # Seed the cache with a fresh "clean" snapshot — the exact pre-pull state
+    # that must NOT survive a successful pull, since the pull is what
+    # introduced the drift.
+    cs._stale_components_cache["ts"] = time.monotonic()
+    cs._stale_components_cache["value"] = []
+
+    class _FakeOrchestrator:
+        async def pull_from_source(self):
+            return True, "ok", "deadbeef"
+
+    monkeypatch.setattr(cs, "get_sync_orchestrator", lambda: _FakeOrchestrator())
+    monkeypatch.setattr(cs, "_update_version_setting", AsyncMock(return_value=None))
+
+    fake_db = MagicMock()
+    fake_db.commit = AsyncMock()
+
+    result = await cs.pull_from_source(db=fake_db, _={"user": "test"})
+    assert result["success"] is True
+
+    # Cache is busted (expired), not eagerly recomputed — pull() stays fast
+    # and the next /status call pays the recompute cost exactly once.
+    assert cs._stale_components_cache["ts"] < 0
+
+    # The next status-path read is a cache MISS: it recomputes and reports
+    # the real (drifted) state instead of the stale cached "clean" list.
+    assert await cs._compute_stale_components() == ["autobot_shared"]
+
+
+async def test_status_read_alone_never_busts_cache(monkeypatch, tmp_path):
+    """No thundering herd: a plain GET /status (no pull) must keep serving
+    the cached value within the TTL, never re-walking on every poll."""
+    import api.code_sync as cs
+
+    _reset_cache(cs)
+    monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot_shared"})
+    monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
+    monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
+    monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": ["x"], "total_compared": 1})
+
+    first = await cs._compute_stale_components()
+    assert first == ["autobot_shared"]
+    ts_after_first = cs._stale_components_cache["ts"]
+
+    monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": [], "total_compared": 1})
+    second = await cs._compute_stale_components()
+    assert second == ["autobot_shared"]  # still cached, not re-walked
+    assert cs._stale_components_cache["ts"] == ts_after_first


### PR DESCRIPTION
## Thinking Path
`GET /api/code-sync/status` derives `stale_components` from `_compute_stale_components()`, a module-level TTL cache in `autobot-slm-backend/api/code_sync.py` (`SLM_STALE_COMPONENTS_TTL_SECONDS`, default 60s, from #11820/#11512). `POST /code-sync/pull` (`pull_from_source`) advances `code_source`/the local commit but never told this cache anything changed, so a status poll within the TTL window right after a pull could keep serving the pre-pull (stale) drift snapshot — an operator sees "up to date" while the pull actually drifted a co-located component.

The codebase already has a precedent for busting this exact cache: `_advance_node_version_if_fully_synced()` (used after drift-resolve) calls `_compute_stale_components(force=True)` to force a fresh scan. For `pull`, eagerly recomputing inline would add the full drift-walk cost to the pull request itself; instead this fix resets the cache timestamp so the *next* `/status` read (the one that actually matters to the operator) is the one that pays the recompute cost — exactly once, no thundering herd on repeated polling.

## What Changed
- `autobot-slm-backend/api/code_sync.py`: added `_invalidate_stale_components_cache()` (resets `_stale_components_cache["ts"]` to an expired value) and call it from `pull_from_source()` immediately after a successful pull (`success and commit`), before returning.
- `autobot-slm-backend/tests/api/test_status_stale_components_11820.py`: added a regression test that seeds the cache with a "clean" pre-pull snapshot, calls `pull_from_source()` with a fake orchestrator, and asserts the cache is expired and the next `_compute_stale_components()` call is a cache miss that reports the real (drifted) state. Added a companion test proving a plain `/status` read alone (no pull) never busts the cache, preserving the TTL's thundering-herd protection.

## Verification
```
$ python3 -m pytest tests/api/test_status_stale_components_11820.py -p no:xdist -q
============================= test session starts ==============================
collected 6 items

tests/api/test_status_stale_components_11820.py ......                   [100%]
============================== 6 passed in 0.96s ===============================

$ python3 -m pytest tests/ -k "code_sync or stale_components or pull" -p no:xdist -q
collected 887 items / 772 deselected / 115 selected
...
=============== 115 passed, 772 deselected, 2 warnings in 16.22s ===============

$ python3 -m black --check api/code_sync.py tests/api/test_status_stale_components_11820.py
All done!  2 files would be left unchanged.

$ python3 -m flake8 api/code_sync.py tests/api/test_status_stale_components_11820.py
(no output — clean)
```

Closes #12451

## Model Used
Sonnet 5