### PR TITLE
tech-debt(backend): converge get_redis_config duplicates onto canonical (#12748)

### DIFF
--- a/autobot-backend/api/redis.py
+++ b/autobot-backend/api/redis.py
@@ -34,7 +34,13 @@ logger = get_logger(__name__)
     error_code_prefix="REDIS",
 )
 async def get_redis_config():
-    """Get current Redis configuration"""
+    """Get current Redis configuration.
+
+    Issue #12748: route handler, not a fork — delegates to
+    ConfigService.get_redis_config() (task-transport scope; see that
+    method's docstring for why it is distinct from the canonical core
+    connection config in config.service_config.ServiceConfigMixin).
+    """
     try:
         return ConfigService.get_redis_config()
     except Exception as e:

--- a/autobot-backend/config/__init__.py
+++ b/autobot-backend/config/__init__.py
@@ -81,13 +81,24 @@ class _ConfigStub:
         return default
 
     def get_redis_config(self):
-        """Env-var fallback so redis_client.get_redis_client() survives re-entry (#3491)."""
+        """SSOT fallback so redis_client.get_redis_client() survives re-entry (#3491).
+
+        Issue #12748: mirrors the canonical superset shape returned by
+        config.service_config.ServiceConfigMixin.get_redis_config() (enabled,
+        host, port, password, db) instead of a hand-rolled subset. Reads the
+        already-imported `config` proxy directly (no manager/mixin call) to
+        avoid re-entering the circular-import path this stub exists to guard.
+        Previously read nonexistent `config.redis_enabled`/`config.redis_db_main`
+        attributes (AttributeError if ever invoked) — fixed to use the real
+        `config.redis.*` sub-config fields.
+        """
 
         return {
-            "enabled": config.redis_enabled.lower() == "true",
-            "host": config.redis_host,
+            "enabled": config.redis.enabled,
+            "host": config.vm.redis,
             "port": int(config.port.redis),
-            "db": int(config.redis_db_main),
+            "password": config.redis.password,
+            "db": int(config.redis.db_main),
         }
 
     def get_llm_config(self):
@@ -285,7 +296,13 @@ def get_llm_config():
 
 
 def get_redis_config():
-    """Get Redis configuration"""
+    """Get Redis configuration.
+
+    Issue #12748: pure pass-through to the cached manager's
+    get_redis_config() (canonical: config.service_config.
+    ServiceConfigMixin.get_redis_config()), or _ConfigStub during
+    circular-import re-entry. Not a fork; already converged by delegation.
+    """
     return _get_cached_config_manager().get_redis_config()
 
 

--- a/autobot-backend/config/compat.py
+++ b/autobot-backend/config/compat.py
@@ -51,7 +51,12 @@ def get_llm_config(manager) -> Dict[str, Any]:
 
 
 def get_redis_config(manager) -> Dict[str, Any]:
-    """Get Redis configuration"""
+    """Get Redis configuration.
+
+    Issue #12748: pure pass-through to manager.get_redis_config() — not a
+    fork of the canonical (config.service_config.ServiceConfigMixin.
+    get_redis_config()); already converged by delegation.
+    """
     return manager.get_redis_config()
 
 

