### PR TITLE
security-tech-debt(backend): repoint UserService password hashing onto shared jwt_core (#12725)

### DIFF
--- a/autobot-backend/user_management/services/user_service.py
+++ b/autobot-backend/user_management/services/user_service.py
@@ -13,11 +13,11 @@ import secrets
 import uuid
 from typing import List
 
-import bcrypt
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from autobot_shared.auth.jwt_core import hash_password, verify_password
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from user_management.models import Role, User, UserRole
@@ -52,9 +52,6 @@ class UserService(BaseService):
     multi-tenancy support.
     """
 
-    # Password hashing configuration
-    BCRYPT_ROUNDS = 12
-
     def __init__(self, session: AsyncSession, context: TenantContext | None = None):
         """Initialize user service."""
         super().__init__(session, context)
@@ -74,8 +71,7 @@ class UserService(BaseService):
         Returns:
             Bcrypt hash string
         """
-        salt = bcrypt.gensalt(rounds=UserService.BCRYPT_ROUNDS)
-        return bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
+        return hash_password(password)
 
     @staticmethod
     def verify_password(password: str, password_hash: str) -> bool:
@@ -89,11 +85,7 @@ class UserService(BaseService):
         Returns:
             True if password matches
         """
-        try:
-            return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
-        except Exception as e:
-            logger.error("Password verification error: %s", e)
-            return False
+        return verify_password(password, password_hash)
 
     @staticmethod
     def generate_temp_password() -> str:


### PR DESCRIPTION
## Thinking Path

Round-4 fork-convergence de-dup under umbrella #12645. `autobot-backend/user_management/services/user_service.py` still had its own byte-for-byte-identical bcrypt hashing/verification implementation instead of delegating to the shared canonical `autobot_shared/auth/jwt_core.py`, unlike its three siblings (`auth_middleware.py`, `autobot-slm-backend/user_management/services/user_service.py`, `autobot-slm-backend/services/auth.py`) which already delegate.

Confirmed `jwt_core.hash_password`/`verify_password` use the exact same scheme before touching anything: `bcrypt.gensalt(rounds=12)` + `bcrypt.hashpw`, and `bcrypt.checkpw` — same cost factor (12), same encoding (`utf-8`), no pepper, no format prefix difference. Since the scheme is identical, this is a pure de-dup with zero behavior change.

## What Changed

- `autobot-backend/user_management/services/user_service.py`:
  - `hash_password` now delegates to `autobot_shared.auth.jwt_core.hash_password` instead of calling `bcrypt.gensalt`/`bcrypt.hashpw` directly.
  - `verify_password` now delegates to `autobot_shared.auth.jwt_core.verify_password` instead of calling `bcrypt.checkpw` directly.
  - Removed the now-unused `BCRYPT_ROUNDS = 12` class constant and the local `bcrypt` import (both were only referenced by the two replaced call sites).

No other files touched. No API/behavior change — same bcrypt scheme, same cost factor 12.

## Verification

- `python3 -m py_compile` on the edited file: passes.
- Real import of `UserService` from the worktree (`from user_management.services.user_service import UserService`) succeeds; `UserService.hash_password`/`verify_password` work end-to-end through the new delegation.
- Round-trip compatibility check (new code hashing/verifying, AND an old-style hash — direct `bcrypt.gensalt(rounds=12)`/`bcrypt.hashpw` — verifying correctly through the new `verify_password`):
  ```
  new hash -> new verify: OK $2b$12$MYIsZESOt26NZOxGPhuq4O
  OLD hash -> NEW verify: OK $2b$12$Xj6HlDiBlLpbaqfXbOMrHO
  cost factor 12 confirmed in both hash formats
  ALL ROUND-TRIP CHECKS PASSED
  ```
  This confirms existing user password hashes in the database will continue to verify correctly after this change.
- `python3 -m pytest autobot-backend/tests -k "user_service or password or auth" -q`:
  ```
  613 passed, 4 skipped, 5285 deselected, 119 warnings in 127.96s
  ```

Closes #12725

## Model Used

Sonnet 4.5