### PR TITLE
fix(fleet): expose recovery/re-enroll action for degraded nodes (#12477)

### DIFF
--- a/autobot-slm-frontend/src/components/fleet/NodeCard.test.ts
+++ b/autobot-slm-frontend/src/components/fleet/NodeCard.test.ts
@@ -1,0 +1,80 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import NodeCard from './NodeCard.vue'
+import en from '@/locales/en.json'
+import type { SLMNode, NodeStatus } from '@/types/slm'
+
+// NodeCard only needs getNodeUpdateSummary from the fleet store.
+vi.mock('@/stores/fleet', () => ({
+  useFleetStore: () => ({
+    getNodeUpdateSummary: () => null,
+  }),
+}))
+
+// vue-i18n 11 requires app.use(); install a real i18n plugin since the
+// template uses the global $t (#11359).
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+function makeNode(status: NodeStatus): SLMNode {
+  return {
+    node_id: 'node-1',
+    hostname: 'test-host',
+    ip_address: '10.0.0.1',
+    status,
+    roles: [],
+    health: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+async function mountCard(status: NodeStatus) {
+  const wrapper = mount(NodeCard, {
+    props: { node: makeNode(status) },
+    global: { plugins: [i18n] },
+  })
+  // The actions dropdown is rendered lazily (v-if="showMenu"); open it first.
+  await wrapper.find('[aria-haspopup="true"]').trigger('click')
+  return wrapper
+}
+
+describe('NodeCard enroll/recovery action (#12477)', () => {
+  it('shows the Enroll action for pending nodes', async () => {
+    const btn = (await mountCard('pending')).find('[data-test="enroll-action"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain(en.fleet.nodeCard.enrollNode)
+  })
+
+  it('shows the Enroll action for registered nodes', async () => {
+    expect((await mountCard('registered')).find('[data-test="enroll-action"]').exists()).toBe(true)
+  })
+
+  it('exposes the recovery action labelled "Recover Connection" for degraded nodes', async () => {
+    const btn = (await mountCard('degraded')).find('[data-test="enroll-action"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain(en.fleet.nodeCard.recoverConnection)
+  })
+
+  it('exposes the recovery action for offline, unhealthy and error nodes', async () => {
+    for (const status of ['offline', 'unhealthy', 'error'] as NodeStatus[]) {
+      const btn = (await mountCard(status)).find('[data-test="enroll-action"]')
+      expect(btn.exists()).toBe(true)
+      expect(btn.text()).toContain(en.fleet.nodeCard.recoverConnection)
+    }
+  })
+
+  it('emits the enroll action (not the decommissioned-only reenroll) when recovering a degraded node', async () => {
+    const wrapper = await mountCard('degraded')
+    await wrapper.find('[data-test="enroll-action"]').trigger('click')
+    const events = wrapper.emitted('action')
+    expect(events).toBeTruthy()
+    expect(events![0]).toEqual(['enroll', 'node-1'])
+  })
+
+  it('does not show the enroll/recovery action for healthy nodes', async () => {
+    expect((await mountCard('healthy')).find('[data-test="enroll-action"]').exists()).toBe(false)
+  })
+})

--- a/autobot-slm-frontend/src/components/fleet/NodeCard.vue
+++ b/autobot-slm-frontend/src/components/fleet/NodeCard.vue
@@ -66,6 +66,21 @@ const canEnroll = computed(() => {
   return props.node.status === 'registered' || props.node.status === 'pending'
 })
 
+// #12477: A degraded/offline/unhealthy/error node has a broken connection the
+// operator must be able to re-establish. The POST /nodes/{id}/enroll endpoint
+// has no status guard and re-runs the enrollment flow (reinstalls the key via
+// an SSH password), so recovery reuses the same 'enroll' action. This is
+// distinct from the decommissioned-only 'reenroll' endpoint, which rejects any
+// non-decommissioned node.
+const canRecover = computed(() => {
+  return (
+    props.node.status === 'degraded' ||
+    props.node.status === 'unhealthy' ||
+    props.node.status === 'offline' ||
+    props.node.status === 'error'
+  )
+})
+
 const isDecommissioned = computed(() => {
   return props.node.status === 'decommissioned'
 })
@@ -179,11 +194,11 @@ const hasFailedServices = computed(() => (serviceSummary.value?.failed ?? 0) > 0
               </svg>
               {{ $t('fleet.nodeCard.manageRoles') }}
             </button>
-            <button v-if="canEnroll" @click="handleAction('enroll')" :disabled="isEnrolling" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2 disabled:opacity-50">
+            <button v-if="canEnroll || canRecover" @click="handleAction('enroll')" :disabled="isEnrolling" role="menuitem" data-test="enroll-action" :class="['w-full px-4 py-2 text-left text-sm flex items-center gap-2 disabled:opacity-50', canRecover ? 'text-green-600 hover:bg-green-50' : 'text-gray-700 hover:bg-gray-100']">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              {{ isEnrolling ? $t('fleet.nodeCard.enrolling') : $t('fleet.nodeCard.enrollNode') }}
+              {{ isEnrolling ? $t('fleet.nodeCard.enrolling') : canRecover ? $t('fleet.nodeCard.recoverConnection') : $t('fleet.nodeCard.enrollNode') }}
             </button>
             <button @click="handleAction('test')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/autobot-slm-frontend/src/locales/en.json
+++ b/autobot-slm-frontend/src/locales/en.json
@@ -786,6 +786,7 @@
       "nodeStatusAria": "Node {hostname}, status: {status}",
       "packagesCount": "{count} pkg{plural}",
       "reEnrollNode": "Re-enroll Node",
+      "recoverConnection": "Recover Connection",
       "restartNodeAria": "Restart {hostname}",
       "secondsAgo": "{seconds}s ago",
       "serviceHealthSummaryAria": "Service health summary",


### PR DESCRIPTION
## Thinking Path

A `degraded` (or `offline`) fleet node was a dead end in the 3-dot menu: `canEnroll` gated the enroll/recovery action to `registered`/`pending` only, so an operator could not re-establish a broken connection from the UI.

Investigated the two enrollment endpoints to pick the correct recovery action:
- `POST /nodes/{id}/enroll` (`enroll_node`) has **no status guard** — it re-runs the enrollment flow (reinstalls the key via an SSH password), valid for any status including `degraded`/`offline`. This is exactly the machinery the issue calls for.
- `POST /nodes/{id}/reenroll` **strictly requires** `DECOMMISSIONED` (returns 400 otherwise), so degraded nodes must NOT route to `reenroll`.

So recovery reuses the existing `enroll` action/handler — no new backend action invented, no dead call wired.

## What Changed

- `NodeCard.vue`: added a `canRecover` computed (`degraded`/`unhealthy`/`offline`/`error`). The existing enroll menu item now shows for `canEnroll || canRecover`, with a state-aware label — "Enroll Node" for pending/registered, "Recover Connection" (green, distinct from destructive actions) for broken states — routing to the existing `enroll` action.
- `en.json`: added `fleet.nodeCard.recoverConnection` (only locale present in `autobot-slm-frontend`).
- `NodeCard.test.ts`: new Vitest suite asserting the recovery action shows and emits `enroll` for degraded/offline/unhealthy/error, shows "Enroll" for pending/registered, and is hidden for healthy.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.json` → EXIT=0, 0 errors.
- `npx vitest run src/components/fleet/NodeCard.test.ts` → 6 passed (1 file).

## Model Used

claude-opus-4-8

Closes #12477
