### PR TITLE
refactor(slm-frontend): migrate core useSlmApi composable onto slmApiClient (#12420 Phase 2 batch 5)

### DIFF
--- a/autobot-slm-frontend/src/composables/useSlmApi.appLogs.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.appLogs.test.ts
@@ -6,73 +6,66 @@
 /**
  * Issue #11302 — Application-log viewer.
  *
- * getAppLogs() calls GET /monitoring/app-logs with the query params required
- * by the backend allowlist-mapped endpoint, and returns the parsed
- * AppLogsResponse untouched (ApiClient/axios envelope already unwrapped by
- * `.data` inside the composable — see feedback_apiclient_envelope_pattern).
+ * getAppLogs() calls GET /monitoring/app-logs with the query params required by
+ * the backend allowlist-mapped endpoint and returns the parsed AppLogsResponse
+ * untouched.
+ *
+ * Post #12420 Phase 2 batch 5 the composable routes through the canonical
+ * `slmApiClient` (via `rawRequest`), so this test drives that seam and asserts
+ * the query string reaches the client and the parsed body is returned.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { jsonResponse } from './useSlmApi.testHelper'
+
+const mockRaw = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  slmApiClient: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+  default: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+}))
+
 import { useSlmApi } from './useSlmApi'
-
-const mockGet = vi.fn()
-
-vi.mock('axios', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('axios')>()
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      create: () => ({
-        get: mockGet,
-        post: vi.fn(),
-        interceptors: {
-          request: { use: vi.fn() },
-          response: { use: vi.fn() },
-        },
-      }),
-    },
-  }
-})
 
 describe('useSlmApi.getAppLogs (#11302)', () => {
   beforeEach(() => {
-    mockGet.mockReset()
+    mockRaw.mockReset()
   })
 
   it('sends node_id and service as required query params', async () => {
-    mockGet.mockResolvedValue({
-      data: { entries: [], total: 0, page: 1, per_page: 100, node_id: 'node-1', service: 'backend' },
-    })
+    mockRaw.mockResolvedValue(
+      jsonResponse({ entries: [], total: 0, page: 1, per_page: 100, node_id: 'node-1', service: 'backend' })
+    )
 
     const api = useSlmApi()
     await api.getAppLogs({ node_id: 'node-1', service: 'backend' })
 
-    expect(mockGet).toHaveBeenCalledTimes(1)
-    const [url] = mockGet.mock.calls[0]
+    expect(mockRaw).toHaveBeenCalledTimes(1)
+    const [url, opts] = mockRaw.mock.calls[0] as [string, { method: string }]
     expect(url).toContain('/monitoring/app-logs?')
     expect(url).toContain('node_id=node-1')
     expect(url).toContain('service=backend')
+    expect(opts.method).toBe('GET')
   })
 
   it('omits optional filters when not provided', async () => {
-    mockGet.mockResolvedValue({
-      data: { entries: [], total: 0, page: 1, per_page: 100, node_id: 'node-1', service: 'backend' },
-    })
+    mockRaw.mockResolvedValue(
+      jsonResponse({ entries: [], total: 0, page: 1, per_page: 100, node_id: 'node-1', service: 'backend' })
+    )
 
     const api = useSlmApi()
     await api.getAppLogs({ node_id: 'node-1', service: 'backend' })
 
-    const [url] = mockGet.mock.calls[0]
+    const [url] = mockRaw.mock.calls[0] as [string]
     expect(url).not.toContain('severity=')
     expect(url).not.toContain('q=')
     expect(url).not.toContain('mcp_instance=')
   })
 
   it('includes severity, hours, q, page, per_page and mcp_instance when provided', async () => {
-    mockGet.mockResolvedValue({
-      data: { entries: [], total: 0, page: 2, per_page: 50, node_id: 'node-1', service: 'mcp-bridge' },
-    })
+    mockRaw.mockResolvedValue(
+      jsonResponse({ entries: [], total: 0, page: 2, per_page: 50, node_id: 'node-1', service: 'mcp-bridge' })
+    )
 
     const api = useSlmApi()
     await api.getAppLogs({
@@ -86,7 +79,7 @@ describe('useSlmApi.getAppLogs (#11302)', () => {
       mcp_instance: 'worker1',
     })
 
-    const [url] = mockGet.mock.calls[0]
+    const [url] = mockRaw.mock.calls[0] as [string]
     expect(url).toContain('severity=error')
     expect(url).toContain('hours=24')
     expect(url).toContain('q=disk')
@@ -106,7 +99,7 @@ describe('useSlmApi.getAppLogs (#11302)', () => {
       node_id: 'node-1',
       service: 'backend',
     }
-    mockGet.mockResolvedValue({ data: backendResponse })
+    mockRaw.mockResolvedValue(jsonResponse(backendResponse))
 
     const api = useSlmApi()
     const result = await api.getAppLogs({ node_id: 'node-1', service: 'backend' })

--- a/autobot-slm-frontend/src/composables/useSlmApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.test.ts
@@ -1,0 +1,243 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 batch 5 — proves the core useSlmApi composable is migrated onto
+ * the canonical `slmApiClient`.
+ *
+ * useSlmApi historically owned its own `axios.create()` instance (base URL from
+ * getSlmApiBase(), a request interceptor injecting the SLM bearer token). It now
+ * routes every call through `slmApiClient.rawRequest` via a thin axios-compatible
+ * adapter. These tests assert the migration preserves the behaviour the ~26
+ * consumers depend on:
+ *
+ *   * every verb routes through slmApiClient.rawRequest with the correct
+ *     method + endpoint (+ serialised query) and body — so the client's auth
+ *     token / base URL / 401 handling apply (those are covered by ApiClient.test.ts);
+ *   * success returns the parsed JSON body (the historical `response.data`);
+ *   * a non-2xx rejection carries the axios-shaped `err.response.status` /
+ *     `err.response.data` consumers read (SetupWizardView, SecretsSettings);
+ *   * a 401 surfaces `err.response.status === 401` (session handling is the
+ *     client's central concern, exercised inside rawRequest);
+ *   * upsertSecret's load-bearing 409 → PUT fallback still works end-to-end.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { jsonResponse, errorResponse } from './useSlmApi.testHelper'
+
+const mockRaw = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  slmApiClient: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+  default: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+}))
+
+import { useSlmApi } from './useSlmApi'
+
+type RawCall = [string, { method: string; body?: unknown }]
+
+describe('useSlmApi — migrated onto slmApiClient (#12420 Phase 2 batch 5)', () => {
+  beforeEach(() => {
+    mockRaw.mockReset()
+  })
+
+  describe('routing + response.data unwrap', () => {
+    it('getNodes GETs /nodes and maps the backend nodes payload', async () => {
+      mockRaw.mockResolvedValue(
+        jsonResponse({
+          nodes: [
+            {
+              id: 1,
+              node_id: 'n1',
+              hostname: 'h1',
+              ip_address: '10.0.0.1',
+              status: 'online',
+              roles: [],
+              cpu_percent: 1,
+              memory_percent: 2,
+              disk_percent: 3,
+              last_heartbeat: null,
+              agent_version: null,
+              os_info: null,
+              created_at: 'c',
+              updated_at: 'u',
+            },
+          ],
+          total: 1,
+        })
+      )
+
+      const result = await useSlmApi().getNodes()
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes')
+      expect(opts.method).toBe('GET')
+      expect(result).toHaveLength(1)
+      expect(result[0]!.node_id).toBe('n1')
+      // health.status derived from status === 'online'
+      expect(result[0]!.health?.status).toBe('healthy')
+    })
+
+    it('registerNode POSTs the node body to /nodes', async () => {
+      mockRaw.mockResolvedValue(
+        jsonResponse({
+          id: 1,
+          node_id: 'n2',
+          hostname: 'h2',
+          ip_address: '10.0.0.2',
+          status: 'online',
+          roles: [],
+          cpu_percent: 0,
+          memory_percent: 0,
+          disk_percent: 0,
+          last_heartbeat: null,
+          agent_version: null,
+          os_info: null,
+          created_at: 'c',
+          updated_at: 'u',
+        })
+      )
+
+      const payload = { hostname: 'h2', ip_address: '10.0.0.2' } as never
+      await useSlmApi().registerNode(payload)
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes')
+      expect(opts.method).toBe('POST')
+      expect(opts.body).toEqual({ hostname: 'h2', ip_address: '10.0.0.2' })
+    })
+
+    it('updateNode PATCHes /nodes/:id with the update body', async () => {
+      mockRaw.mockResolvedValue(
+        jsonResponse({
+          id: 1,
+          node_id: 'n1',
+          hostname: 'h1',
+          ip_address: '10.0.0.1',
+          status: 'online',
+          roles: [],
+          cpu_percent: 0,
+          memory_percent: 0,
+          disk_percent: 0,
+          last_heartbeat: null,
+          agent_version: null,
+          os_info: null,
+          created_at: 'c',
+          updated_at: 'u',
+        })
+      )
+
+      await useSlmApi().updateNode('n1', { ssh_port: 2222 } as never)
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes/n1')
+      expect(opts.method).toBe('PATCH')
+      expect(opts.body).toEqual({ ssh_port: 2222 })
+    })
+
+    it('deleteNode DELETEs /nodes/:id (204 handled gracefully)', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({}, 204))
+
+      await expect(useSlmApi().deleteNode('n1')).resolves.toBeUndefined()
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes/n1')
+      expect(opts.method).toBe('DELETE')
+    })
+
+    it('getFleetMetrics returns the parsed body directly', async () => {
+      const body = { nodes: [], totals: { cpu: 0 } }
+      mockRaw.mockResolvedValue(jsonResponse(body))
+
+      const result = await useSlmApi().getFleetMetrics()
+
+      expect((mockRaw.mock.calls[0] as RawCall)[0]).toBe('/monitoring/metrics/fleet')
+      expect(result).toEqual(body)
+    })
+  })
+
+  describe('query-param serialisation', () => {
+    it('getProvisionStatus serialises the axios params object onto the endpoint', async () => {
+      mockRaw.mockResolvedValue(
+        jsonResponse({ status: 'running', lines: [], total_lines: 0, error: null })
+      )
+
+      await useSlmApi().getProvisionStatus(7)
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/setup/provision-status?since_line=7')
+      expect(opts.method).toBe('GET')
+    })
+
+    it('getAlerts serialises inline query params', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ alerts: [] }))
+
+      await useSlmApi().getAlerts({ severity: 'critical', hours: 12 })
+
+      const [url] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toContain('/monitoring/alerts?')
+      expect(url).toContain('severity=critical')
+      expect(url).toContain('hours=12')
+    })
+  })
+
+  describe('error shape parity (axios-compatible err.response)', () => {
+    it('surfaces err.response.status and err.response.data on a non-2xx', async () => {
+      mockRaw.mockResolvedValue(errorResponse(400, { detail: 'bad node id' }))
+
+      await expect(useSlmApi().getNode('nope')).rejects.toMatchObject({
+        response: { status: 400, data: { detail: 'bad node id' } },
+      })
+    })
+
+    it('surfaces err.response.status === 401 (client 401 handling runs in rawRequest)', async () => {
+      mockRaw.mockResolvedValue(errorResponse(401, { detail: 'expired' }))
+
+      await expect(useSlmApi().getNodes()).rejects.toMatchObject({
+        response: { status: 401 },
+      })
+    })
+  })
+
+  describe('upsertSecret 409 → PUT fallback (load-bearing error-shape contract)', () => {
+    it('POSTs first, then PUTs on a 409 conflict', async () => {
+      mockRaw
+        .mockResolvedValueOnce(errorResponse(409, { detail: 'exists' }))
+        .mockResolvedValueOnce(jsonResponse({}, 204))
+
+      await useSlmApi().upsertSecret('API_KEY', 'v', 'api_key', 'desc')
+
+      expect(mockRaw).toHaveBeenCalledTimes(2)
+      const post = mockRaw.mock.calls[0] as RawCall
+      const put = mockRaw.mock.calls[1] as RawCall
+      expect(post[0]).toBe('/secrets')
+      expect(post[1].method).toBe('POST')
+      expect(put[0]).toBe('/secrets/API_KEY')
+      expect(put[1].method).toBe('PUT')
+      expect(put[1].body).toEqual({ value: 'v', description: 'desc' })
+    })
+
+    it('re-throws non-409 errors from the initial POST (no PUT fallback)', async () => {
+      mockRaw.mockResolvedValueOnce(errorResponse(500, { detail: 'boom' }))
+
+      await expect(useSlmApi().upsertSecret('API_KEY', 'v')).rejects.toMatchObject({
+        response: { status: 500 },
+      })
+      expect(mockRaw).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('getSecretValue null-on-error contract', () => {
+    it('returns the value on success', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ key: 'K', value: 'secret' }))
+      await expect(useSlmApi().getSecretValue('K')).resolves.toBe('secret')
+    })
+
+    it('returns null when the request fails', async () => {
+      mockRaw.mockResolvedValue(errorResponse(404, { detail: 'missing' }))
+      await expect(useSlmApi().getSecretValue('K')).resolves.toBeNull()
+    })
+  })
+})

--- a/autobot-slm-frontend/src/composables/useSlmApi.testHelper.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.testHelper.ts
@@ -1,0 +1,41 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Response-builder helpers for the useSlmApi ↔ slmApiClient seam (#12420 Phase 2).
+ *
+ * useSlmApi's adapter routes every call through `slmApiClient.rawRequest`, which
+ * resolves a Fetch `Response`. Tests mock that seam per-file (so the vi.mock
+ * factory hoists correctly) and use these builders to produce Response-shaped
+ * stubs the adapter understands — driving the `response.data` unwrap and the
+ * reproduced axios error shape.
+ */
+
+/** A minimal Fetch-Response stub the adapter understands. */
+export function makeResponse(
+  status: number,
+  body: unknown,
+  contentType = 'application/json'
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'content-type' ? contentType : null),
+    },
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response
+}
+
+/** 2xx JSON response. */
+export function jsonResponse(body: unknown, status = 200): Response {
+  return makeResponse(status, body, 'application/json')
+}
+
+/** Non-2xx JSON error response (the adapter surfaces body as err.response.data). */
+export function errorResponse(status: number, body: unknown): Response {
+  return makeResponse(status, body, 'application/json')
+}

