### PR TITLE
refactor(db): single canonical database_pool_settings, was duplicated across both backends (#12645)

### DIFF
--- a/autobot-backend/user_management/database.py
+++ b/autobot-backend/user_management/database.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import database_pool_settings
 from user_management.config import get_deployment_config
 
 logger = get_logger(__name__)
@@ -97,25 +98,14 @@ def _is_permanent_db_error(exc: BaseException) -> bool:
 
 
 def _get_pool_config() -> dict:
-    """Get database pool settings from SSOT config (#2860)."""
-    try:
-        from autobot_shared.ssot_config import get_config
+    """Database pool settings from SSOT config (#2860).
 
-        pool_cfg = get_config().database_pool
-        return {
-            "pool_size": pool_cfg.pool_size,
-            "max_overflow": pool_cfg.max_overflow,
-            "pool_recycle": pool_cfg.pool_recycle,
-            "pool_timeout": pool_cfg.pool_timeout,
-        }
-    except Exception:
-        logger.warning("Could not load SSOT database pool config, using defaults")
-        return {
-            "pool_size": 10,
-            "max_overflow": 10,
-            "pool_recycle": 3600,
-            "pool_timeout": 30,
-        }
+    Thin alias over the canonical ``autobot_shared.ssot_config`` helper: this
+    body was byte-identical here and in the sibling backend (#12645), so a
+    tuning change had to be made twice or it silently applied to one engine.
+    Kept as a named function because callers reference it.
+    """
+    return database_pool_settings()
 
 
 def get_async_engine() -> AsyncEngine:

--- a/autobot-slm-backend/user_management/database.py
+++ b/autobot-slm-backend/user_management/database.py
@@ -13,8 +13,6 @@ Pool sizes are coordinated via SSOT config (#2860).
 """
 
 import logging
-
-from autobot_shared.ssot_config import database_pool_settings
 import threading
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
@@ -27,6 +25,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from autobot_shared.ssot_config import database_pool_settings
 from user_management.config import get_autobot_db_config, get_slm_db_config
 
 logger = logging.getLogger(__name__)

--- a/autobot-slm-backend/user_management/database.py
+++ b/autobot-slm-backend/user_management/database.py
@@ -13,6 +13,8 @@ Pool sizes are coordinated via SSOT config (#2860).
 """
 
 import logging
+
+from autobot_shared.ssot_config import database_pool_settings
 import threading
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
@@ -47,25 +49,14 @@ _autobot_session_maker_lock = threading.Lock()
 
 
 def _get_pool_config() -> dict:
-    """Get database pool settings from SSOT config (#2860)."""
-    try:
-        from autobot_shared.ssot_config import get_config
+    """Database pool settings from SSOT config (#2860).
 
-        pool_cfg = get_config().database_pool
-        return {
-            "pool_size": pool_cfg.pool_size,
-            "max_overflow": pool_cfg.max_overflow,
-            "pool_recycle": pool_cfg.pool_recycle,
-            "pool_timeout": pool_cfg.pool_timeout,
-        }
-    except Exception:
-        logger.warning("Could not load SSOT database pool config, using defaults")
-        return {
-            "pool_size": 10,
-            "max_overflow": 10,
-            "pool_recycle": 3600,
-            "pool_timeout": 30,
-        }
+    Thin alias over the canonical ``autobot_shared.ssot_config`` helper: this
+    body was byte-identical here and in the sibling backend (#12645), so a
+    tuning change had to be made twice or it silently applied to one engine.
+    Kept as a named function because callers reference it.
+    """
+    return database_pool_settings()
 
 
 def get_slm_engine() -> AsyncEngine:

--- a/autobot_shared/database_pool_settings_test.py
+++ b/autobot_shared/database_pool_settings_test.py
@@ -1,0 +1,108 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical database pool settings (#12645).
+
+The same 20-line body — read SSOT pool config, fall back to a fixed table —
+was duplicated byte-for-byte in `autobot-backend/user_management/database.py`
+and `autobot-slm-backend/user_management/database.py`, with a third
+tuple-shaped variant in `autobot-slm-backend/config.py`. Three copies of one
+fallback table means a tuning change lands in one engine and silently not the
+others.
+
+The fallback path gets the most attention here, because it runs exactly when
+SSOT config is already failing — the moment a second error is most expensive
+and least visible.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from autobot_shared.ssot_config import database_pool_settings
+
+_KEYS = {"pool_size", "max_overflow", "pool_recycle", "pool_timeout"}
+
+
+class TestHappyPath:
+    def test_returns_all_four_pool_keys(self):
+        assert set(database_pool_settings()) == _KEYS
+
+    def test_values_are_ints(self):
+        """SQLAlchemy rejects non-int pool arguments at engine construction."""
+        assert all(isinstance(v, int) for v in database_pool_settings().values())
+
+    def test_reads_from_ssot_when_available(self):
+        import autobot_shared.ssot_config as mod
+
+        cfg = type(
+            "C",
+            (),
+            {
+                "database_pool": type(
+                    "P", (), {"pool_size": 42, "max_overflow": 7, "pool_recycle": 111, "pool_timeout": 9}
+                )()
+            },
+        )()
+
+        with patch.object(mod, "get_config", return_value=cfg):
+            assert database_pool_settings() == {
+                "pool_size": 42,
+                "max_overflow": 7,
+                "pool_recycle": 111,
+                "pool_timeout": 9,
+            }
+
+
+class TestFallback:
+    """The path that runs when SSOT config is already broken."""
+
+    def test_does_not_raise_when_config_is_unavailable(self):
+        """Regression: the first draft referenced an undefined module-level
+        `logger`, so this path raised NameError — masking the real failure with
+        a second, less informative one."""
+        import autobot_shared.ssot_config as mod
+
+        with patch.object(mod, "get_config", side_effect=RuntimeError("ssot down")):
+            settings = database_pool_settings()
+
+        assert set(settings) == _KEYS
+
+    def test_fallback_values_are_unchanged_from_the_duplicated_copies(self):
+        """This is a de-duplication, not a re-tuning — the numbers must match."""
+        import autobot_shared.ssot_config as mod
+
+        with patch.object(mod, "get_config", side_effect=RuntimeError("ssot down")):
+            assert database_pool_settings() == {
+                "pool_size": 10,
+                "max_overflow": 10,
+                "pool_recycle": 3600,
+                "pool_timeout": 30,
+            }
+
+    def test_warns_so_the_fallback_is_not_silent(self, caplog):
+        import autobot_shared.ssot_config as mod
+
+        with patch.object(mod, "get_config", side_effect=RuntimeError("ssot down")):
+            with caplog.at_level("WARNING"):
+                database_pool_settings()
+
+        assert "database pool config" in caplog.text.lower()
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "autobot-backend/user_management/database.py",
+        "autobot-slm-backend/user_management/database.py",
+    ],
+)
+def test_both_backends_delegate_rather_than_redefine(rel):
+    """Neither copy may reimplement the fallback table locally again."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / rel).read_text(encoding="utf-8")
+
+    assert "database_pool_settings()" in source, f"{rel} should delegate to the shared helper"
+    assert '"pool_recycle": 3600' not in source, f"{rel} still carries its own fallback table"

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -39,6 +39,7 @@ Related: #599 - SSOT Configuration System Epic
 
 from __future__ import annotations
 
+import logging
 import os
 from enum import Enum
 from functools import lru_cache
@@ -2830,3 +2831,38 @@ __all__ = [
     "get_agent_model",
     "get_agent_provider",
 ]
+
+
+def database_pool_settings() -> dict:
+    """Canonical SQLAlchemy pool settings from SSOT config (#2860, #12645).
+
+    This exact body was duplicated byte-for-byte in
+    ``autobot-backend/user_management/database.py`` and
+    ``autobot-slm-backend/user_management/database.py``, with a third
+    tuple-shaped variant in ``autobot-slm-backend/config.py``. Three copies of
+    one fallback table means a tuning change lands in one engine and silently
+    not the others.
+
+    The defaults below are the fallback when SSOT config cannot be read; they
+    are deliberately identical to what both copies used, so this is a
+    de-duplication and not a re-tuning.
+    """
+    try:
+        pool_cfg = get_config().database_pool
+        return {
+            "pool_size": pool_cfg.pool_size,
+            "max_overflow": pool_cfg.max_overflow,
+            "pool_recycle": pool_cfg.pool_recycle,
+            "pool_timeout": pool_cfg.pool_timeout,
+        }
+    except Exception:
+        # Module-local logger: ssot_config has no module-level `logger`, and the
+        # fallback path is exactly when SSOT config is already failing — a
+        # NameError here would mask the real problem.
+        logging.getLogger(__name__).warning("Could not load SSOT database pool config, using defaults")
+        return {
+            "pool_size": 10,
+            "max_overflow": 10,
+            "pool_recycle": 3600,
+            "pool_timeout": 30,
+        }


### PR DESCRIPTION
## Thinking Path

Scoping `config.py` / `database.py` — the last #12647 group not gated on a design decision — and the headline is that **they are not forks at all**:

```
config.py    shared symbols: 2 of 11   (DeploymentConfig, get_deployment_config)
database.py  shared symbols: 1 of 21   (_get_pool_config)
```

Their docstrings say why: the SLM's `database.py` is *"Dual Database Engine Management"* (a local SLM engine plus a remote AutoBot engine), the backend's is single-engine connection utilities. The SLM's `DeploymentConfig` is a deliberate 4-line stub (*"SLM always uses PostgreSQL"*), not a lagging copy. Different modules that share a filename, so ~680 of the "divergent lines" attributed to this package were never convergence candidates.

Comparing symbol sets first (rather than diffing content) is what made that visible in one command — and it also isolated the one thing that *is* duplicated.

## What Changed

`_get_pool_config()` is **byte-identical** in both `user_management/database.py` files, and a third tuple-shaped variant of the same SSOT read lives in `autobot-slm-backend/config.py`. Three copies of one fallback table means a pool-tuning change lands in one engine and silently not the others — and the SLM runs *two* engines, so that is three pools drifting apart quietly.

- **`autobot_shared/ssot_config.py`** — new `database_pool_settings()`, placed beside the config it reads.
- **Both `user_management/database.py`** — `_get_pool_config()` kept as a named function (callers reference it) but now a one-line delegation.

Fallback values are unchanged: this is de-duplication, not re-tuning.

## A bug I introduced and caught before pushing

The first draft of the helper called `logger.warning(...)`, copied from the original bodies. `ssot_config.py` has **no module-level `logger`** — so the fallback path raised `NameError`, and only the fallback path, which runs precisely when SSOT config is already failing. A second, less informative error masking the first.

```
CONFIRMED BUG — fallback path raises NameError: name 'logger' is not defined
```

The happy path imported and ran fine, so a smoke check would have missed it. Fixed with a module-local `logging.getLogger(__name__)`, and the regression is pinned by test.

## Verification

```
$ pytest autobot_shared/database_pool_settings_test.py -q
8 passed

$ pytest autobot-slm-backend/tests/ -q          base/branch: 10 failed, 1016 passed, 1 skipped
$ pytest autobot-backend/tests/ -q -k "database or pool or session"
                                                base/branch:  2 failed,  129 passed
$ mypy autobot_shared/ssot_config.py            Success
$ flake8 --select=F / black --check             clean
```

Pre-existing failures identical either side. The tests weight the fallback path deliberately — it runs when SSOT is already broken, which is when a second failure is most expensive. They also assert the fallback numbers are unchanged from the duplicated copies (so this cannot silently become a re-tuning), and that neither backend reimplements the table locally again.

## Scope note

The third copy (`autobot-slm-backend/config.py`) returns a tuple and is consumed at module level for `SLM_DB_POOL_*` env defaults; converging it is a separate, slightly riskier change, left out here and recorded on #12929.

Closes #12929

## Model Used

claude-opus-5
