### PR TITLE
tech-debt(backend): single-source ProviderStatus/ProvidersResponse media models (#12710)

### DIFF
--- a/autobot-backend/api/image_generation.py
+++ b/autobot-backend/api/image_generation.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
+from api.schemas_media import ProvidersResponse, ProviderStatus
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 
@@ -58,16 +59,6 @@ class ImageGenerationResponse(BaseModel):
     prompt: str = ""
     size: str = ""
     error: Optional[str] = None
-
-
-class ProviderStatus(BaseModel):
-    name: str
-    available: bool
-    reason: Optional[str] = None
-
-
-class ProvidersResponse(BaseModel):
-    providers: List[ProviderStatus]
 
 
 # ------------------------------------------------------------------

--- a/autobot-backend/api/schemas_media.py
+++ b/autobot-backend/api/schemas_media.py
@@ -1,0 +1,30 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Shared media-generation Pydantic schemas (GH#12710).
+
+`ProviderStatus`/`ProvidersResponse` were byte-identical duplicates in
+api/image_generation.py and api/video_generation.py (provider-availability
+listing for the `GET /providers` endpoints). Single-sourced here so both
+routers import the same model instead of maintaining two copies.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class ProviderStatus(BaseModel):
+    """Availability of a single media-generation provider (image or video)."""
+
+    name: str
+    available: bool
+    reason: Optional[str] = None
+
+
+class ProvidersResponse(BaseModel):
+    """Response for GET /providers — list of provider availability statuses."""
+
+    providers: List[ProviderStatus]

--- a/autobot-backend/api/video_generation.py
+++ b/autobot-backend/api/video_generation.py
@@ -28,6 +28,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from api._video_providers_loader import load_video_providers
+from api.schemas_media import ProvidersResponse, ProviderStatus
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import redis_get, redis_set
@@ -96,16 +97,6 @@ class VideoStatusResponse(BaseModel):
     provider: str = ""
     prompt: str = ""
     error: Optional[str] = None
-
-
-class ProviderStatus(BaseModel):
-    name: str
-    available: bool
-    reason: Optional[str] = None
-
-
-class ProvidersResponse(BaseModel):
-    providers: list[ProviderStatus]
 
 
 # ------------------------------------------------------------------

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -87275,7 +87275,10 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** ProviderStatus */
+        /**
+         * ProviderStatus
+         * @description Availability of a single media-generation provider (image or video).
+         */
         ProviderStatus: {
             /** Name */
             name: string;
@@ -100842,13 +100845,6 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** ProvidersResponse */
-        api__image_generation__ProvidersResponse: {
-            /** Providers */
-            providers: components["schemas"]["ProviderStatus"][];
-        } & {
-            [key: string]: unknown;
-        };
         /**
          * SearchRequest
          * @description Request for similarity search.
@@ -101255,6 +101251,16 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * ProvidersResponse
+         * @description Response for GET /providers — list of provider availability statuses.
+         */
+        api__schemas_media__ProvidersResponse: {
+            /** Providers */
+            providers: components["schemas"]["ProviderStatus"][];
+        } & {
+            [key: string]: unknown;
+        };
         /** ClearAllResponse */
         api__schemas_system__ClearAllResponse: {
             /** Success */
@@ -101319,13 +101325,6 @@ export interface components {
         api__task_workspace_ws__RestoreRequest: {
             /** Checkpoint Name */
             checkpoint_name: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /** ProvidersResponse */
-        api__video_generation__ProvidersResponse: {
-            /** Providers */
-            providers: components["schemas"]["ProviderStatus"][];
         } & {
             [key: string]: unknown;
         };
@@ -146454,7 +146453,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["api__image_generation__ProvidersResponse"];
+                    "application/json": components["schemas"]["api__schemas_media__ProvidersResponse"];
                 };
             };
         };
@@ -146507,7 +146506,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["api__video_generation__ProvidersResponse"];
+                    "application/json": components["schemas"]["api__schemas_media__ProvidersResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Thinking Path

`ProviderStatus`/`ProvidersResponse` were byte-identical duplicates between
`api/image_generation.py` and `api/video_generation.py` (only `List` vs
`list` typing differed). Both existing `schemas_*.py` files follow a
per-domain naming convention (`schemas_common.py`, `schemas_agent.py`,
etc.) — created `api/schemas_media.py` for the shared media-generation
provider-status models and imported it from both routers, deleting the
local duplicates.

## What Changed

- Added `autobot-backend/api/schemas_media.py` with `ProviderStatus` and
  `ProvidersResponse` (single source of truth).
- `api/image_generation.py`: import from `api.schemas_media`, removed
  local duplicate class definitions.
- `api/video_generation.py`: same.
- No behavior change — `response_model=` on both `/providers` endpoints
  still resolves to the same field shape (`name`/`available`/`reason`,
  `providers: list[ProviderStatus]`).

## Verification

- `python3 -m pytest api/video_generation_test.py -q` → 6 passed
  (no test file exists yet for `image_generation.py`; manually exercised
  its `/providers` endpoint via `TestClient`, see below).
- Manual `TestClient` GET `/providers` on `image_generation.router` →
  200, same JSON shape as before (`{"providers": [{"name": ..., "available": ..., "reason": ...}]}`).
- `python3 -m pytest autobot-backend/tests/test_startup_imports.py -q`
  → 348 passed (includes `test_no_duplicate_class_names_across_schema_modules`,
  confirms `ProviderStatus`/`ProvidersResponse` now resolve from exactly
  one `schemas_*.py` module).
- Dumped `app.openapi()` with both routers mounted — `ProviderStatus`/
  `ProvidersResponse` component schemas confirmed present and correctly
  shaped (`required: [name, available]` / `required: [providers]`,
  `providers` items `$ref` to `ProviderStatus`).
- `grep -n "^class ProviderStatus\|^class ProvidersResponse" autobot-backend/api/` → only one hit each, both in `schemas_media.py`.
- `ruff check` on the three touched files → all checks passed.
- `pyflakes` on the three touched files → no unused-import warnings.

## Model Used

Sonnet 5

Closes #12710
Refs #12645