### PR TITLE
refactor(slm-frontend): migrate useCodeSync onto slmApiClient preserving #12593 poll semantics (#12420 Phase 2 batch 6)

### DIFF
--- a/autobot-slm-frontend/src/composables/useCodeSync.test.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSync.test.ts
@@ -10,58 +10,79 @@
  * composable methods return promptly with a job_id and that status polling
  * distinguishes "unknown job" (stop) from "transient error during the
  * component's own service restart" (keep polling).
+ *
+ * #12420 Phase 2 (batch 6) — useCodeSync migrated off its per-composable axios
+ * instance onto the canonical `slmApiClient`. The 404-vs-transient poll
+ * contract that backs #12593 (see the getUpdateAllStatus block below) is
+ * asserted end-to-end through the new `rawRequest` path.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useCodeSync } from './useCodeSync'
 
-const mockPost = vi.fn()
 const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDelete = vi.fn()
+const mockRawRequest = vi.fn()
 
-vi.mock('@/stores/auth', () => ({
-  useAuthStore: () => ({ logout: vi.fn() }),
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+    rawRequest: (...args: unknown[]) => mockRawRequest(...args),
+  },
 }))
 
-vi.mock('axios', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('axios')>()
+// useRoles owns its own axios client (out of scope for this batch); stub it so
+// syncNode's SLM-server role lookup (#9956) is deterministic and offline.
+const mockGetNodeRoles = vi.fn()
+vi.mock('./useRoles', () => ({
+  useRoles: () => ({
+    roles: [],
+    fetchRoles: vi.fn(),
+    syncRole: vi.fn(),
+    pullFromSource: vi.fn(),
+    getNodeRoles: (...args: unknown[]) => mockGetNodeRoles(...args),
+  }),
+}))
+
+import { useCodeSync } from './useCodeSync'
+
+// Minimal Response-like stub for the rawRequest-based methods.
+function mockResponse(status: number, body: unknown): Response {
   return {
-    ...actual,
-    default: {
-      ...actual.default,
-      create: () => ({
-        post: mockPost,
-        get: mockGet,
-        interceptors: {
-          request: { use: vi.fn() },
-          response: { use: vi.fn() },
-        },
-      }),
-    },
-  }
-})
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
 
 describe('useCodeSync — async drift/resolve job (#11303)', () => {
   beforeEach(() => {
     mockPost.mockReset()
     mockGet.mockReset()
+    mockRawRequest.mockReset()
   })
 
   it('startResolveDriftAsync resolves immediately with a job_id (no inline rsync/post-steps wait)', async () => {
-    mockPost.mockResolvedValue({
-      data: { job_id: 'job-1', component: 'autobot-slm-backend', status: 'running' },
-    })
+    mockRawRequest.mockResolvedValue(
+      mockResponse(200, { job_id: 'job-1', component: 'autobot-slm-backend', status: 'running' }),
+    )
 
     const codeSync = useCodeSync()
     const result = await codeSync.startResolveDriftAsync('autobot-slm-backend')
 
-    expect(mockPost).toHaveBeenCalledWith('/code-sync/drift/resolve-async', {
-      component: 'autobot-slm-backend',
+    expect(mockRawRequest).toHaveBeenCalledWith('/code-sync/drift/resolve-async', {
+      method: 'POST',
+      body: { component: 'autobot-slm-backend' },
     })
     expect(result).toEqual({ job_id: 'job-1', component: 'autobot-slm-backend', status: 'running' })
   })
 
-  it('startResolveDriftAsync surfaces a 409 (restart in flight) without throwing', async () => {
-    mockPost.mockRejectedValue({ response: { status: 409, data: { detail: 'restart in flight' } } })
+  it('startResolveDriftAsync surfaces a 409 (restart in flight) detail verbatim without throwing', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(409, { detail: 'restart in flight' }))
 
     const codeSync = useCodeSync()
     const result = await codeSync.startResolveDriftAsync('autobot-slm-backend')
@@ -71,8 +92,8 @@ describe('useCodeSync — async drift/resolve job (#11303)', () => {
   })
 
   it('getResolveDriftStatus returns the persisted job row once the job finishes', async () => {
-    mockGet.mockResolvedValue({
-      data: {
+    mockRawRequest.mockResolvedValue(
+      mockResponse(200, {
         job_id: 'job-1',
         component: 'autobot-slm-backend',
         status: 'completed',
@@ -82,19 +103,21 @@ describe('useCodeSync — async drift/resolve job (#11303)', () => {
         post_steps: ['rsync ok', 'pip install ok'],
         created_at: null,
         completed_at: null,
-      },
-    })
+      }),
+    )
 
     const codeSync = useCodeSync()
     const result = await codeSync.getResolveDriftStatus('job-1')
 
-    expect(mockGet).toHaveBeenCalledWith('/code-sync/drift/resolve/status/job-1')
+    expect(mockRawRequest).toHaveBeenCalledWith('/code-sync/drift/resolve/status/job-1', {
+      method: 'GET',
+    })
     expect(result?.status).toBe('completed')
     expect(result?.success).toBe(true)
   })
 
   it('getResolveDriftStatus returns null on a true 404 so the poller stops', async () => {
-    mockGet.mockRejectedValue({ response: { status: 404 } })
+    mockRawRequest.mockResolvedValue(mockResponse(404, { detail: 'unknown job' }))
 
     const codeSync = useCodeSync()
     const result = await codeSync.getResolveDriftStatus('unknown-job')
@@ -102,13 +125,230 @@ describe('useCodeSync — async drift/resolve job (#11303)', () => {
     expect(result).toBeNull()
   })
 
-  it('getResolveDriftStatus returns undefined on a transient error (component self-restart) so the poller keeps retrying', async () => {
-    mockGet.mockRejectedValue(new Error('ECONNREFUSED'))
+  it('getResolveDriftStatus returns undefined on a 5xx (component self-restart) so the poller keeps retrying', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(503, { detail: 'service unavailable' }))
 
     const codeSync = useCodeSync()
     const result = await codeSync.getResolveDriftStatus('job-1')
 
     expect(result).toBeUndefined()
+  })
+
+  it('getResolveDriftStatus returns undefined on a connection-refused error so the poller keeps retrying', async () => {
+    mockRawRequest.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getResolveDriftStatus('job-1')
+
+    expect(result).toBeUndefined()
+  })
+})
+
+/**
+ * Issue #12593 (backed by the #12420 batch-6 migration) — during Update-All
+ * stage 3 (`slm_self_update`) the SLM control plane restarts itself. The
+ * code-sync page polls that SAME control plane via getUpdateAllStatus(), so it
+ * sees ~1min of transient poll failures (connection refused / 5xx). The poll
+ * loop MUST keep polling through that window (return `undefined`) and only stop
+ * on a true 404 (no job ever started → return `null`). This contract is what
+ * lets the reconnecting affordance render instead of a hard "job failed".
+ *
+ * These tests prove the contract survives the slmApiClient migration by driving
+ * getUpdateAllStatus()/startUpdateAll() through the mocked `rawRequest` path.
+ */
+describe('getUpdateAllStatus poll contract through slmApiClient (#12593 / #12420 batch 6)', () => {
+  beforeEach(() => {
+    mockRawRequest.mockReset()
+  })
+
+  const job = {
+    job_id: 'job-ua',
+    status: 'running',
+    stages: [],
+    total_fleet_nodes: 0,
+    completed_fleet_nodes: 0,
+    failed_fleet_nodes: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    completed_at: null,
+    failure_reason: null,
+  }
+
+  it('returns the job on 200 and targets the status endpoint via rawRequest (single-shot GET)', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(200, job))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getUpdateAllStatus()
+
+    expect(mockRawRequest).toHaveBeenCalledWith('/code-sync/update-all/status', {
+      method: 'GET',
+    })
+    expect(result).toEqual(job)
+  })
+
+  it('returns null ONLY on a true 404 (no job started) so the caller stops polling', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(404, { detail: 'no job' }))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getUpdateAllStatus()
+
+    expect(result).toBeNull()
+  })
+
+  it('returns undefined on a 502 during the SLM self-restart so the caller KEEPS polling', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(502, { detail: 'bad gateway' }))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getUpdateAllStatus()
+
+    // Not null — a self-restart bounce must never be read as "stop polling".
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined on a 503 (control plane bouncing) so the caller KEEPS polling', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(503, { detail: 'unavailable' }))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getUpdateAllStatus()
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined on connection-refused / network error so the caller KEEPS polling', async () => {
+    mockRawRequest.mockRejectedValue(new Error('Failed to fetch'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getUpdateAllStatus()
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined on a request timeout so the caller KEEPS polling', async () => {
+    mockRawRequest.mockRejectedValue(new Error('Request timeout after 30000ms'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getUpdateAllStatus()
+
+    expect(result).toBeUndefined()
+  })
+
+  it('startUpdateAll returns the initial job on 200', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(200, job))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.startUpdateAll()
+
+    expect(mockRawRequest).toHaveBeenCalledWith('/code-sync/update-all', {
+      method: 'POST',
+    })
+    expect(result).toEqual(job)
+  })
+
+  it('startUpdateAll returns null and surfaces the 409 detail (already running)', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(409, { detail: 'Update already in progress' }))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.startUpdateAll()
+
+    expect(result).toBeNull()
+    expect(codeSync.error.value).toBe('Update already in progress')
+  })
+
+  it('startUpdateAll returns null on a network error without throwing', async () => {
+    mockRawRequest.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.startUpdateAll()
+
+    expect(result).toBeNull()
+    expect(codeSync.error.value).toBe('Failed to start update')
+  })
+})
+
+/**
+ * Issue #12420 Phase 2 (batch 6) — spot-check that the convenience-method
+ * migration preserves the graceful-return contracts: mutating/fetch helpers
+ * keep their `[]`/`null`/`false` returns and populate `error.value` from the
+ * thrown message, and syncNode still treats the SLM self-restart 502 as success.
+ */
+describe('useCodeSync — slmApiClient convenience migration (#12420 batch 6)', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockRawRequest.mockReset()
+    mockGetNodeRoles.mockReset()
+  })
+
+  it('fetchStatus GETs /code-sync/status and stores the parsed body', async () => {
+    const body = {
+      latest_version: 'abc',
+      local_version: 'abc',
+      last_fetch: null,
+      has_update: false,
+      outdated_nodes: 0,
+      total_nodes: 3,
+    }
+    mockGet.mockResolvedValue(body)
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.fetchStatus()
+
+    expect(mockGet).toHaveBeenCalledWith('/code-sync/status')
+    expect(result).toEqual(body)
+    expect(codeSync.status.value).toEqual(body)
+  })
+
+  it('fetchStatus returns null and sets error.value from the thrown message', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 500: boom'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.fetchStatus()
+
+    expect(result).toBeNull()
+    expect(codeSync.error.value).toBe('HTTP 500: boom')
+  })
+
+  it('fetchPendingNodes returns [] on failure (graceful)', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 500'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.fetchPendingNodes()
+
+    expect(result).toEqual([])
+  })
+
+  it('getRecentJobs GETs a single-shot poll with the limit on the path and returns [] on failure', async () => {
+    mockGet.mockRejectedValue(new Error('HTTP 503'))
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.getRecentJobs(5)
+
+    expect(mockGet).toHaveBeenCalledWith('/code-sync/fleet/jobs?limit=5', {
+      maxRetries: 1,
+    })
+    expect(result).toEqual([])
+  })
+
+  it('syncNode treats the SLM self-restart 502 as success when the node is an SLM server', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(502, { detail: 'bad gateway' }))
+    mockGetNodeRoles.mockResolvedValue({ detected_roles: ['slm-backend'] })
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.syncNode('node-1', { restart: true })
+
+    expect(result.success).toBe(true)
+    expect(result.node_id).toBe('node-1')
+    expect(result.message).toContain('SLM Manager restart')
+  })
+
+  it('syncNode surfaces a 502 as failure when the node is NOT an SLM server', async () => {
+    mockRawRequest.mockResolvedValue(mockResponse(502, { detail: 'bad gateway' }))
+    mockGetNodeRoles.mockResolvedValue({ detected_roles: ['worker'] })
+
+    const codeSync = useCodeSync()
+    const result = await codeSync.syncNode('node-1', { restart: true })
+
+    expect(result.success).toBe(false)
+    expect(codeSync.error.value).toBe('bad gateway')
   })
 })
 

