### PR TITLE
fix(security): make CodeQL FP-suppression functional for reviewed clear-text-logging marks (#12307)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,10 +1,23 @@
 # CodeQL configuration for AutoBot
 # Configures scan paths and query packs for Python analysis.
 #
+# ── How false positives are suppressed (read before adding suppressions) ──────
+# Inline `# codeql[query-id]` / `# lgtm[query-id]` source comments are NON-FUNCTIONAL
+# for GitHub code scanning — they do NOT dismiss alerts (legacy LGTM.com syntax;
+# LGTM.com retired Dec 2022, and the github/codeql-action pipeline does not
+# propagate inline-comment suppressions to alert state). See #12307.
+#
+# Reviewed false positives are suppressed by EITHER:
+#   • dismissing the individual alert via the Security tab / REST API
+#     (per-line granularity, persists across runs, does not hide new alerts), OR
+#   • a query-filters / paths-ignore exclusion below
+#     (per-query / per-path granularity — ALSO hides future alerts of that query
+#      in that path, so justify each entry inline).
+#
+# Full guide: docs/developer/CODEQL_SUPPRESSION.md
+#
 # Note: Python CodeQL does not support custom sanitizer declarations via
 # data extensions (only sourceModel, sinkModel, summaryModel, typeModel).
-# False positives from custom sanitizers should be dismissed via the
-# GitHub Security tab or query filters instead.
 #
 # Related issue: #1826
 

--- a/docs/developer/CODEQL_SUPPRESSION.md
+++ b/docs/developer/CODEQL_SUPPRESSION.md
@@ -1,0 +1,87 @@
+# CodeQL False-Positive Suppression — How It Actually Works
+
+> **TL;DR:** Inline `# codeql[query-id]` / `# lgtm[query-id]` comments do **not**
+> dismiss GitHub code-scanning alerts in this repository. They are non-functional.
+> Reviewed false positives are suppressed by **dismissing the alert** (Security tab
+> or REST API) or by a **`query-filters` / `paths-ignore` exclusion** in
+> `.github/codeql/codeql-config.yml`. See #12307.
+
+## Why the inline comments never worked
+
+`// lgtm[...]` (and the newer `// codeql[...]`) inline suppression comments were a
+feature of **LGTM.com**, which was retired in **December 2022**. GitHub code
+scanning — the pipeline this repo runs via `github/codeql-action` in
+[`.github/workflows/codeql.yml`](../../.github/workflows/codeql.yml) — does **not**
+propagate inline-comment suppressions to alert state. The CodeQL CLI's
+alert-suppression queries only affect alert state when you run
+`codeql database analyze` and interpret the SARIF yourself; the hosted
+code-scanning action does not.
+
+Result: an alert whose sink line carries `# codeql[py/clear-text-logging-sensitive-data]`
+still appears as **Open** on the Security tab. This was proven on alert #689
+(`context_window_manager.py`) — it carried the comment yet stayed open. All 93
+`py/clear-text-logging-sensitive-data` alerts were ultimately resolved by **API
+dismissal** in #12280, not by the inline comments.
+
+## The three mechanisms that DO work
+
+| Granularity | Mechanism | Persists? | Suppresses future alerts? |
+|---|---|---|---|
+| Per-alert (one line) | Dismiss via Security tab or REST API | Yes — matched across runs by fingerprint | No — only that reviewed alert |
+| Per-query / per-path | `query-filters` / `paths-ignore` in `codeql-config.yml` | Yes | **Yes** — also hides future alerts of that query in that path |
+| Root cause | Fix the sink (don't log/store the sensitive value) | N/A | N/A |
+
+### 1. Per-alert dismissal (use this for line-level FPs)
+
+Use for `py/clear-text-logging-sensitive-data` false positives where the logged
+value is not actually sensitive (a model name, a file path, a masked phone number,
+a secret's *label* rather than its value, a generic message, a caught exception).
+
+- **UI:** Security → Code scanning → the alert → **Dismiss alert → "Used in tests" /
+  "Won't fix" / "False positive"**.
+- **API:**
+
+  ```bash
+  gh api -X PATCH \
+    /repos/{owner}/{repo}/code-scanning/alerts/{alert_number} \
+    -f state=dismissed -f dismissed_reason="false positive" \
+    -f dismissed_comment="Logged value is a model name, not sensitive. Reviewed <issue>."
+  ```
+
+Dismissals are matched to the same alert on later runs by CodeQL's location
+fingerprint, so they **stick** while genuinely new/unreviewed alerts still surface.
+
+### 2. `query-filters` / `paths-ignore` (use for whole-query or whole-file FPs)
+
+Use only when the **entire** query is a FP for the **entire** path — e.g. a file
+that centralizes validated I/O. See the existing entries in
+[`.github/codeql/codeql-config.yml`](../../.github/codeql/codeql-config.yml) for
+`py/full-ssrf` (`external_importer.py`) and `py/path-injection`
+(`upload_security.py`). This is coarser: it also hides **future** alerts of that
+query in that path, so document the justification inline in the config.
+
+### 3. Fix the sink
+
+If the data is genuinely sensitive, don't suppress — remove it from the log/store
+or mask it.
+
+## Workflow for a new false positive
+
+1. Confirm it is a FP (the flagged value is not sensitive).
+2. **Dismiss the alert** (API/UI) with a comment citing the reviewing issue/PR.
+3. Do **not** add an inline `# codeql[...]` comment — it does nothing here.
+
+## About the existing inline markers
+
+~69 legacy inline `# codeql[...]` / `# lgtm[...]` markers remain across ~33 files.
+They **do not suppress anything**; the corresponding alerts were dismissed via the
+API in #12280. Treat them as historical human annotations only. **Do not add new
+ones.** Removing an existing one is a deliberate follow-up task, not a drive-by
+edit: altering or deleting a marked line changes the alert's location fingerprint
+and can transiently **re-open** the dismissed alert until it is re-dismissed.
+
+## References
+
+- GitHub Docs — *Resolving code scanning alerts* (dismiss via UI/REST API).
+- GitHub Docs — *Customizing your advanced setup for code scanning* (`query-filters`, `paths-ignore`).
+- GitHub Changelog — *LGTM.com deprecation and shutdown* (December 2022).


### PR DESCRIPTION
## Thinking Path

#12307 reported that ~40 (actually 69, across 33 files) log sinks carrying an inline
`# codeql[py/clear-text-logging-sensitive-data]` comment stayed OPEN as code-scanning
alerts despite being team-reviewed FPs (proven on alert #689). I verified the CodeQL
setup: `.github/workflows/codeql.yml` runs the hosted `github/codeql-action`
(init + analyze) with `.github/codeql/codeql-config.yml` (`packs: codeql/python-queries`,
two `query-filters`). Nothing consumes inline suppression comments.

## What Changed — the real mechanism + why inline was non-functional

**Root cause:** inline `# codeql[...]` / `# lgtm[...]` comments are a legacy **LGTM.com**
feature (LGTM.com retired **Dec 2022**). GitHub code scanning via `github/codeql-action`
does **not** propagate inline-comment suppressions to alert state — such alerts stay
**Open**. The CodeQL CLI's alert-suppression queries only affect state when you run
`codeql database analyze` and interpret the SARIF yourself, which this hosted pipeline
does not. So all 69 markers were no-ops; the alerts were actually resolved by **API
dismissal in #12280**. (One marker, `auth_middleware.py:111`, is even malformed —
`# noqa: codeql[...]`, mixing flake8 + CodeQL syntax — doubly non-functional.)

Enabling inline suppression (issue Option 1) is therefore **not achievable** on hosted
code scanning; the correct, granular, non-weakening mechanism for line-level FPs is
per-alert dismissal (Option 2). This PR makes that convention correct and durable:

- **New** `docs/developer/CODEQL_SUPPRESSION.md` — authoritative guide: why inline
  comments don't work; the three mechanisms that do (per-alert dismiss via UI/API,
  `query-filters`/`paths-ignore`, fix the sink); the workflow for a new FP; guidance on
  the existing legacy markers.
- **Updated** `.github/codeql/codeql-config.yml` header — states inline comments are
  NON-FUNCTIONAL, documents the two working config/dismissal paths, links the guide.
  Existing `py/full-ssrf` and `py/path-injection` query-filters are preserved unchanged.

**Deliberately NOT touching the 69 marked source lines.** Code-scanning matches alerts
across runs by a line-content **fingerprint**; editing/removing a marked line changes the
fingerprint and can **re-open** the alert #12280 already dismissed. Bulk marker removal is
recommended as a deliberate owner-gated follow-up (remove → re-run → re-dismiss any that
re-surface), not a drive-by change.

**Spot-check (real vs FP):** sampled `main.py:83` (logs TLS key *path*), `auth_middleware.py`
(generic "generated JWT secret" message + caught exception, no value), `secrets.py` (secret
*name/scope label*, not value), `context_window_manager.py` / `model_param_registry.py`
(model names). All are genuine FPs — no actual secret **values** logged. No real
sensitive-data leak found in the sample; nothing here should be un-dismissed.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/codeql/codeql-config.yml'))"`
  → OK; keys `name`, `query-filters` (2 entries preserved), `packs` intact.
- `git diff --stat`: config +15/-2; new doc 87 lines. No source/behavior changes.
- CodeQL itself runs only in CI (cannot execute the scan locally); config is YAML-valid
  and functionally equivalent for scanning (comment-only + preserved filters).

## Model Used

claude-opus-4-8

Closes #12307
