### PR TITLE
tech-debt: normalize inline datetime.now(utc).isoformat() onto utc_timestamp() (#12726)

### DIFF
--- a/autobot-backend/api/chat_folders.py
+++ b/autobot-backend/api/chat_folders.py
@@ -15,7 +15,6 @@ Response shape: plain JSONResponse (matches chat_presets.py pattern).
 
 import json
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, Depends, Request
@@ -25,6 +24,7 @@ from api.schemas_chat import FolderCreate, FolderUpdate, SessionFolderAssign
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from constants.redis_constants import REDIS_KEY
 
 logger = get_logger(__name__)
@@ -143,7 +143,7 @@ async def create_folder(
         "owner": username,
         "pinned": False,
         "archived": False,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": utc_timestamp(),
         "session_ids": [],
     }
     folders.append(folder)

--- a/autobot-backend/api/desktop_control_lock.py
+++ b/autobot-backend/api/desktop_control_lock.py
@@ -33,10 +33,10 @@ navigates away or closes the tab does not permanently mute the agent.
 
 import json
 import os
-from datetime import datetime, timezone
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 logger = get_logger(__name__)
 
@@ -113,7 +113,7 @@ async def acquire_human_control(session_id: str, owner: str) -> dict:
     key = _lock_key(session_id)
     record = {
         "owner": owner,
-        "acquired_at": datetime.now(timezone.utc).isoformat(),
+        "acquired_at": utc_timestamp(),
     }
     try:
         redis = await get_async_redis_client(database="main")

--- a/autobot-backend/api/marketplace_sources.py
+++ b/autobot-backend/api/marketplace_sources.py
@@ -15,7 +15,6 @@ import json
 import re
 import socket
 import uuid
-from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlparse
 
@@ -32,6 +31,7 @@ from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.time_utils import utc_timestamp
 from autobot_shared.url_safety import resolve_safe_ip_async
 
 logger = get_logger(__name__)
@@ -144,7 +144,7 @@ async def add_marketplace(
         url=url,
         description=request.description,
         is_builtin=False,
-        created_at=datetime.now(timezone.utc).isoformat(),
+        created_at=utc_timestamp(),
     )
     redis = await get_async_redis_client(database="main")
     if redis is None:

--- a/autobot-backend/chat_workflow/stop_hook.py
+++ b/autobot-backend/chat_workflow/stop_hook.py
@@ -19,9 +19,8 @@ All ``.delay()`` calls are synchronous and non-blocking; they only publish
 a message to Redis.  The actual work happens in background Celery workers.
 """
 
-from datetime import datetime, timezone
-
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 
 logger = get_logger(__name__)
 
@@ -57,7 +56,7 @@ async def on_turn_complete(
         from tasks.memory_tasks import extract_facts_task as _ef  # type: ignore[assignment]
         from tasks.memory_tasks import write_verbatim_task as _wv  # type: ignore[assignment]
 
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = utc_timestamp()
 
     try:
         # Verbatim store writes — one task per role for parallelism

--- a/autobot-backend/code_analysis/src/remediation_loop_test.py
+++ b/autobot-backend/code_analysis/src/remediation_loop_test.py
@@ -27,6 +27,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.time_utils import utc_timestamp
+
 # ---------------------------------------------------------------------------
 # Helpers — build lightweight stubs that match the real dataclass shapes.
 # ---------------------------------------------------------------------------
@@ -119,7 +121,7 @@ def _stub_shared(sys_mod):
     if not hasattr(tu, "now_utc"):
         tu.now_utc = lambda: datetime.now(timezone.utc)
     if not hasattr(tu, "utc_timestamp"):
-        tu.utc_timestamp = lambda: datetime.now(timezone.utc).isoformat()
+        tu.utc_timestamp = lambda: utc_timestamp()
 
     # Keep autobot_shared package-level accessible
     shared = sys_mod.modules["autobot_shared"]

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -15,12 +15,12 @@ import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
 
 from fastapi import FastAPI
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import STARTUP_ERROR_FILE
+from autobot_shared.time_utils import utc_timestamp
 from autobot_shared.tracing import (
     instrument_aiohttp,
     instrument_redis,
@@ -508,7 +508,7 @@ async def initialize_critical_services(app: FastAPI):
                 json.dumps(
                     {
                         "error_type": error_type,
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "timestamp": utc_timestamp(),
                     }
                 ),
                 encoding="utf-8",

--- a/autobot-backend/knowledge/backends/async_chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/async_chromadb_adapter.py
@@ -19,6 +19,7 @@ import re
 from typing import Any, List, Sequence
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from knowledge.backends.async_base import AsyncBaseClient, AsyncBaseCollection
 from knowledge.backends.base import Embedding, Metadata, Where, WhereDocument
 
@@ -210,9 +211,7 @@ class AsyncChromaDBClient(AsyncBaseClient):
         metadata: Metadata | None = None,
         embedding_function: Any | None = None,
     ) -> AsyncBaseCollection:
-        from datetime import datetime, timezone
-
-        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        provenance: dict = {"created_at": utc_timestamp()}
         if metadata:
             provenance.update(metadata)
         raw_col = await self._raw.get_or_create_collection(
@@ -236,9 +235,7 @@ class AsyncChromaDBClient(AsyncBaseClient):
         metadata: Metadata | None = None,
         embedding_function: Any | None = None,
     ) -> AsyncBaseCollection:
-        from datetime import datetime, timezone
-
-        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        provenance: dict = {"created_at": utc_timestamp()}
         if metadata:
             provenance.update(metadata)
         try:

--- a/autobot-backend/knowledge/backends/chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/chromadb_adapter.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Any, List, Sequence
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from knowledge.backends.base import (
     BaseClient,
     BaseCollection,
@@ -191,9 +192,8 @@ class ChromaDBClient(BaseClient):
         metadata: Metadata | None = None,
         embedding_function: Any | None = None,
     ) -> BaseCollection:
-        from datetime import datetime, timezone
 
-        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        provenance: dict = {"created_at": utc_timestamp()}
         if metadata:
             provenance.update(metadata)
         kwargs: dict = {"name": name, "metadata": provenance}
@@ -214,9 +214,8 @@ class ChromaDBClient(BaseClient):
         metadata: Metadata | None = None,
         embedding_function: Any | None = None,
     ) -> BaseCollection:
-        from datetime import datetime, timezone
 
-        provenance: dict = {"created_at": datetime.now(timezone.utc).isoformat()}
+        provenance: dict = {"created_at": utc_timestamp()}
         if metadata:
             provenance.update(metadata)
         kwargs: dict = {"name": name, "metadata": provenance}

--- a/autobot-backend/llc/kb/handoff_brief.py
+++ b/autobot-backend/llc/kb/handoff_brief.py
@@ -5,10 +5,10 @@
 """LLC HandoffBriefGenerator — AI→Human and Human→AI KB-powered briefs (GH#8239)."""
 
 import json
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from llm_shared.types import LLMType
 
 from .rag_assembler import AssemblerProfile, LLCRAGAssembler
@@ -108,7 +108,7 @@ class HandoffBriefGenerator:
                 "open_questions": brief_content.get("open_questions", []),
                 "next_steps": brief_content.get("next_steps", []),
                 "artifacts": brief_content.get("artifacts", []),
-                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "generated_at": utc_timestamp(),
                 "generator": "handoff_brief_generator",
             }
 
@@ -196,7 +196,7 @@ class HandoffBriefGenerator:
                 "company_standards": brief_content.get("company_standards", []),
                 "project_context": brief_content.get("project_context", []),
                 "suggested_approach": brief_content.get("suggested_approach", ""),
-                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "generated_at": utc_timestamp(),
                 "generator": "handoff_brief_generator",
             }
 
