### PR TITLE
test: fix order-dependent state leak in celery_beat_registration_test (#12522)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -196,6 +196,17 @@ if "celery_app" not in sys.modules:
         import celery as _cel_pkg  # noqa: F401
 
         _test_app = _cel_pkg.Celery("test_autobot", broker="memory://", backend="cache+memory://")
+        # GH#12522: ``store_eager_result`` is bound onto each task class at
+        # *finalize* time (Task.from_config), and ``Task.bind`` only reads the
+        # conf value while the attribute is still ``None``. Any test that
+        # introspects ``celery_app.tasks`` (celery_beat_registration_test,
+        # analytics_cache_population_test, batch_job_tasks_test) finalizes this
+        # shared session app first, freezing ``store_eager_result=False`` before
+        # an eager-result test's fixture can flip the runtime conf -- a later
+        # ``AsyncResult`` then reads the stale PROGRESS meta and reports
+        # "running". Setting it at creation binds every task with terminal-result
+        # storage regardless of which test file finalizes the app first.
+        _test_app.conf.task_store_eager_result = True
     except (ImportError, Exception):
         # Fall back to the stub Celery that is already in sys.modules["celery"]
         _StubCeleryClass = sys.modules["celery"].Celery

--- a/autobot-backend/tasks/conftest.py
+++ b/autobot-backend/tasks/conftest.py
@@ -22,6 +22,7 @@ register tasks on a lightweight in-process Celery app.
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 import types
 from unittest.mock import MagicMock
@@ -69,8 +70,16 @@ def _ensure_stub(name: str) -> types.ModuleType:
     return mod
 
 
+# GH#12522: ``get_logger`` must return a REAL stdlib logger, not a MagicMock.
+# ``_ensure_stub`` may hand back the already-imported real logging_manager
+# module, so overwriting ``get_logger`` here mutates a process-global that every
+# later import sees. A MagicMock return value made any module imported after
+# this conftest (e.g. api.codebase_analytics.chromadb_storage) log to a mock,
+# so ``caplog`` captured nothing and order-dependent log assertions failed. A
+# thin ``logging.getLogger`` factory keeps the heavy real logging_manager import
+# stubbed out while still emitting propagating records that caplog can capture.
 _logging_stub = _ensure_stub("autobot_shared.logging_manager")
-_logging_stub.get_logger = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+_logging_stub.get_logger = lambda name="autobot", *args, **kwargs: logging.getLogger(name)  # type: ignore[attr-defined]
 
 _async_compat_stub = _ensure_stub("autobot_shared.async_compat")
 _async_compat_stub.run_or_schedule = MagicMock()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Thinking Path

`-p no:xdist -q` runs surfaced two order-dependent failures rooted in shared-state leaks across test files (not in the code under test):

1. **Celery** — `celery_result_to_status` resolved a completed eager task to `running`. Celery binds `store_eager_result` onto each task class at **finalize** time (`Task.from_config`), and `Task.bind` only reads the conf value while the attribute is still `None`. The shared session Celery app (created once in `conftest.py`, #7766) is finalized the moment any test introspects `celery_app.tasks` — `celery_beat_registration_test`, `analytics_cache_population_test`, `batch_job_tasks_test`. Whichever runs first freezes `store_eager_result=False`, so `analytics_tasks_test`'s `celery_eager` fixture flips the runtime conf too late; the terminal SUCCESS never overwrites the intermediate PROGRESS meta and a later `AsyncResult` reads the stale `running` state.

2. **Logging (`caplog`)** — `chromadb_storage_test::test_swallows_exceptions_with_warning` captured no records. `tasks/conftest.py` set `autobot_shared.logging_manager.get_logger` to a `MagicMock`. `_ensure_stub` hands back the already-imported real module, so this mutated a process-global; any module imported afterwards (`chromadb_storage`) got a mock logger whose `.warning()` emits nothing, so `caplog` was empty.

## What Changed

- `autobot-backend/conftest.py` — set `task_store_eager_result=True` on the shared test Celery app at creation, so every finalize (regardless of which file runs first) binds tasks with terminal-result storage. `task_always_eager` stays per-test (opt-in via the victim's fixture), so this is inert until a test enables eager mode.
- `autobot-backend/tasks/conftest.py` — the `get_logger` stub now returns a real `logging.getLogger(name)` instead of a `MagicMock`, keeping the heavy real `logging_manager` import stubbed out while emitting propagating records `caplog` can capture.

## Verification

Both orders + both reported repros pass:

```
celery_beat_registration_test.py tasks/analytics_tasks_test.py  -> 10 passed
tasks/analytics_tasks_test.py celery_beat_registration_test.py  -> 10 passed
tasks/ api/codebase_analytics/                                  -> 290 passed, 11 skipped
api/codebase_analytics/ tasks/                                  -> 290 passed, 11 skipped
```

Regression sweep over `tasks/` plus every `caplog`-using suite: failures dropped **33 -> 6** with the fix; the remaining 6 (`github_integration`, `rag_integration`, `chat_phase4::TestSSOTStrictMode`) are all present on the base branch too — pre-existing, unrelated order flakes of a different class (env/global-registry leaks), tracked separately. Zero new failures introduced. `black` + `flake8` clean.

Closes #12522

## Model Used

claude-opus-4-8
