### PR TITLE
test(config): fix all 9 stale failures in the config suite (#12774)

### DIFF
--- a/autobot-backend/config/config_migration_integration_test.py
+++ b/autobot-backend/config/config_migration_integration_test.py
@@ -106,34 +106,28 @@ class TestConfigurationMigration:
                 pass
 
     def test_config_environment_variable_priorities(self):
-        """Test environment variable priority order (AUTOBOT_, AB_, none)"""
-        test_config = ConfigManager()
+        """Env-var override is ConfigRegistry's job, via the AUTOBOT_ prefix.
 
-        # Test priority order: AUTOBOT_ > AB_ > unprefixed
-        with patch.dict(
-            os.environ,
-            {
-                "AUTOBOT_TEST_KEY": "autobot_value",
-                "AB_TEST_KEY": "ab_value",
-                "TEST_KEY": "unprefixed_value",
-            },
-        ):
-            # Should prefer AUTOBOT_ prefix
-            assert test_config.get("test.key") == "autobot_value"
+        This previously asserted a three-tier AUTOBOT_ > AB_ > unprefixed order
+        against ConfigManager.get(). ConfigManager.get() is a FLAT dict lookup
+        (config/sync_ops.py) — it resolves neither dotted paths nor env vars —
+        and no AB_/unprefixed tier exists anywhere in the codebase. The test was
+        asserting a migration-era design that was never implemented.
 
-        # Test AB_ prefix when AUTOBOT_ not available
-        with patch.dict(
-            os.environ,
-            {"AB_TEST_KEY2": "ab_value2", "TEST_KEY2": "unprefixed_value2"},
-            clear=True,
-        ):
-            # Should use AB_ prefix
-            assert test_config.get("test.key2") == "ab_value2"
+        ConfigRegistry.get() is the component that does consult the environment,
+        and it builds exactly one key: AUTOBOT_<KEY_WITH_DOTS_AS_UNDERSCORES>.
+        """
+        from config.registry import ConfigRegistry
 
-        # Test unprefixed when neither AUTOBOT_ nor AB_ available
-        with patch.dict(os.environ, {"TEST_KEY3": "unprefixed_value3"}, clear=True):
-            # Should use unprefixed
-            assert test_config.get("test.key3") == "unprefixed_value3"
+        ConfigRegistry.clear_cache()
+        with patch.object(ConfigRegistry, "_fetch_from_redis", return_value=None):
+            with patch.dict(os.environ, {"AUTOBOT_TEST_KEY": "autobot_value"}, clear=True):
+                assert ConfigRegistry.get("test.key") == "autobot_value"
+
+            # No AB_ tier and no unprefixed tier: the caller default stands.
+            ConfigRegistry.clear_cache()
+            with patch.dict(os.environ, {"AB_TEST_KEY2": "ab", "TEST_KEY2": "plain"}, clear=True):
+                assert ConfigRegistry.get("test.key2", default="fallback") == "fallback"
 
     def test_unified_multimodal_processor_config_usage(self):
         """Test that unified multimodal processor uses centralized config"""
@@ -141,13 +135,15 @@ class TestConfigurationMigration:
 
         # Create test config with vision settings
         test_config = ConfigManager()
-        test_config.set("multimodal.vision.confidence_threshold", 0.9)
-        test_config.set("multimodal.vision.processing_timeout", 60)
-        test_config.set("multimodal.vision.enabled", False)
+        # set() is a FLAT dict write (config/sync_ops.py), so a dotted key would
+        # not land in the nested tree that get_config_section() reads.
+        test_config.set_nested("multimodal.vision.confidence_threshold", 0.9)
+        test_config.set_nested("multimodal.vision.processing_timeout", 60)
+        test_config.set_nested("multimodal.vision.enabled", False)
 
         with patch(
             "multimodal_processor.processors.vision.get_config_section",
-            lambda section: test_config.get_section(section),
+            lambda section: test_config.get_config_section(section),
         ):
             vision_proc = VisionProcessor()
 
@@ -161,8 +157,9 @@ class TestConfigurationMigration:
         cm = ConfigManager()
 
         # Test that all expected sections exist in default config
+        # NOTE: "llm" is deliberately absent — it is not a top-level section;
+        # LLM config lives under backend.llm (see config/defaults.py).
         required_sections = [
-            "llm",
             "deployment",
             "data",
             "redis",
@@ -177,7 +174,7 @@ class TestConfigurationMigration:
         ]
 
         for section in required_sections:
-            config_section = cm.get_section(section)
+            config_section = cm.get_config_section(section)
             assert isinstance(config_section, dict), f"Section {section} should be a dict"
             assert len(config_section) > 0, f"Section {section} should not be empty"
 
@@ -186,56 +183,68 @@ class TestConfigurationMigration:
         cm = ConfigManager()
 
         # Test boolean values
-        assert isinstance(cm.get("multimodal.vision.enabled"), bool)
-        assert isinstance(cm.get("security.enable_sandboxing"), bool)
-        assert isinstance(cm.get("hardware.acceleration.enabled"), bool)
+        assert isinstance(cm.get_nested("multimodal.vision.enabled"), bool)
+        assert isinstance(cm.get_nested("security.enable_sandboxing"), bool)
+        assert isinstance(cm.get_nested("hardware.acceleration.enabled"), bool)
 
         # Test integer values
-        assert isinstance(cm.get("redis.port"), int)
-        assert isinstance(cm.get("deployment.port"), int)
-        assert isinstance(cm.get("llm.ollama.port"), int)
+        assert isinstance(cm.get_nested("redis.port"), int)
+        assert isinstance(cm.get_nested("deployment.port"), int)
+        assert isinstance(cm.get_nested("backend.server_port"), int)
 
         # Test float values
-        assert isinstance(cm.get("multimodal.vision.confidence_threshold"), (int, float))
-        assert isinstance(cm.get("multimodal.voice.confidence_threshold"), (int, float))
+        assert isinstance(cm.get_nested("multimodal.vision.confidence_threshold"), (int, float))
+        assert isinstance(cm.get_nested("multimodal.voice.confidence_threshold"), (int, float))
 
         # Test string values
-        assert isinstance(cm.get("llm.orchestrator_llm"), str)
-        assert isinstance(cm.get("deployment.host"), str)
-        assert isinstance(cm.get("redis.host"), str)
+        assert isinstance(cm.get_nested("backend.llm.provider_type"), str)
+        assert isinstance(cm.get_nested("deployment.host"), str)
+        assert isinstance(cm.get_nested("redis.host"), str)
 
         # Test list values
-        assert isinstance(cm.get("hardware.acceleration.priority_order"), list)
-        assert isinstance(cm.get("security.blocked_commands"), list)
+        assert isinstance(cm.get_nested("hardware.acceleration.priority_order"), list)
+        assert isinstance(cm.get_nested("security.blocked_commands"), list)
 
     def test_config_migration_backward_compatibility(self):
         """Test that migration maintains backward compatibility"""
         # Test that old config patterns still work during transition period
-        from utils.config_manager import config
+        # The backward-compat wrapper is config.compat.Config. `utils.config_manager`
+        # (the old import path) no longer exists, and `from config import config`
+        # yields the SSOT _ConfigProxy, which exposes neither .config nor .get.
+        from config.compat import Config
+
+        legacy = Config(config_manager)
 
         # The backward compatibility wrapper should work
-        assert hasattr(config, "config")  # Old interface
-        assert hasattr(config, "get")  # Old interface
+        assert hasattr(legacy, "config")  # Old interface
+        assert hasattr(legacy, "get")  # Old interface
 
-        # Should return same values as new interface
-        assert config.get("llm.orchestrator_llm") == config_manager.get("llm.orchestrator_llm")
+        # Should return the same values as the new interface. Use a key that
+        # actually EXISTS — the previous "llm.orchestrator_llm" is absent from
+        # the config tree, so both sides were None and the assertion was vacuous.
+        assert legacy.get("redis") == config_manager.get("redis")
+        assert isinstance(legacy.config, dict) and legacy.config
 
     def test_config_default_value_handling(self):
         """Test proper handling of default values across components"""
         cm = ConfigManager()
 
-        # Test that defaults are reasonable and consistent
-        # LLM defaults
-        assert cm.get("llm.orchestrator_llm") in ["ollama", "openai"]
-        assert cm.get("llm.ollama.base_url").startswith("http")
+        # LLM defaults. NOTE: "llm.orchestrator_llm" and "llm.ollama.base_url"
+        # do not exist — LLM config lives under backend.llm, whose provider URL
+        # is local.providers.ollama.host.
+        assert isinstance(cm.get_nested("backend.llm.provider_type"), str)
+        assert cm.get_nested("backend.llm.local.providers.ollama.host").startswith("http")
 
-        # Redis defaults
-        assert cm.get("redis.host") in ["localhost", "127.0.0.1"]
-        assert 1 <= cm.get("redis.port") <= 65535
+        # Redis defaults. The host is deployment-specific (it is an SSOT value,
+        # not a literal), so assert it is a non-empty string rather than pinning
+        # it to localhost — pinning made this fail on every real deployment.
+        assert isinstance(cm.get_nested("redis.host"), str)
+        assert cm.get_nested("redis.host")
+        assert 1 <= cm.get_nested("redis.port") <= 65535
 
         # Security defaults should be secure by default
-        assert cm.get("security.enable_sandboxing") is True
-        assert len(cm.get("security.blocked_commands")) > 0
+        assert cm.get_nested("security.enable_sandboxing") is True
+        assert len(cm.get_nested("security.blocked_commands")) > 0
 
 
 if __name__ == "__main__":

--- a/autobot-backend/config/timeout_configuration_test.py
+++ b/autobot-backend/config/timeout_configuration_test.py
@@ -12,6 +12,7 @@ Validates:
 """
 
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -211,18 +212,27 @@ class TestBackwardCompatibility:
         assert self.config.get_timeout("redis", "default") == 5.0
 
     def test_environment_variable_override(self):
-        """Test that AUTOBOT_LLM_TIMEOUT env var still works"""
-        original = config.llm_timeout
-        try:
-            config.llm_timeout = "999.0"
-            # Reload config would be needed here
-            # For now, just test the mechanism exists
-            assert "AUTOBOT_LLM_TIMEOUT" in os.environ
-        finally:
-            if original:
-                config.llm_timeout = original
-            elif "AUTOBOT_LLM_TIMEOUT" in os.environ:
-                del config.llm_timeout
+        """AUTOBOT_LLM_TIMEOUT must override the default on a fresh config.
+
+        This previously assigned `config.llm_timeout = "999.0"` and then asserted
+        `"AUTOBOT_LLM_TIMEOUT" in os.environ` — assignment to the proxy does not
+        write the environment, so the assertion failed on every run. Its own
+        comment conceded it only "test[ed] the mechanism exists".
+
+        The real mechanism is pydantic-settings reading the env at construction.
+        The module-level `config` proxy is built once and cached, so the override
+        must be observed on a NEW instance.
+        """
+        from autobot_shared.ssot_config import AutoBotConfig
+
+        default_timeout = AutoBotConfig().llm_timeout
+
+        with patch.dict(os.environ, {"AUTOBOT_LLM_TIMEOUT": "999.0"}):
+            assert AutoBotConfig().llm_timeout == 999
+
+        # And it is genuinely the env doing the work, not a coincidence.
+        assert AutoBotConfig().llm_timeout == default_timeout
+        assert default_timeout != 999
 
 
 class TestIntegration:

--- a/autobot-backend/config/validation_test.py
+++ b/autobot-backend/config/validation_test.py
@@ -77,21 +77,41 @@ class TestFalsyValidValues:
         redis_errors = [e for e in result.errors if "redis.host" in e]
         assert redis_errors == [], f"Unexpected errors: {redis_errors}"
 
-    def test_server_host_none_is_rejected(self):
-        """Only an actual None value must produce a required-key error."""
-        cfg = _base_config()
-        cfg["backend"]["server_host"] = None
-        result = validate_startup_config(cfg)
-        host_errors = [e for e in result.errors if "server_host" in e]
-        assert len(host_errors) == 1
+    def test_server_host_is_no_longer_required(self):
+        """GH#9232 removed backend.server_host from the required set.
 
-    def test_server_host_missing_key_is_rejected(self):
-        """A completely absent key must produce a required-key error."""
-        cfg = _base_config()
-        del cfg["backend"]["server_host"]
-        result = validate_startup_config(cfg)
-        host_errors = [e for e in result.errors if "server_host" in e]
-        assert len(host_errors) == 1
+        _REQUIRED_CONFIG_KEYS is now empty (validation.py) because server_host
+        defaults to 0.0.0.0 in config/defaults.py. These two cases previously
+        asserted it WAS required and so failed on every run.
+        """
+        for mutate in (
+            lambda c: c["backend"].__setitem__("server_host", None),
+            lambda c: c["backend"].pop("server_host"),
+        ):
+            cfg = _base_config()
+            mutate(cfg)
+            result = validate_startup_config(cfg)
+            assert [e for e in result.errors if "server_host" in e] == []
+
+    def test_conditionally_required_key_uses_is_none_not_truthiness(self):
+        """The is-None-vs-falsy invariant this class exists for, on a key that
+        IS still required.
+
+        memory.redis.host is conditionally required when memory.redis.enabled,
+        and validation.py gates it on `if value is None`. So None/absent must
+        error, while a falsy-but-present value ('0', tested above) must not —
+        which is exactly the distinction #9232 left untested once server_host
+        stopped being required.
+        """
+        for mutate in (
+            lambda c: c["memory"]["redis"].__setitem__("host", None),
+            lambda c: c["memory"]["redis"].pop("host"),
+        ):
+            cfg = _base_config()
+            cfg["memory"]["redis"]["enabled"] = True
+            mutate(cfg)
+            result = validate_startup_config(cfg)
+            assert len([e for e in result.errors if "redis.host" in e]) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

`config/` was **9 failed, 93 passed**. Every one turned out to be a test asserting an API, module or value that no longer exists — the same class as #12668 (stale attributes) and #12673 (environment-dependent assertions) — **not** product bugs. So the work was verifying what each subject actually does now, then retargeting the test at that, rather than "making it pass".

The recurring trap: `ConfigManager.get()` and `.set()` are **flat** dict operations (`config/sync_ops.py`). They resolve neither dotted paths nor env vars. Six of the nine failures trace back to tests assuming otherwise.

## What Changed

**`validation_test` (2)** — GH#9232 removed `backend.server_host` from the required set; `_REQUIRED_CONFIG_KEYS` is now literally empty because it defaults to `0.0.0.0`. The tests asserted it *was* required.

Rather than delete the coverage, I kept the invariant the class exists for. Its docstring is *"Ensure `is None` (not truthiness) is used for required-key checks"* — so that distinction is now exercised against `memory.redis.host`, which **is** still conditionally required and **is** still gated on `if value is None`. The falsy-but-present side (`'0'`) was already covered.

**`timeout_configuration_test` (1)** — assigned `config.llm_timeout = "999.0"` then asserted `"AUTOBOT_LLM_TIMEOUT" in os.environ`. Assignment to the proxy doesn't write the environment; the test's own comment conceded it only *"test[ed] the mechanism exists"*.

The real mechanism is pydantic-settings reading env at construction, and the module-level proxy is built once and cached. Verified directly before rewriting:

```
fresh AutoBotConfig().llm_timeout with env set:  999
fresh without env:                                30
```

**`config_migration_integration_test` (6)** — each verified against the live objects:

| Assumption | Reality |
|---|---|
| `cm.get("a.b.c")` | flat lookup — needs `get_nested()` |
| `cm.set("a.b.c", v)` | flat write — needs `set_nested()`; this is why the processor read `0.7` not the `0.9` the test "set" |
| `get_section()` | renamed `get_config_section()` |
| `from utils.config_manager import config` | module removed |
| `from config import config` | yields SSOT `_ConfigProxy` — has neither `.get` nor `.config`; the legacy wrapper is `config.compat.Config` |
| `"llm"` top-level section | LLM config lives under `backend.llm` |
| `llm.orchestrator_llm` / `llm.ollama.port` | **do not exist anywhere** — the old equality assertion compared `None` to `None` and was vacuous |
| `redis.host in ["localhost","127.0.0.1"]` | an SSOT deployment value — pinned assertion fails on any real deployment |

## Verification

```
before (unmodified tree):   9 failed, 93 passed
after:                    102 passed
```

Two of these were fixed by making the assertion *stronger*, not weaker: the backward-compat check now compares a key that actually exists (the previous one was vacuously true), and the required-key test now targets a key that is genuinely still required.

## Model Used

Claude Opus 5 (1M context)

Closes #12774