### PR TITLE
fix(agent): omit self-awareness context block when maturity/capability data is empty (#12509)

### DIFF
--- a/autobot-backend/llm_self_awareness.py
+++ b/autobot-backend/llm_self_awareness.py
@@ -430,10 +430,43 @@ class LLMSelfAwareness:
             }
         return rules
 
+    @staticmethod
+    def _has_meaningful_awareness_data(context: Dict[str, Any]) -> bool:
+        """
+        Check whether the system context carries real maturity/capability data.
+
+        Issue #12509: when the phase-progression subsystem's `PhaseValidator`
+        is unavailable (see #12458), `current_capabilities` never gets
+        populated and every metric reports zero. Injecting that broken
+        "0% maturity / 0 capabilities" state into every prompt is worse than
+        omitting it — it pollutes context and biases the model toward
+        hedging. Only treat the context as meaningful when at least one
+        maturity/capability/phase signal is non-zero. Uses `.get()` so a
+        malformed/error fallback context (see `_get_error_context`) is
+        treated as "not meaningful" rather than raising.
+        """
+        identity = context.get("system_identity", {})
+        capabilities = context.get("current_capabilities", {})
+        phase_info = context.get("phase_information", {})
+
+        return bool(identity.get("system_maturity") or capabilities.get("count") or phase_info.get("completed_phases"))
+
     async def inject_awareness_context(self, prompt: str, context_level: str = "basic") -> str:
-        """Inject system awareness context into a prompt"""
+        """Inject system awareness context into a prompt.
+
+        Issue #12509: omits the block entirely when the underlying
+        maturity/capability data is empty (zero-state), instead of
+        asserting a broken "0% maturity / 0 capabilities" state.
+        """
         include_detailed = context_level in DETAILED_CONTEXT_LEVELS  # O(1) lookup (Issue #326)
         context = await self.get_system_context(include_detailed=include_detailed)
