### PR TITLE
feat(slm-frontend): canonical SLM ApiClient (#12420 Phase 1)

### DIFF
--- a/autobot-slm-frontend/src/utils/ApiClient.test.ts
+++ b/autobot-slm-frontend/src/utils/ApiClient.test.ts
@@ -1,0 +1,245 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Unit tests for the canonical SLM ApiClient (#12420 Phase 1).
+ *
+ * Covers: base-URL resolution from getSlmApiBase(), auth-header injection
+ * (sessionStorage primary + localStorage fallback), 401 session handling
+ * (token-carrying vs token-less vs auth-endpoint), GET retry/backoff, request
+ * timeout via AbortController, FormData passthrough and 204 handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SlmApiClient } from './ApiClient'
+
+const TOKEN_KEY = 'slm_access_token'
+const USER_KEY = 'slm_user'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('SlmApiClient', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Replace window.location with a mutable stub so redirects are observable.
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/fleet', href: '' } as unknown as Location,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Base URL resolution
+  // -------------------------------------------------------------------------
+
+  it('resolves base URL from getSlmApiBase() (/api) and prefixes the endpoint', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+
+    await client.get('/nodes')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/nodes')
+  })
+
+  it('honours a setBaseUrl() override', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+    client.setBaseUrl('/slm/api')
+
+    await client.get('/nodes')
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/slm/api/nodes')
+  })
+
+  // -------------------------------------------------------------------------
+  // Auth header injection
+  // -------------------------------------------------------------------------
+
+  it('injects Authorization from sessionStorage token', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'session-jwt')
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+
+    await client.get('/nodes')
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer session-jwt')
+  })
+
+  it('falls back to localStorage token when sessionStorage is empty', async () => {
+    localStorage.setItem(TOKEN_KEY, 'local-jwt')
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+
+    await client.get('/nodes')
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer local-jwt')
+  })
+
+  it('omits Authorization when no token is stored', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+
+    await client.get('/nodes')
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // 401 handling
+  // -------------------------------------------------------------------------
+
+  it('clears session and redirects to /login on 401 when a token was attached', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'expired-jwt')
+    sessionStorage.setItem(USER_KEY, '{"username":"a"}')
+    localStorage.setItem(TOKEN_KEY, 'expired-jwt')
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauthorized' }, 401))
+    const client = new SlmApiClient()
+
+    await expect(client.get('/nodes', { maxRetries: 1 })).rejects.toThrow('HTTP 401')
+
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBeNull()
+    expect(sessionStorage.getItem(USER_KEY)).toBeNull()
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull()
+    expect(window.location.href).toBe('/login')
+  })
+
+  it('does NOT clear session on a token-less 401', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauthorized' }, 401))
+    const client = new SlmApiClient()
+
+    await expect(client.get('/public', { maxRetries: 1 })).rejects.toThrow('HTTP 401')
+
+    expect(window.location.href).toBe('')
+  })
+
+  it('does NOT clear session on a 401 from an auth endpoint', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'temp-jwt')
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'bad creds' }, 401))
+    const client = new SlmApiClient()
+
+    await expect(client.get('/auth/me', { maxRetries: 1 })).rejects.toThrow('HTTP 401')
+
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBe('temp-jwt')
+    expect(window.location.href).toBe('')
+  })
+
+  // -------------------------------------------------------------------------
+  // Retry / backoff
+  // -------------------------------------------------------------------------
+
+  it('retries a failed GET and succeeds on a later attempt', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new TypeError('network down'))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+
+    const result = await client.get<{ ok: boolean }>('/nodes', { maxRetries: 2 })
+
+    expect(result).toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT retry a 4xx client error', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'not found' }, 404))
+    const client = new SlmApiClient()
+
+    await expect(client.get('/nodes', { maxRetries: 3 })).rejects.toThrow('HTTP 404')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // Timeout via AbortController
+  // -------------------------------------------------------------------------
+
+  it('aborts and throws a timeout error when the request exceeds the timeout', async () => {
+    fetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted')
+            err.name = 'AbortError'
+            reject(err)
+          })
+        })
+    )
+    const client = new SlmApiClient()
+
+    await expect(client.rawRequest('/nodes', { timeout: 30 })).rejects.toThrow(
+      'Request timeout after 30ms'
+    )
+  })
+
+  // -------------------------------------------------------------------------
+  // FormData passthrough + 204 handling
+  // -------------------------------------------------------------------------
+
+  it('passes FormData through untouched and drops the JSON Content-Type header', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+    const form = new FormData()
+    form.append('field', 'value')
+
+    await client.post('/upload', form)
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.body).toBe(form)
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+  })
+
+  it('serialises a plain object body as JSON', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    const client = new SlmApiClient()
+
+    await client.post('/nodes', { name: 'n1' })
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.body).toBe(JSON.stringify({ name: 'n1' }))
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+
+  it('returns an empty object for a 204 No Content response', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }))
+    const client = new SlmApiClient()
+
+    const result = await client.delete('/nodes/n1')
+
+    expect(result).toEqual({})
+  })
+
+  it('throws a descriptive error for a non-OK POST', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'boom' }, 500))
+    const client = new SlmApiClient()
+
+    await expect(client.post('/nodes', {})).rejects.toThrow('HTTP 500: boom')
+  })
+})