--- a/autobot-slm-frontend/src/composables/useCodeSync.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSync.ts
@@ -8,17 +8,24 @@
  *
  * Provides reactive state and methods for code version tracking
  * and sync operations across the SLM fleet.
+ *
+ * #12420 Phase 2 (batch 6): migrated off a per-composable axios instance onto
+ * the canonical `slmApiClient`. The client injects the SLM bearer token and
+ * handles 401 (session clear + redirect to /login), replacing the former
+ * request/response interceptors — including #10369's expired-token logout.
+ *
+ * LOAD-BEARING for #12593: `getUpdateAllStatus()` and `getResolveDriftStatus()`
+ * MUST return `undefined` on connection-refused/network/5xx (so the code-sync
+ * page keeps polling through the SLM self-restart window) and `null` only on a
+ * true 404. `slmApiClient`'s convenience methods THROW on non-2xx, which would
+ * collapse that distinction, so those two pollers (and any specific-status
+ * handling) use `rawRequest` to inspect `response.status` directly.
  */
 
 import { ref, computed, readonly, toRef } from 'vue'
-import axios, { type AxiosInstance } from 'axios'
 import { useRoles, type Role, type SyncResult } from './useRoles'
 import { formatCommitHash } from '@/utils/commitHashUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
-import { useAuthStore } from '@/stores/auth'
-
-// SLM Admin uses the local SLM backend API
-const API_BASE = getSlmApiBase()
+import slmApiClient from '@/utils/ApiClient'
 
 // =============================================================================
 // Type Definitions
