### PR TITLE
tech-debt(transcriber): extract shared format_timestamp helper (#12709)

### DIFF
--- a/autobot-backend/transcriber/ai/context.py
+++ b/autobot-backend/transcriber/ai/context.py
@@ -5,11 +5,7 @@
 # Author: mrveiss
 """Build transcript context string for LLM analysis."""
 
-
-def _fmt_ts(seconds: float) -> str:
-    m, s = divmod(int(seconds), 60)
-    h, m = divmod(m, 60)
-    return f"{h:02d}:{m:02d}:{s:02d}"
+from transcriber.util import format_timestamp as _fmt_ts
 
 
 def build_context(segments: list[dict], *, max_chars: int = 30_000) -> str:

--- a/autobot-backend/transcriber/export/docx_export.py
+++ b/autobot-backend/transcriber/export/docx_export.py
@@ -10,6 +10,8 @@ import io
 from docx import Document
 from docx.shared import RGBColor
 
+from transcriber.util import format_timestamp as _fmt_ts
+
 _SPEAKER_COLORS = [
     RGBColor(0x1A, 0x73, 0xE8),
     RGBColor(0xD9, 0x34, 0x25),
@@ -17,12 +19,6 @@ _SPEAKER_COLORS = [
     RGBColor(0xFB, 0xBC, 0x04),
     RGBColor(0x8A, 0x2B, 0xE2),
 ]
-
-
-def _fmt_ts(seconds: float) -> str:
-    m, s = divmod(int(seconds), 60)
-    h, m = divmod(m, 60)
-    return f"{h:02d}:{m:02d}:{s:02d}"
 
 
 def build_docx(

--- a/autobot-backend/transcriber/export/pdf_export.py
+++ b/autobot-backend/transcriber/export/pdf_export.py
@@ -9,15 +9,11 @@ import html as html_lib
 
 from autobot_shared.logging_manager import get_logger
 
+from transcriber.util import format_timestamp as _fmt_ts
+
 logger = get_logger(__name__)
 
 _SPEAKER_COLORS = ["#1a73e8", "#d93425", "#188a38", "#fbbc04", "#8a2be2"]
-
-
-def _fmt_ts(seconds: float) -> str:
-    m, s = divmod(int(seconds), 60)
-    h, m = divmod(m, 60)
-    return f"{h:02d}:{m:02d}:{s:02d}"
 
 
 def build_pdf(

--- a/autobot-backend/transcriber/export/pdf_export.py
+++ b/autobot-backend/transcriber/export/pdf_export.py
@@ -8,7 +8,6 @@
 import html as html_lib
 
 from autobot_shared.logging_manager import get_logger
-
 from transcriber.util import format_timestamp as _fmt_ts
 
 logger = get_logger(__name__)

--- a/autobot-backend/transcriber/knowledge/kb_push.py
+++ b/autobot-backend/transcriber/knowledge/kb_push.py
@@ -6,7 +6,6 @@
 """Manual Knowledge Base push — formats transcript segments as KB documents."""
 
 from autobot_shared.logging_manager import get_logger
-
 from transcriber.util import format_timestamp as _fmt_ts
 
 logger = get_logger(__name__)

--- a/autobot-backend/transcriber/knowledge/kb_push.py
+++ b/autobot-backend/transcriber/knowledge/kb_push.py
@@ -7,13 +7,9 @@
 
 from autobot_shared.logging_manager import get_logger
 
+from transcriber.util import format_timestamp as _fmt_ts
+
 logger = get_logger(__name__)
-
-
-def _fmt_ts(seconds: float) -> str:
-    m, s = divmod(int(seconds), 60)
-    h, m = divmod(m, 60)
-    return f"{h:02d}:{m:02d}:{s:02d}"
 
 
 def _get_indexer():

--- a/autobot-backend/transcriber/util.py
+++ b/autobot-backend/transcriber/util.py
@@ -1,0 +1,13 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# autobot-backend/transcriber/util.py
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared formatting helpers for transcriber export/knowledge/ai modules."""
+
+
+def format_timestamp(seconds: float) -> str:
+    """Format seconds as HH:MM:SS."""
+    m, s = divmod(int(seconds), 60)
+    h, m = divmod(m, 60)
+    return f"{h:02d}:{m:02d}:{s:02d}"


### PR DESCRIPTION
## Thinking Path
Round-3 of umbrella #12645: `_fmt_ts(seconds)` (`divmod` → `HH:MM:SS`) was byte-identical across 4 transcriber files (`export/pdf_export.py`, `export/docx_export.py`, `knowledge/kb_push.py`, `ai/context.py`). Confirmed identical via diff before extraction, then centralized into one shared helper.

## What Changed
- Added `autobot-backend/transcriber/util.py` with `format_timestamp(seconds)` — same `divmod`/`f"{h:02d}:{m:02d}:{s:02d}"` logic, single canonical definition.
- Repointed all 4 files to `from transcriber.util import format_timestamp as _fmt_ts`, deleting each local `_fmt_ts` def. Call sites unchanged (alias preserves existing name), so diff is minimal and behavior-identical.

## Verification
- `grep -rn "def _fmt_ts" autobot-backend/transcriber` → 0 matches (no duplicate defs remain)
- `grep -rn "def format_timestamp" autobot-backend/transcriber` → 1 match (`transcriber/util.py`)
- Import-smoke + output-equivalence check: `format_timestamp(3661) == pdf._fmt_ts(3661) == docx._fmt_ts(3661) == context._fmt_ts(3661) == kb_push._fmt_ts(3661) == '01:01:01'`
- `pytest autobot-backend/transcriber/tests` → 101 passed, 1 skipped (pre-existing, unrelated)
- `black --check` and `ruff check` on all 5 touched files → clean

Closes #12709
Refs #12645

## Model Used
Claude Opus 4.8