### PR TITLE
fix(tests): give the MemoryManager stub the async API TakeoverManager awaits (#12939)

### DIFF
--- a/autobot-backend/tests/test_cross_worker_registries.py
+++ b/autobot-backend/tests/test_cross_worker_registries.py
@@ -269,12 +269,28 @@ class _FakeRedis:
 
 
 def _make_memory_manager() -> MagicMock:
-    """Return a MemoryManager stub that records calls but doesn't touch DB."""
+    """Return a MemoryManager stub that records calls but doesn't touch DB.
+
+    The a-prefixed methods must be AsyncMock: TakeoverManager awaits
+    ``acreate_task_record``/``astart_task``/``acomplete_task``/``afail_task``,
+    and awaiting a plain MagicMock raises
+    ``TypeError: object MagicMock can't be used in 'await' expression``.
+
+    The sync spellings are kept alongside them. This stub was written against
+    the sync API; MemoryManager later grew the async variants and the stub was
+    never updated, which is what broke all 8 tests in this module. Same shape as
+    the redis-client stub rot in #12903 — a hand-listed double lagging the thing
+    it doubles.
+    """
     mm = MagicMock()
     mm.create_task_record.return_value = "task-123"
     mm.start_task.return_value = None
     mm.complete_task.return_value = None
     mm.fail_task.return_value = None
+    mm.acreate_task_record = AsyncMock(return_value="task-123")
+    mm.astart_task = AsyncMock(return_value=None)
+    mm.acomplete_task = AsyncMock(return_value=None)
+    mm.afail_task = AsyncMock(return_value=None)
     return mm
 
 


### PR DESCRIPTION
## Thinking Path

Found by running a cumulative verification pass over the current tip rather than by picking an issue — tonight's 17 merges were each checked against base individually, but never together. That pass turned up one failure, and the first question was whether I had caused it.

I hadn't: `8 failed, 8 passed` reproduces identically at `79091a4f0`, before any of tonight's work. Pre-existing, and worth fixing rather than filing and moving on, because of what it covers.

The module's docstring (#11639) describes cross-worker correctness of **human takeover**: a request created on worker A being approvable on B, `GETDEL` preventing double-approve, TTL expiry rejecting stale approvals. That is a control gating human intervention in agent runs, and every test touching it has been red.

## What Changed

`_make_memory_manager()` stubbed the sync API (`create_task_record`, `start_task`, …) while `TakeoverManager` awaits the async variants:

```
takeover_manager.py:694   task_id = await self.memory_manager.acreate_task_record(...)
E   TypeError: object MagicMock can't be used in 'await' expression
```

`MemoryManager` grew `acreate_task_record` / `astart_task` / `acomplete_task` / `afail_task` — all present in `memory/manager.py` — and the stub was never updated. Added `AsyncMock` for the four, keeping the sync spellings alongside so nothing that still calls them changes.

One file, one function.

## Verification

```
$ pytest autobot-backend/tests/test_cross_worker_registries.py -q
before: 8 failed, 8 passed
after:  16 passed

$ pytest autobot-backend/tests/ -q -k "npu or rbac or permission or audit or redis or rate_limit or database or takeover or streaming"
756 passed, 8 skipped, 5334 deselected
```

`flake8 --select=F` and `black --check` clean.

## Note

Third instance tonight of the same defect family (#12902, #12903, this): a hand-listed test double lagging the interface it doubles, where the symptom names the stub rather than the migration that outdated it. The tell is consistent — an `await` on a `MagicMock`, or an `ImportError` for a symbol the real module has. Worth a lint rule if it recurs again; three is not yet a pattern I would automate on.

## Model Used

claude-opus-5

Closes #12939