@@ -229,7 +229,7 @@ class HandoffBriefGenerator:
             "open_questions": [],
             "next_steps": [],
             "artifacts": [],
-            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generated_at": utc_timestamp(),
             "generator": "fallback",
         }
 
@@ -240,7 +240,7 @@ class HandoffBriefGenerator:
             "company_standards": [],
             "project_context": [],
             "suggested_approach": "Proceed with default best practices. Escalate if unclear.",
-            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generated_at": utc_timestamp(),
             "generator": "fallback",
         }
 

--- a/autobot-backend/llc/kb/sprint_summarizer.py
+++ b/autobot-backend/llc/kb/sprint_summarizer.py
@@ -13,12 +13,12 @@ On sprint close:
 """
 
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from llm_shared.types import LLMType
 
 from ..kb.collections import KbCollectionManager
@@ -268,7 +268,7 @@ class SprintKbSummarizer:
             )
             await self._direct_merge(docs, dst_collection, sprint_id, project_id)
             return "[direct-merged: LLM returned empty content]"
-        closed_at = datetime.now(timezone.utc).isoformat()
+        closed_at = utc_timestamp()
         sprint_name = sprint.name if sprint else str(sprint_id)
 
         from knowledge import get_knowledge_base  # lazy

--- a/autobot-backend/llc/notifications/publisher.py
+++ b/autobot-backend/llc/notifications/publisher.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ class LLCWebSocketPublisher:
             "entity_id": entity_id,
             "payload": payload,
             "actor_id": actor_id,
-            "ts": datetime.now(timezone.utc).isoformat(),
+            "ts": utc_timestamp(),
         }
         try:
             if get_live_event_manager is not None:

--- a/autobot-backend/llc/services/handoff.py
+++ b/autobot-backend/llc/services/handoff.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 from ..kb.handoff_brief import HandoffBriefGenerator
 from ..models.enums import ActivityEventType, WorkItemStatus
@@ -541,7 +542,7 @@ class HandoffService(LLCServiceBase):
             "comment_count": len(item.comments or []),
             "recent_comments": comment_excerpts[-5:],
             "agent_notes": agent_notes,
-            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generated_at": utc_timestamp(),
             "generator": "stub-phase4",
         }
 

--- a/autobot-backend/services/kb_folder_watcher.py
+++ b/autobot-backend/services/kb_folder_watcher.py
@@ -20,7 +20,6 @@ Features:
 import asyncio
 import json
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -30,6 +29,7 @@ from watchdog.observers import Observer
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.time_utils import utc_timestamp
 
 logger = get_logger(__name__)
 
@@ -67,7 +67,7 @@ class WatchFolderConfig:
         self.recursive = recursive
         self.category = category
         self.tags = tags or []
-        self.created_at = datetime.now(timezone.utc).isoformat()
+        self.created_at = utc_timestamp()
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -466,7 +466,7 @@ class KBFolderWatcherService:
             # Update stats
             if folder_id in self._stats:
                 self._stats[folder_id]["files_ingested"] += 1
-                self._stats[folder_id]["last_change"] = datetime.now(timezone.utc).isoformat()
+                self._stats[folder_id]["last_change"] = utc_timestamp()
 
             logger.info("Successfully ingested file: %s into collection %s", file_path.name, config.collection)
 

--- a/autobot-backend/services/task_workspace.py
+++ b/autobot-backend/services/task_workspace.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from services.task_workspace_common import validate_task_id
 
 logger = get_logger(__name__)
@@ -146,7 +147,7 @@ def allocate(
     workspace_base.mkdir(parents=True, exist_ok=True)
     _enforce_limit(agent_id, max_per_agent, root)
 
-    created_at = datetime.now(timezone.utc).isoformat()
+    created_at = utc_timestamp()
     _git_add_worktree(root, workspace_dir, branch)
 
     meta = {

--- a/autobot-backend/tests/test_voice_realtime_telemetry.py
+++ b/autobot-backend/tests/test_voice_realtime_telemetry.py
@@ -22,6 +22,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.time_utils import utc_timestamp
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -33,7 +35,7 @@ def _make_record(**kwargs):
         "session_id": "test-session-1",
         "user_id": "user-42",
         "model": "gpt-realtime-2",
-        "started_at": datetime.now(timezone.utc).isoformat(),
+        "started_at": utc_timestamp(),
         "ended_at": None,
         "duration_s": 0.0,
         "audio_in_s": 0.0,

--- a/autobot-backend/utils/celery_reliability.py
+++ b/autobot-backend/utils/celery_reliability.py
@@ -23,7 +23,6 @@ validation errors (ValueError/TypeError) fail fast and are never retried.
 
 import json
 import logging
-from datetime import datetime, timezone
 from functools import wraps
 from typing import Any, Callable, Dict
 
@@ -33,6 +32,7 @@ from autobot_shared.redis_client import get_async_redis_client, get_redis_client
 from autobot_shared.retry_mechanism import RETRYABLE_EXCEPTIONS
 from autobot_shared.ssot_config import config
 from autobot_shared.status_enums import TaskStatus
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ def park_dead_letter(task_name: str, task_id: str, args_summary: str, error: str
         "args_summary": args_summary,
         "error": error,
         "status": TaskStatus.PARKED.value,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": utc_timestamp(),
     }
     logger.error("Celery task parked in dead-letter queue: %s (%s) — %s", task_name, task_id, error)
     try:

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from celery_app import celery_app
 
 logger = get_logger(__name__)
@@ -348,7 +349,7 @@ def audit_testgaps(self) -> dict:
     """Every-6h task: find Python modules changed since last run that lack tests."""
     redis = _get_redis()
     last_run = _redis_get(redis, _TESTGAPS_LAST_RUN_KEY)
-    run_at = datetime.now(timezone.utc).isoformat()
+    run_at = utc_timestamp()
 
     repo_root = _repo_root()
     modules = _changed_python_modules(last_run, repo_root)
@@ -441,7 +442,7 @@ def audit_dead_code(self) -> dict:
 
     result = {
         "status": "success",
-        "run_at": datetime.now(timezone.utc).isoformat(),
+        "run_at": utc_timestamp(),
         "total_findings": len(current_lines),
         "new_findings": len(new_findings_raw),
         "issues_filed": filed,
@@ -550,7 +551,7 @@ def audit_claims(self) -> dict:
     """Weekly task: verify README/docs capability claims have wired implementations."""
     redis = _get_redis()
     _redis_get(redis, _CLAIMS_LAST_RUN_KEY)
-    run_at = datetime.now(timezone.utc).isoformat()
+    run_at = utc_timestamp()
 
     repo_root = _repo_root()
     claims = _extract_capability_claims(repo_root)

--- a/autobot-backend/workers/consolidate_tasks.py
+++ b/autobot-backend/workers/consolidate_tasks.py
@@ -14,10 +14,10 @@ lives in ``TrajectoryStore.consolidate`` which is fully delete-only.
 """
 
 import os
