### PR TITLE
fix(llc): robust claude CLI resolution + clear error instead of silent skip (#12478)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import shutil
 import time
 import uuid
 from dataclasses import replace
@@ -40,12 +39,14 @@ from typing import Optional
 from autobot_shared.cli_tool_flags import sanitize_tool_names
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_config import config as _ssot_config
 
 from ..models.enums import LLCRunStatus
 from .base import AdapterRunStatus
 from .subprocess_base import DEFAULT_OUTPUT_DIR as _DEFAULT_OUTPUT_DIR
 from .subprocess_base import SIGTERM_GRACE_SECONDS as _SIGTERM_GRACE_SECONDS
 from .subprocess_base import SubprocessLifecycleAdapter
+from .subprocess_base import resolve_cli_binary as _resolve_cli_binary
 from .subprocess_base import resolve_timeout as _resolve_timeout
 from .subprocess_support import (
     extract_usage,
@@ -92,10 +93,21 @@ def _stderr_path(output_file: str) -> str:
     return f"{output_file}.stderr.log"
 
 
+# GH#12478: `claude` often lands off the service account's PATH (e.g. a
+# per-user npm/curl install into ~/.local/bin). Resolution order: the
+# AUTOBOT_CLAUDE_CLI_PATH override, then PATH, then common per-user install
+# locations — see resolve_cli_binary(). Kept as the exact message the
+# heartbeat-skip path surfaces (CLAUDE_CLI_NOT_FOUND_MESSAGE) for consistency
+# between the invoke-time RuntimeError and the pre-dispatch skip reason.
+CLAUDE_CLI_NOT_FOUND_MESSAGE = (
+    "claude CLI not found on PATH or configured location; install it or set AUTOBOT_CLAUDE_CLI_PATH"
+)
+
+
 def _resolve_claude_cli() -> str:
-    path = shutil.which("claude")
+    path = _resolve_cli_binary("claude", _ssot_config.path.claude_cli_path or None)
     if path is None:
-        raise RuntimeError("claude CLI not found on PATH. " "Install Claude Code and ensure 'claude' is on PATH.")
+        raise RuntimeError(CLAUDE_CLI_NOT_FOUND_MESSAGE)
     return path
 
 
@@ -105,6 +117,14 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
     _LOG_NAME = "ClaudeCodeAdapter"
     _state_path = staticmethod(_state_path)
     _required_cli = "claude"  # GH#9793: CLI-availability gate in heartbeat dispatch
+
+    def _configured_cli_path(self) -> Optional[str]:
+        """AUTOBOT_CLAUDE_CLI_PATH override, if set (GH#12478)."""
+        return _ssot_config.path.claude_cli_path or None
+
+    def cli_not_found_message(self) -> str:
+        """Actionable, config-aware message when `claude` cannot be resolved (GH#12478)."""
+        return CLAUDE_CLI_NOT_FOUND_MESSAGE
 
     @staticmethod
     def _tool_permission_args(cfg: dict) -> list[str]:

--- a/autobot-backend/llc/adapters/subprocess_base.py
+++ b/autobot-backend/llc/adapters/subprocess_base.py
@@ -28,7 +28,7 @@ import os
 import pathlib
 import shutil
 import time
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional
 
 from autobot_shared.logging_manager import get_logger
 
@@ -42,6 +42,66 @@ SIGTERM_GRACE_SECONDS = 10
 ADAPTER_TIMEOUT_SECONDS = 3600  # per-adapter default (preserves current behavior)
 DEFAULT_TIMEOUT_SECONDS = 3600  # fallback when a state file omits timeout_seconds
 DEFAULT_OUTPUT_DIR = "/tmp"  # nosec B108 - test/controlled code uses tmpdir intentionally
+
+# Per-user CLI install locations that a systemd service account's PATH typically
+# does NOT include (GH#12478). Checked, in order, after a bare `shutil.which()`
+# miss — e.g. the Claude Code CLI's curl installer lands in ~/.local/bin, and its
+# npm installer lands in an npm global bin dir that is rarely on a service PATH.
+_COMMON_CLI_INSTALL_DIRS: tuple[str, ...] = (
+    "~/.local/bin",
+    "/usr/local/bin",
+    "~/.npm-global/bin",
+)
+
+
+def _common_cli_search_dirs() -> list[str]:
+    """Common install dirs, plus the npm global bin dir when NPM_CONFIG_PREFIX is set."""
+    dirs = list(_COMMON_CLI_INSTALL_DIRS)
+    npm_prefix = os.environ.get("NPM_CONFIG_PREFIX")
+    if npm_prefix:
+        dirs.insert(0, str(pathlib.PurePosixPath(npm_prefix) / "bin"))
+    return dirs
+
+
+def resolve_cli_binary(
+    binary_name: str,
+    configured_path: Optional[str] = None,
+    common_dirs: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    """Resolve *binary_name* to an absolute path via a robust 3-tier fallback (GH#12478).
+
+    Resolution order:
+
+    1. ``configured_path`` — an explicit operator-supplied override (e.g. an
+       ssot_config field). Used only if it exists on disk and is executable.
+    2. ``shutil.which(binary_name)`` — standard PATH lookup.
+    3. Common per-user CLI install locations that a service account's PATH often
+       excludes (``~/.local/bin``, ``/usr/local/bin``, the npm global bin dir).
+
+    Returns ``None`` when the binary cannot be found anywhere so the caller can
+    raise/log a clear, actionable error instead of silently skipping the run.
+    """
+    if configured_path:
+        candidate = pathlib.Path(configured_path).expanduser()
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+        logger.warning(
+            "Configured CLI path %r for %r does not exist or is not executable; "
+            "falling back to PATH / common install locations",
+            configured_path,
+            binary_name,
+        )
+
+    found = shutil.which(binary_name)
+    if found:
+        return found
+
+    for directory in common_dirs if common_dirs is not None else _common_cli_search_dirs():
+        candidate = pathlib.Path(directory).expanduser() / binary_name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+
+    return None
 
 
 def resolve_timeout(cfg: dict) -> int:
@@ -70,18 +130,43 @@ class SubprocessLifecycleAdapter:
     # Subclasses declare this; None means no external CLI required (GH#9793).
     _required_cli: Optional[str] = None
 
-    # CLI availability gate (GH#9793) ----------------------------------------
+    # CLI availability gate (GH#9793, robust resolution GH#12478) -----------
+    def _configured_cli_path(self) -> Optional[str]:
+        """Optional explicit CLI path override (e.g. from ssot_config).
+
+        Default: not configured. Subclasses that expose an operator override
+        (e.g. ``ClaudeCodeAdapter`` → ``AUTOBOT_CLAUDE_CLI_PATH``) return it here
+        so both :meth:`is_cli_available` and the adapter's own invoke-time
+        resolution agree on the same resolved binary.
+        """
+        return None
+
     def is_cli_available(self) -> bool:
-        """Return True if the adapter's required CLI binary is on PATH.
+        """Return True if the adapter's required CLI binary can be resolved.
 
         Called by the heartbeat scheduler before dispatch so that runs are
         skipped (logged) rather than dispatched and immediately FAILED when the
-        CLI is absent from the container image.  Adapters with no required CLI
-        (``_required_cli is None``) always return True.
+        CLI is absent. Resolution checks, in order: the configured override
+        path, ``PATH``, then common per-user install locations (GH#12478).
+        Adapters with no required CLI (``_required_cli is None``) always
+        return True.
         """
         if self._required_cli is None:
             return True
-        return shutil.which(self._required_cli) is not None
+        return resolve_cli_binary(self._required_cli, self._configured_cli_path()) is not None
+
+    def cli_not_found_message(self) -> str:
+        """Actionable message when ``_required_cli`` cannot be resolved anywhere (GH#12478).
+
+        Used by the heartbeat scheduler to log/record a clear reason instead of a
+        bare "not on PATH" skip. Subclasses with a configured-path override
+        (e.g. ``ClaudeCodeAdapter``) override this to name the specific env var.
+        """
+        return (
+            f"{self._required_cli!r} CLI not found on PATH or common install "
+            "locations (~/.local/bin, /usr/local/bin, npm global bin); "
+            "install it and ensure it's on the service account's PATH."
+        )
 
     # Invoke ----------------------------------------------------------------
     async def invoke(self, agent_config: dict, context: dict) -> str:
@@ -186,6 +271,7 @@ __all__ = [
     "DEFAULT_TIMEOUT_SECONDS",
     "DEFAULT_OUTPUT_DIR",
     "resolve_timeout",
+    "resolve_cli_binary",
     "is_subprocess_adapter",
 ]
 

--- a/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
@@ -23,6 +23,7 @@ import pytest
 from llc.adapters.base import LLCAdapter
 from llc.adapters.claude_code_adapter import (
     ClaudeCodeAdapter,
+    _resolve_claude_cli,
     _state_path,
 )
 
@@ -142,7 +143,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -156,10 +157,116 @@ class TestInvoke:
         assert len(parts[1]) == 36  # UUID
 
     async def test_invoke_raises_when_claude_missing(self) -> None:
+        # GH#12478: also neutralize the configured-path and common-install-dir
+        # fallbacks — otherwise a dev machine with a real `claude` install (e.g.
+        # ~/.local/bin/claude) resolves the binary and this test's premise
+        # ("claude is genuinely absent") no longer holds.
         adapter = ClaudeCodeAdapter()
-        with patch("llc.adapters.claude_code_adapter.shutil.which", return_value=None):
+        with (
+            patch("llc.adapters.claude_code_adapter._ssot_config.path.claude_cli_path", ""),
+            patch("llc.adapters.subprocess_base.shutil.which", return_value=None),
+            patch(
+                "llc.adapters.subprocess_base._common_cli_search_dirs",
+                return_value=["/nonexistent/gh12478/dir"],
+            ),
+        ):
             with pytest.raises(RuntimeError, match="claude CLI not found"):
                 await adapter.invoke(_agent_cfg(), {})
+
+
+# ---------------------------------------------------------------------------
+# GH#12478: robust CLI resolution — AUTOBOT_CLAUDE_CLI_PATH override + gate
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCliResolution:
+    """AUTOBOT_CLAUDE_CLI_PATH (config path) > PATH > common install dirs > error."""
+
+    def test_configured_path_used_when_set_and_executable(self, tmp_path) -> None:
+        configured = tmp_path / "claude"
+        configured.write_text("#!/bin/sh\n")
+        configured.chmod(0o755)
+
+        with (
+            patch("llc.adapters.claude_code_adapter._ssot_config.path.claude_cli_path", str(configured)),
+            patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
+        ):
+            resolved = ClaudeCodeAdapter()._configured_cli_path()
+            assert resolved == str(configured)
+
+    def test_no_configured_path_returns_none(self) -> None:
+        with patch("llc.adapters.claude_code_adapter._ssot_config.path.claude_cli_path", ""):
+            assert ClaudeCodeAdapter()._configured_cli_path() is None
+
+    def test_is_cli_available_honors_configured_path(self, tmp_path) -> None:
+        configured = tmp_path / "claude"
+        configured.write_text("#!/bin/sh\n")
+        configured.chmod(0o755)
+
+        with (
+            patch("llc.adapters.claude_code_adapter._ssot_config.path.claude_cli_path", str(configured)),
+            patch("llc.adapters.subprocess_base.shutil.which", return_value=None),
+        ):
+            assert ClaudeCodeAdapter().is_cli_available() is True
+
+    def test_is_cli_available_false_when_nowhere_found(self, monkeypatch) -> None:
+        with (
+            patch("llc.adapters.claude_code_adapter._ssot_config.path.claude_cli_path", ""),
+            patch("llc.adapters.subprocess_base.shutil.which", return_value=None),
+            patch(
+                "llc.adapters.subprocess_base._common_cli_search_dirs",
+                return_value=["/nonexistent/gh12478/dir"],
+            ),
+        ):
+            assert ClaudeCodeAdapter().is_cli_available() is False
+
+    @pytest.mark.asyncio
+    async def test_invoke_uses_configured_path_over_path(self, tmp_path) -> None:
+        """A configured override resolves even when a different `claude` is on PATH."""
+        configured = tmp_path / "claude"
+        configured.write_text("#!/bin/sh\n")
+        configured.chmod(0o755)
+
+        adapter = ClaudeCodeAdapter()
+        fake_proc = _make_fake_proc(101)
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.claude_code_adapter._ssot_config.path.claude_cli_path", str(configured)),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
+                patch(
+                    "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
+                ),
+                patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc) as mock_exec,
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                await adapter.invoke(cfg, {"task_id": "t1"})
+
+        assert mock_exec.call_args.args[0] == str(configured)
+
+    def test_cli_not_found_message_is_actionable_and_config_aware(self) -> None:
+        message = ClaudeCodeAdapter().cli_not_found_message()
+        assert "claude CLI not found" in message
+        assert "AUTOBOT_CLAUDE_CLI_PATH" in message
+
+    def test_invoke_error_matches_scheduler_skip_message(self) -> None:
+        """RuntimeError text matches cli_not_found_message() so ops sees one consistent reason
+        whether the run was gated pre-dispatch (heartbeat scheduler) or slipped through to invoke().
+        """
+        adapter = ClaudeCodeAdapter()
+        with (
+            patch("llc.adapters.claude_code_adapter._ssot_config.path.claude_cli_path", ""),
+            patch("llc.adapters.subprocess_base.shutil.which", return_value=None),
+            patch(
+                "llc.adapters.subprocess_base._common_cli_search_dirs",
+                return_value=["/nonexistent/gh12478/dir"],
+            ),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                _resolve_claude_cli()
+
+        assert str(exc_info.value) == adapter.cli_not_found_message()
 
     async def test_invoke_writes_state_file(self) -> None:
         adapter = ClaudeCodeAdapter()
@@ -171,7 +278,7 @@ class TestInvoke:
             # written for real to the temp dir so the os.path.exists assertion
             # below is meaningful. Only the subprocess + redis are mocked.
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -201,7 +308,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client",
                     new_callable=AsyncMock,
@@ -238,7 +345,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client",
                     new_callable=AsyncMock,
@@ -265,7 +372,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td, allowed_tools=["Bash", "Read"])
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -291,7 +398,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -320,7 +427,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -339,7 +446,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -361,7 +468,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -395,7 +502,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),
@@ -421,7 +528,7 @@ class TestInvoke:
         with tempfile.TemporaryDirectory() as td:
             cfg = _agent_cfg(output_dir=td)
             with (
-                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"),
                 patch(
                     "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
                 ),

--- a/autobot-backend/llc/adapters/tests/test_subprocess_base.py
+++ b/autobot-backend/llc/adapters/tests/test_subprocess_base.py
@@ -24,6 +24,7 @@ from llc.adapters.subprocess_base import (
     ADAPTER_TIMEOUT_SECONDS,
     SIGTERM_GRACE_SECONDS,
     SubprocessLifecycleAdapter,
+    resolve_cli_binary,
     resolve_timeout,
 )
 from llc.models.enums import LLCRunStatus
@@ -62,6 +63,160 @@ class TestResolveTimeout:
     def test_adapter_default(self, monkeypatch) -> None:
         monkeypatch.delenv("LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS", raising=False)
         assert resolve_timeout({}) == ADAPTER_TIMEOUT_SECONDS == 3600
+
+
+# ---------------------------------------------------------------------------
+# resolve_cli_binary — configured path > PATH > common install dirs > None (GH#12478)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCliBinary:
+    def test_configured_path_wins_over_which(self, tmp_path) -> None:
+        """An existing, executable configured_path is used even if PATH also resolves it."""
+        configured = tmp_path / "claude"
+        configured.write_text("#!/bin/sh\n")
+        configured.chmod(0o755)
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"):
+            resolved = resolve_cli_binary("claude", configured_path=str(configured))
+
+        assert resolved == str(configured)
+
+    def test_configured_path_missing_falls_back_to_which(self, tmp_path) -> None:
+        """A configured_path that doesn't exist logs a warning and falls back."""
+        missing = tmp_path / "does-not-exist" / "claude"
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"):
+            resolved = resolve_cli_binary("claude", configured_path=str(missing))
+
+        assert resolved == "/usr/bin/claude"
+
+    def test_which_wins_over_common_dirs(self, tmp_path) -> None:
+        """A bare PATH hit is used before common install dirs are even checked."""
+        common_dir = tmp_path / "common"
+        common_dir.mkdir()
+        (common_dir / "claude").write_text("#!/bin/sh\n")
+        (common_dir / "claude").chmod(0o755)
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"):
+            resolved = resolve_cli_binary("claude", common_dirs=[str(common_dir)])
+
+        assert resolved == "/usr/bin/claude"
+
+    def test_falls_back_to_common_install_dir_when_which_misses(self, tmp_path) -> None:
+        """PATH miss (which() -> None) falls through to a common install dir hit."""
+        common_dir = tmp_path / "local-bin"
+        common_dir.mkdir()
+        binary = common_dir / "claude"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value=None):
+            resolved = resolve_cli_binary("claude", common_dirs=[str(common_dir)])
+
+        assert resolved == str(binary)
+
+    def test_common_dirs_checked_in_order(self, tmp_path) -> None:
+        """The first common dir containing the binary wins."""
+        first_dir = tmp_path / "first"
+        second_dir = tmp_path / "second"
+        first_dir.mkdir()
+        second_dir.mkdir()
+        for d in (first_dir, second_dir):
+            binary = d / "claude"
+            binary.write_text("#!/bin/sh\n")
+            binary.chmod(0o755)
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value=None):
+            resolved = resolve_cli_binary("claude", common_dirs=[str(first_dir), str(second_dir)])
+
+        assert resolved == str(first_dir / "claude")
+
+    def test_non_executable_common_dir_file_skipped(self, tmp_path) -> None:
+        """A file that exists but isn't executable is not treated as a resolution hit."""
+        common_dir = tmp_path / "local-bin"
+        common_dir.mkdir()
+        (common_dir / "claude").write_text("not executable")
+        (common_dir / "claude").chmod(0o644)
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value=None):
+            resolved = resolve_cli_binary("claude", common_dirs=[str(common_dir)])
+
+        assert resolved is None
+
+    def test_returns_none_when_nowhere_found(self, tmp_path) -> None:
+        """Genuinely absent everywhere: no configured path, no PATH hit, no common dir hit."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value=None):
+            resolved = resolve_cli_binary("claude", common_dirs=[str(empty_dir)])
+
+        assert resolved is None
+
+    def test_default_common_dirs_include_local_bin_and_npm_global(self) -> None:
+        """The default search list covers the documented per-user install locations."""
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value=None):
+            # No filesystem hits expected (real home dir unlikely to have a
+            # binary named this) — this just exercises the default-dirs path
+            # without raising, proving the default list is well-formed.
+            resolved = resolve_cli_binary("autobot-nonexistent-cli-gh12478")
+
+        assert resolved is None
+
+
+# ---------------------------------------------------------------------------
+# CLI availability gate hooks — is_cli_available / cli_not_found_message (GH#12478)
+# ---------------------------------------------------------------------------
+
+
+class _CliRequiringAdapter(SubprocessLifecycleAdapter):
+    _LOG_NAME = "CliRequiringAdapter"
+    _state_path = staticmethod(_state_path)
+    _required_cli = "claude"
+
+    async def _invoke(self, agent_config, context):  # pragma: no cover - not exercised
+        return "1/x"
+
+
+class TestCliAvailabilityHooks:
+    def test_no_required_cli_always_available(self) -> None:
+        assert _DummyAdapter().is_cli_available() is True
+
+    def test_available_when_which_resolves(self) -> None:
+        adapter = _CliRequiringAdapter()
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value="/usr/bin/claude"):
+            assert adapter.is_cli_available() is True
+
+    def test_unavailable_when_nowhere_found(self, monkeypatch) -> None:
+        adapter = _CliRequiringAdapter()
+        with (
+            patch("llc.adapters.subprocess_base.shutil.which", return_value=None),
+            patch(
+                "llc.adapters.subprocess_base._common_cli_search_dirs",
+                return_value=["/nonexistent/gh12478/dir"],
+            ),
+        ):
+            assert adapter.is_cli_available() is False
+
+    def test_configured_path_used_by_availability_gate(self, tmp_path) -> None:
+        """A subclass-provided _configured_cli_path() is honored by is_cli_available()."""
+        configured = tmp_path / "claude"
+        configured.write_text("#!/bin/sh\n")
+        configured.chmod(0o755)
+
+        class _ConfiguredAdapter(_CliRequiringAdapter):
+            def _configured_cli_path(self):
+                return str(configured)
+
+        with patch("llc.adapters.subprocess_base.shutil.which", return_value=None):
+            assert _ConfiguredAdapter().is_cli_available() is True
+
+    def test_default_message_is_actionable(self) -> None:
+        message = _CliRequiringAdapter().cli_not_found_message()
+        assert "claude" in message
+        assert "PATH" in message
+        assert "install" in message.lower()
 
     def test_precedence_order_all_three_tiers(self, monkeypatch) -> None:
         """Verify precedence: per-agent > global env > adapter default."""

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -832,14 +832,15 @@ async def _dispatch_adapter(agent: Dict[str, Any], context: Dict[str, Any]) -> O
             agent["agent_id"], f"no LLC adapter registered for type {adapter_type!r}"
         ) from None
 
-    # GH#9793: skip dispatch when the required CLI binary is absent from PATH.
+    # GH#9793: skip dispatch when the required CLI binary can't be resolved
+    # (PATH, configured override, or common install locations — GH#12478).
     # Converts every-heartbeat FAILED runs into a clean degraded state (GH#9951).
     if is_subprocess_adapter(adapter) and not adapter.is_cli_available():  # type: ignore[union-attr]
-        raise HeartbeatDispatchSkipped(
-            agent["agent_id"],
-            f"adapter {adapter_type!r} requires CLI "
-            f"{adapter._required_cli!r} which is not on PATH",  # type: ignore[union-attr]
-        )
+        message = adapter.cli_not_found_message()  # type: ignore[union-attr]
+        # GH#12478: this is a genuine deployment misconfiguration, not routine
+        # degraded-agent noise — warn so it's visible without polling run history.
+        logger.warning("Heartbeat dispatch skipped for agent %s: %s", agent["agent_id"], message)
+        raise HeartbeatDispatchSkipped(agent["agent_id"], message)
 
     return await _dispatch_registry_adapter(adapter, agent, context)
 

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1280,6 +1280,15 @@ class PathConfig(BaseSettings):
         validation_alias=AliasChoices("AUTOBOT_SSH_KEY_PATH", "SLM_SSH_KEY"),
     )
 
+    # Explicit override for the `claude` CLI binary used by the LLC claude_code
+    # adapter (GH#12478). Empty string means "not configured" — the adapter falls
+    # back to shutil.which("claude") then common per-user install locations before
+    # raising a clear error. Set this when the service account's PATH does not
+    # include the directory the Claude Code CLI was installed into (e.g. a
+    # per-user npm/curl install landed in ~/.local/bin, which systemd services
+    # typically don't inherit).
+    claude_cli_path: str = Field(default="", alias="AUTOBOT_CLAUDE_CLI_PATH")
+
     def resolve(self, relative: str) -> Path:
         """Resolve a path relative to base_dir."""
         p = Path(relative)


### PR DESCRIPTION
## Thinking Path

`ClaudeCodeAdapter` (and the base `SubprocessLifecycleAdapter._required_cli` gate all subprocess adapters share) resolved `claude` via a bare `shutil.which("claude")`. On the deployed instance the systemd service PATH is `venv/bin:/usr/local/bin:/usr/bin:/bin`, which excludes the per-user location (`~/.local/bin`) a curl/npm install of Claude Code CLI typically lands in — so the heartbeat scheduler's pre-dispatch CLI-availability gate (GH#9793) always skips `claude_code` runs on a stock deploy, and the skip reason ("requires CLI 'claude' which is not on PATH") gives the operator no next step.

Fix scope is the two resolution call sites the LLC `claude_code` adapter actually uses: the invoke-time `_resolve_claude_cli()` and the pre-dispatch `is_cli_available()` gate. Both now share one robust resolver.

## What Changed

**`autobot-backend/llc/adapters/subprocess_base.py`**
- New `resolve_cli_binary(binary_name, configured_path=None, common_dirs=None)`: resolves in order — (1) an explicit configured path if it exists and is executable, (2) `shutil.which()`, (3) common per-user install dirs (`~/.local/bin`, `/usr/local/bin`, the npm global bin dir, plus `$NPM_CONFIG_PREFIX/bin` when set). Returns `None` if nowhere found.
- `SubprocessLifecycleAdapter.is_cli_available()` now uses `resolve_cli_binary()` (via a new `_configured_cli_path()` hook subclasses can override) instead of a bare `shutil.which()`.
- New `cli_not_found_message()` hook — an actionable message (adapter-specific override point) instead of the previous "requires CLI X which is not on PATH".

**`autobot-backend/llc/adapters/claude_code_adapter.py`**
- `_resolve_claude_cli()` now calls `resolve_cli_binary("claude", config.path.claude_cli_path or None)`; raises `RuntimeError("claude CLI not found on PATH or configured location; install it or set AUTOBOT_CLAUDE_CLI_PATH")` only when genuinely absent everywhere.
- `ClaudeCodeAdapter` overrides `_configured_cli_path()` (returns the `AUTOBOT_CLAUDE_CLI_PATH` override) and `cli_not_found_message()` so the pre-dispatch skip reason and the invoke-time error use the identical, actionable text. `ClaudeCodeSubscriptionAdapter` inherits both automatically.

**`autobot_shared/ssot_config.py`**
- New `PathConfig.claude_cli_path` (`AUTOBOT_CLAUDE_CLI_PATH`, default `""` = not configured) — the explicit override operators can set when the CLI lands somewhere none of the automatic fallbacks cover.

**`autobot-backend/llc/scheduler/heartbeat_scheduler.py`**
- The CLI-unavailable skip path now calls `adapter.cli_not_found_message()` for the `HeartbeatDispatchSkipped` reason and logs it at `WARNING` (was `INFO`-only, and the message named the missing CLI but gave no remediation) — this is a genuine deployment misconfiguration, not routine agent-degraded noise, so it's now visible without polling run history.

**Part B — provisioning (not touched, reported below).**

## Verification

```
$ python3 -m pytest autobot-backend/llc/adapters/ autobot-backend/llc/tests/test_heartbeat_scheduler.py -p no:xdist -q
...
200 passed in 2.58s
```

New tests cover the resolution order explicitly (`TestResolveCliBinary` in `test_subprocess_base.py`): configured-path-wins-over-which, configured-path-missing-falls-back, which-wins-over-common-dirs, common-dirs-checked-in-order, non-executable-file-skipped, returns-None-when-nowhere-found; plus `TestCliAvailabilityHooks` (gate hooks) and `TestClaudeCliResolution` in `test_claude_code_adapter.py` (AUTOBOT_CLAUDE_CLI_PATH override honored by both the invoke path and the availability gate, actionable/config-aware message, invoke-time error text matches the pre-dispatch skip text).

Existing `test_invoke_raises_when_claude_missing` had to be updated: on a dev box with a real `claude` install (`~/.local/bin/claude` — exactly the location this fix now resolves), a bare `shutil.which` patch is no longer sufficient to simulate "genuinely absent" now that the fallback chain is real; the test now also neutralizes the configured-path and common-dir fallbacks.

```
$ black --check autobot-backend/llc/adapters/subprocess_base.py autobot-backend/llc/adapters/claude_code_adapter.py autobot-backend/llc/adapters/tests/test_subprocess_base.py autobot-backend/llc/adapters/tests/test_claude_code_adapter.py autobot-backend/llc/scheduler/heartbeat_scheduler.py autobot_shared/ssot_config.py
All done! 6 files would be left unchanged.

$ flake8 <same files>
(clean, no output)
```

**Part B report (owner decision, not implemented):** searched `autobot-slm-backend/ansible/` — no role currently installs the `claude` CLI or extends the backend/celery service PATH for it. The `nodejs` role (NodeSource) exists but is only wired into the `frontend` playbook, not `backend`/`celery`. A `sudo npm install -g @anthropic-ai/claude-code` as root would land the binary in `/usr/local/bin` (already on the service PATH — no systemd changes needed), but provisioning it by default raises decisions outside this PR's scope: (1) whether Node.js becomes a new backend-host dependency, (2) licensing/subscription — the `autobot` service account needs its own Anthropic auth (API key or `claude login` session) to actually run, (3) version pinning strategy. Recommend the owner decide the install source/auth model before an ansible task is added; Part A's `AUTOBOT_CLAUDE_CLI_PATH` override plus the common-install-dir fallback already make a manual/scripted install "just work" without any playbook changes in the meantime.

## Model Used

Sonnet 5

Closes #12478