### PR TITLE
fix(llc): claim the claude session id with --session-id so resume can work (#12848)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -157,7 +157,14 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
         return args
 
     @staticmethod
-    def _build_command(cli: str, resume_session_id: Optional[str], cfg: dict, prompt: str) -> list[str]:
+    def _build_command(
+        cli: str,
+        resume_session_id: Optional[str],
+        cfg: dict,
+        prompt: str,
+        *,
+        session_id: str,
+    ) -> list[str]:
         """Build the claude CLI argv (GH#11186). Pure and unit-testable.
 
         Tool-permission flags (``--allowedTools``/``--disallowedTools``) apply on
@@ -166,6 +173,10 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
         ``--model``/``--max-turns`` are session-establishment options (fresh only).
         The prompt is passed positionally after ``--`` so a prompt starting with
         ``-`` can never be parsed as an option (matches the execution backend).
+
+        ``session_id`` is keyword-only and required so a caller cannot silently
+        omit it and reintroduce #12848 — a fresh run that does not claim an id
+        stores one the CLI never saw, and every later resume fails.
         """
         # #12683: Claude Code rejects `--print --output-format stream-json`
         # unless --verbose is also present ("Error: When using --print,
@@ -176,6 +187,13 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
         if resume_session_id:
             cmd += ["--resume", resume_session_id]
         else:
+            # #12848: claim the id we generated instead of letting the CLI mint
+            # its own. Without this the id stored for a later --resume is one the
+            # CLI has never heard of, so EVERY resume fails with "No conversation
+            # found with session ID" and agents never carry context between runs.
+            # Verified against Claude Code 2.1.220: --session-id is adopted
+            # verbatim and --resume with that id replays the conversation.
+            cmd += ["--session-id", session_id]
             model = cfg.get("model")
             if model:
                 cmd += ["--model", str(model)]
@@ -210,7 +228,7 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
             session_id = resume_session_id
             logger.info("ClaudeCodeAdapter: resuming session %s for agent %s", session_id, agent_id)
 
-        cmd = self._build_command(cli, resume_session_id, cfg, prompt)
+        cmd = self._build_command(cli, resume_session_id, cfg, prompt, session_id=session_id)
 
         workspace_dir: str | None = context.get("workspace_dir")
         env = {**os.environ, "LLC_INVOKE_CONTEXT": serialize_invoke_context(context)}

--- a/autobot-backend/llc/adapters/claude_code_subscription_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_subscription_adapter.py
@@ -86,7 +86,7 @@ class ClaudeCodeSubscriptionAdapter(ClaudeCodeAdapter):
         # GH#11186: reuse the parent's governed command builder so this adapter
         # inherits --disallowedTools (fresh + resume), input sanitization, and the
         # `--` prompt terminator instead of the old inline build that lacked them.
-        cmd = self._build_command(cli, resume_session_id, cfg, prompt)
+        cmd = self._build_command(cli, resume_session_id, cfg, prompt, session_id=session_id)
 
         workspace_dir: str | None = context.get("workspace_dir")
 

--- a/autobot-backend/llc/adapters/tests/test_claude_code_session_id_12848.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_session_id_12848.py
@@ -1,0 +1,89 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Session-id continuity for the Claude Code adapters (Issue #12848).
+
+The adapters generated a uuid4, stored it for later ``--resume``, and never told
+the CLI about it — so the CLI minted its own id and every resume failed with
+"No conversation found with session ID". Resume had never worked on any run;
+agents silently started a fresh conversation on every heartbeat.
+
+The fix claims the id up front with ``--session-id``. Verified against Claude
+Code 2.1.220: the CLI adopts the passed id verbatim, and ``--resume`` with that
+id replays the conversation. These tests pin the argv contract so the behaviour
+cannot revert to always-fresh unnoticed.
+"""
+
+import pytest
+
+from llc.adapters.claude_code_adapter import ClaudeCodeAdapter
+from llc.adapters.claude_code_subscription_adapter import ClaudeCodeSubscriptionAdapter
+
+_ADAPTERS = [ClaudeCodeAdapter, ClaudeCodeSubscriptionAdapter]
+
+
+def _fresh(adapter, session_id: str) -> list[str]:
+    return adapter._build_command("claude", None, {}, "prompt", session_id=session_id)
+
+
+def _resume(adapter, session_id: str) -> list[str]:
+    return adapter._build_command("claude", session_id, {}, "prompt", session_id=session_id)
+
+
+def _flag_value(cmd: list[str], flag: str) -> str | None:
+    return cmd[cmd.index(flag) + 1] if flag in cmd else None
+
+
+@pytest.mark.parametrize("adapter", _ADAPTERS)
+def test_fresh_run_claims_the_id_we_will_store(adapter):
+    """The defect: a fresh run let the CLI pick an id we would never learn."""
+    cmd = _fresh(adapter, "sid-1")
+
+    assert _flag_value(cmd, "--session-id") == "sid-1"
+    assert "--resume" not in cmd, "a fresh run must not resume"
+
+
+@pytest.mark.parametrize("adapter", _ADAPTERS)
+def test_resume_passes_the_stored_id(adapter):
+    """A resumed run replays the claimed conversation and re-claims nothing."""
+    cmd = _resume(adapter, "sid-1")
+
+    assert _flag_value(cmd, "--resume") == "sid-1"
+    assert "--session-id" not in cmd, "--session-id on a resume would fight --resume"
+
+
+@pytest.mark.parametrize("adapter", _ADAPTERS)
+def test_fresh_then_resume_then_resume_stays_one_conversation(adapter):
+    """The sequence the issue names: continuity must survive repeated heartbeats."""
+    session_id = "sid-continuity"
+    first, second, third = (
+        _fresh(adapter, session_id),
+        _resume(adapter, session_id),
+        _resume(adapter, session_id),
+    )
+
+    assert _flag_value(first, "--session-id") == session_id
+    assert _flag_value(second, "--resume") == session_id
+    assert _flag_value(third, "--resume") == session_id
+
+
+@pytest.mark.parametrize("adapter", _ADAPTERS)
+def test_fresh_run_can_never_be_built_without_an_id(adapter):
+    """session_id is keyword-only and required — omitting it is a TypeError.
+
+    A default would let a caller silently reintroduce the bug, since a fresh run
+    with no id looks identical until the *next* heartbeat fails to resume.
+    """
+    with pytest.raises(TypeError):
+        adapter._build_command("claude", None, {}, "prompt")
+
+
+@pytest.mark.parametrize("adapter", _ADAPTERS)
+def test_session_flags_do_not_disturb_the_prompt_terminator(adapter):
+    """The claimed id must land before ``--``, not among the positional args."""
+    cmd = _fresh(adapter, "sid-1")
+    terminator = cmd.index("--")
+
+    assert cmd.index("--session-id") < terminator
+    assert cmd[terminator + 1 :] == ["prompt"]

--- a/autobot-backend/llc/adapters/tests/test_claude_code_subscription_governance.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_subscription_governance.py
@@ -14,7 +14,7 @@ from llc.adapters.claude_code_subscription_adapter import ClaudeCodeSubscription
 
 
 def _cmd(resume, cfg, prompt="do it"):
-    return ClaudeCodeSubscriptionAdapter._build_command("claude", resume, cfg, prompt)
+    return ClaudeCodeSubscriptionAdapter._build_command("claude", resume, cfg, prompt, session_id="fresh-sid")
 
 
 def test_fresh_session_enforces_disallowed_and_terminator():

--- a/autobot-backend/llc/adapters/tests/test_claude_code_tool_permissions.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_tool_permissions.py
@@ -38,7 +38,7 @@ def test_sanitizes_injection_and_delimiters():
 
 
 def _cmd(resume, cfg, prompt="do it"):
-    return ClaudeCodeAdapter._build_command("claude", resume, cfg, prompt)
+    return ClaudeCodeAdapter._build_command("claude", resume, cfg, prompt, session_id="fresh-sid")
 
 
 def test_fresh_session_command_has_model_and_tools_and_terminator():

--- a/autobot-backend/tests/test_llc_agent_run_recovery.py
+++ b/autobot-backend/tests/test_llc_agent_run_recovery.py
@@ -26,7 +26,7 @@ import pytest
 def _build(resume=None, cfg=None):
     from llc.adapters.claude_code_adapter import ClaudeCodeAdapter
 
-    return ClaudeCodeAdapter._build_command("claude", resume, cfg or {}, "do the thing")
+    return ClaudeCodeAdapter._build_command("claude", resume, cfg or {}, "do the thing", session_id="fresh-sid")
 
 
 def test_stream_json_print_includes_verbose():


### PR DESCRIPTION
## Thinking Path

The issue's diagnosis holds exactly: the adapter generated a uuid4, stored it for later `--resume`, and never told the CLI about it. The CLI minted its own id, so the stored value was one it had never heard of and every resume was guaranteed to fail. Not a race — never right.

The issue could not choose between its two fix options because the `claude` binary was unavailable to verify either. That blocker does not hold here, so I checked both against the installed CLI (2.1.220) rather than guessing:

- `--session-id <uuid>` **is** a supported flag, and the CLI adopts the id verbatim.
- the stream-json events **do** carry `session_id`, so option 2 was viable too.

Option 1 is the better of the two: the stored id is correct *by construction*, there is no output parsing to drift, and `run_id = "<pid>/<session_id>"` keeps its meaning. Option 2 would only make the id correct after a successful run, leaving the same wrong-id window the issue describes.

While tracing the call sites I found `claude_code_subscription_adapter.py` has the identical bug — it inherits `_build_command`, generates its own uuid4 the same way, and was equally broken. Both are fixed by the one change.

## What Changed

**`llc/adapters/claude_code_adapter.py`**
- `_build_command` takes a required keyword-only `session_id` and, on fresh runs, emits `--session-id <id>`. Resumed runs are unchanged (`--resume`; passing both would conflict).
- Keyword-only and required deliberately: a default would let a caller silently reintroduce this bug, since a fresh run with no id looks fine until the *next* heartbeat fails to resume.

**`llc/adapters/claude_code_subscription_adapter.py`** — passes its generated id to the shared builder, fixing the same defect.

**Tests** — `test_claude_code_session_id_12848.py` (new, parametrized over both adapters): fresh run claims the id; resume passes it and re-claims nothing; the fresh → resume → resume sequence stays one conversation; omitting `session_id` raises `TypeError`; the flag lands before the `--` prompt terminator. Three existing `_build_command` test helpers updated for the new signature.

## Verification

Live against Claude Code 2.1.220 — the check the issue asked for and could not run. A fresh run with an id we chose, then a resume of that id in a separate process:

```
$ SID=fdc47dc6-4b28-4db3-b666-66eab7781e9d
$ claude --session-id "$SID" --print --output-format stream-json --verbose \
    "Remember the word: zucchini. Reply with just OK."
EVENT system session_id= fdc47dc6-4b28-4db3-b666-66eab7781e9d      # CLI adopted OUR id

$ claude --resume "$SID" --print "What word did I ask you to remember?"
zucchini                                                            # conversation replayed
```

That is the "Done when" condition: a second invocation resumes the first one's conversation using an id the CLI recognises.

Test suites green:

```
$ python3 -m pytest autobot-backend/llc/adapters/tests/ -q
169 passed in 2.28s

$ python3 -m pytest autobot-backend/tests/test_llc_agent_run_recovery.py \
    autobot-backend/tests/test_claude_code_backend.py -q
39 passed, 2 warnings in 1.17s

$ python3 -m black --check --line-length=120 autobot-backend/llc/adapters/
24 files would be left unchanged.
```

Note this supersedes the framing in #12683 (a race) — that diagnosis implied the stored id was usually right. PR #12847's self-healing clear-on-failure stays useful for genuinely stale ids, but is no longer the only thing standing between agents and a working resume.

Closes #12848

## Model Used

claude-opus-5
