### PR TITLE
refactor(frontend): migrate monitoring/health composables off raw fetch (#12363 Phase 2 batch 3)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useHealthProbeRegistry.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useHealthProbeRegistry.test.ts
@@ -1,0 +1,94 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for useHealthProbeRegistry (#12363 Phase 2).
+ *
+ * Verifies the registry fetch was migrated off raw fetch() onto the
+ * fetchWithAuth bridge (attaches the JWT), and that the graceful-null probe
+ * semantics (non-ok / non-array / thrown error never poison the cache) are
+ * preserved exactly.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const fetchWithAuthSpy = vi.fn()
+
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthSpy(...args),
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}))
+
+import {
+  getProbeRegistry,
+  refreshProbeRegistry,
+  findProbeByName,
+  _resetProbeRegistryForTesting,
+} from '../useHealthProbeRegistry'
+
+beforeEach(() => {
+  fetchWithAuthSpy.mockReset()
+  _resetProbeRegistryForTesting()
+})
+
+describe('useHealthProbeRegistry — fetchWithAuth migration (#12363)', () => {
+  it('routes the registry fetch through fetchWithAuth and returns a name Set', async () => {
+    fetchWithAuthSpy.mockResolvedValue({ ok: true, json: async () => ['batch_jobs', 'long_running'] })
+
+    const registry = await getProbeRegistry()
+
+    expect(fetchWithAuthSpy).toHaveBeenCalledTimes(1)
+    expect(fetchWithAuthSpy).toHaveBeenCalledWith('/api/system/health/probes')
+    expect(registry).toEqual(new Set(['batch_jobs', 'long_running']))
+  })
+
+  it('caches after first fetch — a second call does not refetch', async () => {
+    fetchWithAuthSpy.mockResolvedValue({ ok: true, json: async () => ['a'] })
+
+    await getProbeRegistry()
+    await getProbeRegistry()
+
+    expect(fetchWithAuthSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshProbeRegistry forces a refetch', async () => {
+    fetchWithAuthSpy.mockResolvedValue({ ok: true, json: async () => ['a'] })
+
+    await getProbeRegistry()
+    await refreshProbeRegistry()
+
+    expect(fetchWithAuthSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null (does not poison cache) on a non-ok response', async () => {
+    fetchWithAuthSpy.mockResolvedValue({ ok: false, status: 503 })
+    expect(await getProbeRegistry()).toBeNull()
+
+    // Next call retries rather than serving a poisoned cache.
+    fetchWithAuthSpy.mockResolvedValue({ ok: true, json: async () => ['a'] })
+    _resetProbeRegistryForTesting()
+    expect(await getProbeRegistry()).toEqual(new Set(['a']))
+  })
+
+  it('returns null when the endpoint returns a non-string array', async () => {
+    fetchWithAuthSpy.mockResolvedValue({ ok: true, json: async () => ({ not: 'an array' }) })
+    expect(await getProbeRegistry()).toBeNull()
+  })
+
+  it('returns null when the fetch throws', async () => {
+    fetchWithAuthSpy.mockRejectedValue(new Error('network down'))
+    expect(await getProbeRegistry()).toBeNull()
+  })
+
+  it('findProbeByName returns the matching probe from the payload', async () => {
+    fetchWithAuthSpy.mockResolvedValue({ ok: true, json: async () => ['known'] })
+    const probes = [{ name: 'known', status: 'ok' as const }]
+    expect(await findProbeByName(probes, 'known')).toEqual({ name: 'known', status: 'ok' })
+  })
+})

--- a/autobot-frontend/src/composables/useHealthProbeRegistry.ts
+++ b/autobot-frontend/src/composables/useHealthProbeRegistry.ts
@@ -21,6 +21,7 @@
  */
 
 import { getApiBase } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useHealthProbeRegistry')
@@ -46,7 +47,7 @@ const _warnedNames = new Set<string>()
 
 async function fetchRegistry(): Promise<Set<string> | null> {
   try {
-    const r = await fetch(`${getApiBase()}/system/health/probes`)
+    const r = await fetchWithAuth(`${getApiBase()}/system/health/probes`)
     if (!r.ok) {
       logger.warn(`probe registry fetch returned ${r.status}; lookups will skip name validation until next call`)
       return null

--- a/autobot-frontend/src/composables/useNetworkStatus.ts
+++ b/autobot-frontend/src/composables/useNetworkStatus.ts
@@ -30,6 +30,7 @@
 import { ref, readonly, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
 
 const logger = createLogger('useNetworkStatus')
 
@@ -71,7 +72,7 @@ function _registerProbeFailure(): void {
 async function _probe(): Promise<void> {
   const url = `${getApiBase()}/health`
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithAuth(url, {
       method: 'HEAD',
       cache: 'no-store',
       signal: AbortSignal.timeout(4500), // must resolve within 5 s window


### PR DESCRIPTION
## Thinking Path
#12363 Phase 2 migrates the main `autobot-frontend` off raw `fetch(`. This batch (3) covers the monitoring/health composables — the HTTP ones only. I grepped each candidate, split them by **which backend** they target and **whether the URL is app-owned vs arbitrary**, and migrated only the app-backend probes. For probes I used the `fetchWithAuth` bridge rather than `ApiClient.rawRequest`, because these sites deliberately keep the raw `Response` and swallow errors into a graceful null — routing them through `ApiClient` would add its 401 → logout/redirect side effect that plain `fetch` never had.

## What Changed
Per file:

- **`composables/useHealthProbeRegistry.ts`** — MIGRATED. `fetch(`${getApiBase()}/system/health/probes`)` → `fetchWithAuth(...)`. App backend, GET. Now attaches the JWT; `.ok`/`.json()`/non-array checks and the "never poison the cache" graceful-null semantics are byte-for-byte preserved.
- **`composables/useNetworkStatus.ts`** — MIGRATED. `fetch(`${getApiBase()}/health`, { method: 'HEAD', cache: 'no-store', signal })` → `fetchWithAuth(url, {...})`. App backend reachability probe; `HEAD` / `cache: 'no-store'` / `AbortSignal.timeout` and the `res.ok || res.status < 500` "any non-5xx = online" logic are unchanged. `fetchWithAuth` returns a raw `Response`, so the probe keeps its exact shape and never triggers a logout on 401.
- **`composables/__tests__/useHealthProbeRegistry.test.ts`** — ADDED. Asserts the registry now routes through `fetchWithAuth` against `/api/system/health/probes`, caches, refetches on refresh, and returns `null` (no cache poisoning) on non-ok / non-string-array / thrown-error.

Deliberately **skipped** (grepped + judged; out of scope for the app-backend bridge):

- **`composables/useConnectionTester.ts`** — `fetch(endpoint.value, ...)` where `endpoint.value` is an **arbitrary/config-supplied** URL (documented examples: backend health, Redis ping, LLM tags, external hosts). Forcing it through the app client would prepend the app base URL and inject the app JWT/org headers onto third-party hosts. Left as raw `fetch` by design.
- **`composables/useHostInventory.ts`** — targets the **SLM control-plane backend** (`getSLMUrl()`), a distinct backend from the app; currently sends no app JWT. The app-scoped `fetchWithAuth` would inject the wrong (app) token. Needs a dedicated SLM client — see Follow-up.
- **`composables/useTLSCredentials.ts`** — also **SLM**, with its own token lifecycle (`authenticate()` / `setAuthToken()` → `Bearer authToken.value`). Routing through the app bridge would inject the wrong JWT. See Follow-up.

No WebSocket/EventSource builders were present in these files (`usePrometheusMetrics` and other WS sites are out of scope per the phase plan).

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (clean).
- `vitest run` on `useHealthProbeRegistry.test.ts`, `useNetworkStatus.test.ts`, `useProbeBackedHealth.test.ts` → **24 passed (3 files)**.
- Grep of migrated files → **no remaining backend raw `fetch(`**; both now import and use `fetchWithAuth`.
- Temporary read-only `node_modules` symlink (from main tree) used for `vue-tsc`/`vitest`, then removed — not committed.

## Model Used
claude-opus-4-8

## Follow-up
Remaining #12363 raw-`fetch` inventory (later batches):
- Components: `DesktopInterface`, `VideoProcessor`, plus the infra component set.
- SLM control-plane composables `useHostInventory` + `useTLSCredentials` — need a dedicated SLM auth bridge (analogous to `slmApiClient` in `autobot-slm-frontend`); MUST NOT be forced through the app `fetchWithAuth`/`ApiClient`.
- Do NOT migrate: WebSocket/EventSource services and `ssot-config` URL builders.

Refs #12363
Closes #12612
