### PR TITLE
tech-debt(backend): migrate remaining async-Redis call sites off the legacy API (#12807)

### DIFF
--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -49,7 +49,7 @@ from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_constants import TTL_30_DAYS
 from llm_shared.types import LLMType
@@ -440,10 +440,10 @@ class CodeGenerationEngine:
     async def _get_redis(self):
         """Get Redis client lazily"""
         if self._redis is None:
-            # get_redis_client(async_client=True) returns a COROUTINE — must be awaited
+            # get_async_redis_client() returns a COROUTINE — must be awaited
             # (see autobot_shared/redis_client.py landmine note). Missing await here
             # silently broke every stats/version Redis op (AttributeError swallowed).
-            self._redis = await get_redis_client(async_client=True, database=RedisDatabase.MAIN)
+            self._redis = await get_async_redis_client(database=RedisDatabase.MAIN)
         return self._redis
 
     def _get_llm_client(self):

--- a/autobot-backend/api/analytics_code_generation_test.py
+++ b/autobot-backend/api/analytics_code_generation_test.py
@@ -208,7 +208,7 @@ class TestTrackGenerationStatsGather:
 
 
 class TestGetRedisAwaitsCoroutine:
-    """Regression: _get_redis must await get_redis_client(async_client=True), which
+    """Regression: _get_redis must await get_async_redis_client(), which
     returns a coroutine. A missing await silently broke every stats/version Redis op
     (AttributeError on the coroutine, swallowed by except)."""
 
@@ -219,7 +219,7 @@ class TestGetRedisAwaitsCoroutine:
         engine._redis = None
         fake_client = MagicMock(name="async_redis_client")
         with patch(
-            "api.analytics_code_generation.get_redis_client",
+            "api.analytics_code_generation.get_async_redis_client",
             new=AsyncMock(return_value=fake_client),
         ) as mock_get:
             result = await engine._get_redis()
@@ -235,7 +235,7 @@ class TestGetRedisAwaitsCoroutine:
         engine._redis = None
         fake_client = MagicMock(name="async_redis_client")
         with patch(
-            "api.analytics_code_generation.get_redis_client",
+            "api.analytics_code_generation.get_async_redis_client",
             new=AsyncMock(return_value=fake_client),
         ) as mock_get:
             first = await engine._get_redis()

--- a/autobot-backend/api/desktop_control_lock.py
+++ b/autobot-backend/api/desktop_control_lock.py
@@ -36,7 +36,7 @@ import os
 from datetime import datetime, timezone
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = get_logger(__name__)
 
@@ -88,7 +88,7 @@ async def _get_lock_record(session_id: str) -> tuple[dict | None, bool]:
     """
     key = _lock_key(session_id)
     try:
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         if redis is None:
             return None, False
         raw = await redis.get(key)
@@ -116,7 +116,7 @@ async def acquire_human_control(session_id: str, owner: str) -> dict:
         "acquired_at": datetime.now(timezone.utc).isoformat(),
     }
     try:
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         if redis is None:
             logger.error("desktop_control_lock: Redis unavailable, cannot acquire lock for %s", session_id)
             return {
@@ -166,7 +166,7 @@ async def release_human_control(session_id: str, owner: str) -> dict:
     """
     key = _lock_key(session_id)
     try:
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         if redis is None:
             logger.error("desktop_control_lock: Redis unavailable, cannot release lock for %s", session_id)
             return {

--- a/autobot-backend/api/desktop_control_lock_test.py
+++ b/autobot-backend/api/desktop_control_lock_test.py
@@ -83,7 +83,7 @@ def fake_redis():
 
 def _patch_redis(fake_redis):
     return patch(
-        "api.desktop_control_lock.get_redis_client",
+        "api.desktop_control_lock.get_async_redis_client",
         new=AsyncMock(return_value=fake_redis),
     )
 
@@ -216,7 +216,7 @@ class TestOwnerAwareMuting:
 
     @pytest.mark.asyncio
     async def test_muted_fails_safe_when_redis_down(self):
-        with patch("api.desktop_control_lock.get_redis_client", new=AsyncMock(return_value=None)):
+        with patch("api.desktop_control_lock.get_async_redis_client", new=AsyncMock(return_value=None)):
             assert await is_actuation_muted(DEFAULT_DESKTOP_SESSION_ID, caller="alice") is True
 
 
@@ -247,7 +247,7 @@ class TestRedisUnavailableFailSafe:
     @pytest.mark.asyncio
     async def test_is_human_active_fails_safe_when_redis_down(self):
         with patch(
-            "api.desktop_control_lock.get_redis_client",
+            "api.desktop_control_lock.get_async_redis_client",
             new=AsyncMock(return_value=None),
         ):
             assert await is_human_active(DEFAULT_DESKTOP_SESSION_ID) is True
@@ -255,7 +255,7 @@ class TestRedisUnavailableFailSafe:
     @pytest.mark.asyncio
     async def test_acquire_fails_cleanly_when_redis_down(self):
         with patch(
-            "api.desktop_control_lock.get_redis_client",
+            "api.desktop_control_lock.get_async_redis_client",
             new=AsyncMock(return_value=None),
         ):
             result = await acquire_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
@@ -265,7 +265,7 @@ class TestRedisUnavailableFailSafe:
     @pytest.mark.asyncio
     async def test_release_fails_cleanly_when_redis_down(self):
         with patch(
-            "api.desktop_control_lock.get_redis_client",
+            "api.desktop_control_lock.get_async_redis_client",
             new=AsyncMock(return_value=None),
         ):
             result = await release_human_control(DEFAULT_DESKTOP_SESSION_ID, "alice")
@@ -276,7 +276,7 @@ class TestRedisUnavailableFailSafe:
     @pytest.mark.asyncio
     async def test_get_lock_owner_none_when_redis_down(self):
         with patch(
-            "api.desktop_control_lock.get_redis_client",
+            "api.desktop_control_lock.get_async_redis_client",
             new=AsyncMock(return_value=None),
         ):
             assert await get_lock_owner(DEFAULT_DESKTOP_SESSION_ID) is None

--- a/autobot-backend/api/memory_privacy.py
+++ b/autobot-backend/api/memory_privacy.py
@@ -328,14 +328,14 @@ async def _amend_verbatim(user_id: str, chunk_id: str, new_content: str) -> bool
 
 async def _amend_working_memory(user_id: str, redis_key: str, new_content: str) -> bool:
     """Replace a working-memory entry's content field in-place."""
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
     from memory.working_memory import is_working_memory_key
 
     # Allowlist the key shape before any Redis op — never touch an arbitrary key.
     if not is_working_memory_key(redis_key):
         logger.warning("_amend_working_memory: rejected non-working-memory key %s", redis_key)
         return False
-    redis = await get_redis_client(async_client=True, database="knowledge")
+    redis = await get_async_redis_client(database="knowledge")
     raw = await redis.get(redis_key)
     if not raw:
         return False

--- a/autobot-backend/api/users.py
+++ b/autobot-backend/api/users.py
@@ -20,7 +20,7 @@ from api.schemas_common import DataResponse
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
 
 logger = get_logger(__name__)
 
@@ -90,7 +90,7 @@ async def _get_user_preferences_from_redis(user_id: str) -> UserPreferences:
         UserPreferences object with stored or default values
     """
     try:
-        redis_client = await get_redis_client(async_client=True, database=RedisDatabase.MAIN)
+        redis_client = await get_async_redis_client(database=RedisDatabase.MAIN)
 
         async def _read(field: str) -> str | None:
             raw = await redis_client.get(f"user:{user_id}:preferences:{field}")
@@ -123,7 +123,7 @@ async def _store_user_preferences_to_redis(user_id: str, preferences: UserPrefer
     Raises:
         RedisError: If Redis operation fails
     """
-    redis_client = await get_redis_client(async_client=True, database=RedisDatabase.MAIN)
+    redis_client = await get_async_redis_client(database=RedisDatabase.MAIN)
 
     # Store each preference under its own key (no expiration - permanent preference)
     for field in ("reasoning_effort", *_APPEARANCE_FIELDS):

--- a/autobot-backend/judges/task_outcome_judge.py
+++ b/autobot-backend/judges/task_outcome_judge.py
@@ -75,9 +75,9 @@ class TaskOutcomeJudge(BaseLLMJudge):
     async def _get_redis(self):
         """Lazily initialize Redis client."""
         if self._redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self._redis_client = await get_redis_client(async_client=True, database="main")
+            self._redis_client = await get_async_redis_client(database="main")
         return self._redis_client
 
     async def evaluate_task_outcome(

--- a/autobot-backend/knowledge/knowledge_base_async_test.py
+++ b/autobot-backend/knowledge/knowledge_base_async_test.py
@@ -5,7 +5,7 @@ Unit tests for KnowledgeBase async Redis initialization.
 
 Covers _init_redis_connections() which uses get_async_redis_client() (#3962).
 
-Root cause of #3962: the original code called get_redis_client(async_client=True)
+Root cause of #3962: the original code called get_async_redis_client()
 without await.  get_redis_client is a *sync* function that returns the coroutine
 produced by RedisConnectionManager.get_async_client() without awaiting it.
 Storing that coroutine in self._aioredis_client then caused:

--- a/autobot-backend/knowledge/memory_graph/query_processor.py
+++ b/autobot-backend/knowledge/memory_graph/query_processor.py
@@ -28,7 +28,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from knowledge.memory_graph.hybrid_scorer import HybridScorer, SearchResult
 
 logger = get_logger(__name__)
@@ -494,7 +494,7 @@ class MemoryGraphQueryProcessor:
     async def _get_redis(self):
         """Lazily obtain the async Redis client."""
         if self._redis is None:
-            self._redis = await get_redis_client(async_client=True, database="knowledge")
+            self._redis = await get_async_redis_client(database="knowledge")
         return self._redis
 
 

--- a/autobot-backend/knowledge/search_components/retrieval_learner.py
+++ b/autobot-backend/knowledge/search_components/retrieval_learner.py
@@ -31,7 +31,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client, get_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.ttl_constants import TTL_30_DAYS
 
@@ -166,7 +166,7 @@ class RetrievalLearner:
             return self._redis
         try:
             self._redis = await asyncio.wait_for(
-                get_redis_client(async_client=True, database="analytics"),
+                get_async_redis_client(database="analytics"),
                 timeout=_REDIS_ACQUIRE_TIMEOUT,
             )
         except (asyncio.TimeoutError, Exception) as exc:

--- a/autobot-backend/knowledge/search_components/retrieval_learner.py
+++ b/autobot-backend/knowledge/search_components/retrieval_learner.py
@@ -31,7 +31,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_async_redis_client, get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.ttl_constants import TTL_30_DAYS
 

--- a/autobot-backend/memory/memory_privacy_test.py
+++ b/autobot-backend/memory/memory_privacy_test.py
@@ -196,12 +196,12 @@ class TestForgetTenantIsolation(unittest.IsolatedAsyncioTestCase):
         redis_mock = AsyncMock()
         redis_mock.get = AsyncMock(return_value=json.dumps({"user_id": "user-B", "content": "secret"}).encode())
 
-        original = mt.get_redis_client
-        mt.get_redis_client = AsyncMock(return_value=redis_mock)
+        original = mt.get_async_redis_client
+        mt.get_async_redis_client = AsyncMock(return_value=redis_mock)
         try:
             result = await _forget_working_memory("user-A", "autobot:session:s1:memory:k1")
         finally:
-            mt.get_redis_client = original
+            mt.get_async_redis_client = original
 
         self.assertFalse(result)
         redis_mock.delete.assert_not_called()
@@ -225,12 +225,12 @@ class TestForgetTenantIsolation(unittest.IsolatedAsyncioTestCase):
         json_mock.get = AsyncMock(return_value={"id": "eid1", "metadata": {"user_id": "user-B"}})
         redis_mock.json = MagicMock(return_value=json_mock)
 
-        original = mt.get_redis_client
-        mt.get_redis_client = AsyncMock(return_value=redis_mock)
+        original = mt.get_async_redis_client
+        mt.get_async_redis_client = AsyncMock(return_value=redis_mock)
         try:
             result = await _forget_graph_entity("user-A", "eid1")
         finally:
-            mt.get_redis_client = original
+            mt.get_async_redis_client = original
 
         self.assertFalse(result)
         redis_mock.delete.assert_not_called()

--- a/autobot-backend/memory/ownership_reassign.py
+++ b/autobot-backend/memory/ownership_reassign.py
@@ -69,7 +69,7 @@ def _bootstrap() -> None:
 
         get_trajectory_store = _gts
     if get_redis_client is None:
-        from autobot_shared.redis_client import get_redis_client as _grc
+        from autobot_shared.redis_client import get_async_redis_client as _grc
 
         get_redis_client = _grc
     if get_knowledge_base_fn is None:
@@ -132,7 +132,7 @@ async def _reassign_trajectory(old_id: str, new_id: str) -> int:
 
 async def _reassign_working_memory(old_id: str, new_id: str) -> int:
     """Reassign Redis working-memory JSON payloads whose ``user_id`` == *old_id*."""
-    redis = await get_redis_client(async_client=True, database="knowledge")
+    redis = await get_async_redis_client(database="knowledge")
     keys = await _redis_scan(redis, "autobot:session:*:memory:*")
 
     count = 0
@@ -160,7 +160,7 @@ async def _reassign_working_memory(old_id: str, new_id: str) -> int:
 
 async def _reassign_graph_entities(old_id: str, new_id: str) -> int:
     """Reassign Redis graph entities whose metadata ``user_id`` or ``owner_id`` == *old_id*."""
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     keys = await _redis_scan(redis, "memory:entity:*")
 
     count = 0
@@ -266,7 +266,7 @@ async def _reassign_kb_facts(old_id: str, new_id: str) -> int:
 
     # --- Redis ownership indexes ---
     try:
-        redis = await get_redis_client(async_client=True, database="knowledge")
+        redis = await get_async_redis_client(database="knowledge")
         # Canonical index written by KnowledgeOwnership._set_owner_indexes
         await _move_redis_facts_index(redis, f"user:kb:facts:{old_id}", f"user:kb:facts:{new_id}")
         # Legacy fallback index written by facts.py when ownership_manager is absent

--- a/autobot-backend/memory/ownership_reassign.py
+++ b/autobot-backend/memory/ownership_reassign.py
@@ -52,14 +52,14 @@ logger = get_logger(__name__)
 # does not use, so the two bootstraps import different symbol sets (#12694).
 get_verbatim_store = None  # type: ignore[assignment]
 get_trajectory_store = None  # type: ignore[assignment]
-get_redis_client = None  # type: ignore[assignment]
+get_async_redis_client = None  # type: ignore[assignment]
 get_knowledge_base_fn = None  # type: ignore[assignment]
 
 
 def _bootstrap() -> None:
     """Lazily import heavy dependencies (same pattern as memory.transparency._bootstrap;
     see module-level NOTE above for why it is not shared)."""
-    global get_verbatim_store, get_trajectory_store, get_redis_client, get_knowledge_base_fn
+    global get_verbatim_store, get_trajectory_store, get_async_redis_client, get_knowledge_base_fn
     if get_verbatim_store is None:
         from memory.verbatim_store import get_verbatim_store as _gvs
 
@@ -68,10 +68,10 @@ def _bootstrap() -> None:
         from memory.trajectory_store import get_trajectory_store as _gts
 
         get_trajectory_store = _gts
-    if get_redis_client is None:
+    if get_async_redis_client is None:
         from autobot_shared.redis_client import get_async_redis_client as _grc
 
-        get_redis_client = _grc
+        get_async_redis_client = _grc
     if get_knowledge_base_fn is None:
         from knowledge._composed import get_knowledge_base as _gkb
 

--- a/autobot-backend/memory/ownership_reassign_test.py
+++ b/autobot-backend/memory/ownership_reassign_test.py
@@ -165,12 +165,12 @@ class TestReassignWorkingMemory:
         payload = {"user_id": "user-A", "content": "hello"}
         redis = self._make_redis_stub([key], {key: payload})
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_working_memory("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 1
         redis.set.assert_called_once()
@@ -188,12 +188,12 @@ class TestReassignWorkingMemory:
         payload = {"user_id": "user-C", "content": "other"}
         redis = self._make_redis_stub([key], {key: payload})
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_working_memory("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 0
         redis.set.assert_not_called()
@@ -208,12 +208,12 @@ class TestReassignWorkingMemory:
         payload = {"user_id": "user-A"}
         redis = self._make_redis_stub([bad_key], {bad_key: payload})
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_working_memory("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 0
         redis.set.assert_not_called()
@@ -241,12 +241,12 @@ class TestReassignWorkingMemory:
         redis.get = AsyncMock(side_effect=_get)
         redis.set = AsyncMock()
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_working_memory("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 1
         assert redis.set.call_count == 1
@@ -285,12 +285,12 @@ class TestReassignGraphEntities:
         entity = {"id": "e1", "name": "Alice", "metadata": {"user_id": "user-A"}}
         redis, json_client = self._make_graph_redis([key], {key: entity})
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_graph_entities("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 1
         json_client.set.assert_called_once()
@@ -307,12 +307,12 @@ class TestReassignGraphEntities:
         entity = {"id": "e2", "metadata": {"owner_id": "user-A"}}
         redis, json_client = self._make_graph_redis([key], {key: entity})
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_graph_entities("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 1
         assert json_client.set.call_args[0][2]["owner_id"] == "user-B"
@@ -325,12 +325,12 @@ class TestReassignGraphEntities:
         entity = {"id": "e3", "metadata": {"user_id": "user-A", "owner_id": "user-A"}}
         redis, json_client = self._make_graph_redis([key], {key: entity})
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_graph_entities("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 1
         saved_meta = json_client.set.call_args[0][2]
@@ -345,12 +345,12 @@ class TestReassignGraphEntities:
         entity = {"id": "e4", "metadata": {"user_id": "user-C"}}
         redis, json_client = self._make_graph_redis([key], {key: entity})
 
-        orig = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             count = await mr._reassign_graph_entities("user-A", "user-B")
         finally:
-            mr.get_redis_client = orig
+            mr.get_async_redis_client = orig
 
         assert count == 0
         json_client.set.assert_not_called()
@@ -476,13 +476,13 @@ class TestReassignKbFactsChroma:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=_make_kb_redis())
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=_make_kb_redis())
         try:
             count = await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         assert count == 2
         # update must have been called for the owner_id pass
@@ -507,13 +507,13 @@ class TestReassignKbFactsChroma:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=_make_kb_redis())
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=_make_kb_redis())
         try:
             count = await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         assert count == 1
         # update called for user_id pass
@@ -533,13 +533,13 @@ class TestReassignKbFactsChroma:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=_make_kb_redis())
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=_make_kb_redis())
         try:
             count = await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         assert count == 0
         col.update.assert_not_called()
@@ -555,13 +555,13 @@ class TestReassignKbFactsChroma:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=_make_kb_redis())
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=_make_kb_redis())
         try:
             count = await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         # 1 from owner_id pass + 1 from user_id pass
         assert count == 2
@@ -576,13 +576,13 @@ class TestReassignKbFactsChroma:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=_make_kb_redis())
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=_make_kb_redis())
         try:
             count = await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         assert count == 0
 
