### PR TITLE
refactor(slm-frontend): migrate Auth/Security/Users domain onto slmApiClient (#12420 Phase 2 batch 2)

### DIFF
--- a/autobot-slm-frontend/src/composables/useApiKeyApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useApiKeyApi.test.ts
@@ -1,0 +1,92 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 2) — proves the API-key composable is migrated onto the
+ * canonical `slmApiClient`: every method routes through the shared client with
+ * endpoints relative to the API base (base URL + bearer token injected by the
+ * client) and returns the parsed JSON body directly (no axios `.data`). These
+ * are non-auth endpoints, so 401 session handling is the client's centralised
+ * concern — the composable no longer owns an axios interceptor.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPatch = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+import { useApiKeyApi } from './useApiKeyApi'
+
+describe('useApiKeyApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPatch.mockReset()
+    mockDelete.mockReset()
+  })
+
+  it('listKeys GETs /api-keys and returns the parsed body directly', async () => {
+    const body = { keys: [], total: 0 }
+    mockGet.mockResolvedValue(body)
+
+    const result = await useApiKeyApi().listKeys()
+
+    expect(mockGet).toHaveBeenCalledWith('/api-keys')
+    expect(result).toEqual(body)
+  })
+
+  it('createKey POSTs the payload to /api-keys', async () => {
+    const payload = { name: 'ci', scopes: ['read'] }
+    mockPost.mockResolvedValue({ id: '1', key: 'k' })
+
+    await useApiKeyApi().createKey(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/api-keys', payload)
+  })
+
+  it('getKey GETs /api-keys/:id', async () => {
+    mockGet.mockResolvedValue({ id: 'abc' })
+
+    await useApiKeyApi().getKey('abc')
+
+    expect(mockGet).toHaveBeenCalledWith('/api-keys/abc')
+  })
+
+  it('updateKey PATCHes /api-keys/:id with the payload', async () => {
+    mockPatch.mockResolvedValue({ id: 'abc', name: 'new' })
+
+    await useApiKeyApi().updateKey('abc', { name: 'new' })
+
+    expect(mockPatch).toHaveBeenCalledWith('/api-keys/abc', { name: 'new' })
+  })
+
+  it('revokeKey DELETEs /api-keys/:id', async () => {
+    mockDelete.mockResolvedValue({})
+
+    await useApiKeyApi().revokeKey('abc')
+
+    expect(mockDelete).toHaveBeenCalledWith('/api-keys/abc')
+  })
+
+  it('getScopes GETs /api-keys/scopes', async () => {
+    mockGet.mockResolvedValue({ read: 'Read access' })
+
+    const result = await useApiKeyApi().getScopes()
+
+    expect(mockGet).toHaveBeenCalledWith('/api-keys/scopes')
+    expect(result).toEqual({ read: 'Read access' })
+  })
+})

