### PR TITLE
refactor(slm-frontend): migrate useRoles onto slmApiClient (#12420 Phase 2 batch 7)

### DIFF
--- a/autobot-slm-frontend/src/composables/useRoles.test.ts
+++ b/autobot-slm-frontend/src/composables/useRoles.test.ts
@@ -1,0 +1,239 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12420 Phase 2 batch 7 — proves the useRoles composable is migrated onto the
+ * canonical `slmApiClient`.
+ *
+ * useRoles historically owned its own `axios.create()` instance (base URL from
+ * getSlmApiBase(), a request interceptor injecting the SLM bearer token). It now
+ * routes every call through `slmApiClient.rawRequest` via a thin axios-compatible
+ * adapter. These tests assert the migration preserves the behaviour the consumers
+ * (FleetOverview, RoleManagementModal, ScheduleModal, DecommissionModal,
+ * OrchestrationView, useCodeSync) depend on:
+ *
+ *   * every verb routes through slmApiClient.rawRequest with the correct
+ *     method + endpoint (+ serialised query) and body — so the client's auth
+ *     token / base URL / 401 handling apply (covered by ApiClient.test.ts);
+ *   * endpoints are RELATIVE (no getSlmApiBase() prefix) — the client prepends it;
+ *   * success returns the parsed JSON body (the historical `response.data`);
+ *   * a non-2xx surfaces `err.response.data.detail` into the reactive `error`
+ *     (or the graceful null / {success:false} return each method contracts);
+ *   * a network/timeout rejection falls back to `err.message`;
+ *   * array query params serialise as axios did (`node_ids[]=...`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { jsonResponse, errorResponse } from './useSlmApi.testHelper'
+
+const mockRaw = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  slmApiClient: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+  default: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+}))
+
+import { useRoles } from './useRoles'
+
+type RawCall = [string, { method: string; body?: unknown }]
+
+describe('useRoles — migrated onto slmApiClient (#12420 Phase 2 batch 7)', () => {
+  beforeEach(() => {
+    mockRaw.mockReset()
+  })
+
+  describe('routing + response.data unwrap (relative endpoints)', () => {
+    it('fetchRoles GETs /roles and stores the parsed body', async () => {
+      const body = [{ name: 'backend', required: true }]
+      mockRaw.mockResolvedValue(jsonResponse(body))
+
+      const r = useRoles()
+      await r.fetchRoles()
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/roles')
+      expect(opts.method).toBe('GET')
+      expect(r.roles).toEqual(body)
+      expect(r.error).toBeNull()
+      expect(r.isLoading).toBe(false)
+    })
+
+    it('getNodeRoles GETs /nodes/:id/detected-roles', async () => {
+      const body = { node_id: 'n1', detected_roles: [], role_versions: {}, listening_ports: [], roles: [] }
+      mockRaw.mockResolvedValue(jsonResponse(body))
+
+      const result = await useRoles().getNodeRoles('n1')
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes/n1/detected-roles')
+      expect(opts.method).toBe('GET')
+      expect(result).toEqual(body)
+    })
+
+    it('assignRole POSTs the role body to /nodes/:id/detected-roles', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ role_name: 'backend' }))
+
+      await useRoles().assignRole('n1', 'backend', 'auto')
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes/n1/detected-roles')
+      expect(opts.method).toBe('POST')
+      expect(opts.body).toEqual({ role_name: 'backend', assignment_type: 'auto' })
+    })
+
+    it('createRole POSTs to /roles and updateRole PUTs to /roles/:name', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ name: 'x' }))
+      await useRoles().createRole({ name: 'x' } as never)
+      let [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/roles')
+      expect(opts.method).toBe('POST')
+
+      mockRaw.mockReset()
+      mockRaw.mockResolvedValue(jsonResponse({ name: 'x' }))
+      await useRoles().updateRole('x', { display_name: 'X' } as never)
+      ;[url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/roles/x')
+      expect(opts.method).toBe('PUT')
+      expect(opts.body).toEqual({ display_name: 'X' })
+    })
+
+    it('deleteRole DELETEs /roles/:name and returns true (204 handled)', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({}, 204))
+
+      await expect(useRoles().deleteRole('x')).resolves.toBe(true)
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/roles/x')
+      expect(opts.method).toBe('DELETE')
+    })
+
+    it('pullFromSource POSTs /code-sync/pull with no body', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ success: true, message: 'ok', commit: 'abc' }))
+
+      const res = await useRoles().pullFromSource()
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/code-sync/pull')
+      expect(opts.method).toBe('POST')
+      expect(opts.body).toBeUndefined()
+      expect(res).toEqual({ success: true, message: 'ok', commit: 'abc' })
+    })
+
+    it('decommissionNode POSTs the confirmation body to /nodes/:id/decommission', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ success: true, message: 'done' }))
+
+      await useRoles().decommissionNode('n1', true, 'n1')
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes/n1/decommission')
+      expect(opts.method).toBe('POST')
+      expect(opts.body).toEqual({ backup: true, confirm_node_id: 'n1' })
+    })
+  })
+
+  describe('query-param serialisation (axios-compatible)', () => {
+    it('removeRole serialises the scalar `backup` param onto the DELETE endpoint', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ success: true, message: 'removed' }))
+
+      await useRoles().removeRole('n1', 'backend', true)
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/nodes/n1/detected-roles/backend?backup=true')
+      expect(opts.method).toBe('DELETE')
+    })
+
+    it('syncRole serialises node_ids as repeated array params (node_ids[]) with null body', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ success: true, message: 'synced', nodes_synced: 2 }))
+
+      await useRoles().syncRole('backend', ['n1', 'n2'], false)
+
+      const [url, opts] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toContain('/code-sync/roles/backend/sync?')
+      expect(url).toContain('restart=false')
+      // axios serialises arrays as key[]=v (URLSearchParams encodes the brackets).
+      expect(url).toContain('node_ids%5B%5D=n1')
+      expect(url).toContain('node_ids%5B%5D=n2')
+      expect(opts.method).toBe('POST')
+      expect(opts.body).toBeUndefined()
+    })
+
+    it('syncRole omits node_ids when none are supplied', async () => {
+      mockRaw.mockResolvedValue(jsonResponse({ success: true, message: 'synced' }))
+
+      await useRoles().syncRole('backend')
+
+      const [url] = mockRaw.mock.calls[0] as RawCall
+      expect(url).toBe('/code-sync/roles/backend/sync?restart=true')
+    })
+  })
+
+  describe('error-shape parity (err.response.data.detail → reactive error / graceful returns)', () => {
+    it('fetchRoles surfaces err.response.data.detail into the reactive error', async () => {
+      mockRaw.mockResolvedValue(errorResponse(500, { detail: 'roles table missing' }))
+
+      const r = useRoles()
+      await r.fetchRoles()
+
+      expect(r.error).toBe('roles table missing')
+      expect(r.isLoading).toBe(false)
+    })
+
+    it('getNodeRoles returns null and records the detail on failure', async () => {
+      mockRaw.mockResolvedValue(errorResponse(404, { detail: 'no such node' }))
+
+      const r = useRoles()
+      const result = await r.getNodeRoles('nope')
+
+      expect(result).toBeNull()
+      expect(r.error).toBe('no such node')
+    })
+
+    it('removeRole returns {success:false, message:detail} on failure', async () => {
+      mockRaw.mockResolvedValue(errorResponse(409, { detail: 'role in use' }))
+
+      const r = useRoles()
+      const result = await r.removeRole('n1', 'backend')
+
+      expect(result).toEqual({ success: false, message: 'role in use' })
+      expect(r.error).toBe('role in use')
+    })
+
+    it('syncRole returns a failed SyncResult carrying the detail', async () => {
+      mockRaw.mockResolvedValue(errorResponse(500, { detail: 'sync exploded' }))
+
+      const result = await useRoles().syncRole('backend', ['n1'])
+
+      expect(result).toEqual({ success: false, message: 'sync exploded', nodes_synced: 0 })
+    })
+
+    it('falls back to err.message when a network error carries no response', async () => {
+      mockRaw.mockRejectedValue(new Error('Request timeout after 30000ms'))
+
+      const r = useRoles()
+      await r.fetchRoles()
+
+      expect(r.error).toBe('Request timeout after 30000ms')
+    })
+
+    it('uses the hard-coded fallback when neither detail nor message is present', async () => {
+      // Non-JSON error body → adapter leaves response.data null → no detail;
+      // the thrown Error still carries `message` = "HTTP 502", the secondary fallback.
+      mockRaw.mockResolvedValue({
+        ok: false,
+        status: 502,
+        headers: { get: () => null },
+        json: async () => {
+          throw new Error('not json')
+        },
+        text: async () => 'Bad Gateway',
+      } as unknown as Response)
+
+      const r = useRoles()
+      await r.fetchRoles()
+
+      expect(r.error).toBe('HTTP 502')
+    })
+  })
+})