@@ -611,13 +611,13 @@ class TestReassignKbFactsReduxIndex:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         # SUNIONSTORE called with canonical new key, old key, new key (idempotent merge)
         redis.sunionstore.assert_any_call("user:kb:facts:user-B", "user:kb:facts:user-A", "user:kb:facts:user-B")
@@ -637,13 +637,13 @@ class TestReassignKbFactsReduxIndex:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         # Legacy index sunionstore'd and old key deleted
         redis.sunionstore.assert_any_call("user:facts:user-B", "user:facts:user-A", "user:facts:user-B")
@@ -664,14 +664,14 @@ class TestReassignKbFactsReduxIndex:
 
         orig = mr.get_knowledge_base_fn
         mr.get_knowledge_base_fn = AsyncMock(return_value=kb_mock)
-        orig_redis = mr.get_redis_client
-        mr.get_redis_client = AsyncMock(return_value=redis)
+        orig_redis = mr.get_async_redis_client
+        mr.get_async_redis_client = AsyncMock(return_value=redis)
         try:
             # Must not raise even when Redis is broken
             result = await mr._reassign_kb_facts("user-A", "user-B")
         finally:
             mr.get_knowledge_base_fn = orig
-            mr.get_redis_client = orig_redis
+            mr.get_async_redis_client = orig_redis
 
         assert isinstance(result, int)
 

