### PR TITLE
fix(analytics): resolve a registry router's module from its import, not its alias (#12953)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -543,9 +543,26 @@ class BackendEndpointScanner:
                 logger.debug("Error scanning include_router in %s: %s", py_file, e)
 
     def _parse_router_registry(self, file_path: Path) -> None:
-        """Parse a router registry file to extract module -> prefix mappings."""
+        """Parse a router registry file to extract module -> prefix mappings.
+
+        #12953: the module was derived by stripping ``_router`` from the router
+        variable. That holds for most entries, but the file states the real
+        mapping in its own imports, and where the two disagree the guess is
+        wrong twice over:
+
+            from api.vnc_manager import router as vnc_router
+            (vnc_router, "/vnc", ["vnc"], "vnc"),
+
+        ``/vnc`` was attributed to ``api.vnc`` -- a different module that also
+        exists -- while ``api.vnc_manager`` got no prefix and emitted its routes
+        unprefixed as ``/api/click``, ``/api/clipboard``. Prefer the import;
+        fall back to the guess when a router is not imported by alias.
+        """
         try:
             content = file_path.read_text(encoding="utf-8")
+            alias_modules = dict(
+                (alias, module) for module, alias in _ROUTER_IMPORT_RE.findall(content)
+            )
 
             # Pattern to match: (router_name, "/prefix", [...], "name")
             # Matches tuples like: (chat_router, "", ["chat"], "chat")
@@ -553,8 +570,8 @@ class BackendEndpointScanner:
                 router_var = match.group(1)  # e.g., "chat_router"
                 prefix = match.group(2)  # e.g., "" or "/system"
 
-                # Extract module name from router variable (chat_router -> chat)
-                module_name = router_var.replace("_router", "")
+                # Prefer the imported module; else chat_router -> chat
+                module_name = alias_modules.get(router_var, router_var.replace("_router", ""))
 
                 # Store mapping: module_name -> full API prefix
                 full_prefix = f"{self.API_PREFIX}{prefix}"
@@ -597,16 +614,34 @@ class BackendEndpointScanner:
                 self._register_module_prefix(module_path, prefix)
 
     def _apply_dynamic_router_pattern(self, content: str, dynamic_router_pattern) -> None:
-        """Helper for _parse_config_tuple_registry. Ref: #1088."""
-        # Issue #552: Also check for dynamic router patterns (terminal_routers.py)
-        # These have router variable names instead of module paths
+        """Helper for _parse_config_tuple_registry. Ref: #1088.
+
+        #12953: the module used to be *guessed* by stripping ``_router`` from the
+        variable name. That is right for most entries but wrong whenever the
+        alias does not mirror its module, and the file states the real mapping
+        two lines up:
+
+            from api.vnc_manager import router as vnc_router   # -> api.vnc_manager
+            (vnc_router, "/vnc", ["vnc"], "vnc"),              # guessed api.vnc
+
+        The guess then attributed ``/vnc`` to ``api.vnc`` -- a different module
+        that also exists -- while ``api.vnc_manager`` got no prefix at all and
+        emitted its routes as ``/api/click``, ``/api/clipboard``. So a mismatch
+        costs twice: a wrong attribution and an unprefixed module. Read the
+        import when it is present; fall back to the guess when it is not, since
+        some registries build routers without importing them by alias.
+        """
+        alias_modules = dict(
+            (alias, module) for module, alias in _ROUTER_IMPORT_RE.findall(content)
+        )
+
         for match in dynamic_router_pattern.finditer(content):
             router_var = match.group(1)  # e.g., "terminal_router"
             prefix = match.group(2)  # e.g., "/terminal"
-            # group(3) contains name (e.g., "terminal") - unused; module derived from var
+            # group(3) contains name (e.g., "terminal") - unused; module resolved below
 
             # terminal_router -> terminal, agent_terminal_router -> agent_terminal
