### PR TITLE
fix(mesh-brain): wire MeshBrainScheduler into lifespan, default-off (#12816)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -2081,9 +2081,18 @@ async def cleanup_services(app: FastAPI):
             logger.info("✅ LLC budget watchdog stopped")
         # #12816: Stop MeshBrainScheduler — stop() cancels every per-job task
         # start() spawned, so none survive shutdown.
+        #
+        # Guarded independently: this whole shutdown block sits inside one broad
+        # `except Exception`, so an error raised here would jump straight to that
+        # handler and SKIP every remaining shutdown step below. Startup is
+        # already treated as non-fatal; shutdown gets the same treatment so one
+        # scheduler cannot abort the rest of the teardown.
         if hasattr(app.state, "mesh_brain_scheduler") and app.state.mesh_brain_scheduler:
-            await app.state.mesh_brain_scheduler.stop()
-            logger.info("✅ MeshBrainScheduler stopped")
+            try:
+                await app.state.mesh_brain_scheduler.stop()
+                logger.info("✅ MeshBrainScheduler stopped")
+            except Exception as mesh_stop_error:
+                logger.warning("MeshBrainScheduler stop failed (non-fatal): %s", mesh_stop_error)
         # GH#9026: Stop LLC session checkpointer
         if hasattr(app.state, "llc_session_checkpointer") and app.state.llc_session_checkpointer:
             app.state.llc_session_checkpointer.stop()

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1696,6 +1696,41 @@ async def _init_budget_watchdog(app: FastAPI) -> None:
         app.state.llc_budget_watchdog = None
 
 
+async def _init_mesh_brain_scheduler(app: FastAPI) -> None:
+    """Start MeshBrainScheduler when explicitly enabled (#12816).
+
+    The scheduler was registered, fully described, and never started — its own
+    registry entry admitted "currently inert". This wires it, but DEFAULT-OFF.
+
+    Off by default is deliberate, not timidity: of its five jobs, `mesh_pruner`
+    DELETES data on a 7-day cadence, and `node_promoter`/`edge_discoverer`
+    mutate node and edge state. Establishing what mesh_pruner removes and under
+    which retention rule is a data-retention decision, not a wiring change, so
+    it must not be switched on as a side effect of fixing the wiring.
+
+    start() returns as soon as it has spawned its own per-job tasks, and only
+    spawns jobs whose component is present, so it is safe to await directly.
+    """
+    from autobot_shared.ssot_config import config as _cfg
+
+    if not _cfg.misc.mesh_brain_scheduler_enabled:
+        logger.info("MeshBrainScheduler: disabled (AUTOBOT_MESH_BRAIN_SCHEDULER_ENABLED not set)")
+        app.state.mesh_brain_scheduler = None
+        return
+
+    logger.info("MeshBrainScheduler: Starting...")
+    try:
+        from services.mesh_brain.scheduler import MeshBrainScheduler
+
+        scheduler = MeshBrainScheduler()
+        await scheduler.start()
+        app.state.mesh_brain_scheduler = scheduler
+        logger.info("MeshBrainScheduler: Started")
+    except Exception as exc:
+        logger.warning("MeshBrainScheduler startup failed (non-fatal): %s", exc)
+        app.state.mesh_brain_scheduler = None
+
+
 async def _recover_agent_sessions(app: FastAPI) -> None:
     """Re-queue runs that were interrupted by a previous server crash (GH#9026)."""
     logger.info("LLC SessionCheckpointer: recovering incomplete runs...")
@@ -1853,6 +1888,7 @@ async def initialize_background_services(app: FastAPI):
         await _init_skill_distillation_scheduler(app)
         await _init_liveness_monitor(app)
         await _init_budget_watchdog(app)
+        await _init_mesh_brain_scheduler(app)
         await _init_session_checkpointer(app)
         await _init_llc_outbound_sync(app)
         await _start_connector_scheduler()
@@ -2043,6 +2079,11 @@ async def cleanup_services(app: FastAPI):
         if hasattr(app.state, "llc_budget_watchdog") and app.state.llc_budget_watchdog:
             app.state.llc_budget_watchdog.stop()
             logger.info("✅ LLC budget watchdog stopped")
+        # #12816: Stop MeshBrainScheduler — stop() cancels every per-job task
+        # start() spawned, so none survive shutdown.
+        if hasattr(app.state, "mesh_brain_scheduler") and app.state.mesh_brain_scheduler:
+            await app.state.mesh_brain_scheduler.stop()
+            logger.info("✅ MeshBrainScheduler stopped")
         # GH#9026: Stop LLC session checkpointer
         if hasattr(app.state, "llc_session_checkpointer") and app.state.llc_session_checkpointer:
             app.state.llc_session_checkpointer.stop()

--- a/autobot-backend/initialization/mesh_brain_scheduler_wiring_12816_test.py
+++ b/autobot-backend/initialization/mesh_brain_scheduler_wiring_12816_test.py
@@ -116,3 +116,17 @@ class TestShutdown:
 
         src = (Path(__file__).resolve().parent / "lifespan.py").read_text(encoding="utf-8")
         assert "await app.state.mesh_brain_scheduler.stop()" in src
+
+    def test_shutdown_stop_is_independently_guarded(self):
+        """A failing stop() must not abort the rest of teardown.
+
+        The whole shutdown block lives inside ONE broad `except Exception`, so an
+        unguarded raise here would jump to that handler and skip every remaining
+        shutdown step. Startup is already non-fatal; shutdown must match.
+        """
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parent / "lifespan.py").read_text(encoding="utf-8")
+        block = src[src.index("Stop MeshBrainScheduler") :][:900]
+        assert "try:" in block
+        assert "MeshBrainScheduler stop failed (non-fatal)" in block

