### PR TITLE
refactor(frontend): migrate getBackendUrl fetch callers onto ApiClient (#12363 Phase 2 batch 4)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useVoiceBundle.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceBundle.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useVoiceBundle — verifies the composable routes voice-bundle calls through
+ * apiClient.rawRequest (base URL resolved by the client, no inline getBackendUrl)
+ * while preserving the exact status/error handling and graceful-null semantics
+ * (#12363 Phase 2 batch 4).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: { rawRequest: vi.fn() },
+}))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }),
+}))
+import apiClient from '@/utils/ApiClient'
+import { useVoiceBundle, useAdminVoiceBundle } from '../useVoiceBundle'
+
+const rawRequest = apiClient.rawRequest as ReturnType<typeof vi.fn>
+
+function okJson(data: unknown): Response {
+  return { ok: true, status: 200, json: async () => data } as unknown as Response
+}
+function errJson(status: number, data: unknown): Response {
+  return { ok: false, status, json: async () => data } as unknown as Response
+}
+
+describe('useVoiceBundle', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fetchMyBundle resolves the bundle via rawRequest on the relative path', async () => {
+    rawRequest.mockResolvedValue(okJson({ bundle_name: 'voice_safe', tool_count: 3, resolution: 'role_default' }))
+    const { fetchMyBundle, bundleInfo, error } = useVoiceBundle()
+    await fetchMyBundle()
+    expect(rawRequest).toHaveBeenCalledWith('/api/voice/realtime/bundle/me')
+    expect(bundleInfo.value?.bundle_name).toBe('voice_safe')
+    expect(error.value).toBeNull()
+  })
+
+  it('fetchMyBundle surfaces the detail error message and nulls the bundle', async () => {
+    rawRequest.mockResolvedValue(errJson(403, { detail: 'forbidden' }))
+    const { fetchMyBundle, bundleInfo, error } = useVoiceBundle()
+    await fetchMyBundle()
+    expect(error.value).toBe('forbidden')
+    expect(bundleInfo.value).toBeNull()
+  })
+})
+
+describe('useAdminVoiceBundle', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('assignBundle PUTs the bundle body and returns true on success', async () => {
+    rawRequest.mockResolvedValue(okJson({}))
+    const { assignBundle } = useAdminVoiceBundle()
+    const ok = await assignBundle('u1', 'voice_admin')
+    expect(ok).toBe(true)
+    expect(rawRequest).toHaveBeenCalledWith('/api/admin/voice/bundle/u1', {
+      method: 'PUT',
+      body: { bundle_name: 'voice_admin' },
+    })
+  })
+
+  it('assignBundle returns false and records the detail error on failure', async () => {
+    rawRequest.mockResolvedValue(errJson(400, { detail: 'bad bundle' }))
+    const { assignBundle, saveError } = useAdminVoiceBundle()
+    expect(await assignBundle('u1', null)).toBe(false)
+    expect(saveError.value).toBe('bad bundle')
+  })
+
+  it('getUserBundle returns null on a non-ok response (graceful)', async () => {
+    rawRequest.mockResolvedValue(errJson(404, {}))
+    const { getUserBundle } = useAdminVoiceBundle()
+    expect(await getUserBundle('u2')).toBeNull()
+  })
+
+  it('getUserBundle returns null when rawRequest throws (graceful)', async () => {
+    rawRequest.mockRejectedValue(new Error('network'))
+    const { getUserBundle } = useAdminVoiceBundle()
+    expect(await getUserBundle('u2')).toBeNull()
+  })
+})

