### PR TITLE
fix(voice): resume AudioContext on user gesture + isSpeaking on real playback so streamed audio plays (#12503)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.playback.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.playback.test.ts
@@ -1,0 +1,205 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// #12503: the WS streaming path plays TTS via _playAudioChunkFromBase64 →
+// _scheduleGaplessChunk. Two client bugs made voice output show the "AutoBot
+// speaking" indicator with NO sound and often leave it stuck:
+//   (1) the AudioContext was never resumed on a user gesture, so a suspended
+//       context outside a gesture silenced every scheduled buffer, and
+//   (2) isSpeaking was set BEFORE playback, so a never-playing chunk left the
+//       indicator on forever.
+// These tests exercise the exact streaming playback path (playAudioChunk) and
+// assert the context is resumed before playback and isSpeaking tracks REAL
+// audio (set on start, cleared on end/stop/failure).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+const mockShowToast = vi.fn()
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+    toasts: { value: [] },
+    removeToast: vi.fn(),
+    clearAllToasts: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useVoiceProfiles', () => ({
+  useVoiceProfiles: () => ({
+    voices: ref([{ id: 'v1' }]),
+    fetchVoices: vi.fn(),
+    effectiveVoiceId: ref('v1'),
+  }),
+}))
+
+vi.mock('@/composables/usePreferences', () => ({
+  usePreferences: () => ({ language: ref('en') }),
+}))
+
+vi.mock('@/utils/fetchWithAuth', () => ({ fetchWithAuth: vi.fn() }))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+  getBackendWsUrl: () => 'ws://test',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+import { useVoiceOutput } from '../useVoiceOutput'
+
+// ── Controllable fake Web Audio, driven by module-scope lets so the retained
+// singleton AudioContext reads current values via getters between tests. ──
+let ctxState: 'running' | 'suspended' = 'running'
+let resumeMakesRunning = true
+let decodeShouldThrow = false
+let resumeCalls = 0
+let scheduledStarts = 0
+let pendingEnded: Array<() => void> = []
+
+class FakeBufferSource {
+  buffer: unknown = null
+  onended: (() => void) | null = null
+  connect() {}
+  start() {
+    scheduledStarts++
+    // Defer onended so a chunk is "playing" until the test flushes it.
+    pendingEnded.push(() => this.onended && this.onended())
+  }
+  stop() {}
+}
+
+class FakeAudioContext {
+  currentTime = 0
+  destination = {}
+  get state() {
+    return ctxState
+  }
+  async resume() {
+    resumeCalls++
+    if (resumeMakesRunning) ctxState = 'running'
+  }
+  async decodeAudioData() {
+    if (decodeShouldThrow) throw new Error('decode failed')
+    return { duration: 0.05 }
+  }
+  createBufferSource() {
+    return new FakeBufferSource()
+  }
+  createGain() {
+    return { gain: { value: 1 }, connect() {} }
+  }
+}
+
+function flushEnded() {
+  const cbs = pendingEnded
+  pendingEnded = []
+  cbs.forEach((cb) => cb())
+}
+
+// A valid base64 WAV-ish payload; bytes are irrelevant since decode is faked.
+const B64 = btoa('fake-audio-bytes')
+
+let _clock = 20_000_000
+let originalAudioContext: unknown
+
+describe('useVoiceOutput — streaming playback unlock + isSpeaking (#12503)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ctxState = 'running'
+    resumeMakesRunning = true
+    decodeShouldThrow = false
+    resumeCalls = 0
+    scheduledStarts = 0
+    pendingEnded = []
+    _clock += 60_000
+    vi.spyOn(Date, 'now').mockImplementation(() => _clock)
+    originalAudioContext = (globalThis as Record<string, unknown>).AudioContext
+    ;(globalThis as Record<string, unknown>).AudioContext = FakeAudioContext
+  })
+
+  afterEach(() => {
+    // Reset shared module state (isSpeaking, scheduling, armed gesture listener).
+    const { stopSpeaking, unlockAudio } = useVoiceOutput()
+    stopSpeaking()
+    unlockAudio()
+    ;(globalThis as Record<string, unknown>).AudioContext = originalAudioContext
+    vi.restoreAllMocks()
+  })
+
+  it('sets isSpeaking only once a buffer is scheduled, and clears it when playback ends', async () => {
+    const { playAudioChunk, isSpeaking } = useVoiceOutput()
+
+    expect(isSpeaking.value).toBe(false)
+    playAudioChunk(B64)
+    // Let the async decode/schedule microtasks settle.
+    await vi.waitFor(() => expect(scheduledStarts).toBe(1))
+
+    // Indicator reflects real, scheduled audio.
+    expect(isSpeaking.value).toBe(true)
+
+    // When the source finishes, the indicator clears.
+    flushEnded()
+    expect(isSpeaking.value).toBe(false)
+  })
+
+  it('resumes a suspended AudioContext before scheduling playback', async () => {
+    ctxState = 'suspended'
+    resumeMakesRunning = true // gesture-equivalent: resume actually unlocks
+
+    const { playAudioChunk, isSpeaking } = useVoiceOutput()
+    playAudioChunk(B64)
+
+    await vi.waitFor(() => expect(scheduledStarts).toBe(1))
+    // resume() was awaited BEFORE the buffer was scheduled/started.
+    expect(resumeCalls).toBeGreaterThanOrEqual(1)
+    expect(isSpeaking.value).toBe(true)
+  })
+
+  it('does NOT set isSpeaking (no stuck indicator) when the context stays suspended, and arms a gesture unlock + hint', async () => {
+    ctxState = 'suspended'
+    resumeMakesRunning = false // resume() cannot unlock outside a user gesture
+    const addSpy = vi.spyOn(window, 'addEventListener')
+
+    const { playAudioChunk, isSpeaking } = useVoiceOutput()
+    playAudioChunk(B64)
+
+    // Wait until the suspended-path bailout runs (hint surfaced after resume()).
+    await vi.waitFor(() => expect(mockShowToast).toHaveBeenCalled())
+    expect(resumeCalls).toBeGreaterThanOrEqual(1)
+    // No buffer was scheduled (context still suspended) → no audio.
+    expect(scheduledStarts).toBe(0)
+    // Critically: the indicator is NOT stuck on.
+    expect(isSpeaking.value).toBe(false)
+    // A one-time gesture listener was armed to unlock on the next interaction.
+    const armedGestureEvents = addSpy.mock.calls.map((c) => c[0])
+    expect(armedGestureEvents).toContain('pointerdown')
+    // And a "tap to enable audio" hint was surfaced.
+    expect(mockShowToast).toHaveBeenCalledWith(expect.any(String), 'info')
+  })
+
+  it('clears isSpeaking when a scheduled chunk fails to decode', async () => {
+    decodeShouldThrow = true
+
+    const { playAudioChunk, isSpeaking } = useVoiceOutput()
+    playAudioChunk(B64)
+
+    // Decode rejects; the awaited/caught path must not leave the indicator stuck.
+    await vi.waitFor(() => expect(isSpeaking.value).toBe(false))
+    expect(scheduledStarts).toBe(0)
+  })
+
+  it('stopSpeaking() clears isSpeaking mid-playback', async () => {
+    const { playAudioChunk, stopSpeaking, isSpeaking } = useVoiceOutput()
+    playAudioChunk(B64)
+    await vi.waitFor(() => expect(isSpeaking.value).toBe(true))
+
+    stopSpeaking()
+    expect(isSpeaking.value).toBe(false)
+  })
+})

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -16,6 +16,7 @@ import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { usePreferences } from '@/composables/usePreferences'
 import { useToast } from '@/composables/useToast'
 import { getBackendWsUrl, getApiBase } from '@/config/ssot-config'
