### PR TITLE
fix(analytics): resolve registry-mounted package routers via their own APIRouter prefix (#12945)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -655,15 +655,18 @@ class BackendEndpointScanner:
         carries the registered prefix, so the routes land under the path they
         are actually served on.
 
-        Deliberately limited to module *files*. A registry entry naming a
-        package cannot have its prefix applied to the modules inside it: the
-        LLC router registers as ``("llc.api", "", …)`` -- an empty prefix --
-        and its real ``/api/llc/*`` paths come from ``include_router`` calls in
-        the package's own ``__init__.py``. Applying the package's prefix to
-        each submodule produced ``/api/costs/…`` instead of ``/api/llc/costs/…``:
+        A registry entry naming a *package* needs its own ``__init__.py`` read
+        first (#12945). LLC registers as ``("llc.api", "", …)`` -- an empty
+        prefix -- while its real ``/api/llc/*`` paths come from the package
+        router declared there:
+
+            llc/api/__init__.py:  router = APIRouter(prefix="/llc")
+            llc/api/costs.py:     router = APIRouter(prefix="/costs")
+
+        so a submodule serves ``/api`` + ``/llc`` + ``/costs``. Applying the
+        registry prefix alone to each submodule yields ``/api/costs/…`` --
         182 endpoints of which 4 were real. Inventing endpoints is worse than
         missing them, since they resurface as phantom "orphaned" findings.
-        Packages need the include_router walk and are left to that follow-up.
         """
         files: Dict[Path, str] = {}
         for module_path, prefix in self._module_prefix_map.items():
@@ -674,10 +677,39 @@ class BackendEndpointScanner:
             if module_path.startswith("api."):
                 continue  # already covered by the api/ walk
 
-            module_file = self.backend_dir.joinpath(*module_path.split(".")).with_suffix(".py")
+            target = self.backend_dir.joinpath(*module_path.split("."))
+            module_file = target.with_suffix(".py")
             if module_file.is_file():
                 files[module_file] = prefix
+            elif (target / "__init__.py").is_file():
+                files.update(self._package_router_files(target, prefix))
         return files
+
+    def _package_router_files(self, package: Path, registry_prefix: str) -> Dict[Path, str]:
+        """Map a registry-mounted package's submodules to their served prefix.
+
+        The package's own ``APIRouter(prefix=...)`` sits between the registry
+        prefix and each submodule's router prefix, and ``_scan_file`` applies
+        the submodule's own prefix separately -- so only the package-level part
+        belongs here.
+
+        Submodules are included only when the package actually mounts them via
+        ``include_router``: a helper module that defines no router contributes
+        no routes, and guessing otherwise is how phantom endpoints appear.
+        """
+        init_file = package / "__init__.py"
+        init_content = init_file.read_text(encoding="utf-8", errors="ignore")
+        package_prefix = self._get_file_router_prefix(init_content) or ""
+        if not _INCLUDE_ROUTER_RE.search(init_content):
+            return {}
+
+        served_prefix = f"{registry_prefix}{package_prefix}"
+        return {
+            py_file: served_prefix
+            for py_file in sorted(package.rglob("*.py"))
+            if not py_file.name.startswith("__")
+            and _APIROUTER_PREFIX_RE.search(py_file.read_text(encoding="utf-8", errors="ignore"))
+        }
 
     def _get_module_prefix(self, file_path: Path) -> str:
         """Get the API prefix for a given file based on router registry."""

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -246,7 +246,7 @@ class TestRegistryRoutersOutsideApi:
             'router = APIRouter(prefix="/llc")\nrouter.include_router(costs_router)\n',
             {
                 "costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/x")\ndef c(): ...\n',
-                "helpers.py": 'def compute(): return 1\n',
+                "helpers.py": "def compute(): return 1\n",
             },
         )
 

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -196,22 +196,75 @@ class TestRegistryRoutersOutsideApi:
 
         assert scanner._registry_router_files() == {}
 
-    def test_package_entries_are_skipped(self, tmp_path):
-        """#12945: a package's prefix does not apply to the modules inside it.
-
-        LLC registers as ``("llc.api", "", …)`` and its real ``/api/llc/*``
-        paths come from include_router calls in the package's own __init__.py.
-        Applying the empty package prefix per-submodule invented 182 endpoints
-        of which 4 were real -- worse than missing them.
-        """
-        backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
+    @staticmethod
+    def _make_package(backend, init_body, submodules):
+        """Create a registry-mounted package with its own router."""
         pkg = backend / "llc" / "api"
         pkg.mkdir(parents=True)
-        (pkg / "costs.py").write_text('@router.get("/by-agent")\ndef c(): ...\n', encoding="utf-8")
+        (pkg / "__init__.py").write_text(init_body, encoding="utf-8")
+        for name, body in submodules.items():
+            (pkg / name).write_text(body, encoding="utf-8")
+        return pkg
 
-        scanner = self._scanner_for(tmp_path, None)
+    def test_package_prefix_comes_from_its_own_router(self, tmp_path):
+        """#12945: the package router sits between registry and submodule.
 
-        assert scanner._registry_router_files() == {}
+        LLC registers as ``("llc.api", "", …)`` -- an empty prefix -- while its
+        real paths come from ``APIRouter(prefix="/llc")`` in the package's own
+        __init__.py. Using the registry prefix alone yielded ``/api/costs/…``
+        instead of ``/api/llc/costs/…``: 182 endpoints of which 4 were real.
+        """
+        backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
+        pkg = self._make_package(
+            backend,
+            'router = APIRouter(prefix="/llc")\nrouter.include_router(costs_router)\n',
+            {"costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/by-agent")\ndef c(): ...\n'},
+        )
+
+        found = self._scanner_for(tmp_path, None)._registry_router_files()
+
+        assert found == {pkg / "costs.py": "/api/llc"}
+
+    def test_package_submodule_route_gets_the_full_served_path(self, tmp_path):
+        """/api + /llc (package) + /costs (submodule) + route."""
+        backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
+        self._make_package(
+            backend,
+            'router = APIRouter(prefix="/llc")\nrouter.include_router(costs_router)\n',
+            {"costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/by-agent")\ndef c(): ...\n'},
+        )
+
+        paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
+
+        assert "/api/llc/costs/by-agent" in paths
+
+    def test_package_helper_modules_without_a_router_are_skipped(self, tmp_path):
+        """A module that defines no router serves nothing -- guessing invents endpoints."""
+        backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
+        pkg = self._make_package(
+            backend,
+            'router = APIRouter(prefix="/llc")\nrouter.include_router(costs_router)\n',
+            {
+                "costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/x")\ndef c(): ...\n',
+                "helpers.py": 'def compute(): return 1\n',
+            },
+        )
+
+        found = self._scanner_for(tmp_path, None)._registry_router_files()
+
+        assert pkg / "helpers.py" not in found
+        assert pkg / "costs.py" in found
+
+    def test_package_that_mounts_nothing_is_skipped(self, tmp_path):
+        """No include_router means the entry is not a router package."""
+        backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
+        self._make_package(
+            backend,
+            'VERSION = "1"\n',
+            {"costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/x")\ndef c(): ...\n'},
+        )
+
+        assert self._scanner_for(tmp_path, None)._registry_router_files() == {}
 
     def test_missing_module_file_is_ignored(self, tmp_path):
         """A registry entry whose module is absent must not break the scan."""


### PR DESCRIPTION
Closes #12945.

## Thinking Path

#12947 handled registry entries naming a module file and deliberately skipped those naming a package, because my first attempt at packages made things measurably worse: applying the registry prefix to each submodule produced 182 endpoints of which 4 were real, pushing scanned-but-not-real from 70 to 209.

Reading how LLC is actually mounted explains why, and what the correct rule is:

```
feature_routers.py:679   ("llc.api", "", ["llc"], "llc"),     <- empty prefix

llc/api/__init__.py:42   router = APIRouter(prefix="/llc", tags=["llc"])
                  :43+   router.include_router(activity_router)   # no extra prefix
llc/api/costs.py:46      router = APIRouter(prefix="/costs")
```

So a submodule serves `/api` + `/llc` (package router) + `/costs` (submodule router) + the route path. There is a *third* prefix level the module-file case does not have, and it lives in the package's own `__init__.py` — nowhere near the registry entry that names it. Confirmed the sub-routers are included with no additional prefix, so the package router is the only intermediate level.

`_scan_file` already applies a file's own `APIRouter(prefix=…)`, so only the package-level part belongs in the prefix map.

Two guards against the failure mode that made the first attempt worse:
- the package must actually mount routers (`include_router` present in `__init__.py`), otherwise the entry is not a router package;
- a submodule is included only if it declares an `APIRouter`, so helper modules contribute nothing rather than endpoints at a guessed path.

## What Changed

`api/codebase_analytics/api_endpoint_scanner.py`:
- `_registry_router_files()` now dispatches a package entry to `_package_router_files()`.
- `_package_router_files()` reads the package's `__init__.py`, takes its router prefix, and maps each router-declaring submodule to `registry_prefix + package_prefix`.

`api_endpoint_scanner_test.py`: the placeholder "packages are skipped" test is replaced with four real ones — the prefix coming from the package's own router, the full served path end-to-end (`/api/llc/costs/by-agent`), helper modules without a router being skipped, and a package that mounts nothing being skipped.

## Verification

```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -q
19 passed in 1.75s

$ python3 -m pytest api/codebase_analytics/ -q
233 passed, 11 skipped in 5.92s        (was 230 passed / 11 skipped)

$ python3 -m flake8 …/api_endpoint_scanner.py …/api_endpoint_scanner_test.py
(clean)
```

Measured on the live install's indexed source `c5939a51-…`, read-only, against `app.openapi()` (2159 unique normalized paths):

| | #12947 | this PR |
|---|---|---|
| router files scanned outside `api/` | 6 | 28 |
| endpoints found | 2041 | 2160 |
| real routes matched | 1789 (82.9%) | **1885 (87.3%)** |
| real routes missed | 370 | **274** |
| scanned but not real | 70 | 71 |

**+96 real routes for +1 spurious.** 119 LLC endpoints discovered, 96 of them confirmed present in `app.openapi()`.

End-user metric across the whole thread, on the same source:

| | before #12943 | #12943 | #12947 | this PR |
|---|---|---|---|---|
| backend endpoints | 0 | 1986 | 2041 | 2160 |
| missing findings | ~2400 | 488 | 435 | **330** |
| false positives among them | ~97% | 95.4% | 94.8% | **93.1%** |
| genuine findings | — | 20 | 20 | **20** |

The genuine count holding at exactly 20 across all three fixes is the useful signal: the number of real drift findings is stable, and everything removed so far was scan gap rather than real drift.

## What remains (not this issue)

274 real routes are still unmatched and 270 of the 290 unique missing findings remain false positives. That residue is no longer about registry-mounted modules — all 7 are now covered — so it belongs to a different gap (routes reached by neither the `api/` walk nor a registry entry, e.g. nested `include_router` chains). Worth a fresh issue with these numbers as the baseline rather than widening this one.

## Model Used

claude-opus-5