-from datetime import datetime, timezone
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import utc_timestamp
 from celery_app import celery_app
 
 logger = get_logger(__name__)
@@ -52,7 +52,7 @@ async def _run_consolidation() -> dict:
 @celery_app.task(bind=True, name="memory.consolidate_trajectories")
 def consolidate_trajectories(self) -> dict:
     """Daily task: dedupe + prune the trajectory store, then record the run time."""
-    run_at = datetime.now(timezone.utc).isoformat()
+    run_at = utc_timestamp()
     summary = run_or_schedule(_run_consolidation())
     try:
         _get_redis().set(_LAST_RUN_KEY, run_at)
@@ -77,7 +77,7 @@ def consolidate_facts(self) -> dict:
     Delete-only and guarded (owned/verified/pinned never eligible); ships in
     dry-run by default so candidates are logged before any deletion is enforced.
     """
-    run_at = datetime.now(timezone.utc).isoformat()
+    run_at = utc_timestamp()
     summary = run_or_schedule(_run_facts_consolidation())
     try:
         _get_redis().set(_FACTS_LAST_RUN_KEY, run_at)

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -21,11 +21,12 @@ import signal
 import socket
 import sqlite3
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 import aiohttp
 from aiohttp import web
+
+from autobot_shared.time_utils import utc_timestamp
 
 from .health_collector import HealthCollector
 from .port_scanner import get_listening_ports
@@ -173,7 +174,7 @@ class SLMAgent:
         conn = sqlite3.connect(self.buffer_db)
         conn.execute(
             "INSERT INTO event_buffer (timestamp, event_type, data) VALUES (?, ?, ?)",
-            (datetime.now(timezone.utc).isoformat(), event_type, json.dumps(data)),
+            (utc_timestamp(), event_type, json.dumps(data)),
         )
         conn.commit()
         conn.close()
@@ -578,7 +579,7 @@ class SLMAgent:
                 "node_id": self.node_id,
                 "commit": commit,
                 "is_code_source": True,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
             }
             async with self._session.post(
                 url,

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/health_collector.py
@@ -17,12 +17,13 @@ import socket
 import subprocess  # nosec B404 - required for systemctl interaction
 import time
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, List
 
 import psutil
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 # App-level /health probes for services that expose engine state beyond
 # systemd (#11723/#11777). Local-only URLs, short timeout, never fatal to
@@ -81,7 +82,7 @@ class HealthCollector:
     def collect(self) -> Dict:
         """Collect all health metrics."""
         health = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": utc_timestamp(),
             "hostname": self.hostname,
             "cpu_percent": psutil.cpu_percent(interval=0.1),
             "memory_percent": psutil.virtual_memory().percent,

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/version.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/version.py
@@ -13,6 +13,8 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
+from autobot_shared.time_utils import utc_timestamp
+
 logger = logging.getLogger(__name__)
 
 # Default paths
@@ -102,7 +104,7 @@ class AgentVersion:
         version_info = {
             "commit": commit,
             "built_at": built_at.isoformat(),
-            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": utc_timestamp(),
         }
 
         if extra_data:

--- a/autobot-slm-backend/api/code_source.py
+++ b/autobot-slm-backend/api/code_source.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from autobot_shared.time_utils import utc_timestamp
 from models.database import (
     CodeSource,
     CodeStatus,
@@ -484,7 +485,7 @@ async def _broadcast_commit_notification(notification: CodeNotification, outdate
                     "message": notification.message,
                     "node_id": notification.node_id,
                     "outdated_nodes": outdated_count,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "timestamp": utc_timestamp(),
                 },
             }
         )

--- a/autobot-slm-backend/api/npu.py
+++ b/autobot-slm-backend/api/npu.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from autobot_shared.time_utils import utc_timestamp
 from models.database import Node, Setting
 from models.schemas import (
     NPUCapabilities,
@@ -195,7 +196,7 @@ async def trigger_npu_detection(
 
     # Query the NPU worker health endpoint (Issue #813)
     capabilities, error_msg = await _detect_npu_capabilities(node.ip_address, node.ssh_port or 8081)
-    result_data = {"last_health_check": datetime.now(timezone.utc).isoformat()}
+    result_data = {"last_health_check": utc_timestamp()}
     if capabilities:
         result_data.update(detection_status="completed", capabilities=capabilities.model_dump())
     else:

--- a/autobot-slm-backend/api/redis_service.py
+++ b/autobot-slm-backend/api/redis_service.py
@@ -15,9 +15,10 @@ Related to Issue #11340.
 
 import asyncio
 import logging
-from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, status
+
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ async def get_redis_status() -> dict:
         "memory_used_bytes": memory_used_bytes,
         "memory_peak_bytes": memory_peak_bytes,
         "connected_clients": connected_clients,
-        "last_checked": datetime.now(timezone.utc).isoformat(),
+        "last_checked": utc_timestamp(),
     }
 
 

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -22,6 +22,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from autobot_shared.time_utils import utc_timestamp
 from models.database import (
     CodeStatus,
     EventSeverity,
@@ -553,7 +554,7 @@ async def _run_discover_job(
         return
 
     job["status"] = "running"
-    job["started_at"] = datetime.now(timezone.utc).isoformat()
+    job["started_at"] = utc_timestamp()
 
     try:
         executor = get_playbook_executor()
@@ -578,7 +579,7 @@ async def _run_discover_job(
         if not result["success"] and not host_results:
             job["status"] = "failed"
             job["message"] = "Playbook failed: " + result["output"][:500]
-            job["completed_at"] = datetime.now(timezone.utc).isoformat()
+            job["completed_at"] = utc_timestamp()
             logger.error("Discover job %s failed — no nodes reported results", job_id)
             return
 
@@ -612,14 +613,14 @@ async def _run_discover_job(
 
         job["progress"] = 100
         job["packages_found"] = total_packages
-        job["completed_at"] = datetime.now(timezone.utc).isoformat()
+        job["completed_at"] = utc_timestamp()
         await _broadcast_job_update(job_id, job["status"], 100, job["message"])
 
     except Exception:
         logger.exception("Discover job failed: %s", job_id)
         job["status"] = "failed"
         job["message"] = "Discover job failed"
-        job["completed_at"] = datetime.now(timezone.utc).isoformat()
+        job["completed_at"] = utc_timestamp()
         await _broadcast_job_update(job_id, "failed", job.get("progress", 0), "Discover job failed")
 
 

--- a/autobot-slm-backend/api/websocket.py
+++ b/autobot-slm-backend/api/websocket.py
@@ -15,6 +15,7 @@ from typing import Dict, Set
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from autobot_shared.time_utils import utc_timestamp
 from services.auth import auth_service
 
 logger = logging.getLogger(__name__)
@@ -183,7 +184,6 @@ class ConnectionManager:
         last_heartbeat: str = None,
     ) -> None:
         """Send health update to global and node-specific event channels."""
-        from datetime import datetime, timezone
 
         message = {
             "type": "health_update",
@@ -193,7 +193,7 @@ class ConnectionManager:
                 "cpu_percent": cpu,
                 "memory_percent": memory,
                 "disk_percent": disk,
-                "last_heartbeat": last_heartbeat or datetime.now(timezone.utc).isoformat(),
+                "last_heartbeat": last_heartbeat or utc_timestamp(),
             },
             "timestamp": asyncio.get_running_loop().time(),
         }

--- a/autobot-slm-backend/monitoring/advanced_apm_system.py
+++ b/autobot-slm-backend/monitoring/advanced_apm_system.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, List
 import aiofiles
 
 from autobot_shared.network_constants import NetworkConstants
-from autobot_shared.time_utils import parse_utc_iso
+from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -318,7 +318,7 @@ class AdvancedAPMSystem:
             request_data = self.active_requests.pop(trace_id, {})
 
             api_metric = APIMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 endpoint=endpoint,
                 method=request_data.get("method", "GET"),
                 status_code=status_code,
@@ -369,7 +369,7 @@ class AdvancedAPMSystem:
             hit_rate = (cache_stat["hits"] / total_ops * 100) if total_ops > 0 else 0
 
             cache_metric = CacheMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 cache_type=cache_type,
                 operation=operation,
                 key=key,
@@ -415,7 +415,7 @@ class AdvancedAPMSystem:
             ).hexdigest()[:12]
 
             db_metric = DatabaseMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 database=database,
                 operation=operation,
                 table_or_collection=table,
@@ -599,7 +599,7 @@ class AdvancedAPMSystem:
             # Create new alert
             msg = f"{rule.name}: {context} - " f"Value: {metric_value:.2f}, Threshold: {rule.threshold_value:.2f}"
             alert = Alert(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 rule_name=rule.name,
                 severity=rule.severity,
                 message=msg,
@@ -625,7 +625,7 @@ class AdvancedAPMSystem:
             for alert_key, alert in self.active_alerts.items():
                 if alert.rule_name == rule_name and not alert.resolved:
                     alert.resolved = True
-                    alert.resolution_timestamp = datetime.now(timezone.utc).isoformat()
+                    alert.resolution_timestamp = utc_timestamp()
                     resolved_keys.append(alert_key)
                     self.logger.info(f"✅ RESOLVED: {alert.message}")
 
@@ -726,7 +726,7 @@ class AdvancedAPMSystem:
             alerts_summary = self._compute_alerts_summary()
 
             return {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
                 "api_performance": api_summary,
                 "cache_performance": cache_summary,
                 "database_performance": db_summary,
@@ -770,7 +770,7 @@ class AdvancedAPMSystem:
                 self.redis_client.hset(
                     "autobot:apm:latest_report",
                     mapping={
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "timestamp": utc_timestamp(),
                         "data": json.dumps(report, default=str),
                     },
                 )

--- a/autobot-slm-backend/monitoring/ai_performance_analytics.py
+++ b/autobot-slm-backend/monitoring/ai_performance_analytics.py
@@ -16,7 +16,7 @@ import statistics
 import time
 import traceback
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -24,6 +24,7 @@ import aiofiles
 import psutil
 
 from autobot_shared.network_constants import NetworkConstants
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +195,7 @@ else:
                 )
 
                 return NPUMetrics(
-                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    timestamp=utc_timestamp(),
                     device_id=device_id,
                     utilization_percent=utilization,
                     memory_used_mb=memory_used,
@@ -283,7 +284,7 @@ else:
         Helper for monitor_multimodal_pipeline. Ref: #1088.
         """
         return MultiModalMetrics(
-            timestamp=datetime.now(timezone.utc).isoformat(),
+            timestamp=utc_timestamp(),
             pipeline_type=pipeline_type,
             input_size_mb=0.0,
             processing_time_ms=0.0,
@@ -319,7 +320,7 @@ else:
             throughput = 1000.0 / total_time if total_time > 0 else 0
 
             return MultiModalMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 pipeline_type=pipeline_type,
                 input_size_mb=input_size,
                 processing_time_ms=total_time,
@@ -410,7 +411,7 @@ else:
         Helper for monitor_knowledge_base_search. Ref: #1088.
         """
         return KnowledgeBaseMetrics(
-            timestamp=datetime.now(timezone.utc).isoformat(),
+            timestamp=utc_timestamp(),
             query_type=search_type,
             query_length=len(query),
             search_time_ms=0.0,
@@ -442,7 +443,7 @@ else:
             ) = await self._run_knowledge_search_stages(query, start_time)
 
             return KnowledgeBaseMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 query_type=search_type,
                 query_length=len(query),
                 search_time_ms=total_time,
@@ -506,7 +507,7 @@ else:
         Helper for monitor_llm_performance. Ref: #1088.
         """
         return LLMPerformanceMetrics(
-            timestamp=datetime.now(timezone.utc).isoformat(),
+            timestamp=utc_timestamp(),
             model_name=request_data.get("model", "unknown"),
             request_type=request_data.get("type", "unknown"),
             input_tokens=0,
@@ -540,7 +541,7 @@ else:
             ) = await self._simulate_llm_processing(request_data, start_time)
 
             return LLMPerformanceMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 model_name=request_data.get("model", "llama3.1"),
                 request_type=request_data.get("type", "chat"),
                 input_tokens=input_tokens,
@@ -694,7 +695,7 @@ else:
 
     async def store_ai_metrics(self, metrics: Dict[str, Any]):
         """Store AI performance metrics in Redis and files."""
-        timestamp = datetime.now(timezone.utc).isoformat()
+        timestamp = utc_timestamp()
 
         # Store in Redis
         if self.redis_client:
@@ -732,7 +733,7 @@ else:
         """Generate comprehensive AI performance report."""
         try:
             report = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
                 "npu_metrics": await self.collect_npu_metrics(),
                 "trends": await self.analyze_performance_trends(),
             }