--- a/autobot-slm-frontend/src/composables/useApiKeyApi.ts
+++ b/autobot-slm-frontend/src/composables/useApiKeyApi.ts
@@ -9,13 +9,17 @@
  * Provides REST API integration for API key management
  * via the SLM backend.
  * Issue #576 - User Management System Phase 5 (API Keys).
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()`, injects the SLM bearer token
+ * (same `slm_access_token` storage the auth store reads), and centrally handles
+ * 401 for these non-auth endpoints by clearing the session and redirecting to
+ * `/login` — matching the previous per-composable axios interceptor that called
+ * `authStore.logout()`. Call sites therefore pass endpoints relative to the API
+ * base and receive parsed JSON directly (no axios `.data`).
  */
 
-import axios, { type AxiosInstance } from 'axios'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
-
-const SLM_API_BASE = getSlmApiBase()
+import slmApiClient from '@/utils/ApiClient'
 
 export interface APIKeyCreate {
   name: string
@@ -58,70 +62,31 @@ export interface APIKeyUpdate {
 }
 
 export function useApiKeyApi() {
-  const authStore = useAuthStore()
-
-  const client: AxiosInstance = axios.create({
-    baseURL: SLM_API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-    timeout: 30000,
-  })
-
-  client.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
-        authStore.logout()
-      }
-      return Promise.reject(error)
-    }
-  )
-
   async function createKey(data: APIKeyCreate): Promise<APIKeyCreateResponse> {
-    const response = await client.post<APIKeyCreateResponse>(
-      '/api-keys',
-      data
-    )
-    return response.data
+    return slmApiClient.post<APIKeyCreateResponse>('/api-keys', data)
   }
 
   async function listKeys(): Promise<APIKeyListResponse> {
-    const response = await client.get<APIKeyListResponse>('/api-keys')
-    return response.data
+    return slmApiClient.get<APIKeyListResponse>('/api-keys')
   }
 
   async function getKey(keyId: string): Promise<APIKeyResponse> {
-    const response = await client.get<APIKeyResponse>(`/api-keys/${keyId}`)
-    return response.data
+    return slmApiClient.get<APIKeyResponse>(`/api-keys/${keyId}`)
   }
 
   async function updateKey(
     keyId: string,
     data: APIKeyUpdate
   ): Promise<APIKeyResponse> {
-    const response = await client.patch<APIKeyResponse>(
-      `/api-keys/${keyId}`,
-      data
-    )
-    return response.data
+    return slmApiClient.patch<APIKeyResponse>(`/api-keys/${keyId}`, data)
   }
 
   async function revokeKey(keyId: string): Promise<void> {
-    await client.delete(`/api-keys/${keyId}`)
+    await slmApiClient.delete(`/api-keys/${keyId}`)
   }
 
   async function getScopes(): Promise<Record<string, string>> {
-    const response = await client.get<Record<string, string>>(
-      '/api-keys/scopes'
-    )
-    return response.data
+    return slmApiClient.get<Record<string, string>>('/api-keys/scopes')
   }
 
   return {

--- a/autobot-slm-frontend/src/composables/useSecretsApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSecretsApi.test.ts
@@ -1,0 +1,88 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 2) — proves the secrets composable routes every method
+ * through the canonical `slmApiClient` with endpoints relative to the API base,
+ * returns parsed JSON directly, and URL-encodes the secret key path segment.
+ * Non-auth endpoints → 401 session handling is the client's concern.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+import { useSecretsApi } from './useSecretsApi'
+
+describe('useSecretsApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDelete.mockReset()
+  })
+
+  it('listSecrets GETs /secrets and returns the parsed body', async () => {
+    mockGet.mockResolvedValue([{ id: 1, key: 'A' }])
+
+    const result = await useSecretsApi().listSecrets()
+
+    expect(mockGet).toHaveBeenCalledWith('/secrets')
+    expect(result).toEqual([{ id: 1, key: 'A' }])
+  })
+
+  it('createSecret POSTs the payload to /secrets', async () => {
+    const payload = { key: 'HF_TOKEN', value: 'x' }
+    mockPost.mockResolvedValue({ id: 1 })
+
+    await useSecretsApi().createSecret(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/secrets', payload)
+  })
+
+  it('updateSecret PUTs to the URL-encoded key path', async () => {
+    mockPut.mockResolvedValue({ id: 1 })
+
+    await useSecretsApi().updateSecret('a b/c', { value: 'v' })
+
+    expect(mockPut).toHaveBeenCalledWith('/secrets/a%20b%2Fc', { value: 'v' })
+  })
+
+  it('deleteSecret DELETEs the URL-encoded key path', async () => {
+    mockDelete.mockResolvedValue({})
+
+    await useSecretsApi().deleteSecret('a b/c')
+
+    expect(mockDelete).toHaveBeenCalledWith('/secrets/a%20b%2Fc')
+  })
+
+  it('getDependentRolesMapping GETs /secrets/dependent-roles', async () => {
+    mockGet.mockResolvedValue({ mapping: {} })
+
+    await useSecretsApi().getDependentRolesMapping()
+
+    expect(mockGet).toHaveBeenCalledWith('/secrets/dependent-roles')
+  })
+
+  it('applySecret POSTs the key to /secrets/apply', async () => {
+    mockPost.mockResolvedValue({ success: true, key: 'A' })
+
+    await useSecretsApi().applySecret('A')
+
+    expect(mockPost).toHaveBeenCalledWith('/secrets/apply', { key: 'A' })
+  })
+})

--- a/autobot-slm-frontend/src/composables/useSecretsApi.ts
+++ b/autobot-slm-frontend/src/composables/useSecretsApi.ts
@@ -8,13 +8,16 @@
  *
  * Provides REST API integration for encrypted system secrets
  * management via the SLM backend. Admin-only.
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()`, injects the SLM bearer token,
+ * and centrally handles 401 for these non-auth endpoints (clear session +
+ * redirect to `/login`) — matching the previous axios interceptor that called
+ * `authStore.logout()`. Call sites pass endpoints relative to the API base and
+ * receive parsed JSON directly.
  */
 
