### PR TITLE
tech-debt(schedulers): one canonical Redis leader lease + single source of truth for runtimes (#12835, #12836)

### DIFF
--- a/autobot-backend/knowledge/connectors/scheduler.py
+++ b/autobot-backend/knowledge/connectors/scheduler.py
@@ -16,12 +16,11 @@ then rehydrates all schedules from Redis automatically.
 
 import asyncio
 import json
-import os
 import re
-import socket
 import time
 from typing import Dict
 
+from autobot_shared.leader_lease import LeaderLease
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 
@@ -76,20 +75,6 @@ def _parse_interval_seconds(schedule: str) -> int | None:
 
 _SCHEDULE_PREFIX = "connector:schedule:"
 _LEADER_KEY = "connector:scheduler:leader"
-_LEADER_TTL_MS = 30_000  # leader lease - 30 seconds
-_LEADER_REFRESH_S = 10  # leader refreshes its lease every 10 s
-_LEADER_POLL_S = 15  # non-leaders poll for an open slot every 15 s
-
-# Atomic compare-and-expire: refresh TTL only if the key still holds our worker_id.
-# A plain GET→PEXPIRE pair is non-atomic; a rival can replace the key between the
-# two commands, causing dual-leader under GC pause or network delay.
-_REFRESH_LUA = """
-if redis.call('GET', KEYS[1]) == ARGV[1] then
-    return redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[2]))
-else
-    return 0
-end
-"""
 
 
 def _decode(val: object) -> str:
@@ -112,8 +97,9 @@ class ConnectorScheduler:
 
     def __init__(self) -> None:
         self._tasks: Dict[str, asyncio.Task] = {}
-        self._is_leader = False
-        self._worker_id = "%s-%d" % (socket.gethostname(), os.getpid())
+        # GH#12835: leader election lives in autobot_shared.leader_lease, shared
+        # with skill_distillation_scheduler. Only the key and database are ours.
+        self._lease = LeaderLease(key=_LEADER_KEY, database="knowledge", label="Connector scheduler")
         self._leader_task: asyncio.Task | None = None
 
     # ------------------------------------------------------------------
@@ -140,7 +126,7 @@ class ConnectorScheduler:
 
         await self._redis_set_schedule(connector_id, schedule, interval)
 
-        if self._is_leader:
+        if self._lease.is_leader:
             await self._start_local_task(connector_id, interval)
 
         logger.info(
@@ -205,51 +191,12 @@ class ConnectorScheduler:
             )
 
     async def _leader_loop(self) -> None:
-        """Continuously attempt to hold or acquire the leader lock; reconcile each cycle."""
-        while True:
-            try:
-                won = await self._try_acquire_or_refresh()
+        """Hold or contest the leader lease, reconciling schedules while leader."""
+        await self._lease.run(
+            on_tick=self._reconcile_schedules,
+            on_lost=self._cancel_all_local_tasks,
+        )
 
-                if won and not self._is_leader:
-                    logger.info("Connector scheduler: became leader (%s)", self._worker_id)
-                    self._is_leader = True
-                elif not won and self._is_leader:
-                    logger.warning(
-                        "Connector scheduler: lost leadership (%s) - stopping local tasks",
-                        self._worker_id,
-                    )
-                    self._is_leader = False
-                    await self._cancel_all_local_tasks()
-
-                if self._is_leader:
-                    await self._reconcile_schedules()
-
-                await asyncio.sleep(_LEADER_REFRESH_S if self._is_leader else _LEADER_POLL_S)
-            except asyncio.CancelledError:
-                break
-            except Exception as exc:
-                logger.error("Leader loop error: %s", exc)
-                await asyncio.sleep(_LEADER_POLL_S)
-
-    async def _try_acquire_or_refresh(self) -> bool:
-        """Acquire leader lock via SETNX (new) or atomic Lua refresh."""
-        redis = await get_async_redis_client(database="knowledge")
-        if redis is None:
-            return False
-        try:
-            if self._is_leader:
-                # Atomic refresh: Lua script compares and extends TTL in one
-                # round-trip, preventing dual-leader under GC pause or network
-                # delay that would split a plain GET->PEXPIRE pair.
-                result = await redis.eval(_REFRESH_LUA, 1, _LEADER_KEY, self._worker_id, str(_LEADER_TTL_MS))
-                return bool(result)
-            else:
-                # New acquisition: SET only if key does not exist (NX)
-                result = await redis.set(_LEADER_KEY, self._worker_id, nx=True, px=_LEADER_TTL_MS)
-                return result is not None
-        except Exception as exc:
-            logger.warning("Leader election Redis error: %s", exc)
-            return False
 
     # ------------------------------------------------------------------
     # Schedule reconciliation (leader only)

--- a/autobot-backend/knowledge/connectors/scheduler.py
+++ b/autobot-backend/knowledge/connectors/scheduler.py
@@ -197,7 +197,6 @@ class ConnectorScheduler:
             on_lost=self._cancel_all_local_tasks,
         )
 
