### PR TITLE
refactor(shared): converge 3 CircuitState forks onto autobot_shared (#12656)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/types.py
+++ b/autobot-backend/agents/agent_orchestration/types.py
@@ -160,12 +160,10 @@ class AgentCapabilityDescriptor:
     resource_usage: str
 
 
-class CircuitState(Enum):
-    """Circuit breaker state for a distributed agent (Issue #4694)."""
-
-    CLOSED = "closed"  # Normal operation — agent receives tasks.
-    OPEN = "open"  # Agent quarantined — excluded from routing.
-    HALF_OPEN = "half_open"  # Recovery probe: one task allowed; result decides next state.
+# #12656: converged onto the canonical enum. Semantics per member are unchanged
+# for a distributed agent — CLOSED: receives tasks; OPEN: quarantined, excluded
+# from routing; HALF_OPEN: one probe task allowed, its result decides.
+from autobot_shared.ssot_constants import CircuitState  # noqa: F401
 
 
 @dataclass

--- a/autobot-backend/circuit_breaker.py
+++ b/autobot-backend/circuit_breaker.py
@@ -12,7 +12,6 @@ import asyncio
 import statistics
 import time
 from dataclasses import dataclass
-from enum import Enum
 from functools import wraps
 from threading import Lock
 from typing import Any, Callable, Dict, List
@@ -25,13 +24,11 @@ from constants import CircuitBreakerDefaults
 logger = get_logger(__name__)
 
 
-class CircuitState(Enum):
-    """Circuit breaker states"""
-
-    CLOSED = "closed"  # Normal operation
-    OPEN = "open"  # Circuit is open, rejecting calls
-    HALF_OPEN = "half_open"  # Testing if service has recovered
-
+# #12656: CircuitState is now canonical in autobot_shared.ssot_constants and
+# re-exported here so the existing `from circuit_breaker import CircuitState`
+# importers keep working. Three identical copies existed; separate Enum classes
+# with the same members never compare equal across module boundaries.
+from autobot_shared.ssot_constants import CircuitState  # noqa: F401
 
 CircuitBreakerState = CircuitState
 

--- a/autobot-npu-worker/core/npu_integration.py
+++ b/autobot-npu-worker/core/npu_integration.py
@@ -101,12 +101,19 @@ __all__ = [
 USE_AUTHENTICATED_CLIENT = True
 
 
-class CircuitState(Enum):
-    """Circuit breaker states for worker health management"""
+# #12656: prefer the canonical enum; keep a local definition only for the
+# PyInstaller standalone build, where autobot_shared is not importable. The
+# members are identical either way, so worker health logic is unchanged.
+try:
+    from autobot_shared.ssot_constants import CircuitState
+except (ImportError, ModuleNotFoundError):
 
-    CLOSED = "closed"  # Normal operation
-    OPEN = "open"  # Worker failed, blocking requests
-    HALF_OPEN = "half_open"  # Testing recovery
+    class CircuitState(Enum):  # type: ignore[no-redef]
+        """Circuit breaker states for worker health management (standalone fallback)."""
+
+        CLOSED = "closed"  # Normal operation
+        OPEN = "open"  # Worker failed, blocking requests
+        HALF_OPEN = "half_open"  # Testing recovery
 
 
 @dataclass

--- a/autobot_shared/circuit_state_convergence_test.py
+++ b/autobot_shared/circuit_state_convergence_test.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""One canonical CircuitState (#12656, part of #12645).
+
+Three byte-identical definitions existed: `circuit_breaker.py`,
+`agents/agent_orchestration/types.py`, and the npu-worker's copy in
+`core/npu_integration.py`.
+
+Duplication was not the only cost. Three separate `Enum` classes with the same
+member names are **not interchangeable** — `A.OPEN == B.OPEN` is False even
+though both carry `"open"`. Any state passed across those boundaries compared
+unequal, silently, and no test would notice because each module only ever
+compared against its own copy.
+
+These tests pin the convergence and that property.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.ssot_constants import CircuitState
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _class_defs(rel_path: str, name: str) -> list[ast.ClassDef]:
+    """Top-level (module-scope) class definitions of *name* in *rel_path*."""
+    tree = ast.parse((_REPO / rel_path).read_text(encoding="utf-8"))
+    return [n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == name]
+
+
+class TestCanonicalDefinition:
+    def test_members_are_unchanged(self):
+        """Convergence must not quietly alter any state's wire value."""
+        assert [s.value for s in CircuitState] == ["closed", "open", "half_open"]
+
+    @pytest.mark.parametrize("member", ["CLOSED", "OPEN", "HALF_OPEN"])
+    def test_every_member_survives(self, member):
+        assert hasattr(CircuitState, member)
+
+
+class TestForksConverged:
+    """Each former copy must now resolve to the canonical enum."""
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            "autobot-backend/circuit_breaker.py",
+            "autobot-backend/agents/agent_orchestration/types.py",
+        ],
+    )
+    def test_backend_copies_are_gone(self, rel_path):
+        assert not _class_defs(rel_path, "CircuitState"), f"{rel_path} still defines its own CircuitState"
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            "autobot-backend/circuit_breaker.py",
+            "autobot-backend/agents/agent_orchestration/types.py",
+            "autobot-npu-worker/core/npu_integration.py",
+        ],
+    )
+    def test_each_module_imports_the_canonical_one(self, rel_path):
+        source = (_REPO / rel_path).read_text(encoding="utf-8")
+
+        assert "from autobot_shared.ssot_constants import CircuitState" in source
+
+    def test_worker_keeps_a_standalone_fallback(self):
+        """The PyInstaller build cannot import autobot_shared — it must still work.
+
+        The fallback is nested inside the `except ImportError` branch, so it is
+        not a module-level definition and does not count as a surviving fork.
+        """
+        rel = "autobot-npu-worker/core/npu_integration.py"
+
+        assert not _class_defs(rel, "CircuitState"), "fallback must be nested, not module-level"
+        assert "except (ImportError, ModuleNotFoundError):" in (_REPO / rel).read_text(encoding="utf-8")
+
+
+def test_cross_module_identity_now_holds():
+    """The bug the fork could cause: same member, different class, never equal."""
+    import sys
+
+    sys.path.insert(0, str(_REPO / "autobot-backend"))
+    from circuit_breaker import CircuitState as FromBreaker
+
+    assert FromBreaker is CircuitState
+    assert FromBreaker.OPEN == CircuitState.OPEN

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -24,9 +24,9 @@ This module replaces:
   - autobot-backend/voice_processing/constants.py
 """
 
-from enum import Enum
 import re
 from dataclasses import dataclass
+from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, FrozenSet, List

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -24,6 +24,7 @@ This module replaces:
   - autobot-backend/voice_processing/constants.py
 """
 
