### PR TITLE
fix(deploy): self-update detaches via writable-log fallback so Update-All deploys the co-located app tier (#12425)

### DIFF
--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -244,12 +244,22 @@
   tags: ['common', 'python']
 
 - name: "Common | Create log directory"
+  # #12425: shared by every autobot-* service role that logs to
+  # /var/log/autobot (backend, ai-stack, tts-worker, npu-worker, ...), not
+  # just the `autobot` user. 02775 (setgid + group-write) lets any service
+  # user that is a MEMBER of the `autobot` group create/write log files here
+  # without needing to own the directory outright — so a role whose own
+  # service account differs from `autobot` (tts-worker -> autobot-tts,
+  # npu-worker -> autobot-npu) never needs to re-chown the shared top-level
+  # dir to itself, which previously clobbered this ownership on every run of
+  # that role and left the `autobot` service user (autobot-slm-backend) with
+  # no permission to create its own self-update-ansible.log here.
   file:
     path: /var/log/autobot
     state: directory
     owner: autobot
     group: autobot
-    mode: '0755'
+    mode: '02775'
   become: true
   tags: ['common', 'logging']
 

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/health_check_cron.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/health_check_cron.yml
@@ -7,13 +7,19 @@
 # Fixes MVA-291: replaces setup_daily_health_check.sh crontab/tmp approach
 ---
 
+# #12425: autobot_log_dir defaults to the SHARED /var/log/autobot (common
+# role, owner autobot:autobot). Creating it here as root:root clobbered that
+# ownership on every run of this role, leaving no autobot-* service user
+# able to write (the common role's autobot:autobot/02775 is the canonical
+# ownership every role sharing this dir must converge to — see
+# common/tasks/main.yml and tts-worker/npu-worker for the same fix).
 - name: "Health Check Cron | Ensure log directory exists"
   ansible.builtin.file:
     path: "{{ autobot_log_dir }}"
     state: directory
-    owner: root
-    group: root
-    mode: "0755"
+    owner: "{{ 'autobot' if autobot_log_dir == '/var/log/autobot' else 'root' }}"
+    group: "{{ 'autobot' if autobot_log_dir == '/var/log/autobot' else 'root' }}"
+    mode: "{{ '02775' if autobot_log_dir == '/var/log/autobot' else '0755' }}"
   tags: ["monitoring", "health_check"]
 
 - name: "Health Check Cron | Deploy wrapper script to stable path"

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
@@ -34,6 +34,19 @@
     state: present
   tags: ['npu', 'users']
 
+# #12425: supplementary (not primary) membership in the shared `autobot`
+# group so this role can write into the shared, setgid /var/log/autobot dir
+# (see common role) via group permission, without owning that directory
+# itself — see the "Create NPU worker directories" task below, which
+# deliberately excludes npu_log_dir from the owner/group it applies to the
+# role's own, exclusively-owned dirs.
+- name: "NPU Worker | Join shared autobot log group (#12425)"
+  ansible.builtin.user:
+    name: "{{ npu_user }}"
+    groups: autobot
+    append: true
+  tags: ['npu', 'users']
+
 # ============================================================
 # Per-role env at /etc/autobot/  (#926 Phase 4)
 # ============================================================
@@ -89,8 +102,36 @@
     group: "{{ npu_group }}"
   loop:
     - "{{ npu_install_dir }}"
-    - "{{ npu_log_dir }}"
     - "{{ npu_models_dir }}"
+
+# #12425: npu_log_dir defaults to the SHARED /var/log/autobot (common role),
+# not an NPU-exclusive path — re-chowning it to npu_user/npu_group above (as
+# the other two, genuinely NPU-exclusive dirs correctly are) clobbered
+# common's autobot:autobot ownership on every run of this role. Converge to
+# the SAME canonical ownership the common role applies, regardless of which
+# role runs last; the group-write bit + this role's own membership in the
+# `autobot` group (above) is what lets npu_user still write its log files
+# here. A future group_vars override to an NPU-exclusive path falls through
+# to the npu_user-owned dir instead.
+- name: "NPU Worker | Ensure shared log directory uses canonical ownership (#12425)"
+  ansible.builtin.file:
+    path: "{{ npu_log_dir }}"
+    state: directory
+    mode: "02775"
+    owner: autobot
+    group: autobot
+  when: npu_log_dir == '/var/log/autobot'
+  tags: ['npu', 'dirs']
+
+- name: "NPU Worker | Create NPU-exclusive log directory (override path only, #12425)"
+  ansible.builtin.file:
+    path: "{{ npu_log_dir }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ npu_user }}"
+    group: "{{ npu_group }}"
+  when: npu_log_dir != '/var/log/autobot'
+  tags: ['npu', 'dirs']
 
 # #11374: Install python3.11 (OpenVINO's supported interpreter) BEFORE any
 # venv work. `ensure_venv_version` removes a wrong-version venv and the

--- a/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
@@ -27,6 +27,19 @@
     state: present
   tags: ['tts', 'users']
 
+# #12425: supplementary (not primary) membership in the shared `autobot`
+# group so this role can write into the shared, setgid /var/log/autobot dir
+# (see common role) via group permission, without owning that directory
+# itself — see the "Create service directories" task below, which
+# deliberately excludes tts_log_dir from the owner/group it applies to the
+# role's own, exclusively-owned dirs.
+- name: "TTS Worker | Join shared autobot log group (#12425)"
+  ansible.builtin.user:
+    name: "{{ tts_user }}"
+    groups: autobot
+    append: true
+  tags: ['tts', 'users']
+
 # ============================================================
 # Per-role env at /etc/autobot/
 # ============================================================
@@ -86,9 +99,40 @@
     group: "{{ tts_group }}"
   loop:
     - "{{ tts_install_dir }}"
-    - "{{ tts_log_dir }}"
     - "{{ tts_models_dir }}"
     - "{{ tts_voices_dir }}"
+  tags: ['tts', 'dirs']
+
+# #12425: tts_log_dir defaults to the SHARED /var/log/autobot (common role),
+# not a TTS-exclusive path — re-chowning it to tts_user/tts_group above (as
+# the other three, genuinely TTS-exclusive dirs correctly are) clobbered
+# common's autobot:autobot ownership on every run of this role, leaving the
+# `autobot` service user (autobot-slm-backend) unable to create its own
+# self-update-ansible.log. Converge to the SAME canonical ownership the
+# common role applies, regardless of which role runs last; the group-write
+# bit + this role's own membership in the `autobot` group (above) is what
+# lets tts_user still write its log files here.
+- name: "TTS Worker | Ensure shared log directory uses canonical ownership (#12425)"
+  ansible.builtin.file:
+    path: "{{ tts_log_dir }}"
+    state: directory
+    mode: "02775"
+    owner: autobot
+    group: autobot
+  # Only applies the shared canonical ownership while tts_log_dir actually
+  # points at the shared dir; a future group_vars override to a
+  # TTS-exclusive path falls through to the tts_user-owned dir below instead.
+  when: tts_log_dir == '/var/log/autobot'
+  tags: ['tts', 'dirs']
+
+- name: "TTS Worker | Create TTS-exclusive log directory (override path only, #12425)"
+  ansible.builtin.file:
+    path: "{{ tts_log_dir }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ tts_user }}"
+    group: "{{ tts_group }}"
+  when: tts_log_dir != '/var/log/autobot'
   tags: ['tts', 'dirs']
 
 - name: "TTS Worker | Fix HF model cache ownership (hub/xet may be owned by earlier user)"

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -81,6 +81,19 @@ ANSIBLE_ENV_ALLOWLIST_EXACT = (
 # precedent (api/setup_wizard.py).
 SELF_UPDATE_LOG_PATH = Path(os.getenv("SLM_SELF_UPDATE_LOG_PATH", "/var/log/autobot/self-update-ansible.log"))
 
+# #12425: /var/log/autobot is a shared dir that any autobot-* service user
+# may have created/re-created first (observed owned by the TTS worker,
+# 0755) — the SLM's own `autobot` user then cannot create a new file there
+# and _prepare_self_update_log_file() raises OSError. Silently dropping to
+# an attached run in that case is the exact regression this constant exists
+# to prevent: #11492's own Play-1 "restart autobot-slm-backend" SIGTERMs an
+# attached run before Play 2/3 (the co-located backend/frontend deploy) ever
+# execute. Before giving up and going attached, retry under this uid-scoped
+# 0700 dir (same one execute_playbook already uses for temp inventories/
+# extra-vars, so no additional permission is required beyond what a normal
+# run already needs).
+SELF_UPDATE_LOG_FALLBACK_PATH = Path(ANSIBLE_LOCAL_TMP) / "self-update-ansible.log"
+
 # Poll interval while tailing the detached run's log file for live progress.
 SELF_UPDATE_LOG_TAIL_POLL_SEC = float(os.getenv("SLM_SELF_UPDATE_LOG_TAIL_POLL_SEC", "1.0"))
 
@@ -543,31 +556,45 @@ class PlaybookExecutor:
         return shutil.which("systemd-run") is not None and "INVOCATION_ID" in os.environ
 
     @staticmethod
+    def _write_fresh_log_file(path: Path) -> Path | None:
+        """Create/truncate a fresh 0600 log file at ``path`` (best-effort).
+
+        Shared by the canonical (#11492) and fallback (#12425) self-update
+        log paths. Truncated per run so log-tailing starts at byte 0 and a
+        stale prior run's content is never replayed as this run's progress.
+        Ansible output can contain sensitive paths/values — 0600, not the
+        world-readable default umask.
+
+        Returns None on any OSError; the caller decides whether to fall back
+        to another path or give up.
+        """
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("", encoding="utf-8")
+            os.chmod(path, 0o600)
+            return path
+        except OSError:
+            return None
+
+    @staticmethod
     def _prepare_self_update_log_file() -> Path | None:
         """Create/truncate a fresh log file for this detached run (#11492).
 
         The detached ansible-playbook process's stdout/stderr are redirected
         here (see _wrap_with_systemd_scope) instead of the backend's pipe, so
-        a dead backend can never BrokenPipe-crash Play 2/3. Truncated per run
-        so log-tailing starts at byte 0 and a stale prior run's content is
-        never replayed as this run's progress.
+        a dead backend can never BrokenPipe-crash Play 2/3.
 
-        Returns None on failure — the caller must NOT detach without
-        file-backed output in that case (a pipe-only detach would just move
-        the same crash risk this fix exists to close from "cgroup kill" to
-        "broken pipe"; direct-exec, though it dies with the backend, is at
-        least a deterministic, well-understood failure mode).
+        Returns None on failure — the caller (#12425) falls back to a
+        writable uid-scoped path before giving up; the caller must NOT detach
+        without file-backed output in the meantime (a pipe-only detach would
+        just move the same crash risk this fix exists to close from "cgroup
+        kill" to "broken pipe"; direct-exec, though it dies with the backend,
+        is at least a deterministic, well-understood failure mode).
         """
-        try:
-            SELF_UPDATE_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-            SELF_UPDATE_LOG_PATH.write_text("", encoding="utf-8")
-            # Ansible output can contain sensitive paths/values — 0600, not
-            # the world-readable default umask (#11492 hardening).
-            os.chmod(SELF_UPDATE_LOG_PATH, 0o600)
-            return SELF_UPDATE_LOG_PATH
-        except OSError as exc:
-            logger.error("Could not prepare self-update log file %s: %s", SELF_UPDATE_LOG_PATH, exc)
-            return None
+        result = PlaybookExecutor._write_fresh_log_file(SELF_UPDATE_LOG_PATH)
+        if result is None:
+            logger.error("Could not prepare canonical self-update log file %s", SELF_UPDATE_LOG_PATH)
+        return result
 
     @staticmethod
     def _systemd_run_env_args(env: Dict[str, str]) -> List[str]:
@@ -627,9 +654,19 @@ class PlaybookExecutor:
         """Resolve the effective argv + log path for a requested detach (#11492).
 
         Helper for _run_subprocess. Returns (cmd, None) unchanged whenever
-        detaching isn't possible (no systemd-run/service context, or the log
-        file couldn't be prepared) so the caller falls back to the exact
-        pipe-attached behavior that existed before this fix.
+        detaching isn't possible (no systemd-run/service context, or neither
+        the canonical nor fallback log file could be prepared) so the caller
+        falls back to the exact pipe-attached behavior that existed before
+        this fix.
+
+        #12425: the canonical SELF_UPDATE_LOG_PATH (/var/log/autobot/...) can
+        be unwritable by this service user (e.g. another autobot-* service
+        owns the shared dir) without systemd-run itself being unavailable.
+        Silently dropping to attached in that case is the regression this
+        fallback closes — an attached run gets SIGTERM'd by Play 1's own
+        "restart autobot-slm-backend" task before Play 2/3 (the co-located
+        backend/frontend deploy) ever execute. Try a writable uid-scoped
+        fallback path and still detach before giving up.
         """
         if not self._self_update_detach_available():
             logger.warning(
@@ -641,7 +678,25 @@ class PlaybookExecutor:
 
         log_path = self._prepare_self_update_log_file()
         if log_path is None:
-            logger.error("Self-update detach requested but log file unavailable — running attached")
+            logger.warning(
+                "Canonical self-update log path %s unwritable — retrying "
+                "under fallback path %s before giving up on detach (#12425)",
+                SELF_UPDATE_LOG_PATH,
+                SELF_UPDATE_LOG_FALLBACK_PATH,
+            )
+            log_path = self._write_fresh_log_file(SELF_UPDATE_LOG_FALLBACK_PATH)
+
+        if log_path is None:
+            logger.critical(
+                "UPDATE-ALL DEGRADED (#12425): neither the canonical (%s) nor "
+                "the fallback (%s) self-update log path is writable — running "
+                "ATTACHED as a last resort. The imminent Play-1 'restart "
+                "autobot-slm-backend' WILL SIGTERM this run before Play 2/3 "
+                "(backend/frontend deploy) execute, silently leaving the "
+                "co-located app tier stale.",
+                SELF_UPDATE_LOG_PATH,
+                SELF_UPDATE_LOG_FALLBACK_PATH,
+            )
             return cmd, None
 
         logger.info("Self-update run detached into transient systemd scope, output -> %s", log_path)

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -287,10 +287,12 @@ async def test_run_subprocess_falls_back_without_systemd(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_run_subprocess_falls_back_when_log_file_prep_fails(tmp_path):
-    """systemd-run is available, but the log file can't be prepared: still
-    falls back to the direct pipe-attached exec rather than detaching without
-    file-backed output (which would just trade one crash risk for another)."""
+async def test_run_subprocess_falls_back_to_attached_when_all_log_paths_fail(tmp_path):
+    """systemd-run is available, but NEITHER the canonical NOR the #12425
+    fallback log path can be prepared (e.g. the uid-scoped tmp dir is also
+    unwritable): only then does the run fall back to the direct
+    pipe-attached exec rather than detaching without file-backed output
+    (which would just trade one crash risk for another)."""
     ex = _executor(tmp_path)
     cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
     env = {"PATH": "/usr/bin"}
@@ -304,13 +306,74 @@ async def test_run_subprocess_falls_back_when_log_file_prep_fails(tmp_path):
 
     with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
         with patch.object(_pe.PlaybookExecutor, "_prepare_self_update_log_file", return_value=None):
-            with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
-                result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
+            with patch.object(_pe.PlaybookExecutor, "_write_fresh_log_file", return_value=None):
+                with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
+                    result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
 
     assert result["returncode"] == 0
     assert captured["args"] == tuple(cmd)
     assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
     assert captured["kwargs"]["stderr"] == asyncio.subprocess.STDOUT
+
+
+@pytest.mark.asyncio
+async def test_run_subprocess_still_detaches_via_fallback_log_path(tmp_path):
+    """#12425: the canonical /var/log/autobot path can be unwritable (e.g.
+    owned by a different autobot-* service user) while systemd-run is fully
+    available. That must NOT silently drop to the known-broken attached run
+    (#11492) — it must retry under the uid-scoped fallback path and still
+    detach."""
+    ex = _executor(tmp_path)
+    cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
+    env = {"PATH": "/usr/bin"}
+    fallback_log_path = tmp_path / "fallback" / "self-update-ansible.log"
+
+    captured = {}
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProcess(returncode=0)
+
+    with patch.object(_pe.PlaybookExecutor, "_self_update_detach_available", return_value=True):
+        with patch.object(_pe.PlaybookExecutor, "_prepare_self_update_log_file", return_value=None):
+            with patch.object(_pe, "SELF_UPDATE_LOG_FALLBACK_PATH", fallback_log_path):
+                with patch.object(asyncio, "create_subprocess_exec", side_effect=_fake_create_subprocess_exec):
+                    result = await ex._run_subprocess(cmd, env, progress_callback=None, detach=True)
+
+    assert result["returncode"] == 0
+    argv = captured["args"]
+    # Still wrapped + detached, not the pipe-attached exec.
+    assert argv[0] == "sudo"
+    assert argv[2] == "systemd-run"
+    tail = list(argv[argv.index("--") + 1 :])
+    assert str(fallback_log_path) in tail[2]
+    assert tail[3:] == cmd
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.DEVNULL
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.DEVNULL
+    # The fallback log file was actually created, truncated, and locked down.
+    assert fallback_log_path.read_text(encoding="utf-8") == ""
+    assert oct(fallback_log_path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_write_fresh_log_file_creates_truncates_and_chmods(tmp_path):
+    log_path = tmp_path / "sub" / "fresh.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("stale prior run content\n", encoding="utf-8")
+
+    result = _pe.PlaybookExecutor._write_fresh_log_file(log_path)
+
+    assert result == log_path
+    assert log_path.read_text(encoding="utf-8") == ""
+    assert oct(log_path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_write_fresh_log_file_returns_none_on_failure(tmp_path):
+    blocked = tmp_path / "not_a_dir"
+    blocked.write_text("x", encoding="utf-8")
+    log_path = blocked / "fresh.log"
+
+    assert _pe.PlaybookExecutor._write_fresh_log_file(log_path) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path

Confirmed the root cause against current code (matches the parked root-cause comment on #12425): `_prepare_detached_run` (`playbook_executor.py`) only ever tries ONE log path — the canonical `SELF_UPDATE_LOG_PATH = /var/log/autobot/self-update-ansible.log`. When that path is unwritable by the `autobot` service user (observed: dir owned `autobot-tts:autobot-tts` 0755), `_prepare_self_update_log_file` returns `None` and the caller silently drops to running the self-update ansible-playbook **attached** inside the `autobot-slm-backend` cgroup. Play-1's own `systemctl restart autobot-slm-backend` (`KillMode=control-group`) then SIGTERMs that attached child (`code -15`) before Play 2 (co-located backend/frontend deploy) and Play 3 (verify) ever run — the whole app tier silently stays stale while the SLM control plane reports healthy.

Traced *why* the dir ends up owned by `autobot-tts`: `tts-worker`'s `tts_log_dir` default is the SAME shared `/var/log/autobot` path the `common` role creates as `autobot:autobot`, but the `tts-worker` role's "Create service directories" task re-chowns it to `autobot-tts:autobot-tts` on every run of that role. `npu-worker` and monitoring's `health_check_cron.yml` have the identical bug (re-chown to `autobot-npu`/`root` respectively) — this is a class of bug, not a single role's mistake, and it directly reproduces the exact ownership state observed on the incident box.

## What Changed

**Code (primary fix) — `autobot-slm-backend/services/playbook_executor.py`:**
- New `SELF_UPDATE_LOG_FALLBACK_PATH` (`ANSIBLE_LOCAL_TMP/self-update-ansible.log`, uid-scoped 0700 dir already used for temp inventories/extra-vars).
- Factored the log-file-writing logic into `_write_fresh_log_file(path)` (shared, 0600, truncate-per-run), used by both the canonical path (`_prepare_self_update_log_file`, unchanged behavior/signature) and the new fallback.
- `_prepare_detached_run` (`:626`) now retries under the fallback path when the canonical path fails, and **still detaches** — it no longer silently drops to the known-broken attached run just because the canonical dir is unwritable. Only when BOTH paths fail does it fall back to attached, now logged at `CRITICAL` with an explicit "UPDATE-ALL DEGRADED" message spelling out that Play 2/3 will be lost.

**Ansible (complementary durable fix, DONE not deferred) — root cause traced and fixed, not guessed:**
- `roles/common/tasks/main.yml`: `/var/log/autobot` created `02775` (setgid + group-write) instead of `0755`, still `autobot:autobot`.
- `roles/tts-worker/tasks/main.yml`, `roles/npu-worker/tasks/main.yml`: each role's own service user (`autobot-tts`, `autobot-npu`) now joins the shared `autobot` group (supplementary, `append: true`), and each role's own directory-creation task no longer re-chowns the *shared* log dir to its own service user — it converges to the same canonical `autobot:autobot`/`02775` ownership instead (guarded by `when: *_log_dir == '/var/log/autobot'`, so a future group_vars override to a role-exclusive path still gets the role's own ownership).
- `roles/monitoring/tasks/health_check_cron.yml`: same fix for the `root:root` re-chown of the shared dir.
- Additive: nothing loses write access — existing owners keep it, and the two role-specific service users gain shared-group write access they didn't have before.

## Verification

Unit tests (`tests/services/test_self_update_systemd_detach_11492.py`, extended with 4 new cases + all 12 pre-existing cases updated/passing):

```
tests/services/test_self_update_systemd_detach_11492.py::test_detach_available_when_systemd_run_present_and_invocation_id_set PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_detach_unavailable_without_systemd_run_binary PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_detach_unavailable_without_invocation_id PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_prepare_self_update_log_file_creates_and_truncates PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_prepare_self_update_log_file_returns_none_on_failure PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_wrap_with_systemd_scope_builds_expected_command PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_systemd_run_env_args_allowlist_excludes_secrets PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_systemd_run_env_args_ansible_allowlist_is_enumerated_not_prefix PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_run_subprocess_wraps_file_backed_when_systemd_available PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_run_subprocess_falls_back_without_systemd PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_run_subprocess_falls_back_to_attached_when_all_log_paths_fail PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_run_subprocess_still_detaches_via_fallback_log_path PASSED   <- new: proves canonical-unwritable still detaches
tests/services/test_self_update_systemd_detach_11492.py::test_write_fresh_log_file_creates_truncates_and_chmods PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_write_fresh_log_file_returns_none_on_failure PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_run_subprocess_unwrapped_when_detach_false PASSED
tests/services/test_self_update_systemd_detach_11492.py::test_tail_playbook_log_parses_existing_lines_then_stops PASSED

16 passed in 0.12s
```

Also ran unaffected adjacent test files individually (all green): `test_role_migration_extra_vars.py`, `test_apply_secrets.py`, `test_node_update_availability_11964.py`, `test_fleet_node_update_11511.py`, `test_extra_vars_file_11735.py`, `test_dynamic_inventory_group_vars_11781.py`.

`ansible-playbook --syntax-check` passed for `update-all-nodes.yml`, `provision-fleet-roles.yml`, and `deploy_role.yml -e role_name=tts-worker|npu-worker`. `python3 -m py_compile` clean on `playbook_executor.py`.

**REQUIRES supervised on-box deploy verify** (cannot be verified locally — this is the update mechanism itself, env-only: dir ownership + real systemd context): after merge, run Update-All on a co-located box and confirm `self-update-ansible.log` (or the fallback path) is created, the playbook is **not** killed at the Play-1 restart (no `code -15`), Play 2 deploys `autobot-backend`/`autobot-frontend`, and `GET /api/code-sync/status` returns `stale_components: []`.

## Model Used

Sonnet 5

Closes #12425