### PR TITLE
tech-debt(backend): route the last two callers off the circuit-breaker shim (#12636)

### DIFF
--- a/autobot-backend/api/error_resilience.py
+++ b/autobot-backend/api/error_resilience.py
@@ -22,7 +22,7 @@ from api.schemas_workflows import (
 from api.system_health import ComponentHealth, KnownProbes, register_health_probe
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from services.resilience.circuit_breaker_manager import (
+from circuit_breaker import (
     get_circuit_breaker_manager,
 )
 from services.resilience.error_budget import get_error_budget_tracker

--- a/autobot-backend/tests/resilience/test_circuit_breaker.py
+++ b/autobot-backend/tests/resilience/test_circuit_breaker.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from services.resilience.circuit_breaker_manager import (
+from circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerConfig,
     CircuitBreakerManager,


### PR DESCRIPTION
## Thinking Path

#12636 says two circuit-breaker managers coexist with "divergent APIs" (`get_all_states()` vs `get_status()`) and calls it a canonical-source violation. Checking the premise before acting — that turns out to be **stale**.

`services/resilience/circuit_breaker_manager.py` is not a second manager. It is a **32-line backward-compat shim** from #6494 whose entire body re-exports the canonical `circuit_breaker` module, and whose own docstring already says:

> `Callers should migrate to: from circuit_breaker import ...`

There is exactly one `CircuitBreakerManager`, and it carries **both** of the supposedly-divergent APIs as aliases on the same class:

```
circuit_breaker.py:484   def get_all_states(...)
circuit_breaker.py:503   def get_status(...)
```

plus the same aliasing for `get_circuit_breaker`/`get_breaker` and `reset_circuit_breaker`/`reset_breaker`. Two names, one implementation, one singleton — so `get_circuit_breaker_manager()` imported via either path returns the *same object*.

So there was no convergence left to do. What *was* left is the unfinished half of #6494: two call sites still reached the canonical class through the shim.

## What Changed

Both remaining callers now import canonically:

- `api/error_resilience.py`
- `tests/resilience/test_circuit_breaker.py`

That takes the shim to **zero in-repo callers**, which is the precondition for retiring it later.

I deliberately did **not** delete the shim. It is a published import path, and removing it is a separate breaking decision rather than a drive-by — consistent with the never-delete-code-wire-it-in rule.

## Verification

```
$ grep -rn "services.resilience.circuit_breaker_manager" --include=*.py .
  (only the shim's own definition — zero callers)

$ python3 -m pytest tests/resilience/test_circuit_breaker.py -q
16 passed

$ python3 -m pytest tests/resilience/ -q
69 passed

$ python3 -m pytest tests/ -q -k "resilience or circuit"
97 passed, 5818 deselected
```

`api/error_resilience.py` verified to now import `get_circuit_breaker_manager` from `circuit_breaker` directly.

## Model Used

Claude Opus 5 (1M context)

Closes #12636