### PR TITLE
security(rbac): unify 6 forked _require_admin onto canonical require_role — fix superadmin lockout (#12704)

### DIFF
--- a/autobot-backend/api/admin_event_logs.py
+++ b/autobot-backend/api/admin_event_logs.py
@@ -20,24 +20,13 @@ Access: admin role required.
 
 from fastapi import APIRouter, Depends, Query, Request
 
-from auth_middleware import get_auth_middleware
+from auth_rbac import require_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.audit.audit import EventType, query_events  # GH#8290 Phase 2
-from utils.catalog_http_exceptions import raise_auth_error
 
 router = APIRouter(prefix="/admin", tags=["admin", "compliance"])
 logger = get_logger(__name__)
-
-
-def _require_admin(request: Request) -> bool:
-    """Dependency: reject non-admin callers."""
-    user_data = get_auth_middleware().get_user_from_request(request)
-    if not user_data:
-        raise_auth_error("AUTH_0002", "Authentication required")
-    if user_data.get("role") != "admin":
-        raise_auth_error("AUTH_0003", "Admin permission required")
-    return True
 
 
 @router.get("/event-logs")
@@ -54,7 +43,7 @@ async def list_event_logs(
     to_ts: float | None = Query(None, description="Unix timestamp upper bound"),
     limit: int = Query(default=100, ge=1, le=1000, description="Max results"),
     offset: int = Query(default=0, ge=0, description="Pagination offset"),
-    _admin: bool = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> dict:
     """Return compliance events with optional filters.
 

--- a/autobot-backend/api/admin_pricing.py
+++ b/autobot-backend/api/admin_pricing.py
@@ -12,22 +12,12 @@ Endpoints:
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
-from auth_middleware import get_auth_middleware
-from utils.catalog_http_exceptions import raise_auth_error
+from auth_rbac import require_role
 
 router = APIRouter(prefix="/admin")
-
-
-def _require_admin(request: Request) -> bool:
-    user_data = get_auth_middleware().get_user_from_request(request)
-    if not user_data:
-        raise_auth_error("AUTH_0002", "Authentication required")
-    if user_data.get("role") != "admin":
-        raise_auth_error("AUTH_0003", "Admin permission required")
-    return True
 
 
 class PricingOverrideRequest(BaseModel):
@@ -42,7 +32,7 @@ async def override_model_pricing(
     provider: str,
     model: str,
     body: PricingOverrideRequest,
-    _admin: bool = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> dict:
     """Write an emergency pricing override directly to Redis."""
     from autobot_shared.logging_manager import get_logger
@@ -82,7 +72,7 @@ async def override_model_pricing(
 async def delete_model_pricing_override(
     provider: str,
     model: str,
-    _admin: bool = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> dict:
     """Remove a pricing override from Redis (next refresh will re-populate)."""
     from llm_shared.pricing.redis_store import PricingRedisStore
@@ -93,7 +83,7 @@ async def delete_model_pricing_override(
 
 
 @router.get("/pricing/status")
-async def get_pricing_refresh_status(_admin: bool = Depends(_require_admin)) -> dict:
+async def get_pricing_refresh_status(_admin: bool = Depends(require_role("admin", "superadmin"))) -> dict:
     """Return the last refresh timestamp and success/failure per provider."""
     from llm_shared.pricing.redis_store import PricingRedisStore
 

--- a/autobot-backend/api/admin_retention_policies.py
+++ b/autobot-backend/api/admin_retention_policies.py
@@ -12,7 +12,7 @@ Endpoints:
     DELETE /api/admin/retention-policies/{type}      - Delete policy by type
     GET    /api/admin/retention-settings             - Active config + per-type storage counts
 
-Access: admin role required (RBAC enforced via _require_admin dependency).
+Access: admin/superadmin role required (RBAC enforced via require_role dependency).
 """
 
 import uuid
@@ -23,7 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_db_session
-from auth_middleware import get_auth_middleware
+from auth_rbac import require_role
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config as ssot_config
@@ -34,28 +34,17 @@ from user_management.schemas.retention_policy import (
     RetentionPolicyListResponse,
     RetentionPolicyResponse,
 )
-from utils.catalog_http_exceptions import raise_auth_error
 
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/admin")
 
 
-def _require_admin(request: Request) -> dict:
-    """Dependency: reject non-admin callers and return user data."""
-    user_data = get_auth_middleware().get_user_from_request(request)
-    if not user_data:
-        raise_auth_error("AUTH_0002", "Authentication required")
-    if user_data.get("role") != "admin":
-        raise_auth_error("AUTH_0003", "Admin permission required")
-    return user_data
-
-
 @router.get("/retention-policies", response_model=RetentionPolicyListResponse)
 async def list_retention_policies(
     request: Request,
     user_id: uuid.UUID | None = Query(None, description="Filter by user_id (NULL = global)"),
-    _admin: dict = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
     session: AsyncSession = Depends(get_db_session),
 ) -> RetentionPolicyListResponse:
     """
@@ -84,7 +73,7 @@ async def list_retention_policies(
 async def create_or_update_retention_policy(
     request: Request,
     policy: RetentionPolicyCreate,
-    _admin: dict = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
     session: AsyncSession = Depends(get_db_session),
 ) -> RetentionPolicyResponse:
     """
@@ -129,7 +118,7 @@ async def get_retention_policy(
     request: Request,
     policy_type: PolicyType,
     user_id: uuid.UUID | None = Query(None, description="User ID for user-specific policy"),
-    _admin: dict = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
     session: AsyncSession = Depends(get_db_session),
 ) -> RetentionPolicyResponse:
     """
@@ -173,7 +162,7 @@ async def delete_retention_policy(
     request: Request,
     policy_type: PolicyType,
     user_id: uuid.UUID | None = Query(None, description="User ID for user-specific policy"),
-    _admin: dict = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     """
@@ -277,7 +266,7 @@ async def _count_kb_facts() -> int:
 @router.get("/retention-settings", response_model=Dict[str, Any])
 async def get_retention_settings(
     request: Request,
-    _admin: dict = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> Dict[str, Any]:
     """Return active retention configuration and per-type storage counts (GH#8995).
 

--- a/autobot-backend/api/admin_schedulers.py
+++ b/autobot-backend/api/admin_schedulers.py
@@ -12,27 +12,16 @@ Access: admin role required.
 
 from dataclasses import asdict
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 
-from auth_middleware import get_auth_middleware
+from auth_rbac import require_role
 from services.scheduler_registry import REGISTRY
-from utils.catalog_http_exceptions import raise_auth_error
 
 router = APIRouter(prefix="/admin")
 
 
-def _require_admin(request: Request) -> bool:
-    """Dependency: reject non-admin callers."""
-    user_data = get_auth_middleware().get_user_from_request(request)
-    if not user_data:
-        raise_auth_error("AUTH_0002", "Authentication required")
-    if user_data.get("role") != "admin":
-        raise_auth_error("AUTH_0003", "Admin permission required")
-    return True
-
-
 @router.get("/schedulers")
-async def list_schedulers(_admin: bool = Depends(_require_admin)) -> dict:
+async def list_schedulers(_admin: bool = Depends(require_role("admin", "superadmin"))) -> dict:
     """Return all registered background schedulers with their runtime metadata."""
     return {
         "count": len(REGISTRY),

--- a/autobot-backend/api/chat_shared_links.py
+++ b/autobot-backend/api/chat_shared_links.py
@@ -39,8 +39,8 @@ from api.schemas_chat import (
     SharedMessageItem,
 )
 from api.user_management.dependencies import get_db_session
-from api.voice_bundle_helpers import _require_admin
 from auth_middleware import get_current_user
+from auth_rbac import require_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.proxy_utils import get_client_ip
@@ -269,7 +269,7 @@ async def list_shared_links(
 )
 async def list_all_shared_links_admin(
     request: Request,
-    admin_user: Dict = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
     db: AsyncSession = Depends(get_db_session),
 ) -> Dict[str, Any]:
     """Return every active (non-expired) shared link with its owner (GH#8996, AC4)."""

--- a/autobot-backend/api/mcp_token_admin.py
+++ b/autobot-backend/api/mcp_token_admin.py
@@ -23,14 +23,13 @@ import secrets
 import time
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Request
+from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
 
-from auth_middleware import get_auth_middleware
+from auth_rbac import require_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-from utils.catalog_http_exceptions import raise_auth_error
 
 logger = get_logger(__name__)
 
@@ -81,17 +80,6 @@ class RevokeTokenResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _require_admin(request: Request) -> bool:
-    """Dependency: reject callers without admin or superadmin role."""
-    user_data = get_auth_middleware().get_user_from_request(request)
-    if not user_data:
-        raise_auth_error("AUTH_0002", "Authentication required")
-    role = user_data.get("role", "")
-    if role not in ("admin", "superadmin"):
-        raise_auth_error("AUTH_0003", "Admin permission required")
-    return True
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -129,7 +117,7 @@ _INDEX_KEY = "mcp:tokens:index"
 )
 async def create_mcp_token(
     body: CreateTokenRequest,
-    _admin: bool = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> CreateTokenResponse:
     """Generate a new scoped MCP client token.
 
@@ -195,7 +183,7 @@ async def create_mcp_token(
     error_code_prefix="MCP",
 )
 async def list_mcp_tokens(
-    _admin: bool = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> ListTokensResponse:
     """List all active MCP tokens.
 
@@ -246,7 +234,7 @@ async def list_mcp_tokens(
 )
 async def revoke_mcp_token(
     token_id: str = Path(..., description="Token ID to revoke"),
-    _admin: bool = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> RevokeTokenResponse:
     """Revoke an MCP token by its ID.
 

--- a/autobot-backend/api/mcp_token_admin_test.py
+++ b/autobot-backend/api/mcp_token_admin_test.py
@@ -65,7 +65,7 @@ def test_create_token_success():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):
@@ -92,7 +92,7 @@ def test_create_token_invalid_scope():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):
@@ -109,7 +109,7 @@ def test_create_token_empty_scopes():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):
@@ -118,10 +118,29 @@ def test_create_token_empty_scopes():
     assert resp.status_code == 422
 
 
+def test_create_token_superadmin_allowed():
+    """superadmin is accepted by the unified require_role gate (#12704)."""
+    superadmin = {"user_id": "u3", "role": "superadmin"}
+    redis_mock = _make_redis_mock()
+    with (
+        patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
+        patch(
+            "auth_rbac.get_auth_middleware",
+            return_value=MagicMock(get_user_from_request=MagicMock(return_value=superadmin)),
+        ),
+    ):
+        client = TestClient(app)
+        resp = client.post(
+            "/api/mcp/tokens",
+            json={"scopes": ["kb"], "label": ""},
+        )
+    assert resp.status_code == 201, resp.text
+
+
 def test_create_token_non_admin_rejected():
     non_admin = {"user_id": "u2", "role": "user"}
     with patch(
-        "api.mcp_token_admin.get_auth_middleware",
+        "auth_rbac.get_auth_middleware",
         return_value=MagicMock(get_user_from_request=MagicMock(return_value=non_admin)),
     ):
         client = TestClient(app, raise_server_exceptions=False)
@@ -144,7 +163,7 @@ def test_list_tokens_empty():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):
@@ -185,7 +204,7 @@ def test_list_tokens_with_entries():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):
@@ -215,7 +234,7 @@ def test_revoke_token_success():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):
@@ -234,7 +253,7 @@ def test_revoke_token_not_found():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(return_value=redis_mock)),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):
@@ -252,7 +271,7 @@ def test_create_token_redis_unavailable():
     with (
         patch("api.mcp_token_admin._get_redis", new=AsyncMock(side_effect=Exception("503 test"))),
         patch(
-            "api.mcp_token_admin.get_auth_middleware",
+            "auth_rbac.get_auth_middleware",
             return_value=MagicMock(get_user_from_request=MagicMock(return_value=_admin_user())),
         ),
     ):

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -16,8 +16,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from api.voice_bundle_constants import VALID_BUNDLES, BundleAssignRequest
-from api.voice_bundle_helpers import _require_admin
 from auth_middleware import get_current_user
+from auth_rbac import require_role
 from autobot_shared.logging_manager import get_logger
 from services.event_log import EventType, emit
 
@@ -88,7 +88,7 @@ async def get_my_bundle(
 async def get_user_bundle(
     user_id: str,
     request: Request,
-    _admin: dict = Depends(_require_admin),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> BundleAssignmentResponse:
     """Return the explicit bundle assignment for a user (admin only)."""
     try:
@@ -120,7 +120,8 @@ async def set_user_bundle(
     user_id: str,
     body: BundleAssignRequest,
     request: Request,
-    admin_user: dict = Depends(_require_admin),
+    admin_user: dict = Depends(get_current_user),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> BundleAssignmentResponse:
     """Assign or clear a voice bundle override for a user (admin only)."""
     if body.bundle_name is not None and body.bundle_name not in VALID_BUNDLES:

--- a/autobot-backend/api/voice_bundle_admin_test.py
+++ b/autobot-backend/api/voice_bundle_admin_test.py
@@ -99,19 +99,20 @@ async def test_set_user_bundle_invalid_bundle():
     from fastapi.testclient import TestClient
 
     from api.voice_bundle_admin import bundle_admin_router
+    from auth_middleware import get_current_user
 
     app = FastAPI()
 
-    # Mock auth middleware to return admin user BEFORE including router
+    # Admin user seen by both the require_role() gate (#12704) and the
+    # acting-user dependency, so validation runs and rejects the bad bundle.
+    admin = {"username": "admin", "role": "admin", "user_id": "admin-1"}
     mock_auth = MagicMock()
-    mock_auth.get_user_from_request.return_value = {
-        "username": "admin",
-        "role": "admin",
-        "user_id": "admin-1",
-    }
+    mock_auth.get_user_from_request.return_value = admin
 
-    with patch("api.voice_bundle_helpers.get_auth_middleware", return_value=mock_auth):
-        app.include_router(bundle_admin_router)
+    app.include_router(bundle_admin_router)
+    app.dependency_overrides[get_current_user] = lambda: admin
+
+    with patch("auth_rbac.get_auth_middleware", return_value=mock_auth):
         with TestClient(app) as client:
             resp = client.put(
                 "/admin/voice/bundle/user-abc",
@@ -132,14 +133,15 @@ async def test_user_cannot_call_admin_bundle_endpoint_unauthenticated():
     app = FastAPI()
     app.include_router(bundle_admin_router)
 
-    with TestClient(app, raise_server_exceptions=False) as client:
-        with patch(
-            "api.voice_bundle_admin._require_admin",
-            side_effect=lambda req: None,  # Returns None to simulate unauthenticated
-        ):
+    # No authenticated user → require_role() (#12704) must reject.
+    mock_auth = MagicMock()
+    mock_auth.get_user_from_request.return_value = None
+
+    with patch("auth_rbac.get_auth_middleware", return_value=mock_auth):
+        with TestClient(app, raise_server_exceptions=False) as client:
             resp = client.get("/admin/voice/bundle/user-abc")
     # Expect 401 or 403
-    assert resp.status_code in (401, 403, 422)
+    assert resp.status_code in (401, 403)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/voice_bundle_helpers.py
+++ b/autobot-backend/api/voice_bundle_helpers.py
@@ -8,26 +8,6 @@ This module breaks the circular import between voice_bundle_user and voice_bundl
 by providing shared functionality that both modules depend on.
 """
 
-from fastapi import Request
-
-from auth_middleware import get_auth_middleware
-from utils.catalog_http_exceptions import raise_auth_error
-
-
-def _require_admin(request: Request) -> dict:
-    """Verify current user is admin, return user_data or raise.
-
-    FastAPI dependency for admin-only routes.
-    Raises AUTH_0002 if not authenticated, AUTH_0003 if not admin.
-    """
-    user_data = get_auth_middleware().get_user_from_request(request)
-    if not user_data:
-        raise_auth_error("AUTH_0002", "Authentication required")
-    if user_data.get("role") != "admin":
-        raise_auth_error("AUTH_0003", "Admin permission required")
-    return user_data
-
-
 _tool_count_cache: dict[tuple[str, bool], int] = {}
 
 

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -20,8 +20,9 @@ from api.voice_bundle_constants import (
     VALID_BUNDLES,
     BundleAssignRequest,
 )
-from api.voice_bundle_helpers import _count_tools_for_bundle, _require_admin
+from api.voice_bundle_helpers import _count_tools_for_bundle
 from auth_middleware import get_current_user
+from auth_rbac import require_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.audit.audit import AuditCategory, AuditEvent, emit
@@ -171,7 +172,8 @@ async def set_user_bundle(
     user_id: str,
     body: BundleAssignRequest,
     request: Request,
-    admin_user: dict = Depends(_require_admin),
+    admin_user: dict = Depends(get_current_user),
+    _admin: bool = Depends(require_role("admin", "superadmin")),
 ) -> UserBundleResponse:
     """Assign or clear a voice bundle override for a user.
 

--- a/autobot-backend/tests/api/test_chat_shared_links.py
+++ b/autobot-backend/tests/api/test_chat_shared_links.py
@@ -12,20 +12,37 @@ Covers the admin cross-user view (AC4):
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.chat_shared_links import router
 from api.user_management.dependencies import get_db_session
-from api.voice_bundle_helpers import _require_admin
 from auth_middleware import get_current_user
 from autobot_shared.time_utils import now_utc
-from utils.catalog_http_exceptions import raise_auth_error
 
 # Test users
 _USER_ALICE = {"user_id": "alice", "username": "alice", "role": "user"}
 _ADMIN = {"user_id": "admin-user", "username": "admin", "role": "admin"}
+_SUPERADMIN = {"user_id": "root", "username": "root", "role": "superadmin"}
+
+# Holds the user the patched auth middleware returns for the current test.
+_CURRENT: dict = {"user": None}
+
+
+@pytest.fixture(autouse=True)
+def _patch_auth_middleware():
+    """Make require_role() (#12704) see the injected test user.
+
+    The admin cross-user route uses ``require_role("admin", "superadmin")``,
+    which reads the user via ``auth_rbac.get_auth_middleware()``.
+    """
+    mw = MagicMock()
+    mw.get_user_from_request.side_effect = lambda request: _CURRENT["user"]
+    with patch("auth_rbac.get_auth_middleware", return_value=mw):
+        yield
+    _CURRENT["user"] = None
 
 
 def _make_link(*, owner: str, session_id: str, has_password: bool = False, expired: bool = False):
@@ -46,19 +63,16 @@ def _make_link(*, owner: str, session_id: str, has_password: bool = False, expir
 def _make_client(user: dict, links: list) -> TestClient:
     """Create a TestClient overriding auth + DB session.
 
-    Admin routes depend on ``_require_admin`` (a Request-based middleware check),
-    so override it too — role-gated against the injected user so the admin route
-    200s for admins and 403s for non-admins.
+    The admin cross-user route uses ``require_role("admin", "superadmin")``
+    (#12704), fed by the autouse middleware patch; ``get_current_user`` (the
+    owner-scoped routes) is overridden so admin routes 200 for admin/superadmin
+    and 403 for others.
     """
+    _CURRENT["user"] = user
     app = FastAPI()
     app.include_router(router)
 
     async def _override_user():
-        return user
-
-    def _override_require_admin() -> dict:
-        if user.get("role") != "admin":
-            raise_auth_error("AUTH_0003", "Admin permission required")
         return user
 
     async def _override_db():
@@ -71,7 +85,6 @@ def _make_client(user: dict, links: list) -> TestClient:
         return session
 
     app.dependency_overrides[get_current_user] = _override_user
-    app.dependency_overrides[_require_admin] = _override_require_admin
     app.dependency_overrides[get_db_session] = _override_db
     return TestClient(app)
 
@@ -101,6 +114,15 @@ class TestAdminListAllSharedLinks:
         protected = {item["owner"]: item["has_password"] for item in data["links"]}
         assert protected["bob"] is True
         assert protected["alice"] is False
+
+    def test_superadmin_lists_all_active_links(self):
+        """superadmin reaches the admin cross-user view — previously admin-only (#12704)."""
+        client = _make_client(_SUPERADMIN, [_make_link(owner="alice", session_id="sess-a")])
+
+        response = client.get("/chat/shared-links/admin")
+
+        assert response.status_code == 200
+        assert response.json()["data"]["count"] == 1
 
     def test_non_admin_cannot_list_all_links(self):
         """Non-admin user receives 403."""

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -18,7 +18,6 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.voice_bundle_helpers import _require_admin
 from api.voice_bundle_user import (
     _check_self_or_admin,
     _get_user_id,
@@ -26,35 +25,46 @@ from api.voice_bundle_user import (
     router,
 )
 from auth_middleware import get_current_user
-from utils.catalog_http_exceptions import raise_auth_error
 
 # Test users
 _USER_ALICE = {"user_id": "alice", "username": "alice", "role": "user"}
 _USER_BOB = {"user_id": "bob", "username": "bob", "role": "user"}
 _ADMIN = {"user_id": "admin-user", "username": "admin", "role": "admin"}
+_SUPERADMIN = {"user_id": "root", "username": "root", "role": "superadmin"}
+
+# Holds the user the patched auth middleware returns for the current test.
+_CURRENT: dict = {"user": None}
+
+
+@pytest.fixture(autouse=True)
+def _patch_auth_middleware():
+    """Make the canonical require_role() gate see the injected test user.
+
+    Admin-gated routes use ``require_role("admin", "superadmin")`` (#12704),
+    which reads the user via ``auth_rbac.get_auth_middleware()``.
+    """
+    mw = MagicMock()
+    mw.get_user_from_request.side_effect = lambda request: _CURRENT["user"]
+    with patch("auth_rbac.get_auth_middleware", return_value=mw):
+        yield
+    _CURRENT["user"] = None
 
 
 def _make_client(user: dict) -> TestClient:
-    """Create a TestClient with dependency_overrides for get_current_user.
+    """Create a TestClient with the injected user wired into auth.
 
-    Admin-gated routes depend on ``_require_admin`` (a Request-based middleware
-    check, GH#9450) rather than ``get_current_user``, so override it too —
-    role-gated against the injected user so admin routes 200 for admins and
-    403 for non-admins (GH#8977).
+    ``get_current_user`` (the acting-user dict) is overridden, and the
+    ``require_role()`` gate reads the same user via the autouse middleware
+    patch, so admin routes 200 for admin/superadmin and 403 for others.
     """
+    _CURRENT["user"] = user
     app = FastAPI()
     app.include_router(router, prefix="/api/voice")
 
     async def _override():
         return user
 
-    def _override_require_admin() -> dict:
-        if user.get("role") != "admin":
-            raise_auth_error("AUTH_0003", "Admin permission required")
-        return user
-
     app.dependency_overrides[get_current_user] = _override
-    app.dependency_overrides[_require_admin] = _override_require_admin
     return TestClient(app)
 
 
@@ -364,6 +374,30 @@ class TestSetUserBundle:
         )
 
         assert response.status_code == 403
+
+    def test_superadmin_assigns_bundle_to_user(self):
+        """superadmin can assign a bundle — previously admin-only (#12704 unlock)."""
+        client = _make_client(_SUPERADMIN)
+
+        with (
+            patch("user_management.database.get_async_session") as mock_session_ctx,
+            patch("api.voice_bundle_user.emit") as mock_emit,
+        ):
+            mock_session = AsyncMock(spec=AsyncSession)
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+            mock_result = MagicMock()
+            mock_result.fetchone.return_value = ("voice_safe",)
+            mock_session.execute.return_value = mock_result
+
+            response = client.put(
+                "/api/voice/users/bob/bundle",
+                json={"bundle_name": "voice_safe"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["bundle_name"] == "voice_safe"
+        mock_emit.assert_called_once()
 
     def test_admin_can_assign_admin_bundle(self):
         """Admin can assign voice_admin bundle."""

--- a/autobot-backend/tests/integration/test_retention_policies_api.py
+++ b/autobot-backend/tests/integration/test_retention_policies_api.py
@@ -15,6 +15,7 @@ Tests for data retention policy CRUD endpoints:
 
 import uuid
 from typing import AsyncGenerator
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -24,7 +25,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.ext.asyncio.session import async_sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from api.admin_retention_policies import _require_admin
 from api.admin_retention_policies import router as retention_router
 from api.user_management.dependencies import get_db_session
 from user_management.models.base import Base
@@ -90,36 +90,56 @@ def regular_user():
     }
 
 
+# Holds the user the patched auth middleware returns for the current test.
+_CURRENT: dict = {"user": None}
+
+
+@pytest.fixture(autouse=True)
+def _patch_auth_middleware():
+    """Feed the canonical require_role() gate (#12704) the injected test user.
+
+    Retention endpoints use ``require_role("admin", "superadmin")``, which reads
+    the user via ``auth_rbac.get_auth_middleware()``.
+    """
+    mw = MagicMock()
+    mw.get_user_from_request.side_effect = lambda request: _CURRENT["user"]
+    with patch("auth_rbac.get_auth_middleware", return_value=mw):
+        yield
+    _CURRENT["user"] = None
+
+
 @pytest.fixture
 def test_client_admin(test_db_session, admin_user):
     """Create a test FastAPI client with admin user."""
+    _CURRENT["user"] = admin_user
     app = FastAPI()
     app.include_router(retention_router, prefix="/api")
-
-    # Override dependencies
     app.dependency_overrides[get_db_session] = lambda: test_db_session
-    app.dependency_overrides[_require_admin] = lambda: admin_user
+    return TestClient(app)
 
+
+@pytest.fixture
+def test_client_superadmin(test_db_session):
+    """superadmin must also reach admin retention endpoints (#12704 unlock)."""
+    _CURRENT["user"] = {
+        "id": str(uuid.uuid4()),
+        "user_id": str(uuid.uuid4()),
+        "email": "root@example.com",
+        "role": "superadmin",
+    }
+    app = FastAPI()
+    app.include_router(retention_router, prefix="/api")
+    app.dependency_overrides[get_db_session] = lambda: test_db_session
     return TestClient(app)
 
 
 @pytest.fixture
 def test_client_regular(test_db_session, regular_user):
     """Create a test FastAPI client with regular user (should be rejected)."""
+    _CURRENT["user"] = regular_user
     app = FastAPI()
     app.include_router(retention_router, prefix="/api")
-
-    # Override dependencies
     app.dependency_overrides[get_db_session] = lambda: test_db_session
-
-    # Regular user will fail admin check
-    def reject_non_admin():
-        from utils.catalog_http_exceptions import raise_auth_error
-
-        raise_auth_error("AUTH_0003", "Admin permission required")
-
-    app.dependency_overrides[_require_admin] = reject_non_admin
-
     return TestClient(app)
 
 
@@ -333,6 +353,22 @@ async def test_validation_retention_days_max(test_client_admin, test_db_session)
     )
 
     assert response.status_code == 422  # Validation error
+
+
+@pytest.mark.asyncio
+async def test_superadmin_rbac_enforcement(test_client_superadmin, test_db_session):
+    """superadmin is accepted on admin retention endpoints (#12704 unlock)."""
+    response = test_client_superadmin.post(
+        "/api/admin/retention-policies",
+        json={
+            "policy_type": "chat",
+            "retention_days": 90,
+            "anonymize_instead_of_delete": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["policy_type"] == "chat"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path

Six API modules each hand-rolled a private `_require_admin` FastAPI dependency instead of using the canonical `auth_rbac.require_role(*roles)`. They had **diverged on who counts as admin**:

- `api/mcp_token_admin.py` accepted `("admin", "superadmin")`.
- `api/admin_schedulers.py`, `api/admin_event_logs.py`, `api/admin_pricing.py`, `api/admin_retention_policies.py`, and the shared `api/voice_bundle_helpers.py` accepted **only `"admin"`** — so a **superadmin was returned 403** on:
  - `GET /api/admin/schedulers`
  - `GET /api/admin/event-logs`
  - `PUT /api/admin/pricing/{provider}/{model}`, `DELETE …`, `GET /api/admin/pricing-refresh-status`
  - all `/api/admin/retention-policies` CRUD
  - `PUT /api/admin/voice/bundle/{user_id}`, `PUT /api/voice/users/{user_id}/bundle`, `GET /chat/shared-links/admin`

`require_role` (auth_rbac.py) enforces identical auth to the local forks — reads the user via `get_auth_middleware().get_user_from_request`, raises `AUTH_0002` (401) when unauthenticated and `AUTH_0003` (403) on role mismatch — and additionally emits an audit-log entry on denial and matches roles case-insensitively. No endpoint protection is weakened; the superadmin-lockout inconsistency is closed by adopting the `("admin", "superadmin")` superset per the consolidation contract.

## What Changed

- Deleted all **6** local `_require_admin` definitions; repointed every `Depends(_require_admin)` onto `Depends(require_role("admin", "superadmin"))`.
- Two `voice_bundle_helpers._require_admin` consumers returned the user dict (`admin_user`): `voice_bundle_admin.set_user_bundle` and `voice_bundle_user.set_user_bundle`. These now obtain the acting-user dict from the already-imported canonical `get_current_user` dependency and gate with `require_role` — preserving the exact `get_user_from_request` semantics.
- `chat_shared_links.list_all_shared_links_admin` never used the returned dict → pure `require_role` gate.
- Removed now-unused imports (`get_auth_middleware`, `raise_auth_error`, dead `Request`).

## Verification

- Local `require_role` semantics confirmed identical (401 unauth / 403 wrong-role) via `static/error_messages.yaml` (`AUTH_0002`=401, `AUTH_0003`=403); denial audit path is exception-safe.
- Added tests proving **superadmin now reaches** the previously locked endpoints AND that a non-admin **still gets 403**:
  - `mcp_token_admin_test.py::test_create_token_superadmin_allowed`
  - `test_voice_bundle_user.py::TestSetUserBundle::test_superadmin_assigns_bundle_to_user`
  - `test_chat_shared_links.py::TestAdminListAllSharedLinks::test_superadmin_lists_all_active_links`
  - `test_retention_policies_api.py::test_superadmin_rbac_enforcement`
  - existing non-admin-403 tests retained and passing.
- `python -m pytest` across the 6 modules + `auth_rbac_test.py`: **88 passed, 4 failed** — the 4 failures are pre-existing, environment-only (`test_resolve_bundle_*` patch `database.session`, which is unimportable without optional deps; untouched by this PR).
- `ruff check`, `black --check`, `isort --check` all clean.
- grep confirms **zero** remaining local `_require_admin` definitions or references.

## Model Used

claude-opus-4-8

Closes #12704
Refs #12645
