### PR TITLE
feat(memory): guarded nightly consolidate_facts decay/prune (#12554)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -244,6 +244,12 @@ celery_app.conf.beat_schedule = {
         "task": "memory.consolidate_trajectories",
         "schedule": crontab(hour=4, minute=0),  # 04:00 UTC, after nightly cleanup
     },
+    # A3 (#12554): nightly fact-lane decay/prune (delete-only, guarded, dry-run
+    # by default) so the always-loaded essential-story facts self-improve.
+    "memory-consolidate-facts-daily": {
+        "task": "memory.consolidate_facts",
+        "schedule": crontab(hour=4, minute=20),  # 04:20 UTC, after trajectory pass
+    },
     # GH#6471: nightly eviction of stale per-task git worktree workspaces
     "workspace-cleanup-nightly": {
         "task": "tasks.cleanup_stale_workspaces",

--- a/autobot-backend/celery_priority.py
+++ b/autobot-backend/celery_priority.py
@@ -31,6 +31,7 @@ PRIORITY_TASK_ROUTES = {
     "workers.audit_claims": {"priority": PRIORITY_CRITICAL},
     # Normal — memory consolidation (#11263 attaches its beat entry).
     "memory.consolidate_trajectories": {"priority": PRIORITY_NORMAL},
+    "memory.consolidate_facts": {"priority": PRIORITY_NORMAL},  # A3 (#12554)
     # Low — nightly cleanup / retention yields to everything else.
     "tasks.cleanup_orphan_documents": {"priority": PRIORITY_LOW},
     "tasks.cleanup_generated_files": {"priority": PRIORITY_LOW},

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -12,8 +12,9 @@ store, retrieve, update, delete, and vectorization.
 import asyncio
 import hashlib
 import json
+import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
@@ -260,6 +261,39 @@ _ACCESS_BUMP_LUA = (
     "redis.call('HSET', KEYS[1], 'last_accessed', ARGV[1]) "
     "return 1 end return 0"
 )
+
+# A3 (#12554): fact-lane consolidation thresholds. A fact is prunable only if it
+# is genuinely dead: low quality AND never recalled (access_count == 0, A1) AND
+# aged past the floor AND unprotected. Conservative defaults honour the
+# no-data-loss invariant; tune per deployment via env.
+_FACTS_PRUNE_QUALITY_FLOOR: float = float(os.environ.get("AUTOBOT_FACTS_PRUNE_QUALITY_FLOOR", "0.1"))
+_FACTS_PRUNE_MAX_AGE_DAYS: int = int(os.environ.get("AUTOBOT_FACTS_PRUNE_MAX_AGE_DAYS", "180"))
+_FACTS_PRUNE_SCAN_LIMIT: int = int(os.environ.get("AUTOBOT_FACTS_PRUNE_SCAN_LIMIT", "5000"))
+
+
+def _fact_is_protected(metadata: Dict[str, Any]) -> bool:
+    """A fact that must never be auto-pruned (A3 #12554, no-data-loss invariant).
+
+    Protected when owned (``owner_id``/``user_id``), human-verified, or explicitly
+    kept (``important`` / ``preserve`` / ``pinned``) — mirrors the ``preserve_important``
+    predicate used by session cleanup.
+    """
+    if metadata.get("important") or metadata.get("preserve") or metadata.get("pinned"):
+        return True
+    if metadata.get("owner_id") or metadata.get("user_id"):
+        return True
+    return metadata.get("verification_status") == "verified"
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Parse an ISO timestamp to an aware UTC datetime, or ``None`` if unusable."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        ts = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+    return ts.replace(tzinfo=timezone.utc) if ts.tzinfo is None else ts
 
 
 def _apply_usage_fields(decoded: Dict[str, Any], metadata: Dict[str, Any]) -> None:
@@ -1400,6 +1434,89 @@ class FactsMixin:
             await self._delete_single_fact_for_session(fact_id, session_id, important_ids, preserve_important, result)
 
         await self._cleanup_session_tracking(session_id, fact_ids)
+
+    def _collect_prune_candidates(
+        self, facts: List[Dict[str, Any]], quality_floor: float, cutoff: datetime
+    ) -> List[str]:
+        """Return fact_ids that are genuinely dead and safe to prune (A3 #12554).
+
+        A candidate must satisfy ALL of: unprotected, ``quality_score`` below the
+        floor, ``access_count == 0`` (never recalled), and a known creation time
+        older than ``cutoff``. Unknown-age or newer facts are kept (fail-safe).
+        """
+        candidates: List[str] = []
+        for fact in facts:
+            meta = fact.get("metadata") or {}
+            if _fact_is_protected(meta):
+                continue
+            try:
+                quality = float(meta.get("quality_score", 0.0) or 0.0)
+                access = int(meta.get("access_count", 0) or 0)
+            except (TypeError, ValueError):
+                continue  # unparseable usage -> keep (fail-safe)
+            if access != 0 or quality >= quality_floor:
+                continue
+            created = _parse_iso(fact.get("timestamp") or meta.get("timestamp"))
+            if created is None or created > cutoff:
+                continue
+            fid = fact.get("fact_id")
+            if fid:
+                candidates.append(fid)
+        return candidates
+
+    async def consolidate_facts(
+        self,
+        *,
+        quality_floor: float = _FACTS_PRUNE_QUALITY_FLOOR,
+        max_age_days: int = _FACTS_PRUNE_MAX_AGE_DAYS,
+        dry_run: bool = True,
+        now: datetime | None = None,
+    ) -> Dict[str, Any]:
+        """Delete-only consolidation of the essential-story facts lane (A3 #12554).
+
+        Prunes only genuinely-dead facts (see ``_collect_prune_candidates``).
+        ``dry_run`` (default True) logs candidates without deleting so the impact
+        can be reviewed before enforcing. Owned/verified/pinned facts are never
+        eligible — the no-data-loss invariant. Never raises: a scan failure
+        returns an empty summary.
+        """
+        self.ensure_initialized()
+        now = now or datetime.now(tz=timezone.utc)
+        cutoff = now - timedelta(days=max_age_days)
+        try:
+            facts = await self.get_all_facts(limit=_FACTS_PRUNE_SCAN_LIMIT)
+        except Exception as exc:
+            logger.warning("consolidate_facts: scan failed (non-fatal): %s", exc)
+            return {"scanned": 0, "candidates": 0, "pruned": 0, "remaining": 0, "dry_run": dry_run}
+
+        candidates = self._collect_prune_candidates(facts, quality_floor, cutoff)
+        pruned = 0
+        if not dry_run:
+            for fid in candidates:
+                try:
+                    res = await self.delete_fact(fid, _skip_bm25_refresh=True)
+                    if res.get("status") == "success":
+                        pruned += 1
+                except Exception:
+                    logger.debug("consolidate_facts: delete failed for %s (non-fatal)", fid)
+            if pruned:
+                self._schedule_bm25_refresh()
+
+        summary = {
+            "scanned": len(facts),
+            "candidates": len(candidates),
+            "pruned": pruned,
+            "remaining": len(facts) - pruned,
+            "dry_run": dry_run,
+        }
+        logger.info(
+            "consolidate_facts: scanned=%d candidates=%d pruned=%d dry_run=%s",
+            len(facts),
+            len(candidates),
+            pruned,
+            dry_run,
+        )
+        return summary
 
     async def delete_facts_by_session(self, session_id: str, preserve_important: bool = True) -> Dict[str, Any]:
         """Delete all facts created during a specific session. Issue #620.

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -262,25 +262,62 @@ _ACCESS_BUMP_LUA = (
     "return 1 end return 0"
 )
 
-# A3 (#12554): fact-lane consolidation thresholds. A fact is prunable only if it
-# is genuinely dead: low quality AND never recalled (access_count == 0, A1) AND
-# aged past the floor AND unprotected. Conservative defaults honour the
-# no-data-loss invariant; tune per deployment via env.
-_FACTS_PRUNE_QUALITY_FLOOR: float = float(os.environ.get("AUTOBOT_FACTS_PRUNE_QUALITY_FLOOR", "0.1"))
-_FACTS_PRUNE_MAX_AGE_DAYS: int = int(os.environ.get("AUTOBOT_FACTS_PRUNE_MAX_AGE_DAYS", "180"))
-_FACTS_PRUNE_SCAN_LIMIT: int = int(os.environ.get("AUTOBOT_FACTS_PRUNE_SCAN_LIMIT", "5000"))
+def _env_int(name: str, default: int) -> int:
+    """Parse an int env var, never raising at import — bad values fall back."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r — using default %s", name, raw, default)
+        return default
+
+
+def _env_float_safe(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r — using default %s", name, raw, default)
+        return default
+    return val if val == val else default  # reject NaN
+
+
+# A3 (#12554): fact-lane consolidation thresholds. Conservative by design — see
+# consolidate_facts for the full no-data-loss reasoning. A fact is prunable only
+# if it is UNPROTECTED, low-quality, never recalled since instrumentation began
+# (access_count == 0, A1 #12552), created AFTER the instrumentation epoch (so a
+# 0 count is meaningful, not "predates A1"), and aged past the floor.
+_FACTS_PRUNE_QUALITY_FLOOR: float = _env_float_safe("AUTOBOT_FACTS_PRUNE_QUALITY_FLOOR", 0.1)
+_FACTS_PRUNE_MAX_AGE_DAYS: int = _env_int("AUTOBOT_FACTS_PRUNE_MAX_AGE_DAYS", 180)
+_FACTS_PRUNE_SCAN_LIMIT: int = _env_int("AUTOBOT_FACTS_PRUNE_SCAN_LIMIT", 5000)
+# Instrumentation epoch: ISO date A1 access-tracking began for THIS deployment.
+# Facts created before it have unknown recall history → never pruned. UNSET =
+# feature inert (no candidates) so an un-configured deploy can never mass-delete.
+_FACTS_PRUNE_EPOCH: str = os.environ.get("AUTOBOT_FACTS_PRUNE_EPOCH", "").strip()
+# Circuit breaker: if a single run would prune more than this many facts, refuse
+# and log loudly — a healthy decay pass sheds a trickle, not thousands.
+_FACTS_PRUNE_MAX_PER_RUN: int = _env_int("AUTOBOT_FACTS_PRUNE_MAX_PER_RUN", 100)
 
 
 def _fact_is_protected(metadata: Dict[str, Any]) -> bool:
     """A fact that must never be auto-pruned (A3 #12554, no-data-loss invariant).
 
-    Protected when owned (``owner_id``/``user_id``), human-verified, or explicitly
-    kept (``important`` / ``preserve`` / ``pinned``) — mirrors the ``preserve_important``
-    predicate used by session cleanup.
+    Protected when owned (``owner_id``/``user_id``), human-verified, explicitly
+    kept (``important``/``preserve``/``pinned``), or **curated/ingested** rather
+    than ephemeral conversational cruft: a ``unique_key`` (e.g. man-page facts)
+    or a ``source_connector_id`` (Confluence/Notion/web-crawl/... ingestion) marks
+    knowledge a user deliberately brought in, which a low access_count must not
+    condemn. Superset of the session-cleanup ``preserve_important`` predicate.
     """
     if metadata.get("important") or metadata.get("preserve") or metadata.get("pinned"):
         return True
     if metadata.get("owner_id") or metadata.get("user_id"):
+        return True
+    if metadata.get("unique_key") or metadata.get("source_connector_id"):
         return True
     return metadata.get("verification_status") == "verified"
 
@@ -1436,13 +1473,15 @@ class FactsMixin:
         await self._cleanup_session_tracking(session_id, fact_ids)
 
     def _collect_prune_candidates(
-        self, facts: List[Dict[str, Any]], quality_floor: float, cutoff: datetime
+        self, facts: List[Dict[str, Any]], quality_floor: float, cutoff: datetime, epoch: datetime
     ) -> List[str]:
         """Return fact_ids that are genuinely dead and safe to prune (A3 #12554).
 
-        A candidate must satisfy ALL of: unprotected, ``quality_score`` below the
-        floor, ``access_count == 0`` (never recalled), and a known creation time
-        older than ``cutoff``. Unknown-age or newer facts are kept (fail-safe).
+        A candidate must satisfy ALL of: unprotected (incl. curated/ingested — see
+        ``_fact_is_protected``); ``quality_score`` below the floor; ``access_count
+        == 0`` (never recalled); creation time **after ``epoch``** so a 0 count
+        reflects real non-use rather than predating A1 instrumentation; and older
+        than ``cutoff``. Unknown-age, pre-epoch, or newer facts are kept (fail-safe).
         """
         candidates: List[str] = []
         for fact in facts:
@@ -1457,7 +1496,9 @@ class FactsMixin:
             if access != 0 or quality >= quality_floor:
                 continue
             created = _parse_iso(fact.get("timestamp") or meta.get("timestamp"))
-            if created is None or created > cutoff:
+            # Keep if age unknown, created before instrumentation (0 count is
+            # meaningless there), or not yet older than the age floor.
+            if created is None or created <= epoch or created > cutoff:
                 continue
             fid = fact.get("fact_id")
             if fid:
@@ -1474,23 +1515,56 @@ class FactsMixin:
     ) -> Dict[str, Any]:
         """Delete-only consolidation of the essential-story facts lane (A3 #12554).
 
-        Prunes only genuinely-dead facts (see ``_collect_prune_candidates``).
-        ``dry_run`` (default True) logs candidates without deleting so the impact
-        can be reviewed before enforcing. Owned/verified/pinned facts are never
-        eligible — the no-data-loss invariant. Never raises: a scan failure
-        returns an empty summary.
+        Prunes only genuinely-dead facts (see ``_collect_prune_candidates``):
+        unprotected, uncurated, low-quality, never recalled since instrumentation
+        began, and aged out. Multiple no-data-loss safeguards, all fail-safe:
+
+        - **Instrumentation epoch** (``AUTOBOT_FACTS_PRUNE_EPOCH``): UNSET → the
+          task is inert (no candidates), so an unconfigured deploy can never
+          delete. Set it to the date A1 access-tracking began for this instance;
+          facts older than that are never eligible.
+        - **Circuit breaker** (``AUTOBOT_FACTS_PRUNE_MAX_PER_RUN``): if a run would
+          prune more than the cap, it refuses and logs loudly — a healthy decay
+          sheds a trickle, a flood means the signals are wrong.
+        - **dry_run** (default True): logs candidates without deleting.
+
+        Owned/verified/pinned/curated facts are never eligible. Never raises.
         """
         self.ensure_initialized()
         now = now or datetime.now(tz=timezone.utc)
         cutoff = now - timedelta(days=max_age_days)
+        epoch = _parse_iso(_FACTS_PRUNE_EPOCH)
+        if epoch is None:
+            logger.info(
+                "consolidate_facts: AUTOBOT_FACTS_PRUNE_EPOCH unset — pruning disabled "
+                "(set it to when A1 access-tracking began to enable decay)."
+            )
+            return {"scanned": 0, "candidates": 0, "pruned": 0, "remaining": 0, "dry_run": dry_run, "epoch_unset": True}
         try:
             facts = await self.get_all_facts(limit=_FACTS_PRUNE_SCAN_LIMIT)
         except Exception as exc:
             logger.warning("consolidate_facts: scan failed (non-fatal): %s", exc)
             return {"scanned": 0, "candidates": 0, "pruned": 0, "remaining": 0, "dry_run": dry_run}
 
-        candidates = self._collect_prune_candidates(facts, quality_floor, cutoff)
+        candidates = self._collect_prune_candidates(facts, quality_floor, cutoff, epoch)
         pruned = 0
+        # Circuit breaker: an unexpectedly large candidate set means the signals
+        # are wrong (mis-set epoch, instrumentation gap). Refuse and shout.
+        if not dry_run and len(candidates) > _FACTS_PRUNE_MAX_PER_RUN:
+            logger.error(
+                "consolidate_facts: %d candidates exceed max-per-run %d — refusing to "
+                "prune (likely misconfigured epoch/floor). Review before enforcing.",
+                len(candidates),
+                _FACTS_PRUNE_MAX_PER_RUN,
+            )
+            return {
+                "scanned": len(facts),
+                "candidates": len(candidates),
+                "pruned": 0,
+                "remaining": len(facts),
+                "dry_run": dry_run,
+                "circuit_broken": True,
+            }
         if not dry_run:
             for fid in candidates:
                 try:

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -262,6 +262,7 @@ _ACCESS_BUMP_LUA = (
     "return 1 end return 0"
 )
 
+
 def _env_int(name: str, default: int) -> int:
     """Parse an int env var, never raising at import — bad values fall back."""
     raw = os.environ.get(name)

--- a/autobot-backend/knowledge/facts_consolidation_test.py
+++ b/autobot-backend/knowledge/facts_consolidation_test.py
@@ -14,11 +14,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import knowledge.facts as facts_mod
 from knowledge.facts import FactsMixin, _fact_is_protected
 
 NOW = datetime(2026, 7, 26, tzinfo=timezone.utc)
 OLD = (NOW - timedelta(days=200)).isoformat()
 RECENT = (NOW - timedelta(days=5)).isoformat()
+# Instrumentation epoch: 1 year ago, so OLD (200d) is post-epoch and eligible.
+EPOCH = (NOW - timedelta(days=365)).isoformat()
+EPOCH_DT = NOW - timedelta(days=365)
+PRE_EPOCH = (NOW - timedelta(days=400)).isoformat()  # predates instrumentation
 
 
 def _fact(fid, *, quality=0.0, access=0, ts=OLD, **meta):
@@ -48,6 +53,8 @@ class _KB(FactsMixin):
         {"owner_id": "u1"},
         {"user_id": "u1"},
         {"verification_status": "verified"},
+        {"unique_key": "man_page:ls"},          # curated (man-page) -> protected
+        {"source_connector_id": "confluence-1"},  # ingested -> protected
     ],
 )
 def test_protected_facts_recognised(meta):
