### PR TITLE
docs(llc): design docs — cross-vendor review gate + agent-scored retros (#12617)

### DIFF
--- a/.session/HANDOFF-issue-12617.md
+++ b/.session/HANDOFF-issue-12617.md
@@ -1,0 +1,14 @@
+# Handoff: issue-12617
+status: complete
+pr: #12620
+base_at_push: e9e16dd290d0c6d3411911580fc748a9f927e9bc
+gates: docs-only (no code) — wiring=N/A duplication=N/A tests=N/A; conflict-marker scan=PASS
+needs_rebase_before_merge: no
+remaining:
+  - Human action: merge PR #12620 (docs only).
+  - Implementation NOT started by design (research/design-only session):
+    - #12618 cross-vendor second-opinion verifier tier (design: docs/design/2026-07-26-cross-vendor-review-gate.md)
+    - #12619 per-agent scorecard in retrospectives (design: docs/design/2026-07-26-agent-scored-retrospectives.md)
+  - Umbrella: #12617
+blocked_on: none
+worktree: .worktrees/issue-12617  (safe to remove after PR #12620 merges)

--- a/docs/design/2026-07-26-agent-scored-retrospectives.md
+++ b/docs/design/2026-07-26-agent-scored-retrospectives.md
@@ -1,0 +1,104 @@
+---
+tags: [type/architecture, status/proposed, component/backend, component/llc]
+date: 2026-07-26
+issue: 12619
+umbrella: 12617
+---
+
+# Agent-Scored Sprint Retrospectives
+
+## Overview
+
+The sprint retrospective summarizes *work product*, not *agent performance over time*. The raw per-agent signal already exists in the LLC but is never aggregated or surfaced. This design adds a **per-agent scorecard** — success rate, throughput, and spend — computed from data the LLC already writes, and shown in the retrospective.
+
+**Scope:** aggregation + presentation. No new data collection.
+
+## Problem
+
+Existing retro surface:
+- `llc/models/enums.py` — `SprintStatus.RETROSPECTIVE` stage exists.
+- `llc/kb/sprint_summarizer.py` — LLM "Learnings" summary merged into the project KB on sprint close.
+- `llc/services/sprint_planning.py` — team-level velocity/burndown only.
+
+Existing but unused per-agent signal:
+- `llc/models/heartbeat_run.py` — per-agent run records (`agent_id`, `status`, `started_at`).
+- `llc/api/costs.py` `/costs/by-agent-model` — per-agent token spend + cache-hit breakdown.
+
+Result: no way to see which specialist agents are reliable vs. regressing across sprints — the exact input routing and hiring decisions need.
+
+## Goals / Non-Goals
+
+**Goals**
+- A per-agent scorecard for a sprint (or company/time window).
+- Metrics: success rate, throughput, spend.
+- Surface the scorecard in the retrospective summary + a read API.
+
+**Non-Goals**
+- New telemetry or run-level data collection (reuse existing rows).
+- Cross-sprint trend charts / streaks in v1 (the aggregate is the foundation; trends are a fast-follow once historical scorecards accumulate).
+- Frontend dashboard (read API is provided; UI is out of scope here).
+
+## Metrics
+
+Per agent, over the sprint window:
+
+| Metric | Definition | Source |
+|--------|-----------|--------|
+| Success rate | `DONE runs / total runs` | `heartbeat_run` (`status`) |
+| Throughput | completed work items (fallback: successful runs) | `heartbeat_run` + work-item relations |
+| Spend | tokens / cost | `/costs/by-agent-model` |
+
+Edge cases: an agent with **zero** runs in the window appears with `runs=0`, `success_rate=None` (not `0.0`, to avoid punishing idle/unassigned agents). Division guards throughout.
+
+## Architecture
+
+```
+Sprint close / retro request
+            │
+            ▼
+   AgentScorecardService.build(company_id, sprint_id | window)
+            │
+            ├─ query heartbeat_run rows for window  ─► per-agent {runs, done, started…}
+            ├─ query /costs/by-agent-model           ─► per-agent {tokens, cost}
+            ▼
+     assemble List[AgentScore]  (success_rate, throughput, spend)
+            │
+      ┌─────┴──────────────────┐
+      ▼                         ▼
+ sprint_summarizer            GET /sprints/{id}/agent-scorecard
+ (append scorecard section    (read API for retro / future UI)
+  to Learnings summary)
+```
+
+### Service
+New `llc/services/agent_scorecard.py`:
+- `build(company_id, *, sprint_id=None, window=None) -> list[AgentScore]`
+- Pure aggregation; no writes. Reuses existing query paths rather than re-implementing cost math.
+
+### Retro integration
+`sprint_summarizer.py` gains a `_render_agent_scorecard(scores)` section appended alongside the existing "Learnings" summary, so the stored `sprint.kb_summary` includes per-agent performance.
+
+### Read API
+`GET /sprints/{id}/agent-scorecard` in `llc/api/sprints.py` returns the `AgentScore` list — consumable by the retro now and a frontend later.
+
+## Files affected
+
+- `autobot-backend/llc/services/agent_scorecard.py` — **new** aggregation service.
+- `autobot-backend/llc/kb/sprint_summarizer.py` — append scorecard section to the summary.
+- `autobot-backend/llc/api/sprints.py` — read endpoint.
+- reuse (read-only): `autobot-backend/llc/models/heartbeat_run.py`, `autobot-backend/llc/api/costs.py`.
+
+## Testing
+
+- Aggregation math: success rate, throughput, spend across mixed run outcomes.
+- Zero-run agent yields `success_rate=None`, not a divide error.
+- Retro summary includes a per-agent section.
+- Read API returns the scorecard for a sprint id.
+
+## Future work (out of v1 scope)
+
+Once per-sprint scorecards persist, add cross-sprint trends and streaks (regressing/improving agents) — a presentation layer over accumulated scorecards, no new collection needed.
+
+## Model Used
+
+Opus 4.8 (1M context)

--- a/docs/design/2026-07-26-cross-vendor-review-gate.md
+++ b/docs/design/2026-07-26-cross-vendor-review-gate.md
@@ -1,0 +1,109 @@
+---
+tags: [type/architecture, status/proposed, component/backend, component/llc]
+date: 2026-07-26
+issue: 12618
+umbrella: 12617
+---
+
+# Cross-Vendor Second-Opinion Review Gate
+
+## Overview
+
+LLC review gates currently verify work with the **same** provider that produced it. This design adds an optional **second-opinion verifier tier** that requires an *independent* LLM provider to sign off before a gate resolves, so a single model's systematic blind spots cannot pass through unchallenged.
+
+**Scope:** review-gate policy + findings verifier only. No new provider transport — it reuses the existing multi-provider `LLMService` and provider-agnostic tier resolution.
+
+## Problem
+
+- `llc/services/review_gate.py` + `llc/models/review_gate.py` — gates are **human** (`requires_human_review`, `reviewer_role`); there is no automated cross-model check.
+- `llc/services/findings_verify.py` — the false-positive verifier calls `get_llm_service()` (the single default `LLMService` singleton). The checker shares the author's provider/model family, so correlated errors (confident-but-wrong findings, consistently-misjudged real bugs) survive the gate.
+- `llc/services/model_tiers.py` — already provider-agnostic and can identify a provider, but nothing requires the verifier to differ from the author.
+
+## Goals / Non-Goals
+
+**Goals**
+- A verifier tier that runs on a provider distinct from the author when ≥2 providers are configured.
+- Per-company, per-item-type policy control, defaulting **off**.
+- Preserve the current **fail-closed** verifier semantics.
+- Graceful, non-fatal degradation on single-provider installs.
+
+**Non-Goals**
+- Replacing the human review gate (cross-vendor disagreement escalates *to* it).
+- Adding a new LLM provider or SDK.
+- Changing the findings data model.
+
+## Architecture
+
+```
+Finding produced (author provider = P_a)
+            │
+            ▼
+   ReviewGatePolicyService.get(company, item_type)
+            │  requires_cross_vendor_review?
+      ┌─────┴─────┐
+      │ false     │ true
+      ▼           ▼
+ same-vendor   resolve verifier provider P_v != P_a
+ verifier      (via model_tiers / LLMService registry)
+ (current)          │
+                    ▼
+             run verifier on P_v  ── fail ──► Verdict(is_real=False, conf=0.0)   [fail-closed]
+                    │
+                    ▼
+          combine(author_verdict, P_v_verdict)
+            ├─ agree      ─► gate resolves automatically
+            └─ disagree   ─► escalate to human review gate
+```
+
+### Provider selection
+`select_verifier_provider(author_provider)` asks the `LLMService` registry for configured providers, excludes `author_provider`, and picks by the existing tier preference in `model_tiers.py`. If the exclusion leaves an empty set → degrade (see below).
+
+### Verdict combination
+- **Agree** (both `is_real` equal): resolve automatically with the higher-confidence rationale attached.
+- **Disagree**: do **not** auto-pass. Route to the existing human review gate (`requires_human_review=True` for this item), recording both verdicts as decision context so the human sees the split.
+
+## Policy model
+
+Extend `LLMReviewGatePolicy` (`llc/models/review_gate.py`) with `requires_cross_vendor_review: bool` (default `False`). `ReviewGatePolicyService.install_defaults` seeds it off for every item type. Exposed/editable via `llc/api/review_gate_policies.py` per company + item type.
+
+## Graceful degradation
+
+If `cross_vendor` is requested but the registry yields no provider ≠ author:
+1. Log a single `warning` (not per-call spam).
+2. Fall back to the current same-vendor verifier.
+3. Never hard-fail — a single-provider deploy behaves exactly as today.
+
+This keeps the feature config-gated and safe for installs with one provider.
+
+## Failure modes
+
+| Condition | Behavior |
+|-----------|----------|
+| Verifier provider call errors/times out | `Verdict(is_real=False, confidence=0.0, rationale="unverifiable: …")` (fail-closed, unchanged) |
+| Only one provider configured | Warn once → same-vendor verifier |
+| Author provider unresolvable | Treat as "no exclusion possible" → degrade |
+| Both verdicts low-confidence | Escalate to human gate |
+
+## Files affected
+
+- `autobot-backend/llc/services/findings_verify.py` — add `cross_vendor` mode + `select_verifier_provider` + verdict combination.
+- `autobot-backend/llc/models/review_gate.py` — add `requires_cross_vendor_review` column.
+- `autobot-backend/llc/services/review_gate.py` — honor the flag; seed default off.
+- `autobot-backend/llc/api/review_gate_policies.py` — expose the flag.
+- `autobot-backend/llc/services/model_tiers.py` — read-only reuse for provider identity/selection.
+- Migration: add nullable-with-default column to the review-gate policy table (no data loss).
+
+## Testing
+
+- Provider selection excludes author provider when ≥2 configured.
+- Verdict combination: agree → auto-resolve; disagree → human gate with both verdicts recorded.
+- Degradation: single-provider deploy warns once and uses same-vendor verifier; no exception.
+- Fail-closed preserved on verifier error.
+
+## Rollout
+
+Ship off by default. Enable per company/item-type (e.g. `bug` items) once a second provider is configured. No behavior change for existing installs until the flag is set.
+
+## Model Used
+
+Opus 4.8 (1M context)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -19,6 +19,8 @@ Pre-implementation design documents. Each captures *why* a feature was designed 
 |---|---|---|
 | [[2026-04-10-causal-error-recovery]] | Causal Error Recovery system design | #2154 |
 | [[2026-04-10-counterfactual-reasoning]] | CounterfactualReasoner — three-tier prediction strategy | #4069 |
+| [[2026-07-26-cross-vendor-review-gate]] | Cross-vendor second-opinion review gate for LLC | #12618 |
+| [[2026-07-26-agent-scored-retrospectives]] | Per-agent scorecard in sprint retrospectives | #12619 |
 
 ---
 


### PR DESCRIPTION
## Thinking Path

A review of the LLC Company-OS control plane (`autobot-backend/llc/`) confirmed our governance surface is mature (board approvals, budget guardrails, agent hiring, RAG decision log, sprint state machine). Two capability gaps remained where the data or seam already exists but the feature is unbuilt. This PR writes those designs down before any implementation, per the "design before build" rule.

## What Changed

Docs only — no code. Two design docs under `docs/design/` + index entry:

- `2026-07-26-cross-vendor-review-gate.md` — optional second-opinion verifier tier that requires an *independent* LLM provider to sign off on findings/review gates; reuses the existing multi-provider `LLMService`, fail-closed, off by default, degrades gracefully on single-provider installs. (#12618)
- `2026-07-26-agent-scored-retrospectives.md` — per-agent scorecard (success rate, throughput, spend) aggregated from existing `heartbeat_run` + `/costs/by-agent-model` rows and surfaced in the sprint retrospective. (#12619)

Tracked under umbrella #12617.

## Verification

- Docs-only change; `git show --stat` = 3 files (2 new design docs + README index row).
- Design docs cite the exact existing modules each feature touches; no code paths modified.

## Model Used

Opus 4.8 (1M context)
