### PR TITLE
fix(logging): route INFO/access to stdout, WARNING+ to stderr so error.log holds only errors (#12488)

### DIFF
--- a/autobot-backend/main.py
+++ b/autobot-backend/main.py
@@ -36,6 +36,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"  # ssot-config-exempt: runtime en
 
 from app_factory import create_app
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.stream_logging import load_uvicorn_log_config
 
 # Get centralized logger (respects AUTOBOT_LOG_LEVEL environment variable)
 logger = get_logger(__name__, "backend")
@@ -98,6 +99,12 @@ if __name__ == "__main__":
             "reload": reload,
             "log_level": "info",
             "access_log": True,
+            # #12488: split stdout (DEBUG/INFO)/stderr (WARNING+) so systemd's
+            # StandardOutput/StandardError append: split lands each line in
+            # the right log file (only used in standalone `python main.py`
+            # mode — the production `uvicorn main:app` CLI gets the same
+            # config via --log-config in the systemd unit).
+            "log_config": load_uvicorn_log_config(),
             "workers": 1 if reload else None,  # Single worker in dev mode
             "loop": "auto",  # Use best available event loop
             "http": "auto",  # Use best available HTTP implementation

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
@@ -36,7 +36,11 @@ ExecStartPre={{ backend_code_dir | default(backend_install_dir) }}/venv/bin/pyth
 # uvicorn waits indefinitely for lingering keep-alive/in-flight connections (nginx,
 # health probes), so `systemctl restart` sat in stop-sigterm for the full 15-min
 # TimeoutStopSec on every code-sync deploy — making the built-in restart look broken.
-ExecStart={{ backend_code_dir }}/venv/bin/uvicorn main:app --host {{ backend_host }} --port {{ backend_port }} --workers {{ backend_workers }} --timeout-graceful-shutdown {{ backend_graceful_shutdown_sec | default(30) }}
+# #12488: --log-config splits uvicorn's own logger output by level (DEBUG/INFO
+# -> stdout, WARNING+ -> stderr) instead of uvicorn's default, which sends
+# everything except the access log (incl. INFO connection-lifecycle lines like
+# "WebSocket ... [accepted]") to stderr — see autobot_shared/uvicorn_log_config.json.
+ExecStart={{ backend_code_dir }}/venv/bin/uvicorn main:app --host {{ backend_host }} --port {{ backend_port }} --workers {{ backend_workers }} --timeout-graceful-shutdown {{ backend_graceful_shutdown_sec | default(30) }} --log-config {{ backend_install_dir | dirname }}/autobot_shared/uvicorn_log_config.json
 Restart=always
 # #11668: escalate to SIGKILL promptly if uvicorn still hasn't exited, so a
 # code-sync restart never blocks on a hung shutdown. Mirrors autobot-celery.

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -17,7 +17,9 @@ EnvironmentFile=-{{ slm_credentials_dir }}/{{ slm_credentials_file }}
 # SLM restart during code-sync self-update doesn't hang on lingering connections.
 # KillMode is intentionally left at the default here — the cgroup-kill behavior
 # during self-update is owned by #11492.
-ExecStart={{ slm_backend_dir }}/venv/bin/uvicorn main:app --host {{ slm_backend_host }} --port {{ slm_backend_port }} --timeout-graceful-shutdown {{ slm_backend_graceful_shutdown_sec | default(30) }}
+# #12488: --log-config splits uvicorn's own logger output by level (DEBUG/INFO
+# -> stdout, WARNING+ -> stderr) — see autobot_shared/uvicorn_log_config.json.
+ExecStart={{ slm_backend_dir }}/venv/bin/uvicorn main:app --host {{ slm_backend_host }} --port {{ slm_backend_port }} --timeout-graceful-shutdown {{ slm_backend_graceful_shutdown_sec | default(30) }} --log-config {{ slm_shared_dir }}/uvicorn_log_config.json
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5

--- a/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
+++ b/autobot-slm-backend/ansible/templates/autobot-backend-single-worker.service.j2
@@ -17,7 +17,9 @@ EnvironmentFile=-/etc/autobot/service-keys/main-backend.env
 
 # Issue #876: Single worker mode to prevent initialization deadlock
 # FastAPI is async - single worker handles high concurrency efficiently
-ExecStart={{ backend_venv }}/bin/uvicorn main:app --host 0.0.0.0 --port 8443 --workers 1
+# #12488: --log-config splits uvicorn's own logger output by level (DEBUG/INFO
+# -> stdout, WARNING+ -> stderr) — see autobot_shared/uvicorn_log_config.json.
+ExecStart={{ backend_venv }}/bin/uvicorn main:app --host 0.0.0.0 --port 8443 --workers 1 --log-config /opt/autobot/autobot_shared/uvicorn_log_config.json
 
 Restart=always
 RestartSec=5

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -11,7 +11,6 @@ Main FastAPI application entry point.
 import asyncio
 import logging
 import os
-import sys
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
@@ -71,6 +70,11 @@ from api.personality_proxy import router as personality_proxy_router
 from api.roles import router as roles_router
 from api.voice_proxy import router as voice_proxy_router
 from autobot_shared.integrity_manifest import verify_integrity_at_startup
+from autobot_shared.stream_logging import (
+    build_stderr_handler,
+    build_stdout_handler,
+    load_uvicorn_log_config,
+)
 from config import settings
 from middleware import ApiRequestCounterMiddleware, SecurityHeadersMiddleware
 from services.a2a_card_fetcher import start_card_refresh_task
@@ -91,10 +95,15 @@ from services.security_posture_auditor import (
     stop_security_posture_auditor,
 )
 
+# #12488: split root-logger output by level instead of a single stdout
+# handler — WARNING+ (e.g. migration failures, table-collision errors)
+# must reach stderr so systemd's StandardError=append:...-error.log
+# actually captures real errors instead of everything landing in the
+# info log.
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)],
+    handlers=[build_stdout_handler(), build_stderr_handler()],
 )
 logger = logging.getLogger(__name__)
 
