### PR TITLE
ci: always report the api-wiring context so path-filtered PRs are not deadlocked (#12934)

### DIFF
--- a/.github/workflows/api-wiring.yml
+++ b/.github/workflows/api-wiring.yml
@@ -29,8 +29,16 @@ on:
       - 'requirements*.txt'
       - '.github/workflows/api-wiring.yml'
   pull_request:
+    # NOTE: no pull_request.paths filter (#12934). This workflow ALWAYS runs on
+    # PRs so its required-check context ("api-wiring") always reports a
+    # conclusion. A path-filtered required check simply never triggers, and an
+    # absent required context is treated as unsatisfied, not passed — the PR is
+    # then permanently blocked and can only land with --admin, which trains the
+    # habit of merging past unreported gates. Same fix and reasoning as
+    # frontend-test.yml (#10019, #10527). The real audit is gated on the
+    # `changes` job below; the `api-wiring-skip` shim (same `name:`) reports the
+    # context green when no relevant path was touched.
     branches: [ main, Dev_new_gui ]
-    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,7 +48,30 @@ permissions:
   contents: read
 
 jobs:
+  # Job 0: detect relevant paths — always runs so the required context reports.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      wiring: ${{ steps.filter.outputs.wiring }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        id: filter
+        with:
+          filters: |
+            wiring:
+              - 'autobot-backend/**/*.py'
+              - 'autobot-slm-backend/**/*.py'
+              - 'autobot-frontend/src/**'
+              - 'scripts/audit_api_wiring.py'
+              - 'scripts/api_wiring_baseline.txt'
+              - 'requirements*.txt'
+              - '.github/workflows/api-wiring.yml'
+
   api-wiring:
+    needs: changes
+    if: needs.changes.outputs.wiring == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -102,3 +133,20 @@ jobs:
             echo "::warning::App build failed in CI — falling back to static (heuristic) audit."
             python scripts/audit_api_wiring.py
           fi
+
+  # Mutually exclusive with `api-wiring` above, and deliberately sharing its
+  # check-context name so a PR always sees exactly one terminal "api-wiring"
+  # conclusion — the real audit when wiring-relevant paths changed, an explicit
+  # green here when they did not (#12934). Mirrors `unit-tests-skip` in
+  # frontend-test.yml (#10527).
+  api-wiring-skip:
+    name: api-wiring
+    needs: changes
+    if: needs.changes.outputs.wiring != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: No wiring-relevant changes — reporting required context as success
+        run: |
+          echo "No backend/frontend/audit-script paths changed in this PR."
+          echo "The API wiring audit has nothing to check, so the required"
+          echo "'api-wiring' context is reported as success (#12934)."


### PR DESCRIPTION
## Thinking Path

`api-wiring` is a **required** status check whose workflow is path-filtered. A PR touching only `autobot_shared/`, `libs/`, `.mcp/` or `docs/` never triggers it, so the context never reports — and GitHub treats an absent required check as unsatisfied, not passed. The PR is then permanently blocked and can only land with `--admin`.

I hit this three times in one session (#12933, #12935, and the still-open dependabot #12923). The cost is not the inconvenience: routinely admin-merging past an unreported required check trains exactly the habit that makes a *genuinely* missing check easy to wave through. The gate stops distinguishing "inapplicable" from "not run yet".

**This repo has already solved it**, and I replicated that rather than inventing anything. `frontend-test.yml` carries the fix and the reasoning, from #10019 / #10527:

> NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so its required-check context always reports a conclusion. A path-filtered required check that never triggers leaves the PR deadlocked on "Expected — Waiting for status". … the `unit-tests-skip` shim job (same `name:`, ubuntu-latest) reports the required context green.

`api-wiring` simply never got the same treatment.

## What Changed

`.github/workflows/api-wiring.yml`, one file:

- **`pull_request.paths` filter removed** so the workflow always runs on PRs. The `push` trigger keeps its filter — branch protection does not apply there, and there is no reason to burn runners on every push.
- **`changes` job added** (`dorny/paths-filter`, pinned to the same SHA `frontend-test.yml` uses) carrying the exact filter list the trigger used to have, so what counts as "wiring-relevant" is unchanged.
- **`api-wiring` gated** on `needs.changes.outputs.wiring == 'true'`.
- **`api-wiring-skip` shim added**, `name: api-wiring`, running only when the filter does *not* match.

The two jobs are mutually exclusive, so a PR always sees exactly one terminal `api-wiring` conclusion: the real audit when wiring-relevant paths changed, an explicit green when they did not.

## Verification

```
$ python3 -c "yaml.safe_load(...)"
YAML OK — jobs: ['changes', 'api-wiring', 'api-wiring-skip']
  pull_request paths filter: NONE (correct)
    changes:         name=Detect changed paths  if=-
    api-wiring:      name=(job id)              if=needs.changes.outputs.wiring == 'true'
    api-wiring-skip: name=api-wiring            if=needs.changes.outputs.wiring != 'true'
```

The real job has no explicit `name:`, so its context is the job id `api-wiring`; the shim sets `name: api-wiring` to emit the same context. That is the detail that makes branch protection see one satisfied check either way.

**This PR exercises the real path, not the shim** — `.github/workflows/api-wiring.yml` is itself in the filter list, so `changes.outputs.wiring` is `true` here and the genuine audit runs. That is the more important half to prove: the gate must not have been weakened. The shim path will be exercised by the next `autobot_shared/`-only PR, which previously could not merge without `--admin`.

`actionlint` is not installed locally; CI runs it on this workflow.

## Scope note

Only `api-wiring` is converted. Other required checks (`code-quality`, `startup-import-smoke`, `verify-generated-types`, `migration-matrix`) report `skipped` rather than going absent, which already satisfies branch protection — they do not have this defect and are left alone.

## Model Used

claude-opus-5

Closes #12934
