### PR TITLE
refactor(analytics): converge codebase-analytics onto the indexed store (single data pipeline) (#12364)

### DIFF
--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -600,6 +600,68 @@ Docstring: {cls.get('docstring', 'No documentation')}
     return f"{prefix}class_{idx}_{cls['name']}", doc_text, metadata
 
 
+def _prepare_import_document(file_path: str, imports: List[str], idx: int, source_id: str | None = None) -> tuple:
+    """Prepare a per-file import document for ChromaDB storage (#12364).
+
+    Persists the raw import-statement list already collected transiently
+    during scanning (``FileAnalysisResult.imports``) so read endpoints can
+    reconstruct the import tree from the index instead of re-walking the
+    filesystem and re-parsing every file on each request.
+    """
+    doc_text = f"Imports: {file_path}\n" + "\n".join(imports)
+
+    metadata = {
+        "type": "import",
+        "file_path": file_path,
+        "imports": json.dumps(imports),
+    }
+    if source_id:
+        metadata["source_id"] = source_id
+
+    prefix = f"{source_id}_" if source_id else ""
+    return f"{prefix}import_{idx}_{file_path}", doc_text, metadata
+
+
+async def _prepare_imports_batch(
+    files: Dict[str, Dict],
+    batch_ids: list,
+    batch_documents: list,
+    batch_metadatas: list,
+    update_progress,
+    total_items: int,
+    items_offset: int,
+    source_id: str | None = None,
+) -> int:
+    """Prepare import documents for every scanned Python file (#12364).
+
+    Only ``.py`` files carry a populated ``imports`` list (the JS/Vue
+    analyzer does not extract imports), matching the scope of the
+    import-tree/dependencies live-walk endpoints this replaces.
+    """
+    items_prepared = items_offset
+    idx = 0
+    for file_path, file_analysis in files.items():
+        if not file_path.endswith(".py"):
+            continue
+        doc_id, doc_text, metadata = _prepare_import_document(
+            file_path, file_analysis.get("imports", []), idx, source_id=source_id
+        )
+        batch_ids.append(doc_id)
+        batch_documents.append(doc_text)
+        batch_metadatas.append(metadata)
+
+        idx += 1
+        items_prepared += 1
+        if items_prepared % 200 == 0:
+            await update_progress(
+                operation="Storing imports",
+                current=items_prepared,
+                total=total_items,
+                current_file=f"Import map {idx}/{len(files)}",
+            )
+    return items_prepared
+
+
 def _prepare_stats_document(analysis_results: Dict, source_id: str | None = None) -> tuple:
     """Prepare stats document for ChromaDB storage (Issue #281: extracted)."""
     stats = analysis_results["stats"]
@@ -721,7 +783,11 @@ async def _prepare_batch_data(
     batch_documents = []
     batch_metadatas = []
 
-    total_items = len(analysis_results["all_functions"]) + len(analysis_results["all_classes"]) + 1
+    files = analysis_results.get("files", {})
+    python_file_count = sum(1 for file_path in files if file_path.endswith(".py"))
+    total_items = (
+        len(analysis_results["all_functions"]) + len(analysis_results["all_classes"]) + python_file_count + 1
+    )
 
     await update_progress(
         operation="Preparing functions",
@@ -749,8 +815,21 @@ async def _prepare_batch_data(
     )
 
     all_classes = analysis_results["all_classes"]
-    await _prepare_classes_batch(
+    items_prepared = await _prepare_classes_batch(
         all_classes,
+        batch_ids,
+        batch_documents,
+        batch_metadatas,
+        update_progress,
+        total_items,
+        items_prepared,
+        source_id=source_id,
+    )
+
+    # #12364: persist per-file import lists so import-tree/dependencies can
+    # read from the index instead of re-walking the filesystem every request.
+    await _prepare_imports_batch(
+        files,
         batch_ids,
         batch_documents,
         batch_metadatas,

--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -785,9 +785,7 @@ async def _prepare_batch_data(
 
     files = analysis_results.get("files", {})
     python_file_count = sum(1 for file_path in files if file_path.endswith(".py"))
-    total_items = (
-        len(analysis_results["all_functions"]) + len(analysis_results["all_classes"]) + python_file_count + 1
-    )
+    total_items = len(analysis_results["all_functions"]) + len(analysis_results["all_classes"]) + python_file_count + 1
 
     await update_progress(
         operation="Preparing functions",

--- a/autobot-backend/api/codebase_analytics/chromadb_storage_test.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage_test.py
@@ -16,11 +16,17 @@ These tests fail against the pre-#6695 code (``existing`` is a coroutine →
 attribute 'get'`` and the bug branch logs a warning instead of deleting).
 """
 
+import json
 from unittest.mock import AsyncMock
 
 import pytest
 
-from api.codebase_analytics.chromadb_storage import _delete_source_documents
+from api.codebase_analytics.chromadb_storage import (
+    _delete_source_documents,
+    _prepare_batch_data,
+    _prepare_import_document,
+    _prepare_imports_batch,
+)
 
 
 class TestDeleteSourceDocuments:
@@ -78,3 +84,86 @@ class TestDeleteSourceDocuments:
             await _delete_source_documents(collection, "task-4", "source-W")
 
         assert any("Could not delete source" in r.message for r in caplog.records)
+
+
+class TestPrepareImportDocument:
+    """Issue #12364: per-file import lists are persisted to the index so
+    import-tree/dependencies can read from ChromaDB instead of re-walking
+    the filesystem on every request."""
+
+    def test_metadata_round_trips_import_list(self):
+        doc_id, doc_text, metadata = _prepare_import_document(
+            "pkg/mod.py", ["os", "pkg.other"], idx=0, source_id="src-A"
+        )
+
+        assert metadata["type"] == "import"
+        assert metadata["file_path"] == "pkg/mod.py"
+        assert json.loads(metadata["imports"]) == ["os", "pkg.other"]
+        assert metadata["source_id"] == "src-A"
+        assert doc_id == "src-A_import_0_pkg/mod.py"
+        assert "pkg/mod.py" in doc_text
+
+    def test_no_source_id_omits_source_metadata_and_prefix(self):
+        doc_id, _doc_text, metadata = _prepare_import_document("mod.py", [], idx=3, source_id=None)
+
+        assert "source_id" not in metadata
+        assert doc_id == "import_3_mod.py"
+
+
+class TestPrepareImportsBatch:
+    """#12364: only .py files get import documents; count reflects offset."""
+
+    async def test_only_python_files_get_import_documents(self):
+        files = {
+            "a.py": {"imports": ["os"]},
+            "b.js": {"imports": []},
+            "sub/c.py": {"imports": ["a"]},
+        }
+        batch_ids, batch_documents, batch_metadatas = [], [], []
+
+        async def _noop_progress(**kwargs):
+            return None
+
+        total = await _prepare_imports_batch(
+            files, batch_ids, batch_documents, batch_metadatas, _noop_progress, total_items=10, items_offset=5
+        )
+
+        stored_paths = {m["file_path"] for m in batch_metadatas}
+        assert stored_paths == {"a.py", "sub/c.py"}
+        assert total == 5 + 2
+
+    async def test_prepare_batch_data_includes_import_documents(self):
+        """End-to-end: _prepare_batch_data (the real call site) emits import
+        docs alongside functions/classes/stats."""
+        analysis_results = {
+            "all_functions": [],
+            "all_classes": [],
+            "files": {"mod.py": {"imports": ["os", "sys"]}},
+            "stats": {
+                "total_files": 1,
+                "total_lines": 10,
+                "python_files": 1,
+                "javascript_files": 0,
+                "vue_files": 0,
+                "total_functions": 0,
+                "total_classes": 0,
+                "last_indexed": "now",
+                "lines_by_category": {},
+            },
+        }
+
+        async def _noop_progress(**kwargs):
+            return None
+
+        def _noop_phase(*args, **kwargs):
+            return None
+
+        batch_ids, batch_documents, batch_metadatas = await _prepare_batch_data(
+            analysis_results, "task-import", _noop_progress, _noop_phase, source_id="src-A"
+        )
+
+        import_metas = [m for m in batch_metadatas if m["type"] == "import"]
+        assert len(import_metas) == 1
+        assert import_metas[0]["file_path"] == "mod.py"
+        assert json.loads(import_metas[0]["imports"]) == ["os", "sys"]
+        assert batch_ids and batch_documents

--- a/autobot-backend/api/codebase_analytics/endpoints/import_tree.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/import_tree.py
@@ -8,6 +8,7 @@ Import tree visualization endpoints
 
 import ast
 import asyncio
+import json
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -20,8 +21,15 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from tasks.analytics_tasks import run_import_tree_analysis
 from utils.celery_task_status import celery_result_to_status, get_latest_task_result, store_latest_task_id
+from utils.chromadb_client import get_all_paginated
 
-from .shared import INTERNAL_MODULE_PREFIXES, STDLIB_MODULES, resolve_scan_root
+from ..storage import get_code_collection
+from .shared import (
+    INTERNAL_MODULE_PREFIXES,
+    STDLIB_MODULES,
+    resolve_scan_root,
+    trigger_auto_index_if_unindexed,
+)
 
 logger = get_logger(__name__)
 
@@ -29,14 +37,32 @@ router = APIRouter()
 
 _REDIS_PREFIX = "import_task:"
 
+# Issue #12330: directories excluded from both the indexed and live-walk scans.
+_EXCLUDED_SCAN_DIRS = {
+    ".git",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    "env",
+    ".env",
+    "archive",
+    "dist",
+    "build",
+}
 
-def _build_module_to_file_mapping(python_files: List[Path], project_root: Path) -> Dict[str, str]:
-    """Build module path to file path mapping (Issue #315)."""
+
+def _build_module_to_file_mapping_from_paths(rel_paths: List[str]) -> Dict[str, str]:
+    """Build module path to file path mapping from relative path strings.
+
+    Issue #315: original extraction. Issue #12364: split out the pure
+    string-manipulation core so the indexed-store path (which only has
+    relative path strings, not filesystem ``Path`` objects) can reuse it.
+    """
     module_to_file: Dict[str, str] = {}
 
-    for py_file in python_files[:500]:
+    for rel_path in rel_paths[:500]:
         try:
-            rel_path = str(py_file.relative_to(project_root))
             module_path = rel_path.replace("/", ".").replace(".py", "")
             module_to_file[module_path] = rel_path
 
@@ -50,6 +76,21 @@ def _build_module_to_file_mapping(python_files: List[Path], project_root: Path) 
             continue
 
     return module_to_file
+
+
+def _build_module_to_file_mapping(python_files: List[Path], project_root: Path) -> Dict[str, str]:
+    """Build module path to file path mapping from filesystem paths (Issue #315).
+
+    Live-walk fallback only (#12364) -- resolves each Path to a relative
+    string then delegates to the shared string-based mapper.
+    """
+    rel_paths: List[str] = []
+    for py_file in python_files[:500]:
+        try:
+            rel_paths.append(str(py_file.relative_to(project_root)))
+        except Exception:
+            continue
+    return _build_module_to_file_mapping_from_paths(rel_paths)
 
 
 def _process_import_node(module_name: str, module_to_file: Dict[str, str]) -> Tuple[Dict, str | None]:
@@ -115,6 +156,73 @@ def _deduplicate_imports(imports: List[Dict]) -> List[Dict]:
     return unique_imports
 
 
+async def _load_import_tree_from_index(
+    source_id: str | None,
+) -> Tuple[Dict[str, List[Dict]], Dict[str, List[Dict]]] | None:
+    """Build the bidirectional import tree from indexed ChromaDB "import" docs.
+
+    Issue #12364: Primary data path. Returns ``None`` when the index has no
+    import documents for this source (unindexed / mid-index) so the caller
+    can fall back to the live filesystem walk instead of returning an empty
+    tree for a source that simply hasn't been indexed yet.
+    """
+    code_collection = await asyncio.to_thread(get_code_collection)
+    if not code_collection:
+        return None
+
+    where = {"$and": [{"type": "import"}, {"source_id": source_id}]} if source_id else {"type": "import"}
+    results = await asyncio.to_thread(get_all_paginated, code_collection, where=where, include=["metadatas"])
+    metadatas = results.get("metadatas", [])
+    if not metadatas:
+        return None
+
+    raw_imports: Dict[str, List[str]] = {}
+    for metadata in metadatas:
+        file_path = metadata.get("file_path")
+        if not file_path:
+            continue
+        try:
+            raw_imports[file_path] = json.loads(metadata.get("imports") or "[]")
+        except (json.JSONDecodeError, TypeError):
+            raw_imports[file_path] = []
+
+    module_to_file = _build_module_to_file_mapping_from_paths(list(raw_imports.keys()))
+
+    file_imports: Dict[str, List[Dict]] = {}
+    file_imported_by: Dict[str, List[Dict]] = {}
+    for rel_path, imports in raw_imports.items():
+        file_imports[rel_path] = []
+        for module_name in imports:
+            import_info, target_file = _process_import_node(module_name, module_to_file)
+            file_imports[rel_path].append(import_info)
+            _add_imported_by_relation(file_imported_by, target_file, rel_path, module_name)
+
+    return file_imports, file_imported_by
+
+
+async def _scan_import_tree_live(source_id: str | None) -> Tuple[Dict[str, List[Dict]], Dict[str, List[Dict]]]:
+    """Live filesystem walk (fallback path, #12364).
+
+    Used only when the indexed store has no import data yet for this
+    source -- e.g. a freshly-registered source whose background index job
+    (triggered by ``trigger_auto_index_if_unindexed``) hasn't completed. Not
+    deleted per the no-code-deletion policy: this is the graceful-degradation
+    path, not dead code.
+    """
+    project_root = await resolve_scan_root(source_id)
+    # Issue #358 - avoid blocking (use lambda to defer rglob to thread)
+    python_files = await asyncio.to_thread(lambda: list(project_root.rglob("*.py")))
+    python_files = [f for f in python_files if not any(excluded in f.parts for excluded in _EXCLUDED_SCAN_DIRS)]
+
+    file_imports: Dict[str, List[Dict]] = {}
+    file_imported_by: Dict[str, List[Dict]] = {}
+    module_to_file = _build_module_to_file_mapping(python_files, project_root)
+    for py_file in python_files[:500]:
+        await _analyze_file_imports(py_file, project_root, module_to_file, file_imports, file_imported_by)
+
+    return file_imports, file_imported_by
+
+
 @router.get("/analytics/import-tree")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -135,36 +243,28 @@ async def get_import_tree(
     (Issue #315 - refactored to reduce nesting)
     Issue #12330: Scope the scan to the requested source's clone path so one
     project cannot see another's import tree.
+    Issue #12364: Reads from the indexed store first (single source of truth,
+    sub-second); falls back to the live filesystem walk -- and kicks off a
+    background index job -- only when the index has no data for this source.
     """
-    project_root = await resolve_scan_root(source_id)
-    # Issue #358 - avoid blocking (use lambda to defer rglob to thread)
-    python_files = await asyncio.to_thread(lambda: list(project_root.rglob("*.py")))
+    effective_source_id = source_id
+    if not effective_source_id:
+        from api.codebase_analytics.source_storage import get_default_source_id
 
-    # Filter out unwanted directories
-    excluded_dirs = {
-        ".git",
-        "__pycache__",
-        "node_modules",
-        ".venv",
-        "venv",
-        "env",
-        ".env",
-        "archive",
-        "dist",
-        "build",
-    }
-    python_files = [f for f in python_files if not any(excluded in f.parts for excluded in excluded_dirs)]
+        effective_source_id = await get_default_source_id()
 
-    # Data structures
-    file_imports: Dict[str, List[Dict]] = {}
-    file_imported_by: Dict[str, List[Dict]] = {}
-
-    # Build module to file mapping (Issue #315 - extracted)
-    module_to_file = _build_module_to_file_mapping(python_files, project_root)
-
-    # Analyze imports (Issue #315 - simplified loop)
-    for py_file in python_files[:500]:
-        await _analyze_file_imports(py_file, project_root, module_to_file, file_imports, file_imported_by)
+    indexed = await _load_import_tree_from_index(effective_source_id)
+    if indexed is not None:
+        file_imports, file_imported_by = indexed
+        storage_type = "chromadb"
+    else:
+        logger.info(
+            "Import-tree index empty for source %s -- falling back to live walk (#12364)",
+            effective_source_id,
+        )
+        await trigger_auto_index_if_unindexed(effective_source_id)
+        file_imports, file_imported_by = await _scan_import_tree_live(effective_source_id)
+        storage_type = "live_walk"
 
     # Build result with bidirectional relationships
     import_tree = _build_import_tree(file_imports, file_imported_by)
@@ -174,6 +274,7 @@ async def get_import_tree(
             "status": "success",
             "import_tree": import_tree,
             "summary": _build_summary(import_tree),
+            "storage_type": storage_type,
         }
     )
 

--- a/autobot-backend/api/codebase_analytics/endpoints/import_tree_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/import_tree_test.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the import-tree indexed-store convergence (Issue #12364).
+
+Codebase Analytics ran on two non-shared data mechanisms: a pre-indexed
+ChromaDB store (stats/declarations) and a live per-request filesystem walk
+(import-tree/call-graph/duplicates/dependencies). These tests assert the
+convergence for the import-tree panel: the indexed store is read first, the
+live walk is used ONLY as a fallback when the index has no data for the
+requested source, and the fallback also triggers a background index job so
+the panel self-heals onto the fast path.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api.codebase_analytics.endpoints import import_tree
+
+
+def _write_module(directory, filename: str, body: str) -> None:
+    (directory / filename).write_text(body, encoding="utf-8")
+
+
+class TestLoadImportTreeFromIndex:
+    """Unit tests for the primary (indexed-store) data path."""
+
+    async def test_returns_none_when_no_collection(self):
+        with patch.object(import_tree, "get_code_collection", return_value=None):
+            result = await import_tree._load_import_tree_from_index("src-A")
+        assert result is None
+
+    async def test_returns_none_when_index_has_no_import_docs(self):
+        with (
+            patch.object(import_tree, "get_code_collection", return_value=MagicMock()),
+            patch.object(import_tree, "get_all_paginated", return_value={"metadatas": []}),
+        ):
+            result = await import_tree._load_import_tree_from_index("src-A")
+        assert result is None
+
+    async def test_builds_bidirectional_tree_from_metadata(self):
+        metadatas = [
+            {"file_path": "app.py", "imports": json.dumps(["utils"])},
+            {"file_path": "utils.py", "imports": json.dumps([])},
+        ]
+        with (
+            patch.object(import_tree, "get_code_collection", return_value=MagicMock()),
+            patch.object(import_tree, "get_all_paginated", return_value={"metadatas": metadatas}),
+        ):
+            result = await import_tree._load_import_tree_from_index("src-A")
+
+        assert result is not None
+        file_imports, file_imported_by = result
+        assert file_imports["app.py"][0]["module"] == "utils"
+        assert file_imports["app.py"][0]["file"] == "utils.py"
+        assert file_imported_by["utils.py"][0]["file"] == "app.py"
+
+    async def test_where_filter_scopes_to_source_id(self):
+        captured = {}
+
+        def _fake_get_all_paginated(collection, where=None, include=None):
+            captured["where"] = where
+            return {"metadatas": []}
+
+        with (
+            patch.object(import_tree, "get_code_collection", return_value=MagicMock()),
+            patch.object(import_tree, "get_all_paginated", side_effect=_fake_get_all_paginated),
+        ):
+            await import_tree._load_import_tree_from_index("src-A")
+
+        assert captured["where"] == {"$and": [{"type": "import"}, {"source_id": "src-A"}]}
+
+
+class TestCrossSourceIsolation:
+    """#12330: source A's indexed imports must never leak into source B's tree."""
+
+    async def test_two_sources_never_bleed(self):
+        all_metadatas = [
+            {"file_path": "a_mod.py", "imports": json.dumps([]), "source_id": "A"},
+            {"file_path": "b_mod.py", "imports": json.dumps([]), "source_id": "B"},
+        ]
+
+        def _fake_get_all_paginated(collection, where=None, include=None):
+            wanted = where["$and"][1]["source_id"]
+            return {"metadatas": [m for m in all_metadatas if m["source_id"] == wanted]}
+
+        with (
+            patch.object(import_tree, "get_code_collection", return_value=MagicMock()),
+            patch.object(import_tree, "get_all_paginated", side_effect=_fake_get_all_paginated),
+        ):
+            result_a = await import_tree._load_import_tree_from_index("A")
+            result_b = await import_tree._load_import_tree_from_index("B")
+
+        assert "a_mod.py" in result_a[0]
+        assert "b_mod.py" not in result_a[0]
+        assert "b_mod.py" in result_b[0]
+        assert "a_mod.py" not in result_b[0]
+
+
+class TestGetImportTreeConvergence:
+    """End-to-end: the endpoint prefers the index and falls back correctly."""
+
+    async def test_uses_indexed_data_when_available(self):
+        indexed = ({"app.py": []}, {})
+        with (
+            patch.object(import_tree, "_load_import_tree_from_index", AsyncMock(return_value=indexed)),
+            patch.object(import_tree, "trigger_auto_index_if_unindexed", AsyncMock()) as auto_trigger,
+            patch.object(import_tree, "_scan_import_tree_live", AsyncMock()) as live_scan,
+        ):
+            response = await import_tree.get_import_tree(source_id="src-A")
+
+        body = json.loads(response.body)
+        assert body["storage_type"] == "chromadb"
+        live_scan.assert_not_called()
+        auto_trigger.assert_not_called()
+
+    async def test_falls_back_to_live_walk_and_triggers_auto_index_when_unindexed(self):
+        with (
+            patch.object(import_tree, "_load_import_tree_from_index", AsyncMock(return_value=None)),
+            patch.object(import_tree, "trigger_auto_index_if_unindexed", AsyncMock()) as auto_trigger,
+            patch.object(import_tree, "_scan_import_tree_live", AsyncMock(return_value=({}, {}))) as live_scan,
+        ):
+            response = await import_tree.get_import_tree(source_id="src-A")
+
+        body = json.loads(response.body)
+        assert body["storage_type"] == "live_walk"
+        live_scan.assert_awaited_once_with("src-A")
+        auto_trigger.assert_awaited_once_with("src-A")
+
+    async def test_default_source_resolved_when_source_id_omitted(self):
+        with (
+            patch(
+                "api.codebase_analytics.source_storage.get_default_source_id",
+                AsyncMock(return_value="default-src"),
+            ),
+            patch.object(import_tree, "_load_import_tree_from_index", AsyncMock(return_value=({}, {}))) as loader,
+        ):
+            await import_tree.get_import_tree(source_id=None)
+
+        loader.assert_awaited_once_with("default-src")
+
+
+class TestLiveWalkFallbackStillScoped:
+    """Regression guard: the fallback path must still honour #12330 scoping
+    (resolve_scan_root), not silently widen to the whole AutoBot tree."""
+
+    async def test_live_scan_uses_resolved_source_root(self, tmp_path):
+        root_a = tmp_path / "proj_a"
+        root_a.mkdir()
+        _write_module(root_a, "mod_a.py", "import os\n")
+
+        async def fake_resolve(source_id, use_default=True):
+            return root_a if source_id == "A" else tmp_path
+
+        with patch.object(import_tree, "resolve_scan_root", side_effect=fake_resolve):
+            file_imports, _file_imported_by = await import_tree._scan_import_tree_live("A")
+
+        assert "mod_a.py" in file_imports

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -221,6 +221,44 @@ async def resolve_scan_root(source_id: "str | None", use_default: bool = True) -
     return Path(resolve_project_root())
 
 
+# Issue #12364: sources whose auto-index has already been fired this process
+# lifetime, so a burst of concurrent panel requests against an unindexed
+# source triggers exactly one background indexing job instead of a flood of
+# duplicate ones queued behind each other.
+_auto_index_inflight: set[str] = set()
+
+
+async def trigger_auto_index_if_unindexed(source_id: "str | None") -> None:
+    """Fire-and-forget background indexing for a source with no index yet.
+
+    Issue #12364: The indexed store is the single source of truth for
+    converged analytics panels, but a freshly-registered source (or one
+    registered before auto-index-on-registration existed) has nothing in it
+    until a job runs. Panels fall back to the live filesystem walk for that
+    one request *and* call this helper so the index gets populated in the
+    background -- the next request (and every panel sharing the index) is
+    then served from ChromaDB without anyone running a manual step.
+
+    No-op when source_id is falsy, already triggered this process lifetime,
+    or the source cannot be resolved to a clone path.
+    """
+    if not source_id or source_id in _auto_index_inflight:
+        return
+    _auto_index_inflight.add(source_id)
+    try:
+        from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
+
+        source = await get_source(source_id)
+        if not source or not source.clone_path:
+            return
+
+        from .sources import _trigger_indexing  # noqa: PLC0415
+
+        await _trigger_indexing(source)
+    except Exception as exc:
+        logger.debug("Auto-index trigger failed for %s: %s", source_id, exc)
+
+
 # Sentinel ownership id for an authenticated, non-service caller whose token
 # carries no derivable identity. It can never equal a real ``owner_id``, so
 # ``_is_visible`` denies another owner's PRIVATE source while still allowing

--- a/autobot-backend/api/codebase_analytics/endpoints/shared_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared_test.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for trigger_auto_index_if_unindexed (Issue #12364).
+
+Converged analytics panels fall back to a live filesystem walk only when the
+indexed store has no data for a source yet; that fallback must also kick off
+a background index job so subsequent requests are served from the index
+without a manual "Run indexing first" step.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from api.codebase_analytics.endpoints import shared
+from api.codebase_analytics.endpoints import sources as sources_ep
+
+
+class TestTriggerAutoIndexIfUnindexed:
+    def setup_method(self):
+        shared._auto_index_inflight.clear()
+
+    async def test_noop_when_source_id_falsy(self):
+        with patch("api.codebase_analytics.source_storage.get_source", AsyncMock()) as get_source:
+            await shared.trigger_auto_index_if_unindexed(None)
+        get_source.assert_not_called()
+
+    async def test_noop_when_source_unresolvable(self):
+        with patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=None)):
+            await shared.trigger_auto_index_if_unindexed("missing-source")
+        # Still marked in-flight so a burst of requests for the same
+        # unresolvable source doesn't repeatedly hit get_source.
+        assert "missing-source" in shared._auto_index_inflight
+
+    async def test_triggers_indexing_for_resolvable_source(self):
+        fake_source = AsyncMock()
+        fake_source.clone_path = "/tmp/some/clone"
+
+        trigger_mock = AsyncMock()
+        with (
+            patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=fake_source)),
+            patch.object(sources_ep, "_trigger_indexing", trigger_mock),
+        ):
+            await shared.trigger_auto_index_if_unindexed("src-A")
+
+        trigger_mock.assert_awaited_once_with(fake_source)
+
+    async def test_second_call_for_same_source_is_a_noop(self):
+        """Concurrent panel requests against an unindexed source must fire
+        exactly one background job, not one per request."""
+        fake_source = AsyncMock()
+        fake_source.clone_path = "/tmp/some/clone"
+
+        trigger_mock = AsyncMock()
+        with (
+            patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=fake_source)),
+            patch.object(sources_ep, "_trigger_indexing", trigger_mock),
+        ):
+            await shared.trigger_auto_index_if_unindexed("src-B")
+            await shared.trigger_auto_index_if_unindexed("src-B")
+
+        trigger_mock.assert_awaited_once()
+
+    async def test_two_sources_each_trigger_independently(self):
+        fake_source = AsyncMock()
+        fake_source.clone_path = "/tmp/some/clone"
+
+        trigger_mock = AsyncMock()
+        with (
+            patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=fake_source)),
+            patch.object(sources_ep, "_trigger_indexing", trigger_mock),
+        ):
+            await shared.trigger_auto_index_if_unindexed("src-C")
+            await shared.trigger_auto_index_if_unindexed("src-D")
+
+        assert trigger_mock.await_count == 2

