### PR TITLE
fix(token-denylist): check negative cache in revoke_jti (fixes #12780)

### DIFF
--- a/autobot-slm-backend/services/token_denylist.py
+++ b/autobot-slm-backend/services/token_denylist.py
@@ -97,6 +97,10 @@ async def revoke_jti(jti: str, ttl_seconds: int) -> None:
     so no background cleanup is needed.  Silently no-ops if Redis is
     unavailable (logs a warning) — bounded by the module deadline.
     """
+    if _redis_marked_unavailable():
+        logger.warning("revoke_jti: jti=%r NOT revoked (Redis marked unavailable)", jti)
+        return
+
     ttl = max(1, ttl_seconds)
 
     async def _do() -> bool:

--- a/autobot-slm-backend/tests/services/test_token_denylist.py
+++ b/autobot-slm-backend/tests/services/test_token_denylist.py
@@ -320,8 +320,9 @@ class TestBoundedRedisAccess:
         with patch.object(_dl_mod, "get_redis_client", get_client):
             assert await is_jti_revoked("jti-a") is False  # arms the window
             assert await is_jti_revoked("jti-b") is False  # short-circuits
+            await revoke_jti("jti-c", ttl_seconds=60)  # short-circuits via negative cache
 
-        get_client.assert_called_once()  # second call never touched Redis
+        get_client.assert_called_once()  # subsequent calls never touched Redis
 
     @pytest.mark.asyncio
     async def test_success_clears_negative_cache(self):


### PR DESCRIPTION
## Summary
Fixes #12780.

## Changes
- Updated `revoke_jti` in `autobot-slm-backend/services/token_denylist.py` to check `_unavailable_until` negative cache before acquiring Redis client.
- Added test coverage in `autobot-slm-backend/tests/services/test_token_denylist.py` verifying `revoke_jti` short-circuits during negative cache fail-open window.