### PR TITLE
fix(deploy): consolidate DB credentials onto one store and strip pre-#12224 residue (#12907)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -780,14 +780,19 @@
       databases:
         - "{{ backend_postgres_db | default('autobot_users') }}"
       postgresql_listen_addresses: "localhost"
-      # #10636: On a collapsed single-box deploy this instance already hosts the
-      # SLM (slm_app) whose creds live in the DEFAULT db-credentials.env. Writing
-      # the backend's AUTOBOT_DB_* creds into that same file would overwrite the
-      # SLM's SLM_DB_* entries — the SLM systemd unit's EnvironmentFile then loads
-      # nothing and the SLM loses DB access. Give the backend its OWN creds file so
-      # both coexist; the SLM's file is never touched. On multi-VM fleets this is
-      # a separate instance/host, so a distinct filename is harmless there too.
-      postgresql_credentials_file: "autobot-db-credentials.env"
+      # #10636 gave the backend its OWN creds file because the postgresql role
+      # then rendered the WHOLE file from a template, so writing AUTOBOT_DB_*
+      # erased the SLM's SLM_DB_* entries on a collapsed single-box deploy.
+      #
+      # #12224 removed that hazard: the role now writes each prefix as its own
+      # marked blockinfile region, so SLM_* and AUTOBOT_* coexist in one file and
+      # neither clobbers the other. The separate file therefore solves a problem
+      # that no longer exists -- and it kept drifting, ending up a month stale
+      # with a password Postgres rejects, which is how #12883 became an outage.
+      #
+      # #12907: the AUTOBOT block now lands in the canonical db-credentials.env
+      # (the role default), and the legacy file is retired once that block is in
+      # place. One store, one authority, no precedence for consumers to know.
       # #10636: The postgresql role's pg_hba render is additive (it discovers every
       # existing login role first — see roles/postgresql/tasks/configure.yml — so
       # slm_app's rules survive), and this second run must ONLY reload, never

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
@@ -134,6 +134,69 @@
   become: true
   no_log: true
 
+# #12907 (Defect 1): hosts provisioned before #12224 still carry UNMARKED
+# assignments written by the old whole-file template (roles/postgresql/
+# templates/db-credentials.env.j2), which used the same key names. blockinfile
+# only owns the region between its markers, so those stale lines survive every
+# redeploy and sit BEFORE the managed block -- two assignments per key, the
+# first one dead. `set -a; . file` takes the last, so this is survivable; any
+# consumer that greps the first match silently reads a dead secret, which is
+# exactly how #12883 became an outage.
+#
+# Runs AFTER blockinfile, never before: the managed block must already be in
+# place, so a play that aborts here can never leave a host with no credentials.
+- name: "Strip pre-#12224 unmarked {{ db_env_prefix }} credential lines (#12907)"
+  ansible.builtin.shell:
+    cmd: |
+      set -euo pipefail
+      f='{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}'
+      [ -f "$f" ] || exit 0
+      tmp="$(mktemp "${f}.XXXXXX")"
+      trap 'rm -f "$tmp"' EXIT
+      awk -v pfx='{{ db_env_prefix }}' '
+        $0 ~ "^# BEGIN " pfx " DB CREDENTIALS" { inblock = 1; print; next }
+        $0 ~ "^# END " pfx " DB CREDENTIALS"   { inblock = 0; print; next }
+        !inblock && $0 ~ "^" pfx "_[A-Z0-9_]*=" { dropped++; next }
+        { print }
+        END { exit (dropped ? 10 : 0) }
+      ' "$f" > "$tmp" && rc=0 || rc=$?
+      if [ "$rc" -eq 10 ]; then
+        chown --reference="$f" "$tmp"
+        chmod --reference="$f" "$tmp"
+        mv -f "$tmp" "$f"
+        trap - EXIT
+        echo CHANGED
+      elif [ "$rc" -ne 0 ]; then
+        exit "$rc"
+      fi
+  register: _cred_strip
+  changed_when: "'CHANGED' in _cred_strip.stdout"
+  become: true
+  no_log: true
+
+# #12907 (Defect 2): #10636 gave the backend its own autobot-db-credentials.env
+# because the whole-file template made the two prefixes clobber each other.
+# #12224's per-prefix markers removed that constraint, but the second file
+# stayed and drifted a month behind, holding a password Postgres rejects.
+# Retire it once the canonical file actually carries this prefix's block --
+# never unconditionally, so a half-applied run cannot strand a host.
+- name: "Retire the superseded {{ db_env_prefix }} credential file (#12907)"
+  ansible.builtin.shell:
+    cmd: |
+      set -euo pipefail
+      canonical='{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}'
+      legacy='{{ postgresql_credentials_dir }}/autobot-db-credentials.env'
+      [ -f "$legacy" ] || exit 0
+      [ "$legacy" != "$canonical" ] || exit 0
+      grep -q "^# BEGIN {{ db_env_prefix }} DB CREDENTIALS" "$canonical" || exit 0
+      mv -f "$legacy" "${legacy}.superseded-12907"
+      echo CHANGED
+  register: _cred_retire
+  changed_when: "'CHANGED' in _cred_retire.stdout"
+  become: true
+  no_log: true
+  when: db_env_prefix == 'AUTOBOT'
+
 - name: Display database setup completion
   ansible.builtin.debug:
     msg:


