### PR TITLE
fix(llc): surface domain-error reasons instead of 'Internal server error' (#12740)

### DIFF
--- a/autobot-backend/llc/api/boards.py
+++ b/autobot-backend/llc/api/boards.py
@@ -280,8 +280,16 @@ async def move_item(
             },
         )
     except InvalidTransition as exc:
-        logger.error("Exception in API handler: %s", exc, exc_info=True)
-        raise HTTPException(status_code=422, detail="Internal server error")
+        # #12740: the service already computed the exact, useful reason
+        # ("Cannot transition from X to Y. Allowed: [...]"). Replacing it with a
+        # generic 422 "Internal server error" threw that away, so the UI could
+        # not tell the user what went wrong or what IS allowed. The message is
+        # purely domain-level — statuses and permitted transitions, no internals
+        # — so it is safe to surface. 409 Conflict is the correct code: the
+        # request is well-formed (422 implies malformed), it conflicts with the
+        # item's current state.
+        logger.info("Rejected illegal work-item transition: %s", exc)
+        raise HTTPException(status_code=409, detail=str(exc))
     except ValueError as exc:
         logger.error("Exception in API handler: %s", exc, exc_info=True)
         raise HTTPException(status_code=404, detail="Internal server error")

--- a/autobot-backend/llc/api/transition_error_detail_12740_test.py
+++ b/autobot-backend/llc/api/transition_error_detail_12740_test.py
@@ -1,0 +1,74 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLC domain errors must surface their reason, not 'Internal server error' (#12740).
+
+An illegal work-item transition returned 422 {"detail": "Internal server error"}
+even though the service had already computed the exact, useful reason —
+"Cannot transition from X to Y. Allowed: [...]". Swallowing it left the UI
+unable to tell the user what went wrong or what IS permitted.
+
+422 was also the wrong code: the request is well-formed (422 implies malformed);
+it conflicts with the item's current state, which is 409.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+_API = pathlib.Path(__file__).resolve().parent
+
+
+def _handlers_for(module: str, exc_name: str):
+    """Yield every `except <exc_name>` handler body in *module*."""
+    tree = ast.parse((_API / module).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler) and node.type is not None:
+            name = getattr(node.type, "id", None)
+            if name == exc_name:
+                yield node
+
+
+def _raises_http(handler) -> tuple[int | None, str]:
+    """Return (status_code, detail-source) from the handler's raise."""
+    for node in ast.walk(handler):
+        if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+            kw = {k.arg: k.value for k in node.exc.keywords}
+            status = getattr(kw.get("status_code"), "value", None)
+            detail = kw.get("detail")
+            return status, ast.unparse(detail) if detail is not None else ""
+    return None, ""
+
+
+@pytest.mark.parametrize("module", ["work_items.py", "boards.py"])
+def test_invalid_transition_returns_409_with_the_real_reason(module):
+    handlers = list(_handlers_for(module, "InvalidTransition"))
+    assert handlers, f"no InvalidTransition handler in {module}"
+    for h in handlers:
+        status, detail = _raises_http(h)
+        assert status == 409, f"{module}: expected 409 Conflict, got {status}"
+        assert "str(exc)" in detail, f"{module}: detail must carry the reason, got {detail!r}"
+        assert "Internal server error" not in detail
+
+
+def test_checkout_conflict_also_surfaces_who_holds_it():
+    """Same defect class: correct code, but the reason was still swallowed."""
+    handlers = list(_handlers_for("work_items.py", "CheckoutConflict"))
+    assert handlers
+    for h in handlers:
+        status, detail = _raises_http(h)
+        assert status == 409
+        assert "str(exc)" in detail
+
+
+def test_no_domain_handler_still_returns_a_generic_message():
+    """Guard against regression across BOTH modules at once."""
+    for module in ("work_items.py", "boards.py"):
+        for exc_name in ("InvalidTransition", "CheckoutConflict"):
+            for h in _handlers_for(module, exc_name):
+                _, detail = _raises_http(h)
+                assert "Internal server error" not in detail, f"{module}/{exc_name} still swallows"

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -550,8 +550,13 @@ async def checkout_work_item(
         await session.commit()
         return await _item_to_dict(item, session)
     except CheckoutConflict as exc:
-        logger.error("Exception in API handler: %s", exc, exc_info=True)
-        raise HTTPException(status_code=409, detail="Internal server error")
+        # #12740 (same defect class, found alongside): the status code was
+        # already correct, but the useful reason ("Work item X already checked
+        # out by agent Y") was still replaced with a generic string, so a caller
+        # could not tell WHO holds the checkout. Domain-level message, safe to
+        # surface.
+        logger.info("Rejected work-item checkout conflict: %s", exc)
+        raise HTTPException(status_code=409, detail=str(exc))
     except ValueError as exc:
         logger.error("Exception in API handler: %s", exc, exc_info=True)
         raise HTTPException(status_code=404, detail="Internal server error")
@@ -600,8 +605,16 @@ async def transition_work_item(
             await _kb_manager.archive_collection(KbCollectionManager.WORK_ITEM_PREFIX, item.id)
         return await _item_to_dict(item, session)
     except InvalidTransition as exc:
-        logger.error("Exception in API handler: %s", exc, exc_info=True)
-        raise HTTPException(status_code=422, detail="Internal server error")
+        # #12740: the service already computed the exact, useful reason
+        # ("Cannot transition from X to Y. Allowed: [...]"). Replacing it with a
+        # generic 422 "Internal server error" threw that away, so the UI could
+        # not tell the user what went wrong or what IS allowed. The message is
+        # purely domain-level — statuses and permitted transitions, no internals
+        # — so it is safe to surface. 409 Conflict is the correct code: the
+        # request is well-formed (422 implies malformed), it conflicts with the
+        # item's current state.
+        logger.info("Rejected illegal work-item transition: %s", exc)
+        raise HTTPException(status_code=409, detail=str(exc))
     except ValueError as exc:
         logger.error("Exception in API handler: %s", exc, exc_info=True)
         raise HTTPException(status_code=404, detail="Internal server error")
@@ -666,8 +679,9 @@ async def claim_work_item(
         await session.commit()
         return await _item_to_dict(item, session)
     except CheckoutConflict as exc:
-        logger.error("Exception in API handler: %s", exc, exc_info=True)
-        raise HTTPException(status_code=409, detail="Internal server error")
+        # #12740 (same defect class): surface WHO holds the checkout.
+        logger.info("Rejected work-item checkout conflict: %s", exc)
+        raise HTTPException(status_code=409, detail=str(exc))
     except ValueError as exc:
         logger.error("Exception in API handler: %s", exc, exc_info=True)
         raise HTTPException(status_code=404, detail="Internal server error")


### PR DESCRIPTION
## Thinking Path

An illegal work-item transition returned `422 {"detail": "Internal server error"}` — while the service had *already computed* the exact, useful reason: `"Cannot transition from X to Y. Allowed: [...]"`. The handler logged it and discarded it, leaving the UI unable to say what went wrong or what is permitted.

Two separate things were wrong:

- **The message was swallowed.** I checked the text before surfacing it: it is purely domain-level (statuses and permitted transitions, no internals, no paths), so it is safe to return.
- **The status was wrong.** 422 implies a malformed request. This request is well-formed and conflicts with the item's current state — that is **409 Conflict**.

## What Changed

- `llc/api/work_items.py` and `llc/api/boards.py` — `InvalidTransition` now returns **409** with the real reason.
- **`CheckoutConflict`, same defect class, found alongside** — its status code was already 409, but `"Work item X already checked out by agent Y"` was still replaced with a generic string, so a caller could not tell *who* held the checkout. Three handlers fixed in total.

Log level dropped from `logger.error(..., exc_info=True)` to `logger.info` for both: a client sending an illegal transition is expected API usage, not a server fault worth a stack trace.

## The test caught a bug in my own fix

I wrote it to assert across **both** modules and **both** exception types rather than the single site the issue names. It immediately failed — surfacing a **second** `CheckoutConflict` handler at `work_items.py:681` that my first single-occurrence replace had missed.

It parses handlers via **AST** rather than grepping, so a handler raising a generic detail fails regardless of formatting or line breaks.

## Verification

```
$ pytest llc/api/transition_error_detail_12740_test.py -q
4 passed

$ pytest llc/ -q -k "work_item or board or transition"
165 passed, 1308 deselected

$ flake8 / black on changed files
clean
```

## Model Used

Claude Opus 5 (1M context)

Closes #12740