### PR TITLE
fix(security): stop semgrep hardcoded-secret-key false positives on (str, Enum) members + test files (#12301)

### DIFF
--- a/.semgrep/rules.yaml
+++ b/.semgrep/rules.yaml
@@ -70,14 +70,31 @@ rules:
       - pattern-not: $VAR = "changeme"
       - pattern-not: $VAR = "your-secret-here"
       - pattern-not: $VAR = "placeholder"
+      # Exclude enum member definitions regardless of other base classes
+      # (e.g. `class Foo(str, Enum):`, `class Foo(SomeMixin, Enum):`). The
+      # ellipsis variants match `Enum` anywhere in the base list.
       - pattern-not-inside: |
           class $CLASS(Enum):
+            ...
+      - pattern-not-inside: |
+          class $CLASS(..., Enum):
+            ...
+      - pattern-not-inside: |
+          class $CLASS(..., Enum, ...):
             ...
     message: >
       Potential hardcoded secret. Use environment variables or a secrets
       manager (e.g. os.environ, Vault) instead.
     languages: [python]
     severity: ERROR
+    paths:
+      # Test fixtures legitimately contain dummy secrets / JWTs; excluding
+      # test files prevents recurring false positives without weakening
+      # detection in production code.
+      exclude:
+        - "**/*_test.py"
+        - "**/test_*.py"
+        - "**/tests/**"
     metadata:
       category: security
       cwe: CWE-798


### PR DESCRIPTION
## Thinking Path

The `autobot-hardcoded-secret-key` rule keeps re-flagging benign code on every daily scan (13 dismissed in #12282). Two root causes:

1. Its only Enum exclusion was `pattern-not-inside: class $CLASS(Enum): ...`, which matches **only** a single-base `Enum` class. The very common `class Foo(str, Enum):` (and other multi-base forms) falls through, so enum member values like `TOKEN = "token"` / `API_KEY = "api_key"` keep matching the `TOKEN = "..."` / `API_KEY = "..."` positive patterns.
2. Test fixtures (dummy JWTs, sample secrets) in `*_test.py` / `test_*.py` / `tests/` also match.

The fix broadens the Enum exclusion to cover `Enum` appearing **anywhere** in the base list, and scopes a `paths.exclude` to test files only. Both exclusions are narrow — production classes that are not Enums and non-test modules are entirely unaffected, so no real hardcoded-secret detection is weakened.

## What Changed

`.semgrep/rules.yaml` — `autobot-hardcoded-secret-key` rule only. Positive patterns and existing placeholder `pattern-not` exclusions are untouched.

```diff
       - pattern-not: $VAR = "placeholder"
-      - pattern-not-inside: |
-          class $CLASS(Enum):
-            ...
+      # Exclude enum member definitions regardless of other base classes
+      # (e.g. `class Foo(str, Enum):`, `class Foo(SomeMixin, Enum):`). The
+      # ellipsis variants match `Enum` anywhere in the base list.
+      - pattern-not-inside: |
+          class $CLASS(Enum):
+            ...
+      - pattern-not-inside: |
+          class $CLASS(..., Enum):
+            ...
+      - pattern-not-inside: |
+          class $CLASS(..., Enum, ...):
+            ...
     message: >
       Potential hardcoded secret. Use environment variables or a secrets
       manager (e.g. os.environ, Vault) instead.
     languages: [python]
     severity: ERROR
+    paths:
+      # Test fixtures legitimately contain dummy secrets / JWTs; excluding
+      # test files prevents recurring false positives without weakening
+      # detection in production code.
+      exclude:
+        - "**/*_test.py"
+        - "**/test_*.py"
+        - "**/tests/**"
     metadata:
       category: security
       cwe: CWE-798
```

Semgrep semantics notes:
- Multiple `pattern-not-inside` entries are independent exclusions: a candidate is dropped if it is inside **any** of them. Adding forms therefore only removes false positives; it can never cause a real secret in a non-Enum class to be missed.
- The three forms cover: single-base `class Foo(Enum):`, trailing `class Foo(str, Enum):`, and `Enum` anywhere via `class Foo(..., Enum, ...):`. This matches the common `(str, Enum)` / `(IntEnum-style mixin, Enum)` declarations that were false-positiving.
- `paths.exclude` is per-rule, so only this rule stops scanning test files; every other rule keeps its coverage. Test-file globs match the repo conventions (`*_test.py` = 708 files, `test_*.py` = 696, `tests/` dirs = 949).

## Verification

- YAML parses cleanly with `yaml.safe_load` — 17 rules loaded, rule well-formed.
- Structural assertion of the edited rule:
  - `pattern-either` positive patterns: 8 (unchanged — `SECRET_KEY`, `secret_key`, `API_KEY`, `api_key`, `PASSWORD`, `password`, `TOKEN`, `token`).
  - `pattern-not-inside` blocks: 3 — `class $CLASS(Enum): ...`, `class $CLASS(..., Enum): ...`, `class $CLASS(..., Enum, ...): ...`.
  - `paths.exclude`: `["**/*_test.py", "**/test_*.py", "**/tests/**"]`.
  - `severity: ERROR`, `languages: [python]`, `cwe: CWE-798` preserved.
- **Honest note:** `semgrep` is not installed in this environment and per repo policy no ad-hoc installs are performed, so a live `semgrep --validate` / sample dry-run (`class Foo(str, Enum)` member should NOT flag; a module-level `SECRET_KEY = "hardcoded123"` in a non-test `.py` SHOULD still flag) was **not** executed locally. The change was validated structurally (YAML parse + rule assertions above) and by reasoning about semgrep's `pattern-not-inside` / ellipsis-in-bases / per-rule `paths.exclude` semantics. The scheduled CI semgrep run on this branch/PR will exercise the rule end-to-end.

## Model Used

claude-opus-4-8

Closes #12301