--- a/autobot-frontend/src/composables/security/__tests__/useSecretsInfraApi.test.ts
+++ b/autobot-frontend/src/composables/security/__tests__/useSecretsInfraApi.test.ts
@@ -1,0 +1,56 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useSecretsInfraApi — verifies the composable routes infra-host / secrets-usage
+ * calls through the canonical apiClient (no inline getBackendUrl prefix) while
+ * preserving the graceful-null fallbacks (#12363 Phase 2 batch 4).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: { get: vi.fn(), delete: vi.fn() },
+}))
+import apiClient from '@/utils/ApiClient'
+import { useSecretsInfraApi } from '../useSecretsInfraApi'
+
+const get = apiClient.get as ReturnType<typeof vi.fn>
+const del = apiClient.delete as ReturnType<typeof vi.fn>
+
+describe('useSecretsInfraApi', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fetchInfraHosts calls the relative infra-hosts path and returns data', async () => {
+    get.mockResolvedValue({ hosts: [{ id: 'h1' }] })
+    const { fetchInfraHosts } = useSecretsInfraApi()
+    const res = await fetchInfraHosts()
+    expect(get).toHaveBeenCalledWith('/api/infrastructure/hosts')
+    expect(res.hosts).toHaveLength(1)
+  })
+
+  it('fetchInfraHosts swallows errors and returns empty hosts', async () => {
+    get.mockRejectedValue(new Error('boom'))
+    const { fetchInfraHosts } = useSecretsInfraApi()
+    expect(await fetchInfraHosts()).toEqual({ hosts: [] })
+  })
+
+  it('fetchSecretsUsage calls the relative secrets-usage path', async () => {
+    get.mockResolvedValue({ secrets_usage: { a: [] } })
+    const { fetchSecretsUsage } = useSecretsInfraApi()
+    const res = await fetchSecretsUsage()
+    expect(get).toHaveBeenCalledWith('/api/templates/templates/secrets-usage')
+    expect(res.secrets_usage).toEqual({ a: [] })
+  })
+
+  it('fetchSecretsUsage swallows errors and returns empty map', async () => {
+    get.mockRejectedValue(new Error('boom'))
+    const { fetchSecretsUsage } = useSecretsInfraApi()
+    expect(await fetchSecretsUsage()).toEqual({ secrets_usage: {} })
+  })
+
+  it('deleteInfraHost calls delete with the relative host path', async () => {
+    del.mockResolvedValue({})
+    const { deleteInfraHost } = useSecretsInfraApi()
+    await deleteInfraHost('h9')
+    expect(del).toHaveBeenCalledWith('/api/infrastructure/hosts/h9')
+  })
+})

