### PR TITLE
fix(tests): install the redis stub only when the real module is unavailable (#12903)

### DIFF
--- a/autobot_shared/alert_cooldown_test.py
+++ b/autobot_shared/alert_cooldown_test.py
@@ -10,6 +10,7 @@ test is imported — the same pattern used by ``message_bus_test.py`` — so a
 live Redis connection is never required.
 """
 
+import importlib
 import sys
 import types
 from unittest.mock import MagicMock
@@ -24,6 +25,19 @@ def _install_redis_stub() -> None:
     mod_name = "autobot_shared.redis_client"
     if mod_name in sys.modules:
         return
+
+    # #12903: prefer the real module when it is importable. The stub exists so
+    # this test can run without a live stack — but it was installed
+    # unconditionally, and because it lands in sys.modules it is inherited by
+    # every sibling test in the same session. Siblings needing a symbol this
+    # stub does not define (reset_async_redis_pools, _get_connection_manager)
+    # then failed, in files unrelated to this one, depending on collection order.
+    try:
+        importlib.import_module(mod_name)
+        return
+    except Exception:
+        pass
+
     stub = types.ModuleType(mod_name)
     stub.get_redis_client = MagicMock(name="stub_get_redis_client")
     sys.modules[mod_name] = stub

--- a/autobot_shared/delta_engine_test.py
+++ b/autobot_shared/delta_engine_test.py
@@ -10,8 +10,8 @@ test is imported — the same pattern used by ``alert_cooldown_test.py`` — so 
 live Redis connection is never required.
 """
 
-import json
 import importlib
+import json
 import sys
 import types
 from unittest.mock import MagicMock

--- a/autobot_shared/delta_engine_test.py
+++ b/autobot_shared/delta_engine_test.py
@@ -11,6 +11,7 @@ live Redis connection is never required.
 """
 
 import json
+import importlib
 import sys
 import types
 from unittest.mock import MagicMock
@@ -25,6 +26,19 @@ def _install_redis_stub() -> None:
     mod_name = "autobot_shared.redis_client"
     if mod_name in sys.modules:
         return
+
+    # #12903: prefer the real module when it is importable. The stub exists so
+    # this test can run without a live stack — but it was installed
+    # unconditionally, and because it lands in sys.modules it is inherited by
+    # every sibling test in the same session. Siblings needing a symbol this
+    # stub does not define (reset_async_redis_pools, _get_connection_manager)
+    # then failed, in files unrelated to this one, depending on collection order.
+    try:
+        importlib.import_module(mod_name)
+        return
+    except Exception:
+        pass
+
     stub = types.ModuleType(mod_name)
     stub.get_redis_client = MagicMock(name="stub_get_redis_client")
     sys.modules[mod_name] = stub


### PR DESCRIPTION
## Thinking Path

Finishes #12903. PR #12933 took `autobot_shared/` from 9 failures to 2 by fixing package-level submodule resolution; these last 2 were a different defect one level down.

Both remaining failures were `ImportError: cannot import name '_get_connection_manager'` / `does not have the attribute 'reset_async_redis_pools'` — a `redis_client` **stub** present in `sys.modules` but lacking symbols its siblings need.

I had already tried the obvious fix and reverted it: making those stubs resolve names on demand cleared one failure but broke four `workflow_memory_test` tests, because a permissive stub satisfies imports that should resolve elsewhere. Net 2 → 5. So the fix had to be narrower.

The narrower answer came from reading what the stubs claim to be for — *"so the module is importable without a live stack"*. That is a **conditional** need, but the installation was unconditional. And in this environment the real module imports fine:

```
real redis_client IS importable
  get_redis_client: yes      reset_async_redis_pools: yes
  get_async_redis_client: yes  _get_connection_manager: yes
```

So the stub was displacing a perfectly good module, and — because it lands in `sys.modules` — every sibling in the same session inherited it. The failures then surfaced in unrelated files, dependent on collection order.

## What Changed

`alert_cooldown_test.py` and `delta_engine_test.py` now attempt the real import first and only fall back to the stub if it fails. Two files, +14 lines each, no production code touched.

## Verification

```
autobot_shared/    before #12933: 9 failed, 1105 passed
                   after  #12933: 2 failed, 1118 passed
                   this PR:       0 failed, 1120 passed
```

The whole package is green.

Each modified and previously-failing module also passes standalone, which is what proves the stub's own purpose is intact and that the earlier `workflow_memory` regression has not returned:

```
alert_cooldown_test.py                       35 passed
delta_engine_test.py                         52 passed
celery_async_redis_test.py                    9 passed
connection_manager_config_poisoning_test.py   8 passed
workflow_memory_test.py                       5 passed
```

I also simulated a stripped environment (forcing the real import to raise) and confirmed the fallback still installs the stub — so the case these stubs exist for still works.

Backend unchanged: `pytest autobot-backend/tests -k "redis or rate_limit"` is `1 failed, 166 passed` on both base and branch, matching every previous run.

## Note

`api-wiring` will not report on this PR — it touches only `autobot_shared/`, which is outside that workflow's path filter. That is a required check that cannot run here; the underlying process defect is filed as #12934.

Closes #12903

## Model Used

claude-opus-5