### PR TITLE
fix(voice): queue fallback sentences + exact cursor span + tail flush so full reply is spoken (#12502)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -309,6 +309,7 @@ import VoiceConversationOverlay from './VoiceConversationOverlay.vue'
 import VoiceConversationPanel from './VoiceConversationPanel.vue'
 import ChatSettingsModal from './ChatSettingsModal.vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { extractCompleteSentences } from '@/utils/ttsSentences'
 // Issue #3232: chain-of-thought reasoning trace
 import ReasoningTrace from './ReasoningTrace.vue'
 import { useReasoningTrace } from '@/composables/useReasoningTrace'
@@ -477,7 +478,7 @@ const onToolDenied = async (comment?: string): Promise<void> => {
 // Voice output (#928)
 const {
   voiceOutputEnabled, isSpeaking, toggleVoiceOutput,
-  speak: _speak, speakStreaming, flushStreaming,
+  speak: _speak, speakStreaming, flushStreaming, stopSpeaking,
 } = useVoiceOutput()
 
 // Voice conversation (#1029)
@@ -1265,7 +1266,7 @@ watch(
       const m = msgs[i]
       if (m.sender !== 'assistant' || !m.content) continue
       if (m.type && !_SPEAKABLE_TYPES.has(m.type)) continue
-      return { id: m.id, content: m.content }
+      return { id: m.id, content: m.content, typing: store.isTyping }
     }
     return null
   },
@@ -1279,20 +1280,32 @@ watch(
     // etc.) and should not be re-spoken. Only reset to 0 when isTyping so newly
     // generated content is picked up from the start.
     if (current.id !== _lastStreamingMsgId) {
+      // New reply detected. When a fresh reply is streaming in, stop the previous
+      // reply's audio and drop its queued fallback sentences (#12502) so the new
+      // reply replaces the old one — same-reply sentences still queue sequentially
+      // below and never abort each other. Historical/session-switch messages
+      // (not typing) must NOT stop anything.
+      if (store.isTyping) stopSpeaking()
       _lastStreamingMsgId = current.id
       _lastSpokenIdx = store.isTyping ? 0 : current.content.length
     }
 
     if (store.isTyping && current.content) {
-      // During streaming: extract and speak completed sentences
+      // During streaming: extract and speak completed sentences. Advance the
+      // cursor by the EXACT consumed span (incl. inter-sentence whitespace), not
+      // by the summed sentence lengths, which drift over multi-paragraph replies
+      // and drop/duplicate slices (#12502).
       const newText = current.content.slice(_lastSpokenIdx)
-      const sentences = _extractCompleteSentences(newText)
-      for (const s of sentences) {
-        speakStreaming(s)
-        _lastSpokenIdx += s.length
-      }
+      const { sentences, consumed } = extractCompleteSentences(
+        newText,
+        _MIN_TTS_SENTENCE_CHARS,
+      )
+      for (const s of sentences) speakStreaming(s)
+      _lastSpokenIdx += consumed
     } else if (!store.isTyping && current.content) {
-      // Stream ended: flush any remaining text
+      // Stream ended: ALWAYS flush the remaining tail (all text after the cursor).
+      // Lists, code blocks and unpunctuated endings have no terminal ". "/"! "/"? "
+      // so they only ever reach TTS via this remainder flush (#12502).
       const remainder = current.content.slice(_lastSpokenIdx).trim()
       if (remainder) speakStreaming(remainder)
       flushStreaming()
@@ -1311,21 +1324,6 @@ watch(
 // buffer them until they combine with the next sentence or flush as a remainder.
 const _MIN_TTS_SENTENCE_CHARS = 20
 
-/** Extract sentences terminated by ". ", "! ", or "? " — remainder stays buffered. */
-function _extractCompleteSentences(text: string): string[] {
-  const sentences: string[] = []
-  const terminators = /(?<=[.!?])\s+/g
-  let lastEnd = 0
-  let match
-  while ((match = terminators.exec(text)) !== null) {
-    const candidate = text.slice(lastEnd, match.index + 1)
-    if (candidate.length >= _MIN_TTS_SENTENCE_CHARS) {
-      sentences.push(candidate)
-      lastEnd = match.index + match[0].length
-    }
-  }
-  return sentences
-}
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
@@ -7,7 +7,7 @@
 // speak()/speakStreaming() must surface a user-visible toast instead of
 // failing silently.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref } from 'vue'
 
 const mockShowToast = vi.fn()
@@ -162,5 +162,156 @@ describe('useVoiceOutput — concurrent voice checks (#11802)', () => {
     await speak('hello', true)
 
     expect(mockShowToast).not.toHaveBeenCalled()
+  })
+})
+
+
+// #12502: when the TTS WebSocket is unavailable, speakStreaming() falls back to
+// per-sentence HTTP synthesis. Previously each fallback went through speak(),
+// which aborts the in-flight utterance — so only the LAST sentence of a reply
+// was heard. The fallback must now QUEUE sentences and play them sequentially
+// without aborting each other.
+describe('useVoiceOutput — sequential fallback queue (#12502)', () => {
+  let originalAudioContext: unknown
+  let originalWebSocket: unknown
+  let bufferSourcesCreated = 0
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _clock += 60_000
+    vi.spyOn(Date, 'now').mockImplementation(() => _clock)
+    voicesRef.value = [{ id: 'v1' }]
+    bufferSourcesCreated = 0
+
+    class FakeBufferSource {
+      buffer: unknown = null
+      onended: (() => void) | null = null
+      connect() {}
+      start() {
+        setTimeout(() => this.onended && this.onended(), 0)
+      }
+      stop() {}
+    }
+    class FakeAudioContext {
+      state = 'running'
+      currentTime = 0
+      destination = {}
+      async resume() {}
+      async decodeAudioData() {
+        return { duration: 0.05 }
+      }
+      createBufferSource() {
+        bufferSourcesCreated++
+        return new FakeBufferSource()
+      }
+      createGain() {
+        return { gain: { value: 1 }, connect() {} }
+      }
+    }
+    // A WebSocket that always fails to connect, forcing the HTTP fallback path.
+    class FailingWebSocket {
+      static OPEN = 1
+      onopen: ((e?: unknown) => void) | null = null
+      onerror: ((e?: unknown) => void) | null = null
+      onclose: ((e?: unknown) => void) | null = null
+      onmessage: ((e?: unknown) => void) | null = null
+      readyState = 0
+      constructor() {
+        setTimeout(() => this.onerror && this.onerror(new Event('error')), 0)
+      }
+      send() {}
+      close() {}
+    }
+
+    originalAudioContext = (globalThis as Record<string, unknown>).AudioContext
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket
+    ;(globalThis as Record<string, unknown>).AudioContext = FakeAudioContext
+    ;(globalThis as Record<string, unknown>).WebSocket = FailingWebSocket
+  })
+
+  afterEach(() => {
+    ;(globalThis as Record<string, unknown>).AudioContext = originalAudioContext
+    ;(globalThis as Record<string, unknown>).WebSocket = originalWebSocket
+  })
+
+  it('queues every fallback sentence and plays them all — none aborted', async () => {
+    const signals: AbortSignal[] = []
+    const texts: string[] = []
+    ;(fetchWithAuth as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_url: string, opts: { body: FormData; signal: AbortSignal }) => {
+        signals.push(opts.signal)
+        texts.push(String(opts.body.get('text')))
+        return {
+          ok: true,
+          status: 200,
+          blob: async () => ({ arrayBuffer: async () => new ArrayBuffer(8) }),
+        }
+      },
+    )
+
+    const { speakStreaming } = useVoiceOutput()
+    const sentences = [
+      'First sentence of the streamed reply.',
+      'Second sentence of the streamed reply.',
+      'Third sentence of the streamed reply.',
+    ]
+    // Dispatch per-sentence exactly like the streaming watcher (not awaited).
+    sentences.forEach((s) => {
+      void speakStreaming(s)
+    })
+
+    // Let the WS reject, the queue drain, and every playback complete.
+    await vi.waitFor(() => {
+      expect(texts.length).toBe(sentences.length)
+      expect(bufferSourcesCreated).toBe(sentences.length)
+    })
+
+    // Every sentence was synthesized — none dropped by a self-aborting fallback.
+    expect([...texts].sort()).toEqual([...sentences].sort())
+    // All were actually played to completion (one audio buffer each).
+    expect(bufferSourcesCreated).toBe(sentences.length)
+    // Critically: NO in-flight utterance was aborted by a later fallback call
+    // (the pre-fix speak() path aborted the previous one every time).
+    expect(signals.some((s) => s.aborted)).toBe(false)
+  })
+
+  it('stopSpeaking() clears the fallback queue and aborts the in-flight utterance', async () => {
+    const signals: AbortSignal[] = []
+    let releaseFirst: () => void = () => {}
+    ;(fetchWithAuth as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_url: string, opts: { signal: AbortSignal }) => {
+        signals.push(opts.signal)
+        // Block the first synthesis so we can stop mid-flight.
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+        return {
+          ok: true,
+          status: 200,
+          blob: async () => ({ arrayBuffer: async () => new ArrayBuffer(8) }),
+        }
+      },
+    )
+
+    const { speakStreaming, stopSpeaking } = useVoiceOutput()
+    void speakStreaming('First blocked sentence of the reply.')
+    void speakStreaming('Second queued sentence of the reply.')
+    void speakStreaming('Third queued sentence of the reply.')
+
+    // Wait until the first synthesis is in-flight.
+    await vi.waitFor(() => {
+      expect(signals.length).toBe(1)
+    })
+
+    // User-initiated stop must abort the in-flight request and drop the queue.
+    stopSpeaking()
+    releaseFirst()
+
+    // Give any (incorrectly) queued follow-ups a chance to fire.
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(signals[0].aborted).toBe(true)
+    // No further synthesis started after the stop — queue was cleared.
+    expect(signals.length).toBe(1)
   })
 })

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -74,6 +74,16 @@ const wsConnected = ref<boolean>(false)
 // Module-level so a new speak() call can abort the previous one.
 let _speakController: AbortController | null = null
 
