### PR TITLE
refactor(frontend): migrate feature composables off raw fetch onto ApiClient (#12363 Phase 2 batch 2)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useThinkingMode.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useThinkingMode.test.ts
@@ -1,0 +1,119 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useThinkingMode.test.ts — server/localStorage persistence of the extended
+ * thinking toggle + budget (GH#8993). Verifies the composable routes its
+ * backend reads/writes through the `fetchWithAuth` bridge (#12363 Phase 2) so
+ * the JWT is attached, while keeping the graceful single-shot fallback to
+ * localStorage on failure.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
+import { nextTick } from 'vue'
+
+const fetchWithAuthMock = vi.fn()
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}))
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+}))
+
+let useThinkingMode: typeof import('../useThinkingMode')['useThinkingMode']
+
+beforeEach(async () => {
+  localStorage.clear()
+  fetchWithAuthMock.mockReset()
+  vi.resetModules()
+  ;({ useThinkingMode } = await import('../useThinkingMode'))
+})
+
+function okJson(body: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(body) } as unknown as Response
+}
+
+describe('useThinkingMode — server load via fetchWithAuth', () => {
+  it('loads server preferences through the auth bridge with credentials', async () => {
+    fetchWithAuthMock.mockResolvedValue(okJson({ enabled: true, budget_tokens: 32000 }))
+
+    const { enabled, budgetTokens, load } = useThinkingMode(() => 'sess-1')
+    await load()
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/api/sessions/sess-1/thinking-preferences',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+    expect(enabled.value).toBe(true)
+    expect(budgetTokens.value).toBe(32000)
+  })
+
+  it('unwraps a { data: prefs } envelope', async () => {
+    fetchWithAuthMock.mockResolvedValue(okJson({ data: { enabled: true, budget_tokens: 5000 } }))
+
+    const { budgetTokens, load } = useThinkingMode(() => 'sess-2')
+    await load()
+
+    expect(budgetTokens.value).toBe(5000)
+  })
+
+  it('falls back to localStorage when the server responds not-ok', async () => {
+    fetchWithAuthMock.mockResolvedValue({ ok: false } as unknown as Response)
+    localStorage.setItem(
+      'autobot_thinking_preferences',
+      JSON.stringify({ enabled: true, budget_tokens: 10000 }),
+    )
+
+    const { enabled, load } = useThinkingMode(() => 'sess-3')
+    await load()
+
+    expect(enabled.value).toBe(true)
+  })
+
+  it('does not hit the server when no session id is present', async () => {
+    const { load } = useThinkingMode(() => null)
+    await load()
+    expect(fetchWithAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('clamps an unknown budget from the server to the default', async () => {
+    fetchWithAuthMock.mockResolvedValue(okJson({ enabled: false, budget_tokens: 999 }))
+
+    const { budgetTokens, load } = useThinkingMode(() => 'sess-4')
+    await load()
+
+    expect(budgetTokens.value).toBe(10000)
+  })
+})
+
+describe('useThinkingMode — persist via fetchWithAuth', () => {
+  it('PUTs updated preferences through the auth bridge on change', async () => {
+    fetchWithAuthMock.mockResolvedValue({ ok: true } as unknown as Response)
+
+    const { setBudget } = useThinkingMode(() => 'sess-9')
+    setBudget(32000)
+    await nextTick()
+    // flush:'post' watcher runs after the DOM tick; allow the microtask queue.
+    await Promise.resolve()
+
+    const putCall = (fetchWithAuthMock as Mock).mock.calls.find(
+      ([, opts]) => (opts as RequestInit | undefined)?.method === 'PUT',
+    )
+    expect(putCall).toBeTruthy()
+    expect(putCall?.[0]).toBe('/api/sessions/sess-9/thinking-preferences')
+    expect((putCall?.[1] as RequestInit).credentials).toBe('include')
+    expect(JSON.parse((putCall?.[1] as RequestInit).body as string)).toEqual({
+      enabled: false,
+      budget_tokens: 32000,
+    })
+    // Also mirrored to localStorage.
+    expect(localStorage.getItem('autobot_thinking_preferences')).toContain('32000')
+  })
+
+  it('swallows a persist failure without throwing', async () => {
+    fetchWithAuthMock.mockRejectedValue(new Error('network down'))
+
+    const { toggle } = useThinkingMode(() => 'sess-10')
+    expect(() => toggle()).not.toThrow()
+    await nextTick()
+    await Promise.resolve()
+  })
+})

--- a/autobot-frontend/src/composables/transcriber/__tests__/useAiAnalysis.test.ts
+++ b/autobot-frontend/src/composables/transcriber/__tests__/useAiAnalysis.test.ts
@@ -1,0 +1,107 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useAiAnalysis.test.ts — transcriber AI-analysis SSE streaming.
+ *
+ * The composable streams an SSE response and accumulates `content`. It must
+ * issue the request through the `fetchWithAuth` bridge (#12363 Phase 2) so the
+ * JWT is attached, while keeping the raw `Response.body` reader available for
+ * incremental parsing (no retrying/JSON-parsing convenience method).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const fetchWithAuthMock = vi.fn()
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}))
+vi.mock('@/config/ssot-config', () => ({
+  getBackendUrl: () => '',
+}))
+
+let useAiAnalysis: typeof import('../useAiAnalysis')['useAiAnalysis']
+
+/** Build a Response-like object whose body streams the given SSE chunks. */
+function sseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  let i = 0
+  return {
+    body: {
+      getReader() {
+        return {
+          read() {
+            if (i < chunks.length) {
+              return Promise.resolve({ done: false, value: encoder.encode(chunks[i++]) })
+            }
+            return Promise.resolve({ done: true, value: undefined })
+          },
+        }
+      },
+    },
+  } as unknown as Response
+}
+
+beforeEach(async () => {
+  fetchWithAuthMock.mockReset()
+  vi.resetModules()
+  ;({ useAiAnalysis } = await import('../useAiAnalysis'))
+})
+
+describe('useAiAnalysis', () => {
+  it('streams SSE content through the auth bridge and accumulates it', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      sseResponse([
+        'data: {"content":"Hello "}\n',
+        'data: {"content":"world"}\n',
+        'data: [DONE]\n',
+      ]),
+    )
+
+    const { ask, content, streaming, activeAction } = useAiAnalysis(42)
+    await ask({ action: 'summarize' })
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/api/transcriber/recordings/42/ai/ask',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    const opts = fetchWithAuthMock.mock.calls[0][1] as RequestInit
+    expect(JSON.parse(opts.body as string)).toEqual({ action: 'summarize', custom_question: null })
+    expect(content.value).toBe('Hello world')
+    expect(streaming.value).toBe(false)
+    expect(activeAction.value).toBe('summarize')
+  })
+
+  it('passes the custom question only for the custom action', async () => {
+    fetchWithAuthMock.mockResolvedValue(sseResponse(['data: [DONE]\n']))
+
+    const { ask } = useAiAnalysis(7)
+    await ask({ action: 'custom', customQuestion: 'What happened?' })
+
+    const opts = fetchWithAuthMock.mock.calls[0][1] as RequestInit
+    expect(JSON.parse(opts.body as string)).toEqual({
+      action: 'custom',
+      custom_question: 'What happened?',
+    })
+  })
+
+  it('surfaces an SSE error frame into content', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      sseResponse(['data: {"error":"boom"}\n']),
+    )
+
+    const { ask, content, streaming } = useAiAnalysis(1)
+    await ask({ action: 'key_facts' })
+
+    expect(content.value).toBe('Error: boom')
+    expect(streaming.value).toBe(false)
+  })
+
+  it('reports a friendly message when the fetch rejects', async () => {
+    fetchWithAuthMock.mockRejectedValue(new Error('network down'))
+
+    const { ask, content, streaming } = useAiAnalysis(1)
+    await ask({ action: 'protocol' })
+
+    expect(content.value).toBe('Analysis failed. Please try again.')
+    expect(streaming.value).toBe(false)
+  })
+})

