### PR TITLE
fix(logging): resolve dead deployment.mode console-handler gate (#12506)

### DIFF
--- a/autobot_shared/logging_manager.py
+++ b/autobot_shared/logging_manager.py
@@ -110,15 +110,28 @@ class LoggingManager:
                 if handler:
                     logger.addHandler(handler)
 
-                # Add console handler for development
-                # #12488: split by level instead of a single bare stderr
-                # StreamHandler() so systemd's StandardOutput/StandardError
-                # append: split (INFO->*.log, WARNING+->*-error.log) matches
-                # what actually gets emitted.
-                if _get_config_manager().get("deployment.mode", "local") == "local":
-                    formatter = cls._get_formatter()
-                    logger.addHandler(build_stdout_handler(formatter))
-                    logger.addHandler(build_stderr_handler(formatter))
+                # Console handler is intentionally unconditional (#12506).
+                # This used to be gated on `_get_config_manager().get(
+                # "deployment.mode", "local") == "local"`, i.e. "console
+                # handler = local dev only". That gate was a no-op in every
+                # environment: `ConfigManager.get()` does a flat dict lookup
+                # (no dotted-key traversal), no config source ever sets a
+                # literal top-level `"deployment.mode"` key, and the real
+                # env var (`AUTOBOT_DEPLOYMENT_MODE`, see
+                # `autobot_shared.ssot_config.config.deployment_mode`) was
+                # never wired into it — so the lookup always fell through to
+                # the `"local"` default and the console handler was already
+                # unconditional before this change.
+                # Per #12488, that's the behavior we want everywhere: systemd
+                # captures each service's stdout/stderr into its log files
+                # (StandardOutput=append:/StandardError=append:), so the
+                # console handler is production infra, not a dev-only extra.
+                # `build_stdout_handler`/`build_stderr_handler` split by
+                # level (DEBUG/INFO->stdout, WARNING+->stderr) instead of a
+                # single bare stderr StreamHandler().
+                formatter = cls._get_formatter()
+                logger.addHandler(build_stdout_handler(formatter))
+                logger.addHandler(build_stderr_handler(formatter))
 
             # Set log level
             log_level = getattr(logging, _get_config_manager().get("logging.level", "INFO").upper())

--- a/autobot_shared/logging_manager_test.py
+++ b/autobot_shared/logging_manager_test.py
@@ -1,0 +1,70 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for LoggingManager's console handler (#12506).
+
+Prior to this fix, the console handler in ``LoggingManager.get_logger`` was
+gated on ``_get_config_manager().get("deployment.mode", "local") ==
+"local"`` — a dead/no-op condition (flat-key lookup, key never set) that
+always fell through to the ``"local"`` default. Per #12488 the console
+handler is meant to be unconditional in every mode (systemd captures
+stdout/stderr into the real log files), so this test proves:
+
+1. ``get_logger()`` always attaches a console handler (no mode gate).
+2. That handler still routes DEBUG/INFO -> stdout, WARNING+ -> stderr
+   (the #12488 split), with no regression from removing the gate.
+"""
+
+import logging
+import logging.handlers
+
+from autobot_shared.logging_manager import LoggingManager
+from autobot_shared.stream_logging import MaxLevelFilter
+
+
+def _console_handlers(logger: logging.Logger) -> list[logging.StreamHandler]:
+    return [
+        h
+        for h in logger.handlers
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+
+
+def test_get_logger_always_attaches_console_handlers():
+    """Console handler is unconditional — no deployment-mode gate (#12506)."""
+    logger = LoggingManager.get_logger("logging_manager_test.always_on", "debug")
+    console_handlers = _console_handlers(logger)
+
+    assert len(console_handlers) == 2, "expected one stdout + one stderr handler regardless of mode"
+
+
+def test_console_handlers_split_info_to_stdout_and_warning_to_stderr(capsys):
+    """No regression from removing the gate: #12488 level split still holds."""
+    logger = LoggingManager.get_logger("logging_manager_test.level_split", "debug")
+    logger.propagate = False
+
+    logger.info("info-line-12506")
+    logger.warning("warn-line-12506")
+
+    captured = capsys.readouterr()
+    assert "info-line-12506" in captured.out
+    assert "warn-line-12506" not in captured.out
+    assert "warn-line-12506" in captured.err
+    assert "info-line-12506" not in captured.err
+
+
+def test_exactly_one_console_handler_carries_the_max_level_filter():
+    """Exactly one of the two console handlers is the stdout side (belt-and-
+    suspenders MaxLevelFilter rejecting WARNING+), the other is the stderr
+    side (setLevel(WARNING), no filter)."""
+    logger = LoggingManager.get_logger("logging_manager_test.filter_check", "debug")
+    console_handlers = _console_handlers(logger)
+
+    with_filter = [h for h in console_handlers if any(isinstance(f, MaxLevelFilter) for f in h.filters)]
+    without_filter = [h for h in console_handlers if h not in with_filter]
+
+    assert len(with_filter) == 1
+    assert len(without_filter) == 1
+    assert without_filter[0].level == logging.WARNING


### PR DESCRIPTION
## Thinking Path

#12506 flagged that `LoggingManager.get_logger()` gates its console handler on `_get_config_manager().get("deployment.mode", "local") == "local"`. Traced the lookup: `ConfigManager.get(key, default)` (`autobot-backend/config/sync_ops.py`) does a **flat** dict lookup — no dotted/nested traversal (that's `get_nested`). No config source (`config.yaml`/`settings.json`) ever defines a literal top-level key named `"deployment.mode"`, and the real env var `AUTOBOT_DEPLOYMENT_MODE` (mapped to `autobot_shared.ssot_config.config.deployment_mode`) is never wired into `ENV_VAR_MAPPINGS` for that lookup. Net effect: the call always falls through to the `"local"` default in every environment, so the gate always evaluates `True` — the console handler has always been unconditional, the "local dev only" intent was dead code.

Checked whether any mode legitimately wants the console handler absent: #12488 (merged) rebuilt this exact handler to split by level (DEBUG/INFO -> stdout, WARNING+ -> stderr) specifically because systemd's `StandardOutput=append:`/`StandardError=append:` capture each service's console streams into its real production log files. That means the console handler is production log-delivery infra, not a dev-only convenience — confirming the always-on behavior is correct and should be made explicit rather than "fixed" into an actually-restrictive gate (which would silence prod console logs and regress #12488).

## What Changed

- `autobot_shared/logging_manager.py`: removed the dead `deployment.mode` gate; the console handler (`build_stdout_handler`/`build_stderr_handler`) is now attached unconditionally with a comment explaining why the old gate was a no-op and why always-on is intentional (references #12506 and #12488).
- `_get_config_manager()` / `_ConfigManagerFallback` are unchanged — still used by `_get_file_handler`, `_get_formatter`, and the log-level lookup, so nothing dead was left behind.
- Added `autobot_shared/logging_manager_test.py`: proves `get_logger()` always attaches exactly one stdout + one stderr console handler (no mode gate), that the #12488 level split (INFO->stdout, WARNING->stderr) still holds, and that the stdout handler still carries its `MaxLevelFilter`.

This is not a regression risk: behavior at runtime is identical (the gate always evaluated `True` before), only the code now says what it does instead of hiding a broken conditional.

## Verification

```
python3 -m pytest autobot_shared/logging_manager_test.py autobot_shared/stream_logging_test.py -p no:xdist -q
======================= 9 passed in 2.04s =======================

python3 -m pytest autobot-backend/tests/test_startup_imports.py -p no:xdist -q
====================== 345 passed, 82 warnings in 19.60s =======================

python3 -m black --check --fast autobot_shared/logging_manager.py autobot_shared/logging_manager_test.py
All done! 2 files would be left unchanged.

python3 -m flake8 autobot_shared/logging_manager.py autobot_shared/logging_manager_test.py
(no output — clean)
```

## Model Used

Sonnet 5

Closes #12506