### PR TITLE
fix(scripts): only call a baselined endpoint renamed when a route still serves its resource (#12894)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
@@ -89,7 +89,9 @@ describe('useKnowledgeCategories', () => {
       const result = await fetchCategory('security')
 
       expect(result).toEqual(mockCategory)
-      expect(apiClient.get).toHaveBeenCalledWith('/knowledge_base/knowledge_base/category/security')
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/categories/security/facts'
+      )
     })
 
     it('should throw error for invalid category', async () => {

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
@@ -124,10 +124,16 @@ export const fetchCategories = async (): Promise<KnowledgeCategoryItem[]> => {
 }
 
 /**
- * Fetch knowledge by category.
+ * Fetch the facts held in a single category.
+ *
+ * Served by GET /api/knowledge_base/categories/{category_id}/facts (#12894) —
+ * the singular /category/{id} form this used to call no longer exists.
+ * @param categoryId - Category identifier
  */
-export const fetchCategory = (category: string): Promise<CategoryResponse> =>
-  apiClient.get<CategoryResponse>(`${getApiBase()}/knowledge_base/category/${category}`)
+export const fetchCategory = (categoryId: string): Promise<CategoryResponse> =>
+  apiClient.get<CategoryResponse>(
+    `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(categoryId)}/facts`
+  )
 
 /**
  * Fetch facts grouped by category for browsing.

--- a/scripts/api_wiring_baseline.txt
+++ b/scripts/api_wiring_baseline.txt
@@ -44,10 +44,15 @@
 /api/system/shutdown
 
 # --- #12378: misc aspirational calls, no backend ---
+# Re-verified in #12894 against a route table built from current source: these
+# have no surviving route that serves the same resource, so they remain
+# unimplemented-endpoint entries, NOT renames. `/api/knowledge/verification/
+# approve` in particular is not the same capability as the real
+# `/api/knowledge_base/verification/{fact_id}/approve`: the caller approves a
+# research SOURCE (posts {source_url, title}, no fact_id), not a pending fact.
 /api/multimodal/health
 /api/service-monitor/resources
 /api/knowledge/verification/approve
-/api/knowledge_base/category/{p}
 /api/knowledge_base/documents/{p}
 /api/knowledge_base/documents/{p}/similar
 

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -628,6 +628,71 @@ def partition_baseline(
     return tracked, new
 
 
+def _resource(path: str) -> str:
+    """The last concrete (non-parameter) segment — what the route acts on.
+
+    ``/api/kb/documents/{id}/similar`` -> ``similar``; ``/api/kb/fact/{id}`` -> ``fact``.
+    """
+    concrete = [s for s in path.strip("/").split("/") if s and not s.startswith("{")]
+    return concrete[-1].lower() if concrete else ""
+
+
+def _namespace(path: str) -> str:
+    """The top-level namespace segment, ignoring a leading ``/api``.
+
+    Static and authoritative mode disagree about the ``/api`` prefix, so it is
+    stripped before comparing — the same reason ``matches()`` tries both forms.
+    """
+    segs = [s for s in path.strip("/").split("/") if s]
+    if segs and segs[0] == "api":
+        segs = segs[1:]
+    return segs[0].lower() if segs else ""
+
+
+def _same_resource(a: str, b: str) -> bool:
+    """Whether two resource segments name the same thing, modulo plurality.
+
+    ``category``/``categories`` is a rename; ``restart``/``health`` is not.
+
+    Each word expands to every singular form it could reduce to, and a shared
+    form means a match. Reducing each word to one canonical form is not enough:
+    ``services`` reduces to ``servic`` via ``-es`` while ``service`` is already
+    singular, so the pair would miss.
+    """
+
+    def forms(word: str) -> set[str]:
+        out = {word}
+        for suffix, base in (("ies", "y"), ("es", ""), ("s", "")):
+            if word.endswith(suffix) and len(word) > len(suffix):
+                out.add(word[: -len(suffix)] + base)
+        return out
+
+    return bool(forms(a) & forms(b))
+
+
+def rename_candidates(path: str, suggestions: list[str]) -> list[str]:
+    """Suggestions that actually look like *path* renamed, not merely nearby.
+
+    ``suggest_routes`` ranks by similarity, which is the right tool for "here
+    are the closest surviving routes" but a poor test for "this endpoint was
+    renamed": every sibling in a surviving namespace clears the floor, because
+    ``_similarity`` weights leading-segment agreement heavily. That made
+    ``/api/system/restart -> /api/system/health`` indistinguishable from a real
+    rename, and a baseline of genuinely-unimplemented endpoints (#12378) read
+    as 29 renamed ones.
+
+    A rename keeps the resource and moves the path around it, so require both:
+    the same top-level namespace (ruling out ``/api/browser/execute`` matching
+    ``/api/workflow/execute``) and the same resource segment (ruling out
+    ``restart`` matching ``health``).
+    """
+    return [
+        s
+        for s in suggestions
+        if _namespace(s) == _namespace(path) and _same_resource(_resource(s), _resource(path))
+    ]
+
+
 def audit_baseline(
     baseline: set[str],
     unwired_all: dict[str, set[str]],
@@ -642,12 +707,17 @@ def audit_baseline(
     was baselined: the gate stays green while the button is dead. Nothing
     distinguished the two cases.
 
-    Returns three buckets:
+    Returns four buckets:
 
     ``rematch``
-        Baselined calls with a close surviving route — almost always a rename.
-        These want rewiring, not suppression, so they are reported with their
-        suggestions instead of being swallowed by the baseline.
+        Baselined calls whose resource survives under a new path in the same
+        namespace — a rename. These want rewiring, not suppression, so they are
+        reported with the matching routes instead of being swallowed.
+    ``namespace_only``
+        The namespace is alive but nothing in it preserves the resource. This
+        is *not* evidence of a rename (#12894): it is the expected shape of an
+        unimplemented endpoint sitting beside implemented siblings, so it stays
+        informational and the nearest routes are shown only as context.
     ``resolved``
         Baselined calls that now match a real route. The entry is stale and
         should be pruned, otherwise the baseline only ever grows.
@@ -658,6 +728,7 @@ def audit_baseline(
     resolved: list[tuple[str, list[str]]] = []
     absent: list[tuple[str, list[str]]] = []
     rematch: list[tuple[str, list[str]]] = []
+    namespace_only: list[tuple[str, list[str]]] = []
 
     for path in sorted(baseline):
         if path not in frontend:
@@ -666,10 +737,20 @@ def audit_baseline(
             resolved.append((path, []))
         else:
             suggestions = suggest_routes(path, backend)
-            if suggestions:
-                rematch.append((path, suggestions))
+            if not suggestions:
+                continue
+            renames = rename_candidates(path, suggestions)
+            if renames:
+                rematch.append((path, renames))
+            else:
+                namespace_only.append((path, suggestions))
 
-    return {"rematch": rematch, "resolved": resolved, "absent": absent}
+    return {
+        "rematch": rematch,
+        "namespace_only": namespace_only,
+        "resolved": resolved,
+        "absent": absent,
+    }
 
 
 def main() -> int:
@@ -748,14 +829,20 @@ def main() -> int:
     if baseline:
         health = audit_baseline(baseline, unwired_all, fe, backend)
         rematch, resolved, absent = health["rematch"], health["resolved"], health["absent"]
+        namespace_only = health["namespace_only"]
         print(
-            f"\n== BASELINE HEALTH: {len(rematch)} rematch, "
+            f"\n== BASELINE HEALTH: {len(rematch)} renamed, "
+            f"{len(namespace_only)} namespace-only, "
             f"{len(resolved)} resolved, {len(absent)} no-longer-called =="
         )
         for path, suggestions in rematch:
-            print(f"  REMOVED-ENDPOINT DRIFT  {path}")
+            print(f"  RENAMED ENDPOINT (rewire the caller)  {path}")
             for suggestion in suggestions:
-                print(f"      ?  did you mean {suggestion}")
+                print(f"      ->  now served by {suggestion}")
+        for path, suggestions in namespace_only:
+            print(f"  NAMESPACE ALIVE, NO MATCHING ROUTE  {path}")
+            for suggestion in suggestions:
+                print(f"      ~  nearest, NOT a rename: {suggestion}")
         for path, _ in resolved:
             print(f"  RESOLVED (prune from baseline)  {path}")
         for path, _ in absent:

--- a/scripts/audit_api_wiring_suggestions_test.py
+++ b/scripts/audit_api_wiring_suggestions_test.py
@@ -68,17 +68,21 @@ class TestSuggestRoutes:
 class TestAuditBaseline:
     """`audit_baseline` — stop the baseline from absorbing removals."""
 
-    BACKEND = {"/api/devices/paired", "/api/chat/sessions"}
+    BACKEND = {"/api/devices/paired", "/api/devices/v2/pairing", "/api/chat/sessions"}
 
     def test_removed_endpoint_in_baseline_is_surfaced_for_rematch(self):
-        """Gap 2: a baselined call whose endpoint was renamed must not stay hidden."""
+        """Gap 2: a baselined call whose endpoint was renamed must not stay hidden.
+
+        Only the route that still serves the ``pairing`` resource counts as the
+        rename; the similarly-named ``/api/devices/paired`` neighbour is not it.
+        """
         baseline = {"/api/devices/pairing"}
         unwired_all = {"/api/devices/pairing": {"src/x.ts"}}
         frontend = {"/api/devices/pairing": {"src/x.ts"}}
 
         health = audit.audit_baseline(baseline, unwired_all, frontend, self.BACKEND)
 
-        assert health["rematch"] == [("/api/devices/pairing", ["/api/devices/paired"])]
+        assert health["rematch"] == [("/api/devices/pairing", ["/api/devices/v2/pairing"])]
         assert health["resolved"] == []
 
     def test_baselined_call_that_now_has_a_route_is_prunable(self):
@@ -104,7 +108,64 @@ class TestAuditBaseline:
 
         health = audit.audit_baseline(baseline, unwired_all, frontend, self.BACKEND)
 
-        assert health == {"rematch": [], "resolved": [], "absent": []}
+        assert health == {
+            "rematch": [],
+            "namespace_only": [],
+            "resolved": [],
+            "absent": [],
+        }
+
+    def _health_for(self, path, backend):
+        """Classify a single still-unwired baselined *path* against *backend*."""
+        return audit.audit_baseline({path}, {path: {"src/x.ts"}}, {path: {"src/x.ts"}}, backend)
+
+    def test_surviving_sibling_is_not_reported_as_a_rename(self):
+        """#12894: an unimplemented endpoint beside implemented siblings is not drift.
+
+        ``_similarity`` weights leading-segment agreement, so every sibling in a
+        live namespace clears the suggestion floor. Treating that as a rename
+        turned a baseline of never-built endpoints into "29 renamed endpoints".
+        """
+        health = self._health_for("/api/system/restart", {"/api/system/health"})
+
+        assert health["rematch"] == []
+        assert health["namespace_only"] == [("/api/system/restart", ["/api/system/health"])]
+
+    def test_same_resource_in_another_namespace_is_not_a_rename(self):
+        """``/api/browser/execute`` is not served by ``/api/workflow/execute``."""
+        health = self._health_for("/api/browser/execute", {"/api/workflow/execute"})
+
+        assert health["rematch"] == []
+        assert [p for p, _ in health["namespace_only"]] == ["/api/browser/execute"]
+
+    def test_pluralised_resource_is_a_rename(self):
+        """``category`` -> ``categories`` is the real drift #12894 found."""
+        health = self._health_for(
+            "/api/knowledge_base/category/{p}", {"/api/knowledge_base/categories/{p}"}
+        )
+
+        assert health["rematch"] == [
+            ("/api/knowledge_base/category/{p}", ["/api/knowledge_base/categories/{p}"])
+        ]
+
+    @pytest.mark.parametrize(
+        "call,route",
+        [
+            ("/api/monitor/services", "/api/monitor/v2/service"),
+            ("/api/monitor/service", "/api/monitor/v2/services"),
+        ],
+    )
+    def test_plurality_matches_in_both_directions(self, call, route):
+        """``services``/``service`` must match however the pair is ordered."""
+        health = self._health_for(call, {route})
+
+        assert health["rematch"] == [(call, [route])]
+
+    def test_relocated_resource_is_a_rename(self):
+        """Same namespace, same resource, deeper path — the classic rename."""
+        health = self._health_for("/api/browser/click", {"/api/browser/mcp/click"})
+
+        assert health["rematch"] == [("/api/browser/click", ["/api/browser/mcp/click"])]
 
 
 @pytest.mark.parametrize("path", ["/api/devices/pairing", "/api/knowledge/searches"])


### PR DESCRIPTION
Closes #12894.

## Thinking Path

#12894 claims 32 baselined frontend calls point at **renamed** endpoints — "dead buttons in the GUI" — based on the baseline-health classifier added in #12738. I checked that premise against a route table built from current source (2161 paths) before changing any caller, and it does not hold.

The classifier's `rematch` bucket only requires that some candidate route shares **one concrete segment** and clears `SUGGESTION_FLOOR`. `_similarity` deliberately weights leading-segment agreement (a rename usually keeps the namespace), so *every* sibling in a surviving namespace clears the bar. The result is that a genuinely-unimplemented endpoint sitting beside implemented siblings is indistinguishable from a real rename:

```
REMOVED-ENDPOINT DRIFT  /api/system/restart
    ?  did you mean /api/system/health      <- not a rename, just the neighbour
REMOVED-ENDPOINT DRIFT  /api/browser/execute
    ?  did you mean /api/workflow/execute   <- different namespace entirely
```

So the 29 flagged entries were mostly #12378's honest "aspirational, no backend" baseline being relabelled as drift. Checking the namespaces confirms it: `/api/dev-speedup/*` really does expose `analyze`/`dead-code`/`duplicates` and none of the 8 baselined paths; `/api/system/backup/*` has only `status`.

A rename keeps the resource and moves the path around it, so the fix requires **both** the same top-level namespace and the same resource segment (modulo plurality). That is precision-first on purpose: a fuzzy resource match would readmit false positives such as `/api/code-intelligence/analysis/{id}` -> `/analyze`, which are different operations (fetch a stored analysis vs run one), not a rename.

Two callers survived manual review and neither is a mechanical rewire:

- `acceptSource` posts `{source_url, title}` with **no** `fact_id` to `/api/knowledge/verification/approve`. The real `/api/knowledge_base/verification/{fact_id}/approve` approves a pending *fact*; this approves a research *source*. Different capability — correctly baselined, and now documented as such.
- `fetchCategory` is the one real rename, but not to the suggested `/categories/{id}`: that returns `{status, category}`, while the function is typed `CategoryResponse` (carrying `facts[]`) and its test is titled "should fetch facts for a specific category". The endpoint matching its intent and shape is `/categories/{category_id}/facts` -> `KnowledgeCategoryFactsResponse`.

## What Changed

- `scripts/audit_api_wiring.py`: added `rename_candidates()` (plus `_namespace`/`_resource`/`_same_resource`); `audit_baseline()` now returns a fourth `namespace_only` bucket. Output distinguishes `RENAMED ENDPOINT (rewire the caller)` with `-> now served by` from `NAMESPACE ALIVE, NO MATCHING ROUTE` with `~ nearest, NOT a rename`.
- `useKnowledgeCategories.ts`: `fetchCategory` now calls `/knowledge_base/categories/{id}/facts`, with `encodeURIComponent` to match `deleteKnowledgeCategory` beside it.
- `api_wiring_baseline.txt`: dropped the now-wired `/api/knowledge_base/category/{p}`; recorded why the remaining misc entries are re-verified as unimplemented rather than renamed.
- Tests: the existing rematch case now asserts the discriminator picks the true rename out of a field of neighbours; added coverage for surviving-sibling, cross-namespace, pluralisation (both orderings) and relocated-resource.

`_same_resource` compares the *set* of singular forms rather than one canonical form — reducing each word once makes `services` (-> `servic`) miss `service`, which is already singular.

## Verification

```
$ python3 -m pytest scripts/audit_api_wiring_suggestions_test.py scripts/audit_api_wiring_test.py -q
30 passed in 12.14s

$ npx vitest run src/composables/__tests__/useKnowledgeCategories.test.ts
Test Files  1 passed (1)     Tests  17 passed (17)

$ python3 -m flake8 scripts/audit_api_wiring.py scripts/audit_api_wiring_suggestions_test.py
(clean)
```

Classifier output against the current route table, before -> after:

```
before:  == BASELINE HEALTH: 29 rematch, 0 resolved, 0 no-longer-called ==
after:   == BASELINE HEALTH: 0 renamed, 28 namespace-only, 0 resolved, 0 no-longer-called ==
```

0 renamed after the rewire (1 before it, the `category` entry this PR fixes) — matching the manual per-namespace review independently.

The gate's own findings are unchanged: `UNWIRED FRONTEND CALLS: 5` before and after, the same five `/api/nodes*` and `/api/tls/*` SLM-targeted paths that need `--slm-openapi` unioned in (the local SLM dump needs a root-only credentials file). `TRACKED UNWIRED` goes 32 -> 31 from pruning the fixed entry. Gating behaviour is untouched — baseline health remains informational.

## Model Used

claude-opus-5
