### PR TITLE
fix(deploy): read the app DB password from the canonical store, last-wins (#12883)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -674,13 +674,32 @@
       no_log: true
       tags: [backend, env]
 
-    # Full user management requires the autobot_app DB password, written by the
-    # single-box provisioning play into autobot-db-credentials.env (#10636).
-    - name: "[PLAY 2] Backend | Read autobot_app DB password (#10636)"
+    # Full user management requires the autobot_app DB password (#10636).
+    #
+    # GH#12883: this used to read ONLY /etc/autobot/autobot-db-credentials.env.
+    # On a live host that file was a month stale and held a value PostgreSQL
+    # rejects — that is what tried to overwrite a working credential and would
+    # have taken the database out on the next backend restart.
+    #
+    # /etc/autobot/db-credentials.env is the canonical store: PLAY 1 already
+    # slurps it for the SLM migrations above, and its value is the one that
+    # actually authenticates. Prefer it; keep the legacy file as a fallback for
+    # hosts provisioned before it existed.
+    #
+    # `tail -n 1` is load-bearing, not defensive. db-credentials.env is appended
+    # to rather than rewritten, so this key can appear more than once with the
+    # CURRENT value LAST. That matches `set -a; . file` semantics (last
+    # assignment wins); a `head -1` would read the stale first copy and
+    # reintroduce the exact outage this fixes.
+    - name: "[PLAY 2] Backend | Read autobot_app DB password (#10636, #12883)"
       ansible.builtin.shell:
-        cmd: >-
-          grep -oP '^AUTOBOT_DB_PASSWORD=\K.*'
-          /etc/autobot/autobot-db-credentials.env 2>/dev/null || true
+        cmd: |
+          k=AUTOBOT_DB_PASSWORD
+          v=$(grep -oP "^${k}=\K.*" /etc/autobot/db-credentials.env 2>/dev/null | tail -n 1)
+          if [ -z "$v" ]; then
+            v=$(grep -oP "^${k}=\K.*" /etc/autobot/autobot-db-credentials.env 2>/dev/null | tail -n 1)
+          fi
+          printf '%s' "$v"
       register: existing_autobot_db_password
       become: true
       when: "'backend' in group_names"
@@ -717,14 +736,15 @@
     # time it ran it overwrote a WORKING AUTOBOT_POSTGRES_PASSWORD with one
     # PostgreSQL rejects — the next backend restart would have lost the database.
     #
-    # Two stores claim to hold this secret and they disagree:
-    #   /etc/autobot/autobot-db-credentials.env   (what the task above reads)
-    #   /opt/autobot/autobot-backend/.env         (what actually authenticates)
+    # Two stores claimed to hold this secret and they disagreed:
+    #   /etc/autobot/autobot-db-credentials.env   (legacy, observed a month stale)
+    #   /etc/autobot/db-credentials.env           (canonical; authenticates)
     #
-    # Converging them is the real fix and needs an owner decision (#12883). Until
-    # then this refuses to replace a working credential with a different one:
-    # a visibly failed update is recoverable, a dead credential on next restart
-    # is an outage.
+    # The read task above now prefers the canonical store (last-wins), which is
+    # the convergence this issue asked for. This check stays as defence in depth:
+    # it costs nothing, and it still catches any host whose stores diverge for a
+    # reason we have not seen yet. A visibly failed update is recoverable; a dead
+    # credential on next restart is an outage.
     - name: "[PLAY 2] Backend | Read the DB password currently in use (#12883)"
       ansible.builtin.shell:
         cmd: >-

--- a/autobot-slm-backend/tests/test_backend_db_credential_source_12883.py
+++ b/autobot-slm-backend/tests/test_backend_db_credential_source_12883.py
@@ -1,0 +1,102 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the autobot_app DB credential source (#12883).
+
+The .env regen in PLAY 2 was unreachable until #12871 was fixed. The first time
+it ran it rendered a value PostgreSQL rejects, because it read the app DB
+password from /etc/autobot/autobot-db-credentials.env — a file observed a month
+stale on a live host. The value that actually authenticates lives in
+/etc/autobot/db-credentials.env, which PLAY 1 already treats as canonical.
+
+Two properties have to hold, and the second is the subtle one:
+
+  1. the canonical store is read first, legacy only as a fallback;
+  2. the LAST occurrence of the key wins. db-credentials.env is appended to
+     rather than rewritten, so the key can appear twice with the current value
+     last. `set -a; . file` resolves that to the last assignment, so a `head -1`
+     here would silently pick the stale copy and reintroduce the outage.
+
+Test 2 executes the extraction snippet rather than pattern-matching it, so the
+behaviour is pinned even if the shell is rewritten.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_PLAYBOOK = (
+    Path(__file__).resolve().parents[1] / "ansible" / "playbooks" / "update-all-nodes.yml"
+)
+_CANONICAL = "/etc/autobot/db-credentials.env"
+_LEGACY = "/etc/autobot/autobot-db-credentials.env"
+
+
+def _read_task_cmd() -> str:
+    """Return the shell body of the task that reads the app DB password."""
+    plays = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+    for play in plays:
+        for task in play.get("tasks") or []:
+            name = task.get("name", "")
+            if "autobot_app DB password" in name:
+                return task["ansible.builtin.shell"]["cmd"]
+    raise AssertionError("no task reading the autobot_app DB password found")
+
+
+def test_prefers_canonical_store_over_legacy() -> None:
+    """The canonical store must be consulted before the legacy file (#12883)."""
+    cmd = _read_task_cmd()
+
+    assert _CANONICAL in cmd, f"canonical store {_CANONICAL} is not read at all"
+    assert cmd.index(_CANONICAL) < cmd.index(
+        _LEGACY
+    ), "legacy store is read before the canonical one — that is the #12883 outage"
+
+
+def test_takes_the_last_occurrence_not_the_first() -> None:
+    """Guard the last-wins requirement against a `head -1` regression (#12883)."""
+    cmd = _read_task_cmd()
+
+    assert "tail -n 1" in cmd, "extraction must take the LAST match (append-only file)"
+    assert not re.search(r"\bhead\b", cmd), "head would select the stale first copy"
+
+
+def test_extraction_resolves_duplicate_keys_to_the_current_value(tmp_path) -> None:
+    """Run the real snippet against an append-style file with a duplicated key."""
+    canonical = tmp_path / "db-credentials.env"
+    canonical.write_text(
+        "AUTOBOT_DB_USER=autobot_app\n"
+        "AUTOBOT_DB_PASSWORD=stale-first-copy\n"
+        "AUTOBOT_DB_USER=autobot_app\n"
+        "AUTOBOT_DB_PASSWORD=current-last-copy\n",
+        encoding="utf-8",
+    )
+    legacy = tmp_path / "autobot-db-credentials.env"
+    legacy.write_text("AUTOBOT_DB_PASSWORD=legacy-should-not-be-used\n", encoding="utf-8")
+
+    snippet = _read_task_cmd().replace(_CANONICAL, str(canonical)).replace(_LEGACY, str(legacy))
+    out = subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True, check=True, timeout=30
+    )
+
+    assert out.stdout == "current-last-copy", (
+        f"expected the last occurrence, got {out.stdout!r} — "
+        "a head/first-match read reintroduces #12883"
+    )
+
+
+def test_falls_back_to_legacy_when_canonical_absent(tmp_path) -> None:
+    """Hosts provisioned before the canonical store still resolve a value."""
+    canonical = tmp_path / "db-credentials.env"  # deliberately not created
+    legacy = tmp_path / "autobot-db-credentials.env"
+    legacy.write_text("AUTOBOT_DB_PASSWORD=legacy-value\n", encoding="utf-8")
+
+    snippet = _read_task_cmd().replace(_CANONICAL, str(canonical)).replace(_LEGACY, str(legacy))
+    out = subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True, check=True, timeout=30
+    )
+
+    assert out.stdout == "legacy-value", f"fallback did not resolve, got {out.stdout!r}"

