### PR TITLE
chore(security): remove 80 legacy no-op codeql/lgtm markers (#12500)

### DIFF
--- a/autobot-backend/agents/npu_code_search_agent.py
+++ b/autobot-backend/agents/npu_code_search_agent.py
@@ -382,7 +382,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
                 self.logger.info("Codebase already indexed, use force_reindex=True to re-index")
                 return {"status": "already_indexed", "index_key": index_key}
 
-            for root, dirs, files in os.walk(root_path):  # codeql[py/path-injection]
+            for root, dirs, files in os.walk(root_path):
                 dirs[:] = [d for d in dirs if not self._is_ignored_dir(d)]
                 indexed, skipped = await self._index_directory_files(root, files, root_path, errors)
                 indexed_files += indexed
@@ -554,9 +554,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
         """Index a single file with embeddings (Issue #207, #398: refactored)."""
         try:
             file_path = str(validate_path(file_path))
-            async with aiofiles.open(  # codeql[py/path-injection]
-                file_path, "r", encoding="utf-8", errors="ignore"
-            ) as f:
+            async with aiofiles.open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                 content = await f.read()
 
             if not content.strip():

--- a/autobot-backend/agents/web_researcher.py
+++ b/autobot-backend/agents/web_researcher.py
@@ -158,7 +158,7 @@ class CaptchaSolver:
     async def solve_recaptcha(self, site_key: str, page_url: str, invisible: bool = False) -> str | None:
         """Solve reCAPTCHA using solving service."""
         if not self.api_key:
-            logger.warning("No CAPTCHA API key configured")  # codeql[py/clear-text-logging-sensitive-data]
+            logger.warning("No CAPTCHA API key configured")
             return None
         try:
             if self.service == "2captcha":

--- a/autobot-backend/api/analytics_dfa.py
+++ b/autobot-backend/api/analytics_dfa.py
@@ -1029,7 +1029,7 @@ async def analyze_file(request: DFAAnalyzeFileRequest, admin_check: bool = Depen
 
     try:
         safe_path = str(validate_path(request.file_path))
-        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:  # codeql[py/path-injection]
+        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:
             source_code = await f.read()
 
         analyzer = DataFlowAnalyzer(source_code, safe_path)

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -1138,12 +1138,12 @@ def _validate_evolution_repo_path(repo_path_str: str):
             status="error",
             message=f"Repository path not found: {repo_path_str}",
         )
-    if not (repo_path / ".git").exists():  # codeql[py/path-injection]
+    if not (repo_path / ".git").exists():
         return None, EvolutionAnalysisResponse(
             status="error",
             message=f"Not a git repository: {repo_path_str}",
         )
-    return repo_path, None  # codeql[py/path-injection]
+    return repo_path, None
 
 
 @router.post("/analyze", response_model=EvolutionAnalysisResponse)

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -2453,7 +2453,7 @@ async def translate_text(
         },
     )
     result = await agent.handle_translate(req)
-    return JSONResponse(content=result, media_type="application/json; charset=utf-8")  # codeql[py/stack-trace-exposure]
+    return JSONResponse(content=result, media_type="application/json; charset=utf-8")
 
 
 @router.post("/detect-language", response_model=DetectLanguageData)
@@ -2478,7 +2478,7 @@ async def detect_language(
         payload={"text": body.text},
     )
     result = await agent.handle_detect_language(req)
-    return JSONResponse(content=result, media_type="application/json; charset=utf-8")  # codeql[py/stack-trace-exposure]
+    return JSONResponse(content=result, media_type="application/json; charset=utf-8")
 
 
 @router.post("/chat/summarize", response_model=DataResponse[Dict[str, Any]])

--- a/autobot-backend/api/chat_embed.py
+++ b/autobot-backend/api/chat_embed.py
@@ -65,12 +65,12 @@ if _TRUSTED_PROXIES:
     logger.info(
         "Embed trusted proxies: %d configured — X-Forwarded-For honored only from: %s",
         len(_TRUSTED_PROXIES),
-        ", ".join(sorted(_TRUSTED_PROXIES)),  # codeql[py/clear-text-logging-sensitive-data]
+        ", ".join(sorted(_TRUSTED_PROXIES)),
     )
 else:
     logger.info(
         "Embed trusted proxies: none — rate limiting by direct connection IP only " "(set %s if behind reverse proxy)",
-        _TRUSTED_PROXIES_ENV,  # codeql[py/clear-text-logging-sensitive-data]
+        _TRUSTED_PROXIES_ENV,
     )
 
 

--- a/autobot-backend/api/code_search.py
+++ b/autobot-backend/api/code_search.py
@@ -171,7 +171,7 @@ async def index_codebase(request: CodeSearchIndexRequest):
         result = await index_project(request.root_path, request.force_reindex)
 
         if result["status"] == "success":
