### PR TITLE
refactor(vnc): inject the transport into the shared useVncControls and wire DesktopInterface to it (#12931)

### DIFF
--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -210,7 +210,8 @@ import LoadingBoundary from '@/components/ui/LoadingBoundary.vue'
 import TouchFriendlyButton from '@/components/ui/TouchFriendlyButton.vue'
 import DesktopContextPanel from '@/components/desktop/DesktopContextPanel.vue'
 import { useLoadingState } from '@/composables/useLoadingState'
-import { useVncControls } from '@/composables/useVncControls'
+import { useVncControls } from '@autobot/vnc'
+import ApiClient from '@/utils/ApiClient'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useDesktopControlLock } from '@/composables/useDesktopControlLock'
 import { createLogger } from '@/utils/debugUtils'
@@ -242,7 +243,15 @@ const errorCheck = ref<Error | null>(null)
 const DESKTOP_CONTROL_SESSION_ID = 'default'
 
 // VNC controls (Issue #74)
-const vncControls = useVncControls(DESKTOP_CONTROL_SESSION_ID)
+// #12931: the shared composable from @autobot/vnc, with this app's ApiClient
+// injected so auth headers, base-URL resolution and error-envelope handling are
+// preserved — the plugin package cannot import ApiClient itself (vue is its only
+// peer dependency), which is why the transport is a parameter.
+const vncControls = useVncControls({
+  sessionId: DESKTOP_CONTROL_SESSION_ID,
+  request: <T,>(method: 'GET' | 'POST', path: string, body?: unknown): Promise<T> =>
+    method === 'GET' ? ApiClient.get<T>(path) : ApiClient.post<T>(path, body),
+})
 const showContextPanel = ref(false)
 
 // Desktop control-lock (Issue #12002, #11506 T1)

--- a/autobot-plugins/vnc/src/components/VncToolbar.vue
+++ b/autobot-plugins/vnc/src/components/VncToolbar.vue
@@ -88,7 +88,7 @@ const emit = defineEmits<{
   error: [message: string]
 }>()
 
-const controls = useVncControls(props.apiBaseUrl ?? '/api')
+const controls = useVncControls({ baseUrl: props.apiBaseUrl ?? '/api' })
 const lastError = ref<string | null>(null)
 const isFullscreen = ref(false)
 const showTypeDialog = ref(false)

--- a/autobot-plugins/vnc/src/composables/useVncControls.ts
+++ b/autobot-plugins/vnc/src/composables/useVncControls.ts
@@ -28,7 +28,37 @@ async function vncFetch<T>(method: 'GET' | 'POST', path: string, body?: unknown)
   return res.json() as Promise<T>
 }
 