+// #12502: sequential fallback queue. When the TTS WebSocket is unavailable,
+// speakStreaming() falls back to per-sentence HTTP synthesis. Routing each
+// sentence through speak() aborted the in-flight utterance, so only the LAST
+// sentence of a reply was heard. Instead, enqueue sentences and drain them
+// sequentially (await each before starting the next) so the full reply is
+// spoken. An intentional stop / new reply clears _speakQueue and aborts
+// _speakController via _stopCurrentAudio(), which breaks the drain loop.
+const _speakQueue: string[] = []
+let _speakDraining = false
+
 /**
  * #9999: Surface the "no voices available" message once per cooldown window.
  * Uses the app's standard toast mechanism so the operator gets feedback
@@ -141,6 +151,11 @@ function unlockAudio(): void {
 }
 
 function _stopCurrentAudio(): void {
+  // #12502: an intentional stop / new reply must cancel ALL pending audio —
+  // drop any queued fallback sentences and abort the in-flight synthesis so the
+  // drain loop stops instead of continuing to speak a superseded reply.
+  _speakQueue.length = 0
+  _speakController?.abort()
   if (_currentSource) {
     try { _currentSource.stop() } catch { /* already stopped */ }
     _currentSource = null
@@ -319,6 +334,82 @@ function _connectTtsWs(): Promise<WebSocket> {
   return _ttsWsConnecting
 }
 