--- a/autobot-backend/initialization/mesh_brain_scheduler_wiring_12816_test.py
+++ b/autobot-backend/initialization/mesh_brain_scheduler_wiring_12816_test.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""MeshBrainScheduler lifespan wiring (#12816).
+
+The scheduler was registered in the canonical scheduler registry, fully
+described, and never started — its own registry entry admitted "currently
+inert", and `grep mesh_brain lifespan.py` found only individual components
+(EdgeLearner, PersonalizedPageRank, CommunityClusterer), never the scheduler
+that drives them.
+
+It is now wired, but DEFAULT-OFF. That is deliberate: of its five jobs
+`mesh_pruner` DELETES data on a 7-day cadence and node_promoter/edge_discoverer
+mutate node and edge state, so enabling it is a data-retention decision, not a
+wiring change. These tests pin both halves — the wiring exists, and it stays off
+unless explicitly enabled.
+
+Mirrors the issue's own Verification section:
+  - startup spawns the scheduler when the flag is on and does not when off
+  - shutdown cancels every task start() launched
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+async def _run_init(app, enabled: bool, scheduler: MagicMock | None = None):
+    from initialization.lifespan import _init_mesh_brain_scheduler
+
+    scheduler = scheduler or MagicMock(start=AsyncMock(), stop=AsyncMock())
+    cfg = SimpleNamespace(misc=SimpleNamespace(mesh_brain_scheduler_enabled=enabled))
+    with patch("autobot_shared.ssot_config.config", cfg):
+        with patch.dict(
+            "sys.modules",
+            {"services.mesh_brain.scheduler": MagicMock(MeshBrainScheduler=lambda: scheduler)},
+        ):
+            await _init_mesh_brain_scheduler(app)
+    return scheduler
+
+
+class TestFlagGating:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default_does_not_start(self, app):
+        """The whole point: fixing the wiring must not enable data-deleting jobs."""
+        scheduler = await _run_init(app, enabled=False)
+        scheduler.start.assert_not_awaited()
+        assert app.state.mesh_brain_scheduler is None
+
+    @pytest.mark.asyncio
+    async def test_enabled_starts_the_scheduler(self, app):
+        scheduler = await _run_init(app, enabled=True)
+        scheduler.start.assert_awaited_once()
+        assert app.state.mesh_brain_scheduler is scheduler
+
+    def test_config_flag_defaults_to_off(self):
+        """Default-off must hold in the shipped config, not just in this test."""
+        from autobot_shared.ssot_config import MiscConfig
+
+        assert MiscConfig().mesh_brain_scheduler_enabled is False
+
+    @pytest.mark.asyncio
+    async def test_startup_failure_is_non_fatal(self, app):
+        """A broken scheduler must not take the whole backend down with it."""
+        from initialization.lifespan import _init_mesh_brain_scheduler
+
+        cfg = SimpleNamespace(misc=SimpleNamespace(mesh_brain_scheduler_enabled=True))
+        boom = MagicMock(start=AsyncMock(side_effect=RuntimeError("boom")), stop=AsyncMock())
+        with patch("autobot_shared.ssot_config.config", cfg):
+            with patch.dict(
+                "sys.modules",
+                {"services.mesh_brain.scheduler": MagicMock(MeshBrainScheduler=lambda: boom)},
+            ):
+                await _init_mesh_brain_scheduler(app)  # must not raise
+        assert app.state.mesh_brain_scheduler is None
+
+
+class TestRegistryTruthfulness:
+    """The registry must not keep claiming the scheduler is unwired."""
+
+    def test_entry_now_has_a_startup_marker(self):
+        from services.scheduler_registry import REGISTRY
+
+        job = next(j for j in REGISTRY if j.name == "MeshBrainScheduler")
+        assert job.startup_marker == "initialization/lifespan.py::_init_mesh_brain_scheduler"
+
+    def test_startup_marker_points_at_a_symbol_that_exists(self):
+        """A marker naming a function that isn't there would be worse than none."""
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parent / "lifespan.py").read_text(encoding="utf-8")
+        assert "async def _init_mesh_brain_scheduler" in src
+        assert "await _init_mesh_brain_scheduler(app)" in src
+
+    def test_inert_reason_still_records_the_open_retention_decision(self):
+        """The wiring gap is closed; the mesh_pruner retention call is NOT."""
+        from services.scheduler_registry import REGISTRY
+
+        job = next(j for j in REGISTRY if j.name == "MeshBrainScheduler")
+        assert "data-retention decision" in job.inert_reason
+
+
+class TestShutdown:
+    def test_shutdown_awaits_stop(self):
+        """stop() cancels every per-job task start() spawned, so none survive."""
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parent / "lifespan.py").read_text(encoding="utf-8")
+        assert "await app.state.mesh_brain_scheduler.stop()" in src

