### PR TITLE
tech-debt(backend): extract memory/_redis_util for shared redis_scan/decode (#12694)

### DIFF
--- a/autobot-backend/memory/_redis_util.py
+++ b/autobot-backend/memory/_redis_util.py
@@ -1,0 +1,41 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Shared Redis helpers for the memory subsystem — Issue #12694.
+
+``decode`` and ``redis_scan`` were duplicated verbatim across
+``memory.transparency`` and ``memory.ownership_reassign``; both now import
+from here instead of carrying their own copy.
+"""
+
+import logging
+from typing import Any, List
+
+logger = logging.getLogger(__name__)
+
+
+def decode(v: Any) -> str:
+    """Decode a Redis reply to ``str``, passing through non-bytes values."""
+    return v.decode("utf-8") if isinstance(v, bytes) else str(v)
+
+
+async def redis_scan(redis: Any, match: str) -> List[str]:
+    """Non-blocking SCAN helper — collects every key matching *match*."""
+    keys: List[str] = []
+    cursor = 0
+    while True:
+        try:
+            cursor, batch = await redis.scan(cursor, match=match, count=200)
+        except Exception as exc:
+            logger.warning("memory._redis_util: redis scan error: %s", exc)
+            break
+        for k in batch:
+            keys.append(decode(k))
+        if cursor == 0:
+            break
+    return keys
+
+
+__all__ = ["decode", "redis_scan"]

--- a/autobot-backend/memory/ownership_reassign.py
+++ b/autobot-backend/memory/ownership_reassign.py
@@ -40,12 +40,16 @@ import json
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from memory._redis_util import redis_scan as _redis_scan
 from memory.working_memory import is_working_memory_key
 
 logger = get_logger(__name__)
 
-# Module-level lazy references — mirrors memory.transparency so tests can
-# pre-assign any one of these without triggering the full import stack.
+# Module-level lazy references — same pattern as memory.transparency so tests
+# can pre-assign any one of these without triggering the full import stack.
+# NOTE: not shared with memory.transparency._bootstrap — this module also
+# lazy-imports get_knowledge_base_fn (kb_facts store), which transparency
+# does not use, so the two bootstraps import different symbol sets (#12694).
 get_verbatim_store = None  # type: ignore[assignment]
 get_trajectory_store = None  # type: ignore[assignment]
 get_redis_client = None  # type: ignore[assignment]
@@ -53,7 +57,8 @@ get_knowledge_base_fn = None  # type: ignore[assignment]
 
 
 def _bootstrap() -> None:
-    """Lazily import heavy dependencies; mirrors memory.transparency._bootstrap."""
+    """Lazily import heavy dependencies (same pattern as memory.transparency._bootstrap;
+    see module-level NOTE above for why it is not shared)."""
     global get_verbatim_store, get_trajectory_store, get_redis_client, get_knowledge_base_fn
     if get_verbatim_store is None:
         from memory.verbatim_store import get_verbatim_store as _gvs
@@ -71,27 +76,6 @@ def _bootstrap() -> None:
         from knowledge._composed import get_knowledge_base as _gkb
 
         get_knowledge_base_fn = _gkb
-
-
-def _decode(v: Any) -> str:
-    return v.decode("utf-8") if isinstance(v, bytes) else str(v)
-
-
-async def _redis_scan(redis: Any, match: str) -> List[str]:
-    """Non-blocking SCAN helper — mirrors memory.transparency._redis_scan."""
-    keys: List[str] = []
-    cursor = 0
-    while True:
-        try:
-            cursor, batch = await redis.scan(cursor, match=match, count=200)
-        except Exception as exc:
-            logger.warning("ownership_reassign: redis scan error: %s", exc)
-            break
-        for k in batch:
-            keys.append(_decode(k))
-        if cursor == 0:
-            break
-    return keys
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/memory/transparency.py
+++ b/autobot-backend/memory/transparency.py
@@ -28,6 +28,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from memory._redis_util import decode as _decode
+from memory._redis_util import redis_scan as _redis_scan
 from memory.working_memory import is_working_memory_key
 
 logger = get_logger(__name__)
@@ -82,27 +84,6 @@ async def _safe(coro, fallback=None):
 
 def _now_iso() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
-
-
-def _decode(v) -> str:
-    return v.decode("utf-8") if isinstance(v, bytes) else str(v)
-
-
-async def _redis_scan(redis, match: str) -> List[str]:
-    """SCAN for all keys matching *match* without blocking the event loop."""
-    keys: List[str] = []
-    cursor = 0
-    while True:
-        try:
-            cursor, batch = await redis.scan(cursor, match=match, count=200)
-        except Exception as exc:
-            logger.warning("memory_transparency: redis scan failed: %s", exc)
-            break
-        for k in batch:
-            keys.append(_decode(k))
-        if cursor == 0:
-            break
-    return keys
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

`memory/ownership_reassign.py` mirrored `memory/transparency.py` in three
helpers: `_redis_scan`, `_decode`, and `_bootstrap`. Diffed all three:

- `_redis_scan` and `_decode`: byte-for-byte identical bodies in both
  modules (only the log-tag string in `_redis_scan`'s warning differed,
  which is not observable behavior — moved into the shared helper's own
  generic log tag).
- `_bootstrap`: **not** identical. `transparency._bootstrap` lazy-imports
  `get_verbatim_store`, `get_trajectory_store`, `get_redis_client` (3
  symbols). `ownership_reassign._bootstrap` lazy-imports those same 3
  **plus** `get_knowledge_base_fn` (from `knowledge._composed`, used by
  the `kb_facts` store pass) — 4 symbols. Since the symbol sets differ,
  merging into one shared bootstrap would either force `transparency` to
  import a symbol it never uses, or silently drop `get_knowledge_base_fn`
  from `ownership_reassign`. Per the task contract, keeping them separate
  (with a code comment explaining why) is safer than a forced merge.

## What Changed

- New `autobot-backend/memory/_redis_util.py` hosting the single shared
  implementation of `redis_scan()` (non-blocking Redis `SCAN` helper) and
  `decode()` (bytes→str Redis reply decoder).
- `memory/transparency.py` and `memory/ownership_reassign.py` now import
  `redis_scan`/`decode` from `_redis_util` (aliased to the existing
  `_redis_scan`/`_decode` names so all call sites are unchanged) instead
  of each carrying its own copy.
- `_bootstrap` is left as two separate functions (see Thinking Path);
  added a module-level comment on `ownership_reassign.py` documenting why
  it isn't shared with `transparency.py`.
- No behavior change — pure extraction.

## Verification

```
$ python3 -m pytest autobot-backend/memory/ -q
============================= 164 passed in 4.87s ==============================

$ python3 -m ruff check autobot-backend/memory/_redis_util.py autobot-backend/memory/transparency.py autobot-backend/memory/ownership_reassign.py
All checks passed!

$ python3 -m flake8 autobot-backend/memory/_redis_util.py autobot-backend/memory/transparency.py autobot-backend/memory/ownership_reassign.py
(no output — clean)

# import-smoke + identity check confirms both modules now share the same function objects
mr._redis_scan is ru.redis_scan: True
mt._redis_scan is ru.redis_scan: True
mt._decode is ru.decode: True

# grep-confirm each helper body now defined exactly once
$ grep -rn "^async def _redis_scan\|^async def redis_scan\|^def _decode\|^def decode" autobot-backend/memory/*.py
memory/_redis_util.py:19:def decode(v: Any) -> str:
memory/_redis_util.py:24:async def redis_scan(redis: Any, match: str) -> List[str]:
```

Closes #12694
Refs #12645

## Model Used

Sonnet 5