### PR TITLE
refactor(slm-frontend): migrate MFA composable onto canonical slmApiClient (#12420 Phase 2 batch 1)

### DIFF
--- a/autobot-slm-frontend/src/composables/useMfaApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useMfaApi.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 1) — proves the MFA composable is migrated onto the
+ * canonical `slmApiClient`: every method routes through the shared client with
+ * endpoints relative to the API base (base URL + bearer token are injected by
+ * the client), returns the parsed JSON body directly (no axios `.data`), and
+ * preserves the historic "logout on 401" behavior even though the client itself
+ * opts out of session-clearing for /mfa/ (auth) endpoints.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockLogout = vi.fn()
+
+// The migrated composable must talk to the canonical client, not axios.
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ logout: mockLogout }),
+}))
+
+import { useMfaApi } from './useMfaApi'
+
+describe('useMfaApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockLogout.mockReset()
+  })
+
+  it('getMFAStatus GETs /mfa/status via slmApiClient and returns the parsed body directly', async () => {
+    const status = {
+      enabled: true,
+      method: 'totp',
+      backup_codes_remaining: 8,
+      last_verified_at: null,
+    }
+    mockGet.mockResolvedValue(status)
+
+    const result = await useMfaApi().getMFAStatus()
+
+    expect(mockGet).toHaveBeenCalledWith('/mfa/status')
+    expect(result).toEqual(status)
+  })
+
+  it('setupMFA POSTs /mfa/setup (no body) and returns the parsed body', async () => {
+    const setup = { secret: 's', otpauth_uri: 'otpauth://x', backup_codes: ['a'] }
+    mockPost.mockResolvedValue(setup)
+
+    const result = await useMfaApi().setupMFA()
+
+    expect(mockPost).toHaveBeenCalledWith('/mfa/setup')
+    expect(result).toEqual(setup)
+  })
+
+  it('verifySetup POSTs the code to /mfa/verify-setup', async () => {
+    mockPost.mockResolvedValue({ success: true, message: 'ok' })
+
+    const result = await useMfaApi().verifySetup('123456')
+
+    expect(mockPost).toHaveBeenCalledWith('/mfa/verify-setup', { code: '123456' })
+    expect(result).toEqual({ success: true, message: 'ok' })
+  })
+
+  it('verifyLogin POSTs code + temp_token to /mfa/verify-login', async () => {
+    mockPost.mockResolvedValue({ success: true, message: 'ok', access_token: 't' })
+
+    const result = await useMfaApi().verifyLogin('123456', 'temp-abc')
+
+    expect(mockPost).toHaveBeenCalledWith('/mfa/verify-login', {
+      code: '123456',
+      temp_token: 'temp-abc',
+    })
+    expect(result.access_token).toBe('t')
+  })
+
+  it('disableMFA POSTs the password to /mfa/disable', async () => {
+    mockPost.mockResolvedValue({})
+
+    await useMfaApi().disableMFA('pw')
+
+    expect(mockPost).toHaveBeenCalledWith('/mfa/disable', { password: 'pw' })
+  })
+
+  it('regenerateBackupCodes POSTs the password to /mfa/backup-codes', async () => {
+    mockPost.mockResolvedValue({ backup_codes: ['x', 'y'] })
+
+    const result = await useMfaApi().regenerateBackupCodes('pw')
+
+    expect(mockPost).toHaveBeenCalledWith('/mfa/backup-codes', { password: 'pw' })
+    expect(result.backup_codes).toEqual(['x', 'y'])
+  })
+
+  it('logs out and re-throws on a 401 (client opts out for /mfa/, composable preserves it)', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 401: Unauthorized'))
+
+    await expect(useMfaApi().getMFAStatus()).rejects.toThrow('HTTP 401')
+    expect(mockLogout).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT log out on a non-401 error (e.g. wrong code → 400)', async () => {
+    mockPost.mockRejectedValue(new Error('HTTP 400: Invalid code'))
+
+    await expect(useMfaApi().verifySetup('000000')).rejects.toThrow('HTTP 400')
+    expect(mockLogout).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-slm-frontend/src/composables/useMfaApi.ts
+++ b/autobot-slm-frontend/src/composables/useMfaApi.ts
@@ -9,13 +9,15 @@
  * Provides REST API integration for Two-Factor Authentication (2FA/MFA)
  * management via the SLM backend.
  * Issue #576 - User Management System Phase 5 (2FA/MFA).
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()` and injects the SLM bearer token
+ * (same `slm_access_token` storage the auth store reads), so call sites pass
+ * endpoints relative to the API base and receive parsed JSON directly.
  */
 
-import axios, { type AxiosInstance } from 'axios'
+import slmApiClient from '@/utils/ApiClient'
 import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
-
-const SLM_API_BASE = getSlmApiBase()
 
 export interface MFASetupResponse {
   secret: string
@@ -41,73 +43,67 @@ export interface MFAVerifyResponse {
 export function useMfaApi() {
   const authStore = useAuthStore()
 
-  const client: AxiosInstance = axios.create({
-    baseURL: SLM_API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-    timeout: 30000,
-  })
-
-  client.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
+  // The canonical client intentionally skips its session-clearing 401 handler
+  // for auth/MFA endpoints (a 401 there is a credential failure, not a rejected
+  // session). MFA management historically logged the user out on any 401 — the
+  // previous axios response interceptor called `authStore.logout()` — so we
+  // preserve that exact behavior explicitly here and re-throw as before.
+  async function withAuthGuard<T>(op: () => Promise<T>): Promise<T> {
+    try {
+      return await op()
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('HTTP 401')) {
         authStore.logout()
       }
-      return Promise.reject(error)
+      throw error
     }
-  )
+  }
 
   async function setupMFA(): Promise<MFASetupResponse> {
-    const response = await client.post<MFASetupResponse>('/mfa/setup')
-    return response.data
+    return withAuthGuard(() => slmApiClient.post<MFASetupResponse>('/mfa/setup'))
   }
 
   async function verifySetup(
     code: string
   ): Promise<{ success: boolean; message: string }> {
-    const response = await client.post<{ success: boolean; message: string }>(
-      '/mfa/verify-setup',
-      { code }
+    return withAuthGuard(() =>
+      slmApiClient.post<{ success: boolean; message: string }>(
+        '/mfa/verify-setup',
+        { code }
+      )
     )
-    return response.data
   }
 
   async function verifyLogin(
     code: string,
     tempToken: string
   ): Promise<MFAVerifyResponse> {
-    const response = await client.post<MFAVerifyResponse>(
-      '/mfa/verify-login',
-      { code, temp_token: tempToken }
+    return withAuthGuard(() =>
+      slmApiClient.post<MFAVerifyResponse>('/mfa/verify-login', {
+        code,
+        temp_token: tempToken,
+      })
     )
-    return response.data
   }
 
   async function disableMFA(password: string): Promise<void> {
-    await client.post('/mfa/disable', { password })
+    await withAuthGuard(() => slmApiClient.post('/mfa/disable', { password }))
   }
 
   async function getMFAStatus(): Promise<MFAStatusResponse> {
-    const response = await client.get<MFAStatusResponse>('/mfa/status')
-    return response.data
+    return withAuthGuard(() =>
+      slmApiClient.get<MFAStatusResponse>('/mfa/status')
+    )
   }
 
   async function regenerateBackupCodes(
     password: string
   ): Promise<{ backup_codes: string[] }> {
-    const response = await client.post<{ backup_codes: string[] }>(
-      '/mfa/backup-codes',
-      { password }
+    return withAuthGuard(() =>
+      slmApiClient.post<{ backup_codes: string[] }>('/mfa/backup-codes', {
+        password,
+      })
     )
-    return response.data
   }
 
   return {


### PR DESCRIPTION
## Thinking Path

Phase 1 (#12420, merged) created the canonical `slmApiClient` (`src/utils/ApiClient.ts`) but nothing imports it yet. Phase 2 migrates the ~71 inline `getSlmApiBase()` call sites + fetch/axios files onto it. This is the **first** Phase-2 batch, so I did **one** cohesive domain: **MFA (2FA)** — the smallest self-contained unit.

I first grepped every `getSlmApiBase(` call site (36 files) and grouped them by domain (see Follow-up). MFA won: a single composable (`useMfaApi.ts`) consumed by exactly one view (`SecuritySettings.vue`), no cross-file coupling.

Behavior-parity checks before migrating:
- **Auth token** — the old axios instance sent `Bearer ${authStore.token}`; `authStore.token` is initialized from `sessionStorage/localStorage` key `slm_access_token`, which is exactly what the client's `getAuthToken()` reads. Identical.
- **Base URL** — old `axios.create({ baseURL: getSlmApiBase() })`; the client resolves the same `getSlmApiBase()` per request.
- **Response shape** — old returned axios `.data` (parsed JSON); the client's `get/post` return parsed JSON directly.
- **Error shape** — `SecuritySettings.vue` only reads `e.message` (never `e.response.status`), so the axios-error → `Error('HTTP <status>: …')` change is safe.
- **401** — the client intentionally treats `/mfa/` as an auth endpoint and does **not** clear the session, but the old response interceptor called `authStore.logout()` on any 401. To preserve exact behavior I kept an explicit `withAuthGuard` that logs out on `HTTP 401` and re-throws, matching the previous interceptor precisely (401 only, then re-throw).

## What Changed

- `src/composables/useMfaApi.ts` — dropped the `axios.create` instance + request/response interceptors and the `getSlmApiBase()`/`axios` imports; all six methods (`setupMFA`, `verifySetup`, `verifyLogin`, `disableMFA`, `getMFAStatus`, `regenerateBackupCodes`) now call `slmApiClient.get/post` with endpoints relative to the API base and return the parsed body directly. Added `withAuthGuard` to preserve the historic logout-on-401. Exported interfaces and function signatures unchanged, so `SecuritySettings.vue` needs no edits.
- `src/composables/useMfaApi.test.ts` — new; mocks `@/utils/ApiClient` + auth store and proves each method routes through the shared client with the correct endpoint/payload, returns the parsed body, logs out + re-throws on 401, and does **not** log out on a non-401 (e.g. wrong code → 400).

## Verification

- `vue-tsc --noEmit -p tsconfig.json` → exit 0 (clean).
- `vitest run src/composables/useMfaApi.test.ts` → **8 passed (8)**.
- `grep -n "getSlmApiBase\|axios\|fetch(" useMfaApi.ts` → only doc-comment mentions; **no code call sites remain**.
- Toolchain via a temporary read-only `node_modules` symlink from the main tree, removed after use (not committed).

## Model Used

claude-opus-4-8

## Follow-up

Full by-domain grouping of the remaining 35 `getSlmApiBase()` files (from the Phase-2 grep) for future batches. Suggested one-domain-per-PR order:

**Auth / Security / Users**
- `composables/useApiKeyApi.ts`, `composables/useSecretsApi.ts`, `composables/useSlmUserApi.ts`, `composables/useSsoApi.ts`
- `views/settings/admin/UserManagementSettings.vue`
- `router/index.ts` (`/setup/status` guard)

**Roles / Fleet / Nodes**
- `composables/useRoles.ts`, `composables/useExternalAgents.ts`, `composables/useVncControls.ts` (axios.create)
- `views/RolesView.vue`, `views/AgentsView.vue`, `views/ToolsView.vue`
- `components/fleet/FleetToolsTab.vue`, `components/fleet/NodeLifecyclePanel.vue` (WS)
- `views/tools/admin/TerminalTool.vue` (WS), `views/tools/admin/NoVNCTool.vue`

**Infrastructure / Deployments**
- `views/InfrastructureView.vue`, `components/InfrastructureWizard.vue`, `components/DeploymentWizard.vue`, `components/DeploymentLogViewer.vue` (WS)

**Code-sync / source / system updates**
- `composables/useCodeSync.ts`, `composables/useCodeSource.ts` (axios.create), `components/CodeSourceModal.vue` (axios.create), `composables/useSystemUpdates.ts`

**Orchestration / Monitoring / Metrics**
- `composables/useOrchestration.ts`, `composables/useOrchestrationManagement.ts`, `composables/usePrometheusMetrics.ts`, `composables/usePerformanceMonitoring.ts`
- `views/monitoring/AlertsMonitor.vue`

**LLM / Personality / Settings**
- `composables/useLlmConfigApi.ts`, `composables/usePersonality.ts`
- `views/settings/APISettings.vue` (WS + health), `views/settings/admin/PersonalitySettings.vue`, `views/settings/admin/ConfigDefaultsSettings.vue`

**Core SLM API**
- `composables/useSlmApi.ts` (large, central — likely its own PR)

**Note on WS endpoints** (`useVncControls`, `NodeLifecyclePanel`, `DeploymentLogViewer`, `TerminalTool`, `APISettings`): these build `ws://` URLs from `getSlmApiBase()` and are **not** HTTP — the current `slmApiClient` has no WS surface, so they should either keep `getSlmApiBase()` for path-building or get a dedicated helper (decide before those batches).

**Additional fetch/axios-only files** not using `getSlmApiBase()` (resolve base via `getApiUrl()`/other — audit per batch, out of this grep's 36): `stores/auth.ts`, `composables/useAutobotApi.ts`, `composables/useSkills.ts`, `composables/useSlmJsonSetting.ts`, `composables/useSlmWebSocket.ts`, `composables/useTimezone.ts`, `components/RedisServicePanel.vue`, `components/agents/{ConfigHistoryTab,OrgChartTab,ProcessMonitorTab}.vue`, `views/DeploymentsView.vue`, `views/settings/{BackendSettings,GeneralSettings,MonitoringSettings,NotificationsSettings}.vue`, `views/settings/admin/CacheSettings.vue`, `views/tools/admin/{AdvancedControlTool,BrowserTool,MCPTool}.vue`.

Refs #12420
Closes #12598