+import i18n from '@/i18n'
 
 const logger = createLogger('useVoiceOutput')
 
@@ -142,12 +143,59 @@ function _getOrCreateContext(): AudioContext {
   return _audioContext
 }
 
+// #12503: browser autoplay policy only unlocks a suspended AudioContext from
+// inside a real user gesture. The WS streaming path plays from an onmessage
+// handler (not a gesture), so a resume() there leaves the context suspended and
+// every scheduled buffer is silent. When we detect that at playback time, arm a
+// one-time global gesture listener that resumes the context so the NEXT reply
+// plays, and surface a "tap to enable audio" hint instead of a silent, stuck
+// "speaking" indicator.
+const _GESTURE_UNLOCK_EVENTS = ['pointerdown', 'keydown', 'touchstart'] as const
+let _gestureUnlockHandler: (() => void) | null = null
+
+function _disarmGestureUnlock(): void {
+  if (!_gestureUnlockHandler) return
+  for (const evt of _GESTURE_UNLOCK_EVENTS) {
+    window.removeEventListener(evt, _gestureUnlockHandler)
+  }
+  _gestureUnlockHandler = null
+}
+
+function _armGestureUnlock(): void {
+  if (_gestureUnlockHandler) return
+  const handler = (): void => {
+    _disarmGestureUnlock()
+    const ctx = _audioContext
+    if (ctx && ctx.state === 'suspended') {
+      ctx.resume().catch((e) => logger.warn('AudioContext resume failed:', e))
+    }
+  }
+  _gestureUnlockHandler = handler
+  for (const evt of _GESTURE_UNLOCK_EVENTS) {
+    window.addEventListener(evt, handler, { passive: true })
+  }
+}
+
+// #12503: suppress repeat "tap to enable audio" hints within a short window so
+// a burst of tts_audio chunks against a suspended context surfaces it once.
+let _tapHintNotifiedAt = 0
+function _notifyTapToEnableAudio(): void {
+  const now = Date.now()
+  if (now - _tapHintNotifiedAt < _NO_VOICES_NOTIFY_COOLDOWN) return
+  _tapHintNotifiedAt = now
+  logger.warn('AudioContext suspended at playback — awaiting user gesture to unlock')
+  useToast().showToast(i18n.global.t('voice.tapToEnableAudio'), 'info')
+}
+
 /** Call from a user-gesture handler to unlock audio for the session. */
 function unlockAudio(): void {
   const ctx = _getOrCreateContext()
   if (ctx.state === 'suspended') {
     ctx.resume().catch((e) => logger.warn('AudioContext resume failed:', e))
   }
+  // A fresh gesture just unlocked (or is unlocking) the context — no need to
+  // keep a pending one-time listener armed.
+  _disarmGestureUnlock()
 }
 
 function _stopCurrentAudio(): void {
@@ -172,7 +220,18 @@ function _stopCurrentAudio(): void {
 
 async function _playAudioBuffer(arrayBuffer: ArrayBuffer): Promise<void> {
   const ctx = _getOrCreateContext()
-  if (ctx.state === 'suspended') await ctx.resume()
+  if (ctx.state === 'suspended') {
+    await ctx.resume().catch((e) => logger.warn('AudioContext resume failed:', e))
+  }
+  if (ctx.state === 'suspended') {
+    // #12503: still suspended outside a user gesture — playback would be silent
+    // and onended would never fire, hanging this promise and sticking the
+    // indicator. Re-arm a gesture listener, hint the user, and return quietly.
+    _armGestureUnlock()
+    _notifyTapToEnableAudio()
+    isSpeaking.value = false
+    return
+  }
   const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0))
   const source = ctx.createBufferSource()
   source.buffer = audioBuffer
@@ -202,7 +261,19 @@ async function _playAudioBuffer(arrayBuffer: ArrayBuffer): Promise<void> {
  */
 async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
   const ctx = _getOrCreateContext()
-  if (ctx.state === 'suspended') await ctx.resume()
+  if (ctx.state === 'suspended') {
+    // A resume() from the WS onmessage handler is not a user gesture; try once,
+    // then bail if the context stays suspended (#12503).
+    await ctx.resume().catch((e) => logger.warn('AudioContext resume failed:', e))
+  }
+  if (ctx.state === 'suspended') {
+    // Autoplay policy still blocks playback — no audio will be heard. Re-arm a
+    // one-time gesture listener + surface a hint, and DON'T set isSpeaking so the
+    // indicator can't stick with no sound (#12503).
+    _armGestureUnlock()
+    _notifyTapToEnableAudio()
+    return
+  }
 
   const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0))
   const source = ctx.createBufferSource()
