### PR TITLE
fix(knowledge): record files as synced only when the KB stored every chunk (#12808)

### DIFF
--- a/autobot-backend/knowledge_sync_incremental.py
+++ b/autobot-backend/knowledge_sync_incremental.py
@@ -279,7 +279,14 @@ class IncrementalKnowledgeSync:
             self.file_metadata = {}
 
     async def _save_sync_state(self):
-        """Save current file metadata and sync state."""
+        """Save current file metadata and sync state, atomically.
+
+        Issue #12808: the manifest is staged to a sibling temp file and promoted with
+        ``os.replace``, so the live path is only ever a complete document. Writing in place
+        left a window where a crash truncated it; ``_load_sync_state`` then discarded the
+        unparseable manifest and forced a full re-sync of every tracked file.
+        """
+        staging_path = self.file_metadata_path.with_suffix(self.file_metadata_path.suffix + ".tmp")
         try:
             # Ensure data directory exists
             # Issue #358 - avoid blocking
@@ -290,15 +297,26 @@ class IncrementalKnowledgeSync:
             for path, metadata in self.file_metadata.items():
                 data[path] = asdict(metadata)
 
-            async with aiofiles.open(self.file_metadata_path, "w", encoding="utf-8") as f:
+            async with aiofiles.open(staging_path, "w", encoding="utf-8") as f:
                 await f.write(json.dumps(data, indent=2))
+            await asyncio.to_thread(os.replace, staging_path, self.file_metadata_path)
 
             logger.info("Saved metadata for %d files", len(self.file_metadata))
 
         except OSError as e:
             logger.error("Failed to write sync state file %s: %s", self.file_metadata_path, e)
+            await self._discard_staging_file(staging_path)
         except Exception as e:
             logger.error("Failed to save sync state: %s", e)
+            await self._discard_staging_file(staging_path)
+
+    @staticmethod
+    async def _discard_staging_file(staging_path: Path) -> None:
+        """Remove a half-written manifest so it can never be mistaken for the real one."""
+        try:
+            await asyncio.to_thread(staging_path.unlink, True)
+        except OSError as e:
+            logger.warning("Failed to remove staging file %s: %s", staging_path, e)
 
     def _compute_content_hash(self, content: str) -> str:
         """Compute SHA-256 hash of file content for change detection."""
@@ -396,6 +414,14 @@ class IncrementalKnowledgeSync:
             # Store chunks using extracted helper (Issue #665)
             vector_ids, fact_ids = await self._store_chunks_in_knowledge_base(chunks, relative_path, base_metadata)
 
+            # Issue #12808: sync state must advance on durable success, not on intent. Recording
+            # the content hash for a file the KB did not fully accept makes the next run classify
+            # it as unchanged, so the missing chunks are never retried and the content is silently
+            # absent from the KB. Returning None keeps the file out of the manifest, and the next
+            # run re-offers it: bounded re-work instead of silent loss.
+            if not self._is_durably_stored(chunks, fact_ids, relative_path):
+                return None
+
             # Create file metadata using extracted helper (Issue #665)
             metadata = self._create_file_metadata(
                 file_path,
@@ -404,14 +430,14 @@ class IncrementalKnowledgeSync:
                 file_stat,
                 vector_ids,
                 fact_ids,
-                len(chunks),
+                len(fact_ids),
                 processing_time,
             )
 
             logger.info(
-                "Processed: %s -> %d chunks in %.3fs",
+                "Processed: %s -> %d chunks stored in %.3fs",
                 relative_path,
-                len(chunks),
+                len(fact_ids),
                 processing_time,
             )
             return metadata
@@ -476,7 +502,13 @@ class IncrementalKnowledgeSync:
     async def _store_chunks_in_knowledge_base(
         self, chunks: List[Any], relative_path: Path, base_metadata: Dict[str, Any]
     ) -> Tuple[List[str], List[str]]:
-        """Issue #665: Extracted from _process_file_with_gpu_chunking to reduce function length."""
+        """Store each chunk as a KB fact, surfacing every rejection.
+
+        Issue #665: Extracted from _process_file_with_gpu_chunking to reduce function length.
+        Issue #12808: a chunk the KB refuses is logged rather than silently dropped, so the
+        caller can compare ``len(fact_ids)`` against ``len(chunks)`` and decide whether the
+        file was durably stored.
+        """
         vector_ids = []
         fact_ids = []
 
@@ -494,8 +526,37 @@ class IncrementalKnowledgeSync:
             result = await self.kb.store_fact(chunk_text, chunk_metadata)
             if result["status"] == "success":
                 fact_ids.append(result["fact_id"])
+            else:
+                logger.error(
+                    "Knowledge base rejected chunk %d/%d of %s: status=%s",
+                    i + 1,
+                    len(chunks),
+                    relative_path,
+                    result.get("status"),
+                )
 
         return vector_ids, fact_ids
+
+    @staticmethod
+    def _is_durably_stored(chunks: List[Any], fact_ids: List[str], relative_path: Path) -> bool:
+        """Did the knowledge base accept every chunk this file produced? (Issue #12808)
+
+        A partial store counts as a failure: the file is left out of the sync manifest so the
+        next run re-offers it whole. Re-storing the chunks that did land is cheaper than the
+        alternative — a file recorded at its current hash with only part of its content
+        retrievable, which nothing would ever correct.
+        """
+        if len(fact_ids) == len(chunks):
+            return True
+
+        logger.error(
+            "Not recording %s as synced: knowledge base stored %d of %d chunks; "
+            "the file stays unsynced and will be retried on the next run",
+            relative_path,
+            len(fact_ids),
+            len(chunks),
+        )
+        return False
 
     def _create_file_metadata(
         self,

--- a/autobot-backend/knowledge_sync_incremental_test.py
+++ b/autobot-backend/knowledge_sync_incremental_test.py
@@ -289,6 +289,129 @@ class TestIncrementalKnowledgeSyncChangedFiles:
 # ---------------------------------------------------------------------------
 
 
+class TestDurableSyncState:
+    """Issue #12808: the manifest must only record files the KB durably accepted."""
+
+    def _make_sync(self, tmp_path: Path) -> IncrementalKnowledgeSync:
+        sync = IncrementalKnowledgeSync.__new__(IncrementalKnowledgeSync)
+        sync.project_root = tmp_path
+        sync.sync_state_path = tmp_path / "data" / "incremental_sync_state.json"
+        sync.file_metadata_path = tmp_path / "data" / "file_metadata.json"
+        sync.kb = MagicMock()
+        sync.semantic_chunker = MagicMock()
+        sync.file_metadata = {}
+        sync.current_sync_time = time.time()
+        sync.max_concurrent_files = 4
+        sync.chunk_batch_size = 50
+        sync.enable_background_sync = True
+        sync.knowledge_ttl_hours = 24 * 7
+        sync.auto_invalidation_enabled = False
+        sync.doc_patterns = ["*.md"]
+        return sync
+
+    @staticmethod
+    def _chunk(text: str) -> MagicMock:
+        return MagicMock(content=text, semantic_score=0.9, sentences=[text])
+
+    async def _process(self, sync: IncrementalKnowledgeSync, doc: Path, statuses):
+        """Run one file through processing with a KB that returns ``statuses`` in order."""
+        sync.semantic_chunker.chunk_text = AsyncMock(
+            return_value=[self._chunk(f"chunk {i}") for i in range(len(statuses))]
+        )
+        sync.kb.store_fact = AsyncMock(
+            side_effect=[
+                {"status": s, "fact_id": f"fact-{i}"} if s == "success" else {"status": s}
+                for i, s in enumerate(statuses)
+            ]
+        )
+        return await sync._process_file_with_gpu_chunking(doc)
+
+    @pytest.mark.asyncio
+    async def test_total_store_failure_is_not_recorded_as_synced(self, tmp_path):
+        """Every chunk rejected -> no metadata, so the next run re-offers the file."""
+        sync = self._make_sync(tmp_path)
+        doc = tmp_path / "doc.md"
+        doc.write_text("some indexable content", encoding="utf-8")
+
+        result = await self._process(sync, doc, ["error", "error"])
+
+        assert result is None
+        sync._update_metadata_from_results([doc], [result], SyncMetrics())
+        assert str(doc) not in sync.file_metadata
+
+        # The file must still be classified as needing work on the next pass.
+        changed, _removed, _new = await sync._analyze_file_changes([doc])
+        assert doc in changed
+
+    @pytest.mark.asyncio
+    async def test_partial_store_failure_is_not_recorded_as_synced(self, tmp_path):
+        """One chunk rejected -> the file is retried whole rather than half-indexed."""
+        sync = self._make_sync(tmp_path)
+        doc = tmp_path / "doc.md"
+        doc.write_text("some indexable content", encoding="utf-8")
+
+        result = await self._process(sync, doc, ["success", "error"])
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_full_success_records_durable_chunk_count(self, tmp_path):
+        """All chunks stored -> metadata recorded, chunk_count reflects stored facts."""
+        sync = self._make_sync(tmp_path)
+        doc = tmp_path / "doc.md"
+        doc.write_text("some indexable content", encoding="utf-8")
+
+        result = await self._process(sync, doc, ["success", "success", "success"])
+
+        assert result is not None
+        assert result.fact_ids == ["fact-0", "fact-1", "fact-2"]
+        assert result.chunk_count == len(result.fact_ids)
+
+        metrics = SyncMetrics()
+        sync._update_metadata_from_results([doc], [result], metrics)
+        assert str(doc) in sync.file_metadata
+        assert metrics.total_chunks_processed == 3
+
+    @pytest.mark.asyncio
+    async def test_save_sync_state_promotes_atomically(self, tmp_path):
+        """The manifest is written whole and leaves no staging file behind."""
+        sync = self._make_sync(tmp_path)
+        sync.file_metadata = {"/a.md": _make_file_metadata("/a.md", _sha256("a"), 1.0)}
+
+        await sync._save_sync_state()
+
+        assert sync.file_metadata_path.is_file()
+        staged = sync.file_metadata_path.with_suffix(sync.file_metadata_path.suffix + ".tmp")
+        assert not staged.exists()
+        import json as _json
+
+        assert "/a.md" in _json.loads(sync.file_metadata_path.read_text(encoding="utf-8"))
+
+    @pytest.mark.asyncio
+    async def test_failed_save_leaves_previous_manifest_intact(self, tmp_path):
+        """A serialization failure must not damage the manifest already on disk."""
+        sync = self._make_sync(tmp_path)
+        sync.file_metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        sync.file_metadata_path.write_text('{"/old.md": {}}', encoding="utf-8")
+
+        # A field json.dumps cannot serialize aborts the write *after* the target file has
+        # been opened for writing — the exact window in which an in-place write truncates
+        # the live manifest.
+        doomed = _make_file_metadata("/new.md", _sha256("new"), 1.0)
+        doomed.vector_ids = [object()]
+        sync.file_metadata = {"/new.md": doomed}
+        await sync._save_sync_state()
+
+        assert sync.file_metadata_path.read_text(encoding="utf-8") == '{"/old.md": {}}'
+        staged = sync.file_metadata_path.with_suffix(sync.file_metadata_path.suffix + ".tmp")
+        assert not staged.exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: force_full flag clears metadata for full rebuild
+# ---------------------------------------------------------------------------
+
+
 class TestForceFullRebuild:
     """Acceptance: full rebuild available via force_full."""
 


### PR DESCRIPTION
## Thinking Path

`IncrementalKnowledgeSync` advanced its sync state on **intent** rather than on **durable success**. A file whose chunks the knowledge base refused was still written into the manifest at its current content hash, so `_analyze_file_changes` classified it as unchanged forever and its content stayed absent from the KB with no error surfaced anywhere. The same ordering flaw appeared in the manifest write itself: an in-place truncating write meant a mid-write failure destroyed the manifest for every tracked file.

The rule applied throughout: **state advances only after the store has accepted the data.** Anything short of that leaves the file out of the manifest so the next run re-offers it — bounded re-work instead of silent loss.

## What Changed

`autobot-backend/knowledge_sync_incremental.py`

- `_store_chunks_in_knowledge_base` now logs every chunk the KB rejects with its index and returned status. Previously a non-`success` result was dropped with no trace, so the caller could not distinguish "stored 10 of 10" from "stored 0 of 10".
- New `_is_durably_stored` gate: `_process_file_with_gpu_chunking` returns `None` unless the KB accepted **every** chunk. A partial store counts as failure — re-storing the chunks that did land is cheaper than a file recorded at its current hash with only part of its content retrievable, which nothing would ever correct.
- `_create_file_metadata` is now called with `len(fact_ids)` instead of `len(chunks)`, so `chunk_count` — and therefore `SyncMetrics.total_chunks_processed` and the chunks/sec figure — describe durable state rather than attempts.
- The per-file completion log reports chunks *stored*, not chunks attempted.
- `_save_sync_state` stages the manifest to `<path>.tmp` and promotes it with `os.replace`, so the live path is only ever a complete document. New `_discard_staging_file` removes a half-written staging file on any failure.

`autobot-backend/knowledge_sync_incremental_test.py`

- New `TestDurableSyncState` class, 5 tests: total store failure, partial store failure, full success (durable chunk count + metrics), atomic promotion, and previous-manifest survival on a failed write.

## Verification

New tests pass against the fix, and 3 of the 5 fail against the pre-fix module — confirming they capture the actual defect rather than restating current behaviour.

Against the fixed module:

```
$ python3 -m pytest knowledge_sync_incremental_test.py -p no:randomly -q
knowledge_sync_incremental_test.py ......................                [100%]
============================== 22 passed in 0.99s ==============================
```

Against the base module (`git checkout origin/Dev_new_gui -- knowledge_sync_incremental.py`):

```
$ python3 -m pytest knowledge_sync_incremental_test.py::TestDurableSyncState -p no:randomly -q
FAILED ...::test_total_store_failure_is_not_recorded_as_synced
    assert FileMetadata(..., fact_ids=[], chunk_count=2, ...) is None
FAILED ...::test_partial_store_failure_is_not_recorded_as_synced
    assert FileMetadata(..., fact_ids=['fact-0'], chunk_count=2, ...) is None
FAILED ...::test_failed_save_leaves_previous_manifest_intact
    assert '' == '{"/old.md": {}}'
========================= 3 failed, 2 passed in 1.42s ==========================
```

The third failure is the manifest-truncation window made concrete: the pre-fix in-place write left the live manifest empty after a serialization error partway through.

Full existing suite for this module (17 pre-existing tests) stays green.

Closes #12808

## Model Used

Claude Opus 5 (1M context)
