### PR TITLE
security-tech-debt: extract shared service-auth HMAC signature helper (#12766)

### DIFF
--- a/autobot-backend/security/service_auth.py
+++ b/autobot-backend/security/service_auth.py
@@ -9,7 +9,6 @@ Implements API Key + HMAC-SHA256 authentication for distributed VM infrastructur
 CRITICAL SECURITY: Prevents CVSS 10.0 vulnerability where any service can call any endpoint
 """
 
-import hashlib
 import hmac
 import secrets
 import time
@@ -18,6 +17,7 @@ from typing import Dict
 import structlog
 from fastapi import HTTPException, Request
 
+from autobot_shared.http_client import _service_signature
 from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_90_DAYS
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
@@ -76,6 +76,10 @@ class ServiceAuthManager:
 
         Signature format: HMAC-SHA256(service_key, "service_id:method:path:timestamp")
 
+        Delegates to ``autobot_shared.http_client._service_signature`` (#12766)
+        — the single canonical implementation shared with the caller-side
+        ``sign_request`` helper, so signer and verifier can never drift.
+
         Args:
             service_id: Service identifier
             service_key: Service's secret key
@@ -86,9 +90,7 @@ class ServiceAuthManager:
         Returns:
             Hex-encoded HMAC-SHA256 signature
         """
-        message = f"{service_id}:{method}:{path}:{timestamp}"
-        signature = hmac.new(service_key.encode(), message.encode(), hashlib.sha256).hexdigest()
-        return signature
+        return _service_signature(service_id, method, path, timestamp, service_key)
 
     def _extract_auth_headers(self, request: Request) -> tuple[str, str, str]:
         """

--- a/autobot-backend/tests/utils/test_service_client_signing.py
+++ b/autobot-backend/tests/utils/test_service_client_signing.py
@@ -103,6 +103,107 @@ class TestSignRequestHelper:
         assert actual == expected
 
 
+class TestSharedSignatureHelperRoundTrip:
+    """Mandatory round-trip/tamper/golden tests for #12766.
+
+    Confirms the extracted ``autobot_shared.http_client._service_signature``
+    helper stays byte-identical to the pre-extraction formula used by both
+    ``sign_request`` (caller) and ``ServiceAuthManager.generate_signature``
+    (receiver).
+    """
+
+    def _auth_manager(self):
+        from security.service_auth import ServiceAuthManager
+
+        return ServiceAuthManager(redis_client=None)
+
+    def test_round_trip_sign_then_verify_succeeds(self):
+        """Sign via the shared helper (sign_request), verify via service_auth's
+        generate_signature + hmac.compare_digest — the real end-to-end path."""
+        service_id = "npu-worker"
+        service_key = "deadbeefcafebabe" * 4
+        method = "GET"
+        path = "/api/npu/results"
+        timestamp = 1712340000
+
+        produced_sig = sign_request(service_id, service_key, method, path, timestamp)["X-Service-Signature"]
+
+        auth_mgr = self._auth_manager()
+        expected_sig = auth_mgr.generate_signature(service_id, service_key, method, path, timestamp)
+
+        assert hmac.compare_digest(produced_sig, expected_sig)
+
+    def test_tamper_wrong_key_fails_verification(self):
+        service_id = "npu-worker"
+        method = "GET"
+        path = "/api/npu/results"
+        timestamp = 1712340000
+
+        produced_sig = sign_request(service_id, "correct-key" * 4, method, path, timestamp)["X-Service-Signature"]
+
+        auth_mgr = self._auth_manager()
+        expected_sig = auth_mgr.generate_signature(service_id, "wrong-key" * 4, method, path, timestamp)
+
+        assert not hmac.compare_digest(produced_sig, expected_sig)
+
+    def test_tamper_wrong_path_fails_verification(self):
+        service_id = "npu-worker"
+        service_key = "deadbeefcafebabe" * 4
+        method = "GET"
+        timestamp = 1712340000
+
+        produced_sig = sign_request(service_id, service_key, method, "/api/npu/results", timestamp)[
+            "X-Service-Signature"
+        ]
+
+        auth_mgr = self._auth_manager()
+        expected_sig = auth_mgr.generate_signature(service_id, service_key, method, "/api/other/path", timestamp)
+
+        assert not hmac.compare_digest(produced_sig, expected_sig)
+
+    def test_tamper_wrong_timestamp_fails_verification(self):
+        service_id = "npu-worker"
+        service_key = "deadbeefcafebabe" * 4
+        method = "GET"
+        path = "/api/npu/results"
+
+        produced_sig = sign_request(service_id, service_key, method, path, 1712340000)["X-Service-Signature"]
+
+        auth_mgr = self._auth_manager()
+        expected_sig = auth_mgr.generate_signature(service_id, service_key, method, path, 1712340099)
+
+        assert not hmac.compare_digest(produced_sig, expected_sig)
+
+    def test_golden_hex_matches_pre_change_formula(self):
+        """The shared helper's output MUST equal the pre-#12766 signer's formula:
+
+        ``hmac.new(key.encode('utf-8'),
+                    f"{service_id}:{method}:{path}:{timestamp}".encode('utf-8'),
+                    hashlib.sha256).hexdigest()``
+
+        computed independently of both ``sign_request`` and
+        ``ServiceAuthManager.generate_signature`` for fixed inputs, then
+        hardcoded here. If this test ever fails, the canonicalization or
+        digest changed — a byte-identical de-dup must never do that.
+        """
+        service_id = "golden-svc"
+        service_key = "0123456789abcdef" * 4
+        method = "POST"
+        path = "/api/golden/test"
+        timestamp = 1712345678
+
+        # Golden hex, independently computed offline with the pre-change
+        # formula: hmac.new(key, f"{sid}:{method}:{path}:{ts}", sha256).hexdigest()
+        expected_golden_hex = "ce4ee781f5d4f001fd1231a41a0293aeb04ad61083fe23dd193531ebbaca7b26"
+
+        actual = sign_request(service_id, service_key, method, path, timestamp)["X-Service-Signature"]
+        assert actual == expected_golden_hex
+
+        auth_mgr = self._auth_manager()
+        actual_verifier_side = auth_mgr.generate_signature(service_id, service_key, method, path, timestamp)
+        assert actual_verifier_side == expected_golden_hex
+
+
 class TestServiceHTTPClientSignRequest:
     """ServiceHTTPClient._sign_request must delegate to the shared helper."""
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -44474,6 +44474,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/infrastructure/hosts/{host_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Infrastructure Host
+         * @description Delete a user-configured infrastructure host.
+         *
+         *     Issue #1310: infra hosts are user Secrets entries of type
+         *     ``infrastructure_host``; deleting the host removes its Secrets entry.
+         *     Mirrors the GET read-shim — the host id IS the secret id. Returns 404
+         *     when no matching infrastructure host exists.
+         */
+        delete: operations["delete_infrastructure_host_api_infrastructure_hosts__host_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/entities/extract": {
         parameters: {
             query?: never;
@@ -159862,6 +159887,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InfrastructureHostsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_infrastructure_host_api_infrastructure_hosts__host_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -465,6 +465,45 @@ def reset_http_client_for_new_loop() -> None:
             HTTPClientManager._lock = asyncio.Lock()
 
 
+def _service_signature(
+    service_id: str,
+    method: str,
+    path: str,
+    timestamp: int,
+    key: str,
+) -> str:
+    """
+    Canonical HMAC-SHA256 signature for service-to-service requests (#12766).
+
+    Single source of truth for the signature computation shared by
+    ``sign_request`` (caller side, below) and
+    ``security.service_auth.ServiceAuthManager.generate_signature``
+    (receiver side, ``autobot-backend``) — the two previously duplicated an
+    identical ``hmac.new(key, "service_id:method:path:timestamp", sha256)``
+    formula. Extracting one helper guarantees they can never silently drift.
+
+    SECURITY: the message format, field order, ``:`` separator, UTF-8
+    encoding, and SHA-256 digest MUST NOT change — any edit here changes
+    every signature this system has ever produced or verified.
+
+    Args:
+        service_id: Caller's service identifier (e.g. ``'main-backend'``).
+        method: HTTP method in upper-case (e.g. ``'GET'``, ``'POST'``).
+        path: URL path component only (e.g. ``'/api/inference'``).
+        timestamp: Unix timestamp (seconds).
+        key: 256-bit hex-encoded secret shared between caller and receiver.
+
+    Returns:
+        Hex-encoded HMAC-SHA256 signature.
+    """
+    message = f"{service_id}:{method}:{path}:{timestamp}"
+    return hmac.new(
+        key.encode(encoding="utf-8"),
+        message.encode(encoding="utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
 def sign_request(
     service_id: str,
     service_key: str,
@@ -496,12 +535,7 @@ def sign_request(
     Returns:
         Dict mapping header name → value, ready to merge into request headers.
     """
-    message = f"{service_id}:{method}:{path}:{timestamp}"
-    signature = hmac.new(
-        service_key.encode(encoding="utf-8"),
-        message.encode(encoding="utf-8"),
-        hashlib.sha256,
-    ).hexdigest()
+    signature = _service_signature(service_id, method, path, timestamp, service_key)
     return {
         "X-Service-ID": service_id,
         "X-Service-Signature": signature,


### PR DESCRIPTION
## Thinking Path
Issue #12766 (fork-convergence #12645 round-3 B, sub-cluster 1A) flagged that the service-to-service HMAC signature computation was duplicated byte-for-byte in two places:
- `autobot_shared/http_client.py:468` `sign_request()` (caller side)
- `autobot-backend/security/service_auth.py:73` `ServiceAuthManager.generate_signature()` (receiver side)

Both used the identical formula `hmac.new(key.encode('utf-8'), f"{service_id}:{method}:{path}:{timestamp}".encode('utf-8'), hashlib.sha256).hexdigest()`. Confirmed byte-for-byte identical by reading both implementations before touching anything (message field order, `:` separator, UTF-8 encoding, digest algo, and `hexdigest()` all matched) — safe to unify per the SECURITY-CRITICAL constraint of the issue.

## What Changed
- Extracted a single canonical `_service_signature(service_id, method, path, timestamp, key) -> str` helper in `autobot_shared/http_client.py` (already imported cross-service).
- `sign_request()` now calls `_service_signature()` instead of computing the HMAC inline — no change to its inputs/outputs.
- `ServiceAuthManager.generate_signature()` in `autobot-backend/security/service_auth.py` now imports and delegates to `_service_signature()` instead of duplicating the formula; the `hashlib` import (only used there) was removed as dead.
- `ServiceAuthManager.validate_signature()`'s `hmac.compare_digest(...)` constant-time comparison is untouched — only the signature *computation* is shared, not the comparison.
- No change to message ordering, encoding, digest algorithm, or any produced/verified signature bytes.

## Verification
Added `TestSharedSignatureHelperRoundTrip` to `autobot-backend/tests/utils/test_service_client_signing.py` covering the mandatory cases:
1. **Round-trip** — sign via `sign_request` (shared helper), verify via `ServiceAuthManager.generate_signature` + `hmac.compare_digest` → passes.
2. **Tamper** — wrong key / wrong path / wrong timestamp → `hmac.compare_digest` returns `False`.
3. **Golden hex** — for fixed inputs (`golden-svc`, key, `POST /api/golden/test`, ts `1712345678`), the shared helper's hex is hardcoded from an independent, offline computation of the pre-change formula:
   ```
   expected_golden_hex = "ce4ee781f5d4f001fd1231a41a0293aeb04ad61083fe23dd193531ebbaca7b26"
   ```
   Both `sign_request(...)["X-Service-Signature"]` and `ServiceAuthManager.generate_signature(...)` are asserted equal to this golden value — proving byte-identical output before and after the extraction.

Test run (worktree, local, no network):
```
$ python3 -m pytest autobot-backend/tests/utils/test_service_client_signing.py -q
18 passed in 0.44s

$ python3 -m pytest autobot-backend/tests/middleware/test_service_auth_enforcement.py -q
42 passed in 0.71s

$ python3 -m pytest autobot_shared/http_client_test.py -q
4 passed in 2.83s

$ python3 -m pytest autobot-backend/tests/test_startup_imports.py -q
348 passed in 27.43s
```
`ruff check` on the three touched files shows only one pre-existing, unrelated `F821` (a forward-ref string annotation in an untouched test class) — not introduced by this change.

Closes #12766

## Model Used
Claude Sonnet 5