### PR TITLE
fix(llc): agent runs execute and keep their output — missing --verbose, resume dead-loop, UUID-aborted replay write (#12683, #12682)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -88,6 +88,19 @@ def _state_path(output_dir: str, run_id: str) -> str:
     return os.path.join(output_dir, f"llc_state_{safe_run}.json")
 
 
+def _is_unresumable_session_output(text: str) -> bool:
+    """True when CLI output says the resume session id does not exist (#12683).
+
+    Matched on the CLI's own wording. Kept deliberately narrow: a broader match
+    would clear a valid session on unrelated errors, forcing agents to lose
+    conversation continuity for no reason.
+    """
+    if not text:
+        return False
+    lowered = text.lower()
+    return "no conversation found with session id" in lowered
+
+
 def _stderr_path(output_file: str) -> str:
     """Sidecar stderr capture next to the stdout .jsonl (GH#9992)."""
     return f"{output_file}.stderr.log"
@@ -154,7 +167,12 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
         The prompt is passed positionally after ``--`` so a prompt starting with
         ``-`` can never be parsed as an option (matches the execution backend).
         """
-        cmd: list[str] = [cli, "--output-format", "stream-json", "--print"]
+        # #12683: Claude Code rejects `--print --output-format stream-json`
+        # unless --verbose is also present ("Error: When using --print,
+        # --output-format=stream-json requires --verbose"), so every fresh run
+        # died before doing any work. --verbose does not change the stream-json
+        # payload we parse; it only satisfies that CLI precondition.
+        cmd: list[str] = [cli, "--output-format", "stream-json", "--print", "--verbose"]
         if resume_session_id:
             cmd += ["--resume", resume_session_id]
         else:
@@ -333,6 +351,20 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
                 status=LLCRunStatus.RATE_LIMITED,
                 error="provider rate-limited (detected in CLI output)",
             )
+
+        # #12683: a stored session id the CLI cannot resume ("No conversation
+        # found with session ID: ...") otherwise fails EVERY subsequent
+        # heartbeat — the same bad id is replayed forever with no way out.
+        # Dropping it degrades the next run to a fresh session instead.
+        if _is_unresumable_session_output(stderr_tail) or _is_unresumable_session_output(tail):
+            agent_id_for_clear: str = agent_config.get("agent_id", "")
+            logger.warning(
+                "ClaudeCodeAdapter: session for agent %s is not resumable — clearing stored id "
+                "so the next heartbeat starts a fresh session (run %s)",
+                agent_id_for_clear,
+                run_id,
+            )
+            await self._clear_session(agent_id_for_clear)
 
         # Surface non-rate-limit stderr so a failed/killed run is diagnosable
         # instead of silent (the PIPE was previously never drained).

--- a/autobot-backend/llc/services/replay_service.py
+++ b/autobot-backend/llc/services/replay_service.py
@@ -29,6 +29,8 @@ import difflib
 import json
 import logging
 import uuid
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
@@ -59,6 +61,35 @@ _REPLAY_FIXTURE_EXCERPT_CAP: int = env_int("LLC_REPLAY_FIXTURE_EXCERPT_CAP", 204
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def _json_safe(value: Any) -> Any:
+    """Recursively coerce a value into something a JSON column can store (#12682).
+
+    Run context and agent snapshots legitimately carry UUIDs, datetimes and
+    Decimals. SQLAlchemy's JSON serializer raises ``TypeError: Object of type
+    UUID is not JSON serializable`` on those, which aborted the whole
+    ``record_run`` write — so a run that genuinely succeeded was reported as
+    ``completed`` with an empty ``output_text`` and its transcript was lost.
+
+    Coercing to ``str`` is right for a replay *snapshot*: it is a record of what
+    the inputs were, not a live object graph, and replay re-dispatches by value.
+    """
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (uuid.UUID, datetime, date, Decimal)):
+        return str(value)
+    # Anything else (custom objects, bytes) — repr rather than explode. Losing
+    # fidelity on an exotic value is far better than losing the entire run log.
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return repr(value)
 
 
 class RunReplayService:
@@ -120,9 +151,9 @@ class RunReplayService:
                 replay_of_run_id=None,
                 company_id=company_id,
                 agent_id=agent_id,
-                inputs_snapshot=raw_context,
-                agent_snapshot=raw_agent,
-                recorded_events=capped_events,
+                inputs_snapshot=_json_safe(raw_context),
+                agent_snapshot=_json_safe(raw_agent),
+                recorded_events=_json_safe(capped_events),
                 output_text=capped_output,
                 final_status=final_status,
             )

--- a/autobot-backend/tests/test_llc_agent_run_recovery.py
+++ b/autobot-backend/tests/test_llc_agent_run_recovery.py
@@ -1,0 +1,165 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLC agent runs must execute and keep their output (#12682, #12683).
+
+Both execution paths of the claude_code adapter were broken, and the recording
+path discarded output when a run did succeed:
+
+- fresh session  -> invalid CLI command (missing --verbose)  (#12683)
+- resume session -> hard-fails on an unresumable id, forever (#12683)
+- successful run -> replay log write aborts on a UUID        (#12682)
+"""
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# #12683 — the CLI command must be valid
+# ---------------------------------------------------------------------------
+
+
+def _build(resume=None, cfg=None):
+    from llc.adapters.claude_code_adapter import ClaudeCodeAdapter
+
+    return ClaudeCodeAdapter._build_command("claude", resume, cfg or {}, "do the thing")
+
+
+def test_stream_json_print_includes_verbose():
+    """Claude Code rejects --print + stream-json without --verbose (#12683)."""
+    cmd = _build()
+
+    assert "--verbose" in cmd, (
+        "Missing --verbose: the CLI errors with 'When using --print, "
+        "--output-format=stream-json requires --verbose' and the run produces nothing."
+    )
+    assert "--print" in cmd and "stream-json" in cmd
+
+
+def test_verbose_present_on_resumed_runs_too():
+    cmd = _build(resume="abc-123")
+
+    assert "--verbose" in cmd
+    assert cmd[cmd.index("--resume") + 1] == "abc-123"
+
+
+def test_prompt_still_passed_positionally_after_dash_dash():
+    """Regression guard: --verbose must not disturb the -- prompt convention."""
+    cmd = _build()
+
+    assert cmd[-2] == "--"
+    assert cmd[-1] == "do the thing"
+
+
+def test_fresh_run_still_carries_session_establishment_options():
+    cmd = _build(cfg={"model": "sonnet", "max_turns": 7})
+
+    assert cmd[cmd.index("--model") + 1] == "sonnet"
+    assert cmd[cmd.index("--max-turns") + 1] == "7"
+
+
+# ---------------------------------------------------------------------------
+# #12683 — an unresumable session must not dead-loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "No conversation found with session ID: 63253ddd-7750-4b51-b493-4d21e7f2e9fb",
+        "error: no conversation found with session id: abc",
+    ],
+)
+def test_unresumable_session_is_detected(text):
+    from llc.adapters.claude_code_adapter import _is_unresumable_session_output
+
+    assert _is_unresumable_session_output(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "rate limit exceeded",
+        "Error: connection reset by peer",
+        "conversation found",
+    ],
+)
+def test_unrelated_output_does_not_clear_the_session(text):
+    """A broad match would drop valid sessions and lose conversation continuity."""
+    from llc.adapters.claude_code_adapter import _is_unresumable_session_output
+
+    assert _is_unresumable_session_output(text) is False
+
+
+# ---------------------------------------------------------------------------
+# #12682 — a UUID in the snapshot must not destroy the run record
+# ---------------------------------------------------------------------------
+
+
+def test_json_safe_coerces_uuid():
+    from llc.services.replay_service import _json_safe
+
+    run_id = uuid.uuid4()
+    assert _json_safe(run_id) == str(run_id)
+
+
+def test_json_safe_handles_nested_structures():
+    """Context is nested; a UUID three levels down broke the write just as well."""
+    from llc.services.replay_service import _json_safe
+
+    company = uuid.uuid4()
+    payload = {"a": [{"company_id": company}], "b": {"c": {"d": company}}}
+    safe = _json_safe(payload)
+
+    assert safe["a"][0]["company_id"] == str(company)
+    assert safe["b"]["c"]["d"] == str(company)
+
+
+def test_json_safe_output_is_actually_serializable():
+    """The real assertion: json.dumps must not raise, since that is what aborted the write."""
+    import json
+
+    from llc.services.replay_service import _json_safe
+
+    payload = {
+        "run_id": uuid.uuid4(),
+        "when": datetime(2026, 7, 28, 12, 0, 0),
+        "cost": Decimal("1.25"),
+        "tags": {"a", "b"},
+        "nested": [{"id": uuid.uuid4()}],
+    }
+
+    json.dumps(_json_safe(payload))  # must not raise
+
+
+def test_json_safe_preserves_plain_values():
+    from llc.services.replay_service import _json_safe
+
+    payload = {"s": "text", "i": 3, "f": 1.5, "b": True, "n": None, "l": [1, 2]}
+    assert _json_safe(payload) == payload
+
+
+def test_json_safe_falls_back_to_repr_for_exotic_objects():
+    """Losing fidelity on one odd value beats losing the entire run log."""
+    from llc.services.replay_service import _json_safe
+
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    assert _json_safe({"x": Weird()}) == {"x": "<weird>"}
+
+
+def test_raw_uuid_payload_is_unserializable_without_the_fix():
+    """Pins the original failure mode so the coercion cannot be quietly removed."""
+    import json
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        json.dumps({"run_id": uuid.uuid4()})

