### PR TITLE
fix(backend): three concrete backend bugs — seed boost, pipeline stage, f-string (#12742, #12743, #12720)

### DIFF
--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -154,6 +154,28 @@ class AdvancedRAGOptimizer:
         self._init_performance_tracking()
         logger.info("AdvancedRAGOptimizer initialized")
 
+    def _apply_seed_priority_boost(self, result: "SearchResult") -> float:
+        """Return *result*'s hybrid score lifted by its seed priority (#4679, #12742).
+
+        CognitionSeeder stamps every seeded document with ``seeded: "true"`` and
+        ``seed_priority: high|medium|low`` (services/knowledge/cognition_seeder.py
+        :219-220) precisely so retrieval can favour them during cold start — when
+        the corpus is otherwise empty and an unseeded document would win on noise.
+
+        That producer has been live while this consumer was missing, so the
+        metadata was written and never read: the boost #4679 exists for was
+        silently inert. Non-seeded results are returned unchanged, and the score
+        is capped at 1.0 so a boost can never push it out of range.
+        """
+        from services.knowledge.cognition_seeder import SEED_PRIORITY_BOOST
+
+        metadata = getattr(result, "metadata", None) or {}
+        if str(metadata.get("seeded", "")).lower() != "true":
+            return result.hybrid_score
+
+        boost = SEED_PRIORITY_BOOST.get(str(metadata.get("seed_priority", "")).lower(), 0.0)
+        return min(1.0, result.hybrid_score + boost)
+
     def _init_search_config(self) -> None:
         """Initialize search configuration parameters. Issue #620."""
         self.hybrid_weight_semantic = 0.7  # Weight for semantic similarity

--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -1058,7 +1058,7 @@ async def get_file_risk(
 
     except Exception as e:
         logger.error("Failed to analyze file %s: %s", file_path, e, exc_info=True)
-        return no_data_response("Analysis failed for {file_path}", files=[], summary={})
+        return no_data_response(f"Analysis failed for {file_path}", files=[], summary={})
 
 
 def _get_file_recommendation(risk_score: float, factors: dict[str, float]) -> str:

--- a/autobot-backend/knowledge/pipeline/base.py
+++ b/autobot-backend/knowledge/pipeline/base.py
@@ -91,7 +91,11 @@ class PipelineResult:
             stages.append("extract")
         if self.entities_extracted > 0 or self.events_extracted > 0 or self.facts_extracted > 0:
             stages.append("cognify")
-        if not self.errors:
+        # #12743: "load" means a load actually happened, not merely "nothing went
+        # wrong". A freshly-constructed PipelineResult has no errors, so the old
+        # `if not self.errors` claimed a completed load stage for a pipeline that
+        # never ran. Require at least one earlier stage to have produced output.
+        if stages and not self.errors:
             stages.append("load")
         return stages
 


### PR DESCRIPTION
## Thinking Path

I had been filtering the backlog on `bug`+`tech-debt` labels and missing a much larger set of concrete, decision-free issues. This is a three-issue batch selected up front from that set.

**#12742 looked like a decision and wasn't.** The issue offers "implement `_apply_seed_priority_boost`, **or** remove the stale tests if superseded". The evidence settles it: `CognitionSeeder` already **writes** `seeded: "true"` and `seed_priority` metadata (`cognition_seeder.py:219-220`) and **queries** on it (`:352`). The producer has been live in production while the consumer was missing — so the metadata was written and never read, leaving #4679's cold-start boost silently inert. That is the same "registered but never wired" shape as #12816 and #9943. Removing the tests would have deleted the spec for a half-built feature.

**#12743** is a contract bug with a tell: `if not self.errors: stages.append("load")`. "No errors" is trivially true for a pipeline that never ran, so a freshly-constructed `PipelineResult()` reported `['load']` — claiming a load stage completed when nothing had executed.

**#12720** is a one-character fix, but I swept for siblings rather than assuming it was unique.

## What Changed

- **`advanced_rag_optimizer.py`** — implemented `_apply_seed_priority_boost`. Non-seeded results pass through unchanged; the boosted score is capped at 1.0 so it can never leave range.
- **`knowledge/pipeline/base.py`** — `"load"` now requires at least one earlier stage to have produced output, satisfying all four existing contract tests including the errors case.
- **`api/analytics_bug_prediction.py:1061`** — added the missing `f` prefix.

## Verification

```
knowledge/pipeline/ + services/knowledge/
  baseline:  20 failed, 628 passed
  after:     14 failed, 634 passed
```

**+6 passing, none introduced** — matching exactly the 5 seed-boost tests plus the 1 pipeline contract test. The remaining 14 are pre-existing and unrelated (identical on an unmodified tree).

```
knowledge/pipeline/base_test.py              22 passed
services/knowledge/test_cognition_seeder.py  18 passed
```

For #12720 I ran an AST pass over the whole file looking for plain strings containing `{identifier}`. The only other hit is the route template `"/status/{task_id}"`, which is correctly **not** an f-string — so no sibling bugs and no false positive fixed.

## Model Used

Claude Opus 5 (1M context)

Closes #12742, #12743, #12720