@@ -764,7 +765,7 @@ else:
             self.logger.error(traceback.format_exc())
             return {
                 "error": "Failed to generate AI performance report",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
             }
 
 

--- a/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
+++ b/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
@@ -21,7 +21,7 @@ import logging
 import os
 import statistics
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -37,6 +37,7 @@ from performance_monitor import ALERT_THRESHOLDS
 from autobot_shared.monitoring.prometheus_query import query_instant
 from autobot_shared.network_constants import NetworkConstants
 from autobot_shared.ssot_config import get_config
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -439,7 +440,7 @@ class BusinessIntelligenceDashboard:
             )
 
             return ROIMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 hardware_investment_usd=total_hardware_cost,
                 operational_cost_monthly_usd=monthly_operational_cost,
                 performance_improvement_percent=performance_improvement,
@@ -453,7 +454,7 @@ class BusinessIntelligenceDashboard:
         except Exception as e:
             self.logger.error("Error calculating ROI metrics: %s", e)
             return ROIMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 hardware_investment_usd=0.0,
                 operational_cost_monthly_usd=0.0,
                 performance_improvement_percent=0.0,
@@ -612,7 +613,7 @@ class BusinessIntelligenceDashboard:
 
                 cost_analyses.append(
                     CostAnalysis(
-                        timestamp=datetime.now(timezone.utc).isoformat(),
+                        timestamp=utc_timestamp(),
                         component=component,
                         monthly_cost_usd=data["monthly_cost"],
                         utilization_percent=utilization,
@@ -741,7 +742,7 @@ class BusinessIntelligenceDashboard:
         try:
             if len(data) < 5:
                 return PerformancePrediction(
-                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    timestamp=utc_timestamp(),
                     metric_name=metric_name,
                     current_value=0.0,
                     predicted_7d=0.0,
@@ -762,7 +763,7 @@ class BusinessIntelligenceDashboard:
             recommendation = self._generate_metric_recommendation(metric_name, trend_direction, predicted_30d)
 
             return PerformancePrediction(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 metric_name=metric_name,
                 current_value=current_value,
                 predicted_7d=predicted_7d,
@@ -775,7 +776,7 @@ class BusinessIntelligenceDashboard:
         except Exception as e:
             self.logger.error("Error predicting trend for %s: %s", metric_name, e)
             return PerformancePrediction(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 metric_name=metric_name,
                 current_value=0.0,
                 predicted_7d=0.0,
@@ -937,7 +938,7 @@ class BusinessIntelligenceDashboard:
             )
 
             return SystemHealthScore(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 overall_score=overall_score,
                 availability_score=availability_score,
                 performance_score=performance_score,
@@ -951,7 +952,7 @@ class BusinessIntelligenceDashboard:
         except Exception as e:
             self.logger.error("Error calculating system health score: %s", e)
             return SystemHealthScore(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 overall_score=0.0,
                 availability_score=0.0,
                 performance_score=0.0,
@@ -971,7 +972,7 @@ class BusinessIntelligenceDashboard:
             health_score = await self.calculate_system_health_score()
 
             dashboard_report = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
                 "summary": {
                     "overall_health_score": health_score.overall_score,
                     "total_roi_percent": roi_metrics.total_roi_percent,
@@ -1000,12 +1001,12 @@ class BusinessIntelligenceDashboard:
             self.logger.error("Error generating dashboard report: %s", e)
             return {
                 "error": "Failed to generate dashboard report",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
             }
 
     async def _store_dashboard_report(self, report: Dict[str, Any]):
         """Store dashboard report in Redis and files."""
-        timestamp = datetime.now(timezone.utc).isoformat()
+        timestamp = utc_timestamp()
 
         if self.redis_client:
             try:

--- a/autobot-slm-backend/monitoring/comprehensive_monitoring_controller.py
+++ b/autobot-slm-backend/monitoring/comprehensive_monitoring_controller.py
@@ -13,7 +13,7 @@ import logging
 import os
 import signal
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -23,6 +23,8 @@ from business_intelligence_dashboard import BusinessIntelligenceDashboard
 
 # Import monitoring components
 from performance_monitor import ALERT_THRESHOLDS, PerformanceMonitor
+
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -291,7 +293,7 @@ class ComprehensiveMonitoringController:
         try:
             self.logger.info("📋 Generating monitoring report...")
 
-            timestamp = datetime.now(timezone.utc).isoformat()
+            timestamp = utc_timestamp()
 
             # Compile all monitoring data
             report = {
@@ -499,7 +501,7 @@ class ComprehensiveMonitoringController:
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
             instant_report = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
                 "report_type": "instant_comprehensive",
                 "performance_data": (
                     results[0] if not isinstance(results[0], Exception) else {"error": str(results[0])}
@@ -523,7 +525,7 @@ class ComprehensiveMonitoringController:
             self.logger.error(f"Error generating instant report: {e}")
             return {
                 "error": "Failed to generate instant report",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
             }
 
     def stop_monitoring(self):

--- a/autobot-slm-backend/monitoring/performance_monitor.py
+++ b/autobot-slm-backend/monitoring/performance_monitor.py
@@ -16,7 +16,7 @@ import os
 import time
 import traceback
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -26,6 +26,7 @@ import psutil
 
 from autobot_shared.network_constants import NetworkConstants
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 from config import ConfigManager
 
 logger = logging.getLogger(__name__)
@@ -200,7 +201,7 @@ class PerformanceMonitor:
             npu_util = await self.get_npu_metrics()
 
             return SystemMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 hostname=hostname,
                 cpu_percent=cpu_percent,
                 memory_percent=memory.percent,
@@ -290,7 +291,7 @@ class PerformanceMonitor:
                 redis_test.ping()
                 response_time = time.time() - start_time
                 return ServiceMetrics(
-                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    timestamp=utc_timestamp(),
                     service_name=service_name,
                     response_time=response_time,
                     status_code=200,
@@ -305,7 +306,7 @@ class PerformanceMonitor:
                         is_healthy = response.status < 400
 
                         return ServiceMetrics(
-                            timestamp=datetime.now(timezone.utc).isoformat(),
+                            timestamp=utc_timestamp(),
                             service_name=service_name,
                             response_time=response_time,
                             status_code=response.status,
@@ -315,7 +316,7 @@ class PerformanceMonitor:
         except Exception as e:
             response_time = time.time() - start_time
             return ServiceMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 service_name=service_name,
                 response_time=response_time,
                 status_code=None,
@@ -352,7 +353,7 @@ class PerformanceMonitor:
             ops_per_second = 1.0 / query_time if query_time > 0 else 0
 
             return DatabaseMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 database_type=f"Redis_DB_{db_num}",
                 connection_time=connection_time,
                 query_count=1,
@@ -364,7 +365,7 @@ class PerformanceMonitor:
         except Exception as e:
             self.logger.error(f"Error testing Redis DB {db_num}: {e}")
             return DatabaseMetrics(
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=utc_timestamp(),
                 database_type=f"Redis_DB_{db_num}",
                 connection_time=0.0,
                 query_count=0,
@@ -431,7 +432,7 @@ class PerformanceMonitor:
         Helper for test_inter_vm_performance.
         """
         return InterVMMetrics(
-            timestamp=datetime.now(timezone.utc).isoformat(),
+            timestamp=utc_timestamp(),
             source_vm="main",
             target_vm=vm_name,
             latency_ms=999.0,
@@ -481,7 +482,7 @@ class PerformanceMonitor:
 
                     inter_vm_metrics.append(
                         InterVMMetrics(
-                            timestamp=datetime.now(timezone.utc).isoformat(),
+                            timestamp=utc_timestamp(),
                             source_vm="main",
                             target_vm=vm_name,
                             latency_ms=latency_ms,
@@ -552,7 +553,7 @@ class PerformanceMonitor:
 
     async def store_metrics(self, metrics: Dict[str, Any]):
         """Store performance metrics in Redis and local files."""
-        timestamp = datetime.now(timezone.utc).isoformat()
+        timestamp = utc_timestamp()
 
         # Store in Redis (if available)
         if self.redis_client:

--- a/autobot-slm-backend/services/a2a_card_fetcher.py
+++ b/autobot-slm-backend/services/a2a_card_fetcher.py
@@ -21,6 +21,8 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict
 
+from autobot_shared.time_utils import utc_timestamp
+
 logger = logging.getLogger(__name__)
 
 # TLS verification for A2A card fetches from internal backend nodes.
@@ -71,7 +73,7 @@ async def _store_card(db, node, card: Dict[str, Any] | None) -> None:
 
     extra = dict(node.extra_data or {})
     extra["a2a_card"] = card
-    extra["a2a_card_fetched_at"] = datetime.now(timezone.utc).isoformat()
+    extra["a2a_card_fetched_at"] = utc_timestamp()
     await db.execute(update(Node).where(Node.node_id == node.node_id).values(extra_data=extra))
     await db.commit()
 

--- a/autobot-slm-backend/services/blue_green.py
+++ b/autobot-slm-backend/services/blue_green.py
@@ -26,6 +26,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.time_utils import utc_timestamp
 from config import settings
 from models.database import BlueGreenDeployment, BlueGreenStatus, Node, NodeStatus
 from models.schemas import BlueGreenCreate, BlueGreenResponse, EligibleNodeResponse
@@ -1375,7 +1376,7 @@ class BlueGreenService:
                     "bg_deployment_id": bg_deployment_id,
                     "event_type": event_type,
                     "message": message,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "timestamp": utc_timestamp(),
                 },
             )
         except Exception as e:

--- a/autobot-slm-backend/services/code_distributor.py
+++ b/autobot-slm-backend/services/code_distributor.py
@@ -14,13 +14,13 @@ import io
 import logging
 import os
 import tarfile
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Tuple
 
 from sqlalchemy import select
 
 from autobot_shared.ssot_config import config
+from autobot_shared.time_utils import utc_timestamp
 from models.database import Setting
 from services.database import db_service
 from services.ssh_utils import _ssh_key_usable
@@ -103,7 +103,7 @@ class CodeDistributor:
                 tar.add(agent_path, arcname="agent")
 
                 # Create and add version.json
-                built_at = datetime.now(timezone.utc).isoformat()
+                built_at = utc_timestamp()
                 version_content = f'{{"commit": "{commit_hash}", "built_at": "{built_at}"}}'
                 version_bytes = version_content.encode("utf-8")
                 version_info = tarfile.TarInfo(name="version.json")
@@ -299,9 +299,7 @@ class CodeDistributor:
             commit_hash: Current commit hash
         """
         version_json = (
-            f'{{"commit": "{commit_hash}", '
-            f'"synced_at": "{datetime.now(timezone.utc).isoformat()}", '
-            f'"source": "fleet-sync"}}'
+            f'{{"commit": "{commit_hash}", ' f'"synced_at": "{utc_timestamp()}", ' f'"source": "fleet-sync"}}'
         )
         version_cmd = self._build_ssh_command(ssh_port)
         version_cmd.extend(

--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -12,10 +12,10 @@ directory to detect files that have been manually patched or missed by Ansible.
 import hashlib
 import logging
 import os
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from autobot_shared.time_utils import utc_timestamp
 from services.deploy_artifacts import ARTIFACT_DIR_SUFFIXES, ARTIFACT_DIRS
 from services.git_tracker import DEFAULT_REPO_PATH
 
@@ -363,7 +363,7 @@ def build_drift_report(
         "drifted_files": drifted,
         "total_compared": total,
         "drift_detected": len(drifted) > 0,
-        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "checked_at": utc_timestamp(),
     }
 
 

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -20,6 +20,7 @@ from typing import Dict, List
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.time_utils import utc_timestamp
 from config import settings
 from models.database import (
     Deployment,
@@ -930,7 +931,7 @@ class ReconcilerService:
                 **(deployment.extra_data or {}),
                 "auto_rollback_attempted": True,
                 "auto_rollback_reason": f"Node status: {node.status}",
-                "auto_rollback_time": datetime.now(timezone.utc).isoformat(),
+                "auto_rollback_time": utc_timestamp(),
             }
 
             # Remove deployed roles from node

--- a/autobot-slm-backend/services/service_orchestrator.py
+++ b/autobot-slm-backend/services/service_orchestrator.py
@@ -24,6 +24,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.ssot_config import config
+from autobot_shared.time_utils import utc_timestamp
 from models.database import Node, Service, ServiceStatus
 
 logger = logging.getLogger(__name__)
@@ -538,7 +539,7 @@ class ServiceOrchestrator:
             Dict with service statuses and health information
         """
         status = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": utc_timestamp(),
             "services": {},
             "healthy_count": 0,
             "unhealthy_count": 0,

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -21,11 +21,12 @@ import signal
 import socket
 import sqlite3
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 import aiohttp
 from aiohttp import web
+
+from autobot_shared.time_utils import utc_timestamp
 
 from .health_collector import HealthCollector
 from .port_scanner import get_listening_ports
@@ -173,7 +174,7 @@ class SLMAgent:
         conn = sqlite3.connect(self.buffer_db)
         conn.execute(
             "INSERT INTO event_buffer (timestamp, event_type, data) VALUES (?, ?, ?)",
-            (datetime.now(timezone.utc).isoformat(), event_type, json.dumps(data)),
+            (utc_timestamp(), event_type, json.dumps(data)),
         )
         conn.commit()
         conn.close()
@@ -578,7 +579,7 @@ class SLMAgent:
                 "node_id": self.node_id,
                 "commit": commit,
                 "is_code_source": True,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": utc_timestamp(),
             }
             async with self._session.post(
                 url,

--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -17,12 +17,13 @@ import socket
 import subprocess  # nosec B404 - required for systemctl interaction
 import time
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, List
 
 import psutil
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 # App-level /health probes for services that expose engine state beyond
 # systemd (#11723/#11777). Local-only URLs, short timeout, never fatal to
@@ -81,7 +82,7 @@ class HealthCollector:
     def collect(self) -> Dict:
         """Collect all health metrics."""
         health = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": utc_timestamp(),
             "hostname": self.hostname,
             "cpu_percent": psutil.cpu_percent(interval=0.1),
             "memory_percent": psutil.virtual_memory().percent,

--- a/autobot-slm-backend/slm/agent/version.py
+++ b/autobot-slm-backend/slm/agent/version.py
@@ -13,6 +13,8 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
+from autobot_shared.time_utils import utc_timestamp
+
 logger = logging.getLogger(__name__)
 
 # Default paths
@@ -102,7 +104,7 @@ class AgentVersion:
         version_info = {
             "commit": commit,
             "built_at": built_at.isoformat(),
-            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": utc_timestamp(),
         }
 
         if extra_data:

--- a/autobot-slm-backend/tests/services/test_sso_vault_client.py
+++ b/autobot-slm-backend/tests/services/test_sso_vault_client.py
@@ -21,6 +21,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.time_utils import utc_timestamp
+
 # Directory of the autobot-slm-backend package root
 _BACKEND = Path(__file__).parent.parent.parent
 
@@ -266,7 +268,7 @@ class TestSSORotationStaleness:
 
     def test_check_staleness_fresh_not_stale(self):
         pid = uuid.uuid4()
-        fresh = datetime.now(timezone.utc).isoformat()
+        fresh = utc_timestamp()
         config = {"client_secret_rotated_at": fresh}
         report = _sso_rotation_mod.check_staleness(pid, config, fields=["client_secret"])
         assert report["client_secret"]["stale"] is False

--- a/autobot-slm-backend/tests/services/version_checker_test.py
+++ b/autobot-slm-backend/tests/services/version_checker_test.py
@@ -7,11 +7,12 @@ Tests for Background Version Checker (Issue #741).
 """
 
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from autobot_shared.time_utils import utc_timestamp
 
 # Import git_tracker module directly
 git_tracker_path = Path(__file__).parent.parent.parent / "services" / "git_tracker.py"
@@ -79,7 +80,7 @@ class TestVersionCheckTask:
                             "has_update": False,
                             "local_commit": "abc123",
                             "remote_commit": "abc123",
-                            "last_fetch": datetime.now(timezone.utc).isoformat(),
+                            "last_fetch": utc_timestamp(),
                         }
                     )
                     mock_get_tracker.return_value = mock_tracker
@@ -115,7 +116,7 @@ class TestVersionCheckTask:
                             "has_update": False,
                             "local_commit": "abc123",
                             "remote_commit": "abc123",
-                            "last_fetch": datetime.now(timezone.utc).isoformat(),
+                            "last_fetch": utc_timestamp(),
                         }
                     )
                     mock_get_tracker.return_value = mock_tracker
@@ -182,7 +183,7 @@ class TestVersionCheckTask:
                         "has_update": False,
                         "local_commit": "abc123",
                         "remote_commit": "abc123",
-                        "last_fetch": datetime.now(timezone.utc).isoformat(),
+                        "last_fetch": utc_timestamp(),
                     },
                 ]
             )
@@ -213,7 +214,7 @@ class TestVersionCheckTask:
                                 "has_update": True,
                                 "local_commit": "abc123",
                                 "remote_commit": "def456",
-                                "last_fetch": datetime.now(timezone.utc).isoformat(),
+                                "last_fetch": utc_timestamp(),
                             }
                         )
                         mock_get_tracker.return_value = mock_tracker

--- a/autobot-slm-backend/user_management/services/sso_rotation.py
+++ b/autobot-slm-backend/user_management/services/sso_rotation.py
@@ -38,6 +38,8 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.time_utils import utc_timestamp
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -200,7 +202,7 @@ async def rotate_kek(
     except VaultClientError as exc:
         raise SSORotationError(f"KEK rotation failed for provider {provider_id} field {field}: {exc}") from exc
 
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = utc_timestamp()
     await _update_provider_config(session, provider_id, {_rotated_at_key(field): now_iso})
     await _write_audit(
         session,
@@ -246,7 +248,7 @@ async def rotate_value(
     except VaultClientError as exc:
         raise SSORotationError(f"value rotation failed for provider {provider_id} field {field}: {exc}") from exc
 
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = utc_timestamp()
     await _update_provider_config(session, provider_id, {_rotated_at_key(field): now_iso})
     await _write_audit(
         session,

--- a/autobot_shared/models/service_message.py
+++ b/autobot_shared/models/service_message.py
@@ -24,10 +24,11 @@ Usage::
 import json
 import logging
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Dict, Literal
 
 from pydantic import BaseModel, Field
+
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class ServiceMessage(BaseModel):
         description="Unique message identifier (UUID4).",
     )
     ts: str = Field(
-        default_factory=lambda: datetime.now(timezone.utc).isoformat(),
+        default_factory=lambda: utc_timestamp(),
         description="UTC ISO 8601 timestamp of message creation.",
     )
     sender: str = Field(


### PR DESCRIPTION
## Thinking Path

Picked as an unblocked, purely mechanical issue. `utc_timestamp()` (`autobot_shared/time_utils.py:49`) is *literally* `datetime.now(timezone.utc).isoformat()`, so this is a consistency change with **no behaviour delta** — confirmed by comparing output formats including the `+00:00` suffix.

The canonical definition itself is deliberately untouched: rewriting `time_utils.utc_timestamp()` to call itself would be infinite recursion.

## What Changed

**100 inline call sites across 44 files** replaced with the canonical helper, imports added where missing.

## Three things a blind find/replace would have shipped

Worth listing, because each was caught by verification rather than by the edit step:

**1. A SyntaxError.** My import-insertion regex matched the *opening line* of a multi-line `from autobot_shared.tracing import (` block and inserted **inside the parentheses**, breaking `initialization/lifespan.py` (`E999`). flake8 caught it; the replace step had no idea. Every changed file is now AST-parsed.

**2. Newly-unused imports.** Removing the last inline use orphaned `from datetime import datetime, timezone` in **24 files** — including two **function-local (indented)** imports that a top-level-only regex missed. Cleaned iteratively, driven by flake8 F401 output rather than guesswork, and only where genuinely unused: files still using `datetime` elsewhere keep it.

**3. A comment-only rewrite.** In `drift_checker_test.py` the sole occurrence was inside a *comment*, so the sweep edited prose and added an import nothing used. That file is reverted — a sweep should change code, not commentary.

## Verification

```
flake8  (all 44 changed files):  0 findings
isort   --check-only:            clean
black   --check:                 44 files unchanged
AST parse:                       all 44 files OK

knowledge/backends/ + api/desktop_control_lock_test.py
  this branch: 38 failed, 63 passed
  baseline:    38 failed, 63 passed     ← byte-identical
```

Those 38 are pre-existing chromadb-unavailable failures, present unmodified on `Dev_new_gui`.

## Model Used

Claude Opus 5 (1M context)

Closes #12726