### PR TITLE
fix(deploy): derive node code_status so agentless nodes report consistently with outdated_nodes (#12428)

### DIFF
--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -421,10 +421,15 @@ async def _query_nodes_page(db: AsyncSession, status_filter: str | None, page: i
     node_ids = [n.node_id for n in nodes]
     svc_counts = await _get_service_counts(db, node_ids)
 
+    # #12428: derive code_status per-node (see get_node) so the fleet list
+    # view agrees with outdated_nodes for agentless/never-heartbeated nodes.
+    latest_version = await _get_latest_code_version(db)
+
     node_responses = []
     for n in nodes:
         resp = NodeResponse.model_validate(n)
         resp.service_summary = svc_counts.get(n.node_id)
+        resp.code_status = _reported_code_status(n, latest_version)
         node_responses.append(resp)
 
     return NodeListResponse(
@@ -550,7 +555,14 @@ async def get_node(
             detail="Node not found",
         )
 
-    return NodeResponse.model_validate(node)
+    # #12428: derive code_status from the live code_version vs latest signal
+    # rather than trusting the heartbeat-only stamp, so an agentless node
+    # (never heartbeats) can't report a stale up_to_date here while
+    # outdated_nodes (api/code_sync.py get_sync_status) counts it as behind.
+    latest_version = await _get_latest_code_version(db)
+    resp = NodeResponse.model_validate(node)
+    resp.code_status = _reported_code_status(node, latest_version)
+    return resp
 
 
 @router.patch("/{node_id}", response_model=NodeResponse)
@@ -1731,6 +1743,73 @@ async def replace_node(
     return NodeResponse.model_validate(new_node)
 
 
+def _derive_code_status(
+    code_version: str | None,
+    latest_version: str | None,
+    was_service_failed: bool = False,
+) -> str | None:
+    """Pure function: the CodeStatus label for code_version vs latest_version.
+
+    Single source of truth for a node's currency label (#12428): mirrors the
+    live signal ``outdated_nodes`` already uses (api/code_sync.py
+    get_sync_status, ``code_version != latest_version``) so a node's
+    reported code_status can never disagree with the fleet-wide outdated
+    count. Shared by both write time (_update_heartbeat_code_status, on a
+    heartbeat) and read time (_reported_code_status, on every GET) — an
+    agentless node that never heartbeats still gets a fresh label on read.
+
+    Returns None when latest_version is unknown — callers should fall back
+    to whatever status is already on hand (mirrors get_sync_status's own
+    fallback when the fleet latest commit isn't set yet).
+
+    was_service_failed preserves the #1605 code_current_service_failed
+    signal when the version still matches latest; that check needs live
+    heartbeat extra_data and cannot be recomputed at read time, so a read
+    derivation passes in the node's own last-known stamp instead.
+    """
+    if not latest_version:
+        return None
+    if not code_version:
+        return CodeStatus.UNKNOWN.value
+    if code_version != latest_version:
+        return CodeStatus.OUTDATED.value
+    if was_service_failed:
+        return CodeStatus.CODE_CURRENT_SERVICE_FAILED.value
+    return CodeStatus.UP_TO_DATE.value
+
+
+async def _get_latest_code_version(db: AsyncSession) -> str | None:
+    """Read the fleet's slm_agent_latest_commit setting.
+
+    Same query used by _update_heartbeat_code_status and
+    api/code_sync.py's get_sync_status — kept here so node reads compare
+    against the exact same live value (#12428).
+    """
+    result = await db.execute(select(Setting).where(Setting.key == "slm_agent_latest_commit"))
+    setting = result.scalar_one_or_none()
+    return setting.value if setting else None
+
+
+def _reported_code_status(node: Node, latest_version: str | None) -> str | None:
+    """Derive the code_status to report for a node READ (#12428).
+
+    node.code_status is a stamp written only by _update_heartbeat_code_status,
+    which runs only on a heartbeat. An agentless node (e.g. role vnc) never
+    heartbeats, so the stamp freezes — often at up_to_date from enrollment —
+    even after code_version drifts behind latest_version, disagreeing with
+    outdated_nodes (api/code_sync.py get_sync_status), which always uses the
+    live code_version != latest_version signal. Recomputing here on every
+    read keeps the two surfaces in agreement; falls back to the stored stamp
+    when latest_version is unknown.
+    """
+    derived = _derive_code_status(
+        node.code_version,
+        latest_version,
+        was_service_failed=node.code_status == CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
+    )
+    return derived if derived is not None else node.code_status
+
+
 async def _update_heartbeat_code_status(db: AsyncSession, node: Node, extra_data: dict | None = None) -> str | None:
     """Query latest commit setting and update node.code_status.
 
@@ -1739,23 +1818,16 @@ async def _update_heartbeat_code_status(db: AsyncSession, node: Node, extra_data
     Issue #1605: Also checks service health — code_current_service_failed
     when commit matches but autobot services are failed/crash-looping.
     """
-    latest_result = await db.execute(select(Setting).where(Setting.key == "slm_agent_latest_commit"))
-    latest_setting = latest_result.scalar_one_or_none()
-    latest_version = latest_setting.value if latest_setting else None
+    latest_version = await _get_latest_code_version(db)
 
     # Compare node.code_version (DB, set by mark-synced) against latest (Issue #918).
     # Do NOT use heartbeat.code_version — agents report stale values (Issue #889).
     if latest_version:
-        if node.code_version == latest_version:
-            # Issue #1605: check if autobot services are actually healthy
-            if _has_failed_autobot_service(extra_data):
-                node.code_status = CodeStatus.CODE_CURRENT_SERVICE_FAILED.value
-            else:
-                node.code_status = CodeStatus.UP_TO_DATE.value
-        elif node.code_version:
-            node.code_status = CodeStatus.OUTDATED.value
-        else:
-            node.code_status = CodeStatus.UNKNOWN.value
+        node.code_status = _derive_code_status(
+            node.code_version,
+            latest_version,
+            was_service_failed=_has_failed_autobot_service(extra_data),
+        )
 
     return latest_version
 

--- a/autobot-slm-backend/tests/api/test_node_code_status_read_derivation_12428.py
+++ b/autobot-slm-backend/tests/api/test_node_code_status_read_derivation_12428.py
@@ -1,0 +1,276 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression test: GET /nodes/{id} code_status must agree with
+GET /code-sync/status's outdated_nodes count (#12428).
+
+Root cause: the per-node ``code_status`` column is only ever written by
+``_update_heartbeat_code_status``, which runs solely on a heartbeat. An
+agentless node (e.g. role ``vnc``, no slm-agent enrolled -> last_heartbeat
+stays ``None``) never heartbeats, so its stamp freezes at whatever it was
+set to (often ``up_to_date`` at enrollment) even after ``code_version``
+drifts behind the fleet's ``latest_version`` -- disagreeing with
+``outdated_nodes`` (api/code_sync.py ``get_sync_status``), which always uses
+the live ``code_version != latest_version`` signal.
+
+Fix: ``get_node``/``list_nodes`` now derive the reported ``code_status`` on
+every read via ``_derive_code_status``/``_reported_code_status`` -- the same
+live signal, computed fresh instead of trusting the frozen stamp.
+
+Follows the real-module-swap pattern from test_nodes_list_timeout_10913.py
+(#11737): the slm-backend root conftest stubs sqlalchemy/models.database/
+models.schemas as MagicMocks for import-time safety, so api.nodes is
+imported inside ``_real_modules_swapped()`` to get the real FastAPI/pydantic
+machinery ``NodeResponse.model_validate`` needs.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_SLM_ROOT = Path(__file__).parent.parent.parent
+if str(_SLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SLM_ROOT))
+
+_SQLALCHEMY_MODULES = ("sqlalchemy", "sqlalchemy.ext", "sqlalchemy.ext.asyncio", "sqlalchemy.orm")
+
+
+def _is_sqlalchemy_key(name: str) -> bool:
+    return name == "sqlalchemy" or name.startswith("sqlalchemy.")
+
+
+def _load_real_module(name: str, path: Path):
+    """Exec *path* under canonical *name* (registered so relative imports work)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _build_real_modules() -> dict:
+    """One-time real sqlalchemy + models.database/models.schemas snapshot.
+
+    Mirrors tests/api/test_nodes_list_timeout_10913.py's setup: the root
+    conftest stubs these as MagicMocks for import-time safety, so the real
+    packages are loaded once here and swapped in on demand.
+    """
+    saved = {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)}
+    saved.update({name: sys.modules.get(name) for name in ("models.database", "models.schemas")})
+    for name in list(saved):
+        sys.modules.pop(name, None)
+    try:
+        for name in _SQLALCHEMY_MODULES:
+            importlib.import_module(name)
+        importlib.import_module("sqlalchemy.dialects.sqlite")
+        _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+        _load_real_module("models.schemas", _SLM_ROOT / "models" / "schemas.py")
+        return {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)} | {
+            "models.database": sys.modules["models.database"],
+            "models.schemas": sys.modules["models.schemas"],
+        }
+    finally:
+        for name in [n for n in sys.modules if _is_sqlalchemy_key(n)]:
+            del sys.modules[name]
+        sys.modules.pop("models.database", None)
+        sys.modules.pop("models.schemas", None)
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
+
+
+_REAL_MODULES = _build_real_modules()
+
+
+@contextlib.contextmanager
+def _real_modules_swapped():
+    """Temporarily put the real sqlalchemy/models modules into sys.modules."""
+    saved = {name: sys.modules.get(name) for name in _REAL_MODULES}
+    sys.modules.update(_REAL_MODULES)
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
+
+
+def _load_nodes_module():
+    """Import the real ``api.nodes`` module under the real-module swap."""
+    with _real_modules_swapped():
+        sys.modules.pop("api.nodes", None)
+        return importlib.import_module("api.nodes")
+
+
+_NODES = _load_nodes_module()
+CodeStatus = _NODES.CodeStatus
+
+
+def _fake_node(
+    node_id: str = "b9a29e04",
+    code_version: str | None = "abc123",
+    code_status: str | None = CodeStatus.UP_TO_DATE.value,
+    last_heartbeat=None,
+) -> SimpleNamespace:
+    """A SimpleNamespace with every attribute NodeResponse.model_validate
+    (from_attributes=True) needs — mirrors an agentless (or heartbeating)
+    node row."""
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=1,
+        node_id=node_id,
+        hostname="vnc-node",
+        ansible_name="vnc-node",
+        ip_address="10.0.0.5",
+        status="degraded",
+        roles=["vnc"],
+        detected_roles=[],
+        ssh_user="autobot",
+        ssh_port=22,
+        auth_method="key",
+        cpu_percent=0.0,
+        memory_percent=0.0,
+        disk_percent=0.0,
+        last_heartbeat=last_heartbeat,
+        agent_version=None,
+        os_info=None,
+        code_version=code_version,
+        code_status=code_status,
+        created_at=now,
+        updated_at=now,
+        a2a_card=None,
+        service_summary=None,
+        extra_data=None,
+    )
+
+
+def _mock_result(value):
+    """A db.execute(...) result stub whose scalar_one_or_none() returns *value*."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# _derive_code_status / _reported_code_status — pure-function coverage
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveCodeStatus:
+    def test_up_to_date_when_versions_match(self):
+        assert _NODES._derive_code_status("abc", "abc") == CodeStatus.UP_TO_DATE.value
+
+    def test_outdated_when_versions_differ(self):
+        assert _NODES._derive_code_status("abc", "def") == CodeStatus.OUTDATED.value
+
+    def test_outdated_when_code_version_none_but_latest_known(self):
+        """Agentless node that never synced still can't claim up_to_date."""
+        assert _NODES._derive_code_status(None, "def") == CodeStatus.UNKNOWN.value
+
+    def test_none_when_latest_unknown(self):
+        """Falls back (caller keeps stored stamp) when there's nothing to compare against."""
+        assert _NODES._derive_code_status("abc", None) is None
+
+    def test_service_failed_preserved_when_versions_match(self):
+        assert (
+            _NODES._derive_code_status("abc", "abc", was_service_failed=True)
+            == CodeStatus.CODE_CURRENT_SERVICE_FAILED.value
+        )
+
+    def test_service_failed_ignored_when_versions_differ(self):
+        """Version mismatch is definitive -- outdated wins over a stale
+        service-failed flag."""
+        assert _NODES._derive_code_status("abc", "def", was_service_failed=True) == CodeStatus.OUTDATED.value
+
+
+class TestReportedCodeStatus:
+    def test_agentless_node_never_reports_up_to_date_when_behind(self):
+        """Core #12428 acceptance criterion: last_heartbeat=None,
+        code_version behind latest -> must NOT report up_to_date, even
+        though the frozen DB stamp says up_to_date."""
+        node = _fake_node(code_version="old-sha", code_status=CodeStatus.UP_TO_DATE.value, last_heartbeat=None)
+        reported = _NODES._reported_code_status(node, latest_version="new-sha")
+        assert reported != CodeStatus.UP_TO_DATE.value
+        assert reported == CodeStatus.OUTDATED.value
+
+    def test_current_node_still_reports_up_to_date(self):
+        node = _fake_node(
+            code_version="new-sha", code_status=CodeStatus.UP_TO_DATE.value, last_heartbeat=datetime.now(timezone.utc)
+        )
+        reported = _NODES._reported_code_status(node, latest_version="new-sha")
+        assert reported == CodeStatus.UP_TO_DATE.value
+
+    def test_falls_back_to_stored_stamp_when_latest_unknown(self):
+        node = _fake_node(code_version="new-sha", code_status=CodeStatus.OUTDATED.value)
+        reported = _NODES._reported_code_status(node, latest_version=None)
+        assert reported == CodeStatus.OUTDATED.value
+
+
+# ---------------------------------------------------------------------------
+# get_node endpoint — end-to-end agreement with outdated_nodes' live signal
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodeDerivesCodeStatus:
+    @pytest.mark.asyncio
+    async def test_agentless_node_reports_outdated_not_up_to_date(self):
+        """The exact #12428 scenario: node_id b9a29e04-style agentless node,
+        last_heartbeat=None, code_version behind latest_version. get_node
+        must report a non-up_to_date status -- consistent with
+        outdated_nodes, which would count this node (code_version !=
+        latest_version)."""
+        node = _fake_node(code_version="old-sha", code_status=CodeStatus.UP_TO_DATE.value, last_heartbeat=None)
+        latest_setting = SimpleNamespace(value="new-sha")
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = [_mock_result(node), _mock_result(latest_setting)]
+
+        resp = await _NODES.get_node(node_id="b9a29e04", db=mock_db, _={"admin": True, "role": "admin"})
+
+        assert resp.code_status != CodeStatus.UP_TO_DATE.value
+        assert resp.code_status == CodeStatus.OUTDATED.value
+
+    @pytest.mark.asyncio
+    async def test_current_node_reports_up_to_date(self):
+        """A node whose code_version matches latest_version still reports
+        up_to_date -- the derivation must not regress the common case."""
+        node = _fake_node(
+            code_version="new-sha",
+            code_status=CodeStatus.UP_TO_DATE.value,
+            last_heartbeat=datetime.now(timezone.utc),
+        )
+        latest_setting = SimpleNamespace(value="new-sha")
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = [_mock_result(node), _mock_result(latest_setting)]
+
+        resp = await _NODES.get_node(node_id="current-node", db=mock_db, _={"admin": True, "role": "admin"})
+
+        assert resp.code_status == CodeStatus.UP_TO_DATE.value
+
+    @pytest.mark.asyncio
+    async def test_404_when_node_missing(self):
+        from fastapi import HTTPException
+
+        mock_db = AsyncMock()
+        mock_db.execute.side_effect = [_mock_result(None)]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _NODES.get_node(node_id="missing", db=mock_db, _={"admin": True, "role": "admin"})
+
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Thinking Path

Issue #12428 (part a — reporting; see my parked root-cause comment on the issue): `GET /code-sync/status`'s `outdated_nodes` uses the live signal `code_version != latest_version` (`api/code_sync.py:625-651`). The per-node `code_status` returned by `GET /nodes/{id}` was serialized raw from the `Node.code_status` DB column, which is **only ever written by `_update_heartbeat_code_status`** (`api/nodes.py`, runs solely on a heartbeat). An agentless node (e.g. role `vnc`, no slm-agent enrolled) never heartbeats, so that stamp freezes — often at `up_to_date` from enrollment — even after `code_version` drifts behind `latest_version`. The two surfaces read different sources and legitimately disagree.

Fix: derive `code_status` on every read from the same live signal `outdated_nodes` already uses, instead of trusting the frozen heartbeat stamp.

## What Changed

`autobot-slm-backend/api/nodes.py`:
- Added `_derive_code_status(code_version, latest_version, was_service_failed)` (nodes.py:1746) — pure function, single source of truth for the currency label. Mirrors `outdated_nodes`'s live signal (`code_version != latest_version`) plus the existing `#1605` service-failed nuance. Returns `None` when `latest_version` is unknown so callers fall back to the stored stamp (mirrors `get_sync_status`'s own fallback).
- `_update_heartbeat_code_status` (nodes.py:1818) refactored to call `_derive_code_status` instead of its previous inline if/elif/else — de-duplicates the logic rather than adding a second copy of it.
- Added `_get_latest_code_version(db)` (nodes.py:1768) — the same `slm_agent_latest_commit` Setting lookup already used by `_update_heartbeat_code_status` and `api/code_sync.py get_sync_status`.
- Added `_reported_code_status(node, latest_version)` (nodes.py:1781) — read-time wrapper: derives from the live signal, preserving the `code_current_service_failed` stamp only when the version still matches (that check needs live heartbeat `extra_data`, unavailable at read time).
- `get_node` (nodes.py:555-562) and `_query_nodes_page`/`list_nodes` (nodes.py:421-429, the fleet dashboard's `GET /nodes` list source per `fleet.ts fetchNodes()`) now call `_get_latest_code_version` + override `resp.code_status` via `_reported_code_status` before returning, instead of trusting `NodeResponse.model_validate(node)`'s raw `code_status`.

**Untouched (explicit scope boundary):** `_is_node_operational` and the fleet-sync coverage gate (`api/code_sync.py:4613`, #11511) are NOT modified — that gate deliberately excludes never-heartbeated nodes from the one-click Update-All fleet stage to stop a dead node aborting the whole rollout. Whether an agentless/SSH-reachable node should be attempted by that stage (part b of #12428) is a separate owner decision, called out on the issue as risky/supervised-review scope. `api/code_sync.py` itself has zero diff in this PR.

**Also discovered, filed as follow-up (not fixed here — different blast radius):** `api/nodes.py`'s `GET /nodes/{node_id}/updates` endpoint and `api/updates.py`'s `is_code_update_available()`/`_build_node_summaries()` (the #11964 fleet-update badge) still read `node.code_status` raw. Fixing those touches #11964's dedicated badge/live-check consistency mechanism across two endpoints — filing separately rather than expanding this PR's surface area.

## Verification

New test file `autobot-slm-backend/tests/api/test_node_code_status_read_derivation_12428.py` (12 tests): pure-function coverage for `_derive_code_status`/`_reported_code_status`, plus an end-to-end `get_node` test proving the exact #12428 scenario — an agentless node (`last_heartbeat=None`, `code_version` behind `latest_version`, stored stamp `up_to_date`) now reports `outdated` (never `up_to_date`), and a current node still reports `up_to_date`.

```
tests/api/test_node_code_status_read_derivation_12428.py::TestGetNodeDerivesCodeStatus::test_agentless_node_reports_outdated_not_up_to_date PASSED
tests/api/test_node_code_status_read_derivation_12428.py::TestGetNodeDerivesCodeStatus::test_current_node_reports_up_to_date PASSED
tests/api/test_node_code_status_read_derivation_12428.py::TestGetNodeDerivesCodeStatus::test_404_when_node_missing PASSED
12 passed in 4.30s
```

Full relevant suite (nodes/code_sync currency + fleet-sync gate + heartbeat, proving `_is_node_operational`/#11511 gate tests are unaffected):

```
$ python3 -m pytest tests/api/test_node_code_status_read_derivation_12428.py \
    tests/api/test_nodes_list_timeout_10913.py tests/api/test_node_update_availability_11964.py \
    tests/api/test_sync_status_outdated_signal.py tests/api/test_collect_outdated_node_ids.py \
    tests/api/test_fleet_node_update_11511.py tests/api/test_drift_resolve_advances_node_version_11512.py \
    tests/services/code_version_test.py -v
87 passed in 8.86s
```

Full `tests/api/` + `tests/services/` (excluding 3 files with a pre-existing cross-file MagicMock collision unrelated to this change, confirmed present on unmodified code by running the same collect-only without my new test file — same 3 errors):

```
$ python3 -m pytest tests/api/ tests/services/ -q \
    --ignore=tests/api/test_code_sync_deploy_bugs.py \
    --ignore=tests/api/test_code_sync_protected_excludes.py \
    --ignore=tests/api/test_code_sync_symlink_restore.py
603 passed, 1 skipped, 7 warnings in 37.72s
```

`git diff --stat` confirms zero changes to `api/code_sync.py`:
```
autobot-slm-backend/api/nodes.py | 100 +++++++++++++++++++++++++++++++++------
1 file changed, 86 insertions(+), 14 deletions(-)
```

Closes #12428

## Model Used

Sonnet 5