### PR TITLE
tech-debt(backend): converge 5 RateLimiter forks onto autobot_shared/rate_limiter (#12646)

### DIFF
--- a/autobot-backend/agents/web_researcher.py
+++ b/autobot-backend/agents/web_researcher.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 from pydantic import BaseModel
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.rate_limiter import RateLimiter as _SharedRateLimiter
 from autobot_shared.url_safety import host_matches
 from circuit_breaker import CircuitBreaker, CircuitBreakerConfig
 from constants.security_constants import SecurityConstants
@@ -274,40 +275,6 @@ class BrowserFingerprint:
         self.current_fingerprint = self._generate_fingerprint()
 
 
-class RateLimiter:
-    """Rate limiter for web research requests (async-safe)."""
-
-    def __init__(self, max_requests: int = 10, window_seconds: int = 60):
-        """Initialize with request limit and time window."""
-        self.max_requests = max_requests
-        self.window_seconds = window_seconds
-        self.requests: List[float] = []
-        self._lock = asyncio.Lock()
-
-    async def acquire(self) -> bool:
-        """Acquire permission for a request (async-safe)."""
-        async with self._lock:
-            return await self._acquire_internal()
-
-    async def _acquire_internal(self) -> bool:
-        """Internal acquire (called when lock is already held)."""
-        now = time.time()
-        self.requests = [t for t in self.requests if now - t < self.window_seconds]
-        if len(self.requests) >= self.max_requests:
-            oldest = min(self.requests)
-            wait_time = self.window_seconds - (now - oldest)
-            if wait_time > 0:
-                logger.info("Rate limit reached, waiting %.2fs", wait_time)
-                self._lock.release()
-                try:
-                    await asyncio.sleep(wait_time)
-                finally:
-                    await self._lock.acquire()
-                return await self._acquire_internal()
-        self.requests.append(now)
-        return True
-
-
 # ---------------------------------------------------------------------------
 # Main class
 # ---------------------------------------------------------------------------
@@ -342,11 +309,15 @@ class WebResearcher:
         )
         self.circuit_breaker = CircuitBreaker("web_research", _cb_config)
 
-        # Global rate limiter
-        self.rate_limiter = RateLimiter(
-            max_requests=self.config.get("rate_limit_requests", 5),
-            window_seconds=self.config.get("rate_limit_window", 60),
-        )
+        # Global rate limiter — delegates to the shared limiter's custom
+        # single-window mode (Issue #12646). Scoped per-instance via
+        # id(self) so independently-constructed WebResearcher instances
+        # (e.g. security_scanner_agent.py) keep isolated budgets, matching
+        # the retired local RateLimiter's per-instance semantics exactly.
+        self._rl_max_requests = self.config.get("rate_limit_requests", 5)
+        self._rl_window_seconds = self.config.get("rate_limit_window", 60)
+        self._rl_key = f"researcher:{id(self)}"
+        self.rate_limiter = _SharedRateLimiter(scope_prefix="web_researcher")
 
         # Cache (TTL-based)
         self._cache: Dict[str, Dict[str, Any]] = {}
@@ -966,7 +937,12 @@ class WebResearcher:
             cached["from_cache"] = True
             return cached
 
-        if not await self.rate_limiter.acquire():
+        if not await self.rate_limiter.acquire_window(
+            self._rl_key,
+            max_requests=self._rl_max_requests,
+            window_seconds=self._rl_window_seconds,
+            wait=True,
+        ):
             return self._build_rate_limited_response(query)
 
         max_res = max_results or self.max_results_default
@@ -1381,15 +1357,18 @@ class WebResearcher:
         self.circuit_breaker.reset()
         logger.info("Circuit breaker reset")
 
-    def get_cache_stats(self) -> Dict[str, Any]:
+    async def get_cache_stats(self) -> Dict[str, Any]:
         """Get cache statistics."""
+        remaining = await self.rate_limiter.get_remaining_in_window(
+            self._rl_key, max_requests=self._rl_max_requests, window_seconds=self._rl_window_seconds
+        )
         return {
             "cache_size": len(self._cache),
             "cache_ttl": self._cache_ttl,
             "rate_limiter": {
-                "max_requests": self.rate_limiter.max_requests,
-                "window_seconds": self.rate_limiter.window_seconds,
-                "current_requests": len(self.rate_limiter.requests),
+                "max_requests": self._rl_max_requests,
+                "window_seconds": self._rl_window_seconds,
+                "current_requests": self._rl_max_requests - remaining,
             },
         }
 
@@ -1398,7 +1377,7 @@ class WebResearcher:
         return {
             "enabled": self.enabled,
             "circuit_breaker": self.get_circuit_breaker_status(),
-            "cache_stats": self.get_cache_stats(),
+            "cache_stats": await self.get_cache_stats(),
             "browser_initialized": self.browser is not None,
         }
 

--- a/autobot-backend/agents/web_researcher_test.py
+++ b/autobot-backend/agents/web_researcher_test.py
@@ -1,0 +1,89 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for WebResearcher's rate-limiter wiring (Issue #12646).
+
+WebResearcher used to carry its own local, in-memory ``RateLimiter`` class
+(blocking-wait, single window). It now delegates to the shared
+``autobot_shared.rate_limiter.RateLimiter``'s custom single-window mode
+(``acquire_window``/``get_remaining_in_window``). The window/limit algorithm
+itself is covered by ``autobot_shared/rate_limiter_test.py``; these tests
+pin the wiring: correct max_requests/window_seconds sourced from config,
+independent per-instance keys, and the ``get_cache_stats()`` introspection
+shape consumed by the frontend (``current_requests``/``max_requests``/
+``window_seconds``).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agents.web_researcher import WebResearcher
+
+_PATCH_TARGET = "autobot_shared.rate_limiter.get_async_redis_client"
+
+
+class TestRateLimiterWiring:
+    def test_defaults_match_prior_fork_values(self) -> None:
+        """Default max_requests=5, window_seconds=60 (prior RateLimiter defaults)."""
+        researcher = WebResearcher()
+        assert researcher._rl_max_requests == 5
+        assert researcher._rl_window_seconds == 60
+
+    def test_config_overrides_applied(self) -> None:
+        researcher = WebResearcher({"rate_limit_requests": 9, "rate_limit_window": 30})
+        assert researcher._rl_max_requests == 9
+        assert researcher._rl_window_seconds == 30
+
+    def test_distinct_instances_get_distinct_keys(self) -> None:
+        """Two WebResearcher instances must not share a rate-limit bucket."""
+        a = WebResearcher()
+        b = WebResearcher()
+        assert a._rl_key != b._rl_key
+
+
+class TestGetCacheStats:
+    @pytest.mark.asyncio
+    async def test_shape_matches_frontend_contract(self) -> None:
+        """cache_stats.rate_limiter must expose max_requests/window_seconds/
+        current_requests — consumed by WebResearchSettings.vue (#12646)."""
+        researcher = WebResearcher({"rate_limit_requests": 5, "rate_limit_window": 60})
+
+        with patch(_PATCH_TARGET, AsyncMock(return_value=None)):
+            stats = await researcher.get_cache_stats()
+
+        assert stats["rate_limiter"]["max_requests"] == 5
+        assert stats["rate_limiter"]["window_seconds"] == 60
+        # Redis unavailable → fail-open remaining=max → current_requests=0.
+        assert stats["rate_limiter"]["current_requests"] == 0
+
+    @pytest.mark.asyncio
+    async def test_current_requests_reflects_remaining(self) -> None:
+        """current_requests = max_requests - remaining_in_window."""
+        researcher = WebResearcher({"rate_limit_requests": 5, "rate_limit_window": 60})
+        researcher.rate_limiter.get_remaining_in_window = AsyncMock(return_value=2)
+
+        stats = await researcher.get_cache_stats()
+
+        assert stats["rate_limiter"]["current_requests"] == 3
+
+
+class TestAcquireBeforeResearch:
+    @pytest.mark.asyncio
+    async def test_conduct_research_acquires_with_configured_limit(self) -> None:
+        """conduct_research must call acquire_window with this instance's
+        rate_limit/window and wait=True (blocking, never rejects) before
+        proceeding — matches the retired local RateLimiter's semantics."""
+        researcher = WebResearcher({"enabled": True, "rate_limit_requests": 3, "rate_limit_window": 45})
+        researcher.rate_limiter.acquire_window = AsyncMock(return_value=True)
+
+        await researcher.conduct_research("test query")
+
+        researcher.rate_limiter.acquire_window.assert_called_once_with(
+            researcher._rl_key,
+            max_requests=3,
+            window_seconds=45,
+            wait=True,
+        )

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -20,10 +20,8 @@ import json
 import os
 import re
 import threading