--- a/autobot-backend/tests/test_llc_agent_run_recovery.py
+++ b/autobot-backend/tests/test_llc_agent_run_recovery.py
@@ -15,10 +15,8 @@ path discarded output when a run did succeed:
 import uuid
 from datetime import datetime
 from decimal import Decimal
-from unittest.mock import AsyncMock, patch
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # #12683 — the CLI command must be valid


### PR DESCRIPTION
Closes #12683, #12682

Batched because they sit on the same path and only one is observable at a time: #12682 (output discarded on success) cannot be seen until #12683 (runs never succeed) is fixed. Together they are the difference between a hired LLC agent producing nothing and producing recorded work.

## Thinking Path

**#12683a — fresh runs built an invalid command.** Direct evidence in the issue: `Error: When using --print, --output-format=stream-json requires --verbose`. Adding `--verbose` does not change the stream-json payload the adapter parses; it only satisfies the CLI precondition.

**#12683b — resume dead-looped.** A stored session id the CLI cannot resume failed *every* subsequent heartbeat, replaying the same bad id forever. The run is detached (`_invoke` returns as soon as the subprocess is spawned), so there is no inline retry point — the failure only surfaces later in stderr. The fix therefore lives in `_status()`, which already scans that stderr: on "No conversation found with session ID" it clears the stored id, so the next heartbeat degrades to a fresh session. One failed run, then automatic recovery, instead of a permanent dead-loop.