@@ -71,16 +78,40 @@ def test_only_dead_facts_are_candidates():
         _fact("new", quality=0.0, access=0, ts=RECENT),          # too new -> keep
         _fact("owned", quality=0.0, access=0, ts=OLD, owner_id="u1"),  # owned -> keep
         _fact("noage", quality=0.0, access=0, ts=""),            # unknown age -> keep
+        _fact("preepoch", quality=0.0, access=0, ts=PRE_EPOCH),  # predates A1 -> keep
+        _fact("curated", quality=0.0, access=0, ts=OLD, unique_key="man_page:ls"),  # curated -> keep
     ]
-    ids = kb._collect_prune_candidates(facts, quality_floor=0.1, cutoff=cutoff)
+    ids = kb._collect_prune_candidates(facts, quality_floor=0.1, cutoff=cutoff, epoch=EPOCH_DT)
     assert ids == ["dead"]
+
+
+def test_pre_epoch_facts_never_pruned():
+    # A fact predating instrumentation has an unknown recall history: access_count
+    # == 0 is meaningless, so it must be kept regardless of age/quality.
+    kb = _KB([])
+    cutoff = NOW - timedelta(days=180)
+    facts = [_fact("ancient", quality=0.0, access=0, ts=PRE_EPOCH)]
+    assert kb._collect_prune_candidates(facts, quality_floor=0.1, cutoff=cutoff, epoch=EPOCH_DT) == []
 
 
 # ---- consolidate_facts orchestration ---------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_dry_run_deletes_nothing():
