### PR TITLE
tech-debt(backend): converge _chunk_text forks onto canonical chunk_text (#12736)

### DIFF
--- a/autobot-backend/knowledge/connectors/file_server.py
+++ b/autobot-backend/knowledge/connectors/file_server.py
@@ -27,6 +27,7 @@ from knowledge.connectors.models import (
     SourceInfo,
 )
 from knowledge.connectors.registry import ConnectorRegistry
+from utils.text_chunking import chunk_text
 
 logger = get_logger(__name__)
 
@@ -253,7 +254,7 @@ class FileServerConnector(AbstractConnector):
             logger.error("Failed to read %s: %s", file_path, exc)
             return None
 
-        chunks = _chunk_text(text)
+        chunks = chunk_text(text, max_chars=2000)
 
         return ContentResult(
             source_id=source_id,
@@ -268,32 +269,3 @@ class FileServerConnector(AbstractConnector):
             },
             chunks=chunks,
         )
-
-
-def _chunk_text(text: str, max_chars: int = 2000) -> List[str]:
-    """Split text into paragraph-based chunks of at most *max_chars* chars.
-
-    Falls back to fixed-size splitting when paragraphs are very long.
-    """
-    paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
-    chunks: List[str] = []
-    current: List[str] = []
-    current_len = 0
-
-    for para in paragraphs:
-        if current_len + len(para) > max_chars and current:
-            chunks.append("\n\n".join(current))
-            current = []
-            current_len = 0
-        # If a single paragraph exceeds max_chars, split by fixed size
-        if len(para) > max_chars:
-            for i in range(0, len(para), max_chars):
-                chunks.append(para[i : i + max_chars])
-        else:
-            current.append(para)
-            current_len += len(para)
-
-    if current:
-        chunks.append("\n\n".join(current))
-
-    return chunks

--- a/autobot-backend/services/knowledge/cognition_seeder.py
+++ b/autobot-backend/services/knowledge/cognition_seeder.py
@@ -27,6 +27,7 @@ import yaml
 
 from autobot_shared.logging_manager import get_logger
 from constants.path_constants import PATH
+from utils.text_chunking import chunk_text
 
 if TYPE_CHECKING:
     from knowledge.backends import BaseClient
@@ -110,22 +111,6 @@ def _load_manifest(manifest_path: str) -> SeedManifest:
         collections.append(SeedCollection(name=coll_data.get("name", COGNITION_COLLECTION), sources=sources))
 
     return SeedManifest(collections=collections)
-
-
-def _chunk_text(content: str, max_chars: int = 1500) -> List[str]:
-    """Split *content* into chunks of at most *max_chars* at paragraph boundaries."""
-    paragraphs = [p.strip() for p in content.split("\n\n") if p.strip()]
-    chunks: List[str] = []
-    current = ""
-    for para in paragraphs:
-        if current and len(current) + len(para) + 2 > max_chars:
-            chunks.append(current)
-            current = para
-        else:
-            current = f"{current}\n\n{para}".strip() if current else para
-    if current:
-        chunks.append(current)
-    return chunks or [content]
 
 
 def _chunk_id(collection: str, rel_path: str, chunk_index: int) -> str:
@@ -224,11 +209,11 @@ class CognitionSeeder:
             return 0
 
         rel_path = os.path.relpath(abs_path, str(self._root_dir))
-        chunks = _chunk_text(content)
+        chunks = chunk_text(content, max_chars=1500, separator_len=2, split_oversized=False, fallback_to_original=True)
         coll = self._get_or_create_collection(collection_name)
         stored = 0
 
-        for idx, chunk_text in enumerate(chunks):
+        for idx, chunk_content in enumerate(chunks):
             cid = _chunk_id(collection_name, rel_path, idx)
             metadata: Dict[str, Any] = {
                 "seeded": "true",
@@ -241,7 +226,7 @@ class CognitionSeeder:
                 "seeded_at": now_iso,
             }
             try:
-                await asyncio.to_thread(self._upsert_chunk, coll, cid, chunk_text, metadata)
+                await asyncio.to_thread(self._upsert_chunk, coll, cid, chunk_content, metadata)
                 stored += 1
             except Exception as exc:
                 logger.error("Failed to upsert seed chunk %s[%d]: %s", rel_path, idx, exc)

--- a/autobot-backend/services/knowledge/test_cognition_seeder.py
+++ b/autobot-backend/services/knowledge/test_cognition_seeder.py
@@ -23,9 +23,15 @@ from services.knowledge.cognition_seeder import (
     SEED_PRIORITY_BOOST,
     CognitionSeeder,
     _chunk_id,
-    _chunk_text,
     _load_manifest,
 )
+from utils.text_chunking import chunk_text
+
+
+def _chunk_text(content: str, max_chars: int = 1500):
+    """Test helper reproducing cognition_seeder's chunk_text() call site params."""
+    return chunk_text(content, max_chars=max_chars, separator_len=2, split_oversized=False, fallback_to_original=True)
+
 
 # ---------------------------------------------------------------------------
 # Helper factories

--- a/autobot-backend/utils/text_chunking.py
+++ b/autobot-backend/utils/text_chunking.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Canonical paragraph-based text chunker.
+
+Issue #12736 (fork-convergence D3, umbrella #12645): converges the
+paragraph-splitting ``_chunk_text`` copies in
+``knowledge/connectors/file_server.py`` and
+``services/knowledge/cognition_seeder.py`` onto one parameterized
+implementation. Every caller passes its own ``max_chars`` and flags so
+output is byte-identical to the pre-convergence behavior.
+
+Two other ``_chunk_text`` forks (``utils/payload_optimizer.py`` and
+``knowledge/pipeline/extractors/semantic_chunker.py``) use genuinely
+different algorithms (fixed-size sliding window with overlap, and
+token-count-based segmentation with overlap-by-segment respectively)
+and are intentionally NOT folded in here — see the PR description for
+#12736 for the full rationale.
+"""
+
+from typing import List
+
+
+def chunk_text(
+    text: str,
+    *,
+    max_chars: int = 2000,
+    separator_len: int = 0,
+    split_oversized: bool = True,
+    fallback_to_original: bool = False,
+) -> List[str]:
+    """Split *text* into paragraph-based chunks of at most *max_chars* chars.
+
+    Args:
+        text: Source text, paragraphs separated by blank lines (``\\n\\n``).
+        max_chars: Maximum characters per chunk.
+        separator_len: Extra chars reserved in the size check for the
+            ``\\n\\n`` joiner between paragraphs already in the current
+            chunk (0 = file_server semantics, 2 = cognition_seeder
+            semantics).
+        split_oversized: When True, a single paragraph longer than
+            ``max_chars`` is hard-split into fixed-size pieces
+            (file_server semantics). When False, an oversized paragraph
+            becomes its own (over-limit) chunk instead of being split
+            (cognition_seeder semantics).
+        fallback_to_original: When True and no chunks were produced
+            (empty/whitespace-only input), return ``[text]`` instead of
+            ``[]`` (cognition_seeder semantics).
+
+    Returns:
+        List of chunk strings.
+    """
+    paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+    chunks: List[str] = []
+    current: List[str] = []
+    current_len = 0
+
+    for para in paragraphs:
+        prospective = current_len + (separator_len if current else 0) + len(para)
+        if prospective > max_chars and current:
+            chunks.append("\n\n".join(current))
+            current = []
+            current_len = 0
+
+        if split_oversized and len(para) > max_chars:
+            for i in range(0, len(para), max_chars):
+                chunks.append(para[i : i + max_chars])
+            continue
+
+        current_len = len(para) if not current else current_len + separator_len + len(para)
+        current.append(para)
+
+    if current:
+        chunks.append("\n\n".join(current))
+
+    if not chunks and fallback_to_original:
+        return [text]
+
+    return chunks

--- a/autobot-backend/utils/text_chunking_test.py
+++ b/autobot-backend/utils/text_chunking_test.py
@@ -1,0 +1,64 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for canonical chunk_text() — Issue #12736 (fork-convergence D3)."""
+
+from utils.text_chunking import chunk_text
+
+
+def test_empty_text_default_returns_empty_list() -> None:
+    assert chunk_text("") == []
+
+
+def test_empty_text_with_fallback_returns_original() -> None:
+    assert chunk_text("", fallback_to_original=True) == [""]
+
+
+def test_short_text_single_chunk() -> None:
+    assert chunk_text("hello world", max_chars=2000) == ["hello world"]
+
+
+def test_paragraphs_combine_when_under_limit() -> None:
+    text = "Para one.\n\nPara two."
+    assert chunk_text(text, max_chars=2000) == ["Para one.\n\nPara two."]
+
+
+def test_split_oversized_true_hard_splits_long_paragraph() -> None:
+    text = "X" * 25
+    chunks = chunk_text(text, max_chars=10, split_oversized=True)
+    assert chunks == ["XXXXXXXXXX", "XXXXXXXXXX", "XXXXX"]
+
+
+def test_split_oversized_false_keeps_paragraph_intact() -> None:
+    text = "X" * 25
+    chunks = chunk_text(text, max_chars=10, split_oversized=False)
+    assert chunks == ["X" * 25]
+
+
+def test_separator_len_affects_flush_threshold() -> None:
+    text = "aaaaa\n\nbbbbb"  # each paragraph 5 chars
+    # max_chars=10: with separator_len=0, "aaaaa"+"bbbbb" = 10 chars -> fits in one chunk
+    assert chunk_text(text, max_chars=10, separator_len=0) == ["aaaaa\n\nbbbbb"]
+    # with separator_len=2, 5+2+5=12 > 10 -> must split into two chunks
+    assert chunk_text(text, max_chars=10, separator_len=2) == ["aaaaa", "bbbbb"]
+
+
+def test_file_server_params_reproduce_original_semantics() -> None:
+    text = "short intro.\n\n" + ("Y" * 30) + "\n\nshort outro."
+    chunks = chunk_text(text, max_chars=10, separator_len=0, split_oversized=True, fallback_to_original=False)
+    assert chunks == [
+        "short intr",
+        "o.",
+        "YYYYYYYYYY",
+        "YYYYYYYYYY",
+        "YYYYYYYYYY",
+        "short outr",
+        "o.",
+    ]
+
+
+def test_cognition_seeder_params_reproduce_original_semantics() -> None:
+    text = "short intro.\n\n" + ("Y" * 30) + "\n\nshort outro."
+    chunks = chunk_text(text, max_chars=10, separator_len=2, split_oversized=False, fallback_to_original=True)
+    assert chunks == ["short intro.", "Y" * 30, "short outro."]


