### PR TITLE
fix(analytics): locate the backend under the scan root instead of assuming its depth (#12853)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -120,6 +120,44 @@ _DYNAMIC_ROUTER_TUPLE_RE = re.compile(
 # =============================================================================
 
 
+#: Directory names that have held the FastAPI backend across layouts. Ordered
+#: most-specific-first so a repo containing both is resolved deterministically.
+_BACKEND_DIR_CANDIDATES = ("autobot-backend", "backend", ".")
+
+#: What makes a directory *the* backend rather than any directory holding an
+#: ``api`` folder — the router registry lives beside the routes it mounts.
+_ROUTER_REGISTRY_RELPATH = Path("initialization") / "router_registry"
+
+
+def find_backend_dir(project_root: Path) -> Path:
+    """Locate the FastAPI backend package inside *project_root* (#12853).
+
+    Callers pass the root of the tree being analysed — a source clone, or
+    AutoBot's own checkout — and the backend sits at different depths in each.
+    Assuming ``project_root / "api"`` silently produced an empty scan for every
+    layout that nests it (this repo's ``autobot-backend/``), which reads as
+    "this backend has no routes" rather than as a failure to look in the right
+    place.
+
+    Prefers a candidate that also carries the router registry, so a directory
+    that merely happens to contain ``api/`` does not win over the real backend.
+    Falls back to *project_root* unchanged when nothing matches, preserving the
+    previous behaviour for callers that already point straight at the backend.
+    """
+    with_registry: Path | None = None
+    with_api: Path | None = None
+
+    for name in _BACKEND_DIR_CANDIDATES:
+        candidate = project_root if name == "." else project_root / name
+        if not (candidate / "api").is_dir():
+            continue
+        if (candidate / _ROUTER_REGISTRY_RELPATH).is_dir():
+            with_registry = with_registry or candidate
+        with_api = with_api or candidate
+
+    return with_registry or with_api or project_root
+
+
 class BackendEndpointScanner:
     """Scans backend Python files for FastAPI route definitions."""
 
@@ -132,7 +170,13 @@ class BackendEndpointScanner:
         # resolves to /opt/autobot -- not the analyzable repo -- in the deployed
         # standalone rsync layout).
         self.project_root = project_root or Path(resolve_project_root())
-        self.backend_path = self.project_root / "api"
+        # Issue #12853: the backend is not always directly under the scan root.
+        # This repo keeps it in autobot-backend/, so `project_root / "api"` found
+        # nothing and the scan reported 0 endpoints against a ~2000-route backend
+        # -- which then made every frontend call look like it targeted a missing
+        # endpoint. Locate the backend package instead of assuming its depth.
+        self.backend_dir = find_backend_dir(self.project_root)
+        self.backend_path = self.backend_dir / "api"
         self._router_prefixes: Dict[str, str] = {}
         # Map module name to router prefix (e.g., "chat" -> "", "system" -> "/system")
         self._module_prefix_map: Dict[str, str] = {}
@@ -181,7 +225,11 @@ class BackendEndpointScanner:
         - backend/initialization/router_registry/terminal_routers.py (config tuples)
         - backend/initialization/router_registry/mcp_routers.py (config tuples)
         """
-        router_registry_path = self.project_root / "backend" / "initialization" / "router_registry"
+        # Issue #12853: this was `project_root / "backend" / ...`, a path that
+        # exists in no current layout -- so no prefix was ever parsed and every
+        # endpoint was recorded without its router prefix. The registry lives
+        # beside the routes, under the resolved backend directory.
+        router_registry_path = self.backend_dir / _ROUTER_REGISTRY_RELPATH
 
         # Parse core_routers.py for module -> prefix mapping (uses tuple format)
         core_routers_file = router_registry_path / "core_routers.py"
@@ -190,13 +238,12 @@ class BackendEndpointScanner:
 
         # Issue #552: Parse all *_routers.py files that use config tuple format
         # These files use ROUTER_CONFIGS pattern: ("module_path", "router", "/prefix", [...], "name")
-        config_tuple_files = [
-            "analytics_routers.py",
-            "monitoring_routers.py",
-            "feature_routers.py",
-            "terminal_routers.py",
-            "mcp_routers.py",
-        ]
+        # Issue #12853: integration_routers.py was missing from this list, so
+        # its routers carried no prefix. Parse every *_routers.py present
+        # instead of a hand-maintained list that drifts as registries are added.
+        config_tuple_files = sorted(
+            p.name for p in router_registry_path.glob("*_routers.py") if p.name != "core_routers.py"
+        )
 
         for config_file in config_tuple_files:
             file_path = router_registry_path / config_file

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -61,3 +61,80 @@ class TestProjectRootFallbackUsesResolveProjectRoot:
             backend_scanner = scanner_mod.BackendEndpointScanner(project_root=explicit_root)
 
         assert backend_scanner.project_root == explicit_root
+
+
+class TestBackendDirResolution:
+    """Issue #12853: the backend is not always directly under the scan root.
+
+    ``project_root / "api"`` found nothing for any layout that nests the
+    backend, so the scan reported 0 endpoints against a ~2000-route backend --
+    which made every frontend call look like it targeted a missing endpoint.
+    """
+
+    @staticmethod
+    def _make_backend(root, name):
+        """Create a backend package (routes + router registry) under *root*."""
+        base = root if name == "." else root / name
+        (base / "api").mkdir(parents=True)
+        (base / "initialization" / "router_registry").mkdir(parents=True)
+        return base
+
+    def test_finds_backend_nested_under_the_scan_root(self, tmp_path):
+        backend = self._make_backend(tmp_path, "autobot-backend")
+
+        assert scanner_mod.find_backend_dir(tmp_path) == backend
+
+    def test_finds_backend_directly_at_the_scan_root(self, tmp_path):
+        """Callers that already point at the backend keep working."""
+        backend = self._make_backend(tmp_path, ".")
+
+        assert scanner_mod.find_backend_dir(tmp_path) == backend
+
+    def test_registry_bearing_candidate_wins_over_a_bare_api_dir(self, tmp_path):
+        """A directory that merely contains api/ is not the backend."""
+        (tmp_path / "api").mkdir()  # decoy at the root
+        backend = self._make_backend(tmp_path, "autobot-backend")
+
+        assert scanner_mod.find_backend_dir(tmp_path) == backend
+
+    def test_unrecognised_layout_falls_back_to_the_scan_root(self, tmp_path):
+        assert scanner_mod.find_backend_dir(tmp_path) == tmp_path
+
+    def test_scanner_points_at_the_nested_backend(self, tmp_path):
+        backend = self._make_backend(tmp_path, "autobot-backend")
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+
+        assert scanner.backend_path == backend / "api"
+
+    def test_router_registry_is_read_from_the_backend_not_the_scan_root(self, tmp_path):
+        """#12853: the registry path was `project_root / "backend" / ...`.
+
+        That exists in no current layout, so no prefix was ever parsed and every
+        endpoint was recorded without its router prefix.
+        """
+        backend = self._make_backend(tmp_path, "autobot-backend")
+        registry = backend / "initialization" / "router_registry"
+        (registry / "core_routers.py").write_text('("chat", "router", "/chat")\n', encoding="utf-8")
+
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        scanner._collect_router_prefixes()
+
+        assert (scanner.backend_dir / "initialization" / "router_registry") == registry
+
+    def test_every_router_registry_file_is_parsed(self, tmp_path):
+        """A hand-maintained list silently skipped integration_routers.py."""
+        backend = self._make_backend(tmp_path, "autobot-backend")
+        registry = backend / "initialization" / "router_registry"
+        for name in ("analytics_routers.py", "integration_routers.py", "brand_new_routers.py"):
+            (registry / name).write_text("ROUTER_CONFIGS = []\n", encoding="utf-8")
+
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        parsed = []
+        with patch.object(scanner, "_parse_config_tuple_registry", side_effect=parsed.append):
+            scanner._collect_router_prefixes()
+
+        assert {p.name for p in parsed} == {
+            "analytics_routers.py",
+            "integration_routers.py",
+            "brand_new_routers.py",
+        }


### PR DESCRIPTION
Closes #12944. Refs #12853 — which stays open for the remaining coverage gap and live per-source validation (see "What remains").

## Thinking Path

#12853 attributes the 0-route scan to `resolve_project_root()` returning the deployed tree rather than the analyzed source, and proposes wiring the scan to the source's indexed tree. I checked that premise first, and the wiring already exists: `resolve_source_root(source_id)` returns `source.clone_path`, `_build_analysis_tasks` threads it as `scan_root`, and `_get_api_endpoint_analysis(project_root=scan_root)` passes it to the scanner (#12372). Handing the scanner a correct root would not have fixed anything.

The actual defect is what the scanner does *with* the root. It looks for routes at `project_root / "api"` and for the router registry at `project_root / "backend" / "initialization" / "router_registry"`. Neither exists in this repo — the backend is `autobot-backend/`:

```
MISSING  api
MISSING  backend/initialization/router_registry
EXISTS   autobot-backend/api
EXISTS   autobot-backend/initialization/router_registry
```

Running the unmodified scanner at two roots isolates it — the root is fine, the assumed depth is not:

```
/…/AutoBot-AI                 backend_path=False  endpoints=0
/…/AutoBot-AI/autobot-backend backend_path=True   endpoints=1986
```

That is the whole "0 of ~2156 routes" symptom: with an empty endpoint map every frontend call matches nothing, which is what produced the ~2400 "missing endpoints" that were 97% false.

**A second defect surfaced while confirming the first.** The registry path is built from a *different* wrong assumption (`project_root/"backend"/…`), so it resolves nowhere in *any* layout — even when the route scan works:

```
registry path tried : /…/autobot-backend/backend/initialization/router_registry
exists              : False
router_prefixes     : 0
```

So endpoints were being recorded without their router prefixes, meaning even a populated map would mismatch against frontend calls. Fixing the route path alone would have left the report wrong in a subtler way. While fixing it I also found `integration_routers.py` absent from the hand-maintained `config_tuple_files` list, so its routers carried no prefix either.

## What Changed

`api/codebase_analytics/api_endpoint_scanner.py`:
- Added `find_backend_dir(project_root)`, which resolves the backend among `autobot-backend/`, `backend/`, and the root itself. It prefers a candidate that *also* holds `initialization/router_registry`, so a directory that merely happens to contain `api/` cannot win, and falls back to the root unchanged — callers already pointing at the backend are unaffected.
- `backend_path` and the router-registry path both derive from that resolved directory.
- The registry file list is now globbed (`*_routers.py`) instead of hand-maintained, which picks up `integration_routers.py` and anything added later.

`api_endpoint_scanner_test.py`: 7 tests — nested layout, backend-at-root, decoy `api/` losing to the registry-bearing candidate, unrecognised-layout fallback, the scanner pointing at the nested backend, the registry resolving under the backend, and every `*_routers.py` being parsed.

## Verification

```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -q
11 passed          (4 pre-existing + 7 new)

$ python3 -m pytest api/codebase_analytics/ -q
225 passed, 11 skipped in 4.84s

$ python3 -m flake8 …/api_endpoint_scanner.py …/api_endpoint_scanner_test.py
(clean)
```

Scanning from the **repo root** (the case that previously returned nothing), before → after:

| | before | after |
|---|---|---|
| endpoints found | 0 | 1986 |
| module prefix map | 16 | 871 |
| paths under `/api/` | 0 | 1984 |

Cross-checked against the authoritative table from `app.openapi()` (2159 unique normalized paths):

```
scanned unique            : 1806
scanned IN openapi        : 1736   (80.4% of real routes)
scanned NOT in openapi    : 70
openapi MISSED by scanner : 423
```

## What remains

The issue's acceptance criteria are not fully met, so this does not close it:

1. **423 real routes still unmatched (~20%).** A static AST scan will not reach dynamically-registered or data-driven mounts, but 423 is too many to assume that is the whole story; it needs its own pass with the numbers above as the baseline.
2. **70 scanned paths that `app.openapi()` does not expose** — prefix reconstruction is still imperfect for some routers.
3. **Live per-source validation** (the `source_id` → indexed-tree case on a real instance, and confirming `scan_error` stays empty) is untouched here — I verified against this checkout, not a running instance.
4. The `file: "?"` / `method: UNKNOWN` loss noted at the end of #12853 is a separate path and not addressed.

This PR fixes the primary defect and makes those remaining numbers measurable rather than hidden behind a zero.

## Model Used

claude-opus-5