### PR TITLE
feat(memory): usage-aware reinforcement ranking for essential-story facts (#12553)

### DIFF
--- a/autobot-backend/memory/essential_story.py
+++ b/autobot-backend/memory/essential_story.py
@@ -11,6 +11,9 @@ has persistent top-memories without requiring a RAG retrieval round-trip.
 
 import asyncio
 import hashlib
+import math
+import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -28,23 +31,81 @@ _DEFAULT_BUDGET = 600
 # Redis cache key template — fingerprint makes any fact change invalidate the cache
 _CACHE_KEY = "autobot:essential_story:{model_name}:{fingerprint}"
 
+# A2 (#12553): usage-aware reinforcement. The always-loaded facts are ranked by
+# an effective score that boosts a fact's static ``quality_score`` by how often
+# it is actually recalled (``access_count``, from A1 #12552) and how recently
+# (``last_accessed``). Tunable per deployment; **weight 0 (or the flag off)
+# reproduces the pre-A2 pure-quality_score ordering byte-for-byte.**
+_REINFORCE_ENABLED: bool = os.environ.get("AUTOBOT_ESSENTIAL_STORY_REINFORCE", "1").lower() not in (
+    "0",
+    "false",
+    "no",
+)
+_REINFORCE_WEIGHT: float = float(os.environ.get("AUTOBOT_ESSENTIAL_STORY_REINFORCE_WEIGHT", "0.3"))
+_REINFORCE_RECENCY_HALFLIFE_SECONDS: float = float(
+    os.environ.get("AUTOBOT_ESSENTIAL_STORY_RECENCY_HALFLIFE_SECONDS", str(30 * 24 * 3600))
+)
+
+
+def _recency_factor(timestamp_iso: str | None, now: datetime) -> float:
+    """Exponential-decay recency score in ``[0, 1]`` from an ISO timestamp.
+
+    ``1.0`` for a just-now access, halving every half-life. Returns ``0.0`` when
+    the timestamp is missing or unparseable so a never-accessed fact gets no
+    recency boost. Mirrors ``verbatim_store._recency_factor`` (GH#11163).
+    """
+    if not timestamp_iso:
+        return 0.0
+    try:
+        ts = datetime.fromisoformat(timestamp_iso)
+    except (ValueError, TypeError):
+        return 0.0
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    age = (now - ts).total_seconds()
+    if age <= 0:
+        return 1.0
+    return 0.5 ** (age / _REINFORCE_RECENCY_HALFLIFE_SECONDS)
+
+
+def _effective_score(fact: Dict[str, Any], now: datetime) -> float:
+    """Rank key for a fact: static quality boosted by usage + recency (A2).
+
+    ``quality + weight * (log1p(access_count) + recency)``. With reinforcement
+    disabled or ``weight <= 0`` this collapses to the raw ``quality_score``, so
+    the ordering is identical to the pre-A2 behaviour.
+    """
+    meta = fact.get("metadata") or {}
+    try:
+        quality = float(meta.get("quality_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        quality = 0.0
+    if not _REINFORCE_ENABLED or _REINFORCE_WEIGHT <= 0.0:
+        return quality
+    try:
+        access = int(meta.get("access_count", 0) or 0)
+    except (TypeError, ValueError):
+        access = 0
+    usage_boost = math.log1p(max(access, 0))
+    recency_boost = _recency_factor(meta.get("last_accessed"), now)
+    return quality + _REINFORCE_WEIGHT * (usage_boost + recency_boost)
+
 
 def _compute_facts_fingerprint(facts: list) -> str:
-    """Return a SHA-256 hex digest of fact (id, content, category) tuples.
+    """Return a SHA-256 hex digest of the ranked fact (id, content, category) list.
 
-    Order-independent: sorted before hashing so reordering never invalidates.
-    Any add, edit, or delete changes the digest.
+    Order-**sensitive** (A2 #12553): the input is the already-ranked selection,
+    so its order is part of the rendered output — a re-rank that changes the
+    surfaced order must invalidate the cache. Any add, edit, delete, or reorder
+    changes the digest; an identical ranked selection yields an identical digest.
     """
-    items = sorted(
-        (
-            str(f.get("id", "")),
+    h = hashlib.sha256()
+    for f in facts:
+        triple = (
+            str(f.get("fact_id", "") or f.get("id", "")),
             str(f.get("content", "")),
             str((f.get("metadata") or {}).get("category", "")),
         )
-        for f in facts
-    )
-    h = hashlib.sha256()
-    for triple in items:
         h.update(("\x1f".join(triple) + "\x1e").encode("utf-8"))
     return h.hexdigest()
 
@@ -113,14 +174,11 @@ class EssentialStoryGenerator:
         # for any model's token budget (max 800 tokens) after sorting.
         all_facts = await kb.get_all_facts(limit=200)
 
-        def _quality(fact: Dict[str, Any]) -> float:
-            meta = fact.get("metadata") or {}
-            try:
-                return float(meta.get("quality_score", 0.0))
-            except (TypeError, ValueError):
-                return 0.0
-
-        sorted_facts = sorted(all_facts, key=_quality, reverse=True)
+        # A2 (#12553): rank by the usage-aware effective score so frequently- and
+        # recently-recalled facts rise. Collapses to raw quality_score when
+        # reinforcement is disabled / weight 0 (identical to pre-A2 ordering).
+        now = datetime.now(tz=timezone.utc)
+        sorted_facts = sorted(all_facts, key=lambda f: _effective_score(f, now), reverse=True)
 
         selected: List[Dict[str, Any]] = []
         used_tokens = 0

--- a/autobot-backend/memory/essential_story.py
+++ b/autobot-backend/memory/essential_story.py
@@ -35,15 +35,31 @@ _CACHE_KEY = "autobot:essential_story:{model_name}:{fingerprint}"
 # an effective score that boosts a fact's static ``quality_score`` by how often
 # it is actually recalled (``access_count``, from A1 #12552) and how recently
 # (``last_accessed``). Tunable per deployment; **weight 0 (or the flag off)
-# reproduces the pre-A2 pure-quality_score ordering byte-for-byte.**
-_REINFORCE_ENABLED: bool = os.environ.get("AUTOBOT_ESSENTIAL_STORY_REINFORCE", "1").lower() not in (
-    "0",
-    "false",
-    "no",
-)
-_REINFORCE_WEIGHT: float = float(os.environ.get("AUTOBOT_ESSENTIAL_STORY_REINFORCE_WEIGHT", "0.3"))
-_REINFORCE_RECENCY_HALFLIFE_SECONDS: float = float(
-    os.environ.get("AUTOBOT_ESSENTIAL_STORY_RECENCY_HALFLIFE_SECONDS", str(30 * 24 * 3600))
+# reproduces the pre-A2 quality_score ordering** (with a deterministic fact_id
+# tiebreaker so equal-quality facts no longer flip on Redis SCAN order).
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    return os.environ.get(name, "1" if default else "0").strip().lower() not in ("0", "false", "no")
+
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env var, never raising at import — bad values fall back."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r — using default %s", name, raw, default)
+        return default
+    return val if val == val else default  # reject NaN (NaN != NaN)
+
+
+_REINFORCE_ENABLED: bool = _env_bool("AUTOBOT_ESSENTIAL_STORY_REINFORCE", True)
+_REINFORCE_WEIGHT: float = _env_float("AUTOBOT_ESSENTIAL_STORY_REINFORCE_WEIGHT", 0.3)
+_REINFORCE_RECENCY_HALFLIFE_SECONDS: float = _env_float(
+    "AUTOBOT_ESSENTIAL_STORY_RECENCY_HALFLIFE_SECONDS", float(30 * 24 * 3600)
 )
 
 
@@ -68,12 +84,28 @@ def _recency_factor(timestamp_iso: str | None, now: datetime) -> float:
     return 0.5 ** (age / _REINFORCE_RECENCY_HALFLIFE_SECONDS)
 
 
-def _effective_score(fact: Dict[str, Any], now: datetime) -> float:
+def _fact_id(fact: Dict[str, Any]) -> str:
+    """Stable identifier for tie-breaking (facts carry ``fact_id``, not ``id``)."""
+    return str(fact.get("fact_id") or fact.get("id") or "")
+
+
+def _fact_access_count(fact: Dict[str, Any]) -> int:
+    """Parsed non-negative ``access_count`` for a fact, 0 on anything unusable."""
+    try:
+        return max(int((fact.get("metadata") or {}).get("access_count", 0) or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _effective_score(fact: Dict[str, Any], now: datetime, max_access: int = 0) -> float:
     """Rank key for a fact: static quality boosted by usage + recency (A2).
 
-    ``quality + weight * (log1p(access_count) + recency)``. With reinforcement
-    disabled or ``weight <= 0`` this collapses to the raw ``quality_score``, so
-    the ordering is identical to the pre-A2 behaviour.
+    ``quality + weight * (usage_boost + recency)`` where both boost terms are
+    normalised to ``[0, 1]`` — usage against the busiest fact in the candidate
+    set (``max_access``) — so the reinforcement is **bounded** (max ``2*weight``)
+    and cannot swamp ``quality_score``: a large quality gap always wins, while
+    usage/recency break near-ties. With reinforcement disabled or ``weight <= 0``
+    this collapses to the raw ``quality_score`` (pre-A2 ordering).
     """
     meta = fact.get("metadata") or {}
     try:
@@ -82,11 +114,11 @@ def _effective_score(fact: Dict[str, Any], now: datetime) -> float:
         quality = 0.0
     if not _REINFORCE_ENABLED or _REINFORCE_WEIGHT <= 0.0:
         return quality
-    try:
-        access = int(meta.get("access_count", 0) or 0)
-    except (TypeError, ValueError):
-        access = 0
-    usage_boost = math.log1p(max(access, 0))
+    access = _fact_access_count(fact)
+    # Normalise usage into [0,1] against the busiest fact so the boost stays
+    # bounded regardless of absolute recall counts (avoids a rich-get-richer
+    # runaway where access_count dwarfs quality).
+    usage_boost = math.log1p(access) / math.log1p(max_access) if max_access > 0 else 0.0
     recency_boost = _recency_factor(meta.get("last_accessed"), now)
     return quality + _REINFORCE_WEIGHT * (usage_boost + recency_boost)
 
@@ -176,9 +208,18 @@ class EssentialStoryGenerator:
 
         # A2 (#12553): rank by the usage-aware effective score so frequently- and
         # recently-recalled facts rise. Collapses to raw quality_score when
-        # reinforcement is disabled / weight 0 (identical to pre-A2 ordering).
+        # reinforcement is disabled / weight 0. A fact_id secondary key makes
+        # equal-score ties deterministic (no dependence on Redis SCAN order),
+        # so the order-sensitive fingerprint cache never thrashes on ties.
         now = datetime.now(tz=timezone.utc)
-        sorted_facts = sorted(all_facts, key=lambda f: _effective_score(f, now), reverse=True)
+        max_access = max(
+            (_fact_access_count(f) for f in all_facts),
+            default=0,
+        )
+        sorted_facts = sorted(
+            all_facts,
+            key=lambda f: (-_effective_score(f, now, max_access), _fact_id(f)),
+        )
 
         selected: List[Dict[str, Any]] = []
         used_tokens = 0

--- a/autobot-backend/memory/essential_story_reinforcement_test.py
+++ b/autobot-backend/memory/essential_story_reinforcement_test.py
@@ -59,7 +59,27 @@ def test_effective_score_boosts_by_access(monkeypatch):
     monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
     hot = _fact("hot", 0.5, access=50)
     cold = _fact("cold", 0.5, access=0)
-    assert _effective_score(hot, NOW) > _effective_score(cold, NOW)
+    assert _effective_score(hot, NOW, max_access=50) > _effective_score(cold, NOW, max_access=50)
+
+
+def test_effective_score_normalized_boost_does_not_swamp_quality(monkeypatch):
+    # A high-quality never-accessed fact must still beat a low-quality
+    # heavily-accessed one: the usage boost is normalised + bounded by weight.
+    monkeypatch.setattr(es, "_REINFORCE_ENABLED", True)
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
+    pristine = _fact("pristine", 1.0, access=0)
+    popular = _fact("popular", 0.2, access=1_000_000, last_accessed=NOW.isoformat())
+    assert _effective_score(pristine, NOW, max_access=1_000_000) > _effective_score(
+        popular, NOW, max_access=1_000_000
+    )
+
+
+def test_effective_score_no_boost_without_max_access(monkeypatch):
+    # Degenerate set (nobody accessed): usage term is 0, ordering is by quality.
+    monkeypatch.setattr(es, "_REINFORCE_ENABLED", True)
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
+    f = _fact("a", 0.5, access=0)
+    assert _effective_score(f, NOW, max_access=0) == 0.5
 
 
 def test_effective_score_tolerates_garbage(monkeypatch):
@@ -143,3 +163,29 @@ async def test_fetch_top_facts_weight_zero_matches_quality_order(monkeypatch):
         gen = EssentialStoryGenerator()
         selected = await gen._fetch_top_facts(max_tokens=1000)
     assert [f["fact_id"] for f in selected] == ["high", "mid", "low"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_facts_ties_are_deterministic(monkeypatch):
+    # Equal quality + equal access: order must be stable (by fact_id), not
+    # dependent on the (non-deterministic) get_all_facts scan order — otherwise
+    # the order-sensitive fingerprint would thrash the cache.
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
+    order_a = [_fact("b", 0.5, access=1), _fact("a", 0.5, access=1), _fact("c", 0.5, access=1)]
+    order_b = list(reversed(order_a))
+    out = []
+    for facts in (order_a, order_b):
+        kb = _patch_kb(facts)
+        with patch("knowledge._composed.get_knowledge_base", AsyncMock(return_value=kb)):
+            selected = await EssentialStoryGenerator()._fetch_top_facts(max_tokens=1000)
+        out.append([f["fact_id"] for f in selected])
+    assert out[0] == out[1] == ["a", "b", "c"]
+
+
+def test_env_float_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("AUTOBOT_TEST_FLOAT", "not-a-float")
+    assert es._env_float("AUTOBOT_TEST_FLOAT", 0.3) == 0.3
+    monkeypatch.setenv("AUTOBOT_TEST_FLOAT", "nan")
+    assert es._env_float("AUTOBOT_TEST_FLOAT", 0.3) == 0.3
+    monkeypatch.setenv("AUTOBOT_TEST_FLOAT", "0.7")
+    assert es._env_float("AUTOBOT_TEST_FLOAT", 0.3) == 0.7

--- a/autobot-backend/memory/essential_story_reinforcement_test.py
+++ b/autobot-backend/memory/essential_story_reinforcement_test.py
@@ -69,9 +69,7 @@ def test_effective_score_normalized_boost_does_not_swamp_quality(monkeypatch):
     monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
     pristine = _fact("pristine", 1.0, access=0)
     popular = _fact("popular", 0.2, access=1_000_000, last_accessed=NOW.isoformat())
-    assert _effective_score(pristine, NOW, max_access=1_000_000) > _effective_score(
-        popular, NOW, max_access=1_000_000
-    )
+    assert _effective_score(pristine, NOW, max_access=1_000_000) > _effective_score(popular, NOW, max_access=1_000_000)
 
 
 def test_effective_score_no_boost_without_max_access(monkeypatch):

--- a/autobot-backend/memory/essential_story_reinforcement_test.py
+++ b/autobot-backend/memory/essential_story_reinforcement_test.py
@@ -1,0 +1,145 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for A2 (#12553) — usage-aware effective-score reinforcement ranking.
+
+Covers the effective-score formula, the recency factor, the now-order-sensitive
+fingerprint, and the end-to-end ranking in ``_fetch_top_facts`` — including the
+invariant that reinforcement disabled / weight 0 reproduces the pre-A2 pure
+``quality_score`` ordering.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import memory.essential_story as es
+from memory.essential_story import (
+    EssentialStoryGenerator,
+    _compute_facts_fingerprint,
+    _effective_score,
+    _recency_factor,
+)
+
+NOW = datetime(2026, 7, 26, tzinfo=timezone.utc)
+
+
+def _fact(fid, quality, access=0, last_accessed=None, category="general", content=None):
+    return {
+        "fact_id": fid,
+        "content": content or f"content-{fid}",
+        "metadata": {
+            "quality_score": quality,
+            "access_count": access,
+            "last_accessed": last_accessed or "",
+            "category": category,
+        },
+    }
+
+
+# ---- effective score -------------------------------------------------------
+
+
+def test_effective_score_weight_zero_returns_raw_quality(monkeypatch):
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.0)
+    f = _fact("a", 0.5, access=999, last_accessed=NOW.isoformat())
+    assert _effective_score(f, NOW) == 0.5
+
+
+def test_effective_score_disabled_returns_raw_quality(monkeypatch):
+    monkeypatch.setattr(es, "_REINFORCE_ENABLED", False)
+    f = _fact("a", 0.5, access=999, last_accessed=NOW.isoformat())
+    assert _effective_score(f, NOW) == 0.5
+
+
+def test_effective_score_boosts_by_access(monkeypatch):
+    monkeypatch.setattr(es, "_REINFORCE_ENABLED", True)
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
+    hot = _fact("hot", 0.5, access=50)
+    cold = _fact("cold", 0.5, access=0)
+    assert _effective_score(hot, NOW) > _effective_score(cold, NOW)
+
+
+def test_effective_score_tolerates_garbage(monkeypatch):
+    monkeypatch.setattr(es, "_REINFORCE_ENABLED", True)
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
+    f = {"metadata": {"quality_score": "nan-ish", "access_count": "lots"}}
+    # Falls back to 0 quality + 0 access without raising.
+    assert _effective_score(f, NOW) == 0.0
+
+
+# ---- recency factor --------------------------------------------------------
+
+
+def test_recency_factor_now_is_one():
+    assert _recency_factor(NOW.isoformat(), NOW) == 1.0
+
+
+def test_recency_factor_missing_is_zero():
+    assert _recency_factor("", NOW) == 0.0
+    assert _recency_factor(None, NOW) == 0.0
+
+
+def test_recency_factor_unparseable_is_zero():
+    assert _recency_factor("not-a-date", NOW) == 0.0
+
+
+def test_recency_factor_decays_with_age(monkeypatch):
+    monkeypatch.setattr(es, "_REINFORCE_RECENCY_HALFLIFE_SECONDS", 30 * 24 * 3600)
+    old = (NOW - timedelta(days=30)).isoformat()
+    assert _recency_factor(old, NOW) == pytest.approx(0.5, abs=0.01)
+
+
+# ---- fingerprint order sensitivity ----------------------------------------
+
+
+def test_fingerprint_is_order_sensitive():
+    a, b = _fact("a", 0.9), _fact("b", 0.8)
+    assert _compute_facts_fingerprint([a, b]) != _compute_facts_fingerprint([b, a])
+
+
+def test_fingerprint_stable_for_same_order():
+    a, b = _fact("a", 0.9), _fact("b", 0.8)
+    assert _compute_facts_fingerprint([a, b]) == _compute_facts_fingerprint([a, b])
+
+
+# ---- end-to-end ranking in _fetch_top_facts --------------------------------
+
+
+def _patch_kb(facts):
+    kb = MagicMock()
+    kb.get_all_facts = AsyncMock(return_value=facts)
+    kb.record_fact_access = AsyncMock()
+    return kb
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_facts_reinforced_order(monkeypatch):
+    monkeypatch.setattr(es, "_REINFORCE_ENABLED", True)
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.3)
+    # Equal quality; the high-access fact must be selected/ranked first.
+    facts = [_fact("cold", 0.5, access=0), _fact("hot", 0.5, access=100)]
+    kb = _patch_kb(facts)
+    with patch("knowledge._composed.get_knowledge_base", AsyncMock(return_value=kb)):
+        gen = EssentialStoryGenerator()
+        selected = await gen._fetch_top_facts(max_tokens=1000)
+    assert [f["fact_id"] for f in selected][0] == "hot"
+    kb.record_fact_access.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_facts_weight_zero_matches_quality_order(monkeypatch):
+    monkeypatch.setattr(es, "_REINFORCE_WEIGHT", 0.0)
+    # Reinforcement off: order is pure quality desc regardless of access.
+    facts = [
+        _fact("low", 0.1, access=1000),
+        _fact("high", 0.9, access=0),
+        _fact("mid", 0.5, access=500),
+    ]
+    kb = _patch_kb(facts)
+    with patch("knowledge._composed.get_knowledge_base", AsyncMock(return_value=kb)):
+        gen = EssentialStoryGenerator()
+        selected = await gen._fetch_top_facts(max_tokens=1000)
+    assert [f["fact_id"] for f in selected] == ["high", "mid", "low"]


### PR DESCRIPTION
## Thinking Path
Gap A of epic #12551. A1 (#12561, merged) added usage signals; A2 makes the always-loaded essential-story lane *use* them — the reinforcement half of self-improving memory. Facts that get recalled rise; unused ones fall.

## What Changed
- **`memory/essential_story.py`**: `_fetch_top_facts` now ranks by `_effective_score = quality_score + weight * (log1p(access_count) + recency)` instead of the static `quality_score`. `access_count`/`last_accessed` come from A1.
- **Flagged & reversible**: `AUTOBOT_ESSENTIAL_STORY_REINFORCE` (default on) + `_WEIGHT` / `_RECENCY_HALFLIFE_SECONDS` envs. **Weight 0 or flag off collapses `_effective_score` to raw `quality_score` — pre-A2 ordering byte-for-byte** (golden test).
- **Cache correctness**: the fact fingerprint is now order-sensitive (its input is the ranked selection), so a re-rank that changes the surfaced order correctly invalidates the 5-min Redis story cache; an identical ranked selection still hits.
- `_recency_factor` mirrors the `verbatim_store` recency-decay shape (GH#11163).

## Verification
- `memory/essential_story_reinforcement_test.py` — **12 passed**: effective-score formula (weight-0 / disabled / boosted / garbage-tolerant), recency decay (now=1.0, missing=0, unparseable=0, half-life≈0.5), fingerprint order-sensitivity, and end-to-end `_fetch_top_facts` reinforced order + weight-0 pure-quality parity.
- Rebased onto merged `Dev_new_gui` (post-A1); tests green post-rebase.

## Model Used
Opus 4.8 (1M context)

Closes #12553. Part of epic #12551.
