### PR TITLE
test: fix residual rag-config/chat-strict global-state leaks breaking test order (#12539)

### DIFF
--- a/autobot-backend/api/chat_phase4_test.py
+++ b/autobot-backend/api/chat_phase4_test.py
@@ -231,23 +231,54 @@ class TestChatMetricsRecorder:
 class TestSSOTStrictMode:
     """AUTOBOT_CHAT_SSOT_STRICT=true must reject missing session_id."""
 
-    def test_strict_mode_flag_reads_env(self):
+    @pytest.fixture(autouse=True)
+    def _restore_chat_module(self, monkeypatch):
+        """Restore api.chat + the ssot_config cache after each test (#12539).
+
+        ``test_strict_mode_flag_reads_env`` / ``test_default_mode_is_lenient``
+        clear the ssot_config lru_cache and ``importlib.reload(api.chat)`` under a
+        patched env.  Without restoration the reloaded module leaks its mutated
+        ``_CHAT_SSOT_STRICT`` value (and a config built from the patched env) into
+        later suites.  Undo the env, clear the config cache and reload api.chat
+        back to its pristine, unpatched state on teardown.
+        """
+        yield
         import importlib
 
-        with patch.dict("os.environ", {"AUTOBOT_CHAT_SSOT_STRICT": "true"}):
-            import api.chat as chat_module
+        from autobot_shared.ssot_config import reload_config
 
-            importlib.reload(chat_module)
-            assert chat_module._CHAT_SSOT_STRICT is True
+        monkeypatch.undo()
+        reload_config()
+        import api.chat as chat_module
 
-    def test_default_mode_is_lenient(self):
+        importlib.reload(chat_module)
+
+    def test_strict_mode_flag_reads_env(self, monkeypatch):
         import importlib
 
-        with patch.dict("os.environ", {"AUTOBOT_CHAT_SSOT_STRICT": "false"}):
-            import api.chat as chat_module
+        from autobot_shared.ssot_config import reload_config
 
-            importlib.reload(chat_module)
-            assert chat_module._CHAT_SSOT_STRICT is False
+        # ``api.chat`` reads ``config.chat_ssot_strict`` (the ssot_config
+        # singleton), so the config lru_cache must be cleared *after* patching
+        # the env for the reload to observe the new value.
+        monkeypatch.setenv("AUTOBOT_CHAT_SSOT_STRICT", "true")
+        reload_config()
+        import api.chat as chat_module
+
+        importlib.reload(chat_module)
+        assert chat_module._CHAT_SSOT_STRICT is True
+
+    def test_default_mode_is_lenient(self, monkeypatch):
+        import importlib
+
+        from autobot_shared.ssot_config import reload_config
+
+        monkeypatch.setenv("AUTOBOT_CHAT_SSOT_STRICT", "false")
+        reload_config()
+        import api.chat as chat_module
+
+        importlib.reload(chat_module)
+        assert chat_module._CHAT_SSOT_STRICT is False
 
     def test_strict_validate_session_id_raises_on_none(self):
         with patch("api.chat._CHAT_SSOT_STRICT", True):

--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -382,3 +382,18 @@ def update_rag_config(updates: Metadata) -> RAGConfig:
 
         logger.info("RAG configuration updated: %s", list(updates.keys()))
         return _rag_config_instance
+
+
+def reset_rag_config() -> None:
+    """Reset the module-level RAG config singleton (test isolation, #12539).
+
+    Tests that call ``update_rag_config`` mutate the process-wide
+    ``_rag_config_instance``.  Without a reset the mutated instance leaks into
+    later test suites (e.g. a runtime ``enable_reranking=False`` update makes a
+    subsequent ``get_rag_config()`` return the wrong default).  Calling this in
+    an autouse fixture nulls the singleton so the next ``get_rag_config()``
+    rebuilds a fresh instance from defaults.
+    """
+    global _rag_config_instance
+    with _rag_config_lock:
+        _rag_config_instance = None

--- a/autobot-backend/services/rag_integration_test.py
+++ b/autobot-backend/services/rag_integration_test.py
@@ -18,8 +18,27 @@ import pytest
 
 from advanced_rag_optimizer import RAGMetrics, SearchResult
 from services.knowledge_base_adapter import KnowledgeBaseAdapter
-from services.rag_config import RAGConfig, get_rag_config, update_rag_config
+from services.rag_config import (
+    RAGConfig,
+    get_rag_config,
+    reset_rag_config,
+    update_rag_config,
+)
 from services.rag_service import RAGService
+
+
+@pytest.fixture(autouse=True)
+def _reset_rag_config_singleton():
+    """Isolate the module-level RAG config singleton between tests (#12539).
+
+    ``test_update_config`` mutates ``_rag_config_instance`` (e.g. sets
+    ``enable_reranking=False``) via ``update_rag_config`` and never restores it,
+    leaking the mutated instance into later suites.  Reset before and after each
+    test so ``get_rag_config()`` always rebuilds fresh defaults.
+    """
+    reset_rag_config()
+    yield
+    reset_rag_config()
 
 
 class TestKnowledgeBaseAdapter:


### PR DESCRIPTION
Closes #12539

## What Changed
Fixed the 2 genuine order-dependent global-state leaks from #12539:
- services/rag_config.py: added reset_rag_config() + autouse fixture (was: _rag_config_instance singleton mutated by test_update_config with no teardown).
- api/chat_phase4_test.py: monkeypatch.setenv + reload_config() + autouse teardown (was: importlib.reload under patched env leaking _CHAT_SSOT_STRICT + lru_cache staleness).

The 3rd item (github rate-limiter) was VERIFIED to already have correct isolation; its residual failures are Redis-less-ENV behavior (not order-dependent) — outside this issue order-flake scope, filed separately.

## Verification
Both leaks: victim fails before / passes after (offender->victim orders green); no new failures in the chat/rag order sweeps. black/flake8 clean.

## Model Used
Opus 4.8.