### PR TITLE
fix(slm): surface the backend->SLM control-link state in system health (#12781)

### DIFF
--- a/autobot-backend/api/system_health.py
+++ b/autobot-backend/api/system_health.py
@@ -52,6 +52,7 @@ class KnownProbes(str, enum.Enum):
     LLC = "llc"
     PRICING = "pricing"  # GH#6480
     CONTENT_REACH = "content_reach"  # #10932
+    SLM_LINK = "slm_link"  # #12781
 
 
 # Per-probe timeout. Probes slower than this become ``status="down"`` so a slow

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1145,6 +1145,12 @@ async def _init_slm_client():
     Falls back gracefully if SLM is unavailable.
     """
     logger.info("✅ [ 89%] SLM Client: Initializing SLM client for agent configs...")
+    # #12781: register the control-link probe BEFORE attempting to connect —
+    # the decorator only fires on import, and a node whose SLM init raises is
+    # precisely the node whose link state must be reported. Registering inside
+    # the try would omit the component on exactly the broken nodes.
+    from services import slm_link_probe  # noqa: F401
+
     try:
         # Issue #768: Get SLM URL from SSOT config, fallback to env var
         from autobot_shared.ssot_config import get_config

--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -878,6 +878,33 @@ _slm_client: SLMClient | None = None
 _discovery_cache = ServiceDiscoveryCache(ttl_seconds=60)
 
 
+def slm_link_state() -> dict:
+    """Snapshot of the backend→SLM control link for health reporting (#12781).
+
+    The link degrades silently today: after ``_WS_AUTH_FAIL_THRESHOLD``
+    rejected handshakes the client pins its backoff to the maximum interval and
+    stops logging, so a node that cannot reach the control plane looks
+    identical to a healthy one from outside. Both paths by which a node reports
+    itself were broken on the node in #12781 and nothing surfaced it — the
+    crash loop in #12777 went unseen in the GUI as a direct result.
+
+    Returns a plain dict (no exceptions) so a health probe can render it even
+    when the client was never initialized.
+    """
+    client = get_slm_client()
+    if client is None:
+        return {"initialized": False, "connected": False, "auth_failures": 0, "backoff_pinned": False}
+
+    return {
+        "initialized": True,
+        "connected": bool(client._ws_connected),
+        "auth_failures": int(client._ws_auth_fail_count),
+        # The tell-tale of a link that has given up rather than one still retrying.
+        "backoff_pinned": client._reconnect_delay >= client._max_reconnect_delay,
+        "slm_url": client.slm_url,
+    }
+
+
 def get_slm_client() -> SLMClient | None:
     """
     Get the global SLM client instance.

--- a/autobot-backend/services/slm_link_probe.py
+++ b/autobot-backend/services/slm_link_probe.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Health probe for the backend→SLM control link (#12781).
+
+The link fails closed and quietly: after a few rejected handshakes the client
+pins its reconnect backoff to the maximum interval and stops logging, so the
+node keeps serving traffic while the control plane sees nothing from it. On the
+node in #12781 both reporting paths were down at once, which is why the
+`autobot-backend` crash loop in #12777 was invisible in the GUI.
+
+Nothing surfaced that state anywhere a human or a monitor would look. This
+probe does, through the standard aggregator, so a broken control link shows up
+as a degraded component instead of a line in a log nobody reads.
+"""
+
+import time
+from typing import Optional
+
+from fastapi import Request
+
+from api.system_health import ComponentHealth, KnownProbes, register_health_probe
+from autobot_shared.logging_manager import get_logger
+from services.slm_client import slm_link_state
+
+logger = get_logger(__name__)
+
+_PROBE_NAME = KnownProbes.SLM_LINK
+
+
+def _status_for(state: dict) -> tuple[str, Optional[str]]:
+    """Map a link snapshot onto (status, detail).
+
+    ``backoff_pinned`` is the meaningful escalation, not the raw failure count:
+    it marks a link that has stopped trying rather than one mid-retry, which is
+    the state that persists until a restart.
+    """
+    if not state["initialized"]:
+        return "down", "SLM client not initialized — this node cannot reach the control plane"
+
+    if state["connected"]:
+        return "ok", None
+
+    if state["backoff_pinned"]:
+        return "down", (
+            f"control link down after {state['auth_failures']} rejected handshakes; "
+            "reconnect backoff pinned to its maximum, so it will not recover without a "
+            "restart. Check that AUTOBOT_JWT_SECRET on the backend matches SLM_SECRET_KEY "
+            "on the SLM host."
+        )
+
+    return "degraded", f"control link reconnecting ({state['auth_failures']} failures so far)"
+
+
+@register_health_probe(_PROBE_NAME)
+async def probe_slm_link(request: Request | None = None) -> ComponentHealth:
+    """Report whether this node's control-plane link is actually up."""
+    start = time.monotonic()
+    try:
+        state = slm_link_state()
+        status, detail = _status_for(state)
+        return ComponentHealth(
+            name=_PROBE_NAME,
+            status=status,
+            detail=detail,
+            data=state,
+            latency_ms=round((time.monotonic() - start) * 1000, 1),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("SLM link health probe failed")
+        return ComponentHealth(
+            name=_PROBE_NAME,
+            status="down",
+            detail=f"probe error: {type(exc).__name__}: {exc}",
+            latency_ms=round((time.monotonic() - start) * 1000, 1),
+        )

--- a/autobot-backend/services/slm_link_probe_test.py
+++ b/autobot-backend/services/slm_link_probe_test.py
@@ -1,0 +1,138 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Control-link health probe (#12781).
+
+The backend→SLM link fails closed and silently: after a few rejected handshakes
+the client pins its reconnect backoff to the maximum and stops logging, so a
+node that cannot reach the control plane looks identical to a healthy one. Both
+of a node's reporting paths were down at once in #12781, which is why the
+crash loop in #12777 never appeared in the GUI.
+
+These tests pin that a broken link is now *reported* rather than merely logged,
+and that the "given up" state is distinguished from "still retrying".
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from services.slm_link_probe import _PROBE_NAME, _status_for, probe_slm_link  # noqa: E402
+
+
+def _state(**overrides) -> dict:
+    base = {
+        "initialized": True,
+        "connected": False,
+        "auth_failures": 0,
+        "backoff_pinned": False,
+        "slm_url": "http://control-plane:8000",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestStatusMapping:
+    def test_connected_link_is_healthy(self):
+        assert _status_for(_state(connected=True))[0] == "ok"
+
+    def test_pinned_backoff_is_down_not_degraded(self):
+        """The state that persists until a restart — it must not read as transient."""
+        status, detail = _status_for(_state(backoff_pinned=True, auth_failures=3))
+
+        assert status == "down"
+        assert "will not recover without a" in detail
+
+    def test_retrying_link_is_degraded(self):
+        """Still reconnecting is real but not yet terminal."""
+        status, detail = _status_for(_state(auth_failures=1))
+
+        assert status == "degraded"
+        assert "reconnecting" in detail
+
+    def test_uninitialized_client_is_down(self):
+        """A node with no client at all cannot reach the control plane either."""
+        status, detail = _status_for(_state(initialized=False))
+
+        assert status == "down"
+        assert "not initialized" in detail
+
+    def test_down_detail_names_the_secret_mismatch(self):
+        """The 403 cause in #12781 — surface the fix, not just the symptom."""
+        _, detail = _status_for(_state(backoff_pinned=True))
+
+        assert "AUTOBOT_JWT_SECRET" in detail
+        assert "SLM_SECRET_KEY" in detail
+
+
+class TestProbe:
+    @pytest.mark.asyncio
+    async def test_probe_reports_link_state(self, monkeypatch):
+        monkeypatch.setattr(
+            "services.slm_link_probe.slm_link_state",
+            lambda: _state(backoff_pinned=True, auth_failures=3),
+        )
+
+        result = await probe_slm_link()
+
+        assert result.name == _PROBE_NAME
+        assert result.status == "down"
+        assert result.data["auth_failures"] == 3
+
+    @pytest.mark.asyncio
+    async def test_healthy_path_validates_against_the_model(self, monkeypatch):
+        """Every branch must build a real ComponentHealth, not just the failing one.
+
+        HealthStatus is Literal["ok", "degraded", "down", ...] — there is no
+        "healthy". Testing only the down path let an invalid literal through
+        that would have raised a ValidationError on the first healthy node.
+        """
+        monkeypatch.setattr("services.slm_link_probe.slm_link_state", lambda: _state(connected=True))
+
+        result = await probe_slm_link()
+
+        assert result.status == "ok"
+        assert result.detail is None
+
+    @pytest.mark.asyncio
+    async def test_degraded_path_validates_against_the_model(self, monkeypatch):
+        monkeypatch.setattr("services.slm_link_probe.slm_link_state", lambda: _state(auth_failures=1))
+
+        assert (await probe_slm_link()).status == "degraded"
+
+    @pytest.mark.asyncio
+    async def test_probe_never_raises(self, monkeypatch):
+        """A probe that raises would take the whole health response with it."""
+
+        def _boom():
+            raise RuntimeError("client exploded")
+
+        monkeypatch.setattr("services.slm_link_probe.slm_link_state", _boom)
+
+        result = await probe_slm_link()
+
+        assert result.status == "down"
+        assert "RuntimeError" in result.detail
+
+    def test_probe_is_registered_under_a_known_name(self):
+        """A typo'd probe name silently drops the component from /health."""
+        from api.system_health import _PROBES, KnownProbes
+
+        assert KnownProbes.SLM_LINK in _PROBES
+
+
+def test_probe_is_imported_during_slm_init():
+    """The decorator only fires on import — an unimported probe is dead code.
+
+    It must also be imported BEFORE the connect attempt: a node whose SLM init
+    raises is exactly the node whose link state has to be reported.
+    """
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / "initialization" / "lifespan.py").read_text(encoding="utf-8")
+    body = source.split("async def _init_slm_client()")[1]
+    import_pos = body.index("from services import slm_link_probe")
+    try_pos = body.index("    try:")
+
+    assert import_pos < try_pos, "probe import must precede the try block, not sit inside it"


### PR DESCRIPTION
## Thinking Path

#12781 proposes three things. Item 1 (verify the secrets actually match on a stock deploy) and the 403 itself need the live node. Item 3 — triage the agents `404` as contract drift — I checked statically and it does **not** hold: the SLM declares `GET /api/agents` (`api/agents.py` mounts `APIRouter(prefix="/agents")` under `prefix="/api"`, with `@router.get("")`). The route exists in source, so a 404 means it is not mounted at runtime on that node — a stale deploy or a router that failed to load, not a client calling a path nobody serves. I could not confirm which without the live instance: building the SLM app locally needs a root-owned credentials file.

That leaves item 2, which is both the actionable one and the one that matters most. The link does not just fail — it fails **silently and permanently**. After `_WS_AUTH_FAIL_THRESHOLD` rejected handshakes the client pins its reconnect backoff to the maximum interval and stops logging, so the node keeps serving traffic while the control plane hears nothing from it, until someone restarts it. Nothing anywhere reported that state.

That silence is the thread connecting these issues: on the node in #12781 both of a node's reporting paths were down at once, which is exactly why the `autobot-backend` crash loop in #12777 was invisible in the GUI. A health component is the smallest thing that turns "invisible until someone reads a log" into "visible to anything that polls health".

## What Changed

**`services/slm_client.py`** — `slm_link_state()`, a snapshot of the link (initialized / connected / auth failures / whether backoff is pinned). Returns a plain dict and never raises, so a probe can render it even when the client was never constructed.

**`services/slm_link_probe.py`** (new) — registers `KnownProbes.SLM_LINK` with the standard aggregator. Status mapping keys on `backoff_pinned`, not the raw failure count: that distinguishes a link that has *given up* (persists until restart → `down`) from one still mid-retry (`degraded`). The `down` detail names the `AUTOBOT_JWT_SECRET` / `SLM_SECRET_KEY` mismatch, so the report carries the fix and not just the symptom.

**`initialization/lifespan.py`** — imports the probe module inside `_init_slm_client`, **before** the `try`. The decorator only fires on import, and a node whose SLM init raises is precisely the node whose link state must be reported; registering inside the `try` would have omitted the component on exactly the broken nodes. A test asserts that ordering.

## Verification

```
$ python3 -m pytest autobot-backend/services/slm_link_probe_test.py -q
11 passed in 0.23s
```

Covers all four status branches, that the probe never raises (a raising probe would take the whole health response with it), that the probe is registered under a `KnownProbes` name, and — by reading `lifespan.py` — that the import precedes the `try`.

```
$ python3 -m pytest autobot-backend/tests/test_system_health_registry.py
32 passed in 2.74s
$ python3 -m black --check --line-length=120 <5 touched files>
5 files would be left unchanged.
```

One bug caught during review rather than in production: the first version returned `status="healthy"`, but `HealthStatus` is `Literal["ok", "degraded", "down", "not_applicable", "idle"]` — there is no `"healthy"`. My tests missed it because only the failing path was built through `ComponentHealth`; the healthy path would have raised a `ValidationError` on the first healthy node. Fixed, and both the `ok` and `degraded` branches now go through the real model in tests.

## Scope note

This makes the broken link **visible**; it does not fix the 403. Item 1 (do the secrets match on a stock deploy, and does #10400's distribution step still run) needs the live node, and the agents 404 needs the deployed SLM's actual route table. #12781 stays open for both.

Refs #12781 (partial delivery — see the scope note above; corrected from `Closes` after merge so it cannot auto-close on the default branch)

## Model Used

claude-opus-5


Closes #12898