### PR TITLE
fix(gui): confirm /api/health before reporting the backend unreachable (#12881)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useSystemStatus.reachability.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSystemStatus.reachability.test.ts
@@ -1,0 +1,96 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#12866: the two service-monitor probes carry a 5s budget, but the backend
+// stalls in bursts (a CPU-bound scan holds the GIL and blocks the event loop for
+// 12s+). Measured: 27.5% of polls exceeded the budget while /api/health kept
+// returning 200 and the process never restarted — so a healthy backend was
+// reported "Unreachable" about a quarter of the time.
+//
+// A failed status probe must therefore be confirmed against /api/health before
+// declaring the backend down.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchWithFallback = vi.fn()
+
+vi.mock('@/utils/ApiEndpointMapper.js', () => ({
+  default: { fetchWithFallback: (...a: unknown[]) => fetchWithFallback(...a) },
+}))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('@/config/ssot-config', () => ({ getApiBase: () => '/api' }))
+vi.mock('@/composables/usePollingJob', () => ({
+  usePollingJob: () => ({ start: vi.fn(), stop: vi.fn() }),
+}))
+
+import { useSystemStatus } from '../useSystemStatus'
+
+const STALLED = new Error('timeout of 5000ms exceeded')
+
+function healthOk() {
+  return { ok: true, status: 200, fallback: false, json: async () => ({ status: 'ok' }), text: async () => 'ok' }
+}
+
+describe('useSystemStatus backend reachability (GH#12866)', () => {
+  beforeEach(() => {
+    fetchWithFallback.mockReset()
+  })
+
+  it('reports Degraded, not Unreachable, when status probes time out but health responds', async () => {
+    fetchWithFallback.mockImplementation((url: string) => {
+      if (url.includes('/health')) return Promise.resolve(healthOk())
+      return Promise.reject(STALLED)
+    })
+
+    const { refreshSystemStatus, systemServices, systemStatus } = useSystemStatus()
+    await refreshSystemStatus()
+
+    const backend = systemServices.value.find((s) => s.name === 'Backend API')
+    expect(backend?.statusText).toContain('Degraded')
+    expect(backend?.statusText).not.toContain('Unreachable')
+    expect(systemStatus.value.backendUnreachable).toBe(false)
+  })
+
+  it('still reports Unreachable when health fails too', async () => {
+    fetchWithFallback.mockRejectedValue(STALLED)
+
+    const { refreshSystemStatus, systemServices, systemStatus } = useSystemStatus()
+    await refreshSystemStatus()
+
+    const backend = systemServices.value.find((s) => s.name === 'Backend API')
+    expect(backend?.statusText).toContain('Unreachable')
+    expect(systemStatus.value.backendUnreachable).toBe(true)
+  })
+
+  it('does not probe health when the status endpoints succeed', async () => {
+    fetchWithFallback.mockResolvedValue({
+      ok: true,
+      status: 200,
+      fallback: false,
+      json: async () => ({ vms: [], services: [] }),
+      text: async () => '',
+    })
+
+    const { refreshSystemStatus } = useSystemStatus()
+    await refreshSystemStatus()
+
+    const healthCalls = fetchWithFallback.mock.calls.filter((c) => String(c[0]).includes('/health'))
+    expect(healthCalls).toHaveLength(0)
+  })
+
+  it('treats a fallback response as not reachable', async () => {
+    // A fallback means the mapper served canned data, not the backend.
+    fetchWithFallback.mockImplementation((url: string) => {
+      if (url.includes('/health')) {
+        return Promise.resolve({ ok: true, status: 200, fallback: true, json: async () => ({}), text: async () => '' })
+      }
+      return Promise.reject(STALLED)
+    })
+
+    const { refreshSystemStatus, systemStatus } = useSystemStatus()
+    await refreshSystemStatus()
+
+    expect(systemStatus.value.backendUnreachable).toBe(true)
+  })
+})

--- a/autobot-frontend/src/composables/useSystemStatus.ts
+++ b/autobot-frontend/src/composables/useSystemStatus.ts
@@ -20,6 +20,11 @@ import { getApiBase } from '@/config/ssot-config'
 // backend restart self-recovers without a manual Refresh.
 const STATUS_POLL_INTERVAL_MS = 15000
 
+// GH#12866: budget for the /api/health confirmation probe. Deliberately short —
+// it only has to distinguish "not answering" from "answering slowly", and a
+// long budget here would just re-add the delay the status probes already hit.
+const BACKEND_HEALTH_TIMEOUT_MS = 3000
+
 // ---------------------------------------------------------------------------
 // Types & Interfaces
 // ---------------------------------------------------------------------------
@@ -182,6 +187,32 @@ function toHealthStatus(raw: string): ServiceHealthStatus {
  *
  * @returns Tuple of [services, hadApiError]
  */
+/**
+ * Is the backend actually reachable, independent of the status endpoints?
+ *
+ * GH#12866: the two service-monitor probes carry a 5s budget, but the backend
+ * stalls in bursts — a CPU-bound scan holds the GIL and blocks the event loop
+ * for 12s+, so 27.5% of polls exceeded the budget while /api/health kept
+ * returning 200 and the process never restarted. Treating any probe timeout as
+ * "unreachable" therefore reported a healthy backend as down roughly a quarter
+ * of the time.
+ *
+ * /api/health is cheap, so a short budget here distinguishes "not answering at
+ * all" from "answering slowly". Returns false only when the backend genuinely
+ * does not respond.
+ */
+async function isBackendReachable(): Promise<boolean> {
+  try {
+    const res = (await apiEndpointMapper.fetchWithFallback(
+      `${getApiBase()}/health`,
+      { timeout: BACKEND_HEALTH_TIMEOUT_MS },
+    )) as FallbackResponse
+    return Boolean(res?.ok) && !res?.fallback
+  } catch {
+    return false
+  }
+}
+
 async function fetchVmStatus(): Promise<[SystemService[], boolean]> {
   const services: SystemService[] = []
   let hadError = false
@@ -377,13 +408,24 @@ export function useSystemStatus(): UseSystemStatusReturn {
       const [svcServices, svcError] = await fetchServiceStatus()
       const hasApiErrors = vmError || svcError
 
+      // GH#12866: a failed status probe does not mean the backend is down.
+      // Confirm with a cheap /api/health call before declaring it unreachable,
+      // so a burst of event-loop stalls reads as "degraded" rather than "down".
+      const reachable = hasApiErrors ? await isBackendReachable() : true
+
       // #10347: NPU/Redis/Ollama/Browser are read THROUGH the backend's
       // /api/service-monitor/*. If the backend API itself is unreachable
       // (e.g. a ~20-30s restart), we don't know their state — show ONE
       // amber "backend unreachable" row, not five false red "down"s.
       if (hasApiErrors) {
         systemServices.value = [
-          { name: 'Backend API', status: 'warning', statusText: 'Unreachable — service status unknown' },
+          {
+            name: 'Backend API',
+            status: 'warning',
+            statusText: reachable
+              ? 'Degraded — status checks timed out, backend responding'
+              : 'Unreachable — service status unknown',
+          },
           { name: 'Frontend', status: 'healthy', statusText: 'Connected' },
           { name: 'WebSocket', status: 'healthy', statusText: 'Connected' },
         ]
@@ -392,7 +434,9 @@ export function useSystemStatus(): UseSystemStatusReturn {
           hasIssues: false,
           lastChecked: new Date(),
           apiErrors: true,
-          backendUnreachable: true,
+          // GH#12866: only true when /api/health also failed. Consumers gate
+          // reconnect banners on this, so a slow poll must not trigger them.
+          backendUnreachable: !reachable,
         }
         return
       }


### PR DESCRIPTION
Closes #12881

Contributes to #12866 but does not close it — the backend half stays open there.

## Thinking Path

`useSystemStatus` polls two service-monitor endpoints with a 5s budget and treats **any** failure as "Backend API — Unreachable". But the backend does not go down; it stalls in bursts. The issue's measurements, on a single-box deployment with `NRestarts=0` and `/api/health` returning 200 throughout:

```
40 samples of /api/service-monitor/vms/status
  p50=0.85s      >5s (GUI trips): 11/40 = 27.5%
  calm window minutes later: 12/12 in 0.020-0.036s
```

So roughly a quarter of polls reported a healthy backend as down. The panel was answering a question it had no evidence for: a status endpoint timing out says nothing about whether the process is alive.

**The tempting fix — raise the timeout — is wrong here.** Real latency during a stall was **≥12s** (eight samples hit the measuring client's own ceiling). A budget large enough to absorb that would make the panel unresponsive in the normal case *and* hide the stall entirely. The label should be correct, not the timeout longer.

So the fix confirms reachability instead: on probe failure, a cheap `/api/health` call disambiguates "not answering" from "answering slowly".

## What Changed

`autobot-frontend/src/composables/useSystemStatus.ts`:
- `isBackendReachable()` — short (3s) `/api/health` probe. A **fallback** response counts as not reachable, since that means the mapper served canned data rather than the backend answering.
- Status text becomes "Degraded — status checks timed out, backend responding" when health responds; unchanged "Unreachable" when it does not.
- `backendUnreachable` is now set **only** when health also failed. Consumers gate reconnect behaviour on that flag, so a slow poll must not trigger a reconnect banner.

The health call is skipped entirely when the status probes succeed, so the normal path costs nothing extra.

## Verification

4 new tests: a timeout with a healthy backend reads degraded and leaves `backendUnreachable` false; a genuinely down backend still reads unreachable; **no** health request is made when the status probes succeed; and a fallback response counts as unreachable.

Frontend tests cannot run locally — `node_modules` is absent in the worktree. Rather than assert a green suite I could not produce, I checked the pieces the tests depend on directly against the source: `refreshSystemStatus` / `systemServices` / `systemStatus` are all on the composable's exported surface, and both `fetchVmStatus` and `fetchServiceStatus` set `hadError` on the same two conditions (a thrown error, or `resp.fallback`). CI runs the tests themselves.

## Scope

#12866's backend half is the actual cause of the stalls — a CPU-bound regex scan in `code_intelligence` holding the GIL and blocking the event loop for 12s+, caught by `py-spy`. That is a separate fix (chunking, yielding, or a process pool) and stays open there. This PR stops the GUI lying about it.

## Model Used

Claude Opus 5
