### PR TITLE
feat(llc): goal tree + children endpoints — child goals were unreachable below the roots (#12739)

### DIFF
--- a/autobot-backend/llc/api/goals.py
+++ b/autobot-backend/llc/api/goals.py
@@ -83,6 +83,12 @@ class GoalResponse(BaseModel):
         from_attributes = True
 
 
+class GoalTreeNode(GoalResponse):
+    """A goal plus its descendants, for the tree read path (#12739)."""
+
+    children: List["GoalTreeNode"] = []
+
+
 class WorkItemSummaryResponse(BaseModel):
     """Compact work item projection returned by GET /llc/goals/{id}/tasks (GH#6469)."""
 
@@ -113,6 +119,26 @@ async def _get_authorized_goal(session: AsyncSession, goal_id: uuid.UUID, ctx: T
     if goal is None or (str(goal.company_id) != str(ctx.org_id) and not ctx.is_platform_admin):
         raise HTTPException(status_code=404, detail="Goal not found")
     return goal
+
+
+def _build_goal_forest(goals: list) -> List["GoalTreeNode"]:
+    """Assemble flat goals into nested roots (#12739).
+
+    Orphans — a goal whose parent is missing or belongs to another company — are
+    surfaced as roots rather than dropped. Silently discarding them would make
+    the tree disagree with the flat list, which is the failure mode this
+    endpoint exists to end.
+    """
+    nodes = {g.id: GoalTreeNode.model_validate(g) for g in goals}
+    roots: List[GoalTreeNode] = []
+    for goal in goals:
+        node = nodes[goal.id]
+        parent = nodes.get(goal.parent_goal_id) if goal.parent_goal_id else None
+        if parent is None:
+            roots.append(node)
+        else:
+            parent.children.append(node)
+    return roots
 
 
 # ------------------------------------------------------------------ Routes
@@ -153,6 +179,28 @@ async def create_goal(
     return GoalResponse.model_validate(goal)
 
 
+# NOTE: /tree is declared BEFORE /{goal_id} on purpose. FastAPI matches routes in
+# declaration order, so a later /tree would never be reached — "tree" would bind
+# to {goal_id} and fail UUID parsing instead (#12739).
+@router.get("/tree", response_model=List[GoalTreeNode])
+async def get_goal_tree(
+    company_id: str = Query(..., description="Company ID to build the goal tree for"),
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[GoalTreeNode]:
+    """Return the company's full goal hierarchy as nested roots (#12739).
+
+    ``GET /goals`` returns only top-level goals, and children were reachable
+    only by already knowing each parent id — so the tree UI could not render
+    anything below the roots. One query, assembled in memory, rather than a
+    round-trip per level.
+    """
+    assert_company_access(ctx, company_id)
+    goals = await _svc().list_all_by_company(session, company_id)
+    return _build_goal_forest(goals)
+
+
 @router.get("/{goal_id}", response_model=GoalResponse)
 async def get_goal(
     goal_id: uuid.UUID,
@@ -191,6 +239,19 @@ async def delete_goal(
     deleted = await _svc().delete(session, goal_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Goal not found")
+
+
+@router.get("/{goal_id}/children", response_model=List[GoalResponse])
+async def list_goal_children(
+    goal_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[GoalResponse]:
+    """Direct children of *goal_id* (#12739). Complements the upward /ancestors."""
+    goal = await _get_authorized_goal(session, goal_id, ctx)
+    children = await _svc().list_by_company(session, str(goal.company_id), goal_id)
+    return [GoalResponse.model_validate(c) for c in children]
 
 
 @router.get("/{goal_id}/ancestors", response_model=List[GoalResponse])

--- a/autobot-backend/llc/services/goal.py
+++ b/autobot-backend/llc/services/goal.py
@@ -129,6 +129,17 @@ class GoalService(LLCServiceBase):
         result = await session.execute(stmt)
         return list(result.scalars().all())
 
+    async def list_all_by_company(self, session: AsyncSession, company_id: str) -> List[LLCGoal]:
+        """Every goal for a company, at any depth (#12739).
+
+        ``list_by_company`` forces ``parent_goal_id IS NULL`` when no parent is
+        given, so it returns roots only — which is why children were unreachable
+        without already knowing each parent id. Building a tree needs the whole
+        set in one query rather than one round-trip per level.
+        """
+        result = await session.execute(select(LLCGoal).where(LLCGoal.company_id == company_id))
+        return list(result.scalars().all())
+
     async def update(
         self,
         session: AsyncSession,

--- a/autobot-backend/llc/tests/test_goal_tree_12739.py
+++ b/autobot-backend/llc/tests/test_goal_tree_12739.py
@@ -11,7 +11,6 @@ so the Goal Tree UI could not render anything below the roots.
 
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/autobot-backend/llc/tests/test_goal_tree_12739.py
+++ b/autobot-backend/llc/tests/test_goal_tree_12739.py
@@ -1,0 +1,147 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Child goals must be reachable (#12739).
+
+`GET /goals` forces `parent_goal_id IS NULL`, so it returns roots only. Children
+persisted fine and a direct `GET /goals/{id}` worked, but nothing listed them —
+so the Goal Tree UI could not render anything below the roots.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_ORG = "22222222-2222-2222-2222-222222222222"
+_USER = uuid.UUID("66666666-6666-6666-6666-666666666666")
+
+
+def _goal(company_id: str, parent=None, title="Goal", level="vision", gid=None) -> MagicMock:
+    g = MagicMock()
+    g.id = gid or uuid.uuid4()
+    g.company_id = company_id
+    g.parent_goal_id = parent
+    g.title = title
+    g.description = None
+    g.level = level
+    g.status = "draft"
+    g.owner_agent_id = None
+    g.due_date = None
+    g.created_at = datetime.now(timezone.utc)
+    g.updated_at = datetime.now(timezone.utc)
+    return g
+
+
+def _client(all_goals=None, children=None, focus_goal=None, caller_org=_ORG) -> TestClient:
+    from api.user_management.dependencies import get_current_user, require_org_context
+    from llc.api.goals import router
+    from user_management.database import get_async_session
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/llc")
+
+    session = AsyncMock()
+    session.commit = AsyncMock()
+
+    async def _fake_session():
+        yield session
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(caller_org), user_id=_USER, is_platform_admin=False
+    )
+
+    patch("llc.api.goals.GoalService.list_all_by_company", new=AsyncMock(return_value=all_goals or [])).start()
+    patch("llc.api.goals.GoalService.list_by_company", new=AsyncMock(return_value=children or [])).start()
+    patch("llc.api.goals.GoalService.get", new=AsyncMock(return_value=focus_goal)).start()
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+def _hierarchy():
+    """mission (root) -> objective -> key_result, plus a second root."""
+    mission = _goal(_ORG, title="Mission", level="mission")
+    vision = _goal(_ORG, title="Vision", level="vision")
+    objective = _goal(_ORG, parent=mission.id, title="Objective", level="objective")
+    kr = _goal(_ORG, parent=objective.id, title="Key Result", level="key_result")
+    return mission, vision, objective, kr
+
+
+def test_tree_returns_nested_descendants():
+    mission, vision, objective, kr = _hierarchy()
+    resp = _client(all_goals=[mission, vision, objective, kr]).get(f"/api/llc/goals/tree?company_id={_ORG}")
+
+    assert resp.status_code == 200
+    roots = resp.json()
+    assert {r["title"] for r in roots} == {"Mission", "Vision"}
+
+    mission_node = next(r for r in roots if r["title"] == "Mission")
+    assert [c["title"] for c in mission_node["children"]] == ["Objective"]
+    assert [c["title"] for c in mission_node["children"][0]["children"]] == ["Key Result"]
+
+
+def test_tree_route_is_not_shadowed_by_the_goal_id_route():
+    """FastAPI matches in declaration order — a later /tree would bind to {goal_id}."""
+    mission, vision, objective, kr = _hierarchy()
+    resp = _client(all_goals=[mission, vision, objective, kr]).get(f"/api/llc/goals/tree?company_id={_ORG}")
+
+    assert resp.status_code == 200, "'/tree' was parsed as a goal_id — route order regressed"
+    assert isinstance(resp.json(), list)
+
+
+def test_tree_is_tenant_scoped():
+    resp = _client(all_goals=[], caller_org=_ORG).get(
+        "/api/llc/goals/tree?company_id=99999999-9999-9999-9999-999999999999"
+    )
+    assert resp.status_code in (403, 404)
+
+
+def test_orphan_is_surfaced_as_a_root_not_dropped():
+    """A goal whose parent is absent must still appear, or the tree disagrees with the flat list."""
+    orphan = _goal(_ORG, parent=uuid.uuid4(), title="Orphan", level="objective")
+    roots = _client(all_goals=[orphan]).get(f"/api/llc/goals/tree?company_id={_ORG}").json()
+
+    assert [r["title"] for r in roots] == ["Orphan"]
+
+
+def test_empty_company_returns_an_empty_forest():
+    resp = _client(all_goals=[]).get(f"/api/llc/goals/tree?company_id={_ORG}")
+    assert resp.status_code == 200 and resp.json() == []
+
+
+def test_children_endpoint_lists_direct_children():
+    mission = _goal(_ORG, title="Mission", level="mission")
+    objective = _goal(_ORG, parent=mission.id, title="Objective", level="objective")
+
+    resp = _client(children=[objective], focus_goal=mission).get(f"/api/llc/goals/{mission.id}/children")
+
+    assert resp.status_code == 200
+    assert [c["title"] for c in resp.json()] == ["Objective"]
+
+
+def test_children_of_a_cross_tenant_goal_is_404():
+    """Tenant isolation must hold on the new read path too (GH#12136 class)."""
+    foreign = _goal("99999999-9999-9999-9999-999999999999", title="Foreign")
+
+    resp = _client(focus_goal=foreign).get(f"/api/llc/goals/{foreign.id}/children")
+
+    assert resp.status_code == 404
+
+
+def test_children_of_a_missing_goal_is_404():
+    resp = _client(focus_goal=None).get(f"/api/llc/goals/{uuid.uuid4()}/children")
+    assert resp.status_code == 404

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -49521,6 +49521,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/goals/tree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Goal Tree
+         * @description Return the company's full goal hierarchy as nested roots (#12739).
+         *
+         *     ``GET /goals`` returns only top-level goals, and children were reachable
+         *     only by already knowing each parent id — so the tree UI could not render
+         *     anything below the roots. One query, assembled in memory, rather than a
+         *     round-trip per level.
+         */
+        get: operations["get_goal_tree_api_llc_goals_tree_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/goals/{goal_id}": {
         parameters: {
             query?: never;
@@ -49538,6 +49563,26 @@ export interface paths {
         head?: never;
         /** Update Goal */
         patch: operations["update_goal_api_llc_goals__goal_id__patch"];
+        trace?: never;
+    };
+    "/api/llc/goals/{goal_id}/children": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Goal Children
+         * @description Direct children of *goal_id* (#12739). Complements the upward /ancestors.
+         */
+        get: operations["list_goal_children_api_llc_goals__goal_id__children_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/llc/goals/{goal_id}/ancestors": {
@@ -74522,6 +74567,50 @@ export interface components {
          * @enum {string}
          */
         GoalStatus: "draft" | "active" | "achieved" | "cancelled" | "on_hold";
+        /**
+         * GoalTreeNode
+         * @description A goal plus its descendants, for the tree read path (#12739).
+         */
+        GoalTreeNode: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Company Id */
+            company_id: string;
+            /** Parent Goal Id */
+            parent_goal_id: string | null;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string | null;
+            /** Level */
+            level: string;
+            /** Status */
+            status: string;
+            /** Owner Agent Id */
+            owner_agent_id: string | null;
+            /** Due Date */
+            due_date: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /**
+             * Children
+             * @default []
+             */
+            children: components["schemas"]["GoalTreeNode"][];
+        } & {
+            [key: string]: unknown;
+        };
         /** GoalUpdate */
         GoalUpdate: {
             /** Title */
@@ -167395,6 +167484,38 @@ export interface operations {
             };
         };
     };
+    get_goal_tree_api_llc_goals_tree_get: {
+        parameters: {
+            query: {
+                /** @description Company ID to build the goal tree for */
+                company_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoalTreeNode"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_goal_api_llc_goals__goal_id__get: {
         parameters: {
             query?: never;
@@ -167477,6 +167598,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["llc__api__goals__GoalResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_goal_children_api_llc_goals__goal_id__children_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                goal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["llc__api__goals__GoalResponse"][];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Closes #12739

## Thinking Path

`GoalService.list_by_company` forces `parent_goal_id IS NULL` when no parent is given, so `GET /goals` returns **roots only**. Children persisted fine and a direct `GET /goals/{id}` worked — but nothing listed them, and the only relational endpoint was `/ancestors`, which walks *upward*. The tree UI therefore had no way to render anything below the roots.

**One correction to the issue's premise:** children were not *entirely* unreachable. `GET /goals?company_id=X&parent_goal_id=Y` does return them — the query param exists. But that is one round-trip per level and requires already knowing each parent id, so there was no way to obtain a subtree, which is the actual gap.

Two details that needed deciding rather than defaulting:

**Route ordering.** FastAPI matches in declaration order, so `/tree` declared *after* `/{goal_id}` would never be reached — `"tree"` would bind to `{goal_id}` and fail UUID parsing. That is a silent, easy-to-reintroduce trap, so it is declared first, commented, and pinned by a test.

**Orphan handling.** A goal whose parent is missing or belongs to another company could be dropped or surfaced. Dropping is worse: the tree would then disagree with the flat list, which is precisely the "child goals vanish from every view" failure this endpoint exists to end. Orphans are surfaced as roots.

## What Changed

- **`GoalService.list_all_by_company()`** — every goal for a company at any depth.
- **`GET /api/llc/goals/tree?company_id=`** — full hierarchy as nested roots, assembled in memory from **one** query rather than a request per level.
- **`GET /api/llc/goals/{id}/children`** — direct children, complementing the upward `/ancestors`.

Both new paths are tenant-scoped — `/tree` via `assert_company_access`, `/children` via `_get_authorized_goal` — so the GH#12136 IDOR class does not reopen on the new read surface. Both have tests.

## Verification

```
llc/tests/test_goal_tree_12739.py     8 passed  (new)
llc/tests/                         1320 passed, 2 skipped
```

Tests cover: nested descendants three levels deep (mission → objective → key_result) alongside a second root, the route-order guard, tenant scoping on `/tree`, orphan retention, an empty company, children listing, cross-tenant `/children` → 404, and missing-goal → 404.

**Mutation-verified** — moving `/tree` after `/{goal_id}`:
```
5 failed, 3 passed
```
So the ordering guard genuinely bites rather than passing by construction.

## Model Used

Claude Opus 5
