### PR TITLE
fix(backend): await the async Redis client at 6 call sites (#12780)

### DIFF
--- a/autobot-backend/api/analytics_pattern_learning.py
+++ b/autobot-backend/api/analytics_pattern_learning.py
@@ -225,9 +225,9 @@ class PatternLearningEngine:
                 return True
 
             try:
-                from autobot_shared.redis_client import get_redis_client
+                from autobot_shared.redis_client import get_async_redis_client
 
-                self.redis_client = get_redis_client(async_client=True, database="analytics")
+                self.redis_client = await get_async_redis_client(database="analytics")
                 # Issue #379: Parallelize independent Redis loading operations
                 await asyncio.gather(
                     self._load_patterns_from_redis(),

--- a/autobot-backend/async_baseline_performance_test.py
+++ b/autobot-backend/async_baseline_performance_test.py
@@ -38,7 +38,7 @@ import aiohttp
 from autobot_shared.logging_manager import get_logger
 
 # Import canonical Redis client pattern
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.network_constants import NetworkConstants, ServiceURLs
 
 # Configure logging
@@ -243,7 +243,7 @@ class AsyncBaselineTest:
         start_time = time.perf_counter()
 
         # Create async Redis connection using canonical pattern
-        redis_client = get_redis_client(async_client=True, database="metrics")  # METRICS_DB
+        redis_client = await get_async_redis_client(database="metrics")  # METRICS_DB
 
         try:
             # Launch all operations concurrently
@@ -341,7 +341,7 @@ class AsyncBaselineTest:
         start_time = time.perf_counter()
 
         # Create async Redis connection using canonical pattern
-        redis_client = get_redis_client(async_client=True, database="metrics")  # METRICS_DB
+        redis_client = await get_async_redis_client(database="metrics")  # METRICS_DB
 
         try:
             # Launch all operations concurrently
@@ -406,7 +406,7 @@ class AsyncBaselineTest:
             try:
                 if vm_name == "redis":
                     # Special handling for Redis (not HTTP) using canonical pattern
-                    redis_client = get_redis_client(async_client=True, database="main")  # MAIN_DB (default DB 0)
+                    redis_client = await get_async_redis_client(database="main")  # MAIN_DB (default DB 0)
                     try:
                         start = time.perf_counter()
                         await redis_client.ping()

--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -16,7 +16,7 @@ import inspect
 from typing import Any, Dict, List, Set
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.redis_management.types import DATABASE_MAPPING
 from autobot_shared.ssot_config import config as _ssot_config
 
@@ -167,7 +167,7 @@ class AutoBotMemoryGraphCore:
                 # the same DB.  The "memory" alias maps to DB 0 for exactly this
                 # purpose — see autobot_shared/redis_management/types.py _ALIASES.
                 # Fixed by #9943 (same root cause as #9904).
-                self.redis_client = get_redis_client(async_client=True, database="memory")
+                self.redis_client = await get_async_redis_client(database="memory")
 
                 # Create search indexes if they don't exist
                 await self._create_search_indexes()

--- a/autobot-backend/chat_workflow/code_exec/broker.py
+++ b/autobot-backend/chat_workflow/code_exec/broker.py
@@ -90,9 +90,9 @@ class CodeExecBroker:
 
     async def _emit_audit(self, tool: str, params_hash: str, ok: bool) -> None:
         try:
-            from autobot_shared.redis_client import get_redis_client  # lazy import
+            from autobot_shared.redis_client import get_async_redis_client  # lazy import
 
-            rc = get_redis_client(async_client=True)
+            rc = await get_async_redis_client()
             await rc.xadd(
                 self._security_key,
                 {"run_id": self._run_id, "tool": tool, "params_hash": params_hash, "ok": str(ok)},

--- a/autobot-backend/knowledge/pipeline/loaders/loaders_test.py
+++ b/autobot-backend/knowledge/pipeline/loaders/loaders_test.py
@@ -163,8 +163,8 @@ class TestRedisGraphLoader:
         mock_redis.zadd = AsyncMock()
 
         with patch(
-            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
-            return_value=mock_redis,
+            "knowledge.pipeline.loaders.redis_graph_loader.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
 
@@ -185,8 +185,8 @@ class TestRedisGraphLoader:
         mock_redis.zadd = AsyncMock()
 
         with patch(
-            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
-            return_value=mock_redis,
+            "knowledge.pipeline.loaders.redis_graph_loader.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
 
@@ -210,8 +210,8 @@ class TestRedisGraphLoader:
         mock_redis.zadd = AsyncMock()
 
         with patch(
-            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
-            return_value=mock_redis,
+            "knowledge.pipeline.loaders.redis_graph_loader.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
 
@@ -225,8 +225,8 @@ class TestRedisGraphLoader:
         mock_redis = MagicMock()
 
         with patch(
-            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
-            return_value=mock_redis,
+            "knowledge.pipeline.loaders.redis_graph_loader.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
 
@@ -249,8 +249,8 @@ class TestRedisGraphLoader:
         mock_redis.zadd = AsyncMock()
 
         with patch(
-            "knowledge.pipeline.loaders.redis_graph_loader.get_redis_client",
-            return_value=mock_redis,
+            "knowledge.pipeline.loaders.redis_graph_loader.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
         ):
             from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
 

--- a/autobot-backend/knowledge/pipeline/loaders/redis_graph_loader.py
+++ b/autobot-backend/knowledge/pipeline/loaders/redis_graph_loader.py
@@ -13,7 +13,7 @@ from typing import List
 
 from autobot_memory_graph.property_graph import PropertyGraph
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from knowledge.pipeline.base import BaseLoader, PipelineContext
 from knowledge.pipeline.models.entity import Entity
 from knowledge.pipeline.models.event import TemporalEvent
@@ -50,7 +50,7 @@ class RedisGraphLoader(BaseLoader):
         Args:
             context: Pipeline context with entities, relationships, events
         """
-        self.redis_client = get_redis_client(async_client=True, database=self.database)
+        self.redis_client = await get_async_redis_client(database=self.database)
         # Wire PropertyGraph to the same Redis connection (no extra pool entry)
         self._property_graph._redis = self.redis_client
 


### PR DESCRIPTION
## Thinking Path

#12780 reports one un-awaited `get_redis_client(async_client=True)` at `autobot_memory_graph/core.py:170`. The premise checks out exactly — the call sits inside `async def initialize` (line 151), so `await` is valid, and `self.redis_client` holds a coroutine for the object's lifetime.

Sweeping for the same defect found **six, not one**:

| Site | Consequence |
|---|---|
| `autobot_memory_graph/core.py:170` | reported — FT indexes never created, entity tracking off |
| `chat_workflow/code_exec/broker.py:95` | **code-exec security audit events silently dropped** — `rc.xadd()` on a coroutine raises `AttributeError` inside a bare `except Exception` |
| `knowledge/pipeline/loaders/redis_graph_loader.py:53` | also wires the coroutine into `_property_graph._redis` |
| `api/analytics_pattern_learning.py:230` | |
| `async_baseline_performance_test.py` (×3) | |

Two further hits are **not** bugs and I left them alone: `retrieval_learner.py:169` and `feedback_aggregator.py:203` pass the coroutine to `asyncio.wait_for()`, which awaits it correctly.

**I did not fix this by adding `await`.** `autobot_shared/redis_client.py` documents the legacy call as *"error-prone because it is a synchronous function that returns an unawaited coroutine"* and `get_async_redis_client()` as *"the safe alternative … making the correct usage impossible to get wrong"*. That wrapper exists because of **#3962 — the identical bug class**. Adding an `await` would fix these six instances and leave the footgun loaded for the seventh.

## What Changed

Six call sites migrated to `get_async_redis_client(database=…)`, with their imports updated. Each changed file was checked for a remaining *sync* `get_redis_client(` usage — none has one, so no import was stripped that a file still needs.

## Verification

```
$ python3 -m pytest autobot_memory_graph/ knowledge/ chat_workflow/ -q -k "redis or memory_graph or broker or graph_loader"
126 passed, 19 skipped, 3 errors
```

The 3 errors (`TestKnowledgeBaseAsyncRedisManagerIntegration`) are **pre-existing** — identical on an unmodified tree.

**The existing loader tests could never have caught this bug.** They patched `get_redis_client` with a plain `return_value=mock_redis` — mocking the call as *synchronous*, which is exactly the buggy shape. So production got a coroutine while the test got a client, and the suite stayed green. They now patch `get_async_redis_client` with `AsyncMock`, so the mock awaits the same way production does:

```
$ python3 -m pytest knowledge/pipeline/loaders/loaders_test.py -q
13 passed
```

## Deliberately out of scope

~47 further call sites use the legacy API **correctly**, with an explicit `await`. They are not broken, and migrating them is a mechanical sweep with its own blast radius — filed separately rather than smuggled into a bug fix.

## Model Used

Claude Opus 5 (1M context)

Closes #12780