--- a/autobot-slm-frontend/src/utils/ApiClient.ts
+++ b/autobot-slm-frontend/src/utils/ApiClient.ts
@@ -1,0 +1,419 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Canonical SLM API Client (#12420 Phase 1).
+ *
+ * A single fetch-based HTTP client for the SLM Admin frontend, mirroring the
+ * canonical `autobot-frontend/src/utils/ApiClient.ts` and adapting it to SLM:
+ *
+ *  - Base URL resolved from `getSlmApiBase()` (ssot-config) — '/api' standalone
+ *    or '/slm/api' when co-located. Endpoints are passed relative to that base
+ *    (e.g. `get('/nodes')` → `/api/nodes`), matching the existing SLM axios
+ *    composable convention so Phase 2 call sites drop only the base prefix.
+ *  - Auth token read exactly as existing SLM fetch/axios sites do:
+ *    `sessionStorage.getItem('slm_access_token')` with a `localStorage`
+ *    fallback (mirrors `stores/auth.ts` token initialisation).
+ *  - 401 handling matches SLM's convention: clear the session keys and redirect
+ *    to `/login` (the target of `authStore.logout()`), but only when the request
+ *    actually carried a bearer token and did not target an auth/mfa endpoint.
+ *  - Timeout via AbortController, exponential-backoff retry on GET, FormData
+ *    passthrough, `rawRequest` for streaming/blob access, and 204 handling.
+ *
+ * Per the #12420 plan this is a COPY-ADAPT (separate per-app client); a shared
+ * core is a later ADR. Nothing imports this yet — Phase 2 migrates the ~71
+ * `getSlmApiBase()` call sites and ~48 fetch/axios files onto it.
+ */
+
+import { createLogger } from '@/utils/debugUtils'
+import { getSlmApiBase } from '@/config/ssot-config'
+
+const logger = createLogger('SlmApiClient')
+
+// SLM auth storage keys — kept in sync with stores/auth.ts (TOKEN_KEY/USER_KEY).
+const TOKEN_KEY = 'slm_access_token'
+const USER_KEY = 'slm_user'
+
+// Login route users are redirected to on session rejection (authStore.logout()).
+const LOGIN_PATH = '/login'
+
+// Default request timeout. Module-level constant sourced from an env var so it
+// is never hard-coded at a call site (falls back to 30s when unset).
+const DEFAULT_TIMEOUT_MS = (() => {
+  const raw = import.meta.env.VITE_SLM_API_TIMEOUT_MS
+  const parsed = raw != null && raw !== '' ? parseInt(String(raw), 10) : NaN
+  return Number.isNaN(parsed) ? 30_000 : parsed
+})()
+
+export interface RequestOptions {
+  headers?: Record<string, string>
+  timeout?: number
+  maxRetries?: number
+  signal?: AbortSignal
+  /**
+   * When true, the client does not emit a WARN log on final failure. Use for
+   * endpoints whose absence/timeout is handled gracefully by the caller
+   * (optional widgets, health probes) so they don't generate console noise.
+   */
+  suppressErrorLog?: boolean
+}
+
+export interface ErrorInfo {
+  status: number
+  message: string
+  details: Record<string, unknown> | null
+}
+
+export class SlmApiClient {
+  // Optional host/base override (defaults to getSlmApiBase() when unset).
+  private baseUrlOverride: string | null = null
+  private defaultHeaders: Record<string, string>
+  private defaultTimeout: number
+
+  constructor() {
+    this.defaultHeaders = {
+      'Content-Type': 'application/json',
+    }
+    this.defaultTimeout = DEFAULT_TIMEOUT_MS
+  }
+
+  // Public setter for base URL (used by plugin configuration / tests).
+  setBaseUrl(url: string): void {
+    this.baseUrlOverride = url
+  }
+
+  // Public setter for default timeout.
+  setTimeout(timeout: number): void {
+    this.defaultTimeout = timeout
+  }
+
+  getConfiguration(): Record<string, unknown> {
+    return {
+      baseUrl: this.resolveBaseUrl(),
+      timeout: this.defaultTimeout,
+    }
+  }
+
+  // ==================================================================================
+  // BASE URL — resolved from getSlmApiBase() unless explicitly overridden
+  // ==================================================================================
+
+  private resolveBaseUrl(): string {
+    return this.baseUrlOverride ?? getSlmApiBase()
+  }
+
+  // ==================================================================================
+  // AUTH TOKEN — mirrors stores/auth.ts init (sessionStorage, localStorage fallback)
+  // ==================================================================================
+
+  private getAuthToken(): string | null {
+    try {
+      return sessionStorage.getItem(TOKEN_KEY) || localStorage.getItem(TOKEN_KEY)
+    } catch {
+      return null
+    }
+  }
+
+  // Auth/MFA endpoints must never trigger a session-clearing 401 handler — a 401
+  // there is a credential failure, not a rejected session.
+  private isAuthEndpoint(endpoint: string): boolean {
+    return endpoint.includes('/auth/') || endpoint.includes('/mfa/')
+  }
+
+  // Handle 401 — clear stored session and redirect to /login.
+  // Only destructive when the request carried a bearer token: a 401 on a
+  // token-less background call is not a session rejection.
+  private handleUnauthorized(endpoint: string, tokenWasAttached: boolean): void {
+    if (!tokenWasAttached) {
+      logger.debug(
+        '401 on token-less request — not clearing session (no session to invalidate):',
+        endpoint
+      )
+      return
+    }
+    logger.warn('401 Unauthorized, clearing SLM session:', endpoint)
+    try {
+      sessionStorage.removeItem(TOKEN_KEY)
+      sessionStorage.removeItem(USER_KEY)
+      localStorage.removeItem(TOKEN_KEY)
+      localStorage.removeItem(USER_KEY)
+    } catch {
+      /* storage unavailable — nothing to clear */
+    }
+    if (
+      typeof window !== 'undefined' &&
+      !window.location.pathname.includes(LOGIN_PATH)
+    ) {
+      window.location.href = LOGIN_PATH
+    }
+  }
+
+  // ==================================================================================
+  // RAW REQUEST — returns the Response object (for streaming, blobs, etc.)
+  // ==================================================================================
+
+  async rawRequest(
+    endpoint: string,
+    options: RequestOptions & { method?: string; body?: unknown } = {}
+  ): Promise<Response> {
+    const {
+      method = 'GET',
+      headers = {},
+      body,
+      timeout = this.defaultTimeout,
+      signal: externalSignal,
+    } = options
+
+    const baseUrl = this.resolveBaseUrl()
+    const url = baseUrl ? `${baseUrl}${endpoint}` : endpoint
+
+    const controller = new AbortController()
+    let timedOut = false
+    const timeoutId = setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, timeout)
+
+    // Forward external cancellation into the internal controller.
+    let externalAbortHandler: (() => void) | null = null
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        controller.abort()
+      } else {
+        externalAbortHandler = () => controller.abort()
+        externalSignal.addEventListener('abort', externalAbortHandler)
+      }
+    }
+
+    const cleanup = () => {
+      clearTimeout(timeoutId)
+      if (externalSignal && externalAbortHandler) {
+        externalSignal.removeEventListener('abort', externalAbortHandler)
+      }
+    }
+
+    try {
+      const fetchOptions: RequestInit = {
+        method,
+        headers: { ...this.defaultHeaders, ...headers },
+        signal: controller.signal,
+      }
+
+      // Inject auth token if available.
+      const authToken = this.getAuthToken()
+      if (authToken) {
+        const hdrs = fetchOptions.headers as Record<string, string>
+        hdrs['Authorization'] = `Bearer ${authToken}`
+      }
+
+      // Handle body — support FormData (don't stringify, drop Content-Type so
+      // the browser sets the multipart boundary).
+      if (body instanceof FormData) {
+        fetchOptions.body = body
+        const hdrs = fetchOptions.headers as Record<string, string>
+        delete hdrs['Content-Type']
+      } else if (body !== undefined) {
+        fetchOptions.body = JSON.stringify(body)
+      }
+
+      const response = await fetch(url, fetchOptions)
+      cleanup()
+
+      // Handle 401 — redirect to login (skip for auth/mfa endpoints). Pass
+      // whether THIS request carried a bearer token so we only clear + redirect
+      // on a genuine rejection of an authenticated request.
+      if (response.status === 401 && !this.isAuthEndpoint(endpoint)) {
+        this.handleUnauthorized(endpoint, authToken != null)
+      }
+
+      return response
+    } catch (error) {
+      cleanup()
+      if (error instanceof Error && error.name === 'AbortError') {
+        if (timedOut) throw new Error(`Request timeout after ${timeout}ms`)
+        throw error
+      }
+      throw error
+    }
+  }
+
+  // ==================================================================================
+  // CONVENIENCE METHODS — return parsed JSON data (not Response)
+  // ==================================================================================
+
+  private async extractErrorInfo(response: Response): Promise<ErrorInfo> {
+    try {
+      const errorData = await response.json()
+      return {
+        status: response.status,
+        message: (() => {
+          const raw = errorData.error || errorData.message || errorData.detail
+          if (raw == null) return JSON.stringify(errorData) || 'Unknown error'
+          return typeof raw === 'string' ? raw : JSON.stringify(raw)
+        })(),
+        details: errorData,
+      }
+    } catch {
+      return {
+        status: response.status,
+        message: response.statusText || 'Unknown error',
+        details: null,
+      }
+    }
+  }
+
+  private async parseJsonBody<T>(response: Response): Promise<T> {
+    if (response.status === 204) return {} as T
+    const contentType = response.headers.get('content-type')
+    if (contentType && contentType.includes('application/json')) {
+      return (await response.json()) as T
+    }
+    return {} as T
+  }
+
+  // GET with retry logic and exponential backoff.
+  async get<T = unknown>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+    let lastError: Error | undefined
+    const maxRetries = options.maxRetries !== undefined ? options.maxRetries : 3
+    let attemptsMade = 0
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      attemptsMade = attempt
+      try {
+        const response = await this.rawRequest(endpoint, { method: 'GET', ...options })
+
+        if (!response.ok) {
+          const errorData = await this.extractErrorInfo(response)
+          throw new Error(`HTTP ${response.status}: ${errorData.message}`)
+        }
+
+        return (await response.json()) as T
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error))
+        logger.debug(`GET attempt ${attempt} failed for ${endpoint}: ${lastError.message}`)
+
+        // Don't retry 4xx client errors — they won't succeed on retry.
+        if (lastError.message.includes('HTTP 4')) {
+          break
+        }
+
+        if (attempt < maxRetries) {
+          const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000)
+          await new Promise((resolve) => setTimeout(resolve, delay))
+        }
+      }
+    }
+
+    if (!options.suppressErrorLog) {
+      logger.warn(
+        `GET failed for ${endpoint} after ${attemptsMade} attempt(s): ${lastError?.message}`
+      )
+    }
+    throw lastError
+  }
+
+  // POST — returns parsed JSON (handles 204 No Content).
+  async post<T = unknown>(endpoint: string, data?: unknown, options: RequestOptions = {}): Promise<T> {
+    const response = await this.rawRequest(endpoint, { method: 'POST', body: data, ...options })
+    if (!response.ok) {
+      const errorData = await this.extractErrorInfo(response)
+      throw new Error(`HTTP ${response.status}: ${errorData.message}`)
+    }
+    return this.parseJsonBody<T>(response)
+  }
+
+  // PUT — returns parsed JSON (handles 204 No Content).
+  async put<T = unknown>(endpoint: string, data?: unknown, options: RequestOptions = {}): Promise<T> {
+    const response = await this.rawRequest(endpoint, { method: 'PUT', body: data, ...options })
+    if (!response.ok) {
+      const errorData = await this.extractErrorInfo(response)
+      throw new Error(`HTTP ${response.status}: ${errorData.message}`)
+    }
+    return this.parseJsonBody<T>(response)
+  }
+
+  // PATCH — partial update, returns parsed JSON (handles 204 No Content).
+  async patch<T = unknown>(endpoint: string, data?: unknown, options: RequestOptions = {}): Promise<T> {
+    const response = await this.rawRequest(endpoint, { method: 'PATCH', body: data, ...options })
+    if (!response.ok) {
+      const errorData = await this.extractErrorInfo(response)
+      throw new Error(`HTTP ${response.status}: ${errorData.message}`)
+    }
+    return this.parseJsonBody<T>(response)
+  }
+
+  // DELETE — returns parsed JSON (handles empty responses).
+  async delete<T = unknown>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+    const response = await this.rawRequest(endpoint, { method: 'DELETE', ...options })
+    if (!response.ok) {
+      const errorData = await this.extractErrorInfo(response)
+      throw new Error(`HTTP ${response.status}: ${errorData.message}`)
+    }
+    return this.parseJsonBody<T>(response)
+  }
+
+  // ==================================================================================
+  // FILE UPLOAD with progress tracking
+  // ==================================================================================
+
+  async uploadFile(
+    endpoint: string,
+    file: File,
+    progressCallback: ((progress: number) => void) | null = null,
+    options: { fields?: Record<string, string>; timeout?: number } = {}
+  ): Promise<Record<string, unknown>> {
+    const formData = new FormData()
+    formData.append('file', file)
+
+    if (options.fields) {
+      Object.entries(options.fields).forEach(([key, value]) => {
+        formData.append(key, value)
+      })
+    }
+
+    const baseUrl = this.resolveBaseUrl()
+    const url = baseUrl ? `${baseUrl}${endpoint}` : endpoint
+    const xhr = new XMLHttpRequest()
+
+    return await new Promise<Record<string, unknown>>((resolve, reject) => {
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            resolve(JSON.parse(xhr.responseText))
+          } catch {
+            resolve({ success: true })
+          }
+        } else {
+          reject(new Error(`Upload failed: HTTP ${xhr.status}`))
+        }
+      }
+
+      xhr.onerror = () => reject(new Error('Upload failed: Network error'))
+      xhr.ontimeout = () => reject(new Error('Upload failed: Timeout'))
+
+      if (progressCallback) {
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) {
+            progressCallback(Math.round((e.loaded / e.total) * 100))
+          }
+        }
+      }
+
+      xhr.open('POST', url)
+      const token = this.getAuthToken()
+      if (token) {
+        xhr.setRequestHeader('Authorization', `Bearer ${token}`)
+      }
+      xhr.timeout = options.timeout || this.defaultTimeout
+      xhr.send(formData)
+    })
+  }
+}
+
+// Singleton — the canonical SLM API client. Construction is side-effect free
+// (base URL is resolved lazily per request), so eager instantiation is safe.
+export const slmApiClient = new SlmApiClient()
+
+export default slmApiClient


