### PR TITLE
refactor(slm-frontend): migrate LLM/Personality/Settings domain onto slmApiClient (#12420 Phase 2 batch 3)

### DIFF
--- a/autobot-slm-frontend/src/composables/useLlmConfigApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useLlmConfigApi.test.ts
@@ -1,0 +1,85 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 3) — proves the LLM-config composable is migrated onto
+ * the canonical `slmApiClient`: every method routes through the shared client
+ * with endpoints relative to the SLM API base (base URL + bearer token injected
+ * by the client) and returns the parsed JSON body directly (no axios `.data`).
+ * These are non-auth endpoints, so 401 session handling is the client's
+ * centralised concern — the composable no longer owns an axios interceptor.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPut = vi.fn()
+const mockPost = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+import { useLlmConfigApi } from './useLlmConfigApi'
+
+describe('useLlmConfigApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPut.mockReset()
+    mockPost.mockReset()
+  })
+
+  it('getConfig GETs /settings/admin/llm and returns the parsed body directly', async () => {
+    const body = { config: { active_provider: 'ollama' }, message: 'ok' }
+    mockGet.mockResolvedValue(body)
+
+    const result = await useLlmConfigApi().getConfig()
+
+    expect(mockGet).toHaveBeenCalledWith('/settings/admin/llm')
+    expect(result).toEqual(body)
+  })
+
+  it('saveConfig PUTs the config to /settings/admin/llm', async () => {
+    const config = { active_provider: 'ollama', providers: [] }
+    mockPut.mockResolvedValue({ config, message: 'saved' })
+
+    await useLlmConfigApi().saveConfig(config as never)
+
+    expect(mockPut).toHaveBeenCalledWith('/settings/admin/llm', config)
+  })
+
+  it('testConnection POSTs the request to /settings/admin/llm/test', async () => {
+    const request = { provider: 'openai', api_key: 'k' }
+    mockPost.mockResolvedValue({ success: true })
+
+    await useLlmConfigApi().testConnection(request)
+
+    expect(mockPost).toHaveBeenCalledWith('/settings/admin/llm/test', request)
+  })
+
+  it('applyToFleet POSTs node_ids to /settings/admin/llm/apply', async () => {
+    mockPost.mockResolvedValue({ success: true, node_count: 2 })
+
+    await useLlmConfigApi().applyToFleet(['a', 'b'])
+
+    expect(mockPost).toHaveBeenCalledWith('/settings/admin/llm/apply', {
+      node_ids: ['a', 'b'],
+    })
+  })
+
+  it('applyToFleet sends node_ids: null when no nodes are provided', async () => {
+    mockPost.mockResolvedValue({ success: true, node_count: 0 })
+
+    await useLlmConfigApi().applyToFleet()
+
+    expect(mockPost).toHaveBeenCalledWith('/settings/admin/llm/apply', {
+      node_ids: null,
+    })
+  })
+})