+/**
+ * Synthesize `text` via the HTTP TTS endpoint and play it to completion.
+ * Shared by the one-shot speak() and the sequential fallback drainer (#12502).
+ * The caller owns the AbortController so it can cancel this request.
+ */
+async function _synthesizeAndPlay(text: string, signal: AbortSignal): Promise<void> {
+  const { effectiveVoiceId } = useVoiceProfiles()
+  const { language: prefLang } = usePreferences()
+  const language = prefLang.value || ''
+  const formData = new FormData()
+  formData.append('text', text)
+  if (effectiveVoiceId.value) {
+    formData.append('voice_id', effectiveVoiceId.value)
+  }
+  if (language) {
+    formData.append('language', language)
+  }
+  const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, { // fetchWithAuth retained: binary audio blob + FormData body — exempt (#6256)
+    method: 'POST',
+    body: formData,
+    signal,
+  })
+  if (!response.ok) {
+    logger.warn('TTS synthesize failed:', response.status)
+    // #9999: 404/503 here means no TTS service/voices on this deployment.
+    if (response.status === 404 || response.status === 503) {
+      _notifyNoVoices()
+    }
+    return
+  }
+  const blob = await response.blob()
+  const arrayBuffer = await blob.arrayBuffer()
+  await _playAudioBuffer(arrayBuffer)
+  // Issue #1146: clear isSpeaking so watch(isSpeaking) in useVoiceConversation fires
+  isSpeaking.value = false
+}
+
+/**
+ * Drain the fallback queue, playing one sentence at a time to completion (#12502).
+ * Never aborts the in-flight utterance itself, so a burst of enqueued sentences
+ * plays end-to-end. Only an external stop (which clears the queue + aborts the
+ * controller) ends the loop early.
+ */
+async function _drainSpeakQueue(): Promise<void> {
+  _speakDraining = true
+  try {
+    while (_speakQueue.length > 0) {
+      const next = _speakQueue.shift() as string
+      _speakController = new AbortController()
+      try {
+        await _synthesizeAndPlay(next, _speakController.signal)
+      } catch (e) {
+        if (e instanceof DOMException && (e as DOMException).name === 'AbortError') {
+          // Intentional stop / new reply cleared the queue — stop draining.
+          break
+        }
+        logger.error('queued speak() error:', e)
+        isSpeaking.value = false
+      }
+    }
+  } finally {
+    _speakDraining = false
+  }
+}
+
+/**
+ * Enqueue a sentence for sequential HTTP playback (#12502). Used by the
+ * speakStreaming() fallback so per-sentence calls never abort each other.
+ */
+function _enqueueFallbackSpeak(text: string): void {
+  if (!text.trim()) return
+  _speakQueue.push(text)
+  if (_speakDraining) return
+  void _drainSpeakQueue()
+}
+
 export function useVoiceOutput() {
   function toggleVoiceOutput(): void {
     voiceOutputEnabled.value = !voiceOutputEnabled.value
@@ -334,6 +425,10 @@ export function useVoiceOutput() {
     }
   }
 
+  // One-shot speak: aborts any in-flight/queued audio first (intentional-abort
+  // semantics for a new one-shot utterance / manual replacement). Per-sentence
+  // streaming does NOT go through here — it uses speakStreaming() + the
+  // sequential fallback queue so sentences never abort each other (#12502).
   async function speak(text: string, force?: boolean): Promise<void> {
     if ((!force && !voiceOutputEnabled.value) || !text.trim()) return
     if (isSpeaking.value) _stopCurrentAudio()
@@ -344,38 +439,9 @@ export function useVoiceOutput() {
 
     _speakController?.abort()
     _speakController = new AbortController()
-    const signal = _speakController.signal
 
     try {
-      const { effectiveVoiceId } = useVoiceProfiles()
-      const { language: prefLang } = usePreferences()
-      const language = prefLang.value || ''
-      const formData = new FormData()
-      formData.append('text', text)
-      if (effectiveVoiceId.value) {
-        formData.append('voice_id', effectiveVoiceId.value)
-      }
-      if (language) {
-        formData.append('language', language)
-      }
-      const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, { // fetchWithAuth retained: binary audio blob + FormData body — exempt (#6256)
-        method: 'POST',
-        body: formData,
-        signal,
-      })
-      if (!response.ok) {
-        logger.warn('TTS synthesize failed:', response.status)
-        // #9999: 404/503 here means no TTS service/voices on this deployment.
-        if (response.status === 404 || response.status === 503) {
-          _notifyNoVoices()
-        }
-        return
-      }
-      const blob = await response.blob()
-      const arrayBuffer = await blob.arrayBuffer()
-      await _playAudioBuffer(arrayBuffer)
-      // Issue #1146: clear isSpeaking so watch(isSpeaking) in useVoiceConversation fires
-      isSpeaking.value = false
+      await _synthesizeAndPlay(text, _speakController.signal)
     } catch (e) {
       if (e instanceof DOMException && (e as DOMException).name === 'AbortError') return
       logger.error('speak() error:', e)
@@ -410,8 +476,10 @@ export function useVoiceOutput() {
         language,
       }))
     } catch {
-      logger.warn('TTS WS unavailable, falling back to HTTP speak()')
-      await speak(text, true)
+      // #12502: enqueue for sequential playback — calling speak() per sentence
+      // aborted the in-flight utterance, so only the last sentence was heard.
+      logger.warn('TTS WS unavailable, falling back to queued HTTP synthesis')
+      _enqueueFallbackSpeak(text.trim())
     }
   }
 

