### PR TITLE
refactor(slm-frontend): consolidate duplicated axios-compat adapter into slmApiCompat (#12654)

### DIFF
--- a/autobot-slm-frontend/src/composables/slmApiClient.testHelper.ts
+++ b/autobot-slm-frontend/src/composables/slmApiClient.testHelper.ts
@@ -4,13 +4,14 @@
 // Author: mrveiss
 
 /**
- * Response-builder helpers for the useSlmApi ↔ slmApiClient seam (#12420 Phase 2).
+ * Shared Response-builder helpers for the slmApiClient seam (#12420 Phase 2,
+ * consolidated in #12654).
  *
- * useSlmApi's adapter routes every call through `slmApiClient.rawRequest`, which
- * resolves a Fetch `Response`. Tests mock that seam per-file (so the vi.mock
- * factory hoists correctly) and use these builders to produce Response-shaped
- * stubs the adapter understands — driving the `response.data` unwrap and the
- * reproduced axios error shape.
+ * The composables that route through `slmApiClient.rawRequest` resolve a Fetch
+ * `Response`. Their tests mock that seam per-file (so the vi.mock factory hoists
+ * correctly) and use these builders to produce Response-shaped stubs the adapter
+ * (and the rawRequest-based useCodeSync methods) understand — driving the
+ * `response.data` unwrap and the reproduced axios error shape.
  */
 
 /** A minimal Fetch-Response stub the adapter understands. */
@@ -38,4 +39,13 @@ export function jsonResponse(body: unknown, status = 200): Response {
 /** Non-2xx JSON error response (the adapter surfaces body as err.response.data). */
 export function errorResponse(status: number, body: unknown): Response {
   return makeResponse(status, body, 'application/json')
+}
+
+/**
+ * `(status, body)` Response stub for the rawRequest-based useCodeSync methods,
+ * which inspect only `response.ok`/`response.status`/`response.json()`. A thin
+ * wrapper over `makeResponse` so every test file shares one builder.
+ */
+export function mockResponse(status: number, body: unknown): Response {
+  return makeResponse(status, body)
 }

--- a/autobot-slm-frontend/src/composables/useCodeSync.test.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSync.test.ts
@@ -49,15 +49,7 @@ vi.mock('./useRoles', () => ({
 }))
 
 import { useCodeSync } from './useCodeSync'
-
-// Minimal Response-like stub for the rawRequest-based methods.
-function mockResponse(status: number, body: unknown): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => body,
-  } as unknown as Response
-}
+import { mockResponse } from './slmApiClient.testHelper'
 
 describe('useCodeSync — async drift/resolve job (#11303)', () => {
   beforeEach(() => {

--- a/autobot-slm-frontend/src/composables/useMfaApi.ts
+++ b/autobot-slm-frontend/src/composables/useMfaApi.ts
@@ -18,6 +18,7 @@
 
 import slmApiClient from '@/utils/ApiClient'
 import { useAuthStore } from '@/stores/auth'
+import { createAuthGuard } from '@/utils/slmAuthGuard'
 
 export interface MFASetupResponse {
   secret: string
@@ -43,21 +44,10 @@ export interface MFAVerifyResponse {
 export function useMfaApi() {
   const authStore = useAuthStore()
 
-  // The canonical client intentionally skips its session-clearing 401 handler
-  // for auth/MFA endpoints (a 401 there is a credential failure, not a rejected
-  // session). MFA management historically logged the user out on any 401 — the
-  // previous axios response interceptor called `authStore.logout()` — so we
-  // preserve that exact behavior explicitly here and re-throw as before.
-  async function withAuthGuard<T>(op: () => Promise<T>): Promise<T> {
-    try {
-      return await op()
-    } catch (error) {
-      if (error instanceof Error && error.message.startsWith('HTTP 401')) {
-        authStore.logout()
-      }
-      throw error
-    }
-  }
+  // Preserve the historic "logout on 401" behaviour: the canonical client skips
+  // its session-clearing 401 handler for /mfa/ (auth) endpoints, so the guard
+  // re-applies it explicitly (shared helper — see utils/slmAuthGuard.ts).
+  const withAuthGuard = createAuthGuard(authStore.logout)
 
   async function setupMFA(): Promise<MFASetupResponse> {
     return withAuthGuard(() => slmApiClient.post<MFASetupResponse>('/mfa/setup'))

--- a/autobot-slm-frontend/src/composables/useRoles.test.ts
+++ b/autobot-slm-frontend/src/composables/useRoles.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { jsonResponse, errorResponse } from './useSlmApi.testHelper'
+import { jsonResponse, errorResponse } from './slmApiClient.testHelper'
 
 const mockRaw = vi.fn()
 

--- a/autobot-slm-frontend/src/composables/useRoles.ts
+++ b/autobot-slm-frontend/src/composables/useRoles.ts
@@ -10,7 +10,7 @@
  */
 
 import { ref, reactive } from 'vue'
-import { slmApiClient } from '@/utils/ApiClient'
+import { makeAxiosCompatClient } from '@/utils/slmApiCompat'
 
 export interface Role {
   name: string
@@ -119,105 +119,16 @@ export interface DecommissionPreflight {
 }
 
 // =============================================================================
-// slmApiClient adapter (#12420 Phase 2 batch 7)
+// slmApiClient adapter (#12420 Phase 2 batch 7 → consolidated in #12654)
 //
-// useRoles historically owned its own `axios.create()` instance (base URL built
-// from getSlmApiBase(), a request interceptor injecting the SLM bearer token, no
-// response interceptor). This adapter routes every call through the canonical
-// `slmApiClient` — where the auth token, base URL and centralised 401 handling
-// now live — while reproducing the axios surface the methods below depend on so
-// their bodies, and all consumers, stay unchanged:
-//
-//   * methods `await client.<verb>(endpoint, body?)` and read `response.data`
-//     → the adapter returns `{ data }`.
-//   * every catch reads `err.response?.data?.detail || err.message` → the
-//     adapter throws an axios-shaped error carrying `response.status` +
-//     `response.data` (and a `message` of `HTTP <n>` as the secondary fallback);
-//     a network/timeout rejection surfaces the raw Error (no `.response`), so
-//     `err.message` remains the fallback exactly as with axios.
-//
-// It delegates to `slmApiClient.rawRequest` (not the get/post/... helpers) on
-// purpose: rawRequest is the single seam that injects the bearer token + base
-// URL and runs the 401 handler, WITHOUT the helpers' GET retry/back-off or the
-// `HTTP <n>: <msg>` error transform — preserving the original single-shot,
-// structured-error behaviour every method relies on.
+// useRoles historically owned its own axios instance; the Phase-2 migration
+// routed every call through the canonical `slmApiClient` via a thin axios-compat
+// adapter. That adapter now lives in `utils/slmApiCompat.ts` (shared with
+// useSlmApi). `arrays: true` preserves this composable's serialisation of array
+// params as repeated `key[]=value` (syncRole's `node_ids`).
 // =============================================================================
 
-interface AxiosLikeResponse<T> {
-  data: T
-}
-
-// Serialise an axios-style params object onto the endpoint, matching axios's
-// default serialisation: scalars as `key=value`, arrays as repeated `key[]=value`
-// (URLSearchParams encodes the brackets to `%5B%5D`, exactly as axios does). Only
-// removeRole (scalar) and syncRole (scalar + array) pass a params object.
-function withParams(endpoint: string, params?: Record<string, unknown>): string {
-  if (!params) return endpoint
-  const usp = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    if (value === undefined || value === null) continue
-    if (Array.isArray(value)) {
-      for (const item of value) usp.append(`${key}[]`, String(item))
-    } else {
-      usp.append(key, String(value))
-    }
-  }
-  const qs = usp.toString()
-  if (!qs) return endpoint
-  return endpoint.includes('?') ? `${endpoint}&${qs}` : `${endpoint}?${qs}`
-}
-
-async function adapterRequest<T>(
-  method: string,
-  endpoint: string,
-  body?: unknown
-): Promise<AxiosLikeResponse<T>> {
-  const response = await slmApiClient.rawRequest(endpoint, { method, body })
-
-  if (!response.ok) {
-    let data: unknown = null
-    try {
-      data = await response.json()
-    } catch {
-      /* non-JSON error body — leave data null, mirroring axios */
-    }
-    const error = new Error(`HTTP ${response.status}`) as Error & {
-      response: { status: number; data: unknown }
-    }
-    // Reproduce the axios error shape the catch blocks read (err.response.data.detail).
-    error.response = { status: response.status, data }
-    throw error
-  }
-
-  if (response.status === 204) return { data: {} as T }
-  const contentType = response.headers.get('content-type')
-  if (contentType && contentType.includes('application/json')) {
-    return { data: (await response.json()) as T }
-  }
-  return { data: {} as T }
-}
-
-// Axios-compatible facade over slmApiClient consumed by every method below.
-const client = {
-  get: <T = unknown>(
-    endpoint: string,
-    config?: { params?: Record<string, unknown> }
-  ): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('GET', withParams(endpoint, config?.params)),
-  post: <T = unknown>(
-    endpoint: string,
-    body?: unknown,
-    config?: { params?: Record<string, unknown> }
-  ): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('POST', withParams(endpoint, config?.params), body ?? undefined),
-  put: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('PUT', endpoint, body),
-  delete: <T = unknown>(
-    endpoint: string,
-    config?: { params?: Record<string, unknown> }
-  ): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('DELETE', withParams(endpoint, config?.params)),
-}
+const client = makeAxiosCompatClient({ arrays: true })
 
 export function useRoles() {
   const roles = ref<Role[]>([])

--- a/autobot-slm-frontend/src/composables/useSlmApi.appLogs.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.appLogs.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { jsonResponse } from './useSlmApi.testHelper'
+import { jsonResponse } from './slmApiClient.testHelper'
 
 const mockRaw = vi.fn()
 

--- a/autobot-slm-frontend/src/composables/useSlmApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.test.ts
@@ -25,7 +25,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { jsonResponse, errorResponse } from './useSlmApi.testHelper'
+import { jsonResponse, errorResponse } from './slmApiClient.testHelper'
 
 const mockRaw = vi.fn()
 

--- a/autobot-slm-frontend/src/composables/useSlmApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.ts
@@ -9,7 +9,7 @@
  * Provides REST API integration for all SLM endpoints.
  */
 
-import { slmApiClient } from '@/utils/ApiClient'
+import { makeAxiosCompatClient } from '@/utils/slmApiCompat'
 import type {
   SLMNode,
   NodeHealth,
@@ -98,94 +98,16 @@ import type {
 } from '@/types/api-responses'
 
 // =============================================================================
-// slmApiClient adapter (#12420 Phase 2 batch 5)
+// slmApiClient adapter (#12420 Phase 2 batch 5 → consolidated in #12654)
 //
-// useSlmApi historically owned its own axios instance (base URL from
-// getSlmApiBase(), a request interceptor injecting the SLM bearer token, and no
-// response interceptor). This adapter routes every call through the canonical
-// `slmApiClient` — where the auth token, base URL and centralised 401 handling
-// now live — while reproducing the axios surface the methods below depend on so
-// their bodies, and all ~26 consumers, stay byte-for-byte unchanged:
-//
-//   * methods `await client.<verb>(endpoint, body?)` and read `response.data`
-//     → the adapter returns `{ data }`.
-//   * consumers read `err.response.status` / `err.response.data.detail` on a
-//     rejected call (e.g. upsertSecret's 409 fallback, SetupWizardView,
-//     SecretsSettings) → the adapter throws an axios-shaped error carrying
-//     `response.status` and `response.data`.
-//
-// It delegates to `slmApiClient.rawRequest` (not the get/post/... helpers) on
-// purpose: rawRequest is the single seam that injects the bearer token + base
-// URL and runs the 401 handler, WITHOUT the helpers' GET retry/back-off or the
-// `HTTP <n>: <msg>` error transform — preserving the original single-shot,
-// structured-error behaviour the consumers rely on.
+// useSlmApi historically owned its own axios instance; the Phase-2 migration
+// routed every call through the canonical `slmApiClient` via a thin axios-compat
+// adapter. That adapter now lives in `utils/slmApiCompat.ts` (shared with
+// useRoles). `textFallback: true` preserves this composable's behaviour of
+// returning `response.text()` for a non-JSON 2xx body (PEM cert downloads).
 // =============================================================================
 
-interface AxiosLikeResponse<T> {
-  data: T
-}
-
-// Serialise an axios-style params object onto the endpoint. Only getProvisionStatus
-// passes a params object; every other method already builds its own query string.
-function withParams(endpoint: string, params?: Record<string, unknown>): string {
-  if (!params) return endpoint
-  const usp = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    if (value !== undefined && value !== null) usp.append(key, String(value))
-  }
-  const qs = usp.toString()
-  if (!qs) return endpoint
-  return endpoint.includes('?') ? `${endpoint}&${qs}` : `${endpoint}?${qs}`
-}
-
-async function adapterRequest<T>(
-  method: string,
-  endpoint: string,
-  body?: unknown
-): Promise<AxiosLikeResponse<T>> {
-  const response = await slmApiClient.rawRequest(endpoint, { method, body })
-
-  if (!response.ok) {
-    let data: unknown = null
-    try {
-      data = await response.json()
-    } catch {
-      /* non-JSON error body — leave data null, mirroring axios */
-    }
-    const error = new Error(`HTTP ${response.status}`) as Error & {
-      response: { status: number; data: unknown }
-    }
-    // Reproduce the axios error shape consumers read (err.response.status/.data).
-    error.response = { status: response.status, data }
-    throw error
-  }
-
-  if (response.status === 204) return { data: {} as T }
-  const contentType = response.headers.get('content-type')
-  if (contentType && contentType.includes('application/json')) {
-    return { data: (await response.json()) as T }
-  }
-  // Non-JSON 2xx (e.g. PEM cert downloads) — return the raw text, as axios does
-  // when its default JSON transform cannot parse the payload.
-  return { data: (await response.text()) as unknown as T }
-}
-
-// Axios-compatible facade over slmApiClient consumed by every method below.
-const client = {
-  get: <T = unknown>(
-    endpoint: string,
-    config?: { params?: Record<string, unknown> }
-  ): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('GET', withParams(endpoint, config?.params)),
-  post: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('POST', endpoint, body),
-  put: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('PUT', endpoint, body),
-  patch: <T = unknown>(endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('PATCH', endpoint, body),
-  delete: <T = unknown>(endpoint: string): Promise<AxiosLikeResponse<T>> =>
-    adapterRequest<T>('DELETE', endpoint),
-}
+const client = makeAxiosCompatClient({ textFallback: true })
 
 // Backend response types (different from frontend SLMNode)
 interface BackendNodeResponse {

--- a/autobot-slm-frontend/src/composables/useSsoApi.ts
+++ b/autobot-slm-frontend/src/composables/useSsoApi.ts
@@ -24,6 +24,7 @@
 
 import slmApiClient from '@/utils/ApiClient'
 import { useAuthStore } from '@/stores/auth'
+import { createAuthGuard } from '@/utils/slmAuthGuard'
 
 // =============================================================================
 // Type Definitions
@@ -113,19 +114,10 @@ export interface SSOProviderHealthResponse {
 export function useSsoApi() {
   const authStore = useAuthStore()
 
-  // The canonical client skips its session-clearing 401 handler for `/auth/**`
-  // endpoints, so the SSO login-flow methods below preserve the historic
-  // interceptor behavior (logout on any 401) explicitly and re-throw as before.
-  async function withAuthGuard<T>(op: () => Promise<T>): Promise<T> {
-    try {
-      return await op()
-    } catch (error) {
-      if (error instanceof Error && error.message.startsWith('HTTP 401')) {
-        authStore.logout()
-      }
-      throw error
-    }
-  }
+  // Preserve the historic "logout on 401" behaviour: the canonical client skips
+  // its session-clearing 401 handler for /auth/** endpoints, so the SSO
+  // login-flow methods re-apply it explicitly (shared helper — utils/slmAuthGuard.ts).
+  const withAuthGuard = createAuthGuard(authStore.logout)
 
   // ===========================================================================
   // SSO Provider CRUD (non-auth endpoints — client handles 401 centrally)

--- a/autobot-slm-frontend/src/utils/slmApiCompat.test.ts
+++ b/autobot-slm-frontend/src/utils/slmApiCompat.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #12654 — focused tests for the shared axios-compat adapter extracted from the
+ * duplicated per-composable copies. Asserts the two behaviour flags that were the
+ * ONLY differences between the useSlmApi and useRoles copies (`textFallback` and
+ * `arrays`) plus the invariant `{ data }` envelope and axios-shaped error.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeResponse } from '@/composables/slmApiClient.testHelper'
+
+const mockRaw = vi.fn()
+
+vi.mock('@/utils/ApiClient', () => ({
+  slmApiClient: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+  default: { rawRequest: (...args: unknown[]) => mockRaw(...args) },
+}))
+
+import { makeAxiosCompatClient, withParams } from './slmApiCompat'
+
+describe('withParams', () => {
+  it('serialises scalars as key=value and leaves the endpoint alone with no params', () => {
+    expect(withParams('/x')).toBe('/x')
+    expect(withParams('/x', { a: 1, b: 'two' })).toBe('/x?a=1&b=two')
+  })
+
+  it('appends with & when the endpoint already has a query string', () => {
+    expect(withParams('/x?z=0', { a: 1 })).toBe('/x?z=0&a=1')
+  })
+
+  it('skips null/undefined values', () => {
+    expect(withParams('/x', { a: undefined, b: null, c: 3 })).toBe('/x?c=3')
+  })
+
+  it('with arrays:false stringifies an array via String() (scalar path)', () => {
+    expect(withParams('/x', { ids: ['a', 'b'] })).toBe('/x?ids=a%2Cb')
+  })
+
+  it('with arrays:true serialises arrays as repeated key[]=value', () => {
+    expect(withParams('/x', { ids: ['a', 'b'] }, { arrays: true })).toBe(
+      '/x?ids%5B%5D=a&ids%5B%5D=b'
+    )
+  })
+})
+
+describe('makeAxiosCompatClient — envelope + routing', () => {
+  beforeEach(() => mockRaw.mockReset())
+
+  it('unwraps a 2xx JSON body into { data } and routes verb + endpoint + body', async () => {
+    mockRaw.mockResolvedValue(makeResponse(200, { ok: true }))
+    const client = makeAxiosCompatClient()
+
+    const res = await client.post('/nodes', { a: 1 })
+
+    expect(mockRaw).toHaveBeenCalledWith('/nodes', { method: 'POST', body: { a: 1 } })
+    expect(res.data).toEqual({ ok: true })
+  })
+
+  it('returns { data: {} } for a 204 No Content', async () => {
+    mockRaw.mockResolvedValue(makeResponse(204, null))
+    const res = await makeAxiosCompatClient().delete('/nodes/1')
+    expect(res.data).toEqual({})
+  })
+
+  it('throws an axios-shaped error carrying response.status + response.data on non-2xx', async () => {
+    mockRaw.mockResolvedValue(makeResponse(409, { detail: 'conflict' }))
+    await expect(makeAxiosCompatClient().post('/secrets')).rejects.toMatchObject({
+      message: 'HTTP 409',
+      response: { status: 409, data: { detail: 'conflict' } },
+    })
+  })
+
+  it('serialises get params through withParams (arrays flag honoured)', async () => {
+    mockRaw.mockResolvedValue(makeResponse(200, {}))
+    const client = makeAxiosCompatClient({ arrays: true })
+    await client.get('/roles', { params: { node_ids: ['n1', 'n2'] } })
+    expect(mockRaw).toHaveBeenCalledWith('/roles?node_ids%5B%5D=n1&node_ids%5B%5D=n2', {
+      method: 'GET',
+      body: undefined,
+    })
+  })
+})
+
+describe('makeAxiosCompatClient — textFallback for non-JSON 2xx', () => {
+  beforeEach(() => mockRaw.mockReset())
+
+  it('with textFallback:true returns response.text() for a non-JSON 2xx (PEM download)', async () => {
+    mockRaw.mockResolvedValue(makeResponse(200, '-----BEGIN CERT-----', 'application/x-pem-file'))
+    const res = await makeAxiosCompatClient({ textFallback: true }).get('/tls/credentials/1/ca-cert')
+    expect(res.data).toBe('-----BEGIN CERT-----')
+  })
+
+  it('without textFallback returns {} for a non-JSON 2xx', async () => {
+    mockRaw.mockResolvedValue(makeResponse(200, 'ignored', 'text/plain'))
+    const res = await makeAxiosCompatClient().get('/roles')
+    expect(res.data).toEqual({})
+  })
+})

--- a/autobot-slm-frontend/src/utils/slmApiCompat.ts
+++ b/autobot-slm-frontend/src/utils/slmApiCompat.ts
@@ -1,0 +1,172 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Shared axios-compat adapter over the canonical `slmApiClient` (#12654).
+ *
+ * The #12420 Phase-2 migration routed every per-composable axios instance
+ * through the canonical `slmApiClient`, reproducing the axios surface each
+ * method body depends on via a thin adapter. That adapter (the
+ * `AxiosLikeResponse` envelope, `withParams`, `adapterRequest` and the
+ * get/post/put/patch/delete facade) was copied byte-for-byte into both
+ * `useSlmApi` and `useRoles`. This module consolidates that single shared core
+ * so it lives in ONE place; the composables import it and pass the two behaviour
+ * flags that were their only real differences:
+ *
+ *   * `textFallback` — a non-JSON 2xx response yields `response.text()` (PEM cert
+ *     downloads in useSlmApi) rather than `{}` (useRoles).
+ *   * `arrays` — `withParams` serialises array values as repeated `key[]=value`
+ *     (useRoles' syncRole `node_ids`) rather than axios's scalar `String(value)`.
+ *
+ * It delegates to `slmApiClient.rawRequest` (not the get/post/... helpers) on
+ * purpose: rawRequest is the single seam that injects the bearer token + base
+ * URL and runs the 401 handler, WITHOUT the helpers' GET retry/back-off or the
+ * `HTTP <n>: <msg>` error transform — preserving the original single-shot,
+ * structured-error behaviour every consumer relies on:
+ *
+ *   * methods `await client.<verb>(endpoint, body?)` and read `response.data`
+ *     → the adapter returns `{ data }`.
+ *   * consumers read `err.response.status` / `err.response.data.detail` on a
+ *     rejected call → the adapter throws an axios-shaped error carrying
+ *     `response.status` and `response.data` (and a `message` of `HTTP <n>` as the
+ *     secondary fallback); a network/timeout rejection surfaces the raw Error
+ *     (no `.response`), so `err.message` remains the fallback exactly as axios.
+ */
+
+import { slmApiClient } from '@/utils/ApiClient'
+
+/** The axios `{ data }` envelope every migrated method reads via `response.data`. */
+export interface AxiosLikeResponse<T> {
+  data: T
+}
+
+export interface AdapterRequestOptions {
+  /**
+   * When true, a non-JSON 2xx body is returned as `response.text()` (mirroring
+   * axios's default transform falling through to the raw string — used for PEM
+   * cert downloads). When false/omitted the adapter returns `{}` for non-JSON 2xx.
+   */
+  textFallback?: boolean
+}
+
+/**
+ * Shared core: route one call through `slmApiClient.rawRequest` and reproduce the
+ * axios `{ data }` / `err.response` surface exactly.
+ */
+export async function adapterRequest<T>(
+  method: string,
+  endpoint: string,
+  body?: unknown,
+  opts?: AdapterRequestOptions
+): Promise<AxiosLikeResponse<T>> {
+  const response = await slmApiClient.rawRequest(endpoint, { method, body })
+
+  if (!response.ok) {
+    let data: unknown = null
+    try {
+      data = await response.json()
+    } catch {
+      /* non-JSON error body — leave data null, mirroring axios */
+    }
+    const error = new Error(`HTTP ${response.status}`) as Error & {
+      response: { status: number; data: unknown }
+    }
+    // Reproduce the axios error shape consumers read (err.response.status/.data).
+    error.response = { status: response.status, data }
+    throw error
+  }
+
+  if (response.status === 204) return { data: {} as T }
+  const contentType = response.headers.get('content-type')
+  if (contentType && contentType.includes('application/json')) {
+    return { data: (await response.json()) as T }
+  }
+  // Non-JSON 2xx (e.g. PEM cert downloads) — useSlmApi returns the raw text as
+  // axios does when its JSON transform cannot parse the payload; useRoles returns
+  // an empty object.
+  if (opts?.textFallback) {
+    return { data: (await response.text()) as unknown as T }
+  }
+  return { data: {} as T }
+}
+
+export interface WithParamsOptions {
+  /**
+   * When true, array values are serialised as repeated `key[]=value` (axios's
+   * default array serialisation; URLSearchParams encodes the brackets to
+   * `%5B%5D`). When false/omitted, arrays fall through to `String(value)` — the
+   * scalar path, matching call sites that never pass arrays.
+   */
+  arrays?: boolean
+}
+
+/**
+ * Serialise an axios-style params object onto the endpoint. Scalars serialise as
+ * `key=value`; arrays serialise as repeated `key[]=value` when `arrays` is set.
+ */
+export function withParams(
+  endpoint: string,
+  params?: Record<string, unknown>,
+  opts?: WithParamsOptions
+): string {
+  if (!params) return endpoint
+  const usp = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue
+    if (opts?.arrays && Array.isArray(value)) {
+      for (const item of value) usp.append(`${key}[]`, String(item))
+    } else {
+      usp.append(key, String(value))
+    }
+  }
+  const qs = usp.toString()
+  if (!qs) return endpoint
+  return endpoint.includes('?') ? `${endpoint}&${qs}` : `${endpoint}?${qs}`
+}
+
+export interface AxiosCompatClientOptions extends AdapterRequestOptions, WithParamsOptions {}
+
+/** Optional per-call config carrying an axios-style `params` object. */
+export interface AxiosCompatConfig {
+  params?: Record<string, unknown>
+}
+
+/** The axios-compatible facade over slmApiClient consumed by the composables. */
+export interface AxiosCompatClient {
+  get: <T = unknown>(endpoint: string, config?: AxiosCompatConfig) => Promise<AxiosLikeResponse<T>>
+  post: <T = unknown>(
+    endpoint: string,
+    body?: unknown,
+    config?: AxiosCompatConfig
+  ) => Promise<AxiosLikeResponse<T>>
+  put: <T = unknown>(endpoint: string, body?: unknown) => Promise<AxiosLikeResponse<T>>
+  patch: <T = unknown>(endpoint: string, body?: unknown) => Promise<AxiosLikeResponse<T>>
+  delete: <T = unknown>(endpoint: string, config?: AxiosCompatConfig) => Promise<AxiosLikeResponse<T>>
+}
+
+/**
+ * Build the axios-compatible facade. `textFallback`/`arrays` tune the two
+ * behaviours that differed between the original per-composable copies; every
+ * other aspect is identical. `post`/`delete`/`get` accept an optional
+ * `{ params }` config (a superset — call sites that never pass one are
+ * unaffected, since `withParams(endpoint, undefined)` returns the endpoint
+ * unchanged).
+ */
+export function makeAxiosCompatClient(opts: AxiosCompatClientOptions = {}): AxiosCompatClient {
+  const wp = (endpoint: string, params?: Record<string, unknown>): string =>
+    withParams(endpoint, params, { arrays: opts.arrays })
+  const req = <T>(method: string, endpoint: string, body?: unknown): Promise<AxiosLikeResponse<T>> =>
+    adapterRequest<T>(method, endpoint, body, { textFallback: opts.textFallback })
+  return {
+    get: <T = unknown>(endpoint: string, config?: AxiosCompatConfig) =>
+      req<T>('GET', wp(endpoint, config?.params)),
+    post: <T = unknown>(endpoint: string, body?: unknown, config?: AxiosCompatConfig) =>
+      req<T>('POST', wp(endpoint, config?.params), body ?? undefined),
+    put: <T = unknown>(endpoint: string, body?: unknown) => req<T>('PUT', endpoint, body),
+    patch: <T = unknown>(endpoint: string, body?: unknown) => req<T>('PATCH', endpoint, body),
+    delete: <T = unknown>(endpoint: string, config?: AxiosCompatConfig) =>
+      req<T>('DELETE', wp(endpoint, config?.params)),
+  }
+}

--- a/autobot-slm-frontend/src/utils/slmAuthGuard.ts
+++ b/autobot-slm-frontend/src/utils/slmAuthGuard.ts
@@ -1,0 +1,32 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Shared "logout on 401" guard for auth-flow endpoints (#12654).
+ *
+ * The canonical `slmApiClient` intentionally skips its session-clearing 401
+ * handler for `/auth/**` and `/mfa/**` endpoints (a 401 there is a credential
+ * failure, not a rejected session). Both `useMfaApi` and `useSsoApi` historically
+ * logged the user out on ANY 401 via their axios response interceptor, so each
+ * wrapped those calls in a byte-identical `withAuthGuard`. This consolidates that
+ * helper: pass the auth store's `logout` and receive the same guard.
+ */
+
+/**
+ * Wrap a composable's auth-flow call so a `HTTP 401` rejection triggers `logout`
+ * (preserving the historic interceptor behaviour) before re-throwing unchanged.
+ */
+export function createAuthGuard(logout: () => void) {
+  return async function withAuthGuard<T>(op: () => Promise<T>): Promise<T> {
+    try {
+      return await op()
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('HTTP 401')) {
+        logout()
+      }
+      throw error
+    }
+  }
+}


### PR DESCRIPTION
## Thinking Path

The #12420 Phase-2 migration routed each per-composable axios instance through the canonical `slmApiClient`, but copied the axios-compat boilerplate byte-for-byte into multiple composables:

- `AxiosLikeResponse<T>` + `withParams()` + `adapterRequest<T>()` + the get/post/put/patch/delete `client` facade — duplicated in `useSlmApi.ts` and `useRoles.ts`. Their only real differences: useSlmApi returns `response.text()` for a non-JSON 2xx (PEM cert downloads) whereas useRoles returns `{}`; and useRoles serialises array params as repeated `key[]=value`.
- `withAuthGuard<T>(op)` — byte-identical in `useMfaApi.ts` and `useSsoApi.ts` (logout on `HTTP 401`, rethrow).

Design: one shared core in `utils/slmApiCompat.ts` keyed by two behaviour flags (`textFallback`, `arrays`) exposed via a `makeAxiosCompatClient()` factory; the tiny logout-on-401 guard in `utils/slmAuthGuard.ts` via `createAuthGuard(logout)`. The canonical `slmApiClient` (utils/ApiClient.ts) is untouched — the compat layer sits separately. Behaviour-preserving: every composable's public API/signatures are unchanged, so the ~26 useSlmApi consumers and all useRoles/useMfaApi/useSsoApi consumers need zero changes.

## What Changed

**New shared modules**
- `utils/slmApiCompat.ts` (+172): `AxiosLikeResponse<T>`, `adapterRequest<T>(method, endpoint, body?, { textFallback? })` (the exact `{ data }` envelope + `err.response = { status, data }` shape + 204/content-type handling), `withParams(endpoint, params, { arrays? })`, and `makeAxiosCompatClient({ textFallback?, arrays? })`.
- `utils/slmAuthGuard.ts` (+32): `createAuthGuard(logout)` → the shared `withAuthGuard`.
- `utils/slmApiCompat.test.ts` (+102): focused coverage of both flags + envelope/error shape.

**Composables refactored to import the shared helpers (local copies deleted)**
- `useSlmApi.ts`: removed local `AxiosLikeResponse`/`withParams`/`adapterRequest`/`client` (~89 lines) → `const client = makeAxiosCompatClient({ textFallback: true })`.
- `useRoles.ts`: removed the same local block (~100 lines) → `const client = makeAxiosCompatClient({ arrays: true })`.
- `useMfaApi.ts` / `useSsoApi.ts`: removed local `withAuthGuard` → `const withAuthGuard = createAuthGuard(authStore.logout)`.

**Test scaffolding consolidated**
- Renamed `composables/useSlmApi.testHelper.ts` → `composables/slmApiClient.testHelper.ts`; updated importers (`useSlmApi.test`, `useSlmApi.appLogs.test`, `useRoles.test`).
- Folded `useCodeSync.test.ts`'s local `mockResponse` into the shared helper (`export function mockResponse`).
- Single `AxiosLikeResponse` type now lives only in `slmApiCompat.ts` (both duplicate decls removed).

Net: +352 / -229 across 12 files; production dedup removes ~189 duplicated adapter lines (the +net is the new focused test + fuller shared-module docs).

## Verification

- `vue-tsc --noEmit -p tsconfig.json` → exit 0 (clean).
- Full slm-frontend unit suite (`vitest run`) → **25 files, 203 tests passed**, zero consumer changes (incl. useSlmApi, useRoles, useMfaApi, useSsoApi, useCodeSync + new slmApiCompat.test).
- `oxlint -D correctness` on all changed files → 0 errors; `eslint` on all changed files → 0 errors. (Repo-wide oxlint reports pre-existing errors in files this PR does not touch — `useThinkingMode.test.ts` handled by #12641, plus 4 unrelated slm-frontend files — none introduced here.)
- grep-confirmed the 4 composables no longer define local `adapterRequest`/`withParams`/`withAuthGuard`/`AxiosLikeResponse`.

## Model Used

claude-opus-4-8

Closes #12654