--- a/autobot-slm-backend/tests/test_backend_db_credential_source_12883.py
+++ b/autobot-slm-backend/tests/test_backend_db_credential_source_12883.py
@@ -28,9 +28,7 @@ import pytest
 
 yaml = pytest.importorskip("yaml")
 
-_PLAYBOOK = (
-    Path(__file__).resolve().parents[1] / "ansible" / "playbooks" / "update-all-nodes.yml"
-)
+_PLAYBOOK = Path(__file__).resolve().parents[1] / "ansible" / "playbooks" / "update-all-nodes.yml"
 _CANONICAL = "/etc/autobot/db-credentials.env"
 _LEGACY = "/etc/autobot/autobot-db-credentials.env"
 
@@ -78,13 +76,10 @@ def test_extraction_resolves_duplicate_keys_to_the_current_value(tmp_path) -> No
     legacy.write_text("AUTOBOT_DB_PASSWORD=legacy-should-not-be-used\n", encoding="utf-8")
 
     snippet = _read_task_cmd().replace(_CANONICAL, str(canonical)).replace(_LEGACY, str(legacy))
-    out = subprocess.run(
-        ["bash", "-c", snippet], capture_output=True, text=True, check=True, timeout=30
-    )
+    out = subprocess.run(["bash", "-c", snippet], capture_output=True, text=True, check=True, timeout=30)
 
     assert out.stdout == "current-last-copy", (
-        f"expected the last occurrence, got {out.stdout!r} — "
-        "a head/first-match read reintroduces #12883"
+        f"expected the last occurrence, got {out.stdout!r} — " "a head/first-match read reintroduces #12883"
     )
 
 
