### PR TITLE
test(llc): fix cross-test KB-collection contamination breaking e2e loop in full suite (#12474)

### DIFF
--- a/autobot-backend/llc/tests/test_company_create_kb_and_list_n1_12323_12325.py
+++ b/autobot-backend/llc/tests/test_company_create_kb_and_list_n1_12323_12325.py
@@ -102,7 +102,7 @@ def _membership() -> MagicMock:
 async def test_create_commits_after_kb_and_serialize(monkeypatch):
     """Happy path: KB ensured + response serialized, then exactly one commit."""
     ensure = AsyncMock()
-    monkeypatch.setattr(companies._kb_manager, "ensure_collection", ensure)
+    monkeypatch.setattr(companies.KbCollectionManager, "ensure_collection", ensure)
     svc = _create_svc()
     membership = _membership()
     async with _client(_app(svc, membership)) as client:
@@ -118,7 +118,7 @@ async def test_create_commits_after_kb_and_serialize(monkeypatch):
 async def test_create_kb_failure_rolls_back_no_commit(monkeypatch):
     """A KB failure must roll the INSERT back and never commit (#12323)."""
     monkeypatch.setattr(
-        companies._kb_manager,
+        companies.KbCollectionManager,
         "ensure_collection",
         AsyncMock(side_effect=RuntimeError("chroma down")),
     )
@@ -135,7 +135,7 @@ async def test_create_kb_failure_rolls_back_no_commit(monkeypatch):
 @pytest.mark.asyncio
 async def test_create_serialize_failure_rolls_back_no_commit(monkeypatch):
     """A serialization failure before commit also rolls back (#12323)."""
-    monkeypatch.setattr(companies._kb_manager, "ensure_collection", AsyncMock())
+    monkeypatch.setattr(companies.KbCollectionManager, "ensure_collection", AsyncMock())
     monkeypatch.setattr(
         companies,
         "_to_read",

--- a/autobot-backend/llc/tests/test_company_crud_authz_12233.py
+++ b/autobot-backend/llc/tests/test_company_crud_authz_12233.py
@@ -280,7 +280,7 @@ async def test_create_requires_authentication():
 async def test_create_root_records_creator_as_owner(monkeypatch):
     from llc.models.enums import MembershipRole
 
-    monkeypatch.setattr(companies._kb_manager, "ensure_collection", AsyncMock())
+    monkeypatch.setattr(companies.KbCollectionManager, "ensure_collection", AsyncMock())
     svc = _create_svc()
     membership = _membership()
     app = _collection_app(svc, membership)
@@ -314,7 +314,7 @@ async def test_create_sub_company_cross_tenant_parent_is_404():
 
 @pytest.mark.asyncio
 async def test_create_sub_company_owned_parent_ok(monkeypatch):
-    monkeypatch.setattr(companies._kb_manager, "ensure_collection", AsyncMock())
+    monkeypatch.setattr(companies.KbCollectionManager, "ensure_collection", AsyncMock())
     svc = _create_svc()
     membership = _membership(is_member=True)
     app = _collection_app(svc, membership)


### PR DESCRIPTION
## Thinking Path

`test_llc_core_loop_end_to_end` passed standalone but failed in the full `llc/tests/` run with `RuntimeError: Failed to ensure KB collection company:<uuid>` (`object MagicMock can't be used in 'await' expression`). That error only fires when the REAL `KbCollectionManager.ensure_collection` body runs — meaning the victim's autouse fixture patch on the class method was being bypassed by an earlier test.

Bisected to two earlier-collected files that patch the module-level singleton `companies._kb_manager` at the INSTANCE level via `monkeypatch.setattr(companies._kb_manager, "ensure_collection", ...)`. `pytest`'s `monkeypatch.undo()` restores by re-`setattr`-ing the value it read with `getattr` — which for an instance without the attribute in `__dict__` is the class method resolved as a bound method. So teardown leaves `_kb_manager.__dict__["ensure_collection"]` populated with a bound method of the REAL implementation, which permanently shadows the class attribute for the rest of the session. The e2e test's autouse fixture patches the CLASS method, but the leftover instance attribute wins the lookup → real `ensure_collection` runs → RuntimeError.

Reproduced deterministically with just two files:
```
pytest llc/tests/test_company_create_kb_and_list_n1_12323_12325.py llc/tests/test_llc_e2e_loop.py -p no:xdist -q
# → 1 failed (RuntimeError: Failed to ensure KB collection ...)
```

## What Changed

Root-cause fix at the leaking tests — patch the CLASS, not the instance, so `monkeypatch` restores cleanly (the attribute exists in the class `__dict__`, so `undo` re-sets the class attribute and never creates a shadowing instance attribute):

- `llc/tests/test_company_create_kb_and_list_n1_12323_12325.py` — 3 sites: `companies._kb_manager` → `companies.KbCollectionManager`
- `llc/tests/test_company_crud_authz_12233.py` — 2 sites: `companies._kb_manager` → `companies.KbCollectionManager`

Behaviour is identical for each individual test (the endpoint calls `_kb_manager.ensure_collection(...)`, which resolves the class-level `AsyncMock`), but the session-wide leak is eliminated. No production code changed; no test weakened, skipped, or reordered.

## Verification

Reproducing subsets (both offenders + victim) now green:
```
pytest test_company_create_kb_and_list_n1_12323_12325.py test_llc_e2e_loop.py -p no:xdist -q  → 8 passed
pytest test_company_crud_authz_12233.py test_llc_e2e_loop.py -p no:xdist -q                   → 19 passed
pytest test_company_create_kb_and_list_n1_12323_12325.py test_company_crud_authz_12233.py     → 25 passed
```

Full `llc/tests/` suite:
```
pytest llc/tests/ -p no:xdist -q
=========== 1308 passed, 2 skipped, 14 warnings in 99.95s ============
```
(was `1 failed, 1307 passed, 2 skipped` before the fix — `test_llc_core_loop_end_to_end` now passes in-suite, no regressions.)

Lint: `black --check` clean, `flake8` clean on both files.

## Model Used

claude-opus-4-8

Closes #12474
