### PR TITLE
ci: skip PR-template gate for bots + keep oxlint pair grouped (#12796, #12798)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,18 @@ updates:
           - "vite"
           - "@vitejs/*"
           - "typescript"
+      # #12798: eslint-plugin-oxlint declares a peer on its OWN matching oxlint
+      # minor (plugin 1.75.0 -> peer oxlint ~1.75.0). Under all-dependencies
+      # nothing kept the pair in lockstep, so a run advanced the plugin while
+      # leaving oxlint at ~1.73.0 — npm ci then died on ERESOLVE and took four
+      # required checks down with it (#12792). Their own group forces them to
+      # move together. A version cap (the @pinia/testing remedy below) is wrong
+      # here: both SHOULD keep advancing, just never apart.
+      # Must stay ABOVE all-dependencies — first matching group wins.
+      oxlint:
+        patterns:
+          - "oxlint"
+          - "eslint-plugin-oxlint"
       all-dependencies:
         patterns:
           - "*"

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -14,6 +14,14 @@ on:
 jobs:
   check-template:
     name: Validate PR template sections
+    # #12796: bots (Dependabot et al.) write their own fixed PR body and can
+    # never fill this human template, so the job failed 100% of the time on
+    # their PRs. That permanent red buried the REAL failures on bot PRs — e.g.
+    # a broken frontend dep bump whose genuine smoke-test/vue-tsc reds sat in
+    # the same list as this known-meaningless one. Skip (not pass) so the gate
+    # stays honest for human PRs; it is not in the required-checks set, so
+    # skipping changes nothing about what can merge.
+    if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
## Thinking Path

Found while draining the PR queue: **all 9 open Dependabot PRs showed a red `Validate PR template sections`.**

`.github/workflows/pr-template-check.yml` runs on every `pull_request` with no author filter and asserts the human template sections are filled in. Dependabot writes its own fixed body, so the job cannot ever pass for it — the red means "this is a bot", not "something is wrong".

It is **advisory**, not required. The branch-protection required set is `smoke-test, code-quality, startup-import-smoke, Unit & Integration Tests, No open blocks-merge…, No commit trailers, verify-generated-types, migration-matrix, verify-precommit-config, api-wiring` — so it never blocked a merge.

The real cost is signal quality, and I hit it directly while triaging: on #12792, a genuinely broken frontend dep bump, the meaningful failures (`Unit & Integration Tests`, `smoke-test`, `verify-generated-types`, `vue-tsc-baseline`) sat in the same list as this known-meaningless one. A permanent red on every bot PR means you must open each one to find out whether it matters.

## What Changed

One job-level condition:

```yaml
jobs:
  check-template:
    if: github.event.pull_request.user.type != 'Bot'
```

**Skip, not pass** — the gate stays honest for human PRs, and because the job is not in the required set, skipping changes nothing about what is allowed to merge.

## Verification

```
$ python3 -c "yaml.safe_load(open('.github/workflows/pr-template-check.yml'))"
YAML valid
if: github.event.pull_request.user.type != 'Bot'
name: Validate PR template sections
steps: 1
```

The job `name:` is unchanged, so the check identity that branch protection and the UI key off is untouched.

This PR is itself human-authored, so the gate still runs here — if it passes on this PR, the non-bot path is proven unchanged.

## Security note

`github.event.pull_request.user.type` is a GitHub-controlled enum (`User`/`Bot`/`Organization`) evaluated in an `if:` condition, not interpolated into a `run:` command, so this adds no workflow-injection surface. Confirmed the workflow has **zero** `${{ github.event… }}` interpolations inside `run:` blocks — the existing body check already reads the PR body via `env:` + `gh pr view`, which is the correct pattern.

## Model Used

Claude Opus 5 (1M context)

## Second fix in this PR — dependabot oxlint grouping (#12798)

Same domain (`.github/` automation config), batched so draining the queue does not grow it.

PR #12792 (24 frontend updates) died at `npm ci`, taking four REQUIRED checks with it. The three majors in that group look like the cause but are not:

```
npm error While resolving: eslint-plugin-oxlint@1.75.0
npm error Found: oxlint@1.73.0
npm error peer oxlint@"~1.75.0" from eslint-plugin-oxlint@1.75.0
```

`eslint-plugin-oxlint` peers on its OWN matching `oxlint` minor. Both are pinned `~1.73.0`, but the group advanced only the plugin. Under `all-dependencies: ["*"]` nothing keeps them in lockstep, so it recurs whenever one moves without the other. Fix: their own group, ordered above the catch-all (first match wins).

A version cap — the remedy used just below for `@pinia/testing` (#11753/#11746) — would be wrong here: both SHOULD keep advancing, just never apart. Only `/autobot-frontend` is affected; `autobot-slm-frontend` has neither package.

Verified by parsing the config:

```
group order: ['frontend-core', 'oxlint', 'all-dependencies']
oxlint patterns: ['oxlint', 'eslint-plugin-oxlint']
ordering OK — oxlint matches before the catch-all
directories with an oxlint group: ['/autobot-frontend']
```

Closes #12796, #12798