### PR TITLE
fix(auth): route hand-rolled admin-role checks through is_admin_role() and gate the class (#12948)

### DIFF
--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -30,6 +30,7 @@ from api.schemas_system import (
     AuditStatisticsResponse,
 )
 from auth_middleware import get_auth_middleware
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.models.pagination import PaginationParams
@@ -40,7 +41,6 @@ from utils.catalog_http_exceptions import (
     raise_server_error,
     raise_validation_error,
 )
-from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter(prefix="/audit", tags=["audit"])
 logger = get_logger(__name__)

--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -40,7 +40,7 @@ from utils.catalog_http_exceptions import (
     raise_server_error,
     raise_validation_error,
 )
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter(prefix="/audit", tags=["audit"])
 logger = get_logger(__name__)

--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -40,6 +40,7 @@ from utils.catalog_http_exceptions import (
     raise_server_error,
     raise_validation_error,
 )
+from auth_rbac import is_admin_role
 
 router = APIRouter(prefix="/audit", tags=["audit"])
 logger = get_logger(__name__)
@@ -59,7 +60,7 @@ def check_admin_permission(request: Request) -> bool:
         user_role = user_data.get("role")
         if not user_role:
             raise_auth_error("AUTH_0002", "User role not assigned - access denied")
-        if user_role != "admin":
+        if not is_admin_role(user_role):
             raise_auth_error("AUTH_0003", "Admin permission required for audit log access")
 
         return True

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -45,7 +45,7 @@ from services.audit.audit import EventType  # GH#8290 Phase 2
 from services.audit.audit import emit as _emit_event  # GH#8290 Phase 2
 from user_management.database import db_session_context
 from user_management.services.user_service import UserService
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter()
 logger = get_logger(__name__)

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -36,7 +36,7 @@ from api.schemas_common import DataResponse
 from api.schemas_system import AuthLogoutData, AuthRefreshData
 from auth_middleware import check_admin_permission, get_auth_middleware, get_current_user
 from autobot_shared.auth.jwt_core import JWTDecodeError, _peek_alg, decode_jwt_no_verify_exp
-from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.password_weakness import check_password_weakness
@@ -45,7 +45,6 @@ from services.audit.audit import EventType  # GH#8290 Phase 2
 from services.audit.audit import emit as _emit_event  # GH#8290 Phase 2
 from user_management.database import db_session_context
 from user_management.services.user_service import UserService
-from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter()
 logger = get_logger(__name__)

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -45,6 +45,7 @@ from services.audit.audit import EventType  # GH#8290 Phase 2
 from services.audit.audit import emit as _emit_event  # GH#8290 Phase 2
 from user_management.database import db_session_context
 from user_management.services.user_service import UserService
+from auth_rbac import is_admin_role
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -283,7 +284,7 @@ async def revoke_rs256_token(
     _token_uid = _token_claims.get("user_id")
     _caller_sub = current_user.get("sub") or current_user.get("username")
     _caller_uid = current_user.get("user_id")
-    _is_admin = bool(current_user.get("admin")) or current_user.get("role") == "admin"
+    _is_admin = bool(current_user.get("admin")) or is_admin_role(current_user.get("role"))
     _owns = (_token_sub and _token_sub == _caller_sub) or (_token_uid and _token_uid == _caller_uid)
     if not _owns and not _is_admin:
         raise HTTPException(status_code=403, detail="Can only revoke your own tokens")

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -42,11 +42,11 @@ from api.schemas_knowledge import (
     MCPToolCallRequest,
 )
 from auth_middleware import check_admin_permission, get_auth_middleware
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_input, raise_not_found
-from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -46,7 +46,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_input, raise_not_found
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],

--- a/autobot-backend/api/conversation_files.py
+++ b/autobot-backend/api/conversation_files.py
@@ -46,6 +46,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_internal_error, raise_invalid_input, raise_not_found
+from auth_rbac import is_admin_role
 
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],
@@ -182,7 +183,7 @@ def _check_admin_access(user_data: Dict, session_id: str) -> bool:
         bool: True if admin access granted, False otherwise
     """
     user_role = user_data.get("role")
-    if user_role == "admin":
+    if is_admin_role(user_role):
         logger.debug("Admin user %s accessing session %s", user_data.get("username"), session_id)
         return True
     return False

--- a/autobot-backend/api/feature_flags.py
+++ b/autobot-backend/api/feature_flags.py
@@ -42,7 +42,7 @@ from .schemas_system import (
     FeatureFlagEnforcementModeResponse,
     FeatureFlagStatusResponse,
 )
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/api/feature_flags.py
+++ b/autobot-backend/api/feature_flags.py
@@ -42,6 +42,7 @@ from .schemas_system import (
     FeatureFlagEnforcementModeResponse,
     FeatureFlagStatusResponse,
 )
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 
@@ -69,7 +70,7 @@ async def require_admin(
     """
     # Check if user has admin role
     user_role = current_user.get("role", "").lower()