@@ -95,8 +90,6 @@ def test_falls_back_to_legacy_when_canonical_absent(tmp_path) -> None:
     legacy.write_text("AUTOBOT_DB_PASSWORD=legacy-value\n", encoding="utf-8")
 
     snippet = _read_task_cmd().replace(_CANONICAL, str(canonical)).replace(_LEGACY, str(legacy))
-    out = subprocess.run(
-        ["bash", "-c", snippet], capture_output=True, text=True, check=True, timeout=30
-    )
+    out = subprocess.run(["bash", "-c", snippet], capture_output=True, text=True, check=True, timeout=30)
 
     assert out.stdout == "legacy-value", f"fallback did not resolve, got {out.stdout!r}"


### PR DESCRIPTION
## Thinking Path

Running a self-update on a live node, PLAY 2's `.env` regen (unreachable until #12871) rendered an `AUTOBOT_POSTGRES_PASSWORD` that PostgreSQL rejects. #12889 landed a guard that refuses the overwrite — correct, and it prevents the outage — but it fails the update closed and explicitly defers the real fix: *"Converging them is the real fix and needs an owner decision (#12883)."* That decision is made; this converges them.

Diagnosing which store is authoritative took some care, because the first answer was wrong:

- `/etc/autobot/autobot-db-credentials.env` — what the task read. Observed **a month stale**; its value does not authenticate.
- `/etc/autobot/db-credentials.env` — mtime four weeks newer, and already treated as canonical by PLAY 1, which slurps it for the SLM migrations. Its value **does** authenticate.

The subtle part: `db-credentials.env` contains **duplicate keys** — `AUTOBOT_DB_PASSWORD` appears twice, first copy stale, second copy current. It is appended to rather than rewritten. `set -a; . file` resolves that to the *last* assignment, so a `grep | head -1` reads the stale copy and reintroduces exactly this outage. That is why `tail -n 1` is load-bearing rather than defensive, and why it is pinned by a test that executes the snippet instead of pattern-matching it.

I did not touch the ordering point raised in the issue (running `migrations.baseline` before the rewrite). The guard plus a correct source makes it much less urgent, and it is a bigger change to the play's shape.

## What Changed

**`autobot-slm-backend/ansible/playbooks/update-all-nodes.yml`**
- `[PLAY 2] Backend | Read autobot_app DB password` now reads the canonical `db-credentials.env` first, falling back to the legacy file only when the key is absent — so hosts provisioned before the canonical store existed still resolve a value.
- Extraction takes the **last** occurrence, matching shell source semantics for an append-only file.
- Updated the #12889 comment block, which said convergence "needs an owner decision", to record the decision and why the guard is kept as defence in depth.

**`autobot-slm-backend/tests/test_backend_db_credential_source_12883.py`** (new, 4 tests)
- canonical store is read before the legacy one
- `tail -n 1` present and no `head` (last-wins pinned)
- executes the real snippet against a duplicate-key fixture, asserting the *current* value wins
- executes it with the canonical file absent, asserting the legacy fallback resolves

No behaviour change for a host whose stores already agree.

## Verification

Extraction verified against the live host — new logic authenticates, previous logic does not:

```
new logic  -> AUTHENTICATES: YES
old logic  -> AUTHENTICATES: NO
```

Tests fail against the pre-fix playbook and pass after (mutation-checked by reverting the play and re-running):

```
# pre-fix
FAILED test_prefers_canonical_store_over_legacy
FAILED test_takes_the_last_occurrence_not_the_first
FAILED test_extraction_resolves_duplicate_keys_to_the_current_value
FAILED test_falls_back_to_legacy_when_canonical_absent
4 failed

# post-fix, with adjacent playbook suites
tests/test_infrastructure_playbooks.py .....................
tests/test_backend_service_faulthandler_12777.py .........
tests/services/test_self_update_systemd_detach_11492.py .......................
tests/test_backend_db_credential_source_12883.py ....
57 passed, 1 warning in 2.05s
```

YAML parses (`yaml.safe_load` → 4 plays) and the task body was inspected as parsed, confirming `\K` survives the block scalar into `grep -P`.

## Follow-ups filed

Not fixed here, discovered while diagnosing — filed as **#12907**:
- The generator that **appends** to `db-credentials.env` instead of rewriting it is what creates the duplicate keys. This change is robust to that, but the generator is the underlying defect.
- `/etc/autobot/autobot-db-credentials.env` is stale on at least one host and nothing reconciles or retires it.

## Model Used

Claude Opus 5 (`claude-opus-5`)

Closes #12883