### PR TITLE
fix(knowledge): derive vectorized status from the vector store, not a drifting Redis flag (#12864)

### DIFF
--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -56,6 +56,36 @@ router = APIRouter(tags=["knowledge_vectorization"])
 # ===== HELPER FUNCTIONS FOR BATCH VECTORIZATION STATUS =====
 
 
+async def _vectorized_ids_from_vector_store(kb_instance, fact_ids: List[str]) -> set | None:
+    """Ask ChromaDB which of *fact_ids* actually have a vector (#12733).
+
+    Vectorization status used to be read from a Redis key
+    (``llama_index/vector_{id}``), i.e. a flag written beside the fact rather
+    than the vector store's own membership. Any Redis/ChromaDB drift therefore
+    made the indicator wrong — and when facts were lost while their 22 vectors
+    survived, the browser reported everything unvectorized on every reload.
+
+    Returns ``None`` (not an empty set) when the vector store cannot be reached,
+    so the caller can fall back rather than report all facts unvectorized — a
+    false "nothing is vectorized" is worse than a stale flag.
+    """
+    try:
+        from knowledge.backends import get_default_client
+
+        client = await asyncio.to_thread(
+            get_default_client,
+            db_path=str(kb_instance.chromadb_path),
+            allow_reset=False,
+            anonymized_telemetry=False,
+        )
+        collection = await asyncio.to_thread(client.get_collection, kb_instance.chromadb_collection)
+        found = await asyncio.to_thread(collection.get, ids=list(fact_ids), include=[])
+        return set(found.get("ids") or [])
+    except Exception as exc:  # noqa: BLE001 - status must degrade, never fail the request
+        logger.warning("Vector-store membership check unavailable, falling back to Redis flags: %s", exc)
+        return None
+
+
 async def _execute_pipeline_exists_check(kb_instance, vector_keys: List[str]) -> list:
     """
     Execute Redis pipeline for batch EXISTS checks.
@@ -169,8 +199,15 @@ async def _check_vectorization_batch_internal(
     vector_keys = [f"llama_index/vector_{fact_id}" for fact_id in fact_ids]
 
     try:
-        # Execute pipeline EXISTS checks (Issue #620: uses helper)
-        results = await _execute_pipeline_exists_check(kb_instance, vector_keys)
+        # #12733: prefer the vector store's own membership over the Redis-side
+        # flag, so the indicator cannot drift from reality.
+        vectorized_ids = await _vectorized_ids_from_vector_store(kb_instance, fact_ids)
+        if vectorized_ids is None:
+            # Vector store unreachable — fall back to the legacy Redis flags
+            # rather than claiming nothing is vectorized.
+            results = await _execute_pipeline_exists_check(kb_instance, vector_keys)
+        else:
+            results = [fact_id in vectorized_ids for fact_id in fact_ids]
 
         # Build status map (Issue #620: uses helper)
         statuses, vectorized_count = _build_status_map(fact_ids, results, include_dimensions, kb_instance)

--- a/autobot-backend/tests/test_vectorization_status_from_store.py
+++ b/autobot-backend/tests/test_vectorization_status_from_store.py
@@ -1,0 +1,111 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Vectorization status must come from the vector store, not a Redis flag (#12733).
+
+Status was read from a Redis key (`llama_index/vector_{id}`) written beside the
+fact. Any Redis/ChromaDB drift made the indicator wrong — and when facts were
+lost while their vectors survived, the Knowledge Browser reported everything
+"unvectorized" on every reload.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.knowledge_vectorization import (
+    _check_vectorization_batch_internal,
+    _vectorized_ids_from_vector_store,
+)
+
+
+def _kb():
+    kb = MagicMock()
+    kb.chromadb_path = "/tmp/chroma-test"
+    kb.chromadb_collection = "autobot_memory"
+    kb.embedding_dimensions = 768
+    return kb
+
+
+def _chroma_returning(ids):
+    collection = MagicMock()
+    collection.get.return_value = {"ids": list(ids)}
+    client = MagicMock()
+    client.get_collection.return_value = collection
+    return client
+
+
+@pytest.mark.asyncio
+async def test_status_reflects_vector_store_membership():
+    kb = _kb()
+    with patch("knowledge.backends.get_default_client", return_value=_chroma_returning(["a", "c"])):
+        result = await _check_vectorization_batch_internal(kb, ["a", "b", "c"])
+
+    assert result["statuses"]["a"]["vectorized"] is True
+    assert result["statuses"]["b"]["vectorized"] is False
+    assert result["statuses"]["c"]["vectorized"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_stale_redis_flag_does_not_win_over_the_store():
+    """The drift case: Redis says vectorized, the store disagrees."""
+    kb = _kb()
+    # Redis would report every key as existing.
+    kb.redis_client.pipeline.return_value.execute.return_value = [1, 1]
+
+    with patch("knowledge.backends.get_default_client", return_value=_chroma_returning([])):
+        result = await _check_vectorization_batch_internal(kb, ["a", "b"])
+
+    assert result["statuses"]["a"]["vectorized"] is False
+    assert result["statuses"]["b"]["vectorized"] is False
+
+
+@pytest.mark.asyncio
+async def test_vectors_without_facts_are_reported_vectorized():
+    """The observed state: 0 facts, 22 vectors. Those ids ARE vectorized."""
+    kb = _kb()
+    with patch("knowledge.backends.get_default_client", return_value=_chroma_returning(["v1", "v2"])):
+        result = await _check_vectorization_batch_internal(kb, ["v1", "v2"])
+
+    assert result["summary"]["vectorized"] == 2
+
+
+@pytest.mark.asyncio
+async def test_unreachable_store_falls_back_to_redis_not_all_unvectorized():
+    """A false 'nothing is vectorized' is worse than a stale flag."""
+    kb = _kb()
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, 0]
+    kb.redis_client.pipeline.return_value = pipe
+
+    with patch("knowledge.backends.get_default_client", side_effect=RuntimeError("chroma down")):
+        result = await _check_vectorization_batch_internal(kb, ["a", "b"])
+
+    assert result["statuses"]["a"]["vectorized"] is True, "fell back to Redis rather than reporting all false"
+    assert result["statuses"]["b"]["vectorized"] is False
+
+
+@pytest.mark.asyncio
+async def test_unreachable_store_returns_none_not_empty_set():
+    """None and empty-set mean different things: 'unknown' vs 'nothing vectorized'."""
+    with patch("knowledge.backends.get_default_client", side_effect=RuntimeError("down")):
+        assert await _vectorized_ids_from_vector_store(_kb(), ["a"]) is None
+
+
+@pytest.mark.asyncio
+async def test_empty_store_returns_an_empty_set():
+    with patch("knowledge.backends.get_default_client", return_value=_chroma_returning([])):
+        assert await _vectorized_ids_from_vector_store(_kb(), ["a"]) == set()
+
+
+@pytest.mark.asyncio
+async def test_status_request_never_raises_when_the_store_errors():
+    """The browser must still render; a status check is not worth a 500."""
+    kb = _kb()
+    kb.redis_client.pipeline.return_value.execute.return_value = [0]
+
+    with patch("knowledge.backends.get_default_client", side_effect=Exception("boom")):
+        result = await _check_vectorization_batch_internal(kb, ["a"])
+
+    assert "statuses" in result and "summary" in result

--- a/autobot-backend/tests/test_vectorization_status_from_store.py
+++ b/autobot-backend/tests/test_vectorization_status_from_store.py
@@ -10,7 +10,7 @@ lost while their vectors survived, the Knowledge Browser reported everything
 "unvectorized" on every reload.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
Closes #12864

Contributes to #12733 but does not close it — that issue's other recommendations are architectural or need the live node, and are enumerated under Scope.

## Thinking Path

Vectorization status was read from a **Redis key** (`llama_index/vector_{id}`), i.e. a flag written *beside* the fact, not derived from the vector store's own membership. Any drift between the two stores therefore makes the indicator wrong.

The live evidence shows exactly that: facts in Redis went to **0** while ChromaDB still held **22 vectors**. With no facts carrying a `vectorized_at` flag, the Knowledge Browser reported everything unvectorized on every reload — while the vectors were sitting there.

**The degradation behaviour was the decision worth making carefully.** The obvious implementation returns an empty set when ChromaDB is unreachable, which reads as "nothing is vectorized" and would invite a pointless full re-vectorisation on every transient outage. So the helper returns `None` for "unknown" and the caller falls back to the legacy Redis flags. A stale flag is a smaller harm than a confident false negative. `None` vs empty-set is distinguished by its own test, because collapsing them is the easy mistake here.

## What Changed

`api/knowledge_vectorization.py`:
- `_vectorized_ids_from_vector_store()` — asks ChromaDB which ids actually have a vector, via `collection.get(ids=[...])`. Returns `None` when the store cannot be reached.
- `_check_vectorization_batch_internal()` — prefers that answer; falls back to the Redis pipeline only when it is `None`.

## Verification

```
tests/test_vectorization_status_from_store.py    7 passed  (new)
vector / knowledge selection                   472 passed
```

Tests cover: status reflects store membership; a **stale Redis flag does not win** over the store (the drift case); ids with vectors but no facts still report vectorized (the observed 0-facts/22-vectors state); an unreachable store falls back rather than reporting all-false; `None` and empty-set are distinguished; and the request never raises when the store errors.

**Mutation-verified** — forcing the fallback path (`vectorized_ids = None`):
```
2 failed, 5 passed
```

The 4 failures in the wider selection are the known gitlab/gitea live-Redis set — confirmed by diffing the failure set against the recorded `Dev_new_gui` baseline, not by eyeballing the count.

## Scope

Deliberately recommendation 3 only. Still open on #12733:
1. **Durable system of record** for facts — Redis with RDB snapshots is not one. Architectural.
2. **Reconcile the two stores** and expose a repair (there are 22 orphaned vectors right now).
4. **Find the wipe** — why facts cleared across backend restarts. Needs the live node.
5. **#12318** — KB lifecycle tasks scheduled but not registered.

This PR stops the *indicator* lying, which is the visible half; it does not make the data durable.

## Model Used

Claude Opus 5