-import axios, { type AxiosInstance } from 'axios'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
-
-const SLM_API_BASE = getSlmApiBase()
+import slmApiClient from '@/utils/ApiClient'
 
 export interface SecretCreate {
   key: string
@@ -52,65 +55,34 @@ export interface ApplySecretsResult {
 }
 
 export function useSecretsApi() {
-  const authStore = useAuthStore()
-
-  const client: AxiosInstance = axios.create({
-    baseURL: SLM_API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-    timeout: 30000,
-  })
-
-  client.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
-        authStore.logout()
-      }
-      return Promise.reject(error)
-    }
-  )
-
   async function listSecrets(): Promise<SecretResponse[]> {
-    const response = await client.get<SecretResponse[]>('/secrets')
-    return response.data
+    return slmApiClient.get<SecretResponse[]>('/secrets')
   }
 
   async function createSecret(data: SecretCreate): Promise<SecretResponse> {
-    const response = await client.post<SecretResponse>('/secrets', data)
-    return response.data
+    return slmApiClient.post<SecretResponse>('/secrets', data)
   }
 
   async function updateSecret(
     key: string,
     data: SecretUpdate
   ): Promise<SecretResponse> {
-    const response = await client.put<SecretResponse>(
+    return slmApiClient.put<SecretResponse>(
       `/secrets/${encodeURIComponent(key)}`,
       data
     )
-    return response.data
   }
 
   async function deleteSecret(key: string): Promise<void> {
-    await client.delete(`/secrets/${encodeURIComponent(key)}`)
+    await slmApiClient.delete(`/secrets/${encodeURIComponent(key)}`)
   }
 
   async function getDependentRolesMapping(): Promise<DependentRolesMapping> {
-    const response = await client.get<DependentRolesMapping>('/secrets/dependent-roles')
-    return response.data
+    return slmApiClient.get<DependentRolesMapping>('/secrets/dependent-roles')
   }
 
   async function applySecret(key: string): Promise<ApplySecretsResult> {
-    const response = await client.post<ApplySecretsResult>('/secrets/apply', { key })
-    return response.data
+    return slmApiClient.post<ApplySecretsResult>('/secrets/apply', { key })
   }
 
   return {

--- a/autobot-slm-frontend/src/composables/useSlmUserApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmUserApi.test.ts
@@ -1,0 +1,170 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 2) — proves the SLM user-management composable routes
+ * every method through the canonical `slmApiClient`, serialises pagination as a
+ * query string on the endpoint (the client takes a relative path, not an axios
+ * `params` object), and returns parsed JSON directly. Non-auth endpoints → 401
+ * session handling is the client's concern.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+import { useSlmUserApi } from './useSlmUserApi'
+
+describe('useSlmUserApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockDelete.mockReset()
+  })
+
+  it('getSlmUsers GETs /slm-users with skip/limit query params and returns the body', async () => {
+    const body = { users: [], total: 0, limit: 100, offset: 0 }
+    mockGet.mockResolvedValue(body)
+
+    const result = await useSlmUserApi().getSlmUsers()
+
+    expect(mockGet).toHaveBeenCalledWith('/slm-users?skip=0&limit=100')
+    expect(result).toEqual(body)
+  })
+
+  it('getSlmUsers honours custom skip/limit', async () => {
+    mockGet.mockResolvedValue({ users: [] })
+
+    await useSlmUserApi().getSlmUsers(20, 50)
+
+    expect(mockGet).toHaveBeenCalledWith('/slm-users?skip=20&limit=50')
+  })
+
+  it('getAutobotUsers GETs /autobot-users with query params', async () => {
+    mockGet.mockResolvedValue({ users: [] })
+
+    await useSlmUserApi().getAutobotUsers()
+
+    expect(mockGet).toHaveBeenCalledWith('/autobot-users?skip=0&limit=100')
+  })
+
+  it('getTeams GETs /autobot-teams with query params', async () => {
+    mockGet.mockResolvedValue({ teams: [] })
+
+    await useSlmUserApi().getTeams()
+
+    expect(mockGet).toHaveBeenCalledWith('/autobot-teams?skip=0&limit=100')
+  })
+
+  it('createSlmUser POSTs the payload to /slm-users', async () => {
+    const payload = { email: 'a@b.c', username: 'a', password: 'p' }
+    mockPost.mockResolvedValue({ id: '1' })
+
+    await useSlmUserApi().createSlmUser(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/slm-users', payload)
+  })
+
+  it('createAutobotUser POSTs the payload to /autobot-users', async () => {
+    const payload = { email: 'a@b.c', username: 'a', password: 'p' }
+    mockPost.mockResolvedValue({ id: '1' })
+
+    await useSlmUserApi().createAutobotUser(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/autobot-users', payload)
+  })
+
+  it('deleteSlmUser DELETEs /slm-users/:id', async () => {
+    mockDelete.mockResolvedValue({})
+
+    await useSlmUserApi().deleteSlmUser('u1')
+
+    expect(mockDelete).toHaveBeenCalledWith('/slm-users/u1')
+  })
+
+  it('deleteAutobotUser DELETEs /autobot-users/:id', async () => {
+    mockDelete.mockResolvedValue({})
+
+    await useSlmUserApi().deleteAutobotUser('u1')
+
+    expect(mockDelete).toHaveBeenCalledWith('/autobot-users/u1')
+  })
+
+  it('changeSlmUserPassword POSTs new_password to the change-password path', async () => {
+    mockPost.mockResolvedValue({})
+
+    await useSlmUserApi().changeSlmUserPassword('u1', 'newpw')
+
+    expect(mockPost).toHaveBeenCalledWith('/slm-users/u1/change-password', {
+      new_password: 'newpw',
+    })
+  })
+
+  it('changeAutobotUserPassword POSTs new_password to the change-password path', async () => {
+    mockPost.mockResolvedValue({})
+
+    await useSlmUserApi().changeAutobotUserPassword('u1', 'newpw')
+
+    expect(mockPost).toHaveBeenCalledWith('/autobot-users/u1/change-password', {
+      new_password: 'newpw',
+    })
+  })
+
+  it('createTeam POSTs the payload to /autobot-teams', async () => {
+    mockPost.mockResolvedValue({ id: 't1' })
+
+    await useSlmUserApi().createTeam({ name: 'team' })
+
+    expect(mockPost).toHaveBeenCalledWith('/autobot-teams', { name: 'team' })
+  })
+
+  it('deleteTeam DELETEs /autobot-teams/:id', async () => {
+    mockDelete.mockResolvedValue({})
+
+    await useSlmUserApi().deleteTeam('t1')
+
+    expect(mockDelete).toHaveBeenCalledWith('/autobot-teams/t1')
+  })
+
+  it('addTeamMember POSTs user_id + role to the members path', async () => {
+    mockPost.mockResolvedValue({})
+
+    await useSlmUserApi().addTeamMember('t1', 'u1', 'admin')
+
+    expect(mockPost).toHaveBeenCalledWith('/autobot-teams/t1/members', {
+      user_id: 'u1',
+      role: 'admin',
+    })
+  })
+
+  it('addTeamMember defaults role to member', async () => {
+    mockPost.mockResolvedValue({})
+
+    await useSlmUserApi().addTeamMember('t1', 'u1')
+
+    expect(mockPost).toHaveBeenCalledWith('/autobot-teams/t1/members', {
+      user_id: 'u1',
+      role: 'member',
+    })
+  })
+
+  it('removeTeamMember DELETEs the member path', async () => {
+    mockDelete.mockResolvedValue({})
+
+    await useSlmUserApi().removeTeamMember('t1', 'u1')
+
+    expect(mockDelete).toHaveBeenCalledWith('/autobot-teams/t1/members/u1')
+  })
+})

