### PR TITLE
fix(web-crawler): checkpoint only seeds actually crawled — silent seed loss on max_pages exhaustion (#12843)

### DIFF
--- a/autobot-backend/knowledge/connectors/web_crawler.py
+++ b/autobot-backend/knowledge/connectors/web_crawler.py
@@ -333,13 +333,23 @@ class WebCrawlerConnector(AbstractConnector):
                 on_seed_complete=_on_seed_done,
             )
             # #12744: on_seed_complete is an OPTIONAL callback — a crawl backend
-            # that does not invoke it left the checkpoint empty, so a resumed
-            # sync re-crawled every seed it had already finished. Once crawl()
-            # returns without raising, every dispatched seed has been attempted,
-            # so record any the callback did not report.
+            # that does not invoke it left the checkpoint empty, so a resumed sync
+            # re-crawled every seed it had already finished.
+            #
+            # #12843: the first fix for that checkpointed every *pending* seed,
+            # which broke GH#8297 in the other direction. crawl() stops dispatching
+            # once max_pages is exhausted, so trailing seeds are never fetched at
+            # all — checkpointing them marks them done and the next incremental
+            # sync skips them permanently. Budget exhaustion is the normal case on
+            # a real crawl, so that silently dropped whole seeds.
+            #
+            # The correct set is the seeds actually crawled: those the callback
+            # reported, plus any with a fetch result to prove it. Derived from
+            # results, never from the input list.
+            fetched_urls = {r.url for r in fetched}
             for seed_url in pending_seeds:
                 source_id = _url_to_source_id(seed_url)
-                if source_id not in crawled_seed_ids:
+                if source_id not in crawled_seed_ids and seed_url in fetched_urls:
                     await self._write_checkpoint(source_id)
 
             await _ingest_results_to_kb(fetched, self, result)

--- a/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
@@ -459,6 +459,54 @@ class TestSync:
 
         assert _url_to_source_id("https://c.com") not in written
 
+    async def test_sync_checkpoints_crawled_seeds_without_callback(self) -> None:
+        """GH#12744: a crawl that never fires on_seed_complete must still checkpoint.
+
+        The callback is optional. When it is not invoked, the fetch results are
+        the evidence that a seed was crawled — without this, a resumed sync
+        re-crawled every seed it had already finished.
+        """
+        urls = ["https://a.com", "https://b.com"]
+        cfg = _make_config(urls, max_pages=50)
+        connector = WebCrawlerConnector(cfg)
+
+        written: list = []
+
+        async def _crawl_no_callback(seed_urls, **kwargs):
+            # Deliberately ignores on_seed_complete, as a backend may.
+            return [_make_fetch_result(u, markdown="content") for u in seed_urls]
+
+        with patch.object(connector, "crawl", new=AsyncMock(side_effect=_crawl_no_callback)):
+            with patch.object(connector, "_write_checkpoint", new=AsyncMock(side_effect=written.append)):
+                with patch("knowledge.connectors.web_crawler._ingest_results_to_kb", new=AsyncMock()):
+                    await connector.sync(incremental=True)
+
+        assert _url_to_source_id("https://a.com") in written
+        assert _url_to_source_id("https://b.com") in written
+
+    async def test_sync_does_not_checkpoint_a_seed_with_no_fetch_result(self) -> None:
+        """GH#12843: no result for a seed means it was never crawled — never checkpoint it.
+
+        Checkpointing marks a seed done, so the next incremental sync skips it.
+        Doing that for an uncrawled seed drops it permanently.
+        """
+        urls = ["https://a.com", "https://skipped.com"]
+        cfg = _make_config(urls, max_pages=50)
+        connector = WebCrawlerConnector(cfg)
+
+        written: list = []
+
+        async def _crawl_partial(seed_urls, **kwargs):
+            return [_make_fetch_result("https://a.com", markdown="content")]
+
+        with patch.object(connector, "crawl", new=AsyncMock(side_effect=_crawl_partial)):
+            with patch.object(connector, "_write_checkpoint", new=AsyncMock(side_effect=written.append)):
+                with patch("knowledge.connectors.web_crawler._ingest_results_to_kb", new=AsyncMock()):
+                    await connector.sync(incremental=True)
+
+        assert _url_to_source_id("https://a.com") in written
+        assert _url_to_source_id("https://skipped.com") not in written
+
 
 # ---------------------------------------------------------------------------
 # Issue #12486 — no-content pages surface a specific, diagnosable reason


### PR DESCRIPTION
Closes #12843

A regression I introduced in #12744 and merged. Filed and fixed separately from PR #12842 (where I found it) because it is a different subsystem and a data-loss-shaped bug rather than tech debt.

## Thinking Path

#12744 was "incremental sync does not checkpoint crawled seed URLs". I fixed it by checkpointing **all** `pending_seeds` once `crawl()` returned, reasoning in the comment that "once crawl() returns without raising, every dispatched seed has been attempted".

That premise is false. `crawl()` breaks out of its seed loop the moment `pages_remaining` hits zero:

```python
for seed in seed_urls:
    if pages_remaining <= 0:
        break
    ...
```

Seeds after the budget runs out are never fetched at all. A checkpoint means "this seed is done", so the next incremental sync skips it — the seed is dropped **permanently**, not retried and not surfaced as an error. `max_pages` exhaustion is the normal case on any real crawl, not an edge case, so this silently lost whole seeds from the knowledge base.

It also broke GH#8297, whose test states the rule in its own docstring: *"only seeds that actually started crawling are checkpointed."* That test has been red on `Dev_new_gui` since my fix landed.

The key realisation is that there are **three** candidate sets, not two, and I collapsed to the wrong one:

| Set | Result |
|---|---|
| Only what the optional callback reported | the original #12744 bug — under-checkpointing |
| All pending seeds | this bug — over-checkpointing, silent data loss |
| **Seeds actually crawled** | correct |

Both requirements are satisfiable at once; they were never in conflict.

## What Changed

`sync()` now derives the checkpoint set from evidence rather than from the input list: a seed is checkpointed if the callback reported it, **or** if there is a fetch result proving it was fetched.

```python
fetched_urls = {r.url for r in fetched}
for seed_url in pending_seeds:
    source_id = _url_to_source_id(seed_url)
    if source_id not in crawled_seed_ids and seed_url in fetched_urls:
        await self._write_checkpoint(source_id)
```

This keeps #12744's fix working (a backend that never invokes `on_seed_complete` still gets its crawled seeds checkpointed) without checkpointing anything that was not crawled.

## Verification

```
tests/unit/knowledge/connectors/test_web_crawler.py    39 passed
  (previously: 1 failed on Dev_new_gui —
   TestSync::test_sync_only_checkpoints_crawled_seeds)
```

Two new tests pin **both** directions, so this cannot regress either way again:
- `test_sync_checkpoints_crawled_seeds_without_callback` — a crawl that ignores `on_seed_complete` still checkpoints seeds it fetched (#12744).
- `test_sync_does_not_checkpoint_a_seed_with_no_fetch_result` — a seed with no result is never checkpointed (#12843).

**Mutation-verified** — with the results-derived fallback removed:
```
FAILED TestSync::test_sync_checkpoints_crawled_seeds_without_callback
1 failed, 1 passed
```
`test_sync_only_checkpoints_crawled_seeds` still passes under that mutation, confirming the two tests constrain opposite directions rather than duplicating one another.

## Model Used

Claude Opus 5
