### PR TITLE
refactor(slm-frontend): migrate Code-source/updates domain onto slmApiClient (#12420 Phase 2 batch 4)

### DIFF
--- a/autobot-slm-frontend/src/components/CodeSourceModal.vue
+++ b/autobot-slm-frontend/src/components/CodeSourceModal.vue
@@ -7,13 +7,17 @@
  * Code Source Assignment Modal (Issue #779)
  *
  * Allows selecting a node to serve as the code source for the fleet.
+ *
+ * The code-source POST is migrated onto the canonical `slmApiClient` (#12420
+ * Phase 2): it resolves the base URL via `getSlmApiBase()`, injects the SLM
+ * bearer token, and centrally handles 401 — replacing the local axios instance
+ * and request interceptor. Node loading still flows through `useSlmApi`.
  */
 
 import { ref, onMounted } from 'vue'
-import axios from 'axios'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { createLogger } from '@/utils/debugUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
+import slmApiClient from '@/utils/ApiClient'
 import type { SLMNode } from '@/types/slm'
 
 const logger = createLogger('CodeSourceModal')
@@ -40,16 +44,6 @@ const isLoading = ref(true)
 const isSaving = ref(false)
 const error = ref<string | null>(null)
 
-// Minimal axios client for code-source POST (Issue #860)
-const api = axios.create({ baseURL: getSlmApiBase(), timeout: 15000 })
-api.interceptors.request.use((config) => {
-  const token = sessionStorage.getItem('slm_access_token')
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`
-  }
-  return config
-})
-
 onMounted(async () => {
   try {
     // Reuse existing API composable (Issue #860)
@@ -71,8 +65,7 @@ async function handleAssign(): Promise<void> {
   error.value = null
 
   try {
-    // Fix double-prefix bug: baseURL is /api, endpoint is /code-source/assign (Issue #860)
-    await api.post('/code-source/assign', {
+    await slmApiClient.post('/code-source/assign', {
       node_id: selectedNodeId.value,
       repo_path: repoPath.value,
       branch: branch.value,
@@ -80,8 +73,7 @@ async function handleAssign(): Promise<void> {
     emit('saved')
     emit('close')
   } catch (e: unknown) {
-    const err = e as { response?: { data?: { detail?: string } }; message?: string }
-    error.value = err.response?.data?.detail || err.message || 'Failed to assign code source'
+    error.value = e instanceof Error ? e.message : 'Failed to assign code source'
   } finally {
     isSaving.value = false
   }

--- a/autobot-slm-frontend/src/composables/useCodeSource.test.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSource.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 4) — proves the code-source composable routes every
+ * method through the canonical `slmApiClient` with endpoints relative to the
+ * API base (base URL + bearer token injected by the client) and returns parsed
+ * JSON directly (no axios `.data`). Also asserts the graceful error semantics
+ * survive the switch to the throw-on-error client: `error.value` is populated
+ * from the thrown message and the methods keep their `null`/`false` returns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+import { useCodeSource } from './useCodeSource'
+
+describe('useCodeSource — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockDelete.mockReset()
+  })
+
+  it('fetchCodeSource GETs /code-source and stores the parsed body', async () => {
+    const body = { node_id: 'n1', is_active: true }
+    mockGet.mockResolvedValue(body)
+
+    const cs = useCodeSource()
+    await cs.fetchCodeSource()
+
+    expect(mockGet).toHaveBeenCalledWith('/code-source')
+    expect(cs.codeSource.value).toEqual(body)
+    expect(cs.error.value).toBeNull()
+    expect(cs.isLoading.value).toBe(false)
+  })
+
+  it('fetchCodeSource populates error.value from the thrown message', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 500: boom'))
+
+    const cs = useCodeSource()
+    await cs.fetchCodeSource()
+
+    expect(cs.error.value).toBe('HTTP 500: boom')
+    expect(cs.isLoading.value).toBe(false)
+  })
+
+  it('assignCodeSource POSTs to /code-source/assign and returns the body', async () => {
+    const body = { node_id: 'n1', is_active: true }
+    mockPost.mockResolvedValue(body)
+
+    const cs = useCodeSource()
+    const result = await cs.assignCodeSource('n1', '/repo', 'main')
+
+    expect(mockPost).toHaveBeenCalledWith('/code-source/assign', {
+      node_id: 'n1',
+      repo_path: '/repo',
+      branch: 'main',
+    })
+    expect(result).toEqual(body)
+    expect(cs.codeSource.value).toEqual(body)
+  })
+
+  it('assignCodeSource uses the documented defaults for repoPath/branch', async () => {
+    mockPost.mockResolvedValue({ node_id: 'n1' })
+
+    await useCodeSource().assignCodeSource('n1')
+
+    expect(mockPost).toHaveBeenCalledWith('/code-source/assign', {
+      node_id: 'n1',
+      repo_path: '/opt/autobot/code_source',
+      branch: 'Dev_new_gui',
+    })
+  })
+
+  it('assignCodeSource returns null and sets error.value on failure', async () => {
+    mockPost.mockRejectedValue(new Error('HTTP 400: bad node'))
+
+    const cs = useCodeSource()
+    const result = await cs.assignCodeSource('n1')
+
+    expect(result).toBeNull()
+    expect(cs.error.value).toBe('HTTP 400: bad node')
+  })
+
+  it('removeCodeSource DELETEs /code-source/assign and clears the state', async () => {
+    mockDelete.mockResolvedValue({})
+
+    const cs = useCodeSource()
+    cs.codeSource.value = { node_id: 'n1' } as never
+    const ok = await cs.removeCodeSource()
+
+    expect(mockDelete).toHaveBeenCalledWith('/code-source/assign')
+    expect(ok).toBe(true)
+    expect(cs.codeSource.value).toBeNull()
+  })
+
+  it('removeCodeSource returns false and sets error.value on failure', async () => {
+    mockDelete.mockRejectedValue(new Error('HTTP 409: conflict'))
+
+    const cs = useCodeSource()
+    const ok = await cs.removeCodeSource()
+
+    expect(ok).toBe(false)
+    expect(cs.error.value).toBe('HTTP 409: conflict')
+  })
+
+  it('clearError resets error.value', () => {
+    const cs = useCodeSource()
+    cs.error.value = 'x'
+    cs.clearError()
+    expect(cs.error.value).toBeNull()
+  })
+})

--- a/autobot-slm-frontend/src/composables/useCodeSource.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSource.ts
@@ -9,11 +9,20 @@
  * Manages the code-source node assignment for the AutoBot repository.
  * The code source is the designated node that has git access to pull
  * the latest code changes which can then be synced to other nodes.
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()`, injects the SLM bearer token
+ * (same `slm_access_token` storage the auth store reads), and centrally handles
+ * 401 for these non-auth endpoints (clear session + redirect to `/login`) —
+ * replacing the previous per-composable axios instance and request interceptor.
+ * Call sites pass endpoints relative to the API base and receive parsed JSON
+ * directly (no axios `.data`). The client throws on non-2xx, so each method
+ * keeps its try/catch and populates `error.value` from the thrown message,
+ * preserving the graceful `null`/`false` return semantics.
  */
 
 import { ref } from 'vue'
-import axios from 'axios'
-import { getSlmApiBase } from '@/config/ssot-config'
+import slmApiClient from '@/utils/ApiClient'
 
 export interface CodeSource {
   node_id: string
@@ -37,16 +46,6 @@ export function useCodeSource() {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
-  // Use relative path for same-origin SLM backend API (Issue #860)
-  const api = axios.create({ baseURL: getSlmApiBase(), timeout: 15000 })
-  api.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
   /**
    * Fetch the current code source configuration.
    */
@@ -55,12 +54,9 @@ export function useCodeSource() {
     error.value = null
 
     try {
-      // Fix double-prefix: baseURL is /api, endpoint is /code-source (Issue #860)
-      const response = await api.get<CodeSource | null>('/code-source')
-      codeSource.value = response.data
+      codeSource.value = await slmApiClient.get<CodeSource | null>('/code-source')
     } catch (e: unknown) {
-      const err = e as { response?: { data?: { detail?: string } }; message?: string }
-      error.value = err.response?.data?.detail || err.message || 'Failed to fetch code source'
+      error.value = e instanceof Error ? e.message : 'Failed to fetch code source'
     } finally {
       isLoading.value = false
     }
@@ -82,17 +78,15 @@ export function useCodeSource() {
     error.value = null
 
     try {
-      // Fix double-prefix: baseURL is /api, endpoint is /code-source/assign (Issue #860)
-      const response = await api.post<CodeSource>('/code-source/assign', {
+      const result = await slmApiClient.post<CodeSource>('/code-source/assign', {
         node_id: nodeId,
         repo_path: repoPath,
         branch,
       })
-      codeSource.value = response.data
-      return response.data
+      codeSource.value = result
+      return result
     } catch (e: unknown) {
-      const err = e as { response?: { data?: { detail?: string } }; message?: string }
-      error.value = err.response?.data?.detail || err.message || 'Failed to assign code source'
+      error.value = e instanceof Error ? e.message : 'Failed to assign code source'
       return null
     } finally {
       isLoading.value = false
@@ -107,13 +101,11 @@ export function useCodeSource() {
     error.value = null
 
     try {
-      // Fix double-prefix: baseURL is /api, endpoint is /code-source/assign (Issue #860)
-      await api.delete('/code-source/assign')
+      await slmApiClient.delete('/code-source/assign')
       codeSource.value = null
       return true
     } catch (e: unknown) {
-      const err = e as { response?: { data?: { detail?: string } }; message?: string }
-      error.value = err.response?.data?.detail || err.message || 'Failed to remove code source'
+      error.value = e instanceof Error ? e.message : 'Failed to remove code source'
       return false
     } finally {
       isLoading.value = false

--- a/autobot-slm-frontend/src/composables/useSystemUpdates.test.ts
+++ b/autobot-slm-frontend/src/composables/useSystemUpdates.test.ts
@@ -1,0 +1,213 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 (batch 4) — proves the system-updates composable routes every
+ * method through the canonical `slmApiClient` with endpoints relative to the
+ * API base and query params serialised onto the path (no axios `params`), and
+ * returns parsed JSON directly (no `.data`). Also asserts the graceful
+ * semantics survive: badge/poll probes fail silently (single-shot, no WARN),
+ * and the mutating methods keep their `[]`/`false`/`null` returns while
+ * populating `error.value` from the thrown message.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+import { useSystemUpdates } from './useSystemUpdates'
+
+describe('useSystemUpdates — migrated onto slmApiClient (#12420 Phase 2)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+  })
+
+  it('fetchSummary GETs /updates/summary single-shot and silent', async () => {
+    const body = {
+      system_update_count: 3,
+      security_update_count: 1,
+      nodes_with_updates: 2,
+      last_checked: null,
+    }
+    mockGet.mockResolvedValue(body)
+
+    const u = useSystemUpdates()
+    const result = await u.fetchSummary()
+
+    expect(mockGet).toHaveBeenCalledWith('/updates/summary', {
+      maxRetries: 1,
+      suppressErrorLog: true,
+    })
+    expect(result).toEqual(body)
+    expect(u.summary.value).toEqual(body)
+    expect(u.updateCount.value).toBe(3)
+  })
+
+  it('fetchSummary fails silently, returning null without setting error', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 503'))
+
+    const u = useSystemUpdates()
+    const result = await u.fetchSummary()
+
+    expect(result).toBeNull()
+    expect(u.error.value).toBeNull()
+  })
+
+  it('fetchPackages serialises node_id/severity onto the path', async () => {
+    mockGet.mockResolvedValue({ packages: [{ update_id: 'a' }], total: 1, by_node: { n1: 1 } })
+
+    const u = useSystemUpdates()
+    const result = await u.fetchPackages('n1', 'critical')
+
+    expect(mockGet).toHaveBeenCalledWith('/updates/packages?node_id=n1&severity=critical')
+    expect(result).toEqual([{ update_id: 'a' }])
+    expect(u.packagesByNode.value).toEqual({ n1: 1 })
+  })
+
+  it('fetchPackages omits the query string when no filters are given', async () => {
+    mockGet.mockResolvedValue({ packages: [], total: 0, by_node: {} })
+
+    await useSystemUpdates().fetchPackages()
+
+    expect(mockGet).toHaveBeenCalledWith('/updates/packages')
+  })
+
+  it('fetchPackages returns [] and sets error.value on failure', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 500: nope'))
+
+    const u = useSystemUpdates()
+    const result = await u.fetchPackages()
+
+    expect(result).toEqual([])
+    expect(u.error.value).toBe('HTTP 500: nope')
+    expect(u.loading.value).toBe(false)
+  })
+
+  it('discoverUpdates POSTs to /updates/discover and returns the job id', async () => {
+    mockPost.mockResolvedValue({ success: true, message: 'ok', job_id: 'job-1' })
+
+    const u = useSystemUpdates()
+    const jobId = await u.discoverUpdates(['n1'], 'gpu')
+
+    expect(mockPost).toHaveBeenCalledWith('/updates/discover', {
+      node_ids: ['n1'],
+      role: 'gpu',
+    })
+    expect(jobId).toBe('job-1')
+    expect(u.discoverStatus.value?.status).toBe('pending')
+  })
+
+  it('discoverUpdates surfaces a non-success message and returns null', async () => {
+    mockPost.mockResolvedValue({ success: false, message: 'busy', job_id: '' })
+
+    const u = useSystemUpdates()
+    const jobId = await u.discoverUpdates()
+
+    expect(mockPost).toHaveBeenCalledWith('/updates/discover', {
+      node_ids: null,
+      role: null,
+    })
+    expect(jobId).toBeNull()
+    expect(u.error.value).toBe('busy')
+  })
+
+  it('pollDiscoverStatus GETs the job status single-shot and silent', async () => {
+    mockGet.mockResolvedValue({ job_id: 'job-1', status: 'running' })
+
+    const u = useSystemUpdates()
+    const result = await u.pollDiscoverStatus('job-1')
+
+    expect(mockGet).toHaveBeenCalledWith('/updates/discover/job-1', {
+      maxRetries: 1,
+      suppressErrorLog: true,
+    })
+    expect(result).toMatchObject({ status: 'running' })
+  })
+
+  it('pollDiscoverStatus returns null silently on failure', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 404'))
+
+    const result = await useSystemUpdates().pollDiscoverStatus('job-1')
+
+    expect(result).toBeNull()
+  })
+
+  it('fetchJobs serialises the limit onto the path', async () => {
+    mockGet.mockResolvedValue({ jobs: [{ job_id: 'j' }], total: 1 })
+
+    const u = useSystemUpdates()
+    const result = await u.fetchJobs(5)
+
+    expect(mockGet).toHaveBeenCalledWith('/updates/jobs?limit=5')
+    expect(result).toEqual([{ job_id: 'j' }])
+  })
+
+  it('applyUpdates POSTs the payload and refreshes jobs on success', async () => {
+    mockPost.mockResolvedValueOnce({ success: true })
+    mockGet.mockResolvedValue({ jobs: [], total: 0 })
+
+    const u = useSystemUpdates()
+    const ok = await u.applyUpdates('n1', ['u1', 'u2'])
+
+    expect(mockPost).toHaveBeenCalledWith('/updates/apply', {
+      node_id: 'n1',
+      update_ids: ['u1', 'u2'],
+    })
+    expect(mockGet).toHaveBeenCalledWith('/updates/jobs?limit=20')
+    expect(ok).toBe(true)
+  })
+
+  it('applyUpdates returns false and sets error.value on failure', async () => {
+    mockPost.mockRejectedValue(new Error('HTTP 500: fail'))
+
+    const u = useSystemUpdates()
+    const ok = await u.applyUpdates('n1', ['u1'])
+
+    expect(ok).toBe(false)
+    expect(u.error.value).toBe('HTTP 500: fail')
+  })
+
+  it('upgradeAll POSTs to /updates/apply-all', async () => {
+    mockPost.mockResolvedValueOnce({ success: true })
+    mockGet.mockResolvedValue({ jobs: [], total: 0 })
+
+    const ok = await useSystemUpdates().upgradeAll('n1')
+
+    expect(mockPost).toHaveBeenCalledWith('/updates/apply-all', {
+      node_id: 'n1',
+      upgrade_all: true,
+    })
+    expect(ok).toBe(true)
+  })
+
+  it('cancelJob POSTs to the cancel endpoint and refreshes jobs', async () => {
+    mockPost.mockResolvedValueOnce({ success: true })
+    mockGet.mockResolvedValue({ jobs: [], total: 0 })
+
+    const ok = await useSystemUpdates().cancelJob('job-1')
+
+    expect(mockPost).toHaveBeenCalledWith('/updates/jobs/job-1/cancel')
+    expect(ok).toBe(true)
+  })
+
+  it('cancelJob returns false and sets error.value on failure', async () => {
+    mockPost.mockRejectedValue(new Error('HTTP 500: nope'))
+
+    const u = useSystemUpdates()
+    const ok = await u.cancelJob('job-1')
+
+    expect(ok).toBe(false)
+    expect(u.error.value).toBe('HTTP 500: nope')
+  })
+})

--- a/autobot-slm-frontend/src/composables/useSystemUpdates.ts
+++ b/autobot-slm-frontend/src/composables/useSystemUpdates.ts
@@ -8,14 +8,24 @@
  *
  * Provides reactive state and methods for system package update
  * discovery and management across the SLM fleet.
+ *
+ * Migrated onto the canonical `slmApiClient` (#12420 Phase 2). The client
+ * resolves the base URL via `getSlmApiBase()`, injects the SLM bearer token,
+ * and centrally handles 401 for these non-auth endpoints (clear session +
+ * redirect to `/login`) — replacing the previous per-composable axios instance
+ * plus request/response interceptors (the response interceptor's #10369
+ * `authStore.logout()` on 401 is now the client's centralised concern). Query
+ * parameters are serialised onto the endpoint since the canonical client takes
+ * a relative path, not an axios `params` object; call sites receive parsed JSON
+ * directly (no axios `.data`). The client throws on non-2xx, so each method
+ * keeps its try/catch and preserves the graceful `null`/`[]`/`false` returns.
+ * The silent poll/badge probes (`fetchSummary`, `pollDiscoverStatus`) request
+ * once (`maxRetries: 1`) and suppress the client's failure WARN so they stay
+ * quiet, matching the previous single-shot axios behaviour.
  */
 
 import { ref, computed, readonly } from 'vue'
-import axios, { type AxiosInstance } from 'axios'
-import { getSlmApiBase } from '@/config/ssot-config'
-import { useAuthStore } from '@/stores/auth'
-
-const API_BASE = getSlmApiBase()
+import slmApiClient from '@/utils/ApiClient'
 
 // =============================================================================
 // Type Definitions
@@ -80,38 +90,17 @@ export interface UpdateJob {
   created_at: string
 }
 
+// Minimal shape of the mutating-endpoint envelopes (apply / apply-all / cancel).
+interface MutationResult {
+  success: boolean
+  message?: string
+}
+
 // =============================================================================
 // Composable
 // =============================================================================
 
 export function useSystemUpdates() {
-  const authStore = useAuthStore()
-
-  const client: AxiosInstance = axios.create({
-    baseURL: API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-  })
-
-  client.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  // #10369 — without a 401 handler an expired/invalid token makes the badge
-  // poller spam 401s forever; log out so the UI redirects to login instead.
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
-        authStore.logout()
-      }
-      return Promise.reject(error)
-    }
-  )
-
   // ===========================================================================
   // Reactive State
   // ===========================================================================
@@ -166,12 +155,14 @@ export function useSystemUpdates() {
 
   async function fetchSummary(): Promise<UpdateSummary | null> {
     try {
-      const response = await client.get<UpdateSummary>(
-        '/updates/summary',
-      )
-      summary.value = response.data
-      return response.data
-    } catch (e) {
+      // Silent fail for badge polling — single-shot, no failure WARN.
+      const data = await slmApiClient.get<UpdateSummary>('/updates/summary', {
+        maxRetries: 1,
+        suppressErrorLog: true,
+      })
+      summary.value = data
+      return data
+    } catch {
       // Silent fail for badge polling — don't overwrite error
       return null
     }
@@ -184,22 +175,19 @@ export function useSystemUpdates() {
     loading.value = true
     error.value = null
     try {
-      const params: Record<string, string> = {}
-      if (nodeId) params.node_id = nodeId
-      if (severity) params.severity = severity
-      const response = await client.get<PackagesResponse>(
-        '/updates/packages',
-        { params },
+      const query = new URLSearchParams()
+      if (nodeId) query.set('node_id', nodeId)
+      if (severity) query.set('severity', severity)
+      const qs = query.toString()
+      const data = await slmApiClient.get<PackagesResponse>(
+        `/updates/packages${qs ? `?${qs}` : ''}`,
       )
-      packages.value = response.data.packages
-      packagesByNode.value = response.data.by_node
-      return response.data.packages
+      packages.value = data.packages
+      packagesByNode.value = data.by_node
+      return data.packages
     } catch (e) {
       error.value =
         e instanceof Error ? e.message : 'Failed to fetch packages'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return []
     } finally {
       loading.value = false
@@ -213,13 +201,13 @@ export function useSystemUpdates() {
     discovering.value = true
     error.value = null
     try {
-      const response = await client.post<DiscoverResponse>(
+      const data = await slmApiClient.post<DiscoverResponse>(
         '/updates/discover',
         { node_ids: nodeIds || null, role: role || null },
       )
-      if (response.data.success) {
+      if (data.success) {
         discoverStatus.value = {
-          job_id: response.data.job_id,
+          job_id: data.job_id,
           status: 'pending',
           progress: 0,
           message: 'Starting discovery...',
@@ -229,16 +217,13 @@ export function useSystemUpdates() {
           started_at: null,
           completed_at: null,
         }
-        return response.data.job_id
+        return data.job_id
       }
-      error.value = response.data.message
+      error.value = data.message
       return null
     } catch (e) {
       error.value =
         e instanceof Error ? e.message : 'Failed to start discovery'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return null
     } finally {
       discovering.value = false
@@ -249,24 +234,27 @@ export function useSystemUpdates() {
     jobId: string,
   ): Promise<DiscoverStatus | null> {
     try {
-      const response = await client.get<DiscoverStatus>(
+      // Single-shot poll — don't retry/backoff or emit a WARN on a miss.
+      const data = await slmApiClient.get<DiscoverStatus>(
         `/updates/discover/${jobId}`,
+        { maxRetries: 1, suppressErrorLog: true },
       )
-      discoverStatus.value = response.data
-      return response.data
-    } catch (e) {
+      discoverStatus.value = data
+      return data
+    } catch {
       return null
     }
   }
 
   async function fetchJobs(limit = 20): Promise<UpdateJob[]> {
     try {
-      const response = await client.get<{
+      const query = new URLSearchParams({ limit: String(limit) })
+      const data = await slmApiClient.get<{
         jobs: UpdateJob[]
         total: number
-      }>('/updates/jobs', { params: { limit } })
-      jobs.value = response.data.jobs
-      return response.data.jobs
+      }>(`/updates/jobs?${query.toString()}`)
+      jobs.value = data.jobs
+      return data.jobs
     } catch (e) {
       error.value =
         e instanceof Error ? e.message : 'Failed to fetch jobs'
@@ -281,22 +269,19 @@ export function useSystemUpdates() {
     loading.value = true
     error.value = null
     try {
-      const response = await client.post('/updates/apply', {
+      const data = await slmApiClient.post<MutationResult>('/updates/apply', {
         node_id: nodeId,
         update_ids: updateIds,
       })
-      if (response.data.success) {
+      if (data.success) {
         await fetchJobs()
         return true
       }
-      error.value = response.data.message
+      error.value = data.message ?? null
       return false
     } catch (e) {
       error.value =
         e instanceof Error ? e.message : 'Failed to apply updates'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return false
     } finally {
       loading.value = false
@@ -307,22 +292,19 @@ export function useSystemUpdates() {
     loading.value = true
     error.value = null
     try {
-      const response = await client.post('/updates/apply-all', {
+      const data = await slmApiClient.post<MutationResult>('/updates/apply-all', {
         node_id: nodeId,
         upgrade_all: true,
       })
-      if (response.data.success) {
+      if (data.success) {
         await fetchJobs()
         return true
       }
-      error.value = response.data.message
+      error.value = data.message ?? null
       return false
     } catch (e) {
       error.value =
         e instanceof Error ? e.message : 'Failed to upgrade all'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return false
     } finally {
       loading.value = false
@@ -331,10 +313,10 @@ export function useSystemUpdates() {
 
   async function cancelJob(jobId: string): Promise<boolean> {
     try {
-      const response = await client.post(
+      const data = await slmApiClient.post<MutationResult>(
         `/updates/jobs/${jobId}/cancel`,
       )
-      if (response.data.success) {
+      if (data.success) {
         await fetchJobs()
         return true
       }


### PR DESCRIPTION
## Thinking Path

Continuation of the #12420 Phase 2 campaign that converges the SLM Admin frontend onto the canonical `slmApiClient` (`autobot-slm-frontend/src/utils/ApiClient.ts`, Phase 1). Prior batches migrated MFA (batch 1) and Auth/Security/Users (batch 2). This batch takes the **Code-source/updates** domain.

Each target owned its own `axios.create({ baseURL: getSlmApiBase() })` instance plus a request interceptor injecting `sessionStorage.getItem('slm_access_token')` — exactly what the canonical client centralises. `useSystemUpdates` additionally had the #10369 response interceptor calling `authStore.logout()` on 401, which the client's central 401 handler (clear session + redirect to `/login`) now replaces.

The client throws on non-2xx (no `.response.data.detail`), so the migration had to explicitly preserve each site's graceful degradation: `null`/`[]`/`false` returns and `error.value` population, plus the two silent polling probes' single-request-no-noise behaviour.

`useCodeSync.ts` was deliberately excluded — see Follow-up.

## What Changed

- **`composables/useCodeSource.ts`** — dropped the local axios instance + interceptor; `fetchCodeSource`/`assignCodeSource`/`removeCodeSource` now call `slmApiClient.get/post/delete` with paths relative to the API base and consume parsed JSON directly. try/catch retained; `error.value` is set from the thrown `Error.message` (which already carries the backend `detail`), preserving the `null`/`false` returns.
- **`composables/useSystemUpdates.ts`** — dropped the axios instance, both interceptors, `useAuthStore` import and the module-level `API_BASE`. All eight methods route through `slmApiClient`. `node_id`/`severity`/`limit` are serialised onto the endpoint via `URLSearchParams` (client takes a relative path, not an axios `params` object). The silent badge/poll probes (`fetchSummary`, `pollDiscoverStatus`) pass `{ maxRetries: 1, suppressErrorLog: true }` to keep the previous single-shot, no-WARN behaviour; the other methods keep their `[]`/`false`/`null` returns and set `error.value` from the thrown message.
- **`components/CodeSourceModal.vue`** — dropped the local axios instance + interceptor and the `axios`/`getSlmApiBase` imports; `handleAssign` POSTs `/code-source/assign` through `slmApiClient`. Node loading via `useSlmApi().getNodes()` is unchanged (out of scope for this batch).
- **Tests** — added `useCodeSource.test.ts` (9 cases) and `useSystemUpdates.test.ts` (14 cases) mocking `@/utils/ApiClient` to assert endpoint/body/query-serialisation routing and that the graceful error / silent-poll semantics survive.

## Verification

- `vue-tsc --noEmit -p tsconfig.json` → exit 0 (clean).
- `vitest run useCodeSource.test.ts useSystemUpdates.test.ts` → **2 files, 23 tests passed**.
- `grep -nE "getSlmApiBase|axios|fetch\("` across the three migrated files → only doc-comment mentions remain; no code-level HTTP usage.
- `git diff --name-only origin/Dev_new_gui...HEAD` does **not** list `useCodeSync.ts` (confirmed untouched).

(Temporary read-only `node_modules` symlink from the main tree was used for vue-tsc/vitest and removed before commit — no manual installs.)

## Model Used

claude-opus-4-8

## Follow-up

- **`useCodeSync.ts` deferred (deliberate):** just modified by #12593; its `getUpdateAllStatus()` returns `undefined` on connection-refused/5xx (load-bearing for the stage-3 reconnecting affordance). `slmApiClient` throws on error by default, so a faithful migration must first add an opt-in "return-undefined-on-transport/5xx" affordance (or wrap with `rawRequest`). Needs its own careful PR.
- **Remaining Phase 2 domains** still on axios/`getSlmApiBase`/fetch across the SLM frontend (nodes, monitoring, config, etc.) — future batches.
- **Skipped this batch (per rules):** no `ws(s)://` builders or cross-host `getBackendUrl()`/`getApiUrl()` calls were present in these three files, so none were touched; the `useSlmApi().getNodes()` call in the modal is left for its own composable's migration.

Closes #12610
Refs #12420
