### PR TITLE
fix(backend): stop import-time Redis storm + fix 2 stale/ambient-state tests (#12674, #12668, #12673)

### DIFF
--- a/autobot-backend/benchmarks/benchmark_belief_state.py
+++ b/autobot-backend/benchmarks/benchmark_belief_state.py
@@ -38,12 +38,12 @@ _autobot_root = _repo_root.parent
 sys.path.insert(0, str(_repo_root))
 sys.path.insert(0, str(_autobot_root))
 
-from autobot_shared.doc_chunking import estimate_tokens as _canonical_estimate_tokens  # noqa: E402
-
 # Import directly from submodules to avoid agent_loop/__init__.py
 # (which imports AgentLoop → heavy FastAPI/Redis/Celery dependencies)
 import importlib.util as _ilu
 import types as _types
+
+from autobot_shared.doc_chunking import estimate_tokens as _canonical_estimate_tokens  # noqa: E402
 
 
 def _load_submodule(dotted_name: str, file_path: Path):
@@ -80,6 +80,7 @@ from agent_loop.belief_state import BeliefStateUpdater  # noqa: E402
 # ---------------------------------------------------------------------------
 # Token-cost estimation helpers
 # ---------------------------------------------------------------------------
+
 
 def _estimate_tokens(obj: Any) -> int:
     """Estimate token count for an arbitrary value by JSON-serialising it.

--- a/autobot-backend/config/config_registry_test.py
+++ b/autobot-backend/config/config_registry_test.py
@@ -126,8 +126,10 @@ class TestConfigRegistryBasic:
 
         ConfigRegistry.clear_cache()
 
+        # "api.port" converts to AUTOBOT_API_PORT — the previous AUTOBOT_BACKEND_API_PORT
+        # never matched, so this asserted the caller default rather than the conversion.
         with patch.object(ConfigRegistry, "_fetch_from_redis", return_value=None):
-            with patch.dict(os.environ, {"AUTOBOT_BACKEND_API_PORT": "9000"}, clear=True):
+            with patch.dict(os.environ, {"AUTOBOT_API_PORT": "9000"}, clear=True):
                 result = ConfigRegistry.get("api.port", default="8001")
                 assert result == "9000"
 
@@ -318,11 +320,15 @@ class TestConfigRegistryDefaults:
 
         ConfigRegistry.clear_cache()
 
+        # Assert the contract (registry defaults are sourced from SSOT), not a
+        # deployment-specific IP literal that only matches one environment.
+        from autobot_shared.ssot_config import config as ssot
+
         with patch.object(ConfigRegistry, "_fetch_from_redis", return_value=None):
             with patch.dict(os.environ, {}, clear=True):
                 # Should get default from registry_defaults
                 result = ConfigRegistry.get("redis.host")
-                assert result == "10.0.0.4"
+                assert result == ssot.vm.redis
 
     def test_get_uses_registry_defaults_for_port(self):
         """Test that get() uses registry defaults for port values."""
@@ -374,14 +380,18 @@ class TestConfigRegistryDefaults:
 
         ConfigRegistry.clear_cache()
 
+        # Assert every vm.* default resolves from SSOT rather than pinning
+        # deployment-specific IP literals, which only match one environment.
+        from autobot_shared.ssot_config import config as ssot
+
         with patch.object(ConfigRegistry, "_fetch_from_redis", return_value=None):
             with patch.dict(os.environ, {}, clear=True):
-                assert ConfigRegistry.get("vm.main") == "10.0.0.1"
-                assert ConfigRegistry.get("vm.frontend") == "10.0.0.2"
-                assert ConfigRegistry.get("vm.npu") == "10.0.0.3"
-                assert ConfigRegistry.get("vm.redis") == "10.0.0.4"
-                assert ConfigRegistry.get("vm.aistack") == "10.0.0.5"
-                assert ConfigRegistry.get("vm.browser") == "10.0.0.6"
+                assert ConfigRegistry.get("vm.main") == ssot.vm.main
+                assert ConfigRegistry.get("vm.frontend") == ssot.vm.frontend
+                assert ConfigRegistry.get("vm.npu") == ssot.vm.npu
+                assert ConfigRegistry.get("vm.redis") == ssot.vm.redis
+                assert ConfigRegistry.get("vm.aistack") == ssot.vm.aistack
+                assert ConfigRegistry.get("vm.browser") == ssot.vm.browser
 
     def test_llm_defaults_available(self):
         """Test that LLM defaults are available."""
@@ -405,3 +415,78 @@ class TestConfigRegistryDefaults:
                 assert ConfigRegistry.get("timeout.http") == "30"
                 assert ConfigRegistry.get("timeout.redis") == "5"
                 assert ConfigRegistry.get("timeout.llm") == "120"
+
+
+class TestRedisConnectBackoff:
+    """_get_redis() failed-connect backoff (Issue #12674).
+
+    Before #12674 a failed connect was never remembered, so every config lookup
+    re-dialled Redis. Importing a module that resolves ~29 config keys with
+    Redis unreachable therefore opened 29 blocking connections and tripped the
+    'main' circuit breaker purely as an import side effect.
+    """
+
+    def test_failed_connect_is_not_retried_within_backoff_window(self):
+        """A failed connect suppresses further dial attempts for the interval."""
+        from config.registry import ConfigRegistry
+
+        ConfigRegistry.clear_cache()
+
+        with patch("autobot_shared.redis_client.get_redis_client", return_value=None) as dial:
+            for _ in range(10):
+                assert ConfigRegistry._get_redis() is None
+            assert dial.call_count == 1
+
+    def test_backoff_expiry_allows_a_fresh_connect_attempt(self):
+        """Once the backoff window lapses, Redis is probed again."""
+        from config.registry import ConfigRegistry
+
+        ConfigRegistry.clear_cache()
+
+        with patch("autobot_shared.redis_client.get_redis_client", return_value=None) as dial:
+            assert ConfigRegistry._get_redis() is None
+            assert dial.call_count == 1
+
+            ConfigRegistry._redis_retry_after = 0.0  # simulate window expiry
+            assert ConfigRegistry._get_redis() is None
+            assert dial.call_count == 2
+
+    def test_circular_import_does_not_arm_backoff(self):
+        """ImportError is transient (network_constants ↔ redis_client), not an outage.
+
+        Arming the backoff here would wrongly degrade config to
+        env/registry_defaults for the whole window on a healthy system.
+        """
+        from config.registry import ConfigRegistry
+
+        ConfigRegistry.clear_cache()
+
+        with patch.dict("sys.modules", {"autobot_shared.redis_client": None}):
+            assert ConfigRegistry._get_redis() is None
+        assert ConfigRegistry._redis_retry_after == 0.0
+
+    def test_successful_connect_is_cached_and_reused(self):
+        """A healthy Redis is dialled once and reused, backoff never armed."""
+        from config.registry import ConfigRegistry
+
+        ConfigRegistry.clear_cache()
+        client = MagicMock()
+
+        with patch("autobot_shared.redis_client.get_redis_client", return_value=client) as dial:
+            for _ in range(5):
+                assert ConfigRegistry._get_redis() is client
+            assert dial.call_count == 1
+        assert ConfigRegistry._redis_retry_after == 0.0
+
+    def test_clear_cache_resets_backoff(self):
+        """clear_cache() re-enables immediate probing."""
+        from config.registry import ConfigRegistry
+
+        ConfigRegistry.clear_cache()
+
+        with patch("autobot_shared.redis_client.get_redis_client", return_value=None):
+            ConfigRegistry._get_redis()
+        assert ConfigRegistry._redis_retry_after > 0.0
+
+        ConfigRegistry.clear_cache()
+        assert ConfigRegistry._redis_retry_after == 0.0

--- a/autobot-backend/config/registry.py
+++ b/autobot-backend/config/registry.py
@@ -40,6 +40,13 @@ logger = logging.getLogger(__name__)
 # Redis key prefix for all config values
 REDIS_CONFIG_PREFIX = "autobot:config:"
 
+# Issue #12674: how long to stop re-dialling Redis after a failed connect.
+# Without this the registry re-attempted a blocking sync connect on EVERY
+# lookup, so a single import that resolves ~29 config keys with Redis
+# unreachable opened 29 connections and tripped the 'main' circuit breaker.
+# Bounded so a Redis that comes up after the config layer is still picked up.
+REDIS_RETRY_INTERVAL_SECONDS = float(os.getenv("AUTOBOT_CONFIG_REGISTRY_REDIS_RETRY_SECONDS", "30"))
+
 
 class ConfigRegistry:
     """
@@ -57,6 +64,9 @@ class ConfigRegistry:
     _lock = threading.RLock()
     _ttl_seconds = 60
     _initialized = False
+    # Issue #12674: monotonic deadline before which _get_redis() skips dialling
+    # Redis because the previous connect attempt failed.
+    _redis_retry_after: float = 0.0
 
     @classmethod
     def get(cls, key: str, default: Any = None) -> Any:
@@ -138,16 +148,47 @@ class ConfigRegistry:
 
     @classmethod
     def _get_redis(cls):
-        """Lazy Redis connection - only when first needed."""
-        if cls._redis_client is None:
+        """Lazy Redis connection - only when first needed.
+
+        Issue #12674: a failed connect is remembered for
+        ``REDIS_RETRY_INTERVAL_SECONDS`` instead of being retried on every
+        lookup. Redis is an optional tier in the fallback chain, so when it is
+        unreachable the registry must degrade to env/registry_defaults without
+        spending a blocking connect (and a circuit-breaker failure) per key.
+        """
+        if cls._redis_client is not None:
+            return cls._redis_client
+
+        with cls._lock:
+            if cls._redis_client is not None:
+                return cls._redis_client
+            if time.monotonic() < cls._redis_retry_after:
+                return None
+
             try:
                 from autobot_shared.redis_client import get_redis_client
+            except ImportError as e:
+                # Transient, NOT a Redis outage: autobot_shared.redis_client
+                # imports network_constants, whose module-level constants resolve
+                # through this registry while network_constants is still
+                # mid-import. Returning None lets the caller fall back to
+                # env/registry_defaults; arming the retry guard here would
+                # wrongly suppress Redis-backed config on a healthy system.
+                logger.debug("Redis client not importable yet (circular import): %s", e)
+                return None
 
-                cls._redis_client = get_redis_client(database="main")
+            try:
+                client = get_redis_client(database="main")
             except Exception as e:
                 logger.debug("Redis connection failed: %s", e)
+                client = None
+
+            if client is None:
+                cls._redis_retry_after = time.monotonic() + REDIS_RETRY_INTERVAL_SECONDS
                 return None
-        return cls._redis_client
+
+            cls._redis_client = client
+            return client
 
     @classmethod
     def clear_cache(cls) -> None:
@@ -156,6 +197,9 @@ class ConfigRegistry:
             cls._cache.clear()
             cls._cache_timestamps.clear()
             cls._redis_client = None
+            # Issue #12674: also drop the failed-connect backoff so a cleared
+            # registry re-probes Redis immediately instead of staying degraded.
+            cls._redis_retry_after = 0.0
 
     @classmethod
     def get_section(cls, prefix: str) -> Dict[str, Any]:

--- a/autobot-backend/config/service_config.py
+++ b/autobot-backend/config/service_config.py
@@ -25,8 +25,6 @@ _LMSTUDIO_HOST = _lmstudio_parsed.hostname or "127.0.0.1"
 _LMSTUDIO_PORT = _lmstudio_parsed.port or 1234
 
 # Issue #380: Module-level cached maps to avoid repeated dictionary creation
-# Issue #1214: Ollama host resolved via ConfigRegistry (SLM-managed, not
-# hardcoded to any VM). ConfigRegistry checks Redis → env → registry_defaults.
 _HOST_SERVICE_MAP = {
     "slm": NetworkConstants.SLM_VM_IP,
     "backend": NetworkConstants.MAIN_MACHINE_IP,
@@ -35,12 +33,26 @@ _HOST_SERVICE_MAP = {
     "npu_worker": NetworkConstants.NPU_WORKER_VM_IP,
     "ai_stack": NetworkConstants.AI_STACK_VM_IP,
     "browser": NetworkConstants.BROWSER_VM_IP,
-    "ollama": ConfigRegistry.get("vm.ollama", "127.0.0.1"),
     "browser_service": NetworkConstants.BROWSER_VM_IP,
     "openai": "api.openai.com",
     "anthropic": "api.anthropic.com",
     "vllm": "localhost",
     "lmstudio": _LMSTUDIO_HOST,
+}
+
+# Issue #1214: Ollama host is SLM-managed (not hardcoded to any VM) and resolved
+# via ConfigRegistry, which checks Redis → env → registry_defaults behind its own
+# TTL cache.
+#
+# Issue #12674: resolve it at call time, never at import. This module sits on the
+# logging-manager init path, so a module-level ConfigRegistry.get() made merely
+# importing anything that logs (e.g. utils.chromadb_client) open five blocking
+# sync Redis connections and trip the 'main' circuit breaker before any Redis
+# client method was ever called. Call-time resolution also lets an SLM host
+# change take effect within the ConfigRegistry TTL instead of being frozen for
+# the lifetime of the process.
+_DYNAMIC_HOST_RESOLVERS = {
+    "ollama": lambda: ConfigRegistry.get("vm.ollama", "127.0.0.1"),
 }
 
 _PORT_SERVICE_MAP = {
@@ -73,7 +85,8 @@ class ServiceConfigMixin:
         Priority order:
         1. Environment variable AUTOBOT_{SERVICE}_HOST
         2. Config file infrastructure.hosts.{service}
-        3. Hardcoded fallback map
+        3. Call-time resolver for SLM-managed hosts (Issue #12674)
+        4. Hardcoded fallback map
 
         Args:
             service: Service name (e.g., 'backend', 'redis', 'frontend', 'ollama')
@@ -92,7 +105,12 @@ class ServiceConfigMixin:
         if host:
             return host
 
-        # 3. Fallback to module-level cached map (Issue #380)
+        # 3. SLM-managed hosts resolve lazily, never at import time (Issue #12674)
+        resolver = _DYNAMIC_HOST_RESOLVERS.get(service)
+        if resolver is not None:
+            return resolver()
+
+        # 4. Fallback to module-level cached map (Issue #380)
         return _HOST_SERVICE_MAP.get(service, "localhost")
 
     def get_port(self, service: str) -> int:

--- a/autobot-backend/monitoring/prometheus_metrics_test.py
+++ b/autobot-backend/monitoring/prometheus_metrics_test.py
@@ -55,27 +55,27 @@ class TestPrometheusMetricsManager:
         assert hasattr(metrics_manager, "requests_total")
         assert hasattr(metrics_manager, "success_rate")
 
-        # Verify workflow metrics
-        assert hasattr(metrics_manager, "workflow_executions_total")
-        assert hasattr(metrics_manager, "workflow_duration")
-        assert hasattr(metrics_manager, "workflow_steps_executed")
-        assert hasattr(metrics_manager, "active_workflows")
-        assert hasattr(metrics_manager, "workflow_approvals")
+        # Verify workflow metrics (#394: delegated to WorkflowMetricsRecorder)
+        assert metrics_manager._workflow is not None
+        assert callable(metrics_manager.record_workflow_execution)
+        assert callable(metrics_manager.record_workflow_step)
+        assert callable(metrics_manager.update_active_workflows)
+        assert callable(metrics_manager.record_workflow_approval)
 
-        # Verify GitHub metrics
-        assert hasattr(metrics_manager, "github_operations_total")
-        assert hasattr(metrics_manager, "github_api_duration")
-        assert hasattr(metrics_manager, "github_rate_limit_remaining")
-        assert hasattr(metrics_manager, "github_commits")
-        assert hasattr(metrics_manager, "github_pull_requests")
-        assert hasattr(metrics_manager, "github_issues")
+        # Verify GitHub metrics (#394: delegated to GitHubMetricsRecorder)
+        assert metrics_manager._github is not None
+        assert callable(metrics_manager.record_github_operation)
+        assert callable(metrics_manager.update_github_rate_limit)
+        assert callable(metrics_manager.record_github_commit)
+        assert callable(metrics_manager.record_github_pull_request)
+        assert callable(metrics_manager.record_github_issue)
 
-        # Verify task metrics
-        assert hasattr(metrics_manager, "tasks_executed_total")
-        assert hasattr(metrics_manager, "task_duration")
-        assert hasattr(metrics_manager, "active_tasks")
-        assert hasattr(metrics_manager, "task_queue_size")
-        assert hasattr(metrics_manager, "task_retries")
+        # Verify task metrics (#394: delegated to TaskMetricsRecorder)
+        assert metrics_manager._task is not None
+        assert callable(metrics_manager.record_task_execution)
+        assert callable(metrics_manager.update_active_tasks)
+        assert callable(metrics_manager.update_task_queue_size)
+        assert callable(metrics_manager.record_task_retry)
 
     # ===== Workflow Metrics Tests =====
 

--- a/autobot-backend/tests/services/rag_service_events_test.py
+++ b/autobot-backend/tests/services/rag_service_events_test.py
@@ -44,6 +44,31 @@ def _bind_real_rag_service() -> None:
 
 _bind_real_rag_service()
 
+
+@pytest.fixture(autouse=True)
+def isolate_hash_cache(tmp_path, monkeypatch):
+    """Isolate the doc-indexer hash cache from ambient on-disk state (#12673).
+
+    ``RAGService._filter_stale_chunks`` reads ``doc_indexer.HASH_CACHE_FILE``
+    through a module-level TTL memo. Without isolation the suite picks up the
+    real ``data/.doc_index_hashes.json`` that exists on any machine where the
+    indexer has run, so the provenance filter drops every test-double chunk.
+    Point the cache at an absent tmp path and reset the memo around each test;
+    classes needing a populated cache patch ``HASH_CACHE_FILE`` themselves.
+    """
+    import services.rag_service as rag_mod
+
+    monkeypatch.setattr(
+        "services.knowledge.doc_indexer.HASH_CACHE_FILE",
+        tmp_path / "absent_doc_index_hashes.json",
+    )
+    rag_mod._hash_cache_memo = {}
+    rag_mod._hash_cache_loaded_at = 0.0
+    yield
+    rag_mod._hash_cache_memo = {}
+    rag_mod._hash_cache_loaded_at = 0.0
+
+
 # =============================================================================
 # _emit_retrieval_feedback Tests
 # =============================================================================
@@ -760,18 +785,11 @@ class TestRetrievedVsRankedIdsSeparation:
 
 
 class TestFilterStaleChunks:
-    """Tests for RAGService._filter_stale_chunks() — provenance validation."""
+    """Tests for RAGService._filter_stale_chunks() — provenance validation.
 
-    @pytest.fixture(autouse=True)
-    def reset_hash_cache_memo(self):
-        """Reset module-level TTL cache before each test to ensure isolation."""
-        import services.rag_service as rag_mod
-
-        rag_mod._hash_cache_memo = {}
-        rag_mod._hash_cache_loaded_at = 0.0
-        yield
-        rag_mod._hash_cache_memo = {}
-        rag_mod._hash_cache_loaded_at = 0.0
+    Hash-cache isolation comes from the module-level ``isolate_hash_cache``
+    fixture; tests here patch ``HASH_CACHE_FILE`` to a populated tmp file.
+    """
 
     def _make_service(self):
         from services.rag_service import RAGService
@@ -983,17 +1001,6 @@ class TestFallbackBasicSearchFiltersStaleChunks:
     Issue #4721: the fallback path previously returned results without calling
     _filter_stale_chunks(), silently returning stale/moved source paths.
     """
-
-    @pytest.fixture(autouse=True)
-    def reset_hash_cache_memo(self):
-        """Reset module-level TTL cache before each test to ensure isolation."""
-        import services.rag_service as rag_mod
-
-        rag_mod._hash_cache_memo = {}
-        rag_mod._hash_cache_loaded_at = 0.0
-        yield
-        rag_mod._hash_cache_memo = {}
-        rag_mod._hash_cache_loaded_at = 0.0
 
     def _make_service(self):
         from services.rag_service import RAGService


### PR DESCRIPTION
## Thinking Path

Three open backend defects batched into one PR — all are "code/tests behave differently depending on ambient environment state", same scope and risk profile.

Each was reproduced first, then root-caused rather than patched at the symptom.

**#12674 — the reported root cause was wrong.** The issue pointed at `ssot_config` eagerly probing Redis. Tracing the actual call stack showed `ssot_config` is innocent. Two real findings:

1. `ConfigRegistry._get_redis()` never remembered a failed connect, so it re-dialled Redis on **every** lookup. Instrumenting `ConfigRegistry.get` showed the import chain resolves **29** config keys — 25 from `autobot_shared/network_constants.py` module-level constants, plus `config/defaults.py` and `config/service_config.py`. Each key cost a blocking connect plus a circuit-breaker failure. The "5x" in the report is simply the breaker threshold capping the visible warnings, not the number of eager sites.
2. There is a genuine circular import: `network_constants` → `config.registry` → `autobot_shared.redis_client` → `network_constants` (still mid-import) → `ImportError`. A first attempt at the fix armed the backoff on that ImportError, which would have wrongly degraded config to env/registry_defaults for the whole window on a **healthy** system. The failure modes are now distinguished explicitly.

**#12673** reproduced only when `data/.doc_index_hashes.json` exists — i.e. on any machine where the doc indexer has run. `TestRetrievedVsRankedIdsSeparation` was the one provenance-touching class without the hash-cache isolation fixture its two siblings already had.

**#12668** is straightforward drift: #394 moved `PrometheusMetricsManager` to domain recorders; the test still asserted the pre-#394 flat attributes.

## What Changed

**`config/registry.py`** — remember a failed connect for `REDIS_RETRY_INTERVAL_SECONDS` (env-tunable, no hard-coded TTL) and skip dialling within that window. `ImportError` is explicitly **not** treated as an outage. `clear_cache()` resets the backoff.

**`config/service_config.py`** — resolve the SLM-managed ollama host at call time via `_DYNAMIC_HOST_RESOLVERS` instead of at import. This module sits on the logging-manager init path, so a module-level `ConfigRegistry.get()` made merely importing anything that logs hit Redis. Side benefit: an SLM host change now takes effect within the ConfigRegistry TTL instead of being frozen for the process lifetime.

**`tests/services/rag_service_events_test.py`** — hoist the hash-cache isolation fixture to module scope so it covers every class, and point `HASH_CACHE_FILE` at an absent tmp path. The two per-class copies are now redundant and removed.

**`monitoring/prometheus_metrics_test.py`** — assert the real post-#394 API (recorder objects + public `record_*` methods) instead of removed flat attributes.

**`config/config_registry_test.py`** — adds `TestRedisConnectBackoff` (5 tests) covering backoff, expiry, the circular-import carve-out, successful-connect caching, and `clear_cache()` reset. Also fixes 3 pre-existing failures found along the way (CLAUDE.md Rule 6): two pinned deployment-specific IP literals rather than the SSOT contract, one used an env var name the dot-to-underscore conversion never produces.

## Verification

**#12674** — import-time behaviour, 3 consecutive runs each:

| | connect failures | breaker trips |
|---|---|---|
| baseline (`Dev_new_gui`) | 5, 5, 5 | yes |
| this branch | 1, 1, 1 | none |

Fallback chain confirmed intact after the change (`vm.main` → registry default, `deployment.mode` → `distributed`, unknown key → caller default), and a fresh connect is re-attempted once the backoff window lapses.

**#12673** — reproduced the exact 5 reported failures by seeding `data/.doc_index_hashes.json`, then re-ran under the same condition:

```
before: 5 failed, 33 passed   (TestRetrievedVsRankedIdsSeparation)
after:  38 passed
```

**#12668** — `monitoring/prometheus_metrics_test.py`: `40 passed, 2 skipped` (was 1 failed).

**Both fixed files together:** `78 passed, 2 skipped`.

**No regressions** — full `config/` suite, this branch vs unmodified base:

```
baseline:     12 failed, 85 passed
this branch:   9 failed, 93 passed
```

The 9 remaining are byte-identical to baseline (`config_migration_integration_test`, `timeout_configuration_test`, `validation_test`) and are pre-existing/out of scope — filed separately rather than dropped.

## Model Used

Claude Opus 5 (1M context)

Closes #12674, #12668, #12673