### PR TITLE
feat(memory): symbolic drawer index for verbatim recall (benchmark-gated, off by default) (#12555)

### DIFF
--- a/autobot-backend/benchmarks/verbatim_symbolic_benchmark.py
+++ b/autobot-backend/benchmarks/verbatim_symbolic_benchmark.py
@@ -1,0 +1,101 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""B1 (#12555) micro-benchmark — symbolic drawer index vs semantic verbatim search.
+
+The merge gate for ``AUTOBOT_VERBATIM_SYMBOLIC_INDEX``: flip the flag on in
+production ONLY if this benchmark shows the symbolic path is **latency-faster
+with no recall@k regression** against the existing semantic ``search`` on a
+representative corpus. Otherwise leave it off and record the numbers on #12555.
+
+Requires a live Redis + ChromaDB (it exercises the real ``VerbatimStore``), so
+it is a standalone script, not a unit test.
+
+Usage::
+
+    AUTOBOT_VERBATIM_SYMBOLIC_INDEX=1 python -m benchmarks.verbatim_symbolic_benchmark
+"""
+
+import argparse
+import asyncio
+import statistics
+import time
+from typing import Dict, List, Tuple
+
+from autobot_shared.logging_manager import get_logger
+from memory.verbatim_store import get_verbatim_store
+
+logger = get_logger(__name__)
+
+# Synthetic corpus: each entity gets a "decision" turn (relevant) plus filler.
+_ENTITIES = [f"ClientAcme{i:03d}" for i in range(50)]
+
+
+def _build_corpus() -> Tuple[List[Tuple[str, int, str, str]], Dict[str, str]]:
+    """Return (turns, ground_truth). turns = (session_id, turn, role, text);
+    ground_truth maps an entity query -> the chunk text that answers it."""
+    turns: List[Tuple[str, int, str, str]] = []
+    truth: Dict[str, str] = {}
+    for i, ent in enumerate(_ENTITIES):
+        decision = f"We decided that {ent} pricing stays flat through Q3 after review."
+        turns.append((f"sess{i}", 0, "assistant", decision))
+        truth[f"{ent} pricing decision"] = decision
+        # filler turns that mention the entity only incidentally
+        for j in range(4):
+            turns.append((f"sess{i}", j + 1, "user", f"Some unrelated chatter number {j} for {ent}."))
+    return turns, truth
+
+
+def _recall_at_k(results: List[dict], answer: str, k: int) -> float:
+    top = results[:k]
+    return 1.0 if any(answer in (r.get("text") or "") for r in top) else 0.0
+
+
+async def _seed(store) -> None:
+    turns, _ = _build_corpus()
+    for session_id, turn, role, text in turns:
+        await store.append(session_id=session_id, turn=turn, role=role, text=text)
+
+
+async def _measure(store, method_name: str, queries: Dict[str, str], k: int) -> Tuple[float, float]:
+    """Return (median_latency_ms, recall_at_k) for the named store method."""
+    method = getattr(store, method_name)
+    latencies: List[float] = []
+    recalls: List[float] = []
+    for query, answer in queries.items():
+        t0 = time.perf_counter()
+        results = await method(query, limit=k)
+        latencies.append((time.perf_counter() - t0) * 1000.0)
+        recalls.append(_recall_at_k(results or [], answer, k))
+    return statistics.median(latencies), sum(recalls) / len(recalls)
+
+
+async def main(k: int) -> None:
+    store = await get_verbatim_store()
+    logger.info("Seeding synthetic verbatim corpus ...")
+    await _seed(store)
+    _, truth = _build_corpus()
+
+    sem_lat, sem_recall = await _measure(store, "search", truth, k)
+    sym_lat, sym_recall = await _measure(store, "search_symbolic", truth, k)
+
+    logger.info("semantic : median=%.2fms recall@%d=%.3f", sem_lat, k, sem_recall)
+    logger.info("symbolic : median=%.2fms recall@%d=%.3f", sym_lat, k, sym_recall)
+    faster = sym_lat < sem_lat
+    no_regress = sym_recall >= sem_recall
+    verdict = "ADOPT (flag-on)" if (faster and no_regress) else "KEEP OFF"
+    logger.info(
+        "VERDICT: %s — faster=%s (%.2fx), recall-neutral=%s",
+        verdict,
+        faster,
+        (sem_lat / sym_lat) if sym_lat else float("inf"),
+        no_regress,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Verbatim symbolic-index benchmark (B1 #12555)")
+    parser.add_argument("-k", type=int, default=5, help="recall@k / result limit")
+    args = parser.parse_args()
+    asyncio.run(main(args.k))

--- a/autobot-backend/benchmarks/verbatim_symbolic_benchmark.py
+++ b/autobot-backend/benchmarks/verbatim_symbolic_benchmark.py
@@ -32,19 +32,27 @@ logger = get_logger(__name__)
 _ENTITIES = [f"ClientAcme{i:03d}" for i in range(50)]
 
 
-def _build_corpus() -> Tuple[List[Tuple[str, int, str, str]], Dict[str, str]]:
-    """Return (turns, ground_truth). turns = (session_id, turn, role, text);
-    ground_truth maps an entity query -> the chunk text that answers it."""
+def _build_corpus() -> Tuple[List[Tuple[str, int, str, str]], Dict[str, str], Dict[str, str]]:
+    """Return (turns, exact_truth, paraphrase_truth).
+
+    turns = (session_id, turn, role, text). ``exact_truth`` maps an entity query
+    that SHARES tokens with its answer (symbolic's ideal case). ``paraphrase_truth``
+    maps a query with **no exact token overlap** with the answer (semantic's job) —
+    included deliberately so the recall verdict isn't biased toward the lexical
+    index (a corpus that only tests exact-token queries would over-report symbolic).
+    """
     turns: List[Tuple[str, int, str, str]] = []
-    truth: Dict[str, str] = {}
+    exact: Dict[str, str] = {}
+    paraphrase: Dict[str, str] = {}
     for i, ent in enumerate(_ENTITIES):
         decision = f"We decided that {ent} pricing stays flat through Q3 after review."
         turns.append((f"sess{i}", 0, "assistant", decision))
-        truth[f"{ent} pricing decision"] = decision
-        # filler turns that mention the entity only incidentally
+        exact[f"{ent} pricing decision"] = decision
+        # Paraphrase: same meaning, zero shared content words with the answer.
+        paraphrase[f"how much will {ent} cost us next quarter"] = decision
         for j in range(4):
             turns.append((f"sess{i}", j + 1, "user", f"Some unrelated chatter number {j} for {ent}."))
-    return turns, truth
+    return turns, exact, paraphrase
 
 
 def _recall_at_k(results: List[dict], answer: str, k: int) -> float:
@@ -52,10 +60,22 @@ def _recall_at_k(results: List[dict], answer: str, k: int) -> float:
     return 1.0 if any(answer in (r.get("text") or "") for r in top) else 0.0
 
 
-async def _seed(store) -> None:
-    turns, _ = _build_corpus()
+async def _seed(store) -> List[str]:
+    turns, _, _ = _build_corpus()
+    sessions = set()
     for session_id, turn, role, text in turns:
         await store.append(session_id=session_id, turn=turn, role=role, text=text)
+        sessions.add(session_id)
+    return sorted(sessions)
+
+
+async def _teardown(store, sessions: List[str]) -> None:
+    """Remove seeded sessions so reruns stay reproducible (don't accumulate)."""
+    for session_id in sessions:
+        try:
+            await store.delete_session(session_id)
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            logger.debug("teardown: delete_session(%s) failed: %s", session_id, exc)
 
 
 async def _measure(store, method_name: str, queries: Dict[str, str], k: int) -> Tuple[float, float]:
@@ -74,24 +94,35 @@ async def _measure(store, method_name: str, queries: Dict[str, str], k: int) -> 
 async def main(k: int) -> None:
     store = await get_verbatim_store()
     logger.info("Seeding synthetic verbatim corpus ...")
-    await _seed(store)
-    _, truth = _build_corpus()
+    sessions = await _seed(store)
+    try:
+        _, exact, paraphrase = _build_corpus()
+        # Exact-token queries: symbolic's ideal case (latency win expected).
+        sem_lat_e, sem_rec_e = await _measure(store, "search", exact, k)
+        sym_lat_e, sym_rec_e = await _measure(store, "search_symbolic", exact, k)
+        # Paraphrase queries: no shared tokens — semantic should win; symbolic
+        # legitimately returns nothing (falls back). This is the honesty check.
+        _, sem_rec_p = await _measure(store, "search", paraphrase, k)
+        _, sym_rec_p = await _measure(store, "search_symbolic", paraphrase, k)
 
-    sem_lat, sem_recall = await _measure(store, "search", truth, k)
-    sym_lat, sym_recall = await _measure(store, "search_symbolic", truth, k)
-
-    logger.info("semantic : median=%.2fms recall@%d=%.3f", sem_lat, k, sem_recall)
-    logger.info("symbolic : median=%.2fms recall@%d=%.3f", sym_lat, k, sym_recall)
-    faster = sym_lat < sem_lat
-    no_regress = sym_recall >= sem_recall
-    verdict = "ADOPT (flag-on)" if (faster and no_regress) else "KEEP OFF"
-    logger.info(
-        "VERDICT: %s — faster=%s (%.2fx), recall-neutral=%s",
-        verdict,
-        faster,
-        (sem_lat / sym_lat) if sym_lat else float("inf"),
-        no_regress,
-    )
+        logger.info("[exact]      semantic median=%.2fms recall@%d=%.3f", sem_lat_e, k, sem_rec_e)
+        logger.info("[exact]      symbolic median=%.2fms recall@%d=%.3f", sym_lat_e, k, sym_rec_e)
+        logger.info("[paraphrase] semantic recall@%d=%.3f  symbolic recall@%d=%.3f", k, sem_rec_p, k, sym_rec_p)
+        faster = sym_lat_e < sem_lat_e
+        no_regress_exact = sym_rec_e >= sem_rec_e
+        # Symbolic must NOT be trusted to answer paraphrase queries — if it did
+        # worse than semantic there (expected), the caller's fallback covers it,
+        # but if symbolic *replaced* semantic it would lose that recall.
+        logger.info(
+            "VERDICT: %s — exact: faster=%s (%.2fx) recall-neutral=%s | paraphrase gap (semantic-symbolic)=%.3f",
+            "ADOPT (flag-on, WITH semantic fallback)" if (faster and no_regress_exact) else "KEEP OFF",
+            faster,
+            (sem_lat_e / sym_lat_e) if sym_lat_e else float("inf"),
+            no_regress_exact,
+            sem_rec_p - sym_rec_p,
+        )
+    finally:
+        await _teardown(store, sessions)
 
 
 if __name__ == "__main__":

--- a/autobot-backend/memory/verbatim_store.py
+++ b/autobot-backend/memory/verbatim_store.py
@@ -21,6 +21,7 @@ Design decisions:
 
 import asyncio
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -32,6 +33,38 @@ logger = get_logger(__name__)
 _COLLECTION_NAME = "autobot_verbatim"
 _DEFAULT_LIMIT = 10
 _DEFAULT_RETENTION_DAYS: int = 90  # override via memory.verbatim.retention_days config
+
+# B1 (#12555): optional MemPalace-style symbolic "drawer" index. An inverted
+# term -> chunk_id index in Redis lets an entity/keyword query resolve candidate
+# chunks in one lookup and rank them lexically, skipping the ANN embed+search on
+# the hot path. Default OFF — merged flag-on only if the micro-benchmark shows a
+# latency win with no recall regression (see benchmarks/verbatim_symbolic_benchmark.py).
+_SYMBOLIC_INDEX_ENABLED: bool = os.environ.get("AUTOBOT_VERBATIM_SYMBOLIC_INDEX", "0").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+_SYM_TERM_KEY = "autobot:vsym:term:{term}"  # set of chunk_ids containing the term
+_SYM_CHUNK_KEY = "autobot:vsym:chunk:{chunk_id}"  # reverse: set of terms (for cleanup)
+_SYM_MAX_TERMS_PER_CHUNK = 32  # cap so a huge turn can't bloat the index
+_SYM_RECENCY_WEIGHT = 0.2  # blend recency into the lexical rank (mirrors search)
+
+# Minimal stopword set — mirrors query_processor._extract_keywords intent without
+# coupling to that private module. Salient-term extraction, not full NLP.
+_SYM_STOPWORDS = frozenset(
+    {
+        "the", "and", "for", "are", "was", "were", "you", "your", "our", "their", "with", "that",
+        "this", "have", "has", "had", "not", "but", "can", "will", "would", "should", "could",
+        "what", "when", "where", "which", "who", "why", "how", "did", "does", "about", "from",
+        "into", "out", "get", "got", "let", "its", "it's", "they", "them", "then", "than",
+    }
+)
+
+
+def _extract_terms(text: str) -> set:
+    """Salient alphanumeric terms (len>2, non-stopword) for the symbolic index."""
+    tokens = re.findall(r"[a-z0-9]+", (text or "").lower())
+    return {t for t in tokens if len(t) > 2 and t not in _SYM_STOPWORDS}
 
 # Recency-weighted re-ranking (GH#11163). Verbatim recall blends semantic
 # similarity with an exponential recency decay so recent turns surface over
@@ -151,8 +184,111 @@ class VerbatimStore:
             documents=[text],
             metadatas=[metadata],
         )
+        if _SYMBOLIC_INDEX_ENABLED:
+            await self._index_symbolic(chunk_id, text)
         logger.debug("VerbatimStore.append: stored chunk %s", chunk_id)
         return chunk_id
+
+    # ------------------------------------------------------------------
+    # B1 (#12555): symbolic drawer index (opt-in, default off)
+    # ------------------------------------------------------------------
+
+    async def _index_symbolic(self, chunk_id: str, text: str) -> None:
+        """Add ``chunk_id`` to the inverted term index. Best-effort, never raises.
+
+        Writes ``term -> {chunk_id}`` sets plus a reverse ``chunk_id -> {terms}``
+        set so ``delete_session`` can clean up without re-tokenising.
+        """
+        try:
+            terms = list(_extract_terms(text))[:_SYM_MAX_TERMS_PER_CHUNK]
+            if not terms:
+                return
+            from autobot_shared.redis_client import get_redis_client
+
+            redis = await get_redis_client(database="knowledge")
+            pipe = redis.pipeline()
+            for term in terms:
+                pipe.sadd(_SYM_TERM_KEY.format(term=term), chunk_id)
+            pipe.sadd(_SYM_CHUNK_KEY.format(chunk_id=chunk_id), *terms)
+            await pipe.execute()
+        except Exception:
+            logger.debug("VerbatimStore._index_symbolic failed (non-fatal)", exc_info=True)
+
+    async def _deindex_symbolic(self, chunk_ids: List[str]) -> None:
+        """Remove chunk_ids from the inverted index (called on delete). Best-effort."""
+        if not chunk_ids:
+            return
+        try:
+            from autobot_shared.redis_client import get_redis_client
+
+            redis = await get_redis_client(database="knowledge")
+            for chunk_id in chunk_ids:
+                chunk_key = _SYM_CHUNK_KEY.format(chunk_id=chunk_id)
+                raw_terms = await redis.smembers(chunk_key)
+                terms = [t.decode() if isinstance(t, bytes) else t for t in raw_terms]
+                if not terms:
+                    continue
+                pipe = redis.pipeline()
+                for term in terms:
+                    pipe.srem(_SYM_TERM_KEY.format(term=term), chunk_id)
+                pipe.delete(chunk_key)
+                await pipe.execute()
+        except Exception:
+            logger.debug("VerbatimStore._deindex_symbolic failed (non-fatal)", exc_info=True)
+
+    async def search_symbolic(
+        self,
+        query: str,
+        session_filter: str | None = None,
+        limit: int = _DEFAULT_LIMIT,
+    ) -> List[Dict[str, Any]] | None:
+        """Entity/keyword recall via the symbolic index — no ANN embed on the path.
+
+        Resolves candidate chunks from the inverted term index, fetches them, and
+        ranks by query-term overlap blended with recency. Returns ``None`` (not
+        ``[]``) when the index is disabled, the query has no salient terms, or no
+        candidate matched — so the caller can fall back to semantic ``search``.
+        """
+        if not _SYMBOLIC_INDEX_ENABLED:
+            return None
+        terms = _extract_terms(query)
+        if not terms:
+            return None
+        try:
+            from autobot_shared.redis_client import get_redis_client
+
+            redis = await get_redis_client(database="knowledge")
+            raw = await redis.sunion([_SYM_TERM_KEY.format(term=t) for t in terms])
+        except Exception:
+            logger.debug("VerbatimStore.search_symbolic union failed (non-fatal)", exc_info=True)
+            return None
+        candidate_ids = [c.decode() if isinstance(c, bytes) else c for c in raw]
+        if not candidate_ids:
+            return None
+        return await self._rank_symbolic_candidates(candidate_ids, terms, session_filter, limit)
+
+    async def _rank_symbolic_candidates(
+        self, candidate_ids: List[str], query_terms: set, session_filter: str | None, limit: int
+    ) -> List[Dict[str, Any]]:
+        """Fetch candidate chunks and rank by term-overlap blended with recency."""
+        collection = await self._get_collection()
+        got = await collection.get(ids=candidate_ids, include=["documents", "metadatas"])
+        ids = got.get("ids", []) or []
+        docs = got.get("documents", []) or []
+        metas = got.get("metadatas", []) or []
+        now = datetime.now(tz=timezone.utc)
+        ranked: List[Dict[str, Any]] = []
+        for cid, doc, meta in zip(ids, docs, metas):
+            meta = meta or {}
+            if session_filter and meta.get("session_id") != session_filter:
+                continue
+            doc_terms = _extract_terms(doc)
+            overlap = len(query_terms & doc_terms) / len(query_terms) if query_terms else 0.0
+            recency = _recency_factor(meta.get("timestamp"), now) or 0.0
+            score = (1.0 - _SYM_RECENCY_WEIGHT) * overlap + _SYM_RECENCY_WEIGHT * recency
+            ranked.append({"id": cid, "text": doc, "score": score, "metadata": meta})
+        ranked.sort(key=lambda c: c["score"], reverse=True)
+        return ranked[:limit]
 
     async def search(
         self,
@@ -245,10 +381,13 @@ class VerbatimStore:
             where=where,
             include=["documents"],
         )
-        count = len(existing.get("ids", []))
+        existing_ids = existing.get("ids", [])
+        count = len(existing_ids)
 
         if count > 0:
             await collection.delete(where=where)
+            if _SYMBOLIC_INDEX_ENABLED:
+                await self._deindex_symbolic(existing_ids)
             logger.info(
                 "VerbatimStore.delete_session: removed %d chunks for session %s",
                 count,

--- a/autobot-backend/memory/verbatim_store.py
+++ b/autobot-backend/memory/verbatim_store.py
@@ -48,15 +48,60 @@ _SYM_TERM_KEY = "autobot:vsym:term:{term}"  # set of chunk_ids containing the te
 _SYM_CHUNK_KEY = "autobot:vsym:chunk:{chunk_id}"  # reverse: set of terms (for cleanup)
 _SYM_MAX_TERMS_PER_CHUNK = 32  # cap so a huge turn can't bloat the index
 _SYM_RECENCY_WEIGHT = 0.2  # blend recency into the lexical rank (mirrors search)
+# A broad term (e.g. a common word) can union to thousands of chunks. Rather than
+# fetch them all from ChromaDB, treat an over-broad match as "not an entity query"
+# and fall back to semantic search.
+_SYM_MAX_CANDIDATES = 200
 
 # Minimal stopword set — mirrors query_processor._extract_keywords intent without
 # coupling to that private module. Salient-term extraction, not full NLP.
 _SYM_STOPWORDS = frozenset(
     {
-        "the", "and", "for", "are", "was", "were", "you", "your", "our", "their", "with", "that",
-        "this", "have", "has", "had", "not", "but", "can", "will", "would", "should", "could",
-        "what", "when", "where", "which", "who", "why", "how", "did", "does", "about", "from",
-        "into", "out", "get", "got", "let", "its", "it's", "they", "them", "then", "than",
+        "the",
+        "and",
+        "for",
+        "are",
+        "was",
+        "were",
+        "you",
+        "your",
+        "our",
+        "their",
+        "with",
+        "that",
+        "this",
+        "have",
+        "has",
+        "had",
+        "not",
+        "but",
+        "can",
+        "will",
+        "would",
+        "should",
+        "could",
+        "what",
+        "when",
+        "where",
+        "which",
+        "who",
+        "why",
+        "how",
+        "did",
+        "does",
+        "about",
+        "from",
+        "into",
+        "out",
+        "get",
+        "got",
+        "let",
+        "its",
+        "it's",
+        "they",
+        "them",
+        "then",
+        "than",
     }
 )
 
@@ -65,6 +110,7 @@ def _extract_terms(text: str) -> set:
     """Salient alphanumeric terms (len>2, non-stopword) for the symbolic index."""
     tokens = re.findall(r"[a-z0-9]+", (text or "").lower())
     return {t for t in tokens if len(t) > 2 and t not in _SYM_STOPWORDS}
+
 
 # Recency-weighted re-ranking (GH#11163). Verbatim recall blends semantic
 # similarity with an exponential recency decay so recent turns surface over
@@ -265,6 +311,15 @@ class VerbatimStore:
         candidate_ids = [c.decode() if isinstance(c, bytes) else c for c in raw]
         if not candidate_ids:
             return None
+        # Over-broad match (a common term) → not a good entity query. Fall back to
+        # semantic search rather than fetch thousands of chunks from ChromaDB.
+        if len(candidate_ids) > _SYM_MAX_CANDIDATES:
+            logger.debug(
+                "search_symbolic: %d candidates exceed cap %d — deferring to semantic",
+                len(candidate_ids),
+                _SYM_MAX_CANDIDATES,
+            )
+            return None
         return await self._rank_symbolic_candidates(candidate_ids, terms, session_filter, limit)
 
     async def _rank_symbolic_candidates(
@@ -284,8 +339,13 @@ class VerbatimStore:
                 continue
             doc_terms = _extract_terms(doc)
             overlap = len(query_terms & doc_terms) / len(query_terms) if query_terms else 0.0
-            recency = _recency_factor(meta.get("timestamp"), now) or 0.0
-            score = (1.0 - _SYM_RECENCY_WEIGHT) * overlap + _SYM_RECENCY_WEIGHT * recency
+            # Blend recency only when present — mirrors search()'s handling of a
+            # missing/unparseable timestamp (skip, don't penalise the chunk).
+            recency = _recency_factor(meta.get("timestamp"), now)
+            if recency is not None:
+                score = (1.0 - _SYM_RECENCY_WEIGHT) * overlap + _SYM_RECENCY_WEIGHT * recency
+            else:
+                score = overlap
             ranked.append({"id": cid, "text": doc, "score": score, "metadata": meta})
         ranked.sort(key=lambda c: c["score"], reverse=True)
         return ranked[:limit]

--- a/autobot-backend/memory/verbatim_symbolic_test.py
+++ b/autobot-backend/memory/verbatim_symbolic_test.py
@@ -1,0 +1,170 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for B1 (#12555) — symbolic drawer index over the verbatim store.
+
+Covers term extraction, the flag-off/no-term/no-candidate fallback contract
+(returns None so the caller uses semantic search), index write/cleanup, and the
+overlap+recency ranking of the symbolic search path. Redis and the ChromaDB
+collection are faked so no infra is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import memory.verbatim_store as vs
+from memory.verbatim_store import VerbatimStore, _extract_terms
+
+
+class _FakePipe:
+    def __init__(self, redis):
+        self._redis = redis
+        self.ops = []
+
+    def sadd(self, key, *vals):
+        self.ops.append(("sadd", key, vals))
+        self._redis.sets.setdefault(key, set()).update(vals)
+        return self
+
+    def srem(self, key, *vals):
+        self.ops.append(("srem", key, vals))
+        self._redis.sets.get(key, set()).difference_update(vals)
+        return self
+
+    def delete(self, key):
+        self.ops.append(("delete", key))
+        self._redis.sets.pop(key, None)
+        return self
+
+    async def execute(self):
+        return [True] * len(self.ops)
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.sets: dict = {}
+
+    def pipeline(self):
+        return _FakePipe(self)
+
+    async def smembers(self, key):
+        return set(self.sets.get(key, set()))
+
+    async def sunion(self, keys):
+        out: set = set()
+        for k in keys:
+            out |= self.sets.get(k, set())
+        return out
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    r = _FakeRedis()
+    monkeypatch.setattr(
+        "autobot_shared.redis_client.get_redis_client",
+        AsyncMock(return_value=r),
+    )
+    return r
+
+
+def _store_with_collection(collection):
+    store = VerbatimStore()
+    store._collection = collection  # bypass lazy init
+    return store
+
+
+# ---- term extraction -------------------------------------------------------
+
+
+def test_extract_terms_drops_stopwords_and_short():
+    terms = _extract_terms("What did we decide about ClientX pricing in March")
+    assert "clientx" in terms
+    assert "pricing" in terms
+    assert "march" in terms
+    assert "did" not in terms  # stopword
+    assert "we" not in terms   # too short
+
+
+# ---- fallback contract -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_symbolic_returns_none_when_disabled(monkeypatch):
+    monkeypatch.setattr(vs, "_SYMBOLIC_INDEX_ENABLED", False)
+    store = VerbatimStore()
+    assert await store.search_symbolic("clientx pricing") is None
+
+
+@pytest.mark.asyncio
+async def test_search_symbolic_returns_none_without_terms(monkeypatch, fake_redis):
+    monkeypatch.setattr(vs, "_SYMBOLIC_INDEX_ENABLED", True)
+    store = VerbatimStore()
+    assert await store.search_symbolic("did we the") is None  # all stopwords/short
+
+
+@pytest.mark.asyncio
+async def test_search_symbolic_returns_none_when_no_candidates(monkeypatch, fake_redis):
+    monkeypatch.setattr(vs, "_SYMBOLIC_INDEX_ENABLED", True)
+    store = VerbatimStore()
+    assert await store.search_symbolic("clientx pricing") is None  # empty index
+
+
+# ---- index write + search --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_and_search_roundtrip(monkeypatch, fake_redis):
+    monkeypatch.setattr(vs, "_SYMBOLIC_INDEX_ENABLED", True)
+    collection = MagicMock()
+    collection.get = AsyncMock(
+        return_value={
+            "ids": ["c1", "c2"],
+            "documents": [
+                "We agreed ClientX pricing stays flat",
+                "Unrelated note about lunch",
+            ],
+            "metadatas": [
+                {"session_id": "s1", "timestamp": "2026-07-25T00:00:00+00:00"},
+                {"session_id": "s1", "timestamp": "2026-07-01T00:00:00+00:00"},
+            ],
+        }
+    )
+    store = _store_with_collection(collection)
+    # Seed the inverted index as append() would.
+    await store._index_symbolic("c1", "We agreed ClientX pricing stays flat")
+    await store._index_symbolic("c2", "Unrelated note about lunch")
+
+    results = await store.search_symbolic("ClientX pricing")
+    assert results is not None
+    assert results[0]["id"] == "c1"  # highest term overlap
+    assert results[0]["score"] > results[-1]["score"]
+
+
+@pytest.mark.asyncio
+async def test_search_symbolic_respects_session_filter(monkeypatch, fake_redis):
+    monkeypatch.setattr(vs, "_SYMBOLIC_INDEX_ENABLED", True)
+    collection = MagicMock()
+    collection.get = AsyncMock(
+        return_value={
+            "ids": ["c1"],
+            "documents": ["ClientX pricing note"],
+            "metadatas": [{"session_id": "other", "timestamp": "2026-07-25T00:00:00+00:00"}],
+        }
+    )
+    store = _store_with_collection(collection)
+    await store._index_symbolic("c1", "ClientX pricing note")
+    results = await store.search_symbolic("clientx pricing", session_filter="s1")
+    assert results == []  # candidate belongs to a different session
+
+
+@pytest.mark.asyncio
+async def test_deindex_removes_chunk_from_terms(monkeypatch, fake_redis):
+    monkeypatch.setattr(vs, "_SYMBOLIC_INDEX_ENABLED", True)
+    store = VerbatimStore()
+    await store._index_symbolic("c1", "ClientX pricing")
+    assert "c1" in fake_redis.sets[vs._SYM_TERM_KEY.format(term="clientx")]
+    await store._deindex_symbolic(["c1"])
+    assert "c1" not in fake_redis.sets.get(vs._SYM_TERM_KEY.format(term="clientx"), set())
+    assert vs._SYM_CHUNK_KEY.format(chunk_id="c1") not in fake_redis.sets

--- a/autobot-backend/memory/verbatim_symbolic_test.py
+++ b/autobot-backend/memory/verbatim_symbolic_test.py
@@ -84,7 +84,7 @@ def test_extract_terms_drops_stopwords_and_short():
     assert "pricing" in terms
     assert "march" in terms
     assert "did" not in terms  # stopword
-    assert "we" not in terms   # too short
+    assert "we" not in terms  # too short
 
 
 # ---- fallback contract -----------------------------------------------------
@@ -157,6 +157,21 @@ async def test_search_symbolic_respects_session_filter(monkeypatch, fake_redis):
     await store._index_symbolic("c1", "ClientX pricing note")
     results = await store.search_symbolic("clientx pricing", session_filter="s1")
     assert results == []  # candidate belongs to a different session
+
+
+@pytest.mark.asyncio
+async def test_over_broad_query_defers_to_semantic(monkeypatch, fake_redis):
+    # A term matching more than the cap => not an entity query => return None so
+    # the caller falls back to semantic search (no giant ChromaDB fetch).
+    monkeypatch.setattr(vs, "_SYMBOLIC_INDEX_ENABLED", True)
+    monkeypatch.setattr(vs, "_SYM_MAX_CANDIDATES", 3)
+    for i in range(5):
+        await VerbatimStore()._index_symbolic(f"c{i}", "pricing pricing pricing")
+    collection = MagicMock()
+    collection.get = AsyncMock()
+    store = _store_with_collection(collection)
+    assert await store.search_symbolic("pricing") is None
+    collection.get.assert_not_awaited()  # never fetched the oversized set
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path
Gap B of epic #12551 — the highest-gain remaining adoption from the source video: MemPalace's **symbolic dense index** for fast, single-pass verbatim recall, adapted to AutoBot's `VerbatimStore`. Targets the "what did we decide about ClientX in March?" pattern where an ANN embed+search is overkill.

## What Changed
- **`memory/verbatim_store.py`**: an inverted **term → chunk_id** index in Redis (`knowledge` DB).
  - `_index_symbolic` on `append`, `_deindex_symbolic` on `delete_session` — kept consistent, both best-effort (never break the write path).
  - `search_symbolic(query, session_filter, limit)`: resolves candidates via `SUNION`, fetches them, ranks by **query-term overlap blended with recency** — no embedding call on the path. Returns `None` (not `[]`) when disabled / no salient terms / no candidate, so callers **fall back to semantic `search`**.
  - Behind `AUTOBOT_VERBATIM_SYMBOLIC_INDEX` (**default OFF**) — zero risk until proven.
- **`benchmarks/verbatim_symbolic_benchmark.py`**: the merge gate — seeds a synthetic corpus and reports median latency + recall@k for symbolic vs semantic, printing an ADOPT/KEEP-OFF verdict.

## Verification
- `memory/verbatim_symbolic_test.py` — **7 passed** (Redis + collection faked): term extraction (stopwords/short dropped), the flag-off/no-term/no-candidate → `None` fallback contract, index+search roundtrip (highest overlap ranks first), session filtering, and deindex cleanup.
- **Hidden-cost gate (honest):** the latency/recall benchmark needs a live Redis+ChromaDB and was **not run in this environment**, so this ships **flag-off**. Flip `AUTOBOT_VERBATIM_SYMBOLIC_INDEX=1` only after running `python -m benchmarks.verbatim_symbolic_benchmark` shows a latency win with no recall regression; otherwise it stays off and the numbers get recorded on #12555.

## Model Used
Opus 4.8 (1M context)

Closes #12555. Part of epic #12551.
