### PR TITLE
feat(llc): board Update and Delete — boards had neither at the backend (#12876)

### DIFF
--- a/autobot-backend/llc/api/boards.py
+++ b/autobot-backend/llc/api/boards.py
@@ -9,6 +9,8 @@ Routes:
   POST  /api/llc/boards/sprint         — get or create sprint board for a sprint
   GET   /api/llc/boards/{board_id}     — get board metadata + columns
   GET   /api/llc/boards/{board_id}/items — get board with work items grouped by column
+  PUT   /api/llc/boards/{board_id}     — rename a board
+  DELETE /api/llc/boards/{board_id}    — delete a board and its columns
   POST  /api/llc/boards/{board_id}/move  — move work item to a column
 """
 
@@ -48,6 +50,12 @@ class SprintBoardRequest(BaseModel):
     company_id: str
     sprint_id: str
     name: Optional[str] = None
+
+
+class BoardUpdateRequest(BaseModel):
+    """GH#12695: rename a board. Only the name is updatable — see BoardService.update_board."""
+
+    name: str
 
 
 class MoveItemRequest(BaseModel):
@@ -238,6 +246,59 @@ async def get_board_items(
         "board": _board_response(board),
         "columns": columns_with_items,
     }
+
+
+@router.put("/{board_id}")
+async def update_board(
+    board_id: str,
+    body: BoardUpdateRequest,
+    session: AsyncSession = Depends(get_session),
+    svc: BoardService = Depends(_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> Dict[str, Any]:
+    """Rename a board (GH#12695). Boards were the only entity with no backend update."""
+    try:
+        uuid.UUID(board_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid board_id")
+
+    # GH#10296: verify tenant ownership BEFORE any cross-tenant mutation.
+    owner = await svc.get_board(session, board_id)
+    if owner is None or str(owner.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail=f"Board {board_id} not found")
+
+    board = await svc.update_board(session, board_id, body.name)
+    if board is None:
+        raise HTTPException(status_code=404, detail=f"Board {board_id} not found")
+    await session.commit()
+    return _board_response(board)
+
+
+@router.delete("/{board_id}", status_code=204)
+async def delete_board(
+    board_id: str,
+    session: AsyncSession = Depends(get_session),
+    svc: BoardService = Depends(_service),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    """Delete a board and its columns (GH#12695).
+
+    Work items are untouched — they belong to the project, not the board, so
+    deleting a view must not destroy the work it displays.
+    """
+    try:
+        uuid.UUID(board_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid board_id")
+
+    owner = await svc.get_board(session, board_id)
+    if owner is None or str(owner.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail=f"Board {board_id} not found")
+
+    await svc.delete_board(session, board_id)
+    await session.commit()
 
 
 @router.post("/{board_id}/move")

--- a/autobot-backend/llc/services/board.py
+++ b/autobot-backend/llc/services/board.py
@@ -151,6 +151,43 @@ class BoardService(LLCServiceBase):
         )
         return result.scalars().all()
 
+    # ------------------------------------------------------------------
+    # Update / Delete (GH#12695 — boards were the only entity with no
+    # backend PUT/DELETE, so a board created by mistake could never be
+    # renamed or removed.)
+    # ------------------------------------------------------------------
+
+    async def update_board(self, session: AsyncSession, board_id: str, name: str) -> Optional[LLCBoard]:
+        """Rename a board. Returns None when it does not exist.
+
+        Only ``name`` is updatable by design: type/project_id/sprint_id
+        participate in the uq_llc_boards_company_project_type and
+        ..._sprint_type constraints, so changing them would silently collide
+        with an existing board rather than doing what the caller meant.
+        """
+        board = await self.get_board(session, board_id)
+        if board is None:
+            return None
+        board.name = name
+        await session.flush()
+        await session.refresh(board)
+        return board
+
+    async def delete_board(self, session: AsyncSession, board_id: str) -> bool:
+        """Delete a board and its columns. Returns False when it does not exist.
+
+        Columns go with it: LLCBoardColumn declares ondelete="CASCADE" and the
+        relationship is cascade="all, delete-orphan", so no orphan rows remain.
+        Work items are NOT touched — they belong to the project, not the board,
+        and deleting a view must not destroy the work it displays.
+        """
+        board = await self.get_board(session, board_id)
+        if board is None:
+            return False
+        await session.delete(board)
+        await session.flush()
+        return True
+
     async def get_board_items(self, session: AsyncSession, board_id: str) -> Dict[str, Any]:
         """Return board columns with work items grouped per column.
 

--- a/autobot-backend/llc/tests/test_boards_update_delete_12695.py
+++ b/autobot-backend/llc/tests/test_boards_update_delete_12695.py
@@ -1,0 +1,132 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Boards must be updatable and deletable (#12695).
+
+Boards were the only LLC entity with no backend PUT/DELETE — a board created by
+mistake could never be renamed or removed, from the UI or the API.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_ORG = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_OTHER_ORG = uuid.UUID("99999999-9999-9999-9999-999999999999")
+_USER = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _board(company_id=_ORG, name="Sprint Board"):
+    b = MagicMock()
+    b.id = uuid.uuid4()
+    b.company_id = company_id
+    b.project_id = None
+    b.sprint_id = None
+    b.type = "kanban"
+    b.name = name
+    b.created_at = datetime.now(timezone.utc)
+    b.updated_at = datetime.now(timezone.utc)
+    b.columns = []
+    return b
+
+
+def _client(board, *, updated=None, deleted=True):
+    from api.user_management.dependencies import get_current_user, require_org_context
+    from llc.api.boards import router
+    from llc.deps import get_session
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/llc")
+    session = AsyncMock()
+    session.commit = AsyncMock()
+
+    async def _sess():
+        yield session
+
+    app.dependency_overrides[get_session] = _sess
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=_ORG, user_id=_USER, is_platform_admin=False
+    )
+
+    patch("llc.api.boards.BoardService.get_board", new=AsyncMock(return_value=board)).start()
+    patch("llc.api.boards.BoardService.update_board", new=AsyncMock(return_value=updated)).start()
+    patch("llc.api.boards.BoardService.delete_board", new=AsyncMock(return_value=deleted)).start()
+    return TestClient(app), session
+
+
+@pytest.fixture(autouse=True)
+def _stop():
+    yield
+    patch.stopall()
+
+
+def test_rename_a_board():
+    board = _board()
+    renamed = _board(name="Renamed")
+    client, session = _client(board, updated=renamed)
+
+    resp = client.put(f"/api/llc/boards/{board.id}", json={"name": "Renamed"})
+
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed"
+    session.commit.assert_awaited()
+
+
+def test_delete_a_board():
+    board = _board()
+    client, session = _client(board)
+
+    resp = client.delete(f"/api/llc/boards/{board.id}")
+
+    assert resp.status_code == 204
+    session.commit.assert_awaited()
+
+
+def test_cannot_rename_another_tenants_board():
+    """404, not 403 — cross-tenant existence must not be disclosed (GH#10296)."""
+    client, session = _client(_board(company_id=_OTHER_ORG))
+
+    resp = client.put(f"/api/llc/boards/{uuid.uuid4()}", json={"name": "Hijacked"})
+
+    assert resp.status_code == 404
+    session.commit.assert_not_awaited()
+
+
+def test_cannot_delete_another_tenants_board():
+    client, session = _client(_board(company_id=_OTHER_ORG))
+
+    resp = client.delete(f"/api/llc/boards/{uuid.uuid4()}")
+
+    assert resp.status_code == 404
+    session.commit.assert_not_awaited()
+
+
+def test_missing_board_is_404_on_both_verbs():
+    client, _ = _client(None)
+    bid = uuid.uuid4()
+
+    assert client.put(f"/api/llc/boards/{bid}", json={"name": "x"}).status_code == 404
+    assert client.delete(f"/api/llc/boards/{bid}").status_code == 404
+
+
+@pytest.mark.parametrize("verb", ["put", "delete"])
+def test_malformed_board_id_is_400(verb):
+    client, _ = _client(_board())
+    call = getattr(client, verb)
+    resp = call("/api/llc/boards/not-a-uuid", **({"json": {"name": "x"}} if verb == "put" else {}))
+
+    assert resp.status_code == 400
+
+
+def test_rename_requires_a_name():
+    client, _ = _client(_board())
+    resp = client.put(f"/api/llc/boards/{uuid.uuid4()}", json={})
+    assert resp.status_code == 422

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48736,9 +48736,20 @@ export interface paths {
          * @description Get board metadata and column configuration.
          */
         get: operations["get_board_api_llc_boards__board_id__get"];
-        put?: never;
+        /**
+         * Update Board
+         * @description Rename a board (GH#12695). Boards were the only entity with no backend update.
+         */
+        put: operations["update_board_api_llc_boards__board_id__put"];
         post?: never;
-        delete?: never;
+        /**
+         * Delete Board
+         * @description Delete a board and its columns (GH#12695).
+         *
+         *     Work items are untouched — they belong to the project, not the board, so
+         *     deleting a view must not destroy the work it displays.
+         */
+        delete: operations["delete_board_api_llc_boards__board_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -58152,6 +58163,16 @@ export interface components {
             mean_precision_at_k?: number | null;
             /** Reason */
             reason?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * BoardUpdateRequest
+         * @description GH#12695: rename a board. Only the name is updatable — see BoardService.update_board.
+         */
+        BoardUpdateRequest: {
+            /** Name */
+            name: string;
         } & {
             [key: string]: unknown;
         };
@@ -166096,6 +166117,72 @@ export interface operations {
                         [key: string]: unknown;
                     };
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_board_api_llc_boards__board_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                board_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BoardUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_board_api_llc_boards__board_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                board_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
Closes #12876

Contributes to #12695 but does not close it — the GUI-side Delete gaps stay open there.

## Thinking Path

Boards are the only entity in #12695's CRUD matrix that is `CR--` at the **backend**:

```
llc/api/boards.py   GET "" | POST /kanban | POST /sprint | GET /{id} | GET /{id}/items | POST /{id}/move
                    <- no PUT, no DELETE
```

So unlike the other gaps (which have backend DELETE and only lack a button), a board created by mistake could not be renamed or removed by *any* means.

Two constraints that needed deciding rather than defaulting:

**Only `name` is updatable.** `type`, `project_id` and `sprint_id` participate in the `uq_llc_boards_company_project_type` / `..._sprint_type` unique constraints. A generic "update any field" endpoint would let a caller move a board onto another board's slot and get a constraint violation instead of the rename they asked for.

**Delete must not touch work items.** They belong to the project, not the board — deleting a *view* must not destroy the work it displays. Columns *do* go with it, which I verified rather than assumed: `LLCBoardColumn` declares `ondelete="CASCADE"` and the relationship is `cascade="all, delete-orphan"`, so no orphan rows remain.

Both verbs check tenant ownership **before** mutating and return 404 (not 403) on cross-tenant, matching the rest of the router so board existence is not disclosed (GH#10296).

## What Changed

- **`llc/services/board.py`** — `update_board()` (rename only) and `delete_board()` (board + columns, work items untouched).
- **`llc/api/boards.py`** — `PUT /api/llc/boards/{board_id}` and `DELETE /api/llc/boards/{board_id}`, both verifying tenant ownership before mutating and returning 404 on cross-tenant.
- **`llc/tests/test_boards_update_delete_12695.py`** — 8 tests.

## Verification

```
llc/tests/test_boards_update_delete_12695.py    8 passed  (new)
llc/tests/                                   1328 passed, 2 skipped
```

Tests cover rename, delete, cross-tenant 404 on **both** verbs, missing board 404 on both, malformed id 400 on both, and rename requiring a name.

**Mutation-verified** — removing the tenant guard from DELETE:
```
2 failed, 6 passed
```
So the isolation check genuinely bites rather than passing by construction.

## Scope

Backend only. #12695's remaining gaps — GUI Delete for portfolios, programs, work-items, goals and sprints — already have backend DELETE endpoints, so they are a frontend task (buttons, confirm dialogs, i18n across 11 locales) and stay open there.

## Model Used

Claude Opus 5