@@ -165,10 +174,13 @@ async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     # Reconfigure root logger AFTER uvicorn's setup so application
     # logs (code_sync, git_tracker, etc.) are visible in service logs.
+    # #12488: keep the same stdout/stderr level split as the module-level
+    # basicConfig() above — force=True replaces it, so it must be
+    # re-applied here too.
     logging.basicConfig(
         level=logging.DEBUG if settings.debug else logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler(sys.stdout)],
+        handlers=[build_stdout_handler(), build_stderr_handler()],
         force=True,
     )
     logger.info("Starting SLM Backend v1.0.0")
@@ -737,6 +749,10 @@ if __name__ == "__main__":
         "port": port,
         "reload": settings.debug,
         "log_level": "debug" if settings.debug else "info",
+        # #12488: split stdout (DEBUG/INFO)/stderr (WARNING+) — only used in
+        # standalone `python main.py` mode; the production `uvicorn main:app`
+        # CLI gets the same config via --log-config in the systemd unit.
+        "log_config": load_uvicorn_log_config(),
     }
 
     if tls_enabled and ssl_keyfile and ssl_certfile:

--- a/autobot_shared/logging_manager.py
+++ b/autobot_shared/logging_manager.py
@@ -14,6 +14,8 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict
 
+from autobot_shared.stream_logging import build_stderr_handler, build_stdout_handler
+
 if TYPE_CHECKING:
     from config.manager import ConfigManager
 
@@ -109,10 +111,14 @@ class LoggingManager:
                     logger.addHandler(handler)
 
                 # Add console handler for development
+                # #12488: split by level instead of a single bare stderr
+                # StreamHandler() so systemd's StandardOutput/StandardError
+                # append: split (INFO->*.log, WARNING+->*-error.log) matches
+                # what actually gets emitted.
                 if _get_config_manager().get("deployment.mode", "local") == "local":