-            module_name = router_var.replace("_router", "")
+            module_name = alias_modules.get(router_var, router_var.replace("_router", ""))
             module_path = f"api.{module_name}"
             self._register_module_prefix(module_path, prefix)
             logger.debug("Dynamic router: %s -> %s%s", module_name, self.API_PREFIX, prefix)

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -560,9 +560,7 @@ class BackendEndpointScanner:
         """
         try:
             content = file_path.read_text(encoding="utf-8")
-            alias_modules = dict(
-                (alias, module) for module, alias in _ROUTER_IMPORT_RE.findall(content)
-            )
+            alias_modules = dict((alias, module) for module, alias in _ROUTER_IMPORT_RE.findall(content))
 
             # Pattern to match: (router_name, "/prefix", [...], "name")
             # Matches tuples like: (chat_router, "", ["chat"], "chat")
@@ -631,9 +629,7 @@ class BackendEndpointScanner:
         import when it is present; fall back to the guess when it is not, since
         some registries build routers without importing them by alias.
         """
-        alias_modules = dict(
-            (alias, module) for module, alias in _ROUTER_IMPORT_RE.findall(content)
-        )
+        alias_modules = dict((alias, module) for module, alias in _ROUTER_IMPORT_RE.findall(content))
 
         for match in dynamic_router_pattern.finditer(content):
             router_var = match.group(1)  # e.g., "terminal_router"

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -342,8 +342,7 @@ class TestRouterAliasResolvesToItsModule:
     def test_alias_not_mirroring_its_module_resolves_via_the_import(self, tmp_path):
         self._registry(
             tmp_path,
-            'from api.vnc_manager import router as vnc_router\n'
-            '(vnc_router, "/vnc", ["vnc"], "vnc"),\n',
+            "from api.vnc_manager import router as vnc_router\n" '(vnc_router, "/vnc", ["vnc"], "vnc"),\n',
         )
         scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
         scanner._collect_router_prefixes()
@@ -354,8 +353,7 @@ class TestRouterAliasResolvesToItsModule:
         """``api.vnc`` exists separately -- it must not inherit vnc_manager's prefix."""
         self._registry(
             tmp_path,
-            'from api.vnc_manager import router as vnc_router\n'
-            '(vnc_router, "/vnc", ["vnc"], "vnc"),\n',
+            "from api.vnc_manager import router as vnc_router\n" '(vnc_router, "/vnc", ["vnc"], "vnc"),\n',
         )
         scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
         scanner._collect_router_prefixes()
@@ -366,8 +364,7 @@ class TestRouterAliasResolvesToItsModule:
         """The common case must be unaffected."""
         self._registry(
             tmp_path,
-            'from api.chat import router as chat_router\n'
-            '(chat_router, "/chat", ["chat"], "chat"),\n',
+            "from api.chat import router as chat_router\n" '(chat_router, "/chat", ["chat"], "chat"),\n',
         )
         scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
         scanner._collect_router_prefixes()

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -320,3 +320,64 @@ class TestTestFilesAreNotEndpoints:
         paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
 
         assert "/api/results" in paths
+
+
+class TestRouterAliasResolvesToItsModule:
+    """#12953: the module was guessed by stripping ``_router`` from the alias.
+
+    Where the alias does not mirror its module the guess is wrong twice: the
+    prefix lands on a different module that also exists, and the real module is
+    left unprefixed, emitting its routes at ``/api/<route>``.
+    """
+
+    @staticmethod
+    def _registry(tmp_path, body):
+        backend = tmp_path / "autobot-backend"
+        (backend / "api").mkdir(parents=True)
+        registry = backend / "initialization" / "router_registry"
+        registry.mkdir(parents=True)
+        (registry / "core_routers.py").write_text(body, encoding="utf-8")
+        return backend
+
+    def test_alias_not_mirroring_its_module_resolves_via_the_import(self, tmp_path):
+        self._registry(
+            tmp_path,
+            'from api.vnc_manager import router as vnc_router\n'
+            '(vnc_router, "/vnc", ["vnc"], "vnc"),\n',
+        )
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        scanner._collect_router_prefixes()
+
+        assert scanner._module_prefix_map.get("vnc_manager") == "/api/vnc"
+
+    def test_the_guessed_module_is_not_given_the_prefix(self, tmp_path):
+        """``api.vnc`` exists separately -- it must not inherit vnc_manager's prefix."""
+        self._registry(
+            tmp_path,
+            'from api.vnc_manager import router as vnc_router\n'
+            '(vnc_router, "/vnc", ["vnc"], "vnc"),\n',
+        )
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        scanner._collect_router_prefixes()
+
+        assert scanner._module_prefix_map.get("vnc") != "/api/vnc"
+
+    def test_alias_mirroring_its_module_still_works(self, tmp_path):
+        """The common case must be unaffected."""
+        self._registry(
+            tmp_path,
+            'from api.chat import router as chat_router\n'
+            '(chat_router, "/chat", ["chat"], "chat"),\n',
+        )
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        scanner._collect_router_prefixes()
+
+        assert scanner._module_prefix_map.get("chat") == "/api/chat"
+
+    def test_router_without_an_import_falls_back_to_the_guess(self, tmp_path):
+        """Some registries build routers without importing them by alias."""
+        self._registry(tmp_path, '(terminal_router, "/terminal", ["terminal"], "terminal"),\n')
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        scanner._collect_router_prefixes()
+
+        assert scanner._module_prefix_map.get("terminal") == "/api/terminal"


