### PR TITLE
tech-debt(backend): unify 9 torch lazy-loaders onto thread-safe lazy_torch (#12714)

### DIFF
--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -35,6 +35,7 @@ from constants.threshold_constants import (
     TimingConstants,
 )
 from knowledge.search import map_kb_result_to_dict  # Issue #10740 shared mapper
+from llm_shared.torch_loader import lazy_torch
 
 if TYPE_CHECKING:
     import torch as _torch_type  # noqa: F401
@@ -52,19 +53,14 @@ except (ImportError, RuntimeError):
 logger = get_llm_logger("ai_hardware_accelerator")
 
 # Issue #3016: lazy module-level imports for torch, torch.nn.functional, PIL
-_torch = None
+# Issue #12714: torch loader unified onto the shared thread-safe llm_shared.torch_loader.
 _torch_F = None
 _PILImage = None
 
 
 def _get_torch():
     """Lazy-load torch on first use. Issue #3016."""
-    global _torch  # noqa: PLW0603
-    if _torch is None:
-        import torch
-
-        _torch = torch
-    return _torch
+    return lazy_torch()
 
 
 def _get_torch_F():

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -383,6 +383,11 @@ if "llm_shared" not in sys.modules:
 
     _real_load_and_bind("llm_shared.types", _llm_root / "types.py")
     _real_load_and_bind("llm_shared.models", _llm_root / "models.py")
+    # #12714: thread-safe lazy torch loader shared by 9 call sites (flash_attention,
+    # ssm_kernels, kv_cache, layer_inference, ai_hardware_accelerator,
+    # multimodal_processor + vision/voice, incremental_trainer). No deps beyond
+    # stdlib threading — safe to real-load unconditionally, early.
+    _real_load_and_bind("llm_shared.torch_loader", _llm_root / "torch_loader.py")
     # #11520: canonical JSON parser and schema-typed extraction helper — lightweight,
     # no heavy deps; load real so tests importing them don't hit the stub.
     _real_load_and_bind("llm_shared.json_utils", _llm_root / "json_utils.py")

--- a/autobot-backend/llm_shared/optimization/flash_attention.py
+++ b/autobot-backend/llm_shared/optimization/flash_attention.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any, Tuple
 
 from autobot_shared.logging_manager import get_logger
 
+from ..torch_loader import lazy_torch
+
 if TYPE_CHECKING:
     import torch  # noqa: F401  # used by deferred (string) type annotations
 
@@ -31,22 +33,12 @@ logger = get_logger(__name__)
 
 # Issue #3009: Lazy-load torch on first use so importing this module does not
 # require torch to be installed (NPU/GPU subsystem is feature-flagged).
-# Issue #10916: double-checked lock prevents two threads from both racing past
-# the None check and importing torch concurrently.
-_torch: Any = None
-_torch_lock = threading.Lock()
+# Issue #12714: unified onto the shared thread-safe llm_shared.torch_loader.
 
 
 def _get_torch() -> Any:
     """Return the torch module, importing it on first call (thread-safe)."""
-    global _torch  # noqa: PLW0603
-    if _torch is None:
-        with _torch_lock:
-            if _torch is None:
-                import torch
-
-                _torch = torch
-    return _torch
+    return lazy_torch()
 
 
 # Lazy imports for optional dependencies

--- a/autobot-backend/llm_shared/optimization/kv_cache.py
+++ b/autobot-backend/llm_shared/optimization/kv_cache.py
@@ -25,30 +25,22 @@ from typing import TYPE_CHECKING, Dict, Tuple
 
 from autobot_shared.logging_manager import get_logger
 
+from ..torch_loader import lazy_torch
+
 if TYPE_CHECKING:
     import torch
 
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Lazy torch import — module degrades gracefully without it
+# Lazy torch import — module degrades gracefully without it.
+# Issue #12714: unified onto the shared thread-safe llm_shared.torch_loader.
 # ---------------------------------------------------------------------------
-_torch = None
-_torch_checked = False
 
 
 def _get_torch():
-    """Return the torch module, importing lazily on first call."""
-    global _torch, _torch_checked  # noqa: PLW0603
-    if not _torch_checked:
-        _torch_checked = True
-        try:
-            import torch as _t
-
-            _torch = _t
-        except (ImportError, RuntimeError):
-            _torch = None
-    return _torch
+    """Return the torch module, importing lazily on first call. None if unavailable."""
+    return lazy_torch(required=False)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llm_shared/optimization/layer_inference.py
+++ b/autobot-backend/llm_shared/optimization/layer_inference.py
@@ -24,31 +24,22 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 
+from ..torch_loader import lazy_torch
+
 if TYPE_CHECKING:
     import torch
 
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Lazy torch import — module degrades gracefully without it
+# Lazy torch import — module degrades gracefully without it.
+# Issue #12714: unified onto the shared thread-safe llm_shared.torch_loader.
 # ---------------------------------------------------------------------------
-
-_torch = None
-_torch_checked = False
 
 
 def _get_torch() -> Any:
-    """Return the torch module, importing lazily on first call."""
-    global _torch, _torch_checked  # noqa: PLW0603
-    if not _torch_checked:
-        _torch_checked = True
-        try:
-            import torch as _t
-
-            _torch = _t
-        except (ImportError, RuntimeError):
-            _torch = None
-    return _torch
+    """Return the torch module, importing lazily on first call. None if unavailable."""
+    return lazy_torch(required=False)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llm_shared/optimization/ssm_kernels.py
+++ b/autobot-backend/llm_shared/optimization/ssm_kernels.py
@@ -40,9 +40,7 @@ from ..torch_loader import lazy_torch
 
 logger = get_logger(__name__)
 
-_TORCH_REQUIRED_MSG = (
-    "torch is required for SSM/linear/hybrid kernels. Install with: pip install torch>=2.0.0"
-)
+_TORCH_REQUIRED_MSG = "torch is required for SSM/linear/hybrid kernels. Install with: pip install torch>=2.0.0"
 
 
 def _get_torch() -> Any:

--- a/autobot-backend/llm_shared/optimization/ssm_kernels.py
+++ b/autobot-backend/llm_shared/optimization/ssm_kernels.py
@@ -30,35 +30,24 @@ Issue #10724: real SSM/linear/hybrid kernels replacing NOT_APPLICABLE stubs.
 
 from __future__ import annotations
 
-import threading
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, List
 
 from autobot_shared.logging_manager import get_logger
 
+from ..torch_loader import lazy_torch
+
 logger = get_logger(__name__)
 
-# Issue #10916: double-checked lock prevents two threads from racing past the
-# None check and importing torch concurrently.
-_torch: Any = None
-_torch_lock = threading.Lock()
+_TORCH_REQUIRED_MSG = (
+    "torch is required for SSM/linear/hybrid kernels. Install with: pip install torch>=2.0.0"
+)
 
 
 def _get_torch() -> Any:
     """Return the torch module, importing it lazily on first use (thread-safe)."""
-    global _torch  # noqa: PLW0603
-    if _torch is None:
-        with _torch_lock:
-            if _torch is None:
-                try:
-                    import torch  # noqa: PLC0415
-                except ImportError as exc:  # pragma: no cover - env-dependent
-                    raise ImportError(
-                        "torch is required for SSM/linear/hybrid kernels. Install with: pip install torch>=2.0.0"
-                    ) from exc
-                _torch = torch
-    return _torch
+    return lazy_torch(required=True, error_message=_TORCH_REQUIRED_MSG)
 
 
 class LayerKind(str, Enum):

--- a/autobot-backend/llm_shared/torch_loader.py
+++ b/autobot-backend/llm_shared/torch_loader.py
@@ -1,0 +1,67 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Shared thread-safe lazy torch loader — Issue #12714 (round-3 of #12645).
+
+A lazy ``import torch`` singleton was reimplemented across 9 modules
+(``ai_hardware_accelerator``, the 4 ``llm_shared/optimization`` kernels,
+``multimodal_processor`` + its ``vision``/``voice`` processors, and
+``services/incremental_trainer``). Only one — ``optimization/flash_attention``
+— used double-checked locking; the other 8 raced two threads past the
+``if _torch is None`` check and could both attempt the import concurrently.
+
+This module extracts that thread-safe pattern once. Torch is a heavy optional
+dependency (NPU/GPU subsystem is feature-flagged, and many hosts — including
+the startup-import-smoke CI job — run without it installed), so ``torch`` is
+imported lazily inside :func:`lazy_torch`, never at module import time.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Optional
+
+_torch: Any = None
+_torch_error: Optional[Exception] = None
+_torch_lock = threading.Lock()
+
+
+def lazy_torch(required: bool = True, error_message: Optional[str] = None) -> Any:
+    """Return the torch module, importing it on first call (thread-safe).
+
+    The result (module or import failure) is cached process-wide after the
+    first attempt, so repeated calls are cheap regardless of which caller
+    made the first one.
+
+    Args:
+        required: if True (default), a missing/broken torch install raises
+            ``ImportError`` (or the originally raised exception, re-raised).
+            If False, returns ``None`` instead.
+        error_message: overrides the raised message when ``required=True``
+            and torch is unavailable due to ``ImportError`` (matches each
+            call site's original wording). Ignored when torch is available,
+            or when the underlying failure was a ``RuntimeError`` (torch
+            present but failed to initialize) — that is always re-raised
+            unchanged, matching every original per-site implementation.
+
+    Returns:
+        The imported ``torch`` module, or ``None`` when ``required=False``
+        and torch could not be imported.
+    """
+    global _torch, _torch_error  # noqa: PLW0603
+    if _torch is None and _torch_error is None:
+        with _torch_lock:
+            if _torch is None and _torch_error is None:
+                try:
+                    import torch as _t  # noqa: PLC0415
+                except (ImportError, RuntimeError) as exc:
+                    _torch_error = exc
+                else:
+                    _torch = _t
+    if _torch is None and required:
+        if error_message and isinstance(_torch_error, ImportError):
+            raise ImportError(error_message) from _torch_error
+        raise _torch_error  # noqa: B904 - re-raising the cached original
+    return _torch

--- a/autobot-backend/multimodal_processor/processor.py
+++ b/autobot-backend/multimodal_processor/processor.py
@@ -16,6 +16,7 @@ import time
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.torch_loader import lazy_torch
 from memory import TaskPriority, get_memory_manager
 from utils.multimodal_performance_monitor import performance_monitor
 
@@ -26,19 +27,14 @@ from .types import EMBEDDING_FIELDS, VISUAL_MODALITY_TYPES, ModalityType
 logger = get_logger(__name__)
 
 # Issue #3016: lazy module-level imports for torch to avoid startup cost
-_torch = None
+# Issue #12714: torch loader unified onto the shared thread-safe llm_shared.torch_loader.
 _torch_nn = None
 _TORCH_NN_AVAILABLE = None
 
 
 def _get_torch():
     """Lazy-load torch on first use. Issue #3016."""
-    global _torch  # noqa: PLW0603
-    if _torch is None:
-        import torch
-
-        _torch = torch
-    return _torch
+    return lazy_torch()
 
 
 def _get_torch_nn():

--- a/autobot-backend/multimodal_processor/processors/vision.py
+++ b/autobot-backend/multimodal_processor/processors/vision.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 from config import get_config_section
+from llm_shared.torch_loader import lazy_torch
 
 from ..base import BaseModalProcessor
 from ..models import MultiModalInput, ProcessingResult
@@ -28,18 +29,13 @@ if TYPE_CHECKING:
     from PIL import Image
 
 # Issue #3016: lazy module-level imports for torch and PIL
-_torch = None
+# Issue #12714: torch loader unified onto the shared thread-safe llm_shared.torch_loader.
 _PILImage = None
 
 
 def _get_torch():
     """Lazy-load torch on first use. Issue #3016."""
-    global _torch  # noqa: PLW0603
-    if _torch is None:
-        import torch
-
-        _torch = torch
-    return _torch
+    return lazy_torch()
 
 
 def _get_pil_image():

--- a/autobot-backend/multimodal_processor/processors/voice.py
+++ b/autobot-backend/multimodal_processor/processors/voice.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from autobot_shared.logging_manager import get_logger
 from config import get_config_section
+from llm_shared.torch_loader import lazy_torch
 
 from ..base import BaseModalProcessor
 from ..models import MultiModalInput, ProcessingResult
@@ -33,17 +34,12 @@ from ..types import (
 )
 
 # Issue #3016: lazy module-level import for torch
-_torch = None
+# Issue #12714: torch loader unified onto the shared thread-safe llm_shared.torch_loader.
 
 
 def _get_torch():
     """Lazy-load torch on first use. Issue #3016."""
-    global _torch  # noqa: PLW0603
-    if _torch is None:
-        import torch
-
-        _torch = torch
-    return _torch
+    return lazy_torch()
 
 
 # Import models for audio processing

--- a/autobot-backend/services/incremental_trainer.py
+++ b/autobot-backend/services/incremental_trainer.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import sessionmaker
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, utc_timestamp
+from llm_shared.torch_loader import lazy_torch
 from models.completion_feedback import CompletionFeedback
 from training.completion_trainer import CompletionTrainer
 from user_management.database import get_async_engine
@@ -21,17 +22,12 @@ from user_management.database import get_async_engine
 logger = get_logger(__name__)
 
 # Issue #3016: lazy module-level import for torch
-_torch = None
+# Issue #12714: torch loader unified onto the shared thread-safe llm_shared.torch_loader.
 
 
 def _get_torch():
     """Lazy-load torch on first use. Issue #3016."""
-    global _torch  # noqa: PLW0603
-    if _torch is None:
-        import torch
-
-        _torch = torch
-    return _torch
+    return lazy_torch()
 
 
 class IncrementalTrainer:


### PR DESCRIPTION
## Thinking Path

A lazy `import torch` singleton (torch is a heavy optional dep — the
NPU/GPU subsystem is feature-flagged and many hosts, including the
startup-import-smoke CI job, run without it installed) was independently
reimplemented in 9 modules:

- `ai_hardware_accelerator.py`
- `llm_shared/optimization/{ssm_kernels,kv_cache,flash_attention,layer_inference}.py`
- `multimodal_processor/processor.py` + `processors/{vision,voice}.py`
- `services/incremental_trainer.py`

Only `flash_attention.py` used double-checked locking (`if _torch is None:
with lock: if _torch is None: ...`). The other 8 raced two threads past the
`if _torch is None` check and could both attempt `import torch`
concurrently — the correct/best implementation per #12645 round-3 scoping.

Auditing all 9 confirmed 3 distinct present/absent-torch contracts that had
to be preserved exactly:

1. **Raise on missing, no message override** (6 sites: `ai_hardware_accelerator`,
   `flash_attention`, `processor.py`, `vision.py`, `voice.py`,
   `incremental_trainer.py`) — the bare `import torch` failure propagates
   unchanged.
2. **Raise on missing, with a custom message** (`ssm_kernels.py`) — wraps
   `ImportError` in a kernel-specific "torch is required for SSM/linear/hybrid
   kernels..." message, chained `from` the original.
3. **Return `None` on missing, no raise** (`kv_cache.py`, `layer_inference.py`)
   — callers check `if torch is None: raise RuntimeError(...)` themselves.

`llm_shared/torch_loader.py::lazy_torch(required=True|False, error_message=None)`
unifies all 3 behind one thread-safe, double-checked-locking implementation:
the import result (success or failure) is cached process-wide after the
first attempt so repeated calls are cheap regardless of which site called
first; `required=True` re-raises the cached failure (wrapped in the custom
message only when it was an `ImportError`, matching `ssm_kernels`'s
original narrower `except ImportError` — an underlying `RuntimeError` is
never silently reworded); `required=False` returns `None`.

## What Changed

- **Added** `autobot-backend/llm_shared/torch_loader.py` — `lazy_torch()`,
  torch imported lazily inside the function only (never at module scope).
- **Repointed** all 9 `_get_torch()` sites onto it; each site's local
  `_get_torch()` wrapper is now a 1-line delegate (kept so none of the
  ~40 call sites across these files needed touching), and the local
  `_torch`/`_torch_lock`/`_torch_checked` globals were deleted.
- Per-site submodule helpers unrelated to the 9 duplicated singletons
  (`_get_torch_F` in `ai_hardware_accelerator.py`, `_get_torch_nn` in
  `processor.py`, `_get_pil_image` in `ai_hardware_accelerator.py`/`vision.py`)
  are untouched — out of this issue's scope.
- `autobot-backend/conftest.py`: registered `llm_shared.torch_loader` in the
  real-load list (alongside `llm_shared.types`/`models`) — the `llm_shared`
  package is stubbed with an empty `__path__` in tests, so a new submodule
  needs an explicit real-load entry to be resolvable via `from ..torch_loader
  import lazy_torch`, matching the established pattern for every other
  light module added to `llm_shared/`.

## Verification

Torch-less import smoke (this sandbox genuinely lacks torch —
`python3 -c "import torch"` raises `ModuleNotFoundError`):
```
$ PYTHONPATH=.:autobot-backend:autobot_shared python3 -c "
import sys
assert 'torch' not in sys.modules
for m in ['llm_shared.torch_loader','llm_shared.optimization.flash_attention',
          'llm_shared.optimization.ssm_kernels','llm_shared.optimization.kv_cache',
          'llm_shared.optimization.layer_inference','multimodal_processor.processors.vision',
          'multimodal_processor.processors.voice','multimodal_processor.processor',
          'ai_hardware_accelerator']:
    __import__(m)
    assert 'torch' not in sys.modules, f'{m} imported torch at module scope!'
print('ALL 9 modules OK, torch never imported at module scope')
"
ALL 9 modules OK, torch never imported at module scope
```
(`services.incremental_trainer` is the one site not directly torch-less
importable — pre-existing, unrelated to the `_get_torch` singleton: it
unconditionally imports `training.completion_trainer`, which itself does
`import torch` at module scope. This predates this PR — confirmed via `git
show origin/Dev_new_gui`, and its sole caller, `routers/feedback.py`,
already documents and defers the import for exactly this reason: "IncrementalTrainer
chains to torchmetrics. Both deferred to avoid import crash.")

Thread-safety fix confirmed with an injected counting `torch` module finder
+ a sleep to widen the race window, 20 concurrent threads:
```
import attempts: 1
THREAD-SAFETY CONFIRMED: single import, all 20 threads got same module object
```

`pytest autobot-backend/tests/test_startup_imports.py` (torch-less startup
import gate): **348 passed**.

`pytest` on the 4 touched `llm_shared/optimization/*_test.py` files: **50
passed, 99 skipped** (torch-tensor tests skip via `requires_torch`/
`importorskip` — expected, torch isn't installed in this dev venv).

`grep -rn "^def lazy_torch" autobot-backend/` → exactly one definition
(`llm_shared/torch_loader.py:31`).

## Model Used

Sonnet 5 (claude-sonnet-5)

Closes #12714
Refs #12645