### PR TITLE
fix(deploy): refuse to overwrite a working DB password during PLAY 2 .env regen (#12883)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -713,6 +713,50 @@
       when: "'backend' in group_names"
       tags: [backend, env]
 
+    # GH#12883: this render was unreachable until #12871 was fixed, and the first
+    # time it ran it overwrote a WORKING AUTOBOT_POSTGRES_PASSWORD with one
+    # PostgreSQL rejects — the next backend restart would have lost the database.
+    #
+    # Two stores claim to hold this secret and they disagree:
+    #   /etc/autobot/autobot-db-credentials.env   (what the task above reads)
+    #   /opt/autobot/autobot-backend/.env         (what actually authenticates)
+    #
+    # Converging them is the real fix and needs an owner decision (#12883). Until
+    # then this refuses to replace a working credential with a different one:
+    # a visibly failed update is recoverable, a dead credential on next restart
+    # is an outage.
+    - name: "[PLAY 2] Backend | Read the DB password currently in use (#12883)"
+      ansible.builtin.shell:
+        cmd: >-
+          grep -oP '^AUTOBOT_POSTGRES_PASSWORD=\K.*'
+          /opt/autobot/autobot-backend/.env 2>/dev/null || true
+      register: current_env_db_password
+      become: true
+      when: "'backend' in group_names"
+      failed_when: false
+      changed_when: false
+      no_log: true
+      tags: [backend, env]
+
+    - name: "[PLAY 2] Backend | Refuse to overwrite a working DB password (#12883)"
+      vars:
+        _current: "{{ current_env_db_password.stdout | default('') | trim }}"
+        _incoming: "{{ existing_autobot_db_password.stdout | default('') | trim }}"
+      ansible.builtin.fail:
+        msg: >-
+          Refusing to rewrite .env: the DB password in
+          /etc/autobot/autobot-db-credentials.env differs from the one currently
+          authenticating in /opt/autobot/autobot-backend/.env. Writing it would
+          break PostgreSQL auth on the next backend restart (#12883). Reconcile
+          the two credential stores, then re-run. The working value is the one in
+          the live .env.
+      when:
+        - "'backend' in group_names"
+        - _current | length > 0
+        - _incoming | length > 0
+        - _current != _incoming
+      tags: [backend, env]
+
     # GH#12871: was a bare playbook-level `template:` task, which cannot see the
     # backend role's defaults — it died on AnsibleUndefinedVariable
     # 'backend_chromadb_auth_token', failing PLAY 2 so PLAY 3 never ran. That


### PR DESCRIPTION
Refs #12883 — stops the destruction; does not close it (the two-store convergence needs an owner decision).

## Thinking Path

My #12871 fix unblocked the PLAY 2 `.env` render, and the first time it ran it overwrote a **working** `AUTOBOT_POSTGRES_PASSWORD` with one PostgreSQL rejects. The backend stayed up only because it had not restarted since — the next restart would have lost the database. So fixing one deploy blocker exposed a destructive task that had been dormant behind it.

Two stores claim to hold this secret and they disagree:

```
/etc/autobot/autobot-db-credentials.env   <- what the play reads  (rejected by PostgreSQL)
/opt/autobot/autobot-backend/.env         <- what actually authenticates
```

**Why a guard rather than "read the other file".** Preferring the live `.env` would keep updates flowing and preserve auth, but it silently entrenches the divergence — the next person still has two files disagreeing about a secret, with no signal. The issue asks for fail-closed, and that is the right call here: a visibly failed update is recoverable in minutes, a dead credential discovered on the next restart is an outage.

## What Changed

`playbooks/update-all-nodes.yml`, before the render:
1. Read the DB password currently in use from the live `.env` (`no_log`).
2. `fail:` with an actionable message if the incoming value differs.

## Verification

The guard's condition was exercised across every combination, since a too-eager guard would block legitimate updates and a too-lax one would not fire:

```
mismatch            -> WOULD FAIL
same                -> would proceed
no current .env     -> would proceed   (fresh install)
no incoming value   -> would proceed
```

It fires only when **both** values are non-empty and differ. Playbook parses as YAML.

## Scope

- **Not closing #12883.** Converging the two credential stores is the actual fix and is an owner decision; until then an affected node sees PLAY 2 fail with a clear message instead of silently breaking auth.
- The issue's ordering suggestion (run `migrations.baseline` before the rewrite) is not addressed — the guard makes it less urgent by preventing the bad write at source.
- Worth noting for whoever reconciles the stores: on an already-affected node the working credential survives only in the timestamped backup written alongside `.env`.

## Model Used

Claude Opus 5