--- a/autobot-backend/memory/security_idor_hotfix_test.py
+++ b/autobot-backend/memory/security_idor_hotfix_test.py
@@ -41,7 +41,7 @@ class ForgetWorkingMemoryTests(unittest.IsolatedAsyncioTestCase):
         redis = self._redis(raw)
         with (
             patch.object(mt, "_bootstrap", lambda: None),
-            patch.object(mt, "get_redis_client", AsyncMock(return_value=redis)),
+            patch.object(mt, "get_async_redis_client", AsyncMock(return_value=redis)),
         ):
             result = await mt._forget_working_memory(user_id, memory_id)
         return result, redis
@@ -78,7 +78,7 @@ class ForgetGraphEntityTests(unittest.IsolatedAsyncioTestCase):
         redis.delete = AsyncMock(return_value=1)
         with (
             patch.object(mt, "_bootstrap", lambda: None),
-            patch.object(mt, "get_redis_client", AsyncMock(return_value=redis)),
+            patch.object(mt, "get_async_redis_client", AsyncMock(return_value=redis)),
         ):
             result = await mt._forget_graph_entity(user_id, "ent1")
         return result, redis

--- a/autobot-backend/memory/transparency.py
+++ b/autobot-backend/memory/transparency.py
@@ -40,17 +40,17 @@ logger = get_logger(__name__)
 # the full application stack.  Real code calls _bootstrap() on first use.
 get_verbatim_store = None  # type: ignore[assignment]
 get_trajectory_store = None  # type: ignore[assignment]
