### PR TITLE
security(chat): ownership filter no longer returns every session when the lookup fails (#12867)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -445,16 +445,34 @@ async def _filter_user_sessions(sessions: list, username: str) -> list:
     """
     from autobot_shared.redis_client import get_redis_client as get_redis_mgr
 
+    from api.chat_sessions_errors import OwnershipUnavailableError
+
     try:
         redis = await get_redis_mgr(async_client=True, database="main")
         validator = _build_ownership_validator(redis)
         user_session_ids = set(await validator.get_user_sessions(username))
-        if not user_session_ids:
-            return sessions  # No ownership data yet; return all
-        return [s for s in sessions if s.get("id") in user_session_ids]
     except Exception as e:
-        logger.debug("Could not filter by user ownership: %s", e)
+        # #12685: this used to `return sessions` — the UNFILTERED list — whenever
+        # the ownership lookup failed. On a tenancy filter that is the wrong
+        # direction to fail: a Redis blip silently exposed every session on the
+        # instance, including other companies' agent conversations. Surfacing an
+        # error lets the UI say "could not load your sessions" instead of
+        # showing someone else's.
+        logger.error("Ownership lookup failed; refusing to return an unfiltered session list: %s", e)
+        raise OwnershipUnavailableError("Could not verify session ownership") from e
+
+    if not user_session_ids:
+        # No ownership records for this user. Kept as-is pending #12685's
+        # decision on pre-ownership legacy sessions: failing closed here would
+        # hide a user's own history on installs that predate ownership
+        # tracking. Logged so the exposure is visible rather than silent.
+        logger.warning(
+            "No ownership records for %s — returning the unfiltered session list (#12685)",
+            username,
+        )
         return sessions
+
+    return [s for s in sessions if s.get("id") in user_session_ids]
 
 
 def _build_ownership_validator(redis):

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -443,9 +443,8 @@ async def _filter_user_sessions(sessions: list, username: str) -> list:
 
     Helper for list_sessions (#684).
     """
-    from autobot_shared.redis_client import get_redis_client as get_redis_mgr
-
     from api.chat_sessions_errors import OwnershipUnavailableError
+    from autobot_shared.redis_client import get_redis_client as get_redis_mgr
 
     try:
         redis = await get_redis_mgr(async_client=True, database="main")

--- a/autobot-backend/api/chat_sessions_errors.py
+++ b/autobot-backend/api/chat_sessions_errors.py
@@ -1,0 +1,20 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Errors for the chat-sessions API (#12685)."""
+
+from fastapi import HTTPException, status
+
+
+class OwnershipUnavailableError(HTTPException):
+    """Session ownership could not be verified, so no list can be returned.
+
+    503 rather than 500: the request is valid and will succeed once the
+    ownership store is reachable again. Returning an unfiltered list instead
+    would leak other tenants' sessions, which is why this is an error rather
+    than a degraded success.
+    """
+
+    def __init__(self, detail: str = "Could not verify session ownership") -> None:
+        super().__init__(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail)

--- a/autobot-backend/tests/test_chat_session_ownership_failclosed.py
+++ b/autobot-backend/tests/test_chat_session_ownership_failclosed.py
@@ -1,0 +1,87 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A failed ownership lookup must not return an unfiltered session list (#12685).
+
+`_filter_user_sessions` used to `return sessions` — every session on the
+instance — whenever the Redis ownership lookup raised. On a tenancy filter that
+is the wrong direction to fail: a Redis blip silently exposed other companies'
+agent conversations (observed live as a `CEO · <company_id>` session appearing
+in an ordinary user's chat list).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.chat_sessions import _filter_user_sessions
+from api.chat_sessions_errors import OwnershipUnavailableError
+
+_ALL = [
+    {"id": "mine-1", "title": "My chat"},
+    {"id": "other-1", "title": "Someone else's chat"},
+    {"id": "agent-1", "title": "CEO · 22d907a9-31fd-4bb4-8b42-89"},
+]
+
+
+def _validator(owned):
+    v = MagicMock()
+    v.get_user_sessions = AsyncMock(return_value=owned)
+    return v
+
+
+@pytest.mark.asyncio
+async def test_returns_only_the_users_own_sessions():
+    with patch("autobot_shared.redis_client.get_redis_client", new=AsyncMock()):
+        with patch("api.chat_sessions._build_ownership_validator", return_value=_validator(["mine-1"])):
+            result = await _filter_user_sessions(list(_ALL), "alice")
+
+    assert [s["id"] for s in result] == ["mine-1"]
+
+
+@pytest.mark.asyncio
+async def test_agent_session_is_excluded_when_not_owned():
+    """The reported symptom: a CEO agent conversation in a user's list."""
+    with patch("autobot_shared.redis_client.get_redis_client", new=AsyncMock()):
+        with patch("api.chat_sessions._build_ownership_validator", return_value=_validator(["mine-1"])):
+            result = await _filter_user_sessions(list(_ALL), "alice")
+
+    assert not any("CEO ·" in s["title"] for s in result)
+
+
+@pytest.mark.asyncio
+async def test_lookup_failure_raises_instead_of_returning_everything():
+    """The core fix: an error, not a silent unfiltered list."""
+    with patch("autobot_shared.redis_client.get_redis_client", new=AsyncMock(side_effect=RuntimeError("redis down"))):
+        with pytest.raises(OwnershipUnavailableError) as exc:
+            await _filter_user_sessions(list(_ALL), "alice")
+
+    assert exc.value.status_code == 503, "a transient store outage is 503, not 500"
+
+
+@pytest.mark.asyncio
+async def test_validator_failure_also_raises():
+    with patch("autobot_shared.redis_client.get_redis_client", new=AsyncMock()):
+        v = MagicMock()
+        v.get_user_sessions = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch("api.chat_sessions._build_ownership_validator", return_value=v):
+            with pytest.raises(OwnershipUnavailableError):
+                await _filter_user_sessions(list(_ALL), "alice")
+
+
+@pytest.mark.asyncio
+async def test_no_ownership_records_still_returns_all_but_warns(caplog):
+    """Legacy-session path, deliberately unchanged — but no longer silent.
+
+    Failing closed here would hide a user's own history on installs predating
+    ownership tracking, so the decision is deferred to #12685. The exposure is
+    logged so it is visible rather than invisible.
+    """
+    with patch("autobot_shared.redis_client.get_redis_client", new=AsyncMock()):
+        with patch("api.chat_sessions._build_ownership_validator", return_value=_validator([])):
+            with caplog.at_level("WARNING"):
+                result = await _filter_user_sessions(list(_ALL), "alice")
+
+    assert len(result) == 3
+    assert any("No ownership records" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Refs #12867 — does not close it.

**Correction (post-merge):** this said "Closes #12867". It delivers that issue's first acceptance criterion (a failed lookup never returns an unfiltered list) but not its second (an explicit decision on the no-records path, which needs an owner call). The keyword is removed so #12867 is not auto-closed when `Dev_new_gui` reaches `main`.

Contributes to #12685 but does not close it — the broader tenancy design (company-scoped sessions, separating agent conversations from human chats) stays open there.

## Thinking Path

`_filter_user_sessions` is the isolation filter on `GET /api/chat/sessions`, and it failed **open** in two places:

```python
if not user_session_ids:
    return sessions          # (a) no ownership data -> every session
...
except Exception as e:
    logger.debug(...)
    return sessions          # (b) lookup failed  -> every session
```

Path **(b)** is indefensible for a tenancy filter: a Redis blip silently returns every session on the instance, including other companies' agent conversations — and at `logger.debug`, so it left no visible trace. That is a plausible mechanism for the live observation in #12685, where a `CEO · <company_id>` session appeared in an ordinary user's chat list.

It now raises **503**, not 500: the request is valid and will succeed once the ownership store is reachable, so the UI can say "could not load your sessions" rather than showing someone else's.

**Path (a) is deliberately left unchanged**, and that restraint is the point. A user with no ownership records currently sees the unfiltered list — failing closed there would be consistent, but on installs predating ownership tracking it would make users' own history vanish. That is an owner call, not something to change unilaterally mid-fix. It now logs a warning, so the exposure is visible rather than silent, and the options (fail closed / backfill then fail closed / keep open) are recorded on #12867.

## What Changed

- **`api/chat_sessions.py`** — the lookup-failure path raises instead of returning an unfiltered list; the no-records path warns.
- **`api/chat_sessions_errors.py`** (new) — `OwnershipUnavailableError` (503).

## Verification

```
tests/test_chat_session_ownership_failclosed.py    5 passed  (new)
chat / session selection                         387 passed
```

Tests cover: only the user's own sessions are returned; the **CEO agent session is excluded** when unowned (the reported symptom); a store failure raises 503 rather than returning everything; a validator failure likewise; and the legacy no-records path still returns all **but warns**, so the deferred decision is pinned rather than forgotten.

## Scope

Still open on #12685:
1. Scope chat sessions by tenant (`company_id` / `agent_id` / `origin`) — the company identity is currently only a display-title string, so it cannot be filtered on.
2. Separate agent conversations from human chats.
3. A two-company test asserting no cross-tenant sessions.

I could not locate the code path that creates the `CEO · <company_id>` session locally — LLC CEO chat has its own `llc_ceo_chat_threads` tables, so the leaking session is created elsewhere. Rather than guess, this PR fixes the filter weakness I could verify in code and leaves the creation-path question on the issue.

## Model Used

Claude Opus 5