### PR TITLE
fix(frontend): getBackendUrl defaults to proxy-mode so baked host doesn't break CSP (#12339, #12313)

### DIFF
--- a/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { reloadConfig, runtimeHttpProto } from '../ssot-config';
+import { reloadConfig, runtimeHttpProto, getBackendUrl } from '../ssot-config';
 
 // Note: In a real test environment, we would need to mock import.meta.env
 // For now, these tests validate the TypeScript structure and default values
@@ -566,5 +566,58 @@ describe('SSOT Config Service Lookup', () => {
     expect(getVmIp('main')).toBe('10.0.0.1');
     expect(getVmIp('redis')).toBe('10.0.0.4');
     expect(getVmIp('unknown')).toBeUndefined();
+  });
+});
+
+
+// =============================================================================
+// Issue #12339: getBackendUrl() defaults to proxy-mode so a baked backend host
+// does not compose an absolute origin that CSP `connect-src 'self'` blocks.
+// =============================================================================
+
+describe('getBackendUrl() — proxy-mode default (#12339)', () => {
+  // getBackendUrl() reads import.meta.env directly, so we mutate/restore keys.
+  const ENV_KEYS = ['VITE_API_BASE_URL', 'VITE_API_URL', 'VITE_BACKEND_HOST', 'VITE_BACKEND_PORT'] as const;
+  let saved: Record<string, unknown>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) {
+      saved[k] = (import.meta.env as Record<string, unknown>)[k];
+      delete (import.meta.env as Record<string, unknown>)[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) {
+        delete (import.meta.env as Record<string, unknown>)[k];
+      } else {
+        (import.meta.env as Record<string, unknown>)[k] = saved[k];
+      }
+    }
+  });
+
+  it('returns "" (proxy mode) when a baked VITE_BACKEND_HOST + VITE_BACKEND_PORT is set but no VITE_API_BASE_URL', () => {
+    (import.meta.env as Record<string, unknown>).VITE_BACKEND_HOST = '10.0.0.42';
+    (import.meta.env as Record<string, unknown>).VITE_BACKEND_PORT = '8443';
+    expect(getBackendUrl()).toBe('');
+  });
+
+  it('returns the explicit VITE_API_BASE_URL unchanged (cross-origin override preserved)', () => {
+    (import.meta.env as Record<string, unknown>).VITE_API_BASE_URL = 'https://api.example.com';
+    // Even with a baked host present, the explicit base URL wins.
+    (import.meta.env as Record<string, unknown>).VITE_BACKEND_HOST = '10.0.0.42';
+    (import.meta.env as Record<string, unknown>).VITE_BACKEND_PORT = '8443';
+    expect(getBackendUrl()).toBe('https://api.example.com');
+  });
+
+  it('returns the legacy VITE_API_URL unchanged when set (override alias)', () => {
+    (import.meta.env as Record<string, unknown>).VITE_API_URL = 'https://legacy.example.com';
+    expect(getBackendUrl()).toBe('https://legacy.example.com');
+  });
+
+  it('returns "" (proxy mode) when neither host nor base URL is set', () => {
+    expect(getBackendUrl()).toBe('');
   });
 });

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -625,17 +625,25 @@ export default config;
 
 /**
  * Get backend URL (backward compatibility).
- * Returns empty string when VITE_BACKEND_HOST is not explicitly set,
- * enabling proxy mode where nginx at the frontend VM routes API calls.
+ *
+ * Defaults to '' (proxy mode) so browser calls stay same-origin and nginx at the
+ * frontend VM proxies /api and /ws to the backend. This is the deployed norm
+ * (#10348): a same-origin SPA behind a reverse proxy under CSP `connect-src 'self'`.
+ *
+ * #12339: a baked VITE_BACKEND_HOST/VITE_BACKEND_PORT alone must NOT force an
+ * absolute origin. The ansible frontend template used to bake host + port 8443,
+ * which produced `https://<host>:8443` — an absolute origin blocked by CSP,
+ * 404-ing onboarding/metrics in production. Only an EXPLICIT VITE_API_BASE_URL
+ * (or legacy VITE_API_URL) forces an absolute URL — the genuine cross-origin
+ * dev/deploy case, which must also be added to CSP connect-src.
  */
 export function getBackendUrl(): string {
-  // Explicit base URL override takes highest priority
+  // Explicit base URL override takes highest priority (cross-origin dev/deploy).
   const explicitBaseUrl = import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL;
   if (explicitBaseUrl) return explicitBaseUrl;
-  // If no explicit backend host, return '' for proxy mode via nginx
-  const explicitHost = import.meta.env.VITE_BACKEND_HOST;
-  if (!explicitHost) return '';
-  return getConfig().backendUrl;
+  // Otherwise proxy mode: same-origin relative URLs via nginx. A baked
+  // VITE_BACKEND_HOST/VITE_BACKEND_PORT is deliberately ignored here (#12339).
+  return '';
 }
 
 

--- a/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
@@ -3,15 +3,19 @@
 # Author: mrveiss
 # Frontend Environment Configuration
 
