### PR TITLE
refactor(user-mgmt): import shared constants canonically, not via the backend-only shim (#12925)

### DIFF
--- a/autobot-backend/user_management/middleware/rbac_middleware.py
+++ b/autobot-backend/user_management/middleware/rbac_middleware.py
@@ -20,7 +20,7 @@ from fastapi import HTTPException, Request, status
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-from constants.ttl_constants import TTL_5_MINUTES
+from autobot_shared.ssot_constants import TTL_5_MINUTES
 from user_management.config import get_deployment_config
 from user_management.database import db_session_context
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType

--- a/autobot-backend/user_management/models/sso.py
+++ b/autobot-backend/user_management/models/sso.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import Uuid
 
 from autobot_shared.time_utils import now_utc
-from constants.threshold_constants import CategoryDefaults
+from autobot_shared.ssot_constants import CategoryDefaults
 from user_management.models.base import Base
 
 if TYPE_CHECKING:

--- a/autobot-backend/user_management/models/sso.py
+++ b/autobot-backend/user_management/models/sso.py
@@ -20,8 +20,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import Uuid
 
-from autobot_shared.time_utils import now_utc
 from autobot_shared.ssot_constants import CategoryDefaults
+from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
 
 if TYPE_CHECKING:

--- a/autobot-backend/user_management/services/session_service.py
+++ b/autobot-backend/user_management/services/session_service.py
@@ -14,7 +14,7 @@ import uuid
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-from constants.ttl_constants import TTL_24_HOURS
+from autobot_shared.ssot_constants import TTL_24_HOURS
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Thinking Path

Step 2 of #12925, and a prerequisite for converging `rbac_middleware.py` and `models/sso.py` under #12647.

Three files in `autobot-backend/user_management/` import from `constants.*` — a package `autobot-slm-backend` does not have at all. That is the same shape as the defect in #12924: copying such a file across to converge it breaks the SLM app build, its OpenAPI dump fails, and `api-wiring` then reports 5 unrelated SLM routes as unwired. A failure three steps removed from its cause, which is why it cost a full CI cycle to diagnose the first time.

The fix turned out to be trivial, because the backend was not depending on anything it needed to. `constants/ttl_constants.py` and `constants/threshold_constants.py` are **pure re-export shims** of `autobot_shared.ssot_constants`, and both carry the same note:

> This module re-exports from autobot_shared.ssot_constants for backward compatibility.
> Import directly from autobot_shared.ssot_constants for new code.

So the backend was reaching shared constants *through a backend-local shim*, against the shim's own documented guidance, and that indirection was the only thing coupling these files to the backend.

## What Changed

Three import lines:

```diff
-from constants.ttl_constants import TTL_5_MINUTES          # rbac_middleware.py
-from constants.ttl_constants import TTL_24_HOURS           # services/session_service.py
-from constants.threshold_constants import CategoryDefaults # models/sso.py
+from autobot_shared.ssot_constants import TTL_5_MINUTES
+from autobot_shared.ssot_constants import TTL_24_HOURS
+from autobot_shared.ssot_constants import CategoryDefaults
```

`session_service.py` is backend-only and not itself a convergence candidate, but the same fix applies and leaving one import behind would keep the package coupled for no reason.

## Verification

The package no longer reaches for anything the SLM lacks:

```
$ grep -rn "from constants\." autobot-backend/user_management/ --include=*.py
(no output)
```

Values are provably unchanged — this is an import path change, not a semantic one:

```
TTL_5_MINUTES=300  TTL_24_HOURS=86400  CategoryDefaults=CategoryDefaults
```

Suites, same command both sides:

```
base:   2 failed, 528 passed, 8 skipped
branch: 2 failed, 528 passed, 8 skipped
```

The 2 failures are pre-existing (`test_cross_worker_registries`) and untouched. The #12926 denial-audit tests still pass (9). `flake8 --select=F` and `black --check` clean.

## Scope note

#12925 stays open for step 3 — the cache-architecture decision (backend L1 dict + Redis pub/sub invalidation vs SLM L2 Redis cache). That is two designs with real trade-offs rather than drift, and it needs an owner call; `rbac_middleware.py` stays out of the #12647 convergence sequence until it is made.

Closes #12927
Refs #12925 (corrected from `Closes` after merge — step 3, the cache-architecture decision, remains)

> **Linkage note:** the `Check PR links to its issue` gate derives the expected issue from the branch name, hence the `#12925` token. It does not auto-close — `Closes` fires on the default branch and this targets `Dev_new_gui`. #12925 stays open for step 3.

## Model Used

claude-opus-5