### PR TITLE
tech-debt(slm): single _find_ansible_playbook helper (#12693)

### DIFF
--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -4,7 +4,37 @@
 # Author: mrveiss
 """Ansible output parsing utilities for slm-backend endpoints."""
 
+import os
 import re
+import shutil
+
+# Common install locations checked when ansible-playbook isn't on PATH
+# (Issue #12693 — shared between DeploymentService and PlaybookExecutor).
+_COMMON_ANSIBLE_PATHS = (
+    "/usr/bin/ansible-playbook",
+    "/usr/local/bin/ansible-playbook",
+    "/opt/ansible/bin/ansible-playbook",
+)
+
+
+def _find_ansible_playbook() -> str:
+    """Find the ansible-playbook executable with system PATH.
+
+    Shared by DeploymentService and PlaybookExecutor (Issue #12693, round-2
+    of the #12645 dedup umbrella) — both previously carried near-identical
+    copies of this search.
+    """
+    # First try with current PATH
+    ansible_path = shutil.which("ansible-playbook")
+    if ansible_path:
+        return ansible_path
+
+    # Try common system paths if not in current PATH
+    for path in _COMMON_ANSIBLE_PATHS:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+
+    raise FileNotFoundError("ansible-playbook not found. Install Ansible: apt install ansible")
 
 
 def _extract_failure_summary(output: str) -> str:

--- a/autobot-slm-backend/services/deployment.py
+++ b/autobot-slm-backend/services/deployment.py
@@ -24,6 +24,7 @@ from autobot_shared.ssot_config import config as ssot_config
 from config import settings
 from models.database import Deployment, DeploymentStatus, Node, NodeStatus
 from models.schemas import DeploymentCreate, DeploymentResponse
+from services.ansible_utils import _find_ansible_playbook as _resolve_ansible_playbook
 from services.encryption import decrypt_data
 
 logger = logging.getLogger(__name__)
@@ -593,23 +594,11 @@ class DeploymentService:
                 logger.error("Deployment failed: %s - %s", deployment_id, e)
 
     def _find_ansible_playbook(self) -> str:
-        """Find the ansible-playbook executable with system PATH."""
-        # First try with current PATH
-        ansible_path = shutil.which("ansible-playbook")
-        if ansible_path:
-            return ansible_path
+        """Find the ansible-playbook executable with system PATH.
 
-        # Try common system paths if not in current PATH
-        common_paths = [
-            "/usr/bin/ansible-playbook",
-            "/usr/local/bin/ansible-playbook",
-            "/opt/ansible/bin/ansible-playbook",
-        ]
-        for path in common_paths:
-            if os.path.isfile(path) and os.access(path, os.X_OK):
-                return path
-
-        raise FileNotFoundError("ansible-playbook not found. Install Ansible: apt install ansible")
+        Shared search logic lives in services.ansible_utils (Issue #12693).
+        """
+        return _resolve_ansible_playbook()
 
     def _build_ansible_base_command(self, playbook_path: Path, host: str, roles: List[str]) -> List[str]:
         """Build the base ansible-playbook command list.

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Callable, Dict, List
 
 from services.ansible_secrets import fetch_deploy_secrets
+from services.ansible_utils import _find_ansible_playbook as _resolve_ansible_playbook
 from services.inventory_builder import (
     build_registry_inventory,
     validate_inventory,
@@ -122,21 +123,11 @@ class PlaybookExecutor:
         self.inventory_path = ansible_dir / "inventory" / "slm-nodes.yml"
 
     def _find_ansible_playbook(self) -> str:
-        """Find ansible-playbook executable."""
-        ansible_path = shutil.which("ansible-playbook")
-        if ansible_path:
-            return ansible_path
+        """Find ansible-playbook executable.
 
-        # Try common paths
-        common_paths = [
-            "/usr/bin/ansible-playbook",
-            "/usr/local/bin/ansible-playbook",
-        ]
-        for path in common_paths:
-            if os.path.isfile(path) and os.access(path, os.X_OK):
-                return path
-
-        raise FileNotFoundError("ansible-playbook not found. Install: apt install ansible")
+        Shared search logic lives in services.ansible_utils (Issue #12693).
+        """
+        return _resolve_ansible_playbook()
 
     @staticmethod
     def _clean_task_name(task_name: str) -> str:


### PR DESCRIPTION
## Thinking Path
`autobot-slm-backend/services/deployment.py:595` and `services/playbook_executor.py:124` each defined a near-identical `_find_ansible_playbook`. Diffed both bodies: `deployment.py`'s version was a strict superset (3 common install paths incl. `/opt/ansible/bin/ansible-playbook` vs. 2, and a slightly more informative `FileNotFoundError` message) — kept it as the canonical implementation per best-impl-wins.

## What Changed
- Added module-level `_find_ansible_playbook()` to `services/ansible_utils.py` (existing shared ansible-utility module — reused rather than creating a new one), carrying the exact search behavior from `deployment.py`'s version (PATH lookup → 3 common paths → `FileNotFoundError`).
- `DeploymentService._find_ansible_playbook` and `PlaybookExecutor._find_ansible_playbook` now each delegate to the shared function via a thin one-line wrapper, instead of duplicating the ~15-line search body.
- Kept the instance-method wrappers (rather than repointing the 3 internal call sites directly at the module function) because `tests/services/test_extra_vars_file_11735.py` monkeypatches `executor._find_ansible_playbook` at the instance level to avoid requiring a real `ansible-playbook` binary during tests — removing the wrapper would have broken that test's mocking seam for no behavioral gain.
- No behavior change: search order, error handling, and error message are unchanged (deployment.py's message is now shared by both callers).

## Verification
```
python3 -m pytest tests/api/test_code_sync_protected_excludes.py tests/test_websocket_connection_manager_12515.py \
  tests/api/test_fleet_node_update_11511.py tests/test_infrastructure_playbooks.py \
  tests/api/test_role_migration_extra_vars.py tests/services/test_dynamic_inventory_group_vars_11781.py \
  tests/services/drift_checker_test.py tests/api/test_apply_secrets.py tests/services/test_extra_vars_file_11735.py \
  tests/services/test_self_update_systemd_detach_11492.py tests/api/test_node_update_availability_11964.py \
  services/ansible_utils_test.py -q
# 127 passed, 2 warnings in 7.43s

python3 -m py_compile services/deployment.py services/playbook_executor.py services/ansible_utils.py  # COMPILE_OK
python3 -m ruff check services/deployment.py services/playbook_executor.py services/ansible_utils.py  # All checks passed!

grep -rn "def _find_ansible_playbook" autobot-slm-backend --include="*.py"
# services/ansible_utils.py:20:def _find_ansible_playbook() -> str:       (module-level, single body)
# services/deployment.py:596:    def _find_ansible_playbook(self) -> str:  (1-line delegate)
# services/playbook_executor.py:125:    def _find_ansible_playbook(self) -> str:  (1-line delegate)
```

## Model Used
Sonnet 5

Closes #12693
Refs #12645