### PR TITLE
test(voice): add integration marker to voice_integration_test (#12510)

### DIFF
--- a/autobot-backend/api/voice_integration_test.py
+++ b/autobot-backend/api/voice_integration_test.py
@@ -16,9 +16,14 @@ import io
 import time
 import wave
 
+import pytest
 import requests
 
 from autobot_shared.ssot_config import config
+
+# #12510: these tests hit a live backend + TTS worker over real HTTP, so they
+# must be excluded from the unit-test job (pytest -m "not integration ...").
+pytestmark = pytest.mark.integration
 
 # ------------------------------------------------------------------ #
 # Config (#1618: use SSOT — no hardcoded IPs)                         #


### PR DESCRIPTION
Closes #12510

## Thinking Path
Discovered during #12501: voice_integration_test.py hits a live backend + TTS worker over real HTTP but had no integration marker, so the unit-test job (pytest -m "not integration ...") collected + failed it wherever a live backend/worker is unreachable.

## What Changed
- autobot-backend/api/voice_integration_test.py: added module-level pytestmark = pytest.mark.integration (marker already registered in pytest.ini).

## Verification
- Under `-m "not integration and not slow and not distributed and not performance"`: 10 deselected / 0 selected (was collected+failing before).
- Without filter: 10 collected, no strict-marker error. black/flake8 clean.

## Model Used
Opus 4.8.