@@ -232,20 +303,32 @@ async function _scheduleGaplessChunk(arrayBuffer: ArrayBuffer): Promise<void> {
   }
 
   source.start(startTime)
+  // #12503: flag "speaking" only once a buffer is actually scheduled on a
+  // RUNNING context — never before decode/resume — so the indicator reflects
+  // real audio and a suspended/failed chunk cannot leave it stuck on.
+  isSpeaking.value = true
 }
 
 /** Decode base64 audio and schedule for gapless playback (#1527). */
-function _playAudioChunkFromBase64(base64Data: string): void {
+async function _playAudioChunkFromBase64(base64Data: string): Promise<void> {
+  let bytes: Uint8Array<ArrayBuffer>
   try {
     const binary = atob(base64Data)
-    const bytes = new Uint8Array(binary.length)
+    bytes = new Uint8Array(binary.length)
     for (let i = 0; i < binary.length; i++) {
       bytes[i] = binary.charCodeAt(i)
     }
-    isSpeaking.value = true
-    _scheduleGaplessChunk(bytes.buffer)
   } catch (e) {
-    logger.error('playAudioChunk error:', e)
+    logger.error('playAudioChunk decode error:', e)
+    return
+  }
+  try {
+    // #12503: await + catch so a decode/scheduling rejection is handled, not
+    // swallowed, and never leaves the "speaking" indicator stuck.
+    await _scheduleGaplessChunk(bytes.buffer)
+  } catch (e) {
+    logger.error('playAudioChunk playback error:', e)
+    if (_activeChunkCount <= 0) isSpeaking.value = false
   }
 }
 
@@ -321,7 +404,7 @@ function _connectTtsWs(): Promise<WebSocket> {
       }
       // Internal: audio playback owned here.
       if (msg.type === 'tts_audio' && msg.data) {
-        _playAudioChunkFromBase64(msg.data)
+        void _playAudioChunkFromBase64(msg.data)
       } else if (msg.type === 'error') {
         logger.warn('Voice WS server error:', msg.message)
       }
@@ -451,7 +534,7 @@ export function useVoiceOutput() {
 
   /** Queue a base64-encoded WAV chunk for sequential playback (#1031). */
   function playAudioChunk(base64Data: string): void {
-    _playAudioChunkFromBase64(base64Data)
+    void _playAudioChunkFromBase64(base64Data)
   }
 
   /** Stop any current or queued audio immediately (#1031). */

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -925,7 +925,8 @@
     "creating": "Creating...",
     "confirmDeleteVoice": "Delete voice \"{name}\"?",
     "languageVoicesActive": "{count} language-specific voice(s) configured",
-    "confirmDeleteVoiceTitle": "حذف ملف الصوت"
+    "confirmDeleteVoiceTitle": "حذف ملف الصوت",
+    "tapToEnableAudio": "انقر في أي مكان لتمكين تشغيل الصوت"
   },
   "analytics": {
     "title": "التحليلات",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -925,7 +925,8 @@
     "creating": "Erstellen...",
     "confirmDeleteVoice": "Stimme „{name}“ löschen?",
     "languageVoicesActive": "{count} sprachspezifische(n) Stimme(n) konfiguriert",
-    "confirmDeleteVoiceTitle": "Stimmprofil löschen"
+    "confirmDeleteVoiceTitle": "Stimmprofil löschen",
+    "tapToEnableAudio": "Tippen Sie irgendwo, um die Audiowiedergabe zu aktivieren"
   },
   "analytics": {
     "title": "Analytik",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -925,7 +925,8 @@
     "creating": "Creating...",
     "confirmDeleteVoice": "Delete voice \"{name}\"?",
     "languageVoicesActive": "{count} language-specific voice(s) configured",
-    "confirmDeleteVoiceTitle": "Delete voice profile"
+    "confirmDeleteVoiceTitle": "Delete voice profile",
+    "tapToEnableAudio": "Tap anywhere to enable audio playback"
   },
   "analytics": {
     "title": "Analytics",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -925,7 +925,8 @@
     "creating": "Creando...",
     "confirmDeleteVoice": "¿Eliminar la voz \"{name}\"?",
     "languageVoicesActive": "Voces específicas del idioma {count} configuradas",
-    "confirmDeleteVoiceTitle": "Eliminar perfil de voz"
+    "confirmDeleteVoiceTitle": "Eliminar perfil de voz",
+    "tapToEnableAudio": "Toca en cualquier lugar para habilitar la reproducción de audio"
   },
   "analytics": {
     "title": "Analítica",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -7245,7 +7245,8 @@
     "custom": "custom",
     "stopListening": "Stop listening",
     "stop": "Stop",
-    "confirmDeleteVoiceTitle": "حذف نمایه صدا"
+    "confirmDeleteVoiceTitle": "حذف نمایه صدا",
+    "tapToEnableAudio": "برای فعال‌سازی پخش صدا هر جایی را لمس کنید"
   },
   "auth": {
     "login": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -925,7 +925,8 @@
     "creating": "Création...",
     "confirmDeleteVoice": "Supprimer la voix « {name} » ?",
     "languageVoicesActive": "Voix {count} spécifiques à la langue configurées",
-    "confirmDeleteVoiceTitle": "Supprimer le profil vocal"
+    "confirmDeleteVoiceTitle": "Supprimer le profil vocal",
+    "tapToEnableAudio": "Touchez n'importe où pour activer la lecture audio"
   },
   "analytics": {
     "title": "Analytique",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -7245,7 +7245,8 @@
     "custom": "custom",
     "stopListening": "Stop listening",
     "stop": "Stop",
-    "confirmDeleteVoiceTitle": "מחיקת פרופיל קול"
+    "confirmDeleteVoiceTitle": "מחיקת פרופיל קול",
+    "tapToEnableAudio": "הקש בכל מקום כדי להפעיל את השמעת האודיו"
   },
   "auth": {
     "login": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -925,7 +925,8 @@
     "creating": "Notiek izveide...",
     "confirmDeleteVoice": "Vai dzēst balsi \"{name}\"?",
     "languageVoicesActive": "{count} valodai konfigurēta balss(-es).",
-    "confirmDeleteVoiceTitle": "Dzēst balss profilu"
+    "confirmDeleteVoiceTitle": "Dzēst balss profilu",
+    "tapToEnableAudio": "Pieskarieties jebkur, lai iespējotu audio atskaņošanu"
   },
   "analytics": {
     "title": "Analytics",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -925,7 +925,8 @@
     "creating": "Tworzenie...",
     "confirmDeleteVoice": "Usunąć głos „{name}”?",
     "languageVoicesActive": "Skonfigurowano głosy specyficzne dla języka {count}",
-    "confirmDeleteVoiceTitle": "Usuń profil głosu"
+    "confirmDeleteVoiceTitle": "Usuń profil głosu",
+    "tapToEnableAudio": "Dotknij dowolnego miejsca, aby włączyć odtwarzanie dźwięku"
   },
   "analytics": {
     "title": "Analityka",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -925,7 +925,8 @@
     "creating": "Criando...",
     "confirmDeleteVoice": "Excluir voz \"{name}\"?",
     "languageVoicesActive": "Vozes específicas do idioma {count} configuradas",
-    "confirmDeleteVoiceTitle": "Excluir perfil de voz"
+    "confirmDeleteVoiceTitle": "Excluir perfil de voz",
+    "tapToEnableAudio": "Toque em qualquer lugar para ativar a reprodução de áudio"
   },
   "analytics": {
     "title": "Análise",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -7245,7 +7245,8 @@
     "custom": "custom",
     "stopListening": "Stop listening",
     "stop": "Stop",
-    "confirmDeleteVoiceTitle": "صوتی پروفائل حذف کریں"
+    "confirmDeleteVoiceTitle": "صوتی پروفائل حذف کریں",
+    "tapToEnableAudio": "آڈیو چلانے کو فعال کرنے کے لیے کہیں بھی ٹیپ کریں"
   },
   "auth": {
     "login": {


### PR DESCRIPTION
## Thinking Path

The chat "AutoBot speaking" indicator pulses but plays no sound, and the indicator often sticks on. Server side is verified healthy (synthesize returns valid WAV, WS streams `tts_audio`). Root cause is client-side in `useVoiceOutput.ts` gapless streaming path:

1. **AudioContext never unlocked in the streaming path.** `_scheduleGaplessChunk` did `if (ctx.state === 'suspended') await ctx.resume()` from the WebSocket `onmessage` handler — not a user gesture. Browser autoplay policy will not unlock a suspended context outside a gesture, so `resume()` there leaves it suspended and every scheduled buffer is silent. `unlockAudio()` (the real gesture-based resume) was only wired to voice toggle / send / activate, so a reload with voice already enabled (or a context that suspended after backgrounding) plays into a suspended context.
2. **`isSpeaking` set before playback.** `_playAudioChunkFromBase64` set `isSpeaking = true` unconditionally before scheduling. When the buffer never actually plays (suspended context), `source.onended` never fires, `_activeChunkCount` never returns to 0, and the indicator sticks forever.
3. **Swallowed rejection.** `_scheduleGaplessChunk` was called un-awaited/un-caught, so decode/schedule failures were silent and also left the indicator stuck.

Not a regression from #12507/#12511 (those touched only the HTTP fallback queue) — the gapless scheduler with the non-gesture resume + pre-playback `isSpeaking` dates to #1527.

## What Changed

`autobot-frontend/src/composables/useVoiceOutput.ts`:
- `_scheduleGaplessChunk` and one-shot `_playAudioBuffer`: after a single `resume()` attempt, if the context is STILL suspended, re-arm a one-time global gesture listener (`pointerdown`/`keydown`/`touchstart`) that resumes on the next interaction, surface a "tap to enable audio" toast (i18n), and return WITHOUT setting `isSpeaking` — so the indicator can't stick with no sound.
- `isSpeaking = true` now set only AFTER a buffer is actually scheduled on a RUNNING context (right after `source.start`), never before decode/resume.
- `_playAudioChunkFromBase64` is now `async` and `await`s + `catch`es `_scheduleGaplessChunk`; a failed/never-playing chunk clears `isSpeaking` instead of swallowing the error. Call sites `void` the promise.
- `unlockAudio()` disarms any pending one-time gesture listener once a real gesture unlocks the context.
- New i18n key `voice.tapToEnableAudio` added to all 11 locales.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `npx eslint src/composables/useVoiceOutput.ts …playback.test.ts` → exit 0.
- New test `useVoiceOutput.playback.test.ts` (5 tests) + existing `useVoiceOutput.test.ts` (8 tests) → 13 passed. Asserts: context resumed before playback in the streaming path; `isSpeaking` set only on real scheduled playback; cleared on end, on `stopSpeaking()`, on decode failure; and NOT set (no stuck indicator) when the context stays suspended, with a gesture-unlock listener armed + hint surfaced.

## Model Used

claude-opus-4-8

Closes #12503