### PR DESCRIPTION
Closes #12907.

## Thinking Path

The issue reports two defects and attributes Defect 1 to the writer appending instead of replacing. Checking the role first showed that is not what happens, and the correction changes the fix.

The writer is `blockinfile` with a **per-prefix marker**, parameterised precisely so `SLM_*` and `AUTOBOT_*` coexist (#12224 — the previous whole-file `template` erased the other phase's keys on a co-located box). It replaces its own marked region, so it cannot produce the reported *same-prefix* duplication.

The duplicates are migration residue. The role still carries the pre-#12224 template `roles/postgresql/templates/db-credentials.env.j2`, emitting the same key names with **no markers**. Nothing renders it any more, but hosts provisioned before the switch still carry those lines, and `blockinfile` appends its block after them. That accounts for every symptom: exactly 2 of each key rather than 3+, the *first* stale and the second current, and no self-healing across redeploys.

Defect 2's premise needed correcting too. The legacy file is not abandoned — `roles/backend/tasks/main.yml:790` deliberately re-invokes the role with the filename overridden, per #10636, so the backend would not clobber the SLM's keys. **But #12224 removed the condition that justified it**, and the workaround stayed and drifted.

So both defects are the same pattern one level apart: #12224 fixed the clobbering and neither workaround was retired. Defect 1 is the pre-#12224 *lines* left inside the canonical file; Defect 2 is the pre-#12224 *file* left beside it. Consolidating was confirmed with the owner, since it changes credential layout on live hosts.

**Ordering is the safety-critical decision here.** The strip runs **after** `blockinfile`, never before. Stripping first would, on a host whose only credentials are legacy lines, leave a window with no valid credentials if the play aborted in between. Running after means the managed block is always in place first. The retirement is likewise conditional on the canonical file actually containing this prefix's `BEGIN` marker, so a half-applied run cannot strand a host.

## What Changed

- `roles/backend/tasks/main.yml`: dropped the `postgresql_credentials_file` override so the backend's `AUTOBOT` block lands in the canonical `db-credentials.env`. The #10636 comment is replaced with why the split is no longer needed rather than deleted, so the history stays legible.
- `roles/postgresql/tasks/databases.yml`: two new tasks after `blockinfile` —
  - strip unmarked `PREFIX_*` assignments outside the markers (Defect 1), writing via `mktemp` + `chown/chmod --reference` + `mv` so ownership and mode are preserved and the replacement is atomic;
  - rename the legacy file to `.superseded-12907` once the canonical carries the block (Defect 2) — renamed, not deleted, per the no-data-loss rule, and guarded to the `AUTOBOT` prefix.

Both are `no_log: true` and report `changed` only when they actually modified something.

## Verification

The awk transform, exercised standalone against a file with both legacy and managed content:

```
input : AUTOBOT_DB_PASSWORD=STALE      (unmarked, first)
        SLM_DB_HOST=slm-host           (different prefix)
        # BEGIN AUTOBOT DB CREDENTIALS (managed by postgresql role)
        AUTOBOT_DB_PASSWORD=CURRENT
        # END AUTOBOT DB CREDENTIALS (managed by postgresql role)

output: SLM_DB_HOST=slm-host
        # BEGIN AUTOBOT DB CREDENTIALS (managed by postgresql role)
        AUTOBOT_DB_PASSWORD=CURRENT
        # END AUTOBOT DB CREDENTIALS (managed by postgresql role)
```

Stale line removed, the other prefix untouched, managed block intact.

```
second run exit=0  -> idempotent, output identical (no churn, no false `changed`)
fresh install      -> exit=0, no-op (managed block only, no legacy lines)
```

```
$ python3 -c "yaml.safe_load(...)"   both task files
YAML OK

$ python3 -m pytest autobot-slm-backend/tests/test_backend_db_credential_source_12883.py -q
4 passed in 1.39s
```

The #12883 precedence test still passes: consumers read the canonical file first, and consolidation puts the `AUTOBOT` keys *into* that file, so the precedence it pins is unchanged.

`config.py` and `migrations/runner.py` reference only the canonical path, so no consumer change was needed — the legacy fallback lives outside them and keeps working for hosts not yet redeployed.

## Not verified here

This is deploy code and I did not run it against the live install — doing so would rewrite a real credential file, and the failure mode is an outage. The awk transform is verified standalone against representative content, and the ordering is chosen so no intermediate state lacks credentials. First real exercise will be the next deploy; the legacy file is renamed rather than removed, so recovery is a `mv` if anything is wrong.

## Model Used

claude-opus-5