--- a/autobot-backend/config/get_redis_config_convergence_test.py
+++ b/autobot-backend/config/get_redis_config_convergence_test.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for Issue #12748 (get_redis_config fork convergence).
+
+Confirms the re-entry-safe _ConfigStub.get_redis_config() returns the
+identical superset shape/values as the canonical
+config.service_config.ServiceConfigMixin.get_redis_config() (reached via
+unified_config_manager), instead of the pre-fix broken/partial dict that
+referenced nonexistent SSOT attributes.
+"""
+
+import config as config_pkg
+
+
+def test_config_stub_redis_config_matches_canonical_shape():
+    """_ConfigStub.get_redis_config() must return the same keys as canonical."""
+    stub_result = config_pkg._ConfigStub().get_redis_config()
+    canonical_result = config_pkg.unified_config_manager.get_redis_config()
+
+    assert set(stub_result.keys()) == set(canonical_result.keys())
+
+
+def test_config_stub_redis_config_matches_canonical_values():
+    """_ConfigStub.get_redis_config() must resolve the same values as canonical."""
+    stub_result = config_pkg._ConfigStub().get_redis_config()
+    canonical_result = config_pkg.unified_config_manager.get_redis_config()
+
+    assert stub_result == canonical_result
+
+
+def test_config_stub_redis_config_has_no_attribute_error():
+    """Regression: pre-fix stub read config.redis_enabled/config.redis_db_main,
+    attributes that do not exist on AutoBotConfig and raised AttributeError.
+    """
+    result = config_pkg._ConfigStub().get_redis_config()
+
+    assert isinstance(result["enabled"], bool)
+    assert isinstance(result["db"], int)
+    assert "host" in result
+    assert "port" in result
+    assert "password" in result

--- a/autobot-backend/config/service_config.py
+++ b/autobot-backend/config/service_config.py
@@ -173,7 +173,20 @@ class ServiceConfigMixin:
         return self.get_nested(section, {})
 
     def get_redis_config(self) -> Dict[str, Any]:
-        """Get Redis configuration from SSOT config (single source of truth)."""
+        """Get Redis configuration from SSOT config (single source of truth).
+
+        Issue #12748: CANONICAL core Redis connection config. Reached via
+        ConfigManager (unified_config_manager / global_config_manager /
+        config_manager), config.get_redis_config() (config/__init__.py, pure
+        delegate), and config.compat.get_redis_config(manager) (pure
+        delegate). config.__init__._ConfigStub.get_redis_config() mirrors
+        this shape for the circular-import re-entry path only.
+
+        NOT the same concern as services.config_service.ConfigService.
+        get_redis_config() (task-transport-scoped redis sub-config, distinct
+        db index db_tasks vs db_main here) — that is a different scope/owner
+        sharing only the function name, intentionally left unconverged.
+        """
         from autobot_shared.ssot_config import config as ssot
 
         return {

--- a/autobot-backend/models/settings.py
+++ b/autobot-backend/models/settings.py
@@ -240,7 +240,15 @@ class AutoBotSettings(BaseSettings):
         }
 
     def get_redis_config(self) -> Metadata:
-        """Get Redis configuration as dict for backward compatibility."""
+        """Get Redis configuration as dict for backward compatibility.
+
+        Issue #12748: same-shape duplicate of the canonical core Redis
+        config (config.service_config.ServiceConfigMixin.get_redis_config())
+        but this entire module (AutoBotSettings and its `settings` singleton)
+        has zero live importers anywhere in the codebase — orphaned, not a
+        caller-facing fork requiring convergence. Left unconverged pending
+        an owner decision (wire in vs formally deprecate): see #12750.
+        """
         return {
             "enabled": self.redis.enabled,
             "host": self.redis.host,

--- a/autobot-backend/services/config_service.py
+++ b/autobot-backend/services/config_service.py
@@ -351,10 +351,19 @@ class ConfigService:
     @staticmethod
     def get_redis_config() -> Metadata:
         """
