### PR TITLE
perf(code-intel): O(1) line lookup for the remaining 19 scanner sites (#12887)

### DIFF
--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -9,6 +9,7 @@ Provides automated code review with pattern checking, security analysis,
 and AI-generated review comments. Learns from past reviews.
 """
 
+from utils.line_index import LineIndex  # #12884
 import asyncio
 import json
 import re
@@ -276,9 +277,12 @@ def analyze_code(content: str, file_path: str) -> list[ReviewComment]:
     for pattern_id, pattern_def in REVIEW_PATTERNS.items():
         if pattern_def.get("pattern"):
             try:
+                # #12884: build the offset->line map once; the per-match
+                # `content[:start].count()` was O(n*m) and held the GIL.
+                _line_index = LineIndex(content)
                 for match in re.finditer(pattern_def["pattern"], content, re.IGNORECASE | re.MULTILINE):
                     # Calculate line number
-                    line_num = content[: match.start()].count("\n") + 1
+                    line_num = _line_index.line_of(match.start())
                     code_snippet = lines[line_num - 1] if line_num <= len(lines) else ""
 
                     comments.append(
@@ -298,8 +302,11 @@ def analyze_code(content: str, file_path: str) -> list[ReviewComment]:
                 logger.warning("Invalid regex pattern: %s", pattern_id)
 
     # Check for long functions
+    # #12884: build the offset->line map once; the per-match
+    # `content[:start].count()` was O(n*m) and held the GIL.
+    _line_index = LineIndex(content)
     for match in _FUNC_DEFINITION_RE.finditer(content):
-        func_start = content[: match.start()].count("\n") + 1
+        func_start = _line_index.line_of(match.start())
         # Find function end (simple heuristic)
         remaining = content[match.end() :]
         indent_match = _NEXT_TOPLEVEL_RE.search(remaining)

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -9,7 +9,6 @@ Provides automated code review with pattern checking, security analysis,
 and AI-generated review comments. Learns from past reviews.
 """
 
-from utils.line_index import LineIndex  # #12884
 import asyncio
 import json
 import re
@@ -52,6 +51,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_7_DAYS
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -9,7 +9,6 @@ Issue #222: Identifies performance anti-patterns like N+1 queries,
 unnecessary loops, blocking I/O in async contexts, and cache misuse.
 """
 
-from utils.line_index import LineIndex  # #12884
 import ast
 import asyncio
 import re
@@ -42,6 +41,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.path_validator import validate_path
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -9,6 +9,7 @@ Issue #222: Identifies performance anti-patterns like N+1 queries,
 unnecessary loops, blocking I/O in async contexts, and cache misuse.
 """
 
+from utils.line_index import LineIndex  # #12884
 import ast
 import asyncio
 import re
@@ -392,9 +393,12 @@ def analyze_with_regex(
 
         try:
             regex = re.compile(pattern.regex_pattern, re.MULTILINE)
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in regex.finditer(content):
                 # Find line number
-                line_start = content[: match.start()].count("\n") + 1
+                line_start = _line_index.line_of(match.start())
 
                 # Get snippet
                 snippet_start = max(0, line_start - 2)

--- a/autobot-backend/code_analysis/auto-tools/playwright_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/playwright_sanitizer.py
@@ -13,6 +13,7 @@ Author: AutoBot Playwright Security Specialist
 Version: 1.0.0
 """
 
+from utils.line_index import LineIndex  # #12884
 import hashlib
 import json
 import logging
@@ -183,8 +184,11 @@ class PlaywrightSecurityFixer:
         for pattern_name, pattern_info in patterns.items():
             matches = list(re.finditer(pattern_info["regex"], content, re.IGNORECASE))
 
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in matches:
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 context_start = max(0, match.start() - 50)
                 context_end = min(len(content), match.end() + 50)
                 context = content[context_start:context_end].strip()

--- a/autobot-backend/code_analysis/auto-tools/playwright_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/playwright_sanitizer.py
@@ -13,7 +13,6 @@ Author: AutoBot Playwright Security Specialist
 Version: 1.0.0
 """
 
-from utils.line_index import LineIndex  # #12884
 import hashlib
 import json
 import logging
@@ -26,6 +25,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from utils.line_index import LineIndex  # #12884
 
 # Configure logging for security fixer
 logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
@@ -23,6 +23,7 @@ NOTE: __init__ method (~141 lines) is an ACCEPTABLE EXCEPTION per Issue #490 -
 initialization of security agent with comprehensive report structure. Low priority.
 """
 
+from utils.line_index import LineIndex  # #12884
 import logging
 import sys
 from pathlib import Path
@@ -268,8 +269,11 @@ class SecurityFixAgent(SecurityFixToolBase):
 
             matches = list(re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE))
 
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in matches:
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 match_text = match.group()
 
                 # Skip if this appears to be safe in context

--- a/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
@@ -23,12 +23,12 @@ NOTE: __init__ method (~141 lines) is an ACCEPTABLE EXCEPTION per Issue #490 -
 initialization of security agent with comprehensive report structure. Low priority.
 """
 
-from utils.line_index import LineIndex  # #12884
 import logging
 import sys
 from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
+from utils.line_index import LineIndex  # #12884
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
@@ -19,6 +19,7 @@ Author: AutoBot Security Fix Agent
 Version: 1.0.0
 """
 
+from utils.line_index import LineIndex  # #12884
 import logging
 import sys
 from pathlib import Path
@@ -118,8 +119,11 @@ class SecurityFixAgent(SecurityFixToolBase):
         for vuln_type, pattern in self.xss_patterns.items():
             matches = list(re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE))
 
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in matches:
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 context_start = max(0, match.start() - 50)
                 context_end = min(len(content), match.end() + 50)
                 context = content[context_start:context_end].strip()

--- a/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
@@ -19,12 +19,12 @@ Author: AutoBot Security Fix Agent
 Version: 1.0.0
 """
 
-from utils.line_index import LineIndex  # #12884
 import logging
 import sys
 from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
+from utils.line_index import LineIndex  # #12884
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
+++ b/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
@@ -5,7 +5,6 @@
 Focused analysis for critical hardcoded environment variables
 """
 
-from utils.line_index import LineIndex  # #12884
 import re
 from pathlib import Path
 from typing import Any, Dict, List
@@ -13,6 +12,7 @@ from typing import Any, Dict, List
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
+++ b/autobot-backend/code_analysis/scripts/analyze_critical_env_vars.py
@@ -5,6 +5,7 @@
 Focused analysis for critical hardcoded environment variables
 """
 
+from utils.line_index import LineIndex  # #12884
 import re
 from pathlib import Path
 from typing import Any, Dict, List
@@ -116,8 +117,11 @@ class CriticalEnvAnalyzer:
 
             # Issue #510: Handle both compiled Pattern and string
             regex = pattern if hasattr(pattern, "finditer") else re.compile(pattern)
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in regex.finditer(content):
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 value = match.group(1) if match.groups() else match.group(0)
 
                 # Get context

--- a/autobot-backend/code_analysis/scripts/analyze_performance_simple.py
+++ b/autobot-backend/code_analysis/scripts/analyze_performance_simple.py
@@ -5,10 +5,11 @@
 Simple performance analysis focusing on critical patterns
 """
 
-from utils.line_index import LineIndex  # #12884
 import re
 from pathlib import Path
 from typing import Any, Dict, List
+
+from utils.line_index import LineIndex  # #12884
 
 
 class SimplePerformanceAnalyzer:

--- a/autobot-backend/code_analysis/scripts/analyze_performance_simple.py
+++ b/autobot-backend/code_analysis/scripts/analyze_performance_simple.py
@@ -5,6 +5,7 @@
 Simple performance analysis focusing on critical patterns
 """
 
+from utils.line_index import LineIndex  # #12884
 import re
 from pathlib import Path
 from typing import Any, Dict, List
@@ -89,8 +90,11 @@ class SimplePerformanceAnalyzer:
         # Issue #510: Use precompiled combined patterns
         for category, compiled in self._compiled_patterns.items():
             try:
+                # #12884: build the offset->line map once; the per-match
+                # `content[:start].count()` was O(n*m) and held the GIL.
+                _line_index = LineIndex(content)
                 for match in compiled.finditer(content):
-                    line_num = content[: match.start()].count("\n") + 1
+                    line_num = _line_index.line_of(match.start())
                     # Find which pattern matched using lastgroup
                     group_name = match.lastgroup
                     description = self._pattern_descriptions.get(group_name, "Performance issue")

--- a/autobot-backend/code_analysis/src/api_consistency_analyzer.py
+++ b/autobot-backend/code_analysis/src/api_consistency_analyzer.py
@@ -5,7 +5,6 @@ API Consistency Analyzer using Redis and NPU acceleration
 Analyzes API endpoints for consistency, patterns, and best practices
 """
 
-from utils.line_index import LineIndex  # #12884
 import ast
 import json
 import re
@@ -17,6 +16,7 @@ from typing import Any, Dict, List
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from constants.ttl_constants import TTL_1_HOUR
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/code_analysis/src/api_consistency_analyzer.py
+++ b/autobot-backend/code_analysis/src/api_consistency_analyzer.py
@@ -5,6 +5,7 @@ API Consistency Analyzer using Redis and NPU acceleration
 Analyzes API endpoints for consistency, patterns, and best practices
 """
 
+from utils.line_index import LineIndex  # #12884
 import ast
 import json
 import re
@@ -294,8 +295,11 @@ class APIConsistencyAnalyzer:
         # Issue #510: Use precompiled patterns for O(1) regex creation
         for framework, compiled_list in self._compiled_framework_patterns.items():
             for compiled_pattern, description in compiled_list:
+                # #12884: build the offset->line map once; the per-match
+                # `content[:start].count()` was O(n*m) and held the GIL.
+                _line_index = LineIndex(content)
                 for match in compiled_pattern.finditer(content):
-                    line_num = content[: match.start()].count("\n") + 1
+                    line_num = _line_index.line_of(match.start())
 
                     if framework == "fastapi":
                         method = match.group(1).upper()

--- a/autobot-backend/code_analysis/src/architectural_analysis/pattern_detector.py
+++ b/autobot-backend/code_analysis/src/architectural_analysis/pattern_detector.py
@@ -9,6 +9,7 @@ Detects design patterns in code.
 Extracted from ArchitecturalPatternAnalyzer as part of Issue #394.
 """
 
+from utils.line_index import LineIndex  # #12884
 import ast
 import re
 from pathlib import Path
@@ -161,8 +162,11 @@ class PatternDetector:
         detected_patterns: List[Dict[str, Any]],
     ) -> None:
         """Match a single pattern and record matches."""
+        # #12884: build the offset->line map once; the per-match
+        # `content[:start].count()` was O(n*m) and held the GIL.
+        _line_index = LineIndex(content)
         for match in re.finditer(regex_pattern, content, re.MULTILINE | re.IGNORECASE):
-            line_num = content[: match.start()].count("\n") + 1
+            line_num = _line_index.line_of(match.start())
             detected_patterns.append(
                 {
                     "pattern": pattern_name,

--- a/autobot-backend/code_analysis/src/architectural_analysis/pattern_detector.py
+++ b/autobot-backend/code_analysis/src/architectural_analysis/pattern_detector.py
@@ -9,13 +9,13 @@ Detects design patterns in code.
 Extracted from ArchitecturalPatternAnalyzer as part of Issue #394.
 """
 
-from utils.line_index import LineIndex  # #12884
 import ast
 import re
 from pathlib import Path
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/code_analysis/src/env_analyzer.py
+++ b/autobot-backend/code_analysis/src/env_analyzer.py
@@ -7,6 +7,7 @@ Environment Variable Analyzer using Redis and NPU acceleration
 Analyzes codebase for hardcoded values that should be environment variables
 """
 
+from utils.line_index import LineIndex  # #12884
 from __future__ import annotations
 
 import ast
@@ -770,8 +771,11 @@ class EnvironmentAnalyzer:
 
         # Use precompiled combined patterns
         for category, compiled in self._compiled_patterns.items():
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in compiled.finditer(content):
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
 
                 # Issue #632: Skip matches inside docstrings
                 if line_num in docstring_lines:

--- a/autobot-backend/code_analysis/src/env_analyzer.py
+++ b/autobot-backend/code_analysis/src/env_analyzer.py
@@ -7,7 +7,6 @@ Environment Variable Analyzer using Redis and NPU acceleration
 Analyzes codebase for hardcoded values that should be environment variables
 """
 
-from utils.line_index import LineIndex  # #12884
 from __future__ import annotations
 
 import ast
@@ -23,6 +22,7 @@ from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import QUALITY_MODEL, config
 from autobot_shared.ssot_constants import TTL_1_HOUR
+from utils.line_index import LineIndex  # #12884
 
 # Issue #542: Handle imports for both standalone execution and backend import
 # When imported from backend, project root is in sys.path

--- a/autobot-backend/code_analysis/src/frontend_analyzer.py
+++ b/autobot-backend/code_analysis/src/frontend_analyzer.py
@@ -5,6 +5,7 @@ Frontend Code Analyzer
 Extends the analysis suite to support JavaScript, TypeScript, Vue, React, and other frontend technologies
 """
 
+from utils.line_index import LineIndex  # #12884
 import asyncio
 import json
 import re
@@ -533,8 +534,11 @@ class FrontendAnalyzer:
                     continue
 
                 for compiled_pattern, description, severity in compiled_list:
+                    # #12884: build the offset->line map once; the per-match
+                    # `content[:start].count()` was O(n*m) and held the GIL.
+                    _line_index = LineIndex(content)
                     for match in compiled_pattern.finditer(content):
-                        line_num = content[: match.start()].count("\n") + 1
+                        line_num = _line_index.line_of(match.start())
 
                         issues.append(
                             FrontendIssue(

--- a/autobot-backend/code_analysis/src/frontend_analyzer.py
+++ b/autobot-backend/code_analysis/src/frontend_analyzer.py
@@ -5,7 +5,6 @@ Frontend Code Analyzer
 Extends the analysis suite to support JavaScript, TypeScript, Vue, React, and other frontend technologies
 """
 
-from utils.line_index import LineIndex  # #12884
 import asyncio
 import json
 import re
@@ -18,6 +17,7 @@ from typing import Any, Dict, List
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import TTL_1_HOUR
+from utils.line_index import LineIndex  # #12884
 
 # Add AutoBot root to path for imports
 autobot_root = Path(__file__).parent.parent.parent

--- a/autobot-backend/code_intelligence/code_review_engine.py
+++ b/autobot-backend/code_intelligence/code_review_engine.py
@@ -25,7 +25,6 @@ Issue #554: Enhanced with Vector/Redis/LLM infrastructure:
 - Historical review pattern learning via embeddings
 """
 
-from utils.line_index import LineIndex  # #12884
 import re
 import subprocess  # nosec B404 - code review tools require subprocess
 from dataclasses import dataclass, field
@@ -36,6 +35,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import TimingConstants
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/code_intelligence/code_review_engine.py
+++ b/autobot-backend/code_intelligence/code_review_engine.py
@@ -25,6 +25,7 @@ Issue #554: Enhanced with Vector/Redis/LLM infrastructure:
 - Historical review pattern learning via embeddings
 """
 
+from utils.line_index import LineIndex  # #12884
 import re
 import subprocess  # nosec B404 - code review tools require subprocess
 from dataclasses import dataclass, field
@@ -554,8 +555,11 @@ class CodeReviewEngine(_BaseClass):
                 if not (path.suffix == "" and ".py" in pattern_def.file_extensions):
                     continue
 
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in pattern.finditer(content):
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 comments.append(
                     self._create_pattern_comment(
                         pattern_id,

--- a/autobot-backend/code_intelligence/performance_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/performance_analysis/analyzer.py
@@ -10,6 +10,7 @@ Issue #554: Added Vector/Redis/LLM infrastructure for semantic analysis.
 Contains the main PerformanceAnalyzer class and convenience functions.
 """
 
+from utils.line_index import LineIndex  # #12884
 import re
 from typing import Any, Callable, Dict, List
 
@@ -53,8 +54,11 @@ class PerformanceAnalyzer(BaseCodeAnalyzer):
         findings: List[PerformanceIssue] = []
         list_lookup_pattern = r"if\s+\w+\s+in\s+\[.*\]:"
 
+        # #12884: build the offset->line map once; the per-match
+        # `content[:start].count()` was O(n*m) and held the GIL.
+        _line_index = LineIndex(content)
         for match in re.finditer(list_lookup_pattern, content):
-            line_num = content[: match.start()].count("\n") + 1
+            line_num = _line_index.line_of(match.start())
             code = lines[line_num - 1] if line_num <= len(lines) else ""
 
             findings.append(
@@ -132,9 +136,12 @@ class PerformanceAnalyzer(BaseCodeAnalyzer):
         findings: List[PerformanceIssue] = []
 
         for pattern, call_desc, fix in self._UNCLOSED_RESOURCE_PATTERNS:
+            # #12884: build the offset->line map once; the per-match
+            # `content[:start].count()` was O(n*m) and held the GIL.
+            _line_index = LineIndex(content)
             for match in re.finditer(pattern, content):
                 # Skip matches already inside a 'with' statement on the same line.
-                line_num = content[: match.start()].count("\n") + 1
+                line_num = _line_index.line_of(match.start())
                 code = lines[line_num - 1] if line_num <= len(lines) else ""
                 if re.match(r"\s*with\b", code):
                     continue
@@ -170,8 +177,11 @@ class PerformanceAnalyzer(BaseCodeAnalyzer):
         findings: List[PerformanceIssue] = []
         string_append_pattern = r"\w+\s*\+=\s*['\"]"
 
+        # #12884: build the offset->line map once; the per-match
+        # `content[:start].count()` was O(n*m) and held the GIL.
+        _line_index = LineIndex(content)
         for match in re.finditer(string_append_pattern, content):
-            line_num = content[: match.start()].count("\n") + 1
+            line_num = _line_index.line_of(match.start())
             # Check if in a loop context (simple heuristic)
             context_start = max(0, line_num - 5)
             context = "\n".join(lines[context_start:line_num])

--- a/autobot-backend/code_intelligence/performance_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/performance_analysis/analyzer.py
@@ -10,7 +10,6 @@ Issue #554: Added Vector/Redis/LLM infrastructure for semantic analysis.
 Contains the main PerformanceAnalyzer class and convenience functions.
 """
 
-from utils.line_index import LineIndex  # #12884
 import re
 from typing import Any, Callable, Dict, List
 
@@ -20,6 +19,7 @@ from code_intelligence.shared.analysis_base import (
     SIMILARITY_MEDIUM,
     BaseCodeAnalyzer,
 )
+from utils.line_index import LineIndex  # #12884
 
 from .ast_visitor import PerformanceASTVisitor
 from .types import PerformanceIssue, PerformanceIssueType, PerformanceSeverity

--- a/autobot-backend/code_intelligence/precommit_analyzer.py
+++ b/autobot-backend/code_intelligence/precommit_analyzer.py
@@ -16,6 +16,7 @@ Part of Issue #223 - Git Pre-commit Hook Analyzer
 Parent Epic: #217 - Advanced Code Intelligence
 """
 
+from utils.line_index import LineIndex  # #12884
 import concurrent.futures
 import re
 import subprocess  # nosec B404 - controlled git process execution
@@ -455,8 +456,11 @@ class PrecommitAnalyzer:
         results: List[CheckResult],
     ) -> None:
         """Run multiline pattern matching against entire file content. Issue #620."""
+        # #12884: build the offset->line map once; the per-match
+        # `content[:start].count()` was O(n*m) and held the GIL.
+        _line_index = LineIndex(content)
         for match in pattern.finditer(content):
-            line_num = content[: match.start()].count("\n") + 1
+            line_num = _line_index.line_of(match.start())
             snippet = self._get_snippet(lines, line_num)
             results.append(self._create_check_result(check, filepath, line_num, snippet))
 

--- a/autobot-backend/code_intelligence/precommit_analyzer.py
+++ b/autobot-backend/code_intelligence/precommit_analyzer.py
@@ -16,7 +16,6 @@ Part of Issue #223 - Git Pre-commit Hook Analyzer
 Parent Epic: #217 - Advanced Code Intelligence
 """
 
-from utils.line_index import LineIndex  # #12884
 import concurrent.futures
 import re
 import subprocess  # nosec B404 - controlled git process execution
@@ -28,6 +27,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/code_intelligence/shared/line_index.py
+++ b/autobot-backend/code_intelligence/shared/line_index.py
@@ -2,59 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""O(1) offset-to-line lookup for regex scanners (#12866).
+"""Re-export of :class:`utils.line_index.LineIndex` (#12884).
 
-Scanners resolved a match's line number with::
+The implementation lives in ``utils/`` because modules outside this package
+(api/, code_analysis/, services/) need it too, and importing
+``code_intelligence.shared.line_index`` from them fails at startup: the
+``code_intelligence`` package is heavy/stubbed in the import-smoke environment,
+so traversing it raises ModuleNotFoundError for the submodule.
 
-    line_num = content[: match.start()].count("\\n") + 1
-
-which slices the file from the start and rescans it **for every match** — O(n·m)
-overall, plus a full string copy per match. On a file that produces many matches
-this dominates the scan, and because both the slice and ``str.count`` run in C
-it holds the GIL for the whole time with no yield point.
-
-Measured on a synthetic file of repeated matches:
-
-===========  ====================  =============  =======
-matches      slice-per-match       precomputed    speedup
-===========  ====================  =============  =======
-2,000        0.073 s               0.004 s        17x
-8,000        1.105 s               0.020 s        56x
-20,000       6.928 s               0.040 s        174x
-===========  ====================  =============  =======
-
-Nearly 7 s of uninterruptible GIL hold at 20k matches, which is the shape of the
-12 s event-loop stalls reported in #12866 (a ThreadPoolExecutor does not help:
-the work never releases the GIL).
+This shim keeps the in-package import path working for
+``code_intelligence/security/analyzer.py`` (#12866).
 """
 
-from __future__ import annotations
-
-from bisect import bisect_right
+from utils.line_index import LineIndex
 
 __all__ = ["LineIndex"]
-
-
-class LineIndex:
-    """Maps character offsets to 1-based line numbers for one piece of content.
-
-    Build once per file, then query per match.
-    """
-
-    __slots__ = ("_starts",)
-
-    def __init__(self, content: str) -> None:
-        # Offset of the first character of each line. Line 1 starts at 0.
-        starts = [0]
-        idx = content.find("\n")
-        while idx != -1:
-            starts.append(idx + 1)
-            idx = content.find("\n", idx + 1)
-        self._starts = starts
-
-    def line_of(self, offset: int) -> int:
-        """Return the 1-based line number containing *offset*."""
-        return bisect_right(self._starts, offset)
-
-    def __len__(self) -> int:
-        return len(self._starts)

--- a/autobot-backend/services/pattern_extractor.py
+++ b/autobot-backend/services/pattern_extractor.py
@@ -8,6 +8,7 @@ Pattern Extractor Service (Issue #903)
 Extracts code patterns from AutoBot codebase for ML training and completion.
 """
 
+from utils.line_index import LineIndex  # #12884
 import ast
 import json
 import re
@@ -264,6 +265,9 @@ class PatternExtractor:
 
         # Extract composable functions
         composable_pattern = r"export\s+function\s+(use[A-Z]\w+)\s*\([^)]*\)\s*:\s*(\{[^}]+\})"
+        # #12884: build the offset->line map once; the per-match
+        # `content[:start].count()` was O(n*m) and held the GIL.
+        _line_index = LineIndex(content)
         for match in re.finditer(composable_pattern, content):
             func_name, return_type = match.groups()
             pattern = {
@@ -273,13 +277,16 @@ class PatternExtractor:
                 "signature": f"export function {func_name}",
                 "body": match.group(0)[:200],  # First 200 chars
                 "file_path": str(file_path.relative_to(self.base_path)),
-                "line_number": content[: match.start()].count("\n") + 1,
+                "line_number": _line_index.line_of(match.start()),
                 "context": {"return_type": return_type},
             }
             self.patterns["composable"].append(pattern)
 
         # Extract interface patterns
         interface_pattern = r"export\s+interface\s+(\w+)\s*\{([^}]+)\}"
+        # #12884: build the offset->line map once; the per-match
+        # `content[:start].count()` was O(n*m) and held the GIL.
+        _line_index = LineIndex(content)
         for match in re.finditer(interface_pattern, content, re.MULTILINE):
             interface_name, body = match.groups()
             pattern = {
@@ -289,7 +296,7 @@ class PatternExtractor:
                 "signature": f"export interface {interface_name}",
                 "body": match.group(0),
                 "file_path": str(file_path.relative_to(self.base_path)),
-                "line_number": content[: match.start()].count("\n") + 1,
+                "line_number": _line_index.line_of(match.start()),
                 "context": {},
             }
             self.patterns["interface"].append(pattern)

--- a/autobot-backend/services/pattern_extractor.py
+++ b/autobot-backend/services/pattern_extractor.py
@@ -8,7 +8,6 @@ Pattern Extractor Service (Issue #903)
 Extracts code patterns from AutoBot codebase for ML training and completion.
 """
 
-from utils.line_index import LineIndex  # #12884
 import ast
 import json
 import re
@@ -18,6 +17,7 @@ from typing import Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from utils.line_index import LineIndex  # #12884
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/tests/test_line_index_12866.py
+++ b/autobot-backend/tests/test_line_index_12866.py
@@ -25,7 +25,7 @@ def _load_line_index():
 
     spec = importlib.util.spec_from_file_location(
         "_line_index_12866",
-        Path(__file__).parent.parent / "code_intelligence" / "shared" / "line_index.py",
+        Path(__file__).parent.parent / "utils" / "line_index.py",
     )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)

--- a/autobot-backend/utils/line_index.py
+++ b/autobot-backend/utils/line_index.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""O(1) offset-to-line lookup for regex scanners (#12866).
+
+Scanners resolved a match's line number with::
+
+    line_num = content[: match.start()].count("\\n") + 1
+
+which slices the file from the start and rescans it **for every match** — O(n·m)
+overall, plus a full string copy per match. On a file that produces many matches
+this dominates the scan, and because both the slice and ``str.count`` run in C
+it holds the GIL for the whole time with no yield point.
+
+Measured on a synthetic file of repeated matches:
+
+===========  ====================  =============  =======
+matches      slice-per-match       precomputed    speedup
+===========  ====================  =============  =======
+2,000        0.073 s               0.004 s        17x
+8,000        1.105 s               0.020 s        56x
+20,000       6.928 s               0.040 s        174x
+===========  ====================  =============  =======
+
+Nearly 7 s of uninterruptible GIL hold at 20k matches, which is the shape of the
+12 s event-loop stalls reported in #12866 (a ThreadPoolExecutor does not help:
+the work never releases the GIL).
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+
+__all__ = ["LineIndex"]
+
+
+class LineIndex:
+    """Maps character offsets to 1-based line numbers for one piece of content.
+
+    Build once per file, then query per match.
+    """
+
+    __slots__ = ("_starts",)
+
+    def __init__(self, content: str) -> None:
+        # Offset of the first character of each line. Line 1 starts at 0.
+        starts = [0]
+        idx = content.find("\n")
+        while idx != -1:
+            starts.append(idx + 1)
+            idx = content.find("\n", idx + 1)
+        self._starts = starts
+
+    def line_of(self, offset: int) -> int:
+        """Return the 1-based line number containing *offset*."""
+        return bisect_right(self._starts, offset)
+
+    def __len__(self) -> int:
+        return len(self._starts)


### PR DESCRIPTION
Closes #12887

Follow-up to #12884 (the branch this work continues from) — that issue covered the 4 sites `py-spy` implicated; #12887 covers the remaining 19.

## Thinking Path

Follow-up to #12885, which fixed the 4 sites `py-spy` implicated. The same per-match rescan — `content[:match.start()].count("\n") + 1`, O(n*m) and holding the GIL in C with no yield point — appears **19 more times** across 15 files.

**My first classification was wrong, and catching it mattered.** I looked back 8 lines for an enclosing `finditer` and concluded 5 sites were single-use and safe to skip. Spot-checking two showed both were inside loops whose `finditer` simply sat further back. Re-scanning to the enclosing `def` gives **19 of 19** in match loops. Trusting the first pass would have left 5 real cases unfixed while reporting the sweep complete.

**The helper had to move.** `code_intelligence/shared/line_index.py` works fine for the in-package import in `security/analyzer.py`, but importing it *absolutely* from `api/`, `code_analysis/` or `services/` fails at startup — the `code_intelligence` package is heavy/stubbed in the import-smoke environment, so traversing it raises `ModuleNotFoundError` for the submodule. `tests/test_startup_imports.py` caught this on `api.analytics_code_review`; a unit test would not have.

So the implementation now lives in `utils/line_index.py` (verified import-clean — no package-level imports), with the old path kept as a re-export so the already-merged in-package import keeps working.

## What Changed

- **`utils/line_index.py`** — canonical home for `LineIndex`.
- **`code_intelligence/shared/line_index.py`** — re-export shim, with the reason documented.
- **15 files** — index built once before each loop, 19 expressions replaced.

## Verification

```
test_startup_imports + test_line_index          362 passed
analyz/pattern/code_review/precommit selection  140 passed, 0 failed
                                                (was 1 failed / 139 pre-relocation)
```

Because this was a mechanical, scripted edit rather than hand-written, I checked the things a script gets wrong:

- **build-before-use ordering at all 19 sites** — an inserted line can easily land after its use.
- every changed file parses.
- helper equivalence re-confirmed against the original expression.

The single flake8 `F821` in `code_analysis/src/api_consistency_analyzer.py` is **pre-existing** on `Dev_new_gui`, confirmed by running flake8 against the baseline file.

## Model Used

Claude Opus 5