### PR TITLE
test(knowledge): fix stale backend.* patch prefix in loaders_test (#12532)

### DIFF
--- a/autobot-backend/knowledge/pipeline/loaders/loaders_test.py
+++ b/autobot-backend/knowledge/pipeline/loaders/loaders_test.py
@@ -85,7 +85,7 @@ class TestChromaDBLoader:
         mock_client.get_or_create_collection.return_value = mock_collection
 
         with patch(
-            "backend.knowledge.pipeline.loaders.chromadb_loader." "get_async_chromadb_client",
+            "knowledge.pipeline.loaders.chromadb_loader.get_async_default_client",
             return_value=mock_client,
         ):
             from knowledge.pipeline.loaders.chromadb_loader import ChromaDBLoader
@@ -102,7 +102,7 @@ class TestChromaDBLoader:
         mock_client.get_or_create_collection.return_value = mock_collection
 
         with patch(
-            "backend.knowledge.pipeline.loaders.chromadb_loader." "get_async_chromadb_client",
+            "knowledge.pipeline.loaders.chromadb_loader.get_async_default_client",
             return_value=mock_client,
         ):
             from knowledge.pipeline.loaders.chromadb_loader import ChromaDBLoader
@@ -119,7 +119,7 @@ class TestChromaDBLoader:
         mock_client.get_or_create_collection.return_value = mock_collection
 
         with patch(
-            "backend.knowledge.pipeline.loaders.chromadb_loader." "get_async_chromadb_client",
+            "knowledge.pipeline.loaders.chromadb_loader.get_async_default_client",
             return_value=mock_client,
         ):
             from knowledge.pipeline.loaders.chromadb_loader import ChromaDBLoader
@@ -134,7 +134,7 @@ class TestChromaDBLoader:
         mock_client = AsyncMock()
 
         with patch(
-            "backend.knowledge.pipeline.loaders.chromadb_loader." "get_async_chromadb_client",
+            "knowledge.pipeline.loaders.chromadb_loader.get_async_default_client",
             return_value=mock_client,
         ):
             from knowledge.pipeline.loaders.chromadb_loader import ChromaDBLoader
@@ -156,10 +156,14 @@ class TestRedisGraphLoader:
     async def test_load_entities(self, context_with_data):
         mock_redis = MagicMock()
         mock_json = MagicMock()
+        mock_json.set = AsyncMock()
         mock_redis.json.return_value = mock_json
+        mock_redis.set = AsyncMock()
+        mock_redis.sadd = AsyncMock()
+        mock_redis.zadd = AsyncMock()
 
         with patch(
-            "backend.knowledge.pipeline.loaders.redis_graph_loader." "get_redis_client",
+            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
             return_value=mock_redis,
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
@@ -174,10 +178,14 @@ class TestRedisGraphLoader:
     async def test_load_relationships(self, context_with_data):
         mock_redis = MagicMock()
         mock_json = MagicMock()
+        mock_json.set = AsyncMock()
         mock_redis.json.return_value = mock_json
+        mock_redis.set = AsyncMock()
+        mock_redis.sadd = AsyncMock()
+        mock_redis.zadd = AsyncMock()
 
         with patch(
-            "backend.knowledge.pipeline.loaders.redis_graph_loader." "get_redis_client",
+            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
             return_value=mock_redis,
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
@@ -195,10 +203,14 @@ class TestRedisGraphLoader:
 
         mock_redis = MagicMock()
         mock_json = MagicMock()
+        mock_json.set = AsyncMock()
         mock_redis.json.return_value = mock_json
+        mock_redis.set = AsyncMock()
+        mock_redis.sadd = AsyncMock()
+        mock_redis.zadd = AsyncMock()
 
         with patch(
-            "backend.knowledge.pipeline.loaders.redis_graph_loader." "get_redis_client",
+            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
             return_value=mock_redis,
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
@@ -213,7 +225,7 @@ class TestRedisGraphLoader:
         mock_redis = MagicMock()
 
         with patch(
-            "backend.knowledge.pipeline.loaders.redis_graph_loader." "get_redis_client",
+            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
             return_value=mock_redis,
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
@@ -230,10 +242,14 @@ class TestRedisGraphLoader:
 
         mock_redis = MagicMock()
         mock_json = MagicMock()
+        mock_json.set = AsyncMock()
         mock_redis.json.return_value = mock_json
+        mock_redis.set = AsyncMock()
+        mock_redis.sadd = AsyncMock()
+        mock_redis.zadd = AsyncMock()
 
         with patch(
-            "backend.knowledge.pipeline.loaders.redis_graph_loader." "get_redis_client",
+            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
             return_value=mock_redis,
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader


### PR DESCRIPTION
## Thinking Path

`loaders_test.py` patched `backend.knowledge.pipeline.loaders.*` — a `backend.` package prefix that does not exist in the current `autobot-backend/` layout (modules import as `knowledge.pipeline.loaders.*`). `mock.patch` therefore raised `ModuleNotFoundError: No module named 'backend'` on entry, breaking 9 tests (4 ChromaDB + 5 RedisGraph) before any assertion ran.

Per the mock rule, the patch target must match the LOOKUP namespace where the name is used:
- `chromadb_loader.py` looks up `get_async_default_client` (from `knowledge.backends`) — the stale test also used the wrong symbol `get_async_chromadb_client` (nonexistent anywhere).
- `redis_graph_loader.py` looks up `get_redis_client` in its own namespace.

Correcting the prefix un-masked a second latent defect: the RedisGraph tests used a plain `MagicMock`, but the loader awaits its redis client (`await redis.json().set(...)`, `await redis.set/sadd/zadd(...)`) — `MagicMock` is not awaitable. These 4 tests had never actually executed because the stale patch always errored first.

## What Changed

- Fixed all 9 stale patch targets:
  - `backend.knowledge.pipeline.loaders.chromadb_loader.get_async_chromadb_client` → `knowledge.pipeline.loaders.chromadb_loader.get_async_default_client`
  - `backend.knowledge.pipeline.loaders.redis_graph_loader.get_redis_client` → `knowledge.pipeline.loaders.redis_graph_loader.get_redis_client`
- Made the RedisGraph mocks async-capable for the methods the loader awaits (`json().set`, `set`, `sadd`, `zadd`) via `AsyncMock`, keeping a `MagicMock` base so the co-located PropertyGraph dual-write (#3230, added after these tests) fails fast on its first `await redis.exists(...)` and is swallowed by the loader's best-effort try/except — isolating the assertions to the legacy Redis-JSON store the tests target.
- No assertions weakened; only patch targets and mock plumbing corrected.

## Verification

```
python3 -m pytest autobot-backend/knowledge/pipeline/loaders/loaders_test.py -p no:xdist -q
# before: 9 failed, 4 passed  (ModuleNotFoundError: No module named 'backend')
# after: 13 passed  (deterministic across 3 runs)
```

black `--check` and flake8: clean.

Closes #12532

## Model Used

claude-opus-4-8