### PR TITLE
fix(config): treat a blank ssot_config knob as absent so six settings stop warning every boot (#12782)

### DIFF
--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -13,6 +13,7 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
+from autobot_shared.env_utils import blank_to_none
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
@@ -44,7 +45,7 @@ except ValueError:
 # Higher values = faster indexing but more CPU/memory usage
 # Default: 1 (sequential processing), Range: 1-8
 try:
-    _parallel = int(config.codebase_index_parallel_batches)
+    _parallel = int(blank_to_none(config.codebase_index_parallel_batches) or 1)
     PARALLEL_BATCH_COUNT = max(1, min(_parallel, 8))
 except ValueError:
     logger.warning("Invalid CODEBASE_INDEX_PARALLEL_BATCHES, using default 1")

--- a/autobot-backend/api/codebase_analytics/file_analyzer.py
+++ b/autobot-backend/api/codebase_analytics/file_analyzer.py
@@ -12,6 +12,7 @@ import asyncio
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from autobot_shared.env_utils import blank_to_none
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from utils.file_categorization import (
@@ -46,7 +47,7 @@ logger = get_logger(__name__)
 # Higher values = faster scanning but more memory/CPU usage
 # Default: 50, Range: 1-200
 try:
-    _parallel_concurrency = int(config.codebase_index_parallel_files)
+    _parallel_concurrency = int(blank_to_none(config.codebase_index_parallel_files) or 50)
     PARALLEL_FILE_CONCURRENCY = max(1, min(_parallel_concurrency, 200))
 except ValueError:
     logger.warning("Invalid CODEBASE_INDEX_PARALLEL_FILES, using default 50")

--- a/autobot-backend/api/codebase_analytics/scanner.py
+++ b/autobot-backend/api/codebase_analytics/scanner.py
@@ -33,6 +33,7 @@ from typing import Callable, Dict, List, Tuple
 
 from fastapi import HTTPException
 
+from autobot_shared.env_utils import blank_to_none
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from constants.path_constants import PATH
@@ -97,7 +98,7 @@ logger = get_logger(__name__)
 # Default: 50, Range: 1-100
 # =============================================================================
 try:
-    _parallel_files = int(config.codebase_scan_parallel_files)
+    _parallel_files = int(blank_to_none(config.codebase_scan_parallel_files) or 50)
     PARALLEL_FILE_PROCESSING = max(1, min(_parallel_files, 100))
 except ValueError:
     logger.warning("Invalid CODEBASE_SCAN_PARALLEL_FILES, using default 50")

--- a/autobot-backend/chat_history/cache.py
+++ b/autobot-backend/chat_history/cache.py
@@ -14,6 +14,7 @@ Provides caching functionality for chat sessions:
 import json
 from typing import Any, Dict
 
+from autobot_shared.env_utils import blank_to_none
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from chat_history.file_io import run_in_chat_io_executor
@@ -34,7 +35,10 @@ logger = get_logger(__name__)
 # by default). Override via env var when tuning memory pressure.
 def _resolve_chat_session_cache_ttl() -> int:
     """Return TTL seconds for chat:session:* Redis keys."""
-    raw = config.misc.chat_session_cache_ttl
+    # #12782: ssot_config declares optional knobs as `str = Field(default="")`,
+    # so an unset var arrives as "" and `raw is None` never fires — int("") then
+    # raised and warned on every boot about a value nobody set.
+    raw = blank_to_none(config.misc.chat_session_cache_ttl)
     if raw is None:
         return TTL_24_HOURS
     try:
@@ -72,7 +76,7 @@ _CHAT_RECENT_MAX_ENTRIES_DEFAULT = 1000
 
 def _resolve_chat_recent_max_entries() -> int:
     """Return max members for the chat:recent sorted set."""
-    raw = config.misc.chat_recent_max_entries
+    raw = blank_to_none(config.misc.chat_recent_max_entries)  # #12782
     if raw is None:
         return _CHAT_RECENT_MAX_ENTRIES_DEFAULT
     try:

--- a/autobot-backend/services/llm_key_rotation_scheduler.py
+++ b/autobot-backend/services/llm_key_rotation_scheduler.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
+from autobot_shared.env_utils import blank_to_none
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from services.llm_api_key_service import get_llm_api_key_service
@@ -29,7 +30,11 @@ def _resolve_rotation_interval_minutes() -> int:
     int("") raised ValueError at import time and silently disabled the scheduler
     on every startup. Default to hourly (#6590) instead of crashing the import.
     """
-    raw = (config.llm_key_rotation_interval_minutes or "").strip()
+    # #12782: an unset knob is "" from ssot_config, not None — treat it as
+    # absent so the default applies silently instead of warning every boot.
+    raw = blank_to_none(config.llm_key_rotation_interval_minutes)
+    if raw is None:
+        return _DEFAULT_ROTATION_INTERVAL_MINUTES
     try:
         minutes = int(raw)
     except ValueError:

--- a/autobot_shared/env_utils.py
+++ b/autobot_shared/env_utils.py
@@ -9,6 +9,26 @@ import os
 logger = logging.getLogger(__name__)
 
 
+def blank_to_none(value: object) -> str | None:
+    """Collapse a blank value to ``None`` — the canonical "blank means absent" rule (#12782).
+
+    Exists separately from :func:`env_raw` because the same defect arrives by two
+    routes. ``env_raw`` covers values read from ``os.environ``; this covers values
+    that reach code through ``ssot_config``, whose optional knobs are declared
+    ``str = Field(default="")``. An unset knob therefore surfaces as ``""``, not
+    ``None``, so ``if raw is None`` never fires and ``int("")`` raises — which is
+    why six settings logged a spurious "invalid value" warning on every boot while
+    quietly using their defaults.
+
+    Kept as one function rather than repeating ``or None`` / ``.strip()`` at each
+    call site, so "what counts as blank" has a single definition.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def env_raw(name: str) -> str | None:
     """Read an env var, treating a blank value as absent (#12782).
 
@@ -22,10 +42,7 @@ def env_raw(name: str) -> str | None:
     Collapsing blank to ``None`` here means callers get their default rather than
     an empty string that only fails later, at parse time or at use.
     """
-    raw = os.environ.get(name)
-    if raw is None or not raw.strip():
-        return None
-    return raw
+    return blank_to_none(os.environ.get(name))
 
 
 def env_str(name: str, default: str) -> str:

--- a/autobot_shared/env_utils_blank_test.py
+++ b/autobot_shared/env_utils_blank_test.py
@@ -1,0 +1,88 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Blank-means-absent coercion for config-sourced values (#12782).
+
+Six tuning knobs logged an "invalid value" warning on every boot while quietly
+using their defaults. None of them was misconfigured: ``ssot_config`` declares
+optional knobs as ``str = Field(default="")``, so an *unset* knob arrives as
+``""`` rather than ``None``. Every read site guarded with ``if raw is None``,
+which never fires for a blank, and ``int("")`` then raised.
+
+The same defect by a different route (blank env var defeating a default
+argument) is what ``env_raw`` already covers, and what broke REDIS_HOST in
+#12778. ``blank_to_none`` is that rule as one function so both routes share a
+single definition of "blank".
+"""
+
+import pytest
+
+from autobot_shared.env_utils import blank_to_none, env_raw
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\t", "\n", None])
+def test_blank_values_collapse_to_none(value):
+    """An unset knob must read as absent, not as a value that fails at parse time."""
+    assert blank_to_none(value) is None
+
+
+@pytest.mark.parametrize("value,expected", [("0", "0"), ("50", "50"), ("  8  ", "8"), ("false", "false")])
+def test_real_values_survive_and_are_stripped(value, expected):
+    """'0' and 'false' are meaningful settings — they must not be treated as blank."""
+    assert blank_to_none(value) == expected
+
+
+def test_non_string_values_are_coerced():
+    """ssot_config fields are typed str, but callers may pass ints — do not crash."""
+    assert blank_to_none(0) == "0"
+    assert blank_to_none(50) == "50"
+
+
+def test_env_raw_delegates_to_the_same_rule(monkeypatch):
+    """One definition of "blank", not two that can drift apart."""
+    monkeypatch.setenv("AUTOBOT_TEST_BLANK", "   ")
+    assert env_raw("AUTOBOT_TEST_BLANK") is None
+
+    monkeypatch.setenv("AUTOBOT_TEST_BLANK", "value")
+    assert env_raw("AUTOBOT_TEST_BLANK") == "value"
+
+
+class TestReadSitesTreatBlankAsAbsent:
+    """The six settings #12782 named must fall back silently, not warn every boot."""
+
+    @pytest.mark.parametrize(
+        "module_path,symbol",
+        [
+            ("autobot-backend/chat_history/cache.py", "config.misc.chat_session_cache_ttl"),
+            ("autobot-backend/chat_history/cache.py", "config.misc.chat_recent_max_entries"),
+            (
+                "autobot-backend/services/llm_key_rotation_scheduler.py",
+                "config.llm_key_rotation_interval_minutes",
+            ),
+            (
+                "autobot-backend/api/codebase_analytics/chromadb_storage.py",
+                "config.codebase_index_parallel_batches",
+            ),
+            (
+                "autobot-backend/api/codebase_analytics/file_analyzer.py",
+                "config.codebase_index_parallel_files",
+            ),
+            (
+                "autobot-backend/api/codebase_analytics/scanner.py",
+                "config.codebase_scan_parallel_files",
+            ),
+        ],
+    )
+    def test_knob_is_read_through_blank_to_none(self, module_path, symbol):
+        """Source-level assertion: a bare read would reintroduce the boot warning.
+
+        Checked statically rather than by import because these are module-level
+        constants evaluated at import time — re-reading them under a patched
+        config would require reloading half the backend.
+        """
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[1] / module_path).read_text(encoding="utf-8")
+
+        assert f"blank_to_none({symbol})" in source, f"{module_path}: {symbol} is not blank-guarded"


### PR DESCRIPTION
## Thinking Path

The issue guesses the cause in item 1: *"most likely a template rendering an undefined variable to `""`"*. It is not a template. `ssot_config.py` declares these optional knobs as `str = Field(default="")`:

```python
codebase_index_parallel_batches: str = Field(default="", alias="CODEBASE_INDEX_PARALLEL_BATCHES")
codebase_index_parallel_files:   str = Field(default="", alias="CODEBASE_INDEX_PARALLEL_FILES")
codebase_scan_parallel_files:    str = Field(default="", alias="CODEBASE_SCAN_PARALLEL_FILES")
```

So an **unset** knob arrives as `""`, not `None`. Every read site guarded with `if raw is None` — which never fires for a blank — and `int("")` then raised, producing a boot warning about an "invalid value" for something nobody had set. `llm_key_rotation_scheduler.py` already had the observation in a comment (*"defaults to '' in ssot_config"*) without the general fix.

Worth being precise about the impact, because the issue slightly overstates it: the values were **not** wrong. Each site caught the `ValueError` and used its default, so behaviour was correct. What was broken is that six settings claimed to be misconfigured on every single boot — noise that trains people to ignore startup warnings, which is how a real one gets missed.

Item 2 asks for a helper that coerces `""` → `None`. One already exists in spirit: `env_raw()` (added for #12778, where a blank `REDIS_HOST` defeated its fallback) does exactly this for `os.environ`. Rather than write a second copy for config-sourced values, I lifted the rule out of `env_raw` into `blank_to_none()` and made `env_raw` call it — so both routes to the same defect share one definition of "blank".

## What Changed

**`autobot_shared/env_utils.py`** — new `blank_to_none(value)`, the canonical rule. `env_raw` now delegates to it (its behaviour is unchanged; it is the same logic in one place).

**Six read sites**, all now reading through `blank_to_none`:
- `chat_history/cache.py` — `AUTOBOT_CHAT_SESSION_CACHE_TTL`, `AUTOBOT_CHAT_RECENT_MAX_ENTRIES`
- `services/llm_key_rotation_scheduler.py` — `AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES`
- `api/codebase_analytics/{chromadb_storage,file_analyzer,scanner}.py` — the three `CODEBASE_*_PARALLEL_*` knobs

A genuinely invalid value (`"abc"`) still warns. Only *blank* is now silent, because blank means unset.

## Verification

```
$ python3 -m pytest autobot_shared/env_utils_blank_test.py -q
17 passed in 0.10s
```

Covers the coercion (blank/whitespace/None → `None`), that meaningful values survive — `"0"` and `"false"` must not be swallowed as blank — that non-string values do not crash, that `env_raw` delegates to the same rule, and a per-knob source assertion that each of the six named settings is blank-guarded, so a bare read cannot silently reintroduce the boot warning.

```
$ python3 -m pytest autobot-backend/chat_history/ autobot_shared/ -q
4 failed, 1148 passed
$ python3 -m black --check --line-length=120 <7 touched files>
7 files would be left unchanged.
```

The 4 failures are **pre-existing** — the identical set reproduces on a clean `Dev_new_gui` checkout (`feature_flags_test`, `test_missing_dep`, two in `tool_sdk_test`), plus a `message_bus_test` collection error that also predates this branch. Untouched by this change; filed separately.

## Scope note

This is item 2 for the six settings the issue names, plus the actual root cause behind item 1 (`ssot_config`'s `default=""`, not a template).

Items 3 and 4 are **not** addressed and need the live node: the `0 .env keys` result (whether the drift detector and the deployed `.env` even agree on key namespace — the issue rightly flags that the "194 drifted" figure may itself be misleading), and the two missing YAML files. #12782 stays open for those.

Closes #12901 — the discrete issue for exactly this scope (one canonical
blank-means-absent helper, the six named settings routed through it, invalid
values still warning, `"0"`/`"false"` preserved). All four are implemented and tested.

Refs #12782 (corrected from `Closes` after merge — items 3 and 4 need the live node)

> **Linkage note:** the `Check PR links to its issue` gate derives the expected issue
> from the branch name, hence the `#12782` token. It does not auto-close — `Closes`
> fires on the default branch and this targets `Dev_new_gui`. #12782 stays open for
> items 3 and 4 (the `0 .env keys` drift-detector question and the two missing YAML
> files), both of which need the live node. See the scope note above.

## Model Used

claude-opus-5