### PR TITLE
fix(tests): conftest re-executed already-loaded modules, breaking isinstance across the suite (#12839)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -78,6 +78,22 @@ def _real_load_and_bind(name: str, path: Path) -> None:
     """
     import importlib.util as _rlb_ilu
 
+    # #12839: never re-execute a module that is ALREADY real-loaded from this
+    # same file. Re-executing builds a second set of class objects and swaps
+    # them into sys.modules, while every module that imported the first set
+    # keeps referencing it — so `isinstance(x, Cls)` fails against an object
+    # whose repr says it IS a Cls. That is what broke test_claim_classifier:
+    # services.claim_classifier imported .knowledge_grounding_models at
+    # collection, then _real_load_light_services re-executed the same file.
+    # Re-execution is only needed to replace a *stub*, so an already-real module
+    # is left alone and only the parent bind below is (re)applied.
+    _existing = sys.modules.get(name)
+    if _existing is not None and getattr(_existing, "__file__", None) == str(path):
+        parent, _, child = name.rpartition(".")
+        if parent and parent in sys.modules:
+            setattr(sys.modules[parent], child, _existing)
+        return
+
     spec = _rlb_ilu.spec_from_file_location(name, str(path))
     if not spec or not spec.loader:
         return

--- a/autobot-backend/tests/services/test_claim_classifier.py
+++ b/autobot-backend/tests/services/test_claim_classifier.py
@@ -31,8 +31,22 @@ from services.knowledge_grounding_models import (
 
 @pytest.fixture
 def mock_knowledge_base():
-    """Create a mock knowledge base."""
-    kb = MagicMock()
+    """Create a mock knowledge base exposing ONLY the sync search API (#12839).
+
+    ClaimClassifier._search_kb prefers ``search_async`` when the KB has it:
+
+        if hasattr(self.kb, "search_async"): results = await self.kb.search_async(...)
+        elif hasattr(self.kb, "search"):     results = self.kb.search(...)
+
+    A bare ``MagicMock()`` auto-creates every attribute, so ``hasattr(kb,
+    "search_async")`` was True and the classifier awaited a plain MagicMock —
+    "object MagicMock can't be used in 'await' expression". The classifier
+    caught that, logged it and returned no results, so the test asserted
+    against a degraded path instead of the one it meant to exercise.
+
+    ``spec`` pins the attribute surface so the hasattr probe answers honestly.
+    """
+    kb = MagicMock(spec=["search"])
     kb.search = MagicMock(return_value=[])
     return kb
 

--- a/autobot-backend/tests/test_conftest_real_load_identity.py
+++ b/autobot-backend/tests/test_conftest_real_load_identity.py
@@ -58,9 +58,9 @@ def test_already_real_module_is_not_re_executed(loader, tmp_path):
 
     try:
         assert second is first, "module was re-executed and replaced"
-        assert second.Marker is first_marker, (
-            "class object was rebuilt — isinstance() against the original would now fail"
-        )
+        assert (
+            second.Marker is first_marker
+        ), "class object was rebuilt — isinstance() against the original would now fail"
     finally:
         sys.modules.pop("identity_probe_mod", None)
 

--- a/autobot-backend/tests/test_conftest_real_load_identity.py
+++ b/autobot-backend/tests/test_conftest_real_load_identity.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""`_real_load_and_bind` must never duplicate an already-real module (#12839).
+
+Re-executing a module that is already loaded builds a *second* set of class
+objects and swaps them into ``sys.modules``, while every module that imported
+the first set keeps referencing it. The result is the confusing failure this
+test exists to prevent:
+
+    assert isinstance(result, Claim)
+    E   AssertionError: assert False
+    E    +  where False = isinstance(Claim(claim_text=...), Claim)
+
+— an object whose repr says it IS a Claim, rejected by isinstance, because the
+two Claim classes come from two executions of the same file.
+"""
+
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def loader():
+    """The real helper from the backend root conftest.
+
+    Loaded by path rather than ``import conftest``: pytest imports conftest
+    files under its own machinery, so a plain import can resolve to a different
+    conftest (or none) depending on rootdir.
+    """
+    import importlib.util
+    import sys as _sys
+    from pathlib import Path
+
+    conftest_path = Path(__file__).parent.parent / "conftest.py"
+    mod = _sys.modules.get("_conftest_under_test")
+    if mod is None:
+        spec = importlib.util.spec_from_file_location("_conftest_under_test", conftest_path)
+        mod = importlib.util.module_from_spec(spec)
+        _sys.modules["_conftest_under_test"] = mod
+        spec.loader.exec_module(mod)
+    return mod._real_load_and_bind
+
+
+def test_already_real_module_is_not_re_executed(loader, tmp_path):
+    """A second call must return the SAME module object, not a fresh execution."""
+    mod_file = tmp_path / "identity_probe.py"
+    mod_file.write_text("class Marker:\n    pass\n", encoding="utf-8")
+
+    loader("identity_probe_mod", mod_file)
+    first = sys.modules["identity_probe_mod"]
+    first_marker = first.Marker
+
+    loader("identity_probe_mod", mod_file)
+    second = sys.modules["identity_probe_mod"]
+
+    try:
+        assert second is first, "module was re-executed and replaced"
+        assert second.Marker is first_marker, (
+            "class object was rebuilt — isinstance() against the original would now fail"
+        )
+    finally:
+        sys.modules.pop("identity_probe_mod", None)
+
+
+def test_isinstance_survives_a_repeat_load(loader, tmp_path):
+    """The concrete symptom: an instance made before the second load stays valid."""
+    mod_file = tmp_path / "iso_probe.py"
+    mod_file.write_text("class Thing:\n    pass\n", encoding="utf-8")
+
+    loader("iso_probe_mod", mod_file)
+    instance = sys.modules["iso_probe_mod"].Thing()
+
+    loader("iso_probe_mod", mod_file)
+    Thing = sys.modules["iso_probe_mod"].Thing
+
+    try:
+        assert isinstance(instance, Thing)
+    finally:
+        sys.modules.pop("iso_probe_mod", None)
+
+
+def test_a_stub_is_still_replaced_by_the_real_module(loader, tmp_path):
+    """The guard must not defeat the loader's actual purpose.
+
+    Replacing a MagicMock package stub with the real module is why this helper
+    exists (#11532/#11618); only an already-*real* module is skipped.
+    """
+    from unittest.mock import MagicMock
+
+    mod_file = tmp_path / "stubbed_probe.py"
+    mod_file.write_text("REAL = True\n", encoding="utf-8")
+
+    sys.modules["stubbed_probe_mod"] = MagicMock()
+    loader("stubbed_probe_mod", mod_file)
+
+    try:
+        assert getattr(sys.modules["stubbed_probe_mod"], "REAL", None) is True
+    finally:
+        sys.modules.pop("stubbed_probe_mod", None)
+
+
+def test_parent_bind_is_applied_on_the_skip_path(loader, tmp_path):
+    """patch("pkg.mod.NAME") resolves via getattr(pkg, "mod") — the bind is load-bearing.
+
+    Skipping re-execution must not skip the bind, or patch() would silently
+    patch a mock instead of the real module (#11532).
+    """
+    from types import ModuleType
+
+    pkg = ModuleType("bindpkg_probe")
+    sys.modules["bindpkg_probe"] = pkg
+
+    mod_file = tmp_path / "child.py"
+    mod_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+    loader("bindpkg_probe.child", mod_file)
+    delattr(pkg, "child")  # simulate a stub clobbering the attribute
+    loader("bindpkg_probe.child", mod_file)  # skip path — must re-bind anyway
+
+    try:
+        assert getattr(pkg, "child", None) is sys.modules["bindpkg_probe.child"]
+    finally:
+        sys.modules.pop("bindpkg_probe.child", None)
+        sys.modules.pop("bindpkg_probe", None)


### PR DESCRIPTION
Closes #12839

## Thinking Path

Two failing tests, and I assumed one cause. There were two independent defects — fixing the obvious one left both tests still red, which is what forced the second investigation.

**Defect 1 — the KB mock lied about its own interface.** `ClaimClassifier._search_kb` picks its branch with `hasattr`:

```python
if hasattr(self.kb, "search_async"):   results = await self.kb.search_async(...)
elif hasattr(self.kb, "search"):       results = self.kb.search(...)
```

The fixture was a bare `MagicMock()`, which auto-creates **every** attribute, so `hasattr(kb, "search_async")` was True and the classifier awaited a plain MagicMock — `object MagicMock can't be used in 'await' expression`. The classifier caught that, logged it, and returned no results, so the test was quietly asserting against a degraded error path instead of the one it meant to exercise. `spec=["search"]` makes the probe answer honestly.

**Defect 2 — the same module executed twice.** Fixing the mock did *not* fix `isinstance`, so the duplicate-identity theory needed proof rather than assumption. A stack probe in `knowledge_grounding_models.py` during a real pytest run showed both executions:

```
### EXEC knowledge_grounding_models
  services/claim_classifier.py:31  from .knowledge_grounding_models import (

### EXEC knowledge_grounding_models
  conftest.py:1141  pytest_configure -> _real_load_light_services()
  conftest.py:1118  _real_load_and_bind(f"services.{name}", svc_path)
```

`_real_load_and_bind` re-executes the file and swaps a fresh module into `sys.modules`, while `services.claim_classifier` keeps holding the classes from the first execution. Hence `isinstance(x, Claim)` returning False for an object whose repr says it **is** a `Claim`, with only one `sys.modules` entry to inspect.

Re-execution exists solely to replace a MagicMock stub, so an already-real module loaded from that same path is now left alone. The parent bind is still (re)applied on that skip path — `patch("pkg.mod.NAME")` resolves via `getattr(pkg, "mod")`, and dropping it would resurrect the inert-patch bug from #11532/#11618. That case has its own test.

## What Changed

- **`conftest.py`** — `_real_load_and_bind` returns early when `sys.modules[name].__file__` already matches the target path, after re-applying the parent bind.
- **`tests/services/test_claim_classifier.py`** — KB fixture uses `MagicMock(spec=["search"])`.
- **`tests/test_conftest_real_load_identity.py`** (new) — pins the loader invariant.

## Verification

`conftest.py` is loaded by every backend test, so this was measured against a pristine `origin/Dev_new_gui` worktree using an identical command:

```
baseline: 14 failed, 5304 passed, 130 skipped
branch:   12 failed, 5310 passed, 130 skipped

failures only on this branch (regressions):  NONE
failures fixed:  test_claim_classifier.py::TestIndividualClassification::test_classify_claim_basic
                 test_claim_classifier.py::TestBatchClassification::test_batch_classify_single_claim
```

The 12 remaining failures are byte-identical on both trees (gitlab/gitea connector tests requiring a live Redis, etc.) and are untouched here. The +6 passes are the 2 fixed tests plus 4 new ones covering: an already-real module is not re-executed, an instance stays `isinstance`-valid across a repeat load, a stub **is** still replaced by the real module, and the parent bind is applied on the skip path.

**A note on the first verification attempt**, since it nearly produced a false conclusion: running `tests/ llc/tests/` together reported *"Interrupted: 49 errors during collection"*, which looked like this change breaking the suite. The identical command on the pristine baseline produced exactly the same 49 errors — pre-existing, triggered by combining those two paths in one invocation, and it meant nothing had actually executed. The numbers above come from a subset that collects cleanly on both trees.

## Model Used

Claude Opus 5