--- a/autobot-slm-frontend/src/composables/useSlmUserApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmUserApi.ts
@@ -9,14 +9,17 @@
  * Provides REST API integration for user management via the SLM backend.
  * Manages both SLM admin users (local DB) and AutoBot application users (remote DB).
  * Issue #576 - User Management System.
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()`, injects the SLM bearer token,
+ * and centrally handles 401 for these non-auth endpoints (clear session +
+ * redirect to `/login`) — matching the previous axios interceptor that called
+ * `authStore.logout()`. Query parameters (skip/limit) are serialised onto the
+ * endpoint since the canonical client takes a relative path, not an axios
+ * `params` object; call sites receive parsed JSON directly.
  */
 
-import axios, { type AxiosInstance } from 'axios'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
-
-// SLM API is proxied via nginx at /api/
-const SLM_API_BASE = getSlmApiBase()
+import slmApiClient from '@/utils/ApiClient'
 
 // =============================================================================
 // Type Definitions
@@ -85,55 +88,35 @@ export interface CreateTeamPayload {
   organization_id?: string
 }
 
+// Serialise pagination params onto the endpoint (the canonical client takes a
+// relative path, not an axios `params` object).
+function withPaging(path: string, skip: number, limit: number): string {
+  const query = new URLSearchParams({
+    skip: String(skip),
+    limit: String(limit),
+  })
+  return `${path}?${query.toString()}`
+}
+
 export function useSlmUserApi() {
-  const authStore = useAuthStore()
-
-  const client: AxiosInstance = axios.create({
-    baseURL: SLM_API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-    timeout: 30000,
-  })
-
-  client.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
-        authStore.logout()
-      }
-      return Promise.reject(error)
-    }
-  )
-
   // ===========================================================================
   // SLM Admin Users (local SLM database)
   // ===========================================================================
 
   async function getSlmUsers(skip = 0, limit = 100): Promise<SlmUserListResponse> {
-    const response = await client.get<SlmUserListResponse>('/slm-users', {
-      params: { skip, limit },
-    })
-    return response.data
+    return slmApiClient.get<SlmUserListResponse>(withPaging('/slm-users', skip, limit))
   }
 
   async function createSlmUser(data: CreateUserPayload): Promise<SlmUserResponse> {
-    const response = await client.post<SlmUserResponse>('/slm-users', data)
-    return response.data
+    return slmApiClient.post<SlmUserResponse>('/slm-users', data)
   }
 
   async function deleteSlmUser(userId: string): Promise<void> {
-    await client.delete(`/slm-users/${userId}`)
+    await slmApiClient.delete(`/slm-users/${userId}`)
   }
 
   async function changeSlmUserPassword(userId: string, newPassword: string): Promise<void> {
-    await client.post(`/slm-users/${userId}/change-password`, { new_password: newPassword })
+    await slmApiClient.post(`/slm-users/${userId}/change-password`, { new_password: newPassword })
   }
 
   // ===========================================================================
@@ -141,23 +124,19 @@ export function useSlmUserApi() {
   // ===========================================================================
 
   async function getAutobotUsers(skip = 0, limit = 100): Promise<SlmUserListResponse> {
-    const response = await client.get<SlmUserListResponse>('/autobot-users', {
-      params: { skip, limit },
-    })
-    return response.data
+    return slmApiClient.get<SlmUserListResponse>(withPaging('/autobot-users', skip, limit))
   }
 
   async function createAutobotUser(data: CreateUserPayload): Promise<SlmUserResponse> {
-    const response = await client.post<SlmUserResponse>('/autobot-users', data)
-    return response.data
+    return slmApiClient.post<SlmUserResponse>('/autobot-users', data)
   }
 
   async function deleteAutobotUser(userId: string): Promise<void> {
-    await client.delete(`/autobot-users/${userId}`)
+    await slmApiClient.delete(`/autobot-users/${userId}`)
   }
 
   async function changeAutobotUserPassword(userId: string, newPassword: string): Promise<void> {
-    await client.post(`/autobot-users/${userId}/change-password`, { new_password: newPassword })
+    await slmApiClient.post(`/autobot-users/${userId}/change-password`, { new_password: newPassword })
   }
 
   // ===========================================================================
@@ -165,19 +144,15 @@ export function useSlmUserApi() {
   // ===========================================================================
 
   async function getTeams(skip = 0, limit = 100): Promise<TeamListResponse> {
-    const response = await client.get<TeamListResponse>('/autobot-teams', {
-      params: { skip, limit },
-    })
-    return response.data
+    return slmApiClient.get<TeamListResponse>(withPaging('/autobot-teams', skip, limit))
   }
 
   async function createTeam(data: CreateTeamPayload): Promise<TeamResponse> {
-    const response = await client.post<TeamResponse>('/autobot-teams', data)
-    return response.data
+    return slmApiClient.post<TeamResponse>('/autobot-teams', data)
   }
 
   async function deleteTeam(teamId: string): Promise<void> {
-    await client.delete(`/autobot-teams/${teamId}`)
+    await slmApiClient.delete(`/autobot-teams/${teamId}`)
   }
 
   async function addTeamMember(
@@ -185,14 +160,14 @@ export function useSlmUserApi() {
     userId: string,
     role = 'member'
   ): Promise<void> {
-    await client.post(`/autobot-teams/${teamId}/members`, {
+    await slmApiClient.post(`/autobot-teams/${teamId}/members`, {
       user_id: userId,
       role,
     })
   }
 
   async function removeTeamMember(teamId: string, userId: string): Promise<void> {
-    await client.delete(`/autobot-teams/${teamId}/members/${userId}`)
+    await slmApiClient.delete(`/autobot-teams/${teamId}/members/${userId}`)
   }
 
   return {

--- a/autobot-slm-frontend/src/composables/useSsoApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSsoApi.test.ts
@@ -1,0 +1,162 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 2) — proves the SSO composable routes every method
+ * through the canonical `slmApiClient`, serialises list filters as a query
+ * string, and preserves the historic "logout on 401" behavior for the
+ * `/auth/sso/**` login-flow endpoints (which the client intentionally excludes
+ * from its own session-clearing handler). The non-auth provider-CRUD endpoints
+ * rely on the client's central 401 handling and do NOT re-trigger logout here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPatch = vi.fn()
+const mockDelete = vi.fn()
+const mockLogout = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ logout: mockLogout }),
+}))
+
+import { useSsoApi } from './useSsoApi'
+
+describe('useSsoApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPatch.mockReset()
+    mockDelete.mockReset()
+    mockLogout.mockReset()
+  })
+
+  it('listProviders GETs /sso-providers with no query when unfiltered', async () => {
+    mockGet.mockResolvedValue({ providers: [], total: 0 })
+
+    await useSsoApi().listProviders()
+
+    expect(mockGet).toHaveBeenCalledWith('/sso-providers')
+  })
+
+  it('listProviders serialises org_id + active_only into the query string', async () => {
+    mockGet.mockResolvedValue({ providers: [], total: 0 })
+
+    await useSsoApi().listProviders('org-1', true)
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/sso-providers?org_id=org-1&active_only=true'
+    )
+  })
+
+  it('createProvider POSTs the payload to /sso-providers', async () => {
+    const payload = { provider_type: 'oauth2', name: 'g', config: {} }
+    mockPost.mockResolvedValue({ id: '1' })
+
+    await useSsoApi().createProvider(payload)
+
+    expect(mockPost).toHaveBeenCalledWith('/sso-providers', payload)
+  })
+
+  it('getProvider GETs /sso-providers/:id', async () => {
+    mockGet.mockResolvedValue({ id: '1' })
+
+    await useSsoApi().getProvider('1')
+
+    expect(mockGet).toHaveBeenCalledWith('/sso-providers/1')
+  })
+
+  it('updateProvider PATCHes /sso-providers/:id', async () => {
+    mockPatch.mockResolvedValue({ id: '1' })
+
+    await useSsoApi().updateProvider('1', { name: 'new' })
+
+    expect(mockPatch).toHaveBeenCalledWith('/sso-providers/1', { name: 'new' })
+  })
+
+  it('deleteProvider DELETEs /sso-providers/:id', async () => {
+    mockDelete.mockResolvedValue({})
+
+    await useSsoApi().deleteProvider('1')
+
+    expect(mockDelete).toHaveBeenCalledWith('/sso-providers/1')
+  })
+
+  it('testProvider GETs /sso-providers/:id/test', async () => {
+    mockGet.mockResolvedValue({ success: true, message: 'ok' })
+
+    await useSsoApi().testProvider('1')
+
+    expect(mockGet).toHaveBeenCalledWith('/sso-providers/1/test')
+  })
+
+  it('getProvidersHealth GETs /sso-providers/health', async () => {
+    mockGet.mockResolvedValue([])
+
+    await useSsoApi().getProvidersHealth()
+
+    expect(mockGet).toHaveBeenCalledWith('/sso-providers/health')
+  })
+
+  it('getActiveProviders GETs /auth/sso/providers', async () => {
+    mockGet.mockResolvedValue([])
+
+    await useSsoApi().getActiveProviders()
+
+    expect(mockGet).toHaveBeenCalledWith('/auth/sso/providers')
+  })
+
+  it('initiateSSOLogin GETs /auth/sso/:id/login', async () => {
+    mockGet.mockResolvedValue({ provider_id: '1', redirect_url: 'x' })
+
+    await useSsoApi().initiateSSOLogin('1')
+
+    expect(mockGet).toHaveBeenCalledWith('/auth/sso/1/login')
+  })
+
+  it('loginWithLDAP POSTs credentials to /auth/sso/ldap/login', async () => {
+    mockPost.mockResolvedValue({ access_token: 't', token_type: 'bearer', expires_in: 3600 })
+
+    await useSsoApi().loginWithLDAP('1', 'user', 'pw')
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/sso/ldap/login', {
+      provider_id: '1',
+      username: 'user',
+      password: 'pw',
+    })
+  })
+
+  it('logs out and re-throws on a 401 from an /auth/** login-flow endpoint', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 401: Unauthorized'))
+
+    await expect(useSsoApi().getActiveProviders()).rejects.toThrow('HTTP 401')
+    expect(mockLogout).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT double-logout on a 401 from a non-auth provider-CRUD endpoint (client handles it)', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 401: Unauthorized'))
+
+    await expect(useSsoApi().getProvider('1')).rejects.toThrow('HTTP 401')
+    expect(mockLogout).not.toHaveBeenCalled()
+  })
+
+  it('does NOT log out on a non-401 error from an /auth/** endpoint', async () => {
+    mockPost.mockRejectedValue(new Error('HTTP 400: Bad credentials'))
+
+    await expect(useSsoApi().loginWithLDAP('1', 'user', 'bad')).rejects.toThrow('HTTP 400')
+    expect(mockLogout).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-slm-frontend/src/composables/useSsoApi.ts
+++ b/autobot-slm-frontend/src/composables/useSsoApi.ts
@@ -9,14 +9,21 @@
  * Provides REST API integration for SSO/OAuth2/LDAP/SAML provider
  * management via the SLM backend.
  * Issue #576 - User Management System Phase 4 (SSO).
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()` and injects the SLM bearer token.
+ *
+ * 401 handling — the previous axios interceptor logged the user out on ANY 401.
+ * For the provider CRUD endpoints (non-auth) the canonical client reproduces
+ * this: it clears the session and redirects to `/login`. The client, however,
+ * intentionally skips its session-clearing handler for `/auth/**` endpoints (a
+ * 401 there is a credential failure, not a rejected session), so the SSO login
+ * flow methods that hit `/auth/sso/**` wrap their call in `withAuthGuard` to
+ * preserve the historic "logout on 401" behavior explicitly.
  */
 
