### PR TITLE
fix(mcp): structured-thinking compiles against pinned SDK 1.27.1 (#12558)

### DIFF
--- a/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/index.ts
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/index.ts
@@ -18,10 +18,7 @@ function createServer() {
     },
     {
       capabilities: {
-        tools: {
-          list: true,
-          call: true
-        }
+        tools: {}
       }
     }
   );

--- a/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/src/tools.ts
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/src/tools.ts
@@ -45,21 +45,18 @@ export const reviseThoughtSchema = captureThoughtSchema.extend({
 export const captureThoughtTool: Tool = {
   name: "capture_thought",
   description: "Stores a new thought in memory and in the thought history and runs a pipeline to classify the thought, return metacognitive feedback, and retrieve relevant thoughts.",
-  parameters: captureThoughtSchema,
   inputSchema: zodToInputSchema(captureThoughtSchema)
 };
 
 export const reviseThoughtTool: Tool = {
   name: "revise_thought",
   description: "Revises a thought in memory and in the thought history.",
-  parameters: reviseThoughtSchema,
   inputSchema: zodToInputSchema(reviseThoughtSchema)
 };
 
 export const retrieveRelevantThoughtsTool: Tool = {
   name: "retrieve_relevant_thoughts",
   description: "Finds thoughts from long-term storage that share tags with the specified thought.",
-  parameters: retrieveRelevantThoughtsSchema,
   inputSchema: zodToInputSchema(retrieveRelevantThoughtsSchema)
 };
 
@@ -68,14 +65,12 @@ export const emptySchema = z.object({});
 export const getThinkingSummaryTool: Tool = {
   name: "get_thinking_summary",
   description: "Generate a comprehensive summary of the entire thinking process.",
-  parameters: emptySchema,
   inputSchema: zodToInputSchema(emptySchema)
 };
 
 export const clearThinkingHistoryTool: Tool = {
   name: "clear_thinking_history",
   description: "Clear all recorded thoughts and reset the server state.",
-  parameters: emptySchema,
   inputSchema: zodToInputSchema(emptySchema)
 };
 

--- a/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/tests/integration.test.ts
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/tests/integration.test.ts
@@ -41,12 +41,7 @@ describe('Sequential Thinking Server Integration', () => {
         version: "1.0.0"
       },
       {
-        capabilities: {
-          tools: {
-            list: true,
-            call: true
-          }
-        }
+        capabilities: {}
       }
     );
 


### PR DESCRIPTION
## Thinking Path
`npm run build` (tsc) in `mcp-structured-thinking` failed with 6 `TS2353` errors against the pinned `@modelcontextprotocol/sdk@1.27.1`. Read the SDK's compiled type declarations (`node_modules/@modelcontextprotocol/sdk/dist/esm/types.d.ts`) to find the current `Tool` and `ServerCapabilities`/`ClientCapabilities` shapes rather than guessing:
- `Tool` only has `inputSchema` (JSON-schema-shaped: `{ type: "object", properties?, required? }`) — no `parameters` field exists on the type.
- `ServerCapabilities.tools` is `{ listChanged?: boolean }` — no `list`/`call` sub-fields; those request types are handled separately via `setRequestHandler(ListToolsRequestSchema/CallToolRequestSchema, ...)`, which this server already does, so dropping `list`/`call` from the capabilities object does not remove any behavior.
- Checked the sibling tool `mcp-autobot-tracker/src/index.ts` in this repo, which already compiles against this same SDK version and declares `tools: {}` for the same "server offers tools" intent — followed that established, working pattern for consistency.
- While verifying, `npm test` also failed to even start (`tests/integration.test.ts:45` — same `TS2353` family: `ClientCapabilities` has no `tools` field at all). Same root cause (SDK API drift) in the same tool, so fixed in this PR per the "fix pre-existing issues discovered along the way" rule rather than filing separately.

## What Changed
- `index.ts` — server capabilities: `tools: { list: true, call: true }` → `tools: {}` (matches `ServerCapabilities.tools = { listChanged?: boolean }`; tool listing/calling is still fully handled by the existing `ListToolsRequestSchema`/`CallToolRequestSchema` handlers, unaffected by this capabilities-advertisement field).
- `src/tools.ts` — removed the stale `parameters: <zodSchema>` key from all 5 tool definitions (`captureThoughtTool`, `reviseThoughtTool`, `retrieveRelevantThoughtsTool`, `getThinkingSummaryTool`, `clearThinkingHistoryTool`). Each definition already carried the correct `inputSchema: zodToInputSchema(<schema>)` field alongside the invalid `parameters` field — the `parameters` key was pure dead weight (not the SDK's `Tool` type, and grepped: no call site in the repo ever read `.parameters` off these objects).
- `tests/integration.test.ts` — client capabilities: `capabilities: { tools: { list: true, call: true } }` → `capabilities: {}`. `ClientCapabilities` has no `tools` field in the current SDK (client-side capabilities cover `sampling`/`elicitation`/`roots`/`tasks`/`experimental`, not tool advertisement — that's server-only); `options.capabilities` is optional on `Client`'s constructor, so `{}` preserves default client behavior.

## Verification
```
$ cd autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking
$ npm install --ignore-scripts
added 383 packages, and audited 384 packages in 8s
...
$ rm -rf dist && npm run build
> structured-thinking@1.0.2 build
> tsc
EXIT=0
```
Zero `tsc` errors (previously 6× `TS2353`).

Also re-ran the test suite, which previously could not even start compiling:
```
$ npm test
PASS tests/integration.test.ts (5.26 s)
  Sequential Thinking Server Integration
    ✓ should list available tools (12 ms)
    ✓ should process a thought and generate a summary (58 ms)
    ✓ should handle thought sequencing and branching (10 ms)
    ✓ should revise an existing thought (9 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

`node_modules`/`dist` are gitignored and not committed. SDK version (`^1.26.0` in `package.json`, resolved+pinned at `1.27.1` in the lockfile) is unchanged — only the tool's own code was adapted to the current SDK API shape.

## Model Used
Claude Sonnet 5

Closes #12558