### PR TITLE
tech-debt(backend): extract knowledge-connector base for _load_ts + change-detection (#12659)

### DIFF
--- a/autobot-backend/integrations/notion_integration.py
+++ b/autobot-backend/integrations/notion_integration.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List
 import aiohttp
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.notion_utils import extract_title as _extract_title
 from integrations.base import (
     BaseIntegration,
     IntegrationAction,
@@ -325,21 +326,6 @@ class NotionIntegration(BaseIntegration):
 # ------------------------------------------------------------------
 # Utilities
 # ------------------------------------------------------------------
-
-
-def _extract_title(obj: Dict[str, Any]) -> str:
-    """Extract the plain-text title from a Notion page or database object."""
-    # Database title field
-    title_array = obj.get("title", [])
-    if title_array and isinstance(title_array, list):
-        return "".join(t.get("plain_text", "") for t in title_array)
-
-    # Page title via Name property
-    props = obj.get("properties", {})
-    for prop_name in ("Name", "Title", "title"):
-        prop = props.get(prop_name, {})
-        title_values = prop.get("title", [])
-        if title_values:
-            return "".join(t.get("plain_text", "") for t in title_values)
-
-    return ""
+# Issue #12659: _extract_title() single-sourced in autobot_shared/notion_utils.py
+# (was byte-identical to knowledge/connectors/notion.py's copy) — imported
+# above as `extract_title as _extract_title`.

--- a/autobot-backend/knowledge/connectors/base.py
+++ b/autobot-backend/knowledge/connectors/base.py
@@ -25,6 +25,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Set, TypeVar
 
 from autobot_shared.datetime_utils import datetime_now
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import parse_utc_iso
 from knowledge.connectors.models import (
     ChangeInfo,
     ConnectorConfig,
@@ -44,6 +45,11 @@ _CHECKPOINT_TTL_SECONDS = 86400
 
 _JOB_KEY_SUFFIX = ":job:current"
 _JOB_TTL_S = 86400  # 24 h
+
+# Issue #12659: TTL for per-source last-modified timestamps written by
+# _store_ts()/read by _load_ts() — shared by connectors doing Redis-backed
+# incremental sync (confluence, gitlab, jira, slack, gdrive, nextcloud, ...).
+_TS_REDIS_TTL_SECONDS = 86400 * 30  # 30 days
 
 
 class RetryableError(Exception):
@@ -78,6 +84,16 @@ class AbstractConnector(ABC):
     connector_type: str = ""
     tier: int = 0
     config_version: int = 1
+
+    # Issue #12659: Redis key prefix used by _load_ts()/_store_ts(). Defaults
+    # to "connector:<connector_type>:ts:"; override when a connector's Redis
+    # namespace differs from its connector_type (e.g. GiteaConnector shares
+    # GitLabConnector's "connector:gitlab:ts:" prefix).
+    _ts_redis_prefix: str | None = None
+
+    # Issue #12659: API field name holding a file's last-modified timestamp,
+    # used by the shared _detect_changes_via_file_listing() helper.
+    _modified_time_field: str = "modifiedTime"
 
     @classmethod
     def migrate_config(cls, stored_version: int, config: dict) -> dict:
@@ -244,6 +260,109 @@ class AbstractConnector(ABC):
             await redis.delete(key)
         except Exception as exc:
             self.logger.warning("checkpoint clear failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Issue #12659 — Per-source last-modified timestamp (incremental sync)
+    # ------------------------------------------------------------------
+
+    def _ts_redis_key(self, source_id: str) -> str:
+        prefix = self._ts_redis_prefix or ("connector:%s:ts:" % self.connector_type)
+        return "%s%s:%s" % (prefix, self.config.connector_id, source_id)
+
+    async def _load_ts(self, source_id: str) -> str | None:
+        """Load the stored last-modified timestamp for *source_id* from Redis.
+
+        Extracted from 6 byte-identical per-connector copies (Issue #12659):
+        confluence, gitlab (+ gitea), jira, slack, gdrive, nextcloud.
+        """
+        try:
+            from autobot_shared.redis_client import get_redis_client
+
+            redis = get_redis_client(database="knowledge")
+            key = self._ts_redis_key(source_id)
+            value = redis.get(key)
+            if hasattr(value, "__await__"):
+                value = await value
+            if isinstance(value, bytes):
+                return value.decode("utf-8")
+            return value
+        except Exception as exc:
+            self.logger.warning("Redis load_ts failed for %s: %s", source_id, exc)
+            return None
+
+    async def _store_ts(self, source_id: str, ts: str) -> None:
+        """Persist the last-modified timestamp for *source_id* in Redis.
+
+        Extracted alongside _load_ts() (Issue #12659) — same duplication,
+        mirrored write path.
+        """
+        try:
+            from autobot_shared.redis_client import get_redis_client
+
+            redis = get_redis_client(database="knowledge")
+            key = self._ts_redis_key(source_id)
+            result = redis.set(key, ts, ex=_TS_REDIS_TTL_SECONDS)
+            if hasattr(result, "__await__"):
+                await result
+        except Exception as exc:
+            self.logger.warning("Redis store_ts failed for %s: %s", source_id, exc)
+
+    # ------------------------------------------------------------------
+    # Issue #12659 — Shared file-listing change detection (gdrive/onedrive)
+    # ------------------------------------------------------------------
+
+    async def _classify_change(
+        self,
+        source_id: str,
+        last_modified: str,
+        since: datetime | None,
+    ) -> ChangeInfo | None:
+        """Return ChangeInfo when a file is new or was modified after *since*.
+
+        Extracted from gdrive.py/onedrive.py (Issue #12659: byte-identical).
+        """
+        if since is None:
+            return ChangeInfo(
+                source_id=source_id,
+                change_type="added",
+                timestamp=datetime_now(),
+                details={"last_modified": last_modified},
+            )
+
+        stored_ts = await self._load_ts(source_id)
+        if stored_ts is None or last_modified > stored_ts:
+            change_type = "added" if stored_ts is None else "modified"
+            return ChangeInfo(
+                source_id=source_id,
+                change_type=change_type,
+                timestamp=parse_utc_iso(last_modified) if last_modified else datetime_now(),
+                details={"last_modified": last_modified},
+            )
+
+        return None
+
+    async def _detect_changes_via_file_listing(self, since: datetime | None) -> List[ChangeInfo]:
+        """Shared detect_changes() body for connectors that list files then
+        classify each via _classify_change() (Issue #12659: gdrive/onedrive).
+
+        Requires the connector to implement ``_list_all_files()`` returning
+        dicts with an ``id`` key, and to set ``_modified_time_field`` to the
+        API's per-file last-modified key (e.g. "modifiedTime" for Google
+        Drive, "lastModifiedDateTime" for OneDrive/Graph).
+        """
+        files = await self._list_all_files()
+        changes: List[ChangeInfo] = []
+
+        for file_item in files:
+            file_id = file_item.get("id", "")
+            source_id = "%s:%s:file:%s" % (self.connector_type, self.config.connector_id, file_id)
+            last_modified = file_item.get(self._modified_time_field, "")
+
+            change = await self._classify_change(source_id, last_modified, since)
+            if change:
+                changes.append(change)
+
+        return changes
 
     # ------------------------------------------------------------------
     # Default implementations — connectors may override

--- a/autobot-backend/knowledge/connectors/confluence.py
+++ b/autobot-backend/knowledge/connectors/confluence.py
@@ -47,9 +47,6 @@ from knowledge.connectors.registry import ConnectorRegistry
 
 logger = get_logger(__name__)
 
-_REDIS_TS_PREFIX = "connector:confluence:ts:"
-_REDIS_TS_TTL = 86400 * 30  # 30 days
-
 
 @ConnectorRegistry.register("confluence")
 class ConfluenceConnector(AbstractConnector):
@@ -137,7 +134,7 @@ class ConfluenceConnector(AbstractConnector):
 
         version_when = page.get("version", {}).get("when", "")
         if version_when:
-            await _store_ts(self.config.connector_id, page_id, version_when)
+            await self._store_ts(page_id, version_when)
 
         return ContentResult(
             source_id=source_id,
@@ -210,10 +207,10 @@ class ConfluenceConnector(AbstractConnector):
             return None
         version_when = result.get("body", {}).get("version", {}).get("when", "")
 
-        stored = await _load_ts(self.config.connector_id, page_id)
+        stored = await self._load_ts(page_id)
         if stored is None or version_when > stored:
             change_type = "added" if stored is None else "modified"
-            await _store_ts(self.config.connector_id, page_id, version_when)
+            await self._store_ts(page_id, version_when)
             return ChangeInfo(
                 source_id=_build_source_id(self.config.connector_id, page_id),
                 change_type=change_type,
@@ -244,45 +241,11 @@ class ConfluenceConnector(AbstractConnector):
 
 
 # ---------------------------------------------------------------------------
-# Redis checkpoint helpers
-# ---------------------------------------------------------------------------
-
-
-async def _load_ts(connector_id: str, page_id: str) -> Optional[str]:
-    """Load the stored ``version.when`` timestamp for *page_id* from Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, page_id)
-        value = redis.get(key)
-        if hasattr(value, "__await__"):
-            value = await value
-        if isinstance(value, bytes):
-            return value.decode("utf-8")
-        return value
-    except Exception as exc:
-        logger.warning("Redis load_ts failed for page %s: %s", page_id, exc)
-        return None
-
-
-async def _store_ts(connector_id: str, page_id: str, version_when: str) -> None:
-    """Persist the ``version.when`` timestamp for *page_id* in Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, page_id)
-        result = redis.set(key, version_when, ex=_REDIS_TS_TTL)
-        if hasattr(result, "__await__"):
-            await result
-    except Exception as exc:
-        logger.warning("Redis store_ts failed for page %s: %s", page_id, exc)
-
-
-# ---------------------------------------------------------------------------
 # Module-level helpers (no state)
 # ---------------------------------------------------------------------------
+# Issue #12659: _load_ts()/_store_ts() moved to AbstractConnector — this
+# connector's Redis prefix ("connector:confluence:ts:") matches the base
+# class default derived from connector_type, so no override is needed.
 
 
 def _build_source_id(connector_id: str, page_id: str) -> str:

--- a/autobot-backend/knowledge/connectors/gdrive.py
+++ b/autobot-backend/knowledge/connectors/gdrive.py
@@ -48,8 +48,6 @@ from knowledge.connectors.registry import ConnectorRegistry
 logger = get_logger(__name__)
 
 _DRIVE_API_BASE = "https://www.googleapis.com/drive/v3"
-_REDIS_TS_PREFIX = "connector:gdrive:ts:"
-_REDIS_TS_TTL = 86400 * 30  # 30 days
 
 # Default supported extensions (Google native + common formats)
 _DEFAULT_EXTENSIONS = [".gdoc", ".gsheet", ".pdf", ".docx", ".md", ".txt"]
@@ -61,37 +59,11 @@ _DEFAULT_MAX_FILE_SIZE = 100 * 1024 * 1024
 _GDOC_MIME = "application/vnd.google-apps.document"
 _GSHEET_MIME = "application/vnd.google-apps.spreadsheet"
 
-
-async def _load_ts(connector_id: str, source_id: str) -> Optional[str]:
-    """Load last-modified timestamp for a source from Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = f"{_REDIS_TS_PREFIX}{connector_id}:{source_id}"
-        value = redis.get(key)
-        if hasattr(value, "__await__"):
-            value = await value
-        if isinstance(value, bytes):
-            return value.decode("utf-8")
-        return value
-    except Exception as exc:
-        logger.warning("Redis load_ts failed for %s: %s", source_id, exc)
-        return None
-
-
-async def _store_ts(connector_id: str, source_id: str, ts: str) -> None:
-    """Store last-modified timestamp for a source in Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = f"{_REDIS_TS_PREFIX}{connector_id}:{source_id}"
-        result = redis.set(key, ts, ex=_REDIS_TS_TTL)
-        if hasattr(result, "__await__"):
-            await result
-    except Exception as exc:
-        logger.warning("Redis store_ts failed for %s: %s", source_id, exc)
+# Issue #12659: _load_ts()/_store_ts()/_classify_change() moved to
+# AbstractConnector (byte-identical to onedrive.py's copies). This
+# connector's Redis prefix ("connector:gdrive:ts:") matches the base class
+# default derived from connector_type, so no override is needed. Its
+# _modified_time_field also matches the base default ("modifiedTime").
 
 
 @ConnectorRegistry.register("gdrive")
@@ -280,7 +252,7 @@ class GoogleDriveConnector(AbstractConnector):
         # Update stored timestamp
         last_modified = file_meta.get("modifiedTime", "")
         if last_modified:
-            await _store_ts(self.config.connector_id, source_id, last_modified)
+            await self._store_ts(source_id, last_modified)
 
         # Build file path from parents
         file_path = await self._build_file_path(file_meta.get("parents", []), file_name)
@@ -307,21 +279,11 @@ class GoogleDriveConnector(AbstractConnector):
         """Return ChangeInfo for files added or modified since *since*.
 
         When *since* is None all files are reported as 'added'. Otherwise
-        compares modifiedTime against stored Redis timestamp.
+        compares modifiedTime against stored Redis timestamp. Shared with
+        onedrive.py via AbstractConnector._detect_changes_via_file_listing()
+        (Issue #12659).
         """
-        files = await self._list_all_files()
-        changes: List[ChangeInfo] = []
-
-        for file_item in files:
-            file_id = file_item.get("id", "")
-            source_id = f"gdrive:{self.config.connector_id}:file:{file_id}"
-            last_modified = file_item.get("modifiedTime", "")
-
-            change = await self._classify_change(source_id, last_modified, since)
-            if change:
-                changes.append(change)
-
-        return changes
+        return await self._detect_changes_via_file_listing(since)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -552,33 +514,6 @@ class GoogleDriveConnector(AbstractConnector):
                 break
 
         return files
-
-    async def _classify_change(
-        self,
-        source_id: str,
-        last_modified: str,
-        since: datetime | None,
-    ) -> ChangeInfo | None:
-        """Return ChangeInfo when the file is new or was modified after *since*."""
-        if since is None:
-            return ChangeInfo(
-                source_id=source_id,
-                change_type="added",
-                timestamp=now_utc(),
-                details={"last_modified": last_modified},
-            )
-
-        stored_ts = await _load_ts(self.config.connector_id, source_id)
-        if stored_ts is None or last_modified > stored_ts:
-            change_type = "added" if stored_ts is None else "modified"
-            return ChangeInfo(
-                source_id=source_id,
-                change_type=change_type,
-                timestamp=parse_utc_iso(last_modified) if last_modified else now_utc(),
-                details={"last_modified": last_modified},
-            )
-
-        return None
 
     def _file_to_source_info(self, file_item: Dict[str, Any]) -> SourceInfo | None:
         """Convert a Drive API file item to SourceInfo."""

--- a/autobot-backend/knowledge/connectors/gdrive_test.py
+++ b/autobot-backend/knowledge/connectors/gdrive_test.py
@@ -165,7 +165,7 @@ class TestGoogleDriveConnector:
             return mock_metadata
 
         with patch.object(connector, "_drive_request", side_effect=mock_request):
-            with patch("knowledge.connectors.gdrive._store_ts", return_value=None):
+            with patch.object(connector, "_store_ts", return_value=None):
                 result = await connector.fetch_content(source_id)
 
                 assert result is not None
@@ -208,7 +208,7 @@ class TestGoogleDriveConnector:
 
         with patch.object(connector, "_drive_request", side_effect=mock_request):
             with patch("knowledge.connectors.gdrive._extract_text_from_pdf", return_value="Extracted PDF text"):
-                with patch("knowledge.connectors.gdrive._store_ts", return_value=None):
+                with patch.object(connector, "_store_ts", return_value=None):
                     result = await connector.fetch_content(source_id)
 
                     assert result is not None
@@ -233,7 +233,7 @@ class TestGoogleDriveConnector:
         ]
 
         with patch.object(connector, "_list_all_files", return_value=mock_files):
-            with patch("knowledge.connectors.gdrive._load_ts", return_value=None):
+            with patch.object(connector, "_load_ts", return_value=None):
                 changes = await connector.detect_changes(since=None)
 
                 assert len(changes) == 1
@@ -259,7 +259,7 @@ class TestGoogleDriveConnector:
         old_timestamp = "2026-06-04T10:00:00Z"  # Older timestamp
 
         with patch.object(connector, "_list_all_files", return_value=mock_files):
-            with patch("knowledge.connectors.gdrive._load_ts", return_value=old_timestamp):
+            with patch.object(connector, "_load_ts", return_value=old_timestamp):
                 changes = await connector.detect_changes(since=now_utc())
 
                 assert len(changes) == 1

--- a/autobot-backend/knowledge/connectors/gitlab.py
+++ b/autobot-backend/knowledge/connectors/gitlab.py
@@ -53,8 +53,11 @@ from knowledge.connectors.registry import ConnectorRegistry
 
 logger = get_logger(__name__)
 
+# Issue #12659: Redis prefix shared by _load_ts()/_store_ts() (base class).
+# GiteaConnector deliberately reuses this same "gitlab" namespace (both
+# classes live in this module) rather than deriving from its own
+# connector_type ("gitea") — preserved via _ts_redis_prefix overrides below.
 _REDIS_TS_PREFIX = "connector:gitlab:ts:"
-_REDIS_TS_TTL = 86400 * 30  # 30 days
 
 
 # ---------------------------------------------------------------------------
@@ -96,36 +99,6 @@ def _file_to_text(path: str, raw_content: str) -> str:
     return "File: %s\n\n%s" % (path, raw_content)
 
 
-async def _load_ts(connector_id: str, source_id: str) -> Optional[str]:
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, source_id)
-        value = redis.get(key)
-        if hasattr(value, "__await__"):
-            value = await value
-        if isinstance(value, bytes):
-            return value.decode("utf-8")
-        return value
-    except Exception as exc:
-        logger.warning("Redis load_ts failed for %s: %s", source_id, exc)
-        return None
-
-
-async def _store_ts(connector_id: str, source_id: str, ts: str) -> None:
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, source_id)
-        result = redis.set(key, ts, ex=_REDIS_TS_TTL)
-        if hasattr(result, "__await__"):
-            await result
-    except Exception as exc:
-        logger.warning("Redis store_ts failed for %s: %s", source_id, exc)
-
-
 # ---------------------------------------------------------------------------
 # GitLab connector
 # ---------------------------------------------------------------------------
@@ -147,6 +120,7 @@ class GitLabConnector(AbstractConnector):
     connector_type = "gitlab"
     tier = 1
     max_concurrency = 4
+    _ts_redis_prefix = _REDIS_TS_PREFIX
 
     @classmethod
     def auth_schema(cls) -> type:
@@ -317,7 +291,7 @@ class GitLabConnector(AbstractConnector):
             if not _is_text_file(path):
                 continue
             sid = self._source_id(project_id, "file", path)
-            stored_ts = await _load_ts(self.config.connector_id, sid)
+            stored_ts = await self._load_ts(sid)
             change_type = "added" if stored_ts is None else "modified"
             changes.append(
                 ChangeInfo(
@@ -337,10 +311,10 @@ class GitLabConnector(AbstractConnector):
                 timestamp=now_utc(),
                 details={"updated_at": updated_at},
             )
-        stored = await _load_ts(self.config.connector_id, source_id)
+        stored = await self._load_ts(source_id)
         if stored is None or updated_at > stored:
             change_type = "added" if stored is None else "modified"
-            await _store_ts(self.config.connector_id, source_id, updated_at)
+            await self._store_ts(source_id, updated_at)
             return ChangeInfo(
                 source_id=source_id,
                 change_type=change_type,
@@ -362,7 +336,7 @@ class GitLabConnector(AbstractConnector):
         text = _issue_to_text(item)
         updated_at = item.get("updated_at", "")
         if updated_at:
-            await _store_ts(self.config.connector_id, source_id, updated_at)
+            await self._store_ts(source_id, updated_at)
         return ContentResult(
             source_id=source_id,
             content=text,
@@ -387,7 +361,7 @@ class GitLabConnector(AbstractConnector):
         text = _issue_to_text(item, is_pr=True)
         updated_at = item.get("updated_at", "")
         if updated_at:
-            await _store_ts(self.config.connector_id, source_id, updated_at)
+            await self._store_ts(source_id, updated_at)
         return ContentResult(
             source_id=source_id,
             content=text,
@@ -411,7 +385,7 @@ class GitLabConnector(AbstractConnector):
             return None
         raw = result.get("body_text", "")
         text = _file_to_text(file_path, raw)
-        await _store_ts(self.config.connector_id, source_id, now_utc().isoformat())
+        await self._store_ts(source_id, now_utc().isoformat())
         return ContentResult(
             source_id=source_id,
             content=text,
@@ -493,6 +467,10 @@ class GiteaConnector(AbstractConnector):
 
     connector_type = "gitea"
     tier = 1
+    # Issue #12659: shares GitLabConnector's "connector:gitlab:ts:" Redis
+    # namespace (pre-existing behavior, preserved — not derived from
+    # connector_type since that would change the key prefix to "gitea").
+    _ts_redis_prefix = _REDIS_TS_PREFIX
     max_concurrency = 4
 
     @classmethod
@@ -671,7 +649,7 @@ class GiteaConnector(AbstractConnector):
             if not _is_text_file(path):
                 continue
             sid = self._source_id(owner, repo, "file", path)
-            stored = await _load_ts(self.config.connector_id, sid)
+            stored = await self._load_ts(sid)
             change_type = "added" if stored is None else "modified"
             changes.append(
                 ChangeInfo(
@@ -691,10 +669,10 @@ class GiteaConnector(AbstractConnector):
                 timestamp=now_utc(),
                 details={"updated_at": updated_at},
             )
-        stored = await _load_ts(self.config.connector_id, source_id)
+        stored = await self._load_ts(source_id)
         if stored is None or updated_at > stored:
             change_type = "added" if stored is None else "modified"
-            await _store_ts(self.config.connector_id, source_id, updated_at)
+            await self._store_ts(source_id, updated_at)
             return ChangeInfo(
                 source_id=source_id,
                 change_type=change_type,
@@ -716,7 +694,7 @@ class GiteaConnector(AbstractConnector):
         text = _issue_to_text(item)
         updated_at = item.get("updated_at", "")
         if updated_at:
-            await _store_ts(self.config.connector_id, source_id, updated_at)
+            await self._store_ts(source_id, updated_at)
         return ContentResult(
             source_id=source_id,
             content=text,
@@ -742,7 +720,7 @@ class GiteaConnector(AbstractConnector):
         text = _issue_to_text(item, is_pr=True)
         updated_at = item.get("updated_at", "")
         if updated_at:
-            await _store_ts(self.config.connector_id, source_id, updated_at)
+            await self._store_ts(source_id, updated_at)
         return ContentResult(
             source_id=source_id,
             content=text,
@@ -766,7 +744,7 @@ class GiteaConnector(AbstractConnector):
             return None
         raw = result.get("body_text", "")
         text = _file_to_text(file_path, raw)
-        await _store_ts(self.config.connector_id, source_id, now_utc().isoformat())
+        await self._store_ts(source_id, now_utc().isoformat())
         return ContentResult(
             source_id=source_id,
             content=text,

--- a/autobot-backend/knowledge/connectors/jira.py
+++ b/autobot-backend/knowledge/connectors/jira.py
@@ -49,8 +49,9 @@ from knowledge.connectors.registry import ConnectorRegistry
 
 logger = get_logger(__name__)
 
-_REDIS_TS_PREFIX = "connector:jira:ts:"
-_REDIS_TS_TTL = 86400 * 30  # 30 days
+# Issue #12659: _load_ts()/_store_ts() moved to AbstractConnector — this
+# connector's Redis prefix ("connector:jira:ts:") matches the base class
+# default derived from connector_type, so no override is needed.
 
 
 @ConnectorRegistry.register("jira")
@@ -136,7 +137,7 @@ class JiraConnector(AbstractConnector):
 
         updated = fields.get("updated", "")
         if updated:
-            await _store_ts(self.config.connector_id, issue_key, updated)
+            await self._store_ts(issue_key, updated)
 
         return ContentResult(
             source_id=source_id,
@@ -191,10 +192,10 @@ class JiraConnector(AbstractConnector):
                 details={"issue_key": issue_key, "updated": updated},
             )
 
-        stored = await _load_ts(self.config.connector_id, issue_key)
+        stored = await self._load_ts(issue_key)
         if stored is None or updated > stored:
             change_type = "added" if stored is None else "modified"
-            await _store_ts(self.config.connector_id, issue_key, updated)
+            await self._store_ts(issue_key, updated)
             return ChangeInfo(
                 source_id=_build_source_id(self.config.connector_id, issue_key),
                 change_type=change_type,
@@ -252,43 +253,6 @@ class JiraConnector(AbstractConnector):
         except aiohttp.ClientError as exc:
             self.logger.warning("Jira request to %s failed: %s", url, exc)
             return {"status_code": 0, "error": str(exc)}
-
-
-# ---------------------------------------------------------------------------
-# Redis checkpoint helpers
-# ---------------------------------------------------------------------------
-
-
-async def _load_ts(connector_id: str, issue_key: str) -> Optional[str]:
-    """Load the stored ``updated`` timestamp for *issue_key* from Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, issue_key)
-        value = redis.get(key)
-        if hasattr(value, "__await__"):
-            value = await value
-        if isinstance(value, bytes):
-            return value.decode("utf-8")
-        return value
-    except Exception as exc:
-        logger.warning("Redis load_ts failed for issue %s: %s", issue_key, exc)
-        return None
-
-
-async def _store_ts(connector_id: str, issue_key: str, updated: str) -> None:
-    """Persist the ``updated`` timestamp for *issue_key* in Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, issue_key)
-        result = redis.set(key, updated, ex=_REDIS_TS_TTL)
-        if hasattr(result, "__await__"):
-            await result
-    except Exception as exc:
-        logger.warning("Redis store_ts failed for issue %s: %s", issue_key, exc)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/knowledge/connectors/nextcloud.py
+++ b/autobot-backend/knowledge/connectors/nextcloud.py
@@ -53,10 +53,6 @@ NS_NC = "{http://nextcloud.org/ns}"
 # Default supported file extensions
 DEFAULT_FILE_EXTENSIONS = ["pdf", "docx", "odt", "md", "txt"]
 
-# Redis key prefix for storing last-modified timestamps
-_REDIS_TS_PREFIX = "connector:nextcloud:ts:"
-_REDIS_TS_TTL = 86400 * 30  # 30 days
-
 
 def _is_supported_file(path: str, extensions: List[str]) -> bool:
     """Check if file extension is in the supported list."""
@@ -66,36 +62,9 @@ def _is_supported_file(path: str, extensions: List[str]) -> bool:
     return ext in extensions
 
 
-async def _load_ts(connector_id: str, source_id: str) -> Optional[str]:
-    """Load last-modified timestamp from Redis for incremental sync."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = f"{_REDIS_TS_PREFIX}{connector_id}:{source_id}"
-        value = redis.get(key)
-        if hasattr(value, "__await__"):
-            value = await value
-        if isinstance(value, bytes):
-            return value.decode("utf-8")
-        return value
-    except Exception as exc:
-        logger.warning("Redis load_ts failed for %s: %s", source_id, exc)
-        return None
-
-
-async def _store_ts(connector_id: str, source_id: str, ts: str) -> None:
-    """Store last-modified timestamp to Redis for incremental sync."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = f"{_REDIS_TS_PREFIX}{connector_id}:{source_id}"
-        result = redis.set(key, ts, ex=_REDIS_TS_TTL)
-        if hasattr(result, "__await__"):
-            await result
-    except Exception as exc:
-        logger.warning("Redis store_ts failed for %s: %s", source_id, exc)
+# Issue #12659: _load_ts()/_store_ts() moved to AbstractConnector — this
+# connector's Redis prefix ("connector:nextcloud:ts:") matches the base
+# class default derived from connector_type, so no override is needed.
 
 
 @ConnectorRegistry.register("nextcloud")
@@ -205,8 +174,7 @@ class NextcloudConnector(AbstractConnector):
                             self.logger.warning("Binary content for %s - may need extraction", source_id)
                             content = content_bytes.decode("utf-8", errors="replace")
 
-                        await _store_ts(
-                            self.config.connector_id,
+                        await self._store_ts(
                             source_id,
                             resp.headers.get("Last-Modified", ""),
                         )
@@ -233,7 +201,7 @@ class NextcloudConnector(AbstractConnector):
         # Re-discover all sources and compare timestamps
         sources = await self.discover_sources()
         for src in sources:
-            stored_ts = await _load_ts(self.config.connector_id, src.source_id)
+            stored_ts = await self._load_ts(src.source_id)
             current_ts = src.last_modified.isoformat()
 
             if not stored_ts:

--- a/autobot-backend/knowledge/connectors/notion.py
+++ b/autobot-backend/knowledge/connectors/notion.py
@@ -26,6 +26,7 @@ import aiohttp
 
 from autobot_shared.auth import BearerAuth
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.notion_utils import extract_title as _extract_title
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector
 from knowledge.connectors.models import (
@@ -316,17 +317,6 @@ def _blocks_to_text(blocks: List[Dict[str, Any]]) -> str:
     return "\n".join(parts)
 
 
-def _extract_title(obj: Dict[str, Any]) -> str:
-    """Extract the plain-text title from a Notion page or database object."""
-    title_array = obj.get("title", [])
-    if title_array and isinstance(title_array, list):
-        return "".join(t.get("plain_text", "") for t in title_array)
-
-    props = obj.get("properties", {})
-    for prop_name in ("Name", "Title", "title"):
-        prop = props.get(prop_name, {})
-        title_values = prop.get("title", [])
-        if title_values:
-            return "".join(t.get("plain_text", "") for t in title_values)
-
-    return ""
+# Issue #12659: _extract_title() single-sourced in autobot_shared/notion_utils.py
+# (was byte-identical to integrations/notion_integration.py's copy) —
+# imported at the top of this module as `extract_title as _extract_title`.

--- a/autobot-backend/knowledge/connectors/onedrive.py
+++ b/autobot-backend/knowledge/connectors/onedrive.py
@@ -52,7 +52,8 @@ from knowledge.connectors.registry import ConnectorRegistry
 logger = get_logger(__name__)
 
 _GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
-_REDIS_TS_PREFIX = "connector:onedrive:ts:"
+# Issue #12659: TTL for the connector-specific _load_ts()/_store_ts()
+# override below (key prefix now derives from AbstractConnector._ts_redis_key()).
 _REDIS_TS_TTL = 86400 * 30  # 30 days
 
 # Default supported extensions
@@ -102,44 +103,14 @@ def _extract_text_from_pptx(content_bytes: bytes) -> str:
         return ""
 
 
-async def _load_ts(connector_id: str, source_id: str) -> Optional[str]:
-    """Load last-modified timestamp for a source from Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        if redis is None:
-            logger.warning("Redis client unavailable for load_ts")
-            return None
-        key = f"{_REDIS_TS_PREFIX}{connector_id}:{source_id}"
-        value = redis.get(key)
-        if hasattr(value, "__await__"):
-            value = await value
-        if isinstance(value, bytes):
-            return value.decode("utf-8")
-        if isinstance(value, str):
-            return value
-        return None
-    except Exception as exc:
-        logger.warning("Redis load_ts failed for %s: %s", source_id, exc)
-        return None
-
-
-async def _store_ts(connector_id: str, source_id: str, ts: str) -> None:
-    """Store last-modified timestamp for a source in Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        if redis is None:
-            logger.warning("Redis client unavailable for store_ts")
-            return
-        key = f"{_REDIS_TS_PREFIX}{connector_id}:{source_id}"
-        result = redis.set(key, ts, ex=_REDIS_TS_TTL)
-        if hasattr(result, "__await__"):
-            await result
-    except Exception as exc:
-        logger.warning("Redis store_ts failed for %s: %s", source_id, exc)
+# Issue #12659: detect_changes()/_classify_change() moved to AbstractConnector
+# (byte-identical to gdrive.py's copies — see
+# AbstractConnector._detect_changes_via_file_listing()/_classify_change()).
+# _load_ts()/_store_ts() are KEPT as connector-specific overrides below: this
+# connector's checks (explicit `redis is None` guard, strict
+# `isinstance(value, str)`) differ from the other 6 connectors' copies, so
+# folding them into the base implementation would silently drop that
+# defensive behavior.
 
 
 @ConnectorRegistry.register("onedrive")
@@ -156,6 +127,9 @@ class OneDriveConnector(AbstractConnector):
     connector_type = "onedrive"
     # Issue #4421: needs OAuth2 access token (tier 2 = credentials/OAuth)
     tier = 2
+    # Issue #12659: Graph API's per-file last-modified key (base default is
+    # "modifiedTime", which matches gdrive.py's Drive API field instead).
+    _modified_time_field = "lastModifiedDateTime"
 
     @classmethod
     def auth_schema(cls) -> type:
@@ -302,7 +276,7 @@ class OneDriveConnector(AbstractConnector):
         # Update stored timestamp
         last_modified = file_meta.get("lastModifiedDateTime", "")
         if last_modified:
-            await _store_ts(self.config.connector_id, source_id, last_modified)
+            await self._store_ts(source_id, last_modified)
 
         return ContentResult(
             source_id=source_id,
@@ -326,21 +300,54 @@ class OneDriveConnector(AbstractConnector):
         """Return ChangeInfo for files added or modified since *since*.
 
         When *since* is None all files are reported as 'added'. Otherwise
-        compares lastModifiedDateTime against stored Redis timestamp.
+        compares lastModifiedDateTime against stored Redis timestamp. Shared
+        with gdrive.py via AbstractConnector._detect_changes_via_file_listing()
+        (Issue #12659).
         """
-        files = await self._list_all_files()
-        changes: List[ChangeInfo] = []
+        return await self._detect_changes_via_file_listing(since)
 
-        for file_item in files:
-            file_id = file_item.get("id", "")
-            source_id = f"onedrive:{self.config.connector_id}:file:{file_id}"
-            last_modified = file_item.get("lastModifiedDateTime", "")
+    async def _load_ts(self, source_id: str) -> str | None:
+        """Load last-modified timestamp for a source from Redis.
 
-            change = await self._classify_change(source_id, last_modified, since)
-            if change:
-                changes.append(change)
+        Issue #12659: kept as a connector-specific override — see module
+        docstring above the class for why this isn't folded into
+        AbstractConnector._load_ts().
+        """
+        try:
+            from autobot_shared.redis_client import get_redis_client
 
-        return changes
+            redis = get_redis_client(database="knowledge")
+            if redis is None:
+                self.logger.warning("Redis client unavailable for load_ts")
+                return None
+            key = self._ts_redis_key(source_id)
+            value = redis.get(key)
+            if hasattr(value, "__await__"):
+                value = await value
+            if isinstance(value, bytes):
+                return value.decode("utf-8")
+            if isinstance(value, str):
+                return value
+            return None
+        except Exception as exc:
+            self.logger.warning("Redis load_ts failed for %s: %s", source_id, exc)
+            return None
+
+    async def _store_ts(self, source_id: str, ts: str) -> None:
+        """Store last-modified timestamp for a source in Redis (Issue #12659 override)."""
+        try:
+            from autobot_shared.redis_client import get_redis_client
+
+            redis = get_redis_client(database="knowledge")
+            if redis is None:
+                self.logger.warning("Redis client unavailable for store_ts")
+                return
+            key = self._ts_redis_key(source_id)
+            result = redis.set(key, ts, ex=_REDIS_TS_TTL)
+            if hasattr(result, "__await__"):
+                await result
+        except Exception as exc:
+            self.logger.warning("Redis store_ts failed for %s: %s", source_id, exc)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -461,33 +468,6 @@ class OneDriveConnector(AbstractConnector):
             next_url = body.get("@odata.nextLink")
 
         return files
-
-    async def _classify_change(
-        self,
-        source_id: str,
-        last_modified: str,
-        since: datetime | None,
-    ) -> ChangeInfo | None:
-        """Return ChangeInfo when the file is new or was modified after *since*."""
-        if since is None:
-            return ChangeInfo(
-                source_id=source_id,
-                change_type="added",
-                timestamp=now_utc(),
-                details={"last_modified": last_modified},
-            )
-
-        stored_ts = await _load_ts(self.config.connector_id, source_id)
-        if stored_ts is None or last_modified > stored_ts:
-            change_type = "added" if stored_ts is None else "modified"
-            return ChangeInfo(
-                source_id=source_id,
-                change_type=change_type,
-                timestamp=parse_utc_iso(last_modified) if last_modified else now_utc(),
-                details={"last_modified": last_modified},
-            )
-
-        return None
 
     def _file_to_source_info(self, file_item: Dict[str, Any]) -> SourceInfo | None:
         """Convert a Graph API file item to SourceInfo."""

--- a/autobot-backend/knowledge/connectors/slack.py
+++ b/autobot-backend/knowledge/connectors/slack.py
@@ -50,8 +50,10 @@ from knowledge.connectors.registry import ConnectorRegistry
 logger = get_logger(__name__)
 
 _SLACK_API_BASE = "https://slack.com/api"
-_REDIS_TS_PREFIX = "connector:slack:ts:"
-_REDIS_TS_TTL = 86400 * 30  # 30 days
+
+# Issue #12659: _load_ts()/_store_ts() moved to AbstractConnector — this
+# connector's Redis prefix ("connector:slack:ts:") matches the base class
+# default derived from connector_type, so no override is needed.
 
 
 @ConnectorRegistry.register("slack")
@@ -143,7 +145,7 @@ class SlackConnector(AbstractConnector):
             reply_count = len(replies)
             text_parts.extend(_message_to_text(r) for r in replies)
 
-        await _store_ts(self.config.connector_id, channel_id, ts)
+        await self._store_ts(channel_id, ts)
         return ContentResult(
             source_id=source_id,
             content="\n\n".join(p for p in text_parts if p.strip()),
@@ -163,7 +165,7 @@ class SlackConnector(AbstractConnector):
         changes: List[ChangeInfo] = []
         for channel_id in self._channel_ids:
             oldest = self._since_to_ts(since)
-            stored = await _load_ts(self.config.connector_id, channel_id)
+            stored = await self._load_ts(channel_id)
             messages = await self._history(channel_id, oldest=oldest)
             newest_ts = stored
             for message in messages:
@@ -180,7 +182,7 @@ class SlackConnector(AbstractConnector):
                 if newest_ts is None or ts > newest_ts:
                     newest_ts = ts
             if newest_ts is not None and newest_ts != stored:
-                await _store_ts(self.config.connector_id, channel_id, newest_ts)
+                await self._store_ts(channel_id, newest_ts)
         return changes
 
     # ------------------------------------------------------------------
@@ -273,43 +275,6 @@ class SlackConnector(AbstractConnector):
         except aiohttp.ClientError as exc:
             self.logger.warning("Slack request to %s failed: %s", url, exc)
             return {"status_code": 0, "body": {"ok": False, "error": str(exc)}}
-
-
-# ---------------------------------------------------------------------------
-# Redis checkpoint helpers
-# ---------------------------------------------------------------------------
-
-
-async def _load_ts(connector_id: str, channel_id: str) -> Optional[str]:
-    """Load the newest processed message ``ts`` for *channel_id* from Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, channel_id)
-        value = redis.get(key)
-        if hasattr(value, "__await__"):
-            value = await value
-        if isinstance(value, bytes):
-            return value.decode("utf-8")
-        return value
-    except Exception as exc:
-        logger.warning("Redis load_ts failed for channel %s: %s", channel_id, exc)
-        return None
-
-
-async def _store_ts(connector_id: str, channel_id: str, ts: str) -> None:
-    """Persist the newest processed message ``ts`` for *channel_id* in Redis."""
-    try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = get_redis_client(database="knowledge")
-        key = "%s%s:%s" % (_REDIS_TS_PREFIX, connector_id, channel_id)
-        result = redis.set(key, ts, ex=_REDIS_TS_TTL)
-        if hasattr(result, "__await__"):
-            await result
-    except Exception as exc:
-        logger.warning("Redis store_ts failed for channel %s: %s", channel_id, exc)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/knowledge/connectors/slack_test.py
+++ b/autobot-backend/knowledge/connectors/slack_test.py
@@ -128,8 +128,8 @@ class TestSlackConnectorChangeDetection:
         history_body = {"ok": True, "messages": [{"ts": "1000.001", "user": "U1", "text": "hi"}]}
         with (
             patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post,
-            patch("knowledge.connectors.slack._load_ts", new=AsyncMock(return_value=None)),
-            patch("knowledge.connectors.slack._store_ts", new=AsyncMock()),
+            patch.object(connector, "_load_ts", new=AsyncMock(return_value=None)),
+            patch.object(connector, "_store_ts", new=AsyncMock()),
         ):
             mock_post.return_value = {"status_code": 200, "body": history_body}
             changes = await connector.detect_changes(since=None)

--- a/autobot_shared/notion_utils.py
+++ b/autobot_shared/notion_utils.py
@@ -1,0 +1,34 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Notion API response parsing helpers.
+
+Issue #12659: ``extract_title()`` was a byte-identical ``_extract_title()``
+copy in both ``integrations/notion_integration.py`` and
+``knowledge/connectors/notion.py``. Neither module depends on the other
+(one implements the agent-callable integrations framework, the other the
+knowledge-connector sync pipeline), so the shared helper lives here rather
+than in either module.
+"""
+
+from typing import Any, Dict
+
+
+def extract_title(obj: Dict[str, Any]) -> str:
+    """Extract the plain-text title from a Notion page or database object."""
+    # Database title field
+    title_array = obj.get("title", [])
+    if title_array and isinstance(title_array, list):
+        return "".join(t.get("plain_text", "") for t in title_array)
+
+    # Page title via Name property
+    props = obj.get("properties", {})
+    for prop_name in ("Name", "Title", "title"):
+        prop = props.get(prop_name, {})
+        title_values = prop.get("title", [])
+        if title_values:
+            return "".join(t.get("plain_text", "") for t in title_values)
+
+    return ""


### PR DESCRIPTION
## Thinking Path

Diffed the six `_load_ts()` copies (`confluence`, `gitlab`+`gitea`, `jira`, `slack`, `gdrive`, `nextcloud`) line-by-line: identical Redis get/decode logic, differing only in module-level `_REDIS_TS_PREFIX`/`_REDIS_TS_TTL` values (all `86400*30`, prefix always `"connector:<connector_type>:ts:"` — except `gitea`, which deliberately reuses `gitlab`'s prefix since both classes live in `gitlab.py`). `_store_ts()` is the byte-identical mirror write path for the same six, so it was folded in alongside `_load_ts()` (same duplication, same fix).

Diffed `detect_changes()`/`_classify_change()` for `gdrive`/`onedrive`: `_classify_change()` is 100% byte-identical; `detect_changes()` differs only in the `source_id` prefix (which equals `connector_type` in both) and the API's per-file timestamp field name (`modifiedTime` vs `lastModifiedDateTime`).

**Base design** — extended the existing `AbstractConnector` (`knowledge/connectors/base.py`, already the canonical connector base — did not create a parallel one):
- `_load_ts()`/`_store_ts()` — new instance methods; key prefix derives from `_ts_redis_prefix` (defaults to `"connector:<connector_type>:ts:"`, override when it must differ — used by `GiteaConnector` to preserve its `gitlab`-shared namespace exactly).
- `_classify_change()` + `_detect_changes_via_file_listing()` — new instance methods; the file-listing helper reads `_modified_time_field` (default `"modifiedTime"`, `OneDriveConnector` overrides to `"lastModifiedDateTime"`) and delegates to the connector's existing `_list_all_files()`.
- **OneDrive exception (documented, not folded in):** `OneDriveConnector`'s own `_load_ts`/`_store_ts` have an explicit `redis is None` guard and a stricter `isinstance(value, str)` check that the other six connectors' copies lack. Folding these into the base would silently drop that defensive behavior, so they're kept as instance-method overrides on `OneDriveConnector` (shadowing the base) — `_classify_change()` calls `self._load_ts()`, which resolves to the override via normal MRO, so `OneDriveConnector`'s distinct behavior is fully preserved while `detect_changes()`/`_classify_change()` are still shared with `gdrive.py`.

**`_extract_title()` disposition:** confirmed byte-identical between `integrations/notion_integration.py:330` and `knowledge/connectors/notion.py:319`. Neither module imports the other (one implements the agent-callable integrations framework, the other the knowledge-connector sync pipeline) so importing one from the other would create an artificial coupling. Single-sourced into a new `autobot_shared/notion_utils.py::extract_title()`, imported by both modules as `extract_title as _extract_title` (zero call-site changes).

## What Changed

- `autobot-backend/knowledge/connectors/base.py` — added `_ts_redis_key()`, `_load_ts()`, `_store_ts()`, `_classify_change()`, `_detect_changes_via_file_listing()`, and the `_ts_redis_prefix`/`_modified_time_field` class attributes.
- `confluence.py`, `gitlab.py` (GitLab + Gitea), `jira.py`, `slack.py`, `gdrive.py`, `nextcloud.py` — deleted the duplicated `_load_ts()`/`_store_ts()` module functions; call sites now use `self._load_ts()`/`self._store_ts()`. `GitLabConnector`/`GiteaConnector` set `_ts_redis_prefix` explicitly to preserve their shared namespace.
- `gdrive.py`/`onedrive.py` — deleted the duplicated `_classify_change()` method and the `detect_changes()` body; both now delegate to `AbstractConnector._detect_changes_via_file_listing()`. `OneDriveConnector` keeps its own `_load_ts`/`_store_ts` overrides (see Thinking Path) and sets `_modified_time_field = "lastModifiedDateTime"`.
- `autobot_shared/notion_utils.py` (new) — single-sourced `extract_title()`.
- `integrations/notion_integration.py`, `knowledge/connectors/notion.py` — import `extract_title as _extract_title` instead of each defining its own copy.
- `knowledge/connectors/gdrive_test.py`, `knowledge/connectors/slack_test.py` — updated `patch("knowledge.connectors.<mod>._load_ts"/"_store_ts", ...)` to `patch.object(connector, "_load_ts"/"_store_ts", ...)` since the target moved from a module function to an inherited instance method.

No public interface changes — every connector's `connector_type`, config schema, and registry registration are unchanged; `ConnectorRegistry` still instantiates all seven classes (`confluence`, `gitlab`, `gitea`/`forgejo`, `jira`, `slack`, `gdrive`, `nextcloud`, `onedrive`) exactly as before.

## Verification

```
python3 -m pytest knowledge/connectors/confluence_test.py knowledge/connectors/gdrive_test.py \
  knowledge/connectors/jira_test.py knowledge/connectors/slack_test.py knowledge/connectors/onedrive_test.py \
  knowledge/connectors/connector_batch_b_test.py knowledge/connectors/connectors_init_gating_test.py \
  knowledge/connectors/registry_health_test.py knowledge/connectors/registry_public_api_test.py \
  knowledge/connectors/tier_test.py knowledge/connectors/versioning_test.py knowledge/connectors/mock_test.py \
  knowledge/connectors/audio_connector_test.py knowledge/connectors/external_adapter_test.py \
  knowledge/connectors/scheduler_test.py integrations/notion_integration_test.py -q
# 239 passed, 35 warnings
```

- `python3 -m flake8`/`pyflakes` on all 11 touched files: 0 issues.
- Import-smoke: all 6 refactored connectors + `base.py` + `notion.py` + `notion_integration.py` + `autobot_shared/notion_utils.py` import cleanly.
- `grep -rn "async def _load_ts" knowledge/connectors/` → exactly 2 hits: `base.py` (canonical) and `onedrive.py` (documented override); `grep -rn "async def _classify_change"` → `base.py` (gdrive/onedrive shared) plus `confluence.py`/`jira.py` (pre-existing, unrelated per-connector methods with different signatures, out of this issue's scope).
- `grep -rln "def extract_title"` → exactly one definition, in `autobot_shared/notion_utils.py`.
- Pre-existing, unrelated failure noted (not touched by this PR): `connector_resilience_test.py::TestWebCrawlerSyncCheckpoint::test_crawled_seeds_written_to_checkpoint` fails on this environment both before and after this change — reproducible in isolation, unrelated to `web_crawler.py` (not touched here).

Closes #12659
Refs #12645

## Model Used
Sonnet 5