### PR TITLE
fix(kb): web_crawler yields docs from reachable pages + surfaces real failure reason (#12486)

### DIFF
--- a/autobot-backend/knowledge/connectors/web_crawler.py
+++ b/autobot-backend/knowledge/connectors/web_crawler.py
@@ -12,6 +12,10 @@ transient 429/5xx responses are retried with exponential backoff instead of fail
 Issue #8284: sync() override now integrates #8146 checkpoint (read/write/clear).
 Issue #8286: Connection-level failures (status_code=None) now also raise RetryableError.
 Issue #8152: Added config_version=2 and migrate_config() (v1→v2: max_depth→crawl_depth).
+Issue #12486: A page that yields no ingestable content now records a specific,
+diagnosable reason (HTTP status, robots block, timeout, empty-after-extraction)
+instead of the opaque ``empty/failed``; HTTP-status failures are labelled
+ERR_HTTP_ERROR (not ERR_CONNECTION).
 """
 
 import hashlib
@@ -32,7 +36,19 @@ from knowledge.connectors.models import (
     SyncResult,
 )
 from knowledge.connectors.registry import ConnectorRegistry
-from web_fetch import ERR_CONNECTION, FetchResult, Frontier, RenderMode, RobotsCache, WebFetcher
+from web_fetch import (
+    ERR_CONNECTION,
+    ERR_HTTP_ERROR,
+    ERR_ROBOTS_BLOCKED,
+    ERR_SSRF_BLOCKED,
+    ERR_TIMEOUT,
+    ERR_UNKNOWN,
+    FetchResult,
+    Frontier,
+    RenderMode,
+    RobotsCache,
+    WebFetcher,
+)
 from web_fetch.extractors import extract_markdown
 from web_fetch.frontier import extract_links
 
@@ -71,6 +87,43 @@ def _fetch_result_to_content(result: FetchResult, connector_id: str) -> ContentR
     )
 
 
+def _no_content_reason(result: FetchResult) -> str:
+    """Return a specific, operator-diagnosable reason a page yielded no content.
+
+    Issue #12486: replaces the opaque ``empty/failed: <url>`` by preserving the
+    ``status_code`` / ``error_code`` the fetch already captured, so a bot-block
+    (403), a rate-limit (429), a robots block, a timeout, a network error and a
+    genuinely empty page are all distinguishable in the sync report.
+    """
+    url = result.url
+    if result.success:
+        # 2xx fetch, but HTML→text extraction produced nothing usable. Most
+        # often a JS-rendered shell whose content never reaches a plain fetch —
+        # robust JS/browser rendering is tracked by the web-connector epic.
+        return "empty after extraction (no readable text — page may require JS rendering): %s" % url
+
+    status = result.status_code
+    code = result.error_code or ERR_UNKNOWN
+    if status is not None:
+        if status == 403:
+            return (
+                "failed: HTTP 403 (forbidden — likely an anti-bot / JS challenge; " "needs browser rendering): %s" % url
+            )
+        if status == 401:
+            return "failed: HTTP 401 (authentication required): %s" % url
+        if status == 429:
+            return "failed: HTTP 429 (rate limited): %s" % url
+        return "failed: HTTP %d (%s): %s" % (status, code, url)
+
+    if code == ERR_ROBOTS_BLOCKED:
+        return "failed: blocked by robots.txt: %s" % url
+    if code == ERR_SSRF_BLOCKED:
+        return "failed: blocked — URL is not publicly reachable/allowed: %s" % url
+    if code == ERR_TIMEOUT:
+        return "failed: request timed out: %s" % url
+    return "failed: %s (no HTTP response — connection/network error): %s" % (code, url)
+
+
 async def _ingest_results_to_kb(
     results: List[FetchResult],
     connector: "WebCrawlerConnector",
@@ -80,7 +133,9 @@ async def _ingest_results_to_kb(
     for fetch_result in results:
         content = _fetch_result_to_content(fetch_result, connector.config.connector_id)
         if content is None:
-            sync_result.errors.append("empty/failed: %s" % fetch_result.url)
+            reason = _no_content_reason(fetch_result)
+            logger.warning("web_crawler: %s", reason)
+            sync_result.errors.append(reason)
             continue
         try:
             await connector._ingest_content(content)
@@ -175,12 +230,6 @@ class WebCrawlerConnector(AbstractConnector):
             return False
         except Exception:
             return False
-        result = await WebFetcher.fetch(self._seed_urls[0])
-        if result.success:
-            self.logger.info("web_fetch connectivity OK for %s", self._seed_urls[0])
-            return True
-        self.logger.warning("web_fetch connectivity check failed: %s", result.error_code)
-        return False
 
     async def discover_sources(self) -> List[SourceInfo]:
         """Return a SourceInfo entry for each seed URL (depth=1 only)."""
@@ -415,11 +464,14 @@ class WebCrawlerConnector(AbstractConnector):
         embedded RobotsCache so respect_robots is still honoured.  Transient
         HTTP errors (429/5xx) are retried via fetch_with_retry() (Issue #8144).
 
-        Returns (FetchResult(success=False, ...), "") on any error.
+        Returns (FetchResult(success=False, ...), "") on any error. HTTP-status
+        failures (>=400) carry ``error_code=ERR_HTTP_ERROR`` and the real
+        ``status_code`` so the sync report can name the cause (Issue #12486);
+        connection/network errors (no response) carry ``ERR_CONNECTION``.
         """
         if fetcher._robots is not None:
             if not await fetcher._robots.is_allowed(url):
-                return FetchResult(url=url, success=False, error_code="robots_blocked"), ""
+                return FetchResult(url=url, success=False, error_code=ERR_ROBOTS_BLOCKED), ""
 
         async def _do_fetch():
             h, s = await WebFetcher.fetch_raw_html(url, timeout=30.0)
@@ -430,15 +482,20 @@ class WebCrawlerConnector(AbstractConnector):
         try:
             html, status = await self.fetch_with_retry(_do_fetch)
         except RetryableError as exc:
-            return FetchResult(url=url, success=False, error_code=ERR_CONNECTION, status_code=exc.status_code), ""
+            # Retries exhausted. status_code is preserved so the report can show
+            # HTTP 429/5xx; None means a genuine connection failure.
+            code = ERR_HTTP_ERROR if exc.status_code else ERR_CONNECTION
+            return FetchResult(url=url, success=False, error_code=code, status_code=exc.status_code or None), ""
         except Exception:
             return FetchResult(url=url, success=False, error_code=ERR_CONNECTION), ""
 
-        if html is None or status is None or status >= 400:
-            return (
-                FetchResult(url=url, success=False, error_code=ERR_CONNECTION, status_code=status),
-                "",
-            )
+        if html is None or status is None:
+            return FetchResult(url=url, success=False, error_code=ERR_CONNECTION, status_code=status), ""
+        if status >= 400:
+            # HTTP-level failure (e.g. 403 anti-bot challenge, 404) — this is an
+            # HTTP error, not a connection error. Preserve the status code so
+            # _no_content_reason() can surface it (Issue #12486).
+            return FetchResult(url=url, success=False, error_code=ERR_HTTP_ERROR, status_code=status), ""
 
         title, markdown = extract_markdown(html)
         fetch_result = FetchResult(

--- a/autobot-backend/tasks/analytics_cache_population_test.py
+++ b/autobot-backend/tasks/analytics_cache_population_test.py
@@ -200,9 +200,8 @@ class TestBeatScheduleRegistration:
     def test_configured_hour_is_off_peak(self):
         """Sanity-check the default schedule lands in the existing off-peak
         maintenance window (00:00-06:00 UTC), not business hours."""
-        from utils.celery_schedules import crontab_from_string
-
         from autobot_shared.ssot_config import AutoBotConfig
+        from utils.celery_schedules import crontab_from_string
 
         default_schedule = AutoBotConfig.model_fields["analytics_cache_population_schedule"].default
         parsed = crontab_from_string(default_schedule)

--- a/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
@@ -458,3 +458,142 @@ class TestSync:
                     await connector.sync(incremental=True)
 
         assert _url_to_source_id("https://c.com") not in written
+
+
+# ---------------------------------------------------------------------------
+# Issue #12486 — no-content pages surface a specific, diagnosable reason
+# ---------------------------------------------------------------------------
+
+from datetime import datetime as _dt  # noqa: E402
+
+from knowledge.connectors.web_crawler import (  # noqa: E402
+    _ingest_results_to_kb,
+    _no_content_reason,
+)
+from web_fetch import (  # noqa: E402
+    ERR_CONNECTION,
+    ERR_HTTP_ERROR,
+    ERR_ROBOTS_BLOCKED,
+    ERR_TIMEOUT,
+    WebFetcher,
+)
+
+
+def _running_sync_result() -> SyncResult:
+    return SyncResult(
+        connector_id="test-crawler",
+        started_at=_dt.utcnow(),
+        completed_at=None,
+        status="running",
+    )
+
+
+class TestNoContentReason:
+    """_no_content_reason maps a no-content FetchResult to a specific reason."""
+
+    def test_http_403_names_anti_bot_challenge(self) -> None:
+        r = FetchResult(url="https://cf.example", success=False, error_code=ERR_HTTP_ERROR, status_code=403)
+        msg = _no_content_reason(r)
+        assert "empty/failed" not in msg
+        assert "403" in msg and "https://cf.example" in msg
+
+    def test_http_429_named(self) -> None:
+        r = FetchResult(url="https://x", success=False, error_code=ERR_HTTP_ERROR, status_code=429)
+        assert "429" in _no_content_reason(r)
+
+    def test_http_500_named(self) -> None:
+        r = FetchResult(url="https://x", success=False, error_code=ERR_HTTP_ERROR, status_code=500)
+        assert "500" in _no_content_reason(r)
+
+    def test_robots_block_named(self) -> None:
+        r = FetchResult(url="https://x", success=False, error_code=ERR_ROBOTS_BLOCKED)
+        assert "robots" in _no_content_reason(r).lower()
+
+    def test_timeout_named(self) -> None:
+        r = FetchResult(url="https://x", success=False, error_code=ERR_TIMEOUT)
+        assert "timed out" in _no_content_reason(r).lower()
+
+    def test_connection_error_named(self) -> None:
+        r = FetchResult(url="https://x", success=False, error_code=ERR_CONNECTION, status_code=None)
+        msg = _no_content_reason(r).lower()
+        assert "connection" in msg or "network" in msg
+
+    def test_empty_after_extraction_named(self) -> None:
+        r = FetchResult(url="https://x", success=True, markdown="   ", status_code=200)
+        msg = _no_content_reason(r)
+        assert "empty/failed" not in msg
+        assert "empty after extraction" in msg.lower()
+
+
+class TestIngestReasonSurfacing:
+    """Successful pages ingest a document; failures surface a real reason (#12486)."""
+
+    async def test_reachable_page_yields_document(self) -> None:
+        """A successful fetch of a normal HTML page produces >=1 ingested doc."""
+        connector = WebCrawlerConnector(_make_config(["https://example.com"]))
+        connector._ingest_content = AsyncMock()
+        sync_result = _running_sync_result()
+        fr = FetchResult(
+            url="https://example.com",
+            success=True,
+            markdown="# Title\n\nReal readable body text for ingestion.",
+            title="Title",
+            status_code=200,
+        )
+        await _ingest_results_to_kb([fr], connector, sync_result)
+        assert sync_result.added == 1
+        assert sync_result.errors == []
+        connector._ingest_content.assert_awaited_once()
+
+    async def test_403_surfaces_status_not_opaque_empty(self) -> None:
+        connector = WebCrawlerConnector(_make_config(["https://cf.example"]))
+        connector._ingest_content = AsyncMock()
+        sync_result = _running_sync_result()
+        fr = FetchResult(url="https://cf.example", success=False, error_code=ERR_HTTP_ERROR, status_code=403)
+        await _ingest_results_to_kb([fr], connector, sync_result)
+        assert sync_result.added == 0
+        assert len(sync_result.errors) == 1
+        msg = sync_result.errors[0]
+        assert "empty/failed" not in msg
+        assert "403" in msg and "https://cf.example" in msg
+        connector._ingest_content.assert_not_awaited()
+
+    async def test_empty_after_extraction_surfaces_reason(self) -> None:
+        connector = WebCrawlerConnector(_make_config(["https://example.com"]))
+        connector._ingest_content = AsyncMock()
+        sync_result = _running_sync_result()
+        fr = FetchResult(url="https://example.com", success=True, markdown="", status_code=200)
+        await _ingest_results_to_kb([fr], connector, sync_result)
+        assert sync_result.added == 0
+        assert "empty/failed" not in sync_result.errors[0]
+        assert "empty after extraction" in sync_result.errors[0].lower()
+
+
+class TestFetchPageHttpErrorLabelling:
+    """_fetch_page_with_html labels HTTP-status failures as ERR_HTTP_ERROR (#12486)."""
+
+    async def test_403_labelled_http_error_with_status(self) -> None:
+        connector = WebCrawlerConnector(_make_config(["https://cf.example"]))
+        fetcher = WebFetcher(robots_cache=None)
+
+        async def _side_effect(url, timeout=30.0):
+            return "<html><head><title>Just a moment...</title></head><body></body></html>", 403
+
+        with patch("knowledge.connectors.web_crawler.WebFetcher.fetch_raw_html", side_effect=_side_effect):
+            fetch_result, raw_html = await connector._fetch_page_with_html(fetcher, "https://cf.example")
+        assert fetch_result.success is False
+        assert fetch_result.status_code == 403
+        assert fetch_result.error_code == ERR_HTTP_ERROR
+        assert raw_html == ""
+
+    async def test_connection_failure_labelled_connection(self) -> None:
+        connector = WebCrawlerConnector(_make_config(["https://x"]))
+        fetcher = WebFetcher(robots_cache=None)
+
+        async def _side_effect(url, timeout=30.0):
+            return None, None
+
+        with patch("knowledge.connectors.web_crawler.WebFetcher.fetch_raw_html", side_effect=_side_effect):
+            fetch_result, _ = await connector._fetch_page_with_html(fetcher, "https://x")
+        assert fetch_result.success is False
+        assert fetch_result.error_code == ERR_CONNECTION


### PR DESCRIPTION
## Thinking Path

KB `web_crawler` reported an opaque `empty/failed: <url>` and `+0 ~0 -0` when a sync ingested nothing, giving operators no cause. Traced the ingest path (`web_crawler.py`): `_fetch_page_with_html` already captures the real `status_code` on the `FetchResult`, but `_ingest_results_to_kb` discarded it into the opaque string. Reproduced locally: a normal reachable HTML page already yields a document; a 403 (Cloudflare/anti-bot) fetch preserved `status_code=403` yet the report showed only `empty/failed`. Two real bugs surfaced: (1) the status/error was thrown away at ingest, and (2) every HTTP-status failure (403/404/5xx) was mislabelled `ERR_CONNECTION` instead of `ERR_HTTP_ERROR`.

Scope is the BUG only — no browser/playwright/anti-bot rendering (that is the epic, #12493–12497). Where plain HTTP genuinely cannot pass a JS/anti-bot challenge, the fix is to surface that clearly as the reason rather than a silent 0-docs.

## What Changed

- Added `_no_content_reason(FetchResult)` — maps a no-content result to a specific reason: `HTTP 403 (anti-bot/JS challenge)`, `HTTP 401/429`, other `HTTP <code>`, robots block, SSRF/non-public, timeout, connection/network error, or `empty after extraction`.
- `_ingest_results_to_kb` now records that reason (and logs it at WARNING) instead of `empty/failed: <url>`.
- `_fetch_page_with_html` now labels HTTP-status failures (`status >= 400`, and retry-exhausted results that carry a status) as `ERR_HTTP_ERROR` with the real `status_code` preserved; genuine no-response failures keep `ERR_CONNECTION`. Robots block uses the `ERR_ROBOTS_BLOCKED` constant.
- Removed unreachable dead code after the `try/except` in `test_connection`.
- Successful fetches of normal reachable pages continue to produce a document (confirmed by test) — that path was never broken; the Cloudflare/JS 0-docs is a genuine plain-HTTP limitation now surfaced as a clear reason.

## Verification

- `python3 -m pytest tests/unit/knowledge/connectors/test_web_crawler.py -p no:xdist -q` → **39 passed** (12 new: reason mapping for 403/429/500/robots/timeout/connection/empty-after-extraction; reachable-page-yields-doc; 403 surfaces status not opaque; HTTP-error labelling).
- `black` clean, `flake8 --max-line-length 120` clean.
- Tests mock `WebFetcher.fetch_raw_html` / `_ingest_content` — no real network.

## Model Used

claude-opus-4-8

Closes #12486