-import axios, { type AxiosInstance } from 'axios'
+import slmApiClient from '@/utils/ApiClient'
 import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
-
-// SLM API is proxied via nginx at /api/
-const SLM_API_BASE = getSlmApiBase()
 
 // =============================================================================
 // Type Definitions
@@ -106,109 +113,87 @@ export interface SSOProviderHealthResponse {
 export function useSsoApi() {
   const authStore = useAuthStore()
 
-  const client: AxiosInstance = axios.create({
-    baseURL: SLM_API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-    timeout: 30000,
-  })
-
-  client.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
+  // The canonical client skips its session-clearing 401 handler for `/auth/**`
+  // endpoints, so the SSO login-flow methods below preserve the historic
+  // interceptor behavior (logout on any 401) explicitly and re-throw as before.
+  async function withAuthGuard<T>(op: () => Promise<T>): Promise<T> {
+    try {
+      return await op()
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('HTTP 401')) {
         authStore.logout()
       }
-      return Promise.reject(error)
+      throw error
     }
-  )
+  }
 
   // ===========================================================================
-  // SSO Provider CRUD
+  // SSO Provider CRUD (non-auth endpoints — client handles 401 centrally)
   // ===========================================================================
 
   async function listProviders(
     orgId?: string,
     activeOnly?: boolean
   ): Promise<SSOProviderListResponse> {
-    const params: Record<string, string | boolean> = {}
-    if (orgId) params.org_id = orgId
-    if (activeOnly !== undefined) params.active_only = activeOnly
-    const response = await client.get<SSOProviderListResponse>(
-      '/sso-providers',
-      { params }
+    const params = new URLSearchParams()
+    if (orgId) params.set('org_id', orgId)
+    if (activeOnly !== undefined) params.set('active_only', String(activeOnly))
+    const query = params.toString()
+    return slmApiClient.get<SSOProviderListResponse>(
+      query ? `/sso-providers?${query}` : '/sso-providers'
     )
-    return response.data
   }
 
   async function createProvider(
     data: SSOProviderCreate
   ): Promise<SSOProviderResponse> {
-    const response = await client.post<SSOProviderResponse>(
-      '/sso-providers',
-      data
-    )
-    return response.data
+    return slmApiClient.post<SSOProviderResponse>('/sso-providers', data)
   }
 
   async function getProvider(
     providerId: string
   ): Promise<SSOProviderResponse> {
-    const response = await client.get<SSOProviderResponse>(
-      `/sso-providers/${providerId}`
-    )
-    return response.data
+    return slmApiClient.get<SSOProviderResponse>(`/sso-providers/${providerId}`)
   }
 
   async function updateProvider(
     providerId: string,
     data: SSOProviderUpdate
   ): Promise<SSOProviderResponse> {
-    const response = await client.patch<SSOProviderResponse>(
+    return slmApiClient.patch<SSOProviderResponse>(
       `/sso-providers/${providerId}`,
       data
     )
-    return response.data
   }
 
   async function deleteProvider(providerId: string): Promise<void> {
-    await client.delete(`/sso-providers/${providerId}`)
+    await slmApiClient.delete(`/sso-providers/${providerId}`)
   }
 
   async function testProvider(
     providerId: string
   ): Promise<SSOTestResponse> {
-    const response = await client.get<SSOTestResponse>(
+    return slmApiClient.get<SSOTestResponse>(
       `/sso-providers/${providerId}/test`
     )
-    return response.data
   }
 
   // ===========================================================================
-  // SSO Login Flow
+  // SSO Login Flow (`/auth/**` — client skips 401, guard preserves logout)
   // ===========================================================================
 
   async function getActiveProviders(): Promise<ActiveProvider[]> {
-    const response = await client.get<ActiveProvider[]>(
-      '/auth/sso/providers'
+    return withAuthGuard(() =>
+      slmApiClient.get<ActiveProvider[]>('/auth/sso/providers')
     )
-    return response.data
   }
 
   async function initiateSSOLogin(
     providerId: string
   ): Promise<SSOLoginInitResponse> {
-    const response = await client.get<SSOLoginInitResponse>(
-      `/auth/sso/${providerId}/login`
+    return withAuthGuard(() =>
+      slmApiClient.get<SSOLoginInitResponse>(`/auth/sso/${providerId}/login`)
     )
-    return response.data
   }
 
   async function loginWithLDAP(
@@ -216,18 +201,19 @@ export function useSsoApi() {
     username: string,
     password: string
   ): Promise<LDAPLoginResponse> {
-    const response = await client.post<LDAPLoginResponse>(
-      '/auth/sso/ldap/login',
-      { provider_id: providerId, username, password }
+    return withAuthGuard(() =>
+      slmApiClient.post<LDAPLoginResponse>('/auth/sso/ldap/login', {
+        provider_id: providerId,
+        username,
+        password,
+      })
     )
-    return response.data
   }
 
   async function getProvidersHealth(): Promise<SSOProviderHealthResponse[]> {
-    const response = await client.get<SSOProviderHealthResponse[]>(
+    return slmApiClient.get<SSOProviderHealthResponse[]>(
       '/sso-providers/health'
     )
-    return response.data
   }
 
   return {

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -10,9 +10,8 @@
  */
 
 import { createRouter, createWebHistory } from 'vue-router'
-import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
+import slmApiClient from '@/utils/ApiClient'
 
 // One-time wizard completion check (Issue #1294)
 let wizardCheckDone = false
@@ -551,10 +550,13 @@ router.beforeEach(async (to, _from) => {
   if (!wizardCheckDone && to.name !== 'setup') {
     wizardCheckDone = true
     try {
-      const token = sessionStorage.getItem('slm_access_token')
-      const { data } = await axios.get(`${getSlmApiBase()}/setup/status`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      // slmApiClient injects the SLM bearer token and resolves the base URL
+      // via getSlmApiBase(); single attempt (maxRetries: 1) so a first-run
+      // navigation is not delayed by GET retry/backoff on a missing endpoint.
+      const data = await slmApiClient.get<{ completed?: boolean }>(
+        '/setup/status',
+        { maxRetries: 1 }
+      )
       if (!data.completed) {
         return { name: 'setup' }
       }


### PR DESCRIPTION
## Thinking Path

Phase 1 (#12591) landed the canonical `slmApiClient` (fetch-based, base URL via `getSlmApiBase()`, bearer-token injection, central 401 → clear session + redirect to `/login`, exactly mirroring `authStore.logout()`'s target). Batch 1 (#12599) migrated the MFA composable and established the `withAuthGuard` pattern for auth endpoints the client deliberately excludes from 401 handling.

This batch does the **Auth / Security / Users** domain. Each composable held an identical, duplicated axios instance: `getSlmApiBase()` base URL, a request interceptor adding `Authorization: Bearer <authStore.token>`, and a response interceptor calling `authStore.logout()` on 401. All three concerns are now the client's, so the composables collapse to thin endpoint wrappers returning parsed JSON directly (no axios `.data`).

Key behavior-preservation decisions:
- **Non-auth endpoints** (`/api-keys`, `/secrets`, `/slm-users`, `/autobot-users`, `/autobot-teams`, `/sso-providers`): the client's central 401 handler reproduces the old interceptor's logout-and-redirect, so no per-site guard is added (adding one would double-fire logout + a hard redirect).
- **SSO login-flow endpoints** (`/auth/sso/**`): the client intentionally skips its session-clearing handler for auth endpoints, so these keep the historic "logout on 401" via an explicit `withAuthGuard` (batch-1 pattern).
- **Query params**: the client takes a relative path, not an axios `params` object, so pagination (`skip`/`limit`) and SSO list filters (`org_id`/`active_only`) are serialised onto the endpoint with `URLSearchParams`.
- **Router**: the one-time `/setup/status` first-run probe uses `maxRetries: 1` so navigation isn't delayed by the client's default GET retry/backoff on a missing endpoint; failures stay swallowed.

## What Changed

- **`composables/useApiKeyApi.ts`** — dropped axios instance + interceptors + `useAuthStore`; 6 methods (`createKey`/`listKeys`/`getKey`/`updateKey`/`revokeKey`/`getScopes`) now call `slmApiClient`.
- **`composables/useSecretsApi.ts`** — same treatment; 6 methods; preserved `encodeURIComponent` on the secret-key path segment.
- **`composables/useSlmUserApi.ts`** — same; 13 methods; `skip`/`limit` serialised via a `withPaging` helper onto `/slm-users`, `/autobot-users`, `/autobot-teams`.
- **`composables/useSsoApi.ts`** — same; 10 methods; `listProviders` filters serialised to the query string; kept `useAuthStore` only for the `withAuthGuard` on the three `/auth/sso/**` login-flow methods.
- **`router/index.ts`** — replaced `axios.get(\`${getSlmApiBase()}/setup/status\`, { headers })` with `slmApiClient.get('/setup/status', { maxRetries: 1 })`; removed now-unused `axios` and `getSlmApiBase` imports.
- **New tests** — `useApiKeyApi.test.ts`, `useSecretsApi.test.ts`, `useSlmUserApi.test.ts`, `useSsoApi.test.ts` (41 cases) assert every method routes through `slmApiClient` with the right endpoint/body, that query strings are built correctly, and that the SSO `/auth/**` 401 guard fires while non-auth endpoints do NOT double-logout.

## Verification

- `vue-tsc --noEmit -p tsconfig.json` → clean (exit 0), including the new test files.
- `vitest run` on the four new suites → **41 passed (4 files)**.
- Grep confirms the migrated composables no longer import `axios` or call `getSlmApiBase()` in code (only doc-comment mentions remain); all five files import `slmApiClient`.
- Temporary read-only `node_modules` symlink from the main tree was used for the tooling gates, then removed (no manual installs).

## Model Used

claude-opus-4-8

## Follow-up

- **Remaining Phase 2 domains** still on axios/`getSlmApiBase()`: nodes/fleet, monitoring, maintenance/updates, and other admin composables (see #12420 for the full ~71 call-site / ~48 file inventory).
- **WebSocket builders**: none encountered in this batch's files (all four composables and the router are plain HTTP). The client still has no WS surface — the deferred WS-builder decision from #12420 is untouched here.
- **`views/settings/admin/UserManagementSettings.vue`** (listed as a candidate) was **deliberately not migrated**: its `getSlmApiBase()` use only builds a full-URL string handed to the cross-app shared `@shared/components/PasswordChangeForm.vue` (which owns its own `api-endpoint`-prop HTTP contract), and its two `fetch` calls target `getBackendUrl()` (the AutoBot backend — a **different host**), so routing them through `slmApiClient` (which resolves `getSlmApiBase()`) would hit the wrong base URL. These belong to the `getBackendUrl()`/`getApiUrl()` follow-up domain.
- **~19 `getApiUrl()`-based files** (auth store `logout`, RBAC status/init, etc.) are a separate follow-up — they target a different backend base than `slmApiClient`.

Closes #12600
Refs #12420