### PR TITLE
security(deps): patch js-yaml 4.2.0 → 4.3.0 (GHSA-52cp-r559-cp3m) (#12568)

### DIFF
--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -85,7 +85,7 @@
     "wavesurfer.js": "^7.12.10"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": ">=4.3.0 <5.0.0",
     "minimatch": ">=9.0.7",
     "uuid": "^14.0.0",
     "qs": ">=6.15.2",


### PR DESCRIPTION
## Thinking Path

Dependabot HIGH alert GHSA-52cp-r559-cp3m flags `js-yaml` (vulnerable `>=4.0.0 <4.3.0`, fixed in `4.3.0`), pulled transitively by `@redocly/openapi-core` which pins it at exactly `4.2.0`.

Audit of the base branch showed the resolved `node_modules/js-yaml` node is already `4.3.0` (a prior fix added a `js-yaml: 4.3.0` override and regenerated the lockfile). So the vulnerable version is already excluded from the resolved tree; the `4.2.0` string that remains in the lockfile is only `@redocly/openapi-core`'s declared dependency range (manifest metadata), not a resolved install.

This PR converts the exact pin into a bounded range so future in-range 4.x security patches are auto-adopted, while formally closing the tracking alert. NOTE: a bare `>=4.3.0` override is unsafe here — js-yaml has since published `5.x`, and npm `overrides` force the max satisfying version regardless of the parent's range, so `>=4.3.0` would resolve js-yaml to `5.2.2` (a breaking major bump for `@redocly/openapi-core`). The override is therefore bounded to `>=4.3.0 <5.0.0`.

## What Changed

- `autobot-frontend/package.json` — `overrides.js-yaml`: `4.3.0` -> `>=4.3.0 <5.0.0` (security floor of 4.3.0, bounded to the 4.x line).
- No lockfile change: `4.3.0` already satisfies the new range and remains the latest 4.x, so `node_modules/js-yaml` stays resolved at `4.3.0` (patch-level, backward-compatible). `npm ci --dry-run` confirms package.json/lockfile remain in sync.

## Verification

Resolved version (override applied):
```
$ npm ls js-yaml --all --package-lock-only
    └── js-yaml@4.3.0 overridden
```
Resolved node in `package-lock.json`:
```
"node_modules/js-yaml": {
  "version": "4.3.0",
  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
```
Clean dependency graph (no unresolved conflicts introduced):
```
$ npm ls --all --package-lock-only 2>&1 | grep -Ei 'ERESOLVE|invalid'
(no output)
```
Lockfile/manifest in sync:
```
$ npm ci --dry-run --ignore-scripts --no-audit --no-fund
added 1175 packages in 979ms
```
(Pre-existing `missing:` notices for the `file:` workspace packages `@autobot/terminal|ui|vnc` are unrelated to js-yaml and present on the base branch.)

## Model Used

claude-opus-4-8

Closes #12568
