### PR TITLE
fix(prompt): wire preference AND skill clauses into prompt assembly — both were built and never called (#12829)

### DIFF
--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -694,6 +694,33 @@ class LLMService:
     # Optimized chat (vLLM prefix-cache variant) (#3185)
     # ------------------------------------------------------------------
 
+    async def _build_prompt_clauses(
+        self,
+        *,
+        agent_type: str,
+        user_message: str,
+        available_tools: List | None,
+        additional_params: Dict | None,
+    ) -> tuple[str | None, str | None]:
+        """Pre-fetch the async prompt clauses for :meth:`chat_optimized` (#12829).
+
+        Returns ``(preference_clause, skill_clause)``, either of which may be
+        ``None`` when there is nothing to add. Tenant scoping is taken from
+        ``additional_params`` when the caller supplied it; without it the
+        aggregator falls back to unscoped biases.
+        """
+        from prompt_manager import build_preference_clause, build_skill_clause
+
+        params = additional_params or {}
+        preference_clause = await build_preference_clause(
+            list(available_tools or []),
+            task_class=agent_type,
+            user_id=params.get("user_id"),
+            org_id=params.get("org_id"),
+        )
+        skill_clause = await build_skill_clause(user_message)
+        return preference_clause, skill_clause
+
     async def chat_optimized(
         self,
         agent_type: str,
@@ -765,6 +792,20 @@ class LLMService:
                 exc_info=True,
             )
 
+        # #12829: get_optimized_prompt accepts a preference clause (#10545) and a
+        # skill clause (#12810), but nothing ever passed either — both halves were
+        # built, tested and left disconnected, so learned tenant preferences and
+        # ranked skills never reached a prompt. Both are async lookups, which is
+        # why they are pre-fetched here rather than inside the sync assembler.
+        # Each helper returns None on any failure, so prompt assembly is unaffected
+        # when the aggregator or ranker is unavailable.
+        preference_clause, skill_clause = await self._build_prompt_clauses(
+            agent_type=agent_type,
+            user_message=user_message,
+            available_tools=available_tools,
+            additional_params=additional_params,
+        )
+
         system_prompt = get_optimized_prompt(
             base_prompt_key=get_base_prompt_for_agent(agent_type),
             session_id=session_id,
@@ -774,6 +815,8 @@ class LLMService:
             recent_context=recent_context,
             additional_params=additional_params,
             tool_descriptions=tool_descriptions,
+            preference_clause=preference_clause,
+            skill_clause=skill_clause,
         )
 
         request_id: str = llm_params.pop("request_id", str(uuid.uuid4()))

--- a/autobot-backend/tests/test_prompt_clause_wiring.py
+++ b/autobot-backend/tests/test_prompt_clause_wiring.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The preference and skill clauses must actually reach an assembled prompt (#12829).
+
+Both `build_preference_clause` (#10545) and `build_skill_clause` (#12810) were
+shipped, unit-tested, and never called from production code — `get_optimized_prompt`
+accepted both parameters and nothing ever passed them, so learned tenant
+preferences and ranked skills never influenced a single prompt.
+
+Unit tests of the builders cannot catch that: they passed the whole time. What
+needs pinning is the *connection*, so these tests assert the call site itself.
+`services/llm_service.py` is parsed rather than imported because the backend test
+suite stubs that module, and a stub would make any import-based assertion vacuous.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_LLM_SERVICE = Path(__file__).parent.parent / "services" / "llm_service.py"
+
+
+def _tree() -> ast.Module:
+    return ast.parse(_LLM_SERVICE.read_text(encoding="utf-8"))
+
+
+def _find_call(tree: ast.Module, func_name: str) -> ast.Call | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == func_name:
+            return node
+    return None
+
+
+def _find_func(tree: ast.Module, name: str) -> ast.AsyncFunctionDef | ast.FunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The wiring itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kwarg", ["preference_clause", "skill_clause"])
+def test_get_optimized_prompt_is_passed_the_clause(kwarg: str) -> None:
+    """The assembly call must pass both clauses, or the builders stay dead code."""
+    call = _find_call(_tree(), "get_optimized_prompt")
+    assert call is not None, "get_optimized_prompt call site not found in llm_service.py"
+
+    passed = {kw.arg for kw in call.keywords}
+    assert kwarg in passed, (
+        f"get_optimized_prompt is not passed {kwarg!r}. Without it the clause builder "
+        "is unreachable and the prompt silently loses that signal (#12829)."
+    )
+
+
+@pytest.mark.parametrize("builder", ["build_preference_clause", "build_skill_clause"])
+def test_clause_builder_is_actually_called(builder: str) -> None:
+    fn = _find_func(_tree(), "_build_prompt_clauses")
+    assert fn is not None, "_build_prompt_clauses helper not found"
+
+    called = {getattr(n.func, "id", None) for n in ast.walk(fn) if isinstance(n, ast.Call)}
+    assert builder in called, f"{builder} is never called — its result cannot reach a prompt"
+
+
+def test_clause_builders_are_awaited() -> None:
+    """Both builders are async; calling without await would pass a coroutine object."""
+    fn = _find_func(_tree(), "_build_prompt_clauses")
+    awaited = {
+        getattr(n.value.func, "id", None) for n in ast.walk(fn) if isinstance(n, ast.Await) and isinstance(n.value, ast.Call)
+    }
+    assert {"build_preference_clause", "build_skill_clause"} <= awaited
+
+
+def test_preference_clause_is_scoped_to_task_class_and_tenant() -> None:
+    """Biases are per task-class and per tenant; an unscoped lookup returns the wrong set."""
+    fn = _find_func(_tree(), "_build_prompt_clauses")
+    call = _find_call(fn, "build_preference_clause")
+    assert call is not None
+
+    passed = {kw.arg for kw in call.keywords}
+    assert {"task_class", "user_id", "org_id"} <= passed
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a clause reaches the assembled prompt text
+# ---------------------------------------------------------------------------
+
+_PROMPT_KEY = "chat.system_prompt"
+
+
+def test_assembled_prompt_contains_both_clauses() -> None:
+    from prompt_manager import get_optimized_prompt
+
+    assembled = get_optimized_prompt(
+        base_prompt_key=_PROMPT_KEY,
+        preference_clause="PREFERENCE_BLOCK_MARKER",
+        skill_clause="SKILL_BLOCK_MARKER",
+    )
+
+    assert "PREFERENCE_BLOCK_MARKER" in assembled
+    assert "SKILL_BLOCK_MARKER" in assembled
+
+
+def test_prompt_unchanged_when_no_clauses() -> None:
+    """No qualifying biases and no ranked skills must leave the prompt untouched."""
+    from prompt_manager import get_optimized_prompt
+
+    baseline = get_optimized_prompt(base_prompt_key=_PROMPT_KEY)
+    with_none = get_optimized_prompt(base_prompt_key=_PROMPT_KEY, preference_clause=None, skill_clause=None)
+
+    assert with_none == baseline
+    assert "PREFERENCE_BLOCK_MARKER" not in baseline

--- a/autobot-backend/tests/test_prompt_clause_wiring.py
+++ b/autobot-backend/tests/test_prompt_clause_wiring.py
@@ -72,7 +72,9 @@ def test_clause_builders_are_awaited() -> None:
     """Both builders are async; calling without await would pass a coroutine object."""
     fn = _find_func(_tree(), "_build_prompt_clauses")
     awaited = {
-        getattr(n.value.func, "id", None) for n in ast.walk(fn) if isinstance(n, ast.Await) and isinstance(n.value, ast.Call)
+        getattr(n.value.func, "id", None)
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Await) and isinstance(n.value, ast.Call)
     }
     assert {"build_preference_clause", "build_skill_clause"} <= awaited
 


### PR DESCRIPTION
Closes #12829

## Thinking Path

`get_optimized_prompt` accepts `preference_clause` (#10545) and `skill_clause` (#12810) and appends each when present — but nothing ever passed either. Both features were built, unit-tested, and left disconnected, so learned tenant preferences and ranked skills never influenced a single prompt.

**Scope correction.** The issue described only the preference clause, on the premise that the skill clause was already wired by #12810 and that this should "mirror exactly what #12810 did". It was not wired:

```
$ grep -rn "skill_clause=" --include=*.py . | grep -v prompt_manager.py
(nothing)
$ grep -rn "build_skill_clause" --include=*.py . | grep -v tests/
prompt_manager.py:1330:  # ...pre-fetch it via ``build_skill_clause``   <- a comment
prompt_manager.py:1337:  async def build_skill_clause(                  <- the definition
```

`build_skill_clause` has tests but no production caller. Both halves are dead at the same single call site, so fixing only the preference clause would have left the identical bug one line away. Both are wired here.

**Why this class of bug survives unit tests.** The builders' own tests passed the entire time — they exercise the functions directly. Nothing asserted the *connection*, which is the part that was missing. So the new tests target the call site rather than the builders.

**Why the tests parse the source instead of importing it.** The backend suite stubs `services.llm_service` (`LLMService.__new__` raises `TypeError: issubclass() arg 1 must be a class` under the stub). An import-based assertion would run against that stub and pass regardless of what the real module does — which is precisely how this stayed invisible. Parsing the file with `ast` asserts against the code that actually ships.

## What Changed

- **`services/llm_service.py`** — new `_build_prompt_clauses()` pre-fetches both clauses on the async path (the sync assembler cannot await them) and returns `(preference_clause, skill_clause)`; `chat_optimized` passes both to `get_optimized_prompt`.
- Preference lookup is scoped by `task_class` (the agent type) and by tenant from `additional_params`; the aggregator falls back to unscoped when those are absent.
- Both builders already return `None` on any internal failure, so prompt assembly is unaffected when the feedback aggregator or the skill ranker is unavailable.

## Verification

```
tests/test_prompt_clause_wiring.py   8 passed   (new)
tests/test_skill_ranker.py          35 passed   (existing, unaffected)
                                    43 passed
```

Tests cover: both clauses passed at the call site, both builders actually called, both **awaited** (calling an async builder without `await` would pass a coroutine object into the prompt), preference lookup scoped by task-class and tenant, a clause reaching the assembled prompt text, and the prompt being byte-identical when both clauses are `None`.

**Mutation-verified** — removing the two kwargs from the `get_optimized_prompt` call:
```
FAILED test_get_optimized_prompt_is_passed_the_clause[preference_clause]
FAILED test_get_optimized_prompt_is_passed_the_clause[skill_clause]
2 failed, 6 passed
```

## Model Used

Claude Opus 5
