### PR TITLE
fix(auth): bound the run-JWT denylist lookup — unbounded Redis await on get_current_user can stall any authenticated request (#12751)

### DIFF
--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -284,8 +284,7 @@ def _unavailable(reason: str) -> bool:
         logger.warning("run_jwt: %s — denylist check skipped (RUN_JWT_REDIS_FAIL_OPEN=1)", reason)
         return False
     raise JWTDecodeError(
-        f"run_jwt: {reason} — cannot verify JTI revocation status "
-        "(set RUN_JWT_REDIS_FAIL_OPEN=1 to allow fail-open)"
+        f"run_jwt: {reason} — cannot verify JTI revocation status " "(set RUN_JWT_REDIS_FAIL_OPEN=1 to allow fail-open)"
     )
 
 

--- a/autobot-backend/services/run_jwt.py
+++ b/autobot-backend/services/run_jwt.py
@@ -53,6 +53,7 @@ Configuration
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 import uuid
@@ -234,6 +235,15 @@ async def _add_to_denylist(jti: str, remaining_ttl: int) -> None:
     logger.debug("run_jwt: denylist key=%s ttl=%ds", key, remaining_ttl)
 
 
+# #12751: the denylist check sits on an auth path, so it must fail fast rather
+# than stall the request. Deliberately short — a revocation lookup that cannot
+# answer in this budget is treated as "Redis unavailable" and follows the same
+# fail-closed policy.
+DENYLIST_TIMEOUT_S: float = float(
+    os.environ.get("AUTOBOT_RUN_JWT_DENYLIST_TIMEOUT_S", "2.0")  # ssot-config-exempt: dynamic env var name
+)
+
+
 async def _is_denied(jti: str) -> bool:
     """Return True if the JTI is present in the Redis denylist.
 
@@ -246,16 +256,37 @@ async def _is_denied(jti: str) -> bool:
     Raises:
         JWTDecodeError: Redis is unavailable and fail-closed mode is active.
     """
+    try:
+        return await asyncio.wait_for(_denylist_lookup(jti), timeout=DENYLIST_TIMEOUT_S)
+    except asyncio.TimeoutError:
+        # #12751: this runs inside get_current_user, a dependency on most
+        # authenticated routes. Without a bound, a slow Redis stalls the whole
+        # request with no HTTP status at all — the caller sees a hang rather
+        # than a 401, which is strictly worse than a fast rejection.
+        return _unavailable(f"denylist lookup timed out after {DENYLIST_TIMEOUT_S}s")
+
+
+async def _denylist_lookup(jti: str) -> bool:
+    """Ask Redis whether *jti* is revoked. Bounded by the caller."""
     redis = await get_async_redis_client(database="main")
     if redis is None:
-        if os.environ.get(_ENV_FAIL_OPEN) == "1":  # ssot-config-exempt: dynamic env var name
-            logger.warning("run_jwt: Redis unavailable — denylist check skipped (RUN_JWT_REDIS_FAIL_OPEN=1)")
-            return False
-        raise JWTDecodeError(
-            "run_jwt: Redis unavailable — cannot verify JTI revocation status "
-            "(set RUN_JWT_REDIS_FAIL_OPEN=1 to allow fail-open)"
-        )
+        return _unavailable("Redis unavailable")
     return bool(await redis.exists(_DENYLIST_PREFIX + jti))
+
+
+def _unavailable(reason: str) -> bool:
+    """Apply the denylist-unavailable policy: fail closed unless opted out.
+
+    Returning False means "not revoked" and is only safe when the operator has
+    explicitly accepted that a revoked token may be honoured during an outage.
+    """
+    if os.environ.get(_ENV_FAIL_OPEN) == "1":  # ssot-config-exempt: dynamic env var name
+        logger.warning("run_jwt: %s — denylist check skipped (RUN_JWT_REDIS_FAIL_OPEN=1)", reason)
+        return False
+    raise JWTDecodeError(
+        f"run_jwt: {reason} — cannot verify JTI revocation status "
+        "(set RUN_JWT_REDIS_FAIL_OPEN=1 to allow fail-open)"
+    )
 
 
 async def validate_run_jwt(token: str) -> Dict[str, object]:

--- a/autobot-backend/tests/test_run_jwt_denylist_timeout.py
+++ b/autobot-backend/tests/test_run_jwt_denylist_timeout.py
@@ -1,0 +1,114 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The run-JWT denylist lookup must fail fast, never stall the request (#12751).
+
+`_is_denied` runs inside `auth_middleware.get_current_user`, which is a
+dependency on most authenticated routes:
+
+    get_current_user -> _extract_user_from_run_jwt -> validate_run_jwt -> _is_denied -> Redis
+
+Before this, both the client acquisition and the `exists` call were unbounded,
+so a slow Redis stalled the whole request with no HTTP status — the caller saw a
+hang rather than a 401, which is strictly worse than a fast rejection.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.auth.jwt_core import JWTDecodeError
+from services import run_jwt
+
+
+@pytest.fixture(autouse=True)
+def _fail_closed(monkeypatch):
+    """Default policy is fail-closed; tests opt into fail-open explicitly."""
+    monkeypatch.delenv("RUN_JWT_REDIS_FAIL_OPEN", raising=False)
+
+
+@pytest.fixture
+def _fast_timeout(monkeypatch):
+    """Keep the tests quick without depending on the shipped default."""
+    monkeypatch.setattr(run_jwt, "DENYLIST_TIMEOUT_S", 0.05)
+
+
+def _hanging_redis() -> AsyncMock:
+    redis = AsyncMock()
+
+    async def _never_returns(*_a, **_kw):
+        await asyncio.sleep(3600)
+
+    redis.exists.side_effect = _never_returns
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_hanging_redis_raises_instead_of_stalling(_fast_timeout):
+    with patch.object(run_jwt, "get_async_redis_client", AsyncMock(return_value=_hanging_redis())):
+        started = time.monotonic()
+        with pytest.raises(JWTDecodeError, match="timed out"):
+            await run_jwt._is_denied("some-jti")
+        elapsed = time.monotonic() - started
+
+    # The point of the fix: bounded, not "eventually".
+    assert elapsed < 1.0, f"denylist check took {elapsed:.2f}s — it is not bounded"
+
+
+@pytest.mark.asyncio
+async def test_hanging_client_acquisition_is_also_bounded(_fast_timeout):
+    """get_async_redis_client itself retries with backoff — it must be inside the bound."""
+
+    async def _slow_client(*_a, **_kw):
+        await asyncio.sleep(3600)
+
+    with patch.object(run_jwt, "get_async_redis_client", _slow_client):
+        started = time.monotonic()
+        with pytest.raises(JWTDecodeError, match="timed out"):
+            await run_jwt._is_denied("some-jti")
+        assert time.monotonic() - started < 1.0
+
+
+@pytest.mark.asyncio
+async def test_timeout_honours_fail_open_opt_out(monkeypatch, _fast_timeout):
+    """Operators who accepted the revocation risk must not start seeing hard failures."""
+    monkeypatch.setenv("RUN_JWT_REDIS_FAIL_OPEN", "1")
+
+    with patch.object(run_jwt, "get_async_redis_client", AsyncMock(return_value=_hanging_redis())):
+        assert await run_jwt._is_denied("some-jti") is False
+
+
+@pytest.mark.asyncio
+async def test_unavailable_redis_still_fails_closed():
+    """Pre-existing policy must be unchanged: no client means no revocation proof."""
+    with patch.object(run_jwt, "get_async_redis_client", AsyncMock(return_value=None)):
+        with pytest.raises(JWTDecodeError, match="Redis unavailable"):
+            await run_jwt._is_denied("some-jti")
+
+
+@pytest.mark.asyncio
+async def test_unavailable_redis_honours_fail_open(monkeypatch):
+    monkeypatch.setenv("RUN_JWT_REDIS_FAIL_OPEN", "1")
+    with patch.object(run_jwt, "get_async_redis_client", AsyncMock(return_value=None)):
+        assert await run_jwt._is_denied("some-jti") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exists_result,expected", [(1, True), (0, False)])
+async def test_healthy_redis_reports_revocation_state(exists_result, expected):
+    """The happy path must be untouched by the timeout wrapper."""
+    redis = AsyncMock()
+    redis.exists.return_value = exists_result
+
+    with patch.object(run_jwt, "get_async_redis_client", AsyncMock(return_value=redis)):
+        assert await run_jwt._is_denied("some-jti") is expected
+
+    redis.exists.assert_awaited_once_with(run_jwt._DENYLIST_PREFIX + "some-jti")
+
+
+def test_timeout_is_configurable_and_short():
+    """A long default would defeat the purpose on an auth path."""
+    assert 0 < run_jwt.DENYLIST_TIMEOUT_S <= 5.0


### PR DESCRIPTION
Closes #12849

Contributes to #12751 but does **not** close it — see Scope below. #12849 is the discrete, fully-delivered scope this PR closes; #12751 stays open for its remaining items.

## Thinking Path

The issue reports two endpoints hanging and attributes it to "the health check itself blocks on [the subsystem] it's probing". Reading the code, that premise does not hold for either endpoint:

- **`/api/web-research/status`** — already bounded. Both probes are wrapped in `asyncio.wait_for(..., HEALTH_PROBE_TIMEOUT_S)` and it returns a structured degraded payload.
- **`/api/entities/extract/health`** — `entity_extraction_health` has **no awaits at all** (it reads `extractor.extractor` and `extractor.graph.initialized`), and `get_entity_extractor` only does a `getattr` on app state. Neither can block on the entity-extraction subsystem.

That leaves the shared dependency, and there the chain is genuinely unbounded:

```
auth_middleware.get_current_user            (:844)
  -> middleware.get_user_from_request(...)   sync, returns early on a valid user JWT
  -> await _extract_user_from_run_jwt(...)   (:886 -> :636)
       -> await validate_run_jwt(token)      (run_jwt.py:261)
            -> await _is_denied(jti)         (run_jwt.py:285) -> Redis
```

No `wait_for` anywhere on it. `_extract_user_from_run_jwt` returns immediately when there is no `Authorization: Bearer` header, so the exposure is a request carrying a Bearer token that **fails primary auth** (expired/invalid user JWT) — it then falls through here and awaits Redis with no bound. A hang with no HTTP status matches the reported `curl` exit 000 far better than a per-endpoint cause, and `get_current_user` is a dependency on most authenticated routes, so the blast radius is much wider than two health endpoints.

I am not claiming this is *proven* to be the cause of the original 8s timeouts — that needs a reproduction against a live backend with a slow Redis. But an auth dependency awaiting Redis with no timeout is a defect on its own merits.

**Security consideration.** A timeout must not become a way to bypass revocation. The module already had a deliberate fail-closed policy with an explicit `RUN_JWT_REDIS_FAIL_OPEN=1` opt-out, so the timeout path reuses that exact policy rather than inventing a new one — and `_unavailable()` now owns it, so the unreachable and timed-out cases cannot drift apart later.

## What Changed

`autobot-backend/services/run_jwt.py`:
- `DENYLIST_TIMEOUT_S` (env `AUTOBOT_RUN_JWT_DENYLIST_TIMEOUT_S`, default `2.0`) bounds the whole check.
- The bound deliberately includes **client acquisition** — `get_async_redis_client` retries with backoff and is itself a stall source, so wrapping only `redis.exists` would have left the longer path unbounded.
- `_denylist_lookup()` does the work; `_unavailable()` applies the fail-closed/fail-open policy for both the unreachable and timed-out cases.

## Verification

```
tests/test_run_jwt_denylist_timeout.py    8 passed   (new)
run_jwt / auth / jwt selection          120 passed
```

Tests cover: a hanging `exists` raising in well under a second, a hanging *client acquisition* also bounded, the timeout honouring the fail-open opt-out, the pre-existing unreachable-Redis policy unchanged in both modes, and the happy path untouched for revoked and non-revoked JTIs.

**Mutation-verified** — with the `wait_for` removed:
```
mutated-run exit=124   (killed after 30s)
```
The test never completes, reproducing the production hang; with the fix it raises in <1s.

## Scope

Deliberately does not close #12751. Still open there:
1. The generic smoke test asserting every `*/health` and `*/status` route answers within a small budget with a `status` field — the part that would catch this class generically.
2. Confirmation against a live backend that this was the actual cause of the reported timeouts.

Full analysis posted as a comment on #12751 so the corrected diagnosis is on the issue, not only in this PR.

## Model Used

Claude Opus 5