-export function useVncControls(baseUrl = '/api') {
+/**
+ * HTTP transport for the VNC control endpoints.
+ *
+ * Injected because the three hosts legitimately differ: the main SPA has
+ * `ApiClient` (auth headers, base-URL resolution, error envelopes), the SLM SPA
+ * has an axios instance bound to `getSlmApiBase()`, and a standalone embed has
+ * neither. This package declares only `vue` as a peer dependency, so it cannot
+ * import either client — sharing the logic requires injecting what differs
+ * (#12931). Same seam as the NPU task-queue getter in #12656.
+ */
+export type VncRequest = <T>(method: 'GET' | 'POST', path: string, body?: unknown) => Promise<T>
+
+export interface UseVncControlsOptions {
+  /** Path prefix for the `/vnc/*` endpoints. */
+  baseUrl?: string
+  /**
+   * Threaded into every request body as `session_id` (#12002), so a lock
+   * owner's toolbar drives their own session rather than whichever is default.
+   */
+  sessionId?: string
+  /** Defaults to plain `fetch` — see {@link VncRequest}. */
+  request?: VncRequest
+}
+
+export function useVncControls(options: UseVncControlsOptions = {}) {
+  const { baseUrl = '/api', sessionId, request = vncFetch } = options
+
+  // #12002: every POST body carries the session id when one was supplied.
+  const withSession = (body?: Record<string, unknown>) =>
+    sessionId === undefined ? body : { ...(body ?? {}), session_id: sessionId }
+
   const loading = ref(false)
   const error = ref<string | null>(null)
 
@@ -40,37 +70,37 @@ export function useVncControls(baseUrl = '/api') {
   }
 
   async function mouseClick(params: MouseClickParams): Promise<VncActionResponse> {
-    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/click`, params)) }
+    try { return await call(() => request<VncActionResponse>('POST', `${baseUrl}/vnc/click`, withSession({ ...params }))) }
     catch (err) { logger.error('Mouse click failed:', err); const m = extractErrorMessage(err, 'Mouse click failed'); error.value = m; return { status: 'error', message: m } }
   }
 
   async function keyboardType(text: string): Promise<VncActionResponse> {
-    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/type`, { text })) }
+    try { return await call(() => request<VncActionResponse>('POST', `${baseUrl}/vnc/type`, withSession({ text }))) }
     catch (err) { logger.error('Keyboard type failed:', err); const m = extractErrorMessage(err, 'Keyboard type failed'); error.value = m; return { status: 'error', message: m } }
   }
 
   async function specialKey(key: string): Promise<VncActionResponse> {
-    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/key`, { key })) }
+    try { return await call(() => request<VncActionResponse>('POST', `${baseUrl}/vnc/key`, withSession({ key }))) }
     catch (err) { logger.error('Special key failed:', err); const m = extractErrorMessage(err, 'Special key failed'); error.value = m; return { status: 'error', message: m } }
   }
 
   async function mouseScroll(params: MouseScrollParams): Promise<VncActionResponse> {
-    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/scroll`, params)) }
+    try { return await call(() => request<VncActionResponse>('POST', `${baseUrl}/vnc/scroll`, withSession({ ...params }))) }
     catch (err) { logger.error('Mouse scroll failed:', err); const m = extractErrorMessage(err, 'Mouse scroll failed'); error.value = m; return { status: 'error', message: m } }
   }
 
   async function mouseDrag(params: MouseDragParams): Promise<VncActionResponse> {
-    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/drag`, params)) }
+    try { return await call(() => request<VncActionResponse>('POST', `${baseUrl}/vnc/drag`, withSession({ ...params }))) }
     catch (err) { logger.error('Mouse drag failed:', err); const m = extractErrorMessage(err, 'Mouse drag failed'); error.value = m; return { status: 'error', message: m } }
   }
 
   async function captureScreenshot(): Promise<VncActionResponse> {
-    try { return await call(() => vncFetch('GET', `${baseUrl}/vnc/screenshot`)) }
+    try { return await call(() => request<VncActionResponse>('GET', `${baseUrl}/vnc/screenshot`)) }
     catch (err) { logger.error('Screenshot capture failed:', err); const m = extractErrorMessage(err, 'Screenshot capture failed'); error.value = m; return { status: 'error', message: m, image_data: '' } }
   }
 
   async function syncClipboard(content: string): Promise<VncActionResponse> {
-    try { return await call(() => vncFetch('POST', `${baseUrl}/vnc/clipboard`, { content })) }
+    try { return await call(() => request<VncActionResponse>('POST', `${baseUrl}/vnc/clipboard`, withSession({ content }))) }
     catch (err) { logger.error('Clipboard sync failed:', err); const m = extractErrorMessage(err, 'Clipboard sync failed'); error.value = m; return { status: 'error', message: m } }
   }
 


### PR DESCRIPTION
## Thinking Path

`useVncControls` exists three times. My first two scopings of this got the details wrong, so the corrected picture first: **all three expose an identical 10-member surface**. The divergence is entirely *transport*, plus one feature:

```
                    transport                        session_id (#12002)
autobot-frontend    ApiClient                        yes
autobot-slm-front   axios + getSlmApiBase()          no
autobot-plugins     raw fetch, baseUrl param         no
```

That rules out the obvious consolidation. `@autobot/vnc` declares only `vue` as a peer dependency — by design, since it is a standalone package — so it cannot import either app's client. Folding onto it as-is would cost the main app ApiClient's auth headers, base-URL resolution and error-envelope handling, and cost the SLM its `getSlmApiBase()` routing.

So the thing that differs per host becomes a parameter: inject the transport. Same seam as the NPU task-queue getter in #12656 — share the logic, inject what legitimately cannot be shared.

## What Changed

**`autobot-plugins/vnc/src/composables/useVncControls.ts`**
- New `VncRequest` type and `UseVncControlsOptions` (`baseUrl`, `sessionId`, `request`), replacing the bare `baseUrl` string parameter. `request` defaults to the existing `fetch` implementation, so standalone use is unchanged.
- `sessionId` threads `session_id` into every POST body, porting #12002 into the shared copy rather than leaving it stranded in the app one.

**`DesktopInterface.vue`** — now imports from `@autobot/vnc` and injects `ApiClient`, so the live desktop-control path keeps auth and envelope handling while using the shared implementation.

**`VncToolbar.vue`** — updated to the options signature.

## Verification

```
$ vue-tsc --noEmit           no VNC or DesktopInterface errors
$ vitest run src/composables/__tests__
  Test Files  73 passed (73)
       Tests  1150 passed | 1 skipped (1151)
```

The composable suite includes the `#12002` session-threading tests, which is the behaviour most at risk here.

**A real breakage this caught.** My earlier scoping searched both SPAs for consumers and concluded the plugin composable had none. It has one — `VncToolbar.vue`, *inside the package itself*, which my SPA-scoped grep never looked at. The signature change broke it:

```
VncToolbar.vue(91,33): error TS2559: Type 'string' has no properties in common with type 'UseVncControlsOptions'
```

Fixed in the same change. Worth noting because it only surfaced once type-checking resolved `@autobot/vnc` to the *worktree* source — my first run had `node_modules` symlinked to the main tree, so it silently type-checked the unmodified plugin and reported clean. A temporary `paths` override pointed it at the real file.

## Scope note

The two app-local copies are untouched and still exported. *Unwired is not orphaned* — the SLM copy may exist for a planned SLM desktop feature, and removing either is a separate decision from proving the shared one works. #12931 stays open for that, and for migrating the SLM caller onto the same seam with its axios instance injected.

## Model Used

claude-opus-5

Refs #12931