-from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timezone
-from time import time
 from typing import Dict, List
 
 from cryptography.fernet import Fernet
@@ -50,6 +48,7 @@ from auth_middleware import check_admin_permission, get_auth_middleware
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.rate_limiter import RateLimiter
 from autobot_shared.time_utils import parse_utc_iso
 from middleware.proxy_utils import get_client_ip
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
@@ -64,41 +63,10 @@ SECRET_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
 RATE_LIMIT_WINDOW = 60  # seconds
 RATE_LIMIT_MAX_REQUESTS = 30  # max requests per window
 
-
-class RateLimiter:
-    """Simple in-memory rate limiter for secrets API"""
-
-    def __init__(
-        self,
-        window: int = RATE_LIMIT_WINDOW,
-        max_requests: int = RATE_LIMIT_MAX_REQUESTS,
-    ):
-        """Initialize rate limiter with window size and request limit."""
-        self.window = window
-        self.max_requests = max_requests
-        self.requests: Dict[str, List[float]] = defaultdict(list)
-
-    def is_allowed(self, client_id: str) -> bool:
-        """Check if request is allowed under rate limit"""
-        now = time()
-        # Clean old requests
-        self.requests[client_id] = [t for t in self.requests[client_id] if now - t < self.window]
-        # Check limit
-        if len(self.requests[client_id]) >= self.max_requests:
-            return False
-        # Record request
-        self.requests[client_id].append(now)
-        return True
-
-    def get_remaining(self, client_id: str) -> int:
-        """Get remaining requests for client"""
-        now = time()
-        self.requests[client_id] = [t for t in self.requests[client_id] if now - t < self.window]
-        return max(0, self.max_requests - len(self.requests[client_id]))
-
-
-# Global rate limiter instance
-rate_limiter = RateLimiter()
+# Shared sliding-window limiter scoped to the secrets API (Issue #12646).
+# Delegates to autobot_shared.rate_limiter.RateLimiter's custom single-window
+# mode (window=60s, max=30) rather than the retired local in-memory class.
+rate_limiter = RateLimiter(scope_prefix="secrets")
 
 
 def validate_secret_name(name: str) -> str:
@@ -490,10 +458,13 @@ def get_client_id(request: Request) -> str:
     return get_client_ip(request) or "unknown"
 
 
-def check_rate_limit(request: Request) -> None:
+async def check_rate_limit(request: Request) -> None:
     """Check rate limit and raise exception if exceeded"""
     client_id = get_client_id(request)
