### PR TITLE
fix(npu-workers): await _save_workers_to_config in _load_workers_from_config (#12526)

### DIFF
--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -117,7 +117,7 @@ class NPUWorkerManager(AsyncInitializable):
 
     async def _initialize_impl(self) -> bool:
         """Load worker configurations from YAML (deferred from __init__ to avoid blocking I/O)."""
-        await asyncio.to_thread(self._load_workers_from_config)
+        await self._load_workers_from_config()
         return True
 
     def _parse_single_worker(self, worker_data: dict) -> bool:
@@ -138,16 +138,25 @@ class NPUWorkerManager(AsyncInitializable):
             logger.error("Failed to load worker config: %s", e)
             return False
 
-    def _load_workers_from_config(self) -> None:
-        """Load worker configurations from YAML file"""
+    def _read_config_file(self) -> Dict[str, Any]:
+        """Blocking YAML read (Issue #12526: run via asyncio.to_thread, never on the event loop)."""
+        with open(self.config_file, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+
+    async def _load_workers_from_config(self) -> None:
+        """Load worker configurations from YAML file.
+
+        Issue #12526: made async so the config-missing branch can actually
+        `await self._save_workers_to_config()` instead of discarding the
+        coroutine. Blocking file I/O is offloaded via `asyncio.to_thread`.
+        """
         try:
-            if not self.config_file.exists():
+            if not await asyncio.to_thread(self.config_file.exists):
                 logger.warning("Worker config file not found: %s", self.config_file)
-                self._save_workers_to_config()
+                await self._save_workers_to_config()
                 return
 
-            with open(self.config_file, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
+            data = await asyncio.to_thread(self._read_config_file)
 
             # Load workers using helper (Issue #315: reduced nesting)
             workers_data = data.get("workers", [])

--- a/autobot-backend/services/test_npu_worker_config_load_12526.py
+++ b/autobot-backend/services/test_npu_worker_config_load_12526.py
@@ -1,0 +1,98 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for #12526.
+
+`_load_workers_from_config` used to call the async `_save_workers_to_config`
+without awaiting it when the config file was missing, silently discarding the
+coroutine (and emitting a "coroutine was never awaited" RuntimeWarning). It is
+now `async` and awaits the save directly.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.npu_worker_manager import NPUWorkerManager
+
+_WORKER_ID = "test-worker-1"
+
+
+def _make_manager(config_file: Path) -> NPUWorkerManager:
+    """Construct NPUWorkerManager with __init__ bypassed for heavy I/O."""
+    mgr = NPUWorkerManager.__new__(NPUWorkerManager)
+    mgr._workers = {}
+    mgr._worker_clients = {}
+    mgr._health_check_task = None
+    mgr._failover_monitor_task = None
+    mgr._pulse_task = None
+    mgr._running = False
+    mgr._load_balancing_config = MagicMock()
+    mgr._load_balancing_config.health_check_interval = 30
+    mgr._load_balancing_config.timeout_seconds = 10
+    mgr._worker_failure_counts = {}
+    mgr._worker_next_check = {}
+    mgr._pulse_failure_counts = {}
+    mgr._pulse_canaries = {}
+    mgr._pulse_defaults = {}
+    mgr.redis_client = None
+    mgr.config_file = config_file
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_load_workers_from_config_awaits_save_when_file_missing(tmp_path):
+    """Missing config file: _load_workers_from_config must actually await the save."""
+    missing_config = tmp_path / "npu_workers.yaml"
+    assert not missing_config.exists()
+
+    mgr = _make_manager(missing_config)
+    mgr._save_workers_to_config = AsyncMock()
+
+    await mgr._load_workers_from_config()
+
+    mgr._save_workers_to_config.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_load_workers_from_config_persists_file_end_to_end(tmp_path):
+    """End-to-end (no mocking of the save): the config file must exist afterwards.
+
+    This is the real regression check — before the fix, the save coroutine was
+    created and discarded, so the file was never written.
+    """
+    missing_config = tmp_path / "npu_workers.yaml"
+    mgr = _make_manager(missing_config)
+
+    await mgr._load_workers_from_config()
+
+    assert missing_config.exists(), "config file should have been created by the awaited save"
+
+
+@pytest.mark.asyncio
+async def test_load_workers_from_config_does_not_save_when_file_present(tmp_path):
+    """Existing config file: the save path must not be invoked at all."""
+    existing_config = tmp_path / "npu_workers.yaml"
+    existing_config.write_text("workers: []\nload_balancing: {}\n", encoding="utf-8")
+
+    mgr = _make_manager(existing_config)
+    mgr._save_workers_to_config = AsyncMock()
+
+    await mgr._load_workers_from_config()
+
+    mgr._save_workers_to_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_initialize_impl_awaits_load_workers_from_config():
+    """_initialize_impl must directly await _load_workers_from_config (no fire-and-forget)."""
+    mgr = _make_manager(Path("config/npu_workers.yaml"))
+    mgr._load_workers_from_config = AsyncMock()
+
+    result = await mgr._initialize_impl()
+
+    assert result is True
+    mgr._load_workers_from_config.assert_awaited_once()


### PR DESCRIPTION
## Thinking Path

`_load_workers_from_config` (sync) called the async `_save_workers_to_config` without `await` on the config-missing branch — the coroutine was created and immediately garbage-collected (silent no-op + `RuntimeWarning: coroutine ... was never awaited`). It ran via `asyncio.to_thread(self._load_workers_from_config)` from `_initialize_impl`, i.e. on a worker thread with no running event loop, so simply adding `await` in place wouldn't have worked — the whole call chain needed to become async so it runs on the event loop where `await` is meaningful.

Checked all other `self._<name>(` call sites against the async-method set in the file: the other 4 `_save_workers_to_config()` calls (add_worker, update_worker, remove_worker, update_load_balancing_config) already correctly `await` it. The only other bare-looking calls (`_health_check_loop`, `failover_monitor`, `_pulse_probe_loop`) are wrapped in `asyncio.create_task(...)` (intentional background tasks) and `_get_worker_status` inside `asyncio.gather(...)` (correctly awaited by gather) — no other bugs found in this file.

## What Changed

- `autobot-backend/services/npu_worker_manager.py`:
  - `_load_workers_from_config` is now `async def` and directly `await self._save_workers_to_config()` on the missing-file branch.
  - `_initialize_impl` now does `await self._load_workers_from_config()` directly instead of `asyncio.to_thread(self._load_workers_from_config)`.
  - Blocking file I/O (`Path.exists()`, `open()` + `yaml.safe_load()`) is still kept off the event loop via `asyncio.to_thread`, extracted into a small `_read_config_file` helper — same pattern `_save_workers_to_config` already uses for `mkdir`.
- `autobot-backend/services/test_npu_worker_config_load_12526.py` (new): regression tests covering
  - missing config file → save is awaited (mocked) and, separately, an end-to-end run where the file is actually written (the real regression check — previously this file was never created).
  - existing config file → save is *not* invoked.
  - `_initialize_impl` awaits `_load_workers_from_config`.

## Verification

```
$ python3 -W error::RuntimeWarning -m pytest services/test_npu_worker_config_load_12526.py \
    services/test_npu_worker_events.py services/npu_worker_manager_pulse_test.py -p no:xdist -q
28 passed in 0.44s
```
No `RuntimeWarning: coroutine ... was never awaited` (elevated to a hard error via `-W error::RuntimeWarning` and the run still passed).

```
$ python3 -m black --check autobot-backend/services/npu_worker_manager.py autobot-backend/services/test_npu_worker_config_load_12526.py
All done! 2 files would be left unchanged.
$ python3 -m flake8 --max-line-length=120 autobot-backend/services/npu_worker_manager.py autobot-backend/services/test_npu_worker_config_load_12526.py
(no output — clean)
```

Closes #12526

## Model Used

Claude Sonnet 5