### PR TITLE
tech-debt(backend): extract BaselinePricingSource base for 5 pricing sources (#12687)

### DIFF
--- a/autobot-backend/llm_shared/pricing/anthropic_source.py
+++ b/autobot-backend/llm_shared/pricing/anthropic_source.py
@@ -12,10 +12,7 @@ the hardcoded fallback.
 
 from __future__ import annotations
 
-from autobot_shared.logging_manager import get_logger
-from llm_shared.pricing.sources import ModelPricing, PricingSource
-
-logger = get_logger(__name__)
+from llm_shared.pricing.sources import BaselinePricingSource
 
 _PROVIDER = "anthropic"
 
@@ -34,20 +31,7 @@ _BASELINE: list[tuple[str, float, float, float]] = [
 ]
 
 
-class AnthropicPricingSource(PricingSource):
+class AnthropicPricingSource(BaselinePricingSource):
     provider = _PROVIDER
-
-    async def fetch(self) -> dict[str, ModelPricing]:
-        now = self._now()
-        result: dict[str, ModelPricing] = {}
-        for model_id, inp, out, cache_read in _BASELINE:
-            result[model_id] = ModelPricing(
-                provider=_PROVIDER,
-                model_id=model_id,
-                input_per_1m=inp,
-                output_per_1m=out,
-                cache_read_per_1m=cache_read,
-                updated_at=now,
-            )
-        logger.debug("AnthropicPricingSource.fetch returned %d models", len(result))
-        return result
+    _PROVIDER = _PROVIDER
+    _BASELINE = _BASELINE

--- a/autobot-backend/llm_shared/pricing/deepseek_source.py
+++ b/autobot-backend/llm_shared/pricing/deepseek_source.py
@@ -12,10 +12,7 @@ the hardcoded fallback.
 
 from __future__ import annotations
 
-from autobot_shared.logging_manager import get_logger
-from llm_shared.pricing.sources import ModelPricing, PricingSource
-
-logger = get_logger(__name__)
+from llm_shared.pricing.sources import BaselinePricingSource
 
 _PROVIDER = "deepseek"
 
@@ -28,19 +25,7 @@ _BASELINE: list[tuple[str, float, float]] = [
 ]
 
 
-class DeepSeekPricingSource(PricingSource):
+class DeepSeekPricingSource(BaselinePricingSource):
     provider = _PROVIDER
-
-    async def fetch(self) -> dict[str, ModelPricing]:
-        now = self._now()
-        result: dict[str, ModelPricing] = {}
-        for model_id, inp, out in _BASELINE:
-            result[model_id] = ModelPricing(
-                provider=_PROVIDER,
-                model_id=model_id,
-                input_per_1m=inp,
-                output_per_1m=out,
-                updated_at=now,
-            )
-        logger.debug("DeepSeekPricingSource.fetch returned %d models", len(result))
-        return result
+    _PROVIDER = _PROVIDER
+    _BASELINE = _BASELINE

--- a/autobot-backend/llm_shared/pricing/google_source.py
+++ b/autobot-backend/llm_shared/pricing/google_source.py
@@ -12,10 +12,7 @@ fallback.
 
 from __future__ import annotations
 
-from autobot_shared.logging_manager import get_logger
-from llm_shared.pricing.sources import ModelPricing, PricingSource
-
-logger = get_logger(__name__)
+from llm_shared.pricing.sources import BaselinePricingSource
 
 _PROVIDER = "google"
 
@@ -33,19 +30,7 @@ _BASELINE: list[tuple[str, float, float]] = [
 ]
 
 
-class GooglePricingSource(PricingSource):
+class GooglePricingSource(BaselinePricingSource):
     provider = _PROVIDER
-
-    async def fetch(self) -> dict[str, ModelPricing]:
-        now = self._now()
-        result: dict[str, ModelPricing] = {}
-        for model_id, inp, out in _BASELINE:
-            result[model_id] = ModelPricing(
-                provider=_PROVIDER,
-                model_id=model_id,
-                input_per_1m=inp,
-                output_per_1m=out,
-                updated_at=now,
-            )
-        logger.debug("GooglePricingSource.fetch returned %d models", len(result))
-        return result
+    _PROVIDER = _PROVIDER
+    _BASELINE = _BASELINE

--- a/autobot-backend/llm_shared/pricing/openai_source.py
+++ b/autobot-backend/llm_shared/pricing/openai_source.py
@@ -11,10 +11,7 @@ accept a future live-fetch implementation without changes to callers.
 
 from __future__ import annotations
 
-from autobot_shared.logging_manager import get_logger
-from llm_shared.pricing.sources import ModelPricing, PricingSource
-
-logger = get_logger(__name__)
+from llm_shared.pricing.sources import BaselinePricingSource
 
 _PROVIDER = "openai"
 
@@ -37,19 +34,7 @@ _BASELINE: list[tuple[str, float, float]] = [
 ]
 
 
-class OpenAIPricingSource(PricingSource):
+class OpenAIPricingSource(BaselinePricingSource):
     provider = _PROVIDER
-
-    async def fetch(self) -> dict[str, ModelPricing]:
-        now = self._now()
-        result: dict[str, ModelPricing] = {}
-        for model_id, inp, out in _BASELINE:
-            result[model_id] = ModelPricing(
-                provider=_PROVIDER,
-                model_id=model_id,
-                input_per_1m=inp,
-                output_per_1m=out,
-                updated_at=now,
-            )
-        logger.debug("OpenAIPricingSource.fetch returned %d models", len(result))
-        return result
+    _PROVIDER = _PROVIDER
+    _BASELINE = _BASELINE

--- a/autobot-backend/llm_shared/pricing/sources.py
+++ b/autobot-backend/llm_shared/pricing/sources.py
@@ -16,6 +16,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
 
 @dataclass
 class ModelPricing:
@@ -78,3 +82,33 @@ class PricingSource(ABC):
 
     def _now(self) -> datetime:
         return datetime.now(tz=timezone.utc)
+
+
+class BaselinePricingSource(PricingSource):
+    """Base for providers with no live pricing API — returns a hardcoded baseline.
+
+    Concrete subclasses set two class attributes:
+        _PROVIDER: str — provider name (also assigned to `provider`).
+        _BASELINE: list of (model_id, input_per_1m, output_per_1m[, cache_read_per_1m])
+                   tuples. The optional 4th element defaults to 0.0 when omitted.
+    """
+
+    _PROVIDER: str = ""
+    _BASELINE: list[tuple] = []
+
+    async def fetch(self) -> dict[str, ModelPricing]:
+        now = self._now()
+        result: dict[str, ModelPricing] = {}
+        for entry in self._BASELINE:
+            model_id, inp, out = entry[0], entry[1], entry[2]
+            cache_read = entry[3] if len(entry) > 3 else 0.0
+            result[model_id] = ModelPricing(
+                provider=self._PROVIDER,
+                model_id=model_id,
+                input_per_1m=inp,
+                output_per_1m=out,
+                cache_read_per_1m=cache_read,
+                updated_at=now,
+            )
+        logger.debug("%s.fetch returned %d models", type(self).__name__, len(result))
+        return result

--- a/autobot-backend/llm_shared/pricing/vertexai_source.py
+++ b/autobot-backend/llm_shared/pricing/vertexai_source.py
@@ -12,10 +12,7 @@ Vertex-specific pricing endpoints.
 
 from __future__ import annotations
 
-from autobot_shared.logging_manager import get_logger
-from llm_shared.pricing.sources import ModelPricing, PricingSource
-
-logger = get_logger(__name__)
+from llm_shared.pricing.sources import BaselinePricingSource
 
 _PROVIDER = "vertexai"
 
@@ -36,19 +33,7 @@ _BASELINE: list[tuple[str, float, float]] = [
 ]
 
 
-class VertexAIPricingSource(PricingSource):
+class VertexAIPricingSource(BaselinePricingSource):
     provider = _PROVIDER
-
-    async def fetch(self) -> dict[str, ModelPricing]:
-        now = self._now()
-        result: dict[str, ModelPricing] = {}
-        for model_id, inp, out in _BASELINE:
-            result[model_id] = ModelPricing(
-                provider=_PROVIDER,
-                model_id=model_id,
-                input_per_1m=inp,
-                output_per_1m=out,
-                updated_at=now,
-            )
-        logger.debug("VertexAIPricingSource.fetch returned %d models", len(result))
-        return result
+    _PROVIDER = _PROVIDER
+    _BASELINE = _BASELINE


### PR DESCRIPTION
## Thinking Path

`autobot-backend/llm_shared/pricing/{anthropic,openai,deepseek,google,vertexai}_source.py` each defined an identical `fetch()`: the same loop over a module-level `_BASELINE` table building `ModelPricing` records tagged with a module-level `_PROVIDER`, plus an identical debug log. The only real variance was data (the baseline table itself, and one extra `cache_read_per_1m` column for Anthropic's 4-tuple rows vs the other providers' 3-tuples).

## What Changed

- Added `BaselinePricingSource(PricingSource)` to `llm_shared/pricing/sources.py` — the existing abstract-base module for this package — holding the single `fetch()` implementation. It reads `self._BASELINE` / `self._PROVIDER` class attributes and handles both 3-tuple `(model_id, input, output)` and Anthropic's 4-tuple `(model_id, input, output, cache_read)` rows (cache_read defaults to `0.0` when absent, matching prior per-source behavior).
- Refactored `AnthropicPricingSource`, `OpenAIPricingSource`, `DeepSeekPricingSource`, `GooglePricingSource`, `VertexAIPricingSource` to subclass `BaselinePricingSource`, keeping only their `_PROVIDER` / `_BASELINE` data and the `provider` class attribute. No source has any additional unique logic, so no overrides were needed.
- Registration/discovery (`services/pricing_refresh.py:_build_sources`) and the `conftest.py` real-load order (`sources → redis_store → per-provider sources → package __init__`) are untouched — `BaselinePricingSource` lives in `sources.py`, which already loads first.

Net: -42 lines, one `fetch()` implementation instead of five identical copies.

## Verification

- `python3 -m pytest autobot-backend/services/pricing_refresh_test.py -v` → **11 passed** (covers `ModelPricing` round-trip, all 4 registered sources' `fetch()`, Redis store, refresh task, cost-tracker integration).
- Import-smoke + before/after equivalence check for all 5 sources + base (model counts, provider tags, `cache_read_per_1m` behavior for Anthropic vs the 3-tuple providers) — all pass, output matches prior per-source hardcoded values exactly.
- `python3 -m py_compile` on all 6 touched files — clean.
- `python3 -m ruff check llm_shared/pricing/` — all checks passed.

## Model Used

Claude Sonnet 5

Closes #12687
Refs #12645