### PR TITLE
tech-debt(backend): single canonical LLMProvider enum (union of 3 forks) (#12661)

### DIFF
--- a/autobot-backend/llm_shared/providers/openrouter.py
+++ b/autobot-backend/llm_shared/providers/openrouter.py
@@ -40,7 +40,12 @@ class OpenRouterProvider(OpenAICompatibleProvider):
               OPENROUTER_API_KEY environment variable
     """
 
-    provider_name = ProviderType.OPENROUTER.value if hasattr(ProviderType, "OPENROUTER") else "openrouter"
+    # ProviderType.OPENROUTER is guaranteed to exist now that ProviderType is
+    # a thin alias of the canonical union enum (#12661); the previous
+    # hasattr() guard was defending against the pre-consolidation gap where
+    # ProviderType lacked OPENROUTER (it only existed in the disagreeing
+    # llm_cost_tracker.LLMProvider fork).
+    provider_name = ProviderType.OPENROUTER.value
     default_model = "gpt-3.5-turbo"
     forward_penalty_params = True
     missing_key_error = "OpenRouter API key not found. Set OPENROUTER_API_KEY or provide api_key in settings."

--- a/autobot-backend/llm_shared/types.py
+++ b/autobot-backend/llm_shared/types.py
@@ -10,6 +10,8 @@ Extracted from llm_interface.py as part of Issue #381 god class refactoring.
 
 from enum import Enum
 
+from autobot_shared.status_enums import LLMProvider as _CanonicalLLMProvider
+
 
 class ArchitectureFamily(str, Enum):
     """Model architecture family — governs attention backend, NPU dispatch, and
@@ -38,24 +40,16 @@ class ArchitectureFamily(str, Enum):
     MOE = "moe"  # Mixture-of-Experts (from NPU registry, #10892)
 
 
-class ProviderType(Enum):
-    """Supported LLM providers."""
-
-    OLLAMA = "ollama"
-    OPENAI = "openai"
-    ANTHROPIC = "anthropic"
-    VLLM = "vllm"
-    HUGGINGFACE = "huggingface"
-    TRANSFORMERS = "transformers"
-    MOCK = "mock"
-    LOCAL = "local"
-    AI_STACK = "ai_stack"  # Issue #1403
-    PROCESS = "process"  # Issue #1403
-    LAYER_INFERENCE = "layer_inference"  # Issue #3104
-    GROQ = "groq"  # Issue #4096
-    MISTRAL = "mistral"  # Issue #10549
-    VERTEX_AI = "vertexai"  # GH#9009
-    BEDROCK = "bedrock"  # GH#9010
+#: Supported LLM providers.
+#:
+#: Single canonical source of truth (#12661): this used to be its own
+#: ``Enum`` and disagreed with ``autobot_shared.status_enums.LLMProvider``
+#: and ``services.llm_cost_tracker.LLMProvider``. All three member sets are
+#: now unioned onto the canonical enum in ``autobot_shared/status_enums.py``;
+#: this name is a thin alias so every existing ``ProviderType.X`` call site
+#: (``ProviderType.OLLAMA``, ``ProviderType.VLLM``, ...) keeps working
+#: unchanged, and every ``.value`` string is preserved exactly.
+ProviderType = _CanonicalLLMProvider
 
 
 class LLMType(str, Enum):

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -21,12 +21,12 @@ import asyncio
 import json
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
-from enum import Enum
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from autobot_shared.status_enums import LLMProvider  # noqa: F401 (re-exported, #12661)
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.model_constants import (
     ANTHROPIC_CLAUDE_HAIKU4_5,
@@ -60,17 +60,14 @@ PRICING_VERSION: str = "2026-03-22"
 PRICING_STALENESS_DAYS: int = 90
 
 
-class LLMProvider(str, Enum):
-    """Supported LLM providers"""
-
-    ANTHROPIC = "anthropic"
-    OPENAI = "openai"
-    OLLAMA = "ollama"
-    GOOGLE = "google"
-    OPENROUTER = "openrouter"
-    MISTRAL = "mistral"
-    LOCAL = "local"
-
+# LLMProvider: single canonical source of truth (#12661). This module used
+# to define its own ``str, Enum`` fork that disagreed with
+# ``autobot_shared.status_enums.LLMProvider`` and
+# ``llm_shared/types.py::ProviderType`` (e.g. it had ``GOOGLE``/``OPENROUTER``
+# that the other two lacked). Imported directly above from the canonical
+# module — unused by name anywhere in this codebase (verified by grep), so
+# no behavioural change; every ``.value`` string it defined is preserved on
+# the canonical enum.
 
 # Model pricing per 1M tokens (USD) - single source of truth in
 # constants/model_constants.py (#3528). Update PRICING_VERSION above when

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -191,6 +191,25 @@ class LLMProvider(Enum):
 
     Used in ssot_config and throughout LLM integration code.
     Replaces hardcoded strings: "ollama", "openai", "anthropic", "custom".
+
+    Single canonical source of truth (#12661): this enum was previously
+    triplicated — ``autobot-backend/llm_shared/types.py::ProviderType`` and
+    ``autobot-backend/services/llm_cost_tracker.py::LLMProvider`` are now
+    thin aliases of this class. The member set below is the UNION of all
+    three historical forks; every ``.value`` string is preserved exactly as
+    it was serialized by its origin fork — no provider was renamed or
+    dropped, per the #12645 consolidation contract.
+
+    Semantic-mapping notes (kept distinct, not merged):
+    - ``VERTEX_AI`` (GCP Vertex AI / ``google-cloud-aiplatform`` SDK, GH#9009,
+      real usage in ``llm_shared/providers/vertexai.py``) and ``GOOGLE``
+      (from the cost-tracker fork, unused by any call site) are kept as two
+      separate values — they can represent different access paths to
+      Google's models (direct Gemini API vs. enterprise Vertex SDK) and the
+      contract forbids merging two potentially-distinct providers.
+    - ``CUSTOM`` (generic custom-endpoint provider, ``ssot_config.custom_endpoint``)
+      and ``PROCESS`` (subprocess-based local inference adapter, Issue #1403)
+      are semantically different providers, kept separate.
     """
 
     OLLAMA = "ollama"
@@ -199,6 +218,24 @@ class LLMProvider(Enum):
     AZURE = "azure"
     CUSTOM = "custom"
     LOCAL = "local"
+    # -- union additions from llm_shared/types.py::ProviderType --
+    VLLM = "vllm"
+    HUGGINGFACE = "huggingface"
+    TRANSFORMERS = "transformers"
+    MOCK = "mock"
+    AI_STACK = "ai_stack"  # Issue #1403
+    PROCESS = "process"  # Issue #1403
+    LAYER_INFERENCE = "layer_inference"  # Issue #3104
+    GROQ = "groq"  # Issue #4096
+    MISTRAL = "mistral"  # Issue #10549
+    VERTEX_AI = "vertexai"  # GH#9009
+    BEDROCK = "bedrock"  # GH#9010
+    # -- union additions from services/llm_cost_tracker.py::LLMProvider --
+    GOOGLE = "google"  # cost-tracker fork; unused by any provider call site
+    OPENROUTER = "openrouter"  # cost-tracker fork; ProviderType lacked this
+    # (llm_shared/providers/openrouter.py had a defensive hasattr() guard
+    # against ProviderType.OPENROUTER not existing — a real symptom of the
+    # triplication bug this consolidation fixes)
 
     @classmethod
     def supports_streaming(cls, provider: "LLMProvider") -> bool:


### PR DESCRIPTION
## Thinking Path

The LLM-provider enum was defined 3x and the copies already disagreed:
- `autobot_shared/status_enums.py::LLMProvider` — ollama, openai, anthropic, azure, custom, local (6, **zero real call sites** anywhere — only re-exported through `constants/status_enums.py` shim, never accessed by name)
- `autobot-backend/llm_shared/types.py::ProviderType` — ollama, openai, anthropic, vllm, huggingface, transformers, mock, ai_stack, process, layer_inference, groq, mistral, vertexai, bedrock, local (15, **70 usage sites across 24 files** — heavily wired into `provider_registry.py`, `optimization/router.py`, every `llm_shared/providers/*.py` implementation)
- `autobot-backend/services/llm_cost_tracker.py::LLMProvider` — anthropic, openai, ollama, google, openrouter, mistral, local (7, **zero real call sites** — defined but never referenced by name anywhere, including its own tests)

**Canonical:** `autobot_shared/status_enums.py::LLMProvider`, per the umbrella's implied target (importable by both backends, already re-exported via `constants/status_enums.py` for 15+ legacy callers).

**Union value set (19 members, every `.value` string preserved exactly as its origin fork serialized it):**
`ollama, openai, anthropic, azure, custom, local, vllm, huggingface, transformers, mock, ai_stack, process, layer_inference, groq, mistral, vertexai, bedrock, google, openrouter`

**Semantic-mapping decisions (nothing merged, nothing dropped):**
- `VERTEX_AI` ("vertexai", real — used by `llm_shared/providers/vertexai.py`, GH#9009) vs `GOOGLE` ("google", from the cost-tracker fork, unused anywhere) — kept as **two distinct** values. They can represent different access paths to Google's models (direct Gemini API vs. enterprise GCP Vertex SDK); the consolidation contract forbids merging two potentially-distinct providers.
- `CUSTOM` ("custom", generic custom-endpoint provider wired through `ssot_config.custom_endpoint`) vs `PROCESS` ("process", subprocess-based local-inference adapter, Issue #1403) — semantically different, kept separate.
- `AZURE` has no current LLM-provider call site (the only "azure" hits in the repo are Azure *cloud-infrastructure* integration, unrelated) — kept per the no-drop rule since it's an existing enum member with a real serialized value.

**Real latent bug found + fixed:** `llm_shared/providers/openrouter.py` had `provider_name = ProviderType.OPENROUTER.value if hasattr(ProviderType, "OPENROUTER") else "openrouter"` — a defensive guard because `ProviderType` lacked `OPENROUTER` (it only existed in the disagreeing `llm_cost_tracker.LLMProvider` fork). This is exactly the "copies already disagree" bug the issue describes. Union canonicalization fixes it; the now-dead `hasattr()` guard was removed.

**Usage counts (blast-radius map):**
| Enum | Real call sites | Files |
|---|---|---|
| `status_enums.LLMProvider` | 0 (definition + shim re-export only) | 2 |
| `llm_shared.types.ProviderType` | 70 `ProviderType.X` accesses | 24 |
| `llm_cost_tracker.LLMProvider` | 0 (defined, never referenced by name, even in its own tests) | 1 |

Given `ProviderType`'s wide, real usage and `status_enums.LLMProvider` / `llm_cost_tracker.LLMProvider`'s zero usage, a big-bang call-site migration was unnecessary and riskier than the safe path: make the canonical class the union, and repoint the two forks as **identity aliases** (`ProviderType = LLMProvider`, `LLMProvider = LLMProvider` import in `llm_cost_tracker.py`) rather than separate classes. Every existing `ProviderType.OLLAMA`, `ProviderType.VLLM`, etc. call site keeps working unchanged — no call-site migration needed, no serialized value changed.

## What Changed

- `autobot_shared/status_enums.py::LLMProvider` — extended to the 19-member union; original 6 members' values untouched; docstring records the semantic-mapping decisions.
- `autobot-backend/llm_shared/types.py::ProviderType` — replaced the standalone `Enum` class with `ProviderType = LLMProvider` (canonical alias); `__all__` unchanged.
- `autobot-backend/services/llm_cost_tracker.py::LLMProvider` — removed the standalone `str, Enum` class; canonical `LLMProvider` imported directly (`# noqa: F401` — re-exported for any future importer, currently unused by name anywhere).
- `autobot-backend/llm_shared/providers/openrouter.py` — removed the dead `hasattr(ProviderType, "OPENROUTER")` defensive guard now that the canonical enum always has it.

## Verification

```
$ python3 -c "... identity checks ..."
canonical members: ['ai_stack', 'anthropic', 'azure', 'bedrock', 'custom', 'google', 'groq',
  'huggingface', 'layer_inference', 'local', 'mistral', 'mock', 'ollama', 'openai',
  'openrouter', 'process', 'transformers', 'vertexai', 'vllm']
ProviderType is LLMProvider: True
ProviderType.OPENROUTER: LLMProvider.OPENROUTER
CostLLMProvider is LLMProvider: True

$ python3 -m pytest llm_shared/ tests/llm_shared/ tests/test_provider_registry.py \
    tests/integration/test_chat_fallback.py tests/services/test_llm_cost_tracker.py \
    tests/test_startup_imports.py -q
1151 passed, 115 skipped

$ python3 -m flake8 --config=.flake8 autobot_shared/status_enums.py \
    autobot-backend/llm_shared/types.py autobot-backend/services/llm_cost_tracker.py \
    autobot-backend/llm_shared/providers/openrouter.py
0

$ python3 -m black --check ... && python3 -m isort --check ...
All done — no changes needed

$ git diff -- autobot_shared/status_enums.py autobot-backend/llm_shared/types.py \
    autobot-backend/services/llm_cost_tracker.py | grep -E '^[+-].*= "'
# every removed `X = "value"` line reappears verbatim as an added line —
# no .value string changed, only relocated
```

No second LLM-provider enum definition remains — `grep -rn "^class LLMProvider\|^class ProviderType"` across the repo returns one enum hit (`autobot_shared/status_enums.py::LLMProvider`) plus unrelated same-named classes that were never part of this triplication and are out of scope: `llm_multi_provider.py::LLMProvider(ABC)` (a provider-client interface, not an enum), `services/memory/external_provider_factory.py::ProviderType` (external memory-provider enum, e.g. mem0/zep — different domain), and several unrelated Pydantic schema classes (`LLMProviderSwitchData` etc.) that merely share the word.

Closes #12661
Refs #12645

## Model Used

Claude Sonnet 5