### PR TITLE
fix(test): stop pytest mis-collecting security_verification CLI helpers as tests (#12480)

### DIFF
--- a/autobot-backend/code_analysis/auto-tools/security_verification.py
+++ b/autobot-backend/code_analysis/auto-tools/security_verification.py
@@ -24,8 +24,8 @@ import sys
 from pathlib import Path
 
 
-def test_security_headers(file_path: str) -> bool:
-    """Test if security headers are present in the HTML file."""
+def verify_security_headers(file_path: str) -> bool:
+    """Check if security headers are present in the HTML file."""
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
@@ -55,8 +55,8 @@ def test_security_headers(file_path: str) -> bool:
         return False
 
 
-def test_runtime_protection(file_path: str) -> bool:
-    """Test if runtime protection script is present."""
+def verify_runtime_protection(file_path: str) -> bool:
+    """Check if runtime protection script is present."""
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
@@ -86,8 +86,8 @@ def test_runtime_protection(file_path: str) -> bool:
         return False
 
 
-def test_backup_exists(file_path: str) -> bool:
-    """Test if backup files were created."""
+def verify_backup_exists(file_path: str) -> bool:
+    """Check if backup files were created."""
     backup_dir = Path(file_path).parent / "security_backups"
 
     if not backup_dir.exists():
@@ -106,8 +106,8 @@ def test_backup_exists(file_path: str) -> bool:
     return len(backup_files) > 0
 
 
-def test_file_integrity(file_path: str) -> bool:
-    """Test if the file structure is still intact."""
+def verify_file_integrity(file_path: str) -> bool:
+    """Check if the file structure is still intact."""
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
@@ -141,27 +141,27 @@ def test_file_integrity(file_path: str) -> bool:
         return False
 
 
-def _print_test_results_summary(results: list, passed: int, total: int) -> None:
-    """Print test verification summary and enhancement list.
+def _print_check_results_summary(results: list, passed: int, total: int) -> None:
+    """Print verification summary and enhancement list.
 
     Issue #1183: Extracted from main() to reduce function length.
     """
     logger.info("=" * 50)
     logger.info("🎯 VERIFICATION SUMMARY")
     logger.info("=" * 50)
-    logger.info("Tests Run: {total}")
-    logger.info("Tests Passed: {passed}")
-    logger.info("Tests Failed: {total - passed}")
+    logger.info("Checks Run: {total}")
+    logger.info("Checks Passed: {passed}")
+    logger.info("Checks Failed: {total - passed}")
     logger.info("Success Rate: {passed/total*100:.1f}%")
     if passed == total:
         logger.info("\n🎉 All security fixes verified successfully!")
         logger.info("🛡️  The file is now protected against XSS attacks")
     else:
-        logger.info(f"\n⚠️  {total - passed} test(s) failed - security fixes may be incomplete")
-        logger.info("Failed tests:")
-        for test_name, result in results:
+        logger.info(f"\n⚠️  {total - passed} check(s) failed - security fixes may be incomplete")
+        logger.info("Failed checks:")
+        for check_name, result in results:
             if not result:
-                logger.info("   • {test_name}")
+                logger.info("   • {check_name}")
     logger.info("\n📄 Original report security enhancements:")
     logger.info("   • Content Security Policy (CSP)")
     logger.info("   • Security meta headers")
@@ -173,8 +173,8 @@ def _print_test_results_summary(results: list, passed: int, total: int) -> None:
 def main():
     """Run comprehensive security fix verification."""
     if len(sys.argv) != 2:
-        logger.info("Usage: python test_security_verification.py <html_file_path>")
-        logger.info("Example: python test_security_verification.py tests/playwright-report/index.html")
+        logger.info("Usage: python security_verification.py <html_file_path>")
+        logger.info("Example: python security_verification.py tests/playwright-report/index.html")
         sys.exit(1)
 
     file_path = sys.argv[1]
@@ -191,25 +191,25 @@ def main():
     logger.info("=" * 50)
     logger.info("Testing file: {file_path}\n")
 
-    # Run all tests
-    tests = [
-        ("Security Headers", test_security_headers),
-        ("Runtime Protection", test_runtime_protection),
-        ("Backup Creation", test_backup_exists),
-        ("File Integrity", test_file_integrity),
+    # Run all checks
+    checks = [
+        ("Security Headers", verify_security_headers),
+        ("Runtime Protection", verify_runtime_protection),
+        ("Backup Creation", verify_backup_exists),
+        ("File Integrity", verify_file_integrity),
     ]
 
     results = []
-    for test_name, test_func in tests:
-        logger.info("\n{test_name}:")
+    for check_name, check_func in checks:
+        logger.info("\n{check_name}:")
         logger.info("-" * 30)
-        result = test_func(file_path)
-        results.append((test_name, result))
+        result = check_func(file_path)
+        results.append((check_name, result))
         logger.info("Result: {'✅ PASS' if result else '❌ FAIL'}")
 
     # Issue #1183: Delegate summary printing to extracted helper
     passed = sum(1 for _, result in results if result)
-    _print_test_results_summary(results, passed, len(results))
+    _print_check_results_summary(results, passed, len(results))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Thinking Path
After #12481 unblocked collection, `test_security_verification.py` still failed at pytest SETUP with `fixture 'file_path' not found`. The file is a **standalone CLI verification script**, not a pytest suite: it has an `if __name__ == "__main__"` entry point, a `main()` that reads `sys.argv`, and helper functions taking a positional `file_path: str` arg. pytest matched the file via `python_files = test_*.py` (auto-discovery) and its helpers via `python_functions = test_*`, then tried to inject a `file_path` fixture that doesn't exist.

Verdict: **standalone CLI script (a)** — not intended as a pytest test suite. Grep confirmed nothing imports the module or its functions by name (only self-referential usage strings).

## What Changed
Lowest-risk correct fix, two complementary parts so pytest never mis-collects under any invocation:
- **Renamed the file** `test_security_verification.py` -> `security_verification.py`, matching the sibling CLI-tool naming in the same dir (`security_sanitizer.py`, `playwright_sanitizer.py`, ...). This removes it from `python_files` auto-discovery.
- **Renamed the `test_*` helper functions** to `verify_*` (and `_print_test_results_summary` -> `_print_check_results_summary`), updating the `main()` dispatch list and internal callers. Explicitly targeting the file with pytest bypasses the `python_files` glob but still applies `python_functions = test_*`; renaming the functions makes explicit runs collect 0 items too.
- Updated the two `Usage:`/`Example:` strings to the new filename.

No functionality removed; the script remains runnable exactly as before. No real tests were weakened (there were none — these were misnamed CLI helpers).

## Verification
```
$ python3 -m pytest code_analysis/auto-tools/security_verification.py -p no:xdist -q
collected 0 items
no tests ran in 0.15s

$ python3 -m pytest code_analysis/auto-tools/ --collect-only -q -p no:xdist
collected 0 items / no tests collected

$ python3 -m pytest code_analysis/ --collect-only -q -p no:xdist
71 tests collected   # neighbours unaffected, no fixture errors

$ python3 -m py_compile .../security_verification.py   # COMPILE OK
$ python3 -m black --check .../security_verification.py # 1 file would be left unchanged (rc=0)
$ python3 -m flake8 .../security_verification.py        # 0 findings (rc=0)
```
Module also imports cleanly with the repo on `PYTHONPATH`, exposing `verify_security_headers`, `verify_runtime_protection`, `verify_backup_exists`, `verify_file_integrity`, `main`.

## Model Used
claude-opus-4-8

Closes #12480
