### PR TITLE
fix(slm): stage detached self-update files outside PrivateTmp (#12803)

### DIFF
--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -58,6 +58,29 @@ SELF_UPDATE_DETACH_UNIT_PREFIX = os.getenv("SLM_SELF_UPDATE_UNIT_PREFIX", "autob
 # ever given cgroup delegation.
 SELF_UPDATE_DETACH_SLICE = os.getenv("SLM_SELF_UPDATE_SLICE", "system.slice")
 
+# #12803: where a DETACHED run's inventory / extra-vars files are written.
+#
+# autobot-slm-backend.service sets PrivateTmp=true, so this process's /tmp is a
+# private mount namespace. Under the old --scope the payload stayed in THIS
+# process's namespace and saw those files fine. A transient service is forked by
+# PID 1 and therefore gets the HOST /tmp — so anything written to
+# ANSIBLE_LOCAL_TMP (/tmp/...) is simply invisible to it, and ansible failed
+# instantly with "Unable to parse ... as an inventory source" / "Could not find
+# or access ...json". The files were never deleted out from under the run; they
+# were never in a namespace it could see.
+#
+# The unit's only writable non-namespaced location is ReadWritePaths=/opt/autobot
+# (ProtectSystem=strict blocks the rest), so detached runs stage these two files
+# there instead. Attached runs keep using ANSIBLE_LOCAL_TMP — same namespace, no
+# need to leave /tmp.
+SELF_UPDATE_SHARED_DIR = Path(os.getenv("SLM_SELF_UPDATE_SHARED_DIR", "/opt/autobot/.slm-self-update"))
+
+# Age after which a stray staged inventory/extra-vars file is pruned. A detached
+# run deliberately outlives this process (Play 1 restarts us), so the caller
+# cannot reliably delete these itself — see _stage_dir_for_run. Pruning on the
+# next run keeps the directory bounded without ever racing a live run.
+SELF_UPDATE_STAGE_TTL_SECONDS = float(os.getenv("SLM_SELF_UPDATE_STAGE_TTL_SECONDS", "86400"))
+
 # Env vars forwarded to the detached scope via explicit --setenv=NAME=VALUE.
 # `sudo` (env_reset, see setup-passwordless-sudo.yml) strips the environment
 # before systemd-run ever sees it, and systemd-run does not forward the
@@ -775,7 +798,63 @@ class PlaybookExecutor:
         await process.wait()
         return {"output": "\n".join(output_lines), "returncode": process.returncode}
 
-    async def _build_dynamic_inventory(self) -> Path:
+    @staticmethod
+    def _stage_dir_for_run(detach: bool) -> str | None:
+        """Directory for this run's inventory / extra-vars files (#12803).
+
+        Returns None for attached runs, meaning "use the default
+        ANSIBLE_LOCAL_TMP" — an attached payload shares this process's mount
+        namespace, so /tmp is fine and nothing needs to change.
+
+        A DETACHED payload is forked by PID 1 and does NOT inherit this
+        service's PrivateTmp namespace, so it cannot see anything under /tmp
+        that we wrote. Stage those files under SELF_UPDATE_SHARED_DIR instead —
+        inside ReadWritePaths=/opt/autobot, the only non-namespaced location
+        this sandboxed unit may write.
+
+        Returns None (falling back to /tmp) if the directory cannot be created,
+        so a staging failure degrades to the previous behaviour rather than
+        aborting the update outright.
+        """
+        if not detach:
+            return None
+        try:
+            SELF_UPDATE_SHARED_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.error(
+                "Could not create self-update staging dir %s (%s) — falling back to %s, "
+                "which a detached run cannot read (#12803)",
+                SELF_UPDATE_SHARED_DIR,
+                exc,
+                ANSIBLE_LOCAL_TMP,
+            )
+            return None
+        PlaybookExecutor._prune_stage_dir()
+        return str(SELF_UPDATE_SHARED_DIR)
+
+    @staticmethod
+    def _prune_stage_dir() -> None:
+        """Delete staged files older than the TTL (#12803).
+
+        A detached run outlives this process by design (Play 1 restarts us
+        mid-run), so the caller cannot delete its own staged files without
+        racing the payload — that race is precisely what #12803 reported. Prune
+        on the NEXT run instead: anything older than the TTL belongs to a run
+        that has long since finished.
+        """
+        cutoff = time.time() - SELF_UPDATE_STAGE_TTL_SECONDS
+        try:
+            entries = list(SELF_UPDATE_SHARED_DIR.iterdir())
+        except OSError:
+            return
+        for stale in entries:
+            try:
+                if stale.is_file() and stale.stat().st_mtime < cutoff:
+                    stale.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.debug("Could not prune staged file %s: %s", stale, exc)
+
+    async def _build_dynamic_inventory(self, stage_dir: str | None = None) -> Path:
         """Generate an Ansible inventory from the DB node registry (#10109, #10095).
 
         Queries all Node records, builds a YAML inventory where each host name
@@ -801,7 +880,7 @@ class PlaybookExecutor:
 
         inv = build_registry_inventory(nodes, is_local_ip)
         validate_inventory(inv)
-        tmp_path = write_temp_inventory(inv, uid_tmp_dir=ANSIBLE_LOCAL_TMP)
+        tmp_path = write_temp_inventory(inv, uid_tmp_dir=stage_dir or ANSIBLE_LOCAL_TMP)
         self._link_group_vars(tmp_path)
         logger.info(
             "_build_dynamic_inventory: wrote inventory for %d node(s) to %s",
@@ -880,6 +959,11 @@ class PlaybookExecutor:
         # Determine which inventory to use.
         # Explicit caller-supplied path (wizard) → use as-is.
         # No path provided → generate from DB node registry (#10109, #10095).
+        # #12803: a detached payload cannot see this process's PrivateTmp /tmp,
+        # so its inventory/extra-vars must be staged somewhere both namespaces
+        # share. None => default ANSIBLE_LOCAL_TMP (attached runs).
+        stage_dir = self._stage_dir_for_run(detach)
+
         dynamic_inv_path: Path | None = None
         if inventory_path is not None:
             effective_inventory = inventory_path
@@ -887,7 +971,7 @@ class PlaybookExecutor:
                 raise FileNotFoundError(f"Inventory not found: {effective_inventory}")
         else:
             try:
-                dynamic_inv_path = await self._build_dynamic_inventory()
+                dynamic_inv_path = await self._build_dynamic_inventory(stage_dir)
                 effective_inventory = dynamic_inv_path
             except Exception as exc:
                 logger.warning(
@@ -907,7 +991,7 @@ class PlaybookExecutor:
         # temp file (-e @file), never argv (#11735).
         extra_vars_file: Path | None = None
         if merged_extra_vars:
-            extra_vars_file = write_temp_extra_vars(merged_extra_vars)
+            extra_vars_file = write_temp_extra_vars(merged_extra_vars, uid_tmp_dir=stage_dir)
 
         cmd = self._build_ansible_command(
             playbook_path,
@@ -944,17 +1028,29 @@ class PlaybookExecutor:
                 "returncode": -1,
             }
         finally:
-            # Clean up the per-run temp inventory and extra-vars files
-            if dynamic_inv_path is not None:
-                try:
-                    dynamic_inv_path.unlink(missing_ok=True)
-                except OSError as exc:
-                    logger.debug("Could not remove temp inventory %s: %s", dynamic_inv_path, exc)
-            if extra_vars_file is not None:
-                try:
-                    extra_vars_file.unlink(missing_ok=True)
-                except OSError as exc:
-                    logger.debug("Could not remove temp extra-vars file %s: %s", extra_vars_file, exc)
+            # Clean up the per-run temp inventory and extra-vars files.
+            #
+            # #12803: NEVER for a detached run. That payload is owned by PID 1
+            # and outlives this coroutine by design — Play 1 restarts this very
+            # service mid-run — so unlinking here can pull the inventory and
+            # extra-vars out from under a playbook that is still starting. Those
+            # files live under SELF_UPDATE_SHARED_DIR and are reclaimed by
+            # _prune_stage_dir() on a later run, which cannot race a live one.
+            if detach:
+                logger.debug(
+                    "Detached run — leaving staged inventory/extra-vars for TTL pruning (#12803)",
+                )
+            else:
+                if dynamic_inv_path is not None:
+                    try:
+                        dynamic_inv_path.unlink(missing_ok=True)
+                    except OSError as exc:
+                        logger.debug("Could not remove temp inventory %s: %s", dynamic_inv_path, exc)
+                if extra_vars_file is not None:
+                    try:
+                        extra_vars_file.unlink(missing_ok=True)
+                    except OSError as exc:
+                        logger.debug("Could not remove temp extra-vars file %s: %s", extra_vars_file, exc)
 
 
 # Singleton instance

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import os
+import time
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -72,6 +73,7 @@ def _load_executor():
 
 
 _pe = _load_executor()
+_DEFAULT_SHARED_DIR = _pe.SELF_UPDATE_SHARED_DIR
 
 
 def _executor(ansible_dir: Path) -> "_pe.PlaybookExecutor":
@@ -496,3 +498,100 @@ def test_detached_service_waits_so_exit_code_still_propagates(tmp_path):
     assert "--wait" in wrapped
     # --wait must be an option to systemd-run, not an argument to the payload.
     assert wrapped.index("--wait") < wrapped.index("--")
+
+
+# ---------------------------------------------------------------------------
+# #12803: a detached payload cannot see this service's PrivateTmp /tmp
+# ---------------------------------------------------------------------------
+
+
+def test_detached_run_stages_files_outside_private_tmp(tmp_path, monkeypatch):
+    """Staging must leave /tmp, because the payload is in a different namespace.
+
+    autobot-slm-backend.service sets PrivateTmp=true, so this process's /tmp is
+    a private mount namespace. Under the old --scope the payload stayed in this
+    process's namespace and read the inventory fine. A transient service is
+    forked by PID 1 and gets the HOST /tmp, so anything under ANSIBLE_LOCAL_TMP
+    is invisible to it — ansible died instantly with "Unable to parse ... as an
+    inventory source" (#12803). ProtectSystem=strict leaves /opt/autobot
+    (ReadWritePaths) as the only writable non-namespaced location.
+    """
+    shared = tmp_path / "shared"
+    monkeypatch.setattr(_pe, "SELF_UPDATE_SHARED_DIR", shared)
+
+    staged = _pe.PlaybookExecutor._stage_dir_for_run(detach=True)
+
+    assert staged == str(shared)
+    assert shared.is_dir()
+    assert oct(shared.stat().st_mode & 0o777) == "0o700"
+
+    # The invariant that actually matters is on the SHIPPED default, not on the
+    # tmp_path fixture above (which is itself under /tmp): the default staging
+    # dir must live outside the namespaced /tmp and inside ReadWritePaths.
+    default = str(_DEFAULT_SHARED_DIR)
+    assert not default.startswith("/tmp"), default
+    assert default.startswith("/opt/autobot"), default
+
+
+def test_attached_run_keeps_using_the_uid_tmp_dir(tmp_path, monkeypatch):
+    """An attached payload shares this process's namespace — /tmp is correct
+    there, so the #12803 staging must not change non-detached behaviour."""
+    monkeypatch.setattr(_pe, "SELF_UPDATE_SHARED_DIR", tmp_path / "unused")
+
+    assert _pe.PlaybookExecutor._stage_dir_for_run(detach=False) is None
+    assert not (tmp_path / "unused").exists(), "attached runs must not create the shared dir"
+
+
+def test_staging_failure_degrades_instead_of_aborting(tmp_path, monkeypatch):
+    """If the shared dir cannot be created, fall back rather than kill the update."""
+    blocked = tmp_path / "not_a_dir"
+    blocked.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(_pe, "SELF_UPDATE_SHARED_DIR", blocked / "sub")
+
+    assert _pe.PlaybookExecutor._stage_dir_for_run(detach=True) is None
+
+
+def test_prune_removes_only_files_past_the_ttl(tmp_path, monkeypatch):
+    """Pruning reclaims old staged files without ever racing a live run."""
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o700)
+    monkeypatch.setattr(_pe, "SELF_UPDATE_SHARED_DIR", shared)
+    monkeypatch.setattr(_pe, "SELF_UPDATE_STAGE_TTL_SECONDS", 100.0)
+
+    fresh = shared / "autobot_inv_fresh.yml"
+    stale = shared / "autobot_inv_stale.yml"
+    for f in (fresh, stale):
+        f.write_text("x", encoding="utf-8")
+    old = time.time() - 500
+    os.utime(stale, (old, old))
+
+    _pe.PlaybookExecutor._prune_stage_dir()
+
+    assert fresh.exists(), "a file inside the TTL belongs to a possibly-live run"
+    assert not stale.exists()
+
+
+def test_detached_finally_deletes_neither_staged_file(tmp_path):
+    """The caller must not unlink files the detached payload still owns.
+
+    #12803 reported this as the root cause. It was not — the real cause was the
+    PrivateTmp namespace — but the deletion IS a live hazard now that the
+    payload outlives this coroutine by design (Play 1 restarts this service
+    mid-run). Both files must survive, not just the inventory: they are removed
+    by two separate branches in the finally, and guarding only one leaves the
+    extra-vars race intact.
+    """
+    import inspect
+
+    src = inspect.getsource(_pe.PlaybookExecutor.execute_playbook)
+    finally_body = src.split("finally:", 1)[1]
+
+    guard = finally_body.index("if detach:")
+    inv_unlink = finally_body.index("dynamic_inv_path.unlink")
+    evars_unlink = finally_body.index("extra_vars_file.unlink")
+
+    # BOTH unlinks must sit after the detach guard, i.e. inside its else branch.
+    assert guard < inv_unlink
+    assert guard < evars_unlink
+    else_branch = finally_body.index("else:")
+    assert else_branch < inv_unlink and else_branch < evars_unlink

--- a/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
+++ b/autobot-slm-backend/tests/services/test_self_update_systemd_detach_11492.py
@@ -38,8 +38,8 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import os
-import time
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
## Thinking Path

This is a CRITICAL regression from my own #12775, so it jumped the queue.

**The reported root cause is wrong, and fixing what the report described would not have worked.** #12803 diagnoses a lifetime race — the caller's `finally` unlinking the temp files out from under the detached run. The files were never *visible* to that run in the first place.

`autobot-slm-backend.service` sets **`PrivateTmp=true`**, so this process's `/tmp` is a private mount namespace. A `--scope` kept the payload inside *this process's* namespace, so it read `/tmp/ansible_local_tmp_999/...` fine. A transient service is forked by **PID 1** and gets the **host** `/tmp`, where that directory either doesn't exist or is a different one entirely.

Every observation in the report fits this and not the race:

- The operator's poll saw exactly one file, `ansible-local-382734j3wq60r1`, and *never* the inventory or extra-vars. That file is created by the unit itself, because `ANSIBLE_LOCAL_TEMP` is forwarded via `--setenv` — so the unit built its own tmp dir in the **host** namespace while the inventory sat in the **private** one.
- `--uid=999` is correct and the dir is `autobot:autobot 700`, which is why it didn't look like permissions.
- The unit "failing at the same instant the directory emptied" is coincidence: it never read those files at all.

`ProtectSystem=strict` with `ReadWritePaths=/opt/autobot` leaves exactly one writable non-namespaced location, which is where the fix puts them.

## What Changed

**Staging (the actual fix).** Detached runs write the inventory and extra-vars under `SELF_UPDATE_SHARED_DIR` (`/opt/autobot/.slm-self-update`, `0700`, env-overridable) instead of `ANSIBLE_LOCAL_TMP`. Attached runs are untouched — they share this namespace, so `/tmp` remains correct. If the dir can't be created, it falls back to the old path and logs an error: a staging failure degrades rather than aborting the update.

**The `finally` guard (a real hazard, just not the cause).** Cleanup is now skipped for detached runs. Once the payload outlives this coroutine by design — Play 1 restarts this very service mid-run — the caller unlinking is genuinely unsafe. Note the original code deleted the two files in **separate** `if` branches, so guarding only the inventory would have left the extra-vars race live; I hit exactly that while writing this and restructured into a single `else`.

**Reclamation.** `_prune_stage_dir()` removes staged files past a TTL on a *later* run, which cannot race a live one.

## Verification

```
$ python3 -m pytest tests/services/test_self_update_systemd_detach_11492.py -q
23 passed

$ python3 -m pytest tests/ -q
973 passed, 1 skipped
```

Five new tests: staging leaves `/tmp`; attached runs unchanged and don't create the dir; staging failure degrades to fallback; TTL pruning spares fresh files and removes stale ones; and both unlinks sit behind the detach guard.

That last test is **mutation-verified** — reverting the guard to `if True:` fails it:

```
guard reverted  → test_detached_finally_deletes_neither_staged_file FAILED
guard restored  → 23 passed
```

The staging assertion deliberately checks the **shipped default**, not the `tmp_path` fixture. My first version asserted `not staged.startswith("/tmp")` against `tmp_path`, which is itself under `/tmp` — it was testing the fixture, not the code.

## Not fixed here

The same report raises two reporting defects that are **not** this regression and need their own change:

- `success: true` with a null `job_id` for a run that never executed
- `local_version` read from `code_source` HEAD, so `has_update:false` contradicts `stale_components` in the same payload

Both are the #12776 blind spot (nothing reads the self-update log post-hoc). Folding them in here would mix a hotfix with a reporting redesign.

**Live verification is still required** before #12596 can close — this restores the mechanism, but only a real Update-All showing a `PLAY [Play 2` header and `PLAY RECAP` proves the end-to-end path.

## Model Used

Claude Opus 5 (1M context)

Closes #12803