--- a/autobot-backend/services/scheduler_registry.py
+++ b/autobot-backend/services/scheduler_registry.py
@@ -81,9 +81,12 @@ REGISTRY: list[ScheduledJob] = [
             "Runs four sub-tasks: edge_sync (300 s), node_promoter (24 h), "
             "edge_discoverer (24 h), mesh_pruner (7 d), edge_learner (realtime Redis consumer)."
         ),
+        startup_marker="initialization/lifespan.py::_init_mesh_brain_scheduler",
         inert_reason=(
-            "Not started — tracked by GH#12816. mesh_pruner deletes data, so enabling this "
-            "scheduler is a data-retention decision, not a wiring change."
+            "Wired in lifespan (#12816) but DEFAULT-OFF via "
+            "AUTOBOT_MESH_BRAIN_SCHEDULER_ENABLED. mesh_pruner deletes data on a 7-day "
+            "cadence, so ENABLING it remains a data-retention decision — the wiring gap "
+            "is closed, the retention call is not."
         ),
     ),
     ScheduledJob(

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1356,6 +1356,12 @@ class MiscConfig(BaseSettings):
         extra="ignore",
     )
 
+    # #12816: MeshBrainScheduler was registered and never started. Now wired in
+    # lifespan but DEFAULT-OFF: mesh_pruner DELETES data on a 7-day cadence and
+    # node_promoter/edge_discoverer mutate state, so ENABLING it is a
+    # data-retention decision rather than a wiring change.
+    mesh_brain_scheduler_enabled: bool = Field(default=False, alias="AUTOBOT_MESH_BRAIN_SCHEDULER_ENABLED")
+
     anthropic_api_base_url: str = Field(default="", alias="ANTHROPIC_API_BASE_URL")
     api_key: str = Field(default="", alias="API_KEY")
     # #11681: restore pre-#7437 default (1000) — 0 silently disabled the AST cache