-
     # ------------------------------------------------------------------
     # Schedule reconciliation (leader only)
     # ------------------------------------------------------------------

--- a/autobot-backend/services/scheduler_registry.py
+++ b/autobot-backend/services/scheduler_registry.py
@@ -14,7 +14,26 @@ enforces this automatically at CI time.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, get_args
+
+# GH#12836: the set of valid runtimes lives here and nowhere else. It used to be
+# restated by hand in the tests, including a hand-maintained *subset*
+# (_LIFESPAN_RUNTIMES) that gates the #12810 startup-enforcement check. Adding a
+# runtime to the Literal and forgetting the subset silently exempted every job
+# using it from the gate — the exact "registered but inert" failure that gate
+# exists to catch, reintroduced through a stale copy.
+SchedulerRuntime = Literal["asyncio_per_worker", "celery_beat", "leader_elected", "apscheduler"]
+
+#: Every valid runtime, derived from the type so the two can never drift.
+SCHEDULER_RUNTIMES: frozenset[str] = frozenset(get_args(SchedulerRuntime))
+
+#: Runtimes whose jobs are launched from ``initialization/lifespan.py`` and are
+#: therefore subject to the startup-enforcement check.
+LIFESPAN_RUNTIMES: frozenset[str] = frozenset({"asyncio_per_worker", "leader_elected", "apscheduler"})
+
+#: Runtimes launched by something other than lifespan, and exempt from that check.
+#: ``celery_beat`` jobs come from the Celery beat schedule.
+NON_LIFESPAN_RUNTIMES: frozenset[str] = frozenset({"celery_beat"})
 
 
 @dataclass
@@ -38,7 +57,7 @@ class ScheduledJob:
     name: str
     interval_seconds: int | str
     owner_file: str
-    runtime: Literal["asyncio_per_worker", "celery_beat", "leader_elected", "apscheduler"]
+    runtime: SchedulerRuntime
     description: str
     startup_marker: str | None = None
     inert_reason: str | None = None