--- a/autobot-frontend/src/utils/__tests__/ttsSentences.test.ts
+++ b/autobot-frontend/src/utils/__tests__/ttsSentences.test.ts
@@ -1,0 +1,92 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// #12502: streaming sentence extraction must return the EXACT consumed span so
+// the caller's cursor never drifts over multi-paragraph replies, and the
+// unpunctuated end-of-stream tail must always be flushed.
+
+import { describe, it, expect } from 'vitest'
+import { extractCompleteSentences } from '../ttsSentences'
+
+const MIN = 20
+
+/** Words (non-whitespace runs) — order-preserving, whitespace-agnostic. */
+const words = (s: string): string[] => s.split(/\s+/).filter(Boolean)
+
+/**
+ * Replay the ChatInterface streaming watcher over `fullText`, revealed a chunk
+ * at a time, using the EXACT consumed span to advance the cursor (#12502).
+ * Returns everything TTS would speak during streaming plus the end-of-stream
+ * remainder flush.
+ */
+function simulateStreaming(fullText: string, chunk: number) {
+  let cursor = 0
+  const spoken: string[] = []
+  const reveal = (content: string) => {
+    const newText = content.slice(cursor)
+    const { sentences, consumed } = extractCompleteSentences(newText, MIN)
+    for (const s of sentences) spoken.push(s)
+    cursor += consumed
+  }
+  for (let end = chunk; end < fullText.length; end += chunk) {
+    reveal(fullText.slice(0, end))
+  }
+  reveal(fullText) // final streamed chunk
+  const remainder = fullText.slice(cursor).trim() // stream-end flush
+  return { spoken, remainder, cursor }
+}
+
+describe('extractCompleteSentences — exact consumed span (#12502)', () => {
+  it('reports consumed span that includes the full inter-sentence whitespace run', () => {
+    // Two paragraphs joined by a blank line: the terminator whitespace run is
+    // "\n\n" (2 chars) but the sentence text only carries one, so summing
+    // sentence lengths under-advances by 1 per boundary — hence `consumed`.
+    const text =
+      'This is the very first paragraph line.\n\nThis is the second paragraph line. '
+    const { sentences, consumed } = extractCompleteSentences(text, MIN)
+    expect(sentences.length).toBe(2)
+    const summed = sentences.reduce((n, s) => n + s.length, 0)
+    // Proof of the drift bug: naive `+= s.length` != the real consumed span.
+    expect(summed).not.toBe(consumed)
+    // The consumed span exactly tiles the accepted region of the source.
+    expect(consumed).toBe(text.trimEnd().length + 1) // through the trailing "\n... . " space
+  })
+
+  it('advances with no dropped or duplicated words over a multi-paragraph reply', () => {
+    const fullText =
+      'Here is the opening statement of the reply.\n\n' +
+      'The second paragraph continues with more detail here.\n\n' +
+      'A third and final paragraph wraps everything up. '
+    const { spoken, remainder } = simulateStreaming(fullText, 7)
+    // Every word spoken exactly once, in order, with none dropped/duplicated.
+    const produced = words(spoken.join(' ') + ' ' + remainder)
+    expect(produced).toEqual(words(fullText))
+  })
+})
+
+describe('extractCompleteSentences — tail flush at stream end (#12502)', () => {
+  it('leaves an unpunctuated list/code tail as the end-of-stream remainder', () => {
+    // No terminal ". "/"! "/"? " on the final line — it can only reach TTS via
+    // the remainder flush.
+    const fullText =
+      'Here is the summary of the available options below.\n\n' +
+      '- first bullet option\n' +
+      '- second bullet option\n' +
+      '- third and final option'
+    const { spoken, remainder } = simulateStreaming(fullText, 9)
+    expect(remainder.length).toBeGreaterThan(0)
+    expect(remainder).toContain('third and final option')
+    // Combined stream + flush loses nothing.
+    const produced = words(spoken.join(' ') + ' ' + remainder)
+    expect(produced).toEqual(words(fullText))
+  })
+
+  it('flushes a short unpunctuated tail that never met the sentence threshold', () => {
+    const fullText = 'ok' // below MIN, no terminator — pure tail
+    const { spoken, remainder } = simulateStreaming(fullText, 4)
+    expect(spoken).toEqual([])
+    expect(remainder).toBe('ok')
+  })
+})