+async def test_epoch_unset_disables_pruning(monkeypatch):
+    # An unconfigured deploy (no epoch) can never delete — feature is inert.
+    monkeypatch.setattr(facts_mod, "_FACTS_PRUNE_EPOCH", "")
+    kb = _KB([_fact("dead", quality=0.0, access=0, ts=OLD)])
+    summary = await kb.consolidate_facts(dry_run=False, now=NOW)
+    assert summary["epoch_unset"] is True
+    assert summary["candidates"] == 0
+    kb.get_all_facts.assert_not_awaited()
+    kb.delete_fact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_deletes_nothing(monkeypatch):
+    monkeypatch.setattr(facts_mod, "_FACTS_PRUNE_EPOCH", EPOCH)
     facts = [_fact("dead", quality=0.0, access=0, ts=OLD)]
     kb = _KB(facts)
     summary = await kb.consolidate_facts(dry_run=True, now=NOW)
@@ -91,22 +122,37 @@ async def test_dry_run_deletes_nothing():
 
 
 @pytest.mark.asyncio
-async def test_enforce_deletes_only_dead_facts():
+async def test_enforce_deletes_only_dead_facts(monkeypatch):
+    monkeypatch.setattr(facts_mod, "_FACTS_PRUNE_EPOCH", EPOCH)
     facts = [
         _fact("dead", quality=0.0, access=0, ts=OLD),
         _fact("owned", quality=0.0, access=0, ts=OLD, owner_id="u1"),
         _fact("recalled", quality=0.0, access=9, ts=OLD),
+        _fact("ancient", quality=0.0, access=0, ts=PRE_EPOCH),
     ]
     kb = _KB(facts)
     summary = await kb.consolidate_facts(dry_run=False, now=NOW)
     kb.delete_fact.assert_awaited_once_with("dead", _skip_bm25_refresh=True)
     assert summary["pruned"] == 1