-    if not rate_limiter.is_allowed(client_id):
+    allowed = await rate_limiter.acquire_window(
+        client_id, max_requests=RATE_LIMIT_MAX_REQUESTS, window_seconds=RATE_LIMIT_WINDOW
+    )
+    if not allowed:
         logger.warning("[Secrets] Rate limit exceeded for client: %s", client_id)
         raise HTTPException(
             status_code=429,
@@ -538,7 +509,7 @@ async def create_secret(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Create a new secret (Issue #744: requires admin authentication)"""
-    check_rate_limit(http_request)
+    await check_rate_limit(http_request)
     try:
         # Issue #666: Wrap blocking file I/O in asyncio.to_thread
         secret = await asyncio.to_thread(secrets_manager.create_secret, request)
@@ -592,7 +563,7 @@ async def list_secrets(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """List secrets with optional filtering (Issue #744: requires admin authentication)"""
-    check_rate_limit(http_request)
+    await check_rate_limit(http_request)
     try:
         # Issue #666: Wrap blocking file I/O in asyncio.to_thread
         secrets = await asyncio.to_thread(secrets_manager.list_secrets, chat_id=chat_id, scope=scope)
@@ -723,7 +694,7 @@ async def get_secret(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Get a specific secret with its value (Issue #744: requires admin authentication)"""
-    check_rate_limit(http_request)
+    await check_rate_limit(http_request)
     try:
         # Issue #666: Wrap blocking file I/O in asyncio.to_thread
         secret = await asyncio.to_thread(secrets_manager.get_secret, secret_id, chat_id=chat_id)
@@ -789,7 +760,7 @@ async def update_secret(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Update a secret's metadata (Issue #744: requires admin authentication)"""
-    check_rate_limit(http_request)
+    await check_rate_limit(http_request)
     try:
         # Issue #666: Wrap blocking file I/O in asyncio.to_thread
         secret = await asyncio.to_thread(secrets_manager.update_secret, secret_id, request, chat_id=chat_id)
@@ -845,7 +816,7 @@ async def delete_secret(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Delete a secret (Issue #744: requires admin authentication)"""
-    check_rate_limit(http_request)
+    await check_rate_limit(http_request)
     try:
         # Issue #666: Wrap blocking file I/O in asyncio.to_thread
         success = await asyncio.to_thread(secrets_manager.delete_secret, secret_id, chat_id=chat_id)
@@ -898,7 +869,7 @@ async def transfer_secrets(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Transfer secrets between scopes (Issue #744: requires admin authentication)"""
-    check_rate_limit(http_request)
+    await check_rate_limit(http_request)
     try:
         # Issue #666: Wrap blocking file I/O in asyncio.to_thread
         result = await asyncio.to_thread(secrets_manager.transfer_secrets, request, chat_id=chat_id)
@@ -958,7 +929,7 @@ async def delete_chat_secrets(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Delete secrets for a specific chat (Issue #744: requires admin authentication)"""
-    check_rate_limit(http_request)
+    await check_rate_limit(http_request)
     try:
         # Issue #666: Wrap blocking file I/O in asyncio.to_thread
         result = await asyncio.to_thread(secrets_manager.delete_chat_secrets, chat_id, secret_ids)

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -13,6 +13,7 @@ the renamed enum stays distinct from the canonical authorization
 """
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -76,3 +77,40 @@ async def test_get_secret_types_response_pinned():
     assert response.status_code == 200
     payload = json.loads(response.body)
     assert payload == {"types": EXPECTED_TYPES, "scopes": EXPECTED_SCOPES}
+
+
+class TestCheckRateLimit:
+    """check_rate_limit() delegates to the shared RateLimiter's custom
+    single-window mode (window=60s, max=30) — migrated off the retired
+    local in-memory class (#12646). No coverage previously existed."""
+
+    def _fake_request(self, host: str) -> MagicMock:
+        from fastapi import Request
+
+        request = MagicMock(spec=Request)
+        request.client = MagicMock(host=host)
+        request.headers = {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_allows_when_under_limit(self):
+        from api.secrets import check_rate_limit
+
+        with patch("autobot_shared.rate_limiter.get_async_redis_client", AsyncMock(return_value=None)):
+            await check_rate_limit(self._fake_request("203.0.113.5"))  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_raises_429_with_retry_after_when_denied(self):
+        from fastapi import HTTPException
+
+        from api.secrets import RATE_LIMIT_WINDOW, check_rate_limit
+
+        redis = AsyncMock()
+        redis.eval = AsyncMock(return_value=[0, "5"])
+
+        with patch("autobot_shared.rate_limiter.get_async_redis_client", AsyncMock(return_value=redis)):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_rate_limit(self._fake_request("203.0.113.6"))
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers["Retry-After"] == str(RATE_LIMIT_WINDOW)

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -66,7 +66,7 @@ async def get_research_status(request: Request):
         circuit_status = integration.get_circuit_breaker_status()
 
         # Get cache stats
-        cache_stats = integration.get_cache_stats()
+        cache_stats = await integration.get_cache_stats()
 
         return JSONResponse(
             status_code=200,
@@ -399,7 +399,7 @@ async def get_usage_stats(request: Request):
     integration = _require_web_researcher(request)
     try:
         # Get basic stats
-        cache_stats = integration.get_cache_stats()
+        cache_stats = await integration.get_cache_stats()
         circuit_status = integration.get_circuit_breaker_status()
 
         stats = {

--- a/autobot-backend/security/threat_intelligence.py
+++ b/autobot-backend/security/threat_intelligence.py
@@ -29,7 +29,14 @@ import aiohttp
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.rate_limiter import RateLimiter as _SharedRateLimiter
 from autobot_shared.ssot_config import config
+
+# Single-window duration used by the per-client rate limiters below — both
+# VirusTotal and URLVoid clients were rate-limited on a 1-minute window
+# (Issue #12646 fold-in of security/threat_intelligence.py's local
+# RateLimiter onto the shared implementation's custom-window mode).
+_RATE_LIMIT_WINDOW_SECONDS = 60
 
 logger = get_logger(__name__)
 
@@ -112,48 +119,6 @@ class ThreatIntelligenceCache:
             self._cache = {k: v for k, v in self._cache.items() if v["expires_at"] > current_time}
 
 
-class RateLimiter:
-    """Async rate limiter for API calls"""
-
-    def __init__(self, requests_per_minute: int = 4):
-        """Initialize rate limiter with requests per minute limit."""
-        self._requests_per_minute = requests_per_minute
-        self._window_size = 60.0  # 1 minute window
-        self._requests: list[float] = []
-        self._lock = asyncio.Lock()
-
-    async def acquire(self) -> bool:
-        """
-        Acquire rate limit slot. Returns True if allowed, False if rate limited.
-        Blocks if necessary to wait for available slot.
-        """
-        async with self._lock:
-            current_time = time.time()
-            window_start = current_time - self._window_size
-
-            # Remove requests outside the current window
-            self._requests = [t for t in self._requests if t > window_start]
-
-            if len(self._requests) >= self._requests_per_minute:
-                # Calculate wait time until oldest request expires
-                wait_time = self._requests[0] - window_start
-                if wait_time > 0:
-                    logger.debug("Rate limited, waiting %.2f seconds", wait_time)
-                    await asyncio.sleep(wait_time)
-                    # Re-check after waiting
-                    return await self.acquire()
-
-            self._requests.append(current_time)
-            return True
-
-    def get_remaining(self) -> int:
-        """Get remaining requests in current window."""
-        current_time = time.time()
-        window_start = current_time - self._window_size
-        active_requests = [t for t in self._requests if t > window_start]
-        return max(0, self._requests_per_minute - len(active_requests))
-
-
 class VirusTotalClient:
     """VirusTotal API v3 client for URL/domain reputation checking"""
 
@@ -174,7 +139,9 @@ class VirusTotalClient:
             timeout: Request timeout in seconds
         """
         self._api_key = api_key or config.virustotal_api_key
-        self._rate_limiter = RateLimiter(rate_limit)
+        self._rate_limiter = _SharedRateLimiter(scope_prefix="threat_intel")
+        self._rate_limit = rate_limit
+        self._rl_key = f"virustotal:{id(self)}"
         self._timeout = timeout
         self._http_client = get_http_client()
 
@@ -227,7 +194,9 @@ class VirusTotalClient:
             return self._build_error_response("VirusTotal API key not configured")
 
         try:
-            await self._rate_limiter.acquire()
+            await self._rate_limiter.acquire_window(
+                self._rl_key, max_requests=self._rate_limit, window_seconds=_RATE_LIMIT_WINDOW_SECONDS, wait=True
+            )
 
             url_id = self._get_url_id(url)
             endpoint = f"{self.BASE_URL}/urls/{url_id}"
@@ -250,7 +219,9 @@ class VirusTotalClient:
     async def _submit_url_for_analysis(self, url: str) -> Dict[str, Any]:
         """Submit URL for analysis if not found in VirusTotal database."""
         try:
-            await self._rate_limiter.acquire()
+            await self._rate_limiter.acquire_window(
+                self._rl_key, max_requests=self._rate_limit, window_seconds=_RATE_LIMIT_WINDOW_SECONDS, wait=True
+            )
 
             endpoint = f"{self.BASE_URL}/urls"
             headers = {
@@ -343,7 +314,9 @@ class URLVoidClient:
             timeout: Request timeout in seconds
         """
         self._api_key = api_key or config.urlvoid_api_key
-        self._rate_limiter = RateLimiter(rate_limit)
+        self._rate_limiter = _SharedRateLimiter(scope_prefix="threat_intel")
+        self._rate_limit = rate_limit
+        self._rl_key = f"urlvoid:{id(self)}"
         self._timeout = timeout
         self._http_client = get_http_client()
 
@@ -404,7 +377,9 @@ class URLVoidClient:
         domain = self._extract_domain_from_url(url)
 
         try:
-            await self._rate_limiter.acquire()
+            await self._rate_limiter.acquire_window(
+                self._rl_key, max_requests=self._rate_limit, window_seconds=_RATE_LIMIT_WINDOW_SECONDS, wait=True
+            )
             endpoint = f"{self.BASE_URL}/{self._api_key}/host/{domain}/"
 
             async with await self._http_client.get(
@@ -706,14 +681,20 @@ class ThreatIntelligenceService:
 
     async def get_service_status(self) -> Dict[str, Any]:
         """Get status of configured threat intelligence services."""
+        vt = self._virustotal
+        uv = self._urlvoid
         return {
             "virustotal": {
-                "configured": self._virustotal.is_configured,
-                "remaining_requests": self._virustotal._rate_limiter.get_remaining(),
+                "configured": vt.is_configured,
+                "remaining_requests": await vt._rate_limiter.get_remaining_in_window(
+                    vt._rl_key, max_requests=vt._rate_limit, window_seconds=_RATE_LIMIT_WINDOW_SECONDS
+                ),
             },
             "urlvoid": {
-                "configured": self._urlvoid.is_configured,
-                "remaining_requests": self._urlvoid._rate_limiter.get_remaining(),
+                "configured": uv.is_configured,
+                "remaining_requests": await uv._rate_limiter.get_remaining_in_window(
+                    uv._rl_key, max_requests=uv._rate_limit, window_seconds=_RATE_LIMIT_WINDOW_SECONDS
+                ),
             },
         }
 

--- a/autobot-backend/security/threat_intelligence_test.py
+++ b/autobot-backend/security/threat_intelligence_test.py
@@ -20,7 +20,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from security.threat_intelligence import (
-    RateLimiter,
     ThreatIntelligenceCache,
     ThreatIntelligenceService,
     ThreatLevel,
@@ -72,31 +71,74 @@ class TestThreatLevel:
         assert ThreatLevel.UNKNOWN.value == "unknown"
 
 
-class TestRateLimiter:
-    """Tests for RateLimiter class"""
+class TestRateLimiterWiring:
+    """VirusTotalClient/URLVoidClient delegate to the shared
+    autobot_shared.rate_limiter.RateLimiter's custom single-window mode --
+    migrated off the retired local RateLimiter class (#12646). The window
+    limit algorithm itself is covered by autobot_shared/rate_limiter_test.py;
+    these tests pin the wiring (correct max_requests/window_seconds per
+    client, independent per-instance keys)."""
+
+    def test_virustotal_wires_configured_rate_limit(self):
+        client = VirusTotalClient(api_key="k", rate_limit=7)
+        assert client._rate_limit == 7
+        assert client._rl_key.startswith("virustotal:")
+
+    def test_urlvoid_wires_configured_rate_limit(self):
+        client = URLVoidClient(api_key="k", rate_limit=12)
+        assert client._rate_limit == 12
+        assert client._rl_key.startswith("urlvoid:")
+
+    def test_distinct_instances_get_distinct_keys(self):
+        """Two clients must not share a rate-limit bucket (Issue #12646)."""
+        client_a = VirusTotalClient(api_key="k")
+        client_b = VirusTotalClient(api_key="k")
+        assert client_a._rl_key != client_b._rl_key
 
     @pytest.mark.asyncio
-    async def test_acquire_within_limit(self):
-        """Test acquiring slots within rate limit."""
-        limiter = RateLimiter(requests_per_minute=10)
+    async def test_check_url_acquires_with_configured_limit(self):
+        """check_url must call acquire_window with this client's rate_limit
+        and the fixed 60s window before hitting the API."""
+        client = VirusTotalClient(api_key="k", rate_limit=9)
+        client._rate_limiter.acquire_window = AsyncMock(return_value=True)
 
-        # Should allow 10 requests
-        for _ in range(10):
-            result = await limiter.acquire()
-            assert result is True
+        mock_http_response = AsyncMock()
+        mock_http_response.status = 200
+        mock_http_response.json = AsyncMock(
+            return_value={"data": {"attributes": {"last_analysis_stats": {}, "last_analysis_date": 0}}}
+        )
+        mock_http_response.__aenter__ = AsyncMock(return_value=mock_http_response)
+        mock_http_response.__aexit__ = AsyncMock()
+        mock_http_client = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_http_response)
+
+        with patch.object(client, "_http_client", mock_http_client):
+            await client.check_url("https://example.com")
+
+        client._rate_limiter.acquire_window.assert_called_once_with(
+            client._rl_key, max_requests=9, window_seconds=60, wait=True
+        )
 
     @pytest.mark.asyncio
-    async def test_get_remaining(self):
-        """Test getting remaining requests."""
-        limiter = RateLimiter(requests_per_minute=5)
+    async def test_check_domain_acquires_with_configured_limit(self):
+        """check_domain must call acquire_window with this client's
+        rate_limit and the fixed 60s window before hitting the API."""
+        client = URLVoidClient(api_key="k", rate_limit=11)
+        client._rate_limiter.acquire_window = AsyncMock(return_value=True)
 
-        assert limiter.get_remaining() == 5
+        mock_http_response = AsyncMock()
+        mock_http_response.status = 429
+        mock_http_response.__aenter__ = AsyncMock(return_value=mock_http_response)
+        mock_http_response.__aexit__ = AsyncMock()
+        mock_http_client = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_http_response)
 
-        await limiter.acquire()
-        assert limiter.get_remaining() == 4
+        with patch.object(client, "_http_client", mock_http_client):
+            await client.check_domain("https://example.com")
 
-        await limiter.acquire()
-        assert limiter.get_remaining() == 3
+        client._rate_limiter.acquire_window.assert_called_once_with(
+            client._rl_key, max_requests=11, window_seconds=60, wait=True
+        )
 
 
 class TestThreatIntelligenceCache:

--- a/autobot-backend/services/gateway/__init__.py
+++ b/autobot-backend/services/gateway/__init__.py
@@ -19,12 +19,11 @@ from .adapters import (
     WhatsAppAdapter,
 )
 from .gateway_manager import GatewayManager
-from .message_queue import MessageQueue, RateLimiter
+from .message_queue import MessageQueue
 
 __all__ = [
     "GatewayManager",
     "MessageQueue",
-    "RateLimiter",
     "BaseAdapter",
     "GatewayMessage",
     "NormalizedResponse",

--- a/autobot-backend/services/gateway/message_queue.py
+++ b/autobot-backend/services/gateway/message_queue.py
@@ -8,66 +8,29 @@ Message Queue with Per-Platform Rate Limiting
 Queues messages and respects platform-specific rate limits (Slack 1/sec, Discord 10/sec, etc).
 Provides async processing with burst support.
 
-Delegates to the shared ``autobot_shared.rate_limiter.RateLimiter`` for the
-sliding-window check available per gateway platform (Issue #4460).
+Delegates to the shared ``autobot_shared.rate_limiter.RateLimiter`` — its
+in-process token-bucket mode (``acquire_token``) provides the per-platform
+burst/throughput control (Issue #4460, folded onto the canonical limiter in
+Issue #12646; previously a local token-bucket ``RateLimiter`` dataclass).
 """
 
 import asyncio
-import time
 from asyncio import Queue
-from dataclasses import dataclass, field
-from typing import Callable, Dict
+from typing import Callable, Dict, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.rate_limiter import RateLimiter as _SharedRateLimiter
 
 logger = get_logger(__name__)
 
-# Shared delegate scoped to gateway operations (Issue #4460).
-# The local token-bucket ``RateLimiter`` dataclass handles per-message
-# burst/throughput control; the shared limiter below provides the sliding-
-# window check for the gateway scope, accessible to other gateway modules.
+# Shared delegate scoped to gateway operations (Issue #4460 / #12646).
+# acquire_token() provides the per-platform token-bucket burst/throughput
+# control; register_platform() below stores each platform's (rps, burst)
+# and passes them through on every acquire.
 gateway_rate_limiter = _SharedRateLimiter(
     scope_prefix="gateway",
     default_tier="privileged",
 )
-
-
-@dataclass
-class RateLimiter:
-    """Per-platform rate limiter using token bucket algorithm."""
-
-    platform: str
-    requests_per_second: int
-    burst_size: int
-    tokens: float = field(default=0.0, init=False)
-    last_refill: float = field(default_factory=time.time, init=False)
-
-    async def acquire(self) -> None:
-        """Acquire token; wait if necessary to respect rate limit."""
-        # Refill tokens based on elapsed time
-        now = time.time()
-        elapsed = now - self.last_refill
-        self.tokens = min(
-            self.burst_size,
-            self.tokens + (elapsed * self.requests_per_second),
-        )
-        self.last_refill = now
-
-        # Wait if we don't have a token
-        while self.tokens < 1.0:
-            wait_time = (1.0 - self.tokens) / self.requests_per_second
-            await asyncio.sleep(wait_time)
-
-            now = time.time()
-            elapsed = now - self.last_refill
-            self.tokens = min(
-                self.burst_size,
-                self.tokens + (elapsed * self.requests_per_second),
-            )
-            self.last_refill = now
-
-        self.tokens -= 1.0
 
 
 class MessageQueue:
@@ -81,17 +44,13 @@ class MessageQueue:
     def __init__(self, max_queue_size: int = 10000) -> None:
         """Initialize message queue."""
         self.queue: Queue = Queue(maxsize=max_queue_size)
-        self.limiters: Dict[str, RateLimiter] = {}
+        self.platform_limits: Dict[str, Tuple[float, float]] = {}
         self.processing = False
         self.logger = get_logger(__name__)
 
     def register_platform(self, platform: str, rps: int, burst_size: int) -> None:
-        """Register platform rate limiter."""
-        self.limiters[platform] = RateLimiter(
-            platform=platform,
-            requests_per_second=rps,
-            burst_size=burst_size,
-        )
+        """Register platform rate limit (requests/sec, burst size)."""
+        self.platform_limits[platform] = (rps, burst_size)
         self.logger.info(f"Registered platform {platform}: {rps} req/s, burst {burst_size}")
 
     async def enqueue(self, message: Dict) -> None:
@@ -129,9 +88,10 @@ class MessageQueue:
                 message = await asyncio.wait_for(self.queue.get(), timeout=1.0)
                 platform = message.get("platform", "unknown")
 
-                limiter = self.limiters.get(platform)
-                if limiter:
-                    await limiter.acquire()
+                limits = self.platform_limits.get(platform)
+                if limits:
+                    rps, burst_size = limits
+                    await gateway_rate_limiter.acquire_token(platform, requests_per_second=rps, burst_size=burst_size)
 
                 await handler(message)
                 self.queue.task_done()

--- a/autobot-backend/tests/api/test_web_research_settings_guard.py
+++ b/autobot-backend/tests/api/test_web_research_settings_guard.py
@@ -30,7 +30,7 @@ def _mock_researcher() -> MagicMock:
     researcher = MagicMock()
     researcher.health_check = AsyncMock(return_value={"enabled": True})
     researcher.get_circuit_breaker_status = MagicMock(return_value={})
-    researcher.get_cache_stats = MagicMock(return_value={"cache_size": 0, "cache_ttl": 300, "rate_limiter": {}})
+    researcher.get_cache_stats = AsyncMock(return_value={"cache_size": 0, "cache_ttl": 300, "rate_limiter": {}})
     researcher.enabled = True
     return researcher
 

--- a/autobot-backend/tests/test_gateway_manager.py
+++ b/autobot-backend/tests/test_gateway_manager.py
@@ -16,7 +16,7 @@ Tests verify:
 
 import asyncio
 import time
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -30,7 +30,7 @@ from services.gateway import (
     WebAdapter,
     WhatsAppAdapter,
 )
-from services.gateway.message_queue import RateLimiter
+from services.gateway.message_queue import MessageQueue, gateway_rate_limiter
 
 
 class TestSlackAdapter:
@@ -472,43 +472,43 @@ class TestGatewayManager:
         }
 
 
-class TestRateLimiter:
-    """Test rate limiter."""
+class TestPlatformRateLimitWiring:
+    """MessageQueue delegates per-platform rate limiting to the shared
+    RateLimiter's token-bucket mode (``acquire_token``) — migrated off the
+    retired local token-bucket dataclass (#12646). The token-bucket
+    algorithm itself is covered by autobot_shared/rate_limiter_test.py;
+    these tests pin the register_platform -> acquire_token wiring."""
+
+    def test_register_platform_stores_limits(self):
+        queue = MessageQueue()
+        queue.register_platform("slack", 1, 5)
+        assert queue.platform_limits["slack"] == (1, 5)
 
     @pytest.mark.asyncio
-    async def test_rate_limiter_respects_limit(self):
-        """Test rate limiter enforces request limit."""
-        limiter = RateLimiter("test", requests_per_second=2, burst_size=2)
+    async def test_worker_acquires_token_with_registered_limits(self):
+        """The worker must call acquire_token with this platform's exact
+        (requests_per_second, burst_size) before dispatching the handler."""
+        queue = MessageQueue()
+        queue.register_platform("wiring-test-platform", 50, 10)
 
-        start = time.time()
-        # Acquire 4 tokens with 2 req/s = should take ~1 second
-        for _ in range(4):
-            await limiter.acquire()
-        elapsed = time.time() - start
+        processed = []
 
-        # Should take approximately 1 second (with generous tolerance for slow CI)
-        assert elapsed > 0.8  # At least some waiting occurs
+        async def handler(msg):
+            processed.append(msg)
 
-    @pytest.mark.asyncio
-    async def test_rate_limiter_burst(self):
-        """Test rate limiter respects burst size."""
-        limiter = RateLimiter("test", requests_per_second=10, burst_size=5)
+        await queue.enqueue({"platform": "wiring-test-platform", "data": "value"})
 
-        # First 5 should succeed quickly (burst)
-        start = time.time()
-        for _ in range(5):
-            await limiter.acquire()
-        burst_elapsed = time.time() - start
+        with patch.object(gateway_rate_limiter, "acquire_token", AsyncMock()) as mock_acquire:
+            task = asyncio.create_task(queue.process_queue(handler, workers=1))
+            await asyncio.sleep(0.2)
+            queue.processing = False
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except asyncio.TimeoutError:
+                pass
 
-        # Burst should be reasonably fast (not waiting much)
-        assert burst_elapsed < 1.0
-
-        # 6th token should wait
-        start = time.time()
-        await limiter.acquire()
-        wait_elapsed = time.time() - start
-        # With 10 req/s rate, 6th token needs to wait for refill
-        assert wait_elapsed > 0.05  # Should wait some time
+        assert processed == [{"platform": "wiring-test-platform", "data": "value"}]
+        mock_acquire.assert_called_once_with("wiring-test-platform", requests_per_second=50, burst_size=10)
 
 
 class TestMessageQueue:
@@ -517,8 +517,6 @@ class TestMessageQueue:
     @pytest.mark.asyncio
     async def test_message_queue_processing(self):
         """Test message queue processes messages."""
-        from services.gateway.message_queue import MessageQueue
-
         queue = MessageQueue()
         queue.register_platform("test", 100, 200)
 

--- a/autobot_shared/rate_limiter.py
+++ b/autobot_shared/rate_limiter.py
@@ -38,10 +38,28 @@ Retry-After helper
 ``get_retry_after_seconds(key)`` returns the integer number of seconds the
 caller should wait before the next request will be allowed.  Pass this value
 directly in an HTTP ``Retry-After`` response header.
+
+Custom single-window mode (Issue #12646)
+-----------------------------------------
+``acquire_window`` / ``get_remaining_in_window`` generalize the fixed
+minute/hour windows above to an arbitrary caller-supplied ``window_seconds``
+with an optional blocking ``wait=True`` mode (retry until a slot frees up
+instead of rejecting). Folded in from ``agents/web_researcher.py``,
+``security/threat_intelligence.py`` and ``api/secrets.py``, which each used
+one configurable window rather than the dual minute/hour scheme.
+
+Token-bucket mode (Issue #12646)
+---------------------------------
+``acquire_token`` is a distinct, in-process (not Redis-backed) continuous
+-refill token-bucket algorithm with burst support, suited to smooth outbound
+pacing against a fixed external rate (e.g. per-platform gateway limits:
+Slack 1/sec, Discord 10/sec). Folded in from
+``services/gateway/message_queue.py``.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -133,6 +151,10 @@ class RateLimiter:
         tier_rpm, tier_rph = tier_defaults[default_tier]
         self._rpm = requests_per_minute if requests_per_minute is not None else tier_rpm
         self._rph = requests_per_hour if requests_per_hour is not None else tier_rph
+        # In-process token-bucket state (Issue #12646 fold-in) — keyed per
+        # caller-supplied key, independent of the Redis-backed windows above.
+        self._token_buckets: dict[str, dict[str, float]] = {}
+        self._token_locks: dict[str, asyncio.Lock] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -364,6 +386,134 @@ class RateLimiter:
                 exc,
             )
             return 0
+
+    # ------------------------------------------------------------------
+    # Custom single-window mode (Issue #12646 fold-in)
+    # ------------------------------------------------------------------
+
+    async def acquire_window(
+        self,
+        key: str,
+        max_requests: int,
+        window_seconds: int,
+        wait: bool = False,
+    ) -> bool:
+        """Atomic check+record against a single, arbitrary-size window.
+
+        Generalizes the fixed minute/hour windows above to a caller-chosen
+        ``window_seconds`` — folded in from ``agents/web_researcher.py``,
+        ``security/threat_intelligence.py`` and ``api/secrets.py`` (Issue
+        #12646), each of which used one configurable window rather than the
+        dual minute/hour scheme.
+
+        When *wait* is True, blocks (async sleep) and retries until a slot
+        frees up instead of returning False — matches the blocking-retry
+        behavior of the forks above, none of which ever rejected a caller.
+        """
+        while True:
+            allowed, retry_after = await self._try_acquire_window(key, max_requests, window_seconds)
+            if allowed or not wait:
+                return allowed
+            await asyncio.sleep(max(retry_after, 0.05))
+
+    async def _try_acquire_window(self, key: str, max_requests: int, window_seconds: int) -> tuple[bool, float]:
+        """Single atomic try against the custom window.
+
+        Returns ``(allowed, retry_after_seconds)``. Fails open (allowed=True)
+        when Redis is unavailable, matching the graceful-degradation policy
+        used everywhere else in this class.
+        """
+        now = time.time()
+        try:
+            redis = await get_async_redis_client(database=self._db)
+            if redis is None:
+                return True, 0.0
+
+            lua_script = """
+            local win_key = KEYS[1]
+            local now = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+            local max_requests = tonumber(ARGV[3])
+            local cutoff = now - window
+
+            redis.call('ZREMRANGEBYSCORE', win_key, '-inf', cutoff)
+            local count = redis.call('ZCARD', win_key)
+            if count >= max_requests then
+                local oldest = redis.call('ZRANGE', win_key, 0, 0, 'WITHSCORES')
+                local retry_after = window
+                if oldest[2] ~= nil then
+                    retry_after = window - (now - tonumber(oldest[2]))
+                end
+                return {0, tostring(retry_after)}
+            end
+
+            redis.call('ZADD', win_key, now, tostring(now))
+            redis.call('EXPIRE', win_key, window * 2)
+            return {1, "0"}
+            """
+            win_key = self._redis_key(key, "window")
+            result = await redis.eval(lua_script, 1, win_key, now, window_seconds, max_requests)
+            return bool(result[0]), max(0.0, float(result[1]))
+        except Exception as exc:
+            logger.warning(
+                "rate_limiter: window acquire error for '%s:%s': %s",
+                self._prefix,
+                key,
+                exc,
+            )
+            return True, 0.0
+
+    async def get_remaining_in_window(self, key: str, max_requests: int, window_seconds: int) -> int:
+        """Return how many more requests are allowed in the custom window.
+
+        Folded in from ``security/threat_intelligence.py`` and
+        ``api/secrets.py`` ``get_remaining()`` (Issue #12646).
+        """
+        now = time.time()
+        try:
+            redis = await get_async_redis_client(database=self._db)
+            if redis is None:
+                return max_requests
+
+            win_key = self._redis_key(key, "window")
+            count = await redis.zcount(win_key, now - window_seconds, "+inf")
+            return max(0, max_requests - int(count))
+        except Exception as exc:
+            logger.warning(
+                "rate_limiter: get_remaining error for '%s:%s': %s",
+                self._prefix,
+                key,
+                exc,
+            )
+            return max_requests
+
+    # ------------------------------------------------------------------
+    # Token-bucket mode (Issue #12646 fold-in)
+    # ------------------------------------------------------------------
+
+    async def acquire_token(self, key: str, requests_per_second: float, burst_size: float) -> None:
+        """Continuous-refill token-bucket acquire; blocks until a token frees.
+
+        Distinct algorithm from the sliding windows above — in-process
+        (not Redis-backed) state, suited to smooth outbound pacing against a
+        fixed external rate with a burst allowance (e.g. per-platform
+        gateway limits: Slack 1/sec, Discord 10/sec). Folded in from
+        ``services/gateway/message_queue.py`` (Issue #12646); state is
+        per-process, matching the fork's original semantics exactly.
+        """
+        lock = self._token_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            bucket = self._token_buckets.setdefault(key, {"tokens": 0.0, "last_refill": time.time()})
+            while True:
+                now = time.time()
+                elapsed = now - bucket["last_refill"]
+                bucket["tokens"] = min(burst_size, bucket["tokens"] + elapsed * requests_per_second)
+                bucket["last_refill"] = now
+                if bucket["tokens"] >= 1.0:
+                    bucket["tokens"] -= 1.0
+                    return
+                wait_time = (1.0 - bucket["tokens"]) / requests_per_second
+                await asyncio.sleep(wait_time)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/autobot_shared/rate_limiter_test.py
+++ b/autobot_shared/rate_limiter_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import time
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -78,6 +79,12 @@ def _make_redis(*, minute_count: int = 0, hour_count: int = 0) -> AsyncMock:
     the cutoff range. For simplicity, the mock always returns *minute_count*
     for the first ``zcount`` call and *hour_count* for the second.
 
+    ``eval`` simulates the Lua script used by ``acquire()`` — it evaluates
+    the same allowed/denied condition as ``is_allowed()`` from *minute_count*
+    / *hour_count* against the ``rpm``/``rph`` args the script receives
+    (pre-existing test gap: ``acquire()`` was previously exercised with an
+    unmocked ``eval``, which always returned truthy and never denied).
+
     Note: ``record()`` calls ``pipe.zadd/zremrangebyscore/expire`` WITHOUT
     ``await`` (they enqueue on the pipeline sync), so those are plain
     MagicMock while ``pipe.execute`` is AsyncMock.
@@ -94,6 +101,11 @@ def _make_redis(*, minute_count: int = 0, hour_count: int = 0) -> AsyncMock:
         return hour_count
 
     redis.zcount = _zcount  # type: ignore[assignment]
+
+    async def _eval(script, numkeys, hour_key, now, rpm, rph):
+        return 0 if (minute_count >= rpm or hour_count >= rph) else 1
+
+    redis.eval = AsyncMock(side_effect=_eval)
 
     # pipeline used by record(): zadd/zremrangebyscore/expire are sync calls
     # on a pipeline object; only execute() is awaited.
@@ -269,22 +281,22 @@ class TestRecord:
 
 class TestAcquire:
     def test_acquire_returns_true_and_records_when_allowed(self) -> None:
-        """acquire() returns True and calls pipeline.execute() when under limit."""
+        """acquire() returns True and invokes the atomic Lua check+record when under limit."""
         lim = _limiter(rpm=5, rph=20)
         redis = _make_redis(minute_count=0, hour_count=0)
         with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
             result = asyncio.run(lim.acquire("user1"))
         assert result is True
-        redis.pipeline.return_value.execute.assert_called_once()
+        redis.eval.assert_called_once()
 
     def test_acquire_returns_false_and_does_not_record_when_denied(self) -> None:
-        """acquire() returns False and does NOT record when over limit."""
+        """acquire() returns False when the Lua script reports the limit is hit."""
         lim = _limiter(rpm=5, rph=20)
         redis = _make_redis(minute_count=5, hour_count=0)
         with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
             result = asyncio.run(lim.acquire("user1"))
         assert result is False
-        redis.pipeline.return_value.execute.assert_not_called()
+        redis.eval.assert_called_once()
 
     def test_acquire_redis_unavailable_returns_true(self) -> None:
         """acquire() returns True (fail-open) when Redis is None."""
@@ -450,3 +462,157 @@ class TestGracefulDegradation:
         lim = _limiter()
         with patch(_PATCH_TARGET, AsyncMock(return_value=None)):
             assert asyncio.run(lim.get_retry_after_seconds("x")) == 0
+
+    def test_acquire_window_none_redis(self) -> None:
+        lim = _limiter()
+        with patch(_PATCH_TARGET, AsyncMock(return_value=None)):
+            assert asyncio.run(lim.acquire_window("x", max_requests=5, window_seconds=60)) is True
+
+    def test_get_remaining_in_window_none_redis(self) -> None:
+        lim = _limiter()
+        with patch(_PATCH_TARGET, AsyncMock(return_value=None)):
+            result = asyncio.run(lim.get_remaining_in_window("x", max_requests=5, window_seconds=60))
+        assert result == 5
+
+
+# ---------------------------------------------------------------------------
+# Tests — acquire_window / get_remaining_in_window (Issue #12646 fold-in)
+# ---------------------------------------------------------------------------
+
+
+def _make_window_redis(*, count: int, oldest_ts_offset: float = 10.0) -> AsyncMock:
+    """Return an AsyncMock Redis client for acquire_window/get_remaining_in_window.
+
+    Simulates the Lua ``eval`` call used by ``_try_acquire_window`` and the
+    plain ``zcount`` used by ``get_remaining_in_window``.
+    """
+    redis = AsyncMock()
+    now = time.time()
+    oldest_ts = now - oldest_ts_offset
+
+    async def _eval(script, numkeys, win_key, now_arg, window, max_requests):
+        if count >= max_requests:
+            retry_after = window - (now_arg - oldest_ts)
+            return [0, str(retry_after)]
+        return [1, "0"]
+
+    redis.eval = _eval  # type: ignore[assignment]
+    redis.zcount = AsyncMock(return_value=count)
+    return redis
+
+
+class TestAcquireWindow:
+    def test_allowed_under_limit(self) -> None:
+        lim = _limiter()
+        redis = _make_window_redis(count=2)
+        with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
+            result = asyncio.run(lim.acquire_window("k", max_requests=5, window_seconds=60))
+        assert result is True
+
+    def test_denied_at_limit_no_wait(self) -> None:
+        """At the limit with wait=False → immediately returns False."""
+        lim = _limiter()
+        redis = _make_window_redis(count=5, oldest_ts_offset=10.0)
+        with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
+            result = asyncio.run(lim.acquire_window("k", max_requests=5, window_seconds=60, wait=False))
+        assert result is False
+
+    def test_wait_true_blocks_then_succeeds(self) -> None:
+        """wait=True retries via _try_acquire_window until allowed; never returns False."""
+        lim = _limiter()
+        calls = {"n": 0}
+
+        async def _fake_try_acquire(key, max_requests, window_seconds):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return False, 0.01
+            return True, 0.0
+
+        lim._try_acquire_window = _fake_try_acquire  # type: ignore[assignment]
+        result = asyncio.run(lim.acquire_window("k", max_requests=5, window_seconds=60, wait=True))
+        assert result is True
+        assert calls["n"] == 2
+
+    def test_redis_exception_allows_request(self) -> None:
+        async def _raise(*a, **kw) -> None:
+            raise ConnectionError("Redis unreachable")
+
+        lim = _limiter()
+        with patch(_PATCH_TARGET, _raise):
+            result = asyncio.run(lim.acquire_window("k", max_requests=5, window_seconds=60))
+        assert result is True
+
+
+class TestGetRemainingInWindow:
+    def test_returns_remaining_count(self) -> None:
+        lim = _limiter()
+        redis = _make_window_redis(count=2)
+        with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
+            result = asyncio.run(lim.get_remaining_in_window("k", max_requests=5, window_seconds=60))
+        assert result == 3
+
+    def test_returns_zero_when_over_limit(self) -> None:
+        lim = _limiter()
+        redis = _make_window_redis(count=10)
+        with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
+            result = asyncio.run(lim.get_remaining_in_window("k", max_requests=5, window_seconds=60))
+        assert result == 0
+
+    def test_redis_exception_returns_max(self) -> None:
+        async def _raise(*a, **kw) -> None:
+            raise ConnectionError("Redis unreachable")
+
+        lim = _limiter()
+        with patch(_PATCH_TARGET, _raise):
+            result = asyncio.run(lim.get_remaining_in_window("k", max_requests=5, window_seconds=60))
+        assert result == 5
+
+
+# ---------------------------------------------------------------------------
+# Tests — acquire_token (token-bucket mode, Issue #12646 fold-in)
+# ---------------------------------------------------------------------------
+
+
+class TestAcquireToken:
+    def test_burst_allows_immediate_acquisition(self) -> None:
+        """First N tokens (N=burst_size) should acquire quickly."""
+        lim = _limiter()
+
+        async def _run() -> float:
+            start = time.time()
+            for _ in range(5):
+                await lim.acquire_token("platform", requests_per_second=10, burst_size=5)
+            return time.time() - start
+
+        elapsed = asyncio.run(_run())
+        assert elapsed < 1.0
+
+    def test_exceeding_burst_waits(self) -> None:
+        """Requests beyond the burst size must wait for refill."""
+        lim = _limiter()
+
+        async def _run() -> float:
+            for _ in range(2):
+                await lim.acquire_token("platform2", requests_per_second=2, burst_size=2)
+            start = time.time()
+            await lim.acquire_token("platform2", requests_per_second=2, burst_size=2)
+            return time.time() - start
+
+        elapsed = asyncio.run(_run())
+        assert elapsed > 0.05
+
+    def test_independent_keys_have_independent_buckets(self) -> None:
+        """Two distinct keys must not share bucket state."""
+        lim = _limiter()
+
+        async def _run() -> None:
+            # Exhaust key "a" down to a near-empty bucket.
+            for _ in range(3):
+                await lim.acquire_token("a", requests_per_second=1, burst_size=1)
+            # A brand-new key "b" must not be throttled by key "a"'s state.
+            start = time.time()
+            await lim.acquire_token("b", requests_per_second=100, burst_size=1)
+            elapsed = time.time() - start
+            assert elapsed < 0.5
+
+        asyncio.run(_run())


### PR DESCRIPTION
## Thinking Path

Enumerated every behavior across the canonical `autobot_shared/rate_limiter.py::RateLimiter` and the 4 forks before touching any caller (Issue #12646 / umbrella #12645 consolidation contract — no feature loss).

**Feature checklist (fork -> canonical):**

| Behavior | Canonical (before) | `agents/web_researcher.py` | `security/threat_intelligence.py` | `api/secrets.py` | `services/gateway/message_queue.py` | Canonical (after) |
|---|---|---|---|---|---|---|
| Algorithm | Dual sliding window (minute+hour), Redis, atomic Lua `acquire()` | Single window (in-memory list), blocking-wait | Single window (in-memory list), blocking-wait | Single window (in-memory dict), reject-immediately | Continuous-refill token bucket w/ burst (in-memory) | Unchanged dual-window methods **+ new** `acquire_window` (custom single window) **+ new** `acquire_token` (token bucket) |
| Reject vs. block | `acquire()`/`is_allowed()` reject (return False) | never rejects — sleeps + retries until allowed | never rejects — sleeps + retries until allowed | rejects immediately (429) | never rejects — sleeps + retries until a token frees | `acquire_window(..., wait=True\|False)` supports both; `acquire_token` always blocks (matches fork) |
| Per-key/per-instance scoping | caller-supplied `key` | one bucket per Python instance (reset on re-instantiation) | one bucket per client instance (VT/URLVoid) | one bucket per client_id (dict) | one bucket per platform name | `acquire_window` keyed by caller `key` (id(self)-scoped for web_researcher/threat_intel to preserve exact per-instance isolation); `acquire_token` keyed by platform name on the shared `gateway_rate_limiter` |
| Burst allowance | none | none | none | none | yes — `burst_size` param, continuous token refill | folded into `acquire_token` |
| Remaining-count introspection | none (had `get_retry_after_seconds`) | `get_cache_stats()` exposes `current_requests` (consumed by `WebResearchSettings.vue`) | `get_remaining()` (live, feeds `get_service_status()`) | `get_remaining()` (dead — zero external callers) | none | new `get_remaining_in_window(key, max_requests, window_seconds)` |
| Distributed correctness | Redis-backed, atomic Lua | in-process only (per-instance, already isolated by design) | in-process only | in-process only | in-process only, **no lock** (race on concurrent same-platform workers) | `acquire_window` is Redis-backed/atomic (upgrade); `acquire_token` stays in-process but adds a per-key `asyncio.Lock` (bug fix — "best implementation wins" per the contract; no observable regression, sequential test timing unaffected) |
| Fail-open on Redis outage | yes | n/a (no Redis) | n/a | n/a | n/a | preserved for the new Redis-backed methods |

No fork behavior was dropped. `api/secrets.py`'s `get_remaining()` was confirmed dead (zero external callers, grepped repo-wide) — the *capability* is still available generically via `get_remaining_in_window`, just not re-wired to an unused pass-through.

## What Changed

- **`autobot_shared/rate_limiter.py`** — added `acquire_window`/`get_remaining_in_window` (generalizes the fixed minute/hour windows to an arbitrary caller-supplied window, with an optional blocking `wait=True` mode) and `acquire_token` (in-process continuous-refill token bucket with burst, folded in from the gateway fork). Also fixed a **pre-existing, unrelated test gap** discovered in the same file: `_make_redis()` in `rate_limiter_test.py` never mocked `redis.eval` (used by the existing `acquire()` Lua script), so `TestAcquire`'s two tests silently passed/failed for the wrong reason on `Dev_new_gui` (`eval()` returned an unmocked truthy `AsyncMock`, so `acquire()` never actually denied). Fixed the mock and the two assertions.
- **`autobot-backend/api/secrets.py`** — deleted the local `RateLimiter` class + dead `get_remaining()`; `check_rate_limit()` is now `async` and delegates to `acquire_window(client_id, max_requests=30, window_seconds=60)`. 7 call sites updated to `await`.
- **`autobot-backend/security/threat_intelligence.py`** — deleted the local async `RateLimiter` class; `VirusTotalClient`/`URLVoidClient` delegate to `acquire_window(..., wait=True)` (preserves the never-reject blocking behavior) via an `id(self)`-scoped key so each client instance keeps an isolated budget exactly like before. `get_service_status()` now awaits `get_remaining_in_window(...)` instead of the deleted `get_remaining()`.
- **`autobot-backend/agents/web_researcher.py`** — deleted the local blocking-wait `RateLimiter` class; `WebResearcher` delegates to `acquire_window(..., wait=True)`, scoped via `id(self)` so independently-constructed instances (`security_scanner_agent.py`, `api/workflow.py`) keep isolated budgets like before. `get_cache_stats()` is now `async` (3 call sites updated: `health_check()`, 2x `api/web_research_settings.py`) so `current_requests` reflects the real remaining count consumed by `WebResearchSettings.vue`.
- **`autobot-backend/services/gateway/message_queue.py`** — deleted the local token-bucket `@dataclass RateLimiter`; `register_platform()` now stores `(rps, burst_size)` tuples, and `_worker()` calls the already-declared-but-previously-unused module-level `gateway_rate_limiter.acquire_token(platform, ...)` singleton. Dropped the dead `RateLimiter` re-export from `services/gateway/__init__.py`.
- Test updates: new/updated tests in `autobot_shared/rate_limiter_test.py`, `api/secrets_test.py` (first-ever coverage), `security/threat_intelligence_test.py`, `agents/web_researcher_test.py` (new file, first-ever coverage), `tests/test_gateway_manager.py`, `tests/api/test_web_research_settings_guard.py`.

Confirmed via repo-wide grep: `class RateLimiter` is now defined in **exactly one place** — `autobot_shared/rate_limiter.py:110`.

## Verification

```
$ python3 -m pytest autobot_shared/rate_limiter_test.py autobot-backend/api/secrets_test.py \
    autobot-backend/security/threat_intelligence_test.py autobot-backend/agents/web_researcher_test.py \
    autobot-backend/tests/test_gateway_manager.py autobot-backend/tests/api/test_web_research_settings_guard.py \
    autobot-backend/tests/test_startup_imports.py -q
475 passed, 82 warnings in 26.32s
```

Also ran a full `autobot-backend --collect-only` (19,835 tests) — no new import errors; the single pre-existing collection error (`cachetools` missing, `security/enterprise/threat_detection/test_learner.py`) is an unrelated, pre-existing optional-dependency gap.

```
$ grep -rn "^class RateLimiter\b" --include="*.py" .
autobot_shared/rate_limiter.py:110:class RateLimiter:
```

Closes #12646
Refs #12645

## Model Used

Claude Sonnet 5