--- a/autobot-frontend/src/utils/ttsSentences.ts
+++ b/autobot-frontend/src/utils/ttsSentences.ts
@@ -1,0 +1,49 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * ttsSentences.ts - streaming sentence extraction for sentence-level TTS (#1319).
+ * Extracted from ChatInterface.vue so the cursor-advance logic is unit-testable
+ * and returns the EXACT consumed span (including the inter-sentence whitespace
+ * run) so the caller's streaming cursor never drifts over multi-paragraph
+ * replies (#12502).
+ */
+
+export interface ExtractedSentences {
+  /** Complete sentences (>= minChars) ready to dispatch to TTS. */
+  sentences: string[]
+  /**
+   * Number of characters consumed from `text` — the end offset of the last
+   * accepted sentence INCLUDING its trailing whitespace run. Callers must
+   * advance their streaming cursor by exactly this amount. Advancing by the
+   * summed sentence lengths instead omits the inter-sentence whitespace (the
+   * sentence text excludes the full whitespace run) and drifts over
+   * multi-paragraph replies, dropping or duplicating slices (#12502).
+   */
+  consumed: number
+}
+
+/**
+ * Extract sentences terminated by ". ", "! ", or "? " from `text`. A trailing
+ * fragment with no terminator (and any sub-`minChars` candidate) stays buffered
+ * for the next call. Returns the accepted sentences plus the exact consumed span.
+ */
+export function extractCompleteSentences(
+  text: string,
+  minChars: number,
+): ExtractedSentences {
+  const sentences: string[] = []
+  const terminators = /(?<=[.!?])\s+/g
+  let lastEnd = 0
+  let match: RegExpExecArray | null
+  while ((match = terminators.exec(text)) !== null) {
+    const candidate = text.slice(lastEnd, match.index + 1)
+    if (candidate.length >= minChars) {
+      sentences.push(candidate)
+      lastEnd = match.index + match[0].length
+    }
+  }
+  return { sentences, consumed: lastEnd }
+}


### PR DESCRIPTION
## Thinking Path

The assistant's chat reply is not fully spoken by TTS (#12502, split from #12460). Traced the sentence-level streaming path across two files: the `speakStreaming()` fallback in `useVoiceOutput.ts` and the streaming watcher + `_extractCompleteSentences` in `ChatInterface.vue`. Three independent defects each drop text:

1. **Fallback self-aborts** — WS-unavailable fallback called `speak(text, true)` per sentence; `speak()` begins with `_stopCurrentAudio()` + `_speakController.abort()`, so rapid per-sentence fallbacks cancel each other and only the LAST sentence is heard.
2. **Cursor drift** — the watcher advanced `_lastSpokenIdx += s.length`, but the sentence text omits the inter-sentence whitespace run that the extractor actually consumes (`match[0]`), so the cursor drifts over multi-paragraph replies and drops/duplicates slices.
3. **Tail dropped** — text with no terminal `. `/`! `/`? ` (lists, code, unpunctuated endings) only reaches TTS via the end-of-stream remainder flush, and the flush branch never fired reliably on the isTyping→false transition.

## What Changed

- **Sequential fallback queue** (`useVoiceOutput.ts`): extracted `_synthesizeAndPlay()`, added `_speakQueue` + `_drainSpeakQueue()` + `_enqueueFallbackSpeak()`. The WS fallback now enqueues sentences and plays them one at a time (awaits each before the next) — no self-abort. `speak()` keeps its intentional one-shot abort semantics but now shares `_synthesizeAndPlay`.
- **Exact cursor span**: moved sentence extraction into a shared, unit-tested util `src/utils/ttsSentences.ts` whose `extractCompleteSentences()` returns `{ sentences, consumed }`. The watcher advances `_lastSpokenIdx += consumed` (the true consumed span incl. whitespace), eliminating drift.
- **Guaranteed tail flush**: the watcher's tracked value now includes `typing: store.isTyping`, so the stream-completion transition always fires the remainder flush of all text after the cursor.
- **Intentional-stop preserved**: `_stopCurrentAudio()` now clears `_speakQueue` + aborts `_speakController`, and the watcher calls `stopSpeaking()` when a fresh reply (new id + isTyping) streams in — a new reply / manual stop still cancels ALL pending audio; only same-reply per-sentence fallback queues instead of aborting.

## Verification

`npx vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (clean).

`npx vitest run` (new + existing voice tests):
```
 ✓ src/utils/__tests__/ttsSentences.test.ts (4 tests) 25ms
 ✓ src/composables/__tests__/useVoiceOutput.test.ts (8 tests) 173ms

 Test Files  2 passed (2)
      Tests  12 passed (12)
```
New tests assert: (a) multiple fallback sentences all synthesized + played, none aborted, plus `stopSpeaking()` clears the queue + aborts in-flight; (b) cursor advances by exact span over a multi-paragraph reply with no dropped/duplicated words; (c) an unpunctuated list/short tail is flushed at stream end.

Regression: `ChatInterface.test.ts` 23/23 pass; eslint clean on all changed files.

## Model Used

claude-opus-4-8

Closes #12502