### PR TITLE
fix(analytics): graceful /cached no_data + daily off-peak cache population (#12365)

### DIFF
--- a/autobot-backend/api/anti_pattern.py
+++ b/autobot-backend/api/anti_pattern.py
@@ -124,25 +124,30 @@ _detector_lock = asyncio.Lock()
 
 
 async def _get_detector():
-    """Get or create the anti-pattern detector instance (lazy initialization, thread-safe)"""
+    """Get or create the anti-pattern detector instance (lazy initialization, thread-safe).
+
+    Issue #12365: previously loaded ``tools/code-analysis-suite/src/anti_pattern_detector.py``
+    via ``importlib.util.spec_from_file_location`` — that directory was deleted during the
+    #781/#926 repo restructuring (#12436), so every call raised FileNotFoundError and every
+    ``/api/anti-pattern/*`` endpoint (including ``/cached``) was broken. The canonical
+    successor is ``code_analysis.src.anti_pattern_detector`` (a normal importable package,
+    no dashes in its path, no importlib hack needed — see ``code_intelligence/
+    anti_pattern_detector.py``'s facade re-export, GH#6757).
+
+    Also wires a real async Redis client into the detector: the class defaults
+    ``redis_client=None``, which makes its own ``_cache_results``/``get_cached_report``
+    no-ops, so ``/analyze`` never actually populated the store ``/cached`` reads.
+    """
     global _detector_instance
     if _detector_instance is None:
         async with _detector_lock:
             # Double-check after acquiring lock
             if _detector_instance is None:
-                import importlib.util
-                import os
+                from autobot_shared.redis_client import get_async_redis_client
+                from code_analysis.src.anti_pattern_detector import AntiPatternDetector
 
-                # Import using file path since directory has dashes
-                module_path = os.path.join(
-                    os.path.dirname(__file__),
-                    "../../tools/code-analysis-suite/src/anti_pattern_detector.py",
-                )
-                spec = importlib.util.spec_from_file_location("anti_pattern_detector", module_path)
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-
-                _detector_instance = module.AntiPatternDetector()
+                redis_client = await get_async_redis_client(database="analytics")
+                _detector_instance = AntiPatternDetector(redis_client=redis_client)
     return _detector_instance
 
 

--- a/autobot-backend/api/anti_pattern_cached_test.py
+++ b/autobot-backend/api/anti_pattern_cached_test.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import api.anti_pattern as anti_pattern_module
 from api.anti_pattern import router
 
 
@@ -22,6 +23,52 @@ def _make_app() -> FastAPI:
 @pytest.fixture
 def client():
     return TestClient(_make_app())
+
+
+@pytest.fixture(autouse=True)
+def _reset_detector_singleton():
+    """_get_detector() memoizes into a module-global singleton; reset it around
+    every test so a real-loaded detector from one test can't leak into the
+    next (or vice versa: a mocked call leaving stale global state)."""
+    anti_pattern_module._detector_instance = None
+    yield
+    anti_pattern_module._detector_instance = None
+
+
+class TestGetDetectorRealLoad:
+    """Issue #12365: _get_detector() previously loaded a deleted file path
+    (tools/code-analysis-suite/src/anti_pattern_detector.py, removed by the
+    #781/#926 restructuring per #12436) via importlib.spec_from_file_location,
+    raising FileNotFoundError on every call -- every /api/anti-pattern/*
+    endpoint was broken. It now imports the canonical
+    code_analysis.src.anti_pattern_detector module directly."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_without_file_not_found(self):
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            AsyncMock(return_value=None),
+        ):
+            detector = await anti_pattern_module._get_detector()
+
+        from code_analysis.src.anti_pattern_detector import AntiPatternDetector
+
+        assert isinstance(detector, AntiPatternDetector)
+
+    @pytest.mark.asyncio
+    async def test_wires_redis_client_for_caching(self):
+        """The detector defaults redis_client=None, which makes its own
+        _cache_results/get_cached_report no-ops -- /analyze would never
+        actually populate the store /cached reads unless a real client is
+        passed at construction."""
+        sentinel_redis = object()
+        with patch(
+            "autobot_shared.redis_client.get_async_redis_client",
+            AsyncMock(return_value=sentinel_redis),
+        ):
+            detector = await anti_pattern_module._get_detector()
+
+        assert detector.redis_client is sentinel_redis
 
 
 class TestGetCachedAnalysis:

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -470,9 +470,11 @@ def _build_empty_pattern_summary() -> Dict[str, Any]:
     Build empty pattern summary response.
 
     Issue #665: Extracted from get_cached_pattern_summary to reduce duplication.
+    Issue #12365: status="no_data" matches the sibling analytics /cached convention
+    (bug-prediction, dependencies, duplicates, import-tree, security/score).
     """
     return {
-        "status": "empty",
+        "status": "no_data",
         "total_patterns": 0,
         "severity_distribution": {},
         "pattern_type_distribution": {},
@@ -536,6 +538,9 @@ async def get_cached_pattern_summary(
     Issue #665: Refactored to use extracted helpers.
     Issue #12384: Scopes the query to source_id so one source's summary never
     aggregates another source's (or AutoBot's own) stored patterns.
+    Issue #12365: A store-read failure (e.g. ChromaDB unavailable) degrades to a
+    graceful no_data 200 instead of a 500, matching the sibling analytics
+    /cached endpoints -- the panel can show "no data yet" instead of erroring.
     Returns summary data from stored patterns, not requiring full analysis.
     """
     try:
@@ -574,8 +579,8 @@ async def get_cached_pattern_summary(
         }
 
     except Exception as e:
-        logger.error("Cached summary failed: %s", e)
-        raise HTTPException(status_code=500, detail="Internal server error")
+        logger.warning("Cached pattern summary read failed, returning no_data (#12365): %s", e)
+        return _build_empty_pattern_summary()
 
 
 def _build_empty_patterns_response() -> Dict[str, Any]:
@@ -583,12 +588,14 @@ def _build_empty_patterns_response() -> Dict[str, Any]:
     Build empty patterns response for when no data exists.
 
     Issue #665: Extracted from get_cached_patterns to reduce duplication.
+    Issue #12365: status="no_data" matches the sibling analytics /cached
+    convention (bug-prediction, dependencies, duplicates, import-tree, anti-pattern).
 
     Returns:
         Empty patterns response dictionary.
     """
     return {
-        "status": "empty",
+        "status": "no_data",
         "patterns": [],
         "total": 0,
     }
@@ -675,6 +682,8 @@ async def get_cached_patterns(
     Issue #665: Refactored to use extracted helpers.
     Issue #12384: Always scopes the query to source_id (default sentinel when
     None) so one source's cached patterns never include another source's.
+    Issue #12365: A store-read failure degrades to a graceful no_data 200
+    instead of a 500, matching the sibling analytics /cached endpoints.
     Supports filtering by pattern_type and severity, with pagination.
     """
     try:
@@ -719,8 +728,8 @@ async def get_cached_patterns(
         }
 
     except Exception as e:
-        logger.error("Cached patterns fetch failed: %s", e)
-        raise HTTPException(status_code=500, detail="Internal server error")
+        logger.warning("Cached patterns read failed, returning no_data (#12365): %s", e)
+        return _build_empty_patterns_response()
 
 
 @router.post("/patterns/storage/clear")

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis_cached_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis_cached_test.py
@@ -1,0 +1,128 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for graceful no_data on GET /patterns/cached-summary and
+/patterns/cached-patterns when the pattern store is empty or unreadable
+(Issue #12365).
+
+NOTE: the top-level autobot-backend/conftest.py stubs
+``code_intelligence.pattern_analysis`` as a bare MagicMock package (avoiding
+its heavy real __init__ chain for unrelated test suites). ``unittest.mock.
+patch("code_intelligence.pattern_analysis.storage.X")`` resolves via a
+getattr chain that silently patches a throwaway attribute on that MagicMock
+instead of the real module the endpoint imports at call time, making the
+patch inert. We instead install a stub module directly at
+``sys.modules["code_intelligence.pattern_analysis.storage"]`` so the
+endpoint's local ``from code_intelligence.pattern_analysis.storage import
+get_pattern_collection_async`` resolves to our controllable stub.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.codebase_analytics.endpoints.pattern_analysis import router
+
+_STORAGE_MODULE_NAME = "code_intelligence.pattern_analysis.storage"
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client():
+    return TestClient(_make_app())
+
+
+@pytest.fixture
+def stub_storage():
+    """Install a stub storage module the endpoint's local import resolves to."""
+    original = sys.modules.get(_STORAGE_MODULE_NAME)
+    mod = ModuleType(_STORAGE_MODULE_NAME)
+    sys.modules[_STORAGE_MODULE_NAME] = mod
+    yield mod
+    if original is not None:
+        sys.modules[_STORAGE_MODULE_NAME] = original
+    else:
+        sys.modules.pop(_STORAGE_MODULE_NAME, None)
+
+
+class TestGetCachedPatternSummary:
+    def test_no_collection_returns_no_data(self, client, stub_storage):
+        """ChromaDB collection unavailable degrades to 200 no_data."""
+        stub_storage.get_pattern_collection_async = AsyncMock(return_value=None)
+
+        resp = client.get("/patterns/cached-summary")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "no_data"
+        assert body["has_cached_data"] is False
+
+    def test_empty_store_returns_no_data(self, client, stub_storage):
+        """Zero indexed patterns degrades to 200 no_data, not an error."""
+        mock_collection = AsyncMock()
+        mock_collection.get.return_value = {"metadatas": []}
+        stub_storage.get_pattern_collection_async = AsyncMock(return_value=mock_collection)
+
+        resp = client.get("/patterns/cached-summary")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "no_data"
+
+    def test_store_read_exception_returns_no_data_not_500(self, client, stub_storage):
+        """A store-read failure degrades to 200 no_data instead of 500."""
+        stub_storage.get_pattern_collection_async = AsyncMock(side_effect=RuntimeError("chromadb unavailable"))
+
+        resp = client.get("/patterns/cached-summary")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "no_data"
+
+    def test_populated_store_returns_success(self, client, stub_storage):
+        """Cached results still return normally when present."""
+        mock_collection = AsyncMock()
+        mock_collection.get.return_value = {
+            "metadatas": [
+                {"pattern_type": "duplicate", "severity": "medium", "file_path": "a.py"},
+            ]
+        }
+        stub_storage.get_pattern_collection_async = AsyncMock(return_value=mock_collection)
+
+        resp = client.get("/patterns/cached-summary")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "success"
+        assert body["has_cached_data"] is True
+        assert body["total_patterns"] == 1
+
+
+class TestGetCachedPatterns:
+    def test_no_collection_returns_no_data(self, client, stub_storage):
+        stub_storage.get_pattern_collection_async = AsyncMock(return_value=None)
+
+        resp = client.get("/patterns/cached-patterns")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "no_data"
+        assert body["patterns"] == []
+
+    def test_store_read_exception_returns_no_data_not_500(self, client, stub_storage):
+        """A store-read failure degrades to 200 no_data instead of 500."""
+        stub_storage.get_pattern_collection_async = AsyncMock(side_effect=RuntimeError("chromadb unavailable"))
+
+        resp = client.get("/patterns/cached-patterns")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "no_data"

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -145,6 +145,9 @@ celery_app.conf.update(
         "analytics.run_bug_prediction_analysis": {"queue": "analytics"},
         "analytics.run_security_analysis": {"queue": "analytics"},
         "analytics.run_dashboard_analysis": {"queue": "analytics"},
+        # Issue #12365: anti-pattern background analysis + daily cache population
+        "analytics.run_anti_pattern_analysis": {"queue": "analytics"},
+        "analytics.populate_all_caches": {"queue": "analytics"},
         # GH#11262: priority tiers on the shared default queue (audit > maintenance).
         **_PRIORITY_TASK_ROUTES,
     },
@@ -291,6 +294,13 @@ celery_app.conf.beat_schedule = {
         "task": "tasks.cleanup_expired_kb_entries",
         "schedule": crontab_from_string(getattr(ssot_config.misc, "kb_retention_schedule", None) or "45 1 * * *"),
         "kwargs": {"dry_run": False},
+    },
+    # Issue #12365: daily off-peak population of the analytics /cached stores
+    # (bug-prediction, security-score, anti-pattern, dependencies, duplicates,
+    # import-tree). Schedule configurable via AUTOBOT_ANALYTICS_CACHE_POPULATION_SCHEDULE.
+    "analytics-cache-population-daily": {
+        "task": "analytics.populate_all_caches",
+        "schedule": crontab_from_string(ssot_config.analytics_cache_population_schedule),
     },
 }
 

--- a/autobot-backend/tasks/__init__.py
+++ b/autobot-backend/tasks/__init__.py
@@ -11,7 +11,9 @@ Note: Deployment tasks removed - now managed by SLM server (#729)
 System tasks (RBAC, updates) maintained as stubs for backward compatibility.
 """
 
+from .analytics_cache_population import populate_all_caches
 from .analytics_tasks import (
+    run_anti_pattern_analysis,
     run_bug_prediction_analysis,
     run_dashboard_analysis,
     run_dependency_analysis,
@@ -67,6 +69,9 @@ __all__ = [
     "run_bug_prediction_analysis",
     "run_security_analysis",
     "run_dashboard_analysis",
+    # anti-pattern background analysis + daily cache population (Issue #12365)
+    "run_anti_pattern_analysis",
+    "populate_all_caches",
     # workspace cleanup (GH#6471)
     "cleanup_stale_workspaces",
     # memory tasks

--- a/autobot-backend/tasks/analytics_cache_population.py
+++ b/autobot-backend/tasks/analytics_cache_population.py
@@ -1,0 +1,134 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Daily off-peak population of the analytics ``/cached`` stores (Issue #12365).
+
+Six analytics modules (bug-prediction, security-score, anti-pattern,
+dependencies, duplicates, import-tree) each expose ``analyze`` (live/slow),
+``cached`` (read a store), and ``status`` -- but nothing ever populated the
+store, so every ``/cached`` was empty (Part 1 of #12365 made that degrade
+gracefully; this is Part 2: actually fill the store).
+
+Design: reuse the EXISTING per-module Celery tasks in ``tasks.analytics_tasks``
+(the same ones ``POST /api/.../analyze`` already dispatches on demand) rather
+than reimplementing any analysis. For the five modules whose ``/cached``
+reads via ``get_latest_task_result(prefix)`` (a Redis pointer to the latest
+Celery task id), dispatching the task and recording it as latest IS the
+store-write -- the task's own return value becomes the Celery result the
+pointer resolves to. Anti-pattern is the exception: its detector writes
+straight into its own Redis key inside ``analyze()``, so no pointer step is
+needed for it.
+
+Scope note (reported per #12365 Task 5): these background/cached-population
+Celery tasks are NOT source-scoped (only the live, synchronous ``GET``
+endpoints accept ``source_id``, per #12330's partial fix) -- they always
+analyze AutoBot's own project root, exactly as they already do when
+triggered on demand today. Populating per-source caches for a multi-source
+deployment is an open scope question for a follow-up, not decided here.
+"""
+
+from datetime import datetime, timezone
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config as ssot_config
+from celery_app import celery_app
+from tasks.analytics_tasks import _run_async, _wrap
+from utils.celery_task_status import store_latest_task_id
+
+logger = get_logger(__name__)
+
+# Issue #12365: seconds between each module's dispatch so 6 analyses (one up
+# to ~280s) don't all run at once and spike CPU/IO. Configurable via
+# AUTOBOT_ANALYTICS_CACHE_POPULATION_STAGGER_SECONDS (ssot_config), not hardcoded.
+_STAGGER_SECONDS = ssot_config.analytics_cache_population_stagger_seconds
+
+
+async def _dispatch(task, args: tuple, prefix: str | None, countdown: int) -> str:
+    """Enqueue *task* with *countdown* stagger; record it as latest for *prefix*.
+
+    *prefix* is the Redis key prefix ``get_latest_task_result`` reads to
+    resolve the pointer to this dispatch's Celery result. Anti-pattern passes
+    ``prefix=None`` -- its detector writes its own cache directly inside
+    ``analyze()``, so no pointer is needed.
+    """
+    result = task.apply_async(args=args, countdown=countdown)
+    if prefix is not None:
+        await store_latest_task_id(prefix, result.id)
+    return result.id
+
+
+def _build_modules(project_root: str) -> list[tuple]:
+    """Build the (name, task, args, redis_prefix) tuples for all 6 modules.
+
+    Imported lazily inside the task body (not module scope) to avoid a
+    heavy-import chain at Celery worker/beat startup, matching the existing
+    lazy-import convention in tasks/analytics_tasks.py's ``_work`` closures.
+    """
+    from api.analytics_bug_prediction import _REDIS_PREFIX as _BUG_PREFIX
+    from api.code_intelligence import _REDIS_PREFIX as _SEC_PREFIX
+    from api.codebase_analytics.endpoints.dependencies import _REDIS_PREFIX as _DEP_PREFIX
+    from api.codebase_analytics.endpoints.duplicates import _REDIS_PREFIX as _DUP_PREFIX
+    from api.codebase_analytics.endpoints.import_tree import _REDIS_PREFIX as _IMPORT_PREFIX
+    from tasks.analytics_tasks import (
+        run_anti_pattern_analysis,
+        run_bug_prediction_analysis,
+        run_dependency_analysis,
+        run_duplicate_analysis,
+        run_import_tree_analysis,
+        run_security_analysis,
+    )
+
+    return [
+        ("dependencies", run_dependency_analysis, (), _DEP_PREFIX),
+        ("duplicates", run_duplicate_analysis, (), _DUP_PREFIX),
+        ("import_tree", run_import_tree_analysis, (), _IMPORT_PREFIX),
+        ("bug_prediction", run_bug_prediction_analysis, (project_root, "*.py", 10000), _BUG_PREFIX),
+        ("security_score", run_security_analysis, (project_root,), _SEC_PREFIX),
+        # No redis_prefix: AntiPatternDetector.analyze() writes its own cache directly.
+        ("anti_pattern", run_anti_pattern_analysis, (project_root,), None),
+    ]
+
+
+async def _populate_all(project_root: str) -> dict:
+    """Dispatch all 6 modules' background analyze tasks, staggered.
+
+    Each module is wrapped independently: one module failing to dispatch does
+    not prevent the others from being scheduled. Extracted from the Celery
+    task body so it's directly unit-testable with ``asyncio.run`` (no Celery
+    eager-mode machinery needed).
+    """
+    modules = _build_modules(project_root)
+
+    results: dict = {}
+    for i, (name, task, args, prefix) in enumerate(modules):
+        countdown = i * _STAGGER_SECONDS
+        try:
+            task_id = await _dispatch(task, args, prefix, countdown)
+            results[name] = {"status": "dispatched", "task_id": task_id, "countdown": countdown}
+            logger.info(
+                "populate_all_caches: dispatched %s (task_id=%s, countdown=%ds)",
+                name,
+                task_id,
+                countdown,
+            )
+        except Exception as e:
+            logger.error("populate_all_caches: failed to dispatch %s: %s", name, e, exc_info=True)
+            results[name] = {"status": "failed", "error": str(e)}
+
+    return results
+
+
+@celery_app.task(bind=True, name="analytics.populate_all_caches")
+def populate_all_caches(self) -> dict:
+    """Daily off-peak dispatch of all 6 analytics modules' background analyze
+    tasks, staggered so they don't all run simultaneously (Issue #12365)."""
+    started = datetime.now(tz=timezone.utc).isoformat()
+
+    async def _work():
+        from api.codebase_analytics.endpoints.shared import resolve_project_root
+
+        return await _populate_all(resolve_project_root())
+
+    return _wrap(_run_async(_work()), started)

--- a/autobot-backend/tasks/analytics_cache_population_test.py
+++ b/autobot-backend/tasks/analytics_cache_population_test.py
@@ -1,0 +1,225 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the daily analytics /cached population job (Issue #12365).
+
+Verifies: each module's Celery task is dispatched (reusing the existing
+analyze + store-write task, not a reimplementation), dispatches are staggered,
+anti-pattern is dispatched without a redis_prefix pointer (it self-caches
+inside analyze()), one module's dispatch failure doesn't abort the others,
+and the beat schedule registers analytics.populate_all_caches at the
+configured hour.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tasks.analytics_cache_population import _build_modules, _dispatch, _populate_all
+
+
+class TestBuildModules:
+    def test_returns_all_six_modules_in_dispatch_order(self):
+        modules = _build_modules("/fake/project/root")
+        names = [m[0] for m in modules]
+        assert names == [
+            "dependencies",
+            "duplicates",
+            "import_tree",
+            "bug_prediction",
+            "security_score",
+            "anti_pattern",
+        ]
+
+    def test_anti_pattern_has_no_redis_prefix(self):
+        """AntiPatternDetector.analyze() writes its own cache directly --
+        no latest_task_id pointer needed, unlike the other 5 modules."""
+        modules = _build_modules("/fake/project/root")
+        by_name = {m[0]: m for m in modules}
+        assert by_name["anti_pattern"][3] is None
+
+    def test_other_five_modules_have_distinct_redis_prefixes(self):
+        modules = _build_modules("/fake/project/root")
+        by_name = {m[0]: m for m in modules}
+        prefixes = {
+            by_name[name][3]
+            for name in ("dependencies", "duplicates", "import_tree", "bug_prediction", "security_score")
+        }
+        assert None not in prefixes
+        assert len(prefixes) == 5  # all distinct -- no cross-module cache collisions
+
+    def test_path_taking_tasks_receive_project_root(self):
+        """bug_prediction, security_score, and anti_pattern take an explicit
+        path argument (their Celery tasks have no source/cwd-relative
+        default); dependencies/duplicates/import_tree self-resolve internally."""
+        modules = _build_modules("/fake/project/root")
+        by_name = {m[0]: m for m in modules}
+        assert by_name["bug_prediction"][2][0] == "/fake/project/root"
+        assert by_name["security_score"][2] == ("/fake/project/root",)
+        assert by_name["anti_pattern"][2] == ("/fake/project/root",)
+        assert by_name["dependencies"][2] == ()
+        assert by_name["duplicates"][2] == ()
+        assert by_name["import_tree"][2] == ()
+
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_dispatch_stores_latest_task_id_when_prefix_given(self):
+        mock_result = MagicMock(id="task-abc")
+        mock_task = MagicMock()
+        mock_task.apply_async.return_value = mock_result
+
+        with patch(
+            "tasks.analytics_cache_population.store_latest_task_id",
+            AsyncMock(),
+        ) as mock_store:
+            task_id = await _dispatch(mock_task, (), "some_prefix:", countdown=120)
+
+        assert task_id == "task-abc"
+        mock_task.apply_async.assert_called_once_with(args=(), countdown=120)
+        mock_store.assert_awaited_once_with("some_prefix:", "task-abc")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_skips_store_when_no_prefix(self):
+        mock_result = MagicMock(id="task-anti")
+        mock_task = MagicMock()
+        mock_task.apply_async.return_value = mock_result
+
+        with patch(
+            "tasks.analytics_cache_population.store_latest_task_id",
+            AsyncMock(),
+        ) as mock_store:
+            task_id = await _dispatch(mock_task, ("/root",), None, countdown=0)
+
+        assert task_id == "task-anti"
+        mock_store.assert_not_awaited()
+
+
+class TestPopulateAll:
+    def _make_mock_module(self, name: str, prefix: str | None):
+        task = MagicMock()
+        task.apply_async.return_value = MagicMock(id=f"{name}-task-id")
+        return name, task, (), prefix
+
+    @pytest.mark.asyncio
+    async def test_dispatches_all_modules_staggered(self):
+        modules = [
+            self._make_mock_module("dependencies", "dep_task:"),
+            self._make_mock_module("duplicates", "dup_task:"),
+            self._make_mock_module("anti_pattern", None),
+        ]
+
+        with (
+            patch("tasks.analytics_cache_population._build_modules", return_value=modules),
+            patch("tasks.analytics_cache_population.store_latest_task_id", AsyncMock()),
+            patch("tasks.analytics_cache_population._STAGGER_SECONDS", 100),
+        ):
+            results = await _populate_all("/fake/root")
+
+        assert results["dependencies"] == {"status": "dispatched", "task_id": "dependencies-task-id", "countdown": 0}
+        assert results["duplicates"] == {"status": "dispatched", "task_id": "duplicates-task-id", "countdown": 100}
+        assert results["anti_pattern"] == {"status": "dispatched", "task_id": "anti_pattern-task-id", "countdown": 200}
+
+    @pytest.mark.asyncio
+    async def test_one_module_failure_does_not_abort_others(self):
+        """A dispatch failure for one module must not prevent the rest from
+        being scheduled (Issue #12365 requirement)."""
+        failing_task = MagicMock()
+        failing_task.apply_async.side_effect = RuntimeError("broker unavailable")
+        ok_task = MagicMock()
+        ok_task.apply_async.return_value = MagicMock(id="ok-task-id")
+
+        modules = [
+            ("dependencies", failing_task, (), "dep_task:"),
+            ("duplicates", ok_task, (), "dup_task:"),
+        ]
+
+        with (
+            patch("tasks.analytics_cache_population._build_modules", return_value=modules),
+            patch("tasks.analytics_cache_population.store_latest_task_id", AsyncMock()),
+        ):
+            results = await _populate_all("/fake/root")
+
+        assert results["dependencies"]["status"] == "failed"
+        assert "broker unavailable" in results["dependencies"]["error"]
+        # The second module still dispatched despite the first one failing.
+        assert results["duplicates"]["status"] == "dispatched"
+        assert results["duplicates"]["task_id"] == "ok-task-id"
+
+    @pytest.mark.asyncio
+    async def test_all_six_real_modules_dispatch(self):
+        """Integration-style check against the real _build_modules wiring:
+        every one of the 6 modules dispatches without raising, using mocked
+        Celery apply_async so no broker is needed."""
+        with (
+            patch("tasks.analytics_tasks.run_dependency_analysis") as dep,
+            patch("tasks.analytics_tasks.run_duplicate_analysis") as dup,
+            patch("tasks.analytics_tasks.run_import_tree_analysis") as imp,
+            patch("tasks.analytics_tasks.run_bug_prediction_analysis") as bug,
+            patch("tasks.analytics_tasks.run_security_analysis") as sec,
+            patch("tasks.analytics_tasks.run_anti_pattern_analysis") as anti,
+            patch("tasks.analytics_cache_population.store_latest_task_id", AsyncMock()),
+        ):
+            for i, mock_task in enumerate([dep, dup, imp, bug, sec, anti]):
+                mock_task.apply_async.return_value = MagicMock(id=f"id-{i}")
+
+            results = await _populate_all("/fake/root")
+
+        assert len(results) == 6
+        assert all(r["status"] == "dispatched" for r in results.values())
+
+
+class TestBeatScheduleRegistration:
+    """celery_app.py is heavy and pytest-stubbed (#7766: the stub Celery app
+    has no beat_schedule), so read source text the same way
+    celery_beat_registration_test.py does, rather than importing the real
+    module. GH#12318's generic ``test_every_beat_scheduled_task_is_registered``
+    already asserts analytics.populate_all_caches resolves in the task
+    registry; these tests check this entry's specifics: it exists, uses the
+    configurable (not hardcoded) schedule, and is dispatched at an off-peak hour.
+    """
+
+    def _celery_app_source(self) -> str:
+        from pathlib import Path
+
+        return (Path(__file__).resolve().parents[1] / "celery_app.py").read_text(encoding="utf-8")
+
+    def test_populate_all_caches_registered_in_beat_schedule(self):
+        src = self._celery_app_source()
+        assert '"task": "analytics.populate_all_caches"' in src
+
+    def test_schedule_is_configurable_not_hardcoded(self):
+        """The entry must read ssot_config.analytics_cache_population_schedule
+        (env-var-backed), not a bare crontab(hour=N) literal -- per project
+        convention (never hard-code a schedule/TTL; module-level constant
+        sourced from config/env var)."""
+        src = self._celery_app_source()
+        assert "crontab_from_string(ssot_config.analytics_cache_population_schedule)" in src
+
+    def test_configured_hour_is_off_peak(self):
+        """Sanity-check the default schedule lands in the existing off-peak
+        maintenance window (00:00-06:00 UTC), not business hours."""
+        from utils.celery_schedules import crontab_from_string
+
+        from autobot_shared.ssot_config import AutoBotConfig
+
+        default_schedule = AutoBotConfig.model_fields["analytics_cache_population_schedule"].default
+        parsed = crontab_from_string(default_schedule)
+        (hour,) = parsed.hour
+        assert 0 <= hour <= 6, f"expected an off-peak UTC hour (0-6), got {hour}"
+
+    def test_anti_pattern_and_population_tasks_registered(self):
+        """GH#12318: both new tasks (the per-module wrapper and the
+        orchestrator) must be reachable via the same registration surface
+        celery_app.py loads at startup, or beat/worker silently drops them."""
+        import importlib
+        import sys
+
+        for module in ("tasks", "workers", "llc.scheduler", "services.pricing_refresh"):
+            importlib.import_module(module)
+        celery_app_mod = sys.modules.get("celery_app")
+        assert celery_app_mod is not None, "celery_app stub missing — check conftest.py"
+        registered = set(celery_app_mod.celery_app.tasks)
+        assert "analytics.run_anti_pattern_analysis" in registered
+        assert "analytics.populate_all_caches" in registered

--- a/autobot-backend/tasks/analytics_tasks.py
+++ b/autobot-backend/tasks/analytics_tasks.py
@@ -337,6 +337,35 @@ def run_security_analysis(self, path: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# 6b. Anti-pattern detection (api/anti_pattern.py) — Issue #12365
+# ---------------------------------------------------------------------------
+
+
+@celery_app.task(bind=True, name="analytics.run_anti_pattern_analysis")
+def run_anti_pattern_analysis(self, root_path: str) -> dict:
+    """Celery wrapper for anti-pattern background analysis (#12365).
+
+    Unlike the other analytics tasks above, ``AntiPatternDetector.analyze()``
+    writes its own result directly into its Redis cache (keyed
+    ``anti_pattern_analysis:latest``) as part of the call -- no separate
+    store-write step is needed here, matching what ``POST /api/anti-pattern/
+    analyze`` already does synchronously today.
+    """
+    started = datetime.now(tz=timezone.utc).isoformat()
+    _progress(self, "Starting anti-pattern analysis", 10.0, started)
+
+    async def _work():
+        from api.anti_pattern import _get_detector
+
+        detector = await _get_detector()
+        _progress(self, "Analyzing codebase", 40.0, started)
+        report = await detector.analyze(root_path=root_path)
+        return report.to_dict()
+
+    return _wrap(_run_async(_work()), started)
+
+
+# ---------------------------------------------------------------------------
 # 7. Dashboard overview (api/analytics.py)
 # ---------------------------------------------------------------------------
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -21450,6 +21450,9 @@ export interface paths {
          *     Issue #665: Refactored to use extracted helpers.
          *     Issue #12384: Scopes the query to source_id so one source's summary never
          *     aggregates another source's (or AutoBot's own) stored patterns.
+         *     Issue #12365: A store-read failure (e.g. ChromaDB unavailable) degrades to a
+         *     graceful no_data 200 instead of a 500, matching the sibling analytics
+         *     /cached endpoints -- the panel can show "no data yet" instead of erroring.
          *     Returns summary data from stored patterns, not requiring full analysis.
          */
         get: operations["get_cached_pattern_summary_api_analytics_codebase_patterns_cached_summary_get"];
@@ -21476,6 +21479,8 @@ export interface paths {
          *     Issue #665: Refactored to use extracted helpers.
          *     Issue #12384: Always scopes the query to source_id (default sentinel when
          *     None) so one source's cached patterns never include another source's.
+         *     Issue #12365: A store-read failure degrades to a graceful no_data 200
+         *     instead of a 500, matching the sibling analytics /cached endpoints.
          *     Supports filtering by pattern_type and severity, with pagination.
          */
         get: operations["get_cached_patterns_api_analytics_codebase_patterns_cached_patterns_get"];

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -2011,6 +2011,30 @@ class AutoBotConfig(BaseSettings):
         ),
     )
 
+    # Issue #12365: daily off-peak population of the analytics /cached stores
+    # (bug-prediction, security-score, anti-pattern, dependencies, duplicates,
+    # import-tree) so panels serve a populated cache instead of always being
+    # empty. 05:30 UTC sits after the 01:00-05:00 data-retention/knowledge/
+    # pricing/audit maintenance block and before the 06:15 testgaps audit.
+    analytics_cache_population_schedule: str = Field(
+        default="30 5 * * *",
+        alias="AUTOBOT_ANALYTICS_CACHE_POPULATION_SCHEDULE",
+        description=(
+            "Cron schedule for analytics.populate_all_caches (daily off-peak "
+            "population of the analytics /cached stores). Default 05:30 UTC "
+            "nightly. 5-field cron: 'm h dom mon dow'."
+        ),
+    )
+    analytics_cache_population_stagger_seconds: int = Field(
+        default=300,
+        alias="AUTOBOT_ANALYTICS_CACHE_POPULATION_STAGGER_SECONDS",
+        description=(
+            "Seconds between each analytics module's population dispatch, so "
+            "6 modules (one up to ~280s) don't all run simultaneously and "
+            "spike CPU/IO. Default 300s (5 min) between modules."
+        ),
+    )
+
     # Issue #858: Handle PORT env var from uvicorn without breaking port config
     @field_validator("port", mode="before")
     @classmethod


### PR DESCRIPTION
## Thinking Path

#12365 describes 6 analytics modules (bug-prediction, security-score, anti-pattern, dependencies, duplicates, import-tree) that each expose `analyze` (live/slow) + `cached` (read a store) + `status`, but nothing populates the store — every `/cached` is empty or errors. Owner-approved plan: (1) make every `/cached` degrade gracefully, (2) add a daily off-peak job that populates the stores by reusing each module's existing analyze + store-write path.

**Part 1 audit.** Grepped every `/cached`-style endpoint across the analytics/codebase surface. Five of six modules already degraded gracefully (`get_latest_task_result` swallows Redis/Celery errors internally, or a prior fix for `anti-pattern/cached`'s 500, #12382/#12383, already landed). Found two more `/cached` endpoints in the same family the issue's own module list didn't call out — `patterns/cached-summary` and `patterns/cached-patterns` (`api/codebase_analytics/endpoints/pattern_analysis.py`) — that still raised a bare 500 on any store-read exception, and used `status:"empty"` instead of the shared `status:"no_data"` convention. Fixed both.

**Part 2 blocker discovered.** Wiring anti-pattern's `analyze()` into the population job required a working detector. `api/anti_pattern.py`'s `_get_detector()` loaded `tools/code-analysis-suite/src/anti_pattern_detector.py` via `importlib.spec_from_file_location` — that directory was deleted during the #781/#926 repo restructuring (confirmed by a comment already in `code_intelligence/anti_pattern_detector_test.py` referencing #12436). Every call raised `FileNotFoundError`, meaning every `/api/anti-pattern/*` endpoint was broken in production. Additionally the detector was constructed with no `redis_client`, making its own cache write/read a no-op even when the import worked. Fixed both (Rule 6: pre-existing bug blocking this task, fixed in scope) — imports the canonical `code_analysis.src.anti_pattern_detector` module directly (same one `code_intelligence/anti_pattern_detector.py`'s facade already re-exports, GH#6757) and wires a real async Redis client.

**Part 2 design.** Rather than reimplementing analysis, the new `analytics.populate_all_caches` beat task dispatches each module's *existing* Celery task (`run_dependency_analysis`, `run_duplicate_analysis`, `run_import_tree_analysis`, `run_bug_prediction_analysis`, `run_security_analysis` — already in `tasks/analytics_tasks.py`, and a new `run_anti_pattern_analysis` for the one module that didn't have one yet) — the exact same task `POST /analyze` already dispatches on demand. For 5 modules, `/cached` resolves via a `latest_task_id` Redis pointer to the Celery result backend, so dispatching + recording the pointer *is* the store-write. Anti-pattern's detector writes its own cache directly inside `analyze()`, so no pointer step is needed for it.

## What Changed

**Part 1 (graceful `/cached`)**
- `api/codebase_analytics/endpoints/pattern_analysis.py`: `/patterns/cached-summary` and `/patterns/cached-patterns` now catch store-read exceptions and return the existing empty-state builder (200) instead of raising 500; empty-state `status` changed from `"empty"` to `"no_data"` to match the sibling convention.

**Discovered-bug fix (blocks Part 2)**
- `api/anti_pattern.py`: `_get_detector()` now imports `code_analysis.src.anti_pattern_detector.AntiPatternDetector` directly instead of a dead file path, and passes a real async Redis client so `analyze()`'s cache write and `/cached`'s cache read actually work.

**Part 2 (daily off-peak population)**
- `tasks/analytics_tasks.py`: new `analytics.run_anti_pattern_analysis` Celery task (mirrors the other 5).
- `tasks/analytics_cache_population.py` (new): `analytics.populate_all_caches` — dispatches all 6 modules' tasks, staggered via `apply_async(countdown=i * stagger_seconds)` so 6 analyses (one up to ~280s per the issue) don't spike CPU/IO simultaneously. Each module's dispatch is independently wrapped — one failing does not abort the others.
- `autobot_shared/ssot_config.py`: new `analytics_cache_population_schedule` (`AUTOBOT_ANALYTICS_CACHE_POPULATION_SCHEDULE`, default `"30 5 * * *"` = 05:30 UTC) and `analytics_cache_population_stagger_seconds` (`AUTOBOT_ANALYTICS_CACHE_POPULATION_STAGGER_SECONDS`, default `300`) — not hardcoded, per project convention.
- `celery_app.py`: registers the `analytics-cache-population-daily` beat entry and routes the 2 new tasks to the `analytics` queue.
- `tasks/__init__.py`: explicit imports so both new tasks register at worker/beat startup (GH#12318 lesson: `autodiscover_tasks` only imports each package's `__init__`).

**Off-peak hour:** 05:30 UTC. The 01:00–05:00 UTC window is already saturated with existing nightly maintenance (data-retention, knowledge cleanup, pricing refresh, dead-code audit, memory-trajectory consolidation); 05:30 sits in the gap after `knowledge-sync-queue-prune` (05:00) and before `audit-testgaps` (06:15).

**Scope question (reported, not decided):** these background/cached-population Celery tasks are NOT source-scoped — only the live synchronous `GET` endpoints accept `source_id` (per #12330's partial fix). The population job analyzes AutoBot's own project root, exactly as these same Celery tasks already do when triggered on demand today (I didn't invent this scope; I matched the existing precedent). Populating per-source caches for a multi-source deployment is an open design question for a follow-up — flagging per the issue's own instruction ("if scope is ambiguous, REPORT it rather than guessing").

**Also filed #12522** (not fixed here — different scope): discovered pre-existing order-dependent test flakes (`celery_beat_registration_test.py` run before `tasks/analytics_tasks_test.py`, and `chromadb_storage_test.py` in combination with the wider suite) unrelated to this change, reproducible with `-p no:xdist -q`.

## Verification

```
$ python3 -m pytest tasks/analytics_tasks_test.py tasks/analytics_cache_population_test.py \
    celery_beat_registration_test.py utils/celery_beat_reconcile_test.py \
    api/anti_pattern_cached_test.py api/codebase_analytics/endpoints/pattern_analysis_cached_test.py \
    code_intelligence/anti_pattern_detector_test.py -p no:xdist -q
...
======================== 66 passed, 5 warnings in 2.86s ========================
```

- `black --check` and `flake8` clean on every changed/added file.
- Confirmed the pre-existing `_get_detector()` `FileNotFoundError` reproduces on `origin/Dev_new_gui` (before this PR) via a standalone script, and no longer reproduces after the fix.
- Confirmed via a standalone script that `_get_detector()` now constructs `code_analysis.src.anti_pattern_detector.AntiPatternDetector` successfully.

## Model Used

Claude Opus 4.8

Closes #12365