### PR TITLE
fix(ci): audit_api_wiring enumerates sub-router parametrized WS routes (#12432)

### DIFF
--- a/scripts/api_wiring_baseline.txt
+++ b/scripts/api_wiring_baseline.txt
@@ -72,9 +72,8 @@
 # actual fetch call itself. Matches the "base-URL constants and cache-key
 # maps" false-positive class documented in the #12326 comment thread.
 /api/user/profile
-# Real WebSocket handlers the audit's WS-route enumeration doesn't yet resolve
-# (sub-router parametrized WS routes) — wired to real handlers, not dead. Tracked
-# for enumeration improvement in #12432.
-/api/advanced-control/ws/desktop/{p}
-/api/advanced-control/ws/monitoring
-/api/overseer/ws/{p}
+# #12432: the 3 sub-router parametrized WS routes previously baselined here
+# (advanced-control/ws/monitoring, advanced-control/ws/desktop/{p},
+# overseer/ws/{p}) now resolve correctly — the WS enumeration walks
+# registry-configured (data-driven config-tuple) mount prefixes, not just
+# literal include_router(prefix=...) calls — and were removed from this file.

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -194,6 +194,50 @@ def backend_paths_from_openapi(src: str) -> set[str]:
 
 
 ROUTER_PREFIX_RE = re.compile(r"APIRouter\([^)]*?prefix\s*=\s*[\'\"]([^\'\"]+)", re.S)
+# #12432: feature/core routers are mounted via *data-driven config tuples* in
+# initialization/router_registry/*.py — e.g.
+#   ("api.advanced_control", "/advanced-control", ["advanced-control"], "advanced_control")
+# in feature_routers.py, or
+#   (overseer_router, "/overseer", ["overseer", "agent"], "overseer")
+# + a top-level ``from api.overseer_handlers import router as overseer_router``
+# in core_routers.py — never a literal ``include_router(prefix=...)`` call
+# (app_factory.py does that generically: ``prefix=f"/api{prefix}"``), so
+# INCLUDE_ROUTER_RE never sees these prefixes at all. Without resolving them,
+# a sub-router's routes (including websocket ones) get NO prefix, not merely
+# the wrong one — e.g. advanced_control.py's ``/ws/monitoring`` never becomes
+# ``/advanced-control/ws/monitoring``.
+ROUTER_CONFIG_ENTRY_RE = re.compile(
+    r"\(\s*(?:[\'\"](?P<mod>api(?:\.\w+)+)[\'\"]|(?P<var>[A-Za-z_]\w*))"
+    r"\s*,\s*(?:[\'\"]router[\'\"]\s*,\s*)?[\'\"](?P<prefix>[^\'\"]*)[\'\"]\s*,\s*\["
+)
+ROUTER_IMPORT_ALIAS_RE = re.compile(r"from\s+(api(?:\.\w+)+)\s+import\s+router\s+as\s+(\w+)")
+
+
+def _registry_module_prefixes(root: Path) -> dict[str, str]:
+    """Map ``api/<module>.py`` -> its registry-configured mount prefix (#12432).
+
+    Scans ``initialization/router_registry/*.py`` for the config-tuple
+    patterns described above, resolving variable-alias entries (core_routers.py
+    style) via their ``from api.X import router as X_router`` import line.
+    Returns {} for backends (e.g. autobot-slm-backend) with no such directory.
+    """
+    registry_dir = root / "initialization" / "router_registry"
+    if not registry_dir.is_dir():
+        return {}
+    alias_to_module: dict[str, str] = {}
+    entries: list[tuple[str, str]] = []
+    for py in registry_dir.glob("*.py"):
+        txt = py.read_text(encoding="utf-8", errors="ignore")
+        alias_to_module.update({alias: mod for mod, alias in ROUTER_IMPORT_ALIAS_RE.findall(txt)})
+        entries.extend(
+            (m.group("mod") or m.group("var"), m.group("prefix")) for m in ROUTER_CONFIG_ENTRY_RE.finditer(txt)
+        )
+    module_prefix: dict[str, str] = {}
+    for mod_or_var, prefix in entries:
+        mod = mod_or_var if mod_or_var.startswith("api.") else alias_to_module.get(mod_or_var)
+        if mod:
+            module_prefix[mod.replace(".", "/") + ".py"] = prefix.rstrip("/")
+    return module_prefix
 
 
 def _scan_route_decorators(
@@ -222,18 +266,27 @@ def _scan_route_decorators(
 
 
 def _combine_prefixed_paths(
-    raw_routes: dict[str, list[str]], module_prefix: dict[str, str], prefixes: set[str]
+    raw_routes: dict[str, list[str]],
+    module_prefix: dict[str, str],
+    prefixes: set[str],
+    registry_prefixes: dict[str, str] | None = None,
 ) -> set[str]:
-    """Combine each module's raw route strings with its own APIRouter prefix
-    and every known mount prefix (loose — mount-prefix combos aren't scoped
-    per-module, matching the pre-existing heuristic)."""
+    """Combine each module's raw route strings with its own APIRouter prefix,
+    its registry-resolved mount prefix if any (#12432 — precise, per-module),
+    and every known literal mount prefix (loose — mount-prefix combos aren't
+    scoped per-module, matching the pre-existing heuristic)."""
     paths: set[str] = set()
+    registry_prefixes = registry_prefixes or {}
     for sp, routes in raw_routes.items():
         own = module_prefix.get(sp, "")
+        reg = next((p for suffix, p in registry_prefixes.items() if sp.endswith("/" + suffix)), None)
         for r in routes:
             base = own + ("" if (r.startswith("/") or not r) else "/") + r
-            for candidate in {r, base}:
-                paths.add(norm_path(candidate) if candidate else norm_path(own or "/"))
+            candidates = {r, base}
+            if reg is not None:
+                candidates.add(reg + ("" if (r.startswith("/") or not r) else "/") + r)
+            for candidate in candidates:
+                paths.add(norm_path(candidate) if candidate else norm_path(own or reg or "/"))
                 for pre in prefixes:
                     paths.add(norm_path(pre + (candidate if candidate.startswith("/")
                                                else "/" + candidate if candidate else "")))
@@ -244,11 +297,15 @@ def backend_paths_static(root: Path = BACKEND) -> tuple[set[str], dict[str, list
     """Best-effort static scan. Returns (normalized paths, module->raw routes)."""
     raw, module_prefix, prefixes = _scan_route_decorators(root)
     raw_routes = {sp: [path for _method, path in entries] for sp, entries in raw.items()}
-    return _combine_prefixed_paths(raw_routes, module_prefix, prefixes), raw_routes
+    registry_prefixes = _registry_module_prefixes(root)
+    return (
+        _combine_prefixed_paths(raw_routes, module_prefix, prefixes, registry_prefixes),
+        raw_routes,
+    )
 
 
 def static_websocket_paths(root: Path) -> set[str]:
-    """Static-scan websocket-only paths under `root` (#12381).
+    """Static-scan websocket-only paths under `root` (#12381, #12432).
 
     Runtime WebSocketRoute introspection of a live app is unreliable across
     FastAPI versions: fastapi>=0.139's lazy ``_IncludedRouter`` wrapping means
@@ -259,7 +316,10 @@ def static_websocket_paths(root: Path) -> set[str]:
     prefix-combination algorithm as backend_paths_static() — is both simpler
     and version-independent. No `add_websocket_route()`/programmatic
     registrations exist in this codebase (verified by grep), so decorator
-    scanning has full coverage.
+    scanning has full coverage. #12432: also resolves data-driven registry
+    mount prefixes (see _registry_module_prefixes) so sub-router WS routes
+    (advanced_control.py, overseer_handlers.py, ...) get their real prefix
+    instead of none at all.
     """
     raw, module_prefix, prefixes = _scan_route_decorators(root)
     ws_routes = {
@@ -267,7 +327,8 @@ def static_websocket_paths(root: Path) -> set[str]:
         for sp, entries in raw.items()
     }
     ws_routes = {sp: paths for sp, paths in ws_routes.items() if paths}
-    return _combine_prefixed_paths(ws_routes, module_prefix, prefixes)
+    registry_prefixes = _registry_module_prefixes(root)
+    return _combine_prefixed_paths(ws_routes, module_prefix, prefixes, registry_prefixes)
 
 
 def _module_served_by_openapi(txt: str, backend: set[str]) -> bool:


### PR DESCRIPTION
## Thinking Path

PR #12418 (#12381) added WS-route enumeration (`x-websocket-paths`) to `audit_api_wiring.py`'s static scan, but 3 real handlers on feature sub-routers still weren't resolving: `advanced_control.py:530` `/ws/monitoring`, `:572` `/ws/desktop/{session_id}`, and `overseer_handlers.py:436` `/ws/{session_id}`.

Root cause: `advanced_control` and `overseer_handlers` aren't mounted via a literal `include_router(prefix="...")` call that the existing `INCLUDE_ROUTER_RE` regex can see. They're mounted through **data-driven config tuples** in `initialization/router_registry/*.py`:
- `feature_routers.py`: `("api.advanced_control", "/advanced-control", ["advanced-control"], "advanced_control")` — string module path.
- `core_routers.py`: `(overseer_router, "/overseer", ["overseer", "agent"], "overseer")`, with `overseer_router` resolved via a top-level `from api.overseer_handlers import router as overseer_router`.

`app_factory.py` applies the prefix generically (`app.include_router(router, prefix=f"/api{prefix}", ...)`), so the literal prefix string never appears next to `include_router(`. The static WS scan therefore combined these modules' `@router.websocket(...)` paths with an empty own-prefix, yielding a bare `/ws/monitoring` instead of `/advanced-control/ws/monitoring` — not the wrong prefix, no prefix at all.

## What Changed

- `scripts/audit_api_wiring.py`: added `_registry_module_prefixes()`, which scans `initialization/router_registry/*.py` for both config-tuple shapes (literal string module path, or import-aliased variable resolved via its `from api.X import router as X_router` line) and returns a `api/<module>.py -> mount prefix` map.
- Threaded this map through `_combine_prefixed_paths()` (new optional `registry_prefixes` param) so each module's routes — WS and, incidentally, the STATIC-fallback HTTP scan too — combine with their real registry-configured prefix, in addition to the existing loose Cartesian combination (unchanged, kept for backward compat).
- `scripts/api_wiring_baseline.txt`: removed the 3 now-correctly-resolved entries (`advanced-control/ws/monitoring`, `advanced-control/ws/desktop/{p}`, `overseer/ws/{p}`) — they were baselined-as-tracked in #12432's filing pending this fix.

## Verification

```
$ python3 -c "
from audit_api_wiring import static_websocket_paths, BACKEND
paths = static_websocket_paths(BACKEND)
for t in ['/advanced-control/ws/monitoring', '/advanced-control/ws/desktop/{p}', '/overseer/ws/{p}']:
    print(t, '->', t in paths)
"
/advanced-control/ws/monitoring -> True
/advanced-control/ws/desktop/{p} -> True
/overseer/ws/{p} -> True
```

`--dump-openapi`: websocket count went from 179 -> 281 (all 3 target routes now included, plus other data-driven-mounted routers' WS routes that were equally affected).

Full audit run (`--openapi ... --baseline scripts/api_wiring_baseline.txt --fail-on-unwired`): identical `backend paths` delta only (+102, from the new WS resolution) and **identical** unwired/unmounted-router findings before and after this change (diffed byte-for-byte against the pre-fix script run against the same openapi dump) — no new false-positives or false-negatives introduced. The 5 pre-existing `/api/nodes*`, `/api/tls/*` unwired findings are SLM control-plane routes that require `--slm-openapi` union (unavailable in this local sandbox — `/etc/autobot/db-credentials.env` permission denied); confirmed unrelated by running the same command against the pre-fix script, which shows the identical 5 items — not introduced by this change.

`scripts/audit_api_wiring_test.py`: 12/12 passed.
`black --check --fast` / `flake8 --max-line-length=120`: no new violations introduced by this diff (pre-existing file-wide black-version formatting drift confirmed unrelated by diffing against `git show HEAD:scripts/audit_api_wiring.py`).

Closes #12432

## Model Used

Sonnet