-get_redis_client = None  # type: ignore[assignment]
+get_async_redis_client = None  # type: ignore[assignment]
 
 
 def _bootstrap() -> None:
     """Lazily import heavy dependencies so tests can patch before first call.
 
     Each reference is guarded independently so a test can pre-assign any one
-    of them (e.g. ``mt.get_redis_client = AsyncMock(…)``) and that assignment
+    of them (e.g. ``mt.get_async_redis_client = AsyncMock(…)``) and that assignment
     is preserved even if the other two have not been set yet.
     """
-    global get_verbatim_store, get_trajectory_store, get_redis_client
+    global get_verbatim_store, get_trajectory_store, get_async_redis_client
     if get_verbatim_store is None:
         from memory.verbatim_store import get_verbatim_store as _gvs
 
@@ -59,10 +59,10 @@ def _bootstrap() -> None:
         from memory.trajectory_store import get_trajectory_store as _gts
 
         get_trajectory_store = _gts
-    if get_redis_client is None:
+    if get_async_redis_client is None:
         from autobot_shared.redis_client import get_async_redis_client as _grc
 
-        get_redis_client = _grc
+        get_async_redis_client = _grc
 
 
 _GRAPH_ENTITY_PATTERN = "memory:entity:*"

--- a/autobot-backend/memory/transparency.py
+++ b/autobot-backend/memory/transparency.py
@@ -60,7 +60,7 @@ def _bootstrap() -> None:
 
         get_trajectory_store = _gts
     if get_redis_client is None:
-        from autobot_shared.redis_client import get_redis_client as _grc
+        from autobot_shared.redis_client import get_async_redis_client as _grc
 
         get_redis_client = _grc
 
@@ -169,7 +169,7 @@ async def _list_working_memory(user_id: str) -> List[Dict[str, Any]]:
     """
     try:
         _bootstrap()
-        redis = await get_redis_client(async_client=True, database="knowledge")
+        redis = await get_async_redis_client(database="knowledge")
         all_keys = await _redis_scan(redis, "autobot:session:*:memory:*")
     except Exception as exc:
         logger.warning("_list_working_memory scan failed: %s", exc)
@@ -208,7 +208,7 @@ async def _list_graph_entities(user_id: str) -> List[Dict[str, Any]]:
     """Return memory-graph entities whose metadata.user_id matches *user_id*."""
     try:
         _bootstrap()
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         all_keys = await _redis_scan(redis, _GRAPH_ENTITY_PATTERN)
     except Exception as exc:
         logger.warning("_list_graph_entities scan failed: %s", exc)
@@ -244,7 +244,7 @@ async def _list_rl_patterns(user_id: str) -> List[Dict[str, Any]]:
     """Return retrieval-learner patterns scoped to *user_id*."""
     try:
         _bootstrap()
-        redis = await get_redis_client(async_client=True, database="analytics")
+        redis = await get_async_redis_client(database="analytics")
         prefix = f"{_RL_PATTERN_PREFIX}{user_id}:"
         all_keys = await _redis_scan(redis, f"{prefix}*")
     except Exception as exc:
@@ -421,7 +421,7 @@ async def _forget_working_memory(user_id: str, memory_id: str) -> bool:
     if not is_working_memory_key(memory_id):
         logger.warning("forget_working_memory: rejected non-working-memory key %s", memory_id)
         return False
-    redis = await get_redis_client(async_client=True, database="knowledge")
+    redis = await get_async_redis_client(database="knowledge")
     raw = await redis.get(memory_id)
     if not raw:
         return False
@@ -439,7 +439,7 @@ async def _forget_working_memory(user_id: str, memory_id: str) -> bool:
 async def _forget_graph_entity(user_id: str, entity_id: str) -> bool:
     """Delete a graph entity (by id) and its relations after verifying ownership."""
     _bootstrap()
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     entity_key = f"memory:entity:{entity_id}"
     raw = await redis.json().get(entity_key)
     if not raw:
@@ -466,7 +466,7 @@ async def _forget_rl_pattern(user_id: str, redis_key: str) -> bool:
     if not redis_key.startswith(expected_prefix):
         logger.warning("forget_rl_pattern: tenant mismatch key=%s user=%s", redis_key, user_id)
         return False
-    redis = await get_redis_client(async_client=True, database="analytics")
+    redis = await get_async_redis_client(database="analytics")
     deleted = await redis.delete(redis_key)
     logger.info("forget_rl_pattern: deleted key %s", redis_key)
     return deleted > 0

--- a/autobot-backend/services/feedback_aggregator.py
+++ b/autobot-backend/services/feedback_aggregator.py
@@ -196,11 +196,11 @@ class FeedbackAggregator:
             return self._redis
         if self._redis_unavailable:
             return None
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
 
         try:
             self._redis = await asyncio.wait_for(
-                get_redis_client(async_client=True, database="analytics"),
+                get_async_redis_client(database="analytics"),
                 timeout=_REDIS_TIMEOUT_SECONDS,
             )
         except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001

--- a/autobot-backend/services/notification_service.py
+++ b/autobot-backend/services/notification_service.py
@@ -43,7 +43,7 @@ from typing import Any, Dict, List
 import aiohttp
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 from constants.ttl_constants import TTL_7_DAYS
 
@@ -183,7 +183,7 @@ class NotificationStore:
         }
         serialised = json.dumps(record)
         try:
-            client = await get_redis_client(async_client=True, database=_NOTIFICATIONS_REDIS_DB)
+            client = await get_async_redis_client(database=_NOTIFICATIONS_REDIS_DB)
             if client is None:
                 logger.warning(
                     "Redis unavailable — in-app notification not stored (user=%s)",
@@ -208,7 +208,7 @@ class NotificationStore:
         Returns an empty list if Redis is unavailable or no notifications exist.
         """
         try:
