### PR TITLE
fix(shared): resolve submodules through the package __getattr__ so patch() is order-independent (#12903)

### DIFF
--- a/autobot_shared/__init__.py
+++ b/autobot_shared/__init__.py
@@ -83,4 +83,28 @@ def __getattr__(name):
         # Cache on module so __getattr__ isn't called again
         globals()[name] = val
         return val
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    # Submodule fallback (#12903). PEP 562 __getattr__ shadows Python's normal
+    # submodule attribute binding, and several test modules install stubs with
+    # ``sys.modules["autobot_shared.redis_client"] = stub`` — which does NOT set
+    # the attribute on this package. Attribute access then succeeded or failed
+    # purely on import order, so ``patch("autobot_shared.redis_client...")``
+    # passed standalone and raised AttributeError in a full-suite run.
+    #
+    # Resolve a real (or stubbed) submodule on demand so the package behaves the
+    # way a package without __getattr__ would.
+    import sys as _sys
+
+    _full = f"{__name__}.{name}"
+    if _full in _sys.modules:
+        globals()[name] = _sys.modules[_full]
+        return globals()[name]
+
+    import importlib as _importlib
+
+    try:
+        _mod = _importlib.import_module(f".{name}", __name__)
+    except ImportError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    globals()[name] = _mod
+    return _mod

--- a/autobot_shared/package_submodule_access_test.py
+++ b/autobot_shared/package_submodule_access_test.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Submodule attribute access on the autobot_shared package (#12903).
+
+`autobot_shared/__init__.py` defines a PEP 562 `__getattr__` for lazily-imported
+*symbols*. That shadows Python's normal submodule attribute binding, and several
+test modules install stubs with:
+
+    sys.modules["autobot_shared.redis_client"] = stub
+
+which does **not** set `redis_client` as an attribute of the package. So
+`mock.patch("autobot_shared.redis_client...")` — which resolves via `getattr` —
+succeeded or failed purely on collection order: the IP rate limiter's seven
+tests passed standalone and failed in a full-suite run, leaving a
+security-relevant control's entire test surface red in CI while green locally.
+
+These tests pin the fallback that makes package attribute access
+order-independent.
+"""
+
+import sys
+import types
+
+import pytest
+
+import autobot_shared
+
+
+def test_real_submodule_is_reachable_as_an_attribute():
+    """The ordinary case a package without __getattr__ gets for free."""
+    assert autobot_shared.env_utils.__name__ == "autobot_shared.env_utils"
+
+
+def test_lazily_exported_symbols_still_work():
+    """The original purpose of __getattr__ must not regress."""
+    assert callable(autobot_shared.lazy_singleton)
+
+
+def test_stub_injected_into_sys_modules_is_reachable(monkeypatch):
+    """The exact shape that broke: sys.modules set, attribute never bound.
+
+    Five test modules across the repo install redis_client stubs this way.
+    """
+    name = "autobot_shared.a_stubbed_submodule_12903"
+    stub = types.ModuleType(name)
+    stub.marker = "stub-value"
+    monkeypatch.setitem(sys.modules, name, stub)
+
+    assert autobot_shared.a_stubbed_submodule_12903.marker == "stub-value"
+
+
+def test_patch_resolves_a_stubbed_submodule(monkeypatch):
+    """`mock.patch` walks attributes, which is why sys.modules alone was not enough."""
+    from unittest.mock import patch
+
+    name = "autobot_shared.another_stub_12903"
+    stub = types.ModuleType(name)
+    stub.some_callable = lambda: "original"
+    monkeypatch.setitem(sys.modules, name, stub)
+
+    with patch("autobot_shared.another_stub_12903.some_callable", return_value="patched"):
+        assert stub.some_callable() == "patched"
+
+
+@pytest.mark.parametrize("missing", ["definitely_not_a_module_12903", "nope_not_here"])
+def test_unknown_names_still_raise_attribute_error(missing):
+    """The fallback must not turn typos into confusing ImportErrors."""
+    with pytest.raises(AttributeError):
+        getattr(autobot_shared, missing)


### PR DESCRIPTION
## Thinking Path

#12903 listed 9 failures, 7 of them the IP rate limiter — a security-relevant control with its entire test surface red. They passed standalone and failed in a full-suite run, so the first useful question was not "what is wrong with the rate limiter" but "what differs between the two runs".

The traceback pointed straight at it:

```
AttributeError: module 'autobot_shared' has no attribute 'redis_client'
  ... mock.patch("autobot_shared.redis_client...") -> _dot_lookup -> getattr
```

`autobot_shared/__init__.py` defines a PEP 562 `__getattr__` for lazily-exported *symbols*. That shadows Python's normal submodule attribute binding — and five test modules across the repo install stubs with:

```python
sys.modules["autobot_shared.redis_client"] = stub
```

Setting `sys.modules` does **not** bind the attribute on the parent package. I verified that directly rather than assuming:

```
$ sys.modules['autobot_shared.redis_client'] = ModuleType(...); getattr(autobot_shared, 'redis_client')
  attribute NOT set -> module 'autobot_shared' has no attribute 'redis_client'
```

So whether `patch("autobot_shared.redis_client...")` worked depended purely on whether a real import had happened first — i.e. on collection order. Green locally, red in CI, with the failure landing in a file that had nothing to do with the cause.

## What Changed

One file. `autobot_shared/__init__.py`'s `__getattr__` gains a submodule fallback: if the name is already in `sys.modules` under this package, return it; otherwise try importing it as a submodule; only then raise `AttributeError`. That restores the behaviour a package *without* `__getattr__` would have had.

## Verification

```
autobot_shared/     base:   9 failed, 1105 passed
                    branch: 2 failed, 1118 passed
```

All 7 rate-limiter tests now pass. The 2 remaining are a different defect (a narrow `redis_client` stub missing `_get_connection_manager` / `reset_async_redis_pools`) and are left for #12903 to keep tracking.

Backend suites unchanged: `pytest autobot-backend/tests -k "redis or rate_limit"` is `1 failed, 166 passed` on **both** base and branch.

6 new tests pin the fallback — real submodules reachable, lazily-exported symbols still working, a `sys.modules`-injected stub reachable, `mock.patch` resolving through it, and unknown names still raising `AttributeError` rather than a confusing `ImportError`.

## A fix I tried and reverted

I first also made the two narrow stubs (`alert_cooldown_test`, `delta_engine_test`) resolve names on demand — the same fix that worked for `message_bus_test` in #12902. It cleared one of the two remaining failures but broke four `workflow_memory_test` tests, because a permissive stub satisfies imports that should resolve elsewhere. **Net 2 → 5.** Reverted; a change that trades two failures for five is not an improvement, and the measurement is what showed it. Left at 9 → 2 with a single-file change.

Closes #12903