+from enum import Enum
 import re
 from dataclasses import dataclass
 from functools import lru_cache
@@ -533,6 +534,22 @@ class ComputerVisionThresholds:
 
     SEARCH_RESULT_LIMIT = 10
     SIMILARITY_THRESHOLD = 0.7
+
+
+class CircuitState(Enum):
+    """Canonical circuit-breaker state (#12656).
+
+    Converged from three byte-identical definitions — `circuit_breaker.py`,
+    `agents/agent_orchestration/types.py`, and the npu-worker's copy in
+    `core/npu_integration.py`. Beyond the duplication, three separate Enum
+    classes with the same members are not interchangeable: a value from one
+    never compares equal to the "same" member of another, so any code that
+    passed a state across those boundaries was silently always-unequal.
+    """
+
+    CLOSED = "closed"  # Normal operation
+    OPEN = "open"  # Failing — calls rejected / worker excluded
+    HALF_OPEN = "half_open"  # Recovery probe: one call allowed, result decides
 
 
 class CircuitBreakerDefaults:


### PR DESCRIPTION
## Thinking Path

Scoping the `npu_integration.py` de-fork (#12656) surfaced this as a prerequisite. The NPU code depends on `CircuitState`, so the shared module cannot exist until the enum does — but the enum turned out to be worth converging on its own merits.

There are **three** identical definitions, not the two the de-fork needed:

```
autobot-backend/circuit_breaker.py:28
autobot-backend/agents/agent_orchestration/types.py:163
autobot-npu-worker/core/npu_integration.py:104
```

all carrying exactly `CLOSED="closed"`, `OPEN="open"`, `HALF_OPEN="half_open"`.

The interesting part is that duplication is not the main cost. Three separate `Enum` classes with the same members are **not interchangeable** — `circuit_breaker.CircuitState.OPEN == types.CircuitState.OPEN` is `False`, because Enum identity is per-class. Any state passed across those boundaries compares unequal, silently. It is latent rather than active: each module only compares against its own copy today, so no test crosses the boundary. But the trap is loaded, and the failure mode is a wrong branch with no error.

`autobot_shared/ssot_constants.py` already hosts `CircuitBreakerDefaults`, and `autobot-backend/constants/threshold_constants.py` is *already* a pure re-export shim from that module — so both the destination and the pattern were established. This follows them rather than inventing a third convention.

## What Changed

- **`autobot_shared/ssot_constants.py`** — canonical `CircuitState`, placed next to `CircuitBreakerDefaults`. Member values unchanged.
- **`autobot-backend/circuit_breaker.py`** — the class replaced by an import + re-export, so the existing `from circuit_breaker import CircuitState` importers are untouched. Its now-unused `from enum import Enum` removed.
- **`autobot-backend/agents/agent_orchestration/types.py`** — same, with the per-member distributed-agent semantics preserved as a comment rather than dropped.
- **`autobot-npu-worker/core/npu_integration.py`** — imports the canonical enum, keeping a **nested** fallback inside `except (ImportError, ModuleNotFoundError)` for the PyInstaller standalone build, where `autobot_shared` is not importable. Nested, so it is not a surviving module-level fork.

Nothing was deleted — each former definition became an import of the same thing.

## Verification

```
$ python3 -m pytest autobot_shared/circuit_state_convergence_test.py -q
11 passed in 1.63s

$ python3 -m pytest autobot-backend/tests/ -q -k circuit
43 passed, 6055 deselected

$ python3 -m flake8 --select=F <4 touched modules>
(clean)

$ python3 -m black --check --line-length=120 <5 files>
(clean)
```

The tests pin that member values did not shift, that no module-level fork survives in any of the three files, that each imports the canonical enum, that the worker's fallback stays nested, and — the point of the exercise — that `from circuit_breaker import CircuitState is autobot_shared…CircuitState` now holds, so cross-module comparison works.

## Scope note

This is the prerequisite only. The `npu_integration.py` extraction itself (#12656) is next, and my scoping comment there records the corrected plan: 6 of its 7 shared symbols are byte-identical, `threshold_constants` turned out to already be shared, and the remaining backend couplings (`create_service_client`, `get_service_url`) should be injected rather than moved — moving them would be ~960 lines touching 15 importers for no benefit.

Closes #12913
Refs #12656 (corrected from `Closes` after merge — the NPU extraction itself is still open)

> **Linkage note:** the `Check PR links to its issue` gate derives the expected issue from the branch name, hence the `#12656` token. It does not auto-close — `Closes` fires on the default branch and this targets `Dev_new_gui`. #12656 stays open for the extraction itself.

## Model Used

claude-opus-5