### PR TITLE
fix(api): repoint auth to /api/auth/login (#1922) + restore infra host DELETE (#1310) — clear api-wiring drift (#12723)

### DIFF
--- a/autobot-backend/api/infrastructure.py
+++ b/autobot-backend/api/infrastructure.py
@@ -13,7 +13,7 @@ Issue #1310: Fleet/system VMs removed — they belong in SLM only.
 
 from typing import Any, Dict, List
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.schemas_system import InfrastructureHostsResponse
 from auth_middleware import get_current_user
@@ -80,3 +80,31 @@ async def get_infrastructure_hosts(
         hosts = [h for h in hosts if capability in h.get("capabilities", [])]
 
     return {"hosts": hosts}
+
+
+@router.delete("/hosts/{host_id}")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="delete_infrastructure_host",
+    error_code_prefix="INFRASTRUCTURE",
+)
+async def delete_infrastructure_host(
+    host_id: str,
+    _user: Any = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Delete a user-configured infrastructure host.
+
+    Issue #1310: infra hosts are user Secrets entries of type
+    ``infrastructure_host``; deleting the host removes its Secrets entry.
+    Mirrors the GET read-shim — the host id IS the secret id. Returns 404
+    when no matching infrastructure host exists.
+    """
+    if not any(h["id"] == host_id for h in _load_secrets_hosts()):
+        raise HTTPException(status_code=404, detail="Infrastructure host not found")
+
+    from api.secrets import secrets_manager
+
+    if not secrets_manager.delete_secret(host_id):
+        raise HTTPException(status_code=404, detail="Infrastructure host not found")
+
+    return {"status": "success", "id": host_id}

--- a/autobot-backend/tests/test_infrastructure_hosts_delete.py
+++ b/autobot-backend/tests/test_infrastructure_hosts_delete.py
@@ -1,0 +1,61 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the infrastructure host DELETE route (#12723).
+
+Issue #1310 made infra hosts user Secrets entries (host id == secret id).
+The FE (useSecretsInfraApi.deleteInfraHost) DELETEs
+``/api/infrastructure/hosts/{id}``; this restores the missing backend half.
+"""
+
+import pytest
+
+import api.infrastructure as infra
+
+
+@pytest.fixture
+def _hosts(monkeypatch):
+    """Stub the secrets-host read-shim with a single known host."""
+    monkeypatch.setattr(
+        infra, "_load_secrets_hosts", lambda: [{"id": "h9", "name": "box"}]
+    )
+
+
+async def test_delete_infrastructure_host_removes_matching_secret(_hosts, monkeypatch):
+    import api.secrets as secrets_mod
+
+    calls = []
+    monkeypatch.setattr(
+        secrets_mod.secrets_manager,
+        "delete_secret",
+        lambda sid, *a, **k: calls.append(sid) or True,
+    )
+
+    result = await infra.delete_infrastructure_host(host_id="h9", _user={"sub": "u"})
+
+    assert result == {"status": "success", "id": "h9"}
+    assert calls == ["h9"]
+
+
+async def test_delete_unknown_host_returns_404(_hosts):
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await infra.delete_infrastructure_host(host_id="missing", _user={"sub": "u"})
+
+    assert exc.value.status_code == 404
+
+
+async def test_delete_404_when_secret_delete_reports_missing(_hosts, monkeypatch):
+    import api.secrets as secrets_mod
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(
+        secrets_mod.secrets_manager, "delete_secret", lambda sid, *a, **k: False
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await infra.delete_infrastructure_host(host_id="h9", _user={"sub": "u"})
+
+    assert exc.value.status_code == 404

--- a/autobot-backend/tests/test_infrastructure_hosts_delete.py
+++ b/autobot-backend/tests/test_infrastructure_hosts_delete.py
@@ -17,9 +17,7 @@ import api.infrastructure as infra
 @pytest.fixture
 def _hosts(monkeypatch):
     """Stub the secrets-host read-shim with a single known host."""
-    monkeypatch.setattr(
-        infra, "_load_secrets_hosts", lambda: [{"id": "h9", "name": "box"}]
-    )
+    monkeypatch.setattr(infra, "_load_secrets_hosts", lambda: [{"id": "h9", "name": "box"}])
 
 
 async def test_delete_infrastructure_host_removes_matching_secret(_hosts, monkeypatch):
@@ -48,12 +46,11 @@ async def test_delete_unknown_host_returns_404(_hosts):
 
 
 async def test_delete_404_when_secret_delete_reports_missing(_hosts, monkeypatch):
-    import api.secrets as secrets_mod
     from fastapi import HTTPException
 
-    monkeypatch.setattr(
-        secrets_mod.secrets_manager, "delete_secret", lambda sid, *a, **k: False
-    )
+    import api.secrets as secrets_mod
+
+    monkeypatch.setattr(secrets_mod.secrets_manager, "delete_secret", lambda sid, *a, **k: False)
 
     with pytest.raises(HTTPException) as exc:
         await infra.delete_infrastructure_host(host_id="h9", _user={"sub": "u"})

--- a/autobot-frontend/src/composables/__tests__/useTLSCredentials.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/useTLSCredentials.spec.ts
@@ -6,7 +6,8 @@
  * Verifies the composable routes SLM TLS calls through the canonical SLM bridge
  * (a SlmClient instance) — not raw getSLMUrl()+fetch — and that the bridge is
  * wired with the composable's in-memory SLM token (read live). Also covers the
- * form-encoded, token-less authenticate() path and graceful-error behaviour.
+ * JSON, token-less authenticate() path (POST /api/auth/login, #1922) and
+ * graceful-error / MFA-challenge behaviour.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
@@ -107,7 +108,7 @@ describe('useTLSCredentials', () => {
     expect(ok).toBe(true)
   })
 
-  it('authenticate POSTs form-encoded credentials with skipAuth and stores the token', async () => {
+  it('authenticate POSTs JSON credentials to /api/auth/login with skipAuth and stores the token', async () => {
     h.rawMock.mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({ access_token: 'new-token' }),
@@ -118,11 +119,11 @@ describe('useTLSCredentials', () => {
 
     expect(ok).toBe(true)
     const [path, options] = h.rawMock.mock.calls[0]
-    expect(path).toBe('/api/auth/token')
+    expect(path).toBe('/api/auth/login')
     expect(options.method).toBe('POST')
     expect(options.skipAuth).toBe(true)
-    expect(options.headers['Content-Type']).toBe('application/x-www-form-urlencoded')
-    expect(options.body).toBeInstanceOf(URLSearchParams)
+    expect(options.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(options.body)).toEqual({ username: 'admin', password: 'pw' })
     expect(isAuthenticated()).toBe(true)
   })
 
@@ -131,6 +132,18 @@ describe('useTLSCredentials', () => {
     const { authenticate } = useTLSCredentials()
 
     await expect(authenticate('admin', 'bad')).resolves.toBe(false)
+  })
+
+  it('authenticate returns false (no crash) on an MFA-challenge response', async () => {
+    h.rawMock.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ requires_mfa: true, temp_token: 'tmp' }),
+    })
+    const { authenticate } = useTLSCredentials()
+
+    // Returns false without throwing; the MFA temp_token is never stored as a
+    // bearer (module-scoped authToken makes isAuthenticated() unreliable here).
+    await expect(authenticate('admin', 'pw')).resolves.toBe(false)
   })
 
   it('fetchNodes returns [] and records the error message on rejection', async () => {

--- a/autobot-frontend/src/composables/useTLSCredentials.ts
+++ b/autobot-frontend/src/composables/useTLSCredentials.ts
@@ -116,17 +116,14 @@ const expiringSoonCount = computed(() => expiringCredentials.value.length)
  */
 async function authenticate(username: string, password: string): Promise<boolean> {
   try {
-    const formData = new URLSearchParams()
-    formData.append('username', username)
-    formData.append('password', password)
-
-    // Token-acquisition endpoint: credential-based, so skip bearer injection.
-    const response = await slm.rawRequest('/api/auth/token', {
+    // Canonical SLM login (Issue #1922): JSON body to /api/auth/login.
+    // Credential-based, so skip bearer injection.
+    const response = await slm.rawRequest('/api/auth/login', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/json',
       },
-      body: formData,
+      body: JSON.stringify({ username, password }),
       skipAuth: true,
     })
 
@@ -135,6 +132,16 @@ async function authenticate(username: string, password: string): Promise<boolean
     }
 
     const data = await response.json()
+    // Login may return a TokenResponse (has access_token) or an
+    // MfaChallengeResponse (requires_mfa, no token). Only the token path
+    // authenticates here; an MFA challenge is surfaced as a non-fatal failure
+    // rather than crashing (full MFA flow not handled by this composable).
+    if (!data?.access_token) {
+      if (data?.requires_mfa) {
+        logger.warn('SLM login requires MFA; TLS credential flow cannot complete unattended')
+      }
+      return false
+    }
     authToken.value = data.access_token
     return true
   } catch (err: unknown) {


### PR DESCRIPTION
## Thinking Path

The `api-wiring` CI audit was correctly red on `Dev_new_gui` for two genuine FE→BE contract bugs — both refactors whose old callers were left pointing at removed routes. Owner decision (#12723): fix the wiring, do NOT baseline. Investigated each side against the real route tables before touching code.

## What Changed

**Bug 1 — auth path/content-type drift (#1922).**
`autobot-frontend/src/composables/useTLSCredentials.ts` `authenticate()` POSTed `application/x-www-form-urlencoded` to the removed `POST /api/auth/token`. The canonical SLM endpoint is `POST /api/auth/login` (`autobot-slm-backend/api/auth.py`, router prefix `/auth` mounted at `/api`), body = JSON `TokenRequest{username, password}`, returning `TokenResponse` (`access_token`) **or** `MfaChallengeResponse` (`requires_mfa`, no token).
- Now POSTs JSON `{username, password}` to `/api/auth/login`, keeps `skipAuth: true`, reads `access_token`.
- Handles the MFA-challenge shape gracefully: no `access_token` → returns `false` (logs a warning if `requires_mfa`) instead of crashing. Full MFA flow intentionally out of scope for this composable.

**Bug 2 — dropped infra host DELETE (#1310).**
`useSecretsInfraApi.deleteInfraHost()` DELETEs `/api/infrastructure/hosts/{id}`, but `autobot-backend/api/infrastructure.py` only had the `GET /hosts` read-shim over `_load_secrets_hosts()`. Infra hosts are user Secrets entries where the host id **is** the secret id.
- Added a symmetric `DELETE /hosts/{host_id}` mirroring the GET shim: same `Depends(get_current_user)` auth, same `@with_error_handling` pattern. Resolves host→secret via `_load_secrets_hosts()`, deletes through `secrets_manager.delete_secret()`, returns 404 when no matching host exists. FE contract `/api/infrastructure/hosts/{id}` preserved unchanged.

**Tests.**
- `useTLSCredentials.spec.ts`: updated the auth test to assert `/api/auth/login` + JSON body; added an MFA-challenge graceful-return test.
- New `autobot-backend/tests/test_infrastructure_hosts_delete.py`: success (deletes matching secret), 404 unknown host, 404 when secret-delete reports missing.

## Verification

Backend (`PYTHONPATH` set, no app-dep installs):
```
pytest tests/test_infrastructure_hosts_delete.py tests/test_startup_imports.py -q
351 passed, 82 warnings in 23.55s
```

Frontend (node_modules reused from main tree, read-only):
```
vitest run useTLSCredentials.spec.ts useSecretsInfraApi.test.ts  → 14 passed
vue-tsc --noEmit -p tsconfig.app.json                            → 0 errors
oxlint src -D correctness                                        → 0 errors
eslint useTLSCredentials.ts + spec                               → 0 errors
```

api-wiring audit:
```
python scripts/audit_api_wiring.py --dump-openapi openapi.json   → wrote 2157 paths
→ /api/infrastructure/hosts/{host_id}  ['delete']   # new route present in authoritative dump
```
- SLM OpenAPI dump could not run locally (`Permission denied: /etc/autobot/db-credentials.env` — environment limitation; per issue #12723, it dumps successfully in CI). Proven statically instead: `autobot-slm-backend/api/auth.py` exposes `POST /login` on a router with prefix `/auth`, mounted at `/api` (`main.py:630 app.include_router(auth_router, prefix="/api")`) → `/api/auth/login` exists, and the FE now targets exactly that path.
- Both FE calls now resolve to real backend routes; neither was added to `scripts/api_wiring_baseline.txt`.

## Model Used

claude-opus-4-8

Closes #12723
