### PR TITLE
fix(lint): clear 4 pre-existing slm-frontend oxlint correctness errors (#12665)

### DIFF
--- a/autobot-slm-frontend/src/composables/usePerformanceMonitoring.ts
+++ b/autobot-slm-frontend/src/composables/usePerformanceMonitoring.ts
@@ -146,7 +146,7 @@ export function usePerformanceMonitoring(options: {
   ): Promise<T> {
     const response = await fetch(url, {
       ...options,
-      headers: { ...getHeaders(), ...(options.headers as Record<string, string> || {}) },
+      headers: { ...getHeaders(), ...(options.headers as Record<string, string>) },
     })
     if (!response.ok) {
       const body = await response.text().catch(() => '')

--- a/autobot-slm-frontend/src/stores/fleet.ts
+++ b/autobot-slm-frontend/src/stores/fleet.ts
@@ -168,7 +168,7 @@ export const useFleetStore = defineStore('fleet', () => {
   async function fetchFleetUpdateSummary(): Promise<void> {
     try {
       fleetUpdateSummary.value = await api.getFleetUpdateSummary()
-    } catch (_err) {
+    } catch {
       // Silently fail - updates are supplementary info
       fleetUpdateSummary.value = null
     }

--- a/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.test.ts
@@ -54,9 +54,7 @@ describe('FindingsPolicySettings', () => {
   })
 
   it('falls back to POST when PUT returns 404', async () => {
-    let callCount = 0
     global.fetch = vi.fn(async (_url, opts) => {
-      callCount++
       if (opts?.method === 'PUT') {
         return { ok: false, status: 404, json: async () => ({}) } as Response
       }

--- a/autobot-slm-frontend/src/views/tools/admin/AdvancedControlTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/AdvancedControlTool.vue
@@ -89,7 +89,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${authStore.token}`,
-      ...(init?.headers || {}),
+      ...(init?.headers),
     },
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)


### PR DESCRIPTION
## Thinking Path
Fast-follow lint cleanup for issue #12665: four pre-existing `oxlint -D correctness` errors in `autobot-slm-frontend/src`. Each site was read to ensure a behavior-preserving fix (no logic changes, no disable comments).

## What Changed
- `src/views/settings/FindingsPolicySettings.test.ts` — removed dead `callCount` local + its `callCount++` (never asserted; the test uses `mock.calls`). `no-unused-vars`.
- `src/stores/fleet.ts` — `catch (_err)` → optional catch binding `catch {`; the error was unused, behavior identical. `no-unused-vars`.
- `src/composables/usePerformanceMonitoring.ts` — `{ ...(options.headers as Record<string, string> || {}) }` → `{ ...(options.headers as Record<string, string>) }`; spreading `undefined`/`null` is a no-op so the `|| {}` fallback was useless. `unicorn/no-useless-fallback-in-spread`.
- `src/views/tools/admin/AdvancedControlTool.vue` — `...(init?.headers || {})` → `...(init?.headers)`; same useless spread fallback. `unicorn/no-useless-fallback-in-spread`.

## Verification
- `oxlint src -D correctness --ignore-path .gitignore` (oxlint 1.71.0) → 0 errors (was 4). All four enumerated errors, all under `src/`, are cleared.
- `vue-tsc --noEmit -p tsconfig.json` → 0 errors.
- `eslint` on the 4 changed files → 0 errors.
- `vitest run` on touched/related tests (FindingsPolicySettings, fleet store, NodeCard) → 3 files, 11 tests passing.

Note (out of scope): `oxlint .` also surfaces 2 pre-existing `no-unused-vars` errors in `.storybook/preview.ts` (`pinia`, `router` created but never wired into the Storybook decorator). These predate this issue (unchanged since #7390), sit outside `src`, and fixing them behavior-preservingly requires wiring the plugins into Storybook's runtime — a separate logic decision, not part of this lint cleanup. Recommend a follow-up issue.

## Model Used
claude-opus-4-8

Closes #12665
