### PR TITLE
fix(analytics): exclude test modules from the endpoint scan (#12957)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -141,11 +141,7 @@ def _is_test_file(path: Path) -> bool:
     Matches the repo's two conventions (``x_test.py`` and ``test_x.py``) plus
     anything under a ``tests`` directory.
     """
-    return (
-        path.name.endswith("_test.py")
-        or path.name.startswith("test_")
-        or "tests" in path.parts
-    )
+    return path.name.endswith("_test.py") or path.name.startswith("test_") or "tests" in path.parts
 
 
 def find_backend_dir(project_root: Path) -> Path:

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -129,6 +129,25 @@ _BACKEND_DIR_CANDIDATES = ("autobot-backend", "backend", ".")
 _ROUTER_REGISTRY_RELPATH = Path("initialization") / "router_registry"
 
 
+def _is_test_file(path: Path) -> bool:
+    """Whether *path* is a test module rather than a served route (#12953).
+
+    A route defined in a test is not an endpoint, and counting one pollutes the
+    report in both directions: it appears as a backend endpoint no frontend
+    calls (a phantom "orphaned" finding telling someone to wire or delete
+    something that does not exist), and as a scanned path absent from
+    ``app.openapi()``.
+
+    Matches the repo's two conventions (``x_test.py`` and ``test_x.py``) plus
+    anything under a ``tests`` directory.
+    """
+    return (
+        path.name.endswith("_test.py")
+        or path.name.startswith("test_")
+        or "tests" in path.parts
+    )
+
+
 def find_backend_dir(project_root: Path) -> Path:
     """Locate the FastAPI backend package inside *project_root* (#12853).
 
@@ -209,6 +228,8 @@ class BackendEndpointScanner:
             if py_file.name.startswith("__"):
                 continue
             if "archive" in str(py_file).lower():
+                continue
+            if _is_test_file(py_file):
                 continue
 
             try:

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -14,9 +14,9 @@ the analyzable repo -- so the fallback must instead use
 #10730).
 """
 
-import pytest
-
 from unittest.mock import patch
+
+import pytest
 
 from api.codebase_analytics import api_endpoint_scanner as scanner_mod
 
@@ -294,9 +294,7 @@ class TestTestFilesAreNotEndpoints:
         backend = tmp_path / "autobot-backend"
         (backend / "api").mkdir(parents=True)
         (backend / "initialization" / "router_registry").mkdir(parents=True)
-        (backend / "api" / name).write_text(
-            '@router.get("/catalog")\ndef c(): ...\n', encoding="utf-8"
-        )
+        (backend / "api" / name).write_text('@router.get("/catalog")\ndef c(): ...\n', encoding="utf-8")
 
         paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
 
@@ -306,9 +304,7 @@ class TestTestFilesAreNotEndpoints:
         backend = tmp_path / "autobot-backend"
         (backend / "api" / "tests").mkdir(parents=True)
         (backend / "initialization" / "router_registry").mkdir(parents=True)
-        (backend / "api" / "tests" / "helper.py").write_text(
-            '@router.get("/x")\ndef c(): ...\n', encoding="utf-8"
-        )
+        (backend / "api" / "tests" / "helper.py").write_text('@router.get("/x")\ndef c(): ...\n', encoding="utf-8")
 
         paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
 
@@ -319,9 +315,7 @@ class TestTestFilesAreNotEndpoints:
         backend = tmp_path / "autobot-backend"
         (backend / "api").mkdir(parents=True)
         (backend / "initialization" / "router_registry").mkdir(parents=True)
-        (backend / "api" / "latest_results.py").write_text(
-            '@router.get("/results")\ndef c(): ...\n', encoding="utf-8"
-        )
+        (backend / "api" / "latest_results.py").write_text('@router.get("/results")\ndef c(): ...\n', encoding="utf-8")
 
         paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
 

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -14,6 +14,8 @@ the analyzable repo -- so the fallback must instead use
 #10730).
 """
 
+import pytest
+
 from unittest.mock import patch
 
 from api.codebase_analytics import api_endpoint_scanner as scanner_mod
@@ -273,3 +275,54 @@ class TestRegistryRoutersOutsideApi:
         scanner = self._scanner_for(tmp_path, None)
 
         assert scanner._registry_router_files() == {}
+
+
+class TestTestFilesAreNotEndpoints:
+    """#12953: a route defined in a test is not a served endpoint.
+
+    Counting one pollutes the report in both directions -- it becomes a backend
+    endpoint no frontend calls (a phantom "orphaned" finding telling someone to
+    wire or delete something that does not exist) and a scanned path absent
+    from app.openapi().
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        ["marketplace_422_test.py", "test_tenant_context_resolution.py"],
+    )
+    def test_test_modules_are_excluded(self, tmp_path, name):
+        backend = tmp_path / "autobot-backend"
+        (backend / "api").mkdir(parents=True)
+        (backend / "initialization" / "router_registry").mkdir(parents=True)
+        (backend / "api" / name).write_text(
+            '@router.get("/catalog")\ndef c(): ...\n', encoding="utf-8"
+        )
+
+        paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
+
+        assert paths == []
+
+    def test_tests_directory_is_excluded(self, tmp_path):
+        backend = tmp_path / "autobot-backend"
+        (backend / "api" / "tests").mkdir(parents=True)
+        (backend / "initialization" / "router_registry").mkdir(parents=True)
+        (backend / "api" / "tests" / "helper.py").write_text(
+            '@router.get("/x")\ndef c(): ...\n', encoding="utf-8"
+        )
+
+        paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
+
+        assert paths == []
+
+    def test_real_modules_are_still_scanned(self, tmp_path):
+        """The exclusion must not swallow modules that merely mention tests."""
+        backend = tmp_path / "autobot-backend"
+        (backend / "api").mkdir(parents=True)
+        (backend / "initialization" / "router_registry").mkdir(parents=True)
+        (backend / "api" / "latest_results.py").write_text(
+            '@router.get("/results")\ndef c(): ...\n', encoding="utf-8"
+        )
+
+        paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
+
+        assert "/api/results" in paths


### PR DESCRIPTION
Closes #12957. Refs #12953, which stays open for the empty-prefix class and the 274 missed routes.

## Thinking Path

Diagnosing #12953's 71 scanned-but-not-real paths turned up a class that needs no judgement to fix: routes declared inside test modules were being counted as backend endpoints. `scan_all_endpoints()` already skips `__*` files and `archive`, but not the repo's test conventions.

The cost is not just a wrong count — it is wrong in **both** directions. A test-defined route is served by nothing, so it becomes an endpoint no frontend calls (a phantom "orphaned" finding, which reads as "wire this up or delete it" for something that does not exist) *and* a scanned path missing from `app.openapi()`.

Only 3 endpoints, so the headline numbers barely move. I did it anyway because it is the one class in #12953 with no ambiguity, and because a phantom orphan is the kind of finding that wastes a person's afternoon.

## What Changed

`api/codebase_analytics/api_endpoint_scanner.py`: added `_is_test_file()` — matching `x_test.py`, `test_x.py`, and anything under a `tests` directory — and skip it in the scan loop beside the existing `__*`/`archive` skips.

`api_endpoint_scanner_test.py`: 4 tests — both naming conventions excluded, a `tests/` directory excluded, and a real module whose name merely *contains* a test-ish substring (`latest_results.py`) still scanned, so the exclusion cannot silently swallow real routes.

## Verification

```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -q
23 passed in 0.77s        (19 pre-existing + 4 new)

$ python3 -m pytest api/codebase_analytics/ -q
237 passed, 11 skipped in 2.72s        (was 233 passed / 11 skipped)

$ python3 -m flake8 …/api_endpoint_scanner.py …/api_endpoint_scanner_test.py
(clean)
```

Measured on the live install's indexed source `c5939a51-…`, read-only:

| | before | after |
|---|---|---|
| endpoints found | 2160 | 2157 |
| endpoints from test files | 3 | **0** |
| scanned but not real | 71 | **69** |
| orphaned findings | 293 | **290** |
| real routes matched | 1885 | **1885** |
| missing findings | 330 | **330** |

Real routes matched and missing findings are both **unchanged** — that is the point of the last two rows. The change removes noise without costing a single real route, which is the property the `latest_results.py` test pins.

## Model Used

claude-opus-5
