### PR TITLE
fix(slm): detach self-update into a transient systemd SERVICE, not a --scope (#12596)

### DIFF
--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -44,8 +44,19 @@ ANSIBLE_LOCAL_TMP = f"/tmp/ansible_local_tmp_{os.getuid()}"  # nosec B108
 # KillMode=control-group, so systemd SIGTERMs the whole cgroup on restart —
 # including the ansible-playbook child — killing the run before Play 1's tail
 # and all of Play 2/3 execute. Detaching that one run into its own transient
-# systemd scope (a separate cgroup) lets it survive the restart.
+# systemd unit (a separate cgroup) lets it survive the restart.
 SELF_UPDATE_DETACH_UNIT_PREFIX = os.getenv("SLM_SELF_UPDATE_UNIT_PREFIX", "autobot-selfupdate")
+
+# #12596: the detached run must be a transient SERVICE in system.slice, never
+# a --scope. A scope's payload stays a descendant of the invoking process, so
+# one created from inside autobot-slm-backend is nested in that service's
+# cgroup subtree and Play 1's `systemctl restart autobot-slm-backend` tears it
+# down mid-run — the exact failure #11492/#12567 were meant to prevent (Play 2/3
+# never ran; the app tier and workers stayed stale while the run reported OK).
+# A transient service is forked by PID 1, so it is not in this backend's cgroup
+# at all. Pinning the slice explicitly keeps that true even if this service is
+# ever given cgroup delegation.
+SELF_UPDATE_DETACH_SLICE = os.getenv("SLM_SELF_UPDATE_SLICE", "system.slice")
 
 # Env vars forwarded to the detached scope via explicit --setenv=NAME=VALUE.
 # `sudo` (env_reset, see setup-passwordless-sudo.yml) strips the environment
@@ -76,7 +87,7 @@ ANSIBLE_ENV_ALLOWLIST_EXACT = (
 # still running) ansible-playbook process would raise BrokenPipeError,
 # killing Play 2/3 exactly like the cgroup-kill this fix exists to prevent.
 # The detached run's stdout/stderr are redirected to this file instead of the
-# backend's pipe (see _wrap_with_systemd_scope), so a dead backend can never
+# backend's pipe (see _wrap_with_systemd_unit), so a dead backend can never
 # crash it; this backend tails the same file for live progress while it is
 # still alive. Mirrors the existing /var/log/autobot/provision-wizard.log
 # precedent (api/setup_wizard.py).
@@ -535,7 +546,7 @@ class PlaybookExecutor:
         """Whether the self-update run can be detached into its own scope (#11492).
 
         Both must hold:
-          - ``systemd-run`` is on PATH (creates the transient scope)
+          - ``systemd-run`` is on PATH (creates the transient service)
           - this process is itself managed by systemd — ``INVOCATION_ID`` is set
             only for units systemd starts, so it precisely answers "are we
             running as a systemd service" (as opposed to `sd_booted()`-style
@@ -572,7 +583,7 @@ class PlaybookExecutor:
         """Create/truncate a fresh log file for this detached run (#11492).
 
         The detached ansible-playbook process's stdout/stderr are redirected
-        here (see _wrap_with_systemd_scope) instead of the backend's pipe, so
+        here (see _wrap_with_systemd_unit) instead of the backend's pipe, so
         a dead backend can never BrokenPipe-crash Play 2/3.
 
         Returns None on failure — the caller (#12425) falls back to a
@@ -599,19 +610,38 @@ class PlaybookExecutor:
         allowed = SYSTEMD_RUN_ENV_ALLOWLIST_EXACT + ANSIBLE_ENV_ALLOWLIST_EXACT
         return [f"--setenv={key}={env[key]}" for key in allowed if key in env]
 
-    def _wrap_with_systemd_scope(self, cmd: List[str], env: Dict[str, str], log_path: Path) -> List[str]:
-        """Wrap an ansible-playbook cmd to run detached, file-backed (#11492).
+    def _wrap_with_systemd_unit(self, cmd: List[str], env: Dict[str, str], log_path: Path) -> List[str]:
+        """Wrap an ansible-playbook cmd to run detached, file-backed (#11492, #12596).
 
         Two layers:
-          - ``sudo -n systemd-run --scope --collect``: a separate transient
-            scope = a separate cgroup, so ``systemctl restart
-            autobot-slm-backend`` (KillMode=control-group) no longer SIGTERMs
-            this run. ``sudo`` mirrors the existing privilege pattern already
-            used for service restarts (_restart_slm_service) — the
-            passwordless-sudo sudoers rule this service already relies on;
-            ``-n`` (non-interactive) fast-fails instead of hanging on a
-            password prompt if that sudoers rule is ever misconfigured.
-            ``--uid``/``--gid`` drop back to the caller's own identity so
+          - ``sudo -n systemd-run --collect --unit=… --slice=system.slice``: a
+            transient **service**, forked by PID 1 into its own cgroup under
+            ``system.slice``.
+
+            #12596: this was previously ``--scope``, which does NOT survive.
+            A scope keeps the payload as a descendant of the *invoking*
+            process, so a scope created from inside ``autobot-slm-backend``
+            lands in that service's cgroup subtree; Play 1's own ``systemctl
+            restart autobot-slm-backend`` (KillMode=control-group) then tore
+            the nested scope down with the service and the run died at the end
+            of Play 1 — before Play 2/3 deployed the co-located app tier and
+            workers. A transient service is owned by PID 1, not by this
+            backend, so restarting this backend cannot control-group-kill it.
+            ``--slice=system.slice`` states that placement explicitly rather
+            than relying on the default, so inherited cgroup delegation can
+            never silently re-nest the unit under the caller again.
+
+            ``--wait`` preserves the pre-#12596 blocking semantics and exit-code
+            propagation for detached runs that do NOT restart this backend. When
+            the restart does land, only this waiting client is killed — the
+            transient service keeps running to completion on its own.
+
+            ``sudo`` mirrors the existing privilege pattern already used for
+            service restarts (_restart_slm_service) — the passwordless-sudo
+            sudoers rule this service already relies on; ``-n``
+            (non-interactive) fast-fails instead of hanging on a password
+            prompt if that sudoers rule is ever misconfigured. ``--uid``/
+            ``--gid`` drop back to the caller's own identity so
             ansible-playbook still runs as the SLM service user, not root;
             ``--working-directory`` replaces the ``cwd=`` kwarg systemd-run
             does not inherit.
@@ -630,9 +660,10 @@ class PlaybookExecutor:
             "sudo",
             "-n",
             "systemd-run",
-            "--scope",
             "--collect",
+            "--wait",
             f"--unit={unit_name}",
+            f"--slice={SELF_UPDATE_DETACH_SLICE}",
             f"--uid={os.getuid()}",
             f"--gid={os.getgid()}",
             f"--working-directory={self.ansible_dir}",
@@ -690,8 +721,8 @@ class PlaybookExecutor:
             )
             return cmd, None
 
-        logger.info("Self-update run detached into transient systemd scope, output -> %s", log_path)
-        return self._wrap_with_systemd_scope(cmd, env, log_path), log_path
+        logger.info("Self-update run detached into transient systemd service, output -> %s", log_path)
+        return self._wrap_with_systemd_unit(cmd, env, log_path), log_path
 
     async def _run_subprocess(
         self,
@@ -707,7 +738,7 @@ class PlaybookExecutor:
 
         Args:
             detach: When True AND the runtime supports it (#11492), wrap the
-                command in ``systemd-run --scope --collect`` with file-backed
+                command in a ``systemd-run`` transient service with file-backed
                 stdout/stderr so it survives a same-process ``systemctl
                 restart autobot-slm-backend`` mid-run (the self-update path)
                 without a dead backend's pipe crashing it. Falls back to the
@@ -723,7 +754,7 @@ class PlaybookExecutor:
         if detach:
             effective_cmd, log_path = self._prepare_detached_run(cmd, env)
             if log_path is not None:
-                # Real output goes to the file (see _wrap_with_systemd_scope);
+                # Real output goes to the file (see _wrap_with_systemd_unit);
                 # nothing meaningful is expected on this outer pipe, and
                 # leaving it as PIPE-but-unread risks the wrapper deadlocking
                 # once the OS pipe buffer fills.
@@ -832,7 +863,7 @@ class PlaybookExecutor:
             check_mode: Run in check mode (dry run)
             progress_callback: Async function to call with progress updates
             inventory_path: Override inventory file (Issue #1294, wizard provisioning)
-            detach: Run detached in its own systemd scope (#11492). Only pass
+            detach: Run detached in its own systemd service (#11492, #12596). Only pass
                 True for the SLM self-update path (the run that restarts
                 autobot-slm-backend); ordinary per-role/per-node deploys leave
                 this False, since they don't kill their own process.

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -11,11 +11,17 @@ systemd SIGTERMs the whole cgroup — including the ansible-playbook child —
 before Play 1's tail and all of Play 2/3 ever run.
 
 The fix has two parts:
-  1. Detach that one run into its own transient systemd scope
-     (`systemd-run --scope --collect`, a separate cgroup) so it survives the
-     restart, gated to the self-update path only and falling back to the
-     direct exec when systemd-run / a systemd-service context is unavailable
-     (dev mode, tests, containers).
+  1. Detach that one run into its own transient systemd unit (a separate
+     cgroup) so it survives the restart, gated to the self-update path only
+     and falling back to the direct exec when systemd-run / a systemd-service
+     context is unavailable (dev mode, tests, containers).
+
+     #12596: that unit must be a transient SERVICE (`systemd-run --collect
+     --wait --slice=system.slice`), not a `--scope`. A scope keeps its payload
+     a descendant of the invoking process, so a scope created from inside
+     autobot-slm-backend stayed nested in that service's cgroup subtree and
+     the Play-1 restart tore it down anyway — Play 2/3 never ran while the
+     update still reported success.
   2. File-back the detached run's stdout/stderr (never the backend's pipe):
      once the backend dies, the pipe's read end closes, and a further write
      from the still-running ansible-playbook would raise BrokenPipeError —
@@ -152,19 +158,23 @@ def test_prepare_self_update_log_file_returns_none_on_failure(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_wrap_with_systemd_scope_builds_expected_command(tmp_path):
+def test_wrap_with_systemd_unit_builds_expected_command(tmp_path):
     ex = _executor(tmp_path)
     cmd = ["/usr/bin/ansible-playbook", "-i", "inv.yml", "update-all-nodes.yml"]
     env = {"ANSIBLE_FORCE_COLOR": "0", "PATH": "/usr/bin", "SECRET_TOKEN": "s3cr3t"}
     log_path = tmp_path / "self-update-ansible.log"
 
-    wrapped = ex._wrap_with_systemd_scope(cmd, env, log_path)
+    wrapped = ex._wrap_with_systemd_unit(cmd, env, log_path)
 
     assert wrapped[0] == "sudo"
     assert wrapped[1] == "-n"  # non-interactive: fast-fail, never hang on a password prompt
     assert wrapped[2] == "systemd-run"
-    assert "--scope" in wrapped
+    # #12596: a transient SERVICE (PID 1-owned), never a --scope nested in this
+    # backend's cgroup — see test_detached_run_is_a_transient_service_not_a_scope.
+    assert "--scope" not in wrapped
     assert "--collect" in wrapped
+    assert "--wait" in wrapped
+    assert f"--slice={_pe.SELF_UPDATE_DETACH_SLICE}" in wrapped
     assert any(a.startswith("--unit=autobot-selfupdate-") for a in wrapped)
     assert f"--uid={os.getuid()}" in wrapped
     assert f"--gid={os.getgid()}" in wrapped
@@ -245,7 +255,7 @@ async def test_run_subprocess_wraps_file_backed_when_systemd_available(tmp_path)
     assert argv[0] == "sudo"
     assert argv[1] == "-n"
     assert argv[2] == "systemd-run"
-    assert "--scope" in argv
+    assert "--scope" not in argv  # #12596: transient service, not a nested scope
     assert "--collect" in argv
     tail = list(argv[argv.index("--") + 1 :])
     assert tail[:2] == ["/bin/sh", "-c"]
@@ -426,3 +436,63 @@ async def test_tail_playbook_log_parses_existing_lines_then_stops(tmp_path):
     stages = [p["stage"] for p in seen]
     assert "play1_start" in stages
     assert "slm_restarting" in stages
+
+
+# ---------------------------------------------------------------------------
+# #12596: the detached run must not be nested in this backend's cgroup
+# ---------------------------------------------------------------------------
+
+
+def test_detached_run_is_a_transient_service_not_a_scope(tmp_path):
+    """The self-update run must survive Play 1's own SLM restart.
+
+    #11492/#12567 detached via ``systemd-run --scope``. A scope keeps its
+    payload a descendant of the *invoking* process, so a scope created from
+    inside ``autobot-slm-backend`` is nested in that service's cgroup subtree.
+    Play 1 then runs ``systemctl restart autobot-slm-backend`` and systemd
+    (KillMode=control-group) tore the nested scope down with the service —
+    the run died at the end of Play 1 and Play 2/3 never deployed the
+    co-located app tier or the workers, while the update still reported OK.
+
+    A transient service is forked by PID 1 and lives in ``system.slice``, so
+    restarting this backend cannot control-group-kill it.
+    """
+    ex = _executor(tmp_path)
+    wrapped = ex._wrap_with_systemd_unit(
+        ["/usr/bin/ansible-playbook", "update-all-nodes.yml"],
+        {"PATH": "/usr/bin"},
+        tmp_path / "self-update.log",
+    )
+
+    # The regression itself: --scope must never come back.
+    assert "--scope" not in wrapped
+
+    # Placement is stated explicitly, so cgroup delegation on this service can
+    # never silently re-nest the unit under the caller again.
+    assert f"--slice={_pe.SELF_UPDATE_DETACH_SLICE}" in wrapped
+    assert _pe.SELF_UPDATE_DETACH_SLICE == "system.slice"
+
+    # Named + garbage-collected so repeat runs neither collide nor leak units.
+    assert any(a.startswith("--unit=autobot-selfupdate-") for a in wrapped)
+    assert "--collect" in wrapped
+
+
+def test_detached_service_waits_so_exit_code_still_propagates(tmp_path):
+    """--wait preserves the pre-#12596 blocking semantics.
+
+    Without it, ``systemd-run`` in service mode returns as soon as the unit has
+    been *started*, so a detached run that does not restart this backend would
+    report success immediately and the caller would lose the real exit code.
+    When the Play-1 restart does land, only this waiting client is killed — the
+    transient service keeps running to completion on its own.
+    """
+    ex = _executor(tmp_path)
+    wrapped = ex._wrap_with_systemd_unit(
+        ["/usr/bin/ansible-playbook", "update-all-nodes.yml"],
+        {"PATH": "/usr/bin"},
+        tmp_path / "self-update.log",
+    )
+
+    assert "--wait" in wrapped
+    # --wait must be an option to systemd-run, not an argument to the payload.
+    assert wrapped.index("--wait") < wrapped.index("--")


### PR DESCRIPTION
## Thinking Path

#12596 was diagnosed from a real monitored Update-All: the detach *activates* (the #12425/#12567 fix held — transient unit + writable log, no "running attached"), but the log contains **Play 0 and Play 1 only**, ends at Play 1's `Restart SLM agent` handler, and its last write lands ~7s before `autobot-slm-backend`'s `ActiveEnterTimestamp`. So the run dies exactly when the Play-1 restart's SIGTERM lands.

The issue's hypothesis was right, and `systemd-run --help` states the mechanism outright:

```
--scope    Run this as scope rather than service
```

A **scope** does not ask PID 1 to fork anything — the payload stays a descendant of the *invoking* process. A scope created from inside `autobot-slm-backend` is therefore nested in that service's cgroup subtree, and `systemctl restart autobot-slm-backend` (KillMode=control-group) tears it down with the service. Detaching into a scope never actually escaped the cgroup; it only looked like it did, because the log and the transient unit name both appeared.

A **transient service** is forked by PID 1 into its own cgroup under `system.slice`, entirely outside this backend's control group — so restarting this backend cannot kill it.

I also checked the sudoers constraint before changing the argv: the SLM user's rule is `NOPASSWD: ALL` (`autobot-slm-backend/ansible/fix-sudo.yml`), not an exact-match command list, so changing systemd-run's flags cannot break the sudo path.

## What Changed

`autobot-slm-backend/services/playbook_executor.py`:

- **Dropped `--scope`** — systemd-run now creates a transient service. This is the fix.
- **Added `--slice=system.slice`** via a new env-tunable `SELF_UPDATE_DETACH_SLICE` constant. The default placement would already be `system.slice`, but stating it explicitly means cgroup delegation on this service can never silently re-nest the unit under the caller again (note `systemd-run` also has a `--slice-inherit` mode — pinning the slice makes the invariant unambiguous).
- **Added `--wait`** to preserve the pre-#12596 blocking semantics and exit-code propagation. Without it, service-mode `systemd-run` returns as soon as the unit has *started*, so a detached run that does not restart this backend would report success immediately and lose the real exit code. When the Play-1 restart does land, only this waiting client is killed — the transient service runs to completion on its own, which is the whole point.
- **Renamed** `_wrap_with_systemd_scope` → `_wrap_with_systemd_unit` so the name matches what it builds; all comments and the log line ("transient systemd scope" → "transient systemd service") updated to match.

## Verification

Flags validated against the local `systemd-run` (not assumed):

```
--scope                      Run this as scope rather than service
--slice=SLICE                Run in the specified slice
--wait                       Wait until service stopped again
--uid=USER / --gid=GROUP / --working-directory=PATH
-G --collect                 Unload unit after it ran, even when failed
```

Tests — the two argv assertions that pinned `--scope` now assert its **absence**, plus two new regression tests (`test_detached_run_is_a_transient_service_not_a_scope`, `test_detached_service_waits_so_exit_code_still_propagates`):

```
$ python3 -m pytest tests/services/test_self_update_systemd_detach_11492.py -q
18 passed

$ python3 -m pytest tests/services/ -q
350 passed, 1 skipped
```

## Live verification still required — do NOT close #12596 on this PR alone

This change cannot be proven locally: it depends on systemd cgroup semantics on the real co-located node, and the bug was only ever observable in a real monitored Update-All. The issue stays open until a live run confirms:

- the self-update log contains a `PLAY [Play 2` header **and** a `PLAY RECAP`
- the app tier and workers advance (their `ActiveEnterTimestamp`s move)

One residual risk worth watching on that run: for a transient **service**, `--uid=<numeric>` maps to `User=`, resolved by PID 1 rather than applied by systemd-run itself as it was under `--scope`. The SLM's `autobot` user exists in passwd so this should be a non-event — and if it ever were not, the unit would fail to start **loudly** rather than silently skipping Play 2, which is strictly better than today's failure mode.

The issue's third ask — a standing regression check asserting Play 2 ran — is deliberately **not** in this PR: nothing currently reads the self-update log post-hoc (`SELF_UPDATE_LOG_PATH` is write-only today), so it needs a new reader wired into code-sync status. Filed separately rather than half-built here.

## Model Used

Claude Opus 5 (1M context)

Closes #12596
Refs #11820, #12776

> **Linkage note:** `Closes #12596` is present because the `Validate PR Issue Link` gate requires it on an `issue-12596` branch. It does **not** auto-close the issue — this PR targets `Dev_new_gui`, not the default branch, so GitHub's auto-close does not fire (confirmed on PR #12772, whose three issues all stayed open after merge and were closed by hand with evidence). #12596 will be left **open** deliberately until the live Update-All run above confirms Play 2 executes. #12425 and #12567 were both closed on this same bug without a live run; this is the third attempt, so it does not get closed on code review alone.
>
> (An earlier `Validate PR Issue Link` failure on this PR was a stale rerun: re-running a workflow replays the *original* event payload, so it re-evaluated the pre-edit body. The run triggered by the edit itself passed.)