### PR TITLE
fix(deploy): route updates.py node code_status through the #12570 derivation (#12571)

### DIFF
--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -70,6 +70,9 @@ from models.schemas import (
     UpdatePolicyResponse,
 )
 from services.auth import get_current_user
+from services.code_status import derive_code_status as _derive_code_status
+from services.code_status import get_latest_code_version as _get_latest_code_version
+from services.code_status import reported_code_status as _reported_code_status
 from services.database import get_db
 from services.encryption import encrypt_data
 from services.reconciler import reconciler_service
@@ -1743,73 +1746,6 @@ async def replace_node(
     return NodeResponse.model_validate(new_node)
 
 
-def _derive_code_status(
-    code_version: str | None,
-    latest_version: str | None,
-    was_service_failed: bool = False,
-) -> str | None:
-    """Pure function: the CodeStatus label for code_version vs latest_version.
-
-    Single source of truth for a node's currency label (#12428): mirrors the
-    live signal ``outdated_nodes`` already uses (api/code_sync.py
-    get_sync_status, ``code_version != latest_version``) so a node's
-    reported code_status can never disagree with the fleet-wide outdated
-    count. Shared by both write time (_update_heartbeat_code_status, on a
-    heartbeat) and read time (_reported_code_status, on every GET) — an
-    agentless node that never heartbeats still gets a fresh label on read.
-
-    Returns None when latest_version is unknown — callers should fall back
-    to whatever status is already on hand (mirrors get_sync_status's own
-    fallback when the fleet latest commit isn't set yet).
-
-    was_service_failed preserves the #1605 code_current_service_failed
-    signal when the version still matches latest; that check needs live
-    heartbeat extra_data and cannot be recomputed at read time, so a read
-    derivation passes in the node's own last-known stamp instead.
-    """
-    if not latest_version:
-        return None
-    if not code_version:
-        return CodeStatus.UNKNOWN.value
-    if code_version != latest_version:
-        return CodeStatus.OUTDATED.value
-    if was_service_failed:
-        return CodeStatus.CODE_CURRENT_SERVICE_FAILED.value
-    return CodeStatus.UP_TO_DATE.value
-
-
-async def _get_latest_code_version(db: AsyncSession) -> str | None:
-    """Read the fleet's slm_agent_latest_commit setting.
-
-    Same query used by _update_heartbeat_code_status and
-    api/code_sync.py's get_sync_status — kept here so node reads compare
-    against the exact same live value (#12428).
-    """
-    result = await db.execute(select(Setting).where(Setting.key == "slm_agent_latest_commit"))
-    setting = result.scalar_one_or_none()
-    return setting.value if setting else None
-
-
-def _reported_code_status(node: Node, latest_version: str | None) -> str | None:
-    """Derive the code_status to report for a node READ (#12428).
-
-    node.code_status is a stamp written only by _update_heartbeat_code_status,
-    which runs only on a heartbeat. An agentless node (e.g. role vnc) never
-    heartbeats, so the stamp freezes — often at up_to_date from enrollment —
-    even after code_version drifts behind latest_version, disagreeing with
-    outdated_nodes (api/code_sync.py get_sync_status), which always uses the
-    live code_version != latest_version signal. Recomputing here on every
-    read keeps the two surfaces in agreement; falls back to the stored stamp
-    when latest_version is unknown.
-    """
-    derived = _derive_code_status(
-        node.code_version,
-        latest_version,
-        was_service_failed=node.code_status == CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
-    )
-    return derived if derived is not None else node.code_status
-
-
 async def _update_heartbeat_code_status(db: AsyncSession, node: Node, extra_data: dict | None = None) -> str | None:
     """Query latest commit setting and update node.code_status.
 
@@ -2607,7 +2543,10 @@ async def get_node_updates(
     Includes code_update_available/code_status (#11964) computed via the
     SAME is_code_update_available() helper the fleet update-summary badge
     uses, so this live "Check for updates" scan can never disagree with
-    the badge shown on the node card.
+    the badge shown on the node card. code_status is derived fresh via
+    _reported_code_status (#12428/#12571) instead of trusting the raw,
+    heartbeat-only node.code_status stamp, so an agentless node's frozen
+    stamp can't surface here either.
     """
     from sqlalchemy import or_
 
@@ -2635,11 +2574,14 @@ async def get_node_updates(
     result = await db.execute(query)
     updates = result.scalars().all()
 
+    latest_version = await _get_latest_code_version(db)
+    reported_status = _reported_code_status(node, latest_version)
+
     return UpdateCheckResponse(
         updates=[UpdateInfoResponse.model_validate(u) for u in updates],
         total=len(updates),
-        code_update_available=is_code_update_available(node),
-        code_status=node.code_status or "unknown",
+        code_update_available=is_code_update_available(node, latest_version),
+        code_status=reported_status or "unknown",
     )
 
 

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -49,6 +49,7 @@ from models.schemas import (
     UpdateSummaryResponse,
 )
 from services.auth import get_current_user
+from services.code_status import get_latest_code_version, reported_code_status
 from services.database import get_db
 from services.playbook_executor import get_playbook_executor
 
@@ -755,28 +756,40 @@ async def check_updates(
     )
 
 
-def is_code_update_available(node: Node) -> bool:
+def is_code_update_available(node: Node, latest_version: str | None = None) -> bool:
     """Canonical check for whether a node has a pending code update.
 
     Single source of truth for "code update available" (#11964): consumed by
     both the fleet update-summary badge (get_fleet_update_summary below) and
     the live per-node "Check for updates" scan (nodes.get_node_updates), so
-    the two can never disagree — they read the exact same node.code_status
-    field via the same helper.
+    the two can never disagree.
+
+    latest_version routes the check through reported_code_status
+    (services/code_status.py, #12428/#12571) instead of the raw,
+    heartbeat-only node.code_status stamp, so an agentless node whose stamp
+    is frozen still reports correctly. Defaults to None (falls back to the
+    stored stamp) for backward-compatible callers that haven't fetched the
+    fleet's latest commit.
     """
-    return (node.code_status or "") == CodeStatus.OUTDATED.value
+    return (reported_code_status(node, latest_version) or "") == CodeStatus.OUTDATED.value
 
 
-def _build_node_summaries(nodes: list, updates_by_node: dict, global_count: int) -> list:
+def _build_node_summaries(
+    nodes: list, updates_by_node: dict, global_count: int, latest_version: str | None = None
+) -> list:
     """Build per-node update summaries.
 
-    Helper for get_fleet_update_summary (#682).
+    Helper for get_fleet_update_summary (#682). latest_version (#12571)
+    routes each node's code_status through reported_code_status so the
+    fleet badge agrees with GET /nodes and GET /nodes/{id}/updates for
+    agentless nodes whose heartbeat stamp is frozen.
     """
     summaries = []
     for node in nodes:
         sys_count = len(updates_by_node.get(node.node_id, []))
         sys_count += global_count
-        code_outdated = is_code_update_available(node)
+        status_label = reported_code_status(node, latest_version)
+        code_outdated = (status_label or "") == CodeStatus.OUTDATED.value
         total = sys_count + (1 if code_outdated else 0)
         summaries.append(
             NodeUpdateSummary(
@@ -784,7 +797,7 @@ def _build_node_summaries(nodes: list, updates_by_node: dict, global_count: int)
                 hostname=node.hostname,
                 system_updates=sys_count,
                 code_update_available=code_outdated,
-                code_status=node.code_status or "unknown",
+                code_status=status_label or "unknown",
                 total_updates=total,
             )
         )
@@ -815,7 +828,8 @@ async def get_fleet_update_summary(
         else:
             global_updates.append(upd)
 
-    summaries = _build_node_summaries(nodes, updates_by_node, len(global_updates))
+    latest_version = await get_latest_code_version(db)
+    summaries = _build_node_summaries(nodes, updates_by_node, len(global_updates), latest_version)
 
     # Unique total: per-node specific + global (not per-node * global)
     total_sys = sum(len(v) for v in updates_by_node.values()) + len(global_updates)

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -133,6 +133,7 @@ del _src_ast
 # the code_sync rot source above.
 _EXTRA_SERVICE_MODULES = (
     "services.blue_green",
+    "services.code_status",
     "services.deployment",
     "services.encryption",
     "services.reconciler",

--- a/autobot-slm-backend/services/code_status.py
+++ b/autobot-slm-backend/services/code_status.py
@@ -1,0 +1,89 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Single source of truth for a node's current-vs-latest code_status label.
+
+Extracted from api/nodes.py (#12428/#12570) into a shared, dependency-light
+module so api/updates.py can reuse the exact same derivation without a
+nodes<->updates circular import (#12571). Every surface that reports a
+node's code currency -- GET /nodes, GET /nodes/{id}, GET /nodes/{id}/updates,
+and the #11964 fleet-update badge (GET /updates/fleet-summary) -- must go
+through these functions so none of them can disagree.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import CodeStatus, Node, Setting
+
+
+def derive_code_status(
+    code_version: str | None,
+    latest_version: str | None,
+    was_service_failed: bool = False,
+) -> str | None:
+    """Pure function: the CodeStatus label for code_version vs latest_version.
+
+    Single source of truth for a node's currency label (#12428): mirrors the
+    live signal ``outdated_nodes`` already uses (api/code_sync.py
+    get_sync_status, ``code_version != latest_version``) so a node's
+    reported code_status can never disagree with the fleet-wide outdated
+    count. Shared by write time (api.nodes._update_heartbeat_code_status, on
+    a heartbeat) and read time (reported_code_status, on every GET) -- an
+    agentless node that never heartbeats still gets a fresh label on read.
+
+    Returns None when latest_version is unknown -- callers should fall back
+    to whatever status is already on hand (mirrors get_sync_status's own
+    fallback when the fleet latest commit isn't set yet).
+
+    was_service_failed preserves the #1605 code_current_service_failed
+    signal when the version still matches latest; that check needs live
+    heartbeat extra_data and cannot be recomputed at read time, so a read
+    derivation passes in the node's own last-known stamp instead.
+    """
+    if not latest_version:
+        return None
+    if not code_version:
+        return CodeStatus.UNKNOWN.value
+    if code_version != latest_version:
+        return CodeStatus.OUTDATED.value
+    if was_service_failed:
+        return CodeStatus.CODE_CURRENT_SERVICE_FAILED.value
+    return CodeStatus.UP_TO_DATE.value
+
+
+async def get_latest_code_version(db: AsyncSession) -> str | None:
+    """Read the fleet's slm_agent_latest_commit setting.
+
+    Same query used by api.nodes._update_heartbeat_code_status and
+    api/code_sync.py's get_sync_status -- kept here so every reader compares
+    against the exact same live value (#12428/#12571).
+    """
+    result = await db.execute(select(Setting).where(Setting.key == "slm_agent_latest_commit"))
+    setting = result.scalar_one_or_none()
+    return setting.value if setting else None
+
+
+def reported_code_status(node: Node, latest_version: str | None) -> str | None:
+    """Derive the code_status to report for a node READ (#12428).
+
+    node.code_status is a stamp written only by
+    api.nodes._update_heartbeat_code_status, which runs only on a heartbeat.
+    An agentless node (e.g. role vnc) never heartbeats, so the stamp
+    freezes -- often at up_to_date from enrollment -- even after
+    code_version drifts behind latest_version, disagreeing with
+    outdated_nodes (api/code_sync.py get_sync_status), which always uses the
+    live code_version != latest_version signal. Recomputing here on every
+    read keeps every surface (GET /nodes, GET /nodes/{id},
+    GET /nodes/{id}/updates, GET /updates/fleet-summary) in agreement; falls
+    back to the stored stamp when latest_version is unknown.
+    """
+    derived = derive_code_status(
+        node.code_version,
+        latest_version,
+        was_service_failed=node.code_status == CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
+    )
+    return derived if derived is not None else node.code_status

--- a/autobot-slm-backend/tests/api/test_node_code_status_read_derivation_12428.py
+++ b/autobot-slm-backend/tests/api/test_node_code_status_read_derivation_12428.py
@@ -60,14 +60,23 @@ def _load_real_module(name: str, path: Path):
 
 
 def _build_real_modules() -> dict:
-    """One-time real sqlalchemy + models.database/models.schemas snapshot.
+    """One-time real sqlalchemy + models.database/models.schemas/
+    services.code_status snapshot.
 
     Mirrors tests/api/test_nodes_list_timeout_10913.py's setup: the root
     conftest stubs these as MagicMocks for import-time safety, so the real
     packages are loaded once here and swapped in on demand.
+
+    services.code_status (#12571) must be real-loaded AFTER the real
+    models.database, since api.nodes now imports its derive_code_status/
+    get_latest_code_version/reported_code_status from there instead of
+    defining them inline (#12428/#12570) -- a stub CodeStatus enum would
+    break the string comparisons the derivation logic depends on.
     """
     saved = {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)}
-    saved.update({name: sys.modules.get(name) for name in ("models.database", "models.schemas")})
+    saved.update(
+        {name: sys.modules.get(name) for name in ("models.database", "models.schemas", "services.code_status")}
+    )
     for name in list(saved):
         sys.modules.pop(name, None)
     try:
@@ -76,15 +85,18 @@ def _build_real_modules() -> dict:
         importlib.import_module("sqlalchemy.dialects.sqlite")
         _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
         _load_real_module("models.schemas", _SLM_ROOT / "models" / "schemas.py")
+        _load_real_module("services.code_status", _SLM_ROOT / "services" / "code_status.py")
         return {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)} | {
             "models.database": sys.modules["models.database"],
             "models.schemas": sys.modules["models.schemas"],
+            "services.code_status": sys.modules["services.code_status"],
         }
     finally:
         for name in [n for n in sys.modules if _is_sqlalchemy_key(n)]:
             del sys.modules[name]
         sys.modules.pop("models.database", None)
         sys.modules.pop("models.schemas", None)
+        sys.modules.pop("services.code_status", None)
         for name, mod in saved.items():
             if mod is not None:
                 sys.modules[name] = mod

--- a/autobot-slm-backend/tests/api/test_node_update_availability_11964.py
+++ b/autobot-slm-backend/tests/api/test_node_update_availability_11964.py
@@ -104,6 +104,26 @@ def _stub_updates_schemas() -> None:
 _stub_updates_schemas()
 
 
+def _load_real_code_status_module():
+    """Real-load services/code_status.py (#12428/#12570/#12571).
+
+    api/updates.py now imports is_code_update_available/_build_node_summaries's
+    currency derivation from services.code_status (reported_code_status /
+    get_latest_code_version) instead of comparing node.code_status raw --
+    that module must be REAL, not a MagicMock stub, since it does an actual
+    string comparison against CodeStatus.OUTDATED.value (same reasoning as
+    the real CodeStatus stand-in above). Registered directly in sys.modules
+    so `from services.code_status import ...` resolves without needing the
+    `services` parent stub to behave like a real package.
+    """
+    code_status_py = _BACKEND_ROOT / "services" / "code_status.py"
+    spec = importlib.util.spec_from_file_location("services.code_status", code_status_py)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["services.code_status"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def _load_updates_module():
     """Load api/updates.py directly, bypassing api/__init__.py (#11964).
 
@@ -115,6 +135,7 @@ def _load_updates_module():
     """
     for mod_name in ("services", "services.auth", "services.database", "services.playbook_executor"):
         sys.modules.setdefault(mod_name, MagicMock(unsafe=True))
+    _load_real_code_status_module()
 
     updates_py = _BACKEND_ROOT / "api" / "updates.py"
     spec = importlib.util.spec_from_file_location("_updates_11964_test", updates_py)
@@ -128,8 +149,13 @@ is_code_update_available = _updates.is_code_update_available
 _build_node_summaries = _updates._build_node_summaries
 
 
-def _fake_node(node_id: str = "node-1", hostname: str = "host-1", code_status: str | None = None):
-    return SimpleNamespace(node_id=node_id, hostname=hostname, code_status=code_status)
+def _fake_node(
+    node_id: str = "node-1",
+    hostname: str = "host-1",
+    code_status: str | None = None,
+    code_version: str | None = "unused-version",
+):
+    return SimpleNamespace(node_id=node_id, hostname=hostname, code_status=code_status, code_version=code_version)
 
 
 # ---------------------------------------------------------------------------
@@ -214,3 +240,67 @@ def test_badge_clears_after_code_status_transitions_to_up_to_date():
     node.code_status = CodeStatus.UP_TO_DATE.value
     after = _build_node_summaries([node], updates_by_node={}, global_count=0)
     assert after[0].code_update_available is False
+
+
+# ---------------------------------------------------------------------------
+# Agentless stale-stamp derivation (#12571) -- same bug class as #12428/
+# #12570: a node that never heartbeats has a frozen node.code_status stamp
+# (often up_to_date from enrollment). is_code_update_available/
+# _build_node_summaries must derive freshly from code_version vs
+# latest_version (via services.code_status) instead of trusting that stamp,
+# so GET /nodes/{id}/updates and the #11964 fleet badge agree with #12570's
+# GET /nodes and GET /nodes/{id} derivation.
+# ---------------------------------------------------------------------------
+
+
+def test_is_code_update_available_derives_outdated_for_agentless_stale_node():
+    """Frozen stamp says up_to_date, but code_version is behind latest --
+    passing latest_version must flip the reported status to outdated,
+    exactly like #12570's _reported_code_status for GET /nodes/{id}."""
+    node = _fake_node(code_status=CodeStatus.UP_TO_DATE.value, code_version="old-sha")
+
+    assert is_code_update_available(node, latest_version="new-sha") is True
+
+
+def test_is_code_update_available_still_up_to_date_when_versions_match():
+    node = _fake_node(code_status=CodeStatus.UP_TO_DATE.value, code_version="new-sha")
+
+    assert is_code_update_available(node, latest_version="new-sha") is False
+
+
+def test_is_code_update_available_falls_back_to_stamp_when_latest_unknown():
+    """No fleet latest_version signal yet -- fall back to the stored stamp,
+    same as #12570's _reported_code_status fallback."""
+    node = _fake_node(code_status=CodeStatus.OUTDATED.value, code_version="whatever")
+
+    assert is_code_update_available(node, latest_version=None) is True
+
+
+def test_fleet_badge_derives_outdated_for_agentless_stale_node():
+    """The #11964 fleet-update badge (_build_node_summaries) must derive the
+    SAME outdated status for an agentless node's frozen up_to_date stamp,
+    consistent with #12570's GET /nodes derivation (#12571)."""
+    node = _fake_node(node_id="agentless-node", code_status=CodeStatus.UP_TO_DATE.value, code_version="old-sha")
+
+    summaries = _build_node_summaries([node], updates_by_node={}, global_count=0, latest_version="new-sha")
+
+    assert summaries[0].code_status == CodeStatus.OUTDATED.value
+    assert summaries[0].code_update_available is True
+
+
+def test_fleet_badge_and_live_check_agree_for_agentless_stale_node():
+    """End-to-end #12571 reconciliation: GET /nodes/{id}/updates's live
+    check and the fleet badge's summary must agree for the exact scenario
+    #12570 fixed for GET /nodes -- a node whose stamp is frozen up_to_date
+    but whose code_version has drifted behind latest_version."""
+    node = _fake_node(node_id="agentless-node-2", code_status=CodeStatus.UP_TO_DATE.value, code_version="old-sha")
+    latest_version = "new-sha"
+
+    summaries = _build_node_summaries([node], updates_by_node={}, global_count=0, latest_version=latest_version)
+    badge_says_available = summaries[0].code_update_available
+
+    live_check_says_available = is_code_update_available(node, latest_version=latest_version)
+
+    assert badge_says_available is True
+    assert live_check_says_available is True
+    assert badge_says_available == live_check_says_available

--- a/autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
+++ b/autobot-slm-backend/tests/api/test_slm_endpoints_12515.py
@@ -63,14 +63,23 @@ def _load_real_module(name: str, path: Path):
 
 
 def _build_real_modules() -> dict:
-    """One-time real sqlalchemy + models.database/models.schemas snapshot.
+    """One-time real sqlalchemy + models.database/models.schemas/
+    services.code_status snapshot.
 
     Copied from tests/api/test_nodes_list_timeout_10913.py: the root conftest
     stubs these as MagicMocks for import-time safety, so the real packages are
     loaded once here and swapped in on demand.
+
+    services.code_status (#12571) must be real-loaded too: api.nodes'
+    _get_latest_code_version/_reported_code_status now delegate there
+    (#12428/#12570), and its own module-level ``select``/``Setting`` bindings
+    need the real sqlalchemy/models.database swapped in first or its queries
+    fail against a genuine aiosqlite AsyncSession.
     """
     saved = {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)}
-    saved.update({name: sys.modules.get(name) for name in ("models.database", "models.schemas")})
+    saved.update(
+        {name: sys.modules.get(name) for name in ("models.database", "models.schemas", "services.code_status")}
+    )
     for name in list(saved):
         sys.modules.pop(name, None)
     try:
@@ -79,15 +88,18 @@ def _build_real_modules() -> dict:
         importlib.import_module("sqlalchemy.dialects.sqlite")
         _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
         _load_real_module("models.schemas", _SLM_ROOT / "models" / "schemas.py")
+        _load_real_module("services.code_status", _SLM_ROOT / "services" / "code_status.py")
         return {name: mod for name, mod in sys.modules.items() if _is_sqlalchemy_key(name)} | {
             "models.database": sys.modules["models.database"],
             "models.schemas": sys.modules["models.schemas"],
+            "services.code_status": sys.modules["services.code_status"],
         }
     finally:
         for name in [n for n in sys.modules if _is_sqlalchemy_key(n)]:
             del sys.modules[name]
         sys.modules.pop("models.database", None)
         sys.modules.pop("models.schemas", None)
+        sys.modules.pop("services.code_status", None)
         for name, mod in saved.items():
             if mod is not None:
                 sys.modules[name] = mod


### PR DESCRIPTION
## Thinking Path

#12570 added `_derive_code_status`/`_get_latest_code_version`/`_reported_code_status` in `api/nodes.py` so `GET /nodes` and `GET /nodes/{id}` derive a node's currency label fresh on every read instead of trusting the heartbeat-only `node.code_status` stamp (which freezes for agentless nodes that never heartbeat). #12571 scoped out `api/updates.py`'s `GET /nodes/{id}/updates` endpoint (actually implemented in `api/nodes.py`, delegating to `api/updates.is_code_update_available`) and the #11964 fleet-update badge (`GET /updates/fleet-summary`), both of which still read `node.code_status` raw — same stale-stamp bug class, different blast radius.

Reusing `api.nodes`'s helpers directly from `api/updates.py` would create a `nodes<->updates` import (nodes.py already lazily imports `is_code_update_available` from updates.py inside `get_node_updates`), so per the task's fallback instruction I extracted the three derivation functions into a new dependency-light `services/code_status.py` that both `api/nodes.py` and `api/updates.py` import from — single source of truth, no cross-router coupling.

## What Changed

- `autobot-slm-backend/services/code_status.py` (new) — `derive_code_status`, `get_latest_code_version`, `reported_code_status`: the pure derivation logic moved out of `api/nodes.py` verbatim.
- `autobot-slm-backend/api/nodes.py:73-75` — imports the three functions from `services.code_status`, aliased to the original private names (`_derive_code_status`, `_get_latest_code_version`, `_reported_code_status`) so every existing call site is unchanged.
- `autobot-slm-backend/api/nodes.py:2577-2582` (`get_node_updates`, the actual `GET /nodes/{id}/updates` handler) — now fetches `latest_version` and derives `reported_status` via `_reported_code_status` instead of reading `node.code_status` raw; passes `latest_version` into `is_code_update_available`.
- `autobot-slm-backend/api/updates.py:52` — imports `get_latest_code_version`/`reported_code_status` from `services.code_status`.
- `autobot-slm-backend/api/updates.py:758-774` (`is_code_update_available`) — now accepts an optional `latest_version` and derives via `reported_code_status` instead of comparing the raw stamp (backward compatible: `latest_version=None` falls back to the stored stamp, matching prior behavior).
- `autobot-slm-backend/api/updates.py:777-804` (`_build_node_summaries`, the #11964 fleet badge builder) — accepts `latest_version` and derives each node's `code_status`/`code_update_available` the same way.
- `autobot-slm-backend/api/updates.py:811-832` (`get_fleet_update_summary`) — fetches `latest_version` once and passes it through.
- `autobot-slm-backend/conftest.py` — added `services.code_status` to the stubbed-services list for the general test suite.
- `autobot-slm-backend/tests/api/test_node_update_availability_11964.py` — real-loads `services/code_status.py` (needed since the derivation does a real string comparison against `CodeStatus.OUTDATED.value`); added `code_version` to the `_fake_node` helper; added 5 new regression tests proving `is_code_update_available`/`_build_node_summaries` now derive (not trust-the-stamp) for an agentless stale node, and that the live-check and fleet badge still agree.
- `autobot-slm-backend/tests/api/test_node_code_status_read_derivation_12428.py` and `autobot-slm-backend/tests/api/test_slm_endpoints_12515.py` — both real-module-swap `api.nodes` for real-DB/real-FastAPI testing; added `services.code_status` to their real-module snapshot (its own `from sqlalchemy import select` binding needs the real sqlalchemy/models.database swapped in, or queries against a genuine `AsyncSession` fail).

No deploy/sync execution behavior changed — this is a read/report consistency fix only; the #11511 fleet-sync safety gate is untouched.

## Verification

New + updated regression suite:
```
tests/api/test_node_update_availability_11964.py .............           [ 24%]
tests/api/test_node_code_status_read_derivation_12428.py ............    [ 46%]
tests/api/test_slm_endpoints_12515.py .............................      [100%]
============================= 54 passed in 11.45s ==============================
```

Full `autobot-slm-backend` suite (no collection/import regressions):
```
================= 952 passed, 1 skipped, 7 warnings in 58.88s ==================
```

`pyflakes` on all touched files: clean (no unused imports).

Closes #12571

## Model Used

Claude Opus 4.6 (Sonnet 5 orchestrator)