### PR TITLE
feat(deploy): post-hoc self-update log verdict — a half-finished run no longer reports success (#12776)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -666,6 +666,11 @@ async def get_sync_status(
     # so the endpoint never reads "up to date" while a managed component is stale.
     stale_components = await _compute_stale_components()
 
+    # #12776: the self-update path restarts this backend mid-run, so nothing
+    # in-process can assert the playbook finished. Read the verdict off the log
+    # instead, so a run that died before Play 2 stops being reported as success.
+    verdict = _read_last_self_update_verdict()
+
     return CodeSyncStatusResponse(
         latest_version=latest_version,
         local_version=local_version,
@@ -674,7 +679,21 @@ async def get_sync_status(
         outdated_nodes=outdated_nodes,
         total_nodes=total_nodes,
         stale_components=stale_components,
+        self_update_incomplete=verdict.degraded,
+        self_update_detail=verdict.reason,
     )
+
+
+def _read_last_self_update_verdict():
+    """Verdict for the last self-update run; never fails the status endpoint (#12776)."""
+    from services.playbook_executor import SELF_UPDATE_LOG_PATH
+    from services.self_update_log_reader import SelfUpdateVerdict, read_self_update_verdict
+
+    try:
+        return read_self_update_verdict(SELF_UPDATE_LOG_PATH)
+    except Exception as exc:  # noqa: BLE001 — status must answer even if this cannot
+        logger.warning("self-update verdict unavailable: %s", exc)
+        return SelfUpdateVerdict(reason=None)
 
 
 @router.get("/drift", response_model=FileDriftReport)

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -1634,6 +1634,13 @@ class CodeSyncStatusResponse(BaseModel):
     # Non-empty means a managed component is stale even if node code_version
     # matches latest — so consumers must not report "up to date" while this is set.
     stale_components: list[str] = []
+    # #12776: post-hoc verdict on the last self-update run. The self-update path
+    # restarts this backend mid-run by design, so the process that launched the
+    # playbook is gone before it finishes — completion can only be judged from
+    # the log afterwards. Without this, a run that died after Play 1 still
+    # reported a successful update (#12596, invisible across two fix attempts).
+    self_update_incomplete: bool = False
+    self_update_detail: str | None = None
 
 
 class CodeSyncRefreshResponse(BaseModel):

--- a/autobot-slm-backend/services/self_update_log_reader.py
+++ b/autobot-slm-backend/services/self_update_log_reader.py
@@ -1,0 +1,133 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Post-hoc completion verdict for the last self-update run (#12776).
+
+``SELF_UPDATE_LOG_PATH`` was write-only: the executor wrote it and nothing ever
+read it back. That is precisely why #12596 stayed invisible across two fix
+attempts — the detached run died at the end of Play 1, Plays 2/3 never executed,
+and the SLM still reported a successful update. The evidence needed to catch it
+was sitting in a log nobody parsed.
+
+A post-hoc reader is structurally required rather than an in-process assertion:
+on the self-update path this backend is **restarted mid-run by design**, so the
+process that launched the playbook is gone before the playbook finishes.
+Completion can only be judged after the fact, on a later start.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Ansible emits "PLAY [name] ****" per play and one "PLAY RECAP" at the end.
+# A run that produced no RECAP did not finish, whatever else it logged.
+_PLAY_HEADER = re.compile(r"^PLAY \[(?P<name>[^\]]*)\]", re.MULTILINE)
+_PLAY_RECAP = re.compile(r"^PLAY RECAP", re.MULTILINE)
+# RECAP lines look like: host : ok=12 changed=3 unreachable=0 failed=0 skipped=1
+_RECAP_COUNTS = re.compile(r"\b(?P<key>failed|unreachable)=(?P<count>\d+)")
+
+# Read a bounded tail: these logs can be large, and everything the verdict needs
+# (play headers and the recap) is cheap to find without holding the whole file.
+MAX_LOG_BYTES = 512 * 1024
+
+
+@dataclass
+class SelfUpdateVerdict:
+    """What the last self-update run actually did."""
+
+    log_present: bool = False
+    complete: bool = False
+    plays_seen: list[str] = field(default_factory=list)
+    failed_hosts: int = 0
+    unreachable_hosts: int = 0
+    reason: str | None = None
+
+    @property
+    def degraded(self) -> bool:
+        """True when the run cannot be treated as a successful update.
+
+        A missing log is NOT degraded: a box that has never self-updated has
+        nothing to report, and flagging that would cry wolf on every fresh
+        install.
+        """
+        if not self.log_present:
+            return False
+        return not self.complete or self.failed_hosts > 0 or self.unreachable_hosts > 0
+
+
+def _read_tail(path: Path, max_bytes: int = MAX_LOG_BYTES) -> str | None:
+    """Return the last *max_bytes* of *path*, or None when it cannot be read."""
+    try:
+        size = path.stat().st_size
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+                fh.readline()  # discard the partial line the seek landed in
+            return fh.read()
+    except (OSError, ValueError) as exc:
+        logger.warning("self-update log unreadable at %s: %s", path, exc)
+        return None
+
+
+def read_self_update_verdict(log_path: Path) -> SelfUpdateVerdict:
+    """Parse *log_path* and report whether the last self-update run completed.
+
+    Never raises: a status endpoint must not fail because a log is missing or
+    malformed. An unreadable log yields ``log_present=False``, which is treated
+    as "nothing to say" rather than as a failure.
+    """
+    if not log_path.exists():
+        return SelfUpdateVerdict(reason="no self-update log yet")
+
+    text = _read_tail(log_path)
+    if text is None:
+        return SelfUpdateVerdict(reason=f"self-update log unreadable: {log_path}")
+
+    plays = _PLAY_HEADER.findall(text)
+    has_recap = bool(_PLAY_RECAP.search(text))
+
+    failed = unreachable = 0
+    if has_recap:
+        recap = text[text.rindex("PLAY RECAP") :]
+        for m in _RECAP_COUNTS.finditer(recap):
+            if m.group("key") == "failed":
+                failed += int(m.group("count"))
+            else:
+                unreachable += int(m.group("count"))
+
+    verdict = SelfUpdateVerdict(
+        log_present=True,
+        complete=has_recap,
+        plays_seen=plays,
+        failed_hosts=failed,
+        unreachable_hosts=unreachable,
+    )
+    verdict.reason = _describe(verdict)
+    if verdict.degraded:
+        logger.error("self-update verdict: %s", verdict.reason)
+    return verdict
+
+
+def _describe(v: SelfUpdateVerdict) -> str:
+    """Human-readable reason, naming what is missing rather than just 'failed'."""
+    if not v.complete:
+        seen = ", ".join(v.plays_seen) if v.plays_seen else "none"
+        return (
+            f"self-update run did not finish — no PLAY RECAP in the log "
+            f"(plays started: {seen}). The run was cut short; later plays did not execute."
+        )
+    if v.unreachable_hosts:
+        return f"self-update finished with {v.unreachable_hosts} unreachable host(s)"
+    if v.failed_hosts:
+        return f"self-update finished with {v.failed_hosts} failed task(s)"
+    return f"self-update completed ({len(v.plays_seen)} plays, no failures)"
+
+
+__all__ = ["SelfUpdateVerdict", "read_self_update_verdict", "MAX_LOG_BYTES"]

--- a/autobot-slm-backend/tests/services/test_self_update_log_reader.py
+++ b/autobot-slm-backend/tests/services/test_self_update_log_reader.py
@@ -1,0 +1,179 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The self-update log must yield a completion verdict (#12776).
+
+Before this, SELF_UPDATE_LOG_PATH was write-only. #12596 — a run that died at
+the end of Play 1, so Plays 2/3 never executed — was reported as a successful
+update across two fix attempts, because nothing read the log back.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_reader():
+    """Load the module for real, past the conftest's session-global services stub.
+
+    Mirrors the pattern in test_self_update_systemd_detach_11492.py — without it
+    ``from services.self_update_log_reader import ...`` yields a MagicMock and
+    every assertion below would pass vacuously against mock attributes.
+    """
+    from unittest.mock import MagicMock
+
+    # autobot_shared.logging_manager builds a real RotatingFileHandler at import;
+    # under the suite's stubs its size args are MagicMocks and it raises. The
+    # reader only needs a logger object, so stub that one module for the load.
+    saved = sys.modules.get("autobot_shared.logging_manager")
+    sys.modules["autobot_shared.logging_manager"] = MagicMock()
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_sulr_12776", _BACKEND_ROOT / "services" / "self_update_log_reader.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["_sulr_12776"] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if saved is None:
+            sys.modules.pop("autobot_shared.logging_manager", None)
+        else:
+            sys.modules["autobot_shared.logging_manager"] = saved
+
+
+read_self_update_verdict = _load_reader().read_self_update_verdict
+
+_COMPLETE = """\
+PLAY [Play 1 - Prepare] ********************************************************
+TASK [sync code] ***************************************************************
+ok: [localhost]
+PLAY [Play 2 - Deploy app tier] ************************************************
+TASK [restart services] ********************************************************
+changed: [localhost]
+PLAY RECAP *********************************************************************
+localhost : ok=12 changed=3 unreachable=0 failed=0 skipped=1
+"""
+
+# The #12596 shape: Play 1 ran, then the process was killed. No Play 2, no RECAP.
+_TRUNCATED = """\
+PLAY [Play 1 - Prepare] ********************************************************
+TASK [sync code] ***************************************************************
+ok: [localhost]
+TASK [restart slm] *************************************************************
+changed: [localhost]
+"""
+
+_FAILED = """\
+PLAY [Play 1 - Prepare] ********************************************************
+PLAY [Play 2 - Deploy app tier] ************************************************
+PLAY RECAP *********************************************************************
+localhost : ok=4 changed=1 unreachable=0 failed=2 skipped=0
+"""
+
+_UNREACHABLE = """\
+PLAY [Play 1 - Prepare] ********************************************************
+PLAY RECAP *********************************************************************
+node-a : ok=0 changed=0 unreachable=1 failed=0 skipped=0
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    p = tmp_path / "self-update-ansible.log"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_complete_run_is_not_degraded(tmp_path):
+    v = read_self_update_verdict(_write(tmp_path, _COMPLETE))
+
+    assert v.log_present and v.complete
+    assert v.degraded is False
+    assert v.plays_seen == ["Play 1 - Prepare", "Play 2 - Deploy app tier"]
+    assert v.failed_hosts == 0 and v.unreachable_hosts == 0
+
+
+def test_run_that_died_after_play_one_is_degraded(tmp_path):
+    v = read_self_update_verdict(_write(tmp_path, _TRUNCATED))
+
+    assert v.log_present
+    assert v.complete is False
+    assert v.degraded is True, "a run with no PLAY RECAP must not read as success"
+    assert v.plays_seen == ["Play 1 - Prepare"]
+    assert "did not finish" in v.reason
+    # The reason must name what was seen, so an operator knows how far it got.
+    assert "Play 1 - Prepare" in v.reason
+
+
+def test_failed_tasks_make_a_completed_run_degraded(tmp_path):
+    v = read_self_update_verdict(_write(tmp_path, _FAILED))
+
+    assert v.complete is True  # it did reach a RECAP
+    assert v.failed_hosts == 2
+    assert v.degraded is True, "reaching RECAP is not enough when tasks failed"
+    assert "2 failed" in v.reason
+
+
+def test_unreachable_hosts_make_a_run_degraded(tmp_path):
+    v = read_self_update_verdict(_write(tmp_path, _UNREACHABLE))
+
+    assert v.unreachable_hosts == 1
+    assert v.degraded is True
+    assert "unreachable" in v.reason
+
+
+def test_missing_log_is_not_degraded(tmp_path):
+    """A box that never self-updated has nothing to report — do not cry wolf."""
+    v = read_self_update_verdict(tmp_path / "absent.log")
+
+    assert v.log_present is False
+    assert v.degraded is False
+    assert v.complete is False
+
+
+def test_unreadable_log_does_not_raise(tmp_path):
+    """A status endpoint must not fail because a log is a directory or unreadable."""
+    d = tmp_path / "self-update-ansible.log"
+    d.mkdir()
+
+    v = read_self_update_verdict(d)
+
+    assert v.degraded is False
+    assert v.log_present is False
+
+
+def test_only_the_last_recap_is_counted(tmp_path):
+    """Appended runs: an old failure must not condemn a later clean run."""
+    text = _FAILED + "\n" + _COMPLETE
+    v = read_self_update_verdict(_write(tmp_path, text))
+
+    assert v.complete is True
+    assert v.failed_hosts == 0, "counts must come from the LAST recap, not every recap"
+    assert v.degraded is False
+
+
+def test_large_log_is_read_from_the_tail(tmp_path):
+    """Logs can be large; the verdict must still see the end of the run."""
+    padding = "TASK [noise] " + "*" * 200 + "\n"
+    text = padding * 6000 + _COMPLETE
+    p = _write(tmp_path, text)
+    assert p.stat().st_size > 512 * 1024
+
+    v = read_self_update_verdict(p)
+
+    assert v.complete is True
+    assert v.degraded is False
+
+
+@pytest.mark.parametrize("empty", ["", "\n\n"])
+def test_empty_log_is_degraded(tmp_path, empty):
+    """An empty log means a run started and produced nothing — not a success."""
+    v = read_self_update_verdict(_write(tmp_path, empty))
+
+    assert v.log_present is True
+    assert v.degraded is True


### PR DESCRIPTION
Closes #12776

## Thinking Path

`SELF_UPDATE_LOG_PATH` was **write-only** — `grep -rn SELF_UPDATE_LOG_PATH` found only the writer in `playbook_executor.py` and its tests. That is exactly why #12596 survived two fix attempts (#12425, #12567): the detached run died at the end of Play 1, Plays 2/3 never executed, and the SLM still reported a successful update. The evidence needed to catch it was sitting in a log nobody parsed.

**Why a post-hoc reader rather than an in-process assertion.** On the self-update path this backend is restarted mid-run *by design*, so the process that launched the playbook is gone before the playbook finishes. There is no moment at which the launching process can check the outcome — completion is only knowable after the fact.

Two judgement calls in the verdict logic:

- **A missing log is not degraded.** A box that has never self-updated has nothing to report. Treating absence as failure would cry wolf on every fresh install and train operators to ignore the flag.
- **Reaching a RECAP is not sufficient.** Non-zero `failed=` / `unreachable=` counts are degraded too — otherwise a playbook that ran to completion while failing every task would report as success, which is the same class of bug in a different disguise.

Counts come from the **last** recap only. Logs are appended across runs, and an old failure must not condemn a later clean run — that has its own test.

## What Changed

- **`services/self_update_log_reader.py`** (new) — parses the log tail for `PLAY [` headers, `PLAY RECAP`, and the recap's `failed=` / `unreachable=` counts. Bounded read (512KB tail): these logs grow, and everything the verdict needs is at the end.
- **`GET /api/code-sync/status`** — now returns `self_update_incomplete` and `self_update_detail`, so a run that ended without a RECAP surfaces as degraded instead of leaving the previous "up to date" answer standing.

The status endpoint can never fail because of this: an unreadable log yields `log_present=False`, and the call site catches anything else.

## Verification

```
tests/services/test_self_update_log_reader.py     10 passed  (new)
self_update / code_sync / playbook selection     170 passed
```

Tests cover the **#12596 shape specifically** (Play 1 only, no RECAP → degraded, with the reason naming how far it got), completed-with-failures, unreachable hosts, missing log, a log path that is a *directory*, last-recap-only counting, tail reading on a >512KB log, and empty logs.

**Mutation-verified** — forcing `degraded` to always return `False`:
```
5 failed, 5 passed
```

**Test-integrity note:** the module is loaded via `importlib` past the suite's session-global `services` stub, mirroring `test_self_update_systemd_detach_11492.py`. Without that, `from services.self_update_log_reader import ...` returns a `MagicMock` and every assertion passes vacuously against mock attributes — I hit exactly that on the first run, where 10 tests "passed" against nothing.

## Scope

This gives the failure *class* a detector, which is the point: even with #12775 merged, any future change to the detach path, playbook ordering, or restart handlers could reintroduce a silent mid-run death. #12596 itself stays open pending its live Play-2 verification.

## Model Used

Claude Opus 5