-    if user_role != "admin":
+    if not is_admin_role(user_role):
         logger.warning(
             f"Non-admin user '{current_user.get('username', 'unknown')}' "
             f"attempted to access feature flags (role: {user_role})"

--- a/autobot-backend/api/feature_flags.py
+++ b/autobot-backend/api/feature_flags.py
@@ -23,6 +23,7 @@ from typing import Dict
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from auth_middleware import get_current_user
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.access_control_metrics import AccessControlMetrics, get_metrics_service
@@ -42,7 +43,6 @@ from .schemas_system import (
     FeatureFlagEnforcementModeResponse,
     FeatureFlagStatusResponse,
 )
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -47,7 +47,7 @@ from models.heartbeat import (
     WakeupTrigger,
 )
 from services.heartbeat_scheduler import HeartbeatScheduler, _get_or_create_state
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -35,6 +35,7 @@ from api.schemas_system import (
 )
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
@@ -47,7 +48,6 @@ from models.heartbeat import (
     WakeupTrigger,
 )
 from services.heartbeat_scheduler import HeartbeatScheduler, _get_or_create_state
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/heartbeat.py
+++ b/autobot-backend/api/heartbeat.py
@@ -47,6 +47,7 @@ from models.heartbeat import (
     WakeupTrigger,
 )
 from services.heartbeat_scheduler import HeartbeatScheduler, _get_or_create_state
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 router = APIRouter()
@@ -349,7 +350,7 @@ async def resume_agent(
     if paused_by.startswith("system:"):
         username = _user.get("username", "") if isinstance(_user, dict) else getattr(_user, "username", "")
         user_role = _user.get("role", "") if isinstance(_user, dict) else getattr(_user, "role", "")
-        if user_role != "admin":
+        if not is_admin_role(user_role):
             approval_id = await _request_skill_approval_for_resume(agent_id, paused_by, username)
             return JSONResponse(
                 status_code=202,

--- a/autobot-backend/api/redis_service.py
+++ b/autobot-backend/api/redis_service.py
@@ -38,6 +38,7 @@ _service_manager_started: bool = False
 
 # Thread-safe lock for singleton
 import asyncio as _asyncio_lock
+from auth_rbac import is_admin_role
 
 _service_manager_lock = _asyncio_lock.Lock()
 
@@ -85,7 +86,7 @@ def check_admin_permission(request: Request) -> str:
         raise HTTPException(status_code=401, detail="Authentication required")
 
     # Check if user has admin role
-    if user_data.get("role") != "admin":
+    if not is_admin_role(user_data.get("role")):
         raise HTTPException(status_code=403, detail="Admin role required for this operation")
 
     return user_data.get("username", "unknown")

--- a/autobot-backend/api/redis_service.py
+++ b/autobot-backend/api/redis_service.py
@@ -38,7 +38,7 @@ _service_manager_started: bool = False
 
 # Thread-safe lock for singleton
 import asyncio as _asyncio_lock
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 _service_manager_lock = _asyncio_lock.Lock()
 

--- a/autobot-backend/api/redis_service.py
+++ b/autobot-backend/api/redis_service.py
@@ -38,6 +38,7 @@ _service_manager_started: bool = False
 
 # Thread-safe lock for singleton
 import asyncio as _asyncio_lock
+
 from autobot_shared.auth.permissions import is_admin_role
 
 _service_manager_lock = _asyncio_lock.Lock()

--- a/autobot-backend/api/service_messages.py
+++ b/autobot-backend/api/service_messages.py
@@ -26,6 +26,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.message_bus import get_message_bus
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 
@@ -54,7 +55,7 @@ def _check_admin(request: Request) -> bool:
         user_role = user_data.get("role")
         if not user_role:
             raise_auth_error("AUTH_0002", "User role not assigned - access denied")
-        if user_role != "admin":
+        if not is_admin_role(user_role):
             raise_auth_error(
                 "AUTH_0003",
                 "Admin permission required for service message access",

--- a/autobot-backend/api/service_messages.py
+++ b/autobot-backend/api/service_messages.py
@@ -26,7 +26,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.message_bus import get_message_bus
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/api/service_messages.py
+++ b/autobot-backend/api/service_messages.py
@@ -22,11 +22,11 @@ from api.schemas_system import (
     SingleMessageResponse,
 )
 from auth_middleware import get_auth_middleware
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.message_bus import get_message_bus
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/api/user_management/dependencies.py
+++ b/autobot-backend/api/user_management/dependencies.py
@@ -16,6 +16,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth_middleware import get_auth_middleware
+from autobot_shared.auth.permissions import is_admin_role
 from user_management.database import get_async_session
 from user_management.services import (
     OrganizationService,
@@ -23,7 +24,6 @@ from user_management.services import (
     TenantContext,
     UserService,
 )
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/user_management/dependencies.py
+++ b/autobot-backend/api/user_management/dependencies.py
@@ -23,7 +23,7 @@ from user_management.services import (
     TenantContext,
     UserService,
 )
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/user_management/dependencies.py
+++ b/autobot-backend/api/user_management/dependencies.py
@@ -23,6 +23,7 @@ from user_management.services import (
     TenantContext,
     UserService,
 )
+from auth_rbac import is_admin_role
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +188,7 @@ async def get_tenant_context(
 
     # Determine platform-admin status
     is_platform_admin = bool(current_user.get("is_platform_admin", False))
-    if current_user.get("role") == "admin":
+    if is_admin_role(current_user.get("role")):
         is_platform_admin = True
 
     # --- org_id resolution ---

--- a/autobot-backend/api/user_management/users.py
+++ b/autobot-backend/api/user_management/users.py
@@ -28,6 +28,7 @@ from api.user_management.dependencies import (
     require_platform_admin,
     require_user_management_enabled,
 )
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.models.pagination import PaginationParams
 from user_management.middleware.rate_limit import (
@@ -47,7 +48,6 @@ from user_management.services.user_service import (
     InvalidCredentialsError,
     UserNotFoundError,
 )
-from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter(prefix="/users", tags=["Users"])
 logger = get_logger(__name__)

--- a/autobot-backend/api/user_management/users.py
+++ b/autobot-backend/api/user_management/users.py
@@ -47,7 +47,7 @@ from user_management.services.user_service import (
     InvalidCredentialsError,
     UserNotFoundError,
 )
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 router = APIRouter(prefix="/users", tags=["Users"])
 logger = get_logger(__name__)

--- a/autobot-backend/api/user_management/users.py
+++ b/autobot-backend/api/user_management/users.py
@@ -47,6 +47,7 @@ from user_management.services.user_service import (
     InvalidCredentialsError,
     UserNotFoundError,
 )
+from auth_rbac import is_admin_role
 
 router = APIRouter(prefix="/users", tags=["Users"])
 logger = get_logger(__name__)
@@ -217,7 +218,7 @@ async def get_current_user_profile(
         is_active=True,
         is_verified=True,
         mfa_enabled=False,
-        is_platform_admin=current_user.get("role") == "admin" or current_user.get("is_platform_admin", False),
+        is_platform_admin=is_admin_role(current_user.get("role")) or current_user.get("is_platform_admin", False),
         preferences={},
         roles=[],
         created_at=None,

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -26,7 +26,7 @@ from api.schemas_code import (
     VoiceTranscribeResponse,
 )
 from auth_middleware import check_admin_permission, get_current_user
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.personality_service import resolve_voice_id

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -17,7 +17,8 @@ from pydantic import BaseModel
 
 from api.voice_bundle_constants import VALID_BUNDLES, BundleAssignRequest
 from auth_middleware import get_current_user
-from auth_rbac import is_admin_role, require_role
+from auth_rbac import require_role
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
 from services.event_log import EventType, emit
 

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -22,7 +22,8 @@ from api.voice_bundle_constants import (
 )
 from api.voice_bundle_helpers import _count_tools_for_bundle
 from auth_middleware import get_current_user
-from auth_rbac import is_admin_role, require_role
+from auth_rbac import require_role
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.audit.audit import AuditCategory, AuditEvent, emit

--- a/autobot-backend/api/ws_security.py
+++ b/autobot-backend/api/ws_security.py
@@ -20,7 +20,7 @@ import logging
 import os
 
 from fastapi import WebSocket
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/ws_security.py
+++ b/autobot-backend/api/ws_security.py
@@ -20,6 +20,7 @@ import logging
 import os
 
 from fastapi import WebSocket
+from auth_rbac import is_admin_role
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +97,7 @@ def authenticate_ws_admin(websocket: WebSocket) -> bool:
         user = get_auth_middleware().get_user_from_request(websocket)  # type: ignore[arg-type]
         if not user:
             return False
-        return user.get("role") == "admin"
+        return is_admin_role(user.get("role"))
     except Exception:
         logger.warning("WS admin auth error — denying", exc_info=True)
         return False

--- a/autobot-backend/api/ws_security.py
+++ b/autobot-backend/api/ws_security.py
@@ -20,6 +20,7 @@ import logging
 import os
 
 from fastapi import WebSocket
+
 from autobot_shared.auth.permissions import is_admin_role
 
 logger = logging.getLogger(__name__)

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -30,6 +30,7 @@ from autobot_shared.time_utils import parse_utc_iso
 from config.manager import get_config_manager
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_auth_error
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 
@@ -966,7 +967,7 @@ def check_admin_permission(request: Request) -> bool:
     user_role = user_data.get("role")
     if not user_role:
         raise_auth_error("AUTH_0002", "User role not assigned - access denied")
-    if user_role != "admin":
+    if not is_admin_role(user_role):
         raise_auth_error("AUTH_0003", "Admin permission required for this operation")
 
     return True

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -23,6 +23,7 @@ from autobot_shared.auth.jwt_core import (
     hash_password,
     verify_password,
 )
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
@@ -30,7 +31,6 @@ from autobot_shared.time_utils import parse_utc_iso
 from config.manager import get_config_manager
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_auth_error
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -30,7 +30,7 @@ from autobot_shared.time_utils import parse_utc_iso
 from config.manager import get_config_manager
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_auth_error
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/auth_rbac.py
+++ b/autobot-backend/auth_rbac.py
@@ -39,9 +39,11 @@ from fastapi import Request
 
 from auth_middleware import get_auth_middleware
 from autobot_shared.auth.permissions import (  # noqa: F401 — re-exported for callers
+    ADMIN_ROLES,
     ROLE_PERMISSIONS,
     Permission,
     Role,
+    is_admin_role,
 )
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
@@ -52,32 +54,12 @@ logger = get_logger(__name__)
 
 _get_security_layer = lazy_singleton(SecurityLayer)
 
-# #12717: the roles that count as administrative.
-#
-# "superadmin" is passed as a raw string to require_role() at 17 call sites but
-# is NOT a member of the canonical Role enum (autobot_shared.auth.permissions),
-# which only defines admin/operator/analyst/editor/user/readonly. require_role
-# tolerates that because it accepts ``Role | str``. The consequence is that any
-# hand-rolled ``role == "admin"`` check silently locks superadmins out of read
-# paths whose write paths already allow them (#12704, #12717).
-#
-# This set is the single place that answers "is this role administrative?" for
-# such checks. Adding superadmin to the shared Role enum would be the deeper
-# fix, but that enum drives ROLE_PERMISSIONS for BOTH backends — tracked
-# separately rather than changed as a drive-by.
-ADMIN_ROLES: frozenset[str] = frozenset({"admin", "superadmin"})
-
-
-def is_admin_role(role: str | None) -> bool:
-    """Return True when *role* is administrative (admin or superadmin).
-
-    Use this instead of ``role == "admin"`` for imperative checks that cannot
-    use the require_role() dependency — e.g. helpers that must also permit
-    self-access, or that pass an ``is_admin`` flag further down.
-
-    Case-insensitive, matching require_role(), which lowercases both sides.
-    """
-    return str(role or "").lower() in ADMIN_ROLES
+# #12717/#12786: ADMIN_ROLES and is_admin_role() now live in
+# autobot_shared.auth.permissions, beside the Role enum whose gap they cover.
+# They moved because auth_middleware needs the same answer, and importing them
+# from here would close a cycle -- this module already imports auth_middleware.
+# Both are re-exported above so existing ``from auth_rbac import is_admin_role``
+# callers keep working.
 
 
 def _get_user_permissions(user_role: str) -> List[str]:

--- a/autobot-backend/auth_rbac_admin_guard_test.py
+++ b/autobot-backend/auth_rbac_admin_guard_test.py
@@ -58,9 +58,7 @@ def _is_role_operand(node: ast.expr) -> bool:
         key = node.slice
         return isinstance(key, ast.Constant) and str(key.value).lower() == "role"
     if isinstance(node, ast.Call):  # e.g. user_data.get("role")
-        return any(
-            isinstance(a, ast.Constant) and str(a.value).lower() == "role" for a in node.args
-        )
+        return any(isinstance(a, ast.Constant) and str(a.value).lower() == "role" for a in node.args)
     return False
 
 
@@ -134,8 +132,8 @@ class TestGuardDetection:
     @pytest.mark.parametrize(
         "source",
         [
-            'if is_admin_role(role): pass',
-            'if role in ADMIN_ROLES: pass',
+            "if is_admin_role(role): pass",
+            "if role in ADMIN_ROLES: pass",
             'if name == "admin": pass',  # not a role
             'if role == "operator": pass',  # not an admin literal
             '"""A docstring mentioning role == \'admin\' must not match."""',

--- a/autobot-backend/auth_rbac_admin_guard_test.py
+++ b/autobot-backend/auth_rbac_admin_guard_test.py
@@ -1,0 +1,145 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Guard against hand-rolled admin-role string comparisons (#12786).
+
+``require_role(*roles: Role | str)`` accepts raw strings, so 17 call sites pass
+``require_role("admin", "superadmin")`` even though ``superadmin`` is not a
+member of the shared ``Role`` enum. That splits authorization into two
+populations that silently disagree: every ``require_role`` guard admits a
+superadmin, while every hand-rolled ``role == "admin"`` check rejects one.
+
+Where a router has both, a superadmin can perform the write but not the read.
+That has already produced #12704 (six forked ``_require_admin`` dependencies)
+and #12717 (a superadmin silently *downgraded* rather than denied).
+
+``is_admin_role()`` is the single answer for imperative checks. This test stops
+the class from returning: a new ``role == "admin"`` comparison fails here rather
+than becoming the next incident.
+
+Adding ``superadmin``/``platform_admin`` to the shared ``Role`` enum is the
+deeper fix and is still open on #12786 — that enum drives ``ROLE_PERMISSIONS``
+for both backends, so it needs a cross-backend review rather than a drive-by.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+BACKEND_ROOT = pathlib.Path(__file__).parent
+
+#: Comparing a role against any of these by hand is the bug this guards.
+ADMIN_ROLE_LITERALS = {"admin", "superadmin", "platform_admin"}
+
+#: ``auth_rbac`` is where the canonical set is *defined*, so it is exempt.
+EXEMPT_FILES = {"auth_rbac.py"}
+
+SKIP_DIR_PARTS = {
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "archive",
+    "migrations",
+}
+
+
+def _is_role_operand(node: ast.expr) -> bool:
+    """Whether *node* reads something called ``role``.
+
+    Covers ``role``/``user_role`` locals, ``obj.role`` attributes, and
+    ``user_data["role"]`` subscripts — the shapes these checks actually take.
+    """
+    if isinstance(node, ast.Name):
+        return "role" in node.id.lower()
+    if isinstance(node, ast.Attribute):
+        return "role" in node.attr.lower()
+    if isinstance(node, ast.Subscript):
+        key = node.slice
+        return isinstance(key, ast.Constant) and str(key.value).lower() == "role"
+    if isinstance(node, ast.Call):  # e.g. user_data.get("role")
+        return any(
+            isinstance(a, ast.Constant) and str(a.value).lower() == "role" for a in node.args
+        )
+    return False
+
+
+def _is_admin_literal(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and str(node.value).lower() in ADMIN_ROLE_LITERALS
+
+
+def _offenders_in(tree: ast.AST) -> list[int]:
+    """Line numbers of ``<role> == "admin"``-shaped comparisons."""
+    lines = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not any(isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops):
+            continue
+        operands = [node.left, *node.comparators]
+        has_role = any(_is_role_operand(o) for o in operands)
+        has_admin = any(_is_admin_literal(o) for o in operands)
+        if has_role and has_admin:
+            lines.append(node.lineno)
+    return lines
+
+
+def _python_files():
+    for path in BACKEND_ROOT.rglob("*.py"):
+        if SKIP_DIR_PARTS & set(path.parts):
+            continue
+        if path.name.endswith("_test.py") or path.name.startswith("test_"):
+            continue
+        if path.name in EXEMPT_FILES:
+            continue
+        yield path
+
+
+def test_no_hand_rolled_admin_role_comparisons():
+    """Use ``is_admin_role()`` instead — it admits superadmin, as guards do."""
+    offenders = []
+    for path in _python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for line in _offenders_in(tree):
+            offenders.append(f"{path.relative_to(BACKEND_ROOT)}:{line}")
+
+    assert not offenders, (
+        "Hand-rolled admin-role comparison(s) found — a superadmin is admitted by "
+        "require_role() but would be rejected here (#12704, #12717, #12786).\n"
+        "Use `from auth_rbac import is_admin_role` and `is_admin_role(role)`:\n  "
+        + "\n  ".join(sorted(offenders))
+    )
+
+
+class TestGuardDetection:
+    """The guard must actually catch the shapes it claims to."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            'if role == "admin": pass',
+            'if user_role == "superadmin": pass',
+            'if user.role != "admin": pass',
+            'if user_data["role"] == "admin": pass',
+            'if user_data.get("role") == "platform_admin": pass',
+            'if "admin" == role: pass',
+        ],
+    )
+    def test_detects_offending_shapes(self, source):
+        assert _offenders_in(ast.parse(source)) == [1]
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            'if is_admin_role(role): pass',
+            'if role in ADMIN_ROLES: pass',
+            'if name == "admin": pass',  # not a role
+            'if role == "operator": pass',  # not an admin literal
+            '"""A docstring mentioning role == \'admin\' must not match."""',
+        ],
+    )
+    def test_ignores_acceptable_shapes(self, source):
+        assert _offenders_in(ast.parse(source)) == []

--- a/autobot-backend/auth_rbac_admin_guard_test.py
+++ b/autobot-backend/auth_rbac_admin_guard_test.py
@@ -109,7 +109,7 @@ def test_no_hand_rolled_admin_role_comparisons():
     assert not offenders, (
         "Hand-rolled admin-role comparison(s) found — a superadmin is admitted by "
         "require_role() but would be rejected here (#12704, #12717, #12786).\n"
-        "Use `from auth_rbac import is_admin_role` and `is_admin_role(role)`:\n  "
+        "Use `from autobot_shared.auth.permissions import is_admin_role` and `is_admin_role(role)`:\n  "
         + "\n  ".join(sorted(offenders))
     )
 

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -65,7 +65,7 @@ from llc.services.portability import PortabilityService
 from user_management.database import get_async_session
 from user_management.models.organization import Organization
 from user_management.services import TenantContext
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -65,6 +65,7 @@ from llc.services.portability import PortabilityService
 from user_management.database import get_async_session
 from user_management.models.organization import Organization
 from user_management.services import TenantContext
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 
@@ -142,7 +143,7 @@ def _is_platform_admin(current_user: dict) -> bool:
     and derive admin status from the JWT the same way the tenant-context
     dependency does: an explicit ``is_platform_admin`` flag or ``role == "admin"``.
     """
-    return bool(current_user.get("is_platform_admin")) or current_user.get("role") == "admin"
+    return bool(current_user.get("is_platform_admin")) or is_admin_role(current_user.get("role"))
 
 
 def _current_user_id(current_user: dict) -> str:

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import _parse_uuid_safe, get_current_user, require_org_context
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
 from llc.deps import assert_company_access, get_session, service_dep
 from llc.kb.collections import KbCollectionManager
@@ -65,7 +66,6 @@ from llc.services.portability import PortabilityService
 from user_management.database import get_async_session
 from user_management.models.organization import Organization
 from user_management.services import TenantContext
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/security/auth_rbac_test.py
+++ b/autobot-backend/security/auth_rbac_test.py
@@ -282,19 +282,19 @@ class TestIsAdminRole:
     """
 
     def test_accepts_both_administrative_roles(self):
-        from auth_rbac import is_admin_role
+        from autobot_shared.auth.permissions import is_admin_role
 
         assert is_admin_role("admin") is True
         assert is_admin_role("superadmin") is True
 
     def test_rejects_every_non_administrative_role(self):
-        from auth_rbac import is_admin_role
+        from autobot_shared.auth.permissions import is_admin_role
 
         for role in ("user", "readonly", "operator", "analyst", "editor"):
             assert is_admin_role(role) is False, role
 
     def test_handles_missing_role_without_raising(self):
-        from auth_rbac import is_admin_role
+        from autobot_shared.auth.permissions import is_admin_role
 
         assert is_admin_role(None) is False
         assert is_admin_role("") is False
@@ -302,7 +302,7 @@ class TestIsAdminRole:
     def test_is_case_insensitive_to_match_require_role(self):
         """require_role lowercases both the user role and the allowed set, so a
         mixed-case token must not pass one gate and fail the other."""
-        from auth_rbac import is_admin_role
+        from autobot_shared.auth.permissions import is_admin_role
 
         assert is_admin_role("SuperAdmin") is True
         assert is_admin_role("ADMIN") is True

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -23,7 +23,7 @@ import yaml
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -20,10 +20,10 @@ from uuid import uuid4
 
 import yaml
 
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 
@@ -772,11 +772,7 @@ class SecurityPolicyManager:
 
         for rule in policy.rules:
             if rule["name"] == "admin_access_approval":
-                if (
-                    rule["value"]
-                    and is_admin_role(user_role)
-                    and not context.get("manager_approved", False)
-                ):
+                if rule["value"] and is_admin_role(user_role) and not context.get("manager_approved", False):
                     result["compliant"] = False
                     result["violation_type"] = "admin_access_not_approved"
                     result["severity"] = "high"

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -23,6 +23,7 @@ import yaml
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 
@@ -771,7 +772,11 @@ class SecurityPolicyManager:
 
         for rule in policy.rules:
             if rule["name"] == "admin_access_approval":
-                if rule["value"] and user_role == "admin" and not context.get("manager_approved", False):
+                if (
+                    rule["value"]
+                    and is_admin_role(user_role)
+                    and not context.get("manager_approved", False)
+                ):
                     result["compliant"] = False
                     result["violation_type"] = "admin_access_not_approved"
                     result["severity"] = "high"

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -30,7 +30,7 @@ import aiohttp
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -30,6 +30,7 @@ import aiohttp
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 
@@ -154,7 +155,7 @@ class MCPDispatcher:
 
         await self._ensure_cache_fresh()
 
-        if role != "admin" and self._is_admin_only(tool_name):
+        if not is_admin_role(role) and self._is_admin_only(tool_name):
             logger.warning(
                 "MCPDispatcher: role=%s denied access to admin-only tool %s",
                 role,
@@ -284,7 +285,7 @@ class MCPDispatcher:
                 "parameters": tool.get("input_schema", {}),
             }
             for tool in self._tool_cache.values()
-            if role == "admin" or not self._is_admin_only(tool["name"])
+            if is_admin_role(role) or not self._is_admin_only(tool["name"])
         ]
 
 

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -27,10 +27,10 @@ import time
 
 import aiohttp
 
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/services/task_owner.py
+++ b/autobot-backend/services/task_owner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 
 from autobot_shared.redis_client import redis_delete, redis_get, redis_set
+from auth_rbac import is_admin_role
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,7 @@ async def verify_task_owner(task_id: str, user_id: str, user_role: str = "") -> 
     Admin bypass: operators must be able to inspect/unblock stuck tasks.
     Registers ownership on first call (first caller becomes owner).
     """
-    if user_role == "admin":
+    if is_admin_role(user_role):
         return True
     try:
         client_key = _key(task_id)

--- a/autobot-backend/services/task_owner.py
+++ b/autobot-backend/services/task_owner.py
@@ -29,8 +29,8 @@ from __future__ import annotations
 
 import logging
 
-from autobot_shared.redis_client import redis_delete, redis_get, redis_set
 from autobot_shared.auth.permissions import is_admin_role
+from autobot_shared.redis_client import redis_delete, redis_get, redis_set
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/task_owner.py
+++ b/autobot-backend/services/task_owner.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 
 from autobot_shared.redis_client import redis_delete, redis_get, redis_set
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/workflow_rbac.py
+++ b/autobot-backend/services/workflow_rbac.py
@@ -27,9 +27,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
+from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
 from services.workflow_permission_service import WorkflowPermissionService
-from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/services/workflow_rbac.py
+++ b/autobot-backend/services/workflow_rbac.py
@@ -29,15 +29,18 @@ from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
 from autobot_shared.logging_manager import get_logger
 from services.workflow_permission_service import WorkflowPermissionService
+from auth_rbac import is_admin_role
 
 logger = get_logger(__name__)
 
-_ADMIN_ROLES = {"admin"}
-
 
 def _is_admin(user_data: dict) -> bool:
-    """Return True when the user holds a system-wide admin role."""
-    return user_data.get("role", "").lower() in _ADMIN_ROLES
+    """Return True when the user holds a system-wide admin role.
+
+    #12786: this held its own ``{"admin"}`` set, so a superadmin was refused the
+    admin bypass that every ``require_role("admin", "superadmin")`` guard grants.
+    """
+    return is_admin_role(user_data.get("role"))
 
 
 def require_workflow_permission(action: str) -> Callable:

--- a/autobot-backend/services/workflow_rbac.py
+++ b/autobot-backend/services/workflow_rbac.py
@@ -29,7 +29,7 @@ from api.user_management.dependencies import get_db_session
 from auth_middleware import get_current_user
 from autobot_shared.logging_manager import get_logger
 from services.workflow_permission_service import WorkflowPermissionService
-from auth_rbac import is_admin_role
+from autobot_shared.auth.permissions import is_admin_role
 
 logger = get_logger(__name__)
 

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -117,6 +117,34 @@ class Role(str, Enum):
     READONLY = "readonly"
 
 
+# ``require_role(*roles: Role | str)`` accepts raw strings, so 17 call sites
+# pass ``require_role("admin", "superadmin")`` even though ``superadmin`` is not
+# a member of Role above. Every such guard admits a superadmin, while any
+# hand-rolled ``role == "admin"`` check rejects one -- so a superadmin could
+# perform the write but not the read (#12704, #12717).
+#
+# This set is the single place that answers "is this role administrative?".
+# It lives here rather than in autobot-backend's auth_rbac because that module
+# imports auth_middleware, which needs this answer too -- importing it back the
+# other way closes a cycle (#12786).
+#
+# Making superadmin a first-class Role member is the deeper fix and is still
+# open: this enum drives ROLE_PERMISSIONS for BOTH backends.
+ADMIN_ROLES: frozenset = frozenset({"admin", "superadmin"})
+
+
+def is_admin_role(role) -> bool:
+    """Return True when *role* is administrative (admin or superadmin).
+
+    Use this instead of ``role == "admin"`` for imperative checks that cannot
+    use the require_role() dependency -- e.g. helpers that must also permit
+    self-access, or that pass an ``is_admin`` flag further down.
+
+    Case-insensitive, matching require_role(), which lowercases both sides.
+    """
+    return str(role or "").lower() in ADMIN_ROLES
+
+
 # Canonical role-to-permission mappings.
 # Both autobot-backend (auth_rbac.py) and autobot-slm-backend import this dict
 # so that a permission added here is enforced by both services automatically.


### PR DESCRIPTION
Closes #12948. Refs #12704, #12717, #12786 — #12786 stays open for the enum decision.

## Thinking Path

#12786 asks for three things. Two of them hinge on an owner decision (whether `superadmin`/`platform_admin` become first-class `Role` members, and the cross-backend permission review that implies). The third — a gate so the class cannot return — is independent, so this delivers that plus the call-site conversion it requires.

**The gate found far more than a regex could.** I started from a regex sweep that showed 5 offenders. An AST-based check found **17**, because the shapes that actually occur are `user_data["role"] == "admin"`, `current_user.get("role") == "admin"` and reversed operands — none of which a regex keyed on variable names catches. AST also ignores comments and docstrings for free, which a regex flagged as false hits.

**Two sites are not "grant superadmin too".** Worth reviewing individually:

- `security_policy_manager._check_access_policy` compares `role == "admin"` in order to **require** manager approval. A superadmin was *escaping* the approval rule — same class, opposite polarity, and the fix tightens rather than widens.
- `services/mcp_dispatch` blocked superadmin from admin-only tools at one site while serving them a *reduced* tool list at another — the silent-downgrade shape #12717 reported for voice.

**The first implementation broke the backend.** Adding `from auth_rbac import is_admin_role` to `auth_middleware.py` closed an import cycle — `auth_rbac` already imports `auth_middleware` — and a module-import smoke check dropped from **14/14 on base to 6/14**. No unit test would have caught this; the backend simply would not have started.

The fix is not a lazy import. `is_admin_role` is a pure string predicate with no dependencies, so it belongs beside the `Role` enum whose gap it covers: `autobot_shared/auth/permissions.py` imports only `enum` and `typing`. `auth_rbac` re-exports both names (verified to be the identical object) so callers added by PR #12785 keep working.

## What Changed

- `autobot_shared/auth/permissions.py`: `ADMIN_ROLES` and `is_admin_role()` now live here, beside `Role`, with the cycle rationale recorded.
- `autobot-backend/auth_rbac.py`: re-exports both instead of defining them.
- **17 call sites** converted to `is_admin_role()` across `api/` (audit, auth, conversation_files, feature_flags, heartbeat, redis_service, service_messages, ws_security, user_management/{dependencies,users}), `auth_middleware.py`, `llc/api/companies.py`, `security/enterprise/security_policy_manager.py`, and `services/` (task_owner, workflow_rbac, mcp_dispatch ×2).
- `services/workflow_rbac.py` also carried its own `_ADMIN_ROLES = {"admin"}` — a fifth forked notion, now removed in favour of the shared one.
- `auth_rbac_admin_guard_test.py` (new): AST guard over `autobot-backend`, plus 11 tests pinning what it must catch (`role ==`, `user.role !=`, `user_data["role"] ==`, `.get("role") ==`, reversed operands) and what it must not (`is_admin_role(...)`, `role in ADMIN_ROLES`, non-role names, non-admin literals, docstrings).

## Verification

```
$ python3 -m pytest auth_rbac_admin_guard_test.py security/auth_rbac_test.py -q
39 passed in 17.90s

$ python3 -m flake8 <all 23 changed files>
(clean)
```

Module-import smoke over the touched modules — the check that caught the cycle:

```
base    : 14/14
first cut: 6/14      <- import cycle via auth_middleware
final   : 18/18      (18 = the original 14 plus 4 more modules this PR touches)
re-export identical: True | ADMIN_ROLES: ['admin', 'superadmin']
is_admin_role: admin=True  SuperAdmin=True  user=False  None=False
```

Full suites, branch vs base — **identical**, so none of the failures are mine:

| selection | branch | base |
|---|---|---|
| `tests/security/ security/` | 18 failed, 216 passed, 1 skipped, 2 xfailed, 25 errors | 18 failed, 216 passed, 1 skipped, 2 xfailed, 25 errors |
| `api/user_management/ services/` | 45 failed, 2052 passed, 12 skipped, 29 errors | 45 failed, 2052 passed, 12 skipped, 29 errors |

Those pre-existing failures are environmental — 19 of 69 requirements are not installed locally and there is no Redis. `security/enterprise/threat_detection` is excluded from both runs for the same reason (`ModuleNotFoundError: cachetools`, identical on base).

## What remains (#12786)

Making `superadmin`/`platform_admin` first-class `Role` members with explicit `ROLE_PERMISSIONS` entries. That enum drives permissions for **both** backends, so it needs a cross-backend check that no permission set is silently widened or narrowed — an owner decision, not a drive-by. This PR is the containment that holds the line until then.

Also unaddressed: `autobot-slm-backend/services/jwks_verifier.py` derives `admin` from `role == "admin"` for JWT claims. It is a separate backend that cannot import this helper, and changing token claims has its own blast radius — the guard deliberately scopes to `autobot-backend`.

## Model Used

claude-opus-5