--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -284,8 +284,28 @@ async def create_code_source(request: CodeSourceCreateRequest, http_request: Req
             source.clone_path = source.repo
         await save_source(source)
         logger.info("Created code source %s (%s)", source.id, source.name)
+        await _auto_index_local_source(source)
 
     return JSONResponse(source.model_dump(), status_code=201)
+
+
+async def _auto_index_local_source(source: CodeSource) -> None:
+    """Trigger indexing immediately for a local source with a valid path (#12364).
+
+    Issue #12364: GitHub sources already auto-index via ``create_github_source``
+    (``auto_sync=True`` -> ``_do_sync`` -> ``_trigger_indexing``). Local sources
+    had no equivalent -- registration alone never populated the index, leaving
+    the indexed-store panels blank until someone manually called
+    ``POST /sources/{id}/sync``. This closes that gap so the indexed path is
+    populated as part of the normal registration flow, not a separate manual
+    step. No-op for non-local sources or an unresolvable/missing clone path.
+    """
+    if source.source_type != "local" or not source.clone_path or not Path(source.clone_path).is_dir():
+        return
+    source.status = SourceStatus.READY
+    source.last_synced = datetime.now(tz=timezone.utc).isoformat()
+    await save_source(source)
+    await _trigger_indexing(source)
 
 
 @router.get("/sources/summary")

--- a/autobot-backend/api/codebase_analytics/endpoints/sources_auto_index_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources_auto_index_test.py
@@ -1,0 +1,99 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for auto-index-on-registration for local sources (Issue #12364).
+
+GitHub sources already auto-index on creation (create_github_source ->
+auto_sync=True -> _do_sync -> _trigger_indexing). Local sources had no
+equivalent: registering one left the indexed-store panels blank ("Run
+indexing first") until someone manually called POST /sources/{id}/sync.
+These tests assert local-source creation now triggers indexing itself
+whenever the given path actually exists.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from api.codebase_analytics.endpoints import sources as sources_ep
+from api.codebase_analytics.source_models import CodeSource, SourceStatus
+
+
+class TestAutoIndexLocalSource:
+    async def test_valid_local_path_triggers_indexing(self, tmp_path):
+        clone_dir = tmp_path / "local_repo"
+        clone_dir.mkdir()
+        source = CodeSource(name="local-proj", source_type="local", clone_path=str(clone_dir))
+
+        with (
+            patch.object(sources_ep, "save_source", AsyncMock()) as save_mock,
+            patch.object(sources_ep, "_trigger_indexing", AsyncMock()) as trigger_mock,
+        ):
+            await sources_ep._auto_index_local_source(source)
+
+        trigger_mock.assert_awaited_once_with(source)
+        assert source.status == SourceStatus.READY
+        assert source.last_synced is not None
+        save_mock.assert_awaited_once()
+
+    async def test_nonexistent_path_is_a_noop(self, tmp_path):
+        source = CodeSource(
+            name="local-proj", source_type="local", clone_path=str(tmp_path / "does-not-exist")
+        )
+
+        with (
+            patch.object(sources_ep, "save_source", AsyncMock()) as save_mock,
+            patch.object(sources_ep, "_trigger_indexing", AsyncMock()) as trigger_mock,
+        ):
+            await sources_ep._auto_index_local_source(source)
+
+        trigger_mock.assert_not_called()
+        save_mock.assert_not_called()
+
+    async def test_github_source_is_a_noop(self, tmp_path):
+        clone_dir = tmp_path / "gh_repo"
+        clone_dir.mkdir()
+        source = CodeSource(
+            name="gh-proj", source_type="github", repo="org/repo", clone_path=str(clone_dir)
+        )
+
+        with (
+            patch.object(sources_ep, "save_source", AsyncMock()) as save_mock,
+            patch.object(sources_ep, "_trigger_indexing", AsyncMock()) as trigger_mock,
+        ):
+            await sources_ep._auto_index_local_source(source)
+
+        trigger_mock.assert_not_called()
+        save_mock.assert_not_called()
+
+    async def test_missing_clone_path_is_a_noop(self):
+        source = CodeSource(name="local-proj", source_type="local", clone_path=None)
+
+        with (
+            patch.object(sources_ep, "save_source", AsyncMock()) as save_mock,
+            patch.object(sources_ep, "_trigger_indexing", AsyncMock()) as trigger_mock,
+        ):
+            await sources_ep._auto_index_local_source(source)
+
+        trigger_mock.assert_not_called()
+        save_mock.assert_not_called()
+
+    async def test_create_code_source_wires_auto_index_for_local(self, tmp_path):
+        """End-to-end through create_code_source: registering a local source
+        with a real, existing path triggers indexing without a separate
+        manual sync call."""
+        from api.codebase_analytics.source_models import CodeSourceCreateRequest
+
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        request = CodeSourceCreateRequest(name="proj", source_type="local", repo=str(clone_dir))
+
+        with (
+            patch("auth_middleware.get_current_user", AsyncMock(return_value={"id": "alice"})),
+            patch.object(sources_ep, "save_source", AsyncMock()),
+            patch.object(sources_ep, "_trigger_indexing", AsyncMock()) as trigger_mock,
+        ):
+            response = await sources_ep.create_code_source(request, http_request=object())
+
+        assert response.status_code == 201
+        trigger_mock.assert_awaited_once()

--- a/autobot-backend/api/codebase_analytics/endpoints/sources_auto_index_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources_auto_index_test.py
@@ -37,9 +37,7 @@ class TestAutoIndexLocalSource:
         save_mock.assert_awaited_once()
 
     async def test_nonexistent_path_is_a_noop(self, tmp_path):
-        source = CodeSource(
-            name="local-proj", source_type="local", clone_path=str(tmp_path / "does-not-exist")
-        )
+        source = CodeSource(name="local-proj", source_type="local", clone_path=str(tmp_path / "does-not-exist"))
 
         with (
             patch.object(sources_ep, "save_source", AsyncMock()) as save_mock,
@@ -53,9 +51,7 @@ class TestAutoIndexLocalSource:
     async def test_github_source_is_a_noop(self, tmp_path):
         clone_dir = tmp_path / "gh_repo"
         clone_dir.mkdir()
-        source = CodeSource(
-            name="gh-proj", source_type="github", repo="org/repo", clone_path=str(clone_dir)
-        )
+        source = CodeSource(name="gh-proj", source_type="github", repo="org/repo", clone_path=str(clone_dir))
 
         with (
             patch.object(sources_ep, "save_source", AsyncMock()) as save_mock,


### PR DESCRIPTION
## Thinking Path

Codebase Analytics ran on two non-shared data mechanisms:
- **Indexed store** (ChromaDB `autobot_code` collection) -- populated only by a background indexing job, read by `stats.py`/`charts.py`/`declarations.py`. Fast, but blank until someone runs `POST /index`.
- **Live filesystem walk** -- `import_tree.py`, `call_graph.py`, `dependencies.py`, `duplicates.py` each `rglob("*.py")` + re-`ast.parse` every file on every request. Slow (10-279s per #12341), but always returns *something*.

Investigation (`autobot-backend/api/codebase_analytics/chromadb_storage.py`, `file_analyzer.py`, `types.py`, `stats_aggregation.py`) found the indexed store's schema only ever stored `function`/`class`/`problem`/`stats` documents. But the raw per-file import list (`FileAnalysisResult.imports`, `type_defs`-level `types.py:67`) was **already being computed during every indexing run** and held in `analysis_results["files"]` -- then silently discarded before ChromaDB storage (`chromadb_storage._prepare_batch_data` only ever read `all_functions`/`all_classes`). That's not a capability gap requiring new analysis logic; it's a persistence gap. Extending the schema with one new document type (`type: "import"`) closes it cleanly, which is why I converged this panel fully rather than treating the whole issue as blocked.

`call_graph.py`/`dependencies.py`'s circular-dependency detection/`duplicates.py`'s duplicate-block detection need genuinely new capabilities the indexer doesn't compute even transiently (call edges, line-range duplicate clusters) -- converging those would balloon this PR into a new indexing-pipeline feature per panel. Per the task's "tractable core + phased plan" instruction, I converged the panel with concrete before/after evidence in #12364 (`import-tree`) end-to-end, plus the systemic auto-index gap that produces symptom #1 ("missing results") for *any* panel, and am reporting the rest as a phased follow-up below.

## What Changed

**1. Persist per-file imports to the index** (`chromadb_storage.py`)
- `_prepare_import_document()` / `_prepare_imports_batch()`: new `type: "import"` ChromaDB doc per `.py` file, `imports` metadata = JSON list of module names, scoped by `source_id` (reuses the existing per-source delete-on-reindex path in `_delete_source_documents` -- no new cleanup code needed).
- Wired into `_prepare_batch_data()` (`chromadb_storage.py:772`) alongside functions/classes/stats.
- Side fix: `_prepare_classes_batch`'s returned `items_prepared` count was silently discarded at the call site (missing `items_prepared = await ...`) -- fixed so the new imports batch's progress offset is accurate.

**2. Route `import-tree` through the index** (`endpoints/import_tree.py`)
- `_load_import_tree_from_index()`: primary path -- reads `type="import"` docs filtered by `source_id`, reconstructs the bidirectional tree using the *same* `_process_import_node`/`_add_imported_by_relation` logic the live walk used (no behavior drift). Returns `None` when the index has no data for the source.
- `_scan_import_tree_live()`: the original `rglob`+`ast.parse` logic, **kept, not deleted** -- demoted to fallback, used only when `_load_import_tree_from_index` returns `None`. Still routes through `resolve_scan_root()` so #12330's per-source scoping is unaffected.
- `_build_module_to_file_mapping()` split into a pure string-based `_build_module_to_file_mapping_from_paths()` (works from relative-path strings, no filesystem access) + a thin `Path`-based wrapper for the live-walk caller -- avoids duplicating the module-name-resolution logic between the two paths.
- Response now reports `storage_type`: `"chromadb"` or `"live_walk"`.

**3. Auto-index so the index is actually populated** (`endpoints/shared.py`, `endpoints/sources.py`)
- `trigger_auto_index_if_unindexed()` (`shared.py`): fire-and-forget background index trigger, called from the live-walk fallback so an unindexed source self-heals onto the fast path on its *next* request instead of staying on the live walk forever. Debounced per-source (in-flight set) so a burst of concurrent panel requests doesn't queue duplicate jobs. Reusable by future converged panels (call-graph/dependencies/duplicates), not import-tree-specific.
- `_auto_index_local_source()` (`sources.py`): GitHub sources already auto-index on creation (`create_github_source(..., auto_sync=True)` -> `_do_sync` -> `_trigger_indexing`); **local sources had no equivalent** -- registering one left every indexed-store panel on `"Run indexing first"` until a separate manual `POST /sources/{id}/sync`. `create_code_source` now triggers indexing immediately for local sources with a valid, existing `clone_path`.

## Phased follow-up (not in this PR)

`call_graph`, `dependencies` (circular-dep/external-dep detection), and `duplicates` still read live-walk-first: they need indexing-pipeline extensions the current schema doesn't compute even transiently (call-graph edges, duplicate-block clustering) -- each is a bigger, independently-reviewable change. Filed as a phased plan rather than attempted here to keep this PR's blast radius to the evidenced, concretely-gapped panel. Will file follow-up issues for each after this merges.

## Verification

Full `codebase_analytics` suite (221 tests, includes 27 new/updated for this change):

```
$ python3 -m pytest autobot-backend/api/codebase_analytics/ -q
213 passed, 1 failed, 7 skipped in 3.36s
```

The 1 failure (`unwired_tracker_test.py::test_detect_unwired_tracker_flags_zero_caller_module`) is **pre-existing and unrelated** -- reproduced identically on a clean `origin/Dev_new_gui` checkout via `git stash -u` + re-run. Filed as #12589.

New/updated coverage:
- `chromadb_storage_test.py`: `_prepare_import_document` metadata round-trip, source_id scoping, `.py`-only filtering, end-to-end `_prepare_batch_data` emits import docs.
- `endpoints/import_tree_test.py`: index-primary path builds correct bidirectional tree; empty-index returns `None`; **two-source isolation** (source A's imports never appear in source B's tree, per the issue's explicit ask); endpoint prefers index and never touches the live walk when indexed data exists; endpoint falls back + triggers auto-index exactly when the index is empty; live-walk fallback still honours `resolve_scan_root` (#12330 scoping intact).
- `endpoints/shared_test.py`: `trigger_auto_index_if_unindexed` no-ops on falsy/unresolvable source, triggers exactly once per source even under concurrent calls, triggers independently per distinct source.
- `endpoints/sources_auto_index_test.py`: local source with valid path triggers indexing; nonexistent path / github source / missing clone_path are no-ops; end-to-end through `POST /sources`.

Router mount sanity check:
```
$ python3 -c "from api.codebase_analytics.router import router; ..."
total routes: 81
import-tree route present: OK
```

Ruff clean on all touched files.

Closes #12364