-            client = await get_redis_client(async_client=True, database=_NOTIFICATIONS_REDIS_DB)
+            client = await get_async_redis_client(database=_NOTIFICATIONS_REDIS_DB)
             if client is None:
                 logger.warning("Redis unavailable — cannot list notifications (user=%s)", user_id)
                 return []
@@ -235,7 +235,7 @@ class NotificationStore:
         is unavailable.
         """
         try:
-            client = await get_redis_client(async_client=True, database=_NOTIFICATIONS_REDIS_DB)
+            client = await get_async_redis_client(database=_NOTIFICATIONS_REDIS_DB)
             if client is None:
                 logger.warning(
                     "Redis unavailable — cannot mark notification %s as read",

--- a/autobot-backend/services/slack_approval_integration.py
+++ b/autobot-backend/services/slack_approval_integration.py
@@ -26,7 +26,7 @@ import time
 from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from circuit_breaker import CircuitState
 
 logger = get_logger(__name__)
@@ -100,7 +100,7 @@ class SlackApprovalManager:
         }
 
         try:
-            client = await get_redis_client(async_client=True, database=_APPROVAL_REDIS_DB)
+            client = await get_async_redis_client(database=_APPROVAL_REDIS_DB)
             if client is None:
                 self._record_redis_failure("store_approval_thread", "Redis client is None")
                 return None
@@ -147,7 +147,7 @@ class SlackApprovalManager:
             return None
 
         try:
-            client = await get_redis_client(async_client=True, database=_APPROVAL_REDIS_DB)
+            client = await get_async_redis_client(database=_APPROVAL_REDIS_DB)
             if client is None:
                 self._record_redis_failure("load_approval_thread", "Redis client is None")
                 return None
@@ -202,7 +202,7 @@ class SlackApprovalManager:
             return False
 
         try:
-            client = await get_redis_client(async_client=True, database=_APPROVAL_REDIS_DB)
+            client = await get_async_redis_client(database=_APPROVAL_REDIS_DB)
             if client is None:
                 self._record_redis_failure("manage_channel_mapping", "Redis client is None")
                 return False

--- a/autobot-backend/tests/api/test_reasoning_effort_integration.py
+++ b/autobot-backend/tests/api/test_reasoning_effort_integration.py
@@ -87,7 +87,7 @@ def _redis_get_only(field: str, value: bytes):
 async def test_get_preferences_returns_stored_value():
     mock_redis = AsyncMock()
     mock_redis.get.side_effect = _redis_get_only("reasoning_effort", b"high")
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         pref = await _get_user_preferences_from_redis("user-123")
     assert pref.reasoning_effort == "high"
 
@@ -96,7 +96,7 @@ async def test_get_preferences_returns_stored_value():
 async def test_get_preferences_defaults_to_auto_when_missing():
     mock_redis = AsyncMock()
     mock_redis.get.return_value = None
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         pref = await _get_user_preferences_from_redis("user-456")
     assert pref.reasoning_effort == "auto"
 
@@ -105,7 +105,7 @@ async def test_get_preferences_defaults_to_auto_when_missing():
 async def test_get_preferences_returns_auto_on_redis_error():
     mock_redis = AsyncMock()
     mock_redis.get.side_effect = RedisError("connection refused")
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         pref = await _get_user_preferences_from_redis("user-789")
     assert pref.reasoning_effort == "auto"
 
@@ -113,7 +113,7 @@ async def test_get_preferences_returns_auto_on_redis_error():
 @pytest.mark.asyncio
 async def test_store_preferences_calls_redis_set():
     mock_redis = AsyncMock()
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         await _store_user_preferences_to_redis("user-123", UserPreferences(reasoning_effort="medium"))
     mock_redis.set.assert_any_await("user:user-123:preferences:reasoning_effort", "medium")
 
@@ -131,7 +131,7 @@ async def test_get_preferences_full_flow_returns_correct_effort():
     """Full get-preferences flow: Redis returns stored value → correct pref returned."""
     mock_redis = AsyncMock()
     mock_redis.get.side_effect = _redis_get_only("reasoning_effort", b"low")
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         pref = await _get_user_preferences_from_redis("u-abc")
     assert pref.reasoning_effort == "low"
 
@@ -140,7 +140,7 @@ async def test_get_preferences_full_flow_returns_correct_effort():
 async def test_update_preferences_full_flow_stores_effort():
     """Full update-preferences flow: stores correct value in Redis."""
     mock_redis = AsyncMock()
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         await _store_user_preferences_to_redis("u-xyz", UserPreferences(reasoning_effort="high"))
     mock_redis.set.assert_any_await("user:u-xyz:preferences:reasoning_effort", "high")
 
@@ -194,7 +194,7 @@ async def test_store_appearance_writes_all_fields():
         font_size="large",
         theme_preset="catppuccin-latte",
     )
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         await _store_user_preferences_to_redis("u-app", prefs)
     mock_redis.set.assert_any_await("user:u-app:preferences:theme", "light")
     mock_redis.set.assert_any_await("user:u-app:preferences:accent_color", "purple")
@@ -225,7 +225,7 @@ async def test_appearance_round_trip_returns_stored_values():
         font_size="small",
         theme_preset="solarized-light",
     )
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         await _store_user_preferences_to_redis("u-rt", saved)
         loaded = await _get_user_preferences_from_redis("u-rt")
 
@@ -241,7 +241,7 @@ async def test_update_preferences_raises_redis_error():
     """Redis errors during store propagate as RedisError."""
     mock_redis = AsyncMock()
     mock_redis.set.side_effect = RedisError("timeout")
-    with patch("api.users.get_redis_client", new=_async_redis(mock_redis)):
+    with patch("api.users.get_async_redis_client", new=_async_redis(mock_redis)):
         with pytest.raises(RedisError):
             await _store_user_preferences_to_redis("u-xyz", UserPreferences(reasoning_effort="medium"))
 

--- a/autobot-backend/tests/knowledge/search_components/retrieval_learner_fastfail_test.py
+++ b/autobot-backend/tests/knowledge/search_components/retrieval_learner_fastfail_test.py
@@ -57,7 +57,7 @@ class TestGetRedisFastFail:
             await asyncio.sleep(10)
 
         with patch(
-            "knowledge.search_components.retrieval_learner.get_redis_client",
+            "knowledge.search_components.retrieval_learner.get_async_redis_client",
             new=_hang,
         ):
             # Allow up to (timeout + 0.5 s) for the call to complete.
@@ -77,7 +77,7 @@ class TestGetRedisFastFail:
             await asyncio.sleep(10)
 
         with patch(
-            "knowledge.search_components.retrieval_learner.get_redis_client",
+            "knowledge.search_components.retrieval_learner.get_async_redis_client",
             new=_hang,
         ):
             await asyncio.wait_for(
@@ -96,7 +96,7 @@ class TestGetRedisFastFail:
             raise ConnectionRefusedError("Redis is down")
 
         with patch(
-            "knowledge.search_components.retrieval_learner.get_redis_client",
+            "knowledge.search_components.retrieval_learner.get_async_redis_client",
             new=_raise,
         ):
             result = await learner._get_redis()
@@ -112,7 +112,7 @@ class TestGetRedisFastFail:
         learner = RetrievalLearner(redis=mock_redis)
 
         with patch(
-            "knowledge.search_components.retrieval_learner.get_redis_client",
+            "knowledge.search_components.retrieval_learner.get_async_redis_client",
             side_effect=AssertionError("should not be called"),
         ):
             result = await learner._get_redis()
@@ -204,7 +204,7 @@ class TestUnavailableCaching:
             raise ConnectionRefusedError("Redis is down")
 
         with patch(
-            "knowledge.search_components.retrieval_learner.get_redis_client",
+            "knowledge.search_components.retrieval_learner.get_async_redis_client",
             new=_raise,
         ):
             # First call: triggers the factory, sets flag, returns None.
@@ -224,7 +224,7 @@ class TestUnavailableCaching:
         learner._redis_unavailable = True
 
         with patch(
-            "knowledge.search_components.retrieval_learner.get_redis_client",
+            "knowledge.search_components.retrieval_learner.get_async_redis_client",
             side_effect=AssertionError("should not be called"),
         ):
             result = await learner._get_redis()

--- a/autobot-backend/tests/services/notification_service_test.py
+++ b/autobot-backend/tests/services/notification_service_test.py
@@ -416,7 +416,7 @@ class TestNotificationStoreStore:
         store = NotificationStore()
         mock_redis = make_async_redis()
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -434,7 +434,7 @@ class TestNotificationStoreStore:
         store = NotificationStore()
         mock_redis = make_async_redis()
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -452,7 +452,7 @@ class TestNotificationStoreStore:
     async def test_returns_none_when_redis_unavailable(self):
         store = NotificationStore()
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=None,
         ):
@@ -470,7 +470,7 @@ class TestNotificationStoreStore:
         mock_redis = make_async_redis()
         mock_redis.lpush = AsyncMock(side_effect=ConnectionError("redis gone"))
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -491,7 +491,7 @@ class TestNotificationStoreStore:
         mock_redis.set = AsyncMock(side_effect=_capture_set)
 
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -534,7 +534,7 @@ class TestNotificationStoreList:
         raw = [json.dumps(record).encode()]
         mock_redis = make_async_redis(lrange_returns=raw)
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -546,7 +546,7 @@ class TestNotificationStoreList:
     async def test_returns_empty_list_when_redis_unavailable(self):
         store = NotificationStore()
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=None,
         ):
@@ -558,7 +558,7 @@ class TestNotificationStoreList:
         store = NotificationStore()
         mock_redis = make_async_redis()
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -571,7 +571,7 @@ class TestNotificationStoreList:
         raw = [b"not-json", json.dumps({"id": "ok"}).encode()]
         mock_redis = make_async_redis(lrange_returns=raw)
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -585,7 +585,7 @@ class TestNotificationStoreList:
         mock_redis = make_async_redis()
         mock_redis.lrange = AsyncMock(side_effect=ConnectionError("redis gone"))
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -617,7 +617,7 @@ class TestNotificationStoreMarkRead:
         store = NotificationStore()
         mock_redis = make_async_redis(get_returns=self._make_record())
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -637,7 +637,7 @@ class TestNotificationStoreMarkRead:
         mock_redis.set = AsyncMock(side_effect=_capture_set)
 
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -651,7 +651,7 @@ class TestNotificationStoreMarkRead:
         store = NotificationStore()
         mock_redis = make_async_redis(get_returns=None)
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):
@@ -662,7 +662,7 @@ class TestNotificationStoreMarkRead:
     async def test_returns_false_when_redis_unavailable(self):
         store = NotificationStore()
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=None,
         ):
@@ -675,7 +675,7 @@ class TestNotificationStoreMarkRead:
         mock_redis = make_async_redis(get_returns=self._make_record())
         mock_redis.set = AsyncMock(side_effect=ConnectionError("redis gone"))
         with patch(
-            "services.notification_service.get_redis_client",
+            "services.notification_service.get_async_redis_client",
             new_callable=AsyncMock,
             return_value=mock_redis,
         ):

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/backfill_activity_user_ids.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/backfill_activity_user_ids.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backend"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import utc_timestamp
 
 # Configure logging
@@ -58,7 +58,7 @@ class ActivityBackfiller:
     async def connect_redis(self) -> None:
         """Connect to Redis database"""
         try:
-            self.redis_client = await get_redis_client(async_client=True, database="main")
+            self.redis_client = await get_async_redis_client(database="main")
             await self.redis_client.ping()
             logger.info("Connected to Redis successfully")
         except Exception as e:

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/cleanup_orphaned_sessions.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/cleanup_orphaned_sessions.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Optional
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backend"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 # Configure logging
@@ -64,7 +64,7 @@ class OrphanedSessionCleaner:
     async def connect_redis(self) -> None:
         """Connect to Redis database"""
         try:
-            self.redis_client = await get_redis_client(async_client=True, database="main")
+            self.redis_client = await get_async_redis_client(database="main")
             await self.redis_client.ping()
             logger.info("Connected to Redis successfully")
         except Exception as e:

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_secrets_ownership.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_secrets_ownership.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Optional
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backend"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import utc_timestamp
 from encryption_service import encrypt_data, is_encryption_enabled
 
@@ -61,7 +61,7 @@ class SecretsMigrator:
     async def connect_redis(self) -> None:
         """Connect to Redis database"""
         try:
-            self.redis_client = await get_redis_client(async_client=True, database="main")
+            self.redis_client = await get_async_redis_client(database="main")
             await self.redis_client.ping()
             logger.info("Connected to Redis successfully")
             logger.info("Encryption enabled: %s", self.encryption_enabled)

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_sessions_user_attribution.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_sessions_user_attribution.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backend"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import utc_timestamp
 
 # Configure logging
@@ -57,7 +57,7 @@ class SessionMigrator:
     async def connect_redis(self) -> None:
         """Connect to Redis database"""
         try:
-            self.redis_client = await get_redis_client(async_client=True, database="main")
+            self.redis_client = await get_async_redis_client(database="main")
             await self.redis_client.ping()
             logger.info("Connected to Redis successfully")
         except Exception as e:

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
@@ -28,7 +28,7 @@ from typing import Dict, List
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backend"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import utc_timestamp
 
 # Configure logging
@@ -79,7 +79,7 @@ class MigrationValidator:
     async def connect_redis(self) -> None:
         """Connect to Redis database"""
         try:
-            self.redis_client = await get_redis_client(async_client=True, database="main")
+            self.redis_client = await get_async_redis_client(database="main")
             await self.redis_client.ping()
             logger.info("Connected to Redis successfully")
         except Exception as e:

--- a/autobot-infrastructure/shared/scripts/generate_service_keys.py
+++ b/autobot-infrastructure/shared/scripts/generate_service_keys.py
@@ -27,7 +27,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "autobot-backend"))
 sys.path.insert(0, str(PROJECT_ROOT / "autobot_shared"))
 
-from autobot_shared.redis_client import get_redis_client  # noqa: E402
+from autobot_shared.redis_client import get_async_redis_client  # noqa: E402
 from autobot_shared.ssot_config import config  # noqa: E402
 from security.service_auth import ServiceAuthManager  # noqa: E402
 
@@ -151,7 +151,7 @@ async def generate_keys():
     logger.info("Services: %d", len(SERVICES))
     logger.info("")
 
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     auth_manager = ServiceAuthManager(redis)
 
     generated_keys = await _generate_all_keys(auth_manager)

--- a/autobot-infrastructure/shared/scripts/verify-service-auth.py
+++ b/autobot-infrastructure/shared/scripts/verify-service-auth.py
@@ -17,7 +17,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "autobot-backend"))
 sys.path.insert(0, str(PROJECT_ROOT / "autobot_shared"))
 
-from autobot_shared.redis_client import get_redis_client  # noqa: E402
+from autobot_shared.redis_client import get_async_redis_client  # noqa: E402
 from security.service_auth import ServiceAuthManager  # noqa: E402
 
 # All 6 services that should have keys
@@ -77,7 +77,7 @@ async def verify():
     logger.info("")
 
     try:
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         auth_mgr = ServiceAuthManager(redis)
         logger.info("ServiceAuthManager initialized successfully")
         logger.info("")

--- a/autobot-slm-backend/services/token_denylist.py
+++ b/autobot-slm-backend/services/token_denylist.py
@@ -32,7 +32,7 @@ import asyncio
 import logging
 import time
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 try:  # redis-py exceptions do NOT inherit builtin ConnectionError/OSError
     from redis.exceptions import RedisError as _RedisError
@@ -100,7 +100,7 @@ async def revoke_jti(jti: str, ttl_seconds: int) -> None:
     ttl = max(1, ttl_seconds)
 
     async def _do() -> bool:
-        redis = await get_redis_client(async_client=True)
+        redis = await get_async_redis_client()
         if redis is None:
             return False
         await redis.set(_denylist_key(jti), "1", ex=ttl)
@@ -131,7 +131,7 @@ async def is_jti_revoked(jti: str) -> bool:
         return False
 
     async def _do() -> bool | None:
-        redis = await get_redis_client(async_client=True)
+        redis = await get_async_redis_client()
         if redis is None:
             return None
         return bool(await redis.exists(_denylist_key(jti)))

--- a/autobot_shared/message_bus.py
+++ b/autobot_shared/message_bus.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncIterator
 
 from autobot_shared.models.service_message import ServiceMessage
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class ServiceMessageBus:
     async def _get_redis(self) -> Any:
         """Return an async Redis client, creating on first use."""
         if self._redis is None:
-            self._redis = await get_redis_client(async_client=True, database="logs")
+            self._redis = await get_async_redis_client(database="logs")
             logger.debug("ServiceMessageBus Redis connection established")
         return self._redis
 

--- a/autobot_shared/redis_management/cache_wrapper.py
+++ b/autobot_shared/redis_management/cache_wrapper.py
@@ -60,7 +60,7 @@ class RedisCache:
     non-critical cache operations.
 
     Args:
-        client:      An async Redis client (e.g. from ``get_redis_client(async_client=True)``).
+        client:      An async Redis client (e.g. from ``get_async_redis_client()``).
         default_ttl: Default expiry in seconds applied to :meth:`set_json` when
                      the caller does not supply an explicit *ttl*.  Pass ``None``
                      to store without expiry.

--- a/autobot_shared/workflow_memory.py
+++ b/autobot_shared/workflow_memory.py
@@ -21,7 +21,7 @@ Usage::
 import logging
 from typing import Dict
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class WorkflowMemory:
             value: String value (JSON-encode complex data).
             agent_id: Optional agent identifier for audit logging.
         """
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         await redis.hset(self._key, key, value)
         await redis.expire(self._key, _DEFAULT_TTL_SECONDS)
         if agent_id:
@@ -73,7 +73,7 @@ class WorkflowMemory:
         Returns:
             Value string or None if not found.
         """
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         return await redis.hget(self._key, key)
 
     async def read_all(self) -> Dict[str, str]:
@@ -82,11 +82,11 @@ class WorkflowMemory:
         Returns:
             Dict of all key-value pairs.
         """
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         return await redis.hgetall(self._key)
 
     async def clear(self) -> None:
         """Clean up workflow memory. Call when workflow completes."""
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         await redis.delete(self._key)
         logger.debug("WorkflowMemory[%s] cleared", self.workflow_id)

--- a/autobot_shared/workflow_memory_test.py
+++ b/autobot_shared/workflow_memory_test.py
@@ -19,7 +19,7 @@ class TestWorkflowMemory:
         assert self.memory._key == "autobot:workflow:wf-123:memory"
 
     @pytest.mark.asyncio
-    @patch("autobot_shared.workflow_memory.get_redis_client")
+    @patch("autobot_shared.workflow_memory.get_async_redis_client")
     async def test_write(self, mock_get_redis) -> None:
         mock_redis = AsyncMock()
         mock_get_redis.return_value = mock_redis
@@ -30,7 +30,7 @@ class TestWorkflowMemory:
         mock_redis.expire.assert_called_once_with("autobot:workflow:wf-123:memory", 3600)
 
     @pytest.mark.asyncio
