### PR TITLE
fix(backend): checkpoint crawled seeds unconditionally + bound web-research status probes (#12744, #12751)

### DIFF
--- a/autobot-backend/api/system_health.py
+++ b/autobot-backend/api/system_health.py
@@ -58,6 +58,12 @@ class KnownProbes(str, enum.Enum):
 # component cannot hold the aggregator hostage.
 _PROBE_TIMEOUT_S = 2.0
 
+# Public alias so other health/status endpoints bound their dependency calls
+# with the SAME budget instead of inventing their own (#12751). Note the #6918
+# caveat: asyncio.wait_for only cancels at await points, so a probe that blocks
+# the event loop synchronously still overruns this.
+HEALTH_PROBE_TIMEOUT_S = _PROBE_TIMEOUT_S
+
 # Issue #12459: "ok"/"degraded"/"down" alone cannot express an EXPECTED
 # absence (single-node topology, dev-only tooling intentionally off,
 # lazy singleton not yet touched). Forcing those into "degraded"/"down"

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -8,6 +8,7 @@ Web Research Settings API
 Provides endpoints for managing web research configuration and preferences.
 """
 
+import asyncio
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
@@ -25,6 +26,7 @@ from api.schemas_workflows import (
     WebResearchUsageStatsData,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from api.system_health import HEALTH_PROBE_TIMEOUT_S
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -59,14 +61,22 @@ async def get_research_status(request: Request):
     """Get current web research status and configuration"""
     integration = _require_web_researcher(request)
     try:
-        # Get health check
-        health_status = await integration.health_check()
+        # #12751: bound every dependency call. A status endpoint that HANGS is
+        # worse than one reporting an error — the UI health panel and monitoring
+        # block instead of getting a clear degraded signal, and `except
+        # Exception` below catches failures but never a hang. Same budget as the
+        # health aggregator so probes cannot disagree about what "too slow"
+        # means. (#6918 caveat: wait_for only cancels at await points.)
+        health_status = await asyncio.wait_for(
+            integration.health_check(), timeout=HEALTH_PROBE_TIMEOUT_S
+        )
 
-        # Get circuit breaker status
+        # Get circuit breaker status (sync, no I/O)
         circuit_status = integration.get_circuit_breaker_status()
 
-        # Get cache stats
-        cache_stats = await integration.get_cache_stats()
+        cache_stats = await asyncio.wait_for(
+            integration.get_cache_stats(), timeout=HEALTH_PROBE_TIMEOUT_S
+        )
 
         return JSONResponse(
             status_code=200,
@@ -77,6 +87,21 @@ async def get_research_status(request: Request):
                 "health": health_status,
                 "circuit_breakers": circuit_status,
                 "cache_stats": cache_stats,
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            },
+        )
+
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Web research status probe exceeded %ss — returning degraded (#12751)",
+            HEALTH_PROBE_TIMEOUT_S,
+        )
+        return JSONResponse(
+            status_code=200,  # graceful degradation, same contract as the error path
+            content={
+                "status": "degraded",
+                "enabled": False,
+                "error": f"health probe timed out after {HEALTH_PROBE_TIMEOUT_S}s",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             },
         )

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -25,8 +25,8 @@ from api.schemas_workflows import (
     WebResearchToggleData,
     WebResearchUsageStatsData,
 )
-from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from api.system_health import HEALTH_PROBE_TIMEOUT_S
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -67,16 +67,12 @@ async def get_research_status(request: Request):
         # Exception` below catches failures but never a hang. Same budget as the
         # health aggregator so probes cannot disagree about what "too slow"
         # means. (#6918 caveat: wait_for only cancels at await points.)
-        health_status = await asyncio.wait_for(
-            integration.health_check(), timeout=HEALTH_PROBE_TIMEOUT_S
-        )
+        health_status = await asyncio.wait_for(integration.health_check(), timeout=HEALTH_PROBE_TIMEOUT_S)
 
         # Get circuit breaker status (sync, no I/O)
         circuit_status = integration.get_circuit_breaker_status()
 
-        cache_stats = await asyncio.wait_for(
-            integration.get_cache_stats(), timeout=HEALTH_PROBE_TIMEOUT_S
-        )
+        cache_stats = await asyncio.wait_for(integration.get_cache_stats(), timeout=HEALTH_PROBE_TIMEOUT_S)
 
         return JSONResponse(
             status_code=200,

--- a/autobot-backend/api/web_research_status_timeout_12751_test.py
+++ b/autobot-backend/api/web_research_status_timeout_12751_test.py
@@ -1,0 +1,84 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GET /web-research/status must never hang (#12751).
+
+The endpoint awaited integration.health_check() and get_cache_stats() with no
+bound. Its `except Exception` catches failures but cannot catch a HANG, so a
+stalled dependency took the endpoint with it — callers (UI health panels,
+monitoring) blocked instead of receiving a clear degraded signal, which is
+strictly worse than an error response.
+
+Probes are now bounded by the same HEALTH_PROBE_TIMEOUT_S the health aggregator
+uses, so the two cannot disagree about what "too slow" means.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _request_with(integration):
+    req = MagicMock()
+    req.app.state.web_researcher = integration
+    return req
+
+
+def _integration(health=None, cache=None, hang: bool = False):
+    async def _hang(*_a, **_k):
+        await asyncio.sleep(3600)
+
+    return SimpleNamespace(
+        health_check=_hang if hang else AsyncMock(return_value=health or {"enabled": True}),
+        get_circuit_breaker_status=MagicMock(return_value={}),
+        get_cache_stats=_hang if hang else AsyncMock(return_value=cache or {}),
+    )
+
+
+class TestStatusIsBounded:
+    @pytest.mark.asyncio
+    async def test_hanging_dependency_returns_degraded_not_a_hang(self, monkeypatch):
+        """The whole point: a stalled probe must degrade, not block the caller."""
+        import api.web_research_settings as mod
+
+        monkeypatch.setattr(mod, "HEALTH_PROBE_TIMEOUT_S", 0.05)
+        monkeypatch.setattr(mod, "_require_web_researcher", lambda request: _integration(hang=True))
+
+        resp = await asyncio.wait_for(
+            mod.get_research_status(_request_with(None)), timeout=5.0
+        )
+
+        body = json.loads(resp.body)
+        assert body["status"] == "degraded"
+        assert body["enabled"] is False
+        assert "timed out" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_healthy_dependency_still_returns_success(self, monkeypatch):
+        """Bounding must not change the happy path."""
+        import api.web_research_settings as mod
+
+        monkeypatch.setattr(
+            mod, "_require_web_researcher",
+            lambda request: _integration(health={"enabled": True}, cache={"hits": 1}),
+        )
+
+        resp = await mod.get_research_status(_request_with(None))
+        body = json.loads(resp.body)
+        assert body["status"] == "success"
+        assert body["enabled"] is True
+
+    def test_shares_the_aggregator_timeout_budget(self):
+        """One source of truth — a divergent local constant would let the
+        aggregator and this endpoint disagree about 'too slow'."""
+        from api.system_health import _PROBE_TIMEOUT_S, HEALTH_PROBE_TIMEOUT_S
+        from api.web_research_settings import HEALTH_PROBE_TIMEOUT_S as endpoint_budget
+
+        assert HEALTH_PROBE_TIMEOUT_S == _PROBE_TIMEOUT_S
+        assert endpoint_budget == _PROBE_TIMEOUT_S

--- a/autobot-backend/api/web_research_status_timeout_12751_test.py
+++ b/autobot-backend/api/web_research_status_timeout_12751_test.py
@@ -50,9 +50,7 @@ class TestStatusIsBounded:
         monkeypatch.setattr(mod, "HEALTH_PROBE_TIMEOUT_S", 0.05)
         monkeypatch.setattr(mod, "_require_web_researcher", lambda request: _integration(hang=True))
 
-        resp = await asyncio.wait_for(
-            mod.get_research_status(_request_with(None)), timeout=5.0
-        )
+        resp = await asyncio.wait_for(mod.get_research_status(_request_with(None)), timeout=5.0)
 
         body = json.loads(resp.body)
         assert body["status"] == "degraded"
@@ -65,7 +63,8 @@ class TestStatusIsBounded:
         import api.web_research_settings as mod
 
         monkeypatch.setattr(
-            mod, "_require_web_researcher",
+            mod,
+            "_require_web_researcher",
             lambda request: _integration(health={"enabled": True}, cache={"hits": 1}),
         )
 

--- a/autobot-backend/knowledge/connectors/web_crawler.py
+++ b/autobot-backend/knowledge/connectors/web_crawler.py
@@ -316,8 +316,12 @@ class WebCrawlerConnector(AbstractConnector):
 
         try:
 
+            crawled_seed_ids: set[str] = set()
+
             async def _on_seed_done(url: str) -> None:
-                await self._write_checkpoint(_url_to_source_id(url))
+                source_id = _url_to_source_id(url)
+                crawled_seed_ids.add(source_id)
+                await self._write_checkpoint(source_id)
 
             fetched = await self.crawl(
                 seed_urls=pending_seeds,
@@ -328,6 +332,16 @@ class WebCrawlerConnector(AbstractConnector):
                 same_origin=self._same_origin,
                 on_seed_complete=_on_seed_done,
             )
+            # #12744: on_seed_complete is an OPTIONAL callback — a crawl backend
+            # that does not invoke it left the checkpoint empty, so a resumed
+            # sync re-crawled every seed it had already finished. Once crawl()
+            # returns without raising, every dispatched seed has been attempted,
+            # so record any the callback did not report.
+            for seed_url in pending_seeds:
+                source_id = _url_to_source_id(seed_url)
+                if source_id not in crawled_seed_ids:
+                    await self._write_checkpoint(source_id)
+
             await _ingest_results_to_kb(fetched, self, result)
             result.status = "success" if not result.errors else "partial"
             if result.status == "success":


### PR DESCRIPTION
## Thinking Path

**#12744** — `sync()` recorded checkpoints *only* through the `on_seed_complete` callback it hands to `crawl()`. That callback is **optional**: a crawl backend that never invokes it leaves the checkpoint empty, so `_read_checkpoint()` returns an empty set on resume and every already-finished seed is crawled again — precisely the waste checkpointing exists to prevent. The failing test was right and the implementation was wrong.

**#12751** — `GET /web-research/status` awaited `health_check()` and `get_cache_stats()` unbounded. Its `except Exception` catches failures but **cannot catch a hang**, so a stalled dependency took the endpoint with it. A status endpoint that hangs is strictly worse than one returning an error: the UI health panel and monitoring block rather than getting a clear degraded signal.

## What Changed

- **`knowledge/connectors/web_crawler.py`** — once `crawl()` returns without raising, every dispatched seed has been attempted, so any seed the callback didn't report is now recorded explicitly. The callback is kept for mid-crawl progress on long runs.
- **`api/system_health.py`** — exposes `HEALTH_PROBE_TIMEOUT_S` as a public alias of the existing `_PROBE_TIMEOUT_S`, so other endpoints reuse the aggregator's budget instead of inventing their own.
- **`api/web_research_settings.py`** — both probes bounded; timeout returns an explicit `degraded` payload on the same 200 contract the error path already uses.

## Why #12751 is `Refs`, not `Closes`

The other endpoint it names, `/api/entities/extract/health`, has **nothing to bound**:

- the handler body is pure attribute checks — **no awaits**
- its dependency `get_entity_extractor` is a sync `getattr` on `app.state`

Neither can hang. So adding a timeout there would be cargo-culting a fix onto code that cannot exhibit the fault. That points instead at **event-loop starvation** — which is exactly what #12779 produced (uncancellable duplicate-detection scans saturating CPU until `/api/health` stopped answering), fixed in #12822. Confirming that needs the live box, so #12751 stays open with the analysis rather than being closed on a half-diagnosis.

## Verification

```
$ pytest api/web_research_status_timeout_12751_test.py -q
3 passed

$ pytest knowledge/connectors/connector_resilience_test.py::TestWebCrawlerSyncCheckpoint -q
3 passed          # was 1 failed, 2 passed

$ pytest api/system_health_test.py -q
5 passed
```

The three new tests cover: a hanging dependency degrades instead of blocking (the actual fault), the happy path is unchanged by bounding, and the endpoint shares the aggregator's budget rather than a divergent local constant — a separate constant would let the two disagree about "too slow".

## Model Used

Claude Opus 5 (1M context)

Closes #12744
Refs #12751, #12779