### PR TITLE
test(code-sync): fix order-dependent collection errors from cross-file mock leakage (#12572)

### DIFF
--- a/autobot-slm-backend/tests/api/_code_sync_import.py
+++ b/autobot-slm-backend/tests/api/_code_sync_import.py
@@ -1,0 +1,134 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared import helper for the ``test_code_sync_*`` unit tests (#12572).
+
+Dev-host / combined-run problem
+-------------------------------
+The root conftest (#3499) stubs ``models`` and ``models.schemas`` as
+``MagicMock``s.  ``api/code_sync.py`` decorates routes with
+``response_model=CodeSyncStatusResponse`` (etc.), and FastAPI validates the
+response model against a real Pydantic type *at decoration time* — a MagicMock
+raises ``FastAPIError`` during module import (i.e. at pytest collection).
+
+Each test file therefore installs minimal real ``BaseModel`` stand-ins for
+``models.schemas`` before importing ``api.code_sync``, then restores the
+original ``models`` entries so the stand-ins never leak into later-collected
+directories (#11794 — ``tests/services`` real-loads ``services/auth.py`` whose
+``from models.schemas import TokenResponse`` must not see our narrow stubs).
+
+Why a shared helper (the #12572 leak)
+-------------------------------------
+``tests/services/conftest.py`` swaps the ``models`` MagicMock for a real hollow
+``ModuleType`` package (so real submodules import).  When ``tests/api`` and
+``tests/services`` are collected together, that conftest runs first, so by the
+time a ``test_code_sync_*`` file is collected ``sys.modules["models"]`` is a
+plain module — not a MagicMock.  The per-file guards keyed on
+``isinstance(models, MagicMock)`` then evaluate ``False`` and skip installing
+the stand-ins, while ``models.schemas`` is *still* a MagicMock → the three
+files fail collection order-dependently.
+
+This helper keys the decision on ``models.schemas`` (the object actually used
+by the router), AST-derives the class list from ``api/code_sync.py`` so it can
+never rot, forces a fresh ``api.code_sync`` import when it installs stand-ins,
+and restores the original ``models`` entries afterwards.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_CODE_SYNC_SRC = _BACKEND_ROOT / "api" / "code_sync.py"
+
+
+def _schema_class_names() -> list[str]:
+    """Every name imported ``from models.schemas`` in api/code_sync.py.
+
+    AST-derived (not hand-maintained) so a new schema import can never rot the
+    stand-in list — same rot-proof pattern the root conftest uses for the
+    ``services.*`` stubs (#11575, #11794).
+    """
+    tree = ast.parse(_CODE_SYNC_SRC.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "models.schemas":
+            names |= {alias.name for alias in node.names}
+    return sorted(names)
+
+
+def _schemas_are_real() -> bool:
+    """True when ``models.schemas`` already exposes real Pydantic response models.
+
+    Keyed on ``models.schemas`` (what the router decorates against) rather than
+    the ``models`` parent — the parent may be a real hollow package installed by
+    ``tests/services/conftest.py`` while ``models.schemas`` is still a MagicMock.
+    """
+    from pydantic import BaseModel
+
+    schemas = sys.modules.get("models.schemas")
+    if schemas is None or isinstance(schemas, MagicMock):
+        return False
+    sentinel = getattr(schemas, "CodeSyncStatusResponse", None)
+    return isinstance(sentinel, type) and issubclass(sentinel, BaseModel)
+
+
+def import_code_sync() -> types.ModuleType:
+    """Import ``api.code_sync`` with real Pydantic schema stand-ins in place.
+
+    Installs minimal ``BaseModel`` stand-ins for ``models.schemas`` only when the
+    real models are absent (dev host / stubbed conftest), imports the router with
+    them bound, then restores the pre-call ``models`` / ``models.schemas``
+    entries so the stand-ins do not leak into later-collected directories.
+    """
+    if str(_BACKEND_ROOT) not in sys.path:
+        sys.path.insert(0, str(_BACKEND_ROOT))
+
+    # A cached api.code_sync is always good: a bad import (MagicMock response
+    # models) raises FastAPIError and never caches.  Reuse the single instance
+    # so every test_code_sync_* file — and any patch("api.code_sync.X") — targets
+    # the SAME module object (distinct instances would make patches miss, #12572).
+    cached = sys.modules.get("api.code_sync")
+    if cached is not None:
+        return cached
+
+    if _schemas_are_real():
+        return importlib.import_module("api.code_sync")
+
+    from pydantic import BaseModel as _BaseModel
+
+    snapshot = {key: sys.modules.get(key) for key in ("models", "models.schemas")}
+
+    schemas = types.ModuleType("models.schemas")
+    for class_name in _schema_class_names():
+        setattr(schemas, class_name, type(class_name, (_BaseModel,), {}))
+
+    models = sys.modules.get("models")
+    if models is None or isinstance(models, MagicMock):
+        models = types.ModuleType("models")
+    models.schemas = schemas  # type: ignore[attr-defined]
+    sys.modules["models"] = models
+    sys.modules["models.schemas"] = schemas
+
+    # Not cached (an earlier bad import would not have cached) — exec fresh with
+    # the stand-ins bound, then restore the original models entries.
+    try:
+        module = importlib.import_module("api.code_sync")
+    finally:
+        for key, value in snapshot.items():
+            if value is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+        restored = sys.modules.get("models")
+        restored_schemas = sys.modules.get("models.schemas")
+        if restored is not None and restored_schemas is not None and not isinstance(restored, MagicMock):
+            restored.schemas = restored_schemas  # type: ignore[attr-defined]
+
+    return module

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -23,56 +23,23 @@ from __future__ import annotations
 import os
 import sys
 import time
-import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # ---------------------------------------------------------------------------
-# Dev-host stub: provide minimal real Pydantic models for models.schemas so
-# the router can be imported without a full SLM venv.
+# #12572: import api.code_sync with real Pydantic schema stand-ins installed
+# then removed.  On the dev host models.schemas is a MagicMock, which makes
+# FastAPI response_model validation fail at router-decoration time; the shared
+# helper installs minimal BaseModel stand-ins for the import and restores the
+# original models entries so they never leak into later-collected directories
+# (#11794).  The helper keys the decision on models.schemas (not the models
+# parent, which tests/services/conftest.py turns into a real hollow package —
+# the root cause of the order-dependent collection errors, #12572).
 # ---------------------------------------------------------------------------
-# #11794: snapshot the models entries — restored right after api.code_sync
-# loads (see below) so the pydantic stand-ins don't leak across directories.
-_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
-if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
-    from pydantic import BaseModel as _BM
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _code_sync_import import import_code_sync  # noqa: E402
 
-    def _pydantic_stub(name: str, **fields) -> type:
-        return type(name, (_BM,), {"__annotations__": {k: type(v) for k, v in fields.items()}, **fields})
-
-    _schemas = types.ModuleType("models.schemas")
-    for _cls in [
-        "CodeSyncStatusResponse",
-        "CodeSyncRefreshResponse",
-        "CodeVersionNotification",
-        "CodeVersionNotificationResponse",
-        "ComponentSyncJobStatus",
-        "DriftResolveJobResponse",
-        "DriftResolveRequest",
-        "DriftResolveResponse",
-        "FileDriftReport",
-        "FleetSyncJobStatus",
-        "FleetSyncNodeStatus",
-        "FleetSyncRequest",
-        "FleetSyncResponse",
-        "MarkSyncedResponse",
-        "NodeSyncRequest",
-        "NodeSyncResponse",
-        "PendingNodeResponse",
-        "PendingNodesResponse",
-        "ScheduleCreate",
-        "ScheduleResponse",
-        "ScheduleRunResponse",
-        "ScheduleUpdate",
-    ]:
-        setattr(_schemas, _cls, _pydantic_stub(_cls))
-    _models = sys.modules.get("models") or types.ModuleType("models")
-    _models.schemas = _schemas  # type: ignore[attr-defined]
-    sys.modules["models"] = _models
-    sys.modules["models.schemas"] = _schemas
-
-_BACKEND_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_BACKEND_ROOT))
+import_code_sync()
 
 import asyncio  # noqa: E402
 
@@ -107,23 +74,17 @@ from api.code_sync import (  # noqa: E402
     _wait_component_healthy,
 )
 
-# #11794: restore the pre-file models/models.schemas sys.modules entries now
-# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
-# into later-collected directories (tests/services/test_saml_slo.py and
-# test_token_denylist.py real-load services/auth.py, whose
-# `from models.schemas import TokenResponse` breaks against them).
-for _k, _v in _MODELS_SNAPSHOT.items():
-    if _v is None:
-        sys.modules.pop(_k, None)
-    else:
-        sys.modules[_k] = _v
-if "models" in sys.modules and "models.schemas" in sys.modules:
-    sys.modules["models"].schemas = sys.modules["models.schemas"]
-del _MODELS_SNAPSHOT
-
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # A dedicated loop per call — resilient when a prior test (e.g. anything in
+    # tests/services) has closed or cleared the main-thread event loop, which
+    # makes the deprecated asyncio.get_event_loop() raise "no current event
+    # loop" under Python 3.10 (#12572).
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/api/test_code_sync_protected_excludes.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_protected_excludes.py
@@ -13,12 +13,18 @@ caller can forget it.
 
 from __future__ import annotations
 
-# Add autobot-slm-backend to path so api.code_sync imports resolve.
 import sys
 from pathlib import Path
 
-_BACKEND_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_BACKEND_ROOT))
+# #12572: import api.code_sync via the shared helper, which installs real
+# Pydantic stand-ins for models.schemas (a MagicMock on the dev host / under
+# the stubbed conftests) only for the duration of the import and then restores
+# the original models entries.  Without it this file cannot collect standalone
+# and fails order-dependently once tests/services/conftest.py has run.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _code_sync_import import import_code_sync  # noqa: E402
+
+import_code_sync()
 
 from api.code_sync import (  # noqa: E402
     _PROTECTED_EXCLUDES,

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -22,61 +22,23 @@ path is ever hardcoded.
 from __future__ import annotations
 
 import sys
-import types
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock  # MagicMock used in sys.modules guard below
+from unittest.mock import AsyncMock
 
 # ---------------------------------------------------------------------------
-# Dev-host stub: models.schemas contains real Pydantic models in CI but on
-# the dev box (no SLM venv) it is a MagicMock that makes FastAPI's
-# response_model validation fail at decoration time.  Pre-populate the module
-# with minimal real BaseModel subclasses so the router can be imported.
-# Must happen before the api.code_sync import below.
+# #12572: import api.code_sync via the shared helper.  On the dev host / under
+# the stubbed conftests models.schemas is a MagicMock, which makes FastAPI's
+# response_model validation fail at router-decoration time.  The helper installs
+# minimal real BaseModel stand-ins for the import only, then restores the
+# original models entries so they never leak into later-collected directories
+# (#11794).  It keys the decision on models.schemas — not the models parent,
+# which tests/services/conftest.py turns into a real hollow package (the root
+# cause of the order-dependent collection errors, #12572).
 # ---------------------------------------------------------------------------
-# #11794: snapshot the models entries — restored right after api.code_sync
-# loads (see below) so the pydantic stand-ins don't leak across directories.
-_MODELS_SNAPSHOT = {_k: sys.modules.get(_k) for _k in ("models", "models.schemas")}
-if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
-    from pydantic import BaseModel as _BM
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _code_sync_import import import_code_sync  # noqa: E402
 
-    def _pydantic_stub(name: str, **fields) -> type:
-        return type(name, (_BM,), {"__annotations__": {k: type(v) for k, v in fields.items()}, **fields})
-
-    _schemas = types.ModuleType("models.schemas")
-    # Enumerate every name imported from models.schemas in api/code_sync.py.
-    for _cls in [
-        "CodeSyncStatusResponse",
-        "CodeSyncRefreshResponse",
-        "CodeVersionNotification",
-        "CodeVersionNotificationResponse",
-        "ComponentSyncJobStatus",
-        "DriftResolveJobResponse",
-        "DriftResolveRequest",
-        "DriftResolveResponse",
-        "FileDriftReport",
-        "FleetSyncJobStatus",
-        "FleetSyncNodeStatus",
-        "FleetSyncRequest",
-        "FleetSyncResponse",
-        "MarkSyncedResponse",
-        "NodeSyncRequest",
-        "NodeSyncResponse",
-        "PendingNodeResponse",
-        "PendingNodesResponse",
-        "ScheduleCreate",
-        "ScheduleResponse",
-        "ScheduleRunResponse",
-        "ScheduleUpdate",
-    ]:
-        setattr(_schemas, _cls, _pydantic_stub(_cls))
-    _models = sys.modules.get("models") or types.ModuleType("models")
-    _models.schemas = _schemas  # type: ignore[attr-defined]
-    sys.modules["models"] = _models
-    sys.modules["models.schemas"] = _schemas
-
-# Add autobot-slm-backend to path so api.code_sync imports resolve.
-_BACKEND_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(_BACKEND_ROOT))
+import_code_sync()
 
 import asyncio  # noqa: E402
 
@@ -88,27 +50,21 @@ from api.code_sync import (  # noqa: E402
     _run_post_sync_steps,
 )
 
-# #11794: restore the pre-file models/models.schemas sys.modules entries now
-# that api.code_sync is loaded.  The narrow pydantic stand-ins otherwise leak
-# into later-collected directories (tests/services/test_saml_slo.py and
-# test_token_denylist.py real-load services/auth.py, whose
-# `from models.schemas import TokenResponse` breaks against them).
-for _k, _v in _MODELS_SNAPSHOT.items():
-    if _v is None:
-        sys.modules.pop(_k, None)
-    else:
-        sys.modules[_k] = _v
-if "models" in sys.modules and "models.schemas" in sys.modules:
-    sys.modules["models"].schemas = sys.modules["models.schemas"]
-del _MODELS_SNAPSHOT
-
 # ---------------------------------------------------------------------------
 # Helper
 # ---------------------------------------------------------------------------
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # A dedicated loop per call — resilient when a prior test (e.g. anything in
+    # tests/services) has closed or cleared the main-thread event loop, which
+    # makes the deprecated asyncio.get_event_loop() raise "no current event
+    # loop" under Python 3.10 (#12572).
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

`tests/api/` + `tests/services/` collected together raised 3 FastAPI `FastAPIError`s at collection — `test_code_sync_deploy_bugs.py`, `test_code_sync_protected_excludes.py`, `test_code_sync_symlink_restore.py` — each passing in isolation. FastAPI validates `response_model=CodeSyncStatusResponse` against a real Pydantic type at router-decoration (import) time, and it was seeing `<MagicMock 'mock.schemas.CodeSyncStatusResponse'>`.

Root leak: the root conftest (#3499) stubs `models` and `models.schemas` as `MagicMock`. `tests/services/conftest.py` then swaps the `models` **parent** for a real hollow `ModuleType` package (`_ensure_real_pkg`) so its real submodules import — but leaves `models.schemas` a `MagicMock`. When both dirs are collected together that conftest runs first, so the code_sync files' guard `isinstance(sys.modules["models"], MagicMock)` evaluated **False** (it's now a real module), the files **skipped** installing their Pydantic stand-ins, and `api.code_sync` executed against the still-`MagicMock` `models.schemas` → `FastAPIError`. Confirmed minimal repro: `pytest tests/services/test_ssh_utils.py tests/api/test_code_sync_deploy_bugs.py --collect-only` errors; the 3 files alone collect clean.

The guard checked the wrong object (`models` parent) instead of `models.schemas` (what the router decorates against). Fix keys the decision on `models.schemas` and shares one rot-proof helper.

## What Changed

- **New `autobot-slm-backend/tests/api/_code_sync_import.py`** — shared `import_code_sync()` helper. `_schemas_are_real()` inspects **`models.schemas`** (not the `models` parent): treats it as needing stand-ins when it is absent, a `MagicMock`, or its `CodeSyncStatusResponse` is not a real `BaseModel` subclass. It AST-derives the schema class list from `api/code_sync.py` (rot-proof, mirrors the root-conftest `services.*` derivation), installs minimal `BaseModel` stand-ins, imports the router, then restores the original `models`/`models.schemas` entries so the stand-ins never leak into later-collected dirs (#11794). It **reuses a cached `api.code_sync`** (a bad import raises and never caches), so all three files and any `patch("api.code_sync.X")` target the same module instance.
- **`test_code_sync_deploy_bugs.py` / `test_code_sync_symlink_restore.py`** — replaced the duplicated ~40-line inline stub/snapshot/restore blocks with `import_code_sync()`; dropped now-unused `types`/`MagicMock` imports.
- **`test_code_sync_protected_excludes.py`** — added `import_code_sync()` (it previously had no stub and only passed by riding on `deploy_bugs` importing `api.code_sync` first; it errored standalone under `--collect-only`).
- **Pre-existing fragility fixed in-scope:** `_run()` in `deploy_bugs`/`symlink_restore` used the deprecated `asyncio.get_event_loop()`, which raises `RuntimeError: There is no current event loop` under Py3.10 once a prior `tests/services` test closes the main-thread loop. This produced 61 runtime failures in the services-first ordering — masked before because collection aborted first. Now uses a dedicated `asyncio.new_event_loop()` per call. No assertion changed.

## Verification

Before (unmodified tree):
```
$ pytest tests/api tests/services --collect-only -q
592 tests collected, 3 errors
ERROR tests/api/test_code_sync_deploy_bugs.py - fastapi.exceptions.FastAPIError
ERROR tests/api/test_code_sync_protected_excludes.py - fastapi.exceptions.FastAPIError
ERROR tests/api/test_code_sync_symlink_restore.py - fastapi.exceptions.FastAPIError
# minimal repro:
$ pytest tests/services/test_ssh_utils.py tests/api/test_code_sync_deploy_bugs.py --collect-only
1 error  (FastAPIError: <MagicMock 'mock.schemas.CodeSyncStatusResponse'>)
# services-first run (once collection is unblocked): 61 failed (asyncio no-current-loop)
```

After:
```
$ pytest tests/api tests/services --collect-only -q      → 696 tests collected in 12s, 0 errors
$ pytest tests/api tests/services -q                      → 695 passed, 1 skipped, 0 failed
$ pytest <the 3 files> -q                                 → 104 passed
$ pytest tests/services tests/api/test_code_sync_deploy_bugs.py -q  → 436 passed, 1 skipped  (was 61 failed)
$ pytest tests/api/test_code_sync_deploy_bugs.py          → 89 passed
$ pytest tests/api/test_code_sync_protected_excludes.py   → 4 passed
$ pytest tests/api/test_code_sync_symlink_restore.py      → 11 passed
```

No other pre-existing errors remain in the combined `tests/api` + `tests/services` collection or run.

Closes #12572

## Model Used

claude-opus-4-8
