### PR TITLE
test(slm): add endpoint coverage for rewritten nodes/stateful/websocket code (#12515)

### DIFF
--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -407,8 +407,11 @@ async def _query_nodes_page(db: AsyncSession, status_filter: str | None, page: i
 
     query = query.order_by(Node.hostname)
 
-    count_result = await db.execute(select(Node.id).where(query.whereclause or True))
-    total = len(count_result.all())
+    # Count the filtered set (the previous `query.whereclause or True`
+    # always collapsed to True, silently dropping the filter -> wrong
+    # total whenever a status filter was applied). Ref #12515.
+    count_result = await db.execute(select(func.count()).select_from(query.subquery()))
+    total = count_result.scalar_one()
 
     query = query.offset((page - 1) * per_page).limit(per_page)
     result = await db.execute(query)

--- a/autobot-slm-backend/api/stateful.py
+++ b/autobot-slm-backend/api/stateful.py
@@ -14,7 +14,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
@@ -66,9 +66,10 @@ async def list_backups(
 
     query = query.order_by(Backup.created_at.desc())
 
-    # Get total count
-    count_result = await db.execute(select(Backup.id).where(query.whereclause or True))
-    total = len(count_result.all())
+    # Count the filtered set; `query.whereclause or True` always
+    # collapsed to True, dropping any filter -> wrong total (#12515).
+    count_result = await db.execute(select(func.count()).select_from(query.subquery()))
+    total = count_result.scalar_one()
 
     # Apply pagination
     query = query.offset((page - 1) * per_page).limit(per_page)
@@ -195,9 +196,10 @@ async def list_replications(
 
     query = query.order_by(Replication.created_at.desc())
 
-    # Get total count
-    count_result = await db.execute(select(Replication.id).where(query.whereclause or True))
-    total = len(count_result.all())
+    # Count the filtered set; `query.whereclause or True` always
+    # collapsed to True, dropping any filter -> wrong total (#12515).
+    count_result = await db.execute(select(func.count()).select_from(query.subquery()))
+    total = count_result.scalar_one()
 
     # Apply pagination
     query = query.offset((page - 1) * per_page).limit(per_page)

--- a/autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
+++ b/autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
@@ -1,0 +1,509 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Endpoint coverage for the rewritten SLM nodes-CRUD and stateful routers (#12515).
+
+Follow-up to #12455, which deleted three dead ``autobot-backend`` tests
+(``nodes_api_test.py``, ``stateful_api_test.py``, ``websockets_test.py``)
+because they imported symbols removed in the layer-separation refactor
+(``get_db_service``, ``StatefulServiceManager``, ``SLMWebSocketManager``, …).
+The rewritten ``autobot-slm-backend`` routers use ``Depends(get_db)``
+(``AsyncSession``) + ``get_current_user`` and had only narrow regression
+coverage.  This module exercises the CURRENT code paths.
+
+Strategy (mirrors ``tests/api/test_nodes_list_timeout_10913.py``): the root
+conftest stubs ``sqlalchemy``/``models.database``/``models.schemas`` as
+MagicMocks for import-time safety, so we snapshot the REAL modules once,
+swap them in to import ``api.nodes``/``api.stateful`` with real FastAPI/
+pydantic/ORM machinery, and drive the endpoints against a genuine
+in-memory SQLite ``AsyncSession`` (aiosqlite).  This tests real query
+logic, real 404s, and real ``model_validate`` contracts — not mock
+identity.  The route functions are called directly (no TestClient), so
+``get_current_user`` is satisfied by passing ``_={"admin": True}`` for the
+already-authenticated principal.
+
+Gaps (documented, not force-tested):
+- ``verify_replication_sync`` happy path and ``verify_data`` redis path
+  reach ``replication_service``/SSH subprocess infra that cannot be
+  unit-tested without a live Redis + SSH target; only their 404 / non-redis
+  branches are covered here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+_SLM_ROOT = Path(__file__).resolve().parents[2]
+if str(_SLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SLM_ROOT))
+
+_SQLALCHEMY_MODULES = ("sqlalchemy", "sqlalchemy.ext", "sqlalchemy.ext.asyncio", "sqlalchemy.orm")
+
+
+def _is_sqlalchemy_key(name: str) -> bool:
+    return name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so relative imports work)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _build_real_modules() -> dict:
+    """One-time real sqlalchemy + models.database/models.schemas snapshot.
+
+    Copied from tests/api/test_nodes_list_timeout_10913.py: the root conftest
+    stubs these as MagicMocks for import-time safety, so the real packages are
+    loaded once here and swapped in on demand.
+    """
+    saved = {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)}
+    saved.update({name: sys.modules.get(name) for name in ("models.database", "models.schemas")})
+    for name in list(saved):
+        sys.modules.pop(name, None)
+    try:
+        for name in _SQLALCHEMY_MODULES:
+            importlib.import_module(name)
+        importlib.import_module("sqlalchemy.dialects.sqlite")
+        _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+        _load_real_module("models.schemas", _SLM_ROOT / "models" / "schemas.py")
+        return {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)} | {
+            "models.database": sys.modules["models.database"],
+            "models.schemas": sys.modules["models.schemas"],
+        }
+    finally:
+        for name in [n for n in sys.modules if _is_sqlalchemy_key(n)]:
+            del sys.modules[name]
+        sys.modules.pop("models.database", None)
+        sys.modules.pop("models.schemas", None)
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
+
+
+_REAL_MODULES = _build_real_modules()
+
+
+@contextlib.contextmanager
+def _real_modules_swapped():
+    """Temporarily put the real sqlalchemy/models modules into sys.modules."""
+    saved = {name: sys.modules.get(name) for name in _REAL_MODULES}
+    sys.modules.update(_REAL_MODULES)
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
+
+
+def _load_api_module(dotted: str):
+    """Import a real ``api.*`` router module under the real-module swap."""
+    with _real_modules_swapped():
+        sys.modules.pop(dotted, None)
+        return importlib.import_module(dotted)
+
+
+# Import the routers + real ORM/schemas once under the swap; the bound
+# references (real Node/select/etc.) survive after stubs are restored.
+_nodes = _load_api_module("api.nodes")
+_stateful = _load_api_module("api.stateful")
+_db_models = _REAL_MODULES["models.database"]
+_schemas = _REAL_MODULES["models.schemas"]
+
+Base = _db_models.Base
+Node = _db_models.Node
+NodeStatus = _db_models.NodeStatus
+Backup = _db_models.Backup
+BackupStatus = _db_models.BackupStatus
+Replication = _db_models.Replication
+ReplicationStatus = _db_models.ReplicationStatus
+
+NodeCreate = _schemas.NodeCreate
+NodeUpdate = _schemas.NodeUpdate
+BackupCreate = _schemas.BackupCreate
+ReplicationCreate = _schemas.ReplicationCreate
+DataVerifyRequest = _schemas.DataVerifyRequest
+
+with _real_modules_swapped():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+# Any already-authenticated principal — the route functions only receive the
+# decoded payload (the auth dependency itself is not exercised here).
+_PRINCIPAL = {"admin": True, "role": "admin", "sub": "tester"}
+
+
+@pytest.fixture
+async def db():
+    """A fresh real in-memory SQLite AsyncSession per test."""
+    with _real_modules_swapped():
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _insert_node(db, node_id: str, ip: str = "10.0.0.10", **overrides) -> Node:
+    """Persist a minimal online Node row and return it."""
+    node = Node(
+        node_id=node_id,
+        hostname=overrides.get("hostname", f"host-{node_id}"),
+        ip_address=ip,
+        status=overrides.get("status", NodeStatus.ONLINE.value),
+    )
+    db.add(node)
+    await db.commit()
+    await db.refresh(node)
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Nodes CRUD (api/nodes.py) — list / create / get / update / delete
+# ---------------------------------------------------------------------------
+
+
+class TestNodesCrud:
+    """The rewritten get_db/auth-based nodes router (#12515)."""
+
+    async def test_list_empty(self, db):
+        result = await _nodes.list_nodes(db=db, _=_PRINCIPAL, status_filter=None, page=1, per_page=20)
+        assert result.total == 0
+        assert result.nodes == []
+        assert result.page == 1
+
+    async def test_create_returns_201_shape_and_persists(self, db):
+        node_data = NodeCreate(
+            hostname="web-1",
+            ansible_name="web-1",
+            ip_address="10.0.0.21",
+            import_existing=True,  # -> ONLINE, and skips enrollment path
+            auth_method="key",  # avoid the password-encryption (mocked) branch
+        )
+        created = await _nodes.create_node(node_data=node_data, db=db, _=_PRINCIPAL)
+
+        assert created.hostname == "web-1"
+        assert created.ip_address == "10.0.0.21"
+        assert created.status == NodeStatus.ONLINE.value
+
+        # Persisted and visible through the list endpoint.
+        listed = await _nodes.list_nodes(db=db, _=_PRINCIPAL, status_filter=None, page=1, per_page=20)
+        assert listed.total == 1
+        assert listed.nodes[0].node_id == created.node_id
+
+    async def test_create_pending_when_not_imported(self, db):
+        node_data = NodeCreate(hostname="p-1", ansible_name="p-1", ip_address="10.0.0.22", auth_method="key")
+        created = await _nodes.create_node(node_data=node_data, db=db, _=_PRINCIPAL)
+        assert created.status == NodeStatus.PENDING.value
+
+    async def test_create_duplicate_ip_rejected_400(self, db):
+        await _insert_node(db, "n-dup", ip="10.0.0.30")
+        node_data = NodeCreate(hostname="dup", ansible_name="dup", ip_address="10.0.0.30", auth_method="key")
+        with pytest.raises(HTTPException) as exc:
+            await _nodes.create_node(node_data=node_data, db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 400
+
+    async def test_get_returns_node(self, db):
+        await _insert_node(db, "n-get", ip="10.0.0.40")
+        got = await _nodes.get_node(node_id="n-get", db=db, _=_PRINCIPAL)
+        assert got.node_id == "n-get"
+        assert got.ip_address == "10.0.0.40"
+
+    async def test_get_not_found_404(self, db):
+        with pytest.raises(HTTPException) as exc:
+            await _nodes.get_node(node_id="ghost", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+    async def test_update_mutates_fields(self, db):
+        await _insert_node(db, "n-upd", ip="10.0.0.50")
+        updated = await _nodes.update_node(
+            node_id="n-upd",
+            node_data=NodeUpdate(hostname="renamed"),
+            db=db,
+            _=_PRINCIPAL,
+        )
+        assert updated.hostname == "renamed"
+        # Round-trips through a fresh read.
+        reread = await _nodes.get_node(node_id="n-upd", db=db, _=_PRINCIPAL)
+        assert reread.hostname == "renamed"
+
+    async def test_update_not_found_404(self, db):
+        with pytest.raises(HTTPException) as exc:
+            await _nodes.update_node(node_id="ghost", node_data=NodeUpdate(hostname="x"), db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+    async def test_delete_removes_node(self, db):
+        await _insert_node(db, "n-del", ip="10.0.0.60")
+        result = await _nodes.delete_node(node_id="n-del", db=db, _=_PRINCIPAL)
+        assert result is None  # 204 No Content
+        with pytest.raises(HTTPException) as exc:
+            await _nodes.get_node(node_id="n-del", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+    async def test_delete_not_found_404(self, db):
+        with pytest.raises(HTTPException) as exc:
+            await _nodes.delete_node(node_id="ghost", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+    async def test_list_status_filter_narrows(self, db):
+        await _insert_node(db, "n-online", ip="10.0.0.71", status=NodeStatus.ONLINE.value)
+        await _insert_node(db, "n-offline", ip="10.0.0.72", status=NodeStatus.OFFLINE.value)
+        online = await _nodes.list_nodes(
+            db=db, _=_PRINCIPAL, status_filter=NodeStatus.ONLINE.value, page=1, per_page=20
+        )
+        assert online.total == 1
+        assert online.nodes[0].node_id == "n-online"
+
+
+# ---------------------------------------------------------------------------
+# Stateful REST (api/stateful.py) — backups + replications
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_bg_tasks(monkeypatch):
+    """Neutralise the fire-and-forget ``asyncio.create_task`` background jobs.
+
+    ``create_backup``/``start_replication``/``restore_backup`` kick off async
+    jobs that reach real backup/replication services (stubbed MagicMocks here).
+    Scheduling those would either raise (MagicMock isn't a coroutine) or leak
+    'never retrieved' task warnings, so replace scheduling with a coroutine-safe
+    no-op for the duration of the test.
+    """
+
+    def _fake_create_task(coro=None, *args, **kwargs):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    monkeypatch.setattr(_stateful.asyncio, "create_task", _fake_create_task)
+
+
+class TestStatefulBackups:
+    """Backup endpoints on the SQLAlchemy-backed stateful router (#12515)."""
+
+    async def test_list_backups_empty(self, db):
+        result = await _stateful.list_backups(
+            db=db, _=_PRINCIPAL, node_id=None, service_type=None, status_filter=None, page=1, per_page=20
+        )
+        assert result.total == 0
+        assert result.backups == []
+
+    async def test_create_backup_201_for_existing_node(self, db, no_bg_tasks):
+        await _insert_node(db, "n-bk", ip="10.0.0.80")
+        created = await _stateful.create_backup(
+            request=BackupCreate(node_id="n-bk", service_type="redis"),
+            db=db,
+            _=_PRINCIPAL,
+        )
+        assert created.node_id == "n-bk"
+        assert created.status == BackupStatus.PENDING.value
+        assert created.backup_id
+
+        listed = await _stateful.list_backups(
+            db=db, _=_PRINCIPAL, node_id=None, service_type=None, status_filter=None, page=1, per_page=20
+        )
+        assert listed.total == 1
+
+    async def test_create_backup_unknown_node_404(self, db, no_bg_tasks):
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.create_backup(
+                request=BackupCreate(node_id="ghost", service_type="redis"), db=db, _=_PRINCIPAL
+            )
+        assert exc.value.status_code == 404
+
+    async def test_get_backup_roundtrip_and_404(self, db, no_bg_tasks):
+        await _insert_node(db, "n-bk2", ip="10.0.0.81")
+        created = await _stateful.create_backup(
+            request=BackupCreate(node_id="n-bk2", service_type="redis"), db=db, _=_PRINCIPAL
+        )
+        got = await _stateful.get_backup(backup_id=created.backup_id, db=db, _=_PRINCIPAL)
+        assert got.backup_id == created.backup_id
+
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.get_backup(backup_id="nope", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+    async def test_restore_rejects_non_completed_backup_400(self, db, no_bg_tasks):
+        await _insert_node(db, "n-bk3", ip="10.0.0.82")
+        created = await _stateful.create_backup(
+            request=BackupCreate(node_id="n-bk3", service_type="redis"), db=db, _=_PRINCIPAL
+        )
+        # Fresh backup is PENDING, not COMPLETED -> cannot restore.
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.restore_backup(backup_id=created.backup_id, db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 400
+
+    async def test_restore_completed_backup_starts_job(self, db, no_bg_tasks):
+        backup = Backup(
+            backup_id="bk-done",
+            node_id="n-any",
+            service_type="redis",
+            status=BackupStatus.COMPLETED.value,
+        )
+        db.add(backup)
+        await db.commit()
+        result = await _stateful.restore_backup(backup_id="bk-done", db=db, _=_PRINCIPAL)
+        assert result.success is True
+        assert result.job_id
+
+    async def test_restore_missing_backup_404(self, db, no_bg_tasks):
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.restore_backup(backup_id="ghost", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+
+class TestStatefulReplications:
+    """Replication endpoints on the stateful router (#12515)."""
+
+    async def test_list_replications_empty(self, db):
+        result = await _stateful.list_replications(
+            db=db, _=_PRINCIPAL, source_node_id=None, target_node_id=None, status_filter=None, page=1, per_page=20
+        )
+        assert result.total == 0
+        assert result.replications == []
+
+    async def test_start_replication_201(self, db, no_bg_tasks):
+        await _insert_node(db, "src", ip="10.0.0.90")
+        await _insert_node(db, "dst", ip="10.0.0.91")
+        created = await _stateful.start_replication(
+            request=ReplicationCreate(source_node_id="src", target_node_id="dst", service_type="redis"),
+            db=db,
+            _=_PRINCIPAL,
+        )
+        assert created.source_node_id == "src"
+        assert created.target_node_id == "dst"
+        assert created.status == ReplicationStatus.PENDING.value
+
+        listed = await _stateful.list_replications(
+            db=db, _=_PRINCIPAL, source_node_id=None, target_node_id=None, status_filter=None, page=1, per_page=20
+        )
+        assert listed.total == 1
+
+    async def test_start_replication_missing_source_404(self, db, no_bg_tasks):
+        await _insert_node(db, "dst2", ip="10.0.0.92")
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.start_replication(
+                request=ReplicationCreate(source_node_id="ghost", target_node_id="dst2"),
+                db=db,
+                _=_PRINCIPAL,
+            )
+        assert exc.value.status_code == 404
+
+    async def test_start_replication_conflict_when_active_exists(self, db, no_bg_tasks):
+        await _insert_node(db, "s3", ip="10.0.0.93")
+        await _insert_node(db, "t3", ip="10.0.0.94")
+        db.add(
+            Replication(
+                replication_id="rep-active",
+                source_node_id="s3",
+                target_node_id="t3",
+                service_type="redis",
+                status=ReplicationStatus.ACTIVE.value,
+            )
+        )
+        await db.commit()
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.start_replication(
+                request=ReplicationCreate(source_node_id="s3", target_node_id="t3"),
+                db=db,
+                _=_PRINCIPAL,
+            )
+        assert exc.value.status_code == 400
+
+    async def test_get_replication_roundtrip_and_404(self, db):
+        db.add(
+            Replication(
+                replication_id="rep-1",
+                source_node_id="a",
+                target_node_id="b",
+                service_type="redis",
+                status=ReplicationStatus.PENDING.value,
+            )
+        )
+        await db.commit()
+        got = await _stateful.get_replication(replication_id="rep-1", db=db, _=_PRINCIPAL)
+        assert got.replication_id == "rep-1"
+
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.get_replication(replication_id="nope", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+    async def test_promote_translates_service_success(self, db, monkeypatch):
+        """promote_replica maps a service (True, msg) into an ActionResponse."""
+        monkeypatch.setattr(
+            _stateful.replication_service,
+            "promote_replica",
+            AsyncMock(return_value=(True, "promoted")),
+        )
+        result = await _stateful.promote_replica(replication_id="rep-x", db=db, _=_PRINCIPAL)
+        assert result.action == "promote"
+        assert result.success is True
+        assert result.message == "promoted"
+        assert result.resource_id == "rep-x"
+
+    async def test_promote_service_failure_400(self, db, monkeypatch):
+        monkeypatch.setattr(
+            _stateful.replication_service,
+            "promote_replica",
+            AsyncMock(return_value=(False, "not a replica")),
+        )
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.promote_replica(replication_id="rep-x", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "not a replica"
+
+    async def test_stop_translates_service_success(self, db, monkeypatch):
+        monkeypatch.setattr(
+            _stateful.replication_service,
+            "stop_replication",
+            AsyncMock(return_value=(True, "stopped")),
+        )
+        result = await _stateful.stop_replication(replication_id="rep-y", db=db, _=_PRINCIPAL)
+        assert result.action == "stop"
+        assert result.success is True
+        assert result.resource_id == "rep-y"
+
+    async def test_verify_replication_sync_missing_404(self, db):
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.verify_replication_sync(replication_id="ghost", db=db, _=_PRINCIPAL)
+        assert exc.value.status_code == 404
+
+
+class TestStatefulVerify:
+    """Data-verification endpoint (api/stateful.py verify_data) — #12515."""
+
+    async def test_verify_unknown_node_404(self, db):
+        with pytest.raises(HTTPException) as exc:
+            await _stateful.verify_data(
+                request=DataVerifyRequest(node_id="ghost", service_type="redis"), db=db, _=_PRINCIPAL
+            )
+        assert exc.value.status_code == 404
+
+    async def test_verify_non_redis_service_is_skipped(self, db):
+        """Non-redis services short-circuit to a 'skipped' check (no infra call)."""
+        await _insert_node(db, "n-vf", ip="10.0.0.99")
+        result = await _stateful.verify_data(
+            request=DataVerifyRequest(node_id="n-vf", service_type="postgres"), db=db, _=_PRINCIPAL
+        )
+        assert result.service_type == "postgres"
+        assert result.is_healthy is True
+        assert any(check["status"] == "skipped" for check in result.checks)

--- a/autobot-slm-backend/tests/test_websocket_connection_manager_12515.py
+++ b/autobot-slm-backend/tests/test_websocket_connection_manager_12515.py
@@ -1,0 +1,179 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the rewritten WebSocket ``ConnectionManager`` (#12515).
+
+Follow-up to #12455, which deleted the dead ``websockets_test.py`` (it imported
+the removed ``SLMWebSocketManager`` + ``create_reconciler_callbacks``).  The
+current ``api/websocket.py`` uses a channel-keyed ``ConnectionManager`` plus a
+set of ``send_*`` fan-out helpers, none of which had coverage.
+
+These tests import ``ConnectionManager`` directly (the root conftest already
+stubs ``services.*`` so ``api.websocket`` imports cleanly — see the existing
+``tests/test_websocket_auth_smoke.py``) and drive it with fake AsyncMock
+WebSockets.  They assert real behaviour: channel registration on connect,
+cleanup on disconnect, message fan-out on broadcast, silent pruning of dead
+sockets, and the dual global+node channel routing of the ``send_*`` helpers.
+
+The accept-then-close-on-auth-fail convention (#12366) is already covered for
+``_authenticate_websocket_token`` in ``tests/test_websocket_auth_smoke.py``;
+this module focuses on the previously-uncovered ``ConnectionManager``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from api.websocket import ConnectionManager
+
+
+def _fake_ws(protocols: str = "") -> AsyncMock:
+    """A fake WebSocket exposing the sync ``headers`` the manager reads."""
+    ws = AsyncMock()
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.headers = MagicMock()
+    ws.headers.get = MagicMock(
+        side_effect=lambda key, default="": protocols if key == "sec-websocket-protocol" else default
+    )
+    return ws
+
+
+class TestConnectLifecycle:
+    """connect/disconnect channel bookkeeping (#12515)."""
+
+    async def test_connect_accepts_and_registers(self):
+        mgr = ConnectionManager()
+        ws = _fake_ws()
+        await mgr.connect(ws, "events:global")
+        ws.accept.assert_awaited_once()
+        assert ws in mgr._connections["events:global"]
+
+    async def test_connect_uses_bearer_subprotocol_when_offered(self):
+        mgr = ConnectionManager()
+        ws = _fake_ws(protocols="bearer, sometoken")
+        await mgr.connect(ws, "events:global")
+        assert ws.accept.call_args.kwargs.get("subprotocol") == "bearer"
+
+    async def test_connect_without_bearer_has_no_subprotocol(self):
+        mgr = ConnectionManager()
+        ws = _fake_ws(protocols="")
+        await mgr.connect(ws, "events:global")
+        assert ws.accept.call_args.kwargs.get("subprotocol") is None
+
+    async def test_disconnect_removes_and_prunes_empty_channel(self):
+        mgr = ConnectionManager()
+        ws = _fake_ws()
+        await mgr.connect(ws, "node:n1")
+        await mgr.disconnect(ws, "node:n1")
+        # Last socket gone -> channel key removed entirely.
+        assert "node:n1" not in mgr._connections
+
+    async def test_disconnect_keeps_channel_with_remaining_sockets(self):
+        mgr = ConnectionManager()
+        ws1, ws2 = _fake_ws(), _fake_ws()
+        await mgr.connect(ws1, "node:n1")
+        await mgr.connect(ws2, "node:n1")
+        await mgr.disconnect(ws1, "node:n1")
+        assert "node:n1" in mgr._connections
+        assert ws2 in mgr._connections["node:n1"]
+        assert ws1 not in mgr._connections["node:n1"]
+
+    async def test_disconnect_unknown_channel_is_noop(self):
+        mgr = ConnectionManager()
+        # Must not raise even though the channel was never registered.
+        await mgr.disconnect(_fake_ws(), "never")
+
+
+class TestBroadcast:
+    """broadcast fan-out + dead-socket pruning (#12515)."""
+
+    async def test_broadcast_sends_to_all_on_channel(self):
+        mgr = ConnectionManager()
+        ws1, ws2 = _fake_ws(), _fake_ws()
+        await mgr.connect(ws1, "events:global")
+        await mgr.connect(ws2, "events:global")
+        message = {"type": "ping"}
+        await mgr.broadcast("events:global", message)
+        ws1.send_json.assert_awaited_once_with(message)
+        ws2.send_json.assert_awaited_once_with(message)
+
+    async def test_broadcast_unknown_channel_is_noop(self):
+        mgr = ConnectionManager()
+        # No connections/channel -> should simply do nothing.
+        await mgr.broadcast("nobody", {"type": "x"})
+
+    async def test_broadcast_prunes_failed_socket(self):
+        mgr = ConnectionManager()
+        good, bad = _fake_ws(), _fake_ws()
+        bad.send_json = AsyncMock(side_effect=RuntimeError("closed"))
+        await mgr.connect(good, "events:global")
+        await mgr.connect(bad, "events:global")
+        await mgr.broadcast("events:global", {"type": "ping"})
+        # The failed socket is dropped; the healthy one is retained.
+        assert bad not in mgr._connections["events:global"]
+        assert good in mgr._connections["events:global"]
+
+
+class TestSendHelpers:
+    """The send_* helpers fan out to both global and node channels (#12515)."""
+
+    async def _connect_global_and_node(self, mgr, node_id):
+        g, n = _fake_ws(), _fake_ws()
+        await mgr.connect(g, "events:global")
+        await mgr.connect(n, f"node:{node_id}")
+        return g, n
+
+    async def test_send_node_status_dual_channel(self):
+        mgr = ConnectionManager()
+        g, n = await self._connect_global_and_node(mgr, "n1")
+        await mgr.send_node_status("n1", "online", hostname="host-1")
+        for ws in (g, n):
+            ws.send_json.assert_awaited_once()
+            payload = ws.send_json.call_args.args[0]
+            assert payload["type"] == "node_status"
+            assert payload["node_id"] == "n1"
+            assert payload["data"]["status"] == "online"
+            assert payload["data"]["hostname"] == "host-1"
+
+    async def test_send_health_update_dual_channel_payload(self):
+        mgr = ConnectionManager()
+        g, n = await self._connect_global_and_node(mgr, "n2")
+        await mgr.send_health_update("n2", cpu=12.5, memory=40.0, disk=55.0, status="online")
+        for ws in (g, n):
+            payload = ws.send_json.call_args.args[0]
+            assert payload["type"] == "health_update"
+            assert payload["node_id"] == "n2"
+            assert payload["data"]["cpu_percent"] == 12.5
+            assert payload["data"]["memory_percent"] == 40.0
+            assert payload["data"]["disk_percent"] == 55.0
+            # last_heartbeat is auto-filled when not supplied.
+            assert payload["data"]["last_heartbeat"]
+
+    async def test_send_remediation_event_dual_channel(self):
+        mgr = ConnectionManager()
+        g, n = await self._connect_global_and_node(mgr, "n3")
+        await mgr.send_remediation_event("n3", "restart_service", success=True, message="ok")
+        for ws in (g, n):
+            payload = ws.send_json.call_args.args[0]
+            assert payload["type"] == "remediation_event"
+            assert payload["node_id"] == "n3"
+            assert payload["data"]["event_type"] == "restart_service"
+            assert payload["data"]["success"] is True
+
+    async def test_send_node_status_only_targets_matching_node_channel(self):
+        """A watcher on node:other must NOT receive node:n1's status event."""
+        mgr = ConnectionManager()
+        other = _fake_ws()
+        await mgr.connect(other, "node:other")
+        await mgr.send_node_status("n1", "offline")
+        other.send_json.assert_not_called()
+
+    async def test_send_to_deployment_routes_to_deployment_channel(self):
+        mgr = ConnectionManager()
+        ws = _fake_ws()
+        await mgr.connect(ws, "deployment:dep-1")
+        await mgr.send_to_deployment("dep-1", {"type": "status", "status": "running"})
+        ws.send_json.assert_awaited_once()
+        assert ws.send_json.call_args.args[0]["status"] == "running"


### PR DESCRIPTION
## Thinking Path
Follow-up to #12455, which deleted three dead `autobot-backend` tests
(`nodes_api_test.py`, `stateful_api_test.py`, `websockets_test.py`) because they
imported symbols removed in the layer-separation refactor (`get_db_service`,
`StatefulServiceManager`, `SLMWebSocketManager`, `create_reconciler_callbacks`).
The rewritten `autobot-slm-backend` routers (`Depends(get_db)` AsyncSession +
`get_current_user`, new `ConnectionManager`) were left with only narrow
regression coverage. This adds real coverage against the CURRENT code, matching
the existing `tests/api/test_nodes_list_timeout_10913.py` real-module-swap
pattern and the `tests/test_websocket_auth_smoke.py` fake-WebSocket pattern.

## What Changed
- **New `tests/api/test_slm_endpoints_12515.py`** (29 tests) — drives the real
  `api.nodes` / `api.stateful` route functions against a genuine in-memory
  SQLite `AsyncSession` (aiosqlite), not tautological mocks:
  - Nodes CRUD: list (empty/filter), create (201 online/pending, duplicate-IP
    400), get (200 / 404), update (mutate / 404), delete (204 / 404).
  - Stateful backups: list, create (201 / node-404), get (200 / 404),
    restore (started / non-completed 400 / 404).
  - Stateful replications: list, start (201 / source-404 / active-conflict 400),
    get (200 / 404), promote + stop (service success → ActionResponse / failure
    400), verify-sync 404, verify-data (node-404 / non-redis skipped).
- **New `tests/test_websocket_connection_manager_12515.py`** (14 tests) —
  `ConnectionManager` connect/disconnect (+ empty-channel pruning), broadcast
  fan-out + dead-socket pruning, and `send_node_status` / `send_health_update` /
  `send_remediation_event` / `send_to_deployment` dual global+node channel
  routing.
- **Fix (in-scope, discovered under test) — `api/nodes.py` + `api/stateful.py`**:
  the paginated list count `select(X.id).where(query.whereclause or True)` always
  collapsed to `True`, dropping the active filter so `total` counted the whole
  table. Replaced with `select(func.count()).select_from(query.subquery())`.
  Regression-locked by `test_list_status_filter_narrows`. Tracked as #12543.

## Verification
```
$ python3 -m pytest tests/api/test_slm_endpoints_12515.py \
    tests/test_websocket_connection_manager_12515.py -p no:xdist -q
43 passed in 7.15s

$ python3 -m pytest tests/api/ -p no:xdist -q
348 passed, 4 warnings in 21.44s   # no regressions

$ flake8 (max-line-length=120) api/nodes.py api/stateful.py <new tests>  # clean
$ black --line-length 120 <files>                                         # clean
```

### Gaps (documented, not force-tested)
`verify_replication_sync` happy path and `verify_data` redis path reach
`replication_service` / SSH-subprocess infra that needs a live Redis + SSH
target; only their 404 / non-redis branches are unit-covered here.

## Model Used
claude-opus-4-8

Closes #12515