The detector is deliberately narrow. A broad "resume failed" match would clear valid sessions on unrelated errors and silently cost agents their conversation continuity, so unrelated stderr is covered by explicit negative tests.

**#12682 — successful runs lost their output.** `record_run` wrote UUID-bearing dicts into JSON columns; SQLAlchemy's serializer raised `TypeError: Object of type UUID is not JSON serializable`, the commit failed, and the run record — including `output_text` — was never written. Externally the run read `completed` with empty output: the agent did the work and the system kept none of it.

Coercing to `str` is the right call for a replay *snapshot* specifically: it records what the inputs **were**, and replay re-dispatches by value rather than rehydrating an object graph. Applied to all three JSON columns, not just the one in the traceback — `inputs_snapshot` and `agent_snapshot` carry the same UUIDs and would have been the next failure. Anything still unserializable falls back to `repr()`, because losing fidelity on one exotic value beats destroying the entire run log.

## What Changed

- **`llc/adapters/claude_code_adapter.py`** — `--verbose` added to the stream-json command; `_is_unresumable_session_output()` plus a self-healing clear in `_status()`.
- **`llc/services/replay_service.py`** — `_json_safe()` applied to `inputs_snapshot`, `agent_snapshot`, `recorded_events`.

## Verification

```
tests/test_llc_agent_run_recovery.py                    16 passed  (new)
tests/test_claude_code_backend.py + llc/tests/    1331 passed, 2 skipped
```

Covers: `--verbose` present on fresh *and* resumed commands, the `--` positional-prompt convention undisturbed, session-establishment options intact, the unresumable detector firing on the CLI's wording and **not** on unrelated stderr, and `_json_safe` handling nested UUIDs / datetimes / Decimals / sets with the output actually surviving `json.dumps`.

One test pins the original failure directly (`json.dumps({"run_id": uuid4()})` raises `TypeError`), so the coercion cannot be quietly removed without a red test.

## Discovered and filed, not silently folded in

#12683's resume diagnosis is **incomplete**. It attributes the stale id to "an earlier run that failed after id generation but before claude saved the conversation". Reading the adapter, the cause is more fundamental: `_invoke` generates `session_id = str(uuid.uuid4())` and **never passes it to the CLI** (no `--session-id` flag), so the CLI always creates its own id, and its real id is never parsed back from the stream-json output. The stored id could therefore never match a real conversation — resume was broken from the start, not only after a failed run.

Fixing that properly means either passing `--session-id` (needs verification that the installed CLI supports it) or parsing the real `session_id` out of the emitted JSONL (needs confirmation those events carry it). The `claude` binary is not available in this environment and the repo's own stream-json fixtures do not include a `session_id` field, so I filed it rather than guessing at CLI behaviour. The self-healing clear above stops the dead-loop regardless of which fix lands.

## Model Used

Claude Opus 5
