### PR TITLE
fix(llc): gate 'Scan for findings' on the policy — feature is off by default so the button always 403'd (#12734)

### DIFF
--- a/autobot-backend/llc/api/findings.py
+++ b/autobot-backend/llc/api/findings.py
@@ -3,6 +3,7 @@
 """LLC findings API — scan / proposals / promote / dismiss (#11271).
 
 Routes (all served under /api/llc via the parent router):
+  GET  /findings/policy
   POST /projects/{project_id}/findings/scan
   GET  /projects/{project_id}/findings/proposals
   POST /findings/proposals/{proposal_id}/promote
@@ -84,6 +85,40 @@ async def _load_owned_proposal(proposal_id: uuid.UUID, session: AsyncSession, ct
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
+
+
+class FindingsPolicyResponse(BaseModel):
+    """Client-visible findings policy (#12734).
+
+    Only the fields a caller needs to decide whether, and how, to offer the
+    scan action. Deliberately excludes operational tuning (verify_batch_size,
+    run_on_index) — those are SLM-side concerns and exposing them would invite
+    the UI to depend on values it has no business reacting to.
+    """
+
+    enabled: bool
+    min_severity: str
+    require_approval_to_promote: bool
+
+
+@router.get("/findings/policy", response_model=FindingsPolicyResponse)
+async def get_policy(
+    _current_user: dict = Depends(get_current_user),
+    _ctx: TenantContext = Depends(require_org_context),
+) -> FindingsPolicyResponse:
+    """Return the findings policy so clients can gate the scan action (#12734).
+
+    The feature is OFF by default, and the policy was previously readable only
+    inside the backend — so the UI rendered a prominent "Scan for findings"
+    button that could only ever return 403. A client cannot gate on a value it
+    has no way to read.
+    """
+    policy = await get_findings_policy()
+    return FindingsPolicyResponse(
+        enabled=policy.enabled,
+        min_severity=policy.min_severity,
+        require_approval_to_promote=policy.require_approval_to_promote,
+    )
 
 
 @router.post("/projects/{project_id}/findings/scan")

--- a/autobot-backend/llc/tests/test_findings_api.py
+++ b/autobot-backend/llc/tests/test_findings_api.py
@@ -340,3 +340,60 @@ def test_promote_conflict_when_non_pending():
     with patch("llc.api.findings.promote", AsyncMock(side_effect=ProposalStateError("already promoted"))):
         resp = client.post(f"/findings/proposals/{proposal.id}/promote")
     assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# GH#12734 — clients must be able to read the policy to gate the scan action
+# ---------------------------------------------------------------------------
+
+
+def test_policy_endpoint_reports_disabled_by_default():
+    """The feature is OFF by default; the UI needs to see that to hide the button."""
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    client, _ = _mk_client(_mk_project())
+    with patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=FindingsPolicy())):
+        resp = client.get("/findings/policy")
+
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+
+
+def test_policy_endpoint_reports_enabled():
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    client, _ = _mk_client(_mk_project())
+    policy = FindingsPolicy(enabled=True, min_severity="high", require_approval_to_promote=True)
+    with patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=policy)):
+        resp = client.get("/findings/policy")
+
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["min_severity"] == "high"
+    assert body["require_approval_to_promote"] is True
+
+
+def test_policy_endpoint_does_not_leak_operational_tuning():
+    """verify_batch_size / run_on_index are SLM-side concerns, not client state."""
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    client, _ = _mk_client(_mk_project())
+    with patch(
+        "llc.api.findings.get_findings_policy",
+        AsyncMock(return_value=FindingsPolicy(enabled=True, verify_batch_size=99, run_on_index=True)),
+    ):
+        body = client.get("/findings/policy").json()
+
+    assert "verify_batch_size" not in body
+    assert "run_on_index" not in body
+
+
+def test_policy_endpoint_requires_auth_and_org_context():
+    """The route must carry the same dependencies as the rest of the findings API."""
+    from llc.api import findings  # noqa: PLC0415
+
+    route = next(r for r in findings.router.routes if getattr(r, "path", "") == "/findings/policy")
+    dep_names = {d.call.__name__ for d in route.dependant.dependencies}
+
+    assert "get_current_user" in dep_names
+    assert "require_org_context" in dep_names

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -49648,6 +49648,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/findings/policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Policy
+         * @description Return the findings policy so clients can gate the scan action (#12734).
+         *
+         *     The feature is OFF by default, and the policy was previously readable only
+         *     inside the backend — so the UI rendered a prominent "Scan for findings"
+         *     button that could only ever return 403. A client cannot gate on a value it
+         *     has no way to read.
+         */
+        get: operations["get_policy_api_llc_findings_policy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/projects/{project_id}/findings/scan": {
         parameters: {
             query?: never;
@@ -73664,6 +73689,25 @@ export interface components {
             score: number | null;
             /** Message */
             message: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * FindingsPolicyResponse
+         * @description Client-visible findings policy (#12734).
+         *
+         *     Only the fields a caller needs to decide whether, and how, to offer the
+         *     scan action. Deliberately excludes operational tuning (verify_batch_size,
+         *     run_on_index) — those are SLM-side concerns and exposing them would invite
+         *     the UI to depend on values it has no business reacting to.
+         */
+        FindingsPolicyResponse: {
+            /** Enabled */
+            enabled: boolean;
+            /** Min Severity */
+            min_severity: string;
+            /** Require Approval To Promote */
+            require_approval_to_promote: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -167654,6 +167698,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_policy_api_llc_findings_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FindingsPolicyResponse"];
                 };
             };
         };

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -801,8 +801,8 @@ onMounted(async () => {
 
 <style scoped>
 .findings-disabled-note {
-  font-size: 0.85rem;
-  color: var(--color-text-muted, #6b7280);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
 }
 
 .llc-browser {

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -167,7 +167,10 @@
         <!-- GH#11271: findings proposal queue -->
         <div v-if="p.code_source_id" class="card-findings">
           <div class="findings-header">
+            <!-- GH#12734: the findings feature is OFF by default, so an
+                 ungated button could only ever return 403. -->
             <BaseButton
+              v-if="findingsEnabled"
               variant="secondary"
               size="sm"
               :loading="scanningProject === p.id"
@@ -176,6 +179,7 @@
             >
               {{ scanningProject === p.id ? t('llcBrowser.findings.scanning') : t('llcBrowser.findings.scan') }}
             </BaseButton>
+            <span v-else class="findings-disabled-note">{{ t('llcBrowser.findings.disabled') }}</span>
           </div>
           <ErrorBanner v-if="findingsError[p.id]" :message="findingsError[p.id]" class="browser-error" />
           <div v-if="proposals[p.id] && proposals[p.id].length === 0" class="findings-empty">
@@ -462,6 +466,10 @@ const lifecycleError = ref<Record<string, string>>({})
 // GH#11271: findings proposal queue state (keyed by project id)
 const proposals = ref<Record<string, FindingProposal[]>>({})
 const scanningProject = ref<string | null>(null)
+// GH#12734: the scan action is gated on the server-side findings policy, which
+// defaults to OFF. Assume disabled until the policy says otherwise so the
+// button never appears during load and then vanishes.
+const findingsEnabled = ref(false)
 const findingsError = ref<Record<string, string>>({})
 
 function velocityFor(projectId: string): number[] {
@@ -774,10 +782,29 @@ async function dismissProposal(project: ProjectResponse, proposal: FindingPropos
   }
 }
 
-onMounted(loadProjects)
+async function loadFindingsPolicy(): Promise<void> {
+  try {
+    const policy = await api.get<{ enabled: boolean }>('/api/llc/findings/policy')
+    findingsEnabled.value = Boolean(policy?.enabled)
+  } catch (err) {
+    // A policy we cannot read is treated as disabled: showing an action that
+    // cannot work is worse than hiding one that might (GH#12734).
+    logger.error('Failed to load findings policy', err)
+    findingsEnabled.value = false
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([loadProjects(), loadFindingsPolicy()])
+})
 </script>
 
 <style scoped>
+.findings-disabled-note {
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
 .llc-browser {
   padding: 1.5rem;
 }

--- a/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.findings.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.findings.test.ts
@@ -80,11 +80,15 @@ const PROPOSAL = {
   dismiss_reason: null,
 }
 
-function makeGetMock(proposals: unknown[] = [PROPOSAL]) {
+function makeGetMock(proposals: unknown[] = [PROPOSAL], findingsEnabled = true) {
   return (url?: string) => {
     if (url?.endsWith('/projects')) return Promise.resolve([PROJECT_WITH_REPO])
     if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
     if (url?.includes('/findings/proposals')) return Promise.resolve(proposals)
+    // GH#12734: the scan button is gated on the server-side findings policy,
+    // which is OFF by default. These tests exercise the scan flow, so the
+    // policy is enabled unless a test opts out.
+    if (url?.includes('/findings/policy')) return Promise.resolve({ enabled: findingsEnabled })
     return Promise.resolve([])
   }
 }
@@ -129,6 +133,32 @@ describe('ProjectBrowserView findings proposal queue (GH#11271 T8)', () => {
     // After scan, proposals list re-fetch should have been called
     const getCalls = get.mock.calls.map(c => c[0] as string)
     expect(getCalls.some(u => u?.includes('/findings/proposals'))).toBe(true)
+  })
+
+  // GH#12734: the findings feature is OFF by default, so an ungated button
+  // could only ever return 403 on a stock install.
+  it('hides the Scan button when the findings policy is disabled', async () => {
+    get.mockImplementation(makeGetMock([], false))
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const scanBtn = wrapper.findAll('button').find(b => b.text().includes('Scan'))
+    expect(scanBtn).toBeUndefined()
+    expect(wrapper.text()).toContain(en.llcBrowser.findings.disabled)
+  })
+
+  it('treats an unreadable findings policy as disabled', async () => {
+    // Offering an action that cannot work is worse than hiding one that might.
+    get.mockImplementation((url?: string) => {
+      if (url?.includes('/findings/policy')) return Promise.reject(new Error('boom'))
+      return makeGetMock([])(url)
+    })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    expect(wrapper.findAll('button').find(b => b.text().includes('Scan'))).toBeUndefined()
   })
 
   it('Promote button calls POST /api/llc/findings/proposals/{id}/promote and refreshes', async () => {


### PR DESCRIPTION
Closes #12734

## Thinking Path

The button was gated only on `code_source_id`, but the findings feature is **OFF by default**, so on a stock install it rendered prominently and every click returned `403 "Findings feature is disabled"`.

The interesting part is why the frontend was written that way: **it could not have gated on the policy.** `get_findings_policy()` was readable only inside the backend and exposed by no endpoint —

```
$ grep "@router.get" llc/api/*.py | grep -i "polic|settings|config|feature"
(nothing)
```

A client cannot gate on a value it has no way to read, so fixing only the Vue file was not possible. Both halves were needed.

Two deliberate choices on the response shape and defaults:

- **The endpoint omits `verify_batch_size` and `run_on_index`.** Those are SLM-side operational tuning. Returning the whole policy because it was convenient would invite the UI to react to values it has no business reading, and make them de-facto public API.
- **State defaults to disabled, and a failed policy load is treated as disabled.** Defaulting to enabled would flash the button in during load and then remove it, and would resurrect the exact bug whenever the policy call fails. Offering an action that cannot work is worse than hiding one that might.

## What Changed

- **`llc/api/findings.py`** — `GET /api/llc/findings/policy` returning `enabled` / `min_severity` / `require_approval_to_promote`, behind the same `get_current_user` + `require_org_context` dependencies as the rest of the findings API.
- **`views/llc/ProjectBrowserView.vue`** — loads the policy on mount (in parallel with projects), renders the scan button only when enabled, and otherwise shows the existing disabled note. The proposals list below is unaffected, so previously-created proposals stay visible either way.

**No new UI strings.** The disabled note reuses `llcBrowser.findings.disabled`, verified present in all 11 locales:

```
ar YES | de YES | en YES | es YES | fa YES | fr YES
he YES | lv YES | pl YES | pt YES | ur YES
```

## Verification

```
llc/tests/test_findings_api.py    17 passed
```

New tests cover: the endpoint reporting the default-off state, reporting an enabled policy with its severity/approval fields, **not** leaking `verify_batch_size` / `run_on_index`, and carrying both auth dependencies on the route (so the new endpoint cannot silently become unauthenticated).

Frontend type-check could not be run locally — `node_modules` is absent in the worktree, so `vue-tsc` reports "Cannot find module 'vue'" for every import rather than anything about this change. CI covers it.

## Model Used

Claude Opus 5
