### PR TITLE
tech-debt(backend): remove 9 redundant _utcnow wrappers, use now_utc directly (#12688)

### DIFF
--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config
-from autobot_shared.time_utils import now_utc
+from autobot_shared.time_utils import utc_timestamp
 
 from .tracing import TraceContext, TraceEvent, new_trace_id
 from .types import A2ATaskStatus, Task, TaskArtifact, TaskState
@@ -48,10 +48,6 @@ _KEY_TASK = "a2a:task:{}"
 _KEY_AUDIT = "a2a:audit:{}"
 _KEY_TASKS = "a2a:tasks"
 _KEY_EVENTS = "a2a:events:{}"  # pub/sub channel for SSE streaming (#4554)
-
-
-def _utcnow() -> str:
-    return now_utc().isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -284,7 +280,7 @@ class TaskManager:
             return task
 
         task.status = A2ATaskStatus(state=state, message=message)
-        task.updated_at = _utcnow()
+        task.updated_at = utc_timestamp()
         event = TraceEvent(
             event="task.state_transition",
             data={"state": state.value, "message": message},
@@ -303,7 +299,7 @@ class TaskManager:
             logger.warning("add_artifact: task %s not found", task_id)
             return False
         task.artifacts.append(artifact)
-        task.updated_at = _utcnow()
+        task.updated_at = utc_timestamp()
         self._save(task)
         return True
 
@@ -318,7 +314,7 @@ class TaskManager:
         if task.status.state in _TERMINAL_STATES:
             return False
         task.status = A2ATaskStatus(state=TaskState.CANCELLED)
-        task.updated_at = _utcnow()
+        task.updated_at = utc_timestamp()
         event = TraceEvent(event="task.cancelled")
         if task.trace_context:
             task.trace_context.events.append(event)

--- a/autobot-backend/a2a/types.py
+++ b/autobot-backend/a2a/types.py
@@ -14,12 +14,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.time_utils import now_utc
-
-
-def _utcnow() -> str:
-    """Return current UTC time as ISO 8601 string."""
-    return now_utc().isoformat()
+from autobot_shared.time_utils import utc_timestamp
 
 
 class TaskState(str, Enum):
@@ -109,7 +104,7 @@ class TaskArtifact:
 
     artifact_type: str  # "text", "json", "error"
     content: Any
-    created_at: str = field(default_factory=_utcnow)
+    created_at: str = field(default_factory=utc_timestamp)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -130,7 +125,7 @@ class A2ATaskStatus:
 
     state: TaskState
     message: str | None = None
-    timestamp: str = field(default_factory=_utcnow)
+    timestamp: str = field(default_factory=utc_timestamp)
 
     def to_dict(self) -> Dict[str, Any]:
         d: Dict[str, Any] = {
@@ -156,8 +151,8 @@ class Task:
     input: str
     context: Dict[str, Any] | None = None
     artifacts: List[TaskArtifact] = field(default_factory=list)
-    created_at: str = field(default_factory=_utcnow)
-    updated_at: str = field(default_factory=_utcnow)
+    created_at: str = field(default_factory=utc_timestamp)
+    updated_at: str = field(default_factory=utc_timestamp)
     # Issue #968: distributed tracing — set on task creation
     trace_context: Optional["TraceContext"] = field(default=None, repr=False)
 

--- a/autobot-backend/knowledge/pipeline/models/causal_edge.py
+++ b/autobot-backend/knowledge/pipeline/models/causal_edge.py
@@ -28,11 +28,6 @@ EffectType = Literal[
 ]
 
 
-def _utcnow() -> datetime:
-    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
-    return now_utc()
-
-
 class CausalEdge(BaseModel):
     """
     Represents an extracted causal relationship between two entities.
@@ -77,8 +72,8 @@ class CausalEdge(BaseModel):
         default=False,
         description="Whether the inverse relationship also holds (rare for causality)",
     )
-    created_at: datetime = Field(default_factory=_utcnow, description="Causal edge creation timestamp")
-    updated_at: datetime = Field(default_factory=_utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=now_utc, description="Causal edge creation timestamp")
+    updated_at: datetime = Field(default_factory=now_utc, description="Last update timestamp")
 
     def to_causal_string(self) -> str:
         """Format as human-readable causal statement."""

--- a/autobot-backend/knowledge/pipeline/models/chunk.py
+++ b/autobot-backend/knowledge/pipeline/models/chunk.py
@@ -17,11 +17,6 @@ from pydantic import BaseModel, ConfigDict, Field
 from autobot_shared.time_utils import now_utc
 
 
-def _utcnow() -> datetime:
-    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
-    return now_utc()
-
-
 class ProcessedChunk(BaseModel):
     """
     Represents a processed chunk of text from a document.
@@ -48,4 +43,4 @@ class ProcessedChunk(BaseModel):
     )
     start_offset: int = Field(default=0, description="Character offset where chunk starts in document")
     end_offset: int = Field(default=0, description="Character offset where chunk ends in document")
-    created_at: datetime = Field(default_factory=_utcnow, description="Chunk creation timestamp")
+    created_at: datetime = Field(default_factory=now_utc, description="Chunk creation timestamp")

--- a/autobot-backend/knowledge/pipeline/models/entity.py
+++ b/autobot-backend/knowledge/pipeline/models/entity.py
@@ -28,11 +28,6 @@ EntityType = Literal[
 ]
 
 
-def _utcnow() -> datetime:
-    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
-    return now_utc()
-
-
 class Entity(BaseModel):
     """
     Represents an extracted entity from document processing.
@@ -58,5 +53,5 @@ class Entity(BaseModel):
     source_document_id: UUID = Field(..., description="Primary source document ID")
     confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Extraction confidence score")
     extraction_count: int = Field(default=1, description="Number of times entity was extracted")
-    created_at: datetime = Field(default_factory=_utcnow, description="Entity creation timestamp")
-    updated_at: datetime = Field(default_factory=_utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=now_utc, description="Entity creation timestamp")
+    updated_at: datetime = Field(default_factory=now_utc, description="Last update timestamp")

--- a/autobot-backend/knowledge/pipeline/models/event.py
+++ b/autobot-backend/knowledge/pipeline/models/event.py
@@ -20,11 +20,6 @@ TemporalType = Literal["point", "range", "relative", "recurring"]
 EventType = Literal["action", "decision", "change", "milestone", "occurrence"]
 
 
-def _utcnow() -> datetime:
-    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
-    return now_utc()
-
-
 class TemporalEvent(BaseModel):
     """
     Represents a temporal event extracted from document processing.
@@ -51,5 +46,5 @@ class TemporalEvent(BaseModel):
     source_chunk_ids: List[UUID] = Field(default_factory=list, description="Chunks where event was mentioned")
     source_document_id: UUID = Field(..., description="Source document ID")
     confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Extraction confidence score")
-    created_at: datetime = Field(default_factory=_utcnow, description="Event creation timestamp")
-    updated_at: datetime = Field(default_factory=_utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=now_utc, description="Event creation timestamp")
+    updated_at: datetime = Field(default_factory=now_utc, description="Last update timestamp")

--- a/autobot-backend/knowledge/pipeline/models/fact.py
+++ b/autobot-backend/knowledge/pipeline/models/fact.py
@@ -28,11 +28,6 @@ FactType = Literal[
 ]
 
 
-def _utcnow() -> datetime:
-    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
-    return now_utc()
-
-
 class AtomicFact(BaseModel):
     """
     Represents an atomic factual statement extracted from document processing.
@@ -71,8 +66,8 @@ class AtomicFact(BaseModel):
         default=1,
         description="Number of chunks supporting this fact (cross-validation)",
     )
-    created_at: datetime = Field(default_factory=_utcnow, description="Fact creation timestamp")
-    updated_at: datetime = Field(default_factory=_utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=now_utc, description="Fact creation timestamp")
+    updated_at: datetime = Field(default_factory=now_utc, description="Last update timestamp")
 
     def as_triple(self) -> tuple[str, str, str]:
         """Return fact as (subject, predicate, object) triple for graph representation."""

--- a/autobot-backend/knowledge/pipeline/models/relationship.py
+++ b/autobot-backend/knowledge/pipeline/models/relationship.py
@@ -43,11 +43,6 @@ RelationType = Literal[
 ]
 
 
-def _utcnow() -> datetime:
-    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
-    return now_utc()
-
-
 class Relationship(BaseModel):
     """
     Represents a directed relationship between two entities.
@@ -71,5 +66,5 @@ class Relationship(BaseModel):
     )
     confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Extraction confidence score")
     source_chunk_ids: List[UUID] = Field(default_factory=list, description="Chunks where relationship was found")
-    created_at: datetime = Field(default_factory=_utcnow, description="Relationship creation timestamp")
-    updated_at: datetime = Field(default_factory=_utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=now_utc, description="Relationship creation timestamp")
+    updated_at: datetime = Field(default_factory=now_utc, description="Last update timestamp")

--- a/autobot-backend/knowledge/pipeline/models/summary.py
+++ b/autobot-backend/knowledge/pipeline/models/summary.py
@@ -19,11 +19,6 @@ from autobot_shared.time_utils import now_utc
 SummaryLevel = Literal["chunk", "section", "document"]
 
 
-def _utcnow() -> datetime:
-    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
-    return now_utc()
-
-
 class Summary(BaseModel):
     """
     Represents a hierarchical summary of text content.
@@ -47,4 +42,4 @@ class Summary(BaseModel):
     key_entities: List[UUID] = Field(default_factory=list, description="Key entities mentioned in summary")
     word_count: int = Field(default=0, description="Number of words in summary")
     compression_ratio: float = Field(default=0.0, description="Ratio of summary to original text length")
-    created_at: datetime = Field(default_factory=_utcnow, description="Summary creation timestamp")
+    created_at: datetime = Field(default_factory=now_utc, description="Summary creation timestamp")


### PR DESCRIPTION
## Thinking Path

Round-2 of umbrella #12645. `def _utcnow(): return now_utc()` was redefined 9x across `autobot-backend/knowledge/pipeline/models/{chunk,fact,entity,event,summary,relationship,causal_edge}.py` and `autobot-backend/a2a/{task_manager,types}.py`.

Grepping each usage showed the 7 model files were **pure delegation** (`_utcnow()` just calls `now_utc()`), used as `Field(default_factory=_utcnow)` on `datetime`-typed fields. `a2a/task_manager.py` and `a2a/types.py` were **not** pure delegation — their `_utcnow()` called `.isoformat()`, because those fields are typed `str` (they get `json.dumps`'d for Redis persistence / SSE wire payloads). Replacing those two with a bare `default_factory=now_utc` would have silently changed the field type from `str` to `datetime`, breaking JSON serialization (`TypeError: Object of type datetime is not JSON serializable`). Instead of inlining a lambda, `autobot_shared.time_utils` already ships `utc_timestamp()` (`datetime.now(timezone.utc).isoformat()`), functionally identical to the old `_utcnow()` output, so those two files use that canonical helper instead.

## What Changed

- 7 pydantic model files: deleted the local `_utcnow` wrapper; `default_factory=_utcnow` → `default_factory=now_utc` (already imported in every file).
- `a2a/task_manager.py`: deleted `_utcnow`; swapped `now_utc` import for `utc_timestamp`; the 3 `task.updated_at = _utcnow()` call sites → `utc_timestamp()`.
- `a2a/types.py`: deleted `_utcnow`; swapped `now_utc` import for `utc_timestamp`; 4 `field(default_factory=_utcnow)` → `field(default_factory=utc_timestamp)`.
- Zero behavior change: `now_utc()` == `datetime.now(timezone.utc)`; `utc_timestamp()` == `datetime.now(timezone.utc).isoformat()` == what the deleted `_utcnow()` produced in the a2a files.

## Verification

- `grep -rn "def _utcnow"` across the 9 files: zero matches.
- `grep -rn "_utcnow\b" --include="*.py" .` repo-wide: zero matches (confirmed no other module imported any of these 9 files' `_utcnow`; `models/document.py`'s unrelated `_utcnow_iso` is untouched).
- Import-smoke: all 9 modules import cleanly; instantiated `ProcessedChunk` (datetime field) and `Task` (str field, JSON-serialized) to confirm identical runtime types/values as before.
- `pytest autobot-backend/knowledge/pipeline/models/models_test.py` + all `knowledge/pipeline/cognifiers/*_test.py` + all `autobot-backend/a2a/*_test.py`: **278 passed, 13 failed (pre-existing on origin/Dev_new_gui baseline — verified byte-for-byte identical failure set before/after this change), 1 skipped.**

## Model Used

Sonnet

Closes #12688
Refs #12645