-# Backend service configuration (ssot-config.ts expects these variables)
-# #10348: never emit 0.0.0.0 (the backend BIND address) — it is not a valid
-# browser connect target. Fall back to the node's real IP; if that is unset too,
-# the frontend uses window.location.hostname at runtime.
-VITE_BACKEND_HOST={{ backend_host if (backend_host | default('')) not in ['', '0.0.0.0'] else (ansible_facts['default_ipv4'].address | default(ansible_host) | default('')) }}
-VITE_BACKEND_PORT={{ backend_port | default(8443) }}
+# Backend service configuration.
+# #12339: do NOT bake VITE_BACKEND_HOST / VITE_BACKEND_PORT into the browser env.
+# nginx serves the SPA on 443 and proxies /api + /ws SAME-ORIGIN to the backend,
+# so the browser must call the origin it loaded from. A baked host+port produced
+# an absolute `https://<host>:8443` origin that CSP `connect-src 'self'` blocks,
+# 404-ing onboarding/metrics in production. With these unset the frontend defaults
+# to proxy mode (relative /api), and falls back to window.location.hostname where a
+# host is still needed at runtime.
 
 # API base URL — empty by default = relative same-origin /api via nginx
-# (frontend_backend_url in defaults/main.yml, #10348).
+# (frontend_backend_url in defaults/main.yml, #10348). Only set to an absolute URL
+# for a genuine cross-origin deployment (and add that origin to CSP connect-src);
+# getBackendUrl() honors an explicit VITE_API_BASE_URL as the override case.
 VITE_API_BASE_URL={{ frontend_backend_url }}
 
 # Feature flags — UX visibility toggles for nav items in src/config/navItems.ts


### PR DESCRIPTION
## Thinking Path

The reported production onboarding/metrics 404 traced to `getBackendUrl()` composing an **absolute** origin. The ansible frontend template baked `VITE_BACKEND_HOST=<node-ip>` + `VITE_BACKEND_PORT=8443`, and `getBackendUrl()` returned `https://<host>:8443` whenever a bare `VITE_BACKEND_HOST` was set. The #10348 deploy design is proxy-mode: nginx serves the SPA on 443 and proxies `/api` + `/ws` same-origin, and CSP `connect-src 'self'` blocks any absolute cross-origin — so every caller (all use `${getBackendUrl()}/api/...`) built an unreachable URL.

Fix is both halves (owner-approved, defense in depth): make the code refuse to compose an absolute origin from a baked host, AND stop the deploy template baking that host. The legitimate cross-origin override (`VITE_API_BASE_URL`) is preserved.

## What Changed

- **`autobot-frontend/src/config/ssot-config.ts`** (`getBackendUrl()`, ~line 631): now returns `''` (proxy mode) by default. Only an **explicit** `VITE_API_BASE_URL` (or legacy `VITE_API_URL`) forces an absolute URL. A baked `VITE_BACKEND_HOST`/`VITE_BACKEND_PORT` is deliberately ignored for browser URL composition. Verified against the ~25 `getBackendUrl` call sites — all build `${getBackendUrl()}/api/...`, so `''` yields correct same-origin relative URLs under the reverse proxy. (`ApiClient._detectBaseUrl` / `ApiRepository.getDefaultBaseUrl` independently also composed absolutes from the baked host — the template change below fixes those too.)
- **`autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2`** (lines ~6-15): stop baking `VITE_BACKEND_HOST` and `VITE_BACKEND_PORT` into the browser env so the built frontend defaults to proxy mode. Kept `VITE_API_BASE_URL={{ frontend_backend_url }}` — it defaults to empty (proxy mode) and is only set for a genuine cross-origin deployment, which `getBackendUrl()` still honors as the override case. Kept the `VITE_FEATURE_TRANSCRIBER` flag untouched.
- **`autobot-frontend/src/config/__tests__/ssot-config.spec.ts`**: added a `getBackendUrl()` suite (proxy-mode default).

## Verification

Unit tests (deps reused read-only from an already-installed tree; no install):

```
RUN  v4.1.9
 ✓ src/config/__tests__/ssot-config.spec.ts (47 tests) 92ms
 Test Files  1 passed (1)
      Tests  47 passed (47)
```

New cases prove: baked `VITE_BACKEND_HOST`+`VITE_BACKEND_PORT` (no `VITE_API_BASE_URL`) → `''` (proxy); explicit `VITE_API_BASE_URL` → returns that absolute URL (override preserved, even with a baked host present); legacy `VITE_API_URL` → returned; neither set → `''`.

Typecheck: `vue-tsc --noEmit -p tsconfig.app.json` → clean (exit 0).

**Supervised on-box deploy verify REQUIRED:** the `frontend.env.j2` change only takes effect after a supervised on-box deploy/sync (rebuilds the frontend env + bundle). After sync, confirm onboarding + metrics load in the deployed build with **no CSP `connect-src` violation** in the browser console (requests should hit same-origin `/api/...`, not `https://<host>:8443`). The code half is unit-tested and mergeable independently; the ansible half is un-runtime-verifiable in WSL.

## Model Used

claude-opus-4-8

Closes #12339
Closes #12313
