### PR TITLE
refactor(automation): establish canonical workflow engine + deprecate dead duplicate (#12373)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1532,16 +1532,23 @@ async def _start_autonomous_loop(app: FastAPI) -> None:
 
 
 async def _wire_scheduler_executor() -> None:
-    """Wire the orchestration WorkflowExecutor into the global WorkflowScheduler (#2166).
+    """Wire Orchestrator.run_workflow into the global WorkflowScheduler (#2166).
 
     Replaces the scheduler's fallback _default_template_executor with an adapter
     that delegates non-template scheduled workflows to Orchestrator, enabling
     full agent coordination, step dependency management, and auto-documentation for
     all scheduled workflows — not just template-based ones.
 
+    Correction (#12373): despite this function's name, it does NOT wire
+    ``orchestration.workflow_executor.WorkflowExecutor`` (that class has had
+    no production callers since #5058). ``orchestrator.run_workflow`` itself
+    delegates to ``orchestration.workflow_runner.WorkflowRunner``. The name
+    is kept for now to avoid an unrelated rename churn; read "orchestration
+    executor" below as "the orchestrator's run_workflow pipeline."
+
     NON-CRITICAL: template-based workflows still work if this fails.
     """
-    logger.info("[ 98%%] Scheduler: Wiring orchestration executor...")
+    logger.info("[ 98%%] Scheduler: Wiring orchestrator run_workflow pipeline...")
     try:
         from orchestrator import get_orchestrator_sync
         from workflow_scheduler import ScheduledWorkflow, get_workflow_scheduler

--- a/autobot-backend/orchestration/__init__.py
+++ b/autobot-backend/orchestration/__init__.py
@@ -18,7 +18,11 @@ This package contains:
 - workflow_planner: Map capability requirements to available agents
 - workflow_planning: StrategyPlanner — multi-agent strategy & plan building
 - workflow_runner: WorkflowRunner — multi-agent execution engine (#5058)
-- workflow_executor: Execute a single workflow step by step
+- workflow_executor: Execute a single workflow step by step. DEPRECATED (#12373)
+  — no production callers since #5058; kept in place (code intact) for its
+  DAG/checkpoint/sub-workflow/parallel-group capabilities, migration tracked
+  under #12577/#6826. The canonical runtime engine is
+  services.workflow_automation.executor.WorkflowExecutor.
 - workflow_documentation: Auto-documentation and knowledge extraction
 - collaboration_coordinator: Redis pub/sub collaboration layer (#6393)
 - subagent_dispatcher: Autonomous subagent spawning for parallel workstreams

--- a/autobot-backend/orchestration/workflow_executor.py
+++ b/autobot-backend/orchestration/workflow_executor.py
@@ -7,6 +7,35 @@ from __future__ import annotations
 """
 Workflow Executor
 
+DEPRECATED — NOT THE PRODUCTION RUNTIME PATH (#12373). This class has had
+**no production callers since #5058**: ``orchestrator.run_workflow`` was
+migrated to delegate to ``orchestration.workflow_runner.WorkflowRunner``
+instead, and nothing else in the codebase instantiates this class outside of
+its own module (a self-typed parameter on ``SubWorkflowExecutor`` that is
+never populated in production) and its test suite. The canonical, actually-
+wired runtime workflow-execution engine is
+``services.workflow_automation.executor.WorkflowExecutor``, instantiated by
+``WorkflowAutomationManager`` and backing the ``/api/workflow/*`` and
+``/api/workflow-automation/*`` API surfaces.
+
+This module is kept **in place, with all its code intact** — per repo policy
+code is never deleted, only wired in or superseded — because it implements
+capabilities the canonical engine does not yet have: DAG/condition-branch
+execution, checkpoint/resume, sub-workflow composition, parallel step-group
+execution, structured ``${steps.<id>.output}`` variable piping, and
+step-level error-handler actions (retry/skip/fallback/pause/abort). Folding
+these into the canonical engine is scoped to the follow-up consolidation
+issue **#12577** (which also covers migrating the third API surface,
+``/api/orchestrator/workflow/*``, currently backed by ``WorkflowRunner``, a
+separate multi-agent engine — out of scope here). The DAG-specific piece of
+that migration (replacing ``DAGExecutor`` with ``GraphRunner``) is tracked
+separately in #6826; see ``orchestration/graph_runner.py``.
+
+Until #12577 lands, treat this module as reference/staging code for future
+wiring, not as a live execution path.
+
+--- Original extraction history (retained for context) ---
+
 Issue #381: Extracted from enhanced_orchestrator.py god class refactoring.
 Contains workflow execution, step coordination, and agent interaction handling.
 
@@ -86,6 +115,12 @@ def _get_notification_service():
 class WorkflowExecutor:
     """
     Executes workflows with coordinated agent management.
+
+    DEPRECATED — not the production runtime path; see the module docstring
+    above for the full rationale. Canonical: ``services.workflow_automation
+    .executor.WorkflowExecutor``. Capability migration tracked in #12577
+    (#6826 for the DAG piece). Retained in full for future wiring — no code
+    removed (#12373).
 
     Handles:
     - Step execution with dependency management

--- a/autobot-backend/orchestration/workflow_runner.py
+++ b/autobot-backend/orchestration/workflow_runner.py
@@ -10,9 +10,17 @@ moved to CollaborationCoordinator and AgentRouter collaborators respectively.
 Executor scope (#6826): WorkflowRunner is the **enhanced/multi-agent strategy engine**.
 It executes WorkflowPlan objects via pluggable ExecutionStrategy instances and delegates
 agent routing and collaboration to injected collaborators.  It does not handle DAG graphs
-or step-level checkpoints — those remain in orchestration.WorkflowExecutor and
-CheckpointResumer.  WorkflowRunner is the post-#5058 successor for the multi-agent path;
-orchestration.WorkflowExecutor remains canonical for the legacy step-based path.
+or step-level checkpoints — that logic still only exists in orchestration.WorkflowExecutor
+and CheckpointResumer, neither of which WorkflowRunner currently calls.
+
+Correction (#12373): despite the "canonical for the legacy step-based path" language this
+docstring used to carry, orchestration.WorkflowExecutor has had NO production callers
+since #5058 — orchestrator.run_workflow delegates to WorkflowRunner (this class), not to
+orchestration.WorkflowExecutor. The actual canonical *runtime* workflow-execution engine
+for the product overall is services.workflow_automation.executor.WorkflowExecutor (a
+third, unrelated class). WorkflowRunner is the live post-#5058 engine for the multi-agent
+orchestration path specifically; consolidating it with the canonical services engine is
+scoped to the follow-up issue #12577.
 
 Moved from enhanced_orchestration.workflow_runner to orchestration.workflow_runner
 (issue #10666 B3).

--- a/autobot-backend/services/workflow_automation/executor.py
+++ b/autobot-backend/services/workflow_automation/executor.py
@@ -6,6 +6,21 @@
 Workflow Execution Module
 
 Handles workflow step execution, dependency checking, and command execution.
+
+CANONICAL RUNTIME ENGINE (#12373): This ``WorkflowExecutor`` is the single
+production workflow-execution engine.  It is the only ``WorkflowExecutor``
+implementation with a live instantiation site (``WorkflowAutomationManager``
+in ``manager.py``), and backs the ``/api/workflow/*`` and
+``/api/workflow-automation/*`` API surfaces via that manager.
+
+A second, unrelated class of the same name, ``orchestration.workflow_executor
+.WorkflowExecutor``, exists but has had **no production callers since #5058**
+(``orchestrator.run_workflow`` now delegates to ``orchestration.workflow_runner
+.WorkflowRunner`` instead).  See that module's docstring for details — its
+unique DAG/checkpoint/sub-workflow/parallel-group/variable-piping capabilities
+are tracked for future consolidation onto *this* engine under #12577 (and
+#6826 for the DAG-specific piece).  Do not confuse the two classes; prefer
+this one for all new integration work.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Thinking Path

Issue #12373 flagged two classes both named `WorkflowExecutor` behind 3 API surfaces. Investigation found the choice was NOT a simple "pick the more feature-rich one":

- `services/workflow_automation/executor.py::WorkflowExecutor` is the **only** `WorkflowExecutor` with a real production instantiation site anywhere in the repo (`services/workflow_automation/manager.py:52`, inside `WorkflowAutomationManager`), which backs `/api/workflow/*` and `/api/workflow-automation/*`.
- `orchestration/workflow_executor.py::WorkflowExecutor` has **zero** production callers. `orchestrator.py:428-429` states explicitly the old `orchestration.WorkflowPlanner/WorkflowExecutor` path "has been removed" — `orchestrator.run_workflow` now delegates to `orchestration.workflow_runner.WorkflowRunner` (a third, unrelated class) instead. The only non-test references to `orchestration.WorkflowExecutor` are a self-typed parameter on `SubWorkflowExecutor` (never populated in production) and the `orchestration/__init__.py` re-export.
- The 3rd API surface, `/api/orchestrator/workflow/*`, is backed by `WorkflowRunner`, not by either `WorkflowExecutor` — `WorkflowRunner`'s own docstring describes it as a deliberately separate "multi-agent strategy engine."
- The dead orchestration engine still carries substantial, non-trivial, non-overlapping capability (DAG/condition-branch execution, checkpoint/resume, sub-workflow composition, parallel step-group execution, structured `${steps.<id>.output}` variable piping, step-level error-handler actions retry/skip/fallback/pause/abort, circuit-breaker+retry decorators, debug-mode step-through, dry-run validation) that the canonical engine does not have. Folding all of that in, plus migrating `WorkflowRunner` for the 3rd surface, is a large multi-file effort — not safe for a single mechanical PR without real feature-loss risk.

Per the ABSOLUTE "never delete code — wire it in" rule and owner direction: declare the canonical engine, deprecate the dead one **in place with all its code intact**, correct the stale comments that claimed it was still wired, and scope the actual capability/API-surface migration to a dedicated follow-up (**#12577**, cross-referencing the DAG-specific migration already tracked in #6826). `WorkflowRunner` and the 3rd API surface are untouched here.

## What Changed

- `autobot-backend/services/workflow_automation/executor.py` — module docstring declares this `WorkflowExecutor` the canonical runtime workflow-execution engine, with evidence (only live instantiation site) and pointers to #12577/#6826 for the pending capability migration.
- `autobot-backend/orchestration/workflow_executor.py` — module + class docstrings marked DEPRECATED / NOT THE PRODUCTION RUNTIME PATH, with the full rationale (no callers since #5058) and an explicit statement that **no code was removed** — it's kept in place for its unique DAG/checkpoint/sub-workflow/parallel-group/variable-piping capabilities, migration scoped to #12577 (#6826 for the DAG piece). All 1210 lines of implementation are untouched.
- `autobot-backend/orchestration/workflow_runner.py` — corrected the stale docstring claim that `orchestration.WorkflowExecutor` "remains canonical for the legacy step-based path"; it now states the actual canonical runtime engine and cross-references #12373/#12577.
- `autobot-backend/initialization/lifespan.py:1534` — `_wire_scheduler_executor()` docstring corrected: it does NOT wire `orchestration.workflow_executor.WorkflowExecutor`; the actual path is `orchestrator.run_workflow()` → `WorkflowRunner`.
- `autobot-backend/orchestration/__init__.py` — package docstring's `workflow_executor` entry annotated DEPRECATED with a pointer to the canonical engine and #12577/#6826; the re-export itself is kept for backward compatibility.

No behavior change — docstrings/comments only, plus the (already-true) declaration of which engine is canonical.

## Verification

```
$ python3 -m pytest orchestration/workflow_executor_checkpoint_test.py orchestration/execution_modes_test.py \
    orchestration/workflow_memory_test.py orchestration/sub_workflow_test.py orchestration/dag_executor_test.py \
    orchestration/workflow_documentation_summary_test.py -q
133 passed in 1.84s

$ python3 -m pytest services/workflow_automation/ chat_workflow/workflow_plan_approval_test.py -q
65 passed in 2.62s

$ python3 -m pytest orchestration/ tests/orchestration/ -q
536 passed, 5 failed in 13.12s
# The 5 failures (test_causal_executor.py::TestCausalValidator) are pre-existing —
# confirmed identical failures with `git stash` (this PR's changes reverted) before
# re-applying. Unrelated to this change; not touched by this PR.

$ python3 -m pytest autobot-backend --collect-only -q
19745 tests collected, 1 error in 126.29s
# The 1 collection error (security/enterprise/threat_detection/test_learner.py) is a
# pre-existing missing optional dependency (`cachetools`, part of the documented
# "19/69 deps NOT installed" sandbox gap) — unrelated to this change, not fixed here
# per no-manual-installs policy.
```

Import smoke (all 5 touched modules + re-export identity):
```
services WorkflowExecutor: <class 'services.workflow_automation.executor.WorkflowExecutor'>
orchestration WorkflowExecutor: <class 'orchestration.workflow_executor.WorkflowExecutor'>
orchestration re-export ok: True
WorkflowRunner: <class 'orchestration.workflow_runner.WorkflowRunner'>
lifespan _wire_scheduler_executor: <function _wire_scheduler_executor at ...>
ALL IMPORTS OK
```

This closes the "two forked engines, ambiguous which is canonical" problem from #12373. It does NOT complete a full merge of the dead engine's unique capabilities or migrate `WorkflowRunner`/the 3rd API surface — that's explicitly scoped to follow-up #12577 (DAG piece: #6826), to avoid feature-loss risk from rushing a large multi-file merge.

Closes #12373

## Model Used

Sonnet 5