### PR TITLE
fix(analytics): scan registry-mounted router modules outside api/ (#12946)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -180,6 +180,8 @@ class BackendEndpointScanner:
         self._router_prefixes: Dict[str, str] = {}
         # Map module name to router prefix (e.g., "chat" -> "", "system" -> "/system")
         self._module_prefix_map: Dict[str, str] = {}
+        # #12945: resolved file -> prefix for registry-mounted routers outside api/
+        self._external_router_prefixes: Dict[Path, str] = {}
 
     def scan_all_endpoints(self) -> List[APIEndpointItem]:
         """
@@ -197,8 +199,13 @@ class BackendEndpointScanner:
         # First pass: collect router prefixes from registry files
         self._collect_router_prefixes()
 
+        # #12945: routers the registries mount from outside api/ are scanned too,
+        # otherwise their routes look missing to every frontend call that uses them.
+        self._external_router_prefixes = self._registry_router_files()
+
         # Second pass: scan all Python files
-        for py_file in self.backend_path.rglob("*.py"):
+        scan_targets = list(self.backend_path.rglob("*.py")) + list(self._external_router_prefixes)
+        for py_file in scan_targets:
             if py_file.name.startswith("__"):
                 continue
             if "archive" in str(py_file).lower():
@@ -210,7 +217,11 @@ class BackendEndpointScanner:
             except Exception as e:
                 logger.debug("Error scanning %s: %s", py_file, e)
 
-        logger.info("Found %d backend endpoints", len(endpoints))
+        logger.info(
+            "Found %d backend endpoints (%d files outside api/)",
+            len(endpoints),
+            len(self._external_router_prefixes),
+        )
         return endpoints
 
     def _collect_router_prefixes(self) -> None:
@@ -631,9 +642,57 @@ class BackendEndpointScanner:
 
         logger.debug("Registered prefix: %s -> %s", module_name, full_prefix)
 
+    def _registry_router_files(self) -> Dict[Path, str]:
+        """Map files to prefixes for registry-mounted routers outside ``api/`` (#12945).
+
+        The scan walks ``api/`` only, but the registries also mount routers from
+        sibling packages -- ``services.advanced_workflow.routes``, ``llc.api``,
+        ``routers.*``. Those routes were never discovered, so every frontend call
+        to one was reported as targeting a missing endpoint: 419 real routes,
+        95.4% of all findings.
+
+        Resolves each registry module path against the backend directory and
+        carries the registered prefix, so the routes land under the path they
+        are actually served on.
+
+        Deliberately limited to module *files*. A registry entry naming a
+        package cannot have its prefix applied to the modules inside it: the
+        LLC router registers as ``("llc.api", "", …)`` -- an empty prefix --
+        and its real ``/api/llc/*`` paths come from ``include_router`` calls in
+        the package's own ``__init__.py``. Applying the package's prefix to
+        each submodule produced ``/api/costs/…`` instead of ``/api/llc/costs/…``:
+        182 endpoints of which 4 were real. Inventing endpoints is worse than
+        missing them, since they resurface as phantom "orphaned" findings.
+        Packages need the include_router walk and are left to that follow-up.
+        """
+        files: Dict[Path, str] = {}
+        for module_path, prefix in self._module_prefix_map.items():
+            # Registry entries are dotted module paths; the map also holds bare
+            # module names and "api/x.py"-style keys, which are not those.
+            if "." not in module_path or "/" in module_path or module_path.endswith(".py"):
+                continue
+            if module_path.startswith("api."):
+                continue  # already covered by the api/ walk
+
+            module_file = self.backend_dir.joinpath(*module_path.split(".")).with_suffix(".py")
+            if module_file.is_file():
+                files[module_file] = prefix
+        return files
+
     def _get_module_prefix(self, file_path: Path) -> str:
         """Get the API prefix for a given file based on router registry."""
-        relative_path = str(file_path.relative_to(self.project_root))
+        # #12945: registry-mounted files outside api/ carry their prefix
+        # explicitly -- neither the relative-path nor the stem lookup below can
+        # find them (the stem of services/advanced_workflow/routes.py is
+        # "routes", which matches nothing).
+        override = self._external_router_prefixes.get(file_path)
+        if override is not None:
+            return override
+
+        try:
+            relative_path = str(file_path.relative_to(self.project_root))
+        except ValueError:
+            return self.API_PREFIX
 
         # Try direct file path match
         if relative_path in self._module_prefix_map:

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -166,14 +166,10 @@ class TestRegistryRoutersOutsideApi:
         return scanner
 
     def test_module_outside_api_is_scanned_with_its_registered_prefix(self, tmp_path):
-        backend = self._backend_with_registry(
-            tmp_path, [("services.advanced_workflow.routes", "/advanced-workflow")]
-        )
+        backend = self._backend_with_registry(tmp_path, [("services.advanced_workflow.routes", "/advanced-workflow")])
         target = backend / "services" / "advanced_workflow"
         target.mkdir(parents=True)
-        (target / "routes.py").write_text(
-            '@router.get("/templates")\nasync def templates(): ...\n', encoding="utf-8"
-        )
+        (target / "routes.py").write_text('@router.get("/templates")\nasync def templates(): ...\n', encoding="utf-8")
 
         scanner = self._scanner_for(tmp_path, None)
         found = scanner._registry_router_files()
@@ -182,14 +178,10 @@ class TestRegistryRoutersOutsideApi:
 
     def test_registered_prefix_reaches_the_scanned_endpoint_path(self, tmp_path):
         """The stem of routes.py matches nothing, so the prefix must be carried."""
-        backend = self._backend_with_registry(
-            tmp_path, [("services.advanced_workflow.routes", "/advanced-workflow")]
-        )
+        backend = self._backend_with_registry(tmp_path, [("services.advanced_workflow.routes", "/advanced-workflow")])
         target = backend / "services" / "advanced_workflow"
         target.mkdir(parents=True)
-        (target / "routes.py").write_text(
-            '@router.get("/templates")\nasync def templates(): ...\n', encoding="utf-8"
-        )
+        (target / "routes.py").write_text('@router.get("/templates")\nasync def templates(): ...\n', encoding="utf-8")
 
         scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
         paths = [e.path for e in scanner.scan_all_endpoints()]

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -138,3 +138,93 @@ class TestBackendDirResolution:
             "integration_routers.py",
             "brand_new_routers.py",
         }
+
+
+class TestRegistryRoutersOutsideApi:
+    """Issue #12945: registries mount routers from packages other than api/.
+
+    Those routes were never scanned, so every frontend call to one was reported
+    as targeting a missing endpoint.
+    """
+
+    @staticmethod
+    def _backend_with_registry(root, entries):
+        """Build a backend whose registry mounts *entries* (module -> prefix)."""
+        backend = root / "autobot-backend"
+        (backend / "api").mkdir(parents=True)
+        registry = backend / "initialization" / "router_registry"
+        registry.mkdir(parents=True)
+        lines = [f'    ("{mod}", "{prefix}", ["t"], "{mod.split(".")[-1]}"),' for mod, prefix in entries]
+        (registry / "feature_routers.py").write_text(
+            "ROUTER_CONFIGS = [\n" + "\n".join(lines) + "\n]\n", encoding="utf-8"
+        )
+        return backend
+
+    def _scanner_for(self, root, entries):
+        scanner = scanner_mod.BackendEndpointScanner(project_root=root)
+        scanner._collect_router_prefixes()
+        return scanner
+
+    def test_module_outside_api_is_scanned_with_its_registered_prefix(self, tmp_path):
+        backend = self._backend_with_registry(
+            tmp_path, [("services.advanced_workflow.routes", "/advanced-workflow")]
+        )
+        target = backend / "services" / "advanced_workflow"
+        target.mkdir(parents=True)
+        (target / "routes.py").write_text(
+            '@router.get("/templates")\nasync def templates(): ...\n', encoding="utf-8"
+        )
+
+        scanner = self._scanner_for(tmp_path, None)
+        found = scanner._registry_router_files()
+
+        assert found == {target / "routes.py": "/api/advanced-workflow"}
+
+    def test_registered_prefix_reaches_the_scanned_endpoint_path(self, tmp_path):
+        """The stem of routes.py matches nothing, so the prefix must be carried."""
+        backend = self._backend_with_registry(
+            tmp_path, [("services.advanced_workflow.routes", "/advanced-workflow")]
+        )
+        target = backend / "services" / "advanced_workflow"
+        target.mkdir(parents=True)
+        (target / "routes.py").write_text(
+            '@router.get("/templates")\nasync def templates(): ...\n', encoding="utf-8"
+        )
+
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        paths = [e.path for e in scanner.scan_all_endpoints()]
+
+        assert "/api/advanced-workflow/templates" in paths
+
+    def test_api_modules_are_not_duplicated_by_the_external_walk(self, tmp_path):
+        """api.* entries are already covered by the api/ walk."""
+        self._backend_with_registry(tmp_path, [("api.chat", "/chat")])
+
+        scanner = self._scanner_for(tmp_path, None)
+
+        assert scanner._registry_router_files() == {}
+
+    def test_package_entries_are_skipped(self, tmp_path):
+        """#12945: a package's prefix does not apply to the modules inside it.
+
+        LLC registers as ``("llc.api", "", …)`` and its real ``/api/llc/*``
+        paths come from include_router calls in the package's own __init__.py.
+        Applying the empty package prefix per-submodule invented 182 endpoints
+        of which 4 were real -- worse than missing them.
+        """
+        backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
+        pkg = backend / "llc" / "api"
+        pkg.mkdir(parents=True)
+        (pkg / "costs.py").write_text('@router.get("/by-agent")\ndef c(): ...\n', encoding="utf-8")
+
+        scanner = self._scanner_for(tmp_path, None)
+
+        assert scanner._registry_router_files() == {}
+
+    def test_missing_module_file_is_ignored(self, tmp_path):
+        """A registry entry whose module is absent must not break the scan."""
+        self._backend_with_registry(tmp_path, [("services.gone.routes", "/gone")])
+
+        scanner = self._scanner_for(tmp_path, None)
+
+        assert scanner._registry_router_files() == {}


### PR DESCRIPTION
Closes #12946. Refs #12945, which stays open for the package case.

## Thinking Path

#12945 measured that 419 of 439 unique "missing endpoint" findings (95.4%) are routes that genuinely exist, and that all 419 are scan gaps rather than matcher bugs. The cause is that `scan_all_endpoints()` walks `backend_dir / "api"` only, while the registries mount seven router modules from sibling packages.

Feeding those files into the existing loop is not enough on its own. `_get_module_prefix()` resolves a file by its path relative to `project_root` and then by `py_file.stem` — and the stem of `services/advanced_workflow/routes.py` is `routes`, which matches nothing. The routes would have been discovered under `/api` instead of `/api/advanced-workflow`, i.e. still wrong, just wrong in a new way. The registry prefix is therefore carried to the resolved file explicitly.

**The package case turned out to be actively harmful, and that shaped the scope.** My first cut expanded a registry entry naming a package by walking its `*.py` files and applying the package's prefix to each. Measured against the live instance, that made things worse:

```
                        files-and-packages   files-only
scanned NOT in openapi          209              70
```

LLC registers as `("llc.api", "", ["llc"], "llc")` — an **empty** prefix — because its real `/api/llc/*` paths come from `include_router` calls inside the package's own `__init__.py`. Applying that per-submodule produced `/api/costs/by-agent-model` instead of `/api/llc/costs/by-agent-model`: 182 endpoints of which 4 were real. Inventing 178 endpoints is worse than missing them, since they come back as phantom "orphaned" findings — the same class of noise this whole thread is trying to remove. So this change is limited to module files, where the registry prefix is unambiguous, and packages are left to #12945 with the include_router walk they need.

## What Changed

`api/codebase_analytics/api_endpoint_scanner.py`:
- `_registry_router_files()` resolves registry module paths (dotted, non-`api.`) against the backend directory and returns `{file: prefix}` for those that resolve to a module file.
- `_external_router_prefixes` is consulted first in `_get_module_prefix()`, so the registered prefix reaches the endpoint path.
- `scan_all_endpoints()` scans those files alongside `api/**`, and logs how many lie outside `api/`.
- `_get_module_prefix()` no longer raises on a file outside `project_root` — `relative_to` was unguarded, and `_scan_file` swallows exceptions, so such a file would have silently contributed zero endpoints.

`api_endpoint_scanner_test.py`: 5 tests — external module resolved with its prefix, the prefix reaching the scanned path end-to-end, `api.*` entries not duplicated, package entries skipped (with the LLC numbers as the rationale), and a missing module file not breaking the scan.

## Verification

```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -q
16 passed          (11 pre-existing + 5 new)

$ python3 -m pytest api/codebase_analytics/ -q
230 passed, 11 skipped in 4.35s        (was 225 passed / 11 skipped)

$ python3 -m flake8 …/api_endpoint_scanner.py …/api_endpoint_scanner_test.py
(clean)
```

Measured on the live install's indexed source `c5939a51-…`, read-only, against the authoritative `app.openapi()` table (2159 unique normalized paths):

| | before | after |
|---|---|---|
| router files scanned outside `api/` | 0 | 6 |
| endpoints found | 1986 | 2041 |
| real routes matched | 1736 (80.4%) | 1789 (82.9%) |
| real routes missed | 423 | 370 |
| **scanned but not real** | **70** | **70** |
| missing findings | 488 | 435 |
| coverage | 86.5% | 86.7% |

53 real routes recovered with **no new spurious endpoints** — the scanned-but-not-real count is unchanged, which is the guard against the failure mode described above.

## What remains (#12945)

The false-positive share moves only 95.4% → 94.8%, because the bulk of the remaining 366 sits behind the package case — LLC alone is ~182 routes. Closing that needs the `include_router` walk to resolve per-submodule prefixes, which is a distinct piece of work and is why this PR does not claim #12945.

## Model Used

claude-opus-5
