### PR TITLE
fix(ws): standardize auth rejection on accept-then-close-with-reason across all WS handlers (#12366)

### DIFF
--- a/autobot-backend/api/transcripts.py
+++ b/autobot-backend/api/transcripts.py
@@ -166,8 +166,12 @@ async def analyze_transcript_ws(websocket: WebSocket, transcript_id: str):
     """
     if not await enforce_ws_origin(websocket):
         return
+    # Issue #12366: accept-then-close on rejection so the client gets a real
+    # close frame (code + reason) instead of an HTTP 403 indistinguishable
+    # from a missing route.
     user = await authenticate_websocket(websocket)
     if user is None:
+        await websocket.accept()
         await websocket.close(code=4001, reason="Unauthorized")
         return
 

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -582,9 +582,13 @@ async def websocket_test_endpoint(websocket: WebSocket):
     """Simple test WebSocket endpoint without event manager integration."""
     if not await enforce_ws_origin(websocket):
         return
-    # Issue #2818: Authenticate before accepting connection
+    # Issue #2818: Authenticate before accepting connection.
+    # Issue #12366: accept-then-close on rejection so the client gets a real
+    # close frame (code + reason) instead of an HTTP 403 indistinguishable
+    # from a missing route.
     user = await authenticate_websocket(websocket)
     if user is None:
+        await websocket.accept()
         await websocket.close(code=4001, reason="Authentication required")
         return
 
@@ -683,9 +687,13 @@ async def websocket_endpoint(websocket: WebSocket):
     """
     if not await enforce_ws_origin(websocket):
         return
-    # Issue #2818: Authenticate before accepting connection
+    # Issue #2818: Authenticate before accepting connection.
+    # Issue #12366: accept-then-close on rejection so the client gets a real
+    # close frame (code + reason) instead of an HTTP 403 indistinguishable
+    # from a missing route.
     user = await authenticate_websocket(websocket)
     if user is None:
+        await websocket.accept()
         await websocket.close(code=4001, reason="Authentication required")
         return
 
@@ -746,9 +754,13 @@ async def npu_workers_websocket_endpoint(websocket: WebSocket):
     """
     if not await enforce_ws_origin(websocket):
         return
-    # Issue #2818: Authenticate before accepting connection
+    # Issue #2818: Authenticate before accepting connection.
+    # Issue #12366: accept-then-close on rejection so the client gets a real
+    # close frame (code + reason) instead of an HTTP 403 indistinguishable
+    # from a missing route.
     user = await authenticate_websocket(websocket)
     if user is None:
+        await websocket.accept()
         await websocket.close(code=4001, reason="Authentication required")
         return
 

--- a/autobot-backend/api/ws_security.py
+++ b/autobot-backend/api/ws_security.py
@@ -103,17 +103,22 @@ def authenticate_ws_admin(websocket: WebSocket) -> bool:
 
 
 async def enforce_ws_admin(websocket: WebSocket) -> bool:
-    """Enforce admin auth and, on rejection, close the socket with ``4001``.
+    """Enforce admin auth and, on rejection, accept then close with ``4001``.
 
-    Convenience wrapper mirroring :func:`enforce_ws_origin`: call before
-    ``websocket.accept()`` and ``return`` when it yields ``False``.
+    Call before the endpoint's own ``websocket.accept()`` and ``return`` when
+    this yields ``False``. On rejection this accepts the handshake itself so
+    the client receives a real WS close frame (code + reason) instead of an
+    HTTP 403 that's indistinguishable from a missing route (#12366 — matches
+    ``live_events.py``'s accept-then-close convention).
 
     Returns ``True`` when the caller is an authenticated admin (or WS auth is
-    disabled for dev/test), ``False`` after having closed the socket ``4001``.
+    disabled for dev/test), ``False`` after having accepted then closed the
+    socket ``4001``.
     """
     if authenticate_ws_admin(websocket):
         return True
     try:
+        await websocket.accept()
         await websocket.close(code=4001, reason="Authentication required (admin)")
     except Exception:  # already closed / handshake not completed
         pass

--- a/autobot-backend/tasks/analytics_cache_population_test.py
+++ b/autobot-backend/tasks/analytics_cache_population_test.py
@@ -200,9 +200,8 @@ class TestBeatScheduleRegistration:
     def test_configured_hour_is_off_peak(self):
         """Sanity-check the default schedule lands in the existing off-peak
         maintenance window (00:00-06:00 UTC), not business hours."""
-        from utils.celery_schedules import crontab_from_string
-
         from autobot_shared.ssot_config import AutoBotConfig
+        from utils.celery_schedules import crontab_from_string
 
         default_schedule = AutoBotConfig.model_fields["analytics_cache_population_schedule"].default
         parsed = crontab_from_string(default_schedule)

--- a/autobot-backend/tests/api/test_transcripts.py
+++ b/autobot-backend/tests/api/test_transcripts.py
@@ -311,15 +311,17 @@ def _make_ws_client(db, user):
 
 
 def test_ws_analyze_rejects_unauthenticated():
-    """Test WS closes 4001 before accept when authentication fails."""
+    """Test WS accepts then closes 4001 when authentication fails (#12366)."""
     from starlette.websockets import WebSocketDisconnect
 
     client = _make_ws_client(_make_db(DEFAULT_RECORDING), user=None)
 
     with patch("api.transcripts.authenticate_websocket", AsyncMock(return_value=None)):
         with pytest.raises(WebSocketDisconnect) as exc_info:
-            with client.websocket_connect("/api/transcripts/456/analyze"):
-                pass
+            with client.websocket_connect("/api/transcripts/456/analyze") as ws:
+                # #12366: accept-then-close — the close frame is now a message
+                # to receive, not an immediate handshake-level rejection.
+                ws.receive_text()
 
     assert exc_info.value.code == 4001
 

--- a/autobot-backend/tests/test_websocket_auth_smoke.py
+++ b/autobot-backend/tests/test_websocket_auth_smoke.py
@@ -170,7 +170,7 @@ class TestWsLiveHappyPath:
 
 
 class TestWsLiveNegativePaths:
-    """Missing or invalid bearer → close before accept (code 4001)."""
+    """Missing or invalid bearer → accept-then-close (code 4001, #12366)."""
 
     def test_no_bearer_rejected(self):
         verify = _verify_none  # always fail auth

--- a/autobot-backend/tests/test_websockets_auth_reject_12366.py
+++ b/autobot-backend/tests/test_websockets_auth_reject_12366.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Auth-reject handshake convention for ``api/websockets.py`` (#12366).
+
+Standardizes ``/ws-test``, ``/ws``, and ``/ws/npu-workers`` on
+accept-then-close (matching ``live_events.py``'s convention) instead of the
+old close-before-accept form (#2818), so an auth-rejected socket gets a real
+WS close frame (code 4001 + reason) rather than an HTTP 403 indistinguishable
+from a missing route (root cause of the #12340 misdiagnosis).
+
+Same pure-import + starlette ``TestClient`` pattern as
+``test_websocket_auth_smoke.py`` — no real server, Redis, or network needed.
+"""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+_BACKEND = Path(__file__).resolve().parent.parent
+for _p in (str(_BACKEND), str(_BACKEND.parent / "autobot_shared")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _repair_stubbed_packages() -> None:
+    """Mirror the backend root-conftest repair (#11791) — earlier-collected
+    test modules may stub ``services``/``api``/``events`` in sys.modules,
+    breaking the late import of ``api.websockets`` below."""
+    for pkg in ("services", "api", "events"):
+        mod = sys.modules.get(pkg)
+        if mod is not None and not mod.__dict__.get("__path__"):
+            mod.__path__ = [str(_BACKEND / pkg)]
+
+
+@contextmanager
+def _websockets_client(*, verify_fn):
+    """Yield a TestClient with the ``api.websockets`` router and controlled auth."""
+
+    async def _fake_authenticate_websocket(websocket) -> dict | None:
+        return verify_fn(websocket.query_params.get("token"))
+
+    _repair_stubbed_packages()
+    # api/websockets.py imports authenticate_websocket at module scope (unlike
+    # live_events.py's deferred import), so the patch target is the bound name
+    # in api.websockets, not auth_middleware itself.
+    with patch("api.websockets.authenticate_websocket", new=_fake_authenticate_websocket):
+        from api.websockets import router as websockets_router
+
+        app = FastAPI()
+        app.include_router(websockets_router)
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+def _verify_valid(token: str | None) -> dict | None:
+    return {"user_id": "u-smoke", "username": "smoketest"} if token == "smoke" else None
+
+
+def _verify_none(token: str | None) -> None:
+    return None
+
+
+@pytest.mark.parametrize("path", ["/ws-test", "/ws", "/ws/npu-workers"])
+def test_unauthenticated_ws_accepted_then_closed_4001(path: str) -> None:
+    """No/invalid bearer -> connection accepted then closed with 4001 + reason,
+    NOT a close-before-accept HTTP 403 (#12366)."""
+    with _websockets_client(verify_fn=_verify_none) as client:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect(path) as ws:
+                ws.receive_text()
+    assert exc_info.value.code == 4001
+
+
+@pytest.mark.parametrize("path", ["/ws-test", "/ws/npu-workers"])
+def test_authenticated_ws_proceeds(path: str) -> None:
+    """A valid bearer accepts the connection and does not close with 4001."""
+    with (
+        _websockets_client(verify_fn=_verify_valid) as client,
+        patch("api.websockets.get_event_bus", return_value=AsyncMock()),
+    ):
+        with client.websocket_connect(f"{path}?token=smoke") as ws:
+            frame = ws.receive_json()
+        assert frame["type"] in ("connected", "connection_established", "initial_workers")

--- a/autobot-backend/tests/test_ws_security_admin.py
+++ b/autobot-backend/tests/test_ws_security_admin.py
@@ -69,8 +69,10 @@ def test_authenticate_ws_admin_fail_closed_on_error():
 
 
 @pytest.mark.asyncio
-async def test_enforce_ws_admin_closes_4001_when_denied():
-    ws = SimpleNamespace(headers={}, close=AsyncMock())
+async def test_enforce_ws_admin_accepts_then_closes_4001_when_denied():
+    """#12366: rejection accepts the handshake before closing so the client
+    receives a real close frame (code + reason), not an HTTP 403."""
+    ws = SimpleNamespace(headers={}, accept=AsyncMock(), close=AsyncMock())
     with (
         patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "1"}),
         patch("auth_middleware.get_auth_middleware") as gam,
@@ -78,13 +80,14 @@ async def test_enforce_ws_admin_closes_4001_when_denied():
     ):
         gam.return_value.get_user_from_request.return_value = {"role": "user"}
         assert await enforce_ws_admin(ws) is False
+    ws.accept.assert_awaited_once()
     ws.close.assert_awaited_once()
     assert ws.close.await_args.kwargs.get("code") == 4001
 
 
 @pytest.mark.asyncio
 async def test_enforce_ws_admin_allows_admin_without_closing():
-    ws = SimpleNamespace(headers={}, close=AsyncMock())
+    ws = SimpleNamespace(headers={}, accept=AsyncMock(), close=AsyncMock())
     with patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "0"}):
         assert await enforce_ws_admin(ws) is True
     ws.close.assert_not_awaited()

--- a/autobot-frontend/src/services/GlobalWebSocketService.ts
+++ b/autobot-frontend/src/services/GlobalWebSocketService.ts
@@ -446,7 +446,17 @@ class GlobalWebSocketService {
 
   /** Schedule reconnection with exponential backoff */
   scheduleReconnect(event: CloseEvent): void {
-    if (event.code === 1000 || event.code === 3000) {
+    // #12366: /ws now accepts-then-closes with 4001 on auth failure (instead
+    // of a close-before-accept HTTP 403 the browser reported as an opaque
+    // code-1006 abnormal closure) — retrying with the same bad/expired token
+    // would just hammer the backend forever, so treat 4001 as terminal like
+    // LiveEventService does for /ws/live.
+    if (event.code === 1000 || event.code === 3000 || event.code === 4001) {
+      if (event.code === 4001) {
+        this.connectionState.value = 'error'
+        this.state.lastError = 'Authentication required — please log in again'
+        logger.warn('GlobalWebSocketService: auth rejected (4001), not reconnecting')
+      }
       return
     }
 


### PR DESCRIPTION
## Thinking Path

`#12366` is an owner-decided reconciliation: two WS auth-reject conventions coexisted — `websockets.py`'s `websocket_endpoint`/`ws/npu-workers`/`ws-test` and `transcripts.py`'s `analyze_transcript_ws` closed with `code=4001` **before** `accept()` (HTTP 403 on the wire, per the old #2818 convention), while `live_events.py` already did `accept()` then `close()` (real WS close frame). The close-before-accept form made an auth-rejected socket indistinguishable from a missing route — root cause of the #12340 misdiagnosis.

Grepped every `@router.websocket` in `autobot-backend` (28 endpoints) and every `close(4001`/`close(code=4001` site to find all auth-reject call sites, then checked accept-timing at each:
- **Close-before-accept (fixed here):** `websockets.py` ×3, `transcripts.py` ×1, and the shared `ws_security.enforce_ws_admin` helper (used by `advanced_control.py`'s `/ws/monitoring` + `/ws/desktop/{id}`).
- **Already accept-then-close (no change needed):** `live_events.py` (the template), `task_workspace_ws.py`'s `workspace_shell` (accepts before its admin-auth close), and `autobot-slm-backend/api/websocket.py` (already documents the exact same GH#10459 uvicorn-403 rationale — good corroborating precedent).
- **Out of scope by design:** the CSWSH/`Origin` check (`enforce_ws_origin`, `1008`) intentionally stays close-before-accept — it's a different security concern (cross-site WS hijacking), not the #2818 JWT-auth convention this issue reconciles, and is deliberately pre-handshake elsewhere too (`task_workspace_ws.py` #11016). `desktop_streaming_manager.py`'s `handle_websocket_client` uses the raw `websockets` library (not FastAPI) — the handshake completes automatically before the handler runs, so there's no `.accept()` call to reorder there.

Checked the frontend WS clients per the task's client-impact ask: `LiveEventService.ts` already special-cases close code `4001` as terminal (no reconnect). `GlobalWebSocketService.ts` (the client for `/ws`, one of the endpoints converted here) had **no** handling for `4001` at all — before this fix the browser never even saw it (close-before-accept collapses to an opaque code-1006 abnormal closure in the browser's native WebSocket API), so this was a latent infinite-reconnect-against-a-bad-token bug that would only start manifesting once the backend actually delivers `4001`. Fixed alongside the backend change.

## What Changed

**Backend — accept-then-close on auth rejection (same auth logic, only the timing changed):**
- `autobot-backend/api/websockets.py`: `websocket_test_endpoint` (`/ws-test`), `websocket_endpoint` (`/ws`), `npu_workers_websocket_endpoint` (`/ws/npu-workers`) — each now does `await websocket.accept()` then `await websocket.close(code=4001, reason="Authentication required")` instead of closing before accept.
- `autobot-backend/api/transcripts.py`: `analyze_transcript_ws` — same conversion, `reason="Unauthorized"`.
- `autobot-backend/api/ws_security.py`: `enforce_ws_admin` (shared helper for `/ws/monitoring` + `/ws/desktop/{session_id}` in `advanced_control.py`) — same conversion, `reason="Authentication required (admin)"`.

**Frontend — fail-loud handling for the now-visible 4001 close code:**
- `autobot-frontend/src/services/GlobalWebSocketService.ts`: `scheduleReconnect` now treats close code `4001` as terminal (like `LiveEventService` already does for `/ws/live`) — sets `connectionState` to `'error'` with a clear message and stops the reconnect loop, instead of retrying against a rejected token forever.

**Tests:**
- New `autobot-backend/tests/test_websockets_auth_reject_12366.py`: parametrized over `/ws-test`, `/ws`, `/ws/npu-workers` — asserts an unauthenticated connect is accepted then closed with `4001` (not a handshake-level rejection), and that a valid bearer proceeds normally.
- Updated `tests/test_ws_security_admin.py::test_enforce_ws_admin_accepts_then_closes_4001_when_denied` (renamed from `_closes_4001_when_denied`) to assert `accept()` is called before `close()`.
- Updated `tests/api/test_transcripts.py::test_ws_analyze_rejects_unauthenticated` and `tests/test_websocket_auth_smoke.py` docstrings/assertions for the new accept-then-close semantics (starlette's `TestClient` now needs an explicit `receive_text()`/`receive_json()` to observe the close frame, since the handshake itself no longer fails).

**Filed (not fixed — different scope):** #12526 — discovered a genuine unrelated bug while writing the `/ws/npu-workers` happy-path test: `NPUWorkerManager._load_workers_from_config` (sync, runs via `asyncio.to_thread`) calls the `async def _save_workers_to_config` without `await`, silently discarding the first-run auto-save (`RuntimeWarning: coroutine ... was never awaited`).

## Verification

```
$ python3 -m pytest autobot-backend/tests/test_ws_security_admin.py autobot-backend/tests/test_websocket_auth_smoke.py autobot-backend/tests/api/test_transcripts.py autobot-backend/tests/test_websockets_auth_reject_12366.py -p no:xdist -q
======================== 35 passed, 1 warning in 0.88s =========================
```
(the 1 warning is the pre-existing, now-filed #12526 npu_worker_manager bug — unrelated to this PR's WS changes)

```
$ python3 -m black --check api/transcripts.py api/websockets.py api/ws_security.py tests/api/test_transcripts.py tests/test_websocket_auth_smoke.py tests/test_ws_security_admin.py tests/test_websockets_auth_reject_12366.py
All done! ✨ 🍰 ✨  7 files would be left unchanged.

$ python3 -m flake8 api/transcripts.py api/websockets.py api/ws_security.py tests/api/test_transcripts.py tests/test_websocket_auth_smoke.py tests/test_ws_security_admin.py tests/test_websockets_auth_reject_12366.py
0
```

Frontend: `node_modules` isn't installed in this WSL worktree (frontend build/vue-tsc runs on the Windows host per project convention), so `vue-tsc` couldn't be run directly here. The `GlobalWebSocketService.ts` change is a 2-line addition using the exact same `this.connectionState.value = 'error'` / `this.state.lastError = <string>` patterns already used elsewhere in the same file (lines 434/458), and a brace-balance check on the file passed.

Confirmed pre-existing, unrelated failures in `tests/test_cross_worker_registries.py::TestTakeoverManagerCrossWorker` (MagicMock-await errors in `takeover_manager.py` — a file untouched by this PR) reproduce in isolation on this branch; not introduced by this change.

Closes #12366

## Model Used

Claude Sonnet 5