### PR TITLE
tech-debt(backend): converge chars/4 token estimators onto autobot_shared canonical (#12764)

### DIFF
--- a/autobot-backend/benchmarks/benchmark_belief_state.py
+++ b/autobot-backend/benchmarks/benchmark_belief_state.py
@@ -38,6 +38,8 @@ _autobot_root = _repo_root.parent
 sys.path.insert(0, str(_repo_root))
 sys.path.insert(0, str(_autobot_root))
 
+from autobot_shared.doc_chunking import estimate_tokens as _canonical_estimate_tokens  # noqa: E402
+
 # Import directly from submodules to avoid agent_loop/__init__.py
 # (which imports AgentLoop → heavy FastAPI/Redis/Celery dependencies)
 import importlib.util as _ilu
@@ -79,26 +81,31 @@ from agent_loop.belief_state import BeliefStateUpdater  # noqa: E402
 # Token-cost estimation helpers
 # ---------------------------------------------------------------------------
 
-# Rough heuristic: 1 token ≈ 4 characters for English/JSON text
-_CHARS_PER_TOKEN = 4
-
-
 def _estimate_tokens(obj: Any) -> int:
-    """Estimate token count for an arbitrary value by JSON-serialising it."""
+    """Estimate token count for an arbitrary value by JSON-serialising it.
+
+    The chars/4 arithmetic delegates to the canonical
+    autobot_shared.doc_chunking.estimate_tokens (#12764); the JSON-serialize
+    step and the 1-token floor are preserved here, unchanged.
+    """
     try:
         text = json.dumps(obj, default=str)
     except Exception:
         text = str(obj)
-    return max(1, len(text) // _CHARS_PER_TOKEN)
+    return max(1, _canonical_estimate_tokens(text))
 
 
 def _assertion_summary_tokens(ctx: TaskContext) -> int:
-    """Compact token cost of surfacing belief state vs. raw tool outputs."""
+    """Compact token cost of surfacing belief state vs. raw tool outputs.
+
+    Same chars/4 family as ``_estimate_tokens`` above — also repointed onto
+    the canonical estimator (#12764), preserving the 1-token floor.
+    """
     active = [a for a in ctx.assertions.values() if a.is_active]
     # Each assertion is roughly "key = value @ conf\n" — very compact
     lines = [f"  {a.key} = {a.value!r} @ {a.confidence:.2f}" for a in active]
     summary = "Belief state:\n" + "\n".join(lines)
-    return max(1, len(summary) // _CHARS_PER_TOKEN)
+    return max(1, _canonical_estimate_tokens(summary))
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/code_intelligence/llm_pattern_analysis/prompt_analyzer.py
+++ b/autobot-backend/code_intelligence/llm_pattern_analysis/prompt_analyzer.py
@@ -14,6 +14,7 @@ Extracted from llm_pattern_analyzer.py as part of Issue #381 refactoring.
 
 from typing import List
 
+from autobot_shared.doc_chunking import estimate_tokens as _canonical_estimate_tokens
 from code_intelligence.llm_pattern_analysis.data_models import PromptAnalysisResult
 from code_intelligence.llm_pattern_analysis.types import (
     EXCESSIVE_CONTEXT_PATTERNS,
@@ -92,7 +93,10 @@ class PromptAnalyzer:
         Estimate token count for text.
 
         Uses a simple heuristic: ~4 characters per token for English text.
-        More accurate counting would require the actual tokenizer.
+        More accurate counting would require the actual tokenizer. Delegates
+        the chars/4 estimate to the canonical autobot_shared.doc_chunking
+        estimator (#12764); the trailing +1 is preserved here to keep this
+        method's output identical to its pre-existing behavior.
 
         Args:
             text: The text to estimate tokens for
@@ -100,7 +104,7 @@ class PromptAnalyzer:
         Returns:
             Estimated token count
         """
-        return len(text) // 4 + 1
+        return _canonical_estimate_tokens(text) + 1
 
     @classmethod
     def extract_variables(cls, template: str) -> List[str]:

--- a/autobot-backend/context_window_manager.py
+++ b/autobot-backend/context_window_manager.py
@@ -173,6 +173,13 @@ class ContextWindowManager:
     def estimate_tokens(self, text: str) -> int:
         """Estimate token count from text.
 
+        NOT repointed onto autobot_shared.doc_chunking.estimate_tokens
+        (#12764/#12645): chars_per_token here is a genuine runtime config
+        knob (config/context_windows.yaml `token_estimation.chars_per_token`,
+        default 4) rather than a hardcoded constant. The canonical estimator
+        hardcodes //4, so delegating would silently ignore any deployment
+        that configures a different ratio and change truncation behavior.
+
         Args:
             text: Text to estimate tokens for
 

--- a/autobot-backend/llm_shared/token_budget.py
+++ b/autobot-backend/llm_shared/token_budget.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+from autobot_shared.doc_chunking import estimate_tokens
 from autobot_shared.env_utils import env_int
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
@@ -47,28 +48,21 @@ TOKEN_BUDGET_PER_RUN: int = env_int("AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN", 0)
 # counter never resets mid-conversation. Default: 24h.
 TOKEN_BUDGET_TTL_SECONDS: int = env_int("AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS", 86400)
 
-# Chars-per-token estimate — the same rough approximation already used by
-# chat_workflow/compact_hook.py and context_window_manager.py. Accurate
-# tokenisation is unnecessary for a budget *ceiling* check.
-_CHARS_PER_TOKEN: int = 4
-
+# Token estimation delegates to autobot_shared.doc_chunking.estimate_tokens
+# (chars/4 — accurate tokenisation is unnecessary for a budget *ceiling*
+# check). Canonical estimator per #12764; family convergence for #12645.
 _KEY_PREFIX = "autobot:llm:token_budget"
-
-
-def _estimate_tokens(char_count: int) -> int:
-    """Cheap chars/4 token estimate (matches compact_hook.py convention)."""
-    return max(0, char_count // _CHARS_PER_TOKEN)
 
 
 def _estimate_request_tokens(request: LLMRequest) -> int:
     """Estimate this request's token cost: input messages + requested output budget."""
-    input_chars = sum(len(str(m.get("content", ""))) for m in request.messages)
-    return _estimate_tokens(input_chars) + (request.max_tokens or 0)
+    input_text = "".join(str(m.get("content", "")) for m in request.messages)
+    return estimate_tokens(input_text) + (request.max_tokens or 0)
 
 
 def _estimate_response_tokens(response: LLMResponse) -> int:
     """Estimate a completed response's token cost when the provider didn't report usage."""
-    return _estimate_tokens(len(response.content or ""))
+    return estimate_tokens(response.content or "")
 
 
 def _scope_key(request: LLMRequest) -> str:


### PR DESCRIPTION
## Thinking Path

Fork-convergence #12645 round-3 B, owner-approved: chars/4 family ONLY (words×1.3 family explicitly excluded by owner decision). Canonical lives at `autobot_shared/doc_chunking.py:23` `estimate_tokens(text) = len(text) // 4`, stdlib-only so the standalone CLI can keep importing it. For each of the 4 target sites, I first determined whether the site's constant is a hardcoded literal (safe to repoint) or a genuine runtime config knob (repointing would silently change behavior for any deployment overriding the value), then confirmed numeric equivalence (empty/short/long/unicode) before and after.

## What Changed

Repointed (chars/4 family, hardcoded `4`):
- `autobot-backend/llm_shared/token_budget.py` — `_estimate_tokens(char_count)` removed; `_estimate_request_tokens`/`_estimate_response_tokens` now build the text directly and call the canonical `estimate_tokens`. `max(0, char_count // 4)` is mathematically identical to `estimate_tokens(text)` since char_count = len(text) is never negative.
- `autobot-backend/code_intelligence/llm_pattern_analysis/prompt_analyzer.py` — `PromptAnalyzer.estimate_tokens` now calls `estimate_tokens(text) + 1`, preserving the pre-existing `+1` exactly (per issue instruction — the `+1` could be represented without changing output, so it was kept, not left).
- `autobot-backend/benchmarks/benchmark_belief_state.py` — both `_estimate_tokens` (JSON-serialize helper) and `_assertion_summary_tokens` (same chars/4 family, found while removing the now-unused `_CHARS_PER_TOKEN` constant they both referenced) now delegate the `//4` step to the canonical estimator; the JSON-serialize step and the `max(1, ...)` floor are unchanged.

Left untouched (with inline explanation):
- `autobot-backend/context_window_manager.py:173` `estimate_tokens` — **NOT repointed**. `chars_per_token` is read from `config/context_windows.yaml` (`token_estimation.chars_per_token`, default 4) — a genuine runtime config knob, not a hardcoded constant. Repointing onto the canonical (which hardcodes `//4`) would silently ignore any deployment that configures a different ratio and change history-truncation behavior. Per the issue's explicit conditional, left in place with an inline comment explaining why.

Not touched (owner-excluded words-based family): `memory/essential_story.py`, `services/memory/compression.py`, `api/openai_compat.py`, `knowledge/pipeline/extractors/semantic_chunker.py`. `autobot_shared/doc_chunking.py` itself untouched — remains stdlib-only canonical.

## Verification

Numeric-output equivalence proof (old formula vs. new canonical-delegating code) for empty / short / long / unicode samples — all identical:

```
=== token_budget.py (real import) ===
request  ''                              old=100 new=100 True
response ''                              old=0   new=0   True
request  'hi'                            old=100 new=100 True
response 'hi'                            old=0   new=0   True
request  'The quick brown fox...'x20     old=320 new=320 True
response 'The quick brown fox...'x20     old=220 new=220 True
request  'héllo wörld 日本語テスト €£¥'   old=105 new=105 True
response 'héllo wörld 日本語テスト €£¥'   old=5   new=5   True
multi-message request (3 messages)       old=64  new=64  True

=== prompt_analyzer.py (real import, +1 preserved) ===
''                              old=1   new=1   True
'hi'                            old=1   new=1   True
'The quick brown fox...'x20     old=221 new=221 True
'héllo wörld 日本語テスト €£¥'   old=6   new=6   True

=== benchmark_belief_state.py (JSON-serialize + max(1,...)) ===
{}                                        old=1   new=1   True
{'a': 1}                                  old=2   new=2   True
{'long': 'x'*500, 'list': range(50)}      old=178 new=178 True
{'unicode': 'héllo wörld 日本語'}          old=13  new=13  True
```

Also ran the benchmark script end-to-end (`python3 benchmarks/benchmark_belief_state.py`) — completes successfully with sane token counts.

Test runs:
- `pytest autobot-backend/tests/test_startup_imports.py -q` → 348 passed
- `pytest autobot-backend/tests/llm_shared/test_token_budget.py autobot-backend/context_window_manager_test.py -q` → 51 passed
- `pytest autobot-backend/code_intelligence/llm_pattern_analyzer_test.py -q` → 63 failed, 8 passed — **identical failure set** (diffed) on `origin/Dev_new_gui` before this change; pre-existing broken mock fixtures, unrelated to token estimation, not caused by this PR.
- `pytest autobot_shared/doc_chunking_test.py -q` → 14 passed (canonical untouched, still green)
- Combined startup-import-smoke + affected suites: 399 passed

Closes #12764

## Model Used

Claude Sonnet 5