### PR TITLE
feat(deploy): per-component resolve for worker components (#12450)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1213,6 +1213,50 @@ _COMPONENT_FRONTEND_DIRS: Dict[str, str] = {
     "autobot-slm-frontend": "/opt/autobot/autobot-slm-frontend",
 }
 
+# #12450: worker components that now have a per-component resolve path.
+#
+# These deliberately do NOT reuse the _COMPONENT_PIP_PATHS branch: that path is
+# backend-shaped (repo-root constraints deploy, target-interpreter provisioning,
+# venv recreation, alembic migrations, autobot_shared symlink restore) and none
+# of it applies here. Running it would be actively wrong — alembic against a
+# worker has no meaning, and venv recreation would wipe the venv the chroma
+# binary lives in (MVA-79).
+_WORKER_COMPONENTS: frozenset = frozenset(
+    {
+        "autobot-ai-stack",
+        "autobot-npu-worker",
+        "autobot-browser-worker",
+        "autobot-slm-agent",
+    }
+)
+
+# Worker components whose dependencies ARE re-installable from a file that the
+# code sync itself updates. Only ai-stack qualifies, and note the filename is
+# requirements-ai.txt, not the conventional requirements.txt
+# (roles/ai-stack/tasks/main.yml:137-153 installs exactly this file into exactly
+# this venv, and :206 sources it from the same directory the ai-stack component
+# syncs — so a resolve genuinely refreshes it).
+#
+# Every OTHER worker is intentionally absent, because its ansible role installs
+# an explicit package LIST rather than a requirements file, so there is nothing
+# a code sync can legitimately re-install:
+#   - autobot-npu-worker: roles/npu-worker/tasks/main.yml:188-218 pip-installs a
+#     named list (FastAPI + OpenVINO) into its py3.11 venv. The repo does ship
+#     autobot-npu-worker/requirements.txt, but ansible never uses it — installing
+#     from it could pull a different OpenVINO build and brick the NPU worker.
+#   - autobot-browser-worker: roles/browser/tasks/main.yml:132-140 installs
+#     playwright/uvicorn/fastapi SYSTEM-wide via pip3 (no venv at all).
+#   - autobot-slm-agent: roles/slm_agent/tasks/main.yml:121-124 installs its
+#     package list system-wide via pip3.
+# For those three a resolve is code-only: rsync + restart the right unit.
+# Dependency changes remain ansible's job (Update-All / per-role redeploy).
+_WORKER_COMPONENT_PIP: Dict[str, Tuple[str, str]] = {
+    "autobot-ai-stack": (
+        "/opt/autobot/autobot-ai-stack/requirements-ai.txt",
+        "/opt/autobot/autobot-ai-stack/venv/bin/pip",
+    ),
+}
+
 # Timeout (seconds) for `npm ci` (dependency install).  Windows-generated
 # package-lock.json on WSL can be slow; 300 s default matches pip (#11351).
 _NPM_INSTALL_TIMEOUT: float = float(os.environ.get("AUTOBOT_NPM_INSTALL_TIMEOUT", "300"))
@@ -1270,6 +1314,25 @@ _COMPONENT_SERVICES: Dict[str, List[str]] = {
         "autobot-npu-worker",
         "autobot-slm-backend",
     ],
+    # #12450: worker components. The unit name is NOT derivable from the
+    # component name for half of these — each mapping is traced to the systemd
+    # unit its own ansible role actually installs, because restarting the wrong
+    # (or no) unit is precisely the silent half-update this wiring must avoid.
+    #
+    # ai-stack: roles/ai-stack/tasks/main.yml installs BOTH units from this one
+    # component tree (:235 autobot-chromadb, :244 autobot-ai-stack) and the
+    # chroma binary lives inside the component's venv (MVA-79), so a sync of
+    # this component affects both. Order mirrors the role's own restart order
+    # (:251 chromadb, then :258 ai-stack) — chromadb must be up first.
+    "autobot-ai-stack": ["autobot-chromadb", "autobot-ai-stack"],
+    "autobot-npu-worker": ["autobot-npu-worker"],
+    # browser: roles/browser/tasks/main.yml:295-298 installs autobot-playwright;
+    # autobot-vnc (:281-284) is optional (install_vnc, default false). Restarts
+    # tolerate absent units, so listing it is safe on nodes without VNC.
+    "autobot-browser-worker": ["autobot-playwright", "autobot-vnc"],
+    # slm-agent: the unit is autobot-agent, NOT autobot-slm-agent
+    # (roles/slm_agent/tasks/main.yml:27, :33).
+    "autobot-slm-agent": ["autobot-agent"],
 }
 
 