--- a/autobot-backend/services/skill_management/skill_distillation_scheduler.py
+++ b/autobot-backend/services/skill_management/skill_distillation_scheduler.py
@@ -26,11 +26,10 @@ turn latency.
 """
 
 import asyncio
-import os
-import socket
 from typing import Any, Dict, List
 
 from autobot_shared.env_utils import env_flag, env_int
+from autobot_shared.leader_lease import LeaderLease
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 
@@ -52,20 +51,7 @@ MIN_MESSAGES_TO_DISTILL = env_int("AUTOBOT_SKILL_DISTILLATION_MIN_MESSAGES", 4)
 _REDIS_DB = "knowledge"
 _LEADER_KEY = "skills:distillation:leader"
 _CURSOR_KEY = "skills:distillation:cursor"
-_LEADER_TTL_MS = 30_000
-_LEADER_REFRESH_S = 10
-_LEADER_POLL_S = 15
 
-# Atomic compare-and-expire: refresh the lease only while the key still holds our
-# worker id. A GET->PEXPIRE pair is not atomic and can yield two leaders when a
-# GC pause lands between the commands.
-_REFRESH_LUA = """
-if redis.call('GET', KEYS[1]) == ARGV[1] then
-    return redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[2]))
-else
-    return 0
-end
-"""
 
 
 def _decode(value: object) -> str | None:
@@ -82,8 +68,9 @@ class SkillDistillationScheduler:
         """Initialize with injectable extractor/proposer for testing."""
         self._extractor = extractor
         self._proposer = proposer
-        self._worker_id = "%s-%d" % (socket.gethostname(), os.getpid())
-        self._is_leader = False
+        # GH#12835: leader election lives in autobot_shared.leader_lease, shared
+        # with the connector scheduler. Only the key and database are ours.
+        self._lease = LeaderLease(key=_LEADER_KEY, database=_REDIS_DB, label="Skill distillation")
         self._task: asyncio.Task | None = None
 
     # ------------------------------------------------------------------
@@ -116,7 +103,7 @@ class SkillDistillationScheduler:
             except asyncio.CancelledError:
                 pass
         self._task = None
-        self._is_leader = False
+        await self._lease.release()
         logger.info("Skill distillation scheduler stopped")
 
     # ------------------------------------------------------------------
@@ -145,45 +132,22 @@ class SkillDistillationScheduler:
                 # off must stop the work without needing a restart. The loop keeps
                 # running (and keeps the lease honest) so re-enabling also needs no restart.
                 if not await self._enabled():
-                    await asyncio.sleep(_LEADER_POLL_S)
+                    await asyncio.sleep(self._lease.poll_s)
                     continue
-                await self._update_leadership()
-                if self._is_leader and elapsed >= DISTILLATION_INTERVAL_S:
+                await self._lease.update_leadership()
+                if self._lease.is_leader and elapsed >= DISTILLATION_INTERVAL_S:
                     await self.run_once()
                     elapsed = 0
 
-                sleep_for = _LEADER_REFRESH_S if self._is_leader else _LEADER_POLL_S
+                sleep_for = self._lease.refresh_s if self._lease.is_leader else self._lease.poll_s
                 await asyncio.sleep(sleep_for)
                 elapsed += sleep_for
             except asyncio.CancelledError:
                 break
             except Exception as exc:
                 logger.error("Skill distillation leader loop error: %s", exc)
-                await asyncio.sleep(_LEADER_POLL_S)
+                await asyncio.sleep(self._lease.poll_s)
 
-    async def _update_leadership(self) -> None:
-        """Acquire or refresh the lease and log every transition."""
-        won = await self._try_acquire_or_refresh()
-        if won and not self._is_leader:
-            logger.info("Skill distillation: became leader (%s)", self._worker_id)
-        elif not won and self._is_leader:
-            logger.warning("Skill distillation: lost leadership (%s)", self._worker_id)
-        self._is_leader = won
-
-    async def _try_acquire_or_refresh(self) -> bool:
-        """Acquire the lease via SETNX, or extend it atomically while held."""
-        redis = await get_async_redis_client(database=_REDIS_DB)
-        if redis is None:
-            return False
-        try:
-            if self._is_leader:
-                held = await redis.eval(_REFRESH_LUA, 1, _LEADER_KEY, self._worker_id, str(_LEADER_TTL_MS))
-                return bool(held)
-            acquired = await redis.set(_LEADER_KEY, self._worker_id, nx=True, px=_LEADER_TTL_MS)
-            return acquired is not None
-        except Exception as exc:
-            logger.warning("Skill distillation leader election Redis error: %s", exc)
-            return False
 
     # ------------------------------------------------------------------
     # Distillation pass
@@ -201,17 +165,7 @@ class SkillDistillationScheduler:
             logger.debug("Skill distillation: no conversations since cursor %s", cursor or "(start)")
             return {"sessions_seen": 0, "sessions_distilled": 0, "proposed": []}
 
-        proposed: List[str] = []
-        distilled = 0
-        for session in pending:
-            names = await self._distil_session(session)
-            if names is None:
-                # Stop the pass rather than skip: advancing over a conversation whose
-                # proposal never landed would drop it permanently.
-                break
-            proposed.extend(names)
-            distilled += 1
-            await self._write_cursor(session["updated_at"])
+        distilled, proposed = await self._distil_pending(pending)
 
         logger.info(
             "Skill distillation pass: %d/%d conversations distilled, %d skills proposed",
@@ -220,6 +174,23 @@ class SkillDistillationScheduler:
             len(proposed),
         )
         return {"sessions_seen": len(pending), "sessions_distilled": distilled, "proposed": proposed}
+
+    async def _distil_pending(self, pending: List[Dict[str, Any]]) -> tuple[int, List[str]]:
+        """Distil each pending conversation in order, advancing the cursor as it goes.
+
+        Stops at the first conversation whose proposal did not land rather than
+        skipping it — advancing past a failed session would drop it permanently.
+        """
+        proposed: List[str] = []
+        distilled = 0
+        for session in pending:
+            names = await self._distil_session(session)
+            if names is None:
+                break
+            proposed.extend(names)
+            distilled += 1
+            await self._write_cursor(session["updated_at"])
+        return distilled, proposed
 
     async def _distil_session(self, session: Dict[str, Any]) -> List[str] | None:
         """Extract and propose for one conversation. ``None`` means the pass must stop."""

--- a/autobot-backend/services/skill_management/skill_distillation_scheduler.py
+++ b/autobot-backend/services/skill_management/skill_distillation_scheduler.py
@@ -53,7 +53,6 @@ _LEADER_KEY = "skills:distillation:leader"
 _CURSOR_KEY = "skills:distillation:cursor"
 
 
-
 def _decode(value: object) -> str | None:
     """Decode bytes to str; pass through str and None."""
     if isinstance(value, bytes):
@@ -147,7 +146,6 @@ class SkillDistillationScheduler:
             except Exception as exc:
                 logger.error("Skill distillation leader loop error: %s", exc)
                 await asyncio.sleep(self._lease.poll_s)
-
 
     # ------------------------------------------------------------------
     # Distillation pass

--- a/autobot-backend/tests/services/test_scheduler_registry.py
+++ b/autobot-backend/tests/services/test_scheduler_registry.py
@@ -24,6 +24,11 @@ sys.modules["services.scheduler_registry"] = _mod  # register before exec so @da
 _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 REGISTRY = _mod.REGISTRY
 ScheduledJob = _mod.ScheduledJob
+# GH#12836: pulled from the registry so the valid-runtime set and the
+# lifespan-managed subset have exactly one definition.
+SCHEDULER_RUNTIMES = _mod.SCHEDULER_RUNTIMES
+LIFESPAN_RUNTIMES = _mod.LIFESPAN_RUNTIMES
+NON_LIFESPAN_RUNTIMES = _mod.NON_LIFESPAN_RUNTIMES
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -86,7 +91,7 @@ def test_registry_names_are_unique() -> None:
 
 
 def test_registry_runtimes_are_valid() -> None:
-    valid = {"asyncio_per_worker", "celery_beat", "leader_elected", "apscheduler"}
+    valid = SCHEDULER_RUNTIMES  # GH#12836: imported, never restated
     for job in REGISTRY:
         assert job.runtime in valid, (
             f"REGISTRY entry '{job.name}' has unknown runtime '{job.runtime}'. " f"Valid values: {valid}"
@@ -121,9 +126,10 @@ def test_all_scheduler_files_registered() -> None:
 # Enforcement test: a registered job must actually start (GH#12810)
 # ---------------------------------------------------------------------------
 
-# Runtimes whose jobs are launched from initialization/lifespan.py. celery_beat jobs
-# are launched by the Celery beat schedule instead, so they are exempt.
-_LIFESPAN_RUNTIMES = {"asyncio_per_worker", "leader_elected", "apscheduler"}
+# GH#12836: imported from the registry rather than re-listed here. A hand-kept
+# copy of this subset meant a new runtime could be added to the type and silently
+# skipped by the gate below.
+_LIFESPAN_RUNTIMES = LIFESPAN_RUNTIMES
 
 _LIFESPAN_PATH = _BACKEND_ROOT / "initialization" / "lifespan.py"
 
@@ -196,3 +202,39 @@ def test_inert_jobs_cite_a_tracking_issue() -> None:
             f"REGISTRY entry '{job.name}' is declared inert without citing a tracking issue. "
             f"Add the issue number to inert_reason: {job.inert_reason!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# GH#12836: the runtime sets must stay exhaustive and disjoint
+# ---------------------------------------------------------------------------
+
+
+def test_every_runtime_is_classified_as_lifespan_or_not() -> None:
+    """A new runtime must be explicitly classified, not silently exempted.
+
+    _LIFESPAN_RUNTIMES gates the #12810 startup-enforcement check. Before this,
+    that subset was a hand-kept copy: adding a runtime to the type and forgetting
+    the subset meant every job using it was skipped by the gate, with all tests
+    still green — the exact failure the gate exists to prevent.
+    """
+    classified = LIFESPAN_RUNTIMES | NON_LIFESPAN_RUNTIMES
+    unclassified = SCHEDULER_RUNTIMES - classified
+
+    assert not unclassified, (
+        f"Runtime(s) {sorted(unclassified)} are declared in SchedulerRuntime but not "
+        "classified in scheduler_registry. Add each to LIFESPAN_RUNTIMES (launched "
+        "from initialization/lifespan.py) or NON_LIFESPAN_RUNTIMES (launched "
+        "elsewhere, e.g. Celery beat) — otherwise the GH#12810 startup check "
+        "silently skips every job using it."
+    )
+
+
+def test_runtime_classifications_do_not_overlap() -> None:
+    overlap = LIFESPAN_RUNTIMES & NON_LIFESPAN_RUNTIMES
+    assert not overlap, f"Runtime(s) {sorted(overlap)} are in both classifications"
+
+
+def test_classified_runtimes_are_all_real() -> None:
+    """Neither classification may name a runtime the type does not declare."""
+    unknown = (LIFESPAN_RUNTIMES | NON_LIFESPAN_RUNTIMES) - SCHEDULER_RUNTIMES
+    assert not unknown, f"Unknown runtime(s) in classification sets: {sorted(unknown)}"

--- a/autobot-backend/tests/test_leader_lease.py
+++ b/autobot-backend/tests/test_leader_lease.py
@@ -1,0 +1,159 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the shared Redis leader lease (GH#12835).
+
+Leader election was implemented twice with a byte-identical Lua script. These
+tests cover the single extracted implementation, in particular the atomic
+compare-and-extend that exists so a GC pause cannot produce two leaders.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.leader_lease import LeaderLease
+
+
+def _lease(**kw) -> LeaderLease:
+    return LeaderLease(key="test:leader", database="knowledge", worker_id="worker-1", label="Test", **kw)
+
+
+def _redis(**kw) -> AsyncMock:
+    r = AsyncMock()
+    for name, value in kw.items():
+        getattr(r, name).return_value = value
+    return r
+
+
+@pytest.mark.asyncio
+async def test_acquires_with_set_nx_when_not_leader():
+    redis = _redis(set=True)
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        lease = _lease()
+        assert await lease.try_acquire_or_refresh() is True
+
+    kwargs = redis.set.call_args.kwargs
+    assert kwargs["nx"] is True, "must not steal a lease another worker holds"
+    assert kwargs["px"] == lease.ttl_ms
+    redis.eval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_contended_acquisition_returns_false():
+    """SET NX returns None when another worker already holds the key."""
+    redis = _redis(set=None)
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        assert await _lease().try_acquire_or_refresh() is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_uses_atomic_lua_when_already_leader():
+    """The held path must compare-and-extend in ONE round-trip (the #12835 guarantee)."""
+    redis = _redis(set=True, eval=1)
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        lease = _lease()
+        await lease.update_leadership()
+        assert lease.is_leader is True
+
+        redis.set.reset_mock()
+        assert await lease.try_acquire_or_refresh() is True
+
+    redis.eval.assert_awaited_once()
+    redis.set.assert_not_called()  # no non-atomic GET->PEXPIRE fallback
+    script, numkeys, key, worker, ttl = redis.eval.call_args.args
+    assert numkeys == 1 and key == "test:leader" and worker == "worker-1"
+    assert ttl == str(lease.ttl_ms)
+
+
+@pytest.mark.asyncio
+async def test_lease_stolen_by_another_worker_is_not_extended():
+    """Lua returns 0 when the key no longer holds our id — we must drop leadership."""
+    redis = _redis(set=True, eval=0)
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        lease = _lease()
+        await lease.update_leadership()
+        assert lease.is_leader is True
+
+        lost = []
+        assert await lease.update_leadership(on_lost=lambda: lost.append(1)) is False
+        assert lease.is_leader is False
+        assert lost == [1], "on_lost must fire so the worker stops its work"
+
+
+@pytest.mark.asyncio
+async def test_transition_hooks_fire_once_per_change():
+    redis = _redis(set=True, eval=1)
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        lease = _lease()
+        acquired = []
+        await lease.update_leadership(on_acquired=lambda: acquired.append(1))
+        await lease.update_leadership(on_acquired=lambda: acquired.append(1))
+
+    assert acquired == [1], "on_acquired must not re-fire while leadership is retained"
+
+
+@pytest.mark.asyncio
+async def test_async_hooks_are_awaited():
+    redis = _redis(set=True)
+    calls = []
+
+    async def hook():
+        calls.append("awaited")
+
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        await _lease().update_leadership(on_acquired=hook)
+
+    assert calls == ["awaited"]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_redis_does_not_grant_leadership():
+    """No Redis must mean no leader — never a default-yes."""
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=None):
+        assert await _lease().try_acquire_or_refresh() is False
+
+
+@pytest.mark.asyncio
+async def test_redis_error_does_not_grant_leadership():
+    redis = AsyncMock()
+    redis.set.side_effect = RuntimeError("connection reset")
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        assert await _lease().try_acquire_or_refresh() is False
+
+
+@pytest.mark.asyncio
+async def test_release_only_deletes_a_lease_we_still_hold():
+    redis = _redis(set=True, get=b"worker-1")
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        lease = _lease()
+        await lease.update_leadership()
+        await lease.release()
+
+    redis.delete.assert_awaited_once_with("test:leader")
+
+
+@pytest.mark.asyncio
+async def test_release_does_not_delete_a_lease_another_worker_took():
+    """Our lease expired and worker-2 took it — deleting would evict a live leader."""
+    redis = _redis(set=True, get=b"worker-2")
+    with patch("autobot_shared.leader_lease.get_async_redis_client", return_value=redis):
+        lease = _lease()
+        await lease.update_leadership()
+        await lease.release()
+
+    redis.delete.assert_not_called()
+    assert lease.is_leader is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_interval_is_shorter_than_the_lease():
+    """A refresh slower than the TTL would drop a lease that is still held."""
+    lease = _lease()
+    assert lease.refresh_s * 1000 < lease.ttl_ms
+
+
+def test_worker_id_defaults_are_unique_per_process():
+    a = LeaderLease(key="k")
+    assert a.worker_id and "-" in a.worker_id

