### PR TITLE
fix(deploy): PLAY 2 aborted on undefined role vars — render .env via include_role (#12871)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -713,17 +713,24 @@
       when: "'backend' in group_names"
       tags: [backend, env]
 
-    - name: "[PLAY 2] Backend | Regenerate .env from template (#2649)"
-      ansible.builtin.template:
-        src: ../roles/backend/templates/backend.env.j2
-        dest: /opt/autobot/autobot-backend/.env
-        mode: "0600"
-        owner: autobot
-        group: autobot
-        backup: true
-      become: true
+    # GH#12871: was a bare playbook-level `template:` task, which cannot see the
+    # backend role's defaults — it died on AnsibleUndefinedVariable
+    # 'backend_chromadb_auth_token', failing PLAY 2 so PLAY 3 never ran. That
+    # variable was only the first of 37 the template needs and this play does
+    # not define. include_role puts the defaults in scope at role-default
+    # precedence, so they fill the other 32 while the secret overrides below
+    # (read off the live host) still win. include_vars would NOT be safe here:
+    # it outranks task vars, so it would replace those secrets with the role's
+    # empty / "change-me-in-production" placeholders.
+    - name: "[PLAY 2] Backend | Regenerate .env from template (#2649, #12871)"
+      ansible.builtin.include_role:
+        name: backend
+        tasks_from: env_only
       when: "'backend' in group_names"
       vars:
+        backend_env_dest: /opt/autobot/autobot-backend/.env
+        backend_env_owner: autobot
+        backend_env_group: autobot
         # backend_secret_key uses a register var specific to this playbook
         backend_secret_key: "{{ existing_secret_key.stdout | default(lookup('env', 'AUTOBOT_SECRET_KEY') | default('autobot-dev-secret-' + (9999999999 | random | string), true), true) }}"
         # #10400: prefer SLM_SECRET_KEY when present, else keep the role default.

--- a/autobot-slm-backend/ansible/roles/backend/tasks/env_only.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/env_only.yml
@@ -1,0 +1,33 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# GH#12871: render backend.env.j2 with the backend role's defaults in scope.
+#
+# The self-update playbook used to render this template from a bare
+# playbook-level `template:` task. Role defaults are not in scope there, so the
+# task died on `AnsibleUndefinedVariable: 'backend_chromadb_auth_token'` — PLAY 2
+# failed and PLAY 3 never ran. That variable was only the first of 37 the
+# template needs and the play does not define.
+#
+# Loading the defaults with `include_vars` would have been worse than the bug:
+# include_vars outranks task vars (verified empirically on ansible 2.17), so it
+# would have overwritten the five secrets the caller reads off the live host
+# (backend_secret_key, backend_jwt_secret, autobot_internal_api_key,
+# backend_postgres_password, autobot_admin_password) with the role's empty /
+# "change-me-in-production" placeholders — writing broken secrets into a
+# production .env.
+#
+# Invoking this file via include_role puts the defaults at role-default
+# precedence, so they fill the other 32 while the caller's overrides still win.
+#
+# Caller must set: backend_env_dest, backend_env_owner, backend_env_group.
+---
+- name: "Backend | Render .env from template (#12871)"
+  ansible.builtin.template:
+    src: backend.env.j2
+    dest: "{{ backend_env_dest }}"
+    mode: "0600"
+    owner: "{{ backend_env_owner }}"
+    group: "{{ backend_env_group }}"
+    backup: true
+  become: true
+  tags: ['backend', 'env']


### PR DESCRIPTION
Closes #12871

## Thinking Path

PLAY 2 rendered `backend.env.j2` from a bare playbook-level `template:` task. Role defaults are not in scope there, so it died on `AnsibleUndefinedVariable: 'backend_chromadb_auth_token'` — PLAY 2 failed, PLAY 3 never ran, and #12777's unit fix stayed undeployable.

**That variable is only the first one Ansible happened to hit.** The template references **37** variables that come from `roles/backend/defaults` and that this play does not define. Adding the one named variable would have moved the failure to the next one and looked like progress.

**The obvious fix is a trap, and it is worse than the bug.** Loading the defaults with `include_vars` would have overwritten the five secrets the play reads off the live host — `backend_secret_key`, `backend_jwt_secret`, `autobot_internal_api_key`, `backend_postgres_password`, `autobot_admin_password` — with the role's `""` / `"change-me-in-production"` placeholders, writing broken secrets into a **production `.env`**.

I did not take that on trust. Ansible is installed here, so I checked the precedence empirically:

```
include_vars vs task vars      ->  secret_var=DEFAULT_PLACEHOLDER      (task vars LOSE)
include_role param vs default  ->  secret_var=REAL_SECRET_FROM_HOST    (param WINS)
```

So the task becomes an `include_role` with `tasks_from: env_only`: role defaults apply at role-default precedence and fill the other 32, while the caller's overrides still win.

## What Changed

- **`roles/backend/tasks/env_only.yml`** (new) — renders the template with the role's defaults in scope; caller supplies `backend_env_dest` / `_owner` / `_group`.
- **`playbooks/update-all-nodes.yml`** — the PLAY 2 task now calls it, keeping its existing secret overrides untouched.

## Verification

Rendered the **real** template against the **real** role defaults, with the five secrets supplied as the play supplies them:

```
before (bare template task):  FAILED — AnsibleUndefinedVariable 'backend_host'
after  (include_role):        changed=1, rendered successfully

  SECRET_KEY=REAL_SECRET_FROM_HOST
  AUTOBOT_JWT_SECRET=REAL_JWT_FROM_HOST
  AUTOBOT_INTERNAL_API_KEY=REAL_INTERNAL_KEY
  AUTOBOT_POSTGRES_PASSWORD=REAL_DB_PASSWORD
  AUTOBOT_ADMIN_PASSWORD=REAL_ADMIN_PASSWORD

  "change-me-in-production" occurrences: 0
  AUTOBOT_CHROMADB_AUTH_TOKEN=            (renders from role default; was undefined)
```

The before-case reproduces the class of failure (a different variable name only because Jinja resolution order differs outside the play's own vars), and the after-case proves both halves: the undefined-variable abort is gone **and** no placeholder secret leaked.

Both files parse as YAML.

## Note

This unblocks PLAY 3, but whether the full self-update then completes still needs a live run — that is #12596's outstanding verification, not something this PR can assert.

## Model Used

Claude Opus 5
