### PR TITLE
fix(voice): lengthen STT endpointing to conversational pause tolerance + wire/remove dead silenceThreshold (#12505)

### DIFF
--- a/autobot-frontend/public/audio-vad-processor.js
+++ b/autobot-frontend/public/audio-vad-processor.js
@@ -13,16 +13,26 @@
 
 // RMS threshold for speech detection (0.0-1.0 range for float32 samples)
 const SPEECH_THRESHOLD = 0.015
-// Number of consecutive frames to confirm speech start/stop
+// Consecutive above-threshold frames to confirm speech START.
 const ONSET_FRAMES = 3
-const OFFSET_FRAMES = 8
+// Consecutive sub-threshold frames to confirm speech STOP (silence window).
+// Derived from the single `silenceThreshold` knob and supplied via
+// processorOptions.offsetFrames (#12505). Falls back to ~800ms at a typical
+// 48kHz render rate (800ms / (128/48000*1000) ~= 300 frames) when no option
+// is passed - the previous hardcoded 8 (~21ms) cut speech off between words.
+const DEFAULT_OFFSET_FRAMES = 300
 
 class VadProcessor extends AudioWorkletProcessor {
-  constructor() {
+  constructor(options) {
     super()
     this._aboveCount = 0
     this._belowCount = 0
     this._speaking = false
+    const opts = options && options.processorOptions
+    this._offsetFrames =
+      opts && typeof opts.offsetFrames === 'number' && opts.offsetFrames > 0
+        ? opts.offsetFrames
+        : DEFAULT_OFFSET_FRAMES
   }
 
   process(inputs) {
@@ -46,7 +56,7 @@ class VadProcessor extends AudioWorkletProcessor {
     } else {
       this._belowCount++
       this._aboveCount = 0
-      if (this._speaking && this._belowCount >= OFFSET_FRAMES) {
+      if (this._speaking && this._belowCount >= this._offsetFrames) {
         this._speaking = false
         this.port.postMessage({ type: 'vad', speaking: false, rms })
       }

--- a/autobot-frontend/src/composables/__tests__/useVoiceConversation.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceConversation.test.ts
@@ -89,7 +89,12 @@ vi.mock('@/utils/debugUtils', () => {
   }
 })
 
-import { useVoiceConversation } from '../useVoiceConversation'
+import {
+  useVoiceConversation,
+  DEFAULT_SILENCE_THRESHOLD_MS,
+  _silenceMsToRedemptionMs,
+  _silenceMsToOffsetFrames,
+} from '../useVoiceConversation'
 import { useVoiceOutput } from '@/composables/useVoiceOutput'
 import { usePreferences } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
@@ -148,5 +153,43 @@ describe('useVoiceConversation — watcher single-registration (#12153)', () => 
     expect(conversation.errorMessage.value).toContain('Chrome, Edge, or Safari 15+')
 
     conversation.isActive.value = false
+  })
+})
+
+describe('useVoiceConversation — endpointing single-knob wiring (#12505)', () => {
+  it('defaults the silence-tolerance knob to a conversational value, not the old ~250ms cutoff', () => {
+    // The bug was a 250ms Silero redemption / ~21ms worklet window that
+    // finalized on a natural sub-second pause. The single knob must default
+    // well above that (≥ ~500ms) so a conversational half-second pause is
+    // tolerated.
+    expect(DEFAULT_SILENCE_THRESHOLD_MS).toBe(800)
+    expect(DEFAULT_SILENCE_THRESHOLD_MS).toBeGreaterThanOrEqual(500)
+    // The default the composable actually exposes matches the constant.
+    const conversation = useVoiceConversation()
+    expect(conversation.silenceThreshold.value).toBe(DEFAULT_SILENCE_THRESHOLD_MS)
+  })
+
+  it('wires the knob into Silero redemptionMs — the endpointer is no longer dead config', () => {
+    // Identity within the slider range: the knob IS the redemption window.
+    expect(_silenceMsToRedemptionMs(DEFAULT_SILENCE_THRESHOLD_MS)).toBe(800)
+    expect(_silenceMsToRedemptionMs(1500)).toBe(1500)
+    // Clamped to the supported UI slider range (500-3000ms).
+    expect(_silenceMsToRedemptionMs(100)).toBe(500)
+    expect(_silenceMsToRedemptionMs(9999)).toBe(3000)
+    // Crucially, it is NEVER the old too-short 250ms cutoff.
+    expect(_silenceMsToRedemptionMs(DEFAULT_SILENCE_THRESHOLD_MS)).toBeGreaterThan(250)
+  })
+
+  it('wires the knob into the AudioWorklet silence window (OFFSET_FRAMES), matching redemption tolerance', () => {
+    // frames = round(ms / (128/sampleRate*1000)). At 48kHz a render quantum
+    // is 128/48000*1000 ≈ 2.667ms, so 800ms ≈ 300 frames — vastly longer
+    // than the old hardcoded 8 frames (~21ms).
+    const frames48k = _silenceMsToOffsetFrames(DEFAULT_SILENCE_THRESHOLD_MS, 48000)
+    expect(frames48k).toBe(300)
+    expect(frames48k).toBeGreaterThan(8)
+    // At 16kHz the render quantum is 8ms, so 800ms = 100 frames.
+    expect(_silenceMsToOffsetFrames(DEFAULT_SILENCE_THRESHOLD_MS, 16000)).toBe(100)
+    // Never collapses below one frame even for tiny values.
+    expect(_silenceMsToOffsetFrames(1, 48000)).toBeGreaterThanOrEqual(1)
   })
 })

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -56,7 +56,19 @@ const micAccessAvailable = ref(
 )
 
 // Hands-free mode state (#1030)
-const silenceThreshold = ref(1500)
+// Silence tolerance is the SINGLE user-facing knob for end-of-turn
+// endpointing (#12505). It is the "silence" slider in
+// VoiceConversationPanel / VoiceConversationOverlay (range 500-3000ms) and
+// now actually drives every endpointer: the Silero VAD `redemptionMs`
+// (hands-free) and the AudioWorklet silence window (full-duplex). It was
+// previously dead config while the real endpointers used a hardcoded 250ms
+// (Silero) / ~21ms (worklet), cutting speech off on a natural pause. 800ms
+// lets a conversational half-second pause through while still ending on a
+// real stop.
+export const DEFAULT_SILENCE_THRESHOLD_MS = 800
+const MIN_SILENCE_THRESHOLD_MS = 500
+const MAX_SILENCE_THRESHOLD_MS = 3000
+const silenceThreshold = ref(DEFAULT_SILENCE_THRESHOLD_MS)
 const audioLevel = ref(0)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -73,15 +85,43 @@ let _fallbackStream: MediaStream | null = null
 // AbortController for transcription requests — aborts in-flight call when new recording starts.
 let _transcribeController: AbortController | null = null
 
-// Issue #1371: Cooldown timer to prevent TTS echo from triggering VAD
+// Issue #1371: Cooldown timer to prevent TTS echo from triggering VAD.
 let _ttsCooldownTimer: ReturnType<typeof setTimeout> | null = null
-const _TTS_COOLDOWN_MS = 600 // Must exceed Silero redemptionMs (250ms)
+// #12505: the cooldown must outlast the VAD silence-redemption window (now
+// `silenceThreshold`), plus a margin, so buffered TTS echo has fully ended
+// before mic input is accepted again. Computed per-resume from the live knob.
+const _TTS_COOLDOWN_MARGIN_MS = 350
 
 // Response message types that should be spoken (skip thoughts/planning/debug)
 const _SPEAKABLE_TYPES = new Set(['response', 'message'])
 
 // Max chars to send to TTS — Pocket TTS at ~200ms/chunk (#1054)
 const _MAX_SPEECH_CHARS = 2000
+
+// AudioWorklet render quantum is fixed at 128 samples (#1031); one VAD
+// silence "frame" therefore lasts 128/sampleRate seconds.
+const _WORKLET_FRAME_SAMPLES = 128
+
+/**
+ * Map the silence-tolerance knob (ms) to the Silero VAD `redemptionMs`
+ * (frames-of-silence-before-end), clamped to the supported slider range.
+ * Single source of truth for end-of-turn tolerance (#12505).
+ */
+export function _silenceMsToRedemptionMs(ms: number): number {
+  return Math.min(
+    MAX_SILENCE_THRESHOLD_MS,
+    Math.max(MIN_SILENCE_THRESHOLD_MS, Math.round(ms)),
+  )
+}
+
+/**
+ * Map the silence-tolerance knob (ms) to the number of consecutive
+ * sub-threshold AudioWorklet frames that confirm end-of-speech (#12505).
+ */
+export function _silenceMsToOffsetFrames(ms: number, sampleRate: number): number {
+  const frameMs = (_WORKLET_FRAME_SAMPLES / sampleRate) * 1000
+  return Math.max(1, Math.round(_silenceMsToRedemptionMs(ms) / frameMs))
+}
 
 function _generateId(): string {
   return `vb_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
@@ -192,7 +232,17 @@ async function _initVad(): Promise<void> {
     await _vadAudioCtx.audioWorklet.addModule('/audio-vad-processor.js')
 
     const source = _vadAudioCtx.createMediaStreamSource(_micStream)
-    _vadNode = new AudioWorkletNode(_vadAudioCtx, 'vad-processor')
+    _vadNode = new AudioWorkletNode(_vadAudioCtx, 'vad-processor', {
+      // #12505: derive the worklet silence window from the single
+      // tolerance knob so full-duplex barge-in endpointing matches
+      // hands-free (was a hardcoded ~21ms cutoff).
+      processorOptions: {
+        offsetFrames: _silenceMsToOffsetFrames(
+          silenceThreshold.value,
+          _vadAudioCtx.sampleRate,
+        ),
+      },
+    })
 
     _vadNode.port.onmessage = (event) => {
       const { speaking } = event.data
@@ -471,7 +521,7 @@ function _resumeAutoListening(): void {
     // state becomes 'listening', creating an echo feedback loop.
     _ttsCooldownTimer = setTimeout(() => {
       _ttsCooldownTimer = null
-    }, _TTS_COOLDOWN_MS)
+    }, silenceThreshold.value + _TTS_COOLDOWN_MARGIN_MS)
     state.value = 'listening'
   }
 }
@@ -634,7 +684,9 @@ async function _startHandsFree(): Promise<void> {
       onnxWASMBasePath: '/',
       positiveSpeechThreshold: 0.8,
       minSpeechMs: 150,
-      redemptionMs: 250,
+      // #12505: derive from the single silence-tolerance knob (was a
+      // hardcoded 250ms that cut speech off on a natural pause).
+      redemptionMs: _silenceMsToRedemptionMs(silenceThreshold.value),
       onSpeechEnd: (audio: Float32Array) => {
         _handleVadSpeechEnd(audio)
       },
@@ -706,7 +758,7 @@ export function _resetForTests(): void {
   bubbles.value = []
   isActive.value = false
   errorMessage.value = ''
-  silenceThreshold.value = 1500
+  silenceThreshold.value = DEFAULT_SILENCE_THRESHOLD_MS
   audioLevel.value = 0
   currentLanguage.value = 'en'
   _recognition = null


### PR DESCRIPTION
## Thinking Path

STT was finalizing an utterance on any brief sub-second pause. Three independent endpointers were all far too aggressive, and the one config value users would expect to govern this (`silenceThreshold = 1500ms`, exposed as the "silence" slider in `VoiceConversationPanel` / `VoiceConversationOverlay`, range 500-3000ms) was **dead** — read/reset/exported but wired to no endpointer.

The three endpointers:
1. **Silero VAD (hands-free, #1030)** — `MicVAD.new({ redemptionMs: 250 })`: speech declared ended after 250ms of silence.
2. **AudioWorklet VAD (full-duplex, #1031)** — `public/audio-vad-processor.js` `OFFSET_FRAMES = 8` (~21ms at 48kHz).
3. Browser `SpeechRecognition` — left intact (see below) to preserve push-to-talk semantics.

**Single-knob decision:** rather than leave three uncoordinated hardcoded values, `silenceThreshold` becomes the **one** source of truth for silence tolerance. It already had a UI slider bound to it; now that slider actually works. Both VAD endpointers are derived from it via two exported pure helpers.

## What Changed

`autobot-frontend/src/composables/useVoiceConversation.ts`
- `silenceThreshold` default `1500` → named constant `DEFAULT_SILENCE_THRESHOLD_MS = 800` (conversational end-of-turn tolerance; range constants `MIN=500`/`MAX=3000` match the existing slider). 800ms lets a natural half-second pause through while still ending on a real stop; 250ms clearly did not.
- New exported pure helpers: `_silenceMsToRedemptionMs(ms)` (clamp to slider range) and `_silenceMsToOffsetFrames(ms, sampleRate)` (frames = round(ms / (128/sampleRate*1000))).
- Silero `redemptionMs: 250` → `_silenceMsToRedemptionMs(silenceThreshold.value)`.
- AudioWorklet node now passes `processorOptions.offsetFrames = _silenceMsToOffsetFrames(silenceThreshold.value, ctx.sampleRate)`.
- TTS echo cooldown previously `_TTS_COOLDOWN_MS = 600` with an explicit invariant "must exceed Silero redemptionMs (250ms)". Since redemption is now the knob, cooldown is computed per-resume as `silenceThreshold.value + _TTS_COOLDOWN_MARGIN_MS (350)` so the anti-echo invariant is preserved without a regression.

`autobot-frontend/public/audio-vad-processor.js`
- `OFFSET_FRAMES = 8` (hardcoded ~21ms) → `constructor(options)` reads `processorOptions.offsetFrames`, falling back to a documented `DEFAULT_OFFSET_FRAMES = 300` (~800ms at 48kHz). Stop-detection uses `this._offsetFrames`.

**Chosen values + why:** single knob = `silenceThreshold`, conversational default **800ms** (Silero redemptionMs and worklet window both derive from it; 800ms ≈ 300 worklet frames @48kHz / 100 @16kHz). Clamp range 500-3000ms = the existing UI slider.

**Intentionally out of scope:** the browser `SpeechRecognition continuous` flag (endpointer #3) is left unchanged. Flipping it to `true` alters push-to-talk/walkie-talkie stop semantics; the task scope is the two VAD endpointers + the dead knob, and push-to-talk behavior must stay intact. A `continuous`+manual-endpoint change can be a separate UX issue.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` — zero errors in the touched files (`useVoiceConversation.ts`, `audio-vad-processor.js`, test); remaining output is pre-existing baseline in unrelated views (transcriber/storybook/secrets).
- `npx vitest run src/composables/__tests__/useVoiceConversation.test.ts` — **5 passed** (2 existing #12153 watcher tests + 3 new #12505 tests asserting: default knob = 800ms conversational value, redemption derivation wired + never the old 250ms, worklet OFFSET_FRAMES derivation = 300 @48kHz / 100 @16kHz, ≥1 floor).
- `npx eslint` on all three files — clean (exit 0).

## Model Used

claude-opus-4-8

Closes #12505