### PR DESCRIPTION
## Thinking Path

I picked this as part of a **two-issue batch chosen before touching code** (#12816 + #12637), per your instruction to group bugs and tech-debt. #12637 dropped out on inspection for a real reason — see the bottom.

`MeshBrainScheduler` was registered in the canonical registry, fully described, and never started; its own entry admitted *"currently inert"*. `grep mesh_brain lifespan.py` finds only individual components (`EdgeLearner`, `PersonalizedPageRank`, `CommunityClusterer`) — never the scheduler that drives them.

The reason it was never switched on opportunistically is sound: of its five jobs, **`mesh_pruner` DELETES data** on a 7-day cadence, and `node_promoter`/`edge_discoverer` mutate node and edge state. So the fix separates the two things that were tangled together — **the wiring gap is a bug; enabling the jobs is a data-retention decision.** This closes the first and deliberately leaves the second open.

## What Changed

- `_init_mesh_brain_scheduler` in `initialization/lifespan.py`, following the existing `_init_*` pattern, gated on `AUTOBOT_MESH_BRAIN_SCHEDULER_ENABLED` (**default false**).
- Shutdown awaits `stop()`, which cancels every per-job task `start()` spawned.
- Registry entry gains `startup_marker` and an `inert_reason` that now states precisely what is resolved and what is not — so it stops claiming the scheduler is unwired while still recording the open retention call.

## A bug I introduced and caught

The first version referenced `config.misc.mesh_brain_scheduler_enabled` in `lifespan.py`. That module has **no `config` symbol** — it would have raised `NameError` at startup, meaning the wiring fix would itself have broken boot. The tests caught it (`does not have the attribute 'config'`), and it now imports ssot config locally, matching the existing pattern at `lifespan.py:1260`.

Worth noting the failure mode: without the tests this would have looked fine in review and failed only on a real startup.

## Verification

```
$ python3 -m pytest initialization/mesh_brain_scheduler_wiring_12816_test.py -q
8 passed
```

Mirrors the issue's own Verification section, and pins both halves:

- flag off → `start()` **not** awaited, `app.state.mesh_brain_scheduler is None`
- flag on → started and stored
- the **shipped** config default is off (`MiscConfig().mesh_brain_scheduler_enabled is False`) — asserted against real config, not just the test's stub
- startup failure is non-fatal (a broken scheduler must not take the backend down)
- registry `startup_marker` names a symbol that **actually exists** in `lifespan.py` (a marker pointing at a missing function would be worse than none)
- `inert_reason` still records the open retention decision
- shutdown awaits `stop()`

## Why #12637 is not in this PR

I selected it as the batch-mate and stopped after checking, rather than shipping a regression. It is described as "relocate + re-wire router/nav/i18n, no behaviour change" — but that cannot hold:

```
autobot-frontend/src/i18n/locales/   -> 11 locales, admin.systemHealth present in ALL 11
autobot-slm-frontend/src/locales/    -> en.json only
```

Relocating as-is would drop those views from 11 languages to 1, against the standing all-11-locales rule. Whether admin surfaces should be localised at all is a product decision, so I left it unclaimed with the analysis on the issue.

## Model Used

Claude Opus 5 (1M context)

Closes #12816