--- a/autobot-slm-frontend/src/composables/useSlmApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.ts
@@ -9,7 +9,7 @@
  * Provides REST API integration for all SLM endpoints.
  */
 
-import axios, { type AxiosInstance } from 'axios'
+import { slmApiClient } from '@/utils/ApiClient'
 import type {
   SLMNode,
   NodeHealth,
@@ -45,7 +45,6 @@ import type {
   FleetUpdateSummary,
   EligibleNode,
 } from '@/types/slm'
-import { getSlmApiBase } from '@/config/ssot-config'
 import type {
   ActionResponse,
   SyncVerifyResponse,
@@ -98,8 +97,95 @@ import type {
   WizardStatusResponse,
 } from '@/types/api-responses'
 
-// SLM Admin uses the local SLM backend API
-const API_BASE = getSlmApiBase()
+// =============================================================================
+// slmApiClient adapter (#12420 Phase 2 batch 5)
+//
+// useSlmApi historically owned its own axios instance (base URL from
+// getSlmApiBase(), a request interceptor injecting the SLM bearer token, and no
+// response interceptor). This adapter routes every call through the canonical
+// `slmApiClient` — where the auth token, base URL and centralised 401 handling
+// now live — while reproducing the axios surface the methods below depend on so
+// their bodies, and all ~26 consumers, stay byte-for-byte unchanged:
+//
+//   * methods `await client.<verb>(endpoint, body?)` and read `response.data`
+//     → the adapter returns `{ data }`.
+//   * consumers read `err.response.status` / `err.response.data.detail` on a
+//     rejected call (e.g. upsertSecret's 409 fallback, SetupWizardView,
+//     SecretsSettings) → the adapter throws an axios-shaped error carrying
+//     `response.status` and `response.data`.
+//
+// It delegates to `slmApiClient.rawRequest` (not the get/post/... helpers) on
+// purpose: rawRequest is the single seam that injects the bearer token + base
+// URL and runs the 401 handler, WITHOUT the helpers' GET retry/back-off or the
+// `HTTP <n>: <msg>` error transform — preserving the original single-shot,
+// structured-error behaviour the consumers rely on.
+// =============================================================================
+
+interface AxiosLikeResponse<T> {
+  data: T
+}
+
+// Serialise an axios-style params object onto the endpoint. Only getProvisionStatus
+// passes a params object; every other method already builds its own query string.
+function withParams(endpoint: string, params?: Record<string, unknown>): string {
+  if (!params) return endpoint
+  const usp = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) usp.append(key, String(value))
+  }
+  const qs = usp.toString()
+  if (!qs) return endpoint
+  return endpoint.includes('?') ? `${endpoint}&${qs}` : `${endpoint}?${qs}`
+}
+
+async function adapterRequest<T>(
+  method: string,
+  endpoint: string,
+  body?: unknown
+): Promise<AxiosLikeResponse<T>> {
+  const response = await slmApiClient.rawRequest(endpoint, { method, body })
+
+  if (!response.ok) {
+    let data: unknown = null
+    try {
+      data = await response.json()
+    } catch {
+      /* non-JSON error body — leave data null, mirroring axios */
+    }
+    const error = new Error(`HTTP ${response.status}`) as Error & {
+      response: { status: number; data: unknown }
+    }
+    // Reproduce the axios error shape consumers read (err.response.status/.data).
+    error.response = { status: response.status, data }
+    throw error
+  }
+
+  if (response.status === 204) return { data: {} as T }
+  const contentType = response.headers.get('content-type')
+  if (contentType && contentType.includes('application/json')) {
+    return { data: (await response.json()) as T }
+  }
+  // Non-JSON 2xx (e.g. PEM cert downloads) — return the raw text, as axios does
+  // when its default JSON transform cannot parse the payload.
+  return { data: (await response.text()) as unknown as T }
+}
+
+// Axios-compatible facade over slmApiClient consumed by every method below.
+const client = {
+  get: <T = unknown>(
+    endpoint: string,
+    config?: { params?: Record<string, unknown> }
+  ): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('GET', withParams(endpoint, config?.params)),
+  post: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('POST', endpoint, body),
+  put: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('PUT', endpoint, body),
+  patch: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('PATCH', endpoint, body),
+  delete: <T = unknown>(endpoint: string): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('DELETE', endpoint),
+}
 
 // Backend response types (different from frontend SLMNode)
 interface BackendNodeResponse {
@@ -178,22 +264,6 @@ interface ReplicationsResponse {
 }
 
 export function useSlmApi() {
-  const client: AxiosInstance = axios.create({
-    baseURL: API_BASE,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-
-  // Add auth token to all requests
-  client.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
   // Nodes
   async function getNodes(): Promise<SLMNode[]> {
     const response = await client.get<NodesResponse>('/nodes')
@@ -326,7 +396,7 @@ export function useSlmApi() {
     nodeId: string,
     updateIds: string[]
   ): Promise<{ applied_updates: string[]; failed_updates: string[] }> {
-    const response = await client.post(`/nodes/${nodeId}/updates/apply`, { update_ids: updateIds })
+    const response = await client.post<{ applied_updates: string[]; failed_updates: string[] }>(`/nodes/${nodeId}/updates/apply`, { update_ids: updateIds })
     return response.data
   }
 
@@ -435,7 +505,7 @@ export function useSlmApi() {
     nodeId: string,
     serviceType = 'redis'
   ): Promise<{ is_healthy: boolean; details: Record<string, unknown> }> {
-    const response = await client.post('/stateful/verify', {
+    const response = await client.post<{ is_healthy: boolean; details: Record<string, unknown> }>('/stateful/verify', {
       node_id: nodeId,
       service_type: serviceType,
     })
@@ -764,7 +834,7 @@ export function useSlmApi() {
   }
 
   async function getNodeMetrics(nodeId: string): Promise<FleetMetrics['nodes'][0]> {
-    const response = await client.get(`/monitoring/metrics/node/${nodeId}`)
+    const response = await client.get<FleetMetrics['nodes'][0]>(`/monitoring/metrics/node/${nodeId}`)
     return response.data
   }
 
@@ -852,7 +922,20 @@ export function useSlmApi() {
     time_window_hours: number
   }> {
     const params = hours ? `?hours=${hours}` : ''
-    const response = await client.get(`/monitoring/errors${params}`)
+    const response = await client.get<{
+      total_errors: number
+      by_type: Record<string, number>
+      by_node: Record<string, number>
+      recent_errors: Array<{
+        event_id: string
+        node_id: string
+        hostname: string
+        event_type: string
+        message: string
+        timestamp: string
+      }>
+      time_window_hours: number
+    }>(`/monitoring/errors${params}`)
     return response.data
   }
 
@@ -1237,7 +1320,13 @@ export function useSlmApi() {
     error: string | null
     elapsed_seconds?: number
   }> {
-    const response = await client.get('/setup/provision-status', {
+    const response = await client.get<{
+      status: string
+      lines: string[]
+      total_lines: number
+      error: string | null
+      elapsed_seconds?: number
+    }>('/setup/provision-status', {
       params: { since_line: sinceLine },
     })
     return response.data
@@ -1250,7 +1339,13 @@ export function useSlmApi() {
     missing_required_roles: string[]
     ready: boolean
   }> {
-    const response = await client.get('/setup/validate')
+    const response = await client.get<{
+      health: string
+      total_nodes: number
+      online_nodes: number
+      missing_required_roles: string[]
+      ready: boolean
+    }>('/setup/validate')
     return response.data
   }
 


### PR DESCRIPTION
## Thinking Path

The central SLM HTTP composable `useSlmApi.ts` owned its own `axios.create({ baseURL: getSlmApiBase() })` instance plus a request interceptor injecting the `slm_access_token` bearer, and **no** response interceptor. It is the highest-blast-radius composable in the SLM frontend.

**Consumer inventory (26 files):** SetupWizardView, SecurityView, MaintenanceView, DeploymentsView, FleetOverview, ErrorMonitor, ReplicationView, NoVNCTool, BackupsView, ServicesView, LogViewer, OrchestrationView; stores fleet/provision; composables useNodeHealth/useNodeServices/useNodeConnectionTest; components CodeSourceModal/NodeServicesPanel/DeploymentWizard/NodeLifecyclePanel/AddNodeModal; plus the existing `useSlmApi.appLogs` test.

**Interceptor-parity analysis (vs `slmApiClient`):**
| Concern | useSlmApi (before) | slmApiClient | Verdict |
|---|---|---|---|
| Base URL | `getSlmApiBase()` (eager) | `getSlmApiBase()` (lazy) | parity |
| Auth token | `sessionStorage['slm_access_token']` | sessionStorage → localStorage fallback | parity (broader, matches `stores/auth.ts` init) |
| 401 | none (threw only) | clear session + redirect `/login` when token attached & non-auth endpoint | **behaviour add** (centralisation goal, matches batches 3-4) |
| Error shape | axios `err.response.status`/`.data` | `get/post/...` helpers throw plain `Error('HTTP <n>: ...')` — **no `.response`** | **client does NOT replicate** |
| Retry | none | `get()` retries 3x w/ back-off | client adds behaviour |
| Params | manual query strings + 1 axios `params` object | relative endpoint only | needs serialisation |

**Risk found & folded in (not stopped):** many consumers read `err.response.data.detail` and `upsertSecret` branches on `err.response.status === 409`. The client's convenience helpers would break this across ~26 files. Rather than a wide regression, the migration delegates to `slmApiClient.rawRequest` (the seam that injects auth + base URL and runs the 401 handler) through a thin **axios-compatible adapter** that reproduces `{ data }` returns and the `err.response.status`/`.data` shape, and avoids the helpers' retry/error-transform — preserving the original single-shot, structured-error behaviour exactly.

## What Changed

- `useSlmApi.ts`: drop `axios.create()` + request interceptor + `getSlmApiBase` import. Add a module-level adapter (`withParams`, `adapterRequest`, `client`) over `slmApiClient.rawRequest`. All ~110 method bodies are **unchanged** (only 6 previously-untyped `client.get/post` calls gained the generic matching their declared return type — invisible to consumers). Handles 204 and non-JSON (PEM cert downloads) like axios; serialises `getProvisionStatus`'s axios `params` object onto the endpoint.
- No WebSocket builder exists in this composable — nothing skipped.
- Tests: new `useSlmApi.test.ts` (parity), new `useSlmApi.testHelper.ts` (Response builders), `useSlmApi.appLogs.test.ts` rewritten onto the `rawRequest` seam.

## Verification

- `vue-tsc --noEmit -p tsconfig.json` → clean (exit 0).
- `grep` → useSlmApi holds no axios instance / interceptor (only comment references remain).
- Focused suite: `useSlmApi.test.ts` + `useSlmApi.appLogs.test.ts` → **17 passed**. Covers per-verb routing (method/endpoint/body), `response.data` unwrap, 400/401 → `err.response.status`/`.data`, param serialisation, upsertSecret 409→PUT fallback, getSecretValue null-on-error.
- **Full slm-frontend unit suite: 23 files, 160 tests, all passed** — no consumer regression.

## Model Used

claude-opus-4-8 (Sonnet-tier equivalent for implementation).

## Follow-up

Remaining #12420 Phase 2 work (out of scope here):
- WS-gated domains (composables that also build `ws://`/`wss://` URLs).
- `useCodeSync.ts` — deliberately untouched (its `getUpdateAllStatus()` returns undefined on conn-refused/5xx, load-bearing for #12593; needs a bespoke non-throwing migration).
- `getBackendUrl` display-string call sites and any `setBaseUrl` plugin wiring.

Refs #12420
Closes #12615