--- a/autobot-frontend/src/composables/transcriber/useAiAnalysis.ts
+++ b/autobot-frontend/src/composables/transcriber/useAiAnalysis.ts
@@ -4,6 +4,7 @@
 // Author: mrveiss
 import { ref, toValue, type MaybeRefOrGetter } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useAiAnalysis')
@@ -17,7 +18,12 @@ export interface AskOptions {
 
 /**
  * Composable for AI analysis SSE streaming
- * Handles fetch-based SSE stream parsing for transcriber AI analysis
+ * Handles fetch-based SSE stream parsing for transcriber AI analysis.
+ *
+ * Uses the `fetchWithAuth` bridge (not the retrying `apiClient.get`/`.post`
+ * convenience methods) so the JWT is attached consistently while the raw
+ * `Response.body` reader stays available for incremental SSE parsing and the
+ * long-lived stream is not aborted by a request timeout.
  */
 export function useAiAnalysis(recordingId: MaybeRefOrGetter<number>) {
   const streaming = ref(false)
@@ -33,7 +39,7 @@ export function useAiAnalysis(recordingId: MaybeRefOrGetter<number>) {
     const url = `${getBackendUrl()}/api/transcriber/recordings/${toValue(recordingId)}/ai/ask`
 
     try {
-      const resp = await fetch(url, {
+      const resp = await fetchWithAuth(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/autobot-frontend/src/composables/useThemeVariant.ts
+++ b/autobot-frontend/src/composables/useThemeVariant.ts
@@ -22,6 +22,7 @@
 
 import { ref, readonly, computed, watch, onMounted, getCurrentInstance } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { fetchInstalledThemes, type InstalledTheme } from './useThemeRegistry'
 
@@ -82,12 +83,14 @@ function isBuiltin(variant: ThemeVariant): boolean {
  *
  * CSP-safe: the CSS text is fetched same-credentials from the backend and
  * adopted via `document.adoptedStyleSheets` — never injected as an inline
- * `<style>` or a cross-origin `<link>`. `apiClient.get` always parses JSON, so
- * a raw `fetch` is used here to retrieve the CSS as text.
+ * `<style>` or a cross-origin `<link>`. Uses the `fetchWithAuth` bridge so the
+ * JWT is attached consistently with `ApiClient`; the response is read as text
+ * (the convenience `apiClient.get` always parses JSON) while keeping the
+ * cookie credentials the endpoint may also rely on.
  */
 async function ensureThemeStylesheet(id: string): Promise<void> {
   if (adopted.has(id)) return
-  const response = await fetch(`${getBackendUrl()}/api/themes/${id}/theme.css`, {
+  const response = await fetchWithAuth(`${getBackendUrl()}/api/themes/${id}/theme.css`, {
     credentials: 'include',
   })
   if (!response.ok) {

--- a/autobot-frontend/src/composables/useThinkingMode.ts
+++ b/autobot-frontend/src/composables/useThinkingMode.ts
@@ -4,6 +4,7 @@
 // Persists to server API when available; falls back to localStorage.
 import { ref, watch } from 'vue'
 import { getApiBase } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useThinkingMode')
@@ -43,7 +44,7 @@ function writeLocalPrefs(prefs: ThinkingPreferences): void {
 
 async function fetchServerPrefs(sessionId: string): Promise<ThinkingPreferences | null> {
   try {
-    const res = await fetch(`${getApiBase()}/sessions/${sessionId}/thinking-preferences`, {
+    const res = await fetchWithAuth(`${getApiBase()}/sessions/${sessionId}/thinking-preferences`, {
       credentials: 'include',
     })
     if (!res.ok) return null
@@ -56,7 +57,7 @@ async function fetchServerPrefs(sessionId: string): Promise<ThinkingPreferences 
 
 async function putServerPrefs(sessionId: string, prefs: ThinkingPreferences): Promise<void> {
   try {
-    await fetch(`${getApiBase()}/sessions/${sessionId}/thinking-preferences`, {
+    await fetchWithAuth(`${getApiBase()}/sessions/${sessionId}/thinking-preferences`, {
       method: 'PUT',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Thinking Path

#12363 Phase 2 retires raw `fetch(` backend calls in favour of the canonical `ApiClient` / `fetchWithAuth` bridge. This batch targets the **feature composables** subset — a clean, plain-HTTP / SSE, non-WebSocket group. Each site was graded against the client's convenience methods: theme CSS is read as **text** (not JSON), thinking-prefs need exact single-shot + graceful-null / fire-and-forget semantics, and the AI-analysis stream needs the raw `Response.body` reader without a request-timeout abort. None fit the retrying JSON `.get()/.post()`, so all three route through the endorsed one-shot `fetchWithAuth` bridge — which adds consistent JWT injection while preserving the existing base-URL builders, `credentials: 'include'`, status handling and response parsing.

## What Changed

- **`composables/useThemeVariant.ts`** — `ensureThemeStylesheet` now fetches installed-theme CSS via `fetchWithAuth` (keeps `credentials: 'include'`, reads `.text()`, same `!response.ok` throw, same `getBackendUrl()` URL). Adds Bearer injection; doc comment updated.
- **`composables/useThinkingMode.ts`** — `fetchServerPrefs` (GET) and `putServerPrefs` (PUT) now use `fetchWithAuth`. Preserves the single-request read, graceful `null` on `!ok`, the `{ data }` envelope unwrap, fire-and-forget PUT with warn-on-catch, and `credentials: 'include'`.
- **`composables/transcriber/useAiAnalysis.ts`** — SSE `ask()` POST now uses `fetchWithAuth`; the raw `Response.body` reader and incremental SSE parsing are unchanged, and no request timeout is introduced (matches prior behaviour).
- **`composables/useTimeout.ts`** — **skipped**: its only `fetch(` is inside a JSDoc `@example` (a pure timer utility, no backend call).
- **Tests** — added `useThinkingMode.test.ts` (7 cases) and `transcriber/useAiAnalysis.test.ts` (4 cases) covering bridge routing, credentials, envelope unwrap, localStorage fallback, budget clamping, SSE accumulation, error frames and rejection handling. Existing `useThemeVariant`/`useThemeVariantRuntime` tests still pass unchanged (they assert native `fetch` is invoked with `credentials: 'include'`, which the bridge preserves).

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (clean).
- `vitest run` on the four touched-composable test files → **23 passed** (11 new + 12 existing).
- grep confirms no remaining raw backend `fetch(` in the three migrated files (only the `useTimeout.ts` JSDoc example remains, by design).
- Temporary read-only `node_modules` symlink used for tooling, then removed (no manual installs).

## Model Used

claude-opus-4-8

## Follow-up

Remaining raw-fetch groups for later #12363 Phase 2 batches:
- **monitoring/health composables** — plain-HTTP, migratable.
- **components** `DesktopInterface` / `VideoProcessor` — review for streaming/media specifics before migrating.
- **infra set** `GlobalWebSocketService`, `LiveEventService`, `RumAgent`, `ssot-config`, `router`:
  - `GlobalWebSocketService` / `LiveEventService` — **do NOT migrate** (WebSocket / EventSource, out of raw-`fetch` HTTP scope).
  - `ssot-config` — **do NOT migrate** (it is the base-URL SSoT the client itself depends on; routing it through the client would be circular).
  - `RumAgent` / `router` — evaluate individually (telemetry beacon / navigation guards may have their own constraints).

Refs #12363
Closes #12605