### PR TITLE
fix(code-quality): clear repo-wide flake8 E501 in analyzer.py (#12594)

### DIFF
--- a/autobot-backend/code_intelligence/performance_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/performance_analysis/analyzer.py
@@ -247,7 +247,9 @@ class PerformanceAnalyzer(SemanticAnalysisMixin):
                         current_code=code.strip(),
                         confidence=0.55,
                         potential_false_positive=True,
-                        false_positive_reason="Static regex cannot confirm the handle is released later in the same scope",
+                        false_positive_reason=(
+                            "Static regex cannot confirm the handle is released later in the same scope"
+                        ),
                     )
                 )
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -20254,6 +20254,9 @@ export interface paths {
          *     (Issue #315 - refactored to reduce nesting)
          *     Issue #12330: Scope the scan to the requested source's clone path so one
          *     project cannot see another's import tree.
+         *     Issue #12364: Reads from the indexed store first (single source of truth,
+         *     sub-second); falls back to the live filesystem walk -- and kicks off a
+         *     background index job -- only when the index has no data for this source.
          */
         get: operations["get_import_tree_api_analytics_codebase_analytics_import_tree_get"];
         put?: never;


### PR DESCRIPTION
## Thinking Path
`code_intelligence/performance_analysis/analyzer.py:250` was 123 chars, failing the required `code-quality` flake8 step on **every** PR against Dev_new_gui — the reason recent memory-epic PRs merged via admin-bypass. One-line wrap clears it for all future PRs.

## What Changed
- Wrapped the `false_positive_reason=` string literal across lines so no line exceeds 120 chars. No behaviour change.

## Verification
- `python3 -m flake8 --select=E501 --max-line-length=120 code_intelligence/performance_analysis/analyzer.py` → **0 issues**. Longest line now 104 chars.

## Model Used
Opus 4.8 (1M context)

Closes #12594.