-                    console_handler = logging.StreamHandler()
-                    console_handler.setFormatter(cls._get_formatter())
-                    logger.addHandler(console_handler)
+                    formatter = cls._get_formatter()
+                    logger.addHandler(build_stdout_handler(formatter))
+                    logger.addHandler(build_stderr_handler(formatter))
 
             # Set log level
             log_level = getattr(logging, _get_config_manager().get("logging.level", "INFO").upper())

--- a/autobot_shared/stream_logging.py
+++ b/autobot_shared/stream_logging.py
@@ -1,0 +1,85 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Centralized stdout/stderr log-stream routing (#12488).
+
+Systemd captures each service's raw stdout into an info/access log file and
+its raw stderr into an error log file (``StandardOutput=append:...``,
+``StandardError=append:...`` — see #12464). Two independent code paths were
+sending INFO-level output to stderr regardless of level, flooding
+``*-error.log`` with benign lines (e.g. uvicorn's "WebSocket ... [accepted]"
+and websockets' "connection open"):
+
+1. Uvicorn's own default ``LOGGING_CONFIG`` sends everything logged via the
+   ``uvicorn``/``uvicorn.error`` logger (startup banner, connection
+   lifecycle, warnings, errors) to a single stderr ``StreamHandler`` —
+   only the separate ``uvicorn.access`` logger goes to stdout.
+2. ``autobot_shared.logging_manager.LoggingManager`` attached a bare
+   ``logging.StreamHandler()`` (which defaults to ``sys.stderr`` and has no
+   level filter) as a "console handler" to every logger it configures.
+
+This module is the single source of truth for the fix: split any logger's
+output so DEBUG/INFO goes to stdout and WARNING+ goes to stderr, without
+changing formats or the level of what is emitted. Reused by:
+
+- ``autobot_shared/logging_manager.py`` (per-module console handler)
+- ``autobot_shared/uvicorn_log_config.json`` (loaded by
+  ``load_uvicorn_log_config()`` for ``uvicorn.run(log_config=...)``, and
+  referenced directly via the uvicorn CLI's ``--log-config`` flag from the
+  systemd ``ExecStart=`` lines for autobot-backend and autobot-slm-backend)
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+_UVICORN_LOG_CONFIG_PATH = Path(__file__).parent / "uvicorn_log_config.json"
+
+
+class MaxLevelFilter(logging.Filter):
+    """Reject any log record at or above ``max_level``.
+
+    Pairs with a sibling handler whose own ``level`` is set to
+    ``max_level`` — together the two handlers split a single logger's
+    output across streams by level without touching format or level of
+    what gets emitted.
+    """
+
+    def __init__(self, max_level: int) -> None:
+        super().__init__()
+        self.max_level = max_level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno < self.max_level
+
+
+def build_stdout_handler(formatter: logging.Formatter | None = None) -> logging.StreamHandler:
+    """Build a DEBUG/INFO handler writing to stdout (WARNING+ filtered out)."""
+    handler = logging.StreamHandler(sys.stdout)
+    if formatter is not None:
+        handler.setFormatter(formatter)
+    handler.addFilter(MaxLevelFilter(logging.WARNING))
+    return handler
+
+
+def build_stderr_handler(formatter: logging.Formatter | None = None) -> logging.StreamHandler:
+    """Build a WARNING+ handler writing to stderr."""
+    handler = logging.StreamHandler(sys.stderr)
+    if formatter is not None:
+        handler.setFormatter(formatter)
+    handler.setLevel(logging.WARNING)
+    return handler
+
+
+def load_uvicorn_log_config() -> dict:
+    """Load the shared stdout/stderr-split uvicorn logging config.
+
+    Single JSON source of truth for both the ``uvicorn --log-config`` CLI
+    flag (systemd ``ExecStart=``) and ``uvicorn.run(log_config=...)``
+    (standalone/dev entry points) so backend and slm-backend never drift.
+    """
+    with _UVICORN_LOG_CONFIG_PATH.open(encoding="utf-8") as f:
+        return json.load(f)

--- a/autobot_shared/stream_logging_test.py
+++ b/autobot_shared/stream_logging_test.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for stdout/stderr log-stream routing (#12488).
+
+Proves the two independent misroutes are fixed:
+
+1. Uvicorn's own logging config (``uvicorn_log_config.json``, loaded via
+   ``load_uvicorn_log_config()``) — an INFO record on ``uvicorn.error``
+   (the logger uvicorn uses for connection-lifecycle lines such as
+   "WebSocket ... [accepted]" and websockets' "connection open") must land
+   on stdout, while WARNING+ lands on stderr.
+2. ``build_stdout_handler``/``build_stderr_handler`` (used by
+   ``autobot_shared.logging_manager``'s per-module console handler and by
+   ``autobot-slm-backend/main.py``'s root-logger ``basicConfig``) split any
+   logger's output the same way.
+"""
+
+import json
+import logging
+import logging.config
+from pathlib import Path
+
+from autobot_shared.stream_logging import (
+    MaxLevelFilter,
+    build_stderr_handler,
+    build_stdout_handler,
+    load_uvicorn_log_config,
+)
+
+
+def _make_record(level: int) -> logging.LogRecord:
+    return logging.LogRecord("test", level, __file__, 1, "msg", None, None)
+
+
+def test_max_level_filter_allows_below_threshold():
+    f = MaxLevelFilter(logging.WARNING)
+    assert f.filter(_make_record(logging.DEBUG)) is True
+    assert f.filter(_make_record(logging.INFO)) is True
+
+
+def test_max_level_filter_rejects_at_or_above_threshold():
+    f = MaxLevelFilter(logging.WARNING)
+    assert f.filter(_make_record(logging.WARNING)) is False
+    assert f.filter(_make_record(logging.ERROR)) is False
+
+
+def test_build_stdout_handler_emits_info_not_warning(capsys):
+    logger = logging.getLogger("stream_logging_test.stdout")
+    logger.handlers = [build_stdout_handler()]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("info-line")
+    logger.warning("warn-line")
+
+    captured = capsys.readouterr()
+    assert "info-line" in captured.out
+    assert "warn-line" not in captured.out
+    assert captured.err == ""
+
+
+def test_build_stderr_handler_emits_warning_not_info(capsys):
+    logger = logging.getLogger("stream_logging_test.stderr")
+    logger.handlers = [build_stderr_handler()]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("info-line")
+    logger.warning("warn-line")
+
+    captured = capsys.readouterr()
+    assert "warn-line" in captured.err
+    assert "info-line" not in captured.err
+    assert captured.out == ""
+
+
+def test_load_uvicorn_log_config_matches_json_on_disk():
+    """Guards against the JSON file and the loader drifting apart."""
+    disk_path = Path(__file__).parent / "uvicorn_log_config.json"
+    with disk_path.open(encoding="utf-8") as f:
+        expected = json.load(f)
+    assert load_uvicorn_log_config() == expected
+
+
+def test_uvicorn_log_config_routes_info_to_stdout_and_warning_to_stderr(capsys):
+    """#12488: 'WebSocket ... [accepted]' (uvicorn.error, INFO) -> stdout;
+    real problems (WARNING+) -> stderr — proves the systemd
+    StandardOutput=append:/StandardError=append: split lands each line in
+    the log file it belongs in.
+    """
+    logging.config.dictConfig(load_uvicorn_log_config())
+    try:
+        logger = logging.getLogger("uvicorn.error")
+        logger.info('%s - "WebSocket %s" [accepted]', "127.0.0.1:1", "/ws")
+        logger.warning("some real problem")
+
+        captured = capsys.readouterr()
+        assert "[accepted]" in captured.out
+        assert "some real problem" not in captured.out
+        assert "some real problem" in captured.err
+        assert "[accepted]" not in captured.err
+    finally:
+        # Reset so this test doesn't leak uvicorn's dictConfig into others.
+        uvicorn_logger = logging.getLogger("uvicorn")
+        uvicorn_logger.handlers = []
+        uvicorn_logger.propagate = True

--- a/autobot_shared/uvicorn_log_config.json
+++ b/autobot_shared/uvicorn_log_config.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "default": {
+      "()": "uvicorn.logging.DefaultFormatter",
+      "fmt": "%(levelprefix)s %(message)s",
+      "use_colors": null
+    },
+    "access": {
+      "()": "uvicorn.logging.AccessFormatter",
+      "fmt": "%(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s"
+    }
+  },
+  "filters": {
+    "below_warning": {
+      "()": "autobot_shared.stream_logging.MaxLevelFilter",
+      "max_level": 30
+    }
+  },
+  "handlers": {
+    "default": {
+      "formatter": "default",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stdout",
+      "filters": ["below_warning"]
+    },
+    "default_error": {
+      "formatter": "default",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stderr",
+      "level": "WARNING"
+    },
+    "access": {
+      "formatter": "access",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stdout"
+    }
+  },
+  "loggers": {
+    "uvicorn": {
+      "handlers": ["default", "default_error"],
+      "level": "INFO",
+      "propagate": false
+    },
+    "uvicorn.error": {
+      "level": "INFO"
+    },
+    "uvicorn.access": {
+      "handlers": ["access"],
+      "level": "INFO",
+      "propagate": false
+    }
+  }
+}


### PR DESCRIPTION
## Thinking Path

systemd captures each service's raw process streams into separate files (`StandardOutput=append:<info>.log`, `StandardError=append:<error>.log`, per #12464). That only produces the intended split if the app actually sends INFO/DEBUG to stdout and WARNING+ to stderr — but two independent pieces of the logging setup instead route by *purpose*, not *level*:

1. **Uvicorn's own default `LOGGING_CONFIG`** attaches a single stderr `StreamHandler` to the `uvicorn`/`uvicorn.error` logger and never touches level — only the separate `uvicorn.access` logger (true per-request access-log lines) goes to stdout. Uvicorn's `WebSocketProtocol` additionally overrides the `websockets` library's own `websockets.server` logger with `logging.getLogger("uvicorn.error")` (see `uvicorn/protocols/websockets/websockets_impl.py`), so *both* the startup banner ("Started server process", "Uvicorn running on...") **and** the reported symptom — `"WebSocket ... [accepted]"`, `"connection open"`, `"connection closed"` — are all INFO-level `uvicorn.error` records that land on stderr regardless of level. Reproduced locally with a bare `uvicorn` CLI invocation (see Verification) — the exact "WebSocket [accepted]" / "connection open" lines end up on stderr with uvicorn's stock config.
2. **`autobot_shared.logging_manager.LoggingManager`** attaches a bare `logging.StreamHandler()` (no `stream=` arg → defaults to `sys.stderr`, no level filter) as a "console handler" to every logger obtained via `get_logger()`/`get_backend_logger()` etc. — used by **1351** backend modules. The handler is gated on `deployment.mode == "local"`, but that lookup (`config_manager.get("deployment.mode", "local")`) never actually resolves to anything other than its own hardcoded default (no config source sets a literal `"deployment.mode"` flat key), so it's effectively always on — meaning virtually every INFO+ log line across the backend gets duplicated onto real stderr, on top of its intended `RotatingFileHandler`. This is almost certainly the dominant contributor to the 718MB `backend-error.log` from #12464.

Root cause in both cases: a bare/default `StreamHandler` with no level split, not a bug in *what* gets logged.

## What Changed

New shared module `autobot_shared/stream_logging.py` — single source of truth for the split (DEBUG/INFO → stdout, WARNING+ → stderr), reused everywhere instead of inventing parallel logic:
- `MaxLevelFilter` — rejects records at/above a threshold (pairs with a sibling handler's own `level=`).
- `build_stdout_handler()` / `build_stderr_handler()` — ready-made split handlers.
- `load_uvicorn_log_config()` — loads `autobot_shared/uvicorn_log_config.json`, a level-split copy of uvicorn's own default `LOGGING_CONFIG` (same formatters/loggers, `default` handler now goes to stdout filtered below WARNING, new `default_error` handler goes to stderr at WARNING+).

Wired in:
- **`autobot_shared/logging_manager.py`** — replaced the bare `StreamHandler()` console handler with `build_stdout_handler()` + `build_stderr_handler()`. No change to *when* the console handler is added, formats, or emitted levels — only where each level goes.
- **`autobot-backend/main.py`** / **`autobot-slm-backend/main.py`** (`__main__` / `uvicorn.run()` standalone path) — pass `log_config=load_uvicorn_log_config()`.
- **`autobot-slm-backend/main.py`** module-level and `lifespan()` `logging.basicConfig(...)` calls — swapped the single stdout handler for the stdout+stderr split (this also fixes the inverse bug: SLM's own `logger.error(...)` calls were landing in `slm-backend.log`, not `slm-backend-error.log`).
- **systemd `ExecStart=`** (production entry point — `uvicorn main:app ...` CLI, not the `python main.py` path) — added `--log-config <path>/autobot_shared/uvicorn_log_config.json` to the canonical `autobot-backend.service.j2`, `autobot-slm-backend.service.j2`, and the legacy `autobot-backend-single-worker.service.j2` rescue-playbook template. No other ExecStart flags touched (worker count, timeouts, etc. all preserved as-is).

Not touched (deliberately, to keep blast radius to level→stream routing only): the `deployment.mode` lookup bug itself (item 2 above) — fixing *when* the console handler is added is a separate, larger behavioral question (would silence console output entirely in modes where it's currently — accidentally — always on). Filed as a discovered issue if not already tracked.

## Verification

New tests in `autobot_shared/stream_logging_test.py` (6 passed):
```
autobot_shared/stream_logging_test.py::test_max_level_filter_allows_below_threshold PASSED
autobot_shared/stream_logging_test.py::test_max_level_filter_rejects_at_or_above_threshold PASSED
autobot_shared/stream_logging_test.py::test_build_stdout_handler_emits_info_not_warning PASSED
autobot_shared/stream_logging_test.py::test_build_stderr_handler_emits_warning_not_info PASSED
autobot_shared/stream_logging_test.py::test_load_uvicorn_log_config_matches_json_on_disk PASSED
autobot_shared/stream_logging_test.py::test_uvicorn_log_config_routes_info_to_stdout_and_warning_to_stderr PASSED
============================== 6 passed in 0.13s ===============================
```

Live end-to-end reproduction with the real uvicorn CLI (`uvicorn ws_app:app --log-config autobot_shared/uvicorn_log_config.json`) against a minimal WebSocket app, streams captured separately:
```
--- STDOUT ---
INFO:     Started server process [...]
INFO:     Uvicorn running on http://127.0.0.1:.../ (Press CTRL+C to quit)
INFO:     127.0.0.1:... - "WebSocket /ws" [accepted]
INFO:     connection open
INFO:     connection closed
--- STDERR ---
(empty)
```
Without `--log-config` (stock uvicorn, the pre-fix behavior), the same run puts all four `INFO:` lines above on stderr and only the HTTP access-log line on stdout — confirming the exact root cause.

`autobot-backend/tests/test_startup_imports.py` (guards against circular-import regressions from the new `logging_manager.py` → `stream_logging.py` dependency, touched by 1351 call sites): `345 passed`.

`black --check` + `flake8` clean on all changed files.

`git -C .worktrees/issue-12488 log origin/issue-12488 -1` → `0ddb25b9f879ddc5787781f3fedcad734fcbfe4d`.

Closes #12488

## Model Used

Sonnet 5 (claude-sonnet-5)