### PR TITLE
ci: detect stale PR branches by compare/behind_by, not mergeStateStatus (#12818)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -51,15 +51,48 @@ jobs:
           # updated a single branch, so every stale PR needed the manual "Update
           # branch" click this job exists to remove.
           #
-          # `mergeStateStatus` IS supported; BEHIND is exactly "needs updating".
-          # `|| true` keeps a transient gh/API failure from re-introducing the
-          # same abort-before-exit-0 behaviour.
-          OUTDATED=$(gh pr list \
+          # #12818: do NOT filter on mergeStateStatus. It is computed LAZILY by
+          # GitHub, and immediately after a push — exactly when this workflow
+          # fires — it comes back UNKNOWN for the very PRs that just went stale.
+          # The filter then matched nothing, the script took the "all up to
+          # date" branch and exited 0, so the job went GREEN while updating
+          # nothing. That is worse than the #12801 crash: a passing check
+          # asserting work that never happened.
+          #
+          # `compare/{base}...{head}` is evaluated on demand and is always
+          # accurate at push time, so no retry loop is needed.
+          # `|| true` on each call keeps a transient API failure from
+          # re-introducing the abort-before-exit-0 behaviour.
+          OPEN_PRS=$(gh pr list \
             --repo "$REPO" \
             --base Dev_new_gui \
             --state open \
-            --json number,mergeStateStatus \
-            --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number' || true)
+            --json number,headRefName \
+            --jq '.[] | "\(.number) \(.headRefName)"' || true)
+
+          OUTDATED=""
+          while read -r PR HEAD_REF; do
+            [ -n "$PR" ] || continue
+            # $HEAD_REF is interpolated into an API PATH, so validate it the same
+            # way $PR is validated numerically below. A branch may legitimately
+            # contain '/', '.', '-' and '_', but '..' would traverse to a
+            # different endpoint — reject anything outside that charset or
+            # containing a dot-dot segment.
+            case "$HEAD_REF" in
+              ''|*..*|-*) echo "  Skipping unsafe head ref for PR #$PR"; continue ;;
+            esac
+            if ! printf '%s' "$HEAD_REF" | grep -qE '^[A-Za-z0-9._/-]+$'; then
+              echo "  Skipping unsafe head ref for PR #$PR"
+              continue
+            fi
+            BEHIND=$(gh api \
+              "repos/$REPO/compare/Dev_new_gui...$HEAD_REF" \
+              --jq '.behind_by' 2>/dev/null || echo "")
+            case "$BEHIND" in
+              ''|0) ;;
+              *) OUTDATED="$OUTDATED $PR"; echo "  PR #$PR is $BEHIND commit(s) behind" ;;
+            esac
+          done <<< "$OPEN_PRS"
 
           if [ -z "$OUTDATED" ]; then
             echo "All PR branches are up to date (or none could be listed)."


### PR DESCRIPTION
## Thinking Path

**Correcting my own #12802.** That PR stopped `auto-update` crashing — a real improvement, it used to abort on its first command — but it did **not** make the workflow work. I claimed it was "doing its job on every push". It was passing, not working.

On base head `f6639e453` the job went green while logging:

```
Dev_new_gui was updated — checking open PRs for staleness...
All PR branches are up to date (or none could be listed).
```

Three PRs (#12806, #12815, #12817) were `BEHIND` at that moment, and each still needed a manual `PUT /pulls/{n}/update-branch`.

**Cause:** `mergeStateStatus` is computed **lazily** by GitHub. Immediately after a push — precisely when this workflow fires — it returns `UNKNOWN` for the very PRs that just went stale. So `select(.mergeStateStatus == "BEHIND")` matched nothing and the script took the "all up to date" path.

The failure mode moved from *loud and broken* to *quiet and broken*, which is worse in one respect: a green check now asserted work that never happened. That's the part worth fixing carefully rather than patching again by guess.

## What Changed

Ask for the comparison directly instead of depending on a lazily-computed field:

```
GET /repos/{owner}/{repo}/compare/Dev_new_gui...{head}   ->  .behind_by
```

This is evaluated on demand and is accurate at push time, so no retry/poll loop is needed.

## Verification

Ran the new detection against the live repo while those three PRs were behind — it finds exactly the ones the old filter reported as up to date:

```
PR #12817  behind_by=2  (issue-12778)
PR #12815  behind_by=1  (issue-12777)
PR #12806  behind_by=1  (issue-12780)
```

Structural checks on the parsed YAML, evaluated against **non-comment** lines (the removed field is still named in the explanatory comment):

```
PASS  no mergeStateStatus in CODE
PASS  uses compare/behind_by
PASS  head-ref validated
PASS  numeric PR guard kept
PASS  REST update-branch kept
PASS  ends with exit 0
```

## Security

`$HEAD_REF` is now interpolated into an API **path**, so it is validated the same way `$PR` already was: skipped unless it matches `^[A-Za-z0-9._/-]+$`, and explicitly skipped if it contains a `..` segment (which would traverse to a different endpoint) or begins with `-`. Branch names are attacker-influenceable in a way PR numbers are not, so this guard is not optional.

Everything else from #12802 is retained: the REST `update-branch` call (verified on 8 PRs during today's queue drain), the `|| true` guards, the numeric `$PR` validation, and the reachable trailing `exit 0`.

## Model Used

Claude Opus 5 (1M context)

Closes #12818