### PR TITLE
fix(code-intel): serve security score from cache and enqueue, instead of a GIL-bound inline scan (#12866)

### DIFF
--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -1334,31 +1334,42 @@ async def get_security_score(
         raise_invalid_input("path", f"does not exist: {path}")
 
     try:
-        analyzer = SecurityAnalyzer(project_root=path)
-        await asyncio.to_thread(analyzer.analyze_directory)
-        summary = analyzer.get_summary()
+        # #12866: this used to run analyzer.analyze_directory() inline via
+        # asyncio.to_thread. That is not a substitute for a separate process
+        # here — the scan is pure-Python and GIL-bound, so the worker thread
+        # holds the GIL and starves the event loop for the whole scan. Every
+        # other request on this worker stalls with it, which is what pushed
+        # /service-monitor/vms/status past the GUI's probe budget and made a
+        # healthy backend report itself "Unreachable" (p90 12s, 27.5% of polls).
+        #
+        # The Celery path for exactly this work already exists
+        # (POST /security/score/analyze -> run_security_analysis). Serve the
+        # latest completed result and enqueue a refresh instead of scanning in
+        # the request. Same response shape either way, so callers are unchanged.
+        cached = await get_latest_task_result(_REDIS_PREFIX)
+        if cached and cached.get("result"):
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "status": "success",
+                    "from_cache": True,
+                    "completed_at": cached.get("completed_at"),
+                    "path": path,
+                    **cached["result"],
+                },
+            )
 
-        # Generate grade and status using extracted helpers
-        score = summary["security_score"]
-        grade = get_grade_from_score(score)
-        status = _get_security_status_message(score)
-
+        queued = run_security_analysis.delay(path)
+        await store_latest_task_id(_REDIS_PREFIX, queued.id)
+        logger.info("Security score not cached; queued analysis task %s for %s", queued.id, path)
         return JSONResponse(
             status_code=200,
             content={
-                "status": "success",
-                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "status": "pending",
+                "task_id": queued.id,
                 "path": path,
-                "security_score": score,
-                "grade": grade,
-                "risk_level": summary["risk_level"],
-                "status_message": status,
-                "total_findings": summary["total_findings"],
-                "critical_issues": summary["critical_issues"],
-                "high_issues": summary["high_issues"],
-                "files_analyzed": summary["files_analyzed"],
-                "severity_breakdown": summary["by_severity"],
-                "owasp_breakdown": summary["by_owasp_category"],
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "message": "Security analysis queued; poll this endpoint for the completed score.",
             },
         )
 

