### PR TITLE
perf(frontend): lazy-load xterm addon + split locale bundle to cut /chat FCP (#12342)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatTabContent.vue
+++ b/autobot-frontend/src/components/chat/ChatTabContent.vue
@@ -141,7 +141,12 @@ import ChatInput from './ChatInput.vue'
 import FileBrowser from '@/components/file-browser/FileBrowser.vue'
 import VisualBrowserPanel from '@/components/chat/VisualBrowserPanel.vue'  // Issue #1130: screenshot-based browser
 import HostSelector from '@/components/ui/HostSelector.vue'  // Issue #715: Dynamic host selection
-import SSHTerminal from '@/components/terminal/SSHTerminal.vue'    // Issue #715: SSH terminal component
+// Issue #715: SSH terminal component.
+// Issue #12342: lazy-load so xterm + its addons (~336KB) are fetched only
+// when a host is selected and the terminal actually renders — not at /chat
+// first paint. Rendered behind v-if="selectedSshHost", so the chunk loads
+// on demand.
+const SSHTerminal = defineAsyncComponent(() => import('@/components/terminal/SSHTerminal.vue'))
 import DesktopInterface from '@/components/desktop/DesktopInterface.vue'  // Issue #4977: full VNC component
 
 /**

--- a/autobot-frontend/src/components/chat/__tests__/ChatTabContent.lazyTerminal.spec.ts
+++ b/autobot-frontend/src/components/chat/__tests__/ChatTabContent.lazyTerminal.spec.ts
@@ -1,0 +1,33 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Regression test for #12342: the SSH terminal (which statically pulls in
+ * xterm + its addons, ~336KB) must be lazy-loaded from ChatTabContent so
+ * xterm's JS is fetched only when a host is selected and the terminal
+ * actually renders — not at /chat first paint.
+ *
+ * This guards the code-splitting at the source level: a future refactor that
+ * reverts SSHTerminal to a static top-level import would put xterm back into
+ * the /chat initial chunk and regress FCP.
+ */
+
+import { describe, it, expect } from 'vitest'
+// Vite `?raw` import returns the component source as a string.
+import source from '../ChatTabContent.vue?raw'
+
+describe('ChatTabContent SSH terminal code-splitting (#12342)', () => {
+  it('loads SSHTerminal via a dynamic import (defineAsyncComponent)', () => {
+    expect(source).toMatch(
+      /defineAsyncComponent\(\s*\(\)\s*=>\s*import\(\s*['"`][^'"`]*terminal\/SSHTerminal\.vue['"`]\s*\)\s*\)/,
+    )
+  })
+
+  it('does NOT statically import SSHTerminal at the top level', () => {
+    // A static `import SSHTerminal from '.../SSHTerminal.vue'` would bundle
+    // xterm into the eager chat chunk again.
+    expect(source).not.toMatch(/^\s*import\s+SSHTerminal\s+from/m)
+  })
+})

--- a/autobot-frontend/src/i18n/__tests__/lazy-locale-loading.spec.ts
+++ b/autobot-frontend/src/i18n/__tests__/lazy-locale-loading.spec.ts
@@ -1,0 +1,46 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Regression test for #12342: locale message bundles (~285KB combined) must be
+ * split so only the active locale (+ the 'en' fallback) is fetched, on demand.
+ * The monolithic `import en from './locales/en.json'` used to pull the whole
+ * English bundle into the initial chunk on every page (incl. /chat).
+ *
+ * Guards both the source-level split (no static locale JSON import) and the
+ * runtime lazy-load contract (loadLocaleMessages / initI18n).
+ */
+
+import { describe, it, expect } from 'vitest'
+import i18n, { loadLocaleMessages, initI18n, SUPPORTED_LOCALES } from '@/i18n'
+// Vite `?raw` import returns the i18n setup source as a string.
+import i18nSource from '@/i18n/index.ts?raw'
+
+describe('i18n locale bundle code-splitting (#12342)', () => {
+  it('does NOT statically import any locale JSON into the i18n setup', () => {
+    // A static `import en from './locales/en.json'` (or any locale) would put
+    // that ~366KB bundle into the eager initial chunk.
+    expect(i18nSource).not.toMatch(/^\s*import\s+\w+\s+from\s+['"`]\.\/locales\/\w+\.json['"`]/m)
+  })
+
+  it('loads a locale on demand via loadLocaleMessages()', async () => {
+    // Pick a non-English supported locale that isn't the active one.
+    const target = SUPPORTED_LOCALES.find(l => l !== 'en' && l !== i18n.global.locale.value)
+    expect(target).toBeDefined()
+    expect(i18n.global.availableLocales).not.toContain(target)
+
+    const ok = await loadLocaleMessages(target as string)
+    expect(ok).toBe(true)
+    expect(i18n.global.availableLocales).toContain(target)
+    // Real messages were loaded, not an empty object.
+    expect(Object.keys(i18n.global.getLocaleMessage(target as string)).length).toBeGreaterThan(0)
+  })
+
+  it('initI18n() loads the active locale and the en fallback', async () => {
+    await initI18n()
+    expect(i18n.global.availableLocales).toContain('en')
+    expect(i18n.global.availableLocales).toContain(i18n.global.locale.value)
+  })
+})

--- a/autobot-frontend/src/i18n/index.ts
+++ b/autobot-frontend/src/i18n/index.ts
@@ -4,9 +4,12 @@
 // Author: mrveiss
 
 import { createI18n } from 'vue-i18n'
-import en from './locales/en.json'
 
-export type MessageSchema = typeof en
+// Issue #12342: the English message bundle (~366KB) is no longer statically
+// imported — that pulled the whole locale JSON into the initial chunk on every
+// page (incl. /chat). The type is derived without emitting a runtime import;
+// messages are loaded lazily via loadLocaleMessages() / initI18n() below.
+export type MessageSchema = typeof import('./locales/en.json')
 
 // Derive supported locales from locale files on disk — no manual sync needed (#1675)
 const localeModules = import.meta.glob('./locales/*.json')
@@ -38,9 +41,9 @@ const i18n = createI18n<[MessageSchema], string>({
   legacy: false,
   locale: localStorage.getItem('autobot-language') || detectBrowserLocale(),
   fallbackLocale: 'en',
-  messages: {
-    en,
-  },
+  // Start with no messages — the active locale and the 'en' fallback are
+  // loaded (and awaited) by initI18n() before the app mounts (#12342).
+  messages: {},
 })
 
 /**
@@ -81,6 +84,21 @@ export async function setLocale(locale: string): Promise<void> {
   localStorage.setItem('autobot-language', locale)
   document.documentElement.setAttribute('lang', locale)
   document.documentElement.setAttribute('dir', getLocaleDir(locale))
+}
+
+/**
+ * Load the active locale and the English fallback, then set html lang/dir.
+ * Awaited by main.ts before app.mount() so the first render never flashes
+ * missing strings even when the active locale isn't English (#12342).
+ */
+export async function initI18n(): Promise<void> {
+  const active = (i18n.global.locale as unknown as { value: string }).value
+  await Promise.all([
+    loadLocaleMessages('en'),
+    active === 'en' ? Promise.resolve(true) : loadLocaleMessages(active),
+  ])
+  document.documentElement.setAttribute('lang', active)
+  document.documentElement.setAttribute('dir', getLocaleDir(active))
 }
 
 export default i18n

--- a/autobot-frontend/src/main.ts
+++ b/autobot-frontend/src/main.ts
@@ -53,7 +53,7 @@ initializeThemeVariant()
 import '@xterm/xterm/css/xterm.css'
 
 // Import i18n
-import i18n from './i18n'
+import i18n, { initI18n } from './i18n'
 
 // Import plugins
 import rumPlugin from './plugins/rum'
@@ -133,8 +133,15 @@ app.config.warnHandler = (msg, _instance, trace) => {
   }
 }
 
-// Mount the app
-app.mount('#app')
+// Mount the app.
+// Issue #12342: the active locale (and 'en' fallback) messages are loaded
+// lazily, so await them before the first render — otherwise the initial
+// paint would flash raw i18n keys instead of translated strings.
+initI18n()
+  .catch(err => logger.error('i18n init failed; mounting with fallback', err))
+  .finally(() => {
+    app.mount('#app')
+  })
 
 // Register Service Worker for caching strategy (Issue #4015, #4041, #3275)
 // #6767: Skip registration on IP-based hosts (172.x, 10.x, 192.168.x, bare-IP) — these


### PR DESCRIPTION
## Thinking Path

Issue #12342: `/chat` FCP is ~3.0s (4× `/dashboard`) — server TTFB is fine, the cost is client JS. Two big modules loaded eagerly on the /chat path but aren't needed at first paint:

- **xterm + addons (~336KB)** — `ChatTabContent.vue` statically imported `SSHTerminal.vue`, which statically imports `@xterm/xterm`, `@xterm/addon-fit`, `@xterm/addon-web-links`. Build proof (before): the `/chat` view chunk `ChatInterface-*.js` contained a **static** `from"./addon-web-links-*.js"` → xterm was fetched at /chat first paint even though the terminal is only shown behind `v-if="selectedSshHost"`.
- **Monolithic locale bundle (~285KB)** — `i18n/index.ts` did `import en from './locales/en.json'` (366KB raw). Build proof (before): `en-*.js` was listed in `dist/index.html` as an eager module → the full English bundle loaded on every page, including /chat, regardless of the active locale.

The per-locale dynamic `import()` in `loadLocaleMessages()` already existed; the only eager cost was the static `en` import plus the fact the active locale wasn't awaited before mount.

## What Changed

- **`autobot-frontend/src/components/chat/ChatTabContent.vue:144`** — replaced `import SSHTerminal from '@/components/terminal/SSHTerminal.vue'` with `const SSHTerminal = defineAsyncComponent(() => import('@/components/terminal/SSHTerminal.vue'))`. `defineAsyncComponent` was already imported. Component is rendered behind `v-if="selectedSshHost"`, so the xterm chunk now loads only when a host is selected and the terminal renders. Full terminal functionality is unchanged once opened.
- **`autobot-frontend/src/i18n/index.ts`** — removed the static `import en from './locales/en.json'`; `createI18n` now starts with `messages: {}`. `MessageSchema` type is derived without emitting a runtime import (`typeof import('./locales/en.json')`). Added `initI18n()` which loads the active locale + the `en` fallback and sets `html[lang]`/`html[dir]` before first render. `loadLocaleMessages()` (per-locale dynamic `import()`) is unchanged, so language switching still lazy-loads any of the 11 locales on demand.
- **`autobot-frontend/src/main.ts`** — imports `initI18n` and awaits it before `app.mount('#app')` (via `initI18n().catch(...).finally(mount)`), so the first paint never flashes raw i18n keys even when the active locale isn't English.
- **Tests** — `ChatTabContent.lazyTerminal.spec.ts` (asserts SSHTerminal is loaded via a dynamic import and never statically imported) and `lazy-locale-loading.spec.ts` (asserts no static locale JSON import; `loadLocaleMessages`/`initI18n` load messages on demand at runtime).

Behavior-neutral: same features, same terminal, same 11 locales — only deferred loading.

## Verification

**`vite build` succeeds; xterm + non-active locales are separate async chunks (not in the /chat initial chunk).**

Build-output key chunks (before vs after — identical because content is unchanged; what changed is *how* they're imported):

| chunk | size | gzip |
|---|---|---|
| `addon-web-links-*.js` (xterm core + addons) | 343.90 kB | 87.60 kB |
| `en-*.js` | 293 kB | ~88 kB |
| `de-*.js` / `fr-*.js` / … (11 locales) | ~293–317 kB each | ~88–99 kB |

Import-graph proof:

- **xterm — before:** `/chat` view chunk `ChatInterface-*.js` had `...from"./addon-web-links-*.js"` (**static**). **after:** xterm's static import moved into a new `SSHTerminal-*.js` chunk; `ChatInterface-*.js` now references it only via `import(\`./SSHTerminal-*.js\`)` (**dynamic**, `defineAsyncComponent`) and lists it in the `__vitePreload` dep array — no static `from` import remains.
- **locales — before:** `dist/index.html` eagerly loaded `assets/en-*.js`. **after:** `dist/index.html` references **no** locale chunk and **no** xterm/SSHTerminal chunk — verified `grep` over the built HTML returns none. Only the small `i18n-*.js` runtime (setup code, not messages) is preloaded.

**`vue-tsc --noEmit -p tsconfig.app.json`** → exit 0 (clean).

**Unit tests:**
- `BaseXTerminal.spec.ts`, `rtl.spec.ts`, `locale-parity.test.ts`, `detectBrowserLocale.spec.ts` → 53 passed.
- New `ChatTabContent.lazyTerminal.spec.ts` + `lazy-locale-loading.spec.ts` → 5 passed.

**Note:** the actual FCP improvement can only be measured on a deployed instance; the local proof is the build-chunk evidence above (xterm + non-active locales moved out of the /chat initial chunk / eager HTML).

## Model Used

claude-opus-4-8

Closes #12342