--- a/autobot-slm-frontend/src/composables/useRoles.ts
+++ b/autobot-slm-frontend/src/composables/useRoles.ts
@@ -10,8 +10,7 @@
  */
 
 import { ref, reactive } from 'vue'
-import axios from 'axios'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
 
 export interface Role {
   name: string
@@ -119,28 +118,119 @@ export interface DecommissionPreflight {
   safe_to_remove: DecommissionRoleInfo[]
 }
 
+// =============================================================================
+// slmApiClient adapter (#12420 Phase 2 batch 7)
+//
+// useRoles historically owned its own `axios.create()` instance (base URL built
+// from getSlmApiBase(), a request interceptor injecting the SLM bearer token, no
+// response interceptor). This adapter routes every call through the canonical
+// `slmApiClient` — where the auth token, base URL and centralised 401 handling
+// now live — while reproducing the axios surface the methods below depend on so
+// their bodies, and all consumers, stay unchanged:
+//
+//   * methods `await client.<verb>(endpoint, body?)` and read `response.data`
+//     → the adapter returns `{ data }`.
+//   * every catch reads `err.response?.data?.detail || err.message` → the
+//     adapter throws an axios-shaped error carrying `response.status` +
+//     `response.data` (and a `message` of `HTTP <n>` as the secondary fallback);
+//     a network/timeout rejection surfaces the raw Error (no `.response`), so
+//     `err.message` remains the fallback exactly as with axios.
+//
+// It delegates to `slmApiClient.rawRequest` (not the get/post/... helpers) on
+// purpose: rawRequest is the single seam that injects the bearer token + base
+// URL and runs the 401 handler, WITHOUT the helpers' GET retry/back-off or the
+// `HTTP <n>: <msg>` error transform — preserving the original single-shot,
+// structured-error behaviour every method relies on.
+// =============================================================================
+
+interface AxiosLikeResponse<T> {
+  data: T
+}
+
+// Serialise an axios-style params object onto the endpoint, matching axios's
+// default serialisation: scalars as `key=value`, arrays as repeated `key[]=value`
+// (URLSearchParams encodes the brackets to `%5B%5D`, exactly as axios does). Only
+// removeRole (scalar) and syncRole (scalar + array) pass a params object.
+function withParams(endpoint: string, params?: Record<string, unknown>): string {
+  if (!params) return endpoint
+  const usp = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      for (const item of value) usp.append(`${key}[]`, String(item))
+    } else {
+      usp.append(key, String(value))
+    }
+  }
+  const qs = usp.toString()
+  if (!qs) return endpoint
+  return endpoint.includes('?') ? `${endpoint}&${qs}` : `${endpoint}?${qs}`
+}
+
+async function adapterRequest<T>(
+  method: string,
+  endpoint: string,
+  body?: unknown
+): Promise<AxiosLikeResponse<T>> {
+  const response = await slmApiClient.rawRequest(endpoint, { method, body })
+
+  if (!response.ok) {
+    let data: unknown = null
+    try {
+      data = await response.json()
+    } catch {
+      /* non-JSON error body — leave data null, mirroring axios */
+    }
+    const error = new Error(`HTTP ${response.status}`) as Error & {
+      response: { status: number; data: unknown }
+    }
+    // Reproduce the axios error shape the catch blocks read (err.response.data.detail).
+    error.response = { status: response.status, data }
+    throw error
+  }
+
+  if (response.status === 204) return { data: {} as T }
+  const contentType = response.headers.get('content-type')
+  if (contentType && contentType.includes('application/json')) {
+    return { data: (await response.json()) as T }
+  }
+  return { data: {} as T }
+}
+
+// Axios-compatible facade over slmApiClient consumed by every method below.
+const client = {
+  get: <T = unknown>(
+    endpoint: string,
+    config?: { params?: Record<string, unknown> }
+  ): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('GET', withParams(endpoint, config?.params)),
+  post: <T = unknown>(
+    endpoint: string,
+    body?: unknown,
+    config?: { params?: Record<string, unknown> }
+  ): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('POST', withParams(endpoint, config?.params), body ?? undefined),
+  put: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('PUT', endpoint, body),
+  delete: <T = unknown>(
+    endpoint: string,
+    config?: { params?: Record<string, unknown> }
+  ): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>('DELETE', withParams(endpoint, config?.params)),
+}
+
 export function useRoles() {
   const roles = ref<Role[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const fleetHealth = ref<FleetHealth | null>(null)
 
-  // Create axios instance with auth
-  const client = axios.create()
-  client.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
   async function fetchRoles(): Promise<void> {
     isLoading.value = true
     error.value = null
 
     try {
-      const response = await client.get<Role[]>(`${getSlmApiBase()}/roles`)
+      const response = await client.get<Role[]>('/roles')
       roles.value = response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -153,7 +243,7 @@ export function useRoles() {
   async function getNodeRoles(nodeId: string): Promise<NodeRolesInfo | null> {
     try {
       const response = await client.get<NodeRolesInfo>(
-        `${getSlmApiBase()}/nodes/${nodeId}/detected-roles`
+        `/nodes/${nodeId}/detected-roles`
       )
       return response.data
     } catch (e: unknown) {
@@ -170,7 +260,7 @@ export function useRoles() {
   ): Promise<NodeRoleItem | null> {
     try {
       const response = await client.post<NodeRoleItem>(
-        `${getSlmApiBase()}/nodes/${nodeId}/detected-roles`,
+        `/nodes/${nodeId}/detected-roles`,
         { role_name: roleName, assignment_type: assignmentType }
       )
       return response.data
@@ -191,7 +281,7 @@ export function useRoles() {
         success: boolean
         message: string
         backup_path?: string
-      }>(`${getSlmApiBase()}/nodes/${nodeId}/detected-roles/${roleName}`, {
+      }>(`/nodes/${nodeId}/detected-roles/${roleName}`, {
         params: { backup },
       })
       return response.data
@@ -205,7 +295,7 @@ export function useRoles() {
 
   async function createRole(roleData: Partial<Role>): Promise<Role | null> {
     try {
-      const response = await client.post<Role>(`${getSlmApiBase()}/roles`, roleData)
+      const response = await client.post<Role>('/roles', roleData)
       return response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -216,7 +306,7 @@ export function useRoles() {
 
   async function updateRole(roleName: string, roleData: Partial<Role>): Promise<Role | null> {
     try {
-      const response = await client.put<Role>(`${getSlmApiBase()}/roles/${roleName}`, roleData)
+      const response = await client.put<Role>(`/roles/${roleName}`, roleData)
       return response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -227,7 +317,7 @@ export function useRoles() {
 
   async function deleteRole(roleName: string): Promise<boolean> {
     try {
-      await client.delete(`${getSlmApiBase()}/roles/${roleName}`)
+      await client.delete(`/roles/${roleName}`)
       return true
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -247,7 +337,7 @@ export function useRoles() {
         params.node_ids = nodeIds
       }
       const response = await client.post<SyncResult>(
-        `${getSlmApiBase()}/code-sync/roles/${roleName}/sync`,
+        `/code-sync/roles/${roleName}/sync`,
         null,
         { params }
       )
@@ -265,7 +355,7 @@ export function useRoles() {
   async function pullFromSource(): Promise<{ success: boolean; message: string; commit: string | null }> {
     try {
       const response = await client.post<{ success: boolean; message: string; commit: string | null }>(
-        `${getSlmApiBase()}/code-sync/pull`
+        '/code-sync/pull'
       )
       return response.data
     } catch (e: unknown) {
@@ -280,7 +370,7 @@ export function useRoles() {
 
   async function fetchFleetHealth(): Promise<void> {
     try {
-      const response = await client.get<FleetHealth>(`${getSlmApiBase()}/roles/fleet-health`)
+      const response = await client.get<FleetHealth>('/roles/fleet-health')
       fleetHealth.value = response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -294,7 +384,7 @@ export function useRoles() {
   ): Promise<PlaybookMigrateResult | null> {
     try {
       const response = await client.post<PlaybookMigrateResult>(
-        `${getSlmApiBase()}/roles/${roleName}/migrate`,
+        `/roles/${roleName}/migrate`,
         { target_node_id: targetNodeId }
       )
       return response.data
@@ -311,7 +401,7 @@ export function useRoles() {
   ): Promise<NodeActionsResponse | null> {
     try {
       const resp = await client.get<NodeActionsResponse>(
-        `${getSlmApiBase()}/roles/node-actions/${nodeId}`
+        `/roles/node-actions/${nodeId}`
       )
       return resp.data
     } catch (e: unknown) {
@@ -334,7 +424,7 @@ export function useRoles() {
   ): Promise<ExecuteActionResult | null> {
     try {
       const resp = await client.post<ExecuteActionResult>(
-        `${getSlmApiBase()}/roles/node-actions/${nodeId}/execute`,
+        `/roles/node-actions/${nodeId}/execute`,
         { role_name: roleName, category }
       )
       return resp.data
@@ -357,7 +447,7 @@ export function useRoles() {
   ): Promise<DecommissionPreflight | null> {
     try {
       const resp = await client.get<DecommissionPreflight>(
-        `${getSlmApiBase()}/nodes/${nodeId}/decommission/preflight`
+        `/nodes/${nodeId}/decommission/preflight`
       )
       return resp.data
     } catch (e: unknown) {
@@ -384,7 +474,7 @@ export function useRoles() {
         message: string
         deployment_id: string
         output: string
-      }>(`${getSlmApiBase()}/nodes/${nodeId}/decommission`, {
+      }>(`/nodes/${nodeId}/decommission`, {
         backup,
         confirm_node_id: confirmNodeId,
       })
@@ -410,7 +500,7 @@ export function useRoles() {
       const resp = await client.post<{
         success: boolean
         message: string
-      }>(`${getSlmApiBase()}/nodes/${nodeId}/reenroll`)
+      }>(`/nodes/${nodeId}/reenroll`)
       return resp.data
     } catch (e: unknown) {
       const err = e as {


### PR DESCRIPTION
## Thinking Path
`#12420` Phase 2 migrates `autobot-slm-frontend` composables off their own axios instances onto the canonical `slmApiClient` (auth token, base URL and central 401 handling in one place). `composables/useRoles.ts` still owned its own `axios.create()` with a bearer-token request interceptor (confirmed non-WebSocket). This batch migrates it, following the merged MFA (#12599), Auth (#12601), useSlmApi (#12616) and useCodeSync (batch 6) batches — reproducing the exact axios surface each method + consumer depends on.

## What Changed
- **`useRoles.ts`** — removed the local `axios.create()` instance + request interceptor and the `getSlmApiBase()` import. Added a thin axios-compatible adapter over `slmApiClient.rawRequest`:
  - success returns `{ data }` (the historical `response.data`);
  - a non-2xx throws an axios-shaped error carrying `response.status` + `response.data`, with `message = HTTP <n>` — so every catch's `err.response?.data?.detail || err.message || <fallback>` resolves identically; a network/timeout rejection surfaces the raw `Error` (no `.response`) so `err.message` stays the fallback exactly as with axios.
  - `rawRequest` (not the get/post helpers) is used on purpose: it injects the token + base URL and runs the 401 handler WITHOUT the GET retry/back-off or `HTTP <n>: <msg>` transform, preserving single-shot structured-error behaviour.
  - Endpoints are now **relative** (the client prepends the base). Query params preserved: scalar `backup` for `removeRole`; axios array serialisation `node_ids[]=...` for `syncRole`.
  - Exported signatures unchanged → the six consumers (FleetOverview, RoleManagementModal, ScheduleModal, DecommissionModal, OrchestrationView, useCodeSync) need **zero** changes.
- **`useRoles.test.ts`** (new, 16 tests) — routing/method/relative-endpoint assertions, `response.data` unwrap, 204 handling, scalar + array query serialisation, and error-shape parity (detail → reactive `error`, graceful null / `{success:false}` returns, `err.message` network fallback, hard-coded fallback).

## Verification
- `vue-tsc --noEmit -p tsconfig.json` → exit 0 (clean).
- `vitest run useRoles.test.ts` → **16 passed**.
- `vitest run useCodeSync.test.ts` (consumer) → **12 passed**.
- `grep` confirms no axios import / `axios.create` / `getSlmApiBase` remains in code (only historical-context comments).

## Model Used
Claude Opus 4.8

Closes #12638
Refs #12420