### PR TITLE
test(rag): reset hook + autouse fixture for _SYNTHESIS_SCHEMA_CACHE isolation (#12531)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -1032,6 +1032,26 @@ def set_test_environment():
     os.environ.update(original_env)
 
 
+@pytest.fixture(autouse=True)
+def _reset_synthesis_schema_cache():
+    """Clear the rag_service synthesis-schema singleton around every test (#12531).
+
+    ``services.rag_service._SYNTHESIS_SCHEMA_CACHE`` is a module-level singleton guarded
+    by ``if ... is None``: the first test that triggers a real load permanently caches
+    the on-disk schema, so later tests that patch ``load_synthesis_schema`` are silently
+    ignored. Resetting before and after each test keeps the cache from leaking across the
+    process regardless of which test populated it.
+    """
+    try:
+        import services.rag_service as _rag
+    except Exception:
+        yield
+        return
+    _rag.reset_synthesis_schema_cache()
+    yield
+    _rag.reset_synthesis_schema_cache()
+
+
 # #12438: Modules deliberately handled elsewhere in this conftest — skip them in
 # the generalized real-load loop so it doesn't clobber their configured stubs or
 # double-load the ones already loaded via _real_load_and_bind above.

--- a/autobot-backend/services/rag_integration_test.py
+++ b/autobot-backend/services/rag_integration_test.py
@@ -373,16 +373,16 @@ class TestKBSynthesisSchemaCache:
     """Tests for module-level synthesis schema caching in RAGService (#4654)."""
 
     def setup_method(self) -> None:
-        """Reset the module-level cache before each test."""
-        import services.rag_service as rag_module
+        """Reset the module-level cache before each test (#12531)."""
+        from services.rag_service import reset_synthesis_schema_cache
 
-        rag_module._SYNTHESIS_SCHEMA_CACHE = None
+        reset_synthesis_schema_cache()
 
     def teardown_method(self) -> None:
-        """Reset the module-level cache after each test."""
-        import services.rag_service as rag_module
+        """Reset the module-level cache after each test (#12531)."""
+        from services.rag_service import reset_synthesis_schema_cache
 
-        rag_module._SYNTHESIS_SCHEMA_CACHE = None
+        reset_synthesis_schema_cache()
 
     @pytest.mark.asyncio
     async def test_load_synthesis_schema_called_only_once_across_multiple_calls(self) -> None:
@@ -427,6 +427,50 @@ class TestKBSynthesisSchemaCache:
 
         assert result1 is result2
         assert result1 is mock_schema
+
+    def test_reset_synthesis_schema_cache_clears_singleton(self) -> None:
+        """reset_synthesis_schema_cache() nulls the singleton so the next call reloads (#12531)."""
+        import services.rag_service as rag_module
+        from services.rag_service import reset_synthesis_schema_cache
+
+        with patch(
+            "services.knowledge.synthesis_schema_loader.load_synthesis_schema",
+            return_value=Mock(),
+        ) as loader:
+            rag_module._get_synthesis_schema()
+            assert rag_module._SYNTHESIS_SCHEMA_CACHE is not None
+            reset_synthesis_schema_cache()
+            assert rag_module._SYNTHESIS_SCHEMA_CACHE is None
+            rag_module._get_synthesis_schema()
+
+        assert loader.call_count == 2
+
+
+class TestSynthesisSchemaCacheAutouseIsolation:
+    """The autouse conftest fixture must clear the singleton between tests even when a
+    test class provides no manual setup/teardown reset (#12531).
+
+    Test methods run in definition order: ``_a_populates`` intentionally leaves the cache
+    populated; ``_b_sees_empty`` then proves the autouse fixture wiped it before entry.
+    """
+
+    def test_a_populates_cache_without_manual_reset(self) -> None:
+        import services.rag_service as rag_module
+
+        with patch(
+            "services.knowledge.synthesis_schema_loader.load_synthesis_schema",
+            return_value=Mock(),
+        ):
+            rag_module._get_synthesis_schema()
+
+        # Deliberately no reset here — relies on the autouse fixture to clean up.
+        assert rag_module._SYNTHESIS_SCHEMA_CACHE is not None
+
+    def test_b_sees_empty_cache_thanks_to_autouse_fixture(self) -> None:
+        import services.rag_service as rag_module
+
+        # If the autouse fixture did not run, the previous test's cache would leak here.
+        assert rag_module._SYNTHESIS_SCHEMA_CACHE is None
 
 
 class TestAPIEndpoints:

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -62,6 +62,19 @@ def _get_synthesis_schema() -> "object":
     return _SYNTHESIS_SCHEMA_CACHE
 
 
+def reset_synthesis_schema_cache() -> None:
+    """Clear the module-level synthesis-schema cache so the next call reloads from disk.
+
+    Primary use is test isolation: the ``is None`` guard in ``_get_synthesis_schema``
+    means the first unpatched load permanently caches the real on-disk schema for the
+    whole process, silently ignoring later ``load_synthesis_schema`` patches. An autouse
+    fixture (see ``conftest.py``) calls this between tests. It is also a manual
+    invalidation seam if a caller ever needs to force a reload at runtime. (#12531)
+    """
+    global _SYNTHESIS_SCHEMA_CACHE
+    _SYNTHESIS_SCHEMA_CACHE = None
+
+
 class RAGService:
     """
     Reusable RAG service providing advanced knowledge retrieval capabilities.


### PR DESCRIPTION
Closes #12531

## Thinking Path
_SYNTHESIS_SCHEMA_CACHE (services/rag_service.py) is a module-level singleton guarded by `is None`, so the first unpatched load wins process-wide and silently poisons every later test that patches load_synthesis_schema.

## What Changed
- Added `reset_synthesis_schema_cache()` (nulls the singleton -> next call reloads), following the repo reset conventions.
- Added an autouse `_reset_synthesis_schema_cache` fixture in conftest.py clearing it before+after each test (import-guarded).
- rag_integration_test.py setup/teardown now use the public reset; +2 tests proving reload + autouse isolation.

## Verification
- TestKBSynthesisSchemaCache + TestSynthesisSchemaCacheAutouseIsolation: 5 passed. Fixture proven load-bearing (autouse=False -> the isolation test fails). black/flake8 clean.

## Model Used
Opus 4.8.

Prod runtime-invalidation is a separate design decision, parked as https://github.com/mrveiss/AutoBot-AI/issues/12537.