--- a/autobot-backend/api/code_intelligence_security_score_12866_test.py
+++ b/autobot-backend/api/code_intelligence_security_score_12866_test.py
@@ -1,0 +1,98 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GET /security/score must not scan in the request (#12866).
+
+The endpoint ran ``SecurityAnalyzer.analyze_directory()`` via
+``asyncio.to_thread``. That looks non-blocking but is not: the scan is pure
+Python and GIL-bound, so the worker thread holds the GIL for its whole
+duration and starves the event loop. Every other request on the worker stalls
+with it — which is what pushed ``/service-monitor/vms/status`` past the GUI's
+5s probe budget (p90 12s, 27.5% of polls) and made a backend with zero
+restarts report itself "Unreachable".
+
+The Celery path for this exact work already existed. These tests pin that the
+endpoint serves the cached result and enqueues a refresh, and never analyses
+inline again.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SOURCE = Path(__file__).resolve().parent / "code_intelligence.py"
+
+
+def _endpoint_source() -> str:
+    """Source text of get_security_score, isolated from its neighbours."""
+    tree = ast.parse(_SOURCE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "get_security_score":
+            return ast.get_source_segment(_SOURCE.read_text(encoding="utf-8"), node) or ""
+    raise AssertionError("get_security_score not found — was it renamed?")
+
+
+def _called_names(source: str) -> set[str]:
+    """Every function/method/attribute actually *called* in *source*."""
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Call):
+            func = node.func
+            names.add(getattr(func, "attr", None) or getattr(func, "id", "") or "")
+    return names
+
+
+class TestNoInlineScan:
+    """The regression guard: the scan must not come back into the request path."""
+
+    def test_endpoint_does_not_call_the_analyzer_inline(self):
+        """Asserted on the AST, not the text: the comment explaining *why* the
+        scan was removed necessarily names it, and a substring check would trip
+        on its own rationale."""
+        called = _called_names(_endpoint_source())
+
+        assert "analyze_directory" not in called, "the GIL-bound scan is back in the request path"
+        assert "SecurityAnalyzer" not in called, "the analyzer must not be constructed per request"
+
+    def test_endpoint_enqueues_the_existing_celery_task(self):
+        """Reuses run_security_analysis rather than introducing a second path."""
+        source = _endpoint_source()
+
+        assert "run_security_analysis.delay" in source
+
+    def test_endpoint_serves_the_cached_result_first(self):
+        """A completed scan must answer immediately; only a miss enqueues."""
+        source = _endpoint_source()
+
+        cache_read = source.index("get_latest_task_result")
+        enqueue = source.index("run_security_analysis.delay")
+        assert cache_read < enqueue, "cache must be consulted before enqueueing"
+
+    def test_queued_task_id_is_recorded_for_later_lookup(self):
+        """Without this the result is orphaned — nothing can find it again."""
+        assert "store_latest_task_id" in _endpoint_source()
+
+
+class TestResponseContract:
+    """Callers must not have to change — the shape is the same either way."""
+
+    def test_cached_response_keeps_the_success_status(self):
+        """useCodeIntelScores maps on `status === 'success'`; anything else is dropped."""
+        source = _endpoint_source()
+
+        assert '"status": "success"' in source
+        assert '"from_cache": True' in source
+
+    def test_cache_miss_reports_pending_not_a_fabricated_score(self):
+        """A zero score would read as 'perfectly insecure', not 'not yet known'."""
+        source = _endpoint_source()
+
+        assert '"status": "pending"' in source
+        assert '"task_id"' in source
+
+    @pytest.mark.parametrize("field", ["completed_at", "path"])
+    def test_cached_response_carries_provenance(self, field):
+        """The GUI shows results as-of a time; both halves need it."""
+        assert f'"{field}"' in _endpoint_source()


### PR DESCRIPTION
## Thinking Path

#12866 lists four fixes. Item 1 is the root cause; items 2–4 are GUI resilience and a deployment choice.

Item 1's wording needed checking before implementing. It says *"the synchronous endpoint path should queue that instead of scanning in-process"* — but `POST /security/score/analyze` **already** calls `run_security_analysis.delay()`. The endpoint actually doing the inline scan is `GET /security/score`:

```python
analyzer = SecurityAnalyzer(project_root=path)
await asyncio.to_thread(analyzer.analyze_directory)
```

The issue's own diagnosis of *why* that is wrong is exactly right, and worth restating because `to_thread` looks like the fix: the scan is pure Python and GIL-bound, so the worker thread holds the GIL for its whole duration and the event loop cannot progress. Every other request on that worker stalls with it — which is how a status endpoint the GUI polls reached p90 12s on a backend with zero restarts.

The pleasing part is how little was needed. The full async trio already exists and is already wired — `POST …/analyze` → `GET …/status/{id}` → `GET …/cached`. The inline endpoint was the odd one out, so this reuses those helpers rather than adding a second analysis path.

## What Changed

**`autobot-backend/api/code_intelligence.py`** — `get_security_score` no longer constructs or runs the analyzer. It now:

1. serves the latest completed result via `get_latest_task_result` when one exists, and
2. on a miss, enqueues `run_security_analysis.delay(path)` and records the id with `store_latest_task_id` so the result can be found again.

Response shape is unchanged for the caller that matters: `useCodeIntelScores.ts` maps on `status === 'success'` and reads `security_score`/`grade`/`risk_level`/`total_findings`/the two breakdowns, all of which the cached payload carries. A miss reports `status: "pending"` with the task id rather than a fabricated zero — a zero score would read as "perfectly insecure" instead of "not yet known".

## Verification

```
$ python3 -m pytest autobot-backend/api/code_intelligence_security_score_12866_test.py -q
8 passed in 0.65s

$ python3 -m pytest autobot-backend/api/ -q -k code_intelligence
8 passed, 3307 deselected

$ python3 -m black --check --line-length=120 <both files>
2 files would be left unchanged.
```

The guard asserts on the **AST**, not the source text: the comment explaining why the scan was removed necessarily names `analyze_directory`, so a substring check trips on its own rationale. It fails if `analyze_directory` or `SecurityAnalyzer` is ever *called* in the handler again, and it pins that the cache is consulted before enqueueing, that the task id is recorded, and both response shapes.

## Scope note

Items 2–4 stay on #12866:

- **Item 2** (separate "no response" from "slow" from `401`; keep last-known state with an as-of stamp) — partly delivered already in PR #12882.
- **Item 3** (raise the probe budget above worst-case p99) — worth doing after this lands, since the p99 it must clear should drop once the loop is not being starved.
- **Item 4** (`--workers > 1`) — a deployment decision, not mine to make.

I have not measured the latency improvement: reproducing the p90 requires the live node, and this environment cannot run the backend under load. What is verified here is that the GIL-bound work no longer happens in the request path.

Closes #12908
Refs #12866 (corrected from `Closes` after merge — partial delivery, see the scope note)

> **Linkage note:** the `Check PR links to its issue` gate derives the expected issue from the branch name, hence the `#12866` token. It does not auto-close — `Closes` fires on the default branch and this targets `Dev_new_gui`. #12866 stays open for items 2–4.

## Model Used

claude-opus-5