### PR TITLE
fix(deps): bump js-yaml to 4.3.0 via override for security alert (#12269)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -9639,9 +9639,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -85,6 +85,7 @@
     "wavesurfer.js": "^7.12.10"
   },
   "overrides": {
+    "js-yaml": "4.3.0",
     "minimatch": ">=9.0.7",
     "uuid": "^14.0.0",
     "qs": ">=6.15.2",


### PR DESCRIPTION
## Thinking Path

Triaged the three JS Dependabot tracking issues against the actual base (`Dev_new_gui`) lockfile state via `gh api .../dependabot/alerts` (exact `first_patched` per alert) and inspection of each affected `package-lock.json`. Most listed alerts were already satisfied on base (recent bumps not yet re-scanned); only a subset remained genuinely open. Applied the one safe, hand-editable transitive bump; flagged the two that require either a breaking major or a full multi-package lockfile regeneration (no npm available in this WSL env — surgical lockfile edits only).

## What Changed

**js-yaml — `autobot-frontend` (#12269): 4.2.0 → 4.3.0 (transitive, via `overrides`)**
- Pulled transitively and pinned **exactly** to `4.2.0` by `@redocly/openapi-core@1.34.17`; vulnerable per GHSA-52cp-r559-cp3m (high, `>=4.0.0 <4.3.0`).
- Forced to `4.3.0` with a new `overrides` entry in `autobot-frontend/package.json` (matches existing transitive-pinning pattern: minimatch/uuid/qs/shell-quote), and surgically updated the `node_modules/js-yaml` node in `autobot-frontend/package-lock.json` (`version`/`resolved`/`integrity` → 4.3.0). 4.3.0 has identical deps/bin/engines as 4.2.0 (dev-only, argparse `^2.0.1`).
- Files: `autobot-frontend/package.json`, `autobot-frontend/package-lock.json`.

**Already patched on base (no change needed — stale alerts will auto-close after re-scan):**
- js-yaml (#12269): `mcp-structured-thinking` and `libs/autobot-sdk-ts` already at **3.15.0** (patched 3.x line).
- hono (#12274): `.mcp`, `mcp-autobot-tracker`, `mcp-structured-thinking` already at **4.12.31** (≥ patched 4.12.27).
- protobufjs (#12276): `autobot-frontend` already at **7.6.5** (= patched).

**Flagged — NOT changed (risky / not safely hand-editable):**
- **@hono/node-server (#12274): 1.19.13 → 2.0.5 is a breaking MAJOR.** It is transitive via `@modelcontextprotocol/sdk@1.27.1`, which pins `@hono/node-server: ^1.19.9` (`<2.0.0`). Forcing v2 would run the MCP SDK against a v2 API it wasn't written for (runtime breakage risk). Correct fix is upstream (SDK adopting node-server v2), not a forced override. Also, `mcp-task-manager-server/package-lock.json` referenced by #12274 does not exist on `Dev_new_gui`, so those 4 alerts cannot be patched here.
- **@babel/core (#12276): 7.26.10 → 7.29.6 (low sev, dev-only, MCP tool).** 7.29.6 requires a 10+ package cascade (`@babel/parser ^7.29.3`, `@babel/generator ^7.29.6`, `@babel/traverse ^7.29.0`, … plus a new `@jridgewell/remapping` dependency). This cannot be produced consistently by hand without a real `npm install`/lockfile regen, so it is deferred rather than committed as an inconsistent lockfile.

Because #12274 and #12276 are only partially resolvable here (remaining items are a breaking major and a regen-required cascade), they are **referenced, not auto-closed** — partial delivery must not close them.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` in `autobot-frontend` (node_modules symlinked read-only from main tree, no install) → **exit 0**.
- Both edited JSON files parse cleanly (`json.load`).
- Registry-confirmed integrity for js-yaml 4.3.0: `sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==`.
- Only 2 files changed; no leftover `js-yaml-4.2.0` reference in the lockfile install nodes.

## Model Used

claude-opus-4-8

Closes #12269
Refs #12274, #12276
