### PR TITLE
fix(frontend): rewire the three verified browser endpoint renames to /browser/mcp/* (#12894)

### DIFF
--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -53,6 +53,15 @@ export interface BrowserAction {
   params: Record<string, unknown>
 }
 
+/** Wire shape returned by POST /api/browser/mcp/screenshot (#12894). */
+interface BrowserScreenshotResponse {
+  success: boolean
+  action: string
+  base64_image?: string
+  mime_type: string
+  timestamp: string
+}
+
 export interface ScreenshotResult {
   session_id: string
   image_data: string
@@ -235,7 +244,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function navigate(sessionId: string, url: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await ApiClient.post<unknown>(`${getApiBase()}/browser/navigate`, { session_id: sessionId, url })
+      await ApiClient.post<unknown>(`${getApiBase()}/browser/mcp/navigate`, { session_id: sessionId, url })
       logger.debug('Navigated to:', url)
       await fetchSessions()
       return true
@@ -250,7 +259,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function click(sessionId: string, selector: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await ApiClient.post<unknown>(`${getApiBase()}/browser/click`, { session_id: sessionId, selector })
+      await ApiClient.post<unknown>(`${getApiBase()}/browser/mcp/click`, { session_id: sessionId, selector })
       logger.debug('Clicked element:', selector)
       return true
     }).catch((err) => {
@@ -278,7 +287,20 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function takeScreenshot(sessionId: string): Promise<ScreenshotResult | null> {
     error.value = null
     return wrap(async () => {
-      const data = await ApiClient.post<ScreenshotResult>(`${getApiBase()}/browser/screenshot`, { session_id: sessionId })
+      // #12894: the route moved to /browser/mcp/screenshot AND its response
+      // shape differs from the old one — it returns base64_image/mime_type
+      // where callers here consume image_data/format. Rewiring the URL alone
+      // would have left every consumer reading undefined, so map it.
+      const raw = await ApiClient.post<BrowserScreenshotResponse>(
+        `${getApiBase()}/browser/mcp/screenshot`,
+        { session_id: sessionId },
+      )
+      const data: ScreenshotResult = {
+        session_id: sessionId,
+        image_data: raw.base64_image ?? '',
+        timestamp: raw.timestamp,
+        format: raw.mime_type === 'image/jpeg' ? 'jpeg' : 'png',
+      }
       screenshots.value.unshift(data)
       logger.debug('Captured screenshot')
       return data

--- a/scripts/api_wiring_baseline.txt
+++ b/scripts/api_wiring_baseline.txt
@@ -20,12 +20,9 @@
 
 # --- #12378: browser-automation panel (aspirational, no backend) ---
 /api/browser/automation/run
-/api/browser/click
 /api/browser/close
 /api/browser/execute
 /api/browser/launch
-/api/browser/navigate
-/api/browser/screenshot
 /api/browser/session/{p}
 /api/browser/type
 


### PR DESCRIPTION
## Thinking Path

#12894 lists 32 baselined calls whose endpoints were renamed. The issue is explicit that a suggestion is a *candidate, not proof*, so I rewired only what I could verify against the real route table (rebuilt locally: 2161 paths), and left the rest.

Of the seven browser calls, only three have a same-namespace replacement:

```
/api/browser/click       -> /api/browser/mcp/click        ✓
/api/browser/navigate    -> /api/browser/mcp/navigate     ✓
/api/browser/screenshot  -> /api/browser/mcp/screenshot   ✓
/api/browser/type        -> no match
/api/browser/close       -> no match
/api/browser/execute     -> no match (suggestions were cross-namespace: workflow/sandbox/terminal)
/api/browser/session/{p} -> no match
```

Corroborating evidence that `/mcp/` is the live namespace rather than a look-alike: `useBrowserAutomation.ts` **already** calls `/api/browser/mcp/status`. This file was half-migrated, and the callers that were missed are the dead buttons.

I then checked each replacement's request schema against what the composable already sends, rather than assuming a rename implies a compatible contract:

- `BrowserNavigateRequest` — `url` (required) + `session_id`; the caller sends `{session_id, url}`. Match.
- `BrowserClickRequest` — `selector` (required) + `session_id`; the caller sends `{session_id, selector}`. Match.
- `BrowserScreenshotRequest` — no required fields, accepts `session_id`. Match.

**Screenshot was not a pure rename**, which is exactly why this is worth checking rather than sed-ing. `BrowserScreenshotResponse` returns `base64_image` / `mime_type`, while the composable's `ScreenshotResult` and its consumers (`DesktopInterface.vue` reads `result.image_data`) expect `image_data` / `format`. Rewiring the URL alone would have turned a 404 into a silently-blank screenshot — arguably worse, since the button would then *look* like it worked.

## What Changed

**`autobot-frontend/src/composables/useBrowserAutomation.ts`**
- `navigate` and `click` repointed to `/browser/mcp/*` (pure renames — request bodies already match).
- `takeScreenshot` repointed *and* its response mapped: a new `BrowserScreenshotResponse` wire type is translated into the existing `ScreenshotResult`, so consumers keep reading `image_data`/`format` unchanged.

**`scripts/api_wiring_baseline.txt`** — the three entries removed. They are genuinely wired now, so suppressing them would hide real drift in future.

## Verification

```
$ node_modules/.bin/vue-tsc --noEmit -p tsconfig.app.json
(clean — no errors)

$ node_modules/.bin/vitest run src/composables/__tests__
Test Files  73 passed (73)
     Tests  1150 passed | 1 skipped (1151)
```

Audit against the rebuilt route table, before and after:

```
before:  TRACKED 35 | UNWIRED 5 | BASELINE HEALTH: 32 rematch
after:   TRACKED 32 | UNWIRED 5 | BASELINE HEALTH: 29 rematch
```

The three no longer appear as unwired at all, and the gating count is unchanged at 5 — so the gate did not move.

## Scope note

29 of the 32 remain, and #12894 stays open for them. They fall into two groups:

- **Four browser calls with no replacement** (`type`, `close`, `execute`, `session/{id}`). The MCP bridge appears not to expose equivalents, so these need a decision: implement them on the bridge, or retire the UI that calls them. That is a product question, not a rename.
- **25 others** (`code-intelligence`, `dev-speedup`, `knowledge_base`, `system/backup`, `system/restart|shutdown`, `user/profile`, …) still need the same per-call schema verification I did here. Given screenshot turned out to be a contract change rather than a rename, doing them in bulk would be guesswork.

Closes #12905 — the discrete issue for exactly this scope (the three verified
renames, per-call schema verification, the screenshot response mapping, and the
baseline prune without moving the gate).

Refs #12894 (corrected from `Closes` after merge — partial delivery, see the scope note)

> **Linkage note:** the `Check PR links to its issue` gate derives the expected
> issue from the branch name, hence the `#12894` token. It does not auto-close —
> `Closes` fires on the default branch and this targets `Dev_new_gui`. #12894 stays
> open for the remaining 29 calls; see the scope note above.

## Model Used

claude-opus-5