### PR DESCRIPTION
Refs #12953 — the empty-prefix class. #12953 stays open for the remaining 243 missed routes.

## Thinking Path

**I have to correct my own earlier comment on #12953 first.** I claimed 90 modules had unresolved prefixes because `core_routers.py` registers routers as `from api.X import router as Y_router` and nothing linked the alias back to the module. That was wrong: the parser *does* derive a module — by stripping `_router` from the alias — and that guess is correct for **88 of the 90**. The real defect is narrower and sharper.

Where the alias does not mirror its module, the guess is wrong twice over:

```python
from api.vnc_manager import router as vnc_router
(vnc_router, "/vnc", ["vnc"], "vnc"),
```

`/vnc` was attributed to `api.vnc` — a different module that also exists, so the mistake is invisible — while `api.vnc_manager` got no prefix at all and emitted its routes unprefixed as `/api/click`, `/api/clipboard`. Each affected route therefore produced **one spurious entry and one missed entry**, which is the overlap I predicted on the issue.

Only two modules are affected (`vnc_manager`, `overseer_handlers`), but they carry 31 routes between them.

A detour worth recording: I first applied this to `_apply_dynamic_router_pattern` and the numbers did not move at all. `core_routers.py` is parsed by `_parse_router_registry` (simple-tuple format), not by `_parse_config_tuple_registry` — so the dynamic path never sees the file where all 90 aliases live. The fix belongs in both, and only one of them mattered.

## What Changed

`api/codebase_analytics/api_endpoint_scanner.py`: both `_parse_router_registry` and `_apply_dynamic_router_pattern` now build an alias→module map from the file's own `_ROUTER_IMPORT_RE` matches and prefer it, falling back to the `_router`-stripping guess when a router is not imported by alias (some registries build routers without importing them).

`api_endpoint_scanner_test.py`: 4 tests — an alias not mirroring its module resolving via the import; the *guessed* module explicitly **not** receiving the prefix (the silent half of the bug); the common mirroring case still working; and the no-import fallback.

## Verification

```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -q
27 passed in 0.75s        (23 pre-existing + 4 new)

$ python3 -m pytest api/codebase_analytics/ -q
241 passed, 11 skipped in 2.71s        (was 237 passed / 11 skipped)

$ python3 -m flake8 …
(clean)
```

Measured on the live install's indexed source `c5939a51-…`, read-only, against `app.openapi()`:

| | before | after |
|---|---|---|
| `vnc_manager` prefix | `None` | `/api/vnc` |
| `overseer_handlers` prefix | `None` | `/api/overseer` |
| real routes matched | 1885 | **1916** (+31) |
| scanned but not real | 69 | **38** (−31) |
| real routes missed | 274 | **243** (−31) |
| missing findings | 330 | **290** |
| false positives among them | 270 | **239** |
| orphaned findings | 290 | **258** |

The **+31 / −31 / −31** symmetry is the point: it confirms spurious and missed were the same defect seen from two sides, exactly as predicted on #12953. This is also the first change in the series to move the *spurious* count materially — it had sat at 70/70/71/69 through everything before it.

## What remains

243 real routes still unmatched and 38 spurious. Those belong to modules registered in no tuple at all (`api_endpoints`, `openai_compat` resolve to `None` for a different reason) — tracked on #12953.

## Model Used

claude-opus-5
