### PR TITLE
refactor(user-mgmt): converge base_service and team_service onto canonical helpers (#12647)

### DIFF
--- a/autobot-slm-backend/user_management/services/base_service.py
+++ b/autobot-slm-backend/user_management/services/base_service.py
@@ -8,14 +8,15 @@ Base Service Class
 Provides tenant context management and common service patterns.
 """
 
-import logging
 import uuid
 from dataclasses import dataclass
 
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = logging.getLogger(__name__)
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -23,7 +24,6 @@ class TenantContext:
     """
     Tenant context for multi-tenancy operations.
 
-    In single_user mode, org_id is None.
     In single_company mode, org_id is the implicit organization.
     In multi_company/provider modes, org_id is set from JWT/session.
     """

--- a/autobot-slm-backend/user_management/services/team_service.py
+++ b/autobot-slm-backend/user_management/services/team_service.py
@@ -9,20 +9,20 @@ Business logic for team management operations including CRUD,
 membership management, and role assignment within teams.
 """
 
-import logging
 import uuid
-from datetime import datetime, timezone
 from typing import List
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
 from user_management.models import Team, TeamMembership
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
 from user_management.services.base_service import BaseService, TenantContext
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class TeamServiceError(Exception):
@@ -291,7 +291,7 @@ class TeamService(BaseService):
         if settings is not None:
             team.settings = settings
 
-        team.updated_at = datetime.now(timezone.utc)
+        team.updated_at = now_utc()
         await self.session.flush()
 
         if changes:
@@ -324,7 +324,7 @@ class TeamService(BaseService):
         if hard_delete:
             await self.session.delete(team)
         else:
-            team.deleted_at = datetime.now(timezone.utc)
+            team.deleted_at = now_utc()
 
         await self.session.flush()
 
@@ -402,7 +402,7 @@ class TeamService(BaseService):
             team_id=team_id,
             user_id=user_id,
             role=role,
-            joined_at=datetime.now(timezone.utc),
+            joined_at=now_utc(),
         )
 
     async def add_member(
@@ -556,7 +556,7 @@ class TeamService(BaseService):
         await self._validate_role_change(team_id, old_role, new_role)
 
         membership.role = new_role
-        membership.updated_at = datetime.now(timezone.utc)
+        membership.updated_at = now_utc()
         await self.session.flush()
 
         await self._log_role_change(team_id, user_id, old_role, new_role)


### PR DESCRIPTION
## Thinking Path

First sub-step of the `user_management` de-fork (#12647), deliberately the smallest one.

I measured the package before starting: **1695 divergent lines across 22 files**. Unlike the NPU fork (#12656), where 6 of 7 shared symbols were byte-identical, *nothing* here is identical — which is what makes it the umbrella's highest-risk cluster.

That measurement also contradicted the issue's recommended opener. It suggests starting with `models/base.py`; that file is the **hardest** in the package, not the easiest:

- backend: `Base(AsyncAttrs, DeclarativeBase)` with timestamps built in, `TimestampMixin` deliberately a no-op alias — #4300 records that inheriting both caused metaclass conflicts, #11684 added `AsyncAttrs` for greenlet-safe `awaitable_attrs`
- slm: plain `Base`, a *separate* `TimestampMixin`, plus `type_annotation_map` for Postgres UUIDs

Converging that changes the declarative base every model in both backends inherits from, including UUID column typing. It is migration-adjacent and belongs last.

These two files are the opposite: the divergence is **one-directional**, with the backend copy already canonical, so there is a right answer rather than a design decision.

## What Changed

**`autobot-slm-backend/user_management/services/base_service.py`**
- `logging.getLogger` → `autobot_shared.logging_manager.get_logger` (the project standard, and what the backend twin already uses).
- Removed a stale docstring line on `TenantContext`: *"In single_user mode, org_id is None."* That mode no longer exists and the backend copy already dropped it. A stale tenancy mode documented on the class that carries tenant context is the kind of thing that misleads someone reading RBAC code.

**`autobot-slm-backend/user_management/services/team_service.py`**
- Same logger change.
- `datetime.now(timezone.utc)` → `now_utc()` at 4 call sites, matching the backend's use of the shared `autobot_shared.time_utils` helper.

Both files are now **byte-identical to their `autobot-backend` twins** — 2 of the 22 divergent files eliminated, with no semantic change to argue about.

## Verification

```
$ diff -u autobot-backend/user_management/services/base_service.py \
          autobot-slm-backend/user_management/services/base_service.py
(no output — identical)

$ diff -u autobot-backend/user_management/services/team_service.py \
          autobot-slm-backend/user_management/services/team_service.py
(no output — identical)
```

SLM suite, same command both sides:

```
base:   10 failed, 1016 passed, 1 skipped
branch: 10 failed, 1016 passed, 1 skipped
```

The 10 failures are pre-existing and unchanged. `flake8 --select=F` and `black --check` clean.

## Scope note

#12647 stays open for the remaining 20 divergent files. My scoping comment there proposes the order: bounded services next (`organization_service.py` 28 L, `user_service.py` 97 L), then `rbac_middleware.py` (331 L), then `config.py`/`database.py`/`models/*`, with `models/base.py` last of all.

Closes #12918
Refs #12647 (corrected from `Closes` after merge — 20 divergent files remain)

> **Linkage note:** the `Check PR links to its issue` gate derives the expected issue from the branch name, hence the `#12647` token. It does not auto-close — `Closes` fires on the default branch and this targets `Dev_new_gui`. #12647 stays open for the other 20 files.

## Model Used

claude-opus-5