-    @patch("autobot_shared.workflow_memory.get_redis_client")
+    @patch("autobot_shared.workflow_memory.get_async_redis_client")
     async def test_read(self, mock_get_redis) -> None:
         mock_redis = AsyncMock()
         mock_redis.hget.return_value = '{"status": "done"}'
@@ -42,7 +42,7 @@ class TestWorkflowMemory:
         mock_redis.hget.assert_called_once_with("autobot:workflow:wf-123:memory", "step1:result")
 
     @pytest.mark.asyncio
-    @patch("autobot_shared.workflow_memory.get_redis_client")
+    @patch("autobot_shared.workflow_memory.get_async_redis_client")
     async def test_read_all(self, mock_get_redis) -> None:
         mock_redis = AsyncMock()
         mock_redis.hgetall.return_value = {"k1": "v1", "k2": "v2"}
@@ -53,7 +53,7 @@ class TestWorkflowMemory:
         assert result == {"k1": "v1", "k2": "v2"}
 
     @pytest.mark.asyncio
-    @patch("autobot_shared.workflow_memory.get_redis_client")
+    @patch("autobot_shared.workflow_memory.get_async_redis_client")
     async def test_clear(self, mock_get_redis) -> None:
         mock_redis = AsyncMock()
         mock_get_redis.return_value = mock_redis

