### PR TITLE
fix(config): blank env vars no longer defeat default fallbacks (#12858)

### DIFF
--- a/autobot-backend/tests/test_env_utils_blank_values.py
+++ b/autobot-backend/tests/test_env_utils_blank_values.py
@@ -1,0 +1,113 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A blank env var must behave as absent, not as a value (#12782).
+
+A deployment template that renders an undefined variable exports ``NAME=``
+instead of omitting the line. That blank is worse than absence: it looks "set"
+to any presence check, and ``os.environ.get(name, default)`` returns ``""`` —
+not the default — so every default-argument fallback is silently defeated.
+
+Observed on a live node as six settings collapsing to defaults with confusing
+"Invalid X=''" warnings every boot, and previously as #12778, where a blank
+REDIS_HOST defeated its fallback and the backend refused to connect.
+"""
+
+import pytest
+
+from autobot_shared.env_utils import (
+    env_flag,
+    env_float,
+    env_int,
+    env_int_clamped,
+    env_raw,
+    env_str,
+)
+
+_BLANKS = ["", "   ", "\t", "\n"]
+
+
+@pytest.mark.parametrize("blank", _BLANKS)
+def test_env_raw_treats_blank_as_absent(monkeypatch, blank):
+    monkeypatch.setenv("PROBE_VAR", blank)
+    assert env_raw("PROBE_VAR") is None
+
+
+def test_env_raw_preserves_a_real_value(monkeypatch):
+    monkeypatch.setenv("PROBE_VAR", " actual ")
+    assert env_raw("PROBE_VAR") == " actual "
+
+
+@pytest.mark.parametrize("blank", _BLANKS)
+def test_env_str_falls_back_on_blank(monkeypatch, blank):
+    """The os.environ.get(k, default) trap: a blank returns "" instead of the default."""
+    monkeypatch.setenv("PROBE_VAR", blank)
+
+    import os
+
+    assert os.environ.get("PROBE_VAR", "fallback") != "fallback"  # the trap, pinned
+    assert env_str("PROBE_VAR", "fallback") == "fallback"  # the fix
+
+
+@pytest.mark.parametrize("blank", _BLANKS)
+def test_env_int_falls_back_on_blank_without_a_warning(monkeypatch, caplog, blank):
+    """A blank is a deployment artefact, not an invalid integer.
+
+    It previously reached int("") and was reported as
+    "AUTOBOT_CHAT_SESSION_CACHE_TTL='' is not an integer" on every boot — noise
+    that trains operators to ignore the warning stream.
+    """
+    monkeypatch.setenv("PROBE_VAR", blank)
+
+    with caplog.at_level("WARNING"):
+        assert env_int("PROBE_VAR", 86400) == 86400
+
+    assert not [r for r in caplog.records if "PROBE_VAR" in r.getMessage()]
+
+
+def test_env_int_still_warns_on_a_genuinely_invalid_value(monkeypatch, caplog):
+    """Blank-tolerance must not silence real misconfiguration."""
+    monkeypatch.setenv("PROBE_VAR", "not-a-number")
+
+    with caplog.at_level("WARNING"):
+        assert env_int("PROBE_VAR", 7) == 7
+
+    assert any("PROBE_VAR" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.parametrize("blank", _BLANKS)
+def test_env_float_falls_back_on_blank(monkeypatch, blank):
+    monkeypatch.setenv("PROBE_VAR", blank)
+    assert env_float("PROBE_VAR", 1.5) == 1.5
+
+
+@pytest.mark.parametrize("blank", _BLANKS)
+def test_env_int_clamped_falls_back_on_blank(monkeypatch, blank):
+    monkeypatch.setenv("PROBE_VAR", blank)
+    assert env_int_clamped("PROBE_VAR", 50, min_v=1, max_v=100) == 50
+
+
+@pytest.mark.parametrize("blank", _BLANKS)
+def test_blank_does_not_silently_disable_a_default_on_flag(monkeypatch, blank):
+    """The sharpest case: truthy("") is False, so a blank would flip a default-True flag OFF."""
+    monkeypatch.setenv("PROBE_VAR", blank)
+
+    assert env_flag("PROBE_VAR", default=True) is True
+    assert env_flag("PROBE_VAR", default=False) is False
+
+
+def test_flag_still_honours_an_explicit_false(monkeypatch):
+    monkeypatch.setenv("PROBE_VAR", "false")
+    assert env_flag("PROBE_VAR", default=True) is False
+
+
+def test_absent_var_behaves_the_same_as_blank(monkeypatch):
+    """The whole point: absent and blank must be indistinguishable to callers."""
+    monkeypatch.delenv("PROBE_VAR", raising=False)
+    absent = (env_raw("PROBE_VAR"), env_str("PROBE_VAR", "d"), env_int("PROBE_VAR", 3), env_flag("PROBE_VAR", True))
+
+    monkeypatch.setenv("PROBE_VAR", "")
+    blank = (env_raw("PROBE_VAR"), env_str("PROBE_VAR", "d"), env_int("PROBE_VAR", 3), env_flag("PROBE_VAR", True))
+
+    assert absent == blank

--- a/autobot_shared/env_utils.py
+++ b/autobot_shared/env_utils.py
@@ -9,13 +9,37 @@ import os
 logger = logging.getLogger(__name__)
 
 
+def env_raw(name: str) -> str | None:
+    """Read an env var, treating a blank value as absent (#12782).
+
+    A deployment template that renders an undefined variable exports ``NAME=``
+    rather than omitting the line. That blank is worse than absence: it looks
+    "set" to any presence check, and ``os.environ.get(name, default)`` returns
+    ``""`` — NOT the default — so every default-argument fallback in the codebase
+    is silently defeated. Same root pattern as #12778, where a blank REDIS_HOST
+    defeated its fallback and the backend refused to connect.
+
+    Collapsing blank to ``None`` here means callers get their default rather than
+    an empty string that only fails later, at parse time or at use.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    return raw
+
+
+def env_str(name: str, default: str) -> str:
+    """Read a string env var, falling back to *default* when absent OR blank (#12782)."""
+    return env_raw(name) or default
+
+
 def env_float(name: str, default: float) -> float:
     """Read a float environment variable, falling back to *default* on absence or bad value.
 
     Returns *default* silently when the var is absent.
     Logs a warning and returns *default* when the var is set but not a valid float.
     """
-    raw = os.environ.get(name)
+    raw = env_raw(name)
     if raw is None:
         return default
     try:
@@ -31,7 +55,7 @@ def env_int(name: str, default: int) -> int:
     Returns *default* silently when the var is absent.
     Logs a warning and returns *default* when the var is set but not a valid integer.
     """
-    raw = os.environ.get(name)
+    raw = env_raw(name)
     if raw is None:
         return default
     try:
@@ -53,7 +77,7 @@ def env_int_clamped(
     valid integer.  Returns *default* silently when the var is absent.
     Clamps to [min_v, max_v] when either bound is provided.
     """
-    raw = os.environ.get(name)
+    raw = env_raw(name)
     if raw is None:
         value = default
     else:
@@ -91,5 +115,7 @@ def env_flag(name: str, default: bool = False) -> bool:
     this everywhere guarantees ``on``/``yes``/``true``/``1`` behave identically
     across all flags.
     """
-    raw = os.environ.get(name)
+    # #12782: a blank export must yield the default, not truthy("") -> False.
+    # A flag defaulting to True would otherwise silently flip off.
+    raw = env_raw(name)
     return default if raw is None else truthy(raw)


### PR DESCRIPTION
Closes #12858

Contributes to #12782 (fix #2 — the read-side defence) but does **not** close it; #12782 stays open for its live-node items. #12858 is the discrete, fully-delivered scope this PR closes.

## Thinking Path

The live symptom was six settings collapsing to defaults with warnings like `AUTOBOT_CHAT_SESSION_CACHE_TTL='' is not an integer`. The underlying trap is broader than those six keys:

```python
os.environ.get("KEY", default)   # returns "" when KEY is set-but-blank, NOT default
```

A deployment template that renders an undefined variable exports `NAME=` rather than omitting the line, so the blank looks *set* to every presence check and defeats every default-argument fallback. This is the same root pattern as #12778, where a blank `REDIS_HOST` defeated its fallback and the backend refused to connect — which is why fixing it centrally matters more than patching the six named keys.

**`env_flag` is the sharpest case and was not in the issue's list.** `truthy("")` is `False`, so before this a blank export silently flipped a **default-True flag OFF** — a value the operator never chose, from a variable they never set. That one has its own test.

**Blank-tolerance must not become error-tolerance.** A blank is a deployment artefact; `"not-a-number"` is real misconfiguration. The former now falls back silently, the latter still warns, and there is a test for each so the distinction cannot erode.

## What Changed

`autobot_shared/env_utils.py`:
- `env_raw(name)` — the single place that collapses blank (and whitespace-only) to `None`.
- `env_str(name, default)` — the string case, replacing the `os.environ.get(k, default)` trap.
- `env_int`, `env_float`, `env_int_clamped`, `env_flag` now read through `env_raw`.

## Verification

```
tests/test_env_utils_blank_values.py       28 passed  (new)
env / config / ttl / flag selection       335 passed, 4 skipped
```

28 tests across all five helpers × four blank shapes (`""`, spaces, tab, newline), plus:
- a test that **pins the trap itself** (`os.environ.get(k, "fallback") != "fallback"` when blank), so the reason this helper exists stays documented in executable form;
- a test asserting absent and blank are **indistinguishable** to callers, which is the actual contract;
- a test that a genuinely invalid value still warns.

**Mutation-verified** — reverting `env_raw` to a plain `is None` check:
```
16 failed, 12 passed
```

The single failure in the wider selection (`test_pending_ttl_prune_removes_stale_index`) is pre-existing — it is in the known `Dev_new_gui` baseline failure set, verified by lookup rather than assumed.

## Scope

Deliberately partial. #12782 also asks for:
1. **Finding what writes the blanks** — a deployment template rendering an undefined variable. Needs the live node.
2. **The `0 .env keys` discrepancy** — a backend `.env` matching none of the 194 SSOT keys suggests the drift detector and the deployed `.env` disagree on key namespace, so that figure needs to be trusted before it can be acted on.

Both stay open on #12782. This PR makes the codebase immune to the blank regardless of what produces it.

## Model Used

Claude Opus 5
