### PR TITLE
feat(skills): add findings-first /secreview skill — emit before exploring (#12951)

### DIFF
--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -196,7 +196,11 @@ If source is too large for single analysis, summarize sections and focus on what
 
 ## Rules
 
-- Output goes to chat only — no file writing unless user asks
+- **Write as you go, don't hold it in the response.** Findings land in
+  `docs/research/<topic>.md` incrementally — Phase 1 is on disk *before* the
+  Phase 2 gate, so an unapproved or interrupted run still leaves the analysis
+  behind. Chat reply is the file path plus a short summary, never the full
+  analysis (#12955)
 - Phase 2 MUST NOT start without explicit user approval after Phase 1
 - Always cite specific files, functions, or sections when making claims
 - When comparing to AutoBot, read actual code — don't assume based on file names

--- a/.claude/skills/secreview/SKILL.md
+++ b/.claude/skills/secreview/SKILL.md
@@ -25,6 +25,7 @@ in step 3 is useful; a perfectly-verified finding that never gets printed is not
 
 | Situation | Use instead |
 |---|---|
+| Unbounded review of the branch, thoroughness over speed | built-in `/security-review` |
 | Deep, recall-biased review of an open PR | `review-fleet` (10 parallel finder + verifier agents) |
 | Whole-codebase security audit | `security-auditor` agent |
 | Syntax, imports, types, lint before merge | `pre-merge-validate` |

--- a/.claude/skills/secreview/SKILL.md
+++ b/.claude/skills/secreview/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: secreview
+description: Fast findings-first security review of a diff — emits a findings table within 3 tool calls, then verifies. Use when asked to security-review a diff, branch, uncommitted changes, or "check this for vulnerabilities". For deep multi-agent PR review use review-fleet instead; for whole-codebase audits use the security-auditor agent.
+---
+
+# Secreview — Findings Before Exploration
+
+A diff-scoped security review that **emits before it explores**. Partial value
+delivered in seconds beats total value delivered in minutes — a review that is
+abandoned mid-exploration delivers nothing at all.
+
+## The Ordering Contract (non-negotiable)
+
+1. **One orientation call.** Read the diff. Nothing else.
+2. **Findings table within 3 tool calls.** No preamble, no full-file reads, no
+   codebase greps before the table is on screen.
+3. **Verify after.** Only once the table is printed, read supporting files to
+   confirm, downgrade, or drop each finding.
+4. **Verdict last.** `BLOCK` / `APPROVE-WITH-NITS` / `APPROVE`.
+
+Never reorder these. A finding stated with `CONFIDENCE: unverified` and corrected
+in step 3 is useful; a perfectly-verified finding that never gets printed is not.
+
+## When NOT to use this skill
+
+| Situation | Use instead |
+|---|---|
+| Deep, recall-biased review of an open PR | `review-fleet` (10 parallel finder + verifier agents) |
+| Whole-codebase security audit | `security-auditor` agent |
+| Syntax, imports, types, lint before merge | `pre-merge-validate` |
+| CI triage / PR merge cycle | `review` |
+
+This skill is the **fast path**. Reach for it when the answer is wanted now.
+
+## Step 1 — Orientation (ONE call)
+
+```bash
+# Pick whichever matches the ask; run exactly one.
+git diff                                  # uncommitted changes
+git diff --staged                         # staged changes
+git diff origin/Dev_new_gui...HEAD        # whole branch vs base
+gh pr diff <number>                       # a specific PR
+```
+
+If the diff exceeds ~1500 lines, add `--stat` first and review the highest-risk
+files by name (auth, config, secrets, migrations, routers, middleware) — but
+still emit the table within the 3-call ceiling. Say explicitly which files were
+deferred; never let truncation read as "everything was covered".
+
+## Step 2 — Emit the findings table (before any other read)
+
+```markdown
+| Sev | file:line | Issue | Fix |
+|-----|-----------|-------|-----|
+| HIGH | app/api/x.py:42 | Endpoint has no authz dependency | Add `Depends(require_role(...))` |
+```
+
+Severity: `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` / `NIT`.
+
+Mark anything not yet confirmed against source as `(unverified)` in the Issue
+cell. That flag is what makes early emission safe.
+
+If the diff is genuinely clean, print the table header with `— no findings —`
+and go straight to the verdict. Do not pad it with speculation.
+
+## Review checklist
+
+These categories have produced real hits in this repo — cover each one.
+
+**Authz & identity**
+- Route added or changed without an auth dependency (`@router.*` with no `Depends`)
+- Hand-rolled role comparison instead of the canonical helper (`is_admin_role()`)
+- Ownership check missing — can user A act on user B's resource?
+- WebSocket auth: token read before `accept()`, close code correct
+
+**Secrets & data exposure**
+- Credentials, tokens, or keys written to disk, logs, or an error response
+- Secret compared with `==` instead of a constant-time / canonical verifier
+  (`verify_internal_api_key`)
+- Internal IPs, hostnames, or filesystem paths leaking into outward artifacts
+- `rsync --delete` or similar without an `.env` exclusion
+
+**Injection & input**
+- Unparameterised SQL, shell interpolation, template injection
+- Path traversal on user-supplied filenames
+- Deserialisation of untrusted input (`pickle`, `yaml.load`)
+
+**Concurrency & state**
+- TOCTOU between a check and its use
+- Rate limiter or lease that can be bypassed by a second path to the same action
+- In-process singleton assumed global across workers
+
+**Refactor fallout** — the highest-yield category historically
+- Renamed function/client with call sites left un-updated (grep the OLD name)
+- Method-name shadowing after a move
+- Changed return shape with callers still reading the old one
+- Fail-open default introduced where the old path failed closed
+
+## Step 3 — Verify
+
+For each finding, read the file and its direct callers. Then update the row:
+promote, downgrade, or strike it. State what changed — a finding that survives
+verification is worth more than one that was never challenged.
+
+For rename fallout specifically, grep the **old** identifier repo-wide; an AST
+or import check misses aliased imports and test monkeypatch targets.
+
+## Step 4 — Verdict
+
+```
+VERDICT: BLOCK | APPROVE-WITH-NITS | APPROVE
+```
+
+- `BLOCK` — any CRITICAL, or a HIGH that survived verification
+- `APPROVE-WITH-NITS` — MEDIUM and below only
+- `APPROVE` — nothing found after verification
+
+## Follow-up
+
+File a GitHub issue for every CRITICAL or HIGH that is out of scope for the
+current change — discovered problems are fixed in scope or filed, never dropped.
+In-scope findings get fixed in the same PR.
+
+Keep the chat response to the table plus the verdict. If the review runs long,
+write the detail to `docs/reports/secreview-<branch>.md` and reply with the path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 - **Branch target:** `Dev_new_gui` for all PRs
 - **Commit format:** `<type>(scope): <description> (#issue-number)`
 - **Security reviews are findings-first:** read the diff only, emit a severity/`file:line`/issue/fix table within 3 tool calls, verify *after* — never explore before the table lands (skill: `secreview`)
+- **Long analyses go to a file, not the response:** research/audit/comparison output is written to `docs/research/<topic>.md` (or `docs/audit/`) incrementally as it is produced; the reply is the path plus a short summary — an interrupted or token-capped response must never lose the work
 - **Never `--no-verify`** — PostToolUse hook auto-formats `.py`
 - **Protected branches:** `main`/`master` blocked by pre-commit hook → use `issue-*` or `hotfix-*`
 - **PR template headings:** `Thinking Path` · `What Changed` · `Verification` · `Model Used`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 
 - **Branch target:** `Dev_new_gui` for all PRs
 - **Commit format:** `<type>(scope): <description> (#issue-number)`
+- **Security reviews are findings-first:** read the diff only, emit a severity/`file:line`/issue/fix table within 3 tool calls, verify *after* — never explore before the table lands (skill: `secreview`)
 - **Never `--no-verify`** — PostToolUse hook auto-formats `.py`
 - **Protected branches:** `main`/`master` blocked by pre-commit hook → use `issue-*` or `hotfix-*`
 - **PR template headings:** `Thinking Path` · `What Changed` · `Verification` · `Model Used`


### PR DESCRIPTION
## Thinking Path

Usage analysis over 59 sessions found `security_review` was the most-requested
goal (11 sessions) and **8 of the 11 delivered nothing** — every one abandoned
during `Read`/`Grep` exploration, before a single finding was printed. The
reviews that did land found real defects, so the quality was never the problem:
the **ordering** was. Absent a constraint, a review optimises for completeness —
read everything, then report — which is right for an unbounded audit and wrong
for a diff, where partial value delivered early beats total value delivered late.

Audited existing coverage before adding anything. `review-fleet` is the
heavyweight 10-agent PR path, `review` is CI triage, `security-auditor` is
whole-codebase, `pre-merge-validate` has no security dimension. A fast,
diff-only, findings-first path was genuinely absent, and no rule for review
ordering existed anywhere:

```
$ grep -rniE "security review|findings.first|findings table" CLAUDE.md docs/developer/*.md
(no matches)
```

## What Changed

- **`.claude/skills/secreview/SKILL.md`** — a non-negotiable ordering contract:
  one orientation call (the diff, nothing else) → findings table within 3 tool
  calls → verify *after* → verdict. Unconfirmed rows are marked `(unverified)`,
  which is what makes early emission safe.
- Routing table pointing at `review-fleet` / `security-auditor` /
  `pre-merge-validate` so the fast path is not misapplied to work that needs depth.
- Checklist weighted to the categories that produced real hits here — authz gaps,
  secrets on disk/in logs, injection, TOCTOU, rate-limit bypass, and **refactor
  fallout** (renames with un-updated call sites), historically the highest-yield
  category.
- **`CLAUDE.md`** — one line under Workflow Quick Rules, so the ordering rule
  applies even when the skill is not explicitly invoked.

### Long analyses to a file, not the response (#12955)

Research sessions were dying to `output token maximum exceeded` and losing the
whole analysis. This turned out not to be a missing rule but an active one
pointing the wrong way — `research/SKILL.md:199` mandated the failing behaviour:

```
- Output goes to chat only — no file writing unless user asks
```

- **`.claude/skills/research/SKILL.md`** — inverted: findings are written to
  `docs/research/<topic>.md` incrementally, so Phase 1 is on disk *before* the
  Phase 2 approval gate and an unapproved or interrupted run still leaves the
  analysis behind. Chat reply is path + summary.
- **`CLAUDE.md`** — the general form, for any long analysis.

## Verification

Dogfooded against a real branch diff (PR #12950). The diff was read in **one**
tool call and the findings table was emitted before any other read — the
contract held. Three findings; two confirmed on verification:

| Sev | Finding | Verdict |
|---|---|---|
| MEDIUM | `rglob("*.py")` descends into nested subpackages but applies only the top-level package prefix | **CONFIRMED** |
| MEDIUM | Docstring claims per-submodule `include_router` matching; the code checks the package mounts *anything*, then includes every router submodule | **CONFIRMED** |
| LOW | Package path built from registry `module_path` could escape `backend_dir` via `..` | Downgraded to NIT — registry is code-controlled, not user input |

Confirmation for the first, showing the nested submodule is yielded while the
nested `__init__.py` that carries its prefix is filtered out:

```
rglob:                          ['__init__.py', 'a.py', 'sub/__init__.py', 'sub/b.py']
filtered (not startswith __):   ['a.py', 'sub/b.py']
```

Both findings reported to #12950. Notably this is the same defect class that PR
is fixing — inventing endpoints under a wrong prefix.

Scope of the second fix confirmed to be a single line — no sibling skill carries
the same instruction, and `canonical-audit` already writes its report to disk:

```
$ grep -rniE "chat only|no file writing|output goes to chat" .claude/skills/
.claude/skills/research/SKILL.md:199:- Output goes to chat only — no file writing unless user asks
```

`docs/research/` already exists, so this adopts an existing convention rather
than inventing one.

No product code touched; this PR changes skills and two CLAUDE.md lines.

Closes #12951, #12955

## Model Used

Claude Opus 5 (1M context)