+
+        if not self._has_meaningful_awareness_data(context):
+            logger.debug(
+                "llm_self_awareness: omitting self-awareness context block — "
+                "no meaningful maturity/capability data available"
+            )
+            return prompt
 
         # Build context injection
         awareness_prompt = f"""[SYSTEM CONTEXT - AutoBot Self-Awareness]

--- a/autobot-backend/llm_self_awareness_test.py
+++ b/autobot-backend/llm_self_awareness_test.py
@@ -1,0 +1,169 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for self-awareness context-block gating (#12509).
+
+Every chat message was getting prefixed with a
+``[SYSTEM CONTEXT - AutoBot Self-Awareness]`` block reporting
+"System Maturity: 0%, 0 capabilities across 0 categories, Completed
+Phases: 0/10" — a broken/uninitialized state (root cause: the optional
+``PhaseValidator``/``phase_validation_system`` dependency is absent, same as
+#12458, so ``current_capabilities`` never gets populated). Injecting that
+zero-state into every prompt both wastes context and biases the model
+toward "0 capabilities" hedging.
+
+These tests verify that ``inject_awareness_context()`` omits the block
+entirely when the underlying maturity/capability data is empty, and still
+injects it when there is real, non-empty data.
+"""
+
+import pytest
+
+from llm_self_awareness import LLMSelfAwareness
+
+ZERO_STATE_CONTEXT = {
+    "system_identity": {
+        "name": "AutoBot",
+        "version": "1.0.0",
+        "current_phase": "phase_6_self_awareness",
+        "system_maturity": 0,
+    },
+    "current_capabilities": {"active": [], "count": 0, "categories": {}},
+    "phase_information": {
+        "current_phase": "phase_6_self_awareness",
+        "completion_status": {},
+        "completed_phases": 0,
+        "total_phases": 10,
+    },
+    "system_metrics": {"maturity_score": 0, "validation_score": 0, "capability_count": 0},
+    "operational_status": {
+        "auto_progression_enabled": True,
+        "last_validation": None,
+        "recent_changes": 0,
+        "milestones_achieved": 0,
+    },
+    "contextual_information": {},
+}
+
+REAL_DATA_CONTEXT = {
+    "system_identity": {
+        "name": "AutoBot",
+        "version": "1.0.0",
+        "current_phase": "Phase 3: LLM Integration",
+        "system_maturity": 40,
+    },
+    "current_capabilities": {
+        "active": ["basic_api", "llm_interface"],
+        "count": 2,
+        "categories": {"core": ["basic_api"], "ai": ["llm_interface"]},
+    },
+    "phase_information": {
+        "current_phase": "Phase 3: LLM Integration",
+        "completion_status": {},
+        "completed_phases": 2,
+        "total_phases": 10,
+    },
+    "system_metrics": {"maturity_score": 40, "validation_score": 80, "capability_count": 2},
+    "operational_status": {
+        "auto_progression_enabled": True,
+        "last_validation": None,
+        "recent_changes": 0,
+        "milestones_achieved": 1,
+    },
+    "contextual_information": {},
+}
+
+ERROR_FALLBACK_CONTEXT = {
+    "system_identity": {
+        "name": "AutoBot",
+        "version": "1.0.0",
+        "error": "Failed to load complete context",
+    },
+    "current_capabilities": {"active": [], "error": "boom"},
+}
+
+
+def _make_awareness() -> LLMSelfAwareness:
+    """Build an LLMSelfAwareness instance without running __init__.
+
+    Issue #12509: __init__ wires up heavy collaborators (progression
+    manager, state tracker, project state manager) that are irrelevant to
+    the gating logic under test.
+    """
+    return object.__new__(LLMSelfAwareness)
+
+
+class TestHasMeaningfulAwarenessData:
+    """Unit tests for the `_has_meaningful_awareness_data` gate."""
+
+    def test_zero_state_is_not_meaningful(self) -> None:
+        assert LLMSelfAwareness._has_meaningful_awareness_data(ZERO_STATE_CONTEXT) is False
+
+    def test_real_data_is_meaningful(self) -> None:
+        assert LLMSelfAwareness._has_meaningful_awareness_data(REAL_DATA_CONTEXT) is True
+
+    def test_error_fallback_context_is_not_meaningful(self) -> None:
+        """Malformed/error-fallback shape must not raise KeyError — treated as empty."""
+        assert LLMSelfAwareness._has_meaningful_awareness_data(ERROR_FALLBACK_CONTEXT) is False
+
+    def test_nonzero_capability_count_alone_is_meaningful(self) -> None:
+        context = {**ZERO_STATE_CONTEXT, "current_capabilities": {"active": ["x"], "count": 1, "categories": {}}}
+        assert LLMSelfAwareness._has_meaningful_awareness_data(context) is True
+
+    def test_nonzero_completed_phases_alone_is_meaningful(self) -> None:
+        context = {
+            **ZERO_STATE_CONTEXT,
+            "phase_information": {**ZERO_STATE_CONTEXT["phase_information"], "completed_phases": 1},
+        }
+        assert LLMSelfAwareness._has_meaningful_awareness_data(context) is True
+
+
+@pytest.mark.asyncio
+class TestInjectAwarenessContext:
+    """Issue #12509: block injection must be gated on non-empty data."""
+
+    async def test_zero_state_omits_block(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        awareness = _make_awareness()
+
+        async def _fake_get_system_context(include_detailed: bool = False):
+            return ZERO_STATE_CONTEXT
+
+        monkeypatch.setattr(awareness, "get_system_context", _fake_get_system_context)
+
+        prompt = "How do I get to the city centre?"
+        result = await awareness.inject_awareness_context(prompt)
+
+        assert result == prompt
+        assert "SYSTEM CONTEXT" not in result
+        assert "System Maturity" not in result
+
+    async def test_real_data_injects_block(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        awareness = _make_awareness()
+
+        async def _fake_get_system_context(include_detailed: bool = False):
+            return REAL_DATA_CONTEXT
+
+        monkeypatch.setattr(awareness, "get_system_context", _fake_get_system_context)
+
+        prompt = "How do I get to the city centre?"
+        result = await awareness.inject_awareness_context(prompt)
+
+        assert "[SYSTEM CONTEXT - AutoBot Self-Awareness]" in result
+        assert "System Maturity: 40%" in result
+        assert result.endswith(prompt)
+
+    async def test_error_fallback_omits_block(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Error-fallback context must not raise nor inject a broken block."""
+        awareness = _make_awareness()
+
+        async def _fake_get_system_context(include_detailed: bool = False):
+            return ERROR_FALLBACK_CONTEXT
+
+        monkeypatch.setattr(awareness, "get_system_context", _fake_get_system_context)
+
+        prompt = "hello"
+        result = await awareness.inject_awareness_context(prompt)
+
+        assert result == prompt


### PR DESCRIPTION
## Thinking Path

Every chat/LLM request routed through `LLMAwarenessMiddleware` (wired for `/api/chat`, `/api/llm`, `/api/intelligent-agent`, `/api/workflow`) got prefixed with a `[SYSTEM CONTEXT - AutoBot Self-Awareness]` block asserting `System Maturity: 0%`, `0 capabilities across 0 categories`, `Completed Phases: 0/10`.

Traced the block to `LLMSelfAwareness.inject_awareness_context()` in `autobot-backend/llm_self_awareness.py`, called from `middleware/llm_awareness_middleware.py::_inject_awareness_into_field()`.

Root cause confirmed: `PhaseProgressionManager.current_capabilities` (`autobot-backend/phase_progression_manager.py`) is initialized as an empty `set()` and is only ever populated inside `_apply_progression()`, which is driven by phase-promotion validation via the optional `PhaseValidator` (`scripts.phase_validation_system`). That import is guarded with a `MissingDep` sentinel and is absent on every backend deploy (the infrastructure repo isn't on `PYTHONPATH`) — the same root cause as #12458. With the validator absent, phase promotion never runs, so `current_capabilities` stays empty forever and `system_maturity` (`len(current_capabilities) * 10`) is permanently `0`. The context is not "the system has zero capabilities" — it's "the maturity-tracking subsystem never ran."

Injecting that broken zero-state into every prompt both wastes context and biases the model toward "0 capabilities" hedging (per the issue's evidence).

## What Changed

- `autobot-backend/llm_self_awareness.py`: added `LLMSelfAwareness._has_meaningful_awareness_data(context)` — returns `True` only when at least one of `system_maturity`, `capabilities.count`, or `completed_phases` is non-zero (uses `.get()` so the malformed error-fallback context shape from `_get_error_context()` is treated as "not meaningful" rather than raising `KeyError`, fixing a latent crash-on-fallback bug discovered along the way).
- `inject_awareness_context()` now checks this gate before building the block: when data is empty/broken it returns the original prompt unchanged (no `[SYSTEM CONTEXT ...]` block); when there is real, non-empty data it builds and injects the block exactly as before.
- Did **not** wire up the absent `PhaseValidator` (that's #12458's optional-dependency territory, out of scope here) and did **not** fabricate maturity numbers — this is purely an injection-gating fix per the issue's "unambiguous, safe fix" guidance.

## Verification

```
$ python3 -m pytest autobot-backend/llm_self_awareness_test.py -p no:xdist -q
8 passed in 0.10s

$ python3 -m pytest autobot-backend/api/system_health_classification_test.py -p no:xdist -q
19 passed, 37 warnings in 1.96s   # no regression in llm_awareness-adjacent health-probe tests

$ python3 -m black --check autobot-backend/llm_self_awareness.py autobot-backend/llm_self_awareness_test.py
All done! 2 files would be left unchanged.

$ python3 -m flake8 autobot-backend/llm_self_awareness.py autobot-backend/llm_self_awareness_test.py
(clean, exit 0)
```

New test file `autobot-backend/llm_self_awareness_test.py` covers:
- `_has_meaningful_awareness_data`: zero-state → `False`; real data → `True`; malformed error-fallback shape → `False` (no raise); any single non-zero signal (capability count, completed phases) → `True`.
- `inject_awareness_context`: zero-state context → prompt returned unmodified, no `SYSTEM CONTEXT` / `System Maturity` text present; real-data context → block injected with correct maturity value, prompt appended at the end; error-fallback context → prompt returned unmodified (no crash).

## Model Used

Sonnet 5

## Product Question (for owner)

The issue's "Requested" section also raised: *"Reconsider injecting the self-awareness block into ordinary user chats at all — gate it to capability/self-status queries rather than every message."* This PR intentionally does **not** make that call — it only omits the block when the data is empty/broken (the unambiguous, safe fix per the issue's own priority ordering). Whether the block should *ever* be injected into ordinary chat turns (vs. only on-demand for self-status queries) is a product decision I'm flagging rather than deciding unilaterally.

Closes #12509