--- a/autobot-frontend/src/composables/security/useSecretsInfraApi.ts
+++ b/autobot-frontend/src/composables/security/useSecretsInfraApi.ts
@@ -10,7 +10,6 @@
  * Extracted from SecretsManager.vue (issue #6081).
  */
 
-import { getBackendUrl } from '@/config/ssot-config';
 import apiClient from '@/utils/ApiClient';
 
 export interface InfraHost {
@@ -41,22 +40,19 @@ export interface SecretsUsageResponse {
 export function useSecretsInfraApi() {
   /** Fetch legacy infrastructure hosts from the old API. */
   async function fetchInfraHosts(): Promise<InfraHostsResponse> {
-    const backendUrl = getBackendUrl();
-    return apiClient.get<InfraHostsResponse>(`${backendUrl}/api/infrastructure/hosts`)
+    return apiClient.get<InfraHostsResponse>(`/api/infrastructure/hosts`)
       .catch(() => ({ hosts: [] }));
   }
 
   /** Fetch workflow-usage mapping for secrets (#1415). */
   async function fetchSecretsUsage(): Promise<SecretsUsageResponse> {
-    const backendUrl = getBackendUrl();
-    return apiClient.get<SecretsUsageResponse>(`${backendUrl}/api/templates/templates/secrets-usage`)
+    return apiClient.get<SecretsUsageResponse>(`/api/templates/templates/secrets-usage`)
       .catch(() => ({ secrets_usage: {} }));
   }
 
   /** Delete a legacy infrastructure host by id. */
   async function deleteInfraHost(id: string): Promise<void> {
-    const backendUrl = getBackendUrl();
-    await apiClient.delete<unknown>(`${backendUrl}/api/infrastructure/hosts/${id}`);
+    await apiClient.delete<unknown>(`/api/infrastructure/hosts/${id}`);
   }
 
   return { fetchInfraHosts, fetchSecretsUsage, deleteInfraHost };

--- a/autobot-frontend/src/composables/useVoiceBundle.ts
+++ b/autobot-frontend/src/composables/useVoiceBundle.ts
@@ -12,8 +12,7 @@
 
 import { ref } from 'vue'
 import type { InjectionKey, Ref } from 'vue'
-import { getBackendUrl } from '@/config/ssot-config'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import apiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useVoiceBundle')
@@ -56,7 +55,7 @@ export function useVoiceBundle() {
     loading.value = true
     error.value = null
     try {
-      const res = await fetchWithAuth(`${getBackendUrl()}/api/voice/realtime/bundle/me`)
+      const res = await apiClient.rawRequest(`/api/voice/realtime/bundle/me`)
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         throw new Error((body as { detail?: string }).detail ?? `HTTP ${res.status}`)
@@ -85,10 +84,9 @@ export function useAdminVoiceBundle() {
     saving.value = true
     saveError.value = null
     try {
-      const res = await fetchWithAuth(`${getBackendUrl()}/api/admin/voice/bundle/${userId}`, {
+      const res = await apiClient.rawRequest(`/api/admin/voice/bundle/${userId}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundle_name: bundleName }),
+        body: { bundle_name: bundleName },
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
@@ -106,7 +104,7 @@ export function useAdminVoiceBundle() {
 
   async function getUserBundle(userId: string): Promise<UserBundleAssignment | null> {
     try {
-      const res = await fetchWithAuth(`${getBackendUrl()}/api/admin/voice/bundle/${userId}`)
+      const res = await apiClient.rawRequest(`/api/admin/voice/bundle/${userId}`)
       if (!res.ok) return null
       return (await res.json()) as UserBundleAssignment
     } catch {

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -241,9 +241,8 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { getBackendUrl } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import apiClient from '@/utils/ApiClient'
 import Icon from '@/components/ui/Icon.vue'
 import { BaseModal } from '@autobot/ui'
 import { useI18n } from 'vue-i18n'
@@ -321,7 +320,7 @@ async function loadUsers(): Promise<void> {
     if (searchQuery.value.trim()) {
       params.set('search', searchQuery.value.trim())
     }
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users?${params}`)
+    const res = await apiClient.rawRequest(`/api/user-management/users?${params}`)
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
       throw new Error((body as { detail?: string }).detail ?? `HTTP ${res.status}`)
@@ -416,10 +415,9 @@ function changePage(delta: number): void {
 
 async function onRoleChange(user: UserRecord, role: string): Promise<void> {
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users/${user.id}/role`, {
+    const res = await apiClient.rawRequest(`/api/user-management/users/${user.id}/role`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ role }),
+      body: { role },
     })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
@@ -435,7 +433,7 @@ async function onRoleChange(user: UserRecord, role: string): Promise<void> {
 async function toggleActive(user: UserRecord, activate: boolean): Promise<void> {
   const action = activate ? 'activate' : 'deactivate'
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users/${user.id}/${action}`, {
+    const res = await apiClient.rawRequest(`/api/user-management/users/${user.id}/${action}`, {
       method: 'POST',
     })
     if (!res.ok) {
@@ -456,7 +454,7 @@ function confirmDelete(user: UserRecord): void {
 async function deleteUser(): Promise<void> {
   if (!deleteTarget.value) return
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users/${deleteTarget.value.id}`, {
+    const res = await apiClient.rawRequest(`/api/user-management/users/${deleteTarget.value.id}`, {
       method: 'DELETE',
     })
     if (!res.ok) {
@@ -476,15 +474,14 @@ async function createUser(): Promise<void> {
   creating.value = true
   createError.value = null
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users`, {
+    const res = await apiClient.rawRequest(`/api/user-management/users`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+      body: {
         email: newUser.value.email,
         username: newUser.value.username,
         password: newUser.value.password,
         display_name: newUser.value.display_name || undefined,
-      }),
+      },
     })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))

--- a/autobot-frontend/src/views/BudgetPolicies.vue
+++ b/autobot-frontend/src/views/BudgetPolicies.vue
@@ -287,9 +287,8 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { getBackendUrl } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import apiClient from '@/utils/ApiClient'
 import { useUserStore } from '@/stores/useUserStore'
 import Icon from '@/components/ui/Icon.vue'
 import { BaseModal } from '@autobot/ui'
@@ -393,7 +392,7 @@ async function loadPolicies(): Promise<void> {
   try {
     const params = new URLSearchParams()
     if (filterScope.value) params.set('scope', filterScope.value)
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/budget-policies?${params}`)
+    const res = await apiClient.rawRequest(`/api/budget-policies?${params}`)
     if (!res.ok) {
       const body = await res.json().catch(() => ({})) as { detail?: string }
       throw new Error(body.detail ?? `HTTP ${res.status}`)
@@ -443,14 +442,13 @@ async function submitForm(): Promise<void> {
   modalError.value = null
   const payload = { ...form.value }
   const url = editTarget.value
-    ? `${getBackendUrl()}/api/budget-policies/${editTarget.value.id}`
-    : `${getBackendUrl()}/api/budget-policies`
+    ? `/api/budget-policies/${editTarget.value.id}`
+    : `/api/budget-policies`
   const method = editTarget.value ? 'PATCH' : 'POST'
   try {
-    const res = await fetchWithAuth(url, {
+    const res = await apiClient.rawRequest(url, {
       method,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: payload,
     })
     if (!res.ok) {
       const body = await res.json().catch(() => ({})) as { detail?: string }
@@ -474,7 +472,7 @@ async function doDelete(): Promise<void> {
   if (!deleteTarget.value) return
   deleting.value = true
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/budget-policies/${deleteTarget.value.id}`, {
+    const res = await apiClient.rawRequest(`/api/budget-policies/${deleteTarget.value.id}`, {
       method: 'DELETE',
     })
     if (!res.ok && res.status !== 204) {
@@ -498,7 +496,7 @@ async function checkAgentStatus(): Promise<void> {
   agentStatus.value = null
   error.value = null
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/budget-policies/${id}/status`)
+    const res = await apiClient.rawRequest(`/api/budget-policies/${id}/status`)
     if (!res.ok) {
       const body = await res.json().catch(() => ({})) as { detail?: string }
       throw new Error(body.detail ?? `HTTP ${res.status}`)
@@ -514,7 +512,7 @@ async function resumeAgent(agentId: string): Promise<void> {
   resuming.value = true
   error.value = null
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/api/budget-policies/${agentId}/resume`, {
+    const res = await apiClient.rawRequest(`/api/budget-policies/${agentId}/resume`, {
       method: 'POST',
     })
     if (!res.ok) {

--- a/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
+++ b/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
@@ -175,8 +175,7 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { getBackendUrl } from '@/config/ssot-config'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import apiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { BaseModal } from '@autobot/ui'
 
@@ -221,7 +220,7 @@ function spendClass(key: KeyRow): string {
 async function loadKeys(): Promise<void> {
   loading.value = true
   try {
-    const resp = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/list')
+    const resp = await apiClient.rawRequest('/api/llm-keys/list')
     const data = (await resp.json()) as { keys: KeyRow[] }
     keys.value = data.keys ?? []
   } catch (err) {
@@ -242,16 +241,15 @@ async function handleIssue(): Promise<void> {
       ? new Date(form.expires_at_str).getTime() / 1000
       : null
 
-    const issueResp = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/issue', {
+    const issueResp = await apiClient.rawRequest('/api/llm-keys/issue', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+      body: {
         team_id: form.team_id,
         label: form.label,
         monthly_budget_usd: form.monthly_budget_usd,
         allowed_models,
         expires_at,
-      }),
+      },
     })
     const issueResult = (await issueResp.json()) as { raw_key: string }
     newRawKey.value = issueResult.raw_key
@@ -271,10 +269,9 @@ function confirmRevoke(keyId: string): void {
 
 async function handleRevoke(): Promise<void> {
   try {
-    await fetchWithAuth(getBackendUrl() + '/api/llm-keys/revoke', {
+    await apiClient.rawRequest('/api/llm-keys/revoke', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ key_id: revokeKeyId.value }),
+      body: { key_id: revokeKeyId.value },
     })
     revokeKeyId.value = ''
     await loadKeys()
@@ -285,10 +282,9 @@ async function handleRevoke(): Promise<void> {
 
 async function handleRotate(keyId: string): Promise<void> {
   try {
-    const rotateResp = await fetchWithAuth(getBackendUrl() + '/api/llm-keys/rotate', {
+    const rotateResp = await apiClient.rawRequest('/api/llm-keys/rotate', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ key_id: keyId }),
+      body: { key_id: keyId },
     })
     const rotateResult = (await rotateResp.json()) as { new_raw_key: string }
     newRawKey.value = rotateResult.new_raw_key


### PR DESCRIPTION
## Thinking Path

#12363 Phase 2: a set of `autobot-frontend/src` files build backend URLs inline via `getBackendUrl()`/`getApiUrl()` + raw fetch instead of routing through the canonical `apiClient`, which resolves the backend base URL itself (proxy-mode default after #12339). This batch migrates a cohesive, clean, plain-HTTP JSON subset.

**Full `getBackendUrl()`/`getApiUrl()` inventory (`autobot-frontend/src`, excluding `ssot-config.ts`):**

_This batch (admin & settings REST management — 5 files):_
- `views/AdminUsersView.vue` — user-management CRUD (list/create/role/activate/deactivate/delete)
- `views/BudgetPolicies.vue` — budget-policies CRUD + status/resume
- `views/secrets/LlmApiKeysView.vue` — LLM API keys list/issue/revoke/rotate
- `composables/useVoiceBundle.ts` — voice bundle (user GET + admin PUT/GET)
- `composables/security/useSecretsInfraApi.ts` — infra hosts + secrets-usage (already on `apiClient`; redundant `getBackendUrl()` prefix stripped)

_Remaining `getBackendUrl()` + `fetchWithAuth`/fetch REST callers (future batches):_
- `components/agents/HeartbeatPanel.vue` (heartbeat REST helper)
- `components/settings/ApiKeySetupWizard.vue`
- `components/ui/HostSelectionDialog.vue` (graceful-null legacy-host fetch; test tightly coupled to `global.fetch` + getBackendUrl mock — deferred to keep this batch clean)
- `composables/transcriber/useTranscriberApi.ts`, `composables/transcriber/useAiAnalysis.ts`
- `composables/useMultiModelCompare.ts` (streaming compare)
- `composables/usePatternAnalysis.ts`, `composables/useBackgroundTask.ts` (local async `getBackendUrl` helpers)
- `composables/useOverseerAgent.ts`, `composables/useWorkflowBuilder.ts` (`baseUrl` field)
- `models/repositories/ChatRepository.ts` (`baseURL` field), `embed/EmbedWidget.stories.ts` (Storybook)

_`appConfig.getApiUrl()` callers (separate sub-domain, future):_
- `composables/useTerminalStore.ts`, `composables/useCommandApproval.ts`, `stores/usePermissionStore.ts`, `models/controllers/ChatController.ts`, `components/chat/ChatInterface.vue`, `utils/ApiClient.ts` (internal), `composables/analytics/useSourceRegistry.ts` (uses `appConfig.getServiceUrl` prefix — same redundant-prefix cleanup)

**Excluded (do NOT migrate — noted per task):**
- `config/ssot-config.ts` — DEFINES `getBackendUrl` (circular).
- WebSocket/EventSource builders: `composables/useCanvasWebSocket.ts` (`ws(s)://`), `composables/transcriber/useSseProgress.ts` (`EventSource`) — no WS surface on the client (parked WS decision).
- `router/index.ts` — infra flagged do-not-migrate.
- `composables/useConnectionTester.ts` — `getBackendUrl` only in JSDoc examples, no live call.
- `composables/useThemeVariant.ts` — reads CSS **text** with `credentials: 'include'` (convenience methods parse JSON); left on the fetchWithAuth bridge (already migrated off raw fetch in #12605).
- `getSLMUrl()`/SLM-bridge callers — separate #12614 domain.

## What Changed
- `fetchWithAuth(\`\${getBackendUrl()}/api/...\`)` → `apiClient.rawRequest('/api/...')` in the four view/composable callers, preserving each site's exact `res.ok`/`detail` error parsing, response parsing and error-swallowing. JSON request bodies passed as objects (rawRequest stringifies + sets Content-Type) — no double-stringify; redundant per-call `Content-Type` headers dropped.
- `useSecretsInfraApi.ts`: removed the redundant `getBackendUrl()` prefix on its existing `apiClient.get/delete` calls (identical in proxy mode; also removes a latent double-prefix in explicit cross-origin mode).
- Added unit tests for `useVoiceBundle` (6) and `useSecretsInfraApi` (5).

**Behaviour note:** routing through `apiClient` adds the canonical request timeout and 401 → login handling for these authenticated management pages (previously `fetchWithAuth` had neither). Intended alignment for authenticated admin/settings surfaces, not a regression; the graceful-null paths still swallow non-401 errors exactly as before.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` — clean (exit 0).
- `vitest run` on the two new tests — 11 passed.
- `grep` confirms the 5 migrated files no longer inline `getBackendUrl`/`fetchWithAuth`.

## Model Used
claude-opus-4-8

## Follow-up
Remaining `getBackendUrl()` REST callers and the `appConfig.getApiUrl()`/`getServiceUrl()` prefix cleanups are listed above for subsequent #12363 batches. Excluded WebSocket/EventSource builders, `ssot-config.ts`, `useThemeVariant` (CSS-text), `router`, and the `getSLMUrl()`/#12614 SLM-bridge set remain out of scope.

Refs #12363
Closes #12628