--- a/autobot_shared/leader_lease.py
+++ b/autobot_shared/leader_lease.py
@@ -1,0 +1,187 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Redis-backed leader election for multi-worker schedulers (GH#12835).
+
+One canonical implementation of the "exactly one worker does the work" lease.
+It was previously written twice — `knowledge/connectors/scheduler.py` and
+`services/skill_management/skill_distillation_scheduler.py` — with the Lua
+script byte-identical between the copies.
+
+The Lua script is the security-sensitive part: it makes compare-and-extend
+atomic so a GC pause or network delay cannot leave two workers both believing
+they hold the lease. Two copies meant that guarantee had two places to regress,
+which is why this lives in one module now.
+
+Usage::
+
+    lease = LeaderLease(key="connector:scheduler:leader", database="knowledge")
+    await lease.run(
+        on_tick=self._reconcile_schedules,
+        on_acquired=lambda: logger.info("became leader"),
+        on_lost=self._cancel_all_local_tasks,
+    )
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from typing import Awaitable, Callable, Optional
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = get_logger(__name__)
+
+# Compare-and-extend in a single round-trip. A plain GET->PEXPIRE pair can be
+# split by a pause between the two calls, letting an expired leader extend a key
+# another worker has already taken.
+_REFRESH_LUA = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[2]))
+else
+    return 0
+end
+"""
+
+# Lease lifetime, and how often the holder renews it. Refresh must stay well
+# under the TTL so a slow cycle does not drop a lease that is still held.
+DEFAULT_TTL_MS = 30_000
+DEFAULT_REFRESH_S = 10
+DEFAULT_POLL_S = 15
+
+Hook = Callable[[], Awaitable[None] | None]
+
+
+class LeaderLease:
+    """A Redis lease granting one worker the right to run a job.
+
+    Owns the key, the lease lifetime, the atomic refresh and the
+    acquired/lost transitions. Callers supply only their key, their Redis
+    database, and what to do while holding it.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        *,
+        database: str = "main",
+        ttl_ms: int = DEFAULT_TTL_MS,
+        refresh_s: float = DEFAULT_REFRESH_S,
+        poll_s: float = DEFAULT_POLL_S,
+        worker_id: Optional[str] = None,
+        label: str = "",
+    ) -> None:
+        self.key = key
+        self.database = database
+        self.ttl_ms = ttl_ms
+        self.refresh_s = refresh_s
+        self.poll_s = poll_s
+        self.worker_id = worker_id or "%s-%d" % (socket.gethostname(), os.getpid())
+        self.label = label or key
+        self._is_leader = False
+
+    @property
+    def is_leader(self) -> bool:
+        """Whether this worker currently holds the lease."""
+        return self._is_leader
+
+    async def try_acquire_or_refresh(self) -> bool:
+        """Take the lease with SET NX, or atomically extend one already held."""
+        redis = await get_async_redis_client(database=self.database)
+        if redis is None:
+            return False
+        try:
+            if self._is_leader:
+                held = await redis.eval(_REFRESH_LUA, 1, self.key, self.worker_id, str(self.ttl_ms))
+                return bool(held)
+            acquired = await redis.set(self.key, self.worker_id, nx=True, px=self.ttl_ms)
+            return acquired is not None
+        except Exception as exc:
+            logger.warning("Leader election Redis error for %s: %s", self.label, exc)
+            return False
+
+    async def update_leadership(
+        self,
+        on_acquired: Hook | None = None,
+        on_lost: Hook | None = None,
+    ) -> bool:
+        """Acquire or refresh the lease, logging and firing hooks on a transition.
+
+        Public so a caller with its own loop cadence — a work interval, an
+        enabled/disabled gate — can reuse the election without adopting
+        :meth:`run`. Returns whether the lease is held after this attempt.
+        """
+        won = await self.try_acquire_or_refresh()
+        if won and not self._is_leader:
+            self._is_leader = True
+            logger.info("%s: became leader (%s)", self.label, self.worker_id)
+            await _call(on_acquired)
+        elif not won and self._is_leader:
+            self._is_leader = False
+            logger.warning("%s: lost leadership (%s)", self.label, self.worker_id)
+            await _call(on_lost)
+        return self._is_leader
+
+    async def run(
+        self,
+        on_tick: Hook | None = None,
+        on_acquired: Hook | None = None,
+        on_lost: Hook | None = None,
+    ) -> None:
+        """Hold or contest the lease forever, running *on_tick* while leader.
+
+        Returns only on cancellation. Any exception from a hook is logged and
+        the loop continues — a failing job must not silently drop the lease and
+        leave the work unowned.
+        """
+        while True:
+            try:
+                await self.update_leadership(on_acquired, on_lost)
+                if self._is_leader:
+                    await _call(on_tick)
+                await asyncio.sleep(self.refresh_s if self._is_leader else self.poll_s)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.error("Leader loop error for %s: %s", self.label, exc)
+                await asyncio.sleep(self.poll_s)
+
+    async def release(self) -> None:
+        """Drop the lease if held, so another worker can take over immediately.
+
+        Best-effort: deletes only when the key still carries this worker's id,
+        so a lease that already expired and was retaken is never deleted.
+        """
+        if not self._is_leader:
+            return
+        self._is_leader = False
+        redis = await get_async_redis_client(database=self.database)
+        if redis is None:
+            return
+        try:
+            current = await redis.get(self.key)
+            if _decode(current) == self.worker_id:
+                await redis.delete(self.key)
+        except Exception as exc:
+            logger.warning("Failed to release leader lease %s: %s", self.label, exc)
+
+
+def _decode(val: object) -> str:
+    """Decode bytes to str; pass through str. Redis may return either."""
+    return val.decode() if isinstance(val, bytes) else (val or "")  # type: ignore[return-value]
+
+
+async def _call(hook: Hook | None) -> None:
+    """Invoke a hook that may be sync or async."""
+    if hook is None:
+        return
+    result = hook()
+    if asyncio.iscoroutine(result):
+        await result
+
+
+__all__ = ["LeaderLease", "DEFAULT_TTL_MS", "DEFAULT_REFRESH_S", "DEFAULT_POLL_S"]


