### PR TITLE
tech-debt(backend): extract shared bases for code-analysis tooling + analyzers (#12660)

### DIFF
--- a/autobot-backend/code_analysis/auto-tools/logging_standardizer.py
+++ b/autobot-backend/code_analysis/auto-tools/logging_standardizer.py
@@ -12,14 +12,21 @@ NOTE: create_dev_logger_utility (~144 lines) is an ACCEPTABLE EXCEPTION
 per Issue #490 - code generator producing utility module. Low priority.
 """
 
-import argparse
-import json
-import os
-import re
-import shutil
-from datetime import datetime, timezone
+import sys
 from pathlib import Path
-from typing import Dict, Tuple
+
+# Issue #12660: auto-tools/ has no __init__.py (hyphenated dir name isn't a
+# valid package identifier) — add this directory to sys.path so the shared
+# tool skeleton can be imported by every standalone script here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import json  # noqa: E402
+import os  # noqa: E402
+import re  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from typing import Dict, Tuple  # noqa: E402
+
+from tool_base import ConsoleLogToolBase  # noqa: E402
 
 _DEV_LOGGER_JS_CODE = """/**
  * Development Logger Utility
@@ -155,8 +162,20 @@ export { devLog as logger };
 """
 
 
-class DevLoggingFixer:
-    """Replaces console.log with environment-aware development logging."""
+class DevLoggingFixer(ConsoleLogToolBase):
+    """Replaces console.log with environment-aware development logging.
+
+    Issue #12660: create_backup/process_file/cli_main now live on
+    ``ConsoleLogToolBase``; this class only provides the console.log
+    conversion logic and the logging_standardizer.py-specific report text.
+    """
+
+    ARG_DESCRIPTION = "Convert console.log to environment-aware development logging"
+    PROJECT_PATH_HELP = "Path to the project root or specific directory to convert"
+    TARGET_DIR_HELP = "Specific directory to convert (e.g., src/)"
+    REPORT_HELP = "Path for the conversion report"
+    REPORT_COUNT_KEY = "console_logs_converted"
+    ERROR_MESSAGE = "File standardization failed"
 
     def __init__(self, project_root: str, backup_dir: str = None):
         self.project_root = Path(project_root)
@@ -213,17 +232,6 @@ class DevLoggingFixer:
             return False
 
         return True
-
-    def create_backup(self, file_path: Path) -> Path:
-        """Create backup of file before modification."""
-        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-        relative_path = file_path.relative_to(self.project_root)
-        backup_path = self.backup_dir / timestamp / relative_path
-
-        backup_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(file_path, backup_path)
-
-        return backup_path
 
     def _get_dev_logger_js_code(self) -> str:
         """
@@ -395,38 +403,13 @@ class DevLoggingFixer:
 
         return single_quotes % 2 == 1 or double_quotes % 2 == 1
 
-    def process_file(self, file_path: Path) -> bool:
-        """Process a single file to convert console.logs."""
-        try:
-            # Read file content
-            with open(file_path, "r", encoding="utf-8") as f:
-                original_content = f.read()
+    def _transform_content(self, content: str, file_path: Path) -> Tuple[str, int]:
+        """Hook for ``ConsoleLogToolBase.process_file``: convert console.logs."""
+        return self.convert_console_logs(content, file_path)
 
-            # Convert console.logs
-            modified_content, converted_count = self.convert_console_logs(original_content, file_path)
-
-            # If content changed, write back
-            if converted_count > 0:
-                # Create backup
-                self.create_backup(file_path)
-
-                # Write modified content
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(modified_content)
-
-                self.report["console_logs_converted"] += converted_count
-                return True
-
-            return False
-
-        except Exception:
-            self.report["errors"].append(
-                {
-                    "file": str(file_path.relative_to(self.project_root)),
-                    "error": "File standardization failed",
-                }
-            )
-            return False
+    def run_project(self, target_dir: str = None) -> Dict:
+        """Hook for ``ConsoleLogToolBase.cli_main``."""
+        return self.convert_project(target_dir)
 
     def convert_project(self, target_dir: str = None) -> Dict:
         """Convert console.logs in entire project or specific directory."""
@@ -573,42 +556,22 @@ Import statement has been added: `import {{ devLog }} from '@/utils/devLogger.js
 
         self._save_report_files(report_content, output_file)
 
+    def _print_cli_summary(self, report: Dict) -> None:
+        """Hook for ``ConsoleLogToolBase.cli_main``."""
+        print(f"\n🎉 Conversion Complete!")  # noqa: print
+        print(f"   - Converted {report['console_logs_converted']} console.log statements")  # noqa: print
+        print(f"   - Modified {report['files_modified']} files")  # noqa: print
+        print(f"   - Created development logger utility")  # noqa: print
+        print(f"   - Backups saved to: {self.backup_dir}")  # noqa: print
+
 
 def main():
     """Main entry point for the development logging conversion tool."""
-    parser = argparse.ArgumentParser(description="Convert console.log to environment-aware development logging")
-    parser.add_argument("project_path", help="Path to the project root or specific directory to convert")
-    parser.add_argument("--target-dir", help="Specific directory to convert (e.g., src/)", default=None)
-    parser.add_argument("--backup-dir", help="Directory to store backups", default=None)
-    parser.add_argument("--report", help="Path for the conversion report", default=None)
-
-    args = parser.parse_args()
-
-    # Create converter instance
-    converter = DevLoggingFixer(args.project_path, args.backup_dir)
-
-    # Run conversion
-    if args.target_dir:
-        target_path = Path(args.project_path) / args.target_dir
-        report = converter.convert_project(str(target_path))
-    else:
-        report = converter.convert_project()
-
-    # Generate report
-    converter.generate_report(args.report)
-
-    # Print summary
-    print(f"\n🎉 Conversion Complete!")  # noqa: print
-    print(f"   - Converted {report['console_logs_converted']} console.log statements")  # noqa: print
-    print(f"   - Modified {report['files_modified']} files")  # noqa: print
-    print(f"   - Created development logger utility")  # noqa: print
-    print(f"   - Backups saved to: {converter.backup_dir}")  # noqa: print
+    DevLoggingFixer.cli_main()
 
 
 if __name__ == "__main__":
     # If run directly without arguments, use AutoBot defaults
-    import sys
-
     if len(sys.argv) == 1:
         # Default to AutoBot frontend directory - use project-relative path
         # This script is in tools/code-analysis-suite/auto-tools/, so project root is 3 levels up

--- a/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
+++ b/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
@@ -7,20 +7,40 @@ Intelligently removes console.log statements from production code
 while preserving important console methods and handling edge cases.
 """
 
-import argparse
-import json
-import os
-import re
-import shutil
-from datetime import datetime, timezone
+import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
 
-from autobot_shared.ssot_config import config
+# Issue #12660: auto-tools/ has no __init__.py (hyphenated dir name isn't a
+# valid package identifier) — add this directory to sys.path so the shared
+# tool skeleton can be imported by every standalone script here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import argparse  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+import re  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from typing import Dict, List, Tuple  # noqa: E402
+
+from autobot_shared.ssot_config import config  # noqa: E402
+from tool_base import ConsoleLogToolBase  # noqa: E402
 
 
-class ConsoleLogCleaner:
-    """Removes console.log statements from JavaScript/TypeScript/Vue files."""
+class ConsoleLogCleaner(ConsoleLogToolBase):
+    """Removes console.log statements from JavaScript/TypeScript/Vue files.
+
+    Issue #12660: create_backup/process_file/cli_main now live on
+    ``ConsoleLogToolBase``; this class only provides the console.log
+    removal logic and the performance_optimizer.py-specific report text
+    and extra CLI flags.
+    """
+
+    ARG_DESCRIPTION = "Remove console.log statements from JavaScript/TypeScript/Vue files"
+    PROJECT_PATH_HELP = "Path to the project root or specific directory to clean"
+    TARGET_DIR_HELP = "Specific directory to clean (e.g., src/)"
+    REPORT_HELP = "Path for the cleanup report"
+    REPORT_COUNT_KEY = "console_logs_removed"
+    ERROR_MESSAGE = "File optimization failed"
 
     def __init__(self, project_root: str, backup_dir: str = None):
         self.project_root = Path(project_root)
@@ -93,17 +113,6 @@ class ConsoleLogCleaner:
             return False
 
         return True
-
-    def create_backup(self, file_path: Path) -> Path:
-        """Create backup of file before modification."""
-        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-        relative_path = file_path.relative_to(self.project_root)
-        backup_path = self.backup_dir / timestamp / relative_path
-
-        backup_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(file_path, backup_path)
-
-        return backup_path
 
     def _resolve_console_log_match(
         self, content: str, line: str, line_start_pos: int, match: "re.Match"
@@ -293,38 +302,13 @@ class ConsoleLogCleaner:
 
         return modified_content, removed_count
 
-    def process_file(self, file_path: Path) -> bool:
-        """Process a single file to remove console.logs."""
-        try:
-            # Read file content
-            with open(file_path, "r", encoding="utf-8") as f:
-                original_content = f.read()
+    def _transform_content(self, content: str, file_path: Path) -> Tuple[str, int]:
+        """Hook for ``ConsoleLogToolBase.process_file``: remove console.logs."""
+        return self.remove_console_logs(content, file_path)
 
-            # Remove console.logs
-            modified_content, removed_count = self.remove_console_logs(original_content, file_path)
-
-            # If content changed, write back
-            if removed_count > 0:
-                # Create backup
-                self.create_backup(file_path)
-
-                # Write modified content
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(modified_content)
-
-                self.report["console_logs_removed"] += removed_count
-                return True
-
-            return False
-
-        except Exception:
-            self.report["errors"].append(
-                {
-                    "file": str(file_path.relative_to(self.project_root)),
-                    "error": "File optimization failed",
-                }
-            )
-            return False
+    def run_project(self, target_dir: str = None) -> Dict:
+        """Hook for ``ConsoleLogToolBase.cli_main``."""
+        return self.clean_project(target_dir)
 
     def clean_project(self, target_dir: str = None) -> Dict:
         """Clean console.logs from entire project or specific directory."""
@@ -409,56 +393,40 @@ class ConsoleLogCleaner:
             json.dump(self.report, f, indent=2)
         print(f"📊 JSON report saved to: {json_report_path}")  # noqa: print
 
+    @classmethod
+    def _extra_cli_args(cls, parser: argparse.ArgumentParser) -> None:
+        """Hook for ``ConsoleLogToolBase.cli_main``: cleanup-specific flags."""
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be removed without making changes",
+        )
+        parser.add_argument(
+            "--dev-mode",
+            action="store_true",
+            help="Enable development mode - preserve console.error, console.warn, etc.",
+        )
+        parser.add_argument(
+            "--replace-with-dev-logging",
+            action="store_true",
+            help="Replace console.log with environment-aware logging",
+        )
+
+    def _print_cli_summary(self, report: Dict) -> None:
+        """Hook for ``ConsoleLogToolBase.cli_main``."""
+        print(f"\n🎉 Cleanup Complete!")  # noqa: print
+        print(f"   - Removed {report['console_logs_removed']} console.log statements")  # noqa: print
+        print(f"   - Modified {report['files_modified']} files")  # noqa: print
+        print(f"   - Backups saved to: {self.backup_dir}")  # noqa: print
+
 
 def main():
     """Main entry point for the console.log cleanup tool."""
-    parser = argparse.ArgumentParser(description="Remove console.log statements from JavaScript/TypeScript/Vue files")
-    parser.add_argument("project_path", help="Path to the project root or specific directory to clean")
-    parser.add_argument("--target-dir", help="Specific directory to clean (e.g., src/)", default=None)
-    parser.add_argument("--backup-dir", help="Directory to store backups", default=None)
-    parser.add_argument("--report", help="Path for the cleanup report", default=None)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be removed without making changes",
-    )
-    parser.add_argument(
-        "--dev-mode",
-        action="store_true",
-        help="Enable development mode - preserve console.error, console.warn, etc.",
-    )
-    parser.add_argument(
-        "--replace-with-dev-logging",
-        action="store_true",
-        help="Replace console.log with environment-aware logging",
-    )
-
-    args = parser.parse_args()
-
-    # Create cleaner instance
-    cleaner = ConsoleLogCleaner(args.project_path, args.backup_dir)
-
-    # Run cleanup
-    if args.target_dir:
-        target_path = Path(args.project_path) / args.target_dir
-        report = cleaner.clean_project(str(target_path))
-    else:
-        report = cleaner.clean_project()
-
-    # Generate report
-    cleaner.generate_report(args.report)
-
-    # Print summary
-    print(f"\n🎉 Cleanup Complete!")  # noqa: print
-    print(f"   - Removed {report['console_logs_removed']} console.log statements")  # noqa: print
-    print(f"   - Modified {report['files_modified']} files")  # noqa: print
-    print(f"   - Backups saved to: {cleaner.backup_dir}")  # noqa: print
+    ConsoleLogCleaner.cli_main()
 
 
 if __name__ == "__main__":
     # If run directly without arguments, use AutoBot defaults
-    import sys
-
     if len(sys.argv) == 1:
         # Default to AutoBot frontend directory
         project_root = config.base_dir  # noqa: ssot-path

--- a/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
+++ b/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
@@ -22,8 +22,9 @@ import re  # noqa: E402
 from datetime import datetime, timezone  # noqa: E402
 from typing import Dict, List, Tuple  # noqa: E402
 
-from autobot_shared.ssot_config import config  # noqa: E402
 from tool_base import ConsoleLogToolBase  # noqa: E402
+
+from autobot_shared.ssot_config import config  # noqa: E402
 
 
 class ConsoleLogCleaner(ConsoleLogToolBase):

--- a/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
@@ -24,12 +24,19 @@ initialization of security agent with comprehensive report structure. Low priori
 """
 
 import logging
+import sys
+from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = get_logger(__name__)
+
+# Issue #12660: auto-tools/ has no __init__.py (hyphenated dir name isn't a
+# valid package identifier) — add this directory to sys.path so the shared
+# tool skeleton can be imported by every standalone script here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # Issue #380: Module-level constant for HTML extensions (performance optimization)
 _HTML_EXTENSIONS = (".html", ".htm")
@@ -94,21 +101,26 @@ _DOM_PURIFY_SCRIPT = """
 })();
 </script>"""
 
-import hashlib
-import json
-import os
-import re
-import shutil
-import sys
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
+import hashlib  # noqa: E402
+import os  # noqa: E402
+import re  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from typing import Any, Dict, List, Tuple  # noqa: E402
+
+from tool_base import SecurityFixToolBase  # noqa: E402
 
 
-class SecurityFixAgent:
+class SecurityFixAgent(SecurityFixToolBase):
     """
     Enhanced automated security fix agent for comprehensive XSS vulnerability remediation.
+
+    Issue #12660: create_backup/save_report/cli_main now live on
+    ``SecurityFixToolBase``; this class only provides the XSS scan/fix
+    logic and the enhanced_security_tool.py-specific report text.
     """
+
+    REPORT_FILE_PREFIX = "enhanced_security_report"
+    USAGE_PROGRAM_NAME = "enhanced_security_tool.py"
 
     @staticmethod
     def _build_xss_patterns() -> Dict[str, Any]:
@@ -245,26 +257,6 @@ class SecurityFixAgent:
             any(lib in code.lower() for lib in ["react", "vue", "angular", "jquery", "lodash"]),
         ]
         return sum(indicators) >= 2
-
-    def create_backup(self, file_path: str) -> str:
-        """Create a backup of the original file."""
-        try:
-            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-            backup_name = f"{Path(file_path).name}.backup_{timestamp}"
-
-            if not self.backup_dir:
-                self.backup_dir = Path(file_path).parent / "security_backups"
-                self.backup_dir.mkdir(exist_ok=True)
-
-            backup_path = self.backup_dir / backup_name
-            shutil.copy2(file_path, backup_path)
-
-            logger.info("Backup created: %sbackup_path ")
-            return str(backup_path)
-
-        except Exception:
-            logger.error("Failed to create backup: %se ")
-            return ""
 
     def scan_for_vulnerabilities(self, content: str, file_path: str) -> List[Dict[str, Any]]:
         """Enhanced vulnerability scanning with context analysis."""
@@ -820,29 +812,6 @@ The Enhanced Security Fix Agent implements a multi-layered defense strategy:
 
         return report_content
 
-    def save_report(self, report_content: str, output_dir: str) -> str:
-        """Save the comprehensive security report."""
-        try:
-            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-            report_filename = f"enhanced_security_report_{timestamp}.md"
-            report_path = os.path.join(output_dir, report_filename)
-
-            with open(report_path, "w", encoding="utf-8") as f:
-                f.write(report_content)
-
-            # Also save JSON version for machine processing
-            json_filename = f"enhanced_security_report_{timestamp}.json"
-            json_path = os.path.join(output_dir, json_filename)
-
-            with open(json_path, "w", encoding="utf-8") as f:
-                json.dump(self.report, f, indent=2)
-
-            return report_path
-
-        except Exception:
-            logger.error("Error saving report: %se ")
-            return ""
-
     def run(self, target_path: str) -> None:
         """Main execution method."""
         logger.info("🛡️  AutoBot Enhanced Security Fix Agent v2.0.0")
@@ -902,20 +871,7 @@ The Enhanced Security Fix Agent implements a multi-layered defense strategy:
 
 def main():
     """Main entry point."""
-    if len(sys.argv) != 2:
-        logger.info("Usage: python enhanced_security_tool.py <file_or_directory_path>")
-        logger.info("Example: python enhanced_security_tool.py /path/to/playwright-report/")
-        sys.exit(1)
-
-    target_path = sys.argv[1]
-
-    if not os.path.exists(target_path):
-        logger.error("Error: Path '%starget_path ' does not exist")
-        sys.exit(1)
-
-    # Create and run the enhanced security fix agent
-    agent = SecurityFixAgent()
-    agent.run(target_path)
+    SecurityFixAgent.cli_main()
 
 
 if __name__ == "__main__":

--- a/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
@@ -20,6 +20,8 @@ Version: 1.0.0
 """
 
 import logging
+import sys
+from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
 
@@ -30,21 +32,31 @@ logger = get_logger(__name__)
 # Issue #380: Module-level constant for HTML extensions (performance optimization)
 _HTML_EXTENSIONS = (".html", ".htm")
 
-import hashlib
-import json
-import os
-import re
-import shutil
-import sys
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
+# Issue #12660: auto-tools/ has no __init__.py (hyphenated dir name isn't a
+# valid package identifier) — add this directory to sys.path so the shared
+# tool skeleton can be imported by every standalone script here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import hashlib  # noqa: E402
+import os  # noqa: E402
+import re  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from typing import Any, Dict, List, Tuple  # noqa: E402
+
+from tool_base import SecurityFixToolBase  # noqa: E402
 
 
-class SecurityFixAgent:
+class SecurityFixAgent(SecurityFixToolBase):
     """
     Automated security fix agent for XSS vulnerability remediation.
+
+    Issue #12660: create_backup/save_report/cli_main now live on
+    ``SecurityFixToolBase``; this class only provides the XSS scan/fix
+    logic and the security_tool.py-specific report text.
     """
+
+    REPORT_FILE_PREFIX = "security_fix_report"
+    USAGE_PROGRAM_NAME = "security_tool.py"
 
     def __init__(self):
         self.fixes_applied = []
@@ -98,26 +110,6 @@ class SecurityFixAgent:
                 "helper_needed": None,
             },
         }
-
-    def create_backup(self, file_path: str) -> str:
-        """Create a backup of the original file."""
-        try:
-            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-            backup_name = f"{Path(file_path).name}.backup_{timestamp}"
-
-            if not self.backup_dir:
-                self.backup_dir = Path(file_path).parent / "security_backups"
-                self.backup_dir.mkdir(exist_ok=True)
-
-            backup_path = self.backup_dir / backup_name
-            shutil.copy2(file_path, backup_path)
-
-            logger.info("Backup created: %sbackup_path ")
-            return str(backup_path)
-
-        except Exception:
-            logger.error("Failed to create backup: %se ")
-            return ""
 
     def scan_for_vulnerabilities(self, content: str, file_path: str) -> List[Dict[str, Any]]:
         """Scan content for XSS vulnerabilities."""
@@ -622,29 +614,6 @@ class SecurityFixAgent:
 
         return report_content
 
-    def save_report(self, report_content: str, output_dir: str) -> str:
-        """Save the security report to file."""
-        try:
-            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
-            report_filename = f"security_fix_report_{timestamp}.md"
-            report_path = os.path.join(output_dir, report_filename)
-
-            with open(report_path, "w", encoding="utf-8") as f:
-                f.write(report_content)
-
-            # Also save JSON version for machine processing
-            json_filename = f"security_fix_report_{timestamp}.json"
-            json_path = os.path.join(output_dir, json_filename)
-
-            with open(json_path, "w", encoding="utf-8") as f:
-                json.dump(self.report, f, indent=2)
-
-            return report_path
-
-        except Exception:
-            logger.error("Error saving report: %se ")
-            return ""
-
     def run(self, target_path: str) -> None:
         """Main execution method."""
         logger.info("🛡️  AutoBot Security Fix Agent v1.0.0")
@@ -701,20 +670,7 @@ class SecurityFixAgent:
 
 def main():
     """Main entry point."""
-    if len(sys.argv) != 2:
-        logger.info("Usage: python security_tool.py <file_or_directory_path>")
-        logger.info("Example: python security_tool.py /path/to/playwright-report/")
-        sys.exit(1)
-
-    target_path = sys.argv[1]
-
-    if not os.path.exists(target_path):
-        logger.error("Error: Path '%starget_path ' does not exist")
-        sys.exit(1)
-
-    # Create and run the security fix agent
-    agent = SecurityFixAgent()
-    agent.run(target_path)
+    SecurityFixAgent.cli_main()
 
 
 if __name__ == "__main__":

--- a/autobot-backend/code_analysis/auto-tools/tool_base.py
+++ b/autobot-backend/code_analysis/auto-tools/tool_base.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared skeleton for the auto-tools CLI sanitizer/fixer scripts (Issue #12660).
+
+``security_sanitizer.py``/``security_deep_sanitizer.py`` and
+``logging_standardizer.py``/``performance_optimizer.py`` each independently
+reimplemented the same ``create_backup``/``save_report``/``process_file``/
+``main`` skeleton (verified byte-identical within each pair). This module
+hosts those two skeletons exactly once; concrete tools subclass one of the
+two bases below and only override their own vulnerability/transform logic.
+
+This directory has no ``__init__.py`` (auto-tools is not an importable
+package — the hyphen in the directory name is not a valid Python identifier,
+and every tool here is invoked as a standalone script). Importers add this
+directory to ``sys.path`` before importing this module; see the top of any
+concrete tool for the pattern.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+class SecurityFixToolBase:
+    """Shared backup/report/CLI skeleton for the XSS security-fix tools.
+
+    Verified byte-identical between ``security_sanitizer.SecurityFixAgent``
+    and ``security_deep_sanitizer.SecurityFixAgent`` (module-level class name
+    collision across two separate scripts — not the same class).
+
+    Subclasses MUST set:
+        - ``REPORT_FILE_PREFIX``: filename prefix for the saved report
+          (e.g. ``"security_fix_report"``, ``"enhanced_security_report"``).
+        - ``USAGE_PROGRAM_NAME``: program name shown in ``cli_main()`` usage
+          text (e.g. ``"security_tool.py"``).
+
+    Subclasses still own ``__init__`` (different ``xss_patterns``/
+    ``safe_fixes`` dicts), the vulnerability scan/fix methods, and ``run()``
+    — those are genuine per-tool specifics, not skeleton.
+    """
+
+    REPORT_FILE_PREFIX: str = "security_fix_report"
+    USAGE_PROGRAM_NAME: str = "security_tool.py"
+
+    def create_backup(self, file_path: str) -> str:
+        """Create a backup of the original file."""
+        try:
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+            backup_name = f"{Path(file_path).name}.backup_{timestamp}"
+
+            if not self.backup_dir:
+                self.backup_dir = Path(file_path).parent / "security_backups"
+                self.backup_dir.mkdir(exist_ok=True)
+
+            backup_path = self.backup_dir / backup_name
+            shutil.copy2(file_path, backup_path)
+
+            logger.info("Backup created: %s", backup_path)
+            return str(backup_path)
+
+        except Exception as e:
+            logger.error("Failed to create backup: %s", e)
+            return ""
+
+    def save_report(self, report_content: str, output_dir: str) -> str:
+        """Save the security report to file."""
+        try:
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+            report_filename = f"{self.REPORT_FILE_PREFIX}_{timestamp}.md"
+            report_path = os.path.join(output_dir, report_filename)
+
+            with open(report_path, "w", encoding="utf-8") as f:
+                f.write(report_content)
+
+            # Also save JSON version for machine processing
+            json_filename = f"{self.REPORT_FILE_PREFIX}_{timestamp}.json"
+            json_path = os.path.join(output_dir, json_filename)
+
+            with open(json_path, "w", encoding="utf-8") as f:
+                json.dump(self.report, f, indent=2)
+
+            return report_path
+
+        except Exception as e:
+            logger.error("Error saving report: %s", e)
+            return ""
+
+    @classmethod
+    def cli_main(cls) -> None:
+        """Shared CLI entrypoint: validate args, construct the agent, run it."""
+        if len(sys.argv) != 2:
+            logger.info("Usage: python %s <file_or_directory_path>", cls.USAGE_PROGRAM_NAME)
+            logger.info("Example: python %s /path/to/playwright-report/", cls.USAGE_PROGRAM_NAME)
+            sys.exit(1)
+
+        target_path = sys.argv[1]
+
+        if not os.path.exists(target_path):
+            logger.error("Error: Path '%s' does not exist", target_path)
+            sys.exit(1)
+
+        agent = cls()
+        agent.run(target_path)
+
+
+class ConsoleLogToolBase:
+    """Shared backup/process/CLI skeleton for the console.log auto-tools.
+
+    Verified byte-identical between ``logging_standardizer.DevLoggingFixer``
+    and ``performance_optimizer.ConsoleLogCleaner``.
+
+    Subclasses MUST set:
+        - ``ARG_DESCRIPTION``, ``PROJECT_PATH_HELP``, ``TARGET_DIR_HELP``,
+          ``REPORT_HELP``: argparse help text (kept per-tool verbatim).
+        - ``REPORT_COUNT_KEY``: ``self.report`` counter key incremented by
+          :meth:`process_file` on a successful transform.
+        - ``ERROR_MESSAGE``: text recorded in ``self.report["errors"]`` on a
+          processing failure.
+
+    Subclasses MUST implement:
+        - :meth:`_transform_content`: the actual console.log conversion/
+          removal logic (returns ``(modified_content, count)``).
+        - :meth:`run_project`: hook so :meth:`cli_main` can invoke either
+          ``convert_project``/``clean_project`` without renaming either
+          tool's existing public method.
+        - :meth:`_print_cli_summary`: per-tool completion message.
+
+    Subclasses MAY override :meth:`_extra_cli_args` to add tool-specific
+    flags (e.g. ``performance_optimizer``'s ``--dry-run``/``--dev-mode``).
+    """
+
+    ARG_DESCRIPTION: str = ""
+    PROJECT_PATH_HELP: str = ""
+    TARGET_DIR_HELP: str = ""
+    REPORT_HELP: str = ""
+    REPORT_COUNT_KEY: str = ""
+    ERROR_MESSAGE: str = "File processing failed"
+
+    def create_backup(self, file_path: Path) -> Path:
+        """Create backup of file before modification."""
+        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+        relative_path = file_path.relative_to(self.project_root)
+        backup_path = self.backup_dir / timestamp / relative_path
+
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(file_path, backup_path)
+
+        return backup_path
+
+    def _transform_content(self, content: str, file_path: Path) -> tuple:
+        """Hook: domain-specific console.log transform. Returns (content, count)."""
+        raise NotImplementedError
+
+    def process_file(self, file_path: Path) -> bool:
+        """Process a single file, backing it up and rewriting it if changed."""
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                original_content = f.read()
+
+            modified_content, count = self._transform_content(original_content, file_path)
+
+            if count > 0:
+                self.create_backup(file_path)
+
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write(modified_content)
+
+                self.report[self.REPORT_COUNT_KEY] += count
+                return True
+
+            return False
+
+        except Exception:
+            self.report["errors"].append(
+                {
+                    "file": str(file_path.relative_to(self.project_root)),
+                    "error": self.ERROR_MESSAGE,
+                }
+            )
+            return False
+
+    def run_project(self, target_dir: str = None) -> Dict[str, Any]:
+        """Hook: invoke this tool's project-wide pass (convert_project/clean_project)."""
+        raise NotImplementedError
+
+    @classmethod
+    def _extra_cli_args(cls, parser: argparse.ArgumentParser) -> None:
+        """Hook: tool-specific CLI flags. Default: none."""
+        return
+
+    def _print_cli_summary(self, report: Dict[str, Any]) -> None:
+        """Hook: per-tool completion summary printed by cli_main()."""
+        raise NotImplementedError
+
+    @classmethod
+    def cli_main(cls) -> None:
+        """Shared CLI entrypoint: parse args, run the project pass, report, summarize."""
+        parser = argparse.ArgumentParser(description=cls.ARG_DESCRIPTION)
+        parser.add_argument("project_path", help=cls.PROJECT_PATH_HELP)
+        parser.add_argument("--target-dir", help=cls.TARGET_DIR_HELP, default=None)
+        parser.add_argument("--backup-dir", help="Directory to store backups", default=None)
+        parser.add_argument("--report", help=cls.REPORT_HELP, default=None)
+        cls._extra_cli_args(parser)
+
+        args = parser.parse_args()
+
+        instance = cls(args.project_path, args.backup_dir)
+
+        if args.target_dir:
+            target_path = Path(args.project_path) / args.target_dir
+            report = instance.run_project(str(target_path))
+        else:
+            report = instance.run_project()
+
+        instance.generate_report(args.report)
+        instance._print_cli_summary(report)
+
+
+__all__ = ["SecurityFixToolBase", "ConsoleLogToolBase"]

--- a/autobot-backend/code_intelligence/performance_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/performance_analysis/analyzer.py
@@ -10,133 +10,39 @@ Issue #554: Added Vector/Redis/LLM infrastructure for semantic analysis.
 Contains the main PerformanceAnalyzer class and convenience functions.
 """
 
-import ast
 import re
-import time
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from code_intelligence.shared.analysis_base import (
+    HAS_ANALYTICS_INFRASTRUCTURE,
+    SIMILARITY_MEDIUM,
+    BaseCodeAnalyzer,
+)
 
 from .ast_visitor import PerformanceASTVisitor
 from .types import PerformanceIssue, PerformanceIssueType, PerformanceSeverity
 
-# Issue #554: Import analytics infrastructure for semantic analysis
-try:
-    from code_intelligence.analytics_infrastructure import (
-        SIMILARITY_MEDIUM,
-        SemanticAnalysisMixin,
-    )
-
-    HAS_ANALYTICS_INFRASTRUCTURE = True
-except ImportError:
-    HAS_ANALYTICS_INFRASTRUCTURE = False
-    SemanticAnalysisMixin = object  # Fallback to object if not available
-
-# Issue #607: Import shared caches for performance optimization
-try:
-    from code_intelligence.shared.ast_cache import get_ast_with_content
-
-    HAS_SHARED_CACHE = True
-except ImportError:
-    HAS_SHARED_CACHE = False
-
 logger = get_logger(__name__)
 
 
-class PerformanceAnalyzer(SemanticAnalysisMixin):
+class PerformanceAnalyzer(BaseCodeAnalyzer):
     """
     Main performance pattern analyzer.
 
     Issue #554: Now includes optional semantic analysis via ChromaDB/Redis/LLM
     infrastructure for detecting semantically similar performance issues.
+    Issue #12660: The scan/cache skeleton (``__init__``, ``analyze_file``,
+    ``analyze_directory``, ``analyze_directory_async``, ``_regex_analysis``,
+    ``_should_exclude``, ``cache_analysis_results``, ``get_cached_analysis``)
+    now lives in ``BaseCodeAnalyzer``; this class only provides the AST
+    visitor, the performance-specific ``_check_*`` regex checkers, and the
+    performance-shaped summary/report methods.
     """
 
-    def __init__(
-        self,
-        project_root: str | None = None,
-        exclude_patterns: List[str] | None = None,
-        use_semantic_analysis: bool = False,
-        use_cache: bool = True,
-        use_shared_cache: bool = True,
-    ):
-        """
-        Initialize performance analyzer with project root and exclusion patterns.
-
-        Args:
-            project_root: Root directory for analysis
-            exclude_patterns: Patterns to exclude from analysis
-            use_semantic_analysis: Whether to use LLM-based semantic analysis (Issue #554)
-            use_cache: Whether to use Redis caching for results (Issue #554)
-            use_shared_cache: Whether to use shared FileListCache/ASTCache (Issue #607)
-        """
-        self.project_root = Path(project_root) if project_root else Path.cwd()
-        self.exclude_patterns = exclude_patterns or [
-            "venv",
-            "node_modules",
-            ".git",
-            "__pycache__",
-            "*.pyc",
-            "test_*",
-            "*_test.py",
-            "archives",
-            "migrations",
-        ]
-        self.results: List[PerformanceIssue] = []
-        self.total_files_scanned: int = 0  # Issue #686: Track total files analyzed
-        self.use_semantic_analysis = use_semantic_analysis and HAS_ANALYTICS_INFRASTRUCTURE
-        self.use_shared_cache = use_shared_cache and HAS_SHARED_CACHE
-
-        # Issue #554: Initialize analytics infrastructure if semantic analysis enabled
-        if self.use_semantic_analysis:
-            self._init_infrastructure(
-                collection_name="performance_analysis_vectors",
-                use_llm=True,
-                use_cache=use_cache,
-                redis_database="analytics",
-            )
-
-    def analyze_file(self, file_path: str) -> List[PerformanceIssue]:
-        """
-        Analyze a single file for performance issues.
-
-        Issue #607: Uses shared ASTCache when available for performance.
-        """
-        findings: List[PerformanceIssue] = []
-        path = Path(file_path)
-
-        if not path.exists() or not path.suffix == ".py":
-            return findings
-
-        try:
-            # Issue #607: Use shared AST cache if available
-            if self.use_shared_cache:
-                tree, content = get_ast_with_content(file_path)
-                lines = content.split("\n") if content else []
-            else:
-                content = path.read_text(encoding="utf-8")
-                lines = content.split("\n")
-                try:
-                    tree = ast.parse(content)
-                except SyntaxError:
-                    tree = None
-
-            # AST-based analysis
-            if tree is not None:
-                visitor = PerformanceASTVisitor(str(path), lines)
-                visitor.visit(tree)
-                findings.extend(visitor.findings)
-            else:
-                logger.warning("Syntax error in %s, skipping AST analysis", file_path)
-
-            # Regex-based analysis for patterns AST can't catch
-            if content:
-                findings.extend(self._regex_analysis(str(path), content, lines))
-
-        except Exception as e:
-            logger.error("Error analyzing %s: %s", file_path, e)
-
-        return findings
+    AST_VISITOR_CLASS = PerformanceASTVisitor
+    SEMANTIC_COLLECTION_NAME = "performance_analysis_vectors"
+    CACHE_PREFIX = "performance_analysis"
 
     def _check_list_lookup_pattern(self, file_path: str, content: str, lines: List[str]) -> List[PerformanceIssue]:
         """
@@ -289,54 +195,14 @@ class PerformanceAnalyzer(SemanticAnalysisMixin):
                 )
         return findings
 
-    def _regex_analysis(self, file_path: str, content: str, lines: List[str]) -> List[PerformanceIssue]:
-        """
-        Perform regex-based performance analysis.
-
-        Issue #620: Refactored with extracted helper methods.
-        """
-        findings: List[PerformanceIssue] = []
-
-        # Check for list used as lookup (Issue #620: uses helper)
-        findings.extend(self._check_list_lookup_pattern(file_path, content, lines))
-
-        # Check for repeated file opens (Issue #620: uses helper)
-        findings.extend(self._check_repeated_file_opens(file_path, content, lines))
-
-        # Check for string concat in loops (Issue #620: uses helper)
-        findings.extend(self._check_string_concat_in_loop(file_path, content, lines))
-
-        # Check for unclosed resources (Issue #12362: uses helper)
-        findings.extend(self._check_unclosed_resources(file_path, content, lines))
-
-        return findings
-
-    def analyze_directory(self, directory: str | None = None) -> List[PerformanceIssue]:
-        """Analyze all Python files in a directory."""
-        target = Path(directory) if directory else self.project_root
-        self.results = []
-        self.total_files_scanned = 0  # Issue #686: Reset counter
-
-        for py_file in target.rglob("*.py"):
-            if self._should_exclude(py_file):
-                continue
-
-            self.total_files_scanned += 1  # Issue #686: Count all files scanned
-            findings = self.analyze_file(str(py_file))
-            self.results.extend(findings)
-
-        return self.results
-
-    def _should_exclude(self, path: Path) -> bool:
-        """Check if path should be excluded."""
-        path_str = str(path)
-        for pattern in self.exclude_patterns:
-            if pattern.startswith("*"):
-                if path_str.endswith(pattern[1:]):
-                    return True
-            elif pattern in path_str:
-                return True
-        return False
+    def _get_checkers(self) -> List[Callable[[str, str, List[str]], List[PerformanceIssue]]]:
+        """Ordered regex checkers run by ``BaseCodeAnalyzer._regex_analysis``."""
+        return [
+            self._check_list_lookup_pattern,
+            self._check_repeated_file_opens,
+            self._check_string_concat_in_loop,
+            self._check_unclosed_resources,
+        ]
 
     def get_summary(self) -> Dict[str, Any]:
         """
@@ -472,50 +338,13 @@ class PerformanceAnalyzer(SemanticAnalysisMixin):
         return "".join(md)
 
     # Issue #554: Async semantic analysis methods
+    # Issue #12660: analyze_directory_async/cache_analysis_results/
+    # get_cached_analysis now live on BaseCodeAnalyzer; only the
+    # domain-specific metadata_keys below remain here.
 
-    async def analyze_directory_async(
+    async def _find_semantic_duplicates(
         self,
-        directory: str | None = None,
-        find_semantic_duplicates: bool = True,
-    ) -> Dict[str, Any]:
-        """
-        Analyze a directory with optional semantic analysis.
-
-        Issue #554: Async version that supports ChromaDB/Redis/LLM infrastructure.
-
-        Args:
-            directory: Path to directory to analyze
-            find_semantic_duplicates: Whether to find semantically similar issues
-
-        Returns:
-            Dictionary with analysis results including semantic matches
-        """
-        start_time = time.time()
-
-        # Run standard analysis first
-        results = self.analyze_directory(directory)
-
-        result = {
-            "results": [r.to_dict() for r in results],
-            "summary": self.get_summary(),
-            "semantic_duplicates": [],
-            "infrastructure_metrics": {},
-        }
-
-        # Run semantic analysis if enabled
-        if self.use_semantic_analysis and find_semantic_duplicates:
-            semantic_dups = await self._find_semantic_performance_duplicates(results)
-            result["semantic_duplicates"] = semantic_dups
-
-            # Add infrastructure metrics
-            result["infrastructure_metrics"] = self._get_infrastructure_metrics()
-
-        result["analysis_time_ms"] = (time.time() - start_time) * 1000
-        return result
-
-    async def _find_semantic_performance_duplicates(
-        self,
-        issues: List[PerformanceIssue],
+        items: List[PerformanceIssue],
     ) -> List[Dict[str, Any]]:
         """
         Find semantically similar performance issues using LLM embeddings.
@@ -524,14 +353,14 @@ class PerformanceAnalyzer(SemanticAnalysisMixin):
         helper from SemanticAnalysisMixin to reduce code duplication.
 
         Args:
-            issues: List of detected performance issues
+            items: List of detected performance issues
 
         Returns:
             List of duplicate pairs with similarity scores
         """
         try:
             return await self._find_semantic_duplicates_with_extraction(
-                items=issues,
+                items=items,
                 code_extractors=["current_code"],
                 metadata_keys={
                     "issue_type": "issue_type",
@@ -544,62 +373,6 @@ class PerformanceAnalyzer(SemanticAnalysisMixin):
         except Exception as e:
             logger.warning("Semantic duplicate detection failed: %s", e)
             return []
-
-    async def cache_analysis_results(
-        self,
-        directory: str,
-        results: List[PerformanceIssue],
-    ) -> bool:
-        """
-        Cache analysis results in Redis for faster retrieval.
-
-        Issue #554: Uses Redis caching from analytics infrastructure.
-
-        Args:
-            directory: Analyzed directory path
-            results: Analysis results to cache
-
-        Returns:
-            True if cached successfully
-        """
-        if not self.use_semantic_analysis:
-            return False
-
-        cache_key = self._generate_content_hash(directory)
-        results_dict = {
-            "results": [r.to_dict() for r in results],
-            "summary": self.get_summary(),
-        }
-
-        return await self._cache_result(
-            key=cache_key,
-            result=results_dict,
-            prefix="performance_analysis",
-        )
-
-    async def get_cached_analysis(
-        self,
-        directory: str,
-    ) -> Dict[str, Any] | None:
-        """
-        Get cached analysis results from Redis.
-
-        Issue #554: Retrieves cached results for faster repeat analysis.
-
-        Args:
-            directory: Directory path to look up
-
-        Returns:
-            Cached analysis results or None if not found
-        """
-        if not self.use_semantic_analysis:
-            return None
-
-        cache_key = self._generate_content_hash(directory)
-        return await self._get_cached_result(
-            key=cache_key,
-            prefix="performance_analysis",
-        )
 
 
 def analyze_performance(directory: str | None = None, exclude_patterns: List[str] | None = None) -> Dict[str, Any]:

--- a/autobot-backend/code_intelligence/security/analyzer.py
+++ b/autobot-backend/code_intelligence/security/analyzer.py
@@ -9,13 +9,15 @@ Issue #712: Extracted from security_analyzer.py for modularity.
 Issue #554: Includes semantic analysis via ChromaDB/Redis/LLM infrastructure.
 """
 
-import ast
 import re
-import time
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from code_intelligence.shared.analysis_base import (
+    HAS_ANALYTICS_INFRASTRUCTURE,
+    SIMILARITY_MEDIUM,
+    BaseCodeAnalyzer,
+)
 
 from .ast_visitor import SecurityASTVisitor
 from .constants import (
@@ -28,106 +30,26 @@ from .constants import (
 from .finding import SecurityFinding
 from .patterns import SECRET_PATTERNS, SQL_INJECTION_PATTERNS
 
-# Issue #554: Import analytics infrastructure for semantic analysis
-try:
-    from code_intelligence.analytics_infrastructure import (
-        SIMILARITY_MEDIUM,
-        SemanticAnalysisMixin,
-    )
-
-    HAS_ANALYTICS_INFRASTRUCTURE = True
-except ImportError:
-    HAS_ANALYTICS_INFRASTRUCTURE = False
-    SemanticAnalysisMixin = object
-    SIMILARITY_MEDIUM = 0.7
-
-# Issue #607: Import shared caches for performance optimization
-try:
-    from code_intelligence.shared.ast_cache import get_ast_with_content
-
-    HAS_SHARED_CACHE = True
-except ImportError:
-    HAS_SHARED_CACHE = False
-
 logger = get_logger(__name__)
 
 
-class SecurityAnalyzer(SemanticAnalysisMixin):
+class SecurityAnalyzer(BaseCodeAnalyzer):
     """
     Main security pattern analyzer.
 
     Issue #554: Now includes optional semantic analysis via ChromaDB/Redis/LLM
     infrastructure for detecting semantically similar security vulnerabilities.
+    Issue #12660: The scan/cache skeleton (``__init__``, ``analyze_file``,
+    ``analyze_directory``, ``analyze_directory_async``, ``_regex_analysis``,
+    ``_should_exclude``, ``cache_analysis_results``, ``get_cached_analysis``)
+    now lives in ``BaseCodeAnalyzer``; this class only provides the AST
+    visitor, the security-specific ``_check_*`` regex checkers, and the
+    security-shaped summary/report methods.
     """
 
-    def __init__(
-        self,
-        project_root: str | None = None,
-        exclude_patterns: List[str] | None = None,
-        use_semantic_analysis: bool = False,
-        use_cache: bool = True,
-        use_shared_cache: bool = True,
-    ):
-        """Initialize security analyzer."""
-        self.project_root = Path(project_root) if project_root else Path.cwd()
-        self.exclude_patterns = exclude_patterns or [
-            "venv",
-            "node_modules",
-            ".git",
-            "__pycache__",
-            "*.pyc",
-            "test_*",
-            "*_test.py",
-            "archives",
-            "migrations",
-        ]
-        self.results: List[SecurityFinding] = []
-        self.total_files_scanned: int = 0
-        self.use_semantic_analysis = use_semantic_analysis and HAS_ANALYTICS_INFRASTRUCTURE
-        self.use_shared_cache = use_shared_cache and HAS_SHARED_CACHE
-
-        if self.use_semantic_analysis:
-            self._init_infrastructure(
-                collection_name="security_analysis_vectors",
-                use_llm=True,
-                use_cache=use_cache,
-                redis_database="analytics",
-            )
-
-    def analyze_file(self, file_path: str) -> List[SecurityFinding]:
-        """Analyze a single file for security vulnerabilities."""
-        findings: List[SecurityFinding] = []
-        path = Path(file_path)
-
-        if not path.exists() or not path.suffix == ".py":
-            return findings
-
-        try:
-            if self.use_shared_cache:
-                tree, content = get_ast_with_content(file_path)
-                lines = content.split("\n") if content else []
-            else:
-                content = path.read_text(encoding="utf-8")
-                lines = content.split("\n")
-                try:
-                    tree = ast.parse(content)
-                except SyntaxError:
-                    tree = None
-
-            if tree is not None:
-                visitor = SecurityASTVisitor(str(path), lines)
-                visitor.visit(tree)
-                findings.extend(visitor.findings)
-            else:
-                logger.warning("Syntax error in %s, skipping AST analysis", file_path)
-
-            if content:
-                findings.extend(self._regex_analysis(str(path), content, lines))
-
-        except Exception as e:
-            logger.error("Error analyzing %s: %s", file_path, e)
-
-        return findings
+    AST_VISITOR_CLASS = SecurityASTVisitor
+    SEMANTIC_COLLECTION_NAME = "security_analysis_vectors"
+    CACHE_PREFIX = "security_analysis"
 
     def _check_hardcoded_secrets(self, file_path: str, content: str, lines: List[str]) -> List[SecurityFinding]:
         """Check for hardcoded secrets."""
@@ -273,40 +195,14 @@ class SecurityAnalyzer(SemanticAnalysisMixin):
 
         return findings
 
-    def _regex_analysis(self, file_path: str, content: str, lines: List[str]) -> List[SecurityFinding]:
-        """Perform regex-based security analysis."""
-        findings: List[SecurityFinding] = []
-        findings.extend(self._check_hardcoded_secrets(file_path, content, lines))
-        findings.extend(self._check_sql_injection(file_path, content, lines))
-        findings.extend(self._check_path_traversal(file_path, content, lines))
-        findings.extend(self._check_weak_encryption(file_path, content, lines))
-        return findings
-
-    def analyze_directory(self, directory: str | None = None) -> List[SecurityFinding]:
-        """Analyze all Python files in a directory."""
-        target = Path(directory) if directory else self.project_root
-        self.results = []
-        self.total_files_scanned = 0
-
-        for py_file in target.rglob("*.py"):
-            if self._should_exclude(py_file):
-                continue
-            self.total_files_scanned += 1
-            findings = self.analyze_file(str(py_file))
-            self.results.extend(findings)
-
-        return self.results
-
-    def _should_exclude(self, path: Path) -> bool:
-        """Check if path should be excluded."""
-        path_str = str(path)
-        for pattern in self.exclude_patterns:
-            if pattern.startswith("*"):
-                if path_str.endswith(pattern[1:]):
-                    return True
-            elif pattern in path_str:
-                return True
-        return False
+    def _get_checkers(self) -> List[Callable[[str, str, List[str]], List[SecurityFinding]]]:
+        """Ordered regex checkers run by ``BaseCodeAnalyzer._regex_analysis``."""
+        return [
+            self._check_hardcoded_secrets,
+            self._check_sql_injection,
+            self._check_path_traversal,
+            self._check_weak_encryption,
+        ]
 
     def get_summary(self) -> Dict[str, Any]:
         """Get summary of security findings."""
@@ -423,39 +319,18 @@ class SecurityAnalyzer(SemanticAnalysisMixin):
         return "".join(md)
 
     # Issue #554: Async semantic analysis methods
+    # Issue #12660: analyze_directory_async/cache_analysis_results/
+    # get_cached_analysis now live on BaseCodeAnalyzer; only the
+    # domain-specific metadata_keys below remain here.
 
-    async def analyze_directory_async(
+    async def _find_semantic_duplicates(
         self,
-        directory: str | None = None,
-        find_semantic_duplicates: bool = True,
-    ) -> Dict[str, Any]:
-        """Analyze a directory with optional semantic analysis."""
-        start_time = time.time()
-        results = self.analyze_directory(directory)
-
-        result = {
-            "results": [r.to_dict() for r in results],
-            "summary": self.get_summary(),
-            "semantic_duplicates": [],
-            "infrastructure_metrics": {},
-        }
-
-        if self.use_semantic_analysis and find_semantic_duplicates:
-            semantic_dups = await self._find_semantic_security_duplicates(results)
-            result["semantic_duplicates"] = semantic_dups
-            result["infrastructure_metrics"] = self._get_infrastructure_metrics()
-
-        result["analysis_time_ms"] = (time.time() - start_time) * 1000
-        return result
-
-    async def _find_semantic_security_duplicates(
-        self,
-        findings: List[SecurityFinding],
+        items: List[SecurityFinding],
     ) -> List[Dict[str, Any]]:
         """Find semantically similar security vulnerabilities using LLM embeddings."""
         try:
             return await self._find_semantic_duplicates_with_extraction(
-                items=findings,
+                items=items,
                 code_extractors=["current_code"],
                 metadata_keys={
                     "vulnerability_type": "vulnerability_type",
@@ -469,35 +344,3 @@ class SecurityAnalyzer(SemanticAnalysisMixin):
         except Exception as e:
             logger.warning("Semantic duplicate detection failed: %s", e)
             return []
-
-    async def cache_analysis_results(
-        self,
-        directory: str,
-        results: List[SecurityFinding],
-    ) -> bool:
-        """Cache analysis results in Redis for faster retrieval."""
-        if not self.use_semantic_analysis:
-            return False
-
-        cache_key = self._generate_content_hash(directory)
-        results_dict = {
-            "results": [r.to_dict() for r in results],
-            "summary": self.get_summary(),
-        }
-
-        return await self._cache_result(
-            key=cache_key,
-            result=results_dict,
-            prefix="security_analysis",
-        )
-
-    async def get_cached_analysis(self, directory: str) -> Dict[str, Any] | None:
-        """Get cached analysis results from Redis."""
-        if not self.use_semantic_analysis:
-            return None
-
-        cache_key = self._generate_content_hash(directory)
-        return await self._get_cached_result(
-            key=cache_key,
-            prefix="security_analysis",
-        )

--- a/autobot-backend/code_intelligence/shared/__init__.py
+++ b/autobot-backend/code_intelligence/shared/__init__.py
@@ -16,6 +16,10 @@ Components:
 Part of EPIC #217 - Advanced Code Intelligence Methods
 """
 
+from code_intelligence.shared.analysis_base import (
+    DEFAULT_EXCLUDE_PATTERNS,
+    BaseCodeAnalyzer,
+)
 from code_intelligence.shared.ast_cache import (
     ASTCache,
     get_ast,
@@ -48,6 +52,9 @@ from code_intelligence.shared.scoring import (
 )
 
 __all__ = [
+    # Analyzer skeleton (Issue #12660)
+    "BaseCodeAnalyzer",
+    "DEFAULT_EXCLUDE_PATTERNS",
     # FileListCache
     "FileListCache",
     "get_file_list_cache",

--- a/autobot-backend/code_intelligence/shared/analysis_base.py
+++ b/autobot-backend/code_intelligence/shared/analysis_base.py
@@ -1,0 +1,247 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Shared skeleton for the Python regex+AST code analyzers (Issue #12660).
+
+``code_intelligence.security.SecurityAnalyzer`` and
+``code_intelligence.performance_analysis.PerformanceAnalyzer`` independently
+reimplemented the same ``__init__``/``analyze_file``/``analyze_directory``/
+``analyze_directory_async``/``_regex_analysis``/``_should_exclude``/
+``cache_analysis_results``/``get_cached_analysis`` skeleton, differing only in
+the AST visitor class, the list of regex ``_check_*`` methods run, and the
+semantic-analysis collection/cache names.
+
+This module hosts that skeleton exactly once. Concrete analyzers subclass
+``BaseCodeAnalyzer`` and only provide the domain-specific hooks documented on
+the class.
+"""
+
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+
+# Issue #554: Import analytics infrastructure for semantic analysis. Guarded
+# once here (was duplicated verbatim in both security/analyzer.py and
+# performance_analysis/analyzer.py); both re-export these names for backward
+# compatibility with existing package __init__ imports.
+try:
+    from code_intelligence.analytics_infrastructure import (
+        SIMILARITY_MEDIUM,
+        SemanticAnalysisMixin,
+    )
+
+    HAS_ANALYTICS_INFRASTRUCTURE = True
+except ImportError:
+    HAS_ANALYTICS_INFRASTRUCTURE = False
+    SemanticAnalysisMixin = object
+    SIMILARITY_MEDIUM = 0.7
+
+# Issue #607: Import shared caches for performance optimization
+try:
+    from code_intelligence.shared.ast_cache import get_ast_with_content
+
+    HAS_SHARED_CACHE = True
+except ImportError:
+    HAS_SHARED_CACHE = False
+
+logger = get_logger(__name__)
+
+# Issue #12660: Default exclusion patterns shared by every analyzer that
+# subclasses BaseCodeAnalyzer (verbatim match of the previous per-class
+# defaults in security/analyzer.py and performance_analysis/analyzer.py).
+DEFAULT_EXCLUDE_PATTERNS: List[str] = [
+    "venv",
+    "node_modules",
+    ".git",
+    "__pycache__",
+    "*.pyc",
+    "test_*",
+    "*_test.py",
+    "archives",
+    "migrations",
+]
+
+
+class BaseCodeAnalyzer(SemanticAnalysisMixin):
+    """Shared scan/cache skeleton for regex+AST Python code analyzers.
+
+    Subclasses MUST override:
+        - ``AST_VISITOR_CLASS``: the ``ast.NodeVisitor`` subclass instantiated
+          by :meth:`analyze_file`.
+        - ``SEMANTIC_COLLECTION_NAME``: vector-store collection name passed to
+          ``_init_infrastructure`` when semantic analysis is enabled.
+        - ``CACHE_PREFIX``: Redis cache-key prefix used by
+          :meth:`cache_analysis_results` / :meth:`get_cached_analysis`.
+        - :meth:`_get_checkers`: ordered list of bound ``_check_*`` methods
+          run by :meth:`_regex_analysis`.
+        - :meth:`_find_semantic_duplicates`: domain-specific semantic
+          duplicate-finder (each domain uses different ``metadata_keys``).
+
+    Subclasses are expected to still own ``get_summary``/``generate_report``/
+    ``_generate_markdown_report`` — those are genuine per-domain analysis
+    specifics (field names, scoring), not skeleton.
+    """
+
+    AST_VISITOR_CLASS: type | None = None
+    SEMANTIC_COLLECTION_NAME: str = ""
+    CACHE_PREFIX: str = ""
+
+    def __init__(
+        self,
+        project_root: str | None = None,
+        exclude_patterns: List[str] | None = None,
+        use_semantic_analysis: bool = False,
+        use_cache: bool = True,
+        use_shared_cache: bool = True,
+    ):
+        """Initialize the analyzer with project root and exclusion patterns."""
+        self.project_root = Path(project_root) if project_root else Path.cwd()
+        self.exclude_patterns = exclude_patterns or list(DEFAULT_EXCLUDE_PATTERNS)
+        self.results: List[Any] = []
+        self.total_files_scanned: int = 0
+        self.use_semantic_analysis = use_semantic_analysis and HAS_ANALYTICS_INFRASTRUCTURE
+        self.use_shared_cache = use_shared_cache and HAS_SHARED_CACHE
+
+        if self.use_semantic_analysis:
+            self._init_infrastructure(
+                collection_name=self.SEMANTIC_COLLECTION_NAME,
+                use_llm=True,
+                use_cache=use_cache,
+                redis_database="analytics",
+            )
+
+    def analyze_file(self, file_path: str) -> List[Any]:
+        """Analyze a single file for this analyzer's domain-specific findings."""
+        findings: List[Any] = []
+        path = Path(file_path)
+
+        if not path.exists() or not path.suffix == ".py":
+            return findings
+
+        try:
+            if self.use_shared_cache:
+                tree, content = get_ast_with_content(file_path)
+                lines = content.split("\n") if content else []
+            else:
+                content = path.read_text(encoding="utf-8")
+                lines = content.split("\n")
+                try:
+                    tree = ast.parse(content)
+                except SyntaxError:
+                    tree = None
+
+            if tree is not None:
+                visitor = self.AST_VISITOR_CLASS(str(path), lines)
+                visitor.visit(tree)
+                findings.extend(visitor.findings)
+            else:
+                logger.warning("Syntax error in %s, skipping AST analysis", file_path)
+
+            if content:
+                findings.extend(self._regex_analysis(str(path), content, lines))
+
+        except Exception as e:
+            logger.error("Error analyzing %s: %s", file_path, e)
+
+        return findings
+
+    def _get_checkers(self) -> List[Callable[[str, str, List[str]], List[Any]]]:
+        """Hook: ordered bound ``_check_*`` methods run by :meth:`_regex_analysis`."""
+        raise NotImplementedError
+
+    def _regex_analysis(self, file_path: str, content: str, lines: List[str]) -> List[Any]:
+        """Run this analyzer's regex-based checkers and collect findings."""
+        findings: List[Any] = []
+        for checker in self._get_checkers():
+            findings.extend(checker(file_path, content, lines))
+        return findings
+
+    def analyze_directory(self, directory: str | None = None) -> List[Any]:
+        """Analyze all Python files in a directory."""
+        target = Path(directory) if directory else self.project_root
+        self.results = []
+        self.total_files_scanned = 0
+
+        for py_file in target.rglob("*.py"):
+            if self._should_exclude(py_file):
+                continue
+
+            self.total_files_scanned += 1
+            findings = self.analyze_file(str(py_file))
+            self.results.extend(findings)
+
+        return self.results
+
+    def _should_exclude(self, path: Path) -> bool:
+        """Check if path should be excluded."""
+        path_str = str(path)
+        for pattern in self.exclude_patterns:
+            if pattern.startswith("*"):
+                if path_str.endswith(pattern[1:]):
+                    return True
+            elif pattern in path_str:
+                return True
+        return False
+
+    async def _find_semantic_duplicates(self, items: List[Any]) -> List[Dict[str, Any]]:
+        """Hook: domain-specific semantic duplicate-finder (``metadata_keys`` differ)."""
+        raise NotImplementedError
+
+    async def analyze_directory_async(
+        self,
+        directory: str | None = None,
+        find_semantic_duplicates: bool = True,
+    ) -> Dict[str, Any]:
+        """Analyze a directory with optional semantic analysis."""
+        start_time = time.time()
+        results = self.analyze_directory(directory)
+
+        result: Dict[str, Any] = {
+            "results": [r.to_dict() for r in results],
+            "summary": self.get_summary(),
+            "semantic_duplicates": [],
+            "infrastructure_metrics": {},
+        }
+
+        if self.use_semantic_analysis and find_semantic_duplicates:
+            semantic_dups = await self._find_semantic_duplicates(results)
+            result["semantic_duplicates"] = semantic_dups
+            result["infrastructure_metrics"] = self._get_infrastructure_metrics()
+
+        result["analysis_time_ms"] = (time.time() - start_time) * 1000
+        return result
+
+    async def cache_analysis_results(self, directory: str, results: List[Any]) -> bool:
+        """Cache analysis results in Redis for faster retrieval."""
+        if not self.use_semantic_analysis:
+            return False
+
+        cache_key = self._generate_content_hash(directory)
+        results_dict = {
+            "results": [r.to_dict() for r in results],
+            "summary": self.get_summary(),
+        }
+
+        return await self._cache_result(
+            key=cache_key,
+            result=results_dict,
+            prefix=self.CACHE_PREFIX,
+        )
+
+    async def get_cached_analysis(self, directory: str) -> Dict[str, Any] | None:
+        """Get cached analysis results from Redis."""
+        if not self.use_semantic_analysis:
+            return None
+
+        cache_key = self._generate_content_hash(directory)
+        return await self._get_cached_result(
+            key=cache_key,
+            prefix=self.CACHE_PREFIX,
+        )


### PR DESCRIPTION
## Thinking Path

Umbrella #12645 (base-class DRY tier). Read the current post-#12588 state of every file named in #12660 before touching anything — #12362/#12588 already converged the code-analysis *analyzers* onto `code_intelligence/*`; this issue is the *shared-skeleton* delta on top of that, not a redo.

**Cluster 1 — `code_analysis/auto-tools/`.** Verified per-method identity with AST diffs (not just eyeballing):
- `create_backup`/`save_report`/`main()` are byte-identical between `security_sanitizer.SecurityFixAgent` and `security_deep_sanitizer.SecurityFixAgent` (only string literals — report-filename prefix, usage program name — differ).
- `create_backup`/`process_file` are byte-identical between `logging_standardizer.DevLoggingFixer` and `performance_optimizer.ConsoleLogCleaner`; their `main()` differs more (extra `--dry-run`/`--dev-mode`/`--replace-with-dev-logging` flags only on the performance tool, different CLI help text) but is still the same skeleton once those are hooks.
- `playwright_sanitizer.py`/`vue_quality_tool.py`/`accessibility_enhancer.py` were **not** touched — their `create_backup` bodies are genuinely different algorithms (different backup-dir strategy), and the issue names exactly 4 tools ("the 4 tools inherit").

Design: two base classes in one new `tool_base.py` (`SecurityFixToolBase`, `ConsoleLogToolBase`) — not a single mega-base, because the two families' `create_backup`/`main` shapes are unrelated to each other even though identical *within* each family. Differences preserved as class-attribute hooks (`REPORT_FILE_PREFIX`, `USAGE_PROGRAM_NAME`, `ARG_DESCRIPTION`, `REPORT_COUNT_KEY`, `ERROR_MESSAGE`, `_extra_cli_args()`, `_transform_content()`, `run_project()`, `_print_cli_summary()`). No `__init__.py` exists in `auto-tools/` (hyphenated dir name isn't a valid package identifier — every tool is a standalone script), so each tool does `sys.path.insert(0, str(Path(__file__).resolve().parent))` before `from tool_base import ...`, matching how these scripts are actually invoked.

**Cluster 2 — `code_intelligence` analyzers.** Confirmed `_get_call_name` (from the issue's list) does **not** currently exist in `security/ast_visitor.py` — it's only in `performance_analysis/ast_visitor.py`, and it lives in the *visitor*, not `analyzer.py`. Nothing to consolidate there (not a regression vs #12588; verified via grep, not assumed). The real, verified duplication is `analyze_file`/`analyze_directory`/`analyze_directory_async`/`_regex_analysis`/`_should_exclude`/`cache_analysis_results`/`get_cached_analysis`/`__init__` — extracted to `BaseCodeAnalyzer` (`code_intelligence/shared/analysis_base.py`, alongside the existing `ast_cache.py`/`scoring.py` cross-cutting helpers). `get_summary`/`generate_report`/`_generate_markdown_report` stay on each analyzer — genuine per-domain specifics (OWASP vs grade/complexity), not skeleton, consistent with #12588's direction. Hooks: `AST_VISITOR_CLASS`, `SEMANTIC_COLLECTION_NAME`, `CACHE_PREFIX`, `_get_checkers()`, `_find_semantic_duplicates()`.

**Cluster 3 — `code_analysis/src`.** Read `performance_analyzer.py`/`security_analyzer.py`: both are already the deprecated legacy-shaped facades #12362 created — thin adapters that delegate all detection to the canonical `code_intelligence.*` analyzers and only remap field names for backward compatibility. This is exactly the "or note if #12588 already made these thin shims — if so, skip" case the issue calls out. **Skipped** — further base-class extraction would only serve a deprecated compatibility layer for callers that should migrate to `code_intelligence` directly.

## What Changed

- **New** `autobot-backend/code_analysis/auto-tools/tool_base.py` — `SecurityFixToolBase` (create_backup/save_report/cli_main) + `ConsoleLogToolBase` (create_backup/process_file/cli_main).
- `security_sanitizer.py`, `security_deep_sanitizer.py`, `logging_standardizer.py`, `performance_optimizer.py` now inherit the matching base; duplicate method bodies removed, replaced with the documented hooks.
- Fixed a pre-existing bug shared by both security tools while moving the code: `create_backup`/`save_report` except-blocks logged a literal `"%s<var>"` string with no substitution (`logger.error("Failed to create backup: %se ")`) instead of `"%s"` + the exception as an arg — corrected to the pattern `playwright_sanitizer.py` already used correctly for the same message.
- **New** `autobot-backend/code_intelligence/shared/analysis_base.py` — `BaseCodeAnalyzer`, re-exported from `code_intelligence/shared/__init__.py`.
- `code_intelligence/security/analyzer.py` and `code_intelligence/performance_analysis/analyzer.py` now subclass `BaseCodeAnalyzer`; `HAS_ANALYTICS_INFRASTRUCTURE`/`SIMILARITY_MEDIUM` re-exported from the base so `performance_analysis/__init__.py`'s existing `from .analyzer import HAS_ANALYTICS_INFRASTRUCTURE` keeps working unchanged.
- `code_analysis/src/` untouched (already-thin #12362 shims — see Thinking Path).
- Filed **#12678** for pre-existing bugs discovered but out of this PR's skeleton scope: missing f-string interpolation in `run()` (`security_sanitizer.py`/`security_deep_sanitizer.py`), and dead `--dry-run`/`--dev-mode`/`--replace-with-dev-logging` CLI flags in `performance_optimizer.py` (parsed, never wired).

## Verification

- `pytest code_intelligence/security_analyzer_test.py code_intelligence/performance_analyzer_test.py code_intelligence/legacy_analyzer_shim_test.py code_analysis/src/` → **70 passed, 71 skipped** (skips are pre-existing missing-optional-dep gates, unrelated to this change).
- Ran the *same* 4 test files against a clean `origin/Dev_new_gui` worktree checkout to confirm baseline — identical pass count, confirming zero regression.
- `pytest code_intelligence/` (full dir, 433 failed/226 passed) — confirmed via a clean baseline worktree that **the exact same 433/226 split exists on `origin/Dev_new_gui` before this change** (missing optional deps: radon/vulture/etc — pre-existing, unrelated to this PR).
- Import-smoke: `SecurityAnalyzer`/`PerformanceAnalyzer` MRO confirms `BaseCodeAnalyzer` in the chain; `_get_checkers()` returns the correct ordered bound methods for each.
- Functional smoke (not just import) for every auto-tools change: `create_backup`/`save_report` invoked directly (backup + `.md`/`.json` report written and verified on disk); `process_file` invoked directly (console.log converted/removed, backup created, counters incremented); full CLI (`python security_deep_sanitizer.py <path>`, `python performance_optimizer.py <path> --target-dir src`, `python logging_standardizer.py <path> --target-dir src`) run end-to-end against real temp fixtures — files transformed correctly, backups + reports written, usage/error messages correctly substituted (confirms the logging-bug fix).
- `pyflakes` on every touched/new file — no new warnings; the two remaining `f-string is missing placeholders` + one unused-local warnings are byte-identical to the pre-existing warnings at the old line numbers on `origin/Dev_new_gui` (confirmed via diff against a `git show HEAD:...` copy).
- grep-confirmed: `create_backup`/`save_report`/`process_file`/`cli_main` (auto-tools) and `analyze_file`/`analyze_directory`/`analyze_directory_async`/`_regex_analysis`/`_should_exclude` (code_intelligence) each now have exactly one definition per intended cluster — no orphaned duplicate left in the 4/2 files this issue scoped in.

Closes #12660
Refs #12645

## Model Used

Sonnet 4.5