### PR DESCRIPTION
## Thinking Path
#12420 found the SLM frontend has no canonical backend client — raw `fetch`/axios is scattered across ~48 files with hand-typed responses. Phase 0 (#12585) stood up type-gen. This **Phase 1** creates the canonical `ApiClient` so Phase 2 has a single seam to migrate onto.

Approach: copy-adapt `autobot-frontend/src/utils/ApiClient.ts` (the reference canonical client) into SLM rather than sharing a core now (a shared core is a later ADR, per the plan). Adapted three SLM specifics after grepping existing sites so behaviour is identical when call sites later migrate:
- **Base URL** from `getSlmApiBase()` (`ssot-config.ts:151`) — `/api` standalone or `/slm/api` co-located. Endpoints are passed relative to that base (e.g. `get('/nodes')`), matching the dominant SLM axios composable convention (`useSlmApi.ts` sets `baseURL = getSlmApiBase()` and calls `/nodes`), so Phase 2 call sites drop only the base prefix.
- **Auth token** read exactly as existing sites do: `sessionStorage['slm_access_token']` with a `localStorage` fallback — mirrors `stores/auth.ts` token init and the `useSlmApi` request interceptor. SLM does not persist an `expiresAt`, so (unlike the reference) no client-side expiry check is added — that would change behaviour.
- **401 handling** matches SLM's convention: clear `slm_access_token`/`slm_user` and redirect to `/login` (the target of `authStore.logout()`), but only when the request carried a bearer token and did not target an `/auth/`|`/mfa/` endpoint.