-            return JSONResponse(  # codeql[py/stack-trace-exposure]
+            return JSONResponse(
                 status_code=200,
                 content={
                     "message": "Codebase indexed successfully",
@@ -182,7 +182,7 @@ async def index_codebase(request: CodeSearchIndexRequest):
                 },
             )
         elif result["status"] == "already_indexed":
-            return JSONResponse(  # codeql[py/stack-trace-exposure]
+            return JSONResponse(
                 status_code=200,
                 content={
                     "message": "Codebase already indexed",
@@ -191,7 +191,7 @@ async def index_codebase(request: CodeSearchIndexRequest):
                 },
             )
         else:
-            return JSONResponse(  # codeql[py/stack-trace-exposure]
+            return JSONResponse(
                 status_code=500,
                 content={
                     "error": "Indexing failed",

--- a/autobot-backend/api/collaboration.py
+++ b/autobot-backend/api/collaboration.py
@@ -372,7 +372,7 @@ async def share_secret_with_session(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Error sharing secret: %s", e)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.error("Error sharing secret: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to share secret",

--- a/autobot-backend/api/elevation.py
+++ b/autobot-backend/api/elevation.py
@@ -98,7 +98,6 @@ async def authorize_elevation(auth: ElevationAuthorization):
         is_valid = await verify_sudo_password(auth.password)
 
         if not is_valid:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.warning("Invalid sudo password for request %s", request_id)
             raise HTTPException(status_code=401, detail="Invalid password")
 

--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -1264,7 +1264,7 @@ async def admin_list_directory(path: str = "/home/autobot") -> dict:  # noqa: ss
     if not target.is_dir():
         raise HTTPException(status_code=400, detail="Path is not a directory")
     try:
-        entries = sorted(target.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower()))  # codeql[py/path-injection]
+        entries = sorted(target.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower()))
         return {"files": [_entry_to_file_item(e) for e in entries]}
     except PermissionError:
         raise HTTPException(status_code=403, detail="Permission denied")
@@ -1291,6 +1291,6 @@ async def admin_read_file(path: str) -> dict:
     try:
         # #7467: was sync `target.read_text(...)` blocking the event loop.
         content = await asyncio.to_thread(target.read_text, encoding="utf-8", errors="replace")
-        return {"content": content}  # codeql[py/path-injection]
+        return {"content": content}
     except PermissionError:
         raise HTTPException(status_code=403, detail="Permission denied")

--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -686,7 +686,7 @@ async def read_text_file_mcp(
         )
 
     try:
-        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:  # codeql[py/path-injection]
+        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:
             lines = await f.readlines()
 
         # Apply head/tail filters
@@ -746,7 +746,7 @@ async def read_media_file_mcp(
         mime_type = "application/octet-stream"
 
     try:
-        async with aiofiles.open(safe_path, "rb") as f:  # codeql[py/path-injection]
+        async with aiofiles.open(safe_path, "rb") as f:
             file_data = await f.read()
 
         base64_data = base64.b64encode(file_data).decode("utf-8")
@@ -799,7 +799,7 @@ async def _read_single_file_for_batch(path: str) -> dict:
                 }
             }
 
-        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:  # codeql[py/path-injection]
+        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:
             content = await f.read()
 
         return {"result": {"path": path, "content": content, "size_bytes": file_size}}
@@ -895,7 +895,7 @@ async def write_file_mcp(
         # Issue #514: Use per-file locking
         file_lock = await _get_file_lock(safe_path)
         async with file_lock:
-            async with aiofiles.open(safe_path, "w", encoding="utf-8") as f:  # codeql[py/path-injection]
+            async with aiofiles.open(safe_path, "w", encoding="utf-8") as f:
                 await f.write(request.content)
 
         file_size = await run_in_file_executor(os.path.getsize, safe_path)
@@ -987,13 +987,13 @@ async def edit_file_mcp(
         # Issue #514: Use per-file locking
         file_lock = await _get_file_lock(safe_path)
         async with file_lock:
-            async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:  # codeql[py/path-injection]
+            async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:
                 original_content = await f.read()
 
             content, edits_applied = _apply_edits_to_content(original_content, request.edits)
 
             if not request.dry_run:
-                async with aiofiles.open(safe_path, "w", encoding="utf-8") as f:  # codeql[py/path-injection]
+                async with aiofiles.open(safe_path, "w", encoding="utf-8") as f:
                     await f.write(content)
 
         return {
@@ -1524,7 +1524,7 @@ async def read_resource_mcp(
         mime_type = "text/plain"
 
     try:
-        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:  # codeql[py/path-injection]
+        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:
             content = await f.read()
 
         return {

--- a/autobot-backend/api/knowledge_mcp.py
+++ b/autobot-backend/api/knowledge_mcp.py
@@ -760,14 +760,14 @@ async def mcp_extract_structured_data(
             "success": False,
             "error_code": "fetch_failed",
             "details": str(exc),
-        }  # codeql[py/stack-trace-exposure] MCP returns structured errors to the AI agent, not public web users
+        }  # MCP returns structured errors to the AI agent, not public web users
     except ValueError as exc:
         logger.warning("mcp_extract_structured_data schema invalid for %s: %s", url, exc)
         return {
             "success": False,
             "error_code": "schema_invalid",
             "details": str(exc),
-        }  # codeql[py/stack-trace-exposure] MCP returns structured errors to the AI agent, not public web users
+        }  # MCP returns structured errors to the AI agent, not public web users
     except Exception as exc:
         logger.error("mcp_extract_structured_data unexpected error: %s", exc)
         return {"success": False, "error": "Internal server error"}

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -226,7 +226,7 @@ async def live_events_endpoint(websocket: WebSocket):
         # instead of a handshake 403 (project WS rule).
         await websocket.accept()
         await websocket.close(code=4001, reason="Unauthorized")
-        logger.info("Live events WebSocket rejected: invalid token")  # codeql[py/clear-text-logging-sensitive-data]
+        logger.info("Live events WebSocket rejected: invalid token")
         return
     await websocket.accept()
     logger.info(

--- a/autobot-backend/api/nl_database.py
+++ b/autobot-backend/api/nl_database.py
@@ -81,7 +81,7 @@ async def _resolve_db_url(db_secret_id: str | None, request: Request) -> str | N
     except HTTPException:
         raise
     except Exception as exc:
-        logger.error("Failed to resolve database secret: %s", exc)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.error("Failed to resolve database secret: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve database credentials",

--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -77,7 +77,7 @@ def _build_multi_task_response(result: dict) -> JSONResponse:
         description = task_result.get("description", f"Task {task_id}")
         workflow_preview.append(description)
 
-    return JSONResponse(  # codeql[py/stack-trace-exposure]
+    return JSONResponse(
         status_code=200,
         content={
             "type": "workflow_orchestration",
@@ -101,7 +101,7 @@ def _build_single_task_response(result: dict) -> JSONResponse:
     else:
         response_text = "Task completed successfully"
 
-    return JSONResponse(  # codeql[py/stack-trace-exposure]
+    return JSONResponse(
         status_code=200,
         content={
             "type": "direct_execution",

--- a/autobot-backend/api/prompts.py
+++ b/autobot-backend/api/prompts.py
@@ -359,7 +359,7 @@ async def save_prompt(prompt_id: str, request: dict, admin_check: bool = Depends
         # Issue #514: Use per-file locking to prevent concurrent write corruption
         file_lock = await _get_prompt_file_lock(resolved_path)
         async with file_lock:
-            async with aiofiles.open(resolved_path, "w", encoding="utf-8") as f:  # codeql[py/path-injection]
+            async with aiofiles.open(resolved_path, "w", encoding="utf-8") as f:
                 await f.write(content)
         logger.info("Saved prompt %s to %s", prompt_id, resolved_path)
         return _build_prompt_save_response(prompt_id, resolved_path, content, prompts_dir)
@@ -382,7 +382,7 @@ async def _write_prompt_from_default(prompt_id: str, default_file_path: str, pro
         logger.warning("No default found for prompt %s", prompt_id)
         raise HTTPException(status_code=404, detail=f"No default prompt found for {prompt_id}")
 
-    async with aiofiles.open(default_file_path, "r", encoding="utf-8") as f:  # codeql[py/path-injection]
+    async with aiofiles.open(default_file_path, "r", encoding="utf-8") as f:
         default_content = await f.read()
 
     custom_file_path = str(validate_relative_path(prompt_id.replace("_", "/"), prompts_dir))
@@ -391,7 +391,7 @@ async def _write_prompt_from_default(prompt_id: str, default_file_path: str, pro
     # Issue #514: per-file locking to prevent concurrent write corruption
     file_lock = await _get_prompt_file_lock(custom_file_path)
     async with file_lock:
-        async with aiofiles.open(custom_file_path, "w", encoding="utf-8") as f:  # codeql[py/path-injection]
+        async with aiofiles.open(custom_file_path, "w", encoding="utf-8") as f:
             await f.write(default_content)
 
     logger.info("Reverted prompt %s to default", prompt_id)

--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -354,7 +354,7 @@ async def oauth_callback(
         # SSRF mitigated: token_url passed _validate_outbound_url() (https + host
         # allowlist + port pin) and _pinned_connector() pins the pre-resolved public
         # IP (defeats DNS-rebind); redirects disabled in exchange_code. (#12278)
-        resp = await exchange_code(  # codeql[py/full-ssrf]
+        resp = await exchange_code(
             provider_cfg,
             stored["client_id"],
             "",  # nosec B106 - PKCE public client: no client_secret
@@ -425,7 +425,7 @@ async def device_initiate(
             # SSRF mitigated: device_authorization_url passed _validate_outbound_url()
             # (https + host allowlist + port pin) and connector pins the pre-resolved
             # public IP (defeats DNS-rebind); redirects disabled. (#12278)
-            async with http.post(  # codeql[py/full-ssrf]
+            async with http.post(
                 req.device_authorization_url,
                 data=payload,
                 headers={"Accept": "application/json"},
@@ -502,7 +502,7 @@ async def device_poll(
             # SSRF mitigated: token_url passed _validate_outbound_url() (https + host
             # allowlist + port pin) and connector pins the pre-resolved public IP
             # (defeats DNS-rebind); redirects disabled. (#12278)
-            async with http.post(  # codeql[py/full-ssrf]
+            async with http.post(
                 req.token_url,
                 data=payload,
                 headers={"Accept": "application/json"},

--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -210,7 +210,7 @@ async def ingest_response_done(session_id: str, body: ResponseDoneRequest) -> di
         await telemetry.check_caps(session_id)
     except CapBreachError as exc:
         await telemetry.session_end(session_id=session_id, reason=exc.reason)
-        # codeql[py/stack-trace-exposure] CapBreachError carries an intentional, hardcoded
+        # CapBreachError carries an intentional, hardcoded
         # client-facing cap-breach notice (e.g. "session ended: N minute limit reached"), not a stack trace.
         return {"status": "cap_breach", "reason": exc.reason.value, "message": str(exc)}
     return {"status": "ok"}

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -146,7 +146,7 @@ class SecretsManager:
             # Fernet key must persist to decrypt secrets on next startup;
             # secured by 0o600 file permissions.
             with open(self.key_file, "wb") as f:
-                f.write(key)  # lgtm[py/clear-text-storage-sensitive-data]
+                f.write(key)
             os.chmod(self.key_file, 0o600)  # Restrict permissions
 
         self.cipher = Fernet(key)
@@ -224,7 +224,6 @@ class SecretsManager:
             with open(self.secrets_file, "w", encoding="utf-8") as f:
                 # Values in `secrets` are Fernet-encrypted (stored as
                 # `encrypted_value`); raw plaintext is never written to disk.
-                # codeql[py/clear-text-storage-sensitive-data]
                 # Fernet-encrypted `encrypted_value` fields — no plaintext secret is written.
                 json.dump(secrets, f, indent=2, default=json_serializer)
             os.chmod(self.secrets_file, 0o600)  # Restrict permissions
@@ -268,7 +267,6 @@ class SecretsManager:
         secrets[secret.id] = secret_data
         self._save_secrets(secrets)
 
-        # codeql[py/clear-text-logging-sensitive-data]
         logger.info("Created %s (ID: %s)", request.get_log_summary(), secret.id)
         return secret
 
@@ -350,7 +348,7 @@ class SecretsManager:
         secrets[secret_id] = secret_data
         self._save_secrets(secrets)
 
-        logger.info("Updated secret (ID: %s...)", secret_id[:8])  # codeql[py/clear-text-logging-sensitive-data]
+        logger.info("Updated secret (ID: %s...)", secret_id[:8])
 
         # Return updated secret model
         safe_data = secret_data.copy()
@@ -373,7 +371,7 @@ class SecretsManager:
         del secrets[secret_id]
         self._save_secrets(secrets)
 
-        logger.info("Deleted secret (ID: %s...)", secret_id[:8])  # codeql[py/clear-text-logging-sensitive-data]
+        logger.info("Deleted secret (ID: %s...)", secret_id[:8])
         return True
 
     def transfer_secrets(self, request: SecretTransferRequest, chat_id: str | None = None) -> Metadata:
@@ -516,11 +514,11 @@ def audit_log(
     status = "SUCCESS" if success else "FAILED"
     # Redact secret_id to prevent sensitive data in logs
     safe_id = secret_id[:8] + "..." if secret_id and len(secret_id) > 8 else secret_id
-    logger.info(  # codeql[py/clear-text-logging-sensitive-data]
+    logger.info(
         "[Secrets Audit] %s | Operation: %s | " "SecretID: %s | Client: %s",
         status,
         operation,
-        safe_id,  # codeql[py/clear-text-logging-sensitive-data]
+        safe_id,
         client_id,
     )
 
@@ -577,7 +575,7 @@ async def create_secret(
         raise HTTPException(status_code=400, detail="Internal server error")
     except Exception as e:
         audit_log("CREATE", "N/A", http_request, success=False, details=str(e))
-        logger.error("Failed to create secret: %s", e)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.error("Failed to create secret: %s", e)
         raise HTTPException(status_code=500, detail="Failed to create secret")
 
 
@@ -750,7 +748,7 @@ async def get_secret(
                             "original_scope": secret.get("scope"),
                         },
                     )
-                    logger.debug(  # codeql[py/clear-text-logging-sensitive-data]
+                    logger.debug(
                         "[Issue #608] Created secret entity for %s... in session %s",
                         secret_id[:8],
                         chat_id,
@@ -773,7 +771,7 @@ async def get_secret(
         raise
     except Exception as e:
         audit_log("ACCESS", secret_id, http_request, success=False, details=str(e))
-        logger.error("Failed to get secret: %s", e)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.error("Failed to get secret: %s", e)
         raise HTTPException(status_code=500, detail="Failed to get secret")
 
 
@@ -830,7 +828,7 @@ async def update_secret(
         raise
     except Exception as e:
         audit_log("UPDATE", secret_id, http_request, success=False, details=str(e))
-        logger.error("Failed to update secret: %s", e)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.error("Failed to update secret: %s", e)
         raise HTTPException(status_code=500, detail="Failed to update secret")
 
 
@@ -883,7 +881,7 @@ async def delete_secret(
         raise
     except Exception as e:
         audit_log("DELETE", secret_id, http_request, success=False, details=str(e))
-        logger.error("Failed to delete secret: %s", e)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.error("Failed to delete secret: %s", e)
         raise HTTPException(status_code=500, detail="Failed to delete secret")
 
 

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -123,7 +123,7 @@ def start_vnc_server() -> Dict[str, str]:
     # Pre-check: VncAuth requires ~/.vnc/passwd to exist
     vnc_passwd = Path.home() / ".vnc" / "passwd"
     if not vnc_passwd.exists():
-        logger.error(  # codeql[py/clear-text-logging-sensitive-data]
+        logger.error(
             "VNC passwd file not found at %s; run vncpasswd before starting VNC server",
             vnc_passwd,
         )
@@ -311,16 +311,14 @@ def _run_xdotool_cmd(args: list[str], timeout: int = 5) -> Dict[str, str]:
             }
         sanitized.append(s)
     try:
-        result = (
-            subprocess.run(  # nosec B603 B607  # lgtm[py/command-line-injection]  # codeql[py/command-line-injection]
-                ["/usr/bin/xdotool"] + sanitized,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                timeout=timeout,
-                shell=False,
-                env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
-            )
+        result = subprocess.run(  # nosec B603 B607
+            ["/usr/bin/xdotool"] + sanitized,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=timeout,
+            shell=False,
+            env={"DISPLAY": NetworkConstants.DESKTOP_DISPLAY},
         )
         if result.returncode != 0:
             return {"status": "error", "message": result.stderr or "Command failed"}
@@ -1585,7 +1583,7 @@ async def save_session_screenshot(
 
     vnc_base = Path("/tmp/vnc_sessions")  # nosec B108
     screenshot_dir = validate_relative_path(session_id, vnc_base)
-    screenshot_dir.mkdir(parents=True, exist_ok=True)  # codeql[py/path-injection]
+    screenshot_dir.mkdir(parents=True, exist_ok=True)
 
     timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
     screenshot_path = validate_relative_path(f"screenshot_{timestamp}.png", screenshot_dir)

--- a/autobot-backend/api/workflow_secrets.py
+++ b/autobot-backend/api/workflow_secrets.py
@@ -189,7 +189,6 @@ async def update_workflow_secret(
     if not updated:
         raise HTTPException(status_code=404, detail=f"Secret '{name}' not found")
 
-    # codeql[py/clear-text-logging-sensitive-data]
     logger.info("Workflow secret updated via API: name=%s owner=%s", name, owner_id)
     return WorkflowSecretMetadata(
         id="",
@@ -234,5 +233,4 @@ async def delete_workflow_secret(
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Secret '{name}' not found")
 
-    # codeql[py/clear-text-logging-sensitive-data]
     logger.info("Workflow secret deleted via API: name=%s owner=%s", name, owner_id)

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -99,19 +99,16 @@ class AuthenticationMiddleware:
             return secret
 
         # 3. Generate and store a secure random secret
-        logger.warning(  # codeql[py/clear-text-logging-sensitive-data]
-            "No secure JWT secret found. Generating secure random secret."
-        )
+        logger.warning("No secure JWT secret found. Generating secure random secret.")
         secure_secret = secrets.token_urlsafe(64)  # 512-bit secret
 
         # Store in configuration for consistency across restarts
         try:
             # Update the config in memory using the correct method
             config.set_nested("security_config.jwt_secret", secure_secret)
-            logger.info("Generated and stored secure JWT secret")  # noqa: codeql[py/clear-text-logging-sensitive-data]
+            logger.info("Generated and stored secure JWT secret")
             return secure_secret
         except Exception as e:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.error("Failed to store JWT secret in config: %s", e)
             # Still return the secure secret even if we can't store it
             return secure_secret

--- a/autobot-backend/autobot_memory_graph/entities.py
+++ b/autobot-backend/autobot_memory_graph/entities.py
@@ -166,7 +166,7 @@ class EntityOperationsMixin:
             entity = self._build_entity_document(entity_id, entity_type, name, observations, entity_metadata)
 
             await self._store_entity_in_redis(entity_id, entity)
-            logger.info(  # codeql[py/clear-text-logging-sensitive-data]
+            logger.info(
                 "Created entity: %s (%s) with ID %s",
                 name,
                 entity_type,

--- a/autobot-backend/autobot_memory_graph/relations.py
+++ b/autobot-backend/autobot_memory_graph/relations.py
@@ -185,7 +185,7 @@ class RelationOperationsMixin:
             )
             await self._store_outgoing_relation(from_entity_id, relation)
             await self._store_incoming_relation(to_entity_id, reverse_rel)
-            logger.debug(  # codeql[py/clear-text-logging-sensitive-data]
+            logger.debug(
                 "Created relation by ID: [%s] --[%s]--> [%s]",
                 from_entity_id[:8] if from_entity_id else "?",
                 relation_type,

--- a/autobot-backend/autobot_memory_graph/secrets.py
+++ b/autobot-backend/autobot_memory_graph/secrets.py
@@ -167,11 +167,9 @@ class SecretManagementMixin:
             entity = await self._create_and_link_secret_entity(
                 name, secret_type, owner_id, scope, session_id, shared_with, metadata
             )
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.info("Created secret entity: %s (scope: %s)", name, scope)
             return entity
         except Exception as e:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.error("Failed to create secret entity: %s", e)
             raise
 
@@ -216,7 +214,6 @@ class SecretManagementMixin:
             return entity
 
         except Exception as e:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.error("Failed to create secret usage audit: %s", e)
             raise
 
@@ -308,6 +305,5 @@ class SecretManagementMixin:
             return owned + shared
 
         except Exception as e:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.error("Failed to get user secrets: %s", e)
             return []

--- a/autobot-backend/chat_workflow/compact_hook.py
+++ b/autobot-backend/chat_workflow/compact_hook.py
@@ -121,7 +121,7 @@ async def on_pre_compact(
         usage,
         CONTEXT_LIMIT_THRESHOLD,
         session_id,
-        model_name,  # codeql[py/clear-text-logging-sensitive-data]
+        model_name,
     )
 
     # Build a compact snapshot from the last N messages.

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -534,9 +534,7 @@ class LLMHandlerMixin:
                 if not endpoint.endswith(PATH_OLLAMA_GENERATE):
                     endpoint = endpoint.rstrip("/") + PATH_OLLAMA_GENERATE
                 return _normalize_outbound_url(endpoint)
-            logger.error(
-                "Invalid endpoint URL: %s, using config-based default", endpoint
-            )  # codeql[py/clear-text-logging-sensitive-data]
+            logger.error("Invalid endpoint URL: %s, using config-based default", endpoint)
             return self._get_ollama_endpoint_fallback()
         except Exception as e:
             logger.error("Failed to load Ollama endpoint from config: %s", e)
@@ -746,19 +744,15 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
     def _get_selected_model(self, requested_model: str | None = None) -> str:
         """Get the LLM model: per-request/per-conversation override, else global config (#11585)."""
         if requested_model:
-            logger.info(
-                "Using per-request LLM model override: %s", requested_model
-            )  # codeql[py/clear-text-logging-sensitive-data]
+            logger.info("Using per-request LLM model override: %s", requested_model)
             return requested_model
         try:
             default_model = get_config().get_default_llm_model()
             selected = get_config().get_nested("backend.llm.ollama.selected_model", default_model)
             if selected and isinstance(selected, str):
-                logger.info("Using LLM model from config: %s", selected)  # codeql[py/clear-text-logging-sensitive-data]
+                logger.info("Using LLM model from config: %s", selected)
                 return selected
-            logger.error(
-                "Invalid model selection: %s, using default", selected
-            )  # codeql[py/clear-text-logging-sensitive-data]
+            logger.error("Invalid model selection: %s, using default", selected)
             return default_model
         except Exception as e:
             logger.error("Failed to load model from config: %s", e)
@@ -878,12 +872,8 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             {"session_id": session.session_id, "message": message},
         )
 
-        logger.info(
-            "[ChatWorkflowManager] Making Ollama request to: %s", ollama_endpoint
-        )  # codeql[py/clear-text-logging-sensitive-data]
-        logger.info(
-            "[ChatWorkflowManager] Using model: %s", selected_model
-        )  # codeql[py/clear-text-logging-sensitive-data]
+        logger.info("[ChatWorkflowManager] Making Ollama request to: %s", ollama_endpoint)
+        logger.info("[ChatWorkflowManager] Using model: %s", selected_model)
 
         return {
             "endpoint": ollama_endpoint,

--- a/autobot-backend/config/async_ops.py
+++ b/autobot-backend/config/async_ops.py
@@ -77,9 +77,7 @@ class AsyncOperationsMixin:
                     # Check if field name contains sensitive pattern
                     if any(pattern in key_lower for pattern in sensitive_patterns):
                         obj[key] = "***REDACTED***"
-                        logger.debug(
-                            "Redacted sensitive field: %s", current_path
-                        )  # codeql[py/clear-text-logging-sensitive-data]
+                        logger.debug("Redacted sensitive field: %s", current_path)
                     elif isinstance(value, _CONTAINER_TYPES):  # Issue #380
                         obj[key] = redact_sensitive_fields(value, current_path)
 

--- a/autobot-backend/config/model_config.py
+++ b/autobot-backend/config/model_config.py
@@ -30,9 +30,7 @@ class ModelConfigMixin:
         selected_model = self.get_nested("backend.llm.local.providers.ollama.selected_model")
 
         if selected_model:
-            logger.info(
-                "UNIFIED CONFIG: Selected model from config.yaml: %s", selected_model
-            )  # codeql[py/clear-text-logging-sensitive-data]
+            logger.info("UNIFIED CONFIG: Selected model from config.yaml: %s", selected_model)
             return selected_model
 
         # Only fall back to environment if config.yaml doesn't have the value

--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -131,14 +131,12 @@ class ContextWindowManager:
             model_name: Name of the LLM model to use
         """
         if model_name not in self.config["models"]:
-            logger.warning(
-                "Unknown model %s, using default", model_name
-            )  # codeql[py/clear-text-logging-sensitive-data]
+            logger.warning("Unknown model %s, using default", model_name)
             self.current_model = self.config["models"]["default"]["name"]
         else:
             self.current_model = model_name
 
-        logger.info("Active model: %s", self.current_model)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.info("Active model: %s", self.current_model)
 
     def get_message_limit(self, model_name: str | None = None) -> int:
         """Get recommended message limit for model.
@@ -351,7 +349,7 @@ class ContextWindowManager:
         if family in _NON_TRANSFORMER_FAMILIES:
             logger.debug(
                 "async_should_compress: %s (family=%s) → False (bypass)",
-                model,  # codeql[py/clear-text-logging-sensitive-data]
+                model,
                 family,
             )
             return False

--- a/autobot-backend/elevation_wrapper.py
+++ b/autobot-backend/elevation_wrapper.py
@@ -170,7 +170,6 @@ class ElevationWrapper:
     async def _execute_normal(self, command: str) -> Dict:
         """Execute command without elevation"""
         try:
-            # codeql[py/command-line-injection]
             # by ElevationManager policy check before reaching this method.
             process = await asyncio.create_subprocess_shell(
                 command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE

--- a/autobot-backend/integrations/whatsapp_integration.py
+++ b/autobot-backend/integrations/whatsapp_integration.py
@@ -515,7 +515,7 @@ class WhatsAppIntegration(BaseIntegration):
             if client is None:
                 logger.warning(
                     "Redis client unavailable for checking opt-in status (phone=%s)",
-                    _mask_phone(phone_number),  # codeql[py/clear-text-logging-sensitive-data]
+                    _mask_phone(phone_number),
                 )
                 return {
                     "phone_number": _mask_phone(phone_number),
@@ -529,7 +529,7 @@ class WhatsAppIntegration(BaseIntegration):
             if not raw:
                 logger.debug(
                     "No opt-in status found for phone=%s (defaulting to opted_in=False)",
-                    _mask_phone(phone_number),  # codeql[py/clear-text-logging-sensitive-data]
+                    _mask_phone(phone_number),
                 )
                 return {
                     "phone_number": _mask_phone(phone_number),
@@ -549,7 +549,7 @@ class WhatsAppIntegration(BaseIntegration):
         except json.JSONDecodeError as exc:
             logger.error(
                 "Malformed JSON in opt-in status (phone=%s): %s",
-                _mask_phone(params.get("phone_number")),  # codeql[py/clear-text-logging-sensitive-data]
+                _mask_phone(params.get("phone_number")),
                 exc,
             )
             return {
@@ -561,7 +561,7 @@ class WhatsAppIntegration(BaseIntegration):
         except Exception as exc:
             logger.error(
                 "Failed to check opt-in status (phone=%s): %s",
-                _mask_phone(params.get("phone_number")),  # codeql[py/clear-text-logging-sensitive-data]
+                _mask_phone(params.get("phone_number")),
                 exc,
             )
             return {
@@ -602,7 +602,7 @@ class WhatsAppIntegration(BaseIntegration):
             if client is None:
                 logger.warning(
                     "Redis client unavailable for setting opt-in status (phone=%s)",
-                    _mask_phone(phone_number),  # codeql[py/clear-text-logging-sensitive-data]
+                    _mask_phone(phone_number),
                 )
                 return {"success": False, "phone_number": _mask_phone(phone_number)}
 
@@ -614,7 +614,7 @@ class WhatsAppIntegration(BaseIntegration):
             )
             logger.info(
                 "Updated opt-in status for phone=%s (opted_in=%s)",
-                _mask_phone(phone_number),  # codeql[py/clear-text-logging-sensitive-data]
+                _mask_phone(phone_number),
                 opted_in,
             )
             return {
@@ -627,7 +627,7 @@ class WhatsAppIntegration(BaseIntegration):
         except Exception as exc:
             logger.error(
                 "Failed to set opt-in status (phone=%s): %s",
-                _mask_phone(params.get("phone_number")),  # codeql[py/clear-text-logging-sensitive-data]
+                _mask_phone(params.get("phone_number")),
                 exc,
             )
             return {

--- a/autobot-backend/intelligence/streaming_executor.py
+++ b/autobot-backend/intelligence/streaming_executor.py
@@ -419,7 +419,6 @@ class StreamingCommandExecutor:
         start_time: float,
     ) -> asyncio.subprocess.Process:
         """Start async subprocess and track it (Issue #281 - extracted helper)."""
-        # codeql[py/command-line-injection]
         # AI executor from validated goal decomposition, not raw user input.
         process = await asyncio.create_subprocess_exec(
             *cmd_parts,

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -537,7 +537,7 @@ async def get_kb_ancestry_collections(
     return [
         KbAncestryCollection(
             collection_name=collection_name,
-            # codeql[py/stack-trace-exposure] False positive: the ValueError above is caught and
+            # False positive: the ValueError above is caught and
             # re-raised as a generic HTTPException; no exception data flows into this response.
             company_id=collection_name.split(":")[0],
             weight=weight,

--- a/autobot-backend/llc/services/routine_service.py
+++ b/autobot-backend/llc/services/routine_service.py
@@ -205,7 +205,7 @@ class RoutineService(LLCServiceBase):
                     if secret_service is None:
                         logger.warning(
                             "Secret ref '%s' in env key '%s' skipped — no SecretService",
-                            secret_name,  # codeql[py/clear-text-logging-sensitive-data]
+                            secret_name,
                             key,
                         )
                         continue
@@ -214,7 +214,7 @@ class RoutineService(LLCServiceBase):
                     except SecretNotFound:
                         logger.warning(
                             "Secret '%s' not found for company %s (env key '%s') — skipping",
-                            secret_name,  # codeql[py/clear-text-logging-sensitive-data]
+                            secret_name,
                             company_id_str,
                             key,
                         )

--- a/autobot-backend/llm_shared/model_param_registry.py
+++ b/autobot-backend/llm_shared/model_param_registry.py
@@ -359,7 +359,7 @@ def get_architecture_family(
                 "Unknown model_type %r for model %r — falling back to pattern match. "
                 "Add an entry to _MODEL_TYPE_MAP or set architecture_family in llm_models.yaml.",
                 model_type,
-                model,  # codeql[py/clear-text-logging-sensitive-data]
+                model,
             )
 
     # 3. Pattern-match fallback
@@ -369,7 +369,7 @@ def get_architecture_family(
             logger.warning(
                 "architecture_family for model %r inferred from pattern %r → %r. "
                 "Set architecture_family explicitly in llm_models.yaml to suppress this warning.",
-                model,  # codeql[py/clear-text-logging-sensitive-data]
+                model,
                 pattern,
                 family,
             )

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -886,10 +886,10 @@ class TestGetOauthAllowedHosts:
         old = os.environ.pop(env_key, None)
         try:
             hosts = get_oauth_allowed_hosts()
-            assert "accounts.google.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
-            assert "github.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
-            assert "api.anthropic.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
-            assert "login.microsoftonline.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
+            assert "accounts.google.com" in hosts
+            assert "github.com" in hosts
+            assert "api.anthropic.com" in hosts
+            assert "login.microsoftonline.com" in hosts
         finally:
             if old is not None:
                 os.environ[env_key] = old
@@ -904,8 +904,8 @@ class TestGetOauthAllowedHosts:
         os.environ[env_key] = "custom.provider.com, other.example.com"
         try:
             hosts = get_oauth_allowed_hosts()
-            assert "custom.provider.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
-            assert "other.example.com" in hosts  # codeql[py/incomplete-url-substring-sanitization]
+            assert "custom.provider.com" in hosts
+            assert "other.example.com" in hosts
             assert "accounts.google.com" not in hosts
         finally:
             if old is None:

--- a/autobot-backend/main.py
+++ b/autobot-backend/main.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         port = config.tls.backend_tls_port
         logger.info("🔒 TLS enabled - using HTTPS on port %s", port)
         logger.info("🔒 TLS cert: %s", ssl_certfile)
-        logger.info("🔒 TLS key: %s", ssl_keyfile)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.info("🔒 TLS key: %s", ssl_keyfile)
 
     # Log configuration
     logger.info("📡 Host: %s", host)

--- a/autobot-backend/memory/essential_story.py
+++ b/autobot-backend/memory/essential_story.py
@@ -94,7 +94,7 @@ class EssentialStoryGenerator:
         except Exception:
             logger.warning(
                 "Could not read token budget for %s — using %d",
-                model_name,  # codeql[py/clear-text-logging-sensitive-data]
+                model_name,
                 _DEFAULT_BUDGET,
             )
             return _DEFAULT_BUDGET

--- a/autobot-backend/modern_ai_integration.py
+++ b/autobot-backend/modern_ai_integration.py
@@ -184,7 +184,6 @@ class OpenAIGPT4VProvider(BaseAIProvider):
                 self.client = openai.AsyncOpenAI(api_key=self.config.api_key)
                 logger.info("OpenAI GPT-4V client initialized")
             else:
-                # codeql[py/clear-text-logging-sensitive-data]
                 logger.warning("OpenAI API key not provided")
         except ImportError:
             logger.warning("OpenAI library not available")
@@ -330,7 +329,6 @@ class AnthropicClaudeProvider(BaseAIProvider):
                 self.client = anthropic.AsyncAnthropic(api_key=self.config.api_key)
                 logger.info("Anthropic Claude client initialized")
             else:
-                # codeql[py/clear-text-logging-sensitive-data]
                 logger.warning("Anthropic API key not provided")
         except ImportError:
             logger.warning("Anthropic library not available")
@@ -466,7 +464,6 @@ class GoogleGeminiProvider(BaseAIProvider):
                 self.client = genai
                 logger.info("Google Gemini client initialized")
             else:
-                # codeql[py/clear-text-logging-sensitive-data]
                 logger.warning("Google AI API key not provided")
         except ImportError:
             logger.warning("Google GenerativeAI library not available")

--- a/autobot-backend/project_state_tracking/metrics.py
+++ b/autobot-backend/project_state_tracking/metrics.py
@@ -31,7 +31,7 @@ async def get_redis_metric(redis_client: Any, key: str, default: int = 0) -> int
         return int(value) if value else default
 
     except Exception:
-        logger.debug(  # codeql[py/clear-text-logging-sensitive-data]
+        logger.debug(
             "Redis metric fetch failed for key: %s",
             key.split(":")[-1] if key else "unknown",
         )

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -403,9 +403,7 @@ class SecureSandboxExecutor:
         safe_lang = "".join(c for c in language if c.isalnum()) or "sh"
 
         # Create temporary script file
-        with tempfile.NamedTemporaryFile(  # codeql[py/path-injection]
-            mode="w", suffix=f".{safe_lang}", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=f".{safe_lang}", delete=False) as f:
             f.write(script_content)
             script_path = f.name
 

--- a/autobot-backend/security/enterprise/compliance_manager.py
+++ b/autobot-backend/security/enterprise/compliance_manager.py
@@ -201,7 +201,7 @@ class ComplianceManager:
                 # Fernet key persists for audit data encryption across
                 # restarts; secured by 0o600 file permissions.
                 with open(key_path, "wb") as f:
-                    f.write(key)  # lgtm[py/clear-text-storage-sensitive-data]
+                    f.write(key)
 
                 # Set restrictive permissions
                 os.chmod(key_path, 0o600)

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -520,9 +520,7 @@ class SecurityPolicyManager:
         self._save_policy(policy)
         self._update_policy_statistics()
 
-        logger.info(  # codeql[py/clear-text-logging-sensitive-data]
-            "Created new security policy: %s (%s)", name, policy_id
-        )
+        logger.info("Created new security policy: %s (%s)", name, policy_id)
         return policy_id
 
     def update_policy(self, policy_id: str, updates: Dict, author: str) -> bool:

--- a/autobot-backend/security/input_validator.py
+++ b/autobot-backend/security/input_validator.py
@@ -26,7 +26,7 @@ _VALID_URL_SCHEMES = frozenset({"http", "https"})
 # #1721: Use [^<]*(?:<(?!/script\b)[^<]*)* to avoid bad-tag-filter bypass
 # #5695: </script\s*> already handles trailing whitespace; suppressing residual
 #        CodeQL py/bad-tag-filter alert — pattern is correct and complete.
-_SCRIPT_TAG_RE = re.compile(  # noqa: S1 codeql[py/bad-tag-filter]
+_SCRIPT_TAG_RE = re.compile(
     r"<script\b[^>]*>[^<]*(?:<(?!/script\b)[^<]*)*</script\s*>",
     re.IGNORECASE | re.DOTALL,
 )

--- a/autobot-backend/services/agent_secrets_integration.py
+++ b/autobot-backend/services/agent_secrets_integration.py
@@ -184,7 +184,6 @@ class AgentSecretsIntegration:
             mapping: The AgentSecretMapping to register
         """
         self._custom_mappings[mapping.agent_type] = mapping
-        # codeql[py/clear-text-logging-sensitive-data]
         logger.info("Registered secret mapping for agent: %s", mapping.agent_type)
 
     def _determine_types_to_fetch(
@@ -253,7 +252,6 @@ class AgentSecretsIntegration:
         """
         mapping = self.get_agent_mapping(agent_type)
         if mapping is None:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.debug("No secret mapping found for agent type: %s", agent_type)
             return {}
 

--- a/autobot-backend/services/autoresearch/auto_research_agent_test.py
+++ b/autobot-backend/services/autoresearch/auto_research_agent_test.py
@@ -114,7 +114,7 @@ class TestParseArxivAtom:
         results = _parse_arxiv_atom(ARXIV_ATOM_SAMPLE)
         assert results[0].source == "arxiv"
         assert "Attention" in results[0].title
-        assert "arxiv.org" in results[0].url  # codeql[py/incomplete-url-substring-sanitization]
+        assert "arxiv.org" in results[0].url
 
     def test_empty_xml_returns_empty_list(self) -> None:
         assert _parse_arxiv_atom("<feed></feed>") == []
@@ -136,7 +136,7 @@ class TestParseGitHubResults:
         r = results[0]
         assert r.source == "github"
         assert r.title == "karpathy/nanoGPT"
-        assert "github.com" in r.url  # codeql[py/incomplete-url-substring-sanitization]
+        assert "github.com" in r.url
 
     def test_empty_items_returns_empty_list(self) -> None:
         assert _parse_github_results({"items": []}) == []
@@ -410,9 +410,9 @@ def _mock_http_handler(request):
     """Return stub responses for arXiv and GitHub during tests."""
     import httpx
 
-    if "arxiv.org" in str(request.url):  # codeql[py/incomplete-url-substring-sanitization]
+    if "arxiv.org" in str(request.url):
         return httpx.Response(200, text=ARXIV_ATOM_SAMPLE)
-    if "api.github.com" in str(request.url):  # codeql[py/incomplete-url-substring-sanitization]
+    if "api.github.com" in str(request.url):
         return httpx.Response(200, json=GITHUB_JSON_SAMPLE)
     return httpx.Response(404)
 

--- a/autobot-backend/services/fast_document_scanner.py
+++ b/autobot-backend/services/fast_document_scanner.py
@@ -394,10 +394,10 @@ class FastDocumentScanner:
         try:
             # Try reading file directly (handles .gz)
             if safe_path.endswith(".gz"):
-                with gzip.open(safe_path, "rt", encoding="utf-8", errors="ignore") as f:  # codeql[py/path-injection]
+                with gzip.open(safe_path, "rt", encoding="utf-8", errors="ignore") as f:
                     return f.read()
             else:
-                with open(safe_path, "r", encoding="utf-8", errors="ignore") as f:  # codeql[py/path-injection]
+                with open(safe_path, "r", encoding="utf-8", errors="ignore") as f:
                     return f.read()
 
         except Exception as file_error:

--- a/autobot-backend/services/terminal_secrets_service.py
+++ b/autobot-backend/services/terminal_secrets_service.py
@@ -103,7 +103,7 @@ class TerminalSecretsService:
     def _create_session_state(self, session_id: str, chat_id: str | None) -> SessionKeyState:
         """Helper for setup_ssh_keys. Ref: #1088."""
         state = SessionKeyState(session_id=session_id, chat_id=chat_id)
-        safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)  # codeql[py/path-injection]
+        safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)
         state.temp_dir = tempfile.mkdtemp(prefix=f"autobot_ssh_{safe_id}_")
         return state
 

--- a/autobot-backend/services/trigger_service.py
+++ b/autobot-backend/services/trigger_service.py
@@ -913,7 +913,7 @@ class TriggerService:
                 f"{_SECRET_PREFIX}{trigger_id}",
                 _TRIGGER_TTL_SECONDS,
                 stored,
-            )  # codeql[py/clear-text-storage-sensitive-data]
+            )
         except Exception as exc:
             logger.warning("_store_webhook_secret failed for %s: %s", trigger_id, exc)
 

--- a/autobot-backend/services/workflow_secret_service.py
+++ b/autobot-backend/services/workflow_secret_service.py
@@ -196,7 +196,6 @@ class WorkflowSecretService:
             updated_by=owner_id,
         )
         if updated:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.info("Workflow secret updated: name=%s owner=%s", name, owner_id)
         return updated
 
@@ -225,7 +224,6 @@ class WorkflowSecretService:
             deleted_by=owner_id,
         )
         if deleted:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.info("Workflow secret deleted: name=%s owner=%s", name, owner_id)
         return deleted
 

--- a/autobot-backend/skills/external_importer.py
+++ b/autobot-backend/skills/external_importer.py
@@ -259,7 +259,7 @@ class ExternalSkillImporter:
             await _run_git("checkout", ref, cwd=clone_dir)
         else:
             logger.info("Cloning %s (ref=%s) -> %s", url, ref, clone_dir)
-            # codeql[py/full-ssrf] SSRF mitigated: url validated by _validate_git_url() enforcing
+            # SSRF mitigated: url validated by _validate_git_url() enforcing
             # https/ssh scheme and blocking private IP ranges
             await _run_git("clone", "--depth=1", "--branch", ref, url, clone_dir)
 
@@ -328,7 +328,7 @@ class ExternalSkillImporter:
             # SSRF mitigated: _validate_catalog_url() enforces scheme+public host and
             # the connector pins the pre-resolved public IP (defeats DNS-rebind);
             # redirects disabled. codeql[py/full-ssrf] (#12278)
-            async with session.get(url, params=params, allow_redirects=False) as response:  # codeql[py/full-ssrf]
+            async with session.get(url, params=params, allow_redirects=False) as response:
                 if response.status != 200:
                     raise RuntimeError(f"Catalog fetch failed: HTTP {response.status} from {url}")
                 data = await response.json()

--- a/autobot-backend/slash_command_handler.py
+++ b/autobot-backend/slash_command_handler.py
@@ -1176,7 +1176,6 @@ Your secret has been securely encrypted and stored.
                 content=f"❌ Failed to create secret: {e}",
             )
         except Exception as e:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.error("Failed to create secret: %s", e)
             return SlashCommandResult(
                 success=False,
@@ -1427,7 +1426,6 @@ class SecretsTransferSubcommand(Command):
             )
 
         except Exception as e:
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.error("Failed to transfer secret: %s", e)
             return SlashCommandResult(
                 success=False,

--- a/autobot-backend/tasks/analytics_cache_population_test.py
+++ b/autobot-backend/tasks/analytics_cache_population_test.py
@@ -200,9 +200,8 @@ class TestBeatScheduleRegistration:
     def test_configured_hour_is_off_peak(self):
         """Sanity-check the default schedule lands in the existing off-peak
         maintenance window (00:00-06:00 UTC), not business hours."""
-        from utils.celery_schedules import crontab_from_string
-
         from autobot_shared.ssot_config import AutoBotConfig
+        from utils.celery_schedules import crontab_from_string
 
         default_schedule = AutoBotConfig.model_fields["analytics_cache_population_schedule"].default
         parsed = crontab_from_string(default_schedule)

--- a/autobot-backend/tests/api/test_marketplace.py
+++ b/autobot-backend/tests/api/test_marketplace.py
@@ -125,7 +125,7 @@ class TestPluginSourceUrl:
 
     def test_contains_github(self):
         url = _plugin_source_url("test")
-        assert "github.com" in url or "http" in url  # codeql[py/incomplete-url-substring-sanitization]
+        assert "github.com" in url or "http" in url
 
     def test_different_slugs_differ(self):
         assert _plugin_source_url("a") != _plugin_source_url("b")

--- a/autobot-backend/tests/content_reach/backends/test_browser.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser.py
@@ -133,7 +133,7 @@ async def test_browser_search_builds_ddg_url(monkeypatch):
 
     # The URL passed to research_url must be the DDG search URL with encoded query
     assert stub_manager.last_url is not None
-    assert "duckduckgo.com" in stub_manager.last_url  # codeql[py/incomplete-url-substring-sanitization]
+    assert "duckduckgo.com" in stub_manager.last_url
     # Accept both + and %20 encoding — urllib.parse.quote_plus uses +
     assert "cats" in stub_manager.last_url
     assert "dogs" in stub_manager.last_url

--- a/autobot-backend/tests/content_reach/test_url_guard.py
+++ b/autobot-backend/tests/content_reach/test_url_guard.py
@@ -560,7 +560,7 @@ async def test_robots_cache_cleared_when_max_reached(monkeypatch):
 
     # After clear + add new, cache should contain exactly 1 entry.
     assert len(guard_mod._robots_cache) == 1
-    assert "http://new-domain.com" in guard_mod._robots_cache  # codeql[py/incomplete-url-substring-sanitization]
+    assert "http://new-domain.com" in guard_mod._robots_cache
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_web_research.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_web_research.py
@@ -140,9 +140,9 @@ def test_format_map_results() -> None:
 
     output = _format_map_results(site_result)
     assert "Mapped 2 URLs" in output
-    assert "example.com" in output  # codeql[py/incomplete-url-substring-sanitization]
+    assert "example.com" in output
     assert "sitemap" in output
-    assert "https://example.com/" in output  # codeql[py/incomplete-url-substring-sanitization]
+    assert "https://example.com/" in output
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +168,7 @@ async def test_exec_scrape_url_success() -> None:
     with patch("web_fetch.WebFetcher.fetch", new_callable=AsyncMock, return_value=mock_result):
         output = await mixin._exec_scrape_url({"url": "https://example.com", "render": "auto"})
 
-    assert "https://example.com" in output  # codeql[py/incomplete-url-substring-sanitization]
+    assert "https://example.com" in output
     assert "Hello world" in output
 
 

--- a/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
@@ -214,7 +214,7 @@ class TestCrawlDepth:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=1))
         results = await connector.crawl(["https://example.com"], max_depth=1, ingest=False, same_origin=True)
         fetched_urls = [r.url for r in results]
-        assert "https://example.com" in fetched_urls  # codeql[py/incomplete-url-substring-sanitization]
+        assert "https://example.com" in fetched_urls
         # With max_depth=1, only the seed (depth=0) is emitted; depth=1 links are
         # added to the frontier but rejected by add_links since depth > max_depth.
         assert "https://example.com/about" not in fetched_urls
@@ -224,7 +224,7 @@ class TestCrawlDepth:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=2))
         results = await connector.crawl(["https://example.com"], max_depth=2, ingest=False, same_origin=True)
         fetched_urls = {r.url for r in results}
-        assert "https://example.com" in fetched_urls  # codeql[py/incomplete-url-substring-sanitization]
+        assert "https://example.com" in fetched_urls
         assert "https://example.com/about" in fetched_urls
         assert "https://example.com/blog" in fetched_urls
         # /contact is linked from /about at depth=2; adding it would require
@@ -251,7 +251,7 @@ class TestSameOrigin:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=2))
         results = await connector.crawl(["https://example.com"], max_depth=2, ingest=False, same_origin=True)
         fetched_urls = {r.url for r in results}
-        assert not any("external.com" in u for u in fetched_urls)  # codeql[py/incomplete-url-substring-sanitization]
+        assert not any("external.com" in u for u in fetched_urls)
 
     async def test_same_origin_false_allows_external(self, mock_bs4, mock_robots_none) -> None:
         connector = WebCrawlerConnector(_make_config(["https://example.com"], max_depth=2, same_origin=False))

--- a/autobot-backend/tests/unit/test_search_web_fetch_full.py
+++ b/autobot-backend/tests/unit/test_search_web_fetch_full.py
@@ -186,7 +186,7 @@ class TestFormatFullSearchResults:
         ]
         output = _format_full_search_results("test query", entries)
         assert "Example" in output
-        assert "https://example.com" in output  # codeql[py/incomplete-url-substring-sanitization]
+        assert "https://example.com" in output
         assert "# Hello" in output
 
     def test_failed_entry_shows_fetch_error(self) -> None:

--- a/autobot-backend/tests/unit/web_fetch/test_frontier.py
+++ b/autobot-backend/tests/unit/web_fetch/test_frontier.py
@@ -117,7 +117,7 @@ class TestFrontier:
         f.add_links(["https://other.com/page", "https://example.com/about"], depth=1)
         item = f.next()
         assert item is not None
-        assert "example.com" in item[0]  # codeql[py/incomplete-url-substring-sanitization]
+        assert "example.com" in item[0]
         assert f.next() is None  # other.com was filtered
 
     def test_exhausted(self) -> None:

--- a/autobot-backend/training/completion_trainer.py
+++ b/autobot-backend/training/completion_trainer.py
@@ -300,9 +300,7 @@ class CompletionTrainer:
         # pickle-based RCE (CodeQL false positive: its taint model does not treat this
         # kwarg as a sanitizer). `version` only selects an on-disk filename the app
         # itself wrote via `torch.save`, so the deserialized bytes are trusted.
-        checkpoint = torch.load(  # codeql[py/unsafe-deserialization]
-            checkpoint_path, map_location=self.device, weights_only=True
-        )
+        checkpoint = torch.load(checkpoint_path, map_location=self.device, weights_only=True)
 
         # Restore model
         config = checkpoint["model_config"]

--- a/autobot-backend/user_management/middleware/rate_limit.py
+++ b/autobot-backend/user_management/middleware/rate_limit.py
@@ -84,5 +84,4 @@ class PasswordChangeRateLimiter:
             # Increment failed attempts
             await redis_client.incr(key)
             await redis_client.expire(key, self.WINDOW_SECONDS)
-            # codeql[py/clear-text-logging-sensitive-data]
             logger.warning("Failed password change attempt for user %s", user_id)

--- a/autobot-backend/user_management/services/session_service.py
+++ b/autobot-backend/user_management/services/session_service.py
@@ -51,7 +51,7 @@ class SessionService:
         await redis_client.sadd(key, token_hash)
         await redis_client.expire(key, ttl)
 
-        logger.info("Added token to blacklist for user %s", user_id)  # codeql[py/clear-text-logging-sensitive-data]
+        logger.info("Added token to blacklist for user %s", user_id)
 
     async def is_token_blacklisted(self, user_id: uuid.UUID, token: str) -> bool:
         """

--- a/autobot-backend/utils/activity_tracker.py
+++ b/autobot-backend/utils/activity_tracker.py
@@ -341,4 +341,4 @@ async def _track_secret_usage(
     db.add(usage)
     await db.commit()
 
-    logger.info("Tracked secret usage: activity=%s", activity_type)  # codeql[py/clear-text-logging-sensitive-data]
+    logger.info("Tracked secret usage: activity=%s", activity_type)

--- a/autobot-backend/utils/chat_utils.py
+++ b/autobot-backend/utils/chat_utils.py
@@ -224,7 +224,7 @@ def create_chat_response(
     }
     if request_id:
         response["request_id"] = request_id
-    return JSONResponse(status_code=status_code, content=response)  # codeql[py/stack-trace-exposure]
+    return JSONResponse(status_code=status_code, content=response)
 
 
 def create_error_response(

--- a/autobot-slm-backend/api/code_source.py
+++ b/autobot-slm-backend/api/code_source.py
@@ -188,7 +188,7 @@ async def _find_similar_paths(node: Node, target_path: str) -> str | None:
     if _is_local_node(node):
         try:
             parent = Path(parent_dir)
-            if parent.is_dir():  # codeql[py/path-injection]
+            if parent.is_dir():
                 for entry in parent.iterdir():
                     if entry.name.lower() == basename.lower() and entry.name != basename:
                         return str(entry)
@@ -237,7 +237,7 @@ async def _validate_repo_path(node: Node, repo_path: str) -> None:
         HTTPException: If path doesn't exist or validation fails
     """
     if _is_local_node(node):
-        if Path(repo_path).is_dir():  # codeql[py/path-injection]
+        if Path(repo_path).is_dir():
             return
         similar_path = await _find_similar_paths(node, repo_path)
         error_detail = f"Repository path does not exist on source node: {repo_path}"

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -4005,7 +4005,7 @@ async def sync_role(
         len(node_roles),
     )
 
-    return {  # codeql[py/stack-trace-exposure]
+    return {
         "success": success_count > 0,
         "message": f"Synced {success_count}/{len(node_roles)} nodes",
         "role_name": role_name,

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -1486,7 +1486,7 @@ async def decommission_node(
         "node_decommissioned",
         {"hostname": node.hostname, "ip_address": node.ip_address},
     )
-    return {  # codeql[py/stack-trace-exposure]
+    return {
         "success": True,
         "message": f"Node {node_id} decommissioned successfully",
         "deployment_id": deployment.deployment_id,

--- a/autobot-slm-backend/api/roles.py
+++ b/autobot-slm-backend/api/roles.py
@@ -376,7 +376,7 @@ async def migrate_role(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Role '{role_name}' has no ansible_playbook configured",
         )
-    result = await run_role_full_procedure(role, migrate_req.target_node_id)  # codeql[py/stack-trace-exposure]
+    result = await run_role_full_procedure(role, migrate_req.target_node_id)
     if result.get("error") == "playbook_not_found":
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/autobot-slm-backend/api/secrets.py
+++ b/autobot-slm-backend/api/secrets.py
@@ -238,7 +238,7 @@ async def apply_secret(
             ),
         )
 
-    return await _run_apply_secrets(payload.key, dependent_roles, target_node_ids)  # codeql[py/stack-trace-exposure]
+    return await _run_apply_secrets(payload.key, dependent_roles, target_node_ids)
 
 
 async def _find_node_ids_for_roles(db: AsyncSession, role_names: List[str]) -> List[str]:

--- a/autobot-slm-backend/api/tls.py
+++ b/autobot-slm-backend/api/tls.py
@@ -416,7 +416,7 @@ async def renew_tls_certificate(
             node.hostname,
         )
 
-        return {  # codeql[py/stack-trace-exposure]
+        return {
             "success": True,
             "message": "Certificate renewed successfully",
             "old_credential_id": credential_id,
@@ -541,9 +541,7 @@ async def rotate_tls_certificate(
             node.hostname,
         )
 
-        return _build_rotation_response(  # codeql[py/stack-trace-exposure]
-            credential_id, new_credential, deployment_result, deactivate_old
-        )
+        return _build_rotation_response(credential_id, new_credential, deployment_result, deactivate_old)
 
     except Exception as e:
         logger.error("Failed to rotate TLS certificate %s: %s", credential_id, e)
@@ -668,7 +666,7 @@ async def bulk_renew_expiring_certificates(
 
     logger.info("Bulk certificate renewal: %d renewed, %d failed", renewed, failed)
 
-    return _build_renewal_response(renewed, failed, results)  # codeql[py/stack-trace-exposure]
+    return _build_renewal_response(renewed, failed, results)
 
 
 def _check_ansible_availability() -> str:
@@ -936,7 +934,7 @@ def _write_cert_files(tmpdir: str, certs: dict) -> tuple:
     # TLS private key written to ephemeral tmpdir for Ansible
     # deployment; directory cleaned up after use.
     with open(key_path, "w", encoding="utf-8") as f:
-        f.write(certs["private_key"])  # lgtm[py/clear-text-storage-sensitive-data]
+        f.write(certs["private_key"])
 
     if chain_path:
         with open(chain_path, "w", encoding="utf-8") as f:

--- a/autobot-slm-backend/scripts/autobot-admin.py
+++ b/autobot-slm-backend/scripts/autobot-admin.py
@@ -92,7 +92,7 @@ def cmd_reset_password(args: argparse.Namespace) -> None:
         )
         if "SLM_ADMIN_PASSWORD=" not in updated:
             updated += f"\nSLM_ADMIN_PASSWORD={args.new_password}\n"
-        with open(secrets_path, "w", encoding="utf-8") as fh:  # codeql[py/clear-text-storage-sensitive-data]
+        with open(secrets_path, "w", encoding="utf-8") as fh:
             fh.write(updated)
         print(f"Updated SLM_ADMIN_PASSWORD in {secrets_path}")
 

--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -275,7 +275,7 @@ def build_drift_report(
     Returns:
         Dict matching the ``FileDriftReport`` schema.
     """
-    drifted, total = compute_drift(source_dir, deployed_dir, component)  # codeql[py/path-injection]
+    drifted, total = compute_drift(source_dir, deployed_dir, component)
 
     return {
         "source_dir": source_dir,

--- a/autobot-slm-backend/tests/api/test_auth_logout.py
+++ b/autobot-slm-backend/tests/api/test_auth_logout.py
@@ -185,7 +185,7 @@ class TestBuildEndSessionUrl:
         assert result is not None
         # urlencode percent-encodes the value; check the key is present and value is encoded
         assert "post_logout_redirect_uri=" in result
-        assert "app.example.com" in result  # codeql[py/incomplete-url-substring-sanitization]
+        assert "app.example.com" in result
 
     def test_appends_id_token_hint_when_present(self):
         link = _mock_sso_link(

--- a/autobot-slm-backend/tests/services/test_sso_logout.py
+++ b/autobot-slm-backend/tests/services/test_sso_logout.py
@@ -126,7 +126,7 @@ class TestOktaEndSessionEndpoint:
     def test_okta_end_session_uses_domain(self):
         template = _get_template("okta", domain="example.okta.com")
         endpoint = template["end_session_endpoint"]
-        assert "example.okta.com" in endpoint  # codeql[py/incomplete-url-substring-sanitization]
+        assert "example.okta.com" in endpoint
         assert "/oauth2/v1/logout" in endpoint
 
 
@@ -138,7 +138,7 @@ class TestMicrosoftEntraEndSessionEndpoint:
     def test_entra_end_session_uses_common_tenant(self):
         template = _get_template("microsoft_entra", domain="common")
         url = template["end_session_endpoint"]
-        assert "login.microsoftonline.com" in url  # codeql[py/incomplete-url-substring-sanitization]
+        assert "login.microsoftonline.com" in url
         assert "common" in url
         assert "oauth2/v2.0/logout" in url
 

--- a/autobot-slm-backend/user_management/services/api_key_service.py
+++ b/autobot-slm-backend/user_management/services/api_key_service.py
@@ -145,18 +145,16 @@ class APIKeyService(BaseService):
         The signing key is read from SLM_HMAC_API_KEY_SECRET (default:
         "autobot-api-key-v1" for backward compatibility with existing hashes).
         """
-        return (
-            hmac.new(  # codeql[py/weak-sensitive-data-hashing] HMAC-SHA256 for API token lookup, not password storage
-                key=settings.hmac_api_key_secret.encode("utf-8"),
-                msg=key.encode("utf-8"),
-                digestmod=hashlib.sha256,
-            ).hexdigest()
-        )
+        return hmac.new(  # HMAC-SHA256 for API token lookup, not password storage
+            key=settings.hmac_api_key_secret.encode("utf-8"),
+            msg=key.encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
 
     @staticmethod
     def _hash_key_legacy(key: str) -> str:
         """Hash using bare SHA-256 (pre-#1721 format, for migration)."""
-        # codeql[py/weak-sensitive-data-hashing] — legacy API token lookup
+        # — legacy API token lookup
         # hash retained for migration only, NOT used for password storage.
         return hashlib.sha256(key.encode()).hexdigest()
 

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -76,7 +76,7 @@ def _pkce_challenge_s256(verifier: str) -> str:
     # is an ephemeral, high-entropy code_verifier — not a stored password — so a slow
     # password KDF is inapplicable and would break OAuth PKCE interoperability (CodeQL
     # false positive: it misclassifies the verifier as password material).
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()  # codeql[py/weak-sensitive-data-hashing]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
@@ -421,7 +421,7 @@ class SSOService(BaseService):
         base_dn = provider.config.get("base_dn", "dc=example,dc=com")
         safe_username = sanitize_ldap_filter(username)
         search_filter = provider.config.get("search_filter", "(uid={})").format(safe_username)
-        conn.search(  # codeql[py/ldap-injection] safe_username is RFC-4515-escaped by sanitize_ldap_filter above
+        conn.search(  # safe_username is RFC-4515-escaped by sanitize_ldap_filter above
             base_dn, search_filter, search_scope=SUBTREE
         )
         if conn.entries:

--- a/autobot_shared/rate_limiter.py
+++ b/autobot_shared/rate_limiter.py
@@ -233,7 +233,7 @@ class RateLimiter:
             logger.warning(
                 "rate_limiter: failed to record request for '%s:%s': %s",
                 self._prefix,
-                key,  # codeql[py/clear-text-logging-sensitive-data]
+                key,
                 exc,
             )
 

--- a/autobot_shared/security/path_validator.py
+++ b/autobot_shared/security/path_validator.py
@@ -86,7 +86,7 @@ def validate_path(
         except ValueError:
             continue
         # Path is within this root — check existence if required
-        if must_exist and not resolved.exists():  # codeql[py/path-injection]
+        if must_exist and not resolved.exists():
             raise ValueError("Path does not exist")
         return resolved
 
@@ -135,7 +135,7 @@ def validate_relative_path(
     except ValueError:
         raise ValueError("Path traversal detected: segment escapes base directory")
 
-    if must_exist and not resolved.exists():  # codeql[py/path-injection]
+    if must_exist and not resolved.exists():
         raise ValueError(f"Path does not exist: {resolved}")
 
     return resolved

--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -189,7 +189,7 @@ async def fetch_safe_url(
     ) as session:
         async with session.get(
             url, allow_redirects=False
-        ) as response:  # codeql[py/full-ssrf] SSRF mitigated: scheme validated, host resolved to public IP via resolve_safe_ip(), connector uses pinned resolver defeating DNS-rebind, redirects disabled (#6533)  # noqa: E501
+        ) as response:  # SSRF mitigated: scheme validated, host resolved to public IP via resolve_safe_ip(), connector uses pinned resolver defeating DNS-rebind, redirects disabled (#6533)  # noqa: E501
             status = response.status
             content_type = response.headers.get("Content-Type", "")
             body = await response.content.read(max_bytes + 1)


### PR DESCRIPTION
## Thinking Path

Follow-up to #12307/#12280 (dismissed via API) and #12498 (established that
inline `# codeql[...]` / `# lgtm[...]` comments are legacy LGTM.com syntax,
retired Dec 2022, and are non-functional no-ops on hosted GitHub code
scanning — `github/codeql-action` never reads them). The alerts they
reference are already resolved via per-alert API dismissal in #12280, so the
inline markers are pure dead weight that misleads readers into thinking a
suppression mechanism exists here that doesn't.

Ran the sweep grep across `autobot-backend`, `autobot-slm-backend`,
`autobot_shared`. The issue's original estimate was 69 markers / 33 files
(scoped to `py/clear-text-logging-sensitive-data`, which the count matches
exactly). The literal grep for `# codeql[`/`# lgtm[`/`# noqa: codeql` also
picks up the same legacy no-op pattern applied to other CodeQL rules added
since (`py/path-injection`, `py/full-ssrf`, `py/stack-trace-exposure`,
`py/incomplete-url-substring-sanitization`, `py/command-line-injection`,
`py/weak-sensitive-data-hashing`, `py/ldap-injection`,
`py/unsafe-deserialization`, `py/clear-text-storage-sensitive-data`) — same
root cause (#12498: ALL inline suppression comments are non-functional
regardless of query ID), so the full 159-line/79-file sweep was completed
rather than limiting to the original 69/33 subset. A residual scan after the
primary sweep also found one more malformed marker
(`autobot-backend/security/input_validator.py:29`, `# noqa: S1
codeql[...]`) in the same category as the `auth_middleware.py:111` special
case called out in the issue — fixed alongside it.

## What Changed

- Removed all 159 + 1 = **80 files'** worth of legacy `# codeql[...]` /
  `# lgtm[...]` marker comments (trailing inline: comment stripped, code
  kept; standalone-only line: line removed).
- Where a marker line carried genuine human-readable rationale after the
  tag (SSRF/LDAP-injection/weak-hashing false-positive explanations in
  `llc/api/companies.py`, `api/realtime_session.py`,
  `skills/external_importer.py`, `api/knowledge_mcp.py`,
  `user_management/services/api_key_service.py`,
  `user_management/services/sso_service.py`,
  `autobot_shared/security/ssrf_guard.py`), only the `codeql[...]`/`lgtm[...]`
  tag was stripped — the rationale comment is preserved verbatim.
- **`auth_middleware.py:111`**: malformed `# noqa: codeql[...]` mixing
  flake8+CodeQL syntax. Verified no real flake8 rule fires on the line
  without it → removed the whole comment (no replacement `# noqa` needed).
- **`security/input_validator.py:29`**: second malformed marker found via
  residual scan (`# noqa: S1 codeql[...]` — `S1` isn't a valid flake8/bandit
  code either), same resolution as above.
- Re-ran `black` after removal: 12 files needed reformatting because
  removing the trailing comment shortened lines enough for black to
  collapse multi-line calls back to one line (verified via diff — pure
  whitespace collapse, no logic change, e.g. `vnc_manager.py`'s
  `subprocess.run(...)` call and `auth_middleware.py`'s `logger.warning(...)`
  call).
- No code-logic changes anywhere — diff is comment removal + resulting
  black reformatting only.

**Sink review (issue step 4):** spot-checked every `clear-text-logging` /
`clear-text-storage` sink while removing its marker. All log/store a
path, name, ID-prefix, or masked value (`_mask_phone`, `secret_id[:8]`,
`safe_id`), never a raw secret value, matching the #12498 spot-check
finding. Two storage sinks intentionally persist a real secret *value* by
design (not a leak): `api/tls.py`'s ephemeral-tmpdir private-key write for
Ansible TLS deployment, and `scripts/autobot-admin.py`'s admin-password
write to an env file the script exists specifically to update — both
already-reviewed FPs, unchanged by this PR. No new secret-value leak found.

## Verification

- `grep -rn "# codeql\[\|# lgtm\[\|# noqa: codeql" autobot-backend
  autobot-slm-backend autobot_shared --include=*.py` → 0 matches (was 159
  across 79 files before the `input_validator.py` residual find, 160/80
  including it).
- Two remaining `codeql[...]` substrings are prose *mentions* of the rule ID
  inside a full explanatory comment (`skills/external_importer.py:330`,
  `autobot-slm-backend/api/roles.py:390`) — not the `#
  codeql[...]`/`# lgtm[...]` marker syntax, left untouched (out of scope,
  legitimate documentation).
- `black --check --fast` on all 80 changed files → clean (after applying
  the 12 reformats black requested).
- `flake8` on all 80 changed files → 0 violations (including
  `auth_middleware.py` and `input_validator.py`, confirming neither line
  needs a real `# noqa`).
- `python3 -m py_compile` on all 80 changed files → OK.
- Manual diff audit: every added (`+`) line that isn't blank/comment-only
  is either unchanged code re-collapsed by black or an unrelated pre-existing
  line shown as diff context — no logic changed.

## PHASE 2 (post-merge, required)

Per #12500: editing/removing a marked line can **re-open** a code-scanning
alert already dismissed via API in #12280, because GitHub matches alerts
across runs by line-content fingerprint. After this PR merges and CodeQL
re-scans `Dev_new_gui`, any `clear-text-logging-sensitive-data` (or other
rule) alerts that reappear on the touched lines are these same
already-reviewed FPs re-surfacing — **expected, not a regression** — and
must be re-dismissed via the API (same rationale as #12280), not treated as
new findings.

## Model Used

claude-sonnet-5

Closes #12500