### PR TITLE
feat(memory): fact usage tracking foundation for reinforcement (#12552)

### DIFF
--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -251,6 +251,16 @@ def get_embedding_metrics() -> Dict[str, int]:
 # loop keeps a strong reference until they finish (create_task otherwise GC-able).
 _ACCESS_TASKS: "set[asyncio.Task]" = set()
 
+# A1 (#12552): atomic usage bump. EXISTS + HINCRBY + HSET in one server-side
+# round-trip so a concurrent delete_fact can never resurrect a ghost hash
+# between the guard and the writes (both HINCRBY/HSET auto-create keys).
+_ACCESS_BUMP_LUA = (
+    "if redis.call('EXISTS', KEYS[1]) == 1 then "
+    "redis.call('HINCRBY', KEYS[1], 'access_count', 1) "
+    "redis.call('HSET', KEYS[1], 'last_accessed', ARGV[1]) "
+    "return 1 end return 0"
+)
+
 
 def _apply_usage_fields(decoded: Dict[str, Any], metadata: Dict[str, Any]) -> None:
     """Surface authoritative usage counters from the Redis hash into metadata.
@@ -878,32 +888,32 @@ class FactsMixin:
         if not ids:
             return
         try:
-            task = asyncio.create_task(self._bump_fact_access(ids))
-            _ACCESS_TASKS.add(task)
-            task.add_done_callback(_ACCESS_TASKS.discard)
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             # No running loop (sync/test context): do it inline, still guarded.
             await self._bump_fact_access(ids)
+            return
+        task = loop.create_task(self._bump_fact_access(ids))
+        _ACCESS_TASKS.add(task)
+        task.add_done_callback(_ACCESS_TASKS.discard)
 
     async def _bump_fact_access(self, fact_ids: List[str]) -> None:
         """Atomically increment ``access_count`` and stamp ``last_accessed``.
 
-        Counters are top-level hash fields (authoritative), so ``HINCRBY`` is
-        atomic and the metadata JSON blob is never rewritten. Missing facts are
-        skipped so a deleted fact is never resurrected.
+        Counters are authoritative top-level hash fields, so the metadata JSON
+        blob is never rewritten. The EXISTS+HINCRBY+HSET is done as one atomic
+        Lua ``EVAL`` per fact, so a deleted fact is never resurrected by a bump
+        racing a concurrent ``delete_fact``. Duplicate ids collapse to one bump.
         """
         now_iso = datetime.now(tz=timezone.utc).isoformat()
+        unique_ids = list(dict.fromkeys(fact_ids))
 
         def _work() -> None:
-            for fid in fact_ids:
-                key = "fact:%s" % fid
+            for fid in unique_ids:
                 try:
-                    if not self.redis_client.exists(key):
-                        continue
-                    self.redis_client.hincrby(key, "access_count", 1)
-                    self.redis_client.hset(key, "last_accessed", now_iso)
+                    self.redis_client.eval(_ACCESS_BUMP_LUA, 1, "fact:%s" % fid, now_iso)
                 except Exception:
-                    continue
+                    logger.debug("record_fact_access: bump failed for %s (non-fatal)", fid)
 
         try:
             await asyncio.to_thread(_work)

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -247,6 +247,27 @@ def get_embedding_metrics() -> Dict[str, int]:
     return {"npu_count": npu_count, "fallback_count": fallback_count}
 
 
+# A1 (#12552): fire-and-forget access-recording tasks are held here so the event
+# loop keeps a strong reference until they finish (create_task otherwise GC-able).
+_ACCESS_TASKS: "set[asyncio.Task]" = set()
+
+
+def _apply_usage_fields(decoded: Dict[str, Any], metadata: Dict[str, Any]) -> None:
+    """Surface authoritative usage counters from the Redis hash into metadata.
+
+    A1 (#12552): ``access_count`` / ``last_accessed`` live as top-level hash
+    fields (so ``HINCRBY`` stays atomic and the metadata JSON blob is never
+    rewritten on access). They are the single source of truth; on read we copy
+    them into the returned metadata dict, defaulting to 0 / "" when absent so
+    every fact — old or new — exposes the keys.
+    """
+    try:
+        metadata["access_count"] = int(decoded.get("access_count") or 0)
+    except (TypeError, ValueError):
+        metadata["access_count"] = 0
+    metadata["last_accessed"] = decoded.get("last_accessed") or ""
+
+
 def _decode_redis_hash(fact_data: Dict[bytes, bytes]) -> Dict[str, Any]:
     """Decode Redis hash bytes to strings and parse metadata (Issue #315: extracted).
 
@@ -833,6 +854,7 @@ class FactsMixin:
                 except (json.JSONDecodeError, TypeError):
                     pass
 
+            _apply_usage_fields(decoded, metadata)
             return {
                 "fact_id": fact_id,
                 "content": decoded.get("content", ""),
@@ -843,6 +865,50 @@ class FactsMixin:
         except Exception as e:
             logger.error("Error retrieving fact %s: %s", fact_id, e)
             return None
+
+    async def record_fact_access(self, fact_ids: List[str]) -> None:
+        """Schedule a non-blocking usage bump for surfaced facts (A1, #12552).
+
+        Returns immediately: the actual ``HINCRBY`` runs in a background task so
+        the read path is never blocked and a failure here never propagates to the
+        caller. Reinforcement is best-effort — a dropped bump only costs one
+        ranking signal, never correctness.
+        """
+        ids = [fid for fid in (fact_ids or []) if fid]
+        if not ids:
+            return
+        try:
+            task = asyncio.create_task(self._bump_fact_access(ids))
+            _ACCESS_TASKS.add(task)
+            task.add_done_callback(_ACCESS_TASKS.discard)
+        except RuntimeError:
+            # No running loop (sync/test context): do it inline, still guarded.
+            await self._bump_fact_access(ids)
+
+    async def _bump_fact_access(self, fact_ids: List[str]) -> None:
+        """Atomically increment ``access_count`` and stamp ``last_accessed``.
+
+        Counters are top-level hash fields (authoritative), so ``HINCRBY`` is
+        atomic and the metadata JSON blob is never rewritten. Missing facts are
+        skipped so a deleted fact is never resurrected.
+        """
+        now_iso = datetime.now(tz=timezone.utc).isoformat()
+
+        def _work() -> None:
+            for fid in fact_ids:
+                key = "fact:%s" % fid
+                try:
+                    if not self.redis_client.exists(key):
+                        continue
+                    self.redis_client.hincrby(key, "access_count", 1)
+                    self.redis_client.hset(key, "last_accessed", now_iso)
+                except Exception:
+                    continue
+
+        try:
+            await asyncio.to_thread(_work)
+        except Exception:
+            logger.debug("record_fact_access bump failed (non-fatal)", exc_info=True)
 
     def _process_fact_data(
         self,
@@ -874,6 +940,7 @@ class FactsMixin:
         if collection and metadata.get("collection") != collection:
             return None
 
+        _apply_usage_fields(decoded, metadata)
         return {
             "fact_id": fact_id,
             "content": decoded.get("content", ""),

--- a/autobot-backend/knowledge/facts_usage_tracking_test.py
+++ b/autobot-backend/knowledge/facts_usage_tracking_test.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from knowledge.facts import FactsMixin, _apply_usage_fields
+from knowledge.facts import _ACCESS_BUMP_LUA, _ACCESS_TASKS, FactsMixin, _apply_usage_fields
 
 
 class _KB(FactsMixin):
@@ -76,34 +76,52 @@ def test_get_fact_defaults_usage_when_never_accessed():
     assert fact["metadata"]["last_accessed"] == ""
 
 
-@pytest.mark.asyncio
-async def test_bump_increments_and_stamps_existing_fact():
+def test_process_fact_data_surfaces_usage_fields():
     kb = _KB()
-    kb.redis_client.exists.return_value = 1
+    raw = {
+        b"content": b"processed fact",
+        b"metadata": b'{"category": "note"}',
+        b"timestamp": b"2026-07-01T00:00:00+00:00",
+        b"access_count": b"5",
+        b"last_accessed": b"2026-07-20T00:00:00+00:00",
+    }
+    fact = kb._process_fact_data("fact:fact-9", raw)
+    assert fact is not None
+    assert fact["metadata"]["access_count"] == 5
+    assert fact["metadata"]["last_accessed"] == "2026-07-20T00:00:00+00:00"
+
+
+def test_bump_lua_guards_existence_atomically():
+    # The atomic guard against ghost-resurrection lives in the Lua script, not
+    # in a TOCTOU exists()->write sequence.
+    assert "EXISTS" in _ACCESS_BUMP_LUA
+    assert "HINCRBY" in _ACCESS_BUMP_LUA
+    assert "HSET" in _ACCESS_BUMP_LUA
+
+
+@pytest.mark.asyncio
+async def test_bump_evals_atomic_script_per_fact():
+    kb = _KB()
     await kb._bump_fact_access(["fact-1"])
-    kb.redis_client.hincrby.assert_called_once_with("fact:fact-1", "access_count", 1)
-    # last_accessed stamped with an ISO timestamp
-    hset_call = kb.redis_client.hset.call_args
-    assert hset_call.args[0] == "fact:fact-1"
-    assert hset_call.args[1] == "last_accessed"
-    assert "T" in hset_call.args[2]
-
-
-@pytest.mark.asyncio
-async def test_bump_skips_missing_fact():
-    kb = _KB()
-    kb.redis_client.exists.return_value = 0
-    await kb._bump_fact_access(["ghost"])
-    kb.redis_client.hincrby.assert_not_called()
-    kb.redis_client.hset.assert_not_called()
+    call = kb.redis_client.eval.call_args
+    assert call.args[0] == _ACCESS_BUMP_LUA
+    assert call.args[1] == 1  # numkeys
+    assert call.args[2] == "fact:fact-1"
+    assert "T" in call.args[3]  # ISO last_accessed stamp
 
 
 @pytest.mark.asyncio
 async def test_bump_counts_each_fact_once():
     kb = _KB()
-    kb.redis_client.exists.return_value = 1
     await kb._bump_fact_access(["a", "b", "c"])
-    assert kb.redis_client.hincrby.call_count == 3
+    assert kb.redis_client.eval.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_bump_dedups_repeated_ids():
+    kb = _KB()
+    await kb._bump_fact_access(["a", "a", "b"])
+    assert kb.redis_client.eval.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -115,12 +133,12 @@ async def test_record_fact_access_noop_on_empty():
 
 @pytest.mark.asyncio
 async def test_record_fact_access_never_raises():
-    kb = _KB()
-    kb.redis_client.exists.side_effect = RuntimeError("redis down")
-    # Must not propagate — reinforcement is best-effort.
-    await kb.record_fact_access(["fact-1"])
-    # allow the scheduled background task to run to completion
     import asyncio
 
-    for _ in range(5):
-        await asyncio.sleep(0)
+    kb = _KB()
+    kb.redis_client.eval.side_effect = RuntimeError("redis down")
+    # Must not propagate — reinforcement is best-effort.
+    await kb.record_fact_access(["fact-1"])
+    # Deterministically drain the scheduled background task(s).
+    if _ACCESS_TASKS:
+        await asyncio.gather(*list(_ACCESS_TASKS), return_exceptions=True)

--- a/autobot-backend/knowledge/facts_usage_tracking_test.py
+++ b/autobot-backend/knowledge/facts_usage_tracking_test.py
@@ -1,0 +1,126 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for A1 (#12552) — fact usage tracking.
+
+Covers:
+  - ``access_count`` / ``last_accessed`` surfaced from the Redis hash into the
+    returned metadata on read (new facts default cleanly to 0 / "");
+  - ``_bump_fact_access`` atomically increments the counter and stamps the time
+    for existing facts, and skips missing ones (no resurrection);
+  - ``record_fact_access`` is a no-op on empty input and never raises into the
+    caller even when Redis blows up (fire-and-forget contract).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from knowledge.facts import FactsMixin, _apply_usage_fields
+
+
+class _KB(FactsMixin):
+    """Minimal FactsMixin host with just the Redis collaborator under test."""
+
+    def __init__(self):
+        self.redis_client = MagicMock()
+
+
+def test_apply_usage_fields_surfaces_counters():
+    meta: dict = {}
+    _apply_usage_fields({"access_count": "7", "last_accessed": "2026-07-26T00:00:00+00:00"}, meta)
+    assert meta["access_count"] == 7
+    assert meta["last_accessed"] == "2026-07-26T00:00:00+00:00"
+
+
+def test_apply_usage_fields_defaults_when_absent():
+    meta: dict = {}
+    _apply_usage_fields({}, meta)
+    assert meta["access_count"] == 0
+    assert meta["last_accessed"] == ""
+
+
+def test_apply_usage_fields_tolerates_garbage():
+    meta: dict = {}
+    _apply_usage_fields({"access_count": "not-a-number"}, meta)
+    assert meta["access_count"] == 0
+
+
+def test_get_fact_surfaces_usage_fields():
+    kb = _KB()
+    kb.redis_client.hgetall.return_value = {
+        b"content": b"the sky is blue",
+        b"metadata": b'{"quality_score": 0.9, "category": "fact"}',
+        b"timestamp": b"2026-07-01T00:00:00+00:00",
+        b"access_count": b"3",
+        b"last_accessed": b"2026-07-25T00:00:00+00:00",
+    }
+    fact = kb.get_fact("fact-1")
+    assert fact is not None
+    assert fact["metadata"]["access_count"] == 3
+    assert fact["metadata"]["last_accessed"] == "2026-07-25T00:00:00+00:00"
+    # existing metadata preserved
+    assert fact["metadata"]["quality_score"] == 0.9
+
+
+def test_get_fact_defaults_usage_when_never_accessed():
+    kb = _KB()
+    kb.redis_client.hgetall.return_value = {
+        b"content": b"new fact",
+        b"metadata": b"{}",
+        b"timestamp": b"2026-07-01T00:00:00+00:00",
+    }
+    fact = kb.get_fact("fact-2")
+    assert fact["metadata"]["access_count"] == 0
+    assert fact["metadata"]["last_accessed"] == ""
+
+
+@pytest.mark.asyncio
+async def test_bump_increments_and_stamps_existing_fact():
+    kb = _KB()
+    kb.redis_client.exists.return_value = 1
+    await kb._bump_fact_access(["fact-1"])
+    kb.redis_client.hincrby.assert_called_once_with("fact:fact-1", "access_count", 1)
+    # last_accessed stamped with an ISO timestamp
+    hset_call = kb.redis_client.hset.call_args
+    assert hset_call.args[0] == "fact:fact-1"
+    assert hset_call.args[1] == "last_accessed"
+    assert "T" in hset_call.args[2]
+
+
+@pytest.mark.asyncio
+async def test_bump_skips_missing_fact():
+    kb = _KB()
+    kb.redis_client.exists.return_value = 0
+    await kb._bump_fact_access(["ghost"])
+    kb.redis_client.hincrby.assert_not_called()
+    kb.redis_client.hset.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bump_counts_each_fact_once():
+    kb = _KB()
+    kb.redis_client.exists.return_value = 1
+    await kb._bump_fact_access(["a", "b", "c"])
+    assert kb.redis_client.hincrby.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_record_fact_access_noop_on_empty():
+    kb = _KB()
+    await kb.record_fact_access([])
+    kb.redis_client.hincrby.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_record_fact_access_never_raises():
+    kb = _KB()
+    kb.redis_client.exists.side_effect = RuntimeError("redis down")
+    # Must not propagate — reinforcement is best-effort.
+    await kb.record_fact_access(["fact-1"])
+    # allow the scheduled background task to run to completion
+    import asyncio
+
+    for _ in range(5):
+        await asyncio.sleep(0)

--- a/autobot-backend/knowledge/search.py
+++ b/autobot-backend/knowledge/search.py
@@ -316,7 +316,7 @@ class SearchMixin:
                 hardware_backend="auto",
             )
             # Convert canonical SearchResult -> legacy dict format expected by callers
-            return [
+            results = [
                 {
                     "content": r.text,
                     "score": r.score,
@@ -326,6 +326,13 @@ class SearchMixin:
                 }
                 for r in engine_results
             ]
+            # A1 (#12552): reinforce facts surfaced by a real query. Fire-and-forget;
+            # never blocks or alters the returned results.
+            try:
+                await self.record_fact_access([r.source for r in engine_results if r.source])
+            except Exception:
+                logger.debug("search: record_fact_access skipped", exc_info=True)
+            return results
         except Exception as exc:
             logger.warning(
                 "VectorSearchEngine delegation failed (%s), falling back to direct ChromaDB",

--- a/autobot-backend/memory/essential_story.py
+++ b/autobot-backend/memory/essential_story.py
@@ -131,6 +131,15 @@ class EssentialStoryGenerator:
                 break
             selected.append(fact)
             used_tokens += tokens
+
+        # A1 (#12552): reinforce the facts we actually surface to the model.
+        # Fire-and-forget — never blocks or fails story generation.
+        try:
+            surfaced_ids = [f.get("fact_id") or f.get("id") for f in selected]
+            await kb.record_fact_access([fid for fid in surfaced_ids if fid])
+        except Exception:
+            logger.debug("essential_story: record_fact_access skipped", exc_info=True)
+
         return selected
 
     async def _format_output(self, facts: List[Dict[str, Any]]) -> str:


### PR DESCRIPTION
## Thinking Path
Foundation for epic #12551 Gap A: the always-loaded essential-story facts lane ranks purely by a static `quality_score`, with no usage signal to later reinforce frequently-recalled facts. This PR adds the usage-tracking substrate (A1) that A2 (ranking) and A3 (decay/prune) build on.

## What Changed
- **`knowledge/facts.py`**: `access_count` / `last_accessed` are now stored as **authoritative top-level Redis hash fields** (atomic `HINCRBY`, so the metadata JSON blob is never rewritten on access) and surfaced into the returned `metadata` on read via `_apply_usage_fields`. Old facts default cleanly to `0` / `""`.
- **`record_fact_access()` / `_bump_fact_access()`**: fire-and-forget recording — schedules a background bump that never blocks the read path and never raises into the caller. Best-effort by design (a dropped bump costs one ranking signal, never correctness). A module-level task set keeps references so the tasks aren't GC'd.
- **Reinforcement hooks**: `essential_story._fetch_top_facts` (facts actually surfaced to the model) and the basic KB search path (`doc_id = r.source`). Non-fact sources are safe no-ops (guarded by a `fact:{id}` existence check).

## Verification
- `knowledge/facts_usage_tracking_test.py` — 10 new tests: surfacing on read, default-when-absent, garbage tolerance, atomic increment, missing-fact skip (no resurrection), each-fact-counted-once, empty no-op, and the never-raise contract. **10 passed.**
- `knowledge/facts_failed_vectorization_test.py` — **6 passed** (no regression).
- Syntax/AST smoke on all three modified modules: OK.

## Model Used
Opus 4.8 (1M context)

Part of #12551. Design captured in the epic.


Closes #12552. Part of epic #12551.
