### PR TITLE
fix(memory-graph): initialize() returned None so a successful init read as failure (#12873)

### DIFF
--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -148,16 +148,27 @@ class AutoBotMemoryGraphCore:
         if not self._initialized:
             raise RuntimeError("AutoBotMemoryGraph not initialized — call await initialize() first")
 
-    async def initialize(self) -> None:
+    async def initialize(self) -> bool:
         """
         Initialize Redis connection and search indexes.
 
         This method is idempotent and thread-safe.
+
+        Returns:
+            True once the graph is usable.
+
+        #12873: this used to be declared ``-> None`` and returned nothing, but
+        ``chat_history/base.py`` does ``initialized = await
+        memory_graph.initialize()`` and then ``if initialized:``. A SUCCESSFUL
+        init therefore returned None, which is falsy, so conversation entity
+        tracking was disabled on every boot while the graph itself was fine —
+        and nothing logged an error, because nothing had failed. That is why
+        #12780's fix removed the visible errors without recovering the feature.
         """
         async with self._lock:
             if self._initialized:
                 logger.debug("AutoBotMemoryGraph already initialized")
-                return
+                return True
 
             try:
                 # Initialize Redis client
@@ -174,6 +185,7 @@ class AutoBotMemoryGraphCore:
 
                 self._initialized = True
                 logger.info("AutoBotMemoryGraph initialized successfully")
+                return True
 
             except Exception as e:
                 logger.error(f"Failed to initialize AutoBotMemoryGraph: {e}")

--- a/autobot-backend/chat_history/base.py
+++ b/autobot-backend/chat_history/base.py
@@ -250,8 +250,16 @@ class ChatHistoryBase:
                 self.memory_graph_enabled = True
                 logger.info("✅ Memory Graph initialized successfully for conversation tracking")
             else:
+                # #12873: a falsy return here used to be unactionable — the graph
+                # logs its own failures and raises, so reaching this branch means
+                # initialize() completed without raising yet reported not-ready.
+                # Report what it actually said about itself instead of just the
+                # outcome, so this cannot go undiagnosed again.
                 logger.warning(
-                    "⚠️ Memory Graph initialization returned False - " "conversation entity tracking disabled"
+                    "⚠️ Memory Graph reported not-ready (returned %r, is_initialized=%s) — "
+                    "conversation entity tracking disabled",
+                    initialized,
+                    getattr(self.memory_graph, "is_initialized", "unknown"),
                 )
                 self.memory_graph = None
 

--- a/autobot-backend/tests/test_memory_graph_init_contract_12873.py
+++ b/autobot-backend/tests/test_memory_graph_init_contract_12873.py
@@ -1,0 +1,91 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Memory graph init must report success truthfully (#12873).
+
+`AutoBotMemoryGraph.initialize()` was declared `-> None` and returned nothing,
+but `chat_history/base.py` does:
+
+    initialized = await self.memory_graph.initialize()
+    if initialized: ...
+
+so a SUCCESSFUL init returned None — falsy — and conversation entity tracking
+was disabled on every boot while the graph itself was fine. Nothing logged an
+error because nothing had failed, which is why #12780's fix removed the visible
+errors without recovering the feature.
+"""
+
+import inspect
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_memory_graph.core import AutoBotMemoryGraphCore as AutoBotMemoryGraph
+
+
+def _graph():
+    g = AutoBotMemoryGraph.__new__(AutoBotMemoryGraph)
+    import asyncio
+
+    g._lock = asyncio.Lock()
+    g._initialized = False
+    g.redis_client = None
+    return g
+
+
+@pytest.mark.asyncio
+async def test_successful_init_returns_true():
+    """The whole bug: this returned None, which the caller read as failure."""
+    g = _graph()
+    with patch("autobot_memory_graph.core.get_async_redis_client", new=AsyncMock(return_value=AsyncMock())):
+        with patch.object(AutoBotMemoryGraph, "_create_search_indexes", new=AsyncMock()):
+            result = await g.initialize()
+
+    assert result is True, "a successful init must be truthy — the caller gates on it"
+    assert g._initialized is True
+
+
+@pytest.mark.asyncio
+async def test_second_call_is_idempotent_and_still_truthy():
+    """The early return also used to yield None, so a re-init reported failure."""
+    g = _graph()
+    with patch("autobot_memory_graph.core.get_async_redis_client", new=AsyncMock(return_value=AsyncMock())):
+        with patch.object(AutoBotMemoryGraph, "_create_search_indexes", new=AsyncMock()):
+            await g.initialize()
+            again = await g.initialize()
+
+    assert again is True
+
+
+@pytest.mark.asyncio
+async def test_failure_still_raises_rather_than_returning_false():
+    """Callers wrap this in try/except; swallowing the cause would hide it."""
+    g = _graph()
+    with patch(
+        "autobot_memory_graph.core.get_async_redis_client",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        with pytest.raises(RuntimeError, match="redis down"):
+            await g.initialize()
+
+    assert g._initialized is False
+
+
+def test_signature_declares_a_bool_return():
+    """A `-> None` annotation is what let the falsy return look intentional."""
+    sig = inspect.signature(AutoBotMemoryGraph.initialize)
+
+    assert sig.return_annotation is bool or sig.return_annotation == "bool", (
+        f"return annotation is {sig.return_annotation!r}; a None-returning init "
+        "silently disables entity tracking at the call site"
+    )
+
+
+def test_every_exit_path_returns_true_or_raises():
+    """No path may fall off the end and implicitly return None again."""
+    src = inspect.getsource(AutoBotMemoryGraph.initialize)
+    body = src.split('"""', 2)[-1]
+
+    assert body.count("return True") == 2, "expected the early-return and success paths to return True"
+    assert "return False" not in body, "failures raise; a False return would be silently unactionable"


### PR DESCRIPTION
Closes #12873

## Thinking Path

The issue frames this as a silent failure and asks for diagnostic logging so the cause can be found. It is not a failure at all — it is a **contract mismatch**, and the "silence" is because nothing was going wrong.

`AutoBotMemoryGraphCore.initialize()` was declared `-> None` with no `return` statement. The caller does:

```python
initialized = await self.memory_graph.initialize()
if initialized:
    self.memory_graph_enabled = True
else:
    logger.warning("⚠️ Memory Graph initialization returned False ...")
```

A **successful** init returns `None`, which is falsy — so entity tracking was disabled on every boot while the graph itself initialised fine and logged `AutoBotMemoryGraph initialized successfully`.

That explains every observation in the issue:
- **No error anywhere in the boot window** — nothing failed.
- **"returned False" every boot** — `None` is falsy, unconditionally.
- **#12780's fix removed the visible errors without recovering the feature** — those errors were real and are genuinely fixed; they were never what disabled tracking.

## What Changed

- **`autobot_memory_graph/core.py`** — `initialize()` returns `bool`: `True` on success and `True` on the idempotent early return. Failures still **raise**, so the cause is never swallowed. The four other callers ignore the return value, so widening it is safe for them.
- **`chat_history/base.py`** — the not-ready branch now reports what the graph said about itself (the returned value and `is_initialized`) rather than only the outcome. That is the issue's fix 1, still worth having for a genuine future failure.

## Verification

```
tests/test_memory_graph_init_contract_12873.py     5 passed  (new)
memory_graph / chat_history selection            219 passed
```

Tests: a successful init is truthy, the idempotent second call is truthy too (that path returned `None` as well), failures still raise rather than returning `False`, the signature declares `bool`, and no exit path falls through to an implicit `None`.

**Mutation-verified** — restoring the implicit `None` return:
```
2 failed, 3 passed
```
which reproduces the original bug exactly.

## Scope

The issue's fix 2 — check whether `memory_entity_idx` / `memory_fulltext_idx` exist, whether the `memory` alias resolves to DB 0, whether RediSearch is loaded — were hypotheses for a failure that turns out not to be occurring. Those are only worth running if entity tracking is still disabled after this lands, which needs the live node to confirm.

## Model Used

Claude Opus 5