--- a/autobot-slm-frontend/src/composables/useLlmConfigApi.ts
+++ b/autobot-slm-frontend/src/composables/useLlmConfigApi.ts
@@ -8,13 +8,17 @@
  *
  * Provides REST API integration for LLM provider configuration
  * management via the SLM backend. Admin-only.
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()`, injects the SLM bearer token
+ * (same `slm_access_token` storage the auth store reads), and centrally handles
+ * 401 for these non-auth endpoints by clearing the session and redirecting to
+ * `/login` — matching the previous per-composable axios interceptor that called
+ * `authStore.logout()`. Call sites therefore pass endpoints relative to the API
+ * base and receive parsed JSON directly (no axios `.data`).
  */
 
-import axios, { type AxiosInstance } from 'axios'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
-
-const SLM_API_BASE = getSlmApiBase()
+import slmApiClient from '@/utils/ApiClient'
 
 export interface LLMProviderConfig {
   name: string
@@ -67,63 +71,24 @@ export interface LLMApplyResponse {
 }
 
 export function useLlmConfigApi() {
-  const authStore = useAuthStore()
-
-  const client: AxiosInstance = axios.create({
-    baseURL: SLM_API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-    timeout: 30000,
-  })
-
-  client.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
-        authStore.logout()
-      }
-      return Promise.reject(error)
-    }
-  )
-
   async function getConfig(): Promise<LLMConfigResponse> {
-    const response = await client.get<LLMConfigResponse>('/settings/admin/llm')
-    return response.data
+    return slmApiClient.get<LLMConfigResponse>('/settings/admin/llm')
   }
 
   async function saveConfig(config: LLMConfig): Promise<LLMConfigResponse> {
-    const response = await client.put<LLMConfigResponse>(
-      '/settings/admin/llm',
-      config
-    )
-    return response.data
+    return slmApiClient.put<LLMConfigResponse>('/settings/admin/llm', config)
   }
 
   async function testConnection(
     request: LLMTestRequest
   ): Promise<LLMTestResponse> {
-    const response = await client.post<LLMTestResponse>(
-      '/settings/admin/llm/test',
-      request
-    )
-    return response.data
+    return slmApiClient.post<LLMTestResponse>('/settings/admin/llm/test', request)
   }
 
-  async function applyToFleet(
-    nodeIds?: string[]
-  ): Promise<LLMApplyResponse> {
-    const response = await client.post<LLMApplyResponse>(
-      '/settings/admin/llm/apply',
-      { node_ids: nodeIds || null }
-    )
-    return response.data
+  async function applyToFleet(nodeIds?: string[]): Promise<LLMApplyResponse> {
+    return slmApiClient.post<LLMApplyResponse>('/settings/admin/llm/apply', {
+      node_ids: nodeIds || null,
+    })
   }
 
   return {

--- a/autobot-slm-frontend/src/composables/usePersonality.test.ts
+++ b/autobot-slm-frontend/src/composables/usePersonality.test.ts
@@ -1,0 +1,138 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 3) — proves the personality composable is migrated onto
+ * the canonical `slmApiClient`: every method routes through the shared client
+ * with endpoints relative to the SLM API base under the `/personality` prefix
+ * (base URL + SLM bearer token injected by the client) and works off parsed
+ * JSON directly (no axios `.data`). Also asserts the `error`/`loading`/null
+ * contract of the internal `_call` wrapper is preserved on failure.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+import { usePersonality } from './usePersonality'
+
+describe('usePersonality — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDelete.mockReset()
+  })
+
+  it('fetchProfiles GETs /personality/profiles + /personality/status', async () => {
+    mockGet.mockImplementation((endpoint: string) => {
+      if (endpoint === '/personality/profiles') {
+        return Promise.resolve([{ id: '1', name: 'P', is_system: false, active: true }])
+      }
+      return Promise.resolve({ enabled: false, active_id: '1' })
+    })
+
+    const p = usePersonality()
+    await p.fetchProfiles()
+
+    expect(mockGet).toHaveBeenCalledWith('/personality/profiles')
+    expect(mockGet).toHaveBeenCalledWith('/personality/status')
+    expect(p.profiles.value).toHaveLength(1)
+    expect(p.enabled.value).toBe(false)
+    expect(p.loading.value).toBe(false)
+  })
+
+  it('fetchProfile GETs /personality/profiles/:id and returns the parsed body', async () => {
+    mockGet.mockResolvedValue({ id: 'abc', name: 'X' })
+
+    const result = await usePersonality().fetchProfile('abc')
+
+    expect(mockGet).toHaveBeenCalledWith('/personality/profiles/abc')
+    expect(result).toEqual({ id: 'abc', name: 'X' })
+  })
+
+  it('createProfile POSTs /personality/profiles then refreshes the list', async () => {
+    mockPost.mockResolvedValue({ id: 'new', name: 'New' })
+    mockGet.mockImplementation((endpoint: string) =>
+      endpoint === '/personality/profiles'
+        ? Promise.resolve([])
+        : Promise.resolve({ enabled: true, active_id: null })
+    )
+
+    const result = await usePersonality().createProfile({ name: 'New' })
+
+    expect(mockPost).toHaveBeenCalledWith('/personality/profiles', { name: 'New' })
+    expect(result).toEqual({ id: 'new', name: 'New' })
+  })
+
+  it('updateProfile PUTs /personality/profiles/:id', async () => {
+    mockPut.mockResolvedValue({ id: 'abc', name: 'Renamed' })
+
+    await usePersonality().updateProfile('abc', { name: 'Renamed' })
+
+    expect(mockPut).toHaveBeenCalledWith('/personality/profiles/abc', { name: 'Renamed' })
+  })
+
+  it('deleteProfile DELETEs /personality/profiles/:id and prunes local state', async () => {
+    mockDelete.mockResolvedValue({})
+
+    const ok = await usePersonality().deleteProfile('abc')
+
+    expect(mockDelete).toHaveBeenCalledWith('/personality/profiles/abc')
+    expect(ok).toBe(true)
+  })
+
+  it('activateProfile POSTs /personality/profiles/:id/activate then fetches active', async () => {
+    mockPost.mockResolvedValue({})
+    mockGet.mockResolvedValue({ id: 'abc' })
+
+    const ok = await usePersonality().activateProfile('abc')
+
+    expect(mockPost).toHaveBeenCalledWith('/personality/profiles/abc/activate')
+    expect(mockGet).toHaveBeenCalledWith('/personality/active')
+    expect(ok).toBe(true)
+  })
+
+  it('resetProfile POSTs /personality/profiles/:id/reset', async () => {
+    mockPost.mockResolvedValue({ id: 'abc', name: 'Default' })
+
+    const result = await usePersonality().resetProfile('abc')
+
+    expect(mockPost).toHaveBeenCalledWith('/personality/profiles/abc/reset')
+    expect(result).toEqual({ id: 'abc', name: 'Default' })
+  })
+
+  it('toggleEnabled POSTs /personality/toggle with the flag', async () => {
+    mockPost.mockResolvedValue({})
+
+    const ok = await usePersonality().toggleEnabled(false)
+
+    expect(mockPost).toHaveBeenCalledWith('/personality/toggle', { enabled: false })
+    expect(ok).toBe(true)
+  })
+
+  it('surfaces errors via `error` and returns null (null-on-error contract)', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 500: boom'))
+
+    const p = usePersonality()
+    const result = await p.fetchProfile('abc')
+
+    expect(result).toBeNull()
+    expect(p.error.value).toBe('HTTP 500: boom')
+    expect(p.loading.value).toBe(false)
+  })
+})

--- a/autobot-slm-frontend/src/composables/usePersonality.ts
+++ b/autobot-slm-frontend/src/composables/usePersonality.ts
@@ -10,19 +10,26 @@
  * Provides reactive state for profile list, active profile, and enabled flag.
  *
  * Related Issue: #964 - Multi-profile personality system
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()` and injects the SLM bearer token
+ * (the `slm_access_token` the auth store reads), so endpoints are passed
+ * relative to the SLM API base under the `/personality` prefix and callers
+ * receive parsed JSON directly (no axios `.data`). Requests still route through
+ * the SLM backend proxy (issue #1145) which validates the SLM JWT and forwards
+ * to the main backend, so the SLM token is the correct credential.
  */
 
-import axios from 'axios'
 import { ref, computed } from 'vue'
-import { useAuthStore } from '@/stores/auth'
 import { createLogger } from '@/utils/debugUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
+import slmApiClient from '@/utils/ApiClient'
 
 const logger = createLogger('usePersonality')
 
 // Issue #1145: Route through SLM backend proxy (validates SLM JWT + forwards to main backend).
 // Using /autobot-api/personality caused JWT mismatch since SLM tokens are unknown to main backend.
-const API_BASE = `${getSlmApiBase()}/personality`
+// Endpoints below are relative to getSlmApiBase() (resolved by slmApiClient) under this prefix.
+const API_PREFIX = '/personality'
 
 export interface ProfileSummary {
   id: string
@@ -80,8 +87,6 @@ export const TONE_OPTIONS = [
 ] as const
 
 export function usePersonality() {
-  const authStore = useAuthStore()
-
   const profiles = ref<ProfileSummary[]>([])
   const activeProfile = ref<PersonalityProfile | null>(null)
   const enabled = ref(true)
@@ -90,26 +95,13 @@ export function usePersonality() {
 
   const activeId = computed(() => profiles.value.find((p) => p.active)?.id ?? null)
 
-  function _client() {
-    const token = authStore.token || localStorage.getItem('autobot_access_token')
-    return axios.create({
-      baseURL: API_BASE,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      timeout: 15000,
-    })
-  }
-
   async function _call<T>(fn: () => Promise<T>): Promise<T | null> {
     error.value = null
     loading.value = true
     try {
       return await fn()
     } catch (err: unknown) {
-      const msg = (err as { response?: { data?: { detail?: string } }; message?: string })
-        ?.response?.data?.detail ?? (err as { message?: string })?.message ?? 'Request failed'
+      const msg = (err as { message?: string })?.message ?? 'Request failed'
       error.value = msg
       logger.error('Personality API error:', msg)
       return null
@@ -121,10 +113,12 @@ export function usePersonality() {
   async function fetchProfiles(): Promise<void> {
     const result = await _call(async () => {
       const [summaries, status] = await Promise.all([
-        _client().get<ProfileSummary[]>('/profiles'),
-        _client().get<{ enabled: boolean; active_id: string | null }>('/status'),
+        slmApiClient.get<ProfileSummary[]>(`${API_PREFIX}/profiles`),
+        slmApiClient.get<{ enabled: boolean; active_id: string | null }>(
+          `${API_PREFIX}/status`
+        ),
       ])
-      return { summaries: summaries.data, status: status.data }
+      return { summaries, status }
     })
     if (result) {
       profiles.value = result.summaries
@@ -133,39 +127,46 @@ export function usePersonality() {
   }
 
   async function fetchProfile(id: string): Promise<PersonalityProfile | null> {
-    const result = await _call(() => _client().get<PersonalityProfile>(`/profiles/${id}`))
-    return result?.data ?? null
+    return _call(() =>
+      slmApiClient.get<PersonalityProfile>(`${API_PREFIX}/profiles/${id}`)
+    )
   }
 
   async function fetchActive(): Promise<void> {
     const result = await _call(() =>
-      _client().get<PersonalityProfile | null>('/active')
+      slmApiClient.get<PersonalityProfile | null>(`${API_PREFIX}/active`)
     )
-    activeProfile.value = result?.data ?? null
+    activeProfile.value = result ?? null
   }
 
   async function createProfile(data: ProfileCreate): Promise<PersonalityProfile | null> {
-    const result = await _call(() => _client().post<PersonalityProfile>('/profiles', data))
-    if (result?.data) {
+    const result = await _call(() =>
+      slmApiClient.post<PersonalityProfile>(`${API_PREFIX}/profiles`, data)
+    )
+    if (result) {
       await fetchProfiles()
-      return result.data
+      return result
     }
     return null
   }
 
   async function updateProfile(id: string, data: ProfileUpdate): Promise<PersonalityProfile | null> {
-    const result = await _call(() => _client().put<PersonalityProfile>(`/profiles/${id}`, data))
-    if (result?.data) {
+    const result = await _call(() =>
+      slmApiClient.put<PersonalityProfile>(`${API_PREFIX}/profiles/${id}`, data)
+    )
+    if (result) {
       if (activeProfile.value?.id === id) {
-        activeProfile.value = result.data
+        activeProfile.value = result
       }
-      return result.data
+      return result
     }
     return null
   }
 
   async function deleteProfile(id: string): Promise<boolean> {
-    const result = await _call(() => _client().delete(`/profiles/${id}`))
+    const result = await _call(() =>
+      slmApiClient.delete(`${API_PREFIX}/profiles/${id}`)
+    )
     if (result !== null) {
       profiles.value = profiles.value.filter((p) => p.id !== id)
       if (activeProfile.value?.id === id) {
@@ -177,7 +178,9 @@ export function usePersonality() {
   }
 
   async function activateProfile(id: string): Promise<boolean> {
-    const result = await _call(() => _client().post(`/profiles/${id}/activate`))
+    const result = await _call(() =>
+      slmApiClient.post(`${API_PREFIX}/profiles/${id}/activate`)
+    )
     if (result !== null) {
       profiles.value = profiles.value.map((p) => ({ ...p, active: p.id === id }))
       await fetchActive()
@@ -187,19 +190,21 @@ export function usePersonality() {
   }
 
   async function resetProfile(id: string): Promise<PersonalityProfile | null> {
-    const result = await _call(() => _client().post<PersonalityProfile>(`/profiles/${id}/reset`))
-    if (result?.data) {
+    const result = await _call(() =>
+      slmApiClient.post<PersonalityProfile>(`${API_PREFIX}/profiles/${id}/reset`)
+    )
+    if (result) {
       if (activeProfile.value?.id === id) {
-        activeProfile.value = result.data
+        activeProfile.value = result
       }
-      return result.data
+      return result
     }
     return null
   }
 
   async function toggleEnabled(value: boolean): Promise<boolean> {
     const result = await _call(() =>
-      _client().post('/toggle', { enabled: value })
+      slmApiClient.post(`${API_PREFIX}/toggle`, { enabled: value })
     )
     if (result !== null) {
       enabled.value = value

--- a/autobot-slm-frontend/src/views/settings/APISettings.vue
+++ b/autobot-slm-frontend/src/views/settings/APISettings.vue
@@ -12,6 +12,7 @@
 import { ref, computed } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import config, { getBackendUrl, getGrafanaUrl, getPrometheusUrl, getSlmApiBase } from '@/config/ssot-config'
+import slmApiClient from '@/utils/ApiClient'
 
 const authStore = useAuthStore()
 const testingConnection = ref(false)
@@ -31,9 +32,12 @@ async function testConnection(): Promise<void> {
 
   try {
     const startTime = Date.now()
-    const response = await fetch(`${getSlmApiBase()}/health`, {
-      headers: authStore.getAuthHeaders(),
-    })
+    // Migrated onto slmApiClient (#12420 Phase 2): rawRequest injects the SLM
+    // bearer token and resolves the base URL, while returning the raw Response
+    // so we can read response.ok/status exactly as before. Note: the WebSocket
+    // URL below is a display-only ws:// builder with no client surface — left
+    // untouched.
+    const response = await slmApiClient.rawRequest('/health', { method: 'GET' })
 
     const responseTime = Date.now() - startTime
 

--- a/autobot-slm-frontend/src/views/settings/admin/ConfigDefaultsSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/ConfigDefaultsSettings.vue
@@ -12,13 +12,11 @@
  */
 
 import { ref, computed, onMounted } from 'vue'
-import { useAuthStore } from '@/stores/auth'
+import slmApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { formatDateTime } from '@/composables/useTimezone'
-import { getSlmApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('ConfigDefaultsSettings')
-const authStore = useAuthStore()
 
 // Types
 interface ConfigEntry {
@@ -52,18 +50,20 @@ const filteredConfigs = computed(() => {
   return configs.value.filter(c => c.config_key.toLowerCase().includes(p))
 })
 
-// API helper
-async function apiFetch<T>(path: string, options?: RequestInit): Promise<T | null> {
+// API helper — migrated onto slmApiClient (#12420 Phase 2). The client resolves
+// the base URL via getSlmApiBase(), injects the SLM bearer token, and centrally
+// handles 401 for these non-auth endpoints (clear session + redirect to /login).
+// It returns parsed JSON directly and throws `Error('HTTP <status>: <detail>')`
+// on failure, so the null-on-error contract to callers is preserved.
+async function apiRequest<T>(
+  method: 'GET' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown
+): Promise<T | null> {
   try {
-    const response = await fetch(`${getSlmApiBase()}${path}`, {
-      ...options,
-      headers: { 'Content-Type': 'application/json', ...authStore.getAuthHeaders(), ...options?.headers },
-    })
-    if (!response.ok) {
-      const body = await response.json().catch(() => ({}))
-      throw new Error(body.detail || `HTTP ${response.status}`)
-    }
-    return await response.json()
+    if (method === 'GET') return await slmApiClient.get<T>(path)
+    if (method === 'PUT') return await slmApiClient.put<T>(path, body)
+    return await slmApiClient.delete<T>(path)
   } catch (err) {
     errorMessage.value = `Request failed: ${err instanceof Error ? err.message : 'Unknown error'}`
     logger.error('API error:', err)
@@ -75,7 +75,7 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T | nul
 async function fetchDefaults(): Promise<void> {
   isLoading.value = true
   errorMessage.value = null
-  const result = await apiFetch<{ configs: ConfigEntry[]; total: number }>('/config/defaults')
+  const result = await apiRequest<{ configs: ConfigEntry[]; total: number }>('GET', '/config/defaults')
   if (result) configs.value = result.configs
   isLoading.value = false
 }
@@ -101,9 +101,10 @@ async function saveConfig(): Promise<void> {
   const key = editingKey.value || newKey.value
   if (!key) { errorMessage.value = 'Key is required'; return }
 
-  const result = await apiFetch<ConfigEntry>(
+  const result = await apiRequest<ConfigEntry>(
+    'PUT',
     `/config/defaults/${encodeURIComponent(key)}`,
-    { method: 'PUT', body: JSON.stringify({ value: newValue.value, value_type: newValueType.value }) }
+    { value: newValue.value, value_type: newValueType.value }
   )
   if (result) {
     successMessage.value = `Config "${key}" saved`
@@ -115,9 +116,9 @@ async function saveConfig(): Promise<void> {
 
 async function deleteConfig(key: string): Promise<void> {
   if (!confirm(`Delete global config "${key}"?`)) return
-  const result = await apiFetch<{ message: string }>(
-    `/config/defaults/${encodeURIComponent(key)}`,
-    { method: 'DELETE' }
+  const result = await apiRequest<{ message: string }>(
+    'DELETE',
+    `/config/defaults/${encodeURIComponent(key)}`
   )
   if (result) {
     successMessage.value = result.message

--- a/autobot-slm-frontend/src/views/settings/admin/PersonalitySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/PersonalitySettings.vue
@@ -15,14 +15,13 @@
  */
 
 import { ref, reactive, onMounted, computed } from 'vue'
-import { useAuthStore } from '@/stores/auth'
+import slmApiClient from '@/utils/ApiClient'
 import {
   usePersonality,
   TONE_OPTIONS,
   type PersonalityProfile,
   type ProfileCreate,
 } from '@/composables/usePersonality'
-import { getSlmApiBase } from '@/config/ssot-config'
 
 const {
   profiles,
@@ -38,7 +37,6 @@ const {
   resetProfile,
   toggleEnabled,
 } = usePersonality()
-const authStore = useAuthStore()
 
 // ---- local state ----
 const selectedId = ref<string | null>(null)
@@ -52,16 +50,18 @@ const confirmDeleteId = ref<string | null>(null)
 // ---- voice list for personality voice assignment (#1135) ----
 const voiceList = ref<{ id: string; name: string; builtin: boolean }[]>([])
 
+type VoiceEntry = { id: string; name: string; builtin: boolean }
+
 async function fetchVoices() {
   try {
-    const token = authStore.token || localStorage.getItem('autobot_access_token') || ''
-    const res = await fetch(`${getSlmApiBase()}/voice/voices`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    })
-    if (res.ok) {
-      const data = await res.json()
-      voiceList.value = Array.isArray(data) ? data : (data.voices || [])
-    }
+    // Migrated onto slmApiClient (#12420 Phase 2): the client resolves the base
+    // URL and injects the SLM bearer token. suppressErrorLog preserves the
+    // historic silent-failure behavior (selector shows empty when unavailable).
+    const data = await slmApiClient.get<VoiceEntry[] | { voices?: VoiceEntry[] }>(
+      '/voice/voices',
+      { suppressErrorLog: true }
+    )
+    voiceList.value = Array.isArray(data) ? data : (data?.voices ?? [])
   } catch {
     // voice list unavailable — selector will show empty
   }


### PR DESCRIPTION
Closes #12606
Refs #12420

## Thinking Path
Phase 1 (#12420) landed the canonical `slmApiClient` (fetch-based, resolves base URL via `getSlmApiBase()`, injects the SLM bearer token, centralises 401 → clear session + redirect to `/login` for non-auth endpoints). Prior batches migrated MFA (#12599) and Auth/Security/Users (#12601). This batch migrates the LLM/Personality/Settings domain, following the exact same COPY-ADAPT convention: drop the per-composable axios instance / raw `fetch()`, pass endpoints relative to the API base, and let the client own token + 401. WebSocket URL builders and `getBackendUrl()`-based (different-host) calls are explicitly out of scope.

## What Changed
- **`composables/useLlmConfigApi.ts`** — 4 methods (`getConfig`/`saveConfig`/`testConnection`/`applyToFleet` on `/settings/admin/llm*`) now call `slmApiClient.get/put/post` and return parsed JSON directly. Dropped the per-composable `axios.create` + request/response interceptors; the interceptor's `authStore.logout()` on 401 is replaced by the client's central non-auth 401 handling. Exported signature unchanged.
- **`composables/usePersonality.ts`** — `/personality/**` CRUD routes through `slmApiClient`; endpoints carry the `/personality` prefix (previously the axios `baseURL` suffix). The internal `_call` error/loading/`null`-on-error contract is preserved (error string now `HTTP <status>: <detail>` from the client). **Behavior note:** the legacy `autobot_access_token` fallback token is dropped — this endpoint proxies through the SLM backend which validates the *SLM* JWT (#1145), so the `slm_access_token` the client injects is the correct (and only valid) credential. This endpoint previously had no 401 interceptor; it now inherits the client's central 401 handling (consistency improvement).
- **`views/settings/APISettings.vue`** — `testConnection()` `/health` probe uses `slmApiClient.rawRequest('/health', { method: 'GET' })`, keeping the raw `Response` so `response.ok`/`response.status` read exactly as before. The `ws://…/ws/events` display builder (line 26) and the `getBackendUrl()` display string are **left untouched**.
- **`views/settings/admin/PersonalitySettings.vue`** — `fetchVoices()` `/voice/voices` routes through `slmApiClient.get(..., { suppressErrorLog: true })`, preserving the historic silent-failure behavior (empty selector). Dropped the now-unused `authStore`/`getSlmApiBase` imports (and the `autobot_access_token` fallback, same rationale as above).
- **`views/settings/admin/ConfigDefaultsSettings.vue`** — the `apiFetch` helper is replaced by `apiRequest(method, path, body?)` dispatching to `slmApiClient.get/put/delete`; `/config/defaults` CRUD callers updated to pass an object body (not a stringified `RequestInit`). `null`-on-error contract preserved.
- **Tests** — `useLlmConfigApi.test.ts` (5 cases) and `usePersonality.test.ts` (9 cases) mock `@/utils/ApiClient` and assert endpoint/body routing, parsed-body return, and (personality) the null-on-error contract.

## Verification
- `vue-tsc --noEmit -p tsconfig.json` → exit 0 (clean).
- `vitest run` on both new test files → **2 files / 14 tests passed**.
- Grep of the 5 migrated files: no code-level `axios`, no raw `fetch(`, no code-level `getSlmApiBase()` — the only remaining `getSlmApiBase()` is the noted `ws://` builder in `APISettings.vue`; remaining `axios`/`getSlmApiBase` hits are docstring text.

## Model Used
Claude Opus 4.8

## Follow-up
- **Remaining domains** — other `getSlmApiBase()`/axios/fetch SLM composables + views not in this batch remain for subsequent Phase 2 batches under #12420.
- **WS-builder decision** — `APISettings.vue` `wsUrl` (and any other `ws(s)://` builders) are intentionally NOT migrated: `slmApiClient` has no WebSocket surface. If Phase 2 wants these centralised, that needs a separate client WS API (own issue).
- **`getBackendUrl()`-based files** — the ~19-file follow-up that targets the AutoBot backend (a different host, `getBackendUrl()`/`getApiUrl()`) is out of scope here; those need the `autobot-frontend` canonical client, not `slmApiClient`.