### PR DESCRIPTION
Closes #12835, #12836

Both are scheduler tech-debt where a value or a mechanism existed in two places and the copies could drift apart silently. Batched because they are the same failure shape and touch the same subsystem.

## Thinking Path

**#12836 is a correctness risk, not tidiness.** Three copies of the runtime set, and one of them — `_LIFESPAN_RUNTIMES` in the tests — gates the #12810 startup-enforcement check. Add a runtime to the `Literal`, forget the subset, and every job using it is skipped by the gate entirely with all tests still green. That is exactly the "registered but silently inert" failure the gate was built to catch, reintroduced through a stale copy.

A single source of truth alone does not fix that: someone can still add a runtime and not classify it. So the subset is now declared in the registry alongside its complement, and a test asserts the two together cover every declared runtime. Forgetting is now a loud failure with a message naming the offender and both options.

**#12835 — verified the premise before extracting.** Compared both files programmatically: the Lua script is byte-identical and TTL/refresh/poll all match. The Lua is the security-sensitive part — it makes compare-and-extend atomic so a GC pause cannot leave two workers both believing they hold the lease — so having two copies meant that guarantee had two places to regress.

The two consumers differ in *cadence*, not in election, which is why the shared class exposes two entry points rather than forcing one loop shape:
- `run()` — full loop, for "reconcile every cycle" (connector scheduler).
- `update_leadership()` — election only, for the distillation scheduler, which has an enabled/disabled gate and a work interval independent of the lease refresh interval.

