### PR TITLE
refactor(frontend): repoint 2 composables onto canonical extractErrorMessage util (#12691)

### DIFF
--- a/autobot-frontend/src/composables/useDesktopControlLock.ts
+++ b/autobot-frontend/src/composables/useDesktopControlLock.ts
@@ -20,6 +20,7 @@
 import { computed, getCurrentScope, onScopeDispose, ref } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { extractErrorMessage } from '@/utils/errorExtract'
 import { useUserStore } from '@/stores/useUserStore'
 
 const logger = createLogger('useDesktopControlLock')
@@ -36,12 +37,6 @@ export interface DesktopControlLockState {
   owner: string | null
   human_active: boolean
   message: string
-}
-
-function extractErrorMessage(err: unknown, fallback: string): string {
-  if (err instanceof Error) return err.message
-  if (typeof err === 'string') return err
-  return fallback
 }
 
 export function useDesktopControlLock(vncType: string = 'desktop', sessionId: string = 'default') {

--- a/autobot-frontend/src/composables/useVncControls.ts
+++ b/autobot-frontend/src/composables/useVncControls.ts
@@ -20,6 +20,7 @@ import { ref } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { useLoadingState } from '@/composables/useLoadingState'
+import { extractErrorMessage } from '@/utils/errorExtract'
 
 const logger = createLogger('useVncControls')
 
@@ -45,12 +46,6 @@ export interface VncActionResponse {
   status: 'success' | 'error'
   message: string
   image_data?: string
-}
-
-function extractErrorMessage(err: unknown, fallback: string): string {
-  if (err instanceof Error) return err.message
-  if (typeof err === 'string') return err
-  return fallback
 }
 
 export function useVncControls(sessionId: string = 'default') {


### PR DESCRIPTION
## Thinking Path

Round-2 of umbrella #12645. The canonical `extractErrorMessage(err: unknown, fallback: string): string` lives in `autobot-frontend/src/utils/errorExtract.ts`. Two composables carried byte-identical inline copies. Confirmed each inline copy matches the canonical export exactly (same name, signature, body), so repointing is a pure no-behavior-change refactor.

## What Changed

- `useDesktopControlLock.ts`: added `import { extractErrorMessage } from '@/utils/errorExtract'`, deleted the inline definition. All 3 call sites unchanged.
- `useVncControls.ts`: added the same import, deleted the inline definition. All 7 call sites unchanged.
- slm-frontend copies intentionally untouched (tracked by #12653).

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json` — clean (exit 0)
- `oxlint ... -D correctness` (scoped to changed files) — 0 errors
- `vitest run` on `useDesktopControlLock.test.ts` + `useVncControls.test.ts` — 14 passed (2 files)
- grep-confirmed: both files now import from `@/utils/errorExtract` and no longer declare a local `extractErrorMessage`.

## Model Used

claude-opus-4-8

Closes #12691
Refs #12645
