### PR TITLE
refactor(frontend): migrate axios importers onto canonical ApiClient (#12363 Phase 2 batch 1)

### DIFF
--- a/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
+++ b/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
@@ -43,7 +43,7 @@ vi.mock('@/utils/ApiClient', () => ({
   ApiClient: vi.fn(),
 }))
 
-// Mock ChatRepository to prevent real axios calls
+// Mock ChatRepository to prevent real HTTP calls
 vi.mock('@/models/repositories', () => {
   const mockChatRepo = {
     getChatList: vi.fn().mockResolvedValue([]),

--- a/autobot-frontend/src/components/__tests__/SettingsPanel.test.ts
+++ b/autobot-frontend/src/components/__tests__/SettingsPanel.test.ts
@@ -4,28 +4,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/vue'
 import SettingsPanel from '../settings/SettingsPanel.vue'
 import { renderComponent } from '../../test/utils/test-utils'
-import axios from 'axios'
+import apiClient from '@/utils/ApiClient'
 
 // ── Mock dependencies ──────────────────────────────────────────────────
-// SettingsPanel imports axios directly for all API calls.
-// The global vitest-setup.ts runs vi.clearAllMocks() in beforeEach,
-// which wipes mockResolvedValue set in vi.mock factories.
-// We must re-configure return values in our own beforeEach using
-// the imported (mocked) axios instance.
-
-vi.mock('axios', () => ({
-  default: {
-    get: vi.fn(),
-    post: vi.fn(),
-    put: vi.fn(),
-    delete: vi.fn(),
-    create: vi.fn().mockReturnThis(),
-    interceptors: {
-      request: { use: vi.fn(), eject: vi.fn() },
-      response: { use: vi.fn(), eject: vi.fn() },
-    },
-  },
-}))
+// #12363 Phase 2: SettingsPanel now calls the canonical ApiClient for all API
+// calls (axios retired). ApiClient convenience methods return PARSED JSON
+// directly (no axios `.data` envelope), so the mocks below resolve with the
+// raw payloads. The global vitest-setup.ts runs vi.clearAllMocks() in
+// beforeEach, which wipes return values set in the vi.mock factory — so we
+// re-configure them in our own beforeEach.
 
 vi.mock('@/utils/ApiClient', () => ({
   default: {
@@ -84,43 +71,45 @@ const mockHealthResponse = {
 }
 
 /**
- * Configure axios mock return values for all endpoints SettingsPanel
+ * Configure ApiClient mock return values for all endpoints SettingsPanel
  * calls on mount:
  *   GET /api/settings/           -> loadSettings
  *   GET /api/cache/stats         -> checkCacheApiAvailability + refreshCacheStats
  *   GET /api/system/health/detailed -> loadHealthStatus
  *   GET /api/system/health       -> loadHealthStatus fallback
+ *
+ * ApiClient.get resolves with PARSED JSON directly (no `.data` envelope).
  */
-function setupAxiosMocks() {
-  vi.mocked(axios.get).mockImplementation((url: string, ..._args: unknown[]) => {
+function setupApiClientMocks() {
+  vi.mocked(apiClient.get).mockImplementation((url: string, ..._args: unknown[]) => {
     if (url === '/api/settings/') {
-      return Promise.resolve({ data: mockSettingsResponse })
+      return Promise.resolve(mockSettingsResponse)
     }
     if (url === '/api/cache/stats') {
-      return Promise.resolve({ data: { hits: 0, misses: 0 } })
+      return Promise.resolve({ hits: 0, misses: 0 })
     }
     if (url === '/api/system/health/detailed') {
-      return Promise.resolve({ data: mockHealthResponse })
+      return Promise.resolve(mockHealthResponse)
     }
     if (url === '/api/system/health') {
-      return Promise.resolve({ data: { status: 'healthy' } })
+      return Promise.resolve({ status: 'healthy' })
     }
     if (url === '/api/prompts') {
-      return Promise.resolve({ data: [] })
+      return Promise.resolve([])
     }
-    // Default: resolve with empty data to prevent undefined crashes
-    return Promise.resolve({ data: {} })
+    // Default: resolve with empty object to prevent undefined crashes
+    return Promise.resolve({})
   })
 
-  vi.mocked(axios.post).mockResolvedValue({ data: { success: true } })
-  vi.mocked(axios.put).mockResolvedValue({ data: { success: true } })
-  vi.mocked(axios.delete).mockResolvedValue({ data: { success: true } })
+  vi.mocked(apiClient.post).mockResolvedValue({ success: true })
+  vi.mocked(apiClient.put).mockResolvedValue({ success: true })
+  vi.mocked(apiClient.delete).mockResolvedValue({ success: true })
 }
 
 describe('SettingsPanel', () => {
   beforeEach(() => {
-    // Re-configure axios mocks after global vi.clearAllMocks() wipes them
-    setupAxiosMocks()
+    // Re-configure mocks after global vi.clearAllMocks() wipes them
+    setupApiClientMocks()
   })
 
   afterEach(() => {
@@ -155,7 +144,7 @@ describe('SettingsPanel', () => {
       renderSettings()
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith('/api/settings/')
+        expect(apiClient.get).toHaveBeenCalledWith('/api/settings/', expect.anything())
       })
     })
 
@@ -163,7 +152,7 @@ describe('SettingsPanel', () => {
       renderSettings()
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith('/api/system/health/detailed')
+        expect(apiClient.get).toHaveBeenCalledWith('/api/system/health/detailed', expect.anything())
       })
     })
 
@@ -171,7 +160,7 @@ describe('SettingsPanel', () => {
       renderSettings()
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith(
+        expect(apiClient.get).toHaveBeenCalledWith(
           '/api/cache/stats',
           expect.objectContaining({ timeout: 3000 })
         )
@@ -193,12 +182,12 @@ describe('SettingsPanel', () => {
     })
 
     it('shows offline status when settings API fails', async () => {
-      vi.mocked(axios.get).mockImplementation((url: string) => {
+      vi.mocked(apiClient.get).mockImplementation((url: string) => {
         if (url === '/api/settings/') {
           return Promise.reject(new Error('Network error'))
         }
         // Other endpoints still resolve to prevent cascading errors
-        return Promise.resolve({ data: {} })
+        return Promise.resolve({})
       })
 
       renderSettings()
@@ -215,7 +204,7 @@ describe('SettingsPanel', () => {
       renderSettings()
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith('/api/settings/')
+        expect(apiClient.get).toHaveBeenCalledWith('/api/settings/', expect.anything())
       })
 
       // After loading, the component should no longer show loading state
@@ -230,7 +219,7 @@ describe('SettingsPanel', () => {
 
       // First call should go through
       await waitFor(() => {
-        const settingsCalls = vi.mocked(axios.get).mock.calls.filter(
+        const settingsCalls = vi.mocked(apiClient.get).mock.calls.filter(
           (call) => call[0] === '/api/settings/'
         )
         // Should only call settings endpoint once (guard prevents concurrent)
@@ -245,11 +234,11 @@ describe('SettingsPanel', () => {
         chat: { auto_scroll: false, max_messages: 50, message_retention_days: 7 },
       })
 
-      vi.mocked(axios.get).mockImplementation((url: string) => {
+      vi.mocked(apiClient.get).mockImplementation((url: string) => {
         if (url === '/api/settings/') {
           return Promise.reject(new Error('Network error'))
         }
-        return Promise.resolve({ data: {} })
+        return Promise.resolve({})
       })
 
       renderSettings()
@@ -293,28 +282,28 @@ describe('SettingsPanel', () => {
       renderSettings()
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith('/api/system/health/detailed')
+        expect(apiClient.get).toHaveBeenCalledWith('/api/system/health/detailed', expect.anything())
       })
     })
 
     it('falls back to basic health when detailed fails', async () => {
-      vi.mocked(axios.get).mockImplementation((url: string) => {
+      vi.mocked(apiClient.get).mockImplementation((url: string) => {
         if (url === '/api/settings/') {
-          return Promise.resolve({ data: mockSettingsResponse })
+          return Promise.resolve(mockSettingsResponse)
         }
         if (url === '/api/system/health/detailed') {
           return Promise.reject(new Error('Not found'))
         }
         if (url === '/api/system/health') {
-          return Promise.resolve({ data: { status: 'healthy' } })
+          return Promise.resolve({ status: 'healthy' })
         }
-        return Promise.resolve({ data: {} })
+        return Promise.resolve({})
       })
 
       renderSettings()
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith('/api/system/health')
+        expect(apiClient.get).toHaveBeenCalledWith('/api/system/health', expect.anything())
       })
     })
   })
@@ -324,7 +313,7 @@ describe('SettingsPanel', () => {
       renderSettings()
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith(
+        expect(apiClient.get).toHaveBeenCalledWith(
           '/api/cache/stats',
           expect.objectContaining({ timeout: 3000 })
         )
@@ -336,7 +325,7 @@ describe('SettingsPanel', () => {
 
       await waitFor(() => {
         // Should have at least the availability check call
-        const cacheCalls = vi.mocked(axios.get).mock.calls.filter(
+        const cacheCalls = vi.mocked(apiClient.get).mock.calls.filter(
           (call) => call[0] === '/api/cache/stats'
         )
         expect(cacheCalls.length).toBeGreaterThanOrEqual(1)
@@ -344,17 +333,17 @@ describe('SettingsPanel', () => {
     })
 
     it('handles cache API unavailability gracefully', async () => {
-      vi.mocked(axios.get).mockImplementation((url: string) => {
+      vi.mocked(apiClient.get).mockImplementation((url: string) => {
         if (url === '/api/settings/') {
-          return Promise.resolve({ data: mockSettingsResponse })
+          return Promise.resolve(mockSettingsResponse)
         }
         if (url === '/api/cache/stats') {
           return Promise.reject(new Error('Cache unavailable'))
         }
         if (url === '/api/system/health/detailed') {
-          return Promise.resolve({ data: mockHealthResponse })
+          return Promise.resolve(mockHealthResponse)
         }
-        return Promise.resolve({ data: {} })
+        return Promise.resolve({})
       })
 
       renderSettings()
@@ -369,7 +358,7 @@ describe('SettingsPanel', () => {
 
   describe('Error Handling', () => {
     it('handles all API failures without crashing', async () => {
-      vi.mocked(axios.get).mockRejectedValue(new Error('All APIs down'))
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('All APIs down'))
 
       renderSettings()
 
@@ -381,11 +370,11 @@ describe('SettingsPanel', () => {
     })
 
     it('shows offline state when settings fail to load', async () => {
-      vi.mocked(axios.get).mockImplementation((url: string) => {
+      vi.mocked(apiClient.get).mockImplementation((url: string) => {
         if (url === '/api/settings/') {
           return Promise.reject(new Error('Offline'))
         }
-        return Promise.resolve({ data: {} })
+        return Promise.resolve({})
       })
 
       renderSettings()
@@ -402,11 +391,11 @@ describe('SettingsPanel', () => {
       renderSettings()
 
       await waitFor(() => {
-        const calledUrls = vi.mocked(axios.get).mock.calls.map((call) => call[0])
+        const calledUrls = vi.mocked(apiClient.get).mock.calls.map((call) => call[0])
         expect(calledUrls).toContain('/api/settings/')
         expect(calledUrls).toContain('/api/system/health/detailed')
         // Cache stats called with timeout option for availability check
-        const cacheCall = vi.mocked(axios.get).mock.calls.find(
+        const cacheCall = vi.mocked(apiClient.get).mock.calls.find(
           (call) => call[0] === '/api/cache/stats'
         )
         expect(cacheCall).toBeDefined()

--- a/autobot-frontend/src/components/settings/SettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/SettingsPanel.vue
@@ -69,11 +69,16 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, reactive, onMounted, provide } from 'vue'
 import { useI18n } from 'vue-i18n'
-import axios from 'axios'
+import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('SettingsPanel')
+
+// #12363 Phase 2: GET options preserving the pre-migration axios behaviour —
+// a single attempt (no retry/backoff) and no client-level warn, since
+// useAsyncHandler already reports failures per its `logErrors` flag.
+const GET_OPTS = { maxRetries: 1, suppressErrorLog: true } as const
 const { t } = useI18n()
 
 // Import error handling composables
@@ -387,7 +392,7 @@ const loadSettings = async () => {
 
   const { execute: fetchSettings } = useAsyncHandler(
     // Issue #552: Use trailing slash to match backend endpoint /api/settings/
-    async () => axios.get(`${getApiBase()}/settings/`),
+    async () => apiClient.get<Partial<SettingsStructure>>(`${getApiBase()}/settings/`, GET_OPTS),
     {
       errorMessage: 'Failed to load settings',
       notify,
@@ -396,7 +401,7 @@ const loadSettings = async () => {
       onSuccess: (response) => {
         settings.value = {
           ...getDefaultSettings(),
-          ...response.data
+          ...response
         }
         isSettingsLoaded.value = true
         settingsLoadingStatus.value = 'loaded'
@@ -429,7 +434,7 @@ const saveSettings = async () => {
 
   const { execute: postSettings } = useAsyncHandler(
     // Issue #552: Use trailing slash to match backend endpoint /api/settings/
-    async () => axios.post(`${getApiBase()}/settings/`, settings.value),
+    async () => apiClient.post(`${getApiBase()}/settings/`, settings.value),
     {
       errorMessage: 'Failed to save settings',
       successMessage: 'Settings saved successfully',
@@ -461,7 +466,7 @@ const discardChanges = () => {
 // Cache management functions with proper error handling
 const checkCacheApiAvailability = async () => {
   const { execute: checkCache } = useAsyncHandler(
-    async () => axios.get(`${getApiBase()}/cache/stats`, { timeout: 3000 }),
+    async () => apiClient.get(`${getApiBase()}/cache/stats`, { ...GET_OPTS, timeout: 3000 }),
     {
       logErrors: false, // Silent check - don't log errors for availability check
       onSuccess: () => {
@@ -485,7 +490,7 @@ const saveCacheConfig = async () => {
   isSaving.value = true
 
   const { execute: postCacheConfig } = useAsyncHandler(
-    async () => axios.post(`${getApiBase()}/cache/config`, cacheConfig),
+    async () => apiClient.post(`${getApiBase()}/cache/config`, cacheConfig),
     {
       errorMessage: 'Failed to save cache configuration',
       successMessage: 'Cache configuration saved',
@@ -537,14 +542,14 @@ const refreshCacheStats = async () => {
   }
 
   const { execute: getCacheStats } = useAsyncHandler(
-    async () => axios.get(`${getApiBase()}/cache/stats`),
+    async () => apiClient.get<CacheStats>(`${getApiBase()}/cache/stats`, GET_OPTS),
     {
       errorMessage: 'Failed to refresh cache statistics',
       notify,
       logErrors: true,
       errorPrefix: '[SettingsPanel]',
       onSuccess: (response) => {
-        cacheStats.value = response.data
+        cacheStats.value = response
       },
       onError: () => {
         cacheStats.value = {
@@ -567,7 +572,7 @@ const clearCache = async (type: string) => {
   isClearing.value = true
 
   const { execute: postClearCache } = useAsyncHandler(
-    async () => axios.post(`${getApiBase()}/cache/clear/${type}`),
+    async () => apiClient.post(`${getApiBase()}/cache/clear/${type}`),
     {
       errorMessage: `Failed to clear ${type} cache`,
       successMessage: `${type} cache cleared successfully`,
@@ -595,7 +600,7 @@ const clearRedisCache = async (database: string) => {
   isClearing.value = true
 
   const { execute: postClearRedis } = useAsyncHandler(
-    async () => axios.post(`${getApiBase()}/cache/redis/clear/${database}`),
+    async () => apiClient.post(`${getApiBase()}/cache/redis/clear/${database}`),
     {
       errorMessage: `Failed to clear Redis ${database} database`,
       successMessage: `Redis ${database} database cleared`,
@@ -624,7 +629,7 @@ const clearCacheType = async (cacheType: string) => {
   isClearing.value = true
 
   const { execute: postClearCacheType } = useAsyncHandler(
-    async () => axios.post(`${getApiBase()}/cache/clear/${cacheType}`),
+    async () => apiClient.post(`${getApiBase()}/cache/clear/${cacheType}`),
     {
       errorMessage: `Failed to clear ${cacheType} cache`,
       successMessage: `${cacheType} cache cleared`,
@@ -653,7 +658,7 @@ const warmupCaches = async () => {
   isClearing.value = true
 
   const { execute: postWarmup } = useAsyncHandler(
-    async () => axios.post(`${getApiBase()}/cache/warmup`),
+    async () => apiClient.post(`${getApiBase()}/cache/warmup`),
     {
       errorMessage: 'Failed to warm up caches',
       successMessage: 'Cache warmup completed',
@@ -711,7 +716,7 @@ const clearSelectedPrompt = () => {
 
 const loadPrompts = async () => {
   const { execute: getPrompts } = useAsyncHandler(
-    async () => axios.get(`${getApiBase()}/prompts`),
+    async () => apiClient.get<Prompt[]>(`${getApiBase()}/prompts`, GET_OPTS),
     {
       errorMessage: 'Failed to load prompts',
       notify,
@@ -725,7 +730,7 @@ const loadPrompts = async () => {
             editedContent: ''
           } as PromptsSettingsType
         }
-        settings.value.prompts.list = response.data
+        settings.value.prompts.list = response
       }
     }
   )
@@ -740,7 +745,7 @@ const savePrompt = async () => {
   }
 
   const { execute: putPrompt } = useAsyncHandler(
-    async () => axios.put(`${getApiBase()}/prompts/${prompt.id}`, {
+    async () => apiClient.put(`${getApiBase()}/prompts/${prompt.id}`, {
       content: settings.value.prompts!.editedContent
     }),
     {
@@ -761,7 +766,7 @@ const savePrompt = async () => {
 
 const revertPromptToDefault = async (promptId: string) => {
   const { execute: postRevert } = useAsyncHandler(
-    async () => axios.post(`${getApiBase()}/prompts/${promptId}/revert`),
+    async () => apiClient.post(`${getApiBase()}/prompts/${promptId}/revert`),
     {
       errorMessage: 'Failed to revert prompt to default',
       successMessage: 'Prompt reverted to default',
@@ -782,23 +787,23 @@ const revertPromptToDefault = async (promptId: string) => {
 const loadHealthStatus = async () => {
   // Try detailed health endpoint first
   const { execute: getDetailedHealth } = useAsyncHandler(
-    async () => axios.get(`${getApiBase()}/system/health/detailed`),
+    async () => apiClient.get<HealthStatus>(`${getApiBase()}/system/health/detailed`, GET_OPTS),
     {
       logErrors: true,
       errorPrefix: '[SettingsPanel]',
       onSuccess: (response) => {
-        healthStatus.value = response.data
+        healthStatus.value = response
       },
       onError: async () => {
         // Fallback to basic health endpoint
         const { execute: getBasicHealth } = useAsyncHandler(
-          async () => axios.get(`${getApiBase()}/system/health`),
+          async () => apiClient.get<Record<string, unknown>>(`${getApiBase()}/system/health`, GET_OPTS),
           {
             logErrors: true,
             errorPrefix: '[SettingsPanel]',
             onSuccess: (fallbackResponse) => {
               healthStatus.value = {
-                basic_health: fallbackResponse.data,
+                basic_health: fallbackResponse,
                 detailed_available: false
               } as HealthStatus
             },

--- a/autobot-frontend/src/composables/llc/useCompanyTemplates.ts
+++ b/autobot-frontend/src/composables/llc/useCompanyTemplates.ts
@@ -15,7 +15,6 @@
 import { ref } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
-import type { AxiosError } from 'axios'
 
 const logger = createLogger('useCompanyTemplates')
 
@@ -88,7 +87,7 @@ export function useCompanyTemplates() {
       templates.value = response
       return response
     } catch (err) {
-      const msg = (err as AxiosError)?.message ?? String(err)
+      const msg = (err as Error)?.message ?? String(err)
       logger.error('Failed to list built-in templates', err)
       error.value = `Failed to load templates: ${msg}`
       throw err
@@ -106,7 +105,7 @@ export function useCompanyTemplates() {
       )
       return response
     } catch (err) {
-      const msg = (err as AxiosError)?.message ?? String(err)
+      const msg = (err as Error)?.message ?? String(err)
       logger.error(`Failed to get template ${templateKey}`, err)
       error.value = `Failed to load template: ${msg}`
       throw err
@@ -128,7 +127,7 @@ export function useCompanyTemplates() {
       )
       return response
     } catch (err) {
-      const msg = (err as AxiosError)?.message ?? String(err)
+      const msg = (err as Error)?.message ?? String(err)
       logger.error(`Failed to import template ${templateId}`, err)
       error.value = `Failed to import template: ${msg}`
       throw err

--- a/autobot-frontend/src/models/repositories/ChatRepository.ts
+++ b/autobot-frontend/src/models/repositories/ChatRepository.ts
@@ -1,12 +1,19 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
-import axios from 'axios'
-import type { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios'
 import { getBackendUrl, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import { readStoredAuthToken } from '@/utils/authToken'
+import type { ApiResponse } from '@/types/models'
 import type { ChatMessage } from '@/types/api'
+
+/**
+ * Minimal per-request config mirroring the subset of axios options this
+ * repository relied on (#12363 Phase 2 — axios retired for fetchWithAuth).
+ */
+interface RequestConfig {
+  params?: Record<string, string>
+  timeout?: number
+}
 
 // Create scoped logger for ChatRepository
 const logger = createLogger('ChatRepository')
@@ -139,51 +146,12 @@ interface BackendMessageEntry {
  * Handles communication with backend chat endpoints
  */
 export class ChatRepository {
-  private axios: AxiosInstance
   private baseURL: string
+  /** Request timeout for chat operations (ms). */
+  private static readonly REQUEST_TIMEOUT_MS = 60000
 
   constructor(baseURL?: string) {
     this.baseURL = baseURL || import.meta.env.VITE_API_URL || getBackendUrl()
-    this.axios = axios.create({
-      baseURL: this.baseURL,
-      timeout: 60000, // 60 second timeout for chat operations
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    })
-
-    // Inject auth token on every request
-    this.axios.interceptors.request.use(config => {
-      const token = this._getAuthToken()
-      if (token) {
-        config.headers['Authorization'] = `Bearer ${token}`
-      }
-      return config
-    })
-
-    // Add response interceptor — redirect to login on 401 (#967)
-    this.axios.interceptors.response.use(
-      response => response,
-      error => {
-        logger.error('Request failed:', error)
-        if (
-          error?.response?.status === 401 &&
-          typeof window !== 'undefined' &&
-          !window.location.pathname.includes('/login')
-        ) {
-          logger.warn('401 Unauthorized — clearing auth and redirecting to login')
-          localStorage.removeItem('autobot_auth')
-          localStorage.removeItem('autobot_user')
-          const redirect = encodeURIComponent(window.location.pathname)
-          window.location.href = `/login?redirect=${redirect}`
-        }
-        return Promise.reject(error)
-      }
-    )
-  }
-
-  private _getAuthToken(): string | null {
-    return readStoredAuthToken()
   }
 
   /**
@@ -273,21 +241,24 @@ export class ChatRepository {
     onChunk?: (chunk: ChatStreamResponse) => void
   ): Promise<void> {
     try {
-      const response = await this.axios.post(
-        `${getApiBase()}/chat`,
+      const response = await fetchWithAuth(
+        `${this.baseURL}${getApiBase()}/chat`,
         {
-          message,
-          chat_id: chatId,
-          stream: true
-        },
-        {
-          responseType: 'stream',
-          adapter: 'fetch' // Use fetch adapter for streaming
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message, chat_id: chatId, stream: true }),
         }
       )
 
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      }
+      if (!response.body) {
+        throw new Error('Streaming response has no readable body')
+      }
+
       // Handle streaming response
-      const reader = response.data.getReader()
+      const reader = response.body.getReader()
       const decoder = new TextDecoder()
 
       while (true) {
@@ -330,12 +301,15 @@ export class ChatRepository {
       // local UUID-A but backend creates UUID-B, and any subsequent
       // /api/chats/{id}/message calls land in different sessions — that's the
       // root of #6745 "answer arrived in different session".
-      const response = await this.post(`${getApiBase()}/chat/sessions`, {
-        id,
-        title: title || 'New Chat',
-        metadata: metadata || {}
-      })
-      return response.data?.data || response.data
+      const response = await this.post<{ data?: ChatSession } & Record<string, unknown>>(
+        `${getApiBase()}/chat/sessions`,
+        {
+          id,
+          title: title || 'New Chat',
+          metadata: metadata || {}
+        }
+      )
+      return (response.data?.data || response.data) as ChatSession
     } catch (error: unknown) {
       logger.error('Failed to create new chat:', error)
       throw error
@@ -350,11 +324,18 @@ export class ChatRepository {
   // Get list of all chat sessions (for compatibility with controller)
   async getChatList(): Promise<ChatSession[]> {
     try {
-      const response = await this.get(`${getApiBase()}/chat/sessions`)
-      // Fix: axios wraps response in .data, and API response has { data: { sessions: [...] } }
+      const response = await this.get<{
+        sessions?: BackendSessionEntry[]
+        data?: { sessions?: BackendSessionEntry[] }
+      }>(`${getApiBase()}/chat/sessions`)
+      // API response may be { sessions: [...] } or { data: { sessions: [...] } }
       const sessions = response.data?.data?.sessions || response.data?.sessions || []
 
-      // Transform backend session format to frontend store format
+      // Transform backend session format to frontend store format.
+      // NOTE: the mapped objects use the store's camelCase/Date shape
+      // (createdAt/updatedAt/isActive) rather than the declared `ChatSession`
+      // wire type — a pre-existing discrepancy that was masked while axios typed
+      // `.data` as `any` (#12363 Phase 2). Runtime shape is unchanged.
       return sessions.map((session: BackendSessionEntry) => ({
         id: session.id || session.chatId,
         title: session.title || session.name || `Chat ${session.id?.slice(0, 8)}`,
@@ -362,7 +343,7 @@ export class ChatRepository {
         createdAt: new Date(session.createdAt || session.createdTime || Date.now()),
         updatedAt: new Date(session.updatedAt || session.lastModified || Date.now()),
         isActive: false // Will be set by store when session is selected
-      }))
+      })) as unknown as ChatSession[]
     } catch (error: unknown) {
       logger.error('Failed to get chat list:', error)
       return [] // Return empty array on error to prevent app crash
@@ -372,7 +353,7 @@ export class ChatRepository {
   // Get single session by ID
   async getSession(sessionId: string): Promise<ChatSession> {
     try {
-      const response = await this.get(`${getApiBase()}/chat/sessions/${sessionId}`)
+      const response = await this.get<ChatSession>(`${getApiBase()}/chat/sessions/${sessionId}`)
       return response.data
     } catch (error: unknown) {
       logger.error('Failed to get session:', error)
@@ -384,7 +365,10 @@ export class ChatRepository {
   async getChatMessages(sessionId: string): Promise<ChatMessage[]> {
     try {
       logger.debug(`Fetching messages for session: ${sessionId}`)
-      const response = await this.get(`${getApiBase()}/chat/sessions/${sessionId}`)
+      const response = await this.get<{
+        messages?: BackendMessageEntry[]
+        data?: { messages?: BackendMessageEntry[] }
+      }>(`${getApiBase()}/chat/sessions/${sessionId}`)
       const data = response.data
       logger.debug(`Raw API response:`, JSON.stringify(data).substring(0, 200))
 
@@ -481,7 +465,7 @@ export class ChatRepository {
     chatId: string,
     fileAction?: 'delete' | 'transfer_kb' | 'transfer_shared',
     fileOptions?: Record<string, unknown>
-  ): Promise<AxiosResponse> {
+  ): Promise<unknown> {
     try {
       const params: Record<string, string> = {}
 
@@ -503,7 +487,7 @@ export class ChatRepository {
 
   // Reset chat (clear current session)
   // Issue #552: Fixed path - backend uses /api/chat/reset
-  async resetChat(): Promise<AxiosResponse> {
+  async resetChat(): Promise<unknown> {
     try {
       const response = await this.post(`${getApiBase()}/chat/reset`)
       return response.data || response
@@ -517,15 +501,15 @@ export class ChatRepository {
   // Issue #552: Fixed path - backend uses /api/chat/sessions
   async getChatHistory(): Promise<{ messages: ChatMessage[] }> {
     try {
-      const response = await this.get(`${getApiBase()}/chat/sessions`)
-      return response.data || response
+      const response = await this.get<{ messages: ChatMessage[] }>(`${getApiBase()}/chat/sessions`)
+      return (response.data || response) as { messages: ChatMessage[] }
     } catch (error: unknown) {
       logger.warn('Failed to get chat history (legacy):', error)
       return { messages: [] }
     }
   }
 
-  async saveChatMessages(params: { chatId: string; messages: ChatMessage[]; name?: string }): Promise<AxiosResponse> {
+  async saveChatMessages(params: { chatId: string; messages: ChatMessage[]; name?: string }): Promise<unknown> {
     try {
       // CRITICAL FIX Issue #259: Wrap messages in 'data' object to match backend expectation
       // Backend expects: { data: { messages: [...], name: "..." } }
@@ -553,8 +537,8 @@ export class ChatRepository {
   async getSessionFacts(sessionId: string): Promise<SessionFactsResponse> {
     try {
       // Issue #552: Fixed path - backend uses /api/chat-knowledge/chat/sessions/*
-      const response = await this.get(`${getApiBase()}/chat-knowledge/chat/sessions/${sessionId}/facts`)
-      return response.data || response
+      const response = await this.get<SessionFactsResponse>(`${getApiBase()}/chat-knowledge/chat/sessions/${sessionId}/facts`)
+      return (response.data || response) as SessionFactsResponse
     } catch (error: unknown) {
       logger.error('Failed to get session facts:', error)
       throw error
@@ -572,32 +556,118 @@ export class ChatRepository {
   ): Promise<PreserveFactsResponse> {
     try {
       // Issue #552: Fixed path - backend uses /api/chat-knowledge/chat/sessions/*
-      const response = await this.post(`${getApiBase()}/chat-knowledge/chat/sessions/${sessionId}/facts/preserve`, {
+      const response = await this.post<PreserveFactsResponse>(`${getApiBase()}/chat-knowledge/chat/sessions/${sessionId}/facts/preserve`, {
         fact_ids: factIds,
         preserve
       })
-      return response.data || response
+      return (response.data || response) as PreserveFactsResponse
     } catch (error: unknown) {
       logger.error('Failed to preserve session facts:', error)
       throw error
     }
   }
 
-  // Helper methods for axios operations
-  private async get(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-    return this.axios.get(url, config)
+  // ==========================================================================
+  // Request layer (#12363 Phase 2) — fetch-based, replaces the former axios
+  // instance. Returns an ApiResponse<T> envelope (preserving the prior
+  // `.data` access pattern) and keeps the previous behaviour: Bearer-token
+  // injection (via fetchWithAuth), 60s timeout, throw-on-non-2xx, and
+  // 401 -> clear-auth + redirect-to-login (#967).
+  // ==========================================================================
+
+  private async _request<T = unknown>(
+    method: string,
+    url: string,
+    data?: unknown,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<T>> {
+    let fullUrl = `${this.baseURL}${url}`
+    if (config?.params) {
+      const query = new URLSearchParams(config.params).toString()
+      if (query) fullUrl += `?${query}`
+    }
+
+    const controller = new AbortController()
+    const timeoutMs = config?.timeout ?? ChatRepository.REQUEST_TIMEOUT_MS
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+    try {
+      const init: RequestInit = {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        signal: controller.signal,
+      }
+      if (data !== undefined) {
+        init.body = JSON.stringify(data)
+      }
+
+      const response = await fetchWithAuth(fullUrl, init)
+      clearTimeout(timeoutId)
+
+      if (!response.ok) {
+        let errorBody: unknown
+        try {
+          errorBody = await response.json()
+        } catch {
+          errorBody = await response.text().catch(() => undefined)
+        }
+        const error = new Error(
+          `HTTP ${response.status}: ${response.statusText}`,
+        ) as Error & { response?: { status: number; data: unknown } }
+        error.response = { status: response.status, data: errorBody }
+        throw error
+      }
+
+      const contentType = response.headers.get('content-type') || ''
+      const body: unknown = contentType.includes('application/json')
+        ? await response.json()
+        : await response.text()
+
+      return {
+        data: body as T,
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      }
+    } catch (error: unknown) {
+      clearTimeout(timeoutId)
+      logger.error('Request failed:', error)
+      this._redirectOnUnauthorized(error)
+      throw error
+    }
   }
 
-  private async post(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-    return this.axios.post(url, data, config)
+  /** Clear stored auth and redirect to login on a 401, mirroring the old interceptor (#967). */
+  private _redirectOnUnauthorized(error: unknown): void {
+    const status = (error as { response?: { status?: number } })?.response?.status
+    if (
+      status === 401 &&
+      typeof window !== 'undefined' &&
+      !window.location.pathname.includes('/login')
+    ) {
+      logger.warn('401 Unauthorized — clearing auth and redirecting to login')
+      localStorage.removeItem('autobot_auth')
+      localStorage.removeItem('autobot_user')
+      const redirect = encodeURIComponent(window.location.pathname)
+      window.location.href = `/login?redirect=${redirect}`
+    }
   }
 
-  private async delete(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-    return this.axios.delete(url, config)
+  private get<T = unknown>(url: string, config?: RequestConfig): Promise<ApiResponse<T>> {
+    return this._request<T>('GET', url, undefined, config)
   }
 
-  private async put(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse> {
-    return this.axios.put(url, data, config)
+  private post<T = unknown>(url: string, data?: unknown, config?: RequestConfig): Promise<ApiResponse<T>> {
+    return this._request<T>('POST', url, data, config)
+  }
+
+  private delete<T = unknown>(url: string, config?: RequestConfig): Promise<ApiResponse<T>> {
+    return this._request<T>('DELETE', url, undefined, config)
+  }
+
+  private put<T = unknown>(url: string, data?: unknown, config?: RequestConfig): Promise<ApiResponse<T>> {
+    return this._request<T>('PUT', url, data, config)
   }
 }
 


### PR DESCRIPTION
## Thinking Path
#12363 Phase 1 (merged) routed every HTTP client onto the canonical `autobot-frontend/src/utils/ApiClient.ts`. Phase 2 retires raw `fetch`/`axios`. This is the **first** Phase-2 batch and deliberately scopes to the small, cohesive **axios importer** set only — the ~19 raw-`fetch` files are left for later batches. Each call site was migrated preserving *exact* behaviour: axios auto-JSON-parses and throws on non-2xx, so response consumption and error shapes seen by callers are unchanged.

Grep confirmed the true axios importer set (4 source + 1 test); the other files that mention "axios" only do so in comments.

## What Changed

**`composables/llc/useCompanyTemplates.ts`** — Already on the canonical client via `useApiClient()`; only imported `AxiosError` as a type for `(err as AxiosError)?.message`. The canonical client throws standard `Error`, so the type-only import was dropped and the three casts became `(err as Error)`. No runtime change.

**`models/repositories/ChatRepository.ts`** — Replaced the bespoke `axios.create()` instance (request/response interceptors, 60s timeout, 401 redirect) with a self-contained `fetchWithAuth`-based request layer (`_request<T>` + thin `get/post/delete/put` helpers) returning the canonical `ApiResponse<T>` envelope, so **all public methods keep their existing `.data` access unchanged**. Behaviour preserved 1:1:
- Bearer-token injection (via `fetchWithAuth`, same token source as before).
- 60s timeout (now a named `REQUEST_TIMEOUT_MS` constant) via `AbortController`.
- `config.params` serialized to a query string (used by `deleteChat`).
- Throw-on-non-2xx with `error.response.status` populated, mirroring axios.
- 401 → clear `autobot_auth`/`autobot_user` + redirect to `/login` (old interceptor, #967).
- `sendStreamingMessage` moved off the axios `fetch` adapter to `fetchWithAuth` + `response.body.getReader()` (one-shot stream; no retry/401-redirect, per Phase-2 guidance).
- Surfaced a **pre-existing** discrepancy: `getChatList()` maps to the store's camelCase/`Date` shape (`createdAt`/`updatedAt`/`isActive`), which never matched the declared `ChatSession` wire type — masked while axios typed `.data` as `any`. Documented with a localized `as unknown as ChatSession[]` assertion; runtime shape unchanged.

**`components/settings/SettingsPanel.vue`** — 14 `axios.get/post/put` calls → canonical `apiClient` typed methods. `onSuccess` handlers updated from `response.data` → `response` (canonical methods return parsed JSON directly). GETs pass `{ maxRetries: 1, suppressErrorLog: true }` (module-level `GET_OPTS`) so the pre-migration **single-attempt, single-log** behaviour is preserved — `useAsyncHandler` still reports failures per its `logErrors` flag, and the snappy offline detection is retained (no retry/backoff). The availability probe keeps its `timeout: 3000`.

**`components/__tests__/SettingsPanel.test.ts`** — Mock swapped from `axios` to `@/utils/ApiClient`; mocked resolutions return parsed JSON directly (no `.data` envelope); assertions updated to `apiClient.get` and to account for the options argument. (`ChatInterface.test.ts` only needed a stale-comment fix; it fully mocks `ChatRepository`.)

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → **exit 0** (clean).
- `vitest run SettingsPanel.test.ts ChatInterface.test.ts` → **45 passed**.
- `vitest run ChatController.test.ts ChatController.dedup.test.ts` → **16 passed** (exercise ChatRepository contracts).
- `eslint` on all 4 changed source/test files → **exit 0**, no new warnings (no `any` introduced).
- `grep "from 'axios'"` across `autobot-frontend/src` → **no remaining axios importers**.
- node_modules for the gates was a temporary read-only symlink from the main tree, removed before commit.

## Model Used
claude-opus-4-8

## Follow-up
Remaining Phase-2 raw-`fetch` batches (tracked under #12363), grouped by area:

- **Monitoring / health composables:** `composables/useHealthProbeRegistry.ts`, `composables/useConnectionTester.ts`, `composables/useNetworkStatus.ts`, `composables/usePrometheusMetrics.ts`, `composables/useHostInventory.ts`, `composables/useTLSCredentials.ts`
- **Feature composables:** `composables/useThemeVariant.ts`, `composables/useThinkingMode.ts`, `composables/useTimeout.ts`, `composables/transcriber/useAiAnalysis.ts`
- **Components:** `components/desktop/DesktopInterface.vue`, `components/vision/VideoProcessor.vue`
- **Services / infra (likely intentionally standalone — evaluate before migrating):** `services/GlobalWebSocketService.ts`, `services/LiveEventService.ts` (SSE/WS), `utils/RumAgent.ts` (telemetry), `config/ssot-config.ts` (bootstrap), `router/index.ts`, `embed/AutobotWidget.ts` (standalone widget), `workers/thumbnailWorker.ts` (worker context)
- Separately, ~30 files already use the `fetchWithAuth` bridge and are candidates to move onto typed `apiClient` methods in a later pass.

Refs #12363
Closes #12602