### PR TITLE
fix: three unresolvable-import/lint defects — utcnow double-count, eager services transport import, nonexistent utils.redis_client (#12670, #12830, #12826)

### DIFF
--- a/autobot-backend/services/__init__.py
+++ b/autobot-backend/services/__init__.py
@@ -9,23 +9,69 @@ This module contains all service layer components for the AutoBot backend,
 including AI Stack integration, database connections, and external service clients.
 
 Issue #640: Added NPU worker client for compute offload.
+
+Issue #12830: re-exports are resolved lazily (PEP 562). Importing them eagerly
+made `import services.<anything>` drag in `ai_stack_client` -> `aiohttp` and
+`npu_client` -> its Redis chain, forcing an HTTP transport dependency on every
+importer whether or not it touches HTTP. Since this package sits under
+`secure_command_executor` / `auth_middleware`, that reached almost the whole
+backend. Same defect class as #12814, at a more central location.
+
+The public surface is unchanged: every name in `__all__` still resolves on
+attribute access, just on first use rather than at import time.
 """
 
-from .ai_stack_client import (
-    AIStackClient,
-    AIStackError,
-    close_ai_stack_client,
-    get_ai_stack_client,
-)
-from .npu_client import (
-    EmbeddingResult,
-    NPUClient,
-    NPUDeviceInfo,
-    cleanup_npu_client,
-    generate_embedding_with_fallback,
-    generate_embeddings_batch_with_fallback,
-    get_npu_client,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only for type checkers
+    from .ai_stack_client import (
+        AIStackClient,
+        AIStackError,
+        close_ai_stack_client,
+        get_ai_stack_client,
+    )
+    from .npu_client import (
+        EmbeddingResult,
+        NPUClient,
+        NPUDeviceInfo,
+        cleanup_npu_client,
+        generate_embedding_with_fallback,
+        generate_embeddings_batch_with_fallback,
+        get_npu_client,
+    )
+
+# Public name -> submodule that defines it.
+_LAZY_EXPORTS = {
+    "AIStackClient": "ai_stack_client",
+    "AIStackError": "ai_stack_client",
+    "get_ai_stack_client": "ai_stack_client",
+    "close_ai_stack_client": "ai_stack_client",
+    "NPUClient": "npu_client",
+    "NPUDeviceInfo": "npu_client",
+    "EmbeddingResult": "npu_client",
+    "get_npu_client": "npu_client",
+    "cleanup_npu_client": "npu_client",
+    "generate_embedding_with_fallback": "npu_client",
+    "generate_embeddings_batch_with_fallback": "npu_client",
+}
+
+
+def __getattr__(name: str):
+    """Resolve a re-export on first access (PEP 562, #12830)."""
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(f".{module_name}", __name__), name)
+    globals()[name] = value  # cache so later lookups skip __getattr__
+    return value
+
+
+def __dir__():
+    """Keep tab-completion and dir() showing the full public surface."""
+    return sorted(set(globals()) | set(_LAZY_EXPORTS))
+
 
 __all__ = [
     # AI Stack

--- a/autobot-infrastructure/shared/scripts/analysis/test_redis_connection.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_redis_connection.py
@@ -128,7 +128,7 @@ def test_agent_communication_fix():
 
     try:
         # This would be the code path that was failing before
-        from utils.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_redis_client
 
         # This should now use the service registry
         redis_client = get_redis_client()

--- a/autobot-infrastructure/shared/scripts/cleanup_redis_metrics.py
+++ b/autobot-infrastructure/shared/scripts/cleanup_redis_metrics.py
@@ -33,7 +33,7 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ async def _connect_redis_clients(results: dict) -> tuple:
 
     # Connect to Redis (main database)
     try:
-        redis_client = await get_redis_client(database="main", async_client=True)
+        redis_client = await get_async_redis_client(database="main")
 
         if not redis_client:
             logger.error("Failed to connect to Redis")
@@ -86,7 +86,7 @@ async def _connect_redis_clients(results: dict) -> tuple:
 
     # Also check knowledge database
     try:
-        kb_redis_client = await get_redis_client(database="knowledge", async_client=True)
+        kb_redis_client = await get_async_redis_client(database="knowledge")
     except Exception:
         kb_redis_client = None
         logger.warning("Knowledge database not available, skipping")

--- a/autobot-infrastructure/shared/scripts/create_kb_index.py
+++ b/autobot-infrastructure/shared/scripts/create_kb_index.py
@@ -10,6 +10,7 @@ Create knowledge base index with correct dimensions using redisvl directly.
 import logging
 import os
 import sys
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import centralized Redis client
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 
 
 def _drop_existing_indexes(r) -> None:

--- a/autobot-infrastructure/shared/scripts/export_service_keys.py
+++ b/autobot-infrastructure/shared/scripts/export_service_keys.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import structlog
 from backend.security.service_auth import ServiceAuthManager
 
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = structlog.get_logger()
 
@@ -84,7 +84,7 @@ async def export_service_configs():
     export_dir.mkdir(parents=True, exist_ok=True)
 
     # Get Redis client for main database
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
 
     # Create auth manager
     auth_manager = ServiceAuthManager(redis)
@@ -169,7 +169,7 @@ async def verify_exports():
         return False
 
     # Get Redis client for main database
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
 
     # Create auth manager
     auth_manager = ServiceAuthManager(redis)

--- a/autobot-infrastructure/shared/scripts/kb_dimension_utility.py
+++ b/autobot-infrastructure/shared/scripts/kb_dimension_utility.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import centralized Redis client
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 
 
 async def fix_dimensions():

--- a/autobot-infrastructure/shared/scripts/monitoring_system.py
+++ b/autobot-infrastructure/shared/scripts/monitoring_system.py
@@ -42,7 +42,7 @@ except ImportError:
     import aiohttp
 
 # Import centralized Redis client
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -336,7 +336,7 @@ class SystemMonitor:
         """
         try:
             # Issue #666: Use async_client=True to avoid blocking the event loop
-            r = await get_redis_client(async_client=True, database="main")
+            r = await get_async_redis_client(database="main")
             if r:
                 await r.ping()
                 service_metrics["status"] = "healthy"
@@ -563,7 +563,7 @@ class SystemMonitor:
 
             elif check["service"] == "redis" and check["endpoint"] == "ping":
                 # Issue #666: Fixed blocking I/O - use async Redis client
-                r = await get_redis_client(async_client=True, database="main")
+                r = await get_async_redis_client(database="main")
                 if r:
                     await r.ping()
                     result["response_time_ms"] = (time.time() - start_time) * 1000

--- a/autobot-infrastructure/shared/scripts/reset_kb_dimensions.py
+++ b/autobot-infrastructure/shared/scripts/reset_kb_dimensions.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import centralized Redis client
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 
 
 def _cleanup_redis_databases(r) -> int:

--- a/autobot-infrastructure/shared/scripts/reset_knowledge_base.py
+++ b/autobot-infrastructure/shared/scripts/reset_knowledge_base.py
@@ -16,7 +16,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from config import global_config_manager
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 async def reset_knowledge_base_index():
     """Reset the knowledge base Redis index to use correct embedding dimensions."""
 
-    redis_client = await get_redis_client(async_client=True)
+    redis_client = await get_async_redis_client(database="main")
     if not redis_client:
         logger.error("Redis client not available")
         return

--- a/autobot-infrastructure/shared/scripts/security/backfill_session_ownership.py
+++ b/autobot-infrastructure/shared/scripts/security/backfill_session_ownership.py
@@ -41,7 +41,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from backend.security.session_ownership import SessionOwnershipValidator
 
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ class SessionOwnershipBackfill:
     async def initialize(self):
         """Initialize Redis connections"""
         logger.info("Initializing Redis connections...")
-        self.redis = await get_redis_client(async_client=True, database="main")
+        self.redis = await get_async_redis_client(database="main")
         self.validator = SessionOwnershipValidator(self.redis)
         logger.info("✓ Connected to Redis")
 

--- a/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
+++ b/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import centralized Redis client
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 
 
 def _clean_redis_indexes(r) -> None:

--- a/autobot-infrastructure/shared/scripts/startup_coordinator.py
+++ b/autobot-infrastructure/shared/scripts/startup_coordinator.py
@@ -30,7 +30,7 @@ import psutil
 sys.path.append(str(Path(__file__).parent.parent))
 from constants.network_constants import NetworkConstants, ServiceURLs
 from constants.threshold_constants import TimingConstants
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 # Configure logging
 logging.basicConfig(
@@ -64,7 +64,7 @@ def _restore_component_from_data(comp: "ComponentInfo", data: dict) -> None:
 async def _check_redis_health() -> bool:
     """Check Redis health via centralized client (Issue #315 - extracted)."""
     try:
-        redis_client = await get_redis_client("main")
+        redis_client = await get_async_redis_client(database="main")
         if redis_client:
             await redis_client.ping()
             return True

--- a/autobot-infrastructure/shared/scripts/utilities/npu_worker.py
+++ b/autobot-infrastructure/shared/scripts/utilities/npu_worker.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -190,7 +190,7 @@ class NPUWorker:
 
         # Initialize Redis connection using centralized client
         try:
-            self.redis_client = await get_redis_client("main")
+            self.redis_client = await get_async_redis_client(database="main")
             if self.redis_client:
                 logger.info("✅ Connected to Redis via centralized client")
             else:

--- a/autobot-infrastructure/shared/scripts/utilities/test_autobot_functionality.py
+++ b/autobot-infrastructure/shared/scripts/utilities/test_autobot_functionality.py
@@ -19,7 +19,7 @@ import requests
 # Import centralized Redis client
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from constants.network_constants import NetworkConstants, ServiceURLs
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -147,7 +147,7 @@ class AutoBotFunctionalityTest:
             logger.info("📊 Testing Redis Connectivity...")
 
             async def test_redis():
-                redis_client = await get_redis_client("main")
+                redis_client = await get_async_redis_client(database="main")
                 if not redis_client:
                     return False
 

--- a/autobot-infrastructure/shared/scripts/verify_knowledge_consistency.py
+++ b/autobot-infrastructure/shared/scripts/verify_knowledge_consistency.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from config import ConfigManager
 from knowledge_base import KnowledgeBase
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 
 # Wire in the canonical chunker so the embedding-model consistency check
 # at `verify_embedding_model_consistency()` can actually verify the

--- a/tools/lint/check_no_utcnow_isoformat.py
+++ b/tools/lint/check_no_utcnow_isoformat.py
@@ -123,6 +123,27 @@ PATTERNS: List[Tuple[str, re.Pattern[str], str]] = [
 ]
 
 
+# A generic pattern must not re-report a line a more specific pattern already
+# caught (#12670). `bare-utcnow` matches the `datetime.utcnow()` prefix of every
+# `utcnow().isoformat()` line, so before this every such line was reported twice
+# — once with the correct `utc_timestamp()` fix and once with the unrelated
+# `datetime_now()` fix, which made the hook's output actively misleading about
+# how many violations a file has and which replacement to use.
+SUBSUMED_BY: dict = {
+    "bare-utcnow": {"isoformat", "z-suffix-isoformat"},
+}
+
+# Patterns whose own reason text already names the correct replacement, so the
+# path-aware timestamp suggestion must not be prepended (#12670).
+SELF_DESCRIBING_FIX = frozenset({"bare-utcnow"})
+
+
+def _dedupe_subsumed(pattern_ids: List[str]) -> List[str]:
+    """Drop generic pattern ids when a more specific one matched the same line."""
+    matched = set(pattern_ids)
+    return [pid for pid in pattern_ids if not (SUBSUMED_BY.get(pid, set()) & matched)]
+
+
 def _is_allowlisted(rel_path: str) -> bool:
     """Check if a file path is in the allowlist (POSIX-normalized)."""
     posix = rel_path.replace("\\", "/")
@@ -149,10 +170,16 @@ def _scan(path: Path, repo_root: Path) -> List[Tuple[int, str, str]]:
         return []
     suggestion = _suggestion_for(rel)
     hits: List[Tuple[int, str, str]] = []
+    reasons = {pattern_id: reason for pattern_id, _, reason in PATTERNS}
     for line_no, line in enumerate(text.splitlines(), start=1):
-        for pattern_id, regex, reason in PATTERNS:
-            if regex.search(line):
-                hits.append((line_no, pattern_id, f"Use {suggestion} {reason}"))
+        line_ids = [pattern_id for pattern_id, regex, _ in PATTERNS if regex.search(line)]
+        for pattern_id in _dedupe_subsumed(line_ids):
+            reason = reasons[pattern_id]
+            # Patterns in SELF_DESCRIBING_FIX already name their own replacement;
+            # prefixing the timestamp-string suggestion produced a message telling
+            # the contributor to use two different helpers in one breath (#12670).
+            message = reason if pattern_id in SELF_DESCRIBING_FIX else f"Use {suggestion} {reason}"
+            hits.append((line_no, pattern_id, message))
     return hits
 
 

--- a/tools/lint/check_no_utcnow_isoformat_test.py
+++ b/tools/lint/check_no_utcnow_isoformat_test.py
@@ -154,19 +154,42 @@ def test_non_iso_strftime_not_flagged(tmp_path: Path) -> None:
     assert rc == 0
 
 
-def test_bare_utcnow_without_isoformat_not_flagged(tmp_path: Path) -> None:
-    # Pattern A/B/C (#5211 territory) — the bare utcnow() call is NOT
-    # the responsibility of THIS hook; #5211's own enforcement (Ruff
-    # DTZ003) will cover it once enabled.
+def test_bare_utcnow_is_flagged_with_datetime_now_fix(tmp_path: Path) -> None:
+    # This test previously asserted bare `datetime.utcnow()` was NOT this hook's
+    # responsibility, deferring to #5211's Ruff DTZ003. #7436 (PR #7593)
+    # deliberately changed that by adding the `bare-utcnow` pattern to eliminate
+    # utcnow() drift, but did not update this test — so it has been failing ever
+    # since (#12670). The hook's actual, intended behaviour is asserted here.
     f = _write(
         tmp_path,
-        "ok.py",
+        "bare.py",
         "from datetime import datetime\n"
         "started_at = datetime.utcnow()\n"
         "delta = (datetime.utcnow() - started_at).total_seconds()\n",
     )
     rc = hook.main(["check_no_utcnow_isoformat", str(f)])
-    assert rc == 0
+    assert rc == 1
+
+    hits = hook._scan(f, tmp_path)
+    assert [h[1] for h in hits] == ["bare-utcnow", "bare-utcnow"]
+    # The fix it names must be datetime_now(), not the timestamp-string helper.
+    assert "datetime_now()" in hits[0][2]
+    assert "utc_timestamp()" not in hits[0][2]
+
+
+def test_utcnow_isoformat_line_reports_one_hit_not_two(tmp_path: Path) -> None:
+    """`bare-utcnow` must not re-report a line `isoformat` already caught (#12670)."""
+    f = _write(
+        tmp_path,
+        "iso.py",
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+    )
+    hits = hook._scan(f, tmp_path)
+
+    assert [h[1] for h in hits] == ["isoformat"]
+    # And the message names the timestamp helper, without contradicting itself.
+    assert "utc_timestamp()" in hits[0][2]
+    assert "datetime_now()" not in hits[0][2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #12670, #12830, #12826

Three import/lint correctness bugs, each verified against `origin/Dev_new_gui` before and after. Batched because they are the same defect class — a module reference that does not resolve to what the code assumes — and none of them touch the others' files.

## Thinking Path

**#12670 — the lint hook double-counts.** The `bare-utcnow` regex matches the `datetime.utcnow()` prefix of every `utcnow().isoformat()` line, so each violation was reported twice: once with the correct `utc_timestamp()` fix and once with the unrelated `datetime_now()` fix. The hook misstated both how many violations a file has and which replacement to use.

One test needed real judgement rather than bending. `test_bare_utcnow_without_isoformat_not_flagged` asserted bare `utcnow()` was *not* this hook's job, deferring to Ruff DTZ003. But `git log -S '"bare-utcnow"'` shows #7436 (PR #7593) added that pattern deliberately, to eliminate `utcnow()` drift, and never updated the test — so it has failed ever since. Code is authoritative here; the test encoded a scope decision that was later reversed on purpose. Replaced with a test of the intended behaviour rather than deleted.

That fix also surfaced a second defect in the same message-construction code: for `bare-utcnow` the output read "Use `utc_timestamp()` … Use `datetime_now()` instead" — two different helpers in one breath.

**#12830 — `services/__init__.py` forced a transport dependency on everything.** It eagerly imported `ai_stack_client` (→ `aiohttp`) and `npu_client` (→ Redis chain), and because the package sits under `secure_command_executor` / `auth_middleware`, that reached nearly the whole backend. Same defect class as #12814, more central.

**#12826 — 14 scripts import a module that does not exist for them.** The issue reported four; there are 14. The only `utils/redis_client.py` in the repo belongs to the Windows NPU worker and has an incompatible signature (`config: dict` vs `async_client=`/`database=`). Sibling scripts in the same directory already import from `autobot_shared.redis_client`, which is canonical and signature-compatible with every call site.

Checking the call shapes turned up two latent misuses worth fixing while there:
- `await get_redis_client(async_client=True, …)` — the function is **sync** and returns an *unawaited* coroutine in that mode, so this only worked by accident. It is precisely the #3962 trap the helper's own docstring warns about.
- `await get_redis_client("main")` — the database name was passed positionally into the `async_client` slot. Correct only because the default database also happened to be `"main"`.

## What Changed

- `tools/lint/check_no_utcnow_isoformat.py` — `SUBSUMED_BY` + `_dedupe_subsumed()` (one hit per violation); `SELF_DESCRIBING_FIX` (no contradictory advice).
- `tools/lint/check_no_utcnow_isoformat_test.py` — stale test replaced; new test pins the one-hit rule.
- `autobot-backend/services/__init__.py` — PEP 562 `__getattr__` lazy re-exports, `TYPE_CHECKING` block for static analysis, `__dir__` for the visible surface. `__all__` unchanged.
- 14 scripts in `autobot-infrastructure/shared/scripts/` — canonical import; awaited sites moved to `get_async_redis_client(database=…)`.
- `create_kb_index.py` — pre-existing missing `from typing import List`.

## Verification

**#12670**
```
28 passed        (was: 5 failed, 22 passed)
```
Hook still exits 0 on clean files, 1 on violations.

**#12830** — `aiohttp` blocked via a `meta_path` importer to simulate a slim runtime:
```
baseline (origin/Dev_new_gui): import services FAILED -> No module named 'aiohttp'
fixed:                         import services OK
                               aiohttp in sys.modules at import time = False
                               dir() exposes all of __all__          = True
                               unknown attribute -> AttributeError
```
`663 passed` across services/ai_stack/npu tests. Accessing an export that genuinely lives in an aiohttp-backed module still imports it on demand — you pay only for what you use.

**#12826**
```
residual "utils.redis_client" imports : none
residual "await get_redis_client("     : none
all 14 files parse                     : OK
flake8 F821/F401/E999 on changed files : clean except pre-existing IndexSchema
get_redis_client(async_client=False, database='main')          -> sync
get_async_redis_client(database='main')  iscoroutinefunction=True
```

## Discovered and filed, not silently dropped

- **#12839** — 2 pre-existing failures in `test_claim_classifier.py`: duplicate module identity breaks `isinstance` despite a matching repr, plus a `MagicMock` awaited. Confirmed pre-existing by re-running against the untouched file. Not folded in: the likely root cause is the `services` conftest stub, which the entire backend suite loads.
- **#12840** — `create_kb_index.py` calls `IndexSchema.from_dict()` but `redisvl` is not a repo dependency at all, so importing it would swap a `NameError` for an `ImportError`. Needs a real decision, not a guess.

## Model Used

Claude Opus 5