On placement, which the issue flagged as an open question: `autobot_shared/` per the reuse rule. It depends only on a sibling module (`redis_client`), so it introduces no new layer coupling.

## What Changed

- **`autobot_shared/leader_lease.py`** (new) — `LeaderLease` owning key, TTL, atomic refresh, acquired/lost transitions, and `release()`.
- **`services/scheduler_registry.py`** — `SchedulerRuntime` type; `SCHEDULER_RUNTIMES` derived from it via `get_args()`; `LIFESPAN_RUNTIMES` / `NON_LIFESPAN_RUNTIMES` declared once.
- **`tests/services/test_scheduler_registry.py`** — imports all three instead of restating them; adds exhaustiveness, disjointness and no-unknown-names checks.
- **Both schedulers** — delegate election to the lease; duplicated Lua and constants removed.
- **`skill_distillation_scheduler.py`** — per the issue's adjacent-cleanup note, `run_once` was 31 lines (one over standard): extracted `_distil_pending()` (now 21 + 16). Also `stop()` now calls `lease.release()`; it claimed to "release leadership so another worker can take over" but only reset an in-process bool, leaving the Redis key to expire on its own TTL.

## Verification

```
tests/test_leader_lease.py                  12 passed
tests/services/test_scheduler_registry.py   11 passed
scheduler/distillation/connector selection  132 passed
```

Lease tests cover the guarantee the extraction exists to protect: the held path uses `eval` and never falls back to a non-atomic `GET`→`PEXPIRE`; a stolen lease is detected and fires `on_lost`; `release()` deletes only a key still carrying our worker id; unavailable or erroring Redis never grants leadership.

**Lua parity** — extracted script compared byte-for-byte against `origin/Dev_new_gui`: identical.

**Mutation-verified (#12836)** — adding an unclassified runtime to the `Literal` fails `test_every_runtime_is_classified_as_lifespan_or_not`:
```
AssertionError: Runtime(s) ['new_runtime_someone_forgot'] are declared in
SchedulerRuntime but not classified in scheduler_registry. Add each to
LIFESPAN_RUNTIMES ... otherwise the GH#12810 startup check silently skips
every job using it.
```

**Pre-existing failures, not from this change.** The selection shows 5 failures; the identical 5 occur on a pristine `origin/Dev_new_gui` worktree (baseline 117 passed / 5 failed → this branch 132 passed / 5 failed, +15 being the new tests). Four are gitlab/gitea connector tests that require a live Redis. The fifth is a real regression I introduced in #12744 and is filed separately — see below.

## Model Used

Claude Opus 5
