### PR TITLE
refactor(frontend): migrate composables onto canonical poller (#12701)

### DIFF
--- a/autobot-frontend/src/composables/useSystemStatus.ts
+++ b/autobot-frontend/src/composables/useSystemStatus.ts
@@ -10,9 +10,10 @@
  * TypeScript migration of useSystemStatus.js
  */
 
-import { ref, watch, onScopeDispose, type Ref } from 'vue'
+import { ref, watch, type Ref } from 'vue'
 import apiEndpointMapper from '@/utils/ApiEndpointMapper.js'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { getApiBase } from '@/config/ssot-config'
 
 // #10347: poll cadence while the System Status panel is open, so a transient
@@ -427,21 +428,21 @@ export function useSystemStatus(): UseSystemStatusReturn {
   // #10347: auto-refresh while the panel is open so a transient backend
   // restart self-recovers without a manual Refresh. Polls only while shown
   // (no cost when closed); cleaned up on scope teardown.
-  let pollTimer: ReturnType<typeof setInterval> | null = null
-  const stopPolling = (): void => {
-    if (pollTimer !== null) {
-      clearInterval(pollTimer)
-      pollTimer = null
-    }
-  }
+  // Backed by the canonical usePollingJob (#12701): fires immediately on start
+  // then re-polls every STATUS_POLL_INTERVAL_MS, with auto scope-dispose cleanup.
+  // maxAttempts is effectively unlimited — lifecycle is driven by the panel
+  // open/close watch below, not an attempt cap. refreshSystemStatus never throws
+  // (internal try/catch → fallback state), so no error-backoff path applies.
+  const statusJob = usePollingJob<void>(
+    async () => { await refreshSystemStatus() },
+    { intervalMs: STATUS_POLL_INTERVAL_MS, maxAttempts: Number.MAX_SAFE_INTEGER },
+  )
   watch(showSystemStatus, (open) => {
-    stopPolling()
+    statusJob.stop()
     if (open) {
-      void refreshSystemStatus()
-      pollTimer = setInterval(() => void refreshSystemStatus(), STATUS_POLL_INTERVAL_MS)
+      statusJob.start('')
     }
   })
-  onScopeDispose(stopPolling)
 
   /**
    * Manually recalculate system status from the current services list


### PR DESCRIPTION
## Thinking Path

Round-2 of umbrella #12645. The issue lists 10 hand-rolled pollers, but investigation against the current `origin/Dev_new_gui` base shows **round-1 already migrated 9 of them** and 2 named files don't exist. Per-composable classification:

- **`useAuditApi.ts`** — (a) ALREADY on `usePollingJob` (round-1). No change.
- **`useAutoResearch.ts`** — (a) ALREADY on `usePollingJob` (round-1). No change.
- **`useBatchProcessing.ts`** — (a) ALREADY on `usePollingJob` (round-1). No change.
- **`useKnowledgeVectorization.ts`** — (a) ALREADY on `usePollingJob` (round-1, #5191). No change.
- **`useOperationsApi.ts`** — (a) ALREADY on `usePollingJob` (round-1). No change.
- **`useServiceMessages.ts`** — (a) ALREADY on `usePollingJob` (round-1). No change.
- **`usePrometheusMetrics.ts`** — (a/b) ALREADY on `usePollingJob` for its HTTP-poll modes; also has a WebSocket path (`useWebSocket`) for real-time. No change.
- **`useSystemStatus.ts`** — (a) **MIGRATED here.** Was the only remaining hand-rolled `setInterval` (opened/closed by a `watch` on `showSystemStatus`, `onScopeDispose` cleanup, #10347).
- **`provision.ts`** — does not exist in the frontend tree (name is stale; historical SLM-frontend refs only).
- **`usePerformanceMonitoring.ts`** — does not exist in the frontend tree.

`useSystemStatus` maps cleanly onto `usePollingJob` with **no behavior change**: `usePollingJob.start()` fires the fetcher immediately then re-polls on the interval (matches the old `void refreshSystemStatus()` + `setInterval(..., STATUS_POLL_INTERVAL_MS)`); `.stop()` clears the timer (matches old `clearInterval`); and it registers its own `onScopeDispose(stop)` (replaces the manual one). `refreshSystemStatus` never throws (internal try/catch → fallback state) so no error path is exercised, and `maxAttempts: Number.MAX_SAFE_INTEGER` keeps the poll alive for the panel's whole open lifetime (lifecycle stays driven by the open/close watch, exactly as before).

## What Changed

- `autobot-frontend/src/composables/useSystemStatus.ts`: replaced the hand-rolled `pollTimer`/`stopPolling`/`onScopeDispose` block with the canonical `usePollingJob<void>`; interval (`STATUS_POLL_INTERVAL_MS = 15000`), immediate-first-fire, open/close gating, and scope-dispose cleanup all preserved. Dropped now-unused `onScopeDispose` import; added `usePollingJob` import. Public API unchanged (polling was never exported → zero consumer edits).

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0, 0 errors.
- `oxlint src/composables/useSystemStatus.ts -D correctness` → exit 0, 0 errors.
- `vitest run src/composables/__tests__/usePollingJob.test.ts` → 14/14 passed (canonical poller contract this migration relies on).
- grep confirms no `setInterval` remains in any of the 8 existing target composables; `useSystemStatus.ts` now imports and uses `usePollingJob`.
- No test file exists for `useSystemStatus`; sole consumer is `App.vue` (public API unchanged, so unaffected).

## Model Used

claude-opus-4-8

## Follow-up

None deferred. All migratable composables from the umbrella list are on the canonical poller; the 2 named files (`provision.ts`, `usePerformanceMonitoring.ts`) do not exist and `usePrometheusMetrics`'s WebSocket path is correctly left as-is (bucket b — real-time WS, not HTTP polling).

Closes #12701
Refs #12645
