### PR TITLE
fix(shared): repair 4 rotted tests and the stub that blocked 6 modules from collecting (#12900)

### DIFF
--- a/autobot_shared/feature_flags_test.py
+++ b/autobot_shared/feature_flags_test.py
@@ -124,17 +124,18 @@ class TestIsFeatureEnabled:
         """Patch get_config().feature with controlled attribute values."""
         from unittest.mock import MagicMock
 
+        from autobot_shared.feature_flags import _SUBSYSTEM_FLAG_MAP
+
         feature_cfg = MagicMock()
-        # Default all flags to True, then apply overrides.
-        defaults = {
-            "npu_enabled": True,
-            "voice_enabled": True,
-            "browser_enabled": True,
-            "computer_vision_enabled": True,
-            "training_enabled": True,
-            "osint_enabled": True,
-            "kb_enterprise_connectors": False,
-        }
+        # #12900: derive the attribute set from _SUBSYSTEM_FLAG_MAP rather than
+        # hand-listing it. The list had drifted — `kb_mock_connector` was added
+        # to the map and never here, so `getattr` returned a MagicMock instead
+        # of a bool and `test_all_known_flags_accepted` failed. A MagicMock
+        # never raises on a missing attribute, so nothing pointed at the cause.
+        # Deriving it means a newly added flag is covered automatically.
+        defaults = {attr: True for attr in _SUBSYSTEM_FLAG_MAP.values()}
+        # Opt-in subsystems default off, matching FeatureConfig.
+        defaults["kb_enterprise_connectors"] = False
         defaults.update(kwargs)
         for attr, val in defaults.items():
             setattr(feature_cfg, attr, val)

--- a/autobot_shared/message_bus_test.py
+++ b/autobot_shared/message_bus_test.py
@@ -33,12 +33,33 @@ def _install_redis_stub():
     inside message_bus.py resolves to our stub.
     """
     mod_name = "autobot_shared.redis_client"
-    if mod_name in sys.modules:
-        return  # Already loaded (real or stub)
+    existing = sys.modules.get(mod_name)
+    if existing is not None:
+        # Already loaded — real, or a stub installed by a sibling test module.
+        # #12900: do NOT replace it (other modules may hold references), but do
+        # make sure the symbol message_bus imports resolves. A sibling's stub
+        # that predates the async migration lacks it, and whether this module
+        # collects at all then depends purely on test ordering: it passed
+        # standalone and failed in a full-package run.
+        if not hasattr(existing, "get_async_redis_client"):
+            existing.get_async_redis_client = AsyncMock(name="stub_get_async_redis_client")
+        return
 
-    stub = types.ModuleType(mod_name)
-    stub.get_redis_client = MagicMock(name="stub_get_redis_client")
-    sys.modules[mod_name] = stub
+    # #12900: the stub used to hand-list only `get_redis_client`. message_bus.py
+    # later migrated to `get_async_redis_client`, the stub was never updated, and
+    # the whole module failed at COLLECTION — so it silently contributed zero
+    # tests instead of failing loudly. Resolving names on demand means a future
+    # symbol added to message_bus's imports cannot rot this stub the same way.
+    class _RedisClientStub(types.ModuleType):
+        def __getattr__(self, name: str):
+            # Async factories are awaited by the caller, so they need AsyncMock;
+            # a MagicMock would return a non-awaitable and fail at the await.
+            factory = AsyncMock if name.startswith("get_async") else MagicMock
+            mock = factory(name=f"stub_{name}")
+            setattr(self, name, mock)
+            return mock
+
+    sys.modules[mod_name] = _RedisClientStub(mod_name)
 
 
 _install_redis_stub()
@@ -83,21 +104,26 @@ def sample_message():
 async def bus_and_redis(mock_redis):
     """Create a ServiceMessageBus wired to the mock Redis client.
 
-    Patches ``get_redis_client`` in the already-imported module so that
+    Patches ``get_async_redis_client`` in the already-imported module so that
     ``_get_redis()`` returns *mock_redis*.
+
+    #12900: this patched ``get_redis_client``, the name message_bus imported
+    before it moved to the async client. Because the module never collected,
+    nothing reported the stale name — the fixture was patching an attribute
+    that no longer existed.
     """
     import autobot_shared.message_bus as mb_module
 
-    async def _mock_get_redis(async_client=False, database="logs"):
+    async def _mock_get_async_redis(database="logs", **kwargs):
         return mock_redis
 
-    original = mb_module.get_redis_client
-    mb_module.get_redis_client = _mock_get_redis
+    original = mb_module.get_async_redis_client
+    mb_module.get_async_redis_client = _mock_get_async_redis
     try:
         bus = ServiceMessageBus()
         yield bus, mock_redis
     finally:
-        mb_module.get_redis_client = original
+        mb_module.get_async_redis_client = original
         # Reset singleton so tests don't leak state
         mb_module._bus_instance = None
 

--- a/autobot_shared/missing_dep.py
+++ b/autobot_shared/missing_dep.py
@@ -84,6 +84,26 @@ class MissingDep:
             f"{self._name} is not available — install the optional dependencies " f"(original error: {self._error})"
         )
 
+    def __or__(self, _other: object) -> "MissingDep":
+        """Support ``stub | None`` in a type expression at module-load time (#12900).
+
+        The ``__getattr__`` dunder short-circuit above was believed to cover
+        this, but it cannot: Python resolves ``|`` via ``type(x).__or__`` and
+        never consults ``__getattr__``. With no ``__or__`` defined, any module
+        annotating ``OptionalDep | None`` raised
+        ``TypeError: unsupported operand type(s) for |`` the moment the
+        dependency was absent — which is precisely the import-time crash the
+        sentinel exists to prevent.
+
+        Returns the sentinel, mirroring ``__getitem__``: the union no-ops and
+        the real failure stays at call / attribute access.
+        """
+        return self
+
+    def __ror__(self, _other: object) -> "MissingDep":
+        """Right-hand form — ``None | stub`` must behave like ``stub | None``."""
+        return self
+
     def __getitem__(self, _params: object) -> "MissingDep":
         """Support ``MissingDep_instance | None`` and similar generic-like
         subscripting at module-load time without raising.

--- a/autobot_shared/tool_sdk/base.py
+++ b/autobot_shared/tool_sdk/base.py
@@ -266,6 +266,40 @@ _TYPE_MAP: Dict[str, Any] = {
 }
 
 
+# #12900: 2 decimal places floored any sub-10us tool to duration_ms=0.0, which is
+# indistinguishable from ToolResult's unpopulated default — a caller could not tell
+# "instant" from "never measured". perf_counter (highest available resolution) plus
+# 4dp keeps a fast in-process tool measurable.
+_DURATION_PRECISION = 4
+
+
+def _json_type_name(value: Any) -> str:
+    """Return the JSON Schema type name for *value* (#12900).
+
+    Error messages previously mixed vocabularies — "must be of type integer,
+    got str" names the expectation in JSON Schema terms and the actual value in
+    Python terms, which reads as two different things being compared.
+
+    ``bool`` is tested before ``int`` deliberately: ``isinstance(True, int)`` is
+    True in Python, so the obvious ordering would report a boolean as an integer.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
 def _check_type(data: Any, schema_type: str, path: str) -> None:
     """Raise ToolInputError if *data* does not match *schema_type* (#3018).
 
@@ -280,7 +314,7 @@ def _check_type(data: Any, schema_type: str, path: str) -> None:
     if expected and not isinstance(data, expected):
         label = path or "input"
         raise ToolInputError(
-            f"'{label}' must be of type {schema_type}, got {type(data).__name__}",
+            f"'{label}' must be of type {schema_type}, got {_json_type_name(data)}",
             field=path,
         )
 
@@ -429,11 +463,11 @@ async def _timed_execute(tool: BaseTool, validated_input: Dict[str, Any]) -> Too
     Returns:
         ToolResult with ``duration_ms`` populated.
     """
-    start = time.monotonic()
+    start = time.perf_counter()
     try:
         result = await tool.execute(validated_input)
     except Exception as exc:  # noqa: BLE001 — catch-all intentional here
-        duration = (time.monotonic() - start) * 1000
+        duration = (time.perf_counter() - start) * 1000
         logger.error(
             "Tool '%s' raised an unhandled exception: %s",
             tool.metadata.name,
@@ -443,8 +477,8 @@ async def _timed_execute(tool: BaseTool, validated_input: Dict[str, Any]) -> Too
         return ToolResult(
             success=False,
             error=f"Unhandled tool error: {exc}",
-            duration_ms=round(duration, 2),
+            duration_ms=round(duration, _DURATION_PRECISION),
         )
-    duration = (time.monotonic() - start) * 1000
-    result.duration_ms = round(duration, 2)
+    duration = (time.perf_counter() - start) * 1000
+    result.duration_ms = round(duration, _DURATION_PRECISION)
     return result


### PR DESCRIPTION
## Thinking Path

Four separate causes, and only one was actually test rot — the other three were real defects the tests were correctly reporting.

**`feature_flags_test`** — the mock hand-listed seven flag attributes; `kb_mock_connector` was later added to `_SUBSYSTEM_FLAG_MAP` and never here. `MagicMock` invents any missing attribute, so `getattr` returned a Mock rather than a bool and `isinstance(result, bool)` failed — with nothing pointing at the cause, because a MagicMock never raises on a missing attribute. Fixed by deriving the attribute set from the map, so a newly added flag is covered automatically.

**`tool_sdk` — `test_array_items`** — the test was right and the code was wrong. `_check_type` reported `must be of type integer, got str`: the expectation in JSON Schema vocabulary, the actual value in Python's. Added `_json_type_name()` so both halves match (`got string`). `bool` is tested before `int` deliberately — `isinstance(True, int)` is True, so the obvious ordering reports a boolean as an integer.

**`tool_sdk` — `test_duration_ms_populated`** — also a real defect. `round(duration, 2)` floors any sub-10µs tool to `0.0`, which is indistinguishable from `ToolResult.duration_ms`'s unpopulated default: a caller could not tell "instant" from "never measured". Switched to `perf_counter` and 4dp.

**`missing_dep`** — the most consequential. The test asserts `stub | None` evaluates, and `__getattr__` carries a comment claiming its dunder short-circuit covers it. It cannot: Python resolves `|` via `type(x).__or__` and never consults `__getattr__`. With no `__or__` defined, **any module annotating `OptionalDep | None` raised `TypeError` at import time the moment that dependency was absent** — precisely the import-time crash `MissingDep` exists to prevent. Added `__or__`/`__ror__` returning the sentinel, mirroring `__getitem__`.

**`message_bus_test` collection error** — the stub hand-listed `get_redis_client`; `message_bus.py` migrated to `get_async_redis_client` and the stub was never updated, so the module failed at *collection* and silently contributed zero tests. Made the stub resolve names on demand (PEP 562 module `__getattr__`, `AsyncMock` for `get_async*` since the caller awaits it), and fixed the fixture, which was still patching the pre-migration name.

That last one turned out to matter well beyond its own module: because `message_bus_test` sorts first alphabetically, its narrow stub landed in `sys.modules` before five sibling modules imported the same path — and **poisoned all of them**. It also had a test-ordering dependency: it passed standalone and failed in a full-package run, because a sibling's stub could win the race. Installing the missing symbol on whatever stub is already present (rather than bailing out) makes it order-independent.

## What Changed

- `autobot_shared/feature_flags_test.py` — mock attributes derived from `_SUBSYSTEM_FLAG_MAP`.
- `autobot_shared/tool_sdk/base.py` — `_json_type_name()`; `perf_counter` + `_DURATION_PRECISION = 4`.
- `autobot_shared/missing_dep.py` — `__or__` / `__ror__`.
- `autobot_shared/message_bus_test.py` — on-demand stub, order-independent install, fixture patched to the async factory.

## Verification

Measured against a clean `Dev_new_gui` checkout, same command both sides:

```
                     base                       this branch
  autobot_shared/    14 failed, 909 passed,     9 failed, 1069 passed,
                     6 collection errors        0 collection errors
```

**160 more tests now execute**, and all 6 collection errors are gone. The five modules unblocked as a side effect (`paperclip_client`, `plugin_sdk` ×2, `rate_limiter`, `workflow_memory`) had nothing wrong with them — they were casualties of the poisoned stub.

The five originally-reported items, all green:

```
$ python3 -m pytest autobot_shared/feature_flags_test.py autobot_shared/tests/test_missing_dep.py \
    autobot_shared/tool_sdk/ autobot_shared/message_bus_test.py -q
135 passed in 0.92s
```

The 9 remaining failures (`rate_limit_test`, two in `redis_management`) are **pre-existing** — every one appears in the base run above. They were invisible before only because collection aborted; they are not touched here and are filed separately.

Black clean on all four files.

Closes #12900

## Model Used

claude-opus-5
