### PR TITLE
perf(code-intel): O(1) line lookup replaces a GIL-holding per-match rescan (#12884)

### DIFF
--- a/autobot-backend/code_intelligence/security/analyzer.py
+++ b/autobot-backend/code_intelligence/security/analyzer.py
@@ -28,6 +28,7 @@ from .constants import (
     VulnerabilityType,
 )
 from .finding import SecurityFinding
+from ..shared.line_index import LineIndex
 from .patterns import SECRET_PATTERNS, SQL_INJECTION_PATTERNS
 
 logger = get_logger(__name__)
@@ -53,11 +54,15 @@ class SecurityAnalyzer(BaseCodeAnalyzer):
 
     def _check_hardcoded_secrets(self, file_path: str, content: str, lines: List[str]) -> List[SecurityFinding]:
         """Check for hardcoded secrets."""
+        # #12866: build the offset->line map ONCE per file. The previous
+        # per-match `content[:start].count("\n")` was O(n*m) and held the
+        # GIL in C for the whole scan.
+        _line_index = LineIndex(content)
         findings: List[SecurityFinding] = []
 
         for pattern, vuln_type, cwe_id in SECRET_PATTERNS:
             for match in re.finditer(pattern, content):
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 code = lines[line_num - 1] if line_num <= len(lines) else ""
 
                 if "os.getenv" in code or "os.environ" in code:
@@ -87,11 +92,15 @@ class SecurityAnalyzer(BaseCodeAnalyzer):
 
     def _check_sql_injection(self, file_path: str, content: str, lines: List[str]) -> List[SecurityFinding]:
         """Check for SQL injection patterns."""
+        # #12866: build the offset->line map ONCE per file. The previous
+        # per-match `content[:start].count("\n")` was O(n*m) and held the
+        # GIL in C for the whole scan.
+        _line_index = LineIndex(content)
         findings: List[SecurityFinding] = []
 
         for pattern, description in SQL_INJECTION_PATTERNS:
             for match in re.finditer(pattern, content, re.IGNORECASE):
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 code = lines[line_num - 1] if line_num <= len(lines) else ""
 
                 findings.append(
@@ -115,11 +124,15 @@ class SecurityAnalyzer(BaseCodeAnalyzer):
 
     def _check_path_traversal(self, file_path: str, content: str, lines: List[str]) -> List[SecurityFinding]:
         """Check for path traversal vulnerabilities."""
+        # #12866: build the offset->line map ONCE per file. The previous
+        # per-match `content[:start].count("\n")` was O(n*m) and held the
+        # GIL in C for the whole scan.
+        _line_index = LineIndex(content)
         findings: List[SecurityFinding] = []
         path_traversal_pattern = r'open\s*\(\s*[^)]*\+[^)]*\)|open\s*\(\s*f["\']'
 
         for match in re.finditer(path_traversal_pattern, content):
-            line_num = content[: match.start()].count("\n") + 1
+            line_num = _line_index.line_of(match.start())
             code = lines[line_num - 1] if line_num <= len(lines) else ""
 
             context_start = max(0, line_num - 3)
@@ -167,13 +180,17 @@ class SecurityAnalyzer(BaseCodeAnalyzer):
 
     def _check_weak_encryption(self, file_path: str, content: str, lines: List[str]) -> List[SecurityFinding]:
         """Check for weak/broken symmetric encryption algorithm usage."""
+        # #12866: build the offset->line map ONCE per file. The previous
+        # per-match `content[:start].count("\n")` was O(n*m) and held the
+        # GIL in C for the whole scan.
+        _line_index = LineIndex(content)
         findings: List[SecurityFinding] = []
 
         for match in self._WEAK_ENCRYPTION_IMPORT_PATTERN.finditer(content):
             module_name = match.group("from_name") or match.group("attr_name")
             key = self._WEAK_ENCRYPTION_MODULE_TO_KEY[module_name]
             msg, cwe_id = WEAK_ENCRYPTION[key]
-            line_num = content[: match.start()].count("\n") + 1
+            line_num = _line_index.line_of(match.start())
             code = lines[line_num - 1] if line_num <= len(lines) else ""
 
             findings.append(

--- a/autobot-backend/code_intelligence/security/analyzer.py
+++ b/autobot-backend/code_intelligence/security/analyzer.py
@@ -19,6 +19,7 @@ from code_intelligence.shared.analysis_base import (
     BaseCodeAnalyzer,
 )
 
+from ..shared.line_index import LineIndex
 from .ast_visitor import SecurityASTVisitor
 from .constants import (
     OWASP_MAPPING,
@@ -28,7 +29,6 @@ from .constants import (
     VulnerabilityType,
 )
 from .finding import SecurityFinding
-from ..shared.line_index import LineIndex
 from .patterns import SECRET_PATTERNS, SQL_INJECTION_PATTERNS
 
 logger = get_logger(__name__)

--- a/autobot-backend/code_intelligence/shared/line_index.py
+++ b/autobot-backend/code_intelligence/shared/line_index.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""O(1) offset-to-line lookup for regex scanners (#12866).
+
+Scanners resolved a match's line number with::
+
+    line_num = content[: match.start()].count("\\n") + 1
+
+which slices the file from the start and rescans it **for every match** — O(n·m)
+overall, plus a full string copy per match. On a file that produces many matches
+this dominates the scan, and because both the slice and ``str.count`` run in C
+it holds the GIL for the whole time with no yield point.
+
+Measured on a synthetic file of repeated matches:
+
+===========  ====================  =============  =======
+matches      slice-per-match       precomputed    speedup
+===========  ====================  =============  =======
+2,000        0.073 s               0.004 s        17x
+8,000        1.105 s               0.020 s        56x
+20,000       6.928 s               0.040 s        174x
+===========  ====================  =============  =======
+
+Nearly 7 s of uninterruptible GIL hold at 20k matches, which is the shape of the
+12 s event-loop stalls reported in #12866 (a ThreadPoolExecutor does not help:
+the work never releases the GIL).
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+
+__all__ = ["LineIndex"]
+
+
+class LineIndex:
+    """Maps character offsets to 1-based line numbers for one piece of content.
+
+    Build once per file, then query per match.
+    """
+
+    __slots__ = ("_starts",)
+
+    def __init__(self, content: str) -> None:
+        # Offset of the first character of each line. Line 1 starts at 0.
+        starts = [0]
+        idx = content.find("\n")
+        while idx != -1:
+            starts.append(idx + 1)
+            idx = content.find("\n", idx + 1)
+        self._starts = starts
+
+    def line_of(self, offset: int) -> int:
+        """Return the 1-based line number containing *offset*."""
+        return bisect_right(self._starts, offset)
+
+    def __len__(self) -> int:
+        return len(self._starts)

--- a/autobot-backend/tests/test_line_index_12866.py
+++ b/autobot-backend/tests/test_line_index_12866.py
@@ -1,0 +1,91 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Offset-to-line lookup must be O(1), not a per-match rescan (#12866).
+
+Scanners resolved each match's line with `content[:start].count("\\n") + 1`,
+which slices the file from the start for every match — O(n*m), and both the
+slice and str.count run in C, so it holds the GIL with no yield point. That is
+the shape of the 12s event-loop stalls reported in #12866; a ThreadPoolExecutor
+does not help, because the work never releases the GIL.
+"""
+
+import re
+import time
+
+import pytest
+
+def _load_line_index():
+    """Load by path: the suite stubs the code_intelligence package, whose
+    __init__ pulls in autobot_shared and fails under the test harness."""
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.spec_from_file_location(
+        "_line_index_12866",
+        Path(__file__).parent.parent / "code_intelligence" / "shared" / "line_index.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.LineIndex
+
+
+LineIndex = _load_line_index()
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", "a", "a\n", "\n", "a\nb\nc", "x\n\ny\n", "no newline at all", "\n\n\n"],
+)
+def test_matches_the_original_computation_at_every_offset(content):
+    """The replacement must be exactly equivalent, including the edge shapes."""
+    idx = LineIndex(content)
+
+    for offset in range(len(content) + 1):
+        expected = content[:offset].count("\n") + 1
+        assert idx.line_of(offset) == expected, f"offset {offset} of {content!r}"
+
+
+def test_first_line_is_one():
+    assert LineIndex("anything").line_of(0) == 1
+
+
+def test_offset_after_a_newline_is_the_next_line():
+    content = "first\nsecond\n"
+    idx = LineIndex(content)
+
+    assert idx.line_of(content.index("second")) == 2
+
+
+def test_scales_linearly_not_quadratically():
+    """The point of the change: cost must not explode with match count."""
+    pattern = r'execute\s*\(\s*f["\']'
+    small = 'cursor.execute(f"SELECT 1")\n' * 2000
+    large = 'cursor.execute(f"SELECT 1")\n' * 8000
+
+    def timed(content):
+        matches = list(re.finditer(pattern, content))
+        idx = LineIndex(content)
+        t0 = time.perf_counter()
+        for m in matches:
+            idx.line_of(m.start())
+        return time.perf_counter() - t0, len(matches)
+
+    t_small, n_small = timed(small)
+    t_large, n_large = timed(large)
+
+    assert n_large == 4 * n_small
+    # Quadratic would be ~16x. Allow generous headroom for a noisy CI box while
+    # still failing loudly if the per-match rescan ever comes back.
+    assert t_large < max(t_small * 8, 0.05), f"{n_small}->{n_large} matches took {t_small:.4f}s->{t_large:.4f}s"
+
+
+def test_the_old_idiom_is_gone_from_the_traced_analyzer():
+    """py-spy caught _check_sql_injection mid-stall; it must not regress."""
+    from pathlib import Path
+
+    src = (Path(__file__).parent.parent / "code_intelligence" / "security" / "analyzer.py").read_text(encoding="utf-8")
+
+    assert 'content[: match.start()].count' not in src
+    assert src.count("LineIndex(content)") == 4, "every checker in this file must build the index once"

--- a/autobot-backend/tests/test_line_index_12866.py
+++ b/autobot-backend/tests/test_line_index_12866.py
@@ -16,6 +16,7 @@ import time
 
 import pytest
 
+
 def _load_line_index():
     """Load by path: the suite stubs the code_intelligence package, whose
     __init__ pulls in autobot_shared and fails under the test harness."""
@@ -87,5 +88,5 @@ def test_the_old_idiom_is_gone_from_the_traced_analyzer():
 
     src = (Path(__file__).parent.parent / "code_intelligence" / "security" / "analyzer.py").read_text(encoding="utf-8")
 
-    assert 'content[: match.start()].count' not in src
+    assert "content[: match.start()].count" not in src
     assert src.count("LineIndex(content)") == 4, "every checker in this file must build the index once"


### PR DESCRIPTION
Closes #12884

Contributes to #12866 (the backend half) but does not close it — see Scope.

## Thinking Path

`py-spy` caught `_check_sql_injection` mid-stall, so the obvious read is "the regex is slow". It isn't. I measured the patterns first: **6 SQL patterns over a 212 KB file in 0.016 s**, with no catastrophic backtracking. The cost is entirely in how each match's line number was resolved:

```python
line_num = content[: match.start()].count("\n") + 1
```

That slices the file from the start and rescans it **for every match** — O(n*m), plus a full string copy per match. Both the slice and `str.count` run in C, so it holds the GIL with **no yield point**.

That last detail is what makes it the right suspect. A ThreadPoolExecutor is already in the stack (`concurrent/futures/thread.py` in the trace) and did not help — pure-Python threads release the GIL every ~5 ms, so a 12 s stall requires an *uninterruptible* C-level call, which this is and the regexes are not.

Measured on a synthetic file of repeated matches:

| matches | slice-per-match | precomputed | speedup |
|---|---|---|---|
| 2,000 | 0.073 s | 0.004 s | 17x |
| 8,000 | 1.105 s | 0.020 s | 56x |
| 20,000 | 6.928 s | 0.040 s | 174x |

~7 s of uninterruptible GIL hold at 20k matches — the shape of the reported 12 s stalls.

## What Changed

- **`code_intelligence/shared/line_index.py`** (new) — `LineIndex` builds the offset→line map once per file (O(n)) and answers each lookup with a `bisect`.
- **`code_intelligence/security/analyzer.py`** — all 4 checkers build the index once and use it, replacing the per-match rescan.

## Verification

```
tests/test_line_index_12866.py    12 passed
```

Correctness first, since this replaces a computation rather than tuning one: the tests assert equivalence with the old expression at **every offset** of 8 content shapes, including empty content, a bare newline, and a trailing newline.

End-to-end on realistic content, the traced checkers produce **identical findings** — 6001 both ways — 24x faster (0.567 s → 0.023 s).

There is also a scaling test: quadrupling the match count must not quadruple-squared the time. It allows generous headroom for a noisy CI box while still failing loudly if the per-match rescan returns.

## Scope

The idiom appears **23 times** across the codebase. This fixes the 4 in the file the profile actually implicates. The other 19 are the same defect off the hot path and are noted on #12884.

#12866 stays open: this removes the largest GIL hold I could measure, but whether it fully eliminates the 12 s stalls needs the live box — the profile was captured there, not here.

## Model Used

Claude Opus 5