@@ -1519,12 +1582,22 @@ async def _install_pip_deps_for_component(component: str, steps: List[str]) -> b
     Returns True on success, False when pip exits non-zero so callers can surface
     the failure (previously the non-zero rc was swallowed — #11322).
     """
-    paths = _COMPONENT_PIP_PATHS.get(component)
+    # #12450: worker components carry their own (req, pip) pair — ai-stack's file
+    # is requirements-ai.txt, not requirements.txt.
+    paths = _COMPONENT_PIP_PATHS.get(component) or _WORKER_COMPONENT_PIP.get(component)
     if paths is None:
         return True
     req_path, pip_bin = paths
     if not Path(req_path).exists():
-        steps.append(f"pip: no requirements.txt at {req_path} — skipped")
+        steps.append(f"pip: no requirements file at {req_path} — skipped")
+        return True
+    if component in _WORKER_COMPONENT_PIP and not Path(pip_bin).exists():
+        # Worker-only relaxation: a worker venv is provisioned by ansible, never
+        # by code-sync, so a missing one means "not deployed here" rather than a
+        # broken install — the code rsync + restart is still valid on its own.
+        # Backends deliberately keep the original behaviour (attempt the exec so
+        # a genuine pip failure surfaces via pip_ok=False, #11322).
+        steps.append(f"pip: no venv pip at {pip_bin} — skipped (provisioned by ansible)")
         return True
     steps.append(f"pip: installing {req_path} into {Path(pip_bin).parent}")
     try:
@@ -2419,6 +2492,10 @@ async def _run_post_sync_steps(
           constraints deploy (#11322) + venv version check (#11323) +
           pip install + symlink restore (#10912) + alembic + restart + health
       - Frontend (autobot-frontend, autobot-slm-frontend): npm ci (conditional) + build + nginx reload + health
+      - Workers (#12450 — ai-stack, npu-worker, browser-worker, slm-agent):
+          optional pip install (ai-stack only) + restart of the unit(s) that
+          component's ansible role actually installs. No constraints/alembic/
+          venv-recreation/symlink work — none of it applies to a worker.
       - autobot_shared: restore BOTH backends' symlinks (#10912) + restart
           dependents (self last) + per-dependent health + rollback (#11496)
     """
@@ -2478,6 +2555,33 @@ async def _run_post_sync_steps(
             # window is only for warm pip-backend restarts. A fresh nginx worker
             # after a large asset swap can lag past 60s, and the generous window
             # avoids logging an otherwise-healthy frontend as "check manually".
+            healthy = await _wait_component_healthy(component, steps, slow_start=True)
+            if not healthy:
+                await _rollback_component(component, snapshot, steps, None)
+                steps.append("post-sync: rolled back to last-known-good due to unhealthy post-restart")
+                pip_ok = False
+        else:
+            steps.append("post-sync: restart deferred")
+    elif component in _WORKER_COMPONENTS:
+        # #12450: worker components. Only ai-stack has a re-installable
+        # requirements file; for the rest this is deliberately code-only
+        # (rsync already happened) plus a restart of the correct unit — see
+        # _WORKER_COMPONENT_PIP for why each is or isn't dep-installable.
+        #
+        # No constraints deploy, no interpreter provisioning, no venv
+        # recreation, no alembic, no autobot_shared symlink: none apply to a
+        # worker, and venv recreation in particular would wipe the venv the
+        # chroma binary lives in (MVA-79).
+        pip_ok = await _install_pip_deps_for_component(component, steps)
+        if not pip_ok:
+            await _rollback_component(component, snapshot, steps, None)
+            return deps_changed, steps, False
+        if restart:
+            await _restart_component_services(component, steps)
+            # Workers have no health URL, so _wait_component_healthy returns
+            # True immediately and rollback is gated purely on the systemd unit
+            # entering 'failed'. Note _is_systemd_unit_failed watches the FIRST
+            # unit in the component's _COMPONENT_SERVICES list.
             healthy = await _wait_component_healthy(component, steps, slow_start=True)
             if not healthy:
                 await _rollback_component(component, snapshot, steps, None)
@@ -4041,7 +4145,10 @@ async def sync_role(
 import json as _json  # noqa: E402
 
 _UPDATE_ALL_RESUME_KEY = "slm_update_all_resume"
-_DEPS_FILES = ["requirements.txt", "package-lock.json"]
+# #12450: requirements-ai.txt is the ai-stack component's dependency file (its
+# ansible role installs that name, not requirements.txt), so the deps_changed
+# signal must watch it too or an ai-stack dep bump is reported as code-only.
+_DEPS_FILES = ["requirements.txt", "requirements-ai.txt", "package-lock.json"]
 _RESUME_PLAN_VERSION = 1
 _RESUME_PLAN_TTL_SECONDS = 7200  # 2 hours (C2-b)
 

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1322,8 +1322,11 @@ _COMPONENT_SERVICES: Dict[str, List[str]] = {
     # ai-stack: roles/ai-stack/tasks/main.yml installs BOTH units from this one
     # component tree (:235 autobot-chromadb, :244 autobot-ai-stack) and the
     # chroma binary lives inside the component's venv (MVA-79), so a sync of
-    # this component affects both. Order mirrors the role's own restart order
-    # (:251 chromadb, then :258 ai-stack) — chromadb must be up first.
+    # this component affects both. Order mirrors the role's own restart order —
+    # roles/ai-stack/handlers/main.yml defines `restart chromadb` before
+    # `restart ai-stack`, and ansible runs handlers in definition order, so
+    # chromadb comes up first. (The tasks at :251/:258 are `state: started`
+    # enable-and-start steps, not the restart path.)
     "autobot-ai-stack": ["autobot-chromadb", "autobot-ai-stack"],
     "autobot-npu-worker": ["autobot-npu-worker"],
     # browser: roles/browser/tasks/main.yml:295-298 installs autobot-playwright;

--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -74,22 +74,35 @@ ALLOWED_COMPONENTS = frozenset(
         # crash-looping every backend that imports it. Resolving it restarts all
         # dependent services (see _COMPONENT_SERVICES in api/code_sync.py).
         "autobot_shared",
+        # #12450: worker components promoted from read-only visibility to a real
+        # per-component resolve path. Each has an explicit post-sync definition in
+        # api/code_sync.py (_WORKER_COMPONENTS / _WORKER_COMPONENT_PIP /
+        # _COMPONENT_SERVICES) traced to its actual ansible deploy task — notably
+        # the restart target is NOT derivable from the component name for two of
+        # them (slm-agent -> autobot-agent, browser-worker -> autobot-playwright).
+        "autobot-ai-stack",
+        "autobot-npu-worker",
+        "autobot-browser-worker",
+        "autobot-slm-agent",
     }
 )
 
-# #12450: additional deployed components that have NO resolve/restart wiring
-# (no per-component post-sync — pip/npm/docker/symlink heterogeneity) but ARE
-# actively running deployed code with no builtin drift signal today. These are
-# READ-ONLY visibility — do NOT add them to ALLOWED_COMPONENTS, which gates
-# /drift/resolve[-async]. Whitelisting resolve for them would rsync files but
-# never install deps or restart the right service (see the parked root-cause
-# comment on #12450) — half-working and worse than the current 400.
+# Deployed components that are visible to the drift walk but still have NO
+# resolve wiring — READ-ONLY. Do NOT add an entry here without either giving it
+# a post-sync definition (then it belongs in ALLOWED_COMPONENTS instead) or
+# recording why it cannot have one. Whitelisting resolve without post-sync would
+# rsync files but never restart the right service — half-working and worse than
+# the current 400.
+#
+# #12450 phase 2 promoted ai-stack, npu-worker, browser-worker and slm-agent out
+# of this set into ALLOWED_COMPONENTS once each had a verified post-sync
+# definition. `plugins` stays here — see below.
 #
 # Every entry must be verified against its actual ansible deploy task before
 # being added here — see _NONSTANDARD_COMPONENT_PATHS below for the ones whose
 # layout isn't the standard code_source/<name> -> /opt/autobot/<name> shape.
 #
-# NOT included (confirmed unmappable, see #12450 PR notes):
+# NOT resolve-capable (confirmed unmappable, see #12450 PR notes):
 #   - autobot-tts-worker: deployed via a single Jinja2-templated file
 #     (tts-worker.py.j2 -> tts-worker.py), not a 1:1 sync of the repo's
 #     autobot-tts-worker/ directory — comparing them would report fake drift.
@@ -100,15 +113,7 @@ ALLOWED_COMPONENTS = frozenset(
 #     packages): synced into TWO deployed locations (autobot-frontend/ and
 #     autobot-slm-frontend/), so there is no single canonical deployed target
 #     to compare against — needs an owner decision on which (or both) to scan.
-EXTRA_VISIBILITY_COMPONENTS = frozenset(
-    {
-        "autobot-ai-stack",
-        "autobot-npu-worker",
-        "autobot-browser-worker",
-        "autobot-slm-agent",
-        "plugins",
-    }
-)
+EXTRA_VISIBILITY_COMPONENTS = frozenset({"plugins"})
 
 # Union of the resolve-capable allowlist and the read-only extras — used by
 # the GET-only drift surfaces (/status stale_components, GET /drift). The

--- a/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
+++ b/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
@@ -1,0 +1,297 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#12450 phase 2: worker components gain a real per-component resolve path.
+
+Phase 1 (#12574) gave ai-stack / npu-worker / browser-worker / slm-agent
+read-only drift visibility but deliberately kept them OUT of ALLOWED_COMPONENTS,
+because whitelisting resolve without a post-sync definition "would rsync files
+but never install deps or restart the right service".
+
+Phase 2 supplies that definition. These tests pin the parts that are NOT
+derivable by convention and would silently half-update a running worker if they
+regressed — above all the restart targets, which for half of these components do
+not match the component name.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+# Same import shims as test_status_stale_components_11820.py: stub the
+# conflicting multipart package and swap benign dicts in for MagicMock schema
+# names so api.code_sync imports under the conftest stub regime.
+if "multipart" in sys.modules and not hasattr(sys.modules["multipart"], "multipart"):
+    sys.modules.pop("multipart", None)
+_mp_stub = types.ModuleType("multipart")
+_mp_stub.multipart = types.ModuleType("multipart.multipart")  # type: ignore[attr-defined]
+sys.modules.setdefault("multipart", _mp_stub)
+sys.modules.setdefault("multipart.multipart", _mp_stub.multipart)  # type: ignore[attr-defined]
+
+_code_sync_src = (_BACKEND_ROOT / "api" / "code_sync.py").read_text(encoding="utf-8")
+_SCHEMA_NAMES = tuple(
+    sorted(
+        alias.name
+        for node in ast.walk(ast.parse(_code_sync_src))
+        if isinstance(node, ast.ImportFrom) and node.module == "models.schemas"
+        for alias in node.names
+    )
+)
+_schemas_stub = sys.modules.get("models.schemas")
+if isinstance(_schemas_stub, MagicMock):
+    for _name in _SCHEMA_NAMES:
+        setattr(_schemas_stub, _name, dict)
+
+
+_WORKERS = (
+    "autobot-ai-stack",
+    "autobot-npu-worker",
+    "autobot-browser-worker",
+    "autobot-slm-agent",
+)
+
+
+def _load_drift_checker():
+    """Load services/drift_checker.py for real.
+
+    The slm-backend conftest registers ``services`` as a MagicMock package, so a
+    plain ``from services.drift_checker import ALLOWED_COMPONENTS`` yields a mock
+    attribute and every set assertion below would vacuously "pass". Load the real
+    module by file location instead (same approach as
+    tests/services/drift_checker_test.py). Its own ``services.*`` imports stay
+    stubbed — irrelevant here, since these tests only read the component sets.
+    """
+    import importlib.util
+
+    services_dir = _BACKEND_ROOT / "services"
+    saved = sys.modules.get("services")
+    pkg = types.ModuleType("services")
+    pkg.__path__ = [str(services_dir)]  # type: ignore[attr-defined]
+    sys.modules["services"] = pkg
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_drift_checker_12450", services_dir / "drift_checker.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if saved is None:
+            sys.modules.pop("services", None)
+        else:
+            sys.modules["services"] = saved
+
+
+_dc = _load_drift_checker()
+
+
+# ---------------------------------------------------------------------------
+# Gating: resolve now accepts the workers; visibility is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_workers_are_resolve_capable():
+    """ALLOWED_COMPONENTS gates /drift/resolve[-async]; the workers 400'd before."""
+    for worker in _WORKERS:
+        assert worker in _dc.ALLOWED_COMPONENTS, f"{worker} still rejected by resolve"
+
+
+def test_visibility_surface_is_unchanged_by_the_promotion():
+    """Promotion must move components between sets, never drop any from view.
+
+    VISIBILITY_COMPONENTS is the union used by the GET-only drift surfaces
+    (/status stale_components, GET /drift). Moving an entry from the read-only
+    set into the allowlist must leave that union identical — otherwise #12574's
+    drift signal silently regresses.
+    """
+    assert _dc.VISIBILITY_COMPONENTS == _dc.ALLOWED_COMPONENTS | _dc.EXTRA_VISIBILITY_COMPONENTS
+    for worker in _WORKERS:
+        assert worker in _dc.VISIBILITY_COMPONENTS
+    assert "plugins" in _dc.VISIBILITY_COMPONENTS
+
+
+def test_plugins_stays_visibility_only():
+    """plugins syncs into TWO deployed locations, so it has no single resolve
+    target and must NOT be promoted without an owner decision."""
+    assert "plugins" in _dc.EXTRA_VISIBILITY_COMPONENTS
+    assert "plugins" not in _dc.ALLOWED_COMPONENTS
+
+
+# ---------------------------------------------------------------------------
+# Restart targets — the half-update risk this whole change hinges on
+# ---------------------------------------------------------------------------
+
+
+def test_every_worker_has_an_explicit_restart_target():
+    """A worker with no mapping would rsync and restart NOTHING — the exact
+    silent half-update #12574 refused to ship."""
+    import api.code_sync as cs
+
+    for worker in _WORKERS:
+        assert cs._COMPONENT_SERVICES.get(worker), f"{worker} has no restart target"
+
+
+def test_restart_targets_that_do_not_match_the_component_name():
+    """These two are the reason a name-derived mapping is unsafe.
+
+    slm-agent's unit is autobot-agent (roles/slm_agent/tasks/main.yml:27,:33) and
+    browser-worker's is autobot-playwright (roles/browser/tasks/main.yml:295-298).
+    Deriving "autobot-slm-agent" / "autobot-browser-worker" would restart units
+    that do not exist, leaving the worker running pre-sync code.
+    """
+    import api.code_sync as cs
+
+    assert cs._COMPONENT_SERVICES["autobot-slm-agent"] == ["autobot-agent"]
+    assert cs._COMPONENT_SERVICES["autobot-browser-worker"][0] == "autobot-playwright"
+
+
+def test_ai_stack_restarts_both_units_in_ansible_order():
+    """The ai-stack component tree installs BOTH units and the chroma binary
+    lives in its venv (MVA-79), so a sync affects both. Order mirrors the role's
+    own restart order — chromadb first (roles/ai-stack/tasks/main.yml:251,:258).
+    """
+    import api.code_sync as cs
+
+    assert cs._COMPONENT_SERVICES["autobot-ai-stack"] == [
+        "autobot-chromadb",
+        "autobot-ai-stack",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Dependency install: only where ansible itself installs from a file
+# ---------------------------------------------------------------------------
+
+
+def test_only_ai_stack_installs_deps_and_from_requirements_ai_txt():
+    """ai-stack's ansible role installs requirements-ai.txt — NOT the
+    conventional requirements.txt — into its own venv."""
+    import api.code_sync as cs
+
+    assert set(cs._WORKER_COMPONENT_PIP) == {"autobot-ai-stack"}
+    req_path, pip_bin = cs._WORKER_COMPONENT_PIP["autobot-ai-stack"]
+    assert req_path.endswith("/requirements-ai.txt")
+    assert pip_bin.endswith("/venv/bin/pip")
+
+
+def test_ansible_managed_workers_have_no_pip_step():
+    """npu-worker, browser-worker and slm-agent get their deps from an explicit
+    ansible package LIST, not a requirements file a code sync can refresh.
+
+    npu-worker is the dangerous one: the repo ships
+    autobot-npu-worker/requirements.txt but ansible never installs it, so
+    running it could pull a different OpenVINO build than the role pinned.
+    """
+    import api.code_sync as cs
+
+    for worker in ("autobot-npu-worker", "autobot-browser-worker", "autobot-slm-agent"):
+        assert worker not in cs._WORKER_COMPONENT_PIP
+        assert worker not in cs._COMPONENT_PIP_PATHS
+
+
+def test_deps_changed_watches_the_ai_stack_requirements_filename():
+    """Without this the deps_changed signal reports an ai-stack dep bump as a
+    code-only change."""
+    import api.code_sync as cs
+
+    assert "requirements-ai.txt" in cs._DEPS_FILES
+
+
+# ---------------------------------------------------------------------------
+# Routing: workers must NOT inherit the backend-shaped post-sync path
+# ---------------------------------------------------------------------------
+
+
+def test_workers_are_not_treated_as_backends():
+    """The backend branch runs constraints deploy, interpreter provisioning,
+    venv RECREATION, alembic and autobot_shared symlink restore. None apply to a
+    worker, and venv recreation would wipe the venv chroma runs from (MVA-79).
+    """
+    import api.code_sync as cs
+
+    for worker in _WORKERS:
+        assert worker in cs._WORKER_COMPONENTS
+        assert worker not in cs._BACKEND_COMPONENTS
+        assert worker not in cs._COMPONENT_FRONTEND_DIRS
+
+
+def test_worker_branch_is_evaluated_before_the_shared_library_branch():
+    """_run_post_sync_steps routes on `elif component in _COMPONENT_SERVICES`
+    for autobot_shared. The workers are in that map too (they need restart
+    targets), so their own branch must come FIRST or they would run the
+    autobot_shared path and restore both backends' symlinks instead.
+    """
+    import inspect
+
+    import api.code_sync as cs
+
+    src = inspect.getsource(cs._run_post_sync_steps)
+    assert src.index("_WORKER_COMPONENTS") < src.index("elif component in _COMPONENT_SERVICES")
+
+
+def test_missing_venv_skips_for_workers_but_still_fails_for_backends():
+    """The missing-venv relaxation must be worker-scoped.
+
+    A worker venv is provisioned by ansible, never by code-sync, so an absent
+    one means "not deployed on this node" and the code rsync + restart is still
+    valid. Applying the same relaxation to a backend would swallow a genuine pip
+    failure that #11322 exists to surface (pip_ok=False).
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    import api.code_sync as cs
+
+    missing_pip = "/nonexistent/venv/bin/pip"
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"boom", b""))
+        return proc
+
+    def _run(coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    with patch("pathlib.Path.exists", return_value=True):
+        # Worker: requirements present, venv pip absent → skip, resolve survives.
+        with patch.dict(cs._WORKER_COMPONENT_PIP, {"worker-comp": ("/req.txt", missing_pip)}):
+            with patch("api.code_sync.Path") as fake_path:
+                fake_path.side_effect = lambda p: _StubPath(p, missing_pip)
+                steps: list[str] = []
+                assert _run(cs._install_pip_deps_for_component("worker-comp", steps)) is True
+                assert any("provisioned by ansible" in s for s in steps)
+
+    # Backend with the same absent pip must NOT take the skip path.
+    with patch.dict(cs._COMPONENT_PIP_PATHS, {"backend-comp": ("/req.txt", missing_pip)}):
+        with patch("api.code_sync.Path") as fake_path:
+            fake_path.side_effect = lambda p: _StubPath(p, missing_pip)
+            with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+                steps = []
+                assert _run(cs._install_pip_deps_for_component("backend-comp", steps)) is False
+
+
+class _StubPath:
+    """Path stub: everything exists except the designated missing pip binary."""
+
+    def __init__(self, p, missing):
+        self._p = str(p)
+        self._missing = missing
+
+    def exists(self):
+        return self._p != self._missing
+
+    @property
+    def parent(self):
+        return _StubPath(self._p.rsplit("/", 1)[0], self._missing)
+
+    def __str__(self):
+        return self._p

--- a/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
+++ b/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
@@ -77,9 +77,7 @@ def _load_drift_checker():
     pkg.__path__ = [str(services_dir)]  # type: ignore[attr-defined]
     sys.modules["services"] = pkg
     try:
-        spec = importlib.util.spec_from_file_location(
-            "_drift_checker_12450", services_dir / "drift_checker.py"
-        )
+        spec = importlib.util.spec_from_file_location("_drift_checker_12450", services_dir / "drift_checker.py")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module

--- a/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
+++ b/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
@@ -153,8 +153,11 @@ def test_restart_targets_that_do_not_match_the_component_name():
 
 def test_ai_stack_restarts_both_units_in_ansible_order():
     """The ai-stack component tree installs BOTH units and the chroma binary
-    lives in its venv (MVA-79), so a sync affects both. Order mirrors the role's
-    own restart order — chromadb first (roles/ai-stack/tasks/main.yml:251,:258).
+    lives in its venv (MVA-79), so a sync affects both.
+
+    Order mirrors the role's own restart order: roles/ai-stack/handlers/main.yml
+    defines `restart chromadb` before `restart ai-stack`, and ansible runs
+    handlers in definition order, so chromadb comes up first.
     """
     import api.code_sync as cs
 


### PR DESCRIPTION
## Thinking Path

Phase 1 (#12574) gave these four components read-only drift visibility but deliberately kept them out of `ALLOWED_COMPONENTS`, with the reason written into the code: whitelisting resolve without a post-sync definition *"would rsync files but never install deps or restart the right service — half-working and worse than the current 400."*

So this is not a whitelist edit. The work is producing a post-sync definition per component, and the only way to get one right is to trace each to its **actual ansible deploy task** rather than infer it. That paid off immediately — the restart target is not derivable from the component name for half of them:

| Component | Restart target | Source |
|---|---|---|
| `autobot-slm-agent` | **`autobot-agent`** | `roles/slm_agent/tasks/main.yml:27,:33` |
| `autobot-browser-worker` | **`autobot-playwright`** (+ optional `autobot-vnc`) | `roles/browser/tasks/main.yml:295-298`, `:281-284` |
| `autobot-ai-stack` | `autobot-chromadb`, then `autobot-ai-stack` | `roles/ai-stack/tasks/main.yml:235,:244`, restart order `:251,:258` |
| `autobot-npu-worker` | `autobot-npu-worker` | `roles/npu-worker/tasks/main.yml:241,:264` |

A name-derived mapping would have restarted `autobot-slm-agent` and `autobot-browser-worker` — units that do not exist — leaving those workers running pre-sync code while reporting success. That is exactly the failure phase 1 refused to ship.

The same tracing settled the dependency question, which is **not** uniform:

- **ai-stack** installs `requirements-ai.txt` (not `requirements.txt`) into its own venv, and `:206` sources that file from the same directory the ai-stack component syncs — so a resolve genuinely refreshes it. Dep install enabled.
- **npu-worker** pip-installs a named list (FastAPI + OpenVINO) into a py3.11 venv. The repo *does* ship `autobot-npu-worker/requirements.txt`, but ansible never uses it — installing from it could pull a different OpenVINO build and brick the NPU worker. **Deliberately no pip step.**
- **browser-worker** and **slm-agent** install their packages **system-wide via `pip3`** (no venv at all). Nothing for a code sync to re-install. **No pip step.**

For those three, resolve is honestly code-only: rsync + restart the right unit. Dependency changes remain ansible's job. That limitation is documented in the code rather than papered over.

## What Changed

**`services/drift_checker.py`** — the four components move from `EXTRA_VISIBILITY_COMPONENTS` into `ALLOWED_COMPONENTS` (which gates `/drift/resolve[-async]`). `VISIBILITY_COMPONENTS` is their union, so the GET-only drift surfaces are **byte-identical** — phase 1's signal cannot regress. `plugins` stays visibility-only: it syncs into two deployed locations, so it has no single resolve target and needs an owner decision.

**`api/code_sync.py`**
- `_COMPONENT_SERVICES` gains the four restart mappings above, each annotated with the role file and line it came from.
- New `_WORKER_COMPONENTS` / `_WORKER_COMPONENT_PIP`, with the reason each component is or isn't dep-installable recorded inline.
- New branch in `_run_post_sync_steps`, ordered **before** the `autobot_shared` branch — the workers are in `_COMPONENT_SERVICES` too, so they would otherwise fall into the library path and restore both backends' symlinks. Deliberately does not reuse the backend branch (repo-root constraints, interpreter provisioning, venv **recreation**, alembic, symlink restore): none applies to a worker, and venv recreation would wipe the venv the chroma binary lives in (MVA-79).
- `_DEPS_FILES` now watches `requirements-ai.txt`, else an ai-stack dependency bump reports as code-only.

## Verification

```
$ python3 -m pytest tests/api/test_worker_component_resolve_12450.py -q
12 passed

$ python3 -m pytest tests/ -q          # full slm-backend suite
965 passed, 1 skipped
```

**I introduced and caught one regression.** My first cut skipped pip whenever the venv binary was absent — which also swallowed genuine backend pip failures that #11322 exists to surface, breaking `test_pip_returns_false_on_failure`. The relaxation is now worker-scoped, and I mutation-tested the guard to prove the new test isn't vacuous:

```
guard removed  → test_missing_venv_skips_for_workers_but_still_fails_for_backends FAILED
guard restored → PASSED
```

The 12 tests pin the parts that would silently half-update a worker if they regressed: the two non-obvious restart targets, ai-stack's dual-unit ansible ordering, the dep-install policy per component, visibility-union invariance, and the branch ordering.

## Scope note

Rollback safety for workers rests on `_is_systemd_unit_failed`, which watches the **first** unit in the component's `_COMPONENT_SERVICES` list — for ai-stack that is `autobot-chromadb`, because ansible's own restart order puts it first. Workers have no entry in `_COMPONENT_HEALTH_URLS`, so `_wait_component_healthy` returns healthy immediately and rollback is gated purely on a systemd `failed` state. I did not add health URLs: their ports come from ansible role defaults and hardcoding them here would violate the no-hardcoded-config rule and risk false rollbacks.

## Model Used

Claude Opus 5 (1M context)

Closes #12450