### PR TITLE
tech-debt(backend): repoint score→grade forks onto canonical get_grade_from_score (#12686)

### DIFF
--- a/autobot-backend/api/analytics_code.py
+++ b/autobot-backend/api/analytics_code.py
@@ -27,6 +27,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.path_validator import validate_path
+from code_intelligence.shared.scoring import get_grade_from_score
 
 # Import shared analytics controller from analytics module
 # This will be set after analytics.py is updated
@@ -552,19 +553,6 @@ def _calculate_quality_factors(cached_analysis: dict) -> dict:
     return quality_factors
 
 
-def _score_to_grade(score: float) -> str:
-    """Convert numeric score to letter grade (Issue #665: extracted)."""
-    if score >= 90:
-        return "A"
-    if score >= 80:
-        return "B"
-    if score >= 70:
-        return "C"
-    if score >= 60:
-        return "D"
-    return "F"
-
-
 @router.get("/code/metrics/quality-score", response_model=AnalyticsCodeQualityScoreResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -595,7 +583,7 @@ async def get_code_quality_score(
 
     return {
         "overall_score": round(overall_score, 1),
-        "grade": _score_to_grade(overall_score),
+        "grade": get_grade_from_score(overall_score),
         "quality_factors": quality_factors,
         "recommendations": [],
         "last_analysis": cached_analysis.get("timestamp"),

--- a/autobot-backend/api/analytics_reporting.py
+++ b/autobot-backend/api/analytics_reporting.py
@@ -29,6 +29,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import utc_timestamp
+from code_intelligence.shared.scoring import get_grade_from_score
 
 logger = get_logger(__name__)
 # Issue #3355: prefix moved to router registry (analytics_routers.py)
@@ -180,20 +181,6 @@ def calculate_composite_health_score(
     return round(quality_component + issues_component + debt_component + perf_component, 1)
 
 
-def get_grade(score: float) -> str:
-    """Convert score to letter grade."""
-    if score >= 90:
-        return "A"
-    elif score >= 80:
-        return "B"
-    elif score >= 70:
-        return "C"
-    elif score >= 60:
-        return "D"
-    else:
-        return "F"
-
-
 def _get_problem_category_mapping() -> list:
     """Get problem type keyword to category mapping (Issue #315)."""
     return [
@@ -260,7 +247,7 @@ def _build_report_response(
         "generated_at": utc_timestamp(),
         "summary": {
             "health_score": health_score,
-            "grade": get_grade(health_score),
+            "grade": get_grade_from_score(health_score),
             "total_issues": total_issues,
             "critical": severity_totals.get("critical", 0),
             "high": severity_totals.get("high", 0),

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -82,6 +82,7 @@ from code_intelligence.security import (
     SecuritySeverity,
     get_vulnerability_types,
 )
+from code_intelligence.shared.scoring import get_grade_from_score
 from constants.ttl_constants import TTL_5_MINUTES
 from tasks.analytics_tasks import run_security_analysis
 from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_input, raise_not_found
@@ -293,29 +294,6 @@ REDIS_OPTIMIZATION_CATEGORIES = (
 # =============================================================================
 # Helper Functions for Score Grading (Issue #315 - extracted/refactored)
 # =============================================================================
-
-
-def _calculate_grade_from_score(score: float) -> str:
-    """
-    Calculate letter grade from numeric score.
-
-    (Issue #315 - extracted/refactored)
-
-    Args:
-        score: Numeric score from 0-100
-
-    Returns:
-        Letter grade: A, B, C, D, or F
-    """
-    if score >= 90:
-        return "A"
-    if score >= 80:
-        return "B"
-    if score >= 70:
-        return "C"
-    if score >= 60:
-        return "D"
-    return "F"
 
 
 def _get_redis_status_message(score: float) -> str:
@@ -914,7 +892,7 @@ async def get_codebase_health_score(
         score = _calculate_health_score(report.anti_patterns)
 
         # Determine grade using extracted helper
-        grade = _calculate_grade_from_score(score)
+        grade = get_grade_from_score(score)
 
         return JSONResponse(
             status_code=200,
@@ -1160,7 +1138,7 @@ async def _run_redis_health_analysis(path: str) -> Dict[str, Any]:
     results = await asyncio.to_thread(optimizer.analyze_directory, path)
 
     score = _calculate_redis_health_score(results)
-    grade = _calculate_grade_from_score(score)
+    grade = get_grade_from_score(score)
     status = _get_redis_status_message(score)
 
     return {
@@ -1362,7 +1340,7 @@ async def get_security_score(
 
         # Generate grade and status using extracted helpers
         score = summary["security_score"]
-        grade = _calculate_grade_from_score(score)
+        grade = get_grade_from_score(score)
         status = _get_security_status_message(score)
 
         return JSONResponse(

--- a/autobot-backend/code_intelligence/conftest.py
+++ b/autobot-backend/code_intelligence/conftest.py
@@ -95,6 +95,17 @@ for _key in list(sys.modules.keys()):
     if _key == "code_intelligence.security" or _key.startswith("code_intelligence.security."):
         del sys.modules[_key]
 
+# code_intelligence.security.analyzer imports code_intelligence.shared.analysis_base
+# (#12686). The top-level conftest installs a leaf-only stub for
+# code_intelligence.shared (empty __path__) so that api/*.py's module-level
+# `from code_intelligence.shared.scoring import get_grade_from_score` resolves
+# without dragging in the heavier ASTCache/FileListCache imports. Drop that
+# stub here too so the real package (with its real __path__, now that
+# code_intelligence.__path__ is repaired above) loads for real analysis_base.
+for _key in list(sys.modules.keys()):
+    if _key == "code_intelligence.shared" or _key.startswith("code_intelligence.shared."):
+        del sys.modules[_key]
+
 importlib.import_module("code_intelligence.security")
 
 # Replace the stub for the shim module with the real one.

--- a/autobot-backend/code_intelligence/performance_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/performance_analysis/analyzer.py
@@ -253,23 +253,6 @@ class PerformanceAnalyzer(BaseCodeAnalyzer):
             "top_issues": self._get_top_issues(),
         }
 
-    def _get_grade(self, score: int) -> str:
-        """
-        Get letter grade from score.
-
-        DEPRECATED: Use get_grade_from_score from shared.scoring instead.
-        Kept for backward compatibility.
-        """
-        if score >= 90:
-            return "A"
-        elif score >= 80:
-            return "B"
-        elif score >= 70:
-            return "C"
-        elif score >= 60:
-            return "D"
-        return "F"
-
     def _get_top_issues(self) -> List[Dict[str, Any]]:
         """Get top issues by severity."""
         severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -713,6 +713,20 @@ _real_load_and_bind(
     backend_root / "code_intelligence" / "code_generation" / "diff.py",
 )
 
+# code_intelligence.shared.scoring real-load (#12686) — api/analytics_code.py,
+# api/code_intelligence.py, api/analytics_reporting.py, and services/analytics_service.py
+# import get_grade_from_score from code_intelligence.shared.scoring at module level
+# (canonicalized 5 duplicate score->grade forks onto this shared helper). scoring.py is
+# self-contained (stdlib only: math, typing), so real-load this leaf submodule bypassing
+# code_intelligence.shared's own __init__ (which pulls ASTCache/FileListCache — heavier
+# deps not needed here), same pattern as code_intelligence.code_generation.diff above.
+if "code_intelligence.shared" not in sys.modules:
+    sys.modules["code_intelligence.shared"] = _make_pkg_stub("code_intelligence.shared")
+_real_load_and_bind(
+    "code_intelligence.shared.scoring",
+    backend_root / "code_intelligence" / "shared" / "scoring.py",
+)
+
 # code_intelligence submodule stubs — code_intelligence itself is stubbed above
 # (its __init__ has Python-3.10-incompatible annotations), so submodule imports
 # from api/*.py need their own stubs with the right symbol names.

--- a/autobot-backend/services/analytics_service.py
+++ b/autobot-backend/services/analytics_service.py
@@ -27,6 +27,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc, utc_timestamp
+from code_intelligence.shared.scoring import get_grade_from_score
 from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
     EXPENSIVE_MODEL_MARKER_OPUS,
@@ -240,7 +241,7 @@ class AnalyticsService(AsyncRedisClientMixin):
             "period_days": days,
             "health": {
                 "score": health_score,
-                "grade": self._get_grade(health_score),
+                "grade": get_grade_from_score(health_score),
                 "status": self._get_health_status(health_score),
             },
             "cost": {
@@ -290,18 +291,6 @@ class AnalyticsService(AsyncRedisClientMixin):
             scores.append(engagement_score)
 
         return round(statistics.mean(scores) if scores else 50, 1)
-
-    def _get_grade(self, score: float) -> str:
-        """Convert score to letter grade."""
-        if score >= 90:
-            return "A"
-        elif score >= 80:
-            return "B"
-        elif score >= 70:
-            return "C"
-        elif score >= 60:
-            return "D"
-        return "F"
 
     def _get_health_status(self, score: float) -> str:
         """Get health status from score."""

--- a/autobot-backend/tasks/analytics_tasks.py
+++ b/autobot-backend/tasks/analytics_tasks.py
@@ -308,8 +308,9 @@ def run_security_analysis(self, path: str) -> dict:
     _progress(self, "Initializing security analyzer", 10.0, started)
 
     async def _work():
-        from api.code_intelligence import _calculate_grade_from_score, _get_security_status_message
+        from api.code_intelligence import _get_security_status_message
         from code_intelligence.security import SecurityAnalyzer
+        from code_intelligence.shared.scoring import get_grade_from_score
 
         analyzer = SecurityAnalyzer(project_root=path)
         _progress(self, "Scanning for vulnerabilities", 30.0, started)
@@ -322,7 +323,7 @@ def run_security_analysis(self, path: str) -> dict:
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             "path": path,
             "security_score": score,
-            "grade": _calculate_grade_from_score(score),
+            "grade": get_grade_from_score(score),
             "risk_level": summary["risk_level"],
             "status_message": _get_security_status_message(score),
             "total_findings": summary["total_findings"],


### PR DESCRIPTION
## Thinking Path

Umbrella #12645 round-2. Canonical `get_grade_from_score()` lives at `code_intelligence/shared/scoring.py:127` (90/80/70/60 -> A/B/C/D/F). Grepped every `score >= 90` grade-ladder-shaped function across `autobot-backend/` and diffed each against the canonical's thresholds/return type before touching it — only collapsed the ones that are byte-identical in behavior.

## What Changed

Repointed 5 identical forks onto the canonical helper and deleted the local defs:
- `api/analytics_code.py:555 _score_to_grade` -> import + `get_grade_from_score`
- `api/code_intelligence.py:298 _calculate_grade_from_score` -> import + `get_grade_from_score` (3 call sites)
- `api/analytics_reporting.py:183 get_grade` -> import + `get_grade_from_score`
- `services/analytics_service.py:294 _get_grade` (bound method) -> import + `get_grade_from_score`
- `code_intelligence/performance_analysis/analyzer.py:256 _get_grade` -> dead code (0 callers, already marked `DEPRECATED: Use get_grade_from_score`, file already imports the canonical elsewhere) -> deleted, nothing to repoint

Also fixed `tasks/analytics_tasks.py`, which lazily imported the now-deleted `api.code_intelligence._calculate_grade_from_score` — repointed to the canonical import.

**Left untouched (differ from canonical, not the same function):**
- `api/anti_pattern.py:157 _get_health_grade` — thresholds 90/70/50/30, returns a `(grade, status)` tuple
- `api/analytics_quality.py:90 get_grade` — same 90/80/70/60 cutoffs but returns a `QualityGrade` str-enum, not a plain `str`
- `code_intelligence/pattern_analysis/complexity_analyzer.py`'s `maintainability_rank` property — thresholds 80/60/40/20, ranks a maintainability index, not a generic score

**Test infra fix required:** the startup-import-smoke conftest stubs the whole `code_intelligence` package (empty `__path__`) to dodge its heavy/py3.10-incompatible `__init__.py`. The new module-level `from code_intelligence.shared.scoring import get_grade_from_score` imports in `api/*.py` needed `code_intelligence.shared.scoring` to resolve under that stub, so `conftest.py` now real-loads it as a leaf module (mirrors the existing `code_intelligence.code_generation.diff` real-load — `scoring.py` is stdlib-only, no heavy deps). `code_intelligence/conftest.py` additionally drops that leaf stub before its own `code_intelligence.security` real-load, so `code_intelligence.shared.analysis_base` (needed by `security/analyzer.py`) still resolves for real.

## Verification

- `pytest tests/test_startup_imports.py` — 346 passed (0 failed; confirmed the 4 that broke without the conftest real-load fix: `api.analytics`, `api.analytics_code`, `api.analytics_reporting`, `api.code_intelligence`)
- `pytest code_intelligence/security_analyzer_test.py code_intelligence/performance_analyzer_test.py code_intelligence/shared/shared_caches_test.py tasks/analytics_tasks_test.py` — 84 passed
- Direct grade-boundary check: `get_grade_from_score(95)=A, (90)=A, (89.9)=B, (59)=F, (0)=F` — matches all 5 deleted forks' semantics
- `grep -rn "def get_grade_from_score"` — exactly 1 definition (canonical) repo-wide
- `grep -rn "_score_to_grade\|_calculate_grade_from_score"` — 0 hits (fully removed)
- Import-smoke of all 6 touched modules individually — all OK
- `code_intelligence/redis_optimizer_test.py` — 11 pre-existing failures confirmed identical on baseline conftest (unrelated order-dependent module-stub issue, out of scope for this PR)

Closes #12686
Refs #12645

## Model Used

Sonnet 5