-        Get current Redis configuration.
+        Get current Redis task-transport configuration.
 
         SSOT Migration (Issue #602):
             Host and port now default to SSOT config values.
+
+        Issue #12748: NOT a fork of config.service_config.ServiceConfigMixin.
+        get_redis_config() (the canonical core connection config). This
+        method resolves the "task_transport.redis" section — used by the
+        redis-backed task queue/pubsub transport, keyed to db_tasks — a
+        different scope/owner than the core cache/connection config (keyed
+        to db_main), sharing only the method name. Consumed by
+        GET/POST /api/redis/config (api/redis.py) for editing transport
+        settings from the frontend. Intentionally left unconverged.
         """
         try:
             task_transport_config = unified_config_manager.get("task_transport", {})

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -10702,7 +10702,12 @@ export interface paths {
         };
         /**
          * Get Redis Config
-         * @description Get current Redis configuration
+         * @description Get current Redis configuration.
+         *
+         *     Issue #12748: route handler, not a fork — delegates to
+         *     ConfigService.get_redis_config() (task-transport scope; see that
+         *     method's docstring for why it is distinct from the canonical core
+         *     connection config in config.service_config.ServiceConfigMixin).
          */
         get: operations["get_redis_config_api_redis_config_get"];
         put?: never;


### PR DESCRIPTION
## Thinking Path
Part of #12645 fork-convergence (round-4 D4). Read all 7 `def get_redis_config` occurrences under `autobot-backend/` (none in `autobot-slm-backend`/`autobot_shared`), traced every caller and the exact keys it consumes, then classified each as true-fork, delegate/facade, different-concern, or orphaned before touching anything — no forced convergence that would change a caller-visible shape.

## What Changed

**Canonical (unchanged, marked):** `config/service_config.py::ServiceConfigMixin.get_redis_config()` — `{enabled, host, port, password, db}` sourced from SSOT (`ssot.redis.enabled`, `ssot.vm.redis`, `ssot.port.redis`, `ssot.redis.password`, `ssot.redis.db_main`). Reached via `unified_config_manager`/`global_config_manager`/`config_manager`.

**True fork converged (bug fix):** `config/__init__.py::_ConfigStub.get_redis_config()` — the circular-import re-entry-safe fallback (#1862/#3491). It read `config.redis_enabled` and `config.redis_db_main`, attributes that **do not exist** on `AutoBotConfig` (confirmed: `AttributeError: 'AutoBotConfig' object has no attribute 'redis_enabled'`) — this path would have crashed if ever actually invoked during re-entry, and even when it didn't crash it returned a partial shape (no `password`). Rewrote it to read the correct SSOT fields (`config.redis.enabled`, `config.vm.redis`, `config.port.redis`, `config.redis.password`, `config.redis.db_main`), producing the identical 5-key superset as canonical. Kept as a separate static-attribute-read implementation (not a delegate) because delegating to the manager mixin is exactly the circular-import re-entry this stub exists to guard against.

**Not forks — already-converged pass-through facades (documented, left as-is):**
- `config/__init__.py::get_redis_config()` (module-level) — pure delegate to `_get_cached_config_manager().get_redis_config()`.
- `config/compat.py::get_redis_config(manager)` — pure delegate to `manager.get_redis_config()`. No live callers found repo-wide (dead pass-through), left per no-deletion policy.
- `api/redis.py::get_redis_config()` — FastAPI route handler (`GET /api/redis/config`), delegates to `ConfigService.get_redis_config()` (a different concern, see below).

**Not forks — genuinely different concern (documented, left unconverged):**
- `services/config_service.py::ConfigService.get_redis_config()` — resolves the **task_transport.redis** sub-config (`{type, host, port, channels, priority}`), keyed to `db_tasks`, not `db_main`. Confirmed via `config/defaults.py::_get_task_transport_config()` vs `_get_redis_config()` that these are distinct default sections with different DB indices — different owner/scope (task queue transport) sharing only the method name with the core connection config. Exposed to the frontend via `GET/POST /api/redis/config`.

**Not a fork — orphaned dead code (documented, filed for owner decision, left unconverged):**
- `models/settings.py::AutoBotSettings.get_redis_config()` — same 5-key shape as canonical, but the entire `AutoBotSettings`/`settings` module has **zero live importers anywhere in the codebase** (verified: `grep -rn "from models.settings import\|models\.settings\.\|AutoBotSettings"` outside the file itself returns nothing). No caller contract to preserve or break; converging it would mean guessing intended env-var semantics for dead code. Filed #12750 for an owner decision (wire in vs formally deprecate).

Out of the original 7-definition grep scope but noted for completeness: `autobot-npu-worker/resources/windows-npu-worker/.../config_bootstrap.py::get_redis_config()` is a separate deployable (Windows NPU worker) with its own bootstrap-config system — different owner/scope, not touched.

## Verification
- `python3 -m pytest autobot-backend/config/get_redis_config_convergence_test.py -q` → **3 passed** (new regression tests proving `_ConfigStub.get_redis_config()` now matches canonical keys+values, and no longer raises `AttributeError`).
- Before/after proof (representative env, `redis.enabled/host/port/password/db`):
  - **Before**: `_ConfigStub.get_redis_config()` → `AttributeError: 'AutoBotConfig' object has no attribute 'redis_enabled'` (would crash if invoked).
  - **After**: `_ConfigStub.get_redis_config()` → `{'enabled': True, 'host': 'YOUR_REDIS_IP', 'port': 6379, 'password': '', 'db': 0}` == `unified_config_manager.get_redis_config()` → identical dict. Verified programmatically (keys and values asserted equal).
- Caller-keys-preserved check — every live caller of the canonical path (`conversation_file_manager.py`, `utils/service_discovery.py`, `utils/resource_factory.py`, `api/developer.py`, `config/validation.py`) reads only `enabled`/`host`/`port` (a subset of the unchanged canonical superset) — confirmed by reading each call site; none read `db`/`password`, so no caller-visible change.
- `python3 -m pytest autobot-backend/config/config_test.py autobot-backend/config/config_consolidation_p2_test.py autobot-backend/utils/config_manager_test.py autobot-backend/utils/connection_utils_test.py -q` → 43 passed (2 pre-existing failures in `config/validation_test.py::TestFalsyValidValues` confirmed unrelated — fail identically on the unmodified base tree, untouched `server_host` validation logic).
- `python3 -m pytest autobot-backend/tests/test_startup_imports.py -q` → **348 passed**.

Closes #12748

## Model Used
Sonnet 5 (claude-sonnet-5-20251101)