### PR TITLE
ci: repair auto-update-pr-branches — it never updated a single branch (#12801)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -42,15 +42,27 @@ jobs:
 
           # List all open PRs targeting Dev_new_gui that are behind.
           # .number is always a GitHub-assigned integer — safe to iterate.
+          #
+          # #12801: this used `--json number,behindBy`, but `behindBy` is not a
+          # field the installed gh exposes — it exits non-zero with "Unknown JSON
+          # field". Because this is an assignment from a command substitution and
+          # Actions runs `run:` under `bash -e`, that aborted the whole step here,
+          # before the `exit 0` below could apply. Net effect: the workflow never
+          # updated a single branch, so every stale PR needed the manual "Update
+          # branch" click this job exists to remove.
+          #
+          # `mergeStateStatus` IS supported; BEHIND is exactly "needs updating".
+          # `|| true` keeps a transient gh/API failure from re-introducing the
+          # same abort-before-exit-0 behaviour.
           OUTDATED=$(gh pr list \
             --repo "$REPO" \
             --base Dev_new_gui \
             --state open \
-            --json number,behindBy \
-            --jq '.[] | select(.behindBy > 0) | .number')
+            --json number,mergeStateStatus \
+            --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number' || true)
 
           if [ -z "$OUTDATED" ]; then
-            echo "All PR branches are up to date."
+            echo "All PR branches are up to date (or none could be listed)."
             exit 0
           fi
 
@@ -65,7 +77,13 @@ jobs:
               continue
             fi
             echo "Updating PR #$PR..."
-            if gh pr update-branch "$PR" --repo "$REPO" 2>&1; then
+            # #12801: `gh pr update-branch` does not exist in the installed gh
+            # build (same class as the missing `behindBy` field above), so this
+            # branch could never have succeeded even if the listing worked. The
+            # REST endpoint is always available and is what the "Update branch"
+            # button calls; a conflicting PR returns non-2xx and is counted as
+            # needing manual resolution rather than failing the job.
+            if gh api -X PUT "repos/$REPO/pulls/$PR/update-branch" 2>&1; then
               echo "  ✓ PR #$PR updated"
               UPDATED=$((UPDATED + 1))
             else


### PR DESCRIPTION
## Thinking Path

After draining the Dependabot queue I checked whether `Dev_new_gui` itself was still healthy, and found `auto-update` red on the base head. It is not an incidental failure — **with the installed `gh`, this workflow could never do its job at all.**

Two independent breakages, both verified against this repo:

**1. It died on its first real command (line 45).**

```
$ gh pr list --repo mrveiss/AutoBot-AI --base Dev_new_gui --state open --json number,behindBy
Unknown JSON field: "behindBy"
exit=1
```

Actions runs `run:` blocks under `bash -e`, and this is an **assignment from a command substitution** — so the non-zero status aborted the step right there, before the `exit 0` on the final line. The comment on that line reads `# Never fail — conflicting PRs just need human resolution`; the guard was simply unreachable.

**2. Even past that, the update call does not exist (line 68).**

```
$ gh pr update-branch --help
unknown command "update-branch" for "gh pr"
```

Same class as the missing `behindBy` field — this `gh` build predates the subcommand. So with a working listing, it still would have updated nothing.

## Why this mattered today

The workflow's own header says it "Eliminates the manual 'Update branch' click and prevents stale merge-conflict surprises at review time." Because it aborted at line 45, no PR branch has ever been auto-updated.

With branch protection at `strict: true` (up-to-date required), the cost lands directly on the queue: **all 9 open Dependabot PRs sat `BEHIND` and each had to be updated by hand** before it could merge. Two of them drifted to `DIRTY` while waiting, forcing a Dependabot rebase and a full regeneration (#12799 → #12800). That is precisely the manual work this job exists to remove.

## What Changed

- **Detect staleness** via `--json number,mergeStateStatus`, selecting `BEHIND`. That field parses correctly on the installed `gh`.
- **Perform the update** via `gh api -X PUT repos/$REPO/pulls/$PR/update-branch` — the same endpoint the "Update branch" button calls, and the one I used successfully on 8 PRs during the drain.
- **Guard the listing with `|| true`** so a transient `gh`/API failure cannot re-introduce the abort-before-`exit 0` behaviour the original comment intended to prevent. A conflicting PR is now counted and reported instead of turning the job red.

The existing numeric validation of `$PR` is retained and now also guards the REST path.

## Verification

Old vs new listing against the live repo — this is the exact failure mode:

```
OLD:  gh pr list --json number,behindBy …   exit=1   <-- aborts the step under bash -e
NEW:  gh pr list --json number,mergeStateStatus …   exit=0   <-- clean
```

Structural checks on the parsed YAML, evaluated against **non-comment lines only** (the removed calls are still named in the explanatory comments):

```
PASS  no behindBy in CODE
PASS  no gh pr update-branch in CODE
PASS  uses mergeStateStatus/BEHIND
PASS  uses REST update-branch
PASS  listing guarded with || true
PASS  numeric PR guard intact
PASS  still ends with exit 0
```

Real end-to-end proof exists from today: the REST endpoint returned `{"message": "Updating pull request branch."}` on 8 separate PRs, each of which then moved `BEHIND` → up-to-date and merged.

## Security note

No untrusted input reaches the `run:` block. `$REPO` comes from `env: github.repository`; `$PR` originates from `gh pr list --json number` (GitHub-assigned integers) and is additionally regex-validated `^[0-9]+$` before use — that guard now protects the REST path too.

## Model Used

Claude Opus 5 (1M context)

Closes #12801