### PR TITLE
security(voice): superadmin no longer locked out of voice read paths (#12717)

### DIFF
--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -26,6 +26,7 @@ from api.schemas_code import (
     VoiceTranscribeResponse,
 )
 from auth_middleware import check_admin_permission, get_current_user
+from auth_rbac import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.personality_service import resolve_voice_id
@@ -66,7 +67,7 @@ async def voice_realtime_list_tools(
     the caller's RBAC role.
     """
     role = current_user.get("role", "user")
-    is_admin = role == "admin"
+    is_admin = is_admin_role(role)  # #12717: superadmin gets the admin realtime bridge
     user_id = current_user.get("user_id") or current_user.get("sub") or current_user.get("username")
     bridge = await get_realtime_bridge(is_admin=is_admin)
     tools = await bridge.list_realtime_tools(user_id=str(user_id) if user_id else None, role=role)
@@ -102,7 +103,7 @@ async def voice_realtime_call_tool(
     """
     from fastapi import HTTPException
 
-    is_admin = current_user.get("role") == "admin"
+    is_admin = is_admin_role(current_user.get("role"))  # #12717
     _id = current_user.get("id")
     user_id = _id if _id is not None else current_user.get("sub")
     session_id = request.headers.get("X-Session-Id")

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 
 from api.voice_bundle_constants import VALID_BUNDLES, BundleAssignRequest
 from auth_middleware import get_current_user
-from auth_rbac import require_role
+from auth_rbac import is_admin_role, require_role
 from autobot_shared.logging_manager import get_logger
 from services.event_log import EventType, emit
 
@@ -67,7 +67,7 @@ async def get_my_bundle(
 
     user_id = current_user.get("user_id") or current_user.get("sub") or current_user.get("username")
     role = current_user.get("role", "user")
-    is_admin = role == "admin"
+    is_admin = is_admin_role(role)  # #12717: superadmin must not see a reduced tool count
 
     bundle_name, resolution = await resolve_bundle_for_user(str(user_id), role=role)
     tool_count = await _count_tools_for_bundle(bundle_name, is_admin=is_admin)

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -22,7 +22,7 @@ from api.voice_bundle_constants import (
 )
 from api.voice_bundle_helpers import _count_tools_for_bundle
 from auth_middleware import get_current_user
-from auth_rbac import require_role
+from auth_rbac import is_admin_role, require_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.audit.audit import AuditCategory, AuditEvent, emit
@@ -60,7 +60,16 @@ class UserBundleResponse(BaseModel):
 
 
 def _is_admin(user: dict) -> bool:
-    return user.get("role") == "admin"
+    """#12717: superadmin counts as admin here, matching this router's own writes.
+
+    Before this, a superadmin could ASSIGN a bundle via
+    PUT /voice/users/{id}/bundle — guarded by
+    require_role("admin", "superadmin") below — but could not READ it back via
+    the GET, because the read path came through here and only accepted "admin".
+    Same superadmin-lockout class as #12704; this helper fell outside that
+    issue's scope because it is not one of the six forked _require_admin deps.
+    """
+    return is_admin_role(user.get("role"))
 
 
 def _get_user_id(user: dict) -> str:

--- a/autobot-backend/auth_rbac.py
+++ b/autobot-backend/auth_rbac.py
@@ -52,6 +52,33 @@ logger = get_logger(__name__)
 
 _get_security_layer = lazy_singleton(SecurityLayer)
 
+# #12717: the roles that count as administrative.
+#
+# "superadmin" is passed as a raw string to require_role() at 17 call sites but
+# is NOT a member of the canonical Role enum (autobot_shared.auth.permissions),
+# which only defines admin/operator/analyst/editor/user/readonly. require_role
+# tolerates that because it accepts ``Role | str``. The consequence is that any
+# hand-rolled ``role == "admin"`` check silently locks superadmins out of read
+# paths whose write paths already allow them (#12704, #12717).
+#
+# This set is the single place that answers "is this role administrative?" for
+# such checks. Adding superadmin to the shared Role enum would be the deeper
+# fix, but that enum drives ROLE_PERMISSIONS for BOTH backends — tracked
+# separately rather than changed as a drive-by.
+ADMIN_ROLES: frozenset[str] = frozenset({"admin", "superadmin"})
+
+
+def is_admin_role(role: str | None) -> bool:
+    """Return True when *role* is administrative (admin or superadmin).
+
+    Use this instead of ``role == "admin"`` for imperative checks that cannot
+    use the require_role() dependency — e.g. helpers that must also permit
+    self-access, or that pass an ``is_admin`` flag further down.
+
+    Case-insensitive, matching require_role(), which lowercases both sides.
+    """
+    return str(role or "").lower() in ADMIN_ROLES
+
 
 def _get_user_permissions(user_role: str) -> List[str]:
     """

--- a/autobot-backend/security/auth_rbac_test.py
+++ b/autobot-backend/security/auth_rbac_test.py
@@ -272,6 +272,48 @@ class TestPermissionIntegration:
         assert role1 != role3
 
 
+class TestIsAdminRole:
+    """#12717: the single answer to "is this role administrative?".
+
+    "superadmin" is passed as a raw string to require_role() at 17 call sites
+    but is NOT a member of the canonical Role enum, so hand-rolled
+    ``role == "admin"`` checks silently locked superadmins out of read paths
+    whose write paths already allowed them.
+    """
+
+    def test_accepts_both_administrative_roles(self):
+        from auth_rbac import is_admin_role
+
+        assert is_admin_role("admin") is True
+        assert is_admin_role("superadmin") is True
+
+    def test_rejects_every_non_administrative_role(self):
+        from auth_rbac import is_admin_role
+
+        for role in ("user", "readonly", "operator", "analyst", "editor"):
+            assert is_admin_role(role) is False, role
+
+    def test_handles_missing_role_without_raising(self):
+        from auth_rbac import is_admin_role
+
+        assert is_admin_role(None) is False
+        assert is_admin_role("") is False
+
+    def test_is_case_insensitive_to_match_require_role(self):
+        """require_role lowercases both the user role and the allowed set, so a
+        mixed-case token must not pass one gate and fail the other."""
+        from auth_rbac import is_admin_role
+
+        assert is_admin_role("SuperAdmin") is True
+        assert is_admin_role("ADMIN") is True
+
+    def test_admin_roles_superset_of_the_canonical_enum_admin(self):
+        from auth_rbac import ADMIN_ROLES
+
+        assert Role.ADMIN.value in ADMIN_ROLES
+        assert "superadmin" in ADMIN_ROLES
+
+
 # Run tests if executed directly
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -422,3 +422,53 @@ class TestSetUserBundle:
         data = response.json()
         assert data["bundle_name"] == "voice_admin"
         mock_emit.assert_called_once()
+
+
+class TestSuperadminIsNotLockedOut:
+    """#12717: superadmin must count as admin on the READ paths too.
+
+    The write path (PUT /voice/users/{id}/bundle) has always been guarded by
+    require_role("admin", "superadmin"), so a superadmin could ASSIGN a bundle
+    but then got 403 reading it back — the read path went through _is_admin,
+    which only accepted "admin". Same class as #12704.
+    """
+
+    def test_is_admin_accepts_superadmin(self):
+        from api.voice_bundle_user import _is_admin
+
+        assert _is_admin({"role": "superadmin"}) is True
+        assert _is_admin({"role": "admin"}) is True
+
+    def test_is_admin_still_rejects_ordinary_roles(self):
+        from api.voice_bundle_user import _is_admin
+
+        for role in ("user", "readonly", "operator", "analyst", "editor"):
+            assert _is_admin({"role": role}) is False, role
+        assert _is_admin({}) is False
+        assert _is_admin({"role": None}) is False
+
+    def test_is_admin_is_case_insensitive_like_require_role(self):
+        """auth_rbac.require_role lowercases both sides; this must match, or a
+        'SuperAdmin' token would pass the write guard and fail the read."""
+        from api.voice_bundle_user import _is_admin
+
+        assert _is_admin({"role": "SuperAdmin"}) is True
+        assert _is_admin({"role": "ADMIN"}) is True
+
+    def test_superadmin_can_read_another_users_bundle(self):
+        """_check_self_or_admin is what the GET actually calls."""
+        from unittest.mock import MagicMock
+
+        from api.voice_bundle_user import _check_self_or_admin
+
+        superadmin = {"role": "superadmin", "user_id": "admin-1"}
+        assert _check_self_or_admin(MagicMock(), superadmin, "some-other-user") is True
+
+    def test_ordinary_user_still_cannot_read_another_users_bundle(self):
+        from unittest.mock import MagicMock
+
+        from api.voice_bundle_user import _check_self_or_admin
+
+        plain = {"role": "user", "user_id": "user-1"}
+        assert _check_self_or_admin(MagicMock(), plain, "user-2") is False
+        assert _check_self_or_admin(MagicMock(), plain, "user-1") is True


### PR DESCRIPTION
## Thinking Path

The reported bug is self-evidencing — the router contradicts itself. `voice_bundle_user.py` guards its **write** path with `require_role("admin", "superadmin")` (:185) but its **read** path went through `_is_admin`, which accepted only `role == "admin"` (:63). So a superadmin could `PUT /voice/users/{id}/bundle` to assign a bundle and then get 403 reading it back with the `GET`.

Since #12704 fixed six sibling `_require_admin` forks and this helper was explicitly left out of that scope, I swept for the rest of the class rather than fixing the one line. That found two more sites — and they are arguably worse than #12717, because they fail *quietly* instead of returning 403:

- `voice_bundle_admin.get_my_bundle` (:70) — `is_admin` feeds `_count_tools_for_bundle`, so a superadmin saw a **reduced tool count**.
- `voice.py` (:69, :105) — `is_admin` feeds `get_realtime_bridge`, so a superadmin got the **non-admin realtime bridge**.

Chasing why this keeps recurring turned up the actual root cause. **`"superadmin"` is not a member of the canonical `Role` enum.** `autobot_shared/auth/permissions.py:109` defines only `admin/operator/analyst/editor/user/readonly`, yet `require_role("admin", "superadmin")` appears at **17 call sites** — it works only because `require_role` accepts `Role | str` and lowercases. The consequence is structural: every `require_role` guard admits superadmin, and every hand-rolled `role == "admin"` check does not. The two will keep drifting apart wherever both styles meet.

## What Changed

**`auth_rbac.py`** — one canonical answer to "is this role administrative?", placed beside `require_role`: `ADMIN_ROLES` + `is_admin_role()`. Case-insensitive to match `require_role` (which lowercases both sides), so a mixed-case `SuperAdmin` token cannot pass one gate and fail the other.

**Four call sites** now route through it instead of repeating the role set: `voice_bundle_user._is_admin`, `voice_bundle_admin.get_my_bundle`, and both in `voice.py`. There are now zero `role == "admin"` comparisons left in the voice routers.

I deliberately did **not** add `superadmin` to the shared `Role` enum here. That enum drives `ROLE_PERMISSIONS` for **both** backends, so it is a real blast radius rather than a drive-by — filed separately.

## Verification

```
$ python3 -m pytest tests/api/test_voice_bundle_user.py -q
36 passed          # was 31; +5 new

$ python3 -m pytest security/auth_rbac_test.py -q
27 passed          # was 22; +5 new

$ python3 -m pytest tests/api/ security/auth_rbac_test.py -q -k "voice or rbac or auth"
129 passed, 341 deselected
```

The 10 new tests pin both directions, since a permissive fix is as bad as the bug:

- `is_admin_role`: both admin roles accepted; **every** non-admin role (`user`, `readonly`, `operator`, `analyst`, `editor`) still rejected; `None`/`""` handled without raising; case-insensitivity; consistency with `Role.ADMIN`.
- Voice read paths: superadmin can read another user's bundle; an ordinary user **still cannot**; self-access still works.

```
$ python3 -m black --check --line-length=120 <changed files>
6 files would be left unchanged
```

## Model Used

Claude Opus 5 (1M context)

Closes #12717