No org/tenant header (SLM has none, unlike the reference).

## What Changed
- **Added** `autobot-slm-frontend/src/utils/ApiClient.ts` — `SlmApiClient` class + `slmApiClient` singleton. Methods: `rawRequest`, `get` (retry + exponential backoff), `post`/`put`/`patch`/`delete` (204 + content-type aware), `uploadFile` (XHR progress + auth header). AbortController timeout with a module-level default sourced from `VITE_SLM_API_TIMEOUT_MS` (fallback 30s). FormData passthrough drops the JSON `Content-Type`.
- **Added** `autobot-slm-frontend/src/utils/ApiClient.test.ts` — 15 unit tests.
- Nothing imports the client yet — Phase 2 owns adoption.

## Verification
- `vue-tsc --noEmit -p tsconfig.json` → exit 0 (clean).
- `eslint` on both new files → exit 0.
- `vitest run src/utils/ApiClient.test.ts` → **15 passed (15)**, covering: base-URL resolution from `getSlmApiBase()` + `setBaseUrl` override; auth-header injection (sessionStorage primary, localStorage fallback, none); 401 handling (token-carrying clears+redirects, token-less no-op, auth-endpoint no-op); GET retry-then-succeed + no-retry on 4xx; AbortController timeout error; FormData passthrough; JSON body serialisation; 204 → `{}`; non-OK error surfacing.
- Grep confirms no other file imports `@/utils/ApiClient` / `slmApiClient`.

## Model Used
Claude Opus 4.8

## Follow-up
- **Phase 2** migrates the ~71 `getSlmApiBase()` call sites + ~48 fetch/axios files onto `slmApiClient`.
- **Phase 3** adopts the generated types (`src/types/generated/api.ts`) for request/response shapes.

Refs #12420
Closes #12590