### PR TITLE
test(github): fix 3 stale integration tests broken by #6311 rewire (#12547)

### DIFF
--- a/autobot-backend/integrations/github_integration_test.py
+++ b/autobot-backend/integrations/github_integration_test.py
@@ -3,14 +3,14 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Unit tests — GitHubIntegration rate limiting (Issues #4097, #4162)
+Unit tests — GitHubIntegration rate limiting (Issues #4097, #4162, #6311)
 
 All HTTP calls are patched; no real network traffic.
 Covers:
-- Successful requests record quota
+- Successful requests delegate recording to the shared Redis-backed limiter
 - HTTP 429 triggers Retry-After enforcement and returns structured response
 - HTTP 403 secondary rate limit is handled gracefully
-- Local window exhaustion returns rate_limit_timeout error
+- Shared-limiter exhaustion returns a structured 429 rate_limit_exceeded error
 - X-RateLimit-Remaining=0 blocks subsequent requests
 - Connection errors return structured error dict
 """
@@ -186,21 +186,31 @@ async def test_x_ratelimit_remaining_zero_blocks_next_request():
 
 
 # ---------------------------------------------------------------------------
-# Local rate limit exhaustion → rate_limit_timeout error
+# Shared-limiter exhaustion → structured 429 rate_limit_exceeded error (#6311)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_acquire_timeout_returns_structured_error():
-    gh = GitHubIntegration(_make_config())
-    # Replace rate limiter with one that always raises TimeoutError on acquire
-    mock_limiter = MagicMock()
-    mock_limiter.acquire = AsyncMock(side_effect=asyncio.TimeoutError)
-    gh._rate_limiter = mock_limiter
+async def test_rate_limit_exceeded_returns_structured_error():
+    """When the shared Redis-backed limiter denies the request (#6311),
+    ``_github_request`` must short-circuit with a structured 429 dict — not
+    raise and not perform the HTTP call.
 
-    result = await gh._github_request("GET", "/repos/owner/repo")
+    Since #6311 the acquire decision comes from the module-level
+    ``_shared_rate_limiter`` (Redis-backed), not the per-instance in-memory
+    limiter; patch that path to simulate exhaustion.
+    """
+    gh = GitHubIntegration(_make_config())
+
+    with patch.object(
+        _gh_mod._shared_rate_limiter,
+        "acquire",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await gh._github_request("GET", "/repos/owner/repo")
+
     assert result["status_code"] == 429
-    assert result["error"] == "rate_limit_timeout"
+    assert result["error"] == "rate_limit_exceeded"
 
 
 # ---------------------------------------------------------------------------
@@ -210,17 +220,22 @@ async def test_acquire_timeout_returns_structured_error():
 
 @pytest.mark.asyncio
 async def test_github_request_connection_error():
+    """A transport-level connection failure returns a structured error dict.
+
+    The response body deliberately reports a generic ``integration_error``
+    message (never the raw exception text) to avoid leaking internal details;
+    the machine-readable ``error`` field carries the ``connection_error`` code.
+    """
     gh = GitHubIntegration(_make_config())
-    with patch.object(gh._rate_limiter, "acquire", new=AsyncMock()):
-        with patch(
-            "aiohttp.ClientSession",
-            side_effect=aiohttp.ClientConnectionError("refused"),
-        ):
-            result = await gh._github_request("GET", "/repos/owner/repo")
+    with patch(
+        "aiohttp.ClientSession",
+        side_effect=aiohttp.ClientConnectionError("refused"),
+    ):
+        result = await gh._github_request("GET", "/repos/owner/repo")
 
     assert result["status_code"] == 0
     assert result["error"] == "connection_error"
-    assert "refused" in result["body"]["message"]
+    assert result["body"]["message"] == "integration_error"
 
 
 # ---------------------------------------------------------------------------
@@ -278,26 +293,33 @@ async def test_execute_action_unknown_returns_error_dict():
 
 
 # ---------------------------------------------------------------------------
-# Rate limiting: quota records after each request
+# Rate limiting: request dispatch delegates recording to the shared limiter
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_rate_limit_records_after_successful_request():
+    """Since #6311 the request slot is acquired+recorded atomically by the
+    shared Redis-backed limiter (``_shared_rate_limiter.acquire``), not the
+    per-instance in-memory limiter's local history.  Assert the successful
+    request delegated acquisition to the shared limiter with the token key.
+    """
     gh = GitHubIntegration(_make_config())
-    # Give fresh limiter so history is clean
-    fresh_limiter = IntegrationRateLimiter(requests_per_minute=100, requests_per_hour=5000)
-    gh._rate_limiter = fresh_limiter
 
     body = {"login": "u", "type": "User"}
-    with patch(
-        "aiohttp.ClientSession",
-        return_value=_build_response_mock(200, body),
-    ):
-        await gh._github_request("GET", "/user")
+    with patch.object(
+        _gh_mod._shared_rate_limiter,
+        "acquire",
+        new=AsyncMock(return_value=True),
+    ) as mock_acquire:
+        with patch(
+            "aiohttp.ClientSession",
+            return_value=_build_response_mock(200, body),
+        ):
+            await gh._github_request("GET", "/user")
 
-    state = fresh_limiter._get_state(gh._token_key)
-    assert len(state.history) == 1
+    mock_acquire.assert_awaited_once()
+    assert mock_acquire.await_args.args[0] == gh._token_key
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #12547

## Thinking Path
Issue #12547 framed 3 failing GitHub integration tests as a Redis-less-environment problem needing a skip guard. Investigation disproved that premise: all 3 fail **identically against a live, flushed Redis** (`redis-cli ping` → `PONG`; monkeypatched the shared limiter's `get_async_redis_client` to a real `redis.asyncio` client). The real cause is commit `054251b7e` (#6311), which rewired `_github_request` to the module-level `_shared_rate_limiter` and left the in-memory `IntegrationRateLimiter` only for `apply_response_headers()`. The 3 tests were never updated and had been broken independent of Redis ever since. A skip guard would have false-greened them locally while leaving them red in CI — the opposite of the goal.

## What Changed
`autobot-backend/integrations/github_integration_test.py` — updated 3 stale tests to the post-#6311 shared-limiter contract (no skip guard; no production code change):
1. `test_acquire_timeout_returns_structured_error` → `test_rate_limit_exceeded_returns_structured_error`: patches `_shared_rate_limiter.acquire` → `False`; asserts `429` / `error == "rate_limit_exceeded"` (the old `rate_limit_timeout` path no longer exists).
2. `test_github_request_connection_error`: dropped the invalid `"refused" in body["message"]` check; asserts `status_code == 0`, `error == "connection_error"`, `body["message"] == "integration_error"`. **Secure default kept — no code change** (generic message avoids leaking raw exception text).
3. `test_rate_limit_records_after_successful_request`: reworked to assert dispatch delegates recording to `_shared_rate_limiter.acquire` with the token key (recording now lives in the shared Redis limiter, not the local deque).

## Verification
- 3 named tests (live, flushed Redis): `3 passed in 0.17s`
- Full file: `13 passed in 0.32s` (no collateral breakage)
- `black --check` unchanged; `flake8` 0

## Model Used
claude-sonnet (testing-engineer agent)