@@ -270,40 +277,33 @@ export function classifyUpdateAllPollError(
 }
 
 // =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * Best-effort read of a FastAPI `{ detail }` error body from a raw Response.
+ * Returns null when the body is absent/non-JSON so callers can fall back to a
+ * generic message. Used by the `rawRequest`-based methods that must preserve
+ * the exact detail-derived error strings the axios implementation produced.
+ */
+async function readDetail(response: Response): Promise<string | null> {
+  try {
+    const body = (await response.json()) as { detail?: unknown } | null
+    const detail = body?.detail
+    return typeof detail === 'string' ? detail : null
+  } catch {
+    return null
+  }
+}
+
+// =============================================================================
 // Composable
 // =============================================================================
 
 export function useCodeSync() {
-  const authStore = useAuthStore()
-
-  // Create axios client
-  const client: AxiosInstance = axios.create({
-    baseURL: API_BASE,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-
-  // Add auth token to all requests
-  client.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
-  // #10369 — without a 401 handler an expired/invalid token makes the status
-  // poller spam 401s forever; log out so the UI redirects to login instead.
-  client.interceptors.response.use(
-    (response) => response,
-    (error) => {
-      if (error.response?.status === 401) {
-        authStore.logout()
-      }
-      return Promise.reject(error)
-    }
-  )
+  // #10369 / auth: token injection and 401 handling (session clear + redirect
+  // to /login) are now performed by `slmApiClient`, replacing the former axios
+  // request/response interceptors — no per-composable client needed.
 
   // Initialize roles composable (Issue #779)
   const rolesComposable = useRoles()
@@ -362,15 +362,12 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.get<CodeSyncStatus>('/code-sync/status')
-      status.value = response.data
+      const data = await slmApiClient.get<CodeSyncStatus>('/code-sync/status')
+      status.value = data
       lastRefresh.value = new Date()
-      return response.data
+      return data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch code sync status'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return null
     } finally {
       loading.value = false
@@ -386,19 +383,16 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.post<RefreshResponse>('/code-sync/refresh')
+      const data = await slmApiClient.post<RefreshResponse>('/code-sync/refresh')
 
-      if (response.data.success) {
+      if (data.success) {
         // Refresh status after manual refresh to get updated data
         await fetchStatus()
       }
 
-      return response.data.success
+      return data.success
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to refresh version'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return false
     } finally {
       loading.value = false
@@ -414,14 +408,11 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.get<PendingNodesResponse>('/code-sync/pending')
-      pendingNodes.value = response.data.nodes
-      return response.data.nodes
+      const data = await slmApiClient.get<PendingNodesResponse>('/code-sync/pending')
+      pendingNodes.value = data.nodes
+      return data.nodes
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch pending nodes'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return []
     } finally {
       loading.value = false
@@ -447,32 +438,16 @@ export function useCodeSync() {
     }
 
     try {
-      const response = await client.post<SyncResponse>(
+      // rawRequest (single-shot, raw status): the SLM Manager self-restart path
+      // returns a 502 that must be interpreted as success, not surfaced as an
+      // error — the convenience `post` would throw and lose the status code.
+      const response = await slmApiClient.rawRequest(
         `/code-sync/nodes/${nodeId}/sync`,
-        payload
+        { method: 'POST', body: payload }
       )
 
-      // Set error if sync failed
-      if (!response.data.success) {
-        error.value = response.data.message
-      } else {
-        // Issue #1231: SLM self-sync is fire-and-forget — the backend
-        // returns immediately before the background task completes.
-        // Refreshing now would return stale data (node still outdated).
-        // Skip refresh and let the caller handle the delayed update.
-        const isSLMSelfSync = response.data.message?.includes(
-          'SLM update queued'
-        )
-        if (!isSLMSelfSync) {
-          await fetchPendingNodes()
-          await fetchStatus()
-        }
-      }
-
-      return response.data
-    } catch (e) {
       // Special handling for SLM Manager self-restart (502 errors expected)
-      if (axios.isAxiosError(e) && e.response?.status === 502) {
+      if (response.status === 502) {
         // #9956: Identify the SLM server by its detected SLM roles, not by a
         // hardcoded/substring node name — operators may rename the node.
         const nodeRoles = await rolesComposable
@@ -492,11 +467,33 @@ export function useCodeSync() {
         }
       }
 
+      if (!response.ok) {
+        const detail = await readDetail(response)
+        error.value = detail || 'Sync failed'
+        return { success: false, message: error.value, node_id: nodeId }
+      }
+
+      const data = (await response.json()) as SyncResponse
+
+      // Set error if sync failed
+      if (!data.success) {
+        error.value = data.message
+      } else {
+        // Issue #1231: SLM self-sync is fire-and-forget — the backend
+        // returns immediately before the background task completes.
+        // Refreshing now would return stale data (node still outdated).
+        // Skip refresh and let the caller handle the delayed update.
+        const isSLMSelfSync = data.message?.includes('SLM update queued')
+        if (!isSLMSelfSync) {
+          await fetchPendingNodes()
+          await fetchStatus()
+        }
+      }
+
+      return data
+    } catch (e) {
       const message = e instanceof Error ? e.message : 'Sync failed'
       error.value = message
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return { success: false, message: error.value || message, node_id: nodeId }
     } finally {
       loading.value = false
@@ -520,26 +517,23 @@ export function useCodeSync() {
     }
 
     try {
-      const response = await client.post<FleetSyncResponse>(
+      const data = await slmApiClient.post<FleetSyncResponse>(
         '/code-sync/fleet/sync',
         payload
       )
 
       // Set error if fleet sync failed
-      if (!response.data.success) {
-        error.value = response.data.message
+      if (!data.success) {
+        error.value = data.message
       } else {
         // Refresh status after fleet sync is queued
         await fetchStatus()
       }
 
-      return response.data
+      return data
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Fleet sync failed'
       error.value = message
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return { success: false, message: error.value || message, job_id: '', nodes_queued: 0 }
     } finally {
       loading.value = false
@@ -553,14 +547,13 @@ export function useCodeSync() {
    */
   async function getJobStatus(jobId: string): Promise<FleetSyncJobStatus | null> {
     try {
-      const response = await client.get<FleetSyncJobStatus>(
-        `/code-sync/fleet/jobs/${jobId}`
+      // Single-shot poll — no retry/backoff (matches the former axios call).
+      return await slmApiClient.get<FleetSyncJobStatus>(
+        `/code-sync/fleet/jobs/${jobId}`,
+        { maxRetries: 1 }
       )
-      return response.data
     } catch (e) {
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
+      error.value = e instanceof Error ? e.message : 'Failed to fetch job status'
       return null
     }
   }
@@ -572,15 +565,13 @@ export function useCodeSync() {
    */
   async function getRecentJobs(limit = 10): Promise<FleetSyncJobStatus[]> {
     try {
-      const response = await client.get<FleetSyncJobStatus[]>(
-        '/code-sync/fleet/jobs',
-        { params: { limit } }
+      // Single-shot poll — no retry/backoff (matches the former axios call).
+      return await slmApiClient.get<FleetSyncJobStatus[]>(
+        `/code-sync/fleet/jobs?limit=${limit}`,
+        { maxRetries: 1 }
       )
-      return response.data
     } catch (e) {
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
+      error.value = e instanceof Error ? e.message : 'Failed to fetch recent jobs'
       return []
     }
   }
@@ -620,14 +611,11 @@ export function useCodeSync() {
    */
   async function fetchSchedules(): Promise<UpdateSchedule[]> {
     try {
-      const response = await client.get<UpdateSchedule[]>('/code-sync/schedules')
-      schedules.value = response.data
-      return response.data
+      const data = await slmApiClient.get<UpdateSchedule[]>('/code-sync/schedules')
+      schedules.value = data
+      return data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch schedules'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return []
     }
   }
@@ -642,17 +630,14 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.post<UpdateSchedule>(
+      const data = await slmApiClient.post<UpdateSchedule>(
         '/code-sync/schedules',
         schedule
       )
       await fetchSchedules()
-      return response.data
+      return data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to create schedule'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return null
     } finally {
       loading.value = false
@@ -670,17 +655,14 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.put<UpdateSchedule>(
+      const data = await slmApiClient.put<UpdateSchedule>(
         `/code-sync/schedules/${id}`,
         update
       )
       await fetchSchedules()
-      return response.data
+      return data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to update schedule'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return null
     } finally {
       loading.value = false
@@ -695,14 +677,11 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      await client.delete(`/code-sync/schedules/${id}`)
+      await slmApiClient.delete(`/code-sync/schedules/${id}`)
       await fetchSchedules()
       return true
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to delete schedule'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return false
     } finally {
       loading.value = false
@@ -725,16 +704,13 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.post<ScheduleRunResponse>(
+      const data = await slmApiClient.post<ScheduleRunResponse>(
         `/code-sync/schedules/${id}/run`
       )
       await fetchSchedules()
-      return response.data
+      return data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to run schedule'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return null
     } finally {
       loading.value = false
@@ -755,16 +731,13 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.get<FileDriftReport>('/code-sync/drift', {
-        params: { component },
-      })
-      driftReport.value = response.data
-      return response.data
+      const data = await slmApiClient.get<FileDriftReport>(
+        `/code-sync/drift?component=${encodeURIComponent(component)}`
+      )
+      driftReport.value = data
+      return data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch drift report'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return null
     } finally {
       loading.value = false
@@ -785,18 +758,15 @@ export function useCodeSync() {
     error.value = null
 
     try {
-      const response = await client.post<DriftResolveResponse>('/code-sync/drift/resolve', {
+      const data = await slmApiClient.post<DriftResolveResponse>('/code-sync/drift/resolve', {
         component,
       })
-      if (!response.data.success) {
-        error.value = response.data.message
+      if (!data.success) {
+        error.value = data.message
       }
-      return response.data
+      return data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to resolve drift'
-      if (axios.isAxiosError(e) && e.response?.data?.detail) {
-        error.value = e.response.data.detail
-      }
       return null
     } finally {
       loading.value = false
@@ -809,17 +779,25 @@ export function useCodeSync() {
    * Returns immediately with a job_id instead of awaiting the full rsync +
    * post-sync steps inline, so the GUI never blocks on a slow resync or the
    * component's own service restart. Poll getResolveDriftStatus() for progress.
+   *
+   * Uses rawRequest so the 409 (restart in flight) detail is surfaced verbatim
+   * in `error.value` (the convenience `post` would prefix "HTTP 409: ").
    */
   async function startResolveDriftAsync(component: string): Promise<DriftResolveJobResponse | null> {
     error.value = null
     try {
-      const response = await client.post<DriftResolveJobResponse>('/code-sync/drift/resolve-async', {
-        component,
+      const response = await slmApiClient.rawRequest('/code-sync/drift/resolve-async', {
+        method: 'POST',
+        body: { component },
       })
-      return response.data
-    } catch (e: unknown) {
-      const axiosErr = e as { response?: { status?: number; data?: { detail?: string } } }
-      error.value = axiosErr?.response?.data?.detail || 'Failed to start drift resolve job'
+      if (!response.ok) {
+        const detail = await readDetail(response)
+        error.value = detail || 'Failed to start drift resolve job'
+        return null
+      }
+      return (await response.json()) as DriftResolveJobResponse
+    } catch {
+      error.value = 'Failed to start drift resolve job'
       return null
     }
   }
@@ -830,17 +808,23 @@ export function useCodeSync() {
    * Returns null ONLY on a true 404 (unknown job_id) so the caller stops
    * polling. Returns undefined on transient errors (network refused / 5xx
    * during the component's own restart) so the caller keeps polling instead
-   * of treating a self-restart as job failure.
+   * of treating a self-restart as job failure. rawRequest gives the raw status
+   * needed to keep this 404-vs-transient distinction intact.
    */
   async function getResolveDriftStatus(jobId: string): Promise<ComponentSyncJobStatus | null | undefined> {
     try {
-      const response = await client.get<ComponentSyncJobStatus>(`/code-sync/drift/resolve/status/${jobId}`)
-      return response.data
-    } catch (e: unknown) {
-      const axiosErr = e as { response?: { status?: number } }
-      if (axiosErr?.response?.status === 404) {
+      const response = await slmApiClient.rawRequest(
+        `/code-sync/drift/resolve/status/${jobId}`,
+        { method: 'GET' }
+      )
+      if (response.status === 404) {
         return null
       }
+      if (!response.ok) {
+        return undefined
+      }
+      return (await response.json()) as ComponentSyncJobStatus
+    } catch {
       return undefined
     }
   }
@@ -918,18 +902,27 @@ export function useCodeSync() {
    * Start the one-click update-all orchestration pipeline.
    * Returns the initial UpdateAllJob or null on 409 (already running).
    * F1: distinguishes 404 (no job) from transient errors (network/5xx).
+   *
+   * rawRequest preserves the exact 409-vs-other detail-derived error strings
+   * the axios implementation surfaced in `error.value`.
    */
   async function startUpdateAll(): Promise<UpdateAllJob | null> {
     try {
-      const response = await client.post<UpdateAllJob>('/code-sync/update-all')
-      return response.data
-    } catch (e: unknown) {
-      const axiosErr = e as { response?: { status?: number; data?: { detail?: string } } }
-      if (axiosErr?.response?.status === 409) {
-        error.value = axiosErr.response?.data?.detail || 'Update already running'
-      } else {
-        error.value = axiosErr?.response?.data?.detail || 'Failed to start update'
+      const response = await slmApiClient.rawRequest('/code-sync/update-all', {
+        method: 'POST',
+      })
+      if (!response.ok) {
+        const detail = await readDetail(response)
+        if (response.status === 409) {
+          error.value = detail || 'Update already running'
+        } else {
+          error.value = detail || 'Failed to start update'
+        }
+        return null
       }
+      return (await response.json()) as UpdateAllJob
+    } catch {
+      error.value = 'Failed to start update'
       return null
     }
   }
@@ -937,36 +930,52 @@ export function useCodeSync() {
   /**
    * Poll the status of the current update-all job.
    *
-   * F1: Returns null ONLY on true 404 (no job ever started).
-   *     Returns undefined on transient errors (network refused / 5xx during
-   *     SLM restart) so the caller can distinguish "stop polling" from "keep polling".
+   * F1 / #12593: Returns null ONLY on a true 404 (no job ever started) so the
+   * caller stops polling. Returns undefined on transient errors (connection
+   * refused / network / 5xx during the SLM self-restart window) so the caller
+   * keeps polling instead of treating the control-plane bounce as a hard stop.
+   *
+   * MUST use rawRequest: `slmApiClient.get` throws a generic `Error('HTTP <n>:
+   * …')` on non-2xx and retries transient failures, which would erase the
+   * 404-vs-transient distinction this #12593 contract depends on.
    */
   async function getUpdateAllStatus(): Promise<UpdateAllJob | null | undefined> {
     try {
-      const response = await client.get<UpdateAllJob>('/code-sync/update-all/status')
-      return response.data
-    } catch (e: unknown) {
-      const axiosErr = e as { response?: { status?: number }; code?: string; message?: string }
+      const response = await slmApiClient.rawRequest('/code-sync/update-all/status', {
+        method: 'GET',
+      })
       // True 404 = no job started yet → stop polling
-      if (axiosErr?.response?.status === 404) {
+      if (response.status === 404) {
         return null
       }
-      // Network error or 5xx during SLM restart → transient, keep polling
+      // 5xx (or any other non-2xx) during SLM restart → transient, keep polling
+      if (!response.ok) {
+        return undefined
+      }
+      return (await response.json()) as UpdateAllJob
+    } catch {
+      // Network error / connection refused / timeout → transient, keep polling
       return undefined
     }
   }
 
   async function selfUpdate(): Promise<{ success: boolean; message: string }> {
     try {
-      const response = await client.post<{ success: boolean; message: string; node_id?: string }>(
-        '/code-sync/self-update'
-      )
-      return { success: response.data.success, message: response.data.message }
-    } catch (e: unknown) {
-      const msg =
-        (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
-        'Self-update request failed'
-      return { success: false, message: msg }
+      const response = await slmApiClient.rawRequest('/code-sync/self-update', {
+        method: 'POST',
+      })
+      if (!response.ok) {
+        const detail = await readDetail(response)
+        return { success: false, message: detail || 'Self-update request failed' }
+      }
+      const data = (await response.json()) as {
+        success: boolean
+        message: string
+        node_id?: string
+      }
+      return { success: data.success, message: data.message }
+    } catch {
+      return { success: false, message: 'Self-update request failed' }
     }
   }
 }


### PR DESCRIPTION
## Thinking Path

`useCodeSync` was the DEFERRED, careful item of the #12420 Phase 2 campaign because it is LOAD-BEARING for the reconnecting affordance shipped in #12593.

During Update-All stage 3 (`slm_self_update`) the SLM control plane restarts itself. The code-sync page polls that SAME control plane via `getUpdateAllStatus()`, so for ~1min it only sees transient failures (connection refused / 5xx). The pre-existing contract:

- `getUpdateAllStatus()` / `getResolveDriftStatus()` return `undefined` on connection-refused / network / 5xx (so the page KEEPS polling through the self-restart), and `null` ONLY on a true 404 (no job → stop polling).

`slmApiClient`'s convenience methods (`get`/`post`/…) THROW a generic `Error('HTTP <n>: …')` on non-2xx AND retry transient failures — a naive migration would collapse the 404-vs-transient distinction and break #12593. So the pollers and every specific-status branch were routed through `slmApiClient.rawRequest`, which returns the raw `Response`, letting the composable inspect `response.status` and reproduce the EXACT mapping:

- 404 → `null`; any other non-2xx (5xx/502/503) → `undefined`; `fetch` throw (refused/network/timeout) → `undefined`.

`rawRequest` also preserves the verbatim FastAPI `{detail}` string in `error.value` for `startUpdateAll` (409), `startResolveDriftAsync` (409), and `selfUpdate` — the convenience methods would have prefixed `HTTP <n>: `. `syncNode`'s "502-as-success during SLM self-restart" (#9956) path is preserved via the raw status too.

The former axios request/response interceptors (bearer-token injection + #10369 expired-token logout) are now provided centrally by `slmApiClient` (session clear + redirect to `/login`), so the per-composable axios instance and `useAuthStore` import were removed.

## What Changed

- `useCodeSync.ts`: removed the `axios.create()` instance + interceptors and the `getSlmApiBase()`/`useAuthStore` imports; all calls now go through `slmApiClient`.
  - Convenience methods (`get`/`post`/`put`/`delete`) for the straightforward fetch/mutate helpers (`fetchStatus`, `refreshVersion`, `fetchPendingNodes`, `syncFleet`, `getJobStatus`, `getRecentJobs`, schedules CRUD, `fetchDrift`, `resolveDrift`); query params serialised onto the path; single-shot pollers pass `maxRetries: 1`.
  - `rawRequest` for the status-sensitive methods (`getUpdateAllStatus`, `getResolveDriftStatus`, `startUpdateAll`, `startResolveDriftAsync`, `selfUpdate`, `syncNode`) to preserve the exact 404/undefined + detail contracts.
  - Public API (exported methods/signatures) unchanged — `CodeSyncView.vue` and other consumers need ZERO changes.
  - WebSocket builder: none exists in this composable (nothing to skip).
- `useCodeSync.test.ts`: swapped the axios mock for a `@/utils/ApiClient` mock; rewrote the #11303 drift tests onto the `rawRequest` path; added explicit #12593-contract tests.

## Verification

- `vue-tsc --noEmit -p tsconfig.json` → exit 0 (clean).
- `eslint` on the two changed files → exit 0.
- Full slm-frontend suite: **22 files, 163 tests passed** (incl. `useCodeSync.test.ts`, `CodeSyncView.test.ts`, and the #12593 reconnecting tests).
- `grep axios src/composables/useCodeSync.ts` → only doc-comment references remain; no axios import or instance.
- Explicit #12593 poll-contract tests (through the new `slmApiClient.rawRequest` path):
  - `getUpdateAllStatus()` returns `undefined` on 502, 503, network-error ("Failed to fetch"), and timeout; returns `null` ONLY on 404; returns the job on 200.
  - `getResolveDriftStatus()` returns `undefined` on 5xx and connection-refused; `null` on 404.
  - `startUpdateAll()` returns `null` + surfaces the 409 detail; returns `null` on network error.
  - `syncNode()` still returns `success: true` on a 502 for an SLM-role node, and `success: false` otherwise.

## Model Used

claude-opus-4-8

Refs #12420
Closes #12626