### PR TITLE
tech-debt(backend): shared no_data_response helper for 7 analytics endpoints (#12705)

### DIFF
--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List
 from celery.result import AsyncResult
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from api.analytics_shared import no_data_response
 from api.schemas_analytics import (
     BugPredictionAnalysisResponse,
     BugPredictionAnalyzeResponse,
@@ -120,28 +121,6 @@ async def _set_cached_bug_prediction(
         )
     except Exception as e:
         logger.debug("Cache write error (non-critical): %s", e)
-
-
-def _no_data_response(
-    message: str = "No bug prediction data available. Run codebase analysis first.",
-) -> dict:
-    """
-    Standardized no-data response.
-
-    Issue #543: Replaces all demo data responses.
-
-    Args:
-        message: Custom message explaining why no data is available
-
-    Returns:
-        Dict with status="no_data", message, and empty data structures
-    """
-    return {
-        "status": "no_data",
-        "message": message,
-        "files": [],
-        "summary": {},
-    }
 
 
 def _parse_git_bug_history_lines(lines: list[str]) -> dict[str, int]:
@@ -813,7 +792,7 @@ async def _run_bug_analysis(path: str, include_pattern: str, limit: int) -> dict
     )
 
     if not files_to_analyze:
-        return _no_data_response(f"No files matching '{include_pattern}' found in '{path}'")
+        return no_data_response(f"No files matching '{include_pattern}' found in '{path}'", files=[], summary={})
 
     analyzed_files = await _analyze_files_parallel(files_to_analyze, change_freq, bug_history)
     analyzed_files.sort(key=lambda x: x["risk_score"], reverse=True)
@@ -878,7 +857,7 @@ async def analyze_codebase(
 
     except Exception as e:
         logger.error("Failed to analyze codebase: %s", e, exc_info=True)
-        return _no_data_response("Analysis failed")
+        return no_data_response("Analysis failed", files=[], summary={})
 
 
 def _build_analysis_result(
@@ -921,7 +900,7 @@ async def get_cached_bug_prediction():
             "completed_at": cached.get("completed_at"),
             **cached["result"],
         }
-    return _no_data_response("No cached bug prediction available")
+    return no_data_response("No cached bug prediction available", files=[], summary={})
 
 
 @router.post("/analyze", response_model=BugPredictionAnalyzeResponse)
@@ -1001,7 +980,7 @@ async def get_high_risk_files(
         )
 
         if not files_to_analyze:
-            return _no_data_response(f"No files matching '{include_pattern}' found in '{path}'")
+            return no_data_response(f"No files matching '{include_pattern}' found in '{path}'", files=[], summary={})
 
         # Issue #609: Analyze files in parallel
         analyzed_files = await _analyze_files_parallel(files_to_analyze, change_freq, bug_history)
@@ -1019,7 +998,7 @@ async def get_high_risk_files(
 
     except Exception as e:
         logger.error("Failed to get high-risk files: %s", e, exc_info=True)
-        return _no_data_response("Analysis failed")
+        return no_data_response("Analysis failed", files=[], summary={})
 
 
 def _build_file_risk_response(file_path: str, factors: dict, bug_history: dict) -> dict:
@@ -1054,7 +1033,7 @@ async def get_file_risk(
     """
     path = Path(file_path)
     if not await asyncio.to_thread(path.exists):
-        return _no_data_response(f"File not found: {file_path}")
+        return no_data_response(f"File not found: {file_path}", files=[], summary={})
 
     try:
         # Issue #664: Parallelize independent data fetches
@@ -1079,7 +1058,7 @@ async def get_file_risk(
 
     except Exception as e:
         logger.error("Failed to analyze file %s: %s", file_path, e, exc_info=True)
-        return _no_data_response("Analysis failed for {file_path}")
+        return no_data_response("Analysis failed for {file_path}", files=[], summary={})
 
 
 def _get_file_recommendation(risk_score: float, factors: dict[str, float]) -> str:
@@ -1166,7 +1145,7 @@ async def get_risk_heatmap(
         )
 
         if not files_to_analyze:
-            return _no_data_response(f"No files matching '{include_pattern}' found in '{path}'")
+            return no_data_response(f"No files matching '{include_pattern}' found in '{path}'", files=[], summary={})
 
         # Issue #609: Analyze files in parallel
         analyzed_files = await _analyze_files_parallel(files_to_analyze, change_freq, bug_history)
@@ -1187,7 +1166,7 @@ async def get_risk_heatmap(
 
     except Exception as e:
         logger.error("Failed to generate heatmap: %s", e, exc_info=True)
-        return _no_data_response("Heatmap generation failed")
+        return no_data_response("Heatmap generation failed", files=[], summary={})
 
 
 @router.get("/trends", response_model=BugPredictionTrendsResponse)
@@ -1223,9 +1202,11 @@ async def get_prediction_trends(
     history = await _get_prediction_history(period_days)
 
     if not history:
-        return _no_data_response(
+        return no_data_response(
             f"No prediction history available for period '{period}'. "
-            "Run /bug-prediction/analyze to start collecting trend data."
+            "Run /bug-prediction/analyze to start collecting trend data.",
+            files=[],
+            summary={},
         )
 
     # Calculate trend metrics
@@ -1330,7 +1311,7 @@ async def get_prediction_summary(
         )
 
         if not files_to_analyze:
-            return _no_data_response(f"No files matching '{include_pattern}' found in '{path}'")
+            return no_data_response(f"No files matching '{include_pattern}' found in '{path}'", files=[], summary={})
 
         # Issue #609: Analyze files in parallel
         analyzed_files = await _analyze_files_parallel(files_to_analyze, change_freq, bug_history)
@@ -1360,7 +1341,7 @@ async def get_prediction_summary(
 
     except Exception as e:
         logger.error("Failed to generate summary: %s", e, exc_info=True)
-        return _no_data_response("Summary generation failed")
+        return no_data_response("Summary generation failed", files=[], summary={})
 
 
 @router.get("/factors", response_model=BugPredictionRiskFactorsResponse)

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -19,6 +19,9 @@ from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from api.analytics_shared import (
+    no_data_response,
+)
 from api.analytics_shared import (  # noqa: F401 – used by history/metrics/summary
     resolve_source_or_404 as _resolve_source_or_404,
 )
@@ -189,24 +192,6 @@ REVIEW_PATTERNS = {
         "suggestion": "Create a GitHub issue to track this work.",
     },
 }
-
-
-# ============================================================================
-# Utility Functions
-# ============================================================================
-
-
-def _no_data_response(
-    message: str = "No code review data. Run a code review first.",
-) -> dict:
-    """Standardized no-data response (Issue #543)."""
-    return {
-        "status": "no_data",
-        "message": message,
-        "review": None,
-        "comments": [],
-        "summary": {},
-    }
 
 
 def _parse_hunk_header(line: str) -> dict[str, Any] | None:
@@ -447,7 +432,12 @@ async def analyze_diff(
 
     if not diff_content:
         # Issue #543: Return no-data response instead of demo data
-        return _no_data_response("No git diff available. Make changes or specify a commit range.")
+        return no_data_response(
+            "No git diff available. Make changes or specify a commit range.",
+            review=None,
+            comments=[],
+            summary={},
+        )
 
     # Parse diff
     files = parse_diff(diff_content)
@@ -675,7 +665,7 @@ async def get_review_history(
 
         redis = get_redis_client(async_client=False, database="analytics")
         if not redis:
-            return _no_data_response("Analytics database unavailable.")
+            return no_data_response("Analytics database unavailable.", review=None, comments=[], summary={})
 
         effective_source = source_id or "default"
         raw_entries = await asyncio.to_thread(redis.lrange, f"code_review:history:{effective_source}", 0, limit - 1)
@@ -699,14 +689,22 @@ async def get_review_history(
             reviews.append(entry)
 
         if not reviews:
-            return _no_data_response(
-                "No review history available. Reviews will be stored here once you run code reviews."
+            return no_data_response(
+                "No review history available. Reviews will be stored here once you run code reviews.",
+                review=None,
+                comments=[],
+                summary={},
             )
 
         return {"status": "success", "reviews": reviews, "total": len(reviews)}
     except Exception as exc:
         logger.warning("Failed to load review history: %s", exc)
-        return _no_data_response("No review history available. Reviews will be stored here once you run code reviews.")
+        return no_data_response(
+            "No review history available. Reviews will be stored here once you run code reviews.",
+            review=None,
+            comments=[],
+            summary={},
+        )
 
 
 @router.get("/metrics", response_model=CodeReviewMetricsResponse)
@@ -730,7 +728,12 @@ async def get_review_metrics(
     """
     await _resolve_source_or_404(source_id)
     # Issue #543: Return no-data response instead of demo data
-    return _no_data_response("No review metrics available. Metrics will accumulate as you run code reviews.")
+    return no_data_response(
+        "No review metrics available. Metrics will accumulate as you run code reviews.",
+        review=None,
+        comments=[],
+        summary={},
+    )
 
 
 @router.post("/feedback", response_model=CodeReviewFeedbackResponse)
@@ -800,8 +803,11 @@ async def get_review_summary(
     """
     await _resolve_source_or_404(source_id)
     # Issue #543: Return no-data response instead of demo data
-    return _no_data_response(
-        "No review summary available. Summary statistics will be generated after running code reviews."
+    return no_data_response(
+        "No review summary available. Summary statistics will be generated after running code reviews.",
+        review=None,
+        comments=[],
+        summary={},
     )
 
 

--- a/autobot-backend/api/analytics_code_review_test.py
+++ b/autobot-backend/api/analytics_code_review_test.py
@@ -8,7 +8,7 @@ Unit tests for analytics_code_review.py source_id scoping (Issue #3436)
 Tests the following functionality:
 - parse_diff helper function
 - calculate_review_score helper function
-- _no_data_response helper function
+- no_data_response shared helper (api.analytics_shared)
 - _resolve_source_or_404 guard logic (mocked via sys.modules)
 """
 
@@ -125,22 +125,22 @@ class TestCalculateReviewScore:
 
 
 class TestNoDataResponse:
-    """Tests for _no_data_response helper."""
+    """Tests for the shared no_data_response helper (Issue #12705)."""
 
     def test_default_message(self):
         """Should include no_data status and message key."""
-        from api.analytics_code_review import _no_data_response
+        from api.analytics_shared import no_data_response
 
-        result = _no_data_response()
+        result = no_data_response("No code review data. Run a code review first.", review=None, comments=[], summary={})
         assert result["status"] == "no_data"
         assert "message" in result
         assert "comments" in result
 
     def test_custom_message(self):
         """Should accept a custom message."""
-        from api.analytics_code_review import _no_data_response
+        from api.analytics_shared import no_data_response
 
-        result = _no_data_response("Custom message")
+        result = no_data_response("Custom message", review=None, comments=[], summary={})
         assert result["message"] == "Custom message"
 
 

--- a/autobot-backend/api/analytics_debt.py
+++ b/autobot-backend/api/analytics_debt.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
+from api.analytics_shared import no_data_response
 from api.schemas_analytics import (
     AnalyticsDebtByCategoryResponse,
     AnalyticsDebtCalculateResponse,
@@ -47,27 +48,6 @@ router = APIRouter(tags=["technical-debt", "analytics"])  # Prefix set in router
 
 # Redis key prefix
 DEBT_PREFIX = "debt:"
-
-
-def _no_data_response(
-    message: str = "No technical debt analysis data. Run codebase indexing first.",
-) -> dict:
-    """
-    Standardized no-data response for debt analytics (Issue #543).
-
-    Args:
-        message: Custom message explaining why no data is available
-
-    Returns:
-        Dictionary with no_data status and empty structures
-    """
-    return {
-        "status": "no_data",
-        "message": message,
-        "summary": {},
-        "items": [],
-        "total_hours": 0,
-    }
 
 
 class DebtCategory(str, Enum):
@@ -546,7 +526,14 @@ async def get_debt_summary(admin_check: bool = Depends(check_admin_permission)):
         )
 
     # Return no_data response if no analysis exists (Issue #543)
-    return JSONResponse(_no_data_response("No debt analysis found. Run POST /calculate first."))
+    return JSONResponse(
+        no_data_response(
+            "No debt analysis found. Run POST /calculate first.",
+            summary={},
+            items=[],
+            total_hours=0,
+        )
+    )
 
 
 @router.get("/by-category/{category}", response_model=DataResponse[AnalyticsDebtByCategoryResponse])

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -298,19 +298,6 @@ def _parse_date_range(start_date: str | None, end_date: str | None) -> tuple:
     return start_ts, end_ts
 
 
-def _no_data_response(
-    message: str = "No evolution data. Redis required for timeline tracking.",
-) -> dict:
-    """Standardized no-data response (Issue #543)."""
-    return {
-        "status": "no_data",
-        "message": message,
-        "timeline": [],
-        "patterns": {},
-        "trends": {},
-    }
-
-
 def _build_timeline_response(timeline: list, start_date: str, end_date: str, granularity: str, metrics: list) -> dict:
     """Build timeline success response (Issue #398: extracted)."""
     return {

--- a/autobot-backend/api/analytics_evolution_test.py
+++ b/autobot-backend/api/analytics_evolution_test.py
@@ -8,7 +8,7 @@ Unit tests for analytics_evolution.py source_id scoping (Issue #3436)
 Tests the following functionality:
 - _decode_redis_value helper function
 - _parse_date_range helper function
-- _no_data_response helper function
+- no_data_response shared helper (api.analytics_shared)
 - _calculate_metric_trend helper function
 - _resolve_source_or_404 guard logic (mocked via sys.modules)
 """
@@ -82,13 +82,18 @@ class TestParseDateRange:
 
 
 class TestNoDataResponse:
-    """Tests for _no_data_response in analytics_evolution."""
+    """Tests for the shared no_data_response helper (Issue #12705)."""
 
     def test_default_response_structure(self):
         """Should include status, message, timeline, patterns, trends keys."""
-        from api.analytics_evolution import _no_data_response
+        from api.analytics_shared import no_data_response
 
-        result = _no_data_response()
+        result = no_data_response(
+            "No evolution data. Redis required for timeline tracking.",
+            timeline=[],
+            patterns={},
+            trends={},
+        )
         assert result["status"] == "no_data"
         assert "message" in result
         assert "timeline" in result
@@ -97,9 +102,9 @@ class TestNoDataResponse:
 
     def test_custom_message(self):
         """Should accept custom message."""
-        from api.analytics_evolution import _no_data_response
+        from api.analytics_shared import no_data_response
 
-        result = _no_data_response("Custom evolution message")
+        result = no_data_response("Custom evolution message", timeline=[], patterns={}, trends={})
         assert result["message"] == "Custom evolution message"
 
 

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -19,6 +19,7 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
+from api.analytics_shared import no_data_response
 from api.schemas_analytics import (
     AnalyticsPerformanceAnalyzeData,
     ImpactLevel,
@@ -504,7 +505,7 @@ async def analyze_path(
     # Return no_data response if no files to analyze
     if not files_to_analyze:
         return JSONResponse(
-            content=_no_data_response("No files found to analyze. Please provide a valid path."),
+            content=no_data_response("No files found to analyze. Please provide a valid path.", issues=[], summary={}),
             status_code=200,
         )
 
@@ -784,20 +785,3 @@ async def get_hotspots(
     ]
 
     return hotspots
-
-
-# ============================================================================
-# Utility Functions
-# ============================================================================
-
-
-def _no_data_response(
-    message: str = "No performance analysis data. Run codebase indexing first.",
-) -> dict:
-    """Standardized no-data response for analytics endpoints."""
-    return {
-        "status": "no_data",
-        "message": message,
-        "issues": [],
-        "summary": {},
-    }

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -21,6 +21,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 
+from api.analytics_shared import no_data_response
 from api.analytics_shared import resolve_source_root_or_404 as _resolve_source_root_or_404
 from api.schemas_analytics import (
     AnalyticsQualityExportData,
@@ -766,25 +767,6 @@ async def calculate_real_quality_metrics(
     }
 
 
-def _no_data_response(
-    message: str = "No analysis data. Run codebase indexing first.",
-) -> dict:
-    """
-    Standardized no-data response for quality endpoints.
-
-    Issue #543: Replaces demo data with proper no_data status.
-    """
-    return {
-        "status": "no_data",
-        "message": message,
-        "metrics": {},
-        "patterns": [],
-        "complexity": {},
-        "stats": {},
-        "trends": [],
-    }
-
-
 # Issue #665: Category type mapping for drill-down filtering
 _CATEGORY_TYPE_MAP: dict[str, set[str]] = {
     "maintainability": {"code_smell", "long_function", "complexity", "technical_debt"},
@@ -1074,11 +1056,25 @@ async def get_health_score(
 
     # Issue #543: Handle no data case
     if data is None:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     metrics = data.get("metrics", {})
     if not metrics:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     health = calculate_health_score(metrics)
 
@@ -1118,11 +1114,25 @@ async def get_quality_metrics(
 
     # Issue #543: Handle no data case
     if data is None:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     raw_metrics = data.get("metrics", {})
     if not raw_metrics:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     metrics = []
     for cat, value in raw_metrics.items():
@@ -1176,7 +1186,14 @@ async def get_pattern_distribution(
 
     # Issue #543: Handle no data case
     if data is None:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     patterns = data.get("patterns", [])
 
@@ -1233,7 +1250,14 @@ async def get_complexity_metrics(
 
     # Issue #543: Handle no data case
     if data is None:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     complexity = data.get("complexity", {})
 
@@ -1353,7 +1377,14 @@ async def get_quality_trends(
     data = await get_quality_data_from_storage(source_root=source_root, source_id=source_id)
 
     if data is None:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     cutoff = datetime.now(tz=timezone.utc) - timedelta(days=int(period[:-1]))
     filtered_trends = _filter_trends_by_period(data.get("trends", []), cutoff)
@@ -1392,11 +1423,25 @@ async def get_quality_snapshot(
 
     # Issue #543: Handle no data case
     if data is None:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     metrics = data.get("metrics", {})
     if not metrics:
-        return _no_data_response()
+        return no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     health = calculate_health_score(metrics)
     patterns = data.get("patterns", [])
@@ -1447,7 +1492,14 @@ async def _drill_down_runtime_risk(limit: int = 50) -> dict[str, Any]:
 
     risk_map = await build_runtime_risk_map()
     if not risk_map:
-        return _no_data_response("No runtime failure data available.")
+        return no_data_response(
+            "No runtime failure data available.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
     sorted_files = sorted(risk_map.items(), key=lambda kv: kv[1], reverse=True)[:limit]
     return {
         "status": "success",
@@ -1491,7 +1543,14 @@ async def drill_down_category(
     problems, stats = await _get_problems_from_chromadb(source_root=source_root)
 
     if not problems:
-        return _no_data_response("No analysis data for category drill-down.")
+        return no_data_response(
+            "No analysis data for category drill-down.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
 
     # Issue #665: Use extracted helper functions
     category_problems = _filter_problems_by_category(problems, category, severity)
@@ -1534,11 +1593,29 @@ async def export_quality_report(
     data = await get_quality_data_from_storage()
 
     if data is None:
-        return JSONResponse(content=_no_data_response())
+        return JSONResponse(
+            content=no_data_response(
+                "No analysis data. Run codebase indexing first.",
+                metrics={},
+                patterns=[],
+                complexity={},
+                stats={},
+                trends=[],
+            )
+        )
 
     metrics = data.get("metrics", {})
     if not metrics:
-        return JSONResponse(content=_no_data_response())
+        return JSONResponse(
+            content=no_data_response(
+                "No analysis data. Run codebase indexing first.",
+                metrics={},
+                patterns=[],
+                complexity={},
+                stats={},
+                trends=[],
+            )
+        )
 
     health = calculate_health_score(metrics)
 

--- a/autobot-backend/api/analytics_quality_test.py
+++ b/autobot-backend/api/analytics_quality_test.py
@@ -8,7 +8,7 @@ Unit tests for analytics_quality.py source_id scoping (Issue #3436)
 Tests the following functionality:
 - get_grade helper function
 - calculate_health_score helper function
-- _no_data_response helper function
+- no_data_response shared helper (api.analytics_shared)
 - _resolve_source_root_or_404 guard logic (mocked via sys.modules)
 """
 
@@ -133,21 +133,28 @@ class TestCalculateHealthScore:
 
 
 class TestNoDataResponse:
-    """Tests for _no_data_response helper."""
+    """Tests for the shared no_data_response helper (Issue #12705)."""
 
     def test_default_message(self):
         """Should return a dict with status=no_data and default message."""
-        from api.analytics_quality import _no_data_response
+        from api.analytics_shared import no_data_response
 
-        result = _no_data_response()
+        result = no_data_response(
+            "No analysis data. Run codebase indexing first.",
+            metrics={},
+            patterns=[],
+            complexity={},
+            stats={},
+            trends=[],
+        )
         assert result["status"] == "no_data"
         assert "message" in result
 
     def test_custom_message(self):
         """Should return the custom message when provided."""
-        from api.analytics_quality import _no_data_response
+        from api.analytics_shared import no_data_response
 
-        result = _no_data_response("Custom error message")
+        result = no_data_response("Custom error message", metrics={}, patterns=[], complexity={}, stats={}, trends=[])
         assert result["message"] == "Custom error message"
 
 

--- a/autobot-backend/api/analytics_shared.py
+++ b/autobot-backend/api/analytics_shared.py
@@ -33,6 +33,25 @@ async def resolve_source_or_404(source_id: str | None) -> None:
         raise HTTPException(status_code=404, detail=f"Source '{source_id}' not found")
 
 
+def no_data_response(message: str, **extra_fields) -> dict:
+    """Standardized no-data response envelope (Issue #543, extracted #12705).
+
+    Every analytics endpoint returns ``status="no_data"`` plus a message when
+    there is nothing to report. The empty result containers differ per
+    endpoint (e.g. "issues"/"summary" vs "timeline"/"patterns"/"trends"), so
+    callers supply those as keyword arguments.
+
+    Args:
+        message: Explanation for why there is no data.
+        extra_fields: Endpoint-specific empty result containers merged into
+            the response (e.g. ``issues=[], summary={}``).
+
+    Returns:
+        Dict with status="no_data", message, and the supplied extra fields.
+    """
+    return {"status": "no_data", "message": message, **extra_fields}
+
+
 async def resolve_source_root_or_404(source_id: str | None) -> Path | None:
     """Validate source_id and return its filesystem root path.
 

--- a/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
+++ b/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
@@ -317,23 +317,25 @@ class TestRecreateChromaDBCollection:
 
 
 class TestNoDataResponse:
-    """Tests for _no_data_response helper."""
+    """Tests for stats.py's use of the shared no_data_response helper (Issue #12705)."""
 
     def test_returns_json_response(self):
-        """Should return JSONResponse with correct structure."""
+        """stats.py wraps the shared helper's dict in a JSONResponse."""
         from fastapi.responses import JSONResponse
 
-        from api.codebase_analytics.endpoints.stats import _no_data_response
+        from api.analytics_shared import no_data_response
 
-        result = _no_data_response()
+        result = JSONResponse(no_data_response("No codebase data found. Run indexing first.", stats=None))
 
         assert isinstance(result, JSONResponse)
 
     def test_default_message(self):
-        """Should use default message when none provided."""
-        from api.codebase_analytics.endpoints.stats import _no_data_response
+        """Should use stats.py's default message when none provided."""
+        from fastapi.responses import JSONResponse
 
-        result = _no_data_response()
+        from api.analytics_shared import no_data_response
+
+        result = JSONResponse(no_data_response("No codebase data found. Run indexing first.", stats=None))
         # JSONResponse body is bytes, need to decode
         import json
 
@@ -347,9 +349,11 @@ class TestNoDataResponse:
         """Should use custom message when provided."""
         import json
 
-        from api.codebase_analytics.endpoints.stats import _no_data_response
+        from fastapi.responses import JSONResponse
 
-        result = _no_data_response("Custom error message")
+        from api.analytics_shared import no_data_response
+
+        result = JSONResponse(no_data_response("Custom error message", stats=None))
         body = json.loads(result.body)
 
         assert body["message"] == "Custom error message"

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
+from api.analytics_shared import no_data_response
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso
@@ -83,11 +84,6 @@ def _parse_stats_metadata(stats_metadata: dict) -> dict:
             stats[ratio_field] = stats_metadata[ratio_field]
 
     return stats
-
-
-def _no_data_response(message: str = "No codebase data found. Run indexing first."):
-    """Return standardized no-data response. (Issue #315 - extracted)"""
-    return JSONResponse({"status": "no_data", "message": message, "stats": None})
 
 
 # Issue #540: Maximum time (seconds) before a task is considered stale
@@ -216,7 +212,7 @@ async def get_codebase_stats(source_id: str | None = None):
                 "Indexing in progress. ChromaDB connection pending.",
                 active_task,
             )
-        return _no_data_response("ChromaDB connection failed.")
+        return JSONResponse(no_data_response("ChromaDB connection failed.", stats=None))
 
     # Issue #1710: Per-source stats use source-scoped document ID
     stats_doc_id = f"codebase_stats_{source_id}" if source_id else "codebase_stats"
@@ -227,7 +223,7 @@ async def get_codebase_stats(source_id: str | None = None):
         # Issue #540, #665: Show indexing status even on query failure
         if active_task:
             return _build_indexing_response("Indexing in progress.", active_task)
-        return _no_data_response()
+        return JSONResponse(no_data_response("No codebase data found. Run indexing first.", stats=None))
 
     # Check if we have data
     if not results.get("metadatas") or len(results["metadatas"]) == 0:
@@ -237,7 +233,7 @@ async def get_codebase_stats(source_id: str | None = None):
                 "Indexing in progress. Stats will be available when complete.",
                 active_task,
             )
-        return _no_data_response()
+        return JSONResponse(no_data_response("No codebase data found. Run indexing first.", stats=None))
 
     # Parse and return stats (Issue #315 - use extracted helper)
     stats_metadata = results["metadatas"][0]


### PR DESCRIPTION
## Thinking Path

Round-3 of umbrella #12645: `_no_data_response` was forked ×7 across `analytics_performance.py`, `analytics_debt.py`, `analytics_quality.py`, `analytics_evolution.py`, `analytics_bug_prediction.py`, `analytics_code_review.py`, and `codebase_analytics/endpoints/stats.py` (all citing #543). Diffing the 7 showed they are **not** byte-identical apart from the message: each returns a different set of empty result containers (`issues`/`summary` vs `items`/`total_hours` vs `metrics`/`patterns`/`complexity`/`stats`/`trends` vs `timeline`/`patterns`/`trends` vs `files`/`summary` vs `review`/`comments`/`summary` vs `stats`-only wrapped in `JSONResponse`). Per the divergence-preservation contract, the shared helper takes `message` plus `**extra_fields` so each caller keeps its own shape.

## What Changed

- Added `no_data_response(message: str, **extra_fields) -> dict` to `api/analytics_shared.py` (the existing common module already imported by 4 of these 7 files).
- Deleted the 7 local `_no_data_response` defs.
- Updated every call site to import the shared helper and pass its own message + extra containers explicitly (no defaults baked into the shared function, since the default message differs per endpoint).
- `codebase_analytics/endpoints/stats.py` keeps wrapping the dict in `JSONResponse` at the call site (unchanged behavior).
- `analytics_evolution.py`'s `_no_data_response` was dead code (no production caller, only unit-tested) — removed along with the others.
- Updated the 4 unit test files (`analytics_quality_test.py`, `analytics_code_review_test.py`, `analytics_evolution_test.py`, `codebase_stats_endpoint_test.py`) that imported the local symbol directly to instead test the shared helper.

No behavior change: every endpoint's no-data response is byte-identical to before (verified below).

## Verification

- `python3 -m pytest` — 115 passed across `analytics_quality_test.py`, `analytics_evolution_test.py`, `analytics_code_review_test.py`, `codebase_stats_endpoint_test.py`, `stats_scoping_test.py`, and the 30 `analytics`-matched cases in `tests/test_startup_imports.py` (import-smoke for all 7 target modules).
- `python3 -m pytest` on the other analytics test files (`analytics_code_generation_test.py`, `analytics_conversation_test.py`, `analytics_root_cause_test.py`, `analytics_tasks_test.py`, etc.) — 74 passed, unaffected.
- `grep -rn "def no_data_response" autobot-backend` — exists exactly once (`api/analytics_shared.py`).
- `grep -rn "_no_data_response" autobot-backend` — zero remaining references (all 7 local defs + call sites migrated).
- Manual shape check: constructed each of the 7 endpoints' exact call-site kwargs and asserted the result dict equals the original hardcoded literal for all 7 (byte-identical `status`/`message`/extra-field keys and values).
- `python3 -m black --check` and `python3 -m isort --check-only` — clean on all 12 changed files.

## Model Used

Sonnet 5

Closes #12705
Refs #12645

<!-- link-check re-trigger -->