### PR TITLE
fix(tests): backend suite no longer leaves npu_workers.yaml in the working tree (#12857)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,11 @@ secrets.key
 # === CONFIGURATION FILES ===
 # Configuration files with sensitive data
 config/*.yaml
+# #12857: runtime worker registrations written by NPUWorkerManager.save_worker_config()
+# (the NPU-workers websocket endpoint bootstraps one on initialize). Never source —
+# it has never been tracked. The rule above is anchored to the repo root, so it does
+# not reach autobot-backend/config/, which is why this kept appearing untracked.
+autobot-backend/config/npu_workers.yaml
 config/settings.json
 backend/config/settings.json
 .env

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -20,8 +20,8 @@ import aiofiles
 import yaml
 
 from autobot_shared.logging_manager import get_logger
-from constants.path_constants import PATH
 from autobot_shared.time_utils import now_utc, utc_timestamp
+from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 from events.bus import PersistStrategy, publish_event
 from models.npu_models import (

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -20,6 +20,7 @@ import aiofiles
 import yaml
 
 from autobot_shared.logging_manager import get_logger
+from constants.path_constants import PATH
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.threshold_constants import TimingConstants
 from events.bus import PersistStrategy, publish_event
@@ -96,7 +97,13 @@ class NPUWorkerManager(AsyncInitializable):
             redis_client: Redis client for state storage
         """
         super().__init__(component_name="npu_worker_manager")
-        self.config_file = config_file or Path("config/npu_workers.yaml")
+        # #12857: the default was CWD-relative, so a bootstrap write landed
+        # wherever the process happened to be running — under pytest that was the
+        # repo working tree (the NPU-workers websocket endpoint saves a default
+        # config during initialize). Anchoring to BACKEND_DIR keeps the same
+        # conventional location, <backend>/config/npu_workers.yaml, but makes it
+        # independent of CWD so a stray write cannot land in an arbitrary place.
+        self.config_file = config_file or (PATH.BACKEND_DIR / "config" / "npu_workers.yaml")
         self.redis_client = redis_client
         self._workers: Dict[str, NPUWorkerConfig] = {}
         self._worker_clients: Dict[str, NPUWorkerClient] = {}

--- a/autobot-backend/services/npu_worker_manager_pulse_test.py
+++ b/autobot-backend/services/npu_worker_manager_pulse_test.py
@@ -12,8 +12,8 @@ Covers:
 - MVA-1399: Heartbeat reachability — stale last_heartbeat → failure class
 """
 
-from datetime import datetime, timedelta, timezone
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 

--- a/autobot-backend/services/npu_worker_manager_pulse_test.py
+++ b/autobot-backend/services/npu_worker_manager_pulse_test.py
@@ -13,6 +13,7 @@ Covers:
 """
 
 from datetime import datetime, timedelta, timezone
+import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -67,7 +68,9 @@ def _make_manager(redis_client=None) -> NPUWorkerManager:
         "latency_throttle_multiplier": 3.0,
     }
     mgr.redis_client = redis_client
-    mgr.config_file = Path("config/npu_workers.yaml")
+    # #12857: never name the real repo config — a save would write into the
+    # working tree. These tests do not read it; they only need a path.
+    mgr.config_file = Path(tempfile.gettempdir()) / "autobot-test-npu-workers.yaml"
     return mgr
 
 

--- a/autobot-backend/services/test_npu_worker_config_load_12526.py
+++ b/autobot-backend/services/test_npu_worker_config_load_12526.py
@@ -11,6 +11,7 @@ coroutine (and emitting a "coroutine was never awaited" RuntimeWarning). It is
 now `async` and awaits the save directly.
 """
 
+import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -89,7 +90,8 @@ async def test_load_workers_from_config_does_not_save_when_file_present(tmp_path
 @pytest.mark.asyncio
 async def test_initialize_impl_awaits_load_workers_from_config():
     """_initialize_impl must directly await _load_workers_from_config (no fire-and-forget)."""
-    mgr = _make_manager(Path("config/npu_workers.yaml"))
+    # #12857: a real repo path here risks a write into the working tree.
+    mgr = _make_manager(Path(tempfile.gettempdir()) / "autobot-test-npu-workers.yaml")
     mgr._load_workers_from_config = AsyncMock()
 
     result = await mgr._initialize_impl()

--- a/autobot-backend/services/test_npu_worker_events.py
+++ b/autobot-backend/services/test_npu_worker_events.py
@@ -13,6 +13,7 @@ Covers (#10602 subtask 6.4, #10698):
 - _build_worker_metrics returns non-zero avg_response_time_ms when pulse data exists
 """
 
+import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -86,7 +87,9 @@ def _make_manager(redis_client=None) -> NPUWorkerManager:
     mgr._pulse_canaries = {}
     mgr._pulse_defaults = {"latency_window": 20}
     mgr.redis_client = redis_client
-    mgr.config_file = Path("config/npu_workers.yaml")
+    # #12857: never name the real repo config — a save would write into the
+    # working tree. These tests do not read it; they only need a path.
+    mgr.config_file = Path(tempfile.gettempdir()) / "autobot-test-npu-workers.yaml"
     return mgr
 
 

--- a/autobot-backend/tests/test_npu_config_path_not_cwd_relative.py
+++ b/autobot-backend/tests/test_npu_config_path_not_cwd_relative.py
@@ -84,6 +84,5 @@ def test_no_test_names_the_real_repo_config(test_file):
     source = (PATH.BACKEND_DIR / test_file).read_text(encoding="utf-8")
 
     assert 'Path("config/npu_workers.yaml")' not in source, (
-        f"{test_file} points a manager at the real repo config; a save would "
-        "write into the working tree"
+        f"{test_file} points a manager at the real repo config; a save would " "write into the working tree"
     )

--- a/autobot-backend/tests/test_npu_config_path_not_cwd_relative.py
+++ b/autobot-backend/tests/test_npu_config_path_not_cwd_relative.py
@@ -1,0 +1,89 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The NPU worker config path must not depend on CWD (#12857).
+
+`NPUWorkerManager` defaulted to `Path("config/npu_workers.yaml")` and writes a
+bootstrap config during initialize. Because the path was CWD-relative, that
+write landed wherever the process happened to be running:
+
+    api/websockets.py:776  npu_workers_websocket_endpoint
+      -> _send_initial_worker_list
+        -> async_initializable.initialize
+          -> NPUWorkerManager.save_worker_config()
+            -> writes ./config/npu_workers.yaml
+
+Under pytest that was the repo working tree, leaving an untracked file that
+blocked `git worktree remove`. In production it depends on the unit's
+WorkingDirectory, which is worse: the same code writes somewhere different.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from constants.path_constants import PATH
+from services.npu_worker_manager import NPUWorkerManager
+
+
+def test_default_config_path_is_absolute():
+    """A relative default means the target depends on where the process started."""
+    mgr = NPUWorkerManager()
+
+    assert mgr.config_file.is_absolute(), (
+        f"default config path {mgr.config_file} is relative — a bootstrap write "
+        "would land wherever CWD happens to be"
+    )
+
+
+def test_default_config_path_is_stable_across_cwd(tmp_path, monkeypatch):
+    """The whole bug: the same manager resolved to different files per CWD."""
+    first = NPUWorkerManager().config_file
+
+    monkeypatch.chdir(tmp_path)
+    second = NPUWorkerManager().config_file
+
+    assert first == second, "config path changed with CWD"
+
+
+def test_default_config_path_keeps_the_conventional_location():
+    """Anchoring must not relocate the file — existing installs read <backend>/config/."""
+    mgr = NPUWorkerManager()
+
+    assert mgr.config_file == PATH.BACKEND_DIR / "config" / "npu_workers.yaml"
+
+
+def test_explicit_config_file_is_still_honoured(tmp_path):
+    """Callers and tests must still be able to point it somewhere else."""
+    target = tmp_path / "custom.yaml"
+
+    assert NPUWorkerManager(config_file=target).config_file == target
+
+
+def test_instantiating_from_a_foreign_cwd_does_not_target_that_directory(tmp_path, monkeypatch):
+    """Guards the specific symptom: a stray write must not land in the caller's CWD."""
+    monkeypatch.chdir(tmp_path)
+    mgr = NPUWorkerManager()
+
+    assert Path(os.getcwd()) not in mgr.config_file.parents
+    assert not str(mgr.config_file).startswith(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "services/npu_worker_manager_pulse_test.py",
+        "services/test_npu_worker_events.py",
+        "services/test_npu_worker_config_load_12526.py",
+    ],
+)
+def test_no_test_names_the_real_repo_config(test_file):
+    """A unit test must never name a config file it could overwrite."""
+    source = (PATH.BACKEND_DIR / test_file).read_text(encoding="utf-8")
+
+    assert 'Path("config/npu_workers.yaml")' not in source, (
+        f"{test_file} points a manager at the real repo config; a save would "
+        "write into the working tree"
+    )


### PR DESCRIPTION
Closes #12857

## Thinking Path

Two independent causes. **Fixing only the first is not enough**, which I found by re-running the suite after it and seeing the file still there — the code change looked right and did not fix the reported symptom.

**1. The default config path was CWD-relative.** `NPUWorkerManager` defaulted to `Path("config/npu_workers.yaml")` and writes a bootstrap config during initialize, so the write target depended on where the process started:

```
api/websockets.py:776   npu_workers_websocket_endpoint
  -> _send_initial_worker_list
    -> async_initializable.initialize
      -> save_worker_config()  ->  ./config/npu_workers.yaml
```

Note this is not a test-only problem: in production the target follows the systemd unit's `WorkingDirectory`, so the same code writes somewhere different depending on how it is launched. Anchored to `PATH.BACKEND_DIR`, which keeps the same conventional location (`<backend>/config/npu_workers.yaml`) while removing the CWD dependence. I deliberately did **not** use `PATH.CONFIG_DIR` — that resolves to `infrastructure/shared/config`, so it would relocate the file and break existing installs that read the current path.

**2. The `.gitignore` rule never matched.** Line 122 already has `config/*.yaml` — but a pattern containing a slash is anchored to the `.gitignore`'s own directory, so it covers `<root>/config/` and never reached `autobot-backend/config/`. That is why the file kept showing as untracked despite an apparently-relevant rule. Added a precise entry for this one generated file; it is runtime worker state written by `save_worker_config()` and has never been tracked.

Both are worth keeping: (1) is the real latent defect, (2) is what actually resolves the reported symptom.

## What Changed

- **`services/npu_worker_manager.py`** — default anchored to `PATH.BACKEND_DIR`.
- **`.gitignore`** — precise rule for the generated file, with a comment explaining why the existing pattern misses it.
- **Three tests** that named the real repo config now use a temp path. They were a latent hazard rather than the cause — running them alone did not reproduce — but a unit test must never name a config file it could overwrite.

## Verification

The symptom itself, which is the only claim that matters here:

```
$ rm -f config/npu_workers.yaml && git status --porcelain | grep -c npu_workers
0
$ pytest tests/ services/ --ignore=tests/agents --ignore=tests/api
$ git status --porcelain            # previously: ?? autobot-backend/config/npu_workers.yaml
 M .gitignore
 M autobot-backend/services/npu_worker_manager.py
 ...                                # only my own changes — no npu_workers.yaml
```

```
4 affected test files    36 passed
```

**On the 53 failures in that broad run:** they are pre-existing, not from this change. The `test_cross_worker_registries` group is the known live-Redis set, and the two npu-adjacent ones (`mcp_worker_metrics_test`, `npu_pipeline/test_dispatcher`) I ran directly against an untouched `Dev_new_gui` checkout — they fail identically there.

8 new tests pin the class: the default path is absolute, stable across CWD, still at the conventional location, still overridable by callers, never targets the caller's CWD, and no test names the real repo config.

## Model Used

Claude Opus 5
