### PR TITLE
fix(analytics): show 'N of M' on the 7 result lists that truncated silently (#12862)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -85,6 +85,10 @@
               {{ rec }}
             </li>
           </ul>
+          <TruncationNotice
+            :shown="Math.min(3, healthScore.recommendations.length)"
+            :total="healthScore.recommendations.length"
+          />
         </div>
       </div>
     </div>
@@ -449,6 +453,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch, reactive } from 'vue';
+import TruncationNotice from './TruncationNotice.vue';
 import type { DirectiveBinding } from 'vue';
 import { BaseModal } from '@autobot/ui'
 import { useRoute } from 'vue-router';

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { defineAsyncComponent } from 'vue'
+import TruncationNotice from './TruncationNotice.vue'
 import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import DependencyTreemap from '@/components/charts/DependencyTreemap.vue'
@@ -196,6 +197,10 @@ const emit = defineEmits<{
             <span class="dep-name">{{ dep.package }}</span>
             <span class="dep-count">{{ dep.usage_count }} imports</span>
           </div>
+          <TruncationNotice
+            :shown="Math.min(20, dependencyData.external_dependencies.length)"
+            :total="dependencyData.external_dependencies.length"
+          />
         </div>
       </div>
     </div>

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -677,7 +677,9 @@ onMounted(() => {
   background: var(--color-info);
   border: none;
   border-radius: var(--radius-md);
-  color: #fff;
+  /* #11515 tokenisation: was a hardcoded #fff. Pre-existing, surfaced because
+     the Stylelint gate lints changed files and this file is touched here. */
+  color: var(--text-on-primary);
   font-size: var(--text-sm);
   cursor: pointer;
   transition: background var(--duration-200);

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -256,6 +256,10 @@
                 </div>
                 <p class="cache-preview">{{ opp.prompt_preview }}</p>
               </div>
+              <TruncationNotice
+                :shown="Math.min(5, cacheOpportunities.length)"
+                :total="cacheOpportunities.length"
+              />
             </div>
           </div>
         </div>
@@ -324,6 +328,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import TruncationNotice from './TruncationNotice.vue'
 import { useExpansion } from '@/composables/useExpansion'
 import {
   useLLMPatternData,

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -188,6 +188,10 @@
                 <button class="btn-fix" @click="showFixDetails(item)">{{ $t('analytics.technicalDebt.fix') }}</button>
               </div>
             </div>
+            <TruncationNotice
+              :shown="Math.min(10, roiPriorities.length)"
+              :total="roiPriorities.length"
+            />
           </div>
         </div>
       </div>
@@ -434,6 +438,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
+import TruncationNotice from './TruncationNotice.vue';
 import { BaseModal } from '@autobot/ui'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils';

--- a/autobot-frontend/src/components/analytics/TruncationNotice.vue
+++ b/autobot-frontend/src/components/analytics/TruncationNotice.vue
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2025-2026 mrveiss
+  SPDX-License-Identifier: Apache-2.0
+  AutoBot - AI-Powered Automation Platform
+  Author: mrveiss
+
+  GH#12741: analytics panels cap result lists with hardcoded slice(0, N) and
+  rendered nothing to say so. If a scan found 100 orphaned endpoints the panel
+  showed 30 and silently dropped 70 — the user had no signal that results were
+  cut. This makes the truncation visible.
+
+  Renders nothing when the list is complete, so panels showing everything stay
+  uncluttered.
+-->
+<template>
+  <p v-if="isTruncated" class="truncation-notice" role="status">
+    {{ $t('analytics.truncation.showingOf', { shown, total }) }}
+  </p>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  /** How many items the panel actually rendered. */
+  shown: number
+  /** How many exist in total before truncation. */
+  total: number
+}>()
+
+const isTruncated = computed(() => props.total > props.shown)
+</script>
+
+<style scoped>
+.truncation-notice {
+  margin: var(--space-2, 0.5rem) 0 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+</style>

--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -168,6 +168,10 @@
               <span class="lines">{{ contrib.lines.toLocaleString() }} lines</span>
               <span class="score">{{ contrib.score.toFixed(0) }} pts</span>
             </div>
+            <TruncationNotice
+              :shown="Math.min(5, analysis.metrics.top_contributors.length)"
+              :total="analysis.metrics.top_contributors.length"
+            />
           </div>
         </div>
 
@@ -266,6 +270,10 @@
                 <span class="dir-lines">{{ dir.total_lines.toLocaleString() }} lines</span>
               </div>
             </div>
+            <TruncationNotice
+              :shown="Math.min(15, analysis.directory_ownership.length)"
+              :total="analysis.directory_ownership.length"
+            />
           </div>
         </div>
 
@@ -291,6 +299,10 @@
                 <span class="file-lines">{{ file.total_lines }} lines</span>
               </div>
             </div>
+            <TruncationNotice
+              :shown="Math.min(30, analysis.file_ownership.length)"
+              :total="analysis.file_ownership.length"
+            />
           </div>
         </div>
       </div>
@@ -341,6 +353,7 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import { ref } from 'vue'
+import TruncationNotice from '../TruncationNotice.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 
 interface OwnershipContributor {

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "عرض {shown} من {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "{shown} von {total} werden angezeigt"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "Showing {shown} of {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "Mostrando {shown} de {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -1905,6 +1905,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "نمایش {shown} از {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "Affichage de {shown} sur {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -1905,6 +1905,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "מוצגים {shown} מתוך {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "Rāda {shown} no {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "Wyświetlanie {shown} z {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -2505,6 +2505,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "A mostrar {shown} de {total}"
     }
   },
   "knowledge": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -1905,6 +1905,9 @@
         "risk": "Risk",
         "confoundingStrength": "Confounding Strength"
       }
+    },
+    "truncation": {
+      "showingOf": "{total} میں سے {shown} دکھائے جا رہے ہیں"
     }
   },
   "knowledge": {


### PR DESCRIPTION
Closes #12862

Contributes to #12741 but does not close it — that issue's remaining parts are tracked as #12364 and #12341, and its part 2 does not reproduce (verification comment posted there).

## Thinking Path

The reported symptom is "panels don't show all results". The issue attributes it partly to ~36 `slice(0, N)` caps, but auditing every one showed **most are not this bug** — a blanket sweep would have added noise to two thirds of them:

- **Already handled.** `CodeSmellsSection`, `DeclarationsSection`, `DuplicatesSection`, `HardcodesSection`, `ProblemsReportSection` and `PatternAnalysis` already render a "showing N of M" affordance next to their truncated lists.
- **Not a list.** `FindingsTable`'s `slice(0, 60)` truncates a *message string* for display.
- **Chart sampling.** `TechnicalDebtDashboard:229` and `:631` slice `trendData` to build X-axis labels and chart geometry. A "showing N of M" there would be actively misleading.

That leaves **7** genuine cases: a result list truncated with no affordance at all.

I also verified the issue's part 2 while here — the "2 miswired 404 calls" do not reproduce. Both route families exist and are registered (`cross_language_patterns.py` has 8 routes, `patterns/status/{task_id}` exists), and the frontend calls the correct paths. The reported 404s came from probing the *base* paths with no suffix or task id, which correctly 404. Documented on #12741 so nobody "fixes" it by inventing routes.

## What Changed

**`TruncationNotice.vue`** (new) — renders `showing N of M`, and renders **nothing** when the list is complete so panels showing everything stay uncluttered. A shared component rather than a seventh hand-rolled variant, matching the direction of the #12730 primitives umbrella.

Wired into the 7 genuine sites:

| Panel | List | Cap |
|---|---|---|
| CodeQualityDashboard | `recommendations` | 3 |
| LLMPatternDashboard | `cacheOpportunities` | 5 |
| TechnicalDebtDashboard | `roiPriorities` | 10 |
| CodebaseDependenciesPanel | `external_dependencies` | 20 |
| CodebaseOwnershipPanel | `top_contributors` | 5 |
| CodebaseOwnershipPanel | `directory_ownership` | 15 |
| CodebaseOwnershipPanel | `file_ownership` | 30 |

`CodebaseDependenciesPanel`'s *circular_dependencies* list was already covered — only its external-dependencies list was silent, so only that one was touched.

**i18n** — one key (`analytics.truncation.showingOf`) in all 11 locales with real translations. Locale diffs are +3 lines each with no reformatting, checked explicitly.

## Verification

Every identifier referenced by a new notice was confirmed to exist in its own component, since a typo here fails at render rather than at build:

```
CodeQualityDashboard      :: healthScore                        15 refs
LLMPatternDashboard       :: cacheOpportunities                  6 refs
TechnicalDebtDashboard    :: roiPriorities                       6 refs
CodebaseDependenciesPanel :: dependencyData                     20 refs
CodebaseOwnershipPanel    :: analysis.metrics.top_contributors   4 refs
CodebaseOwnershipPanel    :: analysis.directory_ownership        4 refs
CodebaseOwnershipPanel    :: analysis.file_ownership             4 refs
```

Frontend type-check and unit tests could not be run locally — `node_modules` is absent in the worktree, so `vue-tsc` reports "Cannot find module 'vue'" for every import rather than anything about this change. CI covers them.

## Model Used

Claude Opus 5
