### PR TITLE
a11y(gui): raw disabled form controls now look disabled (#12874)

### DIFF
--- a/autobot-frontend/src/assets/base.css
+++ b/autobot-frontend/src/assets/base.css
@@ -168,6 +168,33 @@ button:disabled {
   cursor: not-allowed;
 }
 
+/* GH#12711: buttons had a disabled treatment but form controls did not, so a
+ * `<input type="checkbox" disabled>` rendered identically to an active one —
+ * users could not tell what was interactive. BaseInput already handles its own
+ * disabled state (.container-disabled); this covers the raw controls used
+ * directly across the app. Mirrors the button treatment so disabled reads the
+ * same everywhere. */
+/* :not(.base-input) matters — BaseInput's container already applies
+ * opacity 0.6 when disabled, and stacking 0.5 on the inner input would
+ * compound to 0.3 and render it nearly invisible. */
+input:not(.base-input):disabled,
+textarea:not(.base-input):disabled,
+select:not(.base-input):disabled,
+input[type='checkbox']:disabled,
+input[type='radio']:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* A disabled control's label must dim with it, or the row still reads as active. */
+input:not(.base-input):disabled + label,
+input[type='checkbox']:disabled + span,
+input[type='radio']:disabled + span,
+label:has(> input:not(.base-input):disabled) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ============================================
  * FORM ELEMENTS
  * ============================================ */


### PR DESCRIPTION
Closes #12874

Contributes to #12711 but does not close it — part 2 (hardcoded-hex contrast failures) stays open there.

## Thinking Path

#12711 attributes the symptom to `BaseInput` and `ThemeToggle` stripping native rendering with `appearance: none`. Neither holds:

- **`BaseInput` is already handled.** It applies a `container-disabled` class and styles it — `background-color: var(--bg-secondary)`, `cursor: not-allowed`, `opacity: 0.6`, plus muted text on the input. Its `appearance: none` is scoped to `[type="number"]` spin buttons, not the whole input.
- **`ThemeToggle` cannot be disabled.** No `disabled` prop, no way to set one — so it cannot exhibit the bug.

**The real gap is the raw controls.** `src/assets/base.css` (loaded by `main.ts`) styles `button:disabled` and nothing else, so a raw `<input type="checkbox" disabled>` — the issue's own reported example — renders identically to an active one. 6 component files use raw disabled form controls.

**The interaction that needed care:** a naive global `input:disabled { opacity: 0.5 }` would stack on top of `BaseInput`'s container `opacity: 0.6`, compounding to **0.3** and making its disabled fields nearly invisible — fixing one control while degrading the shared one. The rule therefore excludes `.base-input`.

Adjacent labels dim with their control, or the row still reads as active.

## What Changed

`autobot-frontend/src/assets/base.css` — disabled treatment for `input` / `textarea` / `select` / `checkbox` / `radio`, mirroring the existing `button:disabled`, with `.base-input` excluded.

## Deliberately not applied to the SLM frontend

`autobot-slm-frontend` has no `:disabled` rules either, but **zero** raw disabled form controls in its `.vue` files. No observed symptom, so a rule there would be speculative — the issue's "both GUIs" framing holds for part 2 (405 hex colours), not for this part.

## Verification

```
braces balanced: True   (44 open / 44 close)
raw disabled form controls in main FE: 6 files
SLM raw disabled form controls: 0
```

Frontend type-check and unit tests cannot run locally (`node_modules` absent), so CI covers them. This is a CSS-only change to a global stylesheet; the risk it carries is the opacity-compounding interaction above, which is why that is excluded explicitly rather than left to chance.

## Model Used

Claude Opus 5
