### PR TITLE
refactor(frontend): migrate more getBackendUrl callers onto ApiClient (#12363 Phase 2 batch 5)

### DIFF
--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -189,8 +189,7 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from 'vue'
 
-import { getBackendUrl } from '@/config/ssot-config'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import apiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { useEventBus } from '@/composables/useEventBus'
 import { useExpansion } from '@/composables/useExpansion'
@@ -310,16 +309,17 @@ onUnmounted(() => {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-function apiBase(): string {
-  return `${getBackendUrl()}/api/heartbeat`
-}
+const API_BASE = '/api/heartbeat'
 
-async function apiFetch(path: string, init?: RequestInit): Promise<unknown> {
-  const resp = await fetchWithAuth(`${apiBase()}${path}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    ...init,
+// Base URL + auth resolved by apiClient (#12363). rawRequest preserves the exact
+// status/text error shape and 204→null contract the panel relies on.
+async function apiFetch(
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<unknown> {
+  const resp = await apiClient.rawRequest(`${API_BASE}${path}`, {
+    method: init?.method ?? 'GET',
+    body: init?.body,
   })
   if (!resp.ok) {
     const text = await resp.text()
@@ -359,11 +359,11 @@ async function saveConfig(): Promise<void> {
   try {
     const updated = await apiFetch(`/${agentId.value}/config`, {
       method: 'PUT',
-      body: JSON.stringify({
+      body: {
         heartbeat_enabled: editEnabled.value,
         heartbeat_interval_seconds: editInterval.value,
         max_run_duration_seconds: editMaxDuration.value,
-      }),
+      },
     })
     config.value = updated as HeartbeatConfig
   } catch (err) {
@@ -396,7 +396,7 @@ async function queueWakeup(): Promise<void> {
   try {
     await apiFetch(`/${agentId.value}/wakeup`, {
       method: 'POST',
-      body: JSON.stringify({ priority: 0, reason: 'Manual wakeup from UI' }),
+      body: { priority: 0, reason: 'Manual wakeup from UI' },
     })
     const wakeupsRes = await apiFetch(`/${agentId.value}/wakeup`)
     pendingWakeups.value = wakeupsRes as WakeupRequest[]
@@ -414,7 +414,7 @@ async function pauseAgent(): Promise<void> {
   try {
     const updated = await apiFetch(`/${agentId.value}/pause`, {
       method: 'POST',
-      body: JSON.stringify({ reason: 'Manual pause from UI', paused_by: 'user' }),
+      body: { reason: 'Manual pause from UI', paused_by: 'user' },
     })
     config.value = updated as HeartbeatConfig
   } catch (err) {

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -150,8 +150,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import { BaseModal } from '@autobot/ui'
-import { getBackendUrl } from '@/config/ssot-config'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import apiClient from '@/utils/ApiClient'
 
 const logger = createLogger('ApiKeySetupWizard')
 const { t } = useI18n()
@@ -279,18 +278,18 @@ async function saveAndClose(): Promise<void> {
 }
 
 async function saveKeys(keys: KeyEntry[]): Promise<void> {
-  const baseUrl = getBackendUrl()
+  // Base URL + auth resolved by apiClient (#12363). rawRequest keeps the
+  // non-throwing per-key contract: a failure logs and continues to the next key.
   for (const key of keys) {
-    const response = await fetchWithAuth(`${baseUrl}/api/secrets/`, {
+    const response = await apiClient.rawRequest(`/api/secrets/`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+      body: {
         name: key.envVar,
         value: key.value,
         secret_type: 'api_key',
         scope: 'general',
         description: key.description,
-      }),
+      },
     })
     if (!response.ok) {
       logger.error('Failed to save key %s: %s', key.envVar, response.statusText)

--- a/autobot-frontend/src/composables/__tests__/useThinkingMode.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useThinkingMode.test.ts
@@ -98,9 +98,12 @@ describe('useThinkingMode — persist via fetchWithAuth', () => {
       ([, opts]) => (opts as RequestInit | undefined)?.method === 'PUT',
     )
     expect(putCall).toBeTruthy()
-    expect(putCall?.[0]).toBe('/api/sessions/sess-9/thinking-preferences')
-    expect((putCall?.[1] as RequestInit).credentials).toBe('include')
-    expect(JSON.parse((putCall?.[1] as RequestInit).body as string)).toEqual({
+    // Destructure once (putCall asserted truthy above) so the RequestInit
+    // access isn't a `?.`-then-required member read (no-unsafe-optional-chaining).
+    const [putUrl, putInit] = putCall ?? []
+    expect(putUrl).toBe('/api/sessions/sess-9/thinking-preferences')
+    expect((putInit as RequestInit).credentials).toBe('include')
+    expect(JSON.parse((putInit as RequestInit).body as string)).toEqual({
       enabled: false,
       budget_tokens: 32000,
     })

--- a/autobot-frontend/src/composables/analytics/__tests__/useSourceRegistry.api.test.ts
+++ b/autobot-frontend/src/composables/analytics/__tests__/useSourceRegistry.api.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useSourceRegistry module-API Tests (#12363)
+ *
+ * Verifies the getBackendUrl-prefix removal for the module-level registry
+ * helpers: paths are now relative (base URL resolved by apiClient) and the
+ * POST/PUT branching in saveCodeSource is preserved.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}))
+
+import apiClient from '@/utils/ApiClient'
+import {
+  fetchSourceSecrets,
+  shareCodeSource,
+  saveCodeSource,
+} from '../useSourceRegistry'
+
+describe('useSourceRegistry module API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetchSourceSecrets calls the relative /api/secrets endpoint and unwraps secrets', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ secrets: [{ id: '1', name: 'k', type: 't', scope: 's' }] })
+
+    const result = await fetchSourceSecrets()
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/secrets')
+    expect(result).toEqual([{ id: '1', name: 'k', type: 't', scope: 's' }])
+  })
+
+  it('fetchSourceSecrets returns [] when the payload has no secrets', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({})
+    expect(await fetchSourceSecrets()).toEqual([])
+  })
+
+  it('shareCodeSource POSTs to the relative share endpoint', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ id: 's1' })
+    const payload = { access: 'shared' as const, user_ids: ['u1'] }
+
+    await shareCodeSource('s1', payload)
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/analytics/codebase/sources/s1/share',
+      payload,
+    )
+  })
+
+  it('saveCodeSource POSTs to a relative path when creating (no id)', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ id: 'new' })
+    const payload = {
+      name: 'n', source_type: 'github' as const, repo: 'r', branch: 'main',
+      access: 'private' as const, credential_id: null,
+    }
+
+    await saveCodeSource(payload)
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/analytics/codebase/sources', payload)
+    expect(apiClient.put).not.toHaveBeenCalled()
+  })
+
+  it('saveCodeSource PUTs to a relative id-scoped path when updating', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({ id: 'x' })
+    const payload = {
+      name: 'n', source_type: 'local' as const, repo: 'r', branch: 'main',
+      access: 'public' as const, credential_id: 'c1',
+    }
+
+    await saveCodeSource(payload, 'x')
+
+    expect(apiClient.put).toHaveBeenCalledWith('/api/analytics/codebase/sources/x', payload)
+    expect(apiClient.post).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
+++ b/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
@@ -17,7 +17,6 @@ import { useRoute } from 'vue-router'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { useSourcesListEndpoint } from '@/composables/analytics/useSourcesListEndpoint'
 import apiClient from '@/utils/ApiClient'
-import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
 import type { ToastType } from '@/composables/useToast'
 
@@ -45,17 +44,13 @@ export interface SourceSavePayload {
   credential_id: string | null
 }
 
-async function _getBackendUrl(): Promise<string> {
-  return appConfig.getServiceUrl('backend')
-}
-
 /**
  * Load credentials available for source authentication.
  * Extracted from AddSourceModal.vue (#6069).
  */
 export async function fetchSourceSecrets(): Promise<RegistrySecret[]> {
-  const backendUrl = await _getBackendUrl()
-  const data = await apiClient.get<{ secrets?: RegistrySecret[] }>(`${backendUrl}/api/secrets`)
+  // Base URL resolved by apiClient (#12363); relative path proxied by nginx/Vite.
+  const data = await apiClient.get<{ secrets?: RegistrySecret[] }>(`/api/secrets`)
   return data.secrets ?? []
 }
 
@@ -73,9 +68,8 @@ export async function shareCodeSource(
   sourceId: string,
   payload: SourceSharePayload,
 ): Promise<CodeSource> {
-  const backendUrl = await _getBackendUrl()
   return await apiClient.post<CodeSource>(
-    `${backendUrl}/api/analytics/codebase/sources/${sourceId}/share`,
+    `/api/analytics/codebase/sources/${sourceId}/share`,
     payload,
   )
 }
@@ -89,10 +83,9 @@ export async function saveCodeSource(
   payload: SourceSavePayload,
   id?: string,
 ): Promise<CodeSource> {
-  const backendUrl = await _getBackendUrl()
   const url = id
-    ? `${backendUrl}/api/analytics/codebase/sources/${id}`
-    : `${backendUrl}/api/analytics/codebase/sources`
+    ? `/api/analytics/codebase/sources/${id}`
+    : `/api/analytics/codebase/sources`
   return id
     ? await apiClient.put<CodeSource>(url, payload)
     : await apiClient.post<CodeSource>(url, payload)

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -14,7 +14,7 @@
  */
 
 import { ref, computed } from 'vue';
-import { getBackendUrl, getBackendWsUrl, getApiBase } from '@/config/ssot-config';
+import { getBackendWsUrl, getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import httpClient from '@/utils/ApiClient';
 import type { ApiResponse } from '@/types/api';
@@ -266,11 +266,9 @@ export interface WorkflowNode {
 // ==================================================================================
 
 class WorkflowBuilderApiClient {
-  private baseUrl: string;
   private timeout: number;
 
   constructor() {
-    this.baseUrl = getBackendUrl();
     this.timeout = 60000;
   }
 
@@ -278,15 +276,16 @@ class WorkflowBuilderApiClient {
     endpoint: string,
     options: RequestInit = {}
   ): Promise<ApiResponse<T>> {
-    const url = `${this.baseUrl}${endpoint}`;
+    // Base URL resolved by httpClient/apiClient (#12363); `endpoint` is the
+    // getApiBase()-prefixed relative path proxied by nginx/Vite.
     try {
       const method = ((options.method as string) || 'GET').toUpperCase();
       let data: T;
       if (method === 'POST') {
         const body = options.body ? JSON.parse(options.body as string) as unknown : undefined;
-        data = await httpClient.post<T>(url, body, { timeout: this.timeout });
+        data = await httpClient.post<T>(endpoint, body, { timeout: this.timeout });
       } else {
-        data = await httpClient.get<T>(url, { timeout: this.timeout });
+        data = await httpClient.get<T>(endpoint, { timeout: this.timeout });
       }
       return { success: true, data };
     } catch (error) {


### PR DESCRIPTION
## Thinking Path
#12363 Phase 2 continues moving `autobot-frontend` REST callers that inline the backend base URL off `getBackendUrl()` onto the canonical `apiClient`, so base-URL resolution, auth-token injection, org/tenant context and 401 handling live in one place. This batch picks a cohesive 6-file subset sharing that single theme; streaming/SSE, AbortController+409-status, WS/EventSource builders and arbitrary-endpoint diagnostics were intentionally left (see Follow-up).

## What Changed
Base URL now resolved by `apiClient` instead of inlined `getBackendUrl()`:

**Redundant-prefix removal (already on apiClient):**
- `composables/security/useSecretsInfraApi.ts` — drop `getBackendUrl()` prefix; relative paths. Graceful `.catch` defaults preserved.
- `composables/analytics/useSourceRegistry.ts` — remove `_getBackendUrl()` helper (+ now-unused `AppConfig` import); relative paths for `fetchSourceSecrets`/`shareCodeSource`/`saveCodeSource`.
- `composables/useWorkflowBuilder.ts` — private `WorkflowBuilderApiClient` no longer sets `baseUrl = getBackendUrl()`; passes the `getApiBase()`-prefixed relative path straight to `httpClient`. `getBackendWsUrl` (WS) retained.

**`fetchWithAuth` → `apiClient.rawRequest` (one-shot / graceful-null, exact behavior):**
- `composables/useVoiceBundle.ts` — preserves manual `res.ok` + `detail` parsing and `getUserBundle` null-swallowing.
- `components/agents/HeartbeatPanel.vue` — `apiFetch` helper on `rawRequest`; exact `${status}: ${text}` error + 204→null retained (object bodies instead of pre-stringified).
- `components/settings/ApiKeySetupWizard.vue` — `saveKeys` on `rawRequest`; non-throwing per-key log-and-continue retained.

Exported signatures unchanged. New unit tests added for the three migratable composables.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` — clean (exit 0).
- `vitest run` (3 new files) — **16 passed**.
- grep-confirmed the 6 files no longer inline `getBackendUrl` / `fetchWithAuth` (WorkflowBuilder keeps only `getBackendWsUrl`).
- No existing test imports the migrated modules.

## Model Used
claude-opus-4-8

## Follow-up
Remaining `getBackendUrl`/`fetch` callers (deliberately excluded — reasons):
- **Streaming / raw body reader:** `useMultiModelCompare`, `transcriber/useAiAnalysis`, `models/repositories/ChatRepository`, `models/controllers/ChatController` (SSE/ReadableStream).
- **AbortController signal + 409/status inspection:** `usePatternAnalysis`, `useBackgroundTask`, `useCommandApproval`, `stores/usePermissionStore` (already documented exempt).
- **WS/EventSource / media URL builders:** `useOverseerAgent`, `useCanvasWebSocket`, `transcriber/useSseProgress`, `useWorkflowBuilder` `getBackendWsUrl`, `transcriber/useTranscriberApi` `audioChunksUrl` (absolute `<audio>`/wavesurfer Range URL).
- **Arbitrary-endpoint diagnostic:** `useConnectionTester` (must raw-`fetch` any user URL).
- **Plain CRUD views (next batch):** `views/BudgetPolicies.vue`, `views/AdminUsersView.vue`, `views/secrets/LlmApiKeysView.vue`, `composables/useTerminalStore.ts`.
- **Raw CSS-text fetch w/ existing fetchWithAuth-mock test:** `composables/useThemeVariant.ts` (deferred to avoid the `global.fetch`/mock coupling seen with HostSelectionDialog).

Refs #12363
Closes #12640