### PR TITLE
fix(deploy): role-manage AUTOBOT_USERS_DATABASE_URL + strip stale slm-secrets DB-URLs, topology-aware (#12297)

### DIFF
--- a/autobot-slm-backend/ansible/roles/postgresql/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/defaults/main.yml
@@ -72,6 +72,17 @@ databases:
   - slm_users
   - autobot_users
 
+# #12297: Host at which the SLM control plane (slm_app) reaches the
+# autobot_users DB. Topology-aware and derived exactly like
+# deploy-user-management-db.yml Phase 3 (redis_host | default('127.0.0.1')):
+#   - Co-located single box: redis_host is left undefined by the inventory
+#     (#12214), so this resolves to 127.0.0.1 (autobot_users is local).
+#   - Remote DB VM: redis_host points at the database VM, so the role-managed
+#     AUTOBOT_USERS_DATABASE_URL targets the correct remote host instead of a
+#     hardcoded localhost. Genuinely-remote credentials/overrides still live in
+#     slm-secrets.env and are preserved by the #12297 duplicate-only strip.
+slm_autobot_users_host: "{{ redis_host | default('127.0.0.1') }}"
+
 # AutoBot user
 autobot_user: "autobot"
 autobot_group: "autobot"

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
@@ -96,7 +96,18 @@
 # prefix as its own marked block so both coexist and neither clobbers the other;
 # this also lets "Reuse existing database password" find the prior password, so
 # a redeploy no longer regenerates it and env/Postgres never diverge.
-- name: "Save credentials to file (per-prefix block, #12224)"
+#
+# #12297 (Arm 1): the SLM connects slm_app -> the autobot_users DB, but that
+# URL used to live ONLY in slm-secrets.env — a stale landmine that overrode
+# the role-managed value forever. Emit a role-managed AUTOBOT_USERS_DATABASE_URL
+# in the SLM block so db-credentials.env is the single authority for all three
+# SLM DB URLs. The host is topology-derived (slm_autobot_users_host =
+# redis_host | default('127.0.0.1')): localhost when autobot_users is
+# co-located, the DB-VM host when it is remote — never a hardcoded localhost.
+# The generic URL loop skips autobot_users for the SLM prefix so this
+# topology-aware line is the single source (no duplicate even when
+# autobot_users is in `databases`, e.g. deploy-slm-manager.yml default list).
+- name: "Save credentials to file (per-prefix block, #12224, #12297)"
   ansible.builtin.blockinfile:
     path: "{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}"
     marker: "# {mark} {{ db_env_prefix }} DB CREDENTIALS (managed by postgresql role)"
@@ -114,9 +125,12 @@
       {{ db_env_prefix }}_DB_{{ db | upper | replace('-', '_') }}={{ db }}
       {% endfor %}
       {{ db_env_prefix }}_DATABASE_URL=postgresql+asyncpg://{{ db_user }}:{{ db_password }}@{{ db_host | default('127.0.0.1') }}:{{ postgresql_port }}/{{ databases | first }}
-      {% for db in databases[1:] %}
+      {% for db in databases[1:] if not (db_env_prefix == 'SLM' and db == 'autobot_users') %}
       {{ db | upper | replace('-', '_') }}_DATABASE_URL=postgresql+asyncpg://{{ db_user }}:{{ db_password }}@{{ db_host | default('127.0.0.1') }}:{{ postgresql_port }}/{{ db }}
       {% endfor %}
+      {% if db_env_prefix == 'SLM' %}
+      AUTOBOT_USERS_DATABASE_URL=postgresql+asyncpg://{{ db_user }}:{{ db_password }}@{{ slm_autobot_users_host }}:{{ postgresql_port }}/autobot_users
+      {% endif %}
   become: true
   no_log: true
 

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -414,6 +414,124 @@
   tags: ['slm', 'secrets']
 
 # ==========================================================
+# #12297: Reconcile stale DB-URL landmines in slm-secrets.env
+#
+# systemd loads db-credentials.env then slm-secrets.env (last wins), so any
+# *_DATABASE_URL planted in slm-secrets.env (e.g. by a manual #12224 recovery)
+# overrides the role-managed value forever and eventually goes stale — the
+# residual outage described in #12297. Strip such a line ONLY when
+# db-credentials.env already provides that key with a MATCHING value (a
+# redundant duplicate of the role-managed value). A DIFFERING value is treated
+# as a deliberate remote-DB override for a non-co-located topology and is LEFT
+# untouched, so legitimate remote overrides survive. This runs AFTER the
+# postgresql role (Arm 1) has written db-credentials.env, and the strip loop
+# only iterates keys db-credentials.env actually provides — so a URL is never
+# removed unless a role-managed replacement already exists (sequencing guard).
+# ==========================================================
+- name: "SLM | #12297: stat db-credentials.env"
+  ansible.builtin.stat:
+    path: "{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}"
+  register: _slm_dbcreds_stat
+  tags: ['slm', 'secrets']
+
+- name: "SLM | #12297: stat slm-secrets.env"
+  ansible.builtin.stat:
+    path: "{{ slm_credentials_dir }}/{{ slm_credentials_file }}"
+  register: _slm_secrets_file_stat
+  tags: ['slm', 'secrets']
+
+- name: "SLM | #12297: reconcile slm-secrets.env DB-URLs against db-credentials.env"
+  when:
+    - _slm_dbcreds_stat.stat.exists
+    - _slm_secrets_file_stat.stat.exists
+  tags: ['slm', 'secrets']
+  block:
+    - name: "SLM | #12297: slurp db-credentials.env"
+      ansible.builtin.slurp:
+        src: "{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}"
+      register: _slm_dbcreds_raw
+      no_log: true
+
+    - name: "SLM | #12297: slurp slm-secrets.env"
+      ansible.builtin.slurp:
+        src: "{{ slm_credentials_dir }}/{{ slm_credentials_file }}"
+      register: _slm_secrets_raw
+      no_log: true
+
+    - name: "SLM | #12297: parse role-managed DB-URLs (db-credentials.env)"
+      ansible.builtin.set_fact:
+        _slm_dbcreds_urls: >-
+          {{ dict(_slm_dbcreds_raw.content | b64decode
+                  | regex_findall('(?m)^([A-Z0-9_]+_DATABASE_URL)=(.*)$')) }}
+      no_log: true
+
+    - name: "SLM | #12297: parse secrets DB-URLs (slm-secrets.env)"
+      ansible.builtin.set_fact:
+        _slm_secrets_urls: >-
+          {{ dict(_slm_secrets_raw.content | b64decode
+                  | regex_findall('(?m)^([A-Z0-9_]+_DATABASE_URL)=(.*)$')) }}
+      no_log: true
+
+    # Duplicate-only strip: remove a DB-URL from slm-secrets.env ONLY when the
+    # role-managed db-credentials.env provides the SAME key with an identical
+    # value. Differing (deliberate remote-override) values are preserved.
+    - name: "SLM | #12297: strip stale DUPLICATE DB-URLs from slm-secrets.env"
+      ansible.builtin.lineinfile:
+        path: "{{ slm_credentials_dir }}/{{ slm_credentials_file }}"
+        regexp: "^{{ item | regex_escape }}=.*$"
+        state: absent
+      loop: "{{ _slm_dbcreds_urls.keys() | list }}"
+      when: >-
+        item in _slm_secrets_urls
+        and (_slm_secrets_urls[item] | trim) == (_slm_dbcreds_urls[item] | trim)
+      no_log: true
+      notify: restart slm backend
+
+    # ---- Regression guard (#12297) ----
+    - name: "SLM | #12297: assert db-credentials.env carries all three SLM DB URLs"
+      ansible.builtin.assert:
+        that:
+          - "'SLM_DATABASE_URL' in _slm_dbcreds_urls"
+          - "'SLM_USERS_DATABASE_URL' in _slm_dbcreds_urls"
+          - "'AUTOBOT_USERS_DATABASE_URL' in _slm_dbcreds_urls"
+        fail_msg: >-
+          db-credentials.env is missing an SLM DB URL — Arm 1 (postgresql role)
+          must run before slm_manager. Present keys: {{ _slm_dbcreds_urls.keys() | list }}
+        success_msg: "db-credentials.env carries all three SLM DB URLs (#12297)."
+
+    - name: "SLM | #12297: re-read slm-secrets.env after strip"
+      ansible.builtin.slurp:
+        src: "{{ slm_credentials_dir }}/{{ slm_credentials_file }}"
+      register: _slm_secrets_after
+      no_log: true
+
+    - name: "SLM | #12297: parse slm-secrets DB-URLs after strip"
+      ansible.builtin.set_fact:
+        _slm_secrets_urls_after: >-
+          {{ dict(_slm_secrets_after.content | b64decode
+                  | regex_findall('(?m)^([A-Z0-9_]+_DATABASE_URL)=(.*)$')) }}
+      no_log: true
+
+    # A key=value token present in BOTH dicts (identical key AND value) is a
+    # residual stale duplicate. intersect of the JSON-encoded {key,value} items
+    # yields exactly those; a deliberate differing override is not in the set.
+    - name: "SLM | #12297: compute residual stale-duplicate DB-URLs"
+      ansible.builtin.set_fact:
+        _slm_stale_dupes: >-
+          {{ (_slm_secrets_urls_after | dict2items | map('to_json') | list)
+             | intersect(_slm_dbcreds_urls | dict2items | map('to_json') | list) }}
+      no_log: true
+
+    - name: "SLM | #12297: assert no STALE duplicate DB-URL remains in slm-secrets.env"
+      ansible.builtin.assert:
+        that:
+          - _slm_stale_dupes | length == 0
+        fail_msg: >-
+          slm-secrets.env still carries DB-URL(s) that duplicate the role-managed
+          db-credentials.env value (stale landmine not stripped): {{ _slm_stale_dupes }}
+        success_msg: "slm-secrets.env has no stale duplicate DB-URL (#12297)."
+
+# ==========================================================
 # Backend systemd service
 # ==========================================================
 - name: "SLM | Deploy backend systemd service"

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -526,9 +526,12 @@
       ansible.builtin.assert:
         that:
           - _slm_stale_dupes | length == 0
+        # Render KEYS ONLY — items are JSON {key,value} strings whose value is
+        # the full postgresql+asyncpg URL (contains the DB password). Never emit
+        # the value to Ansible stdout/logs (#12297 security review).
         fail_msg: >-
-          slm-secrets.env still carries DB-URL(s) that duplicate the role-managed
-          db-credentials.env value (stale landmine not stripped): {{ _slm_stale_dupes }}
+          slm-secrets.env still carries stale duplicate DB-URL key(s) that must be
+          stripped: {{ _slm_stale_dupes | map('from_json') | map(attribute='key') | list }}
         success_msg: "slm-secrets.env has no stale duplicate DB-URL (#12297)."
 
 # ==========================================================

--- a/docs/runbooks/EMERGENCY_RECOVERY.md
+++ b/docs/runbooks/EMERGENCY_RECOVERY.md
@@ -104,6 +104,56 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-slm-manager.yml -i inventory/slm-nodes.yml --limit 00-SLM-Manager
 ```
 
+### Scenario: SLM `database: unhealthy` / `asyncpg InvalidPasswordError` after Update-All
+
+The SLM control plane connects `slm_app` to three databases (`slm`, `slm_users`,
+`autobot_users`). Those URLs are **role-managed in `/etc/autobot/db-credentials.env`**.
+systemd loads `db-credentials.env` first and `slm-secrets.env` second (last wins),
+so any `*_DATABASE_URL` line in `slm-secrets.env` overrides the role-managed value.
+
+> IMPORTANT (#12224 / #12297): a DB-URL written to `slm-secrets.env` goes **stale**
+> the next time the postgresql role reconciles the password and takes the DB
+> unhealthy. **Recovery must write DB URLs to `db-credentials.env` (or fix the
+> Postgres role/password) — NEVER to `slm-secrets.env`.** Since #12297 the
+> postgresql role emits all three SLM DB URLs to `db-credentials.env`
+> (topology-aware host) and the `slm_manager` role strips any *duplicate* DB-URL
+> from `slm-secrets.env`; a *deliberate remote-DB override* in `slm-secrets.env`
+> (value that differs) is preserved.
+
+**Step 1: Confirm the source of the URL the service actually uses**
+
+```bash
+ssh autobot@<slm-manager-ip> "sudo grep -H DATABASE_URL /etc/autobot/db-credentials.env /etc/autobot/slm-secrets.env"
+```
+
+**Step 2: Preferred fix — re-run provisioning so the role reconciles both files**
+
+```bash
+# From dev machine (supervised one-box deploy, NOT unattended Update-All):
+cd autobot-slm-backend/ansible
+ansible-playbook playbooks/deploy-slm-manager.yml -i inventory/slm-nodes.yml --limit 00-SLM-Manager --tags postgresql,slm
+```
+
+This writes the correct role-managed URLs to `db-credentials.env` and strips any
+stale *duplicate* DB-URL from `slm-secrets.env`.
+
+**Step 3: Manual break-glass (only if you cannot run Ansible right now)**
+
+Edit `db-credentials.env` — never `slm-secrets.env`. If `slm-secrets.env` holds a
+DB-URL that *duplicates* `db-credentials.env`, comment it out; if it *differs* and
+is a real remote-DB override, leave it. Back up before editing:
+
+```bash
+ssh autobot@<slm-manager-ip> "sudo cp /etc/autobot/db-credentials.env /etc/autobot/db-credentials.env.bak-$(date +%Y%m%d-%H%M%S)"
+# Fix the offending *_DATABASE_URL in db-credentials.env to match the working
+# slm_app password, then restart and verify:
+ssh autobot@<slm-manager-ip> "sudo systemctl restart autobot-slm-backend && sleep 5 && systemctl show autobot-slm-backend -p NRestarts"
+ssh autobot@<slm-manager-ip> "curl -sf http://127.0.0.1:8000/api/health"
+```
+
+Do **not** run `ALTER ROLE` / regenerate the password (that reintroduces the
+#12224 desync). Confirm `database: healthy` and `NRestarts=0` before leaving.
+
 ---
 
 ## Node Recovery


### PR DESCRIPTION
## Thinking Path
#12224 (PR #12236) stopped the postgresql role from regenerating `slm_app`'s password, but two residual defects can still take the SLM control-plane DB unhealthy after an Update-All:

- **Defect A — stale landmine:** the SLM systemd unit loads `db-credentials.env` then `slm-secrets.env` (last wins). `slm-secrets.env` is only written when it does not exist, so a manually-planted `*_DATABASE_URL` there wins forever and never self-heals — stale URL ≠ Postgres → `asyncpg InvalidPasswordError`.
- **Defect B — missing key:** `AUTOBOT_USERS_DATABASE_URL` is not guaranteed role-managed. `deploy-user-management-db.yml` Phase 1 overrides `databases: [slm, slm_users]` (excludes `autobot_users`), so on that path the URL can only live in `slm-secrets.env`.

Owner topology decision: the box is **sometimes co-located, sometimes a remote DB VM**. The fix must role-manage the URL AND preserve legitimate remote-DB overrides — so flipping the `EnvironmentFile` order is explicitly rejected (it would silently break remote overrides).

## What Changed
**Arm 1 — role-managed home for `AUTOBOT_USERS_DATABASE_URL`, topology-aware host** (`roles/postgresql/tasks/databases.yml`, `roles/postgresql/defaults/main.yml`):
- The SLM credentials block now always emits `AUTOBOT_USERS_DATABASE_URL` for `slm_app@autobot_users` with the role-managed password, so `db-credentials.env` is the single authority for all three SLM DB URLs.
- The host is derived, not hardcoded: `slm_autobot_users_host = redis_host | default('127.0.0.1')` (same convention as this playbook's Phase 3 / #12214). Co-located boxes (redis_host left undefined) get `127.0.0.1`; remote-DB deployments get the DB-VM host.
- The generic URL loop skips `autobot_users` for the SLM prefix, so exactly one topology-aware line is emitted — no duplicate even when `autobot_users` is in `databases` (e.g. the `deploy-slm-manager.yml` default list).

**Arm 2 — duplicate-only strip that preserves remote overrides** (`roles/slm_manager/tasks/main.yml`):
- Reads both files and strips a `*_DATABASE_URL` from `slm-secrets.env` **only when** `db-credentials.env` provides that exact key with an **identical** value (a redundant stale duplicate).
- If `slm-secrets.env` has a DB-URL that **differs** (a deliberate remote-DB override for a non-co-located topology), it is **left untouched** — remote overrides survive and continue to win via `EnvironmentFile` order.

**Regression guard** (deploy-time asserts in `slm_manager`):
- Asserts `db-credentials.env` carries all three SLM DB URLs.
- Asserts `slm-secrets.env` has no **stale duplicate** DB-URL after the strip (computed via set-intersection of JSON-encoded `{key,value}` items, so only exact key+value duplicates count; differing overrides are not flagged).

**Sequencing:** Arm 1 (postgresql role) runs before Arm 2 (slm_manager) in `deploy-slm-manager.yml` (roles: postgresql → slm_manager). Arm 2's strip loop only iterates keys `db-credentials.env` actually provides, so a URL is never stripped without a role-managed replacement.

**Runbook** (`docs/runbooks/EMERGENCY_RECOVERY.md`): new scenario for `database: unhealthy` / `asyncpg InvalidPasswordError` — recoveries must write DB URLs to `db-credentials.env` (or fix Postgres), NEVER to `slm-secrets.env`; do not `ALTER ROLE`/regenerate (reintroduces #12224).

No app-code change (config.py already reads the var). No `ALTER ROLE`, no password regeneration, no migrations, no data loss. `EnvironmentFile` order unchanged.

## Verification
- `ansible-playbook --syntax-check` passes for `deploy-slm-manager.yml` and `deploy-user-management-db.yml` (only pre-existing env-var host-pattern warnings).
- `yaml.safe_load` parses all three changed YAML files.
- **Jinja render test** of the db-credentials block across four combos (SLM co-located both playbook paths, SLM remote-DB, AUTOBOT phase): exactly one `AUTOBOT_USERS_DATABASE_URL` in the SLM block with the correct host (`127.0.0.1` co-located, remote host when `redis_host` set); AUTOBOT phase never emits it — all assertions pass.
- **Arm 2 duplicate-only strip validated** in two ways: (1) a Python simulation of the parse → strip → residual-dupe pipeline across four cases (exact-duplicate → stripped; remote override differs → preserved; stale differing → left; mixed → dupe stripped + override kept); (2) a localhost Ansible filter-chain playbook confirming the real `regex_findall`/`dict`/`dict2items`/`to_json`/`intersect` filters behave identically (override → empty stale set; duplicate → detected). Non-URL keys are never touched.

Prod rollout note: this must be applied as a **supervised one-box deploy** (verify `database: healthy` and `NRestarts=0` afterwards), NOT an unattended Update-All.

Follow-up filed for the same drift class in the managed backend's private `.env` (`AUTOBOT_POSTGRES_PASSWORD` vs role-managed `autobot-db-credentials.env`): #12520.

## Model Used
claude-opus-4-8

Closes #12297