### PR TITLE
fix(infra-scripts): build the KB index from one schema definition, without redisvl (#12840)

### DIFF
--- a/autobot-infrastructure/shared/scripts/create_kb_index.py
+++ b/autobot-infrastructure/shared/scripts/create_kb_index.py
@@ -4,7 +4,13 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Create knowledge base index with correct dimensions using redisvl directly.
+Create the knowledge base index with the dimensions nomic-embed-text emits.
+
+Talks to Redis with raw FT.* commands via the centralized client, the same way
+every other helper in this file does — no redisvl. The schema below is the one
+source of truth for the index; it used to be declared twice (once as a redisvl
+``IndexSchema`` dict, once as the FT.CREATE argv that actually ran), which left
+the two free to drift (#12840).
 """
 
 import logging
@@ -13,6 +19,15 @@ import sys
 from typing import List
 
 logger = logging.getLogger(__name__)
+
+# Index definition — consumed by _build_index_create_command() and the log line
+# that reports what is being created, so both always describe the same index.
+INDEX_NAME = "llama_index"
+INDEX_PREFIX = "llama_index/vector"
+LEGACY_INDEX_NAME = "autobot_kb_768"
+# nomic-embed-text emits 768-dimensional vectors; the index must match exactly
+# or FT.SEARCH rejects every query vector.
+VECTOR_DIM = 768
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -26,17 +41,12 @@ def _drop_existing_indexes(r) -> None:
 
     Helper for create_index_with_correct_dimensions (Issue #825).
     """
-    try:
-        r.execute_command("FT.DROPINDEX", "llama_index", "DD")
-        logger.info("Dropped existing llama_index")
-    except Exception as e:
-        logger.info(f"No existing llama_index to drop: {e}")
-
-    try:
-        r.execute_command("FT.DROPINDEX", "autobot_kb_768", "DD")
-        logger.info("Dropped existing autobot_kb_768")
-    except Exception as e:
-        logger.info(f"No existing autobot_kb_768 to drop: {e}")
+    for index_name in (INDEX_NAME, LEGACY_INDEX_NAME):
+        try:
+            r.execute_command("FT.DROPINDEX", index_name, "DD")
+            logger.info("Dropped existing %s", index_name)
+        except Exception as e:
+            logger.info("No existing %s to drop: %s", index_name, e)
 
 
 def _build_index_create_command() -> List:
@@ -46,12 +56,12 @@ def _build_index_create_command() -> List:
     """
     return [
         "FT.CREATE",
-        "llama_index",
+        INDEX_NAME,
         "ON",
         "HASH",
         "PREFIX",
         "1",
-        "llama_index/vector",
+        INDEX_PREFIX,
         "SCHEMA",
         "id",
         "TAG",
@@ -66,7 +76,7 @@ def _build_index_create_command() -> List:
         "TYPE",
         "FLOAT32",
         "DIM",
-        "768",
+        str(VECTOR_DIM),
         "DISTANCE_METRIC",
         "COSINE",
     ]
@@ -77,7 +87,7 @@ def _verify_index_creation(r) -> None:
 
     Helper for create_index_with_correct_dimensions (Issue #825).
     """
-    info = r.execute_command("FT.INFO", "llama_index")
+    info = r.execute_command("FT.INFO", INDEX_NAME)
     logger.info("\nIndex created with attributes:")
     for attr in info[info.index(b"attributes") + 1]:
         if b"vector" in attr and b"dim" in attr:
@@ -86,7 +96,7 @@ def _verify_index_creation(r) -> None:
 
 
 def create_index_with_correct_dimensions():
-    """Create Redis index with 768 dimensions for nomic-embed-text."""
+    """Create the Redis index sized for nomic-embed-text (VECTOR_DIM)."""
 
     r = get_redis_client(database="main")
     if r is None:
@@ -95,37 +105,14 @@ def create_index_with_correct_dimensions():
 
     _drop_existing_indexes(r)
 
-    schema_dict = {
-        "index": {
-            "name": "llama_index",
-            "prefix": "llama_index/vector",
-            "storage_type": "hash",
-        },
-        "fields": [
-            {"name": "id", "type": "tag"},
-            {"name": "doc_id", "type": "tag"},
-            {"name": "text", "type": "text"},
-            {
-                "name": "vector",
-                "type": "vector",
-                "attrs": {
-                    "dims": 768,
-                    "algorithm": "flat",
-                    "distance_metric": "cosine",
-                },
-            },
-        ],
-    }
-
-    schema = IndexSchema.from_dict(schema_dict)
+    create_cmd = _build_index_create_command()
 
     logger.info("Creating index with schema:")
-    logger.info(f"  Name: {schema.index.name}")
-    logger.info("  Vector dimensions: 768")
+    logger.info("  Name: %s", INDEX_NAME)
+    logger.info("  Prefix: %s", INDEX_PREFIX)
+    logger.info("  Vector dimensions: %d", VECTOR_DIM)
 
     try:
-        create_cmd = _build_index_create_command()
-
         result = r.execute_command(*create_cmd)
         logger.info(f"Index created successfully: {result}")
 
@@ -141,7 +128,7 @@ def create_index_with_correct_dimensions():
 if __name__ == "__main__":
     success = create_index_with_correct_dimensions()
     if success:
-        logger.info("\nIndex created successfully with 768 dimensions!")
+        logger.info("\nIndex created successfully with %d dimensions!", VECTOR_DIM)
         logger.info("You can now run populate_knowledge_base.py")
     else:
         logger.error("\nFailed to create index")

--- a/autobot-infrastructure/shared/scripts/create_kb_index_test.py
+++ b/autobot-infrastructure/shared/scripts/create_kb_index_test.py
@@ -1,0 +1,116 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for create_kb_index — the KB index build (#12840).
+
+These drive the real code path with a fake Redis client rather than a live one:
+``create_index_with_correct_dimensions`` DROPs the index before recreating it,
+so running it against a real instance would discard the indexed vectors.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_MODULE_PATH = pathlib.Path(__file__).with_name("create_kb_index.py")
+
+
+def _load_module():
+    """Import create_kb_index by path — its directory is not a package."""
+    spec = importlib.util.spec_from_file_location("create_kb_index", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["create_kb_index"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+kb_index = _load_module()
+
+
+class FakeRedis:
+    """Records every command, and answers FT.INFO like a freshly built index."""
+
+    def __init__(self, drop_error: Exception | None = None):
+        self.commands: list[tuple] = []
+        self._drop_error = drop_error
+
+    def execute_command(self, *args):
+        self.commands.append(args)
+        if args[0] == "FT.DROPINDEX" and self._drop_error is not None:
+            raise self._drop_error
+        if args[0] == "FT.INFO":
+            return [b"attributes", [[b"vector", b"dim", str(kb_index.VECTOR_DIM).encode()]]]
+        return "OK"
+
+    def command_names(self) -> list[str]:
+        return [c[0] for c in self.commands]
+
+    def first(self, name: str) -> tuple:
+        return next(c for c in self.commands if c[0] == name)
+
+
+@pytest.fixture
+def redis(monkeypatch):
+    client = FakeRedis()
+    monkeypatch.setattr(kb_index, "get_redis_client", lambda **_: client)
+    return client
+
+
+def test_module_imports_without_redisvl():
+    """#12840: the module referenced IndexSchema, which nothing ever imported.
+
+    redisvl is not a repo dependency, and the repo already documents its import
+    chain as broken, so the schema must be expressible without it.
+    """
+    assert "redisvl" not in sys.modules
+    assert not hasattr(kb_index, "IndexSchema")
+
+
+def test_create_runs_end_to_end(redis):
+    """The whole function completes — this used to raise NameError mid-way."""
+    assert kb_index.create_index_with_correct_dimensions() is True
+    assert redis.command_names() == ["FT.DROPINDEX", "FT.DROPINDEX", "FT.CREATE", "FT.INFO"]
+
+
+def test_create_command_declares_the_expected_index(redis):
+    """The FT.CREATE argv is the only schema definition, so pin its shape."""
+    kb_index.create_index_with_correct_dimensions()
+    create = redis.first("FT.CREATE")
+
+    assert create[1] == kb_index.INDEX_NAME
+    assert create[create.index("PREFIX") + 2] == kb_index.INDEX_PREFIX
+    assert create[create.index("DIM") + 1] == str(kb_index.VECTOR_DIM)
+    assert create[create.index("DISTANCE_METRIC") + 1] == "COSINE"
+    assert create[create.index("TYPE") + 1] == "FLOAT32"
+
+
+def test_dimension_is_declared_as_a_string(redis):
+    """redis-py rejects a bare int in argv; DIM must be stringified."""
+    kb_index.create_index_with_correct_dimensions()
+    create = redis.first("FT.CREATE")
+
+    assert isinstance(create[create.index("DIM") + 1], str)
+
+
+def test_legacy_index_is_dropped_too(redis):
+    """Both the current and the pre-rename index are cleared before rebuild."""
+    kb_index.create_index_with_correct_dimensions()
+    dropped = [c[1] for c in redis.commands if c[0] == "FT.DROPINDEX"]
+
+    assert dropped == [kb_index.INDEX_NAME, kb_index.LEGACY_INDEX_NAME]
+
+
+def test_missing_index_on_drop_is_not_fatal(monkeypatch):
+    """A first-ever run has nothing to drop; that must not abort the build."""
+    client = FakeRedis(drop_error=RuntimeError("Unknown index name"))
+    monkeypatch.setattr(kb_index, "get_redis_client", lambda **_: client)
+
+    assert kb_index.create_index_with_correct_dimensions() is True
+    assert "FT.CREATE" in client.command_names()
+
+
+def test_unreachable_redis_reports_failure(monkeypatch):
+    monkeypatch.setattr(kb_index, "get_redis_client", lambda **_: None)
+
+    assert kb_index.create_index_with_correct_dimensions() is False


### PR DESCRIPTION
Closes #12840.

## Thinking Path

`create_index_with_correct_dimensions()` raised `NameError` at `IndexSchema.from_dict(...)` — the name was never imported. The issue framed the fix as a three-way decision (add `redisvl` as a dependency / rewrite with raw `FT.CREATE` / retire the script), so I looked for evidence rather than picking.

Two findings settled it without needing a product call:

**1. The repo already treats `redisvl` as unusable.** Beyond it being absent from every requirements file, `chat_workflow/graph.py:1534` and `chat_workflow/graph_redis_unavailable_test.py` describe *"the broken redisvl → `redis.commands.search.indexDefinition` import chain"* as a production failure mode, with a regression test simulating it. Adding it back to fix a script would reintroduce a dependency the codebase documents as broken.

**2. The proposed "rewrite with raw FT.CREATE" already existed.** `_build_index_create_command()` builds the full schema as `FT.CREATE` argv, and `r.execute_command(*create_cmd)` is what actually created the index. The `schema_dict` + `IndexSchema` block fed *nothing but a log line* (`schema.index.name`).

So the schema was declared **twice** — once in a redisvl dict that never reached Redis, once in the argv that did — with nothing keeping them in agreement. The dict already said `"prefix": "llama_index/vector"` while the argv said the same thing independently; either could have been edited alone. That duplication is the real defect, and the `NameError` only made it visible.

This consolidates onto the definition that actually runs. No behaviour change to the created index: same name, prefix, field set, `FLAT`/`FLOAT32`/`COSINE`, same 768 dimensions.

## What Changed

`autobot-infrastructure/shared/scripts/create_kb_index.py`:
- Removed the unreachable `IndexSchema` build; the logging now reports the values the `FT.CREATE` argv is built from, so it can no longer describe an index different from the one created.
- Hoisted `INDEX_NAME`, `INDEX_PREFIX`, `LEGACY_INDEX_NAME`, `VECTOR_DIM` to module constants, read by the argv builder, the drop step, `FT.INFO` verification, and the log lines — previously each repeated the literals.
- Collapsed the two copy-pasted drop blocks into one loop over both index names.
- Module docstring no longer claims it uses "redisvl directly"; `%s`-style logging on the touched lines.

`create_kb_index_test.py` (new): 7 tests driving the real function with a fake Redis client.

## Verification

```
$ python3 -m pytest autobot-infrastructure/shared/scripts/create_kb_index_test.py -q
7 passed in 1.49s

$ python3 -m flake8 autobot-infrastructure/shared/scripts/create_kb_index.py
(clean — was: 120:14: F821 undefined name 'IndexSchema')
```

The tests are not vacuous — the same path against the pre-fix file from `origin/Dev_new_gui`:

```
PRE-FIX NameError: name 'IndexSchema' is not defined
```

**On the issue's "runs end-to-end against a live Redis" criterion:** I deliberately did not do that. `create_index_with_correct_dimensions()` issues `FT.DROPINDEX ... DD` before rebuilding, so running it against the only reachable instance — the local test deployment — would discard its indexed KB vectors. The tests drive the identical code path with a recording client instead, asserting the exact `FT.CREATE` argv (name, prefix, `DIM`, `DISTANCE_METRIC`, `TYPE`), that both the current and legacy indexes are dropped, that a first-ever run with no index to drop still builds, and that an unreachable Redis returns `False`. One test pins `DIM` as a *string*, since redis-py rejects a bare int in argv — the failure the `str(VECTOR_DIM)` conversion prevents.

## Model Used

claude-opus-5
