### PR TITLE
test(deploy): surface the roles the builtin updater never applies (#12959)

### DIFF
--- a/autobot-slm-backend/tests/test_update_all_applies_roles_12959.py
+++ b/autobot-slm-backend/tests/test_update_all_applies_roles_12959.py
@@ -1,0 +1,141 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Guard: the builtin updater must APPLY the roles it deploys (#12959).
+
+`update-all-nodes.yml` is the playbook behind code-sync / self-update — the only
+updater a GUI user can reach. It deploys components with inline tasks and
+applies exactly one role, and only a single task file of it:
+
+    ansible.builtin.include_role:
+      name: backend
+      tasks_from: env_only
+
+So **any fix that lands in an Ansible role is inert on every host updated
+through the builtin path**. The merge is green, the issue gets closed,
+`code_source` carries the change, and the host never receives it. Four
+confirmed instances: #12777 (faulthandler, `roles/backend/templates/`), #12886
+(TTS worker, `roles/tts-worker`), #12907 (credential consolidation,
+`roles/postgresql`), and #12959's own report.
+
+The failure is silent, which is what makes it expensive: nothing distinguishes
+"delivered" from "merged but never applied". This test makes it loud.
+
+It is marked ``xfail(strict=True)`` rather than baselined: while the gap exists
+the suite stays green, and the moment the updater applies these roles the test
+XPASSes — which strict xfail reports as a FAILURE, forcing whoever fixed it to
+delete the marker. A baseline would instead quietly absorb the fix and keep
+claiming the problem is still there (the #12894 lesson).
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+_ANSIBLE = pathlib.Path(__file__).resolve().parents[1] / "ansible"
+_PLAYBOOK = _ANSIBLE / "playbooks" / "update-all-nodes.yml"
+_ROLES_DIR = _ANSIBLE / "roles"
+
+#: Components the updater deploys, mapped to the role that owns their real
+#: deployment logic (unit files, templates, credentials, worker config).
+#: A component here whose role is never applied receives code but no role
+#: changes — the #12959 failure.
+MANAGED_COMPONENT_ROLES = {
+    "backend": "backend",
+    "ai-stack": "ai-stack",
+    "npu-worker": "npu-worker",
+    "frontend": "frontend",
+    "browser": "browser",
+    "tts-worker": "tts-worker",
+    "postgresql": "postgresql",
+}
+
+
+def _iter_tasks(node):
+    """Yield every mapping in the playbook, at any nesting depth."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_tasks(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_tasks(item)
+
+
+def applied_roles() -> dict[str, set[str | None]]:
+    """Map each role the playbook applies to the ``tasks_from`` values used.
+
+    ``None`` means the role is applied in full. A role that only ever appears
+    with a ``tasks_from`` delivers just that task file — which is how `backend`
+    ships `env_only` and nothing else.
+    """
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+    applied: dict[str, set[str | None]] = {}
+
+    for task in _iter_tasks(playbook):
+        include = task.get("ansible.builtin.include_role") or task.get("include_role")
+        if isinstance(include, dict) and include.get("name"):
+            applied.setdefault(include["name"], set()).add(include.get("tasks_from"))
+        # A bare `roles:` list on a play applies each role in full.
+        for entry in task.get("roles") or []:
+            name = entry.get("role") or entry.get("name") if isinstance(entry, dict) else entry
+            if name:
+                applied.setdefault(name, set()).add(None)
+
+    return applied
+
+
+def test_playbook_is_parseable_and_still_the_updater():
+    """Fail loudly if the playbook moved, rather than vacuously passing."""
+    assert _PLAYBOOK.is_file(), f"{_PLAYBOOK} not found — did the updater move?"
+    assert yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8")), "playbook parsed empty"
+
+
+@pytest.mark.parametrize("component,role", sorted(MANAGED_COMPONENT_ROLES.items()))
+def test_managed_component_role_exists(component, role):
+    """The role that owns each managed component's deployment must exist."""
+    assert (_ROLES_DIR / role).is_dir(), f"{component}: roles/{role} missing"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#12959: the updater applies only backend/env_only, so role changes are inert on hosts. "
+    "When the inline tasks become role applications this XPASSes — delete this marker then.",
+)
+def test_updater_applies_every_managed_role_in_full():
+    """Every managed component's role must be applied, and applied in full.
+
+    Applying with ``tasks_from`` is not delivery: `backend` is applied that way
+    today and still never receives its unit-file template (#12777).
+    """
+    applied = applied_roles()
+    undelivered = []
+
+    for component, role in sorted(MANAGED_COMPONENT_ROLES.items()):
+        if role not in applied:
+            undelivered.append(f"{component}: roles/{role} is NEVER applied")
+        elif None not in applied[role]:
+            partial = ", ".join(sorted(str(t) for t in applied[role]))
+            undelivered.append(f"{component}: roles/{role} applied only via tasks_from={partial}")
+
+    assert not undelivered, (
+        "Roles whose changes cannot reach a host through the builtin updater "
+        "(#12959) — a fix merged into any of these is inert:\n  " + "\n  ".join(undelivered)
+    )
+
+
+def test_undelivered_roles_are_reported_for_visibility(capsys):
+    """Always print the current delivery gap, so CI logs carry it while xfail hides the failure."""
+    applied = applied_roles()
+    gap = [
+        f"{c}: roles/{r} " + ("NEVER applied" if r not in applied else f"partial {sorted(str(t) for t in applied[r])}")
+        for c, r in sorted(MANAGED_COMPONENT_ROLES.items())
+        if r not in applied or None not in applied[r]
+    ]
+    print("\n#12959 delivery gap — roles the builtin updater does not apply in full:")
+    for line in gap:
+        print(f"  {line}")
+
+    # Not an assertion about the gap's size — only that the report ran and the
+    # playbook still applies *something*, so a refactor cannot silently empty it.
+    assert applied, "update-all-nodes.yml applies no roles at all"


### PR DESCRIPTION
Refs #12959 — first of two steps. This one adds visibility only and changes nothing about what any host applies; the inline-tasks → role-application conversion is deliberately held for a separate PR.

## Thinking Path

`update-all-nodes.yml` is the playbook behind code-sync / self-update — the only updater a GUI user can reach. Across 1302 lines it applies exactly **one** role, and only one task file of it:

```yaml
ansible.builtin.include_role:
  name: backend
  tasks_from: env_only
```

Meanwhile 31 roles exist. So any fix that lands in a role is inert on every host updated through the builtin path: the merge is green, the issue closes, `code_source` carries the change, and the host never receives it.

**I can confirm a fourth instance from my own work tonight.** #12907's credential consolidation lives entirely in `roles/postgresql/tasks/databases.yml` and `roles/backend/tasks/main.yml`. I closed that issue with merge evidence — and the fix cannot reach a host. Same for #12886 (`roles/tts-worker`), which is *closed* while TTS is still returning 404, and #12777 (`roles/backend/templates/`).

Verified against the live install after tonight's update: the deployed tree is at `30541c5e98` with all of tonight's Python-level changes present, and the backend restarted cleanly. So code-sync **does** deliver plain Python — the gap is specifically role-driven artifacts: unit files, templates, credential tasks, worker config.

**Why xfail(strict=True) rather than a baseline.** A baseline would list the seven undelivered roles and pass; when someone later fixes the updater, the baseline would silently absorb it and keep asserting the problem exists. That is exactly what #12894 showed suppression does to a findings family. Strict xfail inverts it: while the gap exists the suite is green, and the moment the updater applies these roles the test XPASSes — which pytest reports as a **failure**, forcing whoever fixed it to delete the marker. The guard retires itself.

The separate always-running report prints the gap into CI logs on every run, so the information is visible even while the assertion is xfailed.

## What Changed

`autobot-slm-backend/tests/test_update_all_applies_roles_12959.py` (new):
- `applied_roles()` walks the playbook at any nesting depth, collecting `include_role` names with their `tasks_from`, and bare `roles:` lists. Applying with `tasks_from` is explicitly *not* counted as delivery — `backend` is applied that way today and still never receives its unit-file template (#12777).
- The invariant (every managed component's role applied in full) under `xfail(strict=True)`.
- A report test that always prints the current gap.
- Guards against vacuous passing: the playbook must exist and parse, each mapped role directory must exist, and the playbook must apply *something* — so a refactor cannot silently empty the check.

## Verification

```
$ python3 -m pytest autobot-slm-backend/tests/test_update_all_applies_roles_12959.py -q -s
9 passed, 1 xfailed in 0.78s

#12959 delivery gap — roles the builtin updater does not apply in full:
  ai-stack:   roles/ai-stack   NEVER applied
  backend:    roles/backend    partial ['env_only']
  browser:    roles/browser    NEVER applied
  frontend:   roles/frontend   NEVER applied
  npu-worker: roles/npu-worker NEVER applied
  postgresql: roles/postgresql NEVER applied
  tts-worker: roles/tts-worker NEVER applied
```

```
$ python3 -m flake8 …/test_update_all_applies_roles_12959.py
(clean)
```

The xfail is the intended state: it documents a real, currently-unfixed gap without blocking merges, and it cannot outlive the fix.

## Not in this PR

The conversion itself. It changes what every host applies — a host could start receiving role changes never applied to it, on top of a tree that drifted for months — so it wants its own PR, ideally with this report's output in hand showing exactly which roles are undelivered per host.

## Model Used

claude-opus-5