### PR DESCRIPTION
## Thinking Path

Read all 4 `_chunk_text` implementations named in #12736 (part of fork-convergence umbrella #12645, owner directive "go with canonical"):

1. `knowledge/connectors/file_server.py` — paragraph-based, `max_chars=2000`, hard-splits any single paragraph that exceeds `max_chars` into fixed-size pieces, returns `[]` on empty input.
2. `services/knowledge/cognition_seeder.py` — paragraph-based, `max_chars=1500`, does **not** split oversized paragraphs (they become their own over-limit chunk), accounts for the `\n\n` separator (+2) in its size check, and falls back to `[content]` when no chunks were produced.
3. `knowledge/pipeline/extractors/semantic_chunker.py` `SemanticChunker._chunk_text` — **genuinely different algorithm**: segments text via `\n\n` + sentence-boundary regex, sizes by estimated *token* count (`len(text.split())`), and carries an `overlap` window of the last N segments into the next chunk. Not a char-length paragraph packer.
4. `utils/payload_optimizer.py` `PayloadOptimizer._chunk_text` — **genuinely different algorithm**: fixed-size sliding window over raw character offsets, snaps the end to the nearest `.` sentence boundary, and re-includes a trailing `overlap_size` characters of the previous chunk at the start of the next one.

(1) and (2) are the same algorithm modulo parameters + a couple of boolean behavior switches (oversized-paragraph handling, separator accounting, empty-input fallback). (3) and (4) chunk by fundamentally different units (tokens vs. sliding character window) and produce structurally different output (overlapping windows) — collapsing them into the paragraph-packer would change behavior, so per the "no force-collapse" instruction they are left untouched and documented here instead.

## What Changed

- **New**: `autobot-backend/utils/text_chunking.py` — canonical `chunk_text(text, *, max_chars, separator_len, split_oversized, fallback_to_original)`. A superset of (1) and (2): each flag reproduces one specific behavioral difference between the two originals.
- **`knowledge/connectors/file_server.py`**: `_chunk_text` module function removed; call site now does `chunk_text(text, max_chars=2000)` (all other flags at their file_server-matching defaults: `separator_len=0`, `split_oversized=True`, `fallback_to_original=False`).
- **`services/knowledge/cognition_seeder.py`**: `_chunk_text` module function removed; call site now does `chunk_text(content, max_chars=1500, separator_len=2, split_oversized=False, fallback_to_original=True)`. Also renamed the `for idx, chunk_text in enumerate(chunks)` loop variable to `chunk_content` to avoid shadowing the newly-imported `chunk_text` function within the same method.
- **`services/knowledge/test_cognition_seeder.py`**: updated the `_chunk_text` import (removed, no longer exported by `cognition_seeder`) to a local test helper that calls the canonical `chunk_text()` with cognition_seeder's exact params, so the existing paragraph-splitting tests keep exercising the same behavior.
- **New**: `autobot-backend/utils/text_chunking_test.py` — unit tests for the canonical helper: empty input (both fallback modes), short text, paragraph combining, `split_oversized` true/false, `separator_len` threshold effect, and one exact-reproduction test per call site's parameter set.
- **NOT changed**: `knowledge/pipeline/extractors/semantic_chunker.py` and `utils/payload_optimizer.py` — different algorithms, left as-is (see Thinking Path).

Not force-collapsed (owner rule: no feature loss) — (3) and (4) keep their own `_chunk_text` methods.

## Verification

Standalone script ran each ORIGINAL `_chunk_text` implementation (copied verbatim from the pre-change source) against the new canonical `chunk_text()` (invoked with each site's exact parameters) across 8 representative inputs (short text, empty, whitespace-only, multi-paragraph with separators, many small paragraphs, one oversized paragraph, mixed short+oversized paragraphs, no-double-newline single block) × 4 `max_chars` values (2000, 1500, 50, 10) = 64 comparisons, asserting the chunk lists are identical:

```
64/64 identical, 0 mismatches
```

(Full per-case output available on request; every one of the 64 comparisons for both `file_server` and `cognition_seeder` parameterizations printed `[OK]`.)

Test suite:

```
$ pytest autobot-backend/tests/test_startup_imports.py -q
348 passed, 82 warnings in 16.79s

$ pytest autobot-backend/utils/text_chunking_test.py -q
9 passed in 0.25s

$ pytest autobot-backend/services/knowledge/test_cognition_seeder.py -q
22 passed, 5 failed in 1.08s
```

The 5 `test_cognition_seeder.py` failures are **pre-existing and unrelated** — `AdvancedRAGOptimizer._apply_seed_priority_boost` does not exist anywhere in the codebase (confirmed via grep), so those 5 `test_seed_priority_boost_*` / `test_cold_start_seeded_beats_unseeded` tests fail before and after this change. Filed as a discovery issue: #12742.

Full-suite `knowledge/connectors/` + `knowledge/pipeline/` run (612 passed, 2 failed, 2 skipped, 439s) surfaced 2 more pre-existing, unrelated failures (neither file imports `chunk_text`/`_chunk_text`) — filed as #12743 (`PipelineResult.stages_completed`) and #12744 (`WebCrawlerConnector` checkpoint).

Closes #12736

## Model Used

Claude Opus 4.8