--- a/docs/examples/service_failure_monitoring.py
+++ b/docs/examples/service_failure_monitoring.py
@@ -80,9 +80,9 @@ async def _send_failure_notification(payload: dict) -> None:
 
 async def monitor_service_health() -> None:
     """Subscribe to HealthCollector state-change events and react to failures."""
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     if redis is None:
         logger.error("Could not connect to Redis — aborting monitor loop.")
         return

--- a/scripts/backfill_session_org_context.py
+++ b/scripts/backfill_session_org_context.py
@@ -63,9 +63,9 @@ async def _update_redis_indices(session_id: str, username: str, org_id: str) -> 
     Helper for backfill_sessions (#684).
     """
     try:
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
 
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
 
         # Org session set
         org_key = f"org_chat_sessions:{org_id}"


### PR DESCRIPTION
## Thinking Path

`autobot_shared/redis_client.py` says it plainly: `get_redis_client(async_client=True)` is *"error-prone because it is a synchronous function that returns an unawaited coroutine"*, and `get_async_redis_client()` is *"the safe alternative … making the correct usage impossible to get wrong"*.

That wrapper exists because of **#3962**. The footgun has misfired twice since — most recently **#12780**, where six sites were wrong at once and one silently dropped **code-exec security audit events** (`rc.xadd()` on a coroutine, swallowed by a bare `except`). Every instance failed *silently*, because a coroutine only raises `AttributeError` at first use and each site happened to sit inside a broad `except`.

This migrates the remaining **51 call sites across 27 files**, so no async call site is left on the legacy form and a new one has no precedent in the tree to copy.

## What Changed

- **51 call sites across 27 files** migrated from `get_redis_client(async_client=True, …)` to `get_async_redis_client(…)`, with imports updated.
- **Lazy-binding modules repaired.** `memory/transparency.py` and `memory/ownership_reassign.py` use a deliberate pattern — a module-level `get_redis_client = None` sentinel, rebound inside a function so tests can monkeypatch it. The rename had to cover the sentinel, the `global` declaration and the rebind, not just the import and call sites.
- **9 test files updated** where patch targets named the renamed symbol.
- Four `autobot-infrastructure` scripts deliberately excluded — see below.

## A mistake I made and caught

My first import-rewrite guard used a Python-style lookbehind in `grep`, which basic grep silently doesn't support. The guard mis-fired and left `retrieval_learner.py` **calling** `get_async_redis_client` while still **importing** `get_redis_client` — a `NameError` at runtime.

So I stopped grepping and verified with AST instead: every changed module must parse, and every module that *calls* `get_async_redis_client` must *import* it. That check is what surfaced it, and it now reports clean across all 32 changed files.

## Deliberately excluded

Four `autobot-infrastructure/shared/scripts/` files import `from utils.redis_client import get_redis_client` — a module that **does not exist for them**. The only `utils/redis_client.py` in the repo belongs to the Windows NPU worker and exposes a different function with a different signature (`get_redis_client(config: dict)`), while the call sites pass `async_client=…, database=…`.

They are broken on `Dev_new_gui` already, independently of this change. Fixing them means verifying those scripts still run at all, which is a different kind of change — filed as **#12826** rather than folded in.

## Test patch targets — the part that matters most

Updated in 6 test files, and this is not cosmetic: **#12780 proved these tests can encode the bug.** Patching `<module>.get_redis_client` with a plain `return_value=mock` mocks the call as *synchronous* — precisely the buggy shape — so production receives a coroutine while the test receives a client and the suite stays green. A migration that renamed the source without the patch targets would have re-created that blind spot.

## Verification

```
$ pytest api/desktop_control_lock_test.py api/analytics_code_generation_test.py -q
34 passed

$ pytest tests/api/test_reasoning_effort_integration.py tests/services/notification_service_test.py \
         tests/knowledge/search_components/retrieval_learner_fastfail_test.py -q
93 passed

$ pytest autobot_shared/workflow_memory_test.py -q
5 passed

AST check across all 32 changed modules: 32 parse OK, 0 calling-without-importing
```

## Model Used

Claude Opus 5 (1M context)

Closes #12807