### PR TITLE
fix(backend): enable faulthandler so the SIGABRT crash-loop is diagnosable (#12777)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
@@ -27,6 +27,17 @@ Group={{ backend_group }}
 WorkingDirectory={{ backend_code_dir | default(backend_install_dir) }}
 Environment="PATH={{ backend_code_dir | default(backend_install_dir) }}/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="PYTHONPATH={{ backend_install_dir }}:{{ backend_code_dir | default(backend_install_dir) }}:{{ backend_install_dir | dirname }}/autobot_shared:{{ backend_install_dir | dirname }}"
+# #12777: the backend SIGABRTs every ~25-55 min and leaves ZERO diagnostics.
+# Without faulthandler a fatal signal raised inside a C extension (uvloop,
+# chromadb, torch/onnx — all compiled against a very new Python 3.14) unwinds
+# without ever printing a Python stack, so backend-error.log just stops
+# mid-stream and resumes at the next boot. Core capture cannot cover for that
+# here either: this platform's core_pattern pipes to /wsl-capture-crash, which
+# does not exist, so the kernel reports code=dumped and the core is discarded.
+# With this set, the next abort writes a native + Python traceback to
+# StandardError (backend-error.log, see below) — which is the prerequisite for
+# identifying the aborting extension at all.
+Environment="PYTHONFAULTHANDLER=1"
 EnvironmentFile={{ backend_code_dir | default(backend_install_dir) }}/.env
 EnvironmentFile=-{{ service_auth_keys_dir | default('/etc/autobot/service-keys') }}/{{ service_auth_service_id | default('main-backend') }}.env
 # MVA-1633: Validate env vars before starting to prevent silent crashes

--- a/autobot-slm-backend/tests/test_backend_service_faulthandler_12777.py
+++ b/autobot-slm-backend/tests/test_backend_service_faulthandler_12777.py
@@ -1,0 +1,72 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Render test for the backend unit's crash diagnostics (#12777).
+
+autobot-backend SIGABRTs roughly every 25-55 minutes and leaves NO diagnostics
+at all. Two things independently destroy the forensic trail:
+
+  1. faulthandler was not enabled, so a fatal signal raised inside a C
+     extension (uvloop / chromadb / torch-onnx, all compiled against a very new
+     Python 3.14) unwinds without printing a Python stack — backend-error.log
+     simply stops mid-stream and resumes at the next boot.
+  2. Core capture is broken on the deployment platform: core_pattern pipes to
+     /wsl-capture-crash, which does not exist, so the kernel reports
+     code=dumped and the core is silently discarded.
+
+Only (1) is fixable in this repo, and it is the prerequisite for diagnosing the
+abort at all. This test pins it so a future unit-template edit cannot quietly
+drop it and return the crash loop to being undiagnosable.
+
+Follows the render-test precedent in test_pg_hba_multiuser.py (#10636).
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+_TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "ansible" / "roles" / "backend" / "templates"
+
+_CTX = {
+    "backend_install_dir": "/opt/autobot/autobot-backend",
+    "backend_code_dir": "/opt/autobot/autobot-backend",
+    "backend_log_dir": "/var/log/autobot",
+    "backend_host": "0.0.0.0",
+    "backend_port": 8001,
+    "backend_workers": 1,
+    "backend_user": "autobot",
+    "backend_group": "autobot",
+}
+
+
+def _render(**overrides) -> str:
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(_TEMPLATE_DIR)))
+    # `dirname` / `basename` are Ansible filters, not Jinja2 builtins — register
+    # the stdlib equivalents so the real template renders outside Ansible.
+    env.filters["dirname"] = os.path.dirname
+    env.filters["basename"] = os.path.basename
+    return env.get_template("autobot-backend.service.j2").render(**{**_CTX, **overrides})
+
+
+def test_faulthandler_is_enabled():
+    """Without this, a native abort prints nothing and cannot be diagnosed."""
+    assert 'Environment="PYTHONFAULTHANDLER=1"' in _render()
+
+
+def test_faulthandler_output_has_somewhere_to_land():
+    """faulthandler writes to stderr, so the unit must still capture stderr.
+
+    Enabling faulthandler while stderr goes nowhere would leave the crash just
+    as invisible — the two settings only work as a pair.
+    """
+    rendered = _render()
+    assert "StandardError=append:" in rendered
+    assert "backend-error.log" in rendered
+
+
+def test_restart_always_is_retained():
+    """The crash loop is survivable only because systemd restarts the unit;
+    the diagnostics change must not alter that."""
+    assert "Restart=always" in _render()


### PR DESCRIPTION
## Thinking Path

`autobot-backend` aborts with SIGABRT every ~25–55 minutes and produces **zero diagnostics**. The issue already ruled out every ordinary cause from cgroup counters — `memory.events` all-zero with a 3.4 GiB peak against a 12 GiB cap, `pids.peak` 65 against a 512 limit — so this is a native abort. And a native abort is precisely what the current setup cannot record.

Two things independently destroy the forensic trail:

1. **faulthandler was never enabled** — no `PYTHONFAULTHANDLER`, no `-X faulthandler`. A fatal signal inside a C extension unwinds without printing a Python stack, so `backend-error.log` stops mid-stream and resumes at the next boot.
2. **Core capture is broken on the platform** — `core_pattern` pipes to `/wsl-capture-crash`, which does not exist. systemd reports `code=dumped` while the core is discarded.

So the first fix is not a fix for the crash — it is making the crash *observable*. Without a stack, step 3 of the issue ("pin the aborting extension") is unactionable.

## What Changed

One line on the canonical unit template (authoritative per #11670):

```
Environment="PYTHONFAULTHANDLER=1"
```

The next abort now writes a native + Python traceback to `StandardError`, which the same unit already appends to `backend-error.log`.

## Deliberately not included

- **`core_pattern`** is host/WSL configuration, not repo state. The issue itself asks for it to be either fixed *or* explicitly opted out of with a recorded reason — that's an owner call, not a drive-by.
- **Pinning or rebuilding the suspect extension** (uvloop / chromadb / torch-onnx against a very new Python 3.14) stays a **hypothesis** until a stack exists. Worth being precise: the single uvloop `OSError: [Errno 88] Socket operation on non-socket` appears **once** in the whole log and preceded only **one** of the two observed aborts — it cannot explain both, and acting on it now would be guessing.

## Verification

```
$ python3 -m pytest tests/test_backend_service_faulthandler_12777.py -q
3 passed

$ python3 -m pytest tests/ -q
976 passed, 1 skipped
```

Three render tests, following the `test_pg_hba_multiuser.py` precedent (#10636): faulthandler stays enabled; stderr still has somewhere to land (the two only work as a **pair** — enabling faulthandler while stderr goes nowhere leaves the crash just as invisible); and `Restart=always` survives, since the loop is only survivable because systemd restarts the unit.

Mutation-verified — deleting the env line fails the first test:

```
env line removed  → test_faulthandler_is_enabled FAILED
env line restored → 3 passed
```

The test registers Ansible's `dirname`/`basename` filters so the **real** template renders outside Ansible, rather than testing a copy.

## Deployment note

This is a **systemd unit** change, so it only takes effect after the backend role is redeployed — it will not reach the box via a code-only sync. The crash loop stays undiagnosable until that happens.

## Model Used

Claude Opus 5 (1M context)

Closes #12777