### PR TITLE
fix(tts): serve /tts/clone-voice and restore drift visibility for the templated worker (#12886)

### DIFF
--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
@@ -447,6 +447,19 @@ def _run_create_voice(name: str, audio_path: str) -> str:
     return vid
 
 
+def _run_clone_synthesis(text: str, audio_path: str) -> bytes:
+    """One-shot synthesis in the reference audio's voice (#12886).
+
+    Deliberately does NOT persist a profile: the caller
+    (``tts_client.clone_voice``) wants audio back, not a registry entry,
+    so the derived state is used once and dropped. ``/voices/create`` is
+    the endpoint for a reusable voice.
+    """
+    voice_state = _model.get_state_for_audio_prompt(audio_path)
+    audio = _model.generate_audio(voice_state, text)
+    return _to_wav_bytes(audio, _model.sample_rate)
+
+
 @app.get("/health")
 async def health() -> JSONResponse:
     """Health check with model status.
@@ -536,6 +549,47 @@ async def synthesize_stream(
             logger.error("Streaming synthesis error: %s", e)
 
     return StreamingResponse(_framed(), media_type="application/octet-stream")
+
+
+@app.post("/tts/clone-voice")
+async def clone_voice(
+    text: str = Form(...),
+    reference_audio: UploadFile = File(...),
+) -> StreamingResponse:
+    """Synthesize ``text`` in the uploaded reference speaker's voice (#12886).
+
+    Field names match ``tts_client.clone_voice``, which has posted here
+    since the backend route existed while the worker never served it —
+    every ``/api/voice/clone-voice`` call 404'd.
+    """
+    if not _model_loaded:
+        raise HTTPException(503, detail=f"Model not ready: {_model_error}")
+    degraded, reason = _compute_degraded_state()
+    if degraded:
+        # The public fallback weights cannot reproduce the reference
+        # speaker — they would return audio in some *other* voice rather
+        # than fail, so say so instead of shipping the wrong voice.
+        raise HTTPException(503, detail=reason or "Voice cloning unavailable")
+    import tempfile
+
+    audio_bytes = await reference_audio.read()
+    suffix = Path(reference_audio.filename or "reference.wav").suffix or ".wav"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(audio_bytes)
+        tmp_path = tmp.name
+    loop = asyncio.get_event_loop()
+    try:
+        wav = await loop.run_in_executor(None, _run_clone_synthesis, text, tmp_path)
+    except Exception as e:
+        logger.error("Voice cloning error: %s", e)
+        raise HTTPException(500, detail=f"Voice cloning failed: {e}") from e
+    finally:
+        os.unlink(tmp_path)
+    return StreamingResponse(
+        io.BytesIO(wav),
+        media_type="audio/wav",
+        headers={"Content-Disposition": "attachment; filename=cloned.wav"},
+    )
 
 
 @app.get("/voices")

--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -9,6 +9,7 @@ Compares file checksums between the code_source directory and the deployed
 directory to detect files that have been manually patched or missed by Ansible.
 """
 
+import ast
 import hashlib
 import logging
 import os
@@ -105,7 +106,10 @@ ALLOWED_COMPONENTS = frozenset(
 # NOT resolve-capable (confirmed unmappable, see #12450 PR notes):
 #   - autobot-tts-worker: deployed via a single Jinja2-templated file
 #     (tts-worker.py.j2 -> tts-worker.py), not a 1:1 sync of the repo's
-#     autobot-tts-worker/ directory — comparing them would report fake drift.
+#     autobot-tts-worker/ directory. It is still VISIBLE — see
+#     _TEMPLATED_COMPONENTS, which compares it render-invariantly instead of
+#     by directory checksum (#12886). Resolve stays blocked because
+#     re-rendering the template needs the ansible var context.
 #   - autobot-celery / celery-beat: no distinct deployed directory — both run
 #     FROM the autobot-backend deployed dir (systemd WorkingDirectory), so
 #     they are already covered by the existing "autobot-backend" entry.
@@ -113,7 +117,31 @@ ALLOWED_COMPONENTS = frozenset(
 #     packages): synced into TWO deployed locations (autobot-frontend/ and
 #     autobot-slm-frontend/), so there is no single canonical deployed target
 #     to compare against — needs an owner decision on which (or both) to scan.
-EXTRA_VISIBILITY_COMPONENTS = frozenset({"plugins"})
+EXTRA_VISIBILITY_COMPONENTS = frozenset({"plugins", "autobot-tts-worker"})
+
+# Components deployed as a *rendered* Jinja2 template rather than a 1:1 file
+# sync (#12886). Maps component -> (template path relative to the repo root,
+# rendered file path relative to the deployed component dir).
+#
+# A directory checksum walk is meaningless for these: the repo dir holds
+# different files entirely (autobot-tts-worker/ ships main.py; the host runs
+# tts-worker.py), so every file would report source_only/deployed_only. That is
+# the fake drift the exclusion above was written to avoid — but excluding the
+# component outright traded noise for *no* signal, and the worker silently fell
+# behind the backend calling it until a user hit a runtime 404.
+#
+# _compute_templated_drift compares structure instead: both sides are parsed as
+# Python and every string constant is blanked before hashing. Rendering only
+# substitutes inside string literals, so a rendered value (install dir, model
+# id, port) can never register as drift, while a missing route, dropped helper
+# or changed call still does — which is exactly the class of skew that broke
+# /tts/synthesize/stream.
+_TEMPLATED_COMPONENTS: dict[str, tuple[str, str]] = {
+    "autobot-tts-worker": (
+        "autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2",
+        "tts-worker.py",
+    ),
+}
 
 # Union of the resolve-capable allowlist and the read-only extras — used by
 # the GET-only drift surfaces (/status stale_components, GET /drift). The
@@ -259,6 +287,137 @@ def _collect_checksums(
     return checksums
 
 
+def _string_constants(tree: ast.AST) -> List[ast.Constant]:
+    """String-literal nodes of *tree* in a stable walk order."""
+    return [n for n in ast.walk(tree) if isinstance(n, ast.Constant) and isinstance(n.value, str)]
+
+
+def _render_invariant_digests(template_src: str, deployed_src: str | None) -> Tuple[str, str | None] | None:
+    """Digest a .j2 template and its rendered file so the two are comparable.
+
+    Only the string literals the template actually *renders* — the ones holding
+    a Jinja expression — are blanked, on both sides at the same walk position.
+    A substituted install dir or model id therefore cannot read as drift, while
+    an ordinary string constant such as a route path still can: blanking every
+    literal would have made a renamed ``/tts/synthesize/stream`` invisible,
+    which is the very skew this exists to catch (#12886).
+
+    Args:
+        template_src: Raw .j2 template text (valid Python — all Jinja
+            expressions sit inside string literals).
+        deployed_src: The rendered file's text, or ``None`` to digest the
+            template alone (deployed file absent).
+
+    Returns:
+        Tuple of (template_digest, deployed_digest_or_None), or ``None`` when
+        either side does not parse as Python.
+    """
+    try:
+        template_tree = ast.parse(template_src)
+    except SyntaxError:
+        return None
+
+    template_strings = _string_constants(template_tree)
+    rendered_at = [i for i, node in enumerate(template_strings) if "{{" in node.value]
+
+    deployed_strings: List[ast.Constant] = []
+    deployed_tree = None
+    if deployed_src is not None:
+        try:
+            deployed_tree = ast.parse(deployed_src)
+        except SyntaxError:
+            return None
+        deployed_strings = _string_constants(deployed_tree)
+
+    for index in rendered_at:
+        template_strings[index].value = ""
+        # Misaligned lengths mean the structures already differ; the digests
+        # will disagree and report drift, which is the right answer.
+        if index < len(deployed_strings):
+            deployed_strings[index].value = ""
+
+    return (
+        _dump_digest(template_tree),
+        _dump_digest(deployed_tree) if deployed_tree is not None else None,
+    )
+
+
+def _dump_digest(tree: ast.AST) -> str:
+    """SHA-256 over an AST dump."""
+    return hashlib.sha256(ast.dump(tree).encode("utf-8")).hexdigest()
+
+
+def _compute_templated_drift(component: str, deployed_dir: str) -> Tuple[List[dict], int]:
+    """Structure-only drift for a template-rendered component (#12886).
+
+    Args:
+        component: A key of ``_TEMPLATED_COMPONENTS``.
+        deployed_dir: Absolute path to the deployed component directory.
+
+    Returns:
+        Tuple of (list_of_drift_dicts, total_files_compared) — same shape as
+        ``compute_drift``, always covering the single rendered file.
+    """
+    template_rel, deployed_rel = _TEMPLATED_COMPONENTS[component]
+    template_path = Path(DEFAULT_REPO_PATH) / template_rel
+    deployed_path = Path(deployed_dir) / deployed_rel
+
+    try:
+        template_src = template_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("drift_checker: cannot read template for %s: %s", component, exc)
+        return [], 0
+
+    try:
+        deployed_src: str | None = deployed_path.read_text(encoding="utf-8")
+    except OSError:
+        deployed_src = None
+
+    digests = _render_invariant_digests(template_src, deployed_src)
+    if digests is None and deployed_src is not None:
+        # The template is known-parseable (pinned by test), so a failure here
+        # means the DEPLOYED file no longer parses — real drift. Fall back to
+        # its raw checksum, which cannot collide with an AST digest.
+        digests = _render_invariant_digests(template_src, None)
+        if digests is not None:
+            return (
+                _templated_drift_entry(deployed_rel, digests[0], _file_checksum(deployed_path), "modified"),
+                1,
+            )
+
+    if digests is None:
+        # An unparseable template is a repo defect, not deployment drift —
+        # there is nothing to compare against. Pinned by drift_checker_test.
+        logger.error("drift_checker: template does not parse as Python: %s", template_path)
+        return [], 0
+
+    source_digest, deployed_digest = digests
+    if deployed_digest is None:
+        return _templated_drift_entry(deployed_rel, source_digest, None, "source_only"), 1
+
+    if deployed_digest == source_digest:
+        return [], 1
+
+    return _templated_drift_entry(deployed_rel, source_digest, deployed_digest, "modified"), 1
+
+
+def _templated_drift_entry(
+    rel_path: str,
+    source_digest: str,
+    deployed_digest: str | None,
+    status: str,
+) -> List[dict]:
+    """Wrap a templated-component comparison in the standard drift dict shape."""
+    return [
+        {
+            "path": rel_path,
+            "source_checksum": source_digest,
+            "deployed_checksum": deployed_digest,
+            "status": status,
+        }
+    ]
+
+
 def compute_drift(
     source_dir: str,
     deployed_dir: str,
@@ -287,6 +446,11 @@ def compute_drift(
     Returns:
         Tuple of (list_of_drift_dicts, total_files_compared).
     """
+    # Template-rendered components never match by directory walk — their repo
+    # dir holds different files than the host does (#12886).
+    if component in _TEMPLATED_COMPONENTS:
+        return _compute_templated_drift(component, deployed_dir)
+
     src_path = Path(source_dir)
     dep_path = Path(deployed_dir)
 

--- a/autobot-slm-backend/tests/services/drift_checker_test.py
+++ b/autobot-slm-backend/tests/services/drift_checker_test.py
@@ -291,3 +291,40 @@ class TestTemplatedComponentDrift:
 
         assert drifted == [], f"a differently-rendered host reported drift: {drifted}"
         assert total == 1
+
+
+class TestExclusionRationales:
+    """The drift exclusions must be asserted, not just argued in a comment (#12886).
+
+    ``autobot-celery`` / ``autobot-celery-beat`` are excluded on the grounds
+    that they run FROM the autobot-backend deployed directory and are therefore
+    already covered by that component's drift entry. That is only true while
+    their systemd units keep pointing at the backend's WorkingDirectory — so
+    pin it, rather than trusting a comment that nothing re-checks.
+    """
+
+    UNIT_DIR = Path(__file__).parent.parent.parent / "ansible" / "roles" / "backend" / "templates"
+
+    def _working_directory(self, unit: str) -> str:
+        import re
+
+        text = (self.UNIT_DIR / unit).read_text(encoding="utf-8")
+        found = re.findall(r"^WorkingDirectory=(.+)$", text, re.MULTILINE)
+        assert len(found) == 1, f"{unit}: expected exactly one WorkingDirectory, got {found}"
+        return found[0].strip()
+
+    def test_celery_units_share_the_backend_working_directory(self):
+        """Celery drift is covered by "autobot-backend" only while this holds."""
+        backend_dir = self._working_directory("autobot-backend.service.j2")
+
+        for unit in ("autobot-celery.service.j2", "autobot-celery-beat.service.j2"):
+            assert self._working_directory(unit) == backend_dir, (
+                f"{unit} no longer runs from the backend deployed dir — it needs its own "
+                "drift entry, since the autobot-backend walk no longer covers it"
+            )
+
+    def test_celery_is_not_silently_dropped_from_both_sets(self):
+        """Celery must stay excluded *because* of the shared dir, not by accident."""
+        for component in ("autobot-celery", "autobot-celery-beat"):
+            assert component not in drift_checker.VISIBILITY_COMPONENTS
+        assert "autobot-backend" in drift_checker.VISIBILITY_COMPONENTS

--- a/autobot-slm-backend/tests/services/drift_checker_test.py
+++ b/autobot-slm-backend/tests/services/drift_checker_test.py
@@ -202,3 +202,92 @@ class TestComputeDriftExclusions:
 
             assert report["drift_detected"] is False
             assert report["drifted_files"] == []
+
+
+class TestTemplatedComponentDrift:
+    """Render-invariant drift for template-deployed components (#12886).
+
+    ``autobot-tts-worker`` is deployed as a rendered Jinja2 template, so a
+    directory checksum walk reports nothing but fake drift (the repo dir ships
+    main.py; the host runs tts-worker.py). It was therefore excluded from drift
+    entirely — and silently fell behind the backend calling it until users hit
+    a runtime 404 on /tts/synthesize/stream. These tests pin both halves of the
+    replacement: a render must NOT read as drift, a missing route MUST.
+    """
+
+    REPO_ROOT = Path(__file__).parent.parent.parent.parent
+    TEMPLATE_REL, DEPLOYED_REL = drift_checker._TEMPLATED_COMPONENTS["autobot-tts-worker"]
+
+    def _render(self) -> str:
+        """Substitute every Jinja expression the way ansible's template task would."""
+        import re
+
+        template = (self.REPO_ROOT / self.TEMPLATE_REL).read_text(encoding="utf-8")
+        assert "{{" in template, "template has no Jinja expressions — test is vacuous"
+        return re.sub(r"{{.*?}}", "/opt/autobot/rendered-value", template)
+
+    def _drift_for(self, deployed_text: str | None, monkeypatch):
+        monkeypatch.setattr(drift_checker, "DEFAULT_REPO_PATH", str(self.REPO_ROOT))
+        with tempfile.TemporaryDirectory() as dep_root:
+            if deployed_text is not None:
+                (Path(dep_root) / self.DEPLOYED_REL).write_text(deployed_text, encoding="utf-8")
+            return compute_drift("unused-for-templated-components", dep_root, "autobot-tts-worker")
+
+    def test_visible_but_not_resolve_capable(self):
+        """Drift surfaces see the worker; resolve still rejects it (no re-render path)."""
+        assert "autobot-tts-worker" in drift_checker.VISIBILITY_COMPONENTS
+        assert "autobot-tts-worker" not in drift_checker.ALLOWED_COMPONENTS
+
+    def test_faithful_render_is_not_drift(self, monkeypatch):
+        """Substituted values must never register as drift — the fake-drift guard."""
+        drifted, total = self._drift_for(self._render(), monkeypatch)
+
+        assert drifted == [], f"faithful render reported fake drift: {drifted}"
+        assert total == 1
+
+    def test_missing_route_is_drift(self, monkeypatch):
+        """A stale worker missing a route the backend calls must be reported."""
+        stale = self._render().replace('@app.post("/tts/synthesize/stream")', '@app.post("/tts/unused")')
+        drifted, total = self._drift_for(stale, monkeypatch)
+
+        assert total == 1
+        assert [d["status"] for d in drifted] == ["modified"]
+        assert drifted[0]["path"] == self.DEPLOYED_REL
+
+    def test_dropped_function_is_drift(self, monkeypatch):
+        """Structure comparison catches removed code, not just changed route strings."""
+        rendered = self._render()
+        marker = "def _run_clone_synthesis(text: str, audio_path: str) -> bytes:"
+        assert marker in rendered, "clone-synthesis helper missing from template (#12886)"
+        stale = rendered.replace(marker, "def _run_clone_synthesis(text, audio_path):")
+
+        drifted, _ = self._drift_for(stale, monkeypatch)
+
+        assert [d["status"] for d in drifted] == ["modified"]
+
+    def test_absent_deployed_file_is_drift(self, monkeypatch):
+        """A host that never received the rendered file reads as source_only, not silence."""
+        drifted, total = self._drift_for(None, monkeypatch)
+
+        assert total == 1
+        assert drifted[0]["status"] == "source_only"
+        assert drifted[0]["deployed_checksum"] is None
+
+    def test_unparseable_deployed_file_is_drift(self, monkeypatch):
+        """Corrupt deployed code falls back to a raw checksum rather than reporting clean."""
+        drifted, _ = self._drift_for("def broken( :\n", monkeypatch)
+
+        assert [d["status"] for d in drifted] == ["modified"]
+        assert drifted[0]["deployed_checksum"] is not None
+
+    def test_different_rendered_values_are_not_drift(self, monkeypatch):
+        """Two hosts rendered with different vars must both read clean."""
+        import re
+
+        template = (self.REPO_ROOT / self.TEMPLATE_REL).read_text(encoding="utf-8")
+        other_host = re.sub(r"{{.*?}}", "/srv/elsewhere/other-value", template)
+
+        drifted, total = self._drift_for(other_host, monkeypatch)
+
+        assert drifted == [], f"a differently-rendered host reported drift: {drifted}"
+        assert total == 1

--- a/autobot-slm-backend/tests/services/tts_contract_test.py
+++ b/autobot-slm-backend/tests/services/tts_contract_test.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Backend↔worker TTS route contract (Issue #12886).
+
+The backend's ``services/tts_client.py`` posted to ``/tts/clone-voice`` for as
+long as the route existed, while the worker template never served it — every
+voice-clone request 404'd, and nothing failed until a user tried it. Nothing
+compared the two sides.
+
+These tests are that comparison: every route the client calls must be served by
+the worker template. They are static (source parsing only, no running worker),
+so a backend that starts calling a route the worker does not serve fails in CI
+rather than at first use.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+_CLIENT = _REPO_ROOT / "autobot-backend" / "services" / "tts_client.py"
+_TEMPLATE = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "tts-worker" / "templates" / "tts-worker.py.j2"
+
+# ``async with session.post(f"{self.base_url}/tts/synthesize", data=data)``
+_CLIENT_CALL = re.compile(r"session\.(get|post|delete|put|patch)\(\s*f?\"\{self\.base_url\}(/[^\"]*)\"")
+# ``@app.post("/tts/synthesize")``
+_WORKER_ROUTE = re.compile(r"@app\.(get|post|delete|put|patch)\(\"([^\"]+)\"")
+
+
+def _client_calls() -> set[tuple[str, str]]:
+    """(method, path) pairs the backend's TTS client issues against the worker."""
+    return {(m.lower(), p) for m, p in _CLIENT_CALL.findall(_CLIENT.read_text(encoding="utf-8"))}
+
+
+def _worker_routes() -> set[tuple[str, str]]:
+    """(method, path) pairs the worker template serves."""
+    return {(m.lower(), p) for m, p in _WORKER_ROUTE.findall(_TEMPLATE.read_text(encoding="utf-8"))}
+
+
+def test_sources_are_present():
+    """Guard against the regexes silently matching nothing after a file move."""
+    assert _CLIENT.is_file(), f"TTS client not found at {_CLIENT}"
+    assert _TEMPLATE.is_file(), f"worker template not found at {_TEMPLATE}"
+    assert _client_calls(), "no client calls parsed — the extraction regex has rotted"
+    assert _worker_routes(), "no worker routes parsed — the extraction regex has rotted"
+
+
+def test_every_client_call_is_served_by_the_worker():
+    """The defect in #12886: /tts/clone-voice was called but never served."""
+    unserved = sorted(_client_calls() - _worker_routes())
+
+    assert not unserved, (
+        "tts_client.py calls routes the worker template does not serve — these 404 at runtime: "
+        + ", ".join(f"{method.upper()} {path}" for method, path in unserved)
+    )
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("get", "/health"),
+        ("post", "/tts/synthesize"),
+        ("post", "/tts/synthesize/stream"),
+        ("post", "/tts/clone-voice"),
+        ("get", "/voices"),
+        ("post", "/voices/create"),
+        ("delete", "/voices/{voice_id}"),
+    ],
+)
+def test_known_contract_routes_present_on_both_sides(method, path):
+    """Pin the contract itself, so dropping a route on EITHER side is caught."""
+    assert (method, path) in _worker_routes(), f"worker no longer serves {method.upper()} {path}"
+    assert (method, path) in _client_calls(), f"client no longer calls {method.upper()} {path}"

--- a/autobot-slm-backend/tests/services/tts_contract_test.py
+++ b/autobot-slm-backend/tests/services/tts_contract_test.py
@@ -53,9 +53,10 @@ def test_every_client_call_is_served_by_the_worker():
     """The defect in #12886: /tts/clone-voice was called but never served."""
     unserved = sorted(_client_calls() - _worker_routes())
 
-    assert not unserved, (
-        "tts_client.py calls routes the worker template does not serve — these 404 at runtime: "
-        + ", ".join(f"{method.upper()} {path}" for method, path in unserved)
+    assert (
+        not unserved
+    ), "tts_client.py calls routes the worker template does not serve — these 404 at runtime: " + ", ".join(
+        f"{method.upper()} {path}" for method, path in unserved
     )
 
 


### PR DESCRIPTION
## Thinking Path

Verified both defects before implementing.

**Defect 2 (dead call)** — a repo-wide grep for `clone-voice` found the backend caller (`services/tts_client.py:120`) and the user-facing route that fronts it (`api/voice.py:253`), but **no route definition anywhere**. Confirmed against the worker template's route table: 6 routes, no clone. Voice cloning has been a guaranteed 404 regardless of deploy state, exactly as reported.

**Defect 1 (no drift signal)** — the exclusion comment's rationale is correct: the repo's `autobot-tts-worker/` ships `main.py`, while the host runs a rendered `tts-worker.py`. A directory checksum walk really would report nothing but fake drift. But excluding the component outright traded noise for *no signal*, which is the worse failure — the worker fell behind the backend calling it and the only symptom was a runtime 404.

So the fix is a comparison that is invariant to the render. First attempt blanked every string constant before hashing the AST — and the test for a renamed route failed, because route paths *are* string constants. Blanking them would have made the exact skew this exists to catch invisible. Corrected to blank only the literals the template actually renders (those holding a Jinja expression), at the same walk position on both sides.

## What Changed

**Worker template** (`ansible/roles/tts-worker/templates/tts-worker.py.j2`)
- Added `POST /tts/clone-voice`, matching `tts_client.clone_voice`'s form contract (`text` + `reference_audio` → `audio/wav`).
- It derives the voice state from the reference audio without persisting a profile — `/voices/create` remains the endpoint for a reusable voice.
- Returns 503 when `_compute_degraded_state()` reports a fallback to the public non-cloning weights, which would otherwise return audio in the *wrong* voice rather than fail.

**Drift checker** (`services/drift_checker.py`)
- `autobot-tts-worker` added to `EXTRA_VISIBILITY_COMPONENTS` — visible, still not resolve-capable (re-rendering needs the ansible var context; documented inline).
- New `_TEMPLATED_COMPONENTS` map and `_compute_templated_drift`, dispatched from `compute_drift`, comparing the `.j2` against the deployed rendered file.
- `_render_invariant_digests` blanks only rendered literals, so a substituted install dir or model id cannot read as drift while a renamed route still does.
- A deployed file that no longer parses falls back to its raw checksum, so corruption surfaces as drift rather than reading clean.

**Tests**
- `tests/services/tts_contract_test.py` (new) — statically extracts the routes `tts_client.py` calls and the routes the worker template serves, and asserts every call is served. This is the recurrence guard: a backend that starts calling an unserved route now fails in CI, not at first use.
- `drift_checker_test.py` — templated-drift coverage (faithful render is not drift; differently-rendered host is not drift; renamed route, dropped helper, absent file and unparseable file all are), plus tests pinning the *rationale* for the celery exclusions rather than leaving it as a comment nothing re-checks.

## Verification

All 29 tests green, plus the 32 existing drift/resolve/visibility tests unaffected:

```
$ python3 -m pytest autobot-slm-backend/tests/services/drift_checker_test.py \
    autobot-slm-backend/tests/services/tts_contract_test.py -q
29 passed in 0.53s

$ python3 -m pytest autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py \
    autobot-slm-backend/tests/api/test_status_stale_components_11820.py \
    autobot-slm-backend/tests/api/test_drift_resolve.py -q
32 passed in 12.04s
```

Rendered template compiles and now serves every route the backend calls:

```
GET  /health                POST /tts/synthesize
POST /tts/synthesize/stream POST /tts/clone-voice   <-- new
GET  /voices                POST /voices/create
DELETE /voices/{voice_id}   GET  /
```

The contract test is not vacuous — run against the pre-fix template it fails, naming the real defect:

```
PRE-FIX unserved routes: ['POST /tts/clone-voice']
=> contract test would have FAILED before the fix: True
```

Note the deployed worker on any given host stays stale until an update run reaches it; that path is tracked separately (#12883). What changes here is that the skew is now *visible* in `stale_components` instead of silent.

Closes #12886

## Model Used

claude-opus-5
