### PR TITLE
fix(security): unify inter-node SSH key resolution to canonical location via ssot_config (#12429)

### DIFF
--- a/autobot-backend/tasks/analytics_cache_population_test.py
+++ b/autobot-backend/tasks/analytics_cache_population_test.py
@@ -200,9 +200,8 @@ class TestBeatScheduleRegistration:
     def test_configured_hour_is_off_peak(self):
         """Sanity-check the default schedule lands in the existing off-peak
         maintenance window (00:00-06:00 UTC), not business hours."""
-        from utils.celery_schedules import crontab_from_string
-
         from autobot_shared.ssot_config import AutoBotConfig
+        from utils.celery_schedules import crontab_from_string
 
         default_schedule = AutoBotConfig.model_fields["analytics_cache_population_schedule"].default
         parsed = crontab_from_string(default_schedule)

--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -4,6 +4,17 @@
 # Global variables for all AutoBot VMs
 
 # ==========================================
+# CANONICAL INTER-NODE SSH KEY (#12429)
+# ==========================================
+# Single source of truth for the fleet private key used by SLM -> node SSH,
+# deploy, code-sync and service orchestration. Every inventory
+# (ansible_ssh_private_key_file) and every pubkey lookup resolves THIS var
+# instead of a per-file literal. Mirrors backend ssot_config.path.ssh_key_path
+# (env AUTOBOT_SSH_KEY_PATH / legacy SLM_SSH_KEY). ansible.cfg keeps the same
+# literal as its bootstrap default because INI cannot template a var.
+autobot_ssh_key_path: "/etc/autobot/ssh/autobot_key"
+
+# ==========================================
 # AUTOBOT APPLICATION CONFIGURATION
 # ==========================================
 

--- a/autobot-slm-backend/ansible/inventory/hosts-router.yml
+++ b/autobot-slm-backend/ansible/inventory/hosts-router.yml
@@ -6,7 +6,7 @@
 all:
   vars:
     ansible_user: autobot
-    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
+    ansible_ssh_private_key_file: "{{ autobot_ssh_key_path }}"
     python_interpreter: /usr/bin/python3
 
   children:

--- a/autobot-slm-backend/ansible/inventory/hosts.yml
+++ b/autobot-slm-backend/ansible/inventory/hosts.yml
@@ -4,7 +4,7 @@
 all:
   vars:
     ansible_user: autobot
-    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
+    ansible_ssh_private_key_file: "{{ autobot_ssh_key_path }}"
     python_interpreter: /usr/bin/python3
 
   children:

--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -9,7 +9,7 @@ all:
     # Global SSH and connection settings - UPDATED FOR PROVIDED VMs
     # Issue #700: SSH key authentication (no plaintext passwords)
     ansible_user: autobot
-    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
+    ansible_ssh_private_key_file: "{{ autobot_ssh_key_path }}"
     ansible_become: true
     # Become password from vault (only needed if passwordless sudo not configured)
     # To use: ansible-playbook ... --ask-vault-pass

--- a/autobot-slm-backend/ansible/inventory/slm-nodes.yml
+++ b/autobot-slm-backend/ansible/inventory/slm-nodes.yml
@@ -19,7 +19,7 @@
 all:
   vars:
     ansible_user: autobot
-    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
+    ansible_ssh_private_key_file: "{{ autobot_ssh_key_path }}"
     ansible_python_interpreter: /usr/bin/python3
 
     # Network and service-discovery — read from install-time secrets.

--- a/autobot-slm-backend/ansible/playbooks/bootstrap-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/bootstrap-node.yml
@@ -47,7 +47,7 @@
     autobot_log_dir: "/var/log/autobot"
     autobot_cert_dir: "/etc/autobot/certs"
     # Issue #2828: Use shared key path — accessible to any user in autobot group
-    ssh_pubkey_path: "/etc/autobot/ssh/autobot_key.pub"
+    ssh_pubkey_path: "{{ autobot_ssh_key_path | default('/etc/autobot/ssh/autobot_key') }}.pub"
 
   pre_tasks:
     - name: "Verify target is a Debian/Ubuntu system"

--- a/autobot-slm-backend/ansible/playbooks/deploy-base.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-base.yml
@@ -169,7 +169,7 @@
     - name: Set up authorized_keys for autobot user (if public key provided)
       authorized_key:
         user: "{{ autobot_user }}"
-        key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
+        key: "{{ lookup('file', autobot_ssh_key_path ~ '.pub') }}"
         state: present
       ignore_errors: true  # In case key doesn't exist yet
 

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -164,7 +164,7 @@
           authorized_key:
             user: "{{ autobot_user }}"
             state: present
-            key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
+            key: "{{ lookup('file', autobot_ssh_key_path ~ '.pub') }}"
           ignore_errors: true  # Key may not exist during initial enrollment
 
         - name: "Create emergency admin user"

--- a/autobot-slm-backend/ansible/playbooks/rotate-ssh-keys.yml
+++ b/autobot-slm-backend/ansible/playbooks/rotate-ssh-keys.yml
@@ -213,8 +213,8 @@
   gather_facts: false
 
   vars:
-    # Issue #2828: Read old key from shared location
-    _old_key_path: "/etc/autobot/ssh/autobot_key"
+    # Issue #2828 / #12429: canonical shared location, single var
+    _old_key_path: "{{ autobot_ssh_key_path | default('/etc/autobot/ssh/autobot_key') }}"
 
   tasks:
     - name: "SSH K4 | Read current old public key"
@@ -245,8 +245,8 @@
   vars:
     _keys_dir: "{{ lookup('env', 'HOME') }}/.ssh/autobot-rotation"
     _new_key_path: "{{ _keys_dir }}/autobot_key_new"
-    # Issue #2828: Install to shared location accessible by any operator
-    _final_key_path: "/etc/autobot/ssh/autobot_key"
+    # Issue #2828 / #12429: canonical shared location, single var
+    _final_key_path: "{{ autobot_ssh_key_path | default('/etc/autobot/ssh/autobot_key') }}"
 
   tasks:
     - name: "SSH K5 | Back up old private key"
@@ -274,22 +274,27 @@
         mode: "0644"
       become: true
 
-    - name: "SSH K5 | Also update autobot user home copy"
-      ansible.builtin.copy:
-        src: "{{ _new_key_path }}"
+    # #12429: previously stored a SECOND real key in the home dir that could
+    # drift from the canonical /etc copy. Link instead so any tool still
+    # referencing the home path resolves the one canonical file.
+    - name: "SSH K5 | Link autobot home key to canonical (#12429)"
+      ansible.builtin.file:
+        src: "{{ _final_key_path }}"
         dest: "/home/autobot/.ssh/autobot_key"
+        state: link
+        force: true
         owner: autobot
         group: autobot
-        mode: "0600"
       become: true
 
-    - name: "SSH K5 | Also update autobot user home public key"
-      ansible.builtin.copy:
-        src: "{{ _new_key_path }}.pub"
+    - name: "SSH K5 | Link autobot home public key to canonical (#12429)"
+      ansible.builtin.file:
+        src: "{{ _final_key_path }}.pub"
         dest: "/home/autobot/.ssh/autobot_key.pub"
+        state: link
+        force: true
         owner: autobot
         group: autobot
-        mode: "0644"
       become: true
 
     - name: "SSH K5 | Confirm installed"

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -102,10 +102,10 @@
 - name: "Common | Configure SSH key authentication"
   authorized_key:
     user: autobot
-    key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
+    key: "{{ lookup('file', autobot_ssh_key_path ~ '.pub') }}"
     state: present
   become: true
-  when: lookup('file', '/etc/autobot/ssh/autobot_key.pub', errors='ignore') is not none
+  when: lookup('file', autobot_ssh_key_path ~ '.pub', errors='ignore') is not none
   tags: ['common', 'ssh']
 
 - name: "Common | Reset UFW to clean state (Issue #895)"

--- a/autobot-slm-backend/ansible/roles/distributed_setup/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/defaults/main.yml
@@ -29,7 +29,7 @@ redis_cli_version: "7.4.0"
 redis_cli_build_from_source: false  # Set true if no sudo access
 
 # SSH configuration
-ssh_key_path: "{{ ansible_facts['env'].HOME }}/.ssh/autobot_fleet"
+ssh_key_path: "{{ autobot_ssh_key_path | default('/etc/autobot/ssh/autobot_key') }}"  # canonical (#12429)
 ssh_key_type: rsa
 ssh_key_bits: 4096
 ssh_setup_required: true

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -34,6 +34,7 @@ from typing_extensions import Annotated
 
 from autobot_shared.db_url import assemble_postgres_url
 from autobot_shared.security.redaction import redact_mapping
+from autobot_shared.ssot_config import config
 from config import settings
 from models.database import CodeSource, CodeStatus
 from models.database import ComponentSyncJob as ComponentSyncJobModel
@@ -2697,7 +2698,7 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
     if is_local_source:
         logger.info("SLM self-sync: code source is local at %s, using direct rsync", repo_path)
     else:
-        ssh_key = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
+        ssh_key = config.path.ssh_key_path  # canonical inter-node key (#12429)
         if not _ssh_key_usable(ssh_key):
             logger.error("SLM self-sync failed: SSH key not usable at %s", ssh_key)
             return

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from autobot_shared.ssot_config import config
 from models.database import (
     Certificate,
     CodeStatus,
@@ -2740,7 +2741,7 @@ async def get_node_service_order(
 # Node SSH Exec endpoint (Issue #933)
 # =============================================================================
 
-_DEFAULT_SSH_KEY = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
+_DEFAULT_SSH_KEY = config.path.ssh_key_path  # canonical inter-node key (#12429)
 _DEFAULT_SSH_USER = os.environ.get("SLM_SSH_USER", "autobot")
 
 

--- a/autobot-slm-backend/api/nodes_execution.py
+++ b/autobot-slm-backend/api/nodes_execution.py
@@ -37,6 +37,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.auth.permissions import Permission
+from autobot_shared.ssot_config import config
 from models.database import EventSeverity, EventType, Node, NodeEvent, NodeStatus
 from services.auth import require_permission
 from services.database import get_db
@@ -491,7 +492,7 @@ async def _audit_execute_event(
     await db.commit()
 
 
-_SSH_KEY_PATH = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
+_SSH_KEY_PATH = config.path.ssh_key_path  # canonical inter-node key (#12429)
 _SSH_KNOWN_HOSTS_PATH = os.environ.get("SLM_SSH_KNOWN_HOSTS", "/home/autobot/.ssh/known_hosts")  # noqa: ssot-path
 # System-wide known_hosts populated by Ansible — used as fallback when the
 # per-user file is absent.  Defined at module level so tests can patch it.
@@ -636,7 +637,8 @@ async def execute_on_node(
     Permission admin.system is required (require_permission dependency).
 
     Local nodes (manager host) execute via subprocess with shell=False;
-    remote nodes execute via SSH using the SLM key (SLM_SSH_KEY env var)
+    remote nodes execute via SSH using the canonical fleet key
+    (ssot_config.path.ssh_key_path; env AUTOBOT_SSH_KEY_PATH / legacy SLM_SSH_KEY)
     and known_hosts verification (SLM_SSH_KNOWN_HOSTS env var). Default
     paths are documented at the module-level constants ``_SSH_KEY_PATH``
     and ``_SSH_KNOWN_HOSTS_PATH``.

--- a/autobot-slm-backend/api/roles.py
+++ b/autobot-slm-backend/api/roles.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from autobot_shared.ssot_config import config
 from models.database import Node, NodeRole, Role, RoleStatus, SyncType
 from services.auth import get_current_user
 from services.database import get_db
@@ -655,7 +656,7 @@ async def _run_ssh_cmd(node: Node, remote_cmd: str) -> tuple:
     """Run a command on a node via SSH. Returns (success, output)."""
     ssh_user = node.ssh_user or "autobot"
     ssh_port = node.ssh_port or 22
-    ssh_key = "/home/autobot/.ssh/id_rsa"  # noqa: S108
+    ssh_key = config.path.ssh_key_path  # canonical inter-node key (#12429)
     ssh_cmd = [
         "/usr/bin/ssh",
         "-o",

--- a/autobot-slm-backend/api/services.py
+++ b/autobot-slm-backend/api/services.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
 from api.websocket import ws_manager
+from autobot_shared.ssot_config import config
 from models.database import Node, Service, ServiceConflict, ServiceStatus
 from models.schemas import (
     FleetServicesResponse,
@@ -60,7 +61,7 @@ def _build_service_ssh_cmd(node: Node, remote_cmd: str) -> list:
     """Build SSH command list for service action. Ref: #1088."""
     ssh_user = node.ssh_user or "autobot"
     ssh_port = node.ssh_port or 22
-    ssh_key = "/home/autobot/.ssh/id_rsa"  # noqa: ssot-path
+    ssh_key = config.path.ssh_key_path  # canonical inter-node key (#12429)
     return [
         "/usr/bin/ssh",
         "-o",
@@ -139,7 +140,7 @@ async def _kill_orphan_on_port(node: Node, port: int) -> Tuple[bool, str]:
     """
     ssh_user = node.ssh_user or "autobot"
     ssh_port = node.ssh_port or 22
-    ssh_key = "/home/autobot/.ssh/id_rsa"  # noqa: ssot-path
+    ssh_key = config.path.ssh_key_path  # canonical inter-node key (#12429)
 
     # Command to find and kill process on port
     # Using fuser which is more reliable than lsof for this purpose
@@ -196,7 +197,7 @@ async def _run_ansible_get_logs(
     # Build SSH command
     ssh_user = node.ssh_user or "autobot"
     ssh_port = node.ssh_port or 22
-    ssh_key = "/home/autobot/.ssh/id_rsa"  # noqa: ssot-path
+    ssh_key = config.path.ssh_key_path  # canonical inter-node key (#12429)
 
     ssh_cmd = [
         "/usr/bin/ssh",

--- a/autobot-slm-backend/services/code_distributor.py
+++ b/autobot-slm-backend/services/code_distributor.py
@@ -20,6 +20,7 @@ from typing import Tuple
 
 from sqlalchemy import select
 
+from autobot_shared.ssot_config import config
 from models.database import Setting
 from services.database import db_service
 from services.ssh_utils import _ssh_key_usable
@@ -33,7 +34,7 @@ DEFAULT_REPO_PATH = os.environ.get("SLM_REPO_PATH", "/opt/autobot")
 # Remote agent installation path on managed nodes
 REMOTE_AGENT_PATH = "/opt/slm-agent"
 # SSH key for connecting to managed nodes
-SSH_KEY_PATH = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
+SSH_KEY_PATH = config.path.ssh_key_path  # canonical inter-node key (#12429)
 
 
 class CodeDistributor:

--- a/autobot-slm-backend/services/deployment.py
+++ b/autobot-slm-backend/services/deployment.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Tuple
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.ssot_config import config as ssot_config
 from config import settings
 from models.database import Deployment, DeploymentStatus, Node, NodeStatus
 from models.schemas import DeploymentCreate, DeploymentResponse
@@ -954,9 +955,12 @@ class DeploymentService:
             The public key content, or empty string if unavailable.
         """
         # Default SSH key paths for the autobot user
-        ssh_dir = Path.home() / ".ssh"
-        pubkey_path = ssh_dir / "id_rsa.pub"
-        privkey_path = ssh_dir / "id_rsa"
+        # Canonical inter-node fleet key (#12429) — same identity Ansible and
+        # every SSH caller resolve, so the pubkey deployed to nodes matches the
+        # private key later used to connect.
+        privkey_path = ssot_config.path.ssh_key
+        pubkey_path = Path(ssot_config.path.ssh_pubkey_path)
+        ssh_dir = privkey_path.parent
 
         # Try to read existing public key
         if pubkey_path.exists():

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -54,6 +54,8 @@ from typing import Any
 
 import yaml
 
+from autobot_shared.ssot_config import config
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -143,7 +145,7 @@ REQUIRED_GROUPS: frozenset = frozenset(
 # Global all.vars — reproduced verbatim from slm-nodes.yml
 _ALL_VARS: dict[str, str] = {
     "ansible_user": "autobot",
-    "ansible_ssh_private_key_file": "/etc/autobot/ssh/autobot_key",
+    "ansible_ssh_private_key_file": config.path.ssh_key_path,  # canonical (#12429)
     "ansible_python_interpreter": "/usr/bin/python3",
     "slm_host": (
         "{{ lookup('env', 'SLM_HOST') | default(lookup('pipe',"

--- a/autobot-slm-backend/services/service_orchestrator.py
+++ b/autobot-slm-backend/services/service_orchestrator.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Tuple
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.ssot_config import config
 from models.database import Node, Service, ServiceStatus
 
 logger = logging.getLogger(__name__)
@@ -276,7 +277,7 @@ class ServiceOrchestrator:
 
     def __init__(self):
         self.registry = ServiceRegistry()
-        self.ssh_key = Path.home() / ".ssh" / "id_rsa"
+        self.ssh_key = Path(config.path.ssh_key_path)  # canonical inter-node key (#12429)
         self.ssh_user = "autobot"
         self._ssh_semaphore = asyncio.Semaphore(self._SSH_MAX_CONCURRENT)
 

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -18,6 +18,7 @@ from typing import Tuple
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.ssot_config import config
 from models.database import CodeSource, Node, NodeRole, Role, RoleStatus
 from services.database import db_service
 from services.ssh_utils import _ssh_key_usable
@@ -44,7 +45,7 @@ class SyncNodeContext:
 
 # Code cache directory
 CODE_CACHE_DIR = Path(os.environ.get("SLM_CODE_CACHE", "/var/lib/slm/code-cache"))
-SSH_KEY_PATH = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
+SSH_KEY_PATH = config.path.ssh_key_path  # canonical inter-node key (#12429)
 
 
 class SyncOrchestrator:

--- a/autobot-slm-backend/tests/test_canonical_ssh_key.py
+++ b/autobot-slm-backend/tests/test_canonical_ssh_key.py
@@ -1,0 +1,95 @@
+# Copyright 2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Guard: inter-node SSH key resolution stays unified on ONE canonical location (#12429).
+
+Every consumer that SSHes to fleet nodes (SLM -> node, deploy, code-sync,
+service orchestration) MUST resolve the private key from the single canonical
+source — ``ssot_config.path.ssh_key_path`` in Python and the
+``autobot_ssh_key_path`` Ansible var (both default
+``/etc/autobot/ssh/autobot_key``).
+
+This test fails if a regression reintroduces a scattered literal: a
+home-dir fleet-key copy (``~/.ssh/autobot_key``), the divergent RSA identity
+(``~/.ssh/id_rsa``), the ``autobot_fleet`` key name, or a hardcoded
+``ansible_ssh_private_key_file`` in an inventory. See the issue for why the
+split caused real ``Permission denied (publickey)`` failures.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+# Python runtime that builds inter-node ssh/rsync commands.
+_PY_SCOPE = (_BACKEND_ROOT / "services", _BACKEND_ROOT / "api")
+
+# Literals that must never reappear in runtime Python — each is a scattered
+# inter-node key path the canonical accessor replaced.
+_FORBIDDEN_PY = (
+    re.compile(r"""["']/home/autobot/\.ssh/autobot_key["']"""),  # home-dir fleet copy
+    re.compile(r"""\.ssh["'/\s]+id_rsa\b"""),  # divergent RSA identity for node comms
+    re.compile(r"autobot_fleet"),  # third key name
+    re.compile(r"""os\.environ\.get\(\s*["']SLM_SSH_KEY["']"""),  # per-module env default
+)
+
+
+def _runtime_py_files() -> list[Path]:
+    files: list[Path] = []
+    for root in _PY_SCOPE:
+        for p in root.rglob("*.py"):
+            name = p.name
+            if name.endswith("_test.py") or name.startswith("test_"):
+                continue
+            files.append(p)
+    return files
+
+
+def test_no_scattered_inter_node_key_literals_in_python():
+    """No runtime Python hardcodes a non-canonical inter-node key path (#12429)."""
+    offenders: list[str] = []
+    for path in _runtime_py_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for pat in _FORBIDDEN_PY:
+                if pat.search(line):
+                    rel = path.relative_to(_BACKEND_ROOT)
+                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Inter-node SSH key must resolve via config.path.ssh_key_path (#12429). "
+        "Scattered literals found:\n" + "\n".join(offenders)
+    )
+
+
+def test_inventories_use_canonical_ssh_key_var():
+    """Every inventory ansible_ssh_private_key_file resolves the canonical var (#12429)."""
+    inv_dir = _BACKEND_ROOT / "ansible" / "inventory"
+    key_line = re.compile(r"ansible_ssh_private_key_file:\s*(.+?)\s*$")
+    offenders: list[str] = []
+    for path in inv_dir.rglob("*.yml"):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            m = key_line.search(line)
+            if not m:
+                continue
+            value = m.group(1).strip().strip('"').strip("'")
+            if "autobot_ssh_key_path" not in value:
+                rel = path.relative_to(_BACKEND_ROOT)
+                offenders.append(f"{rel}:{lineno}: {value}")
+    assert not offenders, (
+        "Inventories must set ansible_ssh_private_key_file to "
+        '"{{ autobot_ssh_key_path }}" (#12429). Hardcoded values:\n' + "\n".join(offenders)
+    )
+
+
+def test_canonical_ssh_key_var_defined_once():
+    """The single canonical Ansible var exists with the /etc default (#12429)."""
+    all_yml = _BACKEND_ROOT / "ansible" / "inventory" / "group_vars" / "all.yml"
+    text = all_yml.read_text(encoding="utf-8")
+    assert re.search(
+        r'^autobot_ssh_key_path:\s*["\']?/etc/autobot/ssh/autobot_key["\']?\s*$',
+        text,
+        re.MULTILINE,
+    ), "group_vars/all.yml must define autobot_ssh_key_path: /etc/autobot/ssh/autobot_key (#12429)"

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1270,6 +1270,16 @@ class PathConfig(BaseSettings):
     # Override via AUTOBOT_VNC_PASSWD_FILE env var.
     vnc_passwd_file: str = Field(default="/home/autobot/.vnc/x11vnc.passwd", alias="AUTOBOT_VNC_PASSWD_FILE")
 
+    # Canonical inter-node SSH private key (#12429). SINGLE source of truth for
+    # every consumer that SSHes to fleet nodes (SLM -> fleet, deploy, code-sync,
+    # service orchestration). Absolute path — never relative to base_dir. Legacy
+    # per-module SLM_SSH_KEY env override is still honoured via AliasChoices so
+    # existing deployments keep working while resolution collapses to one place.
+    ssh_key_path: str = Field(
+        default="/etc/autobot/ssh/autobot_key",
+        validation_alias=AliasChoices("AUTOBOT_SSH_KEY_PATH", "SLM_SSH_KEY"),
+    )
+
     def resolve(self, relative: str) -> Path:
         """Resolve a path relative to base_dir."""
         p = Path(relative)
@@ -1311,6 +1321,16 @@ class PathConfig(BaseSettings):
     def vnc_passwd_path(self) -> Path:
         """Absolute path to the x11vnc password file."""
         return Path(self.vnc_passwd_file)
+
+    @property
+    def ssh_key(self) -> Path:
+        """Absolute path to the canonical inter-node SSH private key (#12429)."""
+        return Path(self.ssh_key_path)
+
+    @property
+    def ssh_pubkey_path(self) -> str:
+        """Path to the canonical inter-node SSH public key (private key + .pub)."""
+        return f"{self.ssh_key_path}.pub"
 
 
 class MiscConfig(BaseSettings):


### PR DESCRIPTION
## Thinking Path

Inter-node SSH keys were resolved from scattered locations that had already
diverged in practice (a home-dir copy, a separate RSA identity, a third
`autobot_fleet` name, and a per-module env default), so which key "worked"
depended on which code path initiated the connection — producing real
`Permission denied (publickey)` on a fleet node from one path while another
connected fine. Owner decision: collapse every inter-node key reference to ONE
canonical location, resolved through a single `ssot_config` accessor (Python)
and a single Ansible var.

## What Changed

**Canonical accessor (`autobot_shared/ssot_config.py`)**
- New `PathConfig.ssh_key_path` (default `/etc/autobot/ssh/autobot_key`,
  env `AUTOBOT_SSH_KEY_PATH`; legacy `SLM_SSH_KEY` still honoured via
  `AliasChoices` so existing deployments keep working).
- Helper properties `path.ssh_key` (Path) and `path.ssh_pubkey_path`.

**Python callers repointed to `config.path.ssh_key_path`**
- `services/inventory_builder.py` (generated inventory `ansible_ssh_private_key_file`)
- `services/sync_orchestrator.py`, `services/code_distributor.py`
- `services/service_orchestrator.py`, `services/deployment.py` (retired the
  divergent `~/.ssh/id_rsa` identity for node comms)
- `api/nodes.py`, `api/nodes_execution.py`, `api/code_sync.py`,
  `api/services.py`, `api/roles.py`
- Removed the now-unneeded `# noqa: ssot-path` markers on those lines.

**Ansible — single `autobot_ssh_key_path` var**
- Defined once in `inventory/group_vars/all.yml` (default canonical path).
- Inventories (`hosts.yml`, `slm-nodes.yml`, `production.yml`,
  `hosts-router.yml`) set `ansible_ssh_private_key_file: "{{ autobot_ssh_key_path }}"`.
- `roles/common`, `playbooks/deploy-base.yml`, `enroll-node.yml`,
  `bootstrap-node.yml`, `rotate-ssh-keys.yml` resolve pubkey/key via the var.
- `roles/distributed_setup/defaults/main.yml`: retired the `autobot_fleet`
  key name → canonical var.
- `rotate-ssh-keys.yml`: the home-dir key **copies** (a second real key that
  could drift) are now **symlinks** to the canonical file — rotation can no
  longer leave a stale duplicate behind.

**Regression guard** — `tests/test_canonical_ssh_key.py`: fails if any runtime
Python reintroduces a scattered key literal, if an inventory hardcodes the
key path, or if the canonical var is missing.

**Intentionally left (noted):**
- `ansible.cfg` `private_key_file` stays a literal equal to the canonical
  path — INI cannot template an Ansible var; it is the bootstrap default and
  matches the var.
- Operator bootstrap shell wrappers (`ansible/deploy.sh`,
  `deploy-autobot-native.sh`, `autobot-infrastructure/shared/scripts/*`) keep
  their `${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}` default — they run
  *before* the canonical `/etc` key exists (pre-canonical staging) and already
  accept an env override; forcing `/etc` would break first-time bootstrap.
- `autobot-backend/pki/config.py` / `models/task_context.py` defaults belong
  to the managed backend service, not SLM inter-node comms — out of scope.
- No key MATERIAL changed and no key files deleted. The supervised prod
  rollout (running the updated playbooks) is the owner's step.

## Verification

- `python3 -c` confirms `config.path.ssh_key_path == /etc/autobot/ssh/autobot_key`
  and that the legacy `SLM_SSH_KEY` env override still resolves.
- `ansible localhost -m debug` renders `ansible_ssh_private_key_file` →
  `/etc/autobot/ssh/autobot_key` end-to-end from the var.
- `ansible-playbook --syntax-check` passes for deploy-base, enroll-node,
  bootstrap-node, rotate-ssh-keys.
- Grep shows no scattered inter-node key literals remain in the SLM runtime
  scope (services/api/inventories/roles/playbooks).
- Tests: new guard (3) + existing SSH tests (`test_ssh_utils`,
  `test_sync_orchestrator_ssh`) + inventory/topology/group_vars +
  `ssot_config_test` (34) all green. isort + pyflakes clean.

## Model Used

claude-opus-4-8

Closes #12429
