### PR TITLE
feat(deploy): read-only drift visibility for all deployed components (#12450)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -70,6 +70,7 @@ from services.database import get_db
 from services.deploy_artifacts import rsync_artifact_excludes
 from services.drift_checker import (
     ALLOWED_COMPONENTS,
+    VISIBILITY_COMPONENTS,
     build_drift_report,
     get_default_deployed_dir,
     get_default_source_dir,
@@ -545,7 +546,7 @@ _stale_components_cache: dict = {"ts": -_STALE_COMPONENTS_TTL_SECONDS - 1.0, "va
 
 
 async def _compute_stale_components(force: bool = False) -> list[str]:
-    """Return ALLOWED_COMPONENTS deployed on this box whose files drift from source.
+    """Return VISIBILITY_COMPONENTS deployed on this box whose files drift from source.
 
     Surfaces the #11820 gap: a co-located managed component can be stale (its
     deployed files differ from code_source) even when a node's code_version
@@ -554,6 +555,13 @@ async def _compute_stale_components(force: bool = False) -> list[str]:
     and the result is cached for _STALE_COMPONENTS_TTL_SECONDS to bound cost on
     the polled status path. Defensive: a failing component is logged and skipped,
     never breaking the status response.
+
+    #12450: scans VISIBILITY_COMPONENTS (ALLOWED_COMPONENTS plus the
+    read-only extras — ai-stack, npu-worker, browser-worker, slm-agent,
+    plugins) so an operator gets a drift signal for every deployed component,
+    not just the 5 with a resolve path. Reporting here does NOT imply those
+    extras can be resolved — /drift/resolve[-async] still gate on the
+    narrower ALLOWED_COMPONENTS.
 
     force=True bypasses the cache and re-scans immediately (#11512): callers
     that just resynced a component need the FRESH drift state, not a stale
@@ -565,7 +573,7 @@ async def _compute_stale_components(force: bool = False) -> list[str]:
 
     stale: list[str] = []
     loop = asyncio.get_running_loop()
-    for component in sorted(ALLOWED_COMPONENTS):
+    for component in sorted(VISIBILITY_COMPONENTS):
         try:
             deployed_dir = get_default_deployed_dir(component)
             if not os.path.isdir(deployed_dir):
@@ -683,14 +691,17 @@ async def get_file_drift(
 
     Query params:
         component: Sub-directory to compare (default: autobot-slm-backend).
-                   Must be one of the allowed components (Issue #3427).
+                   Must be one of the visibility-scanned components (Issue
+                   #3427; extended to read-only extras by #12450). Components
+                   outside this set have no verified path map and are
+                   excluded rather than guessed.
 
     Returns a FileDriftReport with a list of drifted files and their checksums.
     """
-    if component not in ALLOWED_COMPONENTS:
+    if component not in VISIBILITY_COMPONENTS:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid component '{component}'. Must be one of: {sorted(ALLOWED_COMPONENTS)}",
+            detail=f"Invalid component '{component}'. Must be one of: {sorted(VISIBILITY_COMPONENTS)}",
         )
 
     try:
@@ -736,6 +747,12 @@ async def resolve_drift(
 
     Body:
         component: Sub-directory under /opt/autobot/. Must be in ALLOWED_COMPONENTS.
+                   #12450: intentionally NOT VISIBILITY_COMPONENTS — the extra
+                   read-only components (ai-stack, npu-worker, browser-worker,
+                   slm-agent, plugins) have no per-component post-sync
+                   (pip/npm/docker/symlink) wired, so resolving them would
+                   rsync files but never install deps or restart the right
+                   service. Deferred pending owner sign-off.
 
     Returns DriftResolveResponse with success flag, rsync output, deps_changed
     flag, and a log of post-sync steps performed.

--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -77,6 +77,81 @@ ALLOWED_COMPONENTS = frozenset(
     }
 )
 
+# #12450: additional deployed components that have NO resolve/restart wiring
+# (no per-component post-sync — pip/npm/docker/symlink heterogeneity) but ARE
+# actively running deployed code with no builtin drift signal today. These are
+# READ-ONLY visibility — do NOT add them to ALLOWED_COMPONENTS, which gates
+# /drift/resolve[-async]. Whitelisting resolve for them would rsync files but
+# never install deps or restart the right service (see the parked root-cause
+# comment on #12450) — half-working and worse than the current 400.
+#
+# Every entry must be verified against its actual ansible deploy task before
+# being added here — see _NONSTANDARD_COMPONENT_PATHS below for the ones whose
+# layout isn't the standard code_source/<name> -> /opt/autobot/<name> shape.
+#
+# NOT included (confirmed unmappable, see #12450 PR notes):
+#   - autobot-tts-worker: deployed via a single Jinja2-templated file
+#     (tts-worker.py.j2 -> tts-worker.py), not a 1:1 sync of the repo's
+#     autobot-tts-worker/ directory — comparing them would report fake drift.
+#   - autobot-celery / celery-beat: no distinct deployed directory — both run
+#     FROM the autobot-backend deployed dir (systemd WorkingDirectory), so
+#     they are already covered by the existing "autobot-backend" entry.
+#   - autobot-plugins (the @autobot/vnc, @autobot/terminal npm workspace
+#     packages): synced into TWO deployed locations (autobot-frontend/ and
+#     autobot-slm-frontend/), so there is no single canonical deployed target
+#     to compare against — needs an owner decision on which (or both) to scan.
+EXTRA_VISIBILITY_COMPONENTS = frozenset(
+    {
+        "autobot-ai-stack",
+        "autobot-npu-worker",
+        "autobot-browser-worker",
+        "autobot-slm-agent",
+        "plugins",
+    }
+)
+
+# Union of the resolve-capable allowlist and the read-only extras — used by
+# the GET-only drift surfaces (/status stale_components, GET /drift). The
+# resolve/resolve-async endpoints must keep checking ALLOWED_COMPONENTS only
+# (#12450).
+VISIBILITY_COMPONENTS = ALLOWED_COMPONENTS | EXTRA_VISIBILITY_COMPONENTS
+
+# Source/deployed path overrides for components whose layout does not follow
+# the code_source/<component> -> <SLM_DEPLOYED_ROOT>/<component> convention
+# assumed by get_default_source_dir/get_default_deployed_dir (#12450). Paths
+# are relative to DEFAULT_REPO_PATH / SLM_DEPLOYED_ROOT respectively. Verified
+# against the live ansible deploy tasks — do not add an entry without tracing
+# it to the actual unarchive/copy/synchronize task.
+_NONSTANDARD_COMPONENT_PATHS: dict[str, tuple[str, str]] = {
+    # ai-stack has no top-level code_source/autobot-ai-stack dir; it lives
+    # under autobot-infrastructure/ and deploys with --strip-components=4 so
+    # the ai-stack/ subtree contents land directly under the deployed root
+    # (ansible/playbooks/update-all-nodes.yml ~135-141, ~1060-1064).
+    "autobot-ai-stack": (
+        "autobot-infrastructure/shared/docker/ai-stack",
+        "autobot-ai-stack",
+    ),
+    # slm-agent has no top-level code_source/autobot-slm-agent dir either;
+    # its source of truth is the individual per-file `copy:` tasks in the
+    # slm_agent role, all of which live under files/slm/agent/ and land at
+    # <slm_agent_dir>/slm/agent/ (ansible/roles/slm_agent/tasks/main.yml
+    # ~132-213). config.yaml/role.json/version.json are Jinja2 templates
+    # (not raw source files) and are intentionally excluded from this scan.
+    "autobot-slm-agent": (
+        "autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent",
+        "autobot-slm-agent/slm/agent",
+    ),
+    # plugins/ ships at the repo root, a SIBLING of autobot-backend/, and is
+    # rsynced into the backend's own plugins/ subdirectory rather than its
+    # own top-level /opt/autobot/plugins tree (ansible/roles/backend/tasks/
+    # main.yml #10294).
+    "plugins": (
+        "plugins",
+        "autobot-backend/plugins",
+    ),
+}
+
+
 # Directory names / suffixes to skip entirely during traversal. Sourced from the
 # canonical deploy-artifact vocabulary (#11459) so the drift walk and the
 # code_sync rsync excludes never disagree about what is an artifact — the
@@ -291,7 +366,9 @@ def get_default_deployed_dir(component: str = "autobot-slm-backend") -> str:
     """Return the expected deployed path for *component* under /opt/autobot.
 
     Reads ``SLM_DEPLOYED_ROOT`` from the environment so the path is
-    configurable without hardcoding.
+    configurable without hardcoding. Components listed in
+    ``_NONSTANDARD_COMPONENT_PATHS`` (#12450) use their verified override
+    sub-path instead of the standard ``<root>/<component>`` convention.
 
     Args:
         component: Sub-directory name under the deployed root.
@@ -300,7 +377,9 @@ def get_default_deployed_dir(component: str = "autobot-slm-backend") -> str:
         Absolute path string for the deployed component directory.
     """
     deployed_root = os.environ.get("SLM_DEPLOYED_ROOT", "/opt/autobot")
-    return str(Path(deployed_root) / component)
+    override = _NONSTANDARD_COMPONENT_PATHS.get(component)
+    rel_path = override[1] if override else component
+    return str(Path(deployed_root) / rel_path)
 
 
 def get_default_source_dir(component: str = "autobot-slm-backend") -> str:
@@ -308,6 +387,10 @@ def get_default_source_dir(component: str = "autobot-slm-backend") -> str:
 
     Uses ``DEFAULT_REPO_PATH`` from ``services.git_tracker``, which resolves
     ``SLM_REPO_PATH`` with the same fallback, ensuring a single source of truth.
+    Components listed in ``_NONSTANDARD_COMPONENT_PATHS`` (#12450) use their
+    verified override sub-path instead of the standard
+    ``code_source/<component>`` convention (e.g. ai-stack, which lives under
+    ``autobot-infrastructure/``).
 
     Args:
         component: Sub-directory name inside the code_source repository.
@@ -315,7 +398,9 @@ def get_default_source_dir(component: str = "autobot-slm-backend") -> str:
     Returns:
         Absolute path string for the source directory to compare against.
     """
-    candidate = Path(DEFAULT_REPO_PATH) / component
+    override = _NONSTANDARD_COMPONENT_PATHS.get(component)
+    rel_path = override[0] if override else component
+    candidate = Path(DEFAULT_REPO_PATH) / rel_path
     if not candidate.is_dir():
         raise ValueError(f"drift_checker: source component directory does not exist: {candidate}")
     return str(candidate)

--- a/autobot-slm-backend/services/drift_checker_test.py
+++ b/autobot-slm-backend/services/drift_checker_test.py
@@ -62,6 +62,9 @@ build_drift_report = _dc.build_drift_report
 get_default_source_dir = _dc.get_default_source_dir
 get_default_deployed_dir = _dc.get_default_deployed_dir
 ALLOWED_COMPONENTS = _dc.ALLOWED_COMPONENTS
+EXTRA_VISIBILITY_COMPONENTS = _dc.EXTRA_VISIBILITY_COMPONENTS
+VISIBILITY_COMPONENTS = _dc.VISIBILITY_COMPONENTS
+_NONSTANDARD_COMPONENT_PATHS = _dc._NONSTANDARD_COMPONENT_PATHS
 _SKIP_DIRS = _dc._SKIP_DIRS
 _INCLUDE_EXTENSIONS = _dc._INCLUDE_EXTENSIONS
 _BACKEND_EXTENSIONS = _dc._BACKEND_EXTENSIONS
@@ -818,3 +821,121 @@ class TestComputeDriftPerComponent:
         drifted, total = compute_drift(str(src), str(dep), "autobot-frontend")
         assert total == 1
         assert drifted == []
+
+
+# ===========================================================================
+# #12450: read-only visibility for extra deployed components
+# ===========================================================================
+
+
+class TestExtraVisibilityComponents:
+    """VISIBILITY_COMPONENTS extends drift REPORTING to components with no
+    resolve/restart wiring — ai-stack, npu-worker, browser-worker, slm-agent,
+    plugins. Must never be merged into ALLOWED_COMPONENTS (the resolve gate)."""
+
+    def test_extra_components_are_exactly_the_expected_five(self):
+        assert set(EXTRA_VISIBILITY_COMPONENTS) == {
+            "autobot-ai-stack",
+            "autobot-npu-worker",
+            "autobot-browser-worker",
+            "autobot-slm-agent",
+            "plugins",
+        }
+
+    def test_extra_components_disjoint_from_resolve_allowlist(self):
+        """The read-only extras must never overlap ALLOWED_COMPONENTS — that
+        would silently grant them a resolve/restart path with no wiring."""
+        assert EXTRA_VISIBILITY_COMPONENTS.isdisjoint(ALLOWED_COMPONENTS)
+
+    def test_visibility_components_is_the_union(self):
+        assert VISIBILITY_COMPONENTS == ALLOWED_COMPONENTS | EXTRA_VISIBILITY_COMPONENTS
+
+    def test_visibility_components_is_frozenset(self):
+        assert isinstance(VISIBILITY_COMPONENTS, frozenset)
+
+
+class TestNonstandardComponentPathMap:
+    """Verify the source/deployed path override for each nonstandard
+    component (#12450) resolves to the paths confirmed against the live
+    ansible deploy tasks."""
+
+    def test_ai_stack_source_path_is_infrastructure_subtree(self, monkeypatch, tmp_path):
+        """ai-stack has no top-level code_source/autobot-ai-stack dir; its
+        source is autobot-infrastructure/shared/docker/ai-stack (playbook
+        Play 0 archive task, ~135-141)."""
+        fake_repo = tmp_path / "repo"
+        (fake_repo / "autobot-infrastructure" / "shared" / "docker" / "ai-stack").mkdir(parents=True)
+        monkeypatch.setattr(_dc, "DEFAULT_REPO_PATH", str(fake_repo))
+        result = get_default_source_dir("autobot-ai-stack")
+        assert result == str(fake_repo / "autobot-infrastructure" / "shared" / "docker" / "ai-stack")
+
+    def test_ai_stack_deployed_path_strips_to_flat_dir(self):
+        """--strip-components=4 (Play 2, ~1060-1064) lands ai-stack's contents
+        flat under /opt/autobot/autobot-ai-stack, not a nested path."""
+        with patch.dict(os.environ, {"SLM_DEPLOYED_ROOT": "/opt/autobot"}):
+            result = get_default_deployed_dir("autobot-ai-stack")
+        assert result == "/opt/autobot/autobot-ai-stack"
+
+    def test_slm_agent_source_path_is_role_files_subtree(self, monkeypatch, tmp_path):
+        """slm-agent's source of truth is the per-file copy: tasks in the
+        slm_agent role (files/slm/agent/*.py), not a top-level
+        code_source/autobot-slm-agent dir."""
+        fake_repo = tmp_path / "repo"
+        nested = fake_repo / "autobot-slm-backend" / "ansible" / "roles" / "slm_agent" / "files" / "slm" / "agent"
+        nested.mkdir(parents=True)
+        monkeypatch.setattr(_dc, "DEFAULT_REPO_PATH", str(fake_repo))
+        result = get_default_source_dir("autobot-slm-agent")
+        assert result == str(nested)
+
+    def test_slm_agent_deployed_path_is_agent_subtree(self):
+        """Deployed target is <slm_agent_dir>/slm/agent (role tasks ~132-213),
+        not the top-level /opt/autobot/autobot-slm-agent dir (which also
+        holds config.yaml/role.json/version.json — templated, not raw source)."""
+        with patch.dict(os.environ, {"SLM_DEPLOYED_ROOT": "/opt/autobot"}):
+            result = get_default_deployed_dir("autobot-slm-agent")
+        assert result == "/opt/autobot/autobot-slm-agent/slm/agent"
+
+    def test_plugins_source_path_is_repo_root_sibling(self, monkeypatch, tmp_path):
+        """plugins/ ships at the repo root, a SIBLING of autobot-backend/, not
+        nested inside it."""
+        fake_repo = tmp_path / "repo"
+        (fake_repo / "plugins").mkdir(parents=True)
+        monkeypatch.setattr(_dc, "DEFAULT_REPO_PATH", str(fake_repo))
+        result = get_default_source_dir("plugins")
+        assert result == str(fake_repo / "plugins")
+
+    def test_plugins_deployed_path_is_inside_backend(self):
+        """plugins/ is rsynced into the backend's own plugins/ subdirectory
+        (backend role #10294), not a top-level /opt/autobot/plugins tree."""
+        with patch.dict(os.environ, {"SLM_DEPLOYED_ROOT": "/opt/autobot"}):
+            result = get_default_deployed_dir("plugins")
+        assert result == "/opt/autobot/autobot-backend/plugins"
+
+    def test_standard_components_are_unaffected_by_the_override_map(self, tmp_path):
+        """npu-worker and browser-worker follow the standard
+        code_source/<name> -> <root>/<name> convention — no override needed,
+        so they must NOT appear in _NONSTANDARD_COMPONENT_PATHS."""
+        assert "autobot-npu-worker" not in _NONSTANDARD_COMPONENT_PATHS
+        assert "autobot-browser-worker" not in _NONSTANDARD_COMPONENT_PATHS
+        with patch.dict(os.environ, {"SLM_DEPLOYED_ROOT": str(tmp_path)}):
+            assert get_default_deployed_dir("autobot-npu-worker") == str(tmp_path / "autobot-npu-worker")
+            assert get_default_deployed_dir("autobot-browser-worker") == str(tmp_path / "autobot-browser-worker")
+
+    def test_allowed_components_are_unaffected_by_the_override_map(self):
+        """The original 5 resolve-capable components must have no entry in
+        the override map — their existing standard-path behavior (relied on
+        by /drift/resolve) must not change."""
+        assert _NONSTANDARD_COMPONENT_PATHS.keys().isdisjoint(ALLOWED_COMPONENTS)
+
+    def test_compute_drift_reports_drift_for_ai_stack_style_deployed_path(self, tmp_path):
+        """End-to-end: a mocked ai-stack-shaped deployed dir (flat, post
+        --strip-components=4) compared against its infrastructure-nested
+        source dir surfaces drift exactly like any other component."""
+        src = tmp_path / "repo" / "autobot-infrastructure" / "shared" / "docker" / "ai-stack"
+        dep = tmp_path / "opt" / "autobot" / "autobot-ai-stack"
+        _write(src / "ai_api_server.py", b"source version")
+        _write(dep / "ai_api_server.py", b"stale deployed version")
+        drifted, total = compute_drift(str(src), str(dep), "autobot-ai-stack")
+        assert total == 1
+        assert drifted[0]["path"] == "ai_api_server.py"
+        assert drifted[0]["status"] == "modified"

--- a/autobot-slm-backend/tests/api/test_status_stale_components_11820.py
+++ b/autobot-slm-backend/tests/api/test_status_stale_components_11820.py
@@ -55,6 +55,7 @@ async def test_flags_only_drifted_deployed_components(monkeypatch, tmp_path):
 
     _reset_cache(cs)
     monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot-slm-backend", "autobot_shared"})
+    monkeypatch.setattr(cs, "VISIBILITY_COMPONENTS", {"autobot-slm-backend", "autobot_shared"})
     monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))  # exists → checked
     monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
 
@@ -71,6 +72,7 @@ async def test_skips_components_not_deployed_here(monkeypatch):
 
     _reset_cache(cs)
     monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot-backend"})
+    monkeypatch.setattr(cs, "VISIBILITY_COMPONENTS", {"autobot-backend"})
     monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: "/nonexistent/deployed/dir")
 
     def _boom(*_a, **_k):  # must never be called when the dir is absent
@@ -86,6 +88,7 @@ async def test_result_is_ttl_cached(monkeypatch, tmp_path):
 
     _reset_cache(cs)
     monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot_shared"})
+    monkeypatch.setattr(cs, "VISIBILITY_COMPONENTS", {"autobot_shared"})
     monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
     monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
     monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": ["x"], "total_compared": 1})
@@ -104,6 +107,7 @@ async def test_failing_component_is_isolated(monkeypatch, tmp_path):
 
     _reset_cache(cs)
     monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot-slm-backend", "autobot_shared"})
+    monkeypatch.setattr(cs, "VISIBILITY_COMPONENTS", {"autobot-slm-backend", "autobot_shared"})
     monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
     monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
 
@@ -125,6 +129,7 @@ async def test_pull_invalidates_stale_components_cache(monkeypatch, tmp_path):
     import api.code_sync as cs
 
     monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot_shared"})
+    monkeypatch.setattr(cs, "VISIBILITY_COMPONENTS", {"autobot_shared"})
     monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
     monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
     monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": ["x"], "total_compared": 1})
@@ -164,6 +169,7 @@ async def test_status_read_alone_never_busts_cache(monkeypatch, tmp_path):
 
     _reset_cache(cs)
     monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", {"autobot_shared"})
+    monkeypatch.setattr(cs, "VISIBILITY_COMPONENTS", {"autobot_shared"})
     monkeypatch.setattr(cs, "get_default_deployed_dir", lambda c: str(tmp_path))
     monkeypatch.setattr(cs, "get_default_source_dir", lambda c: str(tmp_path))
     monkeypatch.setattr(cs, "build_drift_report", lambda *a: {"drifted_files": ["x"], "total_compared": 1})
@@ -176,3 +182,52 @@ async def test_status_read_alone_never_busts_cache(monkeypatch, tmp_path):
     second = await cs._compute_stale_components()
     assert second == ["autobot_shared"]  # still cached, not re-walked
     assert cs._stale_components_cache["ts"] == ts_after_first
+
+
+async def test_extended_scan_covers_ai_stack_with_correct_path_map(monkeypatch, tmp_path):
+    """#12450: VISIBILITY_COMPONENTS extends the _compute_stale_components
+    scan beyond the 5 resolve-capable ALLOWED_COMPONENTS to also report
+    drift for the read-only extras (ai-stack, npu-worker, browser-worker,
+    slm-agent, plugins). Simulates the ai-stack nonstandard layout (source
+    nested under autobot-infrastructure/..., deployed flat after
+    --strip-components=4 — ansible/playbooks/update-all-nodes.yml ~135-141,
+    ~1060-1064) with real tmp_path directories and asserts
+    _compute_stale_components resolves the EXACT path pair for the
+    component before reporting it stale — proving both scan coverage and
+    path-map correctness. (get_default_source_dir/get_default_deployed_dir's
+    own nonstandard-path-map logic is covered directly by
+    TestNonstandardComponentPathMap in services/drift_checker_test.py.)"""
+    import api.code_sync as cs
+
+    _reset_cache(cs)
+
+    # Mirrors the real ai-stack layout: source nested under
+    # autobot-infrastructure/..., deployed flat at <root>/autobot-ai-stack.
+    ai_stack_src = tmp_path / "repo" / "autobot-infrastructure" / "shared" / "docker" / "ai-stack"
+    ai_stack_src.mkdir(parents=True)
+    ai_stack_dep = tmp_path / "opt" / "autobot" / "autobot-ai-stack"
+    ai_stack_dep.mkdir(parents=True)
+    expected_paths = {"autobot-ai-stack": (str(ai_stack_src), str(ai_stack_dep))}
+
+    def fake_source_dir(component):
+        return expected_paths[component][0]
+
+    def fake_deployed_dir(component):
+        return expected_paths[component][1]
+
+    def fake_report(src, dep, comp):
+        # Only reports drift when called with the exact path-map pair above —
+        # proving _compute_stale_components resolved the correct nonstandard
+        # source/deployed paths for a newly-covered component, not a naive
+        # code_source/<name> guess.
+        assert (src, dep) == expected_paths[comp]
+        return {"drifted_files": ["ai_api_server.py"], "total_compared": 1}
+
+    monkeypatch.setattr(cs, "ALLOWED_COMPONENTS", frozenset())
+    monkeypatch.setattr(cs, "VISIBILITY_COMPONENTS", frozenset({"autobot-ai-stack"}))
+    monkeypatch.setattr(cs, "get_default_source_dir", fake_source_dir)
+    monkeypatch.setattr(cs, "get_default_deployed_dir", fake_deployed_dir)
+    monkeypatch.setattr(cs, "build_drift_report", fake_report)
+
+    stale = await cs._compute_stale_components()
+    assert stale == ["autobot-ai-stack"]


### PR DESCRIPTION
Closes #12450

## Thinking Path

`ALLOWED_COMPONENTS` in `autobot-slm-backend/services/drift_checker.py` (~65-78) lists only 5 components and is enforced as a hard 400 at every `/code-sync/drift*` entry point. `_compute_stale_components` (`api/code_sync.py` ~547-586) iterates only that 5-component set, so `ai-stack`, `npu-worker`, `browser-worker`, `slm-agent`, `celery`/`celery-beat`, `plugins`, and `tts-worker` — all actively deployed, running services — have no drift signal at all.

Per the parked root-cause comment on #12450, the fix splits into two halves:
- **SAFE (this PR):** extend the read-only drift *scan* (`GET /status` `stale_components`, `GET /drift`) to report drift for every component with a *verified* deployed path, without wiring any resolve/restart path.
- **NEEDS OWNER DECISION (deferred):** per-component `resolve` + restart wiring — heterogeneous post-sync (pip/npm/docker/symlink) for live prod workers, risky, supervised deploy required.

For each extra component I traced the actual ansible deploy task (not assumed `code_source/<name>` → `/opt/autobot/<name>`) before adding it, per the "if you can't confidently determine the path, exclude it" instruction.

## What Changed

- `autobot-slm-backend/services/drift_checker.py`
  - `EXTRA_VISIBILITY_COMPONENTS` (new, ~80-108): `autobot-ai-stack`, `autobot-npu-worker`, `autobot-browser-worker`, `autobot-slm-agent`, `plugins` — read-only only, deliberately **not** merged into `ALLOWED_COMPONENTS`.
  - `VISIBILITY_COMPONENTS = ALLOWED_COMPONENTS | EXTRA_VISIBILITY_COMPONENTS` — used by the GET-only surfaces.
  - `_NONSTANDARD_COMPONENT_PATHS` (new, ~109-140): verified source→deployed path overrides for the 3 components whose layout isn't `code_source/<name>` → `<root>/<name>`:
    | component | source (relative to `code_source/`) | deployed (relative to `SLM_DEPLOYED_ROOT`) | verified against |
    |---|---|---|---|
    | `autobot-ai-stack` | `autobot-infrastructure/shared/docker/ai-stack` | `autobot-ai-stack` | `update-all-nodes.yml` Play 0 archive task (~135-141) + Play 2 `unarchive --strip-components=4` (~1060-1064) |
    | `autobot-slm-agent` | `autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent` | `autobot-slm-agent/slm/agent` | `roles/slm_agent/tasks/main.yml` per-file `copy:` tasks (~132-213) — no top-level `code_source/autobot-slm-agent` dir exists; `config.yaml`/`role.json`/`version.json` are Jinja2 templates, intentionally excluded |
    | `plugins` | `plugins` | `autobot-backend/plugins` | `roles/backend/tasks/main.yml` `synchronize` task (#10294) — repo-root sibling of `autobot-backend/`, rsynced into the backend's own subdir |
  - `autobot-npu-worker` / `autobot-browser-worker` need no override — standard `code_source/<name>` → `<root>/<name>` layout, confirmed against `update-all-nodes.yml` Play 2 unarchive tasks.
  - `get_default_source_dir` / `get_default_deployed_dir` now consult the override map first, falling back to the existing standard convention (zero behavior change for the original 5 components).
- `autobot-slm-backend/api/code_sync.py`
  - `_compute_stale_components` (~548-586) now loops `sorted(VISIBILITY_COMPONENTS)` instead of `sorted(ALLOWED_COMPONENTS)`.
  - `GET /drift` (~688-704) validates against `VISIBILITY_COMPONENTS` (400 message updated to match).
  - `POST /drift/resolve` / `POST /drift/resolve-async` **unchanged** — still gate on `ALLOWED_COMPONENTS` only; docstring on `resolve_drift` (~747-753) explicitly notes why `VISIBILITY_COMPONENTS` is NOT used there.

**Components now visible in `stale_components` / `GET /drift`:** `autobot-ai-stack`, `autobot-npu-worker`, `autobot-browser-worker`, `autobot-slm-agent`, `plugins` (in addition to the existing 5).

**Confirmed NOT mappable, excluded (documented inline in `drift_checker.py` ~93-104):**
- `autobot-tts-worker` — deployed via a single Jinja2-templated file (`tts-worker.py.j2` → `tts-worker.py`), not a 1:1 sync of the repo's `autobot-tts-worker/` directory; comparing them would report fake drift.
- `autobot-celery` / `celery-beat` — no distinct deployed directory; both run FROM the `autobot-backend` deployed dir (systemd `WorkingDirectory`), so they're already implicitly covered by the existing `autobot-backend` entry.
- `autobot-plugins` (the `@autobot/vnc` / `@autobot/terminal` npm workspace packages, distinct from the `plugins` component above) — synced into TWO deployed locations (`autobot-frontend/autobot-plugins/` and `autobot-slm-frontend/autobot-plugins/`), so there's no single canonical deployed target — needs an owner decision on which (or both) to scan.

## Verification

```
python3 -m pytest services/drift_checker_test.py tests/services/drift_checker_test.py \
  tests/api/test_status_stale_components_11820.py tests/api/test_drift_resolve.py \
  tests/api/test_drift_resolve_advances_node_version_11512.py tests/test_code_sync_topology.py \
  tests/api/test_code_sync_protected_excludes.py tests/api/test_code_sync_deploy_bugs.py \
  tests/api/test_code_sync_symlink_restore.py -q
...
234 passed in 13.59s
```

New tests added:
- `services/drift_checker_test.py`: `TestExtraVisibilityComponents` (allowlist/visibility-set invariants — disjoint from `ALLOWED_COMPONENTS`, correct union) + `TestNonstandardComponentPathMap` (per-component source/deployed path assertions for ai-stack/slm-agent/plugins, confirms npu-worker/browser-worker/the original 5 are unaffected by the override map, and an end-to-end `compute_drift` run against an ai-stack-shaped nested-source/flat-deployed pair that reports real drift).
- `tests/api/test_status_stale_components_11820.py`: `test_extended_scan_covers_ai_stack_with_correct_path_map` — proves `_compute_stale_components` resolves the exact ai-stack nonstandard path pair (nested source, flat `--strip-components=4`-style deployed dir) before reporting it stale, using the real scan loop over an injected `VISIBILITY_COMPONENTS`.

`black --check` / `isort --check-only` clean on all 4 touched files. Full `autobot-slm-backend` collection (`pytest --collect-only`): 1436 tests, no collection errors.

**Discovered pre-existing issue (filed, not fixed here — out of scope):** #12573 — a collection-order-dependent FastAPI/Pydantic failure when `tests/services/` is collected before `tests/api/test_code_sync_deploy_bugs.py` (and 2 siblings) in the same pytest session. Reproduced identically against the literal unmodified `HEAD` content of the 4 files this PR touches, confirming it predates this change.

## Follow-up

Per-component `resolve`/restart wiring for the 5 newly-visible components (ai-stack, npu-worker, browser-worker, slm-agent, plugins) is **deferred pending owner decision** — see the parked root-cause comment on #12450 for the open questions (which components get a resolve path, per-service post-sync shape: venv vs npm vs docker vs symlink, whether resolve should auto-restart live prod workers). `POST /drift/resolve[-async]` continue to 400 on all of them.

## Model Used

Claude Opus 4.6