### PR TITLE
tech-debt(frontend): converge format-helper copies onto canonical formatHelpers (#12737)

### DIFF
--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -152,7 +152,7 @@
               <td class="text-right" :class="getErrorClass(agent.error_rate)">
                 {{ agent.error_rate?.toFixed(1) }}%
               </td>
-              <td class="text-right">{{ formatDuration(agent.avg_duration_ms) }}</td>
+              <td class="text-right">{{ formatDuration(agent.avg_duration_ms, { style: 'msSeconds2dp', nullText: '0ms' }) }}</td>
             </tr>
           </tbody>
         </table>
@@ -215,7 +215,7 @@
             <h4><Icon name="clock" /> {{ $t('analytics.advanced.avgSessionDuration') }}</h4>
           </template>
           <div class="metric-value">
-            {{ formatDuration(engagementMetrics?.metrics?.avg_session_duration_ms || 0) }}
+            {{ formatDuration(engagementMetrics?.metrics?.avg_session_duration_ms || 0, { style: 'msSeconds2dp', nullText: '0ms' }) }}
           </div>
         </BasePanel>
 
@@ -321,6 +321,7 @@
 
 <script setup lang="ts">
 import type { IconName } from '@/components/ui/Icon.vue'
+import { formatDuration } from '@/utils/formatHelpers'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -481,12 +482,6 @@ const trendIcon = computed(() => {
 const formatNumber = (num: number): string => {
   if (!num) return '0'
   return num.toLocaleString()
-}
-
-const formatDuration = (ms: number): string => {
-  if (!ms) return '0ms'
-  if (ms < 1000) return `${ms.toFixed(0)}ms`
-  return `${(ms / 1000).toFixed(2)}s`
 }
 
 const getSuccessClass = (rate: number): string => {

--- a/autobot-frontend/src/components/chat/OverseerStepMessage.vue
+++ b/autobot-frontend/src/components/chat/OverseerStepMessage.vue
@@ -11,7 +11,7 @@
       </div>
       <span v-if="step.execution_time" class="step-time">
         <Icon name="clock" />
-        {{ formatDuration(step.execution_time) }}
+        {{ formatDuration(step.execution_time, { style: 'secondsCompact' }) }}
       </span>
     </div>
 
@@ -148,6 +148,7 @@
  */
 
 import type { IconName } from '@/components/ui/Icon.vue'
+import { formatDuration } from '@/utils/formatHelpers'
 import Icon from '@/components/ui/Icon.vue'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -196,13 +197,6 @@ const copyCommand = () => {
   }
 }
 
-const formatDuration = (seconds: number): string => {
-  if (seconds < 1) return `${Math.round(seconds * 1000)}ms`
-  if (seconds < 60) return `${seconds.toFixed(1)}s`
-  const mins = Math.floor(seconds / 60)
-  const secs = Math.round(seconds % 60)
-  return `${mins}m ${secs}s`
-}
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -11,6 +11,7 @@
  */
 
 import Icon from '@/components/ui/Icon.vue'
+import { formatFileSize } from '@/utils/formatHelpers'
 import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
@@ -93,12 +94,6 @@ function clearFile(): void {
   }
   analysisResult.value = null
   if (fileInput.value) fileInput.value.value = ''
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return bytes + ' B'
-  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
-  return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
 }
 
 async function analyzeImage(): Promise<void> {
@@ -201,7 +196,7 @@ onUnmounted(() => {
             <img :src="previewUrl" :alt="$t('chat.vision.preview')" class="preview-image" loading="lazy" />
             <div class="file-info">
               <span class="filename">{{ selectedFile.name }}</span>
-              <span class="filesize">{{ formatFileSize(selectedFile.size) }}</span>
+              <span class="filesize">{{ formatFileSize(selectedFile.size, { units: ['B', 'KB', 'MB'], decimals: 1, keepTrailingZeros: true, integerBase: true }) }}</span>
             </div>
             <button @click.stop="clearFile" class="btn-clear">
               <Icon name="times" />

--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -34,7 +34,7 @@
     >
       <div class="detail-item" data-testid="redis-service-uptime">
         <span class="text-xs text-autobot-text-muted uppercase tracking-wide">{{ $t('redis.uptime') }}</span>
-        <span class="text-lg font-semibold text-autobot-text-primary">{{ formatUptime(serviceStatus.uptime_seconds) }}</span>
+        <span class="text-lg font-semibold text-autobot-text-primary">{{ formatUptime(serviceStatus.uptime_seconds, { nullText: 'N/A', zeroText: 'N/A', daysIncludeMinutes: true }) }}</span>
       </div>
       <div class="detail-item" data-testid="redis-service-memory">
         <span class="text-xs text-autobot-text-muted uppercase tracking-wide">{{ $t('redis.memory') }}</span>
@@ -228,6 +228,7 @@
 
 <script setup>
 import Icon from '@/components/ui/Icon.vue'
+import { formatUptime } from '@/utils/formatHelpers'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useServiceManagement } from '@/composables/useServiceManagement'
@@ -357,17 +358,6 @@ const handleStopService = () => {
 /**
  * Format uptime from seconds
  */
-const formatUptime = (seconds) => {
-  if (!seconds) return 'N/A'
-
-  const days = Math.floor(seconds / 86400)
-  const hours = Math.floor((seconds % 86400) / 3600)
-  const minutes = Math.floor((seconds % 3600) / 60)
-
-  if (days > 0) return `${days}d ${hours}h ${minutes}m`
-  if (hours > 0) return `${hours}h ${minutes}m`
-  return `${minutes}m`
-}
 
 /**
  * Format last check timestamp

--- a/autobot-frontend/src/components/vision/VideoProcessor.vue
+++ b/autobot-frontend/src/components/vision/VideoProcessor.vue
@@ -36,8 +36,8 @@
           />
           <div class="file-info">
             <span class="filename">{{ selectedFile.name }}</span>
-            <span class="filesize">{{ formatFileSize(selectedFile.size) }}</span>
-            <span class="duration" v-if="videoDuration">{{ formatDuration(videoDuration) }}</span>
+            <span class="filesize">{{ formatFileSize(selectedFile.size, { units: ['B', 'KB', 'MB'], decimals: 1, keepTrailingZeros: true, integerBase: true }) }}</span>
+            <span class="duration" v-if="videoDuration">{{ formatDuration(videoDuration, { style: 'clock', rounding: 'floor' }) }}</span>
           </div>
           <button @click.stop="clearFile" class="btn-clear">
             <Icon name="times" />
@@ -133,7 +133,7 @@
           <div class="frame-index">#{{ idx + 1 }}</div>
           <div class="frame-info">
             <span class="confidence">{{ (frame.confidence * 100).toFixed(0) }}%</span>
-            <span class="time" v-if="frame.timestamp">{{ formatDuration(frame.timestamp) }}</span>
+            <span class="time" v-if="frame.timestamp">{{ formatDuration(frame.timestamp, { style: 'clock', rounding: 'floor' }) }}</span>
           </div>
         </div>
       </div>
@@ -192,6 +192,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
+import { formatFileSize, formatDuration } from '@/utils/formatHelpers'
 import { ref, computed, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
@@ -314,18 +315,6 @@ const clearFile = () => {
   if (fileInput.value) {
     fileInput.value.value = '';
   }
-};
-
-const formatFileSize = (bytes: number): string => {
-  if (bytes < 1024) return bytes + ' B';
-  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-  return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-};
-
-const formatDuration = (seconds: number): string => {
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${mins}:${secs.toString().padStart(2, '0')}`;
 };
 
 const processVideo = async () => {

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -163,7 +163,7 @@
                 left: `${activity.startPercent}%`,
                 width: `${activity.widthPercent}%`
               }"
-              :title="`${activity.task} (${formatDuration(activity.duration)})`"
+              :title="`${activity.task} (${formatDuration(activity.duration, { style: 'msMinutes', rounding: 'floor' })})`"
             ></div>
           </div>
         </div>
@@ -198,6 +198,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
+import { formatDuration } from '@/utils/formatHelpers'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
@@ -268,12 +269,6 @@ function formatUptime(seconds: number): string {
   if (seconds < 60) return `${seconds}s`
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
   return `${Math.floor(seconds / 3600)}h`
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
-  return `${Math.floor(ms / 60000)}m`
 }
 
 function formatTimeAgo(timestamp: number): string {

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -184,7 +184,7 @@
                 :y="nodeHeight / 2 + 35"
                 text-anchor="middle"
               >
-                {{ formatDuration(node.duration) }}
+                {{ formatDuration(node.duration, { style: 'msMinutes' }) }}
               </text>
             </g>
           </g>
@@ -237,7 +237,7 @@
           </div>
           <div class="detail-row" v-if="selectedNode.duration">
             <span class="label">{{ t('visualizations.workflowViz.duration') }}</span>
-            <span class="value">{{ formatDuration(selectedNode.duration) }}</span>
+            <span class="value">{{ formatDuration(selectedNode.duration, { style: 'msMinutes' }) }}</span>
           </div>
           <div class="detail-row" v-if="selectedNode.startTime">
             <span class="label">{{ t('visualizations.workflowViz.started') }}</span>
@@ -263,6 +263,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
+import { formatDuration } from '@/utils/formatHelpers'
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getCssVar } from '@/composables/useCssVars'
@@ -495,12 +496,6 @@ function formatStatus(status?: string): string {
     failed: t('visualizations.workflowViz.failed')
   }
   return statusMap[status] || status.charAt(0).toUpperCase() + status.slice(1)
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
-  return `${Math.round(ms / 60000)}m`
 }
 
 function formatTime(timestamp: number): string {

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
@@ -65,7 +65,7 @@
             <span class="metric-label">{{ $t('workflow.agentObservability.failed') }}</span>
           </div>
           <div class="metric">
-            <span class="metric-value">{{ formatDuration(agent.avgDuration) }}</span>
+            <span class="metric-value">{{ formatDuration(agent.avgDuration, { style: 'secondsCompact', zeroText: '--' }) }}</span>
             <span class="metric-label">{{ $t('workflow.agentObservability.avgTime') }}</span>
           </div>
         </div>
@@ -101,6 +101,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { formatDuration } from '@/utils/formatHelpers'
 import type { AgentPerformance, AgentCapability } from '@/composables/useWorkflowBuilder';
 import Icon from '@/components/ui/Icon.vue'
 
@@ -173,13 +174,6 @@ function formatPercent(score: number): string {
   return `${Math.round(score * 100)}%`;
 }
 
-function formatDuration(seconds: number): string {
-  if (seconds === 0) return '--';
-  if (seconds < 1) return `${Math.round(seconds * 1000)}ms`;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const min = Math.floor(seconds / 60);
-  return `${min}m ${Math.round(seconds % 60)}s`;
-}
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -8,6 +8,7 @@
  */
 
 import { getFileIconNameByMimeType } from '@/utils/iconMappings'
+import { formatFileSize } from '@/utils/formatHelpers'
 import type { IconName } from '@/components/ui/Icon.vue'
 import { ref, computed } from 'vue'
 import { useApiClient } from '@/plugins/api'
@@ -309,16 +310,6 @@ export function useConversationFiles(sessionId: string) {
   // SVG IconName; the previous FA class strings rendered empty SVGs.
   const getFileIcon = (mimeType: string): IconName => {
     return getFileIconNameByMimeType(mimeType)
-  }
-
-  const formatFileSize = (bytes: number): string => {
-    if (bytes === 0) return '0 Bytes'
-
-    const k = 1024
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
-    const i = Math.floor(Math.log(bytes) / Math.log(k))
-
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
   }
 
   // Issue #70: New file manager operations

--- a/autobot-frontend/src/utils/__tests__/formatHelpers.test.ts
+++ b/autobot-frontend/src/utils/__tests__/formatHelpers.test.ts
@@ -3,7 +3,13 @@
 // AutoBot - AI-Powered Automation Platform
 // Author: mrveiss
 import { describe, it, expect } from 'vitest'
-import { formatCategoryName } from '@/utils/formatHelpers'
+import {
+  formatCategoryName,
+  formatFileSize,
+  formatBytes,
+  formatUptime,
+  formatDuration
+} from '@/utils/formatHelpers'
 
 describe('formatCategoryName', () => {
   it('title-cases underscore/hyphen separated categories', () => {
@@ -24,5 +30,259 @@ describe('formatCategoryName', () => {
     expect(formatCategoryName(42 as unknown as string)).toBe('42')
     expect(() => formatCategoryName({ a: 1 } as unknown as string)).not.toThrow()
     expect(() => formatCategoryName(['x', 'y'] as unknown as string)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #12737 fork-convergence: each converged call site must keep byte-for-byte
+// output. Below, the ORIGINAL local implementation is inlined and asserted
+// equal to the parameterized canonical helper across representative values.
+// ---------------------------------------------------------------------------
+
+const BYTE_SAMPLES = [0, 1, 512, 1023, 1024, 1536, 1048576, 1500000, 5242880, 1.5e12]
+const SECOND_SAMPLES = [0, 0.5, 1, 30, 59, 59.9, 60, 90.5, 125, 3599, 3661, 90061]
+const MS_SAMPLES = [0, 1, 500, 999, 1000, 1500, 59999, 60000, 90000, 3600000, 5400000]
+
+describe('formatFileSize / formatBytes canonical default', () => {
+  it('renders the documented ladder', () => {
+    expect(formatFileSize(0)).toBe('0 Bytes')
+    expect(formatFileSize(1023)).toBe('1023 Bytes')
+    expect(formatFileSize(1024)).toBe('1 KB')
+    expect(formatFileSize(1536)).toBe('1.5 KB')
+    expect(formatFileSize(1048576)).toBe('1 MB')
+    expect(formatFileSize(1.5e12)).toBe('1.36 TB')
+  })
+
+  it('formatBytes is an alias', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB')
+  })
+
+  // useConversationFiles.ts original (parseFloat, 2 decimals, Bytes ladder)
+  it('matches useConversationFiles original output', () => {
+    const original = (bytes: number): string => {
+      if (bytes === 0) return '0 Bytes'
+      const k = 1024
+      const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
+      const i = Math.floor(Math.log(bytes) / Math.log(k))
+      return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
+    }
+    for (const v of BYTE_SAMPLES.filter((b) => b < 1024 ** 5)) {
+      expect(formatFileSize(v)).toBe(original(v))
+    }
+  })
+})
+
+describe('formatBytes options — slm B ladder (BackupsView / CacheSettings)', () => {
+  it('matches BackupsView original (B..TB)', () => {
+    const original = (bytes: number): string => {
+      if (bytes === 0) return '0 B'
+      const k = 1024
+      const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+      const i = Math.floor(Math.log(bytes) / Math.log(k))
+      return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+    }
+    const opts = { units: ['B', 'KB', 'MB', 'GB', 'TB'], zeroText: '0 B' }
+    for (const v of [0, 1, 512, 1024, 1536, 1048576, 1500000]) {
+      expect(formatBytes(v, opts)).toBe(original(v))
+    }
+  })
+
+  it('matches CacheSettings original (B..GB)', () => {
+    const original = (bytes: number): string => {
+      if (bytes === 0) return '0 B'
+      const k = 1024
+      const sizes = ['B', 'KB', 'MB', 'GB']
+      const i = Math.floor(Math.log(bytes) / Math.log(k))
+      return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+    }
+    const opts = { units: ['B', 'KB', 'MB', 'GB'], zeroText: '0 B' }
+    for (const v of [0, 1, 512, 1024, 1536, 1048576, 1500000]) {
+      expect(formatBytes(v, opts)).toBe(original(v))
+    }
+  })
+})
+
+describe('formatBytes options — manual B/KB/MB (Vision/Video/Redis group C)', () => {
+  const opts = {
+    units: ['B', 'KB', 'MB'],
+    decimals: 1,
+    keepTrailingZeros: true,
+    integerBase: true
+  }
+  it('matches the manual <1024/<1MB/else original', () => {
+    const original = (bytes: number): string => {
+      if (bytes < 1024) return bytes + ' B'
+      if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
+      return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
+    }
+    for (const v of BYTE_SAMPLES.filter((b) => b > 0 && b < 1024 ** 4)) {
+      expect(formatBytes(v, opts)).toBe(original(v))
+    }
+    expect(formatBytes(0, opts)).toBe('0 B')
+  })
+
+  it('supports nullText for the Redis panel variant', () => {
+    expect(formatBytes(null, { ...opts, nullText: '-' })).toBe('-')
+    expect(formatBytes(1024, { ...opts, nullText: '-' })).toBe('1.0 KB')
+  })
+})
+
+describe('formatUptime', () => {
+  // AdvancedControlView / AdminMonitoringView / NPUPerformanceMetrics (d h / h m / m)
+  it('matches the d/h/m ladder original', () => {
+    const original = (seconds: number): string => {
+      const days = Math.floor(seconds / 86400)
+      const hours = Math.floor((seconds % 86400) / 3600)
+      const minutes = Math.floor((seconds % 3600) / 60)
+      if (days > 0) return `${days}d ${hours}h`
+      if (hours > 0) return `${hours}h ${minutes}m`
+      return `${minutes}m`
+    }
+    for (const v of [0, 59, 60, 3599, 3661, 86400, 90061, 172800]) {
+      expect(formatUptime(v)).toBe(original(v))
+    }
+  })
+
+  it('returns nullText for nullish / negative / NaN', () => {
+    expect(formatUptime(null)).toBe('—')
+    expect(formatUptime(undefined)).toBe('—')
+    expect(formatUptime(-5)).toBe('—')
+    expect(formatUptime(NaN)).toBe('—')
+  })
+
+  // RedisServiceControl (3-part days line + !seconds -> 'N/A')
+  it('matches RedisServiceControl original with options', () => {
+    const original = (seconds: number): string => {
+      if (!seconds) return 'N/A'
+      const days = Math.floor(seconds / 86400)
+      const hours = Math.floor((seconds % 86400) / 3600)
+      const minutes = Math.floor((seconds % 3600) / 60)
+      if (days > 0) return `${days}d ${hours}h ${minutes}m`
+      if (hours > 0) return `${hours}h ${minutes}m`
+      return `${minutes}m`
+    }
+    const opts = { nullText: 'N/A', zeroText: 'N/A', daysIncludeMinutes: true }
+    for (const v of [0, 59, 60, 3599, 3661, 90061, 172800]) {
+      expect(formatUptime(v, opts)).toBe(original(v))
+    }
+    expect(formatUptime(null, opts)).toBe('N/A')
+  })
+})
+
+describe('formatDuration — range form (unchanged)', () => {
+  it('renders the legacy range ladder', () => {
+    expect(formatDuration('2025-01-01T00:00:00Z', '2025-01-01T00:01:30Z')).toBe('1m 30s')
+    expect(formatDuration(null, null)).toBe('-')
+    expect(formatDuration('2025-01-01T00:00:00Z', '2025-01-01T00:00:00.500Z')).toBe('500ms')
+    expect(formatDuration('2025-01-01T00:00:00Z', '2025-01-01T02:05:00Z')).toBe('2h 5m')
+  })
+})
+
+describe('formatDuration — msSeconds2dp (Analytics / Tracing / PerformanceOverview)', () => {
+  it('matches Tracing/PerformanceOverview original', () => {
+    const original = (ms: number): string => {
+      if (ms < 1000) return `${ms.toFixed(0)}ms`
+      return `${(ms / 1000).toFixed(2)}s`
+    }
+    for (const v of MS_SAMPLES) {
+      expect(formatDuration(v, { style: 'msSeconds2dp' })).toBe(original(v))
+    }
+  })
+
+  it('matches AdvancedAnalytics original (nullText 0ms guard)', () => {
+    const original = (ms: number | undefined | null): string => {
+      if (!ms) return '0ms'
+      if (ms < 1000) return `${ms.toFixed(0)}ms`
+      return `${(ms / 1000).toFixed(2)}s`
+    }
+    const opts = { style: 'msSeconds2dp' as const, nullText: '0ms' }
+    for (const v of MS_SAMPLES) {
+      expect(formatDuration(v, opts)).toBe(original(v))
+    }
+    expect(formatDuration(undefined, opts)).toBe(original(undefined))
+    expect(formatDuration(null, opts)).toBe(original(null))
+  })
+})
+
+describe('formatDuration — secondsCompact (AgentObservability / OverseerStep)', () => {
+  it('matches OverseerStepMessage original', () => {
+    const original = (seconds: number): string => {
+      if (seconds < 1) return `${Math.round(seconds * 1000)}ms`
+      if (seconds < 60) return `${seconds.toFixed(1)}s`
+      const mins = Math.floor(seconds / 60)
+      const secs = Math.round(seconds % 60)
+      return `${mins}m ${secs}s`
+    }
+    for (const v of SECOND_SAMPLES) {
+      expect(formatDuration(v, { style: 'secondsCompact' })).toBe(original(v))
+    }
+  })
+
+  it('matches AgentObservabilityPanel original (zeroText --)', () => {
+    const original = (seconds: number): string => {
+      if (seconds === 0) return '--'
+      if (seconds < 1) return `${Math.round(seconds * 1000)}ms`
+      if (seconds < 60) return `${seconds.toFixed(1)}s`
+      const min = Math.floor(seconds / 60)
+      return `${min}m ${Math.round(seconds % 60)}s`
+    }
+    const opts = { style: 'secondsCompact' as const, zeroText: '--' }
+    for (const v of SECOND_SAMPLES) {
+      expect(formatDuration(v, opts)).toBe(original(v))
+    }
+  })
+})
+
+describe('formatDuration — clock M:SS (ProjectDetailView / VideoProcessor)', () => {
+  it('matches ProjectDetailView original (round + nullText)', () => {
+    const original = (seconds: number | null): string => {
+      if (seconds === null || Number.isNaN(seconds)) return '—'
+      const total = Math.round(seconds)
+      const mins = Math.floor(total / 60)
+      const secs = total % 60
+      return `${mins}:${secs.toString().padStart(2, '0')}`
+    }
+    const opts = { style: 'clock' as const, nullText: '—' }
+    for (const v of SECOND_SAMPLES) {
+      expect(formatDuration(v, opts)).toBe(original(v))
+    }
+    expect(formatDuration(null, opts)).toBe(original(null))
+  })
+
+  it('matches VideoProcessor original (floor)', () => {
+    const original = (seconds: number): string => {
+      const mins = Math.floor(seconds / 60)
+      const secs = Math.floor(seconds % 60)
+      return `${mins}:${secs.toString().padStart(2, '0')}`
+    }
+    const opts = { style: 'clock' as const, rounding: 'floor' as const }
+    for (const v of SECOND_SAMPLES) {
+      expect(formatDuration(v, opts)).toBe(original(v))
+    }
+  })
+})
+
+describe('formatDuration — msMinutes (WorkflowVisualization / AgentActivity)', () => {
+  it('matches WorkflowVisualization original (round minutes)', () => {
+    const original = (ms: number): string => {
+      if (ms < 1000) return `${ms}ms`
+      if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+      return `${Math.round(ms / 60000)}m`
+    }
+    for (const v of MS_SAMPLES) {
+      expect(formatDuration(v, { style: 'msMinutes' })).toBe(original(v))
+    }
+  })
+
+  it('matches AgentActivityVisualization original (floor minutes)', () => {
+    const original = (ms: number): string => {
+      if (ms < 1000) return `${ms}ms`
+      if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+      return `${Math.floor(ms / 60000)}m`
+    }
+    const opts = { style: 'msMinutes' as const, rounding: 'floor' as const }
+    for (const v of MS_SAMPLES) {
+      expect(formatDuration(v, opts)).toBe(original(v))
+    }
   })
 })

--- a/autobot-frontend/src/utils/formatHelpers.ts
+++ b/autobot-frontend/src/utils/formatHelpers.ts
@@ -192,23 +192,112 @@ export function formatTimeAgo(timestamp: Date | string | number): string {
   }
 }
 
+// ==================== DURATION FORMATTING ====================
+
 /**
- * Format duration between two timestamps in human-readable form
+ * Numeric duration formatting style.
  *
- * @param startTime - ISO timestamp string or null
- * @param endTime - ISO timestamp string or null (if null, uses Date.now())
- * @returns Formatted duration (e.g., "1.5s", "2m 30s", "1h 15m") or "-" if no start
+ * Each style reproduces the exact rendered output of a group of former local
+ * `formatDuration` copies (see #12737 fork-convergence). Input unit is implied
+ * by the style:
+ * - `msSeconds2dp`  (ms): `<1000` → "{n}ms" (0 decimals), else "{n/1000}s" (2 decimals)
+ * - `secondsCompact` (s): `<1` → "{n*1000}ms", `<60` → "{n}s" (1 decimal),
+ *                          else "{floor(n/60)}m {round(n%60)}s"
+ * - `clock`          (s): "M:SS" (minutes:zero-padded-seconds)
+ * - `msMinutes`     (ms): `<1000` → "{n}ms" (raw), `<60000` → "{n/1000}s" (1 decimal),
+ *                          else "{n/60000}m"
+ */
+export type DurationStyle = 'msSeconds2dp' | 'secondsCompact' | 'clock' | 'msMinutes'
+
+/**
+ * Options for the numeric ({@link DurationStyle}) form of {@link formatDuration}.
+ */
+export interface FormatDurationOptions {
+  /** Selects the numeric formatting style / input unit. */
+  style: DurationStyle
+  /** Text for null / undefined / NaN input (default `'—'`). */
+  nullText?: string
+  /** Text for an exact zero value; when omitted, zero follows the normal ladder. */
+  zeroText?: string
+  /** Rounding for the top tier of `clock` / `msMinutes` styles (default `'round'`). */
+  rounding?: 'round' | 'floor'
+}
+
+/**
+ * Format a numeric duration in the given {@link DurationStyle}.
+ * Internal helper backing the numeric overload of {@link formatDuration}.
+ */
+function formatDurationValue(
+  value: number | null | undefined,
+  options: FormatDurationOptions
+): string {
+  const nullText = options.nullText ?? '—'
+  if (value === null || value === undefined || Number.isNaN(value)) return nullText
+  if (value === 0 && options.zeroText !== undefined) return options.zeroText
+
+  const roundFn = options.rounding === 'floor' ? Math.floor : Math.round
+
+  switch (options.style) {
+    case 'msSeconds2dp':
+      if (value < 1000) return `${value.toFixed(0)}ms`
+      return `${(value / 1000).toFixed(2)}s`
+    case 'secondsCompact':
+      if (value < 1) return `${Math.round(value * 1000)}ms`
+      if (value < 60) return `${value.toFixed(1)}s`
+      return `${Math.floor(value / 60)}m ${Math.round(value % 60)}s`
+    case 'clock': {
+      const total = roundFn(value)
+      const mins = Math.floor(total / 60)
+      const secs = total % 60
+      return `${mins}:${secs.toString().padStart(2, '0')}`
+    }
+    case 'msMinutes':
+      if (value < 1000) return `${value}ms`
+      if (value < 60000) return `${(value / 1000).toFixed(1)}s`
+      return `${roundFn(value / 60000)}m`
+    default:
+      return nullText
+  }
+}
+
+/**
+ * Format a duration in human-readable form.
+ *
+ * Two forms:
+ * 1. **Range** (ISO timestamps): `formatDuration(startTime, endTime)` — renders
+ *    "{ms}ms" / "{s}s" / "{m}m {s}s" / "{h}h {m}m", or `'-'` when no start.
+ * 2. **Numeric** ({@link DurationStyle}): `formatDuration(value, { style, ... })` —
+ *    formats a single ms/seconds value, reproducing each converged call site's
+ *    exact output (see {@link DurationStyle}).
  *
  * @example
  * ```typescript
  * formatDuration('2025-01-01T00:00:00Z', '2025-01-01T00:01:30Z') // "1m 30s"
  * formatDuration(null, null) // "-"
+ * formatDuration(1500, { style: 'msSeconds2dp' }) // "1.50s"
+ * formatDuration(90, { style: 'clock' }) // "1:30"
  * ```
  */
 export function formatDuration(
   startTime: string | null | undefined,
   endTime: string | null | undefined
+): string
+export function formatDuration(
+  value: number | null | undefined,
+  options: FormatDurationOptions
+): string
+export function formatDuration(
+  a: string | number | null | undefined,
+  b?: string | null | undefined | FormatDurationOptions
 ): string {
+  // Numeric form: second argument is an options object.
+  if (b !== null && typeof b === 'object') {
+    return formatDurationValue(a as number | null | undefined, b)
+  }
+
+  // Range form (unchanged legacy behavior).
+  const startTime = a as string | null | undefined
+  const endTime = b as string | null | undefined
   if (!startTime) return '-'
 
   const start = new Date(startTime).getTime()
@@ -228,15 +317,90 @@ export function formatDuration(
   return `${hours}h ${mins}m`
 }
 
+// ==================== UPTIME FORMATTING ====================
+
+/**
+ * Options for {@link formatUptime}.
+ */
+export interface FormatUptimeOptions {
+  /** Text for null / undefined / NaN / negative input (default `'—'`). */
+  nullText?: string
+  /** Text for an exact zero value; when omitted, zero renders as `'0m'`. */
+  zeroText?: string
+  /** Include minutes on the days line (`'Xd Yh Zm'` vs `'Xd Yh'`) (default `false`). */
+  daysIncludeMinutes?: boolean
+}
+
+/**
+ * Format an uptime given in seconds as a coarse `d`/`h`/`m` string.
+ *
+ * Renders `'Xd Yh'` when days > 0 (or `'Xd Yh Zm'` with `daysIncludeMinutes`),
+ * `'Yh Zm'` when hours > 0, otherwise `'Zm'`.
+ *
+ * @example
+ * ```typescript
+ * formatUptime(0)      // "0m"
+ * formatUptime(3661)   // "1h 1m"
+ * formatUptime(90061)  // "1d 1h"
+ * ```
+ */
+export function formatUptime(
+  seconds: number | null | undefined,
+  options: FormatUptimeOptions = {}
+): string {
+  const nullText = options.nullText ?? '—'
+  if (seconds === null || seconds === undefined || Number.isNaN(seconds) || seconds < 0) {
+    return nullText
+  }
+  if (seconds === 0 && options.zeroText !== undefined) return options.zeroText
+
+  const total = Math.floor(seconds)
+  const days = Math.floor(total / 86400)
+  const hours = Math.floor((total % 86400) / 3600)
+  const mins = Math.floor((total % 3600) / 60)
+
+  if (days > 0) {
+    return options.daysIncludeMinutes ? `${days}d ${hours}h ${mins}m` : `${days}d ${hours}h`
+  }
+  if (hours > 0) return `${hours}h ${mins}m`
+  return `${mins}m`
+}
+
 // ==================== FILE SIZE FORMATTING ====================
 
 /**
- * Format bytes to human-readable file size
+ * Options for {@link formatFileSize} / {@link formatBytes}.
  *
- * Consolidates 10 different implementations across the codebase.
+ * Defaults reproduce the canonical output exactly: trimmed decimals (via
+ * `parseFloat`), a `'Bytes'`-based ladder, `'0 Bytes'` for zero and `'Invalid'`
+ * for negatives. Options let each converged call site reproduce its own output.
+ */
+export interface FormatBytesOptions {
+  /** Decimal places for scaled units (default `2`). */
+  decimals?: number
+  /** Unit ladder (default `['Bytes','KB','MB','GB','TB','PB']`). */
+  units?: readonly string[]
+  /** Text for a zero-byte value (default `'0 ' + units[0]`). */
+  zeroText?: string
+  /** Text for negative values (default `'Invalid'`). */
+  invalidText?: string
+  /** Text for null / undefined input (default same as `invalidText`). */
+  nullText?: string
+  /** Keep trailing zeros instead of trimming via `parseFloat` (default `false`). */
+  keepTrailingZeros?: boolean
+  /** Render the base unit (`units[0]`) as an integer with no decimals (default `false`). */
+  integerBase?: boolean
+}
+
+const DEFAULT_BYTE_UNITS = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
+
+/**
+ * Format bytes to a human-readable file size.
+ *
+ * Consolidates many local implementations across both frontends (#12737).
  *
  * @param bytes - File size in bytes
- * @param decimals - Number of decimal places (default: 2)
+ * @param decimalsOrOptions - Decimal places (number) or {@link FormatBytesOptions}
  * @returns Formatted file size string (e.g., "1.5 MB")
  *
  * @example
@@ -245,22 +409,43 @@ export function formatDuration(
  * formatFileSize(1024) // "1 KB"
  * formatFileSize(1536) // "1.5 KB"
  * formatFileSize(1048576) // "1 MB"
+ * formatFileSize(1024, { units: ['B','KB','MB'], zeroText: '0 B' }) // "1 KB"
  * ```
  */
-export function formatFileSize(bytes: number, decimals: number = 2): string {
-  if (bytes === 0) return '0 Bytes'
-  if (bytes < 0) return 'Invalid'
+export function formatFileSize(
+  bytes: number | null | undefined,
+  decimalsOrOptions: number | FormatBytesOptions = 2
+): string {
+  const opts: FormatBytesOptions =
+    typeof decimalsOrOptions === 'number' ? { decimals: decimalsOrOptions } : decimalsOrOptions
+
+  const units = opts.units ?? DEFAULT_BYTE_UNITS
+  const invalidText = opts.invalidText ?? 'Invalid'
+  const zeroText = opts.zeroText ?? `0 ${units[0]}`
+
+  if (bytes === null || bytes === undefined) return opts.nullText ?? invalidText
+  if (bytes === 0) return zeroText
+  if (bytes < 0) return invalidText
 
   const k = 1024
+  const decimals = opts.decimals ?? 2
   const dm = decimals < 0 ? 0 : decimals
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB']
 
   const i = Math.floor(Math.log(bytes) / Math.log(k))
-
   // Prevent array overflow for extremely large numbers
-  const sizeIndex = Math.min(i, sizes.length - 1)
+  const sizeIndex = Math.min(i, units.length - 1)
+  const value = bytes / Math.pow(k, sizeIndex)
 
-  return parseFloat((bytes / Math.pow(k, sizeIndex)).toFixed(dm)) + ' ' + sizes[sizeIndex]
+  let text: string
+  if (opts.integerBase && sizeIndex === 0) {
+    text = String(bytes)
+  } else if (opts.keepTrailingZeros) {
+    text = value.toFixed(dm)
+  } else {
+    text = String(parseFloat(value.toFixed(dm)))
+  }
+
+  return `${text} ${units[sizeIndex]}`
 }
 
 /**
@@ -376,6 +561,7 @@ export default {
   formatISOString,
   formatTimeAgo,
   formatDuration,
+  formatUptime,
 
   // File Size
   formatFileSize,

--- a/autobot-frontend/src/views/AdvancedControlView.vue
+++ b/autobot-frontend/src/views/AdvancedControlView.vue
@@ -420,6 +420,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { formatUptime } from '@/utils/formatHelpers'
 import { useI18n } from 'vue-i18n'
 import { useTabs } from '@/composables/useTabs'
 import { useAdvancedControl } from '@/composables/useAdvancedControl'
@@ -652,17 +653,6 @@ function formatPercent(value: number | null | undefined): string {
 function formatLoadAverage(loadAverage: [number, number, number] | null): string {
   if (!loadAverage) return '—'
   return loadAverage.map((v) => v.toFixed(2)).join(' / ')
-}
-
-function formatUptime(seconds: number | null | undefined): string {
-  if (seconds == null || Number.isNaN(seconds) || seconds < 0) return '—'
-  const totalSeconds = Math.floor(seconds)
-  const days = Math.floor(totalSeconds / 86400)
-  const hours = Math.floor((totalSeconds % 86400) / 3600)
-  const mins = Math.floor((totalSeconds % 3600) / 60)
-  if (days > 0) return `${days}d ${hours}h`
-  if (hours > 0) return `${hours}h ${mins}m`
-  return `${mins}m`
 }
 
 async function onEmergencyStop(): Promise<void> {

--- a/autobot-frontend/src/views/transcriber/ProjectDetailView.vue
+++ b/autobot-frontend/src/views/transcriber/ProjectDetailView.vue
@@ -2,6 +2,7 @@
 <!-- Copyright (c) 2025-2026 mrveiss -->
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
+import { formatDuration } from '@/utils/formatHelpers'
 import { useRoute, useRouter } from 'vue-router'
 import UploadModal from '@/components/transcriber/UploadModal.vue'
 import ProcessingProgress from '@/components/transcriber/ProcessingProgress.vue'
@@ -93,14 +94,6 @@ function isInProgress(r: Recording): boolean {
   return r.status === 'pending' || r.status === 'processing'
 }
 
-function formatDuration(seconds: number | null): string {
-  if (seconds === null || Number.isNaN(seconds)) return '—'
-  const total = Math.round(seconds)
-  const mins = Math.floor(total / 60)
-  const secs = total % 60
-  return `${mins}:${secs.toString().padStart(2, '0')}`
-}
-
 function formatDate(iso: string): string {
   const d = new Date(iso)
   return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString()
@@ -148,7 +141,7 @@ onMounted(load)
             <span class="recording-status" :class="`recording-status-${recording.status}`">
               {{ recording.status }}
             </span>
-            <span>{{ formatDuration(recording.duration) }}</span>
+            <span>{{ formatDuration(recording.duration, { style: 'clock', nullText: '—' }) }}</span>
             <span>{{ formatDate(recording.uploaded_at) }}</span>
           </span>
 

--- a/autobot-slm-frontend/src/components/RedisServicePanel.vue
+++ b/autobot-slm-frontend/src/components/RedisServicePanel.vue
@@ -14,6 +14,7 @@
  */
 
 import { ref, onMounted, onUnmounted } from 'vue'
+import { formatBytes } from '@/utils/formatHelpers'
 import { getBackendUrl } from '@/config/ssot-config'
 import i18n from '@/i18n'
 import { useAuthStore } from '@/stores/auth'
@@ -67,13 +68,6 @@ function formatUptime(seconds: number | null): string {
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)
   return `${h}h ${m}m`
-}
-
-function formatBytes(bytes: number | null): string {
-  if (bytes === null || bytes === undefined) return '-'
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 function statusDotClass(status: string | undefined): string {
@@ -246,13 +240,13 @@ onUnmounted(() => {
       <div class="bg-white px-4 py-3">
         <div class="text-xs text-gray-500 mb-0.5">{{ $t('redisServicePanel.memoryUsed') }}</div>
         <div class="text-sm font-semibold text-gray-900">
-          {{ redisStatus ? formatBytes(redisStatus.memory_used_bytes) : '-' }}
+          {{ redisStatus ? formatBytes(redisStatus.memory_used_bytes, { units: ['B', 'KB', 'MB'], decimals: 1, keepTrailingZeros: true, integerBase: true, nullText: '-' }) : '-' }}
         </div>
       </div>
       <div class="bg-white px-4 py-3">
         <div class="text-xs text-gray-500 mb-0.5">{{ $t('redisServicePanel.peakMemory') }}</div>
         <div class="text-sm font-semibold text-gray-900">
-          {{ redisStatus ? formatBytes(redisStatus.memory_peak_bytes) : '-' }}
+          {{ redisStatus ? formatBytes(redisStatus.memory_peak_bytes, { units: ['B', 'KB', 'MB'], decimals: 1, keepTrailingZeros: true, integerBase: true, nullText: '-' }) : '-' }}
         </div>
       </div>
       <div class="bg-white px-4 py-3">

--- a/autobot-slm-frontend/src/components/fleet/NPUPerformanceMetrics.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUPerformanceMetrics.vue
@@ -13,6 +13,7 @@
  */
 
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { formatUptime } from '@/utils/formatHelpers'
 import type { NPUFleetMetrics, NPUWorkerMetrics } from '@/types/slm'
 import { useFleetStore } from '@/stores/fleet'
 import { createLogger } from '@/utils/debugUtils'
@@ -37,15 +38,6 @@ const nodeMetrics = computed<NPUWorkerMetrics[]>(
 )
 
 // -- Helpers --
-
-function formatUptime(seconds: number): string {
-  const days = Math.floor(seconds / 86400)
-  const hrs = Math.floor((seconds % 86400) / 3600)
-  const mins = Math.floor((seconds % 3600) / 60)
-  if (days > 0) return `${days}d ${hrs}h`
-  if (hrs > 0) return `${hrs}h ${mins}m`
-  return `${mins}m`
-}
 
 function utilizationBarColor(pct: number): string {
   if (pct > 80) return 'bg-red-500'

--- a/autobot-slm-frontend/src/utils/formatHelpers.ts
+++ b/autobot-slm-frontend/src/utils/formatHelpers.ts
@@ -1,0 +1,215 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Shared byte / uptime / duration formatting utilities for the SLM frontend.
+ *
+ * Mirrors the canonical `autobot-frontend/src/utils/formatHelpers.ts` helpers so
+ * both frontends share identical, parameterized formatting behavior (#12737).
+ * Date/time formatting lives in `dateUtils.ts` / `useTimezone`.
+ *
+ * @module formatHelpers
+ */
+
+// ==================== DURATION FORMATTING ====================
+
+/**
+ * Numeric duration formatting style (see canonical formatHelpers for details).
+ * - `msSeconds2dp`  (ms): `<1000` → "{n}ms" (0 decimals), else "{n/1000}s" (2 decimals)
+ * - `secondsCompact` (s): `<1` → "{n*1000}ms", `<60` → "{n}s" (1 decimal),
+ *                          else "{floor(n/60)}m {round(n%60)}s"
+ * - `clock`          (s): "M:SS"
+ * - `msMinutes`     (ms): `<1000` → "{n}ms" (raw), `<60000` → "{n/1000}s" (1 decimal),
+ *                          else "{n/60000}m"
+ */
+export type DurationStyle = 'msSeconds2dp' | 'secondsCompact' | 'clock' | 'msMinutes'
+
+/** Options for the numeric form of {@link formatDuration}. */
+export interface FormatDurationOptions {
+  /** Selects the numeric formatting style / input unit. */
+  style: DurationStyle
+  /** Text for null / undefined / NaN input (default `'—'`). */
+  nullText?: string
+  /** Text for an exact zero value; when omitted, zero follows the normal ladder. */
+  zeroText?: string
+  /** Rounding for the top tier of `clock` / `msMinutes` styles (default `'round'`). */
+  rounding?: 'round' | 'floor'
+}
+
+function formatDurationValue(
+  value: number | null | undefined,
+  options: FormatDurationOptions
+): string {
+  const nullText = options.nullText ?? '—'
+  if (value === null || value === undefined || Number.isNaN(value)) return nullText
+  if (value === 0 && options.zeroText !== undefined) return options.zeroText
+
+  const roundFn = options.rounding === 'floor' ? Math.floor : Math.round
+
+  switch (options.style) {
+    case 'msSeconds2dp':
+      if (value < 1000) return `${value.toFixed(0)}ms`
+      return `${(value / 1000).toFixed(2)}s`
+    case 'secondsCompact':
+      if (value < 1) return `${Math.round(value * 1000)}ms`
+      if (value < 60) return `${value.toFixed(1)}s`
+      return `${Math.floor(value / 60)}m ${Math.round(value % 60)}s`
+    case 'clock': {
+      const total = roundFn(value)
+      const mins = Math.floor(total / 60)
+      const secs = total % 60
+      return `${mins}:${secs.toString().padStart(2, '0')}`
+    }
+    case 'msMinutes':
+      if (value < 1000) return `${value}ms`
+      if (value < 60000) return `${(value / 1000).toFixed(1)}s`
+      return `${roundFn(value / 60000)}m`
+    default:
+      return nullText
+  }
+}
+
+/**
+ * Format a duration in human-readable form.
+ *
+ * Range form: `formatDuration(startTime, endTime)` (ISO strings).
+ * Numeric form: `formatDuration(value, { style, ... })` (see {@link DurationStyle}).
+ */
+export function formatDuration(
+  startTime: string | null | undefined,
+  endTime: string | null | undefined
+): string
+export function formatDuration(
+  value: number | null | undefined,
+  options: FormatDurationOptions
+): string
+export function formatDuration(
+  a: string | number | null | undefined,
+  b?: string | null | undefined | FormatDurationOptions
+): string {
+  if (b !== null && typeof b === 'object') {
+    return formatDurationValue(a as number | null | undefined, b)
+  }
+
+  const startTime = a as string | null | undefined
+  const endTime = b as string | null | undefined
+  if (!startTime) return '-'
+
+  const start = new Date(startTime).getTime()
+  const end = endTime ? new Date(endTime).getTime() : Date.now()
+  const durationMs = end - start
+
+  if (durationMs < 1000) return `${durationMs}ms`
+  if (durationMs < 60000) return `${Math.round(durationMs / 1000)}s`
+  if (durationMs < 3600000) {
+    const mins = Math.floor(durationMs / 60000)
+    const secs = Math.round((durationMs % 60000) / 1000)
+    return `${mins}m ${secs}s`
+  }
+
+  const hours = Math.floor(durationMs / 3600000)
+  const mins = Math.floor((durationMs % 3600000) / 60000)
+  return `${hours}h ${mins}m`
+}
+
+// ==================== UPTIME FORMATTING ====================
+
+/** Options for {@link formatUptime}. */
+export interface FormatUptimeOptions {
+  /** Text for null / undefined / NaN / negative input (default `'—'`). */
+  nullText?: string
+  /** Text for an exact zero value; when omitted, zero renders as `'0m'`. */
+  zeroText?: string
+  /** Include minutes on the days line (`'Xd Yh Zm'` vs `'Xd Yh'`) (default `false`). */
+  daysIncludeMinutes?: boolean
+}
+
+/**
+ * Format an uptime given in seconds as a coarse `d`/`h`/`m` string.
+ */
+export function formatUptime(
+  seconds: number | null | undefined,
+  options: FormatUptimeOptions = {}
+): string {
+  const nullText = options.nullText ?? '—'
+  if (seconds === null || seconds === undefined || Number.isNaN(seconds) || seconds < 0) {
+    return nullText
+  }
+  if (seconds === 0 && options.zeroText !== undefined) return options.zeroText
+
+  const total = Math.floor(seconds)
+  const days = Math.floor(total / 86400)
+  const hours = Math.floor((total % 86400) / 3600)
+  const mins = Math.floor((total % 3600) / 60)
+
+  if (days > 0) {
+    return options.daysIncludeMinutes ? `${days}d ${hours}h ${mins}m` : `${days}d ${hours}h`
+  }
+  if (hours > 0) return `${hours}h ${mins}m`
+  return `${mins}m`
+}
+
+// ==================== FILE SIZE FORMATTING ====================
+
+/** Options for {@link formatFileSize} / {@link formatBytes}. */
+export interface FormatBytesOptions {
+  /** Decimal places for scaled units (default `2`). */
+  decimals?: number
+  /** Unit ladder (default `['Bytes','KB','MB','GB','TB','PB']`). */
+  units?: readonly string[]
+  /** Text for a zero-byte value (default `'0 ' + units[0]`). */
+  zeroText?: string
+  /** Text for negative values (default `'Invalid'`). */
+  invalidText?: string
+  /** Text for null / undefined input (default same as `invalidText`). */
+  nullText?: string
+  /** Keep trailing zeros instead of trimming via `parseFloat` (default `false`). */
+  keepTrailingZeros?: boolean
+  /** Render the base unit (`units[0]`) as an integer with no decimals (default `false`). */
+  integerBase?: boolean
+}
+
+const DEFAULT_BYTE_UNITS = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
+
+/**
+ * Format bytes to a human-readable file size.
+ */
+export function formatFileSize(
+  bytes: number | null | undefined,
+  decimalsOrOptions: number | FormatBytesOptions = 2
+): string {
+  const opts: FormatBytesOptions =
+    typeof decimalsOrOptions === 'number' ? { decimals: decimalsOrOptions } : decimalsOrOptions
+
+  const units = opts.units ?? DEFAULT_BYTE_UNITS
+  const invalidText = opts.invalidText ?? 'Invalid'
+  const zeroText = opts.zeroText ?? `0 ${units[0]}`
+
+  if (bytes === null || bytes === undefined) return opts.nullText ?? invalidText
+  if (bytes === 0) return zeroText
+  if (bytes < 0) return invalidText
+
+  const k = 1024
+  const decimals = opts.decimals ?? 2
+  const dm = decimals < 0 ? 0 : decimals
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const sizeIndex = Math.min(i, units.length - 1)
+  const value = bytes / Math.pow(k, sizeIndex)
+
+  let text: string
+  if (opts.integerBase && sizeIndex === 0) {
+    text = String(bytes)
+  } else if (opts.keepTrailingZeros) {
+    text = value.toFixed(dm)
+  } else {
+    text = String(parseFloat(value.toFixed(dm)))
+  }
+
+  return `${text} ${units[sizeIndex]}`
+}
+
+/** Alias for formatFileSize (backward compatibility). */
+export const formatBytes = formatFileSize

--- a/autobot-slm-frontend/src/views/BackupsView.vue
+++ b/autobot-slm-frontend/src/views/BackupsView.vue
@@ -10,6 +10,7 @@
  */
 
 import { ref, computed, onMounted } from 'vue'
+import { formatBytes } from '@/utils/formatHelpers'
 import { useRoute, useRouter } from 'vue-router'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { useFleetStore } from '@/stores/fleet'
@@ -199,14 +200,6 @@ function getReplicationStatusClass(state: string): string {
   }
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B'
-  const k = 1024
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
-}
-
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '-'
   return formatDateTime(dateStr)
@@ -306,7 +299,7 @@ function getNodeHostname(nodeId: string): string {
                 {{ backup.service_type }}
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {{ formatBytes(backup.size_bytes) }}
+                {{ formatBytes(backup.size_bytes, { units: ['B', 'KB', 'MB', 'GB', 'TB'], zeroText: '0 B' }) }}
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <span :class="['px-2 py-1 text-xs font-medium rounded-full', getBackupStatusClass(backup.state)]">
@@ -395,7 +388,7 @@ function getNodeHostname(nodeId: string): string {
               <td class="px-6 py-4 whitespace-nowrap">
                 <div class="flex items-center gap-2">
                   <span class="text-xs text-gray-500">
-                    {{ repl.lag_bytes > 0 ? formatBytes(repl.lag_bytes) + ' lag' : 'In sync' }}
+                    {{ repl.lag_bytes > 0 ? formatBytes(repl.lag_bytes, { units: ['B', 'KB', 'MB', 'GB', 'TB'], zeroText: '0 B' }) + ' lag' : 'In sync' }}
                   </span>
                 </div>
               </td>

--- a/autobot-slm-frontend/src/views/monitoring/admin/AdminMonitoringView.vue
+++ b/autobot-slm-frontend/src/views/monitoring/admin/AdminMonitoringView.vue
@@ -4,6 +4,7 @@
 
 <script setup lang="ts">
 import { createLogger } from '@/utils/debugUtils'
+import { formatUptime } from '@/utils/formatHelpers'
 
 const logger = createLogger('AdminMonitoringView')
 /**
@@ -93,14 +94,6 @@ const healthIcon = computed(() => {
 })
 
 // Methods
-function formatUptime(seconds: number): string {
-  const days = Math.floor(seconds / 86400)
-  const hours = Math.floor((seconds % 86400) / 3600)
-  const minutes = Math.floor((seconds % 3600) / 60)
-  if (days > 0) return `${days}d ${hours}h`
-  if (hours > 0) return `${hours}h ${minutes}m`
-  return `${minutes}m`
-}
 
 function formatDate(dateStr: string): string {
   return formatDateTime(dateStr)

--- a/autobot-slm-frontend/src/views/performance/PerformanceOverview.vue
+++ b/autobot-slm-frontend/src/views/performance/PerformanceOverview.vue
@@ -12,6 +12,7 @@
  */
 
 import { onMounted, onUnmounted, computed } from 'vue'
+import { formatDuration } from '@/utils/formatHelpers'
 import { usePerformanceMonitoring } from '@/composables/usePerformanceMonitoring'
 import { formatDateTime } from '@/composables/useTimezone'
 
@@ -89,10 +90,6 @@ function statusBadgeClass(status: string): string {
 /**
  * Format duration for display.
  */
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms.toFixed(0)}ms`
-  return `${(ms / 1000).toFixed(2)}s`
-}
 
 function formatDate(dateStr: string): string {
   return formatDateTime(dateStr)
@@ -143,19 +140,19 @@ function formatDate(dateStr: string): string {
       <div class="bg-white rounded-lg shadow-xs border border-gray-200 p-4">
         <p class="text-sm text-gray-500 mb-1">{{ $t('performance.performanceOverview.avgLatency') }}</p>
         <p :class="['text-3xl font-bold', latencyColor(avgLatency)]">
-          {{ formatDuration(avgLatency) }}
+          {{ formatDuration(avgLatency, { style: 'msSeconds2dp' }) }}
         </p>
-        <p class="text-xs text-gray-400 mt-1">P95: {{ formatDuration(p95Latency) }}</p>
+        <p class="text-xs text-gray-400 mt-1">P95: {{ formatDuration(p95Latency, { style: 'msSeconds2dp' }) }}</p>
       </div>
 
       <!-- P95 Latency -->
       <div class="bg-white rounded-lg shadow-xs border border-gray-200 p-4">
         <p class="text-sm text-gray-500 mb-1">{{ $t('performance.performanceOverview.p95Latency') }}</p>
         <p :class="['text-3xl font-bold', latencyColor(p95Latency)]">
-          {{ formatDuration(p95Latency) }}
+          {{ formatDuration(p95Latency, { style: 'msSeconds2dp' }) }}
         </p>
         <p class="text-xs text-gray-400 mt-1">
-          P99: {{ formatDuration(overview?.p99_latency_ms ?? 0) }}
+          P99: {{ formatDuration(overview?.p99_latency_ms ?? 0, { style: 'msSeconds2dp' }) }}
         </p>
       </div>
 
@@ -226,7 +223,7 @@ function formatDate(dateStr: string): string {
               </td>
               <td class="px-4 py-2 text-sm font-mono">
                 <span :class="latencyColor(trace.duration_ms)">
-                  {{ formatDuration(trace.duration_ms) }}
+                  {{ formatDuration(trace.duration_ms, { style: 'msSeconds2dp' }) }}
                 </span>
               </td>
               <td class="px-4 py-2 text-sm text-gray-600">{{ trace.span_count }}</td>

--- a/autobot-slm-frontend/src/views/performance/TracingView.vue
+++ b/autobot-slm-frontend/src/views/performance/TracingView.vue
@@ -12,6 +12,7 @@
  */
 
 import { ref, onMounted, watch } from 'vue'
+import { formatDuration } from '@/utils/formatHelpers'
 import { usePagination } from '@autobot/ui'
 import { usePerformanceMonitoring } from '@/composables/usePerformanceMonitoring'
 import { formatDateTime } from '@/composables/useTimezone'
@@ -200,15 +201,10 @@ function spanBarColor(status: string): string {
 /**
  * Format duration for display.
  */
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms.toFixed(0)}ms`
-  return `${(ms / 1000).toFixed(2)}s`
-}
 
 function formatDate(dateStr: string): string {
   return formatDateTime(dateStr)
 }
-
 
 // Watch for filter changes that require immediate reload
 watch([timeRange, statusFilter], () => {
@@ -348,7 +344,7 @@ onMounted(() => {
                   {{ trace.name }}
                 </td>
                 <td class="px-4 py-2 text-sm font-mono">
-                  {{ formatDuration(trace.duration_ms) }}
+                  {{ formatDuration(trace.duration_ms, { style: 'msSeconds2dp' }) }}
                 </td>
                 <td class="px-4 py-2 text-sm text-gray-600">{{ trace.span_count }}</td>
                 <td class="px-4 py-2">
@@ -396,7 +392,7 @@ onMounted(() => {
                         ></div>
                       </div>
                       <span class="text-xs font-mono text-gray-600 w-16 text-right shrink-0">
-                        {{ formatDuration(span.duration_ms) }}
+                        {{ formatDuration(span.duration_ms, { style: 'msSeconds2dp' }) }}
                       </span>
                       <span
                         :class="[

--- a/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
@@ -11,6 +11,7 @@
  */
 
 import { ref, reactive, computed, onMounted } from 'vue'
+import { formatBytes } from '@/utils/formatHelpers'
 import { useAuthStore } from '@/stores/auth'
 import { useAutobotApi, type CacheConfig, type CacheStats } from '@/composables/useAutobotApi'
 import { getBackendUrl } from '@/config/ssot-config'
@@ -74,7 +75,7 @@ async function fetchCacheConfig(): Promise<void> {
     if (config) {
       Object.assign(cacheConfig, config)
     }
-  } catch (e) {
+  } catch {
     // Cache API may not be available
     cacheApiAvailable.value = false
   } finally {
@@ -92,7 +93,7 @@ async function fetchCacheStats(): Promise<void> {
     if (statsAny?.redis_databases) {
       redisStats.value = statsAny.redis_databases as Record<string, RedisDbInfo>
     }
-  } catch (e) {
+  } catch {
     // Silently fail - stats may not be available
   }
 }
@@ -167,14 +168,6 @@ async function warmupCaches(): Promise<void> {
   } finally {
     clearing.value = false
   }
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B'
-  const k = 1024
-  const sizes = ['B', 'KB', 'MB', 'GB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
 }
 
 function formatCacheType(type: string): string {
@@ -373,7 +366,7 @@ onMounted(async () => {
           </div>
           <div class="p-4 bg-gray-50 rounded-lg">
             <p class="text-sm text-gray-500">{{ $t('settings.admin.cacheSettings.cacheSize') }}</p>
-            <p class="text-2xl font-semibold text-gray-900">{{ formatBytes((cacheStats.size_mb || 0) * 1024 * 1024) }}</p>
+            <p class="text-2xl font-semibold text-gray-900">{{ formatBytes((cacheStats.size_mb || 0) * 1024 * 1024, { units: ['B', 'KB', 'MB', 'GB'], zeroText: '0 B' }) }}</p>
           </div>
           <div class="p-4 bg-gray-50 rounded-lg">
             <p class="text-sm text-gray-500">{{ $t('settings.admin.cacheSettings.hitRate') }}</p>


### PR DESCRIPTION
## Thinking Path
Part of #12645 fork-convergence (D2, owner directive "go with canonical"). Goal: collapse ~25 duplicated frontend format helpers onto canonical, **parameterized** helpers while preserving each call site's exact rendered output (zero visual regression).

Method: inventoried every `formatBytes`/`formatUptime`/`formatDuration`/`formatFileSize` copy in both apps, recorded each variant's exact output rules (precision, unit ladder, null/zero handling, input unit), then extended the canonical helpers with options that reproduce each site byte-for-byte. Genuine one-offs (unique output that can't be parameterized without changing it) were LEFT local and are listed below — no output was forced onto all.

## What Changed
**Canonical helpers — `autobot-frontend/src/utils/formatHelpers.ts`**
- `formatFileSize`/`formatBytes`: added `FormatBytesOptions` (`units`, `zeroText`, `invalidText`, `nullText`, `decimals`, `keepTrailingZeros`, `integerBase`). Default path is **byte-identical** to the previous implementation (existing ~15 callers unaffected); second arg still accepts a plain `number` for back-compat.
- `formatUptime`: **new** canonical (`FormatUptimeOptions`: `nullText`, `zeroText`, `daysIncludeMinutes`) — `d/h/m` ladder.
- `formatDuration`: kept the existing ISO-range form **unchanged**; added a numeric overload `formatDuration(value, { style, nullText?, zeroText?, rounding? })` with four output-preserving styles: `msSeconds2dp`, `secondsCompact`, `clock`, `msMinutes`.

**New shared util — `autobot-slm-frontend/src/utils/formatHelpers.ts`** (slm had none): mirrors the canonical `formatBytes`/`formatFileSize`/`formatUptime`/`formatDuration`.

**Converged 20 local copies** (removed + repointed with exact-output params):
- Bytes (6): useConversationFiles, BackupsView, CacheSettings, VisionAnalysisModal, VideoProcessor, RedisServicePanel(slm)
- Uptime (4): AdvancedControlView, AdminMonitoringView, NPUPerformanceMetrics, RedisServiceControl
- Duration (10): AdvancedAnalytics, TracingView, PerformanceOverview, AgentObservabilityPanel, OverseerStepMessage, ProjectDetailView, VideoProcessor, WorkflowVisualization, AgentActivityVisualization (+ range callers already shared)

Also fixed 2 pre-existing unused-`catch(e)` eslint warnings in the touched CacheSettings.vue.

**Left local intentionally (genuine one-offs — unique output, noted to avoid regression):**
- `NodeServicesPanel.formatBytes` — mixed per-unit precision (1 dp KB/MB, 2 dp GB).
- `RedisServicePanel.formatUptime` (slm) — seconds-inclusive `s / m s / h m` style.
- `AgentActivityVisualization.formatUptime` — single-unit `s / m / h`.
- `CompanyDashboard`, `ConnectorHistoryPanel`, `WorkflowHistory` (ActiveWorkflow object), `ReasoningTrace`, `AgentTaskDetail`, `BatchTool`, `ProcessMonitorTab`, `NodeLifecyclePanel` `formatDuration` — each a distinct ladder/rounding/input shape.

## Verification
- **Old-vs-new proof:** 22 vitest cases in `formatHelpers.test.ts` inline each ORIGINAL local implementation and assert equality with the new parameterized helper across sweeps (bytes `0,512,1023,1024,1536,1048576,1.5e12`; seconds `0,0.5,1,59,60,90.5,3661,90061`; ms `0,500,1000,1500,90000,…`). Spot values: `formatFileSize(1.5e12)="1.36 TB"`, `formatUptime(90061)="1d 1h"`, group-C `formatBytes(1024)="1.0 KB"` / `512="512 B"`, `msSeconds2dp(1500)="1.50s"`, `clock(90)="1:30"`, `secondsCompact(0,{zeroText:'--'})="--"`.
- `npx vitest run` → **22/22 pass** (plus useKnowledgeBase, useKnowledgeFiles/Stats, ProjectDetailView specs green).
- `npx vue-tsc --noEmit -p autobot-frontend/tsconfig.app.json` → **0 errors**.
- `npx vue-tsc --noEmit -p autobot-slm-frontend/tsconfig.json` → **0 errors**.
- `npx oxlint src -D correctness` (both frontends) → **0 errors** (CI "Unit & Integration Tests" gate).
- `npx eslint` on all changed files (both frontends) → **0 problems**.
- Pure refactor: **no** user-facing strings added/changed (no i18n impact).

Closes #12737

## Model Used
claude-opus-4-8
