### PR TITLE
feat(design-system): check oklch wide-gamut tokens for contrast + fix text-on-success (#12922)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -1174,7 +1174,10 @@
 
     /* Text on colored backgrounds */
     --text-on-primary: oklch(100% 0 0);
-    --text-on-success: oklch(100% 0 0);
+    /* #12922: was oklch(100% 0 0) = white = 2.54:1 on --color-success, the same
+       failure #12915 fixed in the sRGB block. Black matches that fix and the
+       treatment already used for --text-on-warning below. */
+    --text-on-success: oklch(0% 0 0);
     --text-on-warning: oklch(0% 0 0);
     --text-on-error: oklch(100% 0 0);
 

--- a/scripts/check_token_contrast.py
+++ b/scripts/check_token_contrast.py
@@ -29,6 +29,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import math
 import re
 import sys
 from pathlib import Path
@@ -58,9 +59,9 @@ _ANY_COLOR_DECL = re.compile(
 def parse_hex_tokens(css: str) -> Dict[str, str]:
     """Map token name -> hex value for every hex-valued custom property.
 
-    Only the first definition of a name is kept: later ones are theme overrides
-    (``oklch`` wide-gamut blocks, media queries), which are reported as skipped
-    rather than silently folded in.
+    Only the first definition of a name is kept: later ones are theme overrides,
+    which are checked separately via :func:`parse_oklch_tokens` rather than
+    silently folded in here.
     """
     tokens: Dict[str, str] = {}
     for name, value in _HEX_DECL.findall(css):
@@ -68,15 +69,78 @@ def parse_hex_tokens(css: str) -> Dict[str, str]:
     return tokens
 
 
+def parse_oklch_tokens(css: str) -> Dict[str, str]:
+    """Map token name -> hex equivalent for every ``oklch()`` custom property (#12922).
+
+    These are the wide-gamut overrides. They were previously reported as
+    unchecked, which is how #12915's sRGB fix left the same failing pair
+    shipping on P3 displays. Converted to sRGB so they can be measured on the
+    same footing as the hex block.
+    """
+    tokens: Dict[str, str] = {}
+    for name, value in _ANY_COLOR_DECL.findall(css):
+        if "oklch" not in value.lower():
+            continue
+        converted = oklch_to_hex(value)
+        if converted:
+            tokens.setdefault(name, converted)
+    return tokens
+
+
 def parse_non_hex_tokens(css: str) -> Dict[str, str]:
     """Colour tokens defined in a format this checker cannot evaluate."""
     skipped: Dict[str, str] = {}
-    hex_names = set(parse_hex_tokens(css))
+    covered = set(parse_hex_tokens(css)) | set(parse_oklch_tokens(css))
     for name, value in _ANY_COLOR_DECL.findall(css):
-        if name not in hex_names:
+        if name not in covered:
             skipped.setdefault(name, value.strip())
     return skipped
 
+
+
+_OKLCH_DECL = re.compile(r"oklch\(\s*([\d.]+)%\s+([\d.]+)\s+([\d.]+)\s*\)", re.IGNORECASE)
+
+
+def oklch_to_hex(value: str) -> str | None:
+    """Convert a CSS ``oklch(L% C H)`` colour to ``#rrggbb`` (#12922).
+
+    The wide-gamut block re-declares the same semantic pairs in oklch, so a
+    hex-only checker reported them as unchecked and #12915's fix covered the
+    sRGB path only — leaving white-on-green still shipping on P3 displays.
+
+    Conversion is the standard oklab pipeline: oklch -> oklab -> linear sRGB ->
+    gamma-encoded sRGB. Out-of-gamut components are clamped, which is what a
+    browser does when rendering an oklch colour on an sRGB display, so the ratio
+    computed here matches what an sRGB viewer actually sees. Returns ``None``
+    when *value* is not an oklch literal.
+    """
+    match = _OKLCH_DECL.search(value)
+    if not match:
+        return None
+
+    lightness = float(match.group(1)) / 100.0
+    chroma = float(match.group(2))
+    hue = math.radians(float(match.group(3)))
+
+    a = chroma * math.cos(hue)
+    b = chroma * math.sin(hue)
+
+    l_ = (lightness + 0.3963377774 * a + 0.2158037573 * b) ** 3
+    m_ = (lightness - 0.1055613458 * a - 0.0638541728 * b) ** 3
+    s_ = (lightness - 0.0894841775 * a - 1.2914855480 * b) ** 3
+
+    linear = (
+        4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_,
+        -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_,
+        -0.0041960863 * l_ - 0.7034186147 * m_ + 1.7076147010 * s_,
+    )
+
+    channels = []
+    for c in linear:
+        c = max(0.0, min(1.0, c))
+        c = 1.055 * (c ** (1 / 2.4)) - 0.055 if c > 0.0031308 else 12.92 * c
+        channels.append(round(max(0.0, min(1.0, c)) * 255))
+    return "#%02x%02x%02x" % tuple(channels)
 
 def _to_rgb(hex_value: str) -> Tuple[int, int, int]:
     """Parse #rgb / #rrggbb / #rrggbbaa into an (r, g, b) triple."""
@@ -136,20 +200,35 @@ def main() -> int:
 
     css = css_path.read_text(encoding="utf-8")
     tokens = parse_hex_tokens(css)
+    oklch_tokens = parse_oklch_tokens(css)
     skipped = parse_non_hex_tokens(css)
-    pairs = build_pairs(tokens)
+
+    # #12922: the wide-gamut block re-declares the same semantic pairs in
+    # oklch. Those overrides shadow names already present in the hex map, so
+    # they were not even reaching the "unchecked" list — they were invisible.
+    # Both themes are now measured, because a P3 display renders the second set.
+    themes = [("sRGB", tokens)]
+    if oklch_tokens:
+        merged = {**tokens, **oklch_tokens}
+        themes.append(("wide-gamut (oklch)", merged))
 
     print(f"[contrast] {css_path.relative_to(REPO_ROOT)}")
-    print(f"[contrast] {len(tokens)} hex tokens, {len(pairs)} derived pairs, {len(skipped)} non-hex tokens skipped")
+    print(
+        f"[contrast] {len(tokens)} hex tokens, {len(oklch_tokens)} oklch overrides, "
+        f"{len(skipped)} tokens still unchecked"
+    )
 
     failures = []
-    for fg, bg, required in pairs:
-        ratio = contrast_ratio(tokens[fg], tokens[bg])
-        ok = ratio >= required
-        marker = "ok  " if ok else "FAIL"
-        print(f"  {marker} {ratio:5.2f}:1 (need {required})  {fg} on {bg}")
-        if not ok:
-            failures.append((fg, bg, ratio, required))
+    for theme_name, theme_tokens in themes:
+        theme_pairs = build_pairs(theme_tokens)
+        print(f"[contrast] -- {theme_name}: {len(theme_pairs)} derived pairs")
+        for fg, bg, required in theme_pairs:
+            ratio = contrast_ratio(theme_tokens[fg], theme_tokens[bg])
+            ok = ratio >= required
+            marker = "ok  " if ok else "FAIL"
+            print(f"  {marker} {ratio:5.2f}:1 (need {required})  {fg} on {bg}")
+            if not ok:
+                failures.append((f"[{theme_name}] {fg}", bg, ratio, required))
 
     if skipped:
         # Never let the gate imply coverage it does not have.

--- a/scripts/check_token_contrast.py
+++ b/scripts/check_token_contrast.py
@@ -97,7 +97,6 @@ def parse_non_hex_tokens(css: str) -> Dict[str, str]:
     return skipped
 
 
-
 _OKLCH_DECL = re.compile(r"oklch\(\s*([\d.]+)%\s+([\d.]+)\s+([\d.]+)\s*\)", re.IGNORECASE)
 
 
@@ -141,6 +140,7 @@ def oklch_to_hex(value: str) -> str | None:
         c = 1.055 * (c ** (1 / 2.4)) - 0.055 if c > 0.0031308 else 12.92 * c
         channels.append(round(max(0.0, min(1.0, c)) * 255))
     return "#%02x%02x%02x" % tuple(channels)
+
 
 def _to_rgb(hex_value: str) -> Tuple[int, int, int]:
     """Parse #rgb / #rrggbb / #rrggbbaa into an (r, g, b) triple."""

--- a/scripts/check_token_contrast_test.py
+++ b/scripts/check_token_contrast_test.py
@@ -120,3 +120,69 @@ class TestRealTokens:
         assert not failures, "tokens below WCAG AA: " + ", ".join(
             f"{fg} on {bg} = {ratio:.2f}:1 < {need}" for fg, bg, ratio, need in failures
         )
+
+
+class TestOklchConversion:
+    """oklch -> sRGB, so wide-gamut overrides are measurable (#12922).
+
+    #12915 fixed `--text-on-success` in the hex block, but the wide-gamut block
+    re-declared the same pair in oklch and kept shipping white-on-green at
+    2.54:1 on P3 displays. Those overrides were not merely unchecked — they
+    shadow names already in the hex map, so they never reached the "NOT CHECKED"
+    list either. They were invisible.
+    """
+
+    @pytest.mark.parametrize(
+        "oklch,expected",
+        [
+            ("oklch(100% 0 0)", "#ffffff"),
+            ("oklch(0% 0 0)", "#000000"),
+            ("oklch(69.6% 0.149 162.5)", "#10b981"),
+        ],
+    )
+    def test_known_colours_round_trip_to_their_srgb_hex(self, oklch, expected):
+        """Pinned against the sRGB values the same tokens carry in the hex block."""
+        assert contrast.oklch_to_hex(oklch) == expected
+
+    def test_non_oklch_values_return_none(self):
+        """rgba()/hex must fall through to their own handling, not be misparsed."""
+        assert contrast.oklch_to_hex("#10b981") is None
+        assert contrast.oklch_to_hex("rgba(0, 0, 0, 0.5)") is None
+
+    def test_out_of_gamut_components_are_clamped(self):
+        """A browser clamps when rendering oklch on sRGB; the ratio must match that."""
+        result = contrast.oklch_to_hex("oklch(100% 0.4 120)")
+
+        assert result is not None and len(result) == 7
+
+    def test_wide_gamut_overrides_are_parsed_from_the_stylesheet(self):
+        css = contrast.TOKENS_CSS.read_text(encoding="utf-8")
+
+        overrides = contrast.parse_oklch_tokens(css)
+
+        assert "--text-on-success" in overrides
+        assert "--color-success" in overrides
+
+    def test_parsed_oklch_tokens_are_not_reported_as_unchecked(self):
+        """Otherwise the gate would claim coverage it has, then list it as missing."""
+        css = contrast.TOKENS_CSS.read_text(encoding="utf-8")
+
+        overrides = contrast.parse_oklch_tokens(css)
+        skipped = contrast.parse_non_hex_tokens(css)
+
+        assert not (set(overrides) & set(skipped))
+
+    def test_wide_gamut_pairs_meet_aa(self):
+        """The gate that would have caught #12922 at the time."""
+        css = contrast.TOKENS_CSS.read_text(encoding="utf-8")
+        merged = {**contrast.parse_hex_tokens(css), **contrast.parse_oklch_tokens(css)}
+
+        failures = [
+            (fg, bg, contrast.contrast_ratio(merged[fg], merged[bg]), need)
+            for fg, bg, need in contrast.build_pairs(merged)
+            if contrast.contrast_ratio(merged[fg], merged[bg]) < need
+        ]
+
+        assert not failures, "wide-gamut pairs below AA: " + ", ".join(
+            f"{fg} on {bg} = {r:.2f}:1 < {n}" for fg, bg, r, n in failures
+        )


### PR DESCRIPTION
## Thinking Path

#12915 fixed `--text-on-success` from 2.54:1 to 8.28:1 in the hex block. The wide-gamut block re-declared the same pair in oklch and kept shipping the failing combination on P3 displays.

**A correction to what I said when filing #12922.** I described those overrides as covered by the checker's honest "NOT CHECKED (45 tokens)" reporting. They were not. `parse_non_hex_tokens` only listed names *absent* from the hex map, and every oklch override shadows a name that is present — so the wide-gamut block was **invisible**, neither checked nor reported. The gate was quieter about its coverage than I credited it for, which is the more useful version of the finding.

Rather than widen the "unchecked" list, the fix makes the block measurable: oklch is a fully-determined colour, so it can be converted and checked on the same footing as hex.

## What Changed

**`scripts/check_token_contrast.py`**
- `oklch_to_hex()` — the standard oklab pipeline (oklch → oklab → linear sRGB → gamma). Out-of-gamut components are clamped, matching what a browser does rendering oklch on an sRGB display, so the computed ratio is what a viewer actually sees.
- `parse_oklch_tokens()` — the wide-gamut overrides as an sRGB-equivalent map.
- `parse_non_hex_tokens()` no longer counts a token as unchecked once it is covered by either parser, so the report cannot claim coverage and list the same token as missing.
- The gate now evaluates **two themes** — sRGB, then the merged wide-gamut set.

**`design-tokens.css`** — `--text-on-success` in the wide-gamut block goes `oklch(100% 0 0)` → `oklch(0% 0 0)`, matching #12915's sRGB fix and the treatment already used for `--text-on-warning` directly below it.

## Verification

The conversion is pinned against the sRGB values the *same tokens* carry in the hex block — not against its own output:

```
oklch(100% 0 0)           -> #ffffff
oklch(0% 0 0)             -> #000000
oklch(69.6% 0.149 162.5)  -> #10b981
```

Before the token fix, the new pass caught it exactly as intended:

```
[contrast] 277 hex tokens, 98 oklch overrides, 45 tokens still unchecked
[contrast] -- sRGB: 8 derived pairs
[contrast] -- wide-gamut (oklch): 8 derived pairs
  FAIL  2.54:1 (need 3.0)  --text-on-success on --color-success
```

After:

```
  ok    8.28:1 (need 3.0)  --text-on-success on --color-success   [sRGB]
  ok    8.28:1 (need 3.0)  --text-on-success on --color-success   [wide-gamut]
exit=0
```

```
$ pytest scripts/check_token_contrast_test.py -q     22 passed
$ flake8 / black --check                             clean
```

The 45 remaining unchecked tokens are `rgba()` with alpha. Those are genuinely unmeasurable without knowing the backdrop they composite against, so they stay reported rather than guessed at.

## Model Used

claude-opus-5

Closes #12922