-    assert summary["remaining"] == 2
+    assert summary["remaining"] == 3
     kb._schedule_bm25_refresh.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_scan_failure_returns_empty_summary():
+async def test_circuit_breaker_refuses_mass_prune(monkeypatch):
+    monkeypatch.setattr(facts_mod, "_FACTS_PRUNE_EPOCH", EPOCH)
+    monkeypatch.setattr(facts_mod, "_FACTS_PRUNE_MAX_PER_RUN", 2)
+    facts = [_fact(f"dead{i}", quality=0.0, access=0, ts=OLD) for i in range(5)]
+    kb = _KB(facts)
+    summary = await kb.consolidate_facts(dry_run=False, now=NOW)
+    assert summary["circuit_broken"] is True
+    assert summary["pruned"] == 0
+    kb.delete_fact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scan_failure_returns_empty_summary(monkeypatch):
+    monkeypatch.setattr(facts_mod, "_FACTS_PRUNE_EPOCH", EPOCH)
     kb = _KB([])
     kb.get_all_facts = AsyncMock(side_effect=RuntimeError("redis down"))
     summary = await kb.consolidate_facts(dry_run=False, now=NOW)

--- a/autobot-backend/knowledge/facts_consolidation_test.py
+++ b/autobot-backend/knowledge/facts_consolidation_test.py
@@ -53,7 +53,7 @@ class _KB(FactsMixin):
         {"owner_id": "u1"},
         {"user_id": "u1"},
         {"verification_status": "verified"},
-        {"unique_key": "man_page:ls"},          # curated (man-page) -> protected
+        {"unique_key": "man_page:ls"},  # curated (man-page) -> protected
         {"source_connector_id": "confluence-1"},  # ingested -> protected
     ],
 )
@@ -72,12 +72,12 @@ def test_only_dead_facts_are_candidates():
     kb = _KB([])
     cutoff = NOW - timedelta(days=180)
     facts = [
-        _fact("dead", quality=0.0, access=0, ts=OLD),           # prunable
-        _fact("recalled", quality=0.0, access=3, ts=OLD),        # accessed -> keep
-        _fact("quality", quality=0.9, access=0, ts=OLD),         # high quality -> keep
-        _fact("new", quality=0.0, access=0, ts=RECENT),          # too new -> keep
+        _fact("dead", quality=0.0, access=0, ts=OLD),  # prunable
+        _fact("recalled", quality=0.0, access=3, ts=OLD),  # accessed -> keep
+        _fact("quality", quality=0.9, access=0, ts=OLD),  # high quality -> keep
+        _fact("new", quality=0.0, access=0, ts=RECENT),  # too new -> keep
         _fact("owned", quality=0.0, access=0, ts=OLD, owner_id="u1"),  # owned -> keep
-        _fact("noage", quality=0.0, access=0, ts=""),            # unknown age -> keep
+        _fact("noage", quality=0.0, access=0, ts=""),  # unknown age -> keep
         _fact("preepoch", quality=0.0, access=0, ts=PRE_EPOCH),  # predates A1 -> keep
         _fact("curated", quality=0.0, access=0, ts=OLD, unique_key="man_page:ls"),  # curated -> keep
     ]

--- a/autobot-backend/knowledge/facts_consolidation_test.py
+++ b/autobot-backend/knowledge/facts_consolidation_test.py
@@ -1,0 +1,114 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for A3 (#12554) — memory.consolidate_facts decay/prune.
+
+Asserts the no-data-loss invariant (owned/verified/pinned/recalled/new/high-quality
+facts are never pruned), that dry-run deletes nothing, and that enforcing mode
+deletes only facts meeting ALL prune conditions.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge.facts import FactsMixin, _fact_is_protected
+
+NOW = datetime(2026, 7, 26, tzinfo=timezone.utc)
+OLD = (NOW - timedelta(days=200)).isoformat()
+RECENT = (NOW - timedelta(days=5)).isoformat()
+
+
+def _fact(fid, *, quality=0.0, access=0, ts=OLD, **meta):
+    m = {"quality_score": quality, "access_count": access, "timestamp": ts}
+    m.update(meta)
+    return {"fact_id": fid, "content": f"c-{fid}", "metadata": m, "timestamp": ts}
+
+
+class _KB(FactsMixin):
+    def __init__(self, facts):
+        self._facts = facts
+        self.ensure_initialized = MagicMock()
+        self.get_all_facts = AsyncMock(return_value=facts)
+        self.delete_fact = AsyncMock(return_value={"status": "success"})
+        self._schedule_bm25_refresh = MagicMock()
+
+
+# ---- protection predicate --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {"important": True},
+        {"preserve": True},
+        {"pinned": True},
+        {"owner_id": "u1"},
+        {"user_id": "u1"},
+        {"verification_status": "verified"},
+    ],
+)
+def test_protected_facts_recognised(meta):
+    assert _fact_is_protected(meta) is True
+
+
+def test_unprotected_fact():
+    assert _fact_is_protected({"quality_score": 0.0}) is False
+
+
+# ---- candidate collection --------------------------------------------------
+
+
+def test_only_dead_facts_are_candidates():
+    kb = _KB([])
+    cutoff = NOW - timedelta(days=180)
+    facts = [
+        _fact("dead", quality=0.0, access=0, ts=OLD),           # prunable
+        _fact("recalled", quality=0.0, access=3, ts=OLD),        # accessed -> keep
+        _fact("quality", quality=0.9, access=0, ts=OLD),         # high quality -> keep
+        _fact("new", quality=0.0, access=0, ts=RECENT),          # too new -> keep
+        _fact("owned", quality=0.0, access=0, ts=OLD, owner_id="u1"),  # owned -> keep
+        _fact("noage", quality=0.0, access=0, ts=""),            # unknown age -> keep
+    ]
+    ids = kb._collect_prune_candidates(facts, quality_floor=0.1, cutoff=cutoff)
+    assert ids == ["dead"]
+
+
+# ---- consolidate_facts orchestration ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_deletes_nothing():
+    facts = [_fact("dead", quality=0.0, access=0, ts=OLD)]
+    kb = _KB(facts)
+    summary = await kb.consolidate_facts(dry_run=True, now=NOW)
+    kb.delete_fact.assert_not_awaited()
+    assert summary["candidates"] == 1
+    assert summary["pruned"] == 0
+    assert summary["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_enforce_deletes_only_dead_facts():
+    facts = [
+        _fact("dead", quality=0.0, access=0, ts=OLD),
+        _fact("owned", quality=0.0, access=0, ts=OLD, owner_id="u1"),
+        _fact("recalled", quality=0.0, access=9, ts=OLD),
+    ]
+    kb = _KB(facts)
+    summary = await kb.consolidate_facts(dry_run=False, now=NOW)
+    kb.delete_fact.assert_awaited_once_with("dead", _skip_bm25_refresh=True)
+    assert summary["pruned"] == 1
+    assert summary["remaining"] == 2
+    kb._schedule_bm25_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_scan_failure_returns_empty_summary():
+    kb = _KB([])
+    kb.get_all_facts = AsyncMock(side_effect=RuntimeError("redis down"))
+    summary = await kb.consolidate_facts(dry_run=False, now=NOW)
+    assert summary == {"scanned": 0, "candidates": 0, "pruned": 0, "remaining": 0, "dry_run": False}
+    kb.delete_fact.assert_not_awaited()

--- a/autobot-backend/workers/__init__.py
+++ b/autobot-backend/workers/__init__.py
@@ -5,6 +5,12 @@
 """Background worker tasks for periodic audit daemons (GH#7356)."""
 
 from .audit_tasks import audit_claims, audit_dead_code, audit_testgaps
-from .consolidate_tasks import consolidate_trajectories  # GH#11263
+from .consolidate_tasks import consolidate_facts, consolidate_trajectories  # GH#11263, A3 #12554
 
-__all__ = ["audit_testgaps", "audit_dead_code", "audit_claims", "consolidate_trajectories"]
+__all__ = [
+    "audit_testgaps",
+    "audit_dead_code",
+    "audit_claims",
+    "consolidate_trajectories",
+    "consolidate_facts",
+]

--- a/autobot-backend/workers/consolidate_tasks.py
+++ b/autobot-backend/workers/consolidate_tasks.py
@@ -13,6 +13,7 @@ Registered in ``celery_app.py`` beat schedule under ``memory.consolidate_traject
 lives in ``TrajectoryStore.consolidate`` which is fully delete-only.
 """
 
+import os
 from datetime import datetime, timezone
 
 from autobot_shared.async_compat import run_or_schedule
@@ -22,6 +23,15 @@ from celery_app import celery_app
 logger = get_logger(__name__)
 
 _LAST_RUN_KEY = "memory:consolidate_trajectories:last_run"
+_FACTS_LAST_RUN_KEY = "memory:consolidate_facts:last_run"
+
+# A3 (#12554): first ship enforces nothing — the task logs prune candidates until
+# the counts are reviewed, then this flips to False (or is overridden per run).
+_FACTS_CONSOLIDATE_DRY_RUN = os.environ.get("AUTOBOT_FACTS_CONSOLIDATE_DRY_RUN", "1").lower() not in (
+    "0",
+    "false",
+    "no",
+)
 
 
 def _get_redis():
@@ -49,4 +59,29 @@ def consolidate_trajectories(self) -> dict:
     except Exception as exc:  # noqa: BLE001 — bookkeeping only, never fail the task
         logger.debug("consolidate_trajectories: last-run write skipped: %s", exc)
     logger.info("consolidate_trajectories complete at %s: %s", run_at, summary)
+    return {"status": "success", "run_at": run_at, **(summary or {})}
+
+
+async def _run_facts_consolidation() -> dict:
+    """Open the knowledge base and run one fact-lane consolidation pass."""
+    from knowledge._composed import get_knowledge_base
+
+    kb = await get_knowledge_base()
+    return await kb.consolidate_facts(dry_run=_FACTS_CONSOLIDATE_DRY_RUN)
+
+
+@celery_app.task(bind=True, name="memory.consolidate_facts")
+def consolidate_facts(self) -> dict:
+    """Nightly task: decay/prune genuinely-dead essential-story facts (A3 #12554).
+
+    Delete-only and guarded (owned/verified/pinned never eligible); ships in
+    dry-run by default so candidates are logged before any deletion is enforced.
+    """
+    run_at = datetime.now(timezone.utc).isoformat()
+    summary = run_or_schedule(_run_facts_consolidation())
+    try:
+        _get_redis().set(_FACTS_LAST_RUN_KEY, run_at)
+    except Exception as exc:  # noqa: BLE001 — bookkeeping only, never fail the task
+        logger.debug("consolidate_facts: last-run write skipped: %s", exc)
+    logger.info("consolidate_facts complete at %s: %s", run_at, summary)
     return {"status": "success", "run_at": run_at, **(summary or {})}


### PR DESCRIPTION
## Thinking Path
Gap A of epic #12551, the decay half of self-improving memory (A2 #12563 is the reinforcement half). The always-loaded essential-story facts lane had no way to shed genuinely-dead facts — old, low-quality, never-recalled entries diluted every prompt. This adds a guarded, delete-only nightly consolidation.

## What Changed
- **`knowledge/facts.py`** — `FactsMixin.consolidate_facts` (delete-only). A fact is prunable **only if ALL** hold: `quality_score` below floor AND `access_count == 0` (never recalled, A1) AND creation age past the floor (default 180d) AND not protected. `_fact_is_protected` shields owned (`owner_id`/`user_id`), human-verified, and `important`/`preserve`/`pinned` facts — the **no-data-loss invariant**. Unknown-age or newer facts are kept (fail-safe). Deletion routes through the existing `delete_fact` (cleans Redis + ChromaDB + ownership indexes).
- **`workers/consolidate_tasks.py`** — Celery task `memory.consolidate_facts` mirroring `consolidate_trajectories`. **Ships dry-run by default** (`AUTOBOT_FACTS_CONSOLIDATE_DRY_RUN`) — logs candidates without deleting until the counts are reviewed.
- Registered in `celery_app.py` beat (04:20 UTC, after the trajectory pass), `celery_priority.py` (NORMAL), and `workers/__init__.py`.

## Verification
- `knowledge/facts_consolidation_test.py` — **11 passed**: protection predicate (owned/verified/important/preserve/pinned), candidate gating (recalled / high-quality / new / owned / unknown-age all kept; only the dead fact prunes), dry-run deletes nothing, enforce deletes only dead facts + refreshes BM25 once, scan-failure returns an empty summary.
- Rebased onto merged `Dev_new_gui`; tests green post-rebase. Thresholds are env-configurable.

## Model Used
Opus 4.8 (1M context)

Closes #12554. Part of epic #12551.
