### PR TITLE
tech-debt(backend): repoint _utcnow_iso + agent_loop _slugify onto canonical helpers (#12724)

### DIFF
--- a/autobot-backend/agent_loop/belief_state.py
+++ b/autobot-backend/agent_loop/belief_state.py
@@ -14,9 +14,9 @@ Update flow:
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any
 
+from agent_loop.text_utils import slugify
 from agent_loop.types import (
     Assertion,
     ContradictionRecord,
@@ -29,13 +29,6 @@ if TYPE_CHECKING:
     from agent_loop.types import TaskContext
 
 logger = get_logger(__name__)
-
-
-def _slugify(text: str) -> str:
-    text = text.lower().strip()
-    text = re.sub(r"[^\w\s-]", "", text)
-    text = re.sub(r"[\s_-]+", "_", text)
-    return text[:80]
 
 
 def build_extractor_key(tool_name: str, tool_args: dict) -> str | None:
@@ -53,7 +46,7 @@ def build_extractor_key(tool_name: str, tool_args: dict) -> str | None:
     elif tool_name == "web_search":
         query = tool_args.get("query") or tool_args.get("q") or tool_args.get("search_query")
         if query:
-            return f"web_search:{_slugify(str(query))}:answered"
+            return f"web_search:{slugify(str(query))}:answered"
     elif tool_name == "run_command":
         from agent_loop.extractors.run_command import _classify_command
 

--- a/autobot-backend/agent_loop/extractors/web_search.py
+++ b/autobot-backend/agent_loop/extractors/web_search.py
@@ -11,15 +11,9 @@ Keys produced:
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
-
-def _slugify(text: str) -> str:
-    text = text.lower().strip()
-    text = re.sub(r"[^\w\s-]", "", text)
-    text = re.sub(r"[\s_-]+", "_", text)
-    return text[:80]
+from agent_loop.text_utils import slugify
 
 
 def _has_answer(tool_output: dict) -> bool:
@@ -56,7 +50,7 @@ class WebSearchExtractor:
         if not query:
             return []
 
-        slug = _slugify(str(query))
+        slug = slugify(str(query))
         results: list[tuple[str, Any, float]] = []
 
         answered = _has_answer(tool_output)

--- a/autobot-backend/agent_loop/text_utils.py
+++ b/autobot-backend/agent_loop/text_utils.py
@@ -1,0 +1,21 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+"""Shared text helpers for agent_loop (#12724).
+
+Canonical ``slugify`` extracted from the byte-identical duplicates
+previously defined in ``belief_state.py`` and
+``extractors/web_search.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def slugify(text: str) -> str:
+    """Return a lowercase, whitespace-collapsed slug capped at 80 chars."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_-]+", "_", text)
+    return text[:80]

--- a/autobot-backend/models/document.py
+++ b/autobot-backend/models/document.py
@@ -14,15 +14,11 @@ of ``autobot:ai_document:{document_id}``.  An index set at
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from pydantic import BaseModel, Field
 
-
-def _utcnow_iso() -> str:
-    """Return current UTC time as ISO-8601 string."""
-    return datetime.now(tz=timezone.utc).isoformat()
+from autobot_shared.time_utils import utc_timestamp
 
 
 class AIDocument(BaseModel):
@@ -50,8 +46,8 @@ class AIDocument(BaseModel):
     user_id: str = Field(..., description="Owning user's ID from the JWT")
     tags: List[str] = Field(default_factory=list)
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    created_at: str = Field(default_factory=_utcnow_iso)
-    updated_at: str = Field(default_factory=_utcnow_iso)
+    created_at: str = Field(default_factory=utc_timestamp)
+    updated_at: str = Field(default_factory=utc_timestamp)
 
     # ------------------------------------------------------------------ #
     # Redis serialisation helpers
@@ -63,4 +59,4 @@ class AIDocument(BaseModel):
 
     def touch(self) -> None:
         """Update the ``updated_at`` timestamp in-place."""
-        self.updated_at = _utcnow_iso()
+        self.updated_at = utc_timestamp()


### PR DESCRIPTION
## Thinking Path

Round-4 mechanical fork-convergence de-dup under umbrella #12645. Two behavior-identical helper forks:

- **A1**: `models/document.py` defines a local `_utcnow_iso()` returning `datetime.now(tz=timezone.utc).isoformat()` — byte-identical output to the canonical `autobot_shared.time_utils.utc_timestamp()` (`datetime.now(timezone.utc).isoformat()`). Positional vs keyword `tz=` arg is the only textual difference; behavior is identical.
- **B1**: `agent_loop/belief_state.py` and `agent_loop/extractors/web_search.py` each define a byte-identical `_slugify(text)` (lowercase, strip, collapse non-word chars, cap at 80 chars). Extracted to one canonical `agent_loop/text_utils.py::slugify`.

Verified `services/personality_service.py::_now_iso` (diverged) and `knowledge/adapters/okf_adapter.py::_slugify` (diverged) are genuinely different and were left untouched, per issue scope.

## What Changed

- `autobot-backend/models/document.py`: deleted local `_utcnow_iso()`; all 3 call sites now use `autobot_shared.time_utils.utc_timestamp`.
- `autobot-backend/agent_loop/text_utils.py` (new): canonical `slugify()` extracted verbatim from the duplicated implementations.
- `autobot-backend/agent_loop/belief_state.py`: deleted local `_slugify`; imports `agent_loop.text_utils.slugify`.
- `autobot-backend/agent_loop/extractors/web_search.py`: deleted local `_slugify`; imports `agent_loop.text_utils.slugify`.

No behavior change — pure repoint of duplicated private helpers onto canonical implementations.

## Verification

- Grep confirms zero remaining `_utcnow_iso` / `_slugify` definitions in the three touched files, and no other file imported the deleted private helpers.
- Import-smoke of all four touched modules (`models.document`, `agent_loop.text_utils`, `agent_loop.belief_state`, `agent_loop.extractors.web_search`) — all import cleanly and produce identical output to the pre-change implementations (`slugify('Hello, World!  Foo_Bar')` → `hello_world_foo_bar`; `AIDocument` create/touch produce valid ISO-8601 `+00:00` timestamps).
- `python -m pytest autobot-backend/tests/api/test_documents.py autobot-backend/tests/agent_loop/test_belief_state.py autobot-backend/agent_loop/tests/test_belief_cache.py -q` → 63 passed, 2 failed. Confirmed the 2 failures (`test_cached_tool_not_in_tools_executed`, `test_belief_cache_hit_event_published`) are **pre-existing test-order pollution on baseline `Dev_new_gui`** (reproduced identically on a clean `origin/Dev_new_gui` worktree with no changes applied; both pass in isolation) — unrelated to this change.
- `python -m pytest autobot-backend/tests/test_startup_imports.py -q` → 348 passed.

## Model Used

Claude Sonnet 5

Closes #12724