### PR TITLE
fix(auto-tools): repair broken log interpolation in the security sanitizers (#12678)

### DIFF
--- a/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
@@ -513,14 +513,14 @@ class SecurityFixAgent(SecurityFixToolBase):
     def fix_file(self, file_path: str) -> Dict[str, Any]:
         """Enhanced file fixing with multiple security layers."""
         try:
-            logger.info("\n🔍 Analyzing file: {file_path}")
+            logger.info("\n🔍 Analyzing file: %s", file_path)
 
             with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                 original_content = f.read()
 
             original_hash = hashlib.sha256(original_content.encode()).hexdigest()
             vulnerabilities = self.scan_for_vulnerabilities(original_content, file_path)
-            logger.warning("Found %slen(vulnerabilities)  potential XSS vulnerabilities")
+            logger.warning("Found %s potential XSS vulnerabilities", len(vulnerabilities))
 
             # Issue #1183: Delegate count display to extracted helper
             library_vulns, direct_vulns = self._display_vuln_counts(vulnerabilities)
@@ -561,8 +561,8 @@ class SecurityFixAgent(SecurityFixToolBase):
                 "enhancements": all_enhancements,
             }
 
-        except Exception:
-            logger.error("Error processing file %sfile_path : %se ")
+        except Exception as e:
+            logger.error("Error processing file %s: %s", file_path, e)
             return {
                 "file": file_path,
                 "status": "error",
@@ -580,8 +580,8 @@ class SecurityFixAgent(SecurityFixToolBase):
                         file_path = os.path.join(root, file)
                         html_files.append(file_path)
 
-        except Exception:
-            logger.error("Error scanning directory %sdirectory : %se ")
+        except Exception as e:
+            logger.error("Error scanning directory %s: %s", directory, e)
 
         return html_files
 
@@ -826,17 +826,17 @@ The Enhanced Security Fix Agent implements a multi-layered defense strategy:
         if os.path.isfile(target_path):
             files_to_process = [target_path]
         elif os.path.isdir(target_path):
-            logger.info("📂 Scanning directory: {target_path}")
+            logger.info("📂 Scanning directory: %s", target_path)
             files_to_process = self.scan_directory(target_path)
         else:
-            logger.error("Target path not found: %starget_path ")
+            logger.error("Target path not found: %s", target_path)
             return
 
         if not files_to_process:
             logger.info("❌ No HTML files found to process")
             return
 
-        logger.info("📋 Found {len(files_to_process)} HTML files to analyze")
+        logger.info("📋 Found %s HTML files to analyze", len(files_to_process))
 
         # Process each file
         results = []
@@ -850,24 +850,24 @@ The Enhanced Security Fix Agent implements a multi-layered defense strategy:
         report_path = self.save_report(report_content, os.path.dirname(target_path))
 
         if report_path:
-            logger.info("Security report saved: %sreport_path ")
+            logger.info("Security report saved: %s", report_path)
 
         # Print summary
-        sum(r.get("vulnerabilities_found", 0) for r in results)
+        total_vulnerabilities = sum(r.get("vulnerabilities_found", 0) for r in results)
         total_fixes = sum(r.get("fixes_applied", 0) for r in results)
         total_enhancements = sum(r.get("security_enhancements", 0) for r in results)
 
         logger.info("=" * 55)
         logger.info("🎯 SECURITY ENHANCEMENT SUMMARY")
         logger.info("=" * 55)
-        logger.info("Files processed: {len(results)}")
-        logger.info("Vulnerabilities found: {total_vulnerabilities}")
-        logger.info("Direct fixes applied: {total_fixes}")
-        logger.info("Security enhancements: {total_enhancements}")
+        logger.info("Files processed: %s", len(results))
+        logger.info("Vulnerabilities found: %s", total_vulnerabilities)
+        logger.info("Direct fixes applied: %s", total_fixes)
+        logger.info("Security enhancements: %s", total_enhancements)
 
         if total_fixes > 0 or total_enhancements > 0:
             logger.info("Security enhancements successfully applied!")
-            logger.info("📁 Backups created in: {self.backup_dir}")
+            logger.info("📁 Backups created in: %s", self.backup_dir)
             logger.info("🛡️  Multi-layer XSS protection now active")
         else:
             logger.info("✅ Files already secure - no enhancements needed")

--- a/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
@@ -351,7 +351,7 @@ class SecurityFixAgent(SecurityFixToolBase):
         for vuln in vulnerabilities:
             icon = severity_icon.get(vuln["severity"], "⚪")
             logger.info(f"  {icon} Line {vuln['line']}: {vuln['type']} ({vuln['severity']})")
-            logger.info("     Match: %s", vuln['match'][:100])
+            logger.info("     Match: %s", vuln["match"][:100])
 
     def _apply_fixes_and_write(
         self,

--- a/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
@@ -351,7 +351,7 @@ class SecurityFixAgent(SecurityFixToolBase):
         for vuln in vulnerabilities:
             icon = severity_icon.get(vuln["severity"], "⚪")
             logger.info(f"  {icon} Line {vuln['line']}: {vuln['type']} ({vuln['severity']})")
-            logger.info("     Match: {vuln['match'][:100]}")
+            logger.info("     Match: %s", vuln['match'][:100])
 
     def _apply_fixes_and_write(
         self,
@@ -371,13 +371,13 @@ class SecurityFixAgent(SecurityFixToolBase):
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(fixed_content)
         fixed_hash = hashlib.sha256(fixed_content.encode()).hexdigest()
-        logger.info("Applied %slen(fixes_applied)  security fixes")
+        logger.info("Applied %s security fixes", len(fixes_applied))
         return fixes_applied, fixed_hash
 
     def fix_file(self, file_path: str) -> Dict[str, Any]:
         """Fix XSS vulnerabilities in a single file."""
         try:
-            logger.info("\n🔍 Analyzing file: {file_path}")
+            logger.info("\n🔍 Analyzing file: %s", file_path)
 
             with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                 original_content = f.read()
@@ -394,7 +394,7 @@ class SecurityFixAgent(SecurityFixToolBase):
                     "fixes_applied": 0,
                 }
 
-            logger.warning("Found %slen(vulnerabilities)  potential XSS vulnerabilities:")
+            logger.warning("Found %s potential XSS vulnerabilities:", len(vulnerabilities))
 
             # Issue #1183: Delegate vuln logging to extracted helper
             self._log_vulnerability_details(vulnerabilities)
@@ -426,8 +426,8 @@ class SecurityFixAgent(SecurityFixToolBase):
                 "fixes": fixes_applied,
             }
 
-        except Exception:
-            logger.error("Error processing file %sfile_path : %se ")
+        except Exception as e:
+            logger.error("Error processing file %s: %s", file_path, e)
             return {
                 "file": file_path,
                 "status": "error",
@@ -445,8 +445,8 @@ class SecurityFixAgent(SecurityFixToolBase):
                         file_path = os.path.join(root, file)
                         html_files.append(file_path)
 
-        except Exception:
-            logger.error("Error scanning directory %sdirectory : %se ")
+        except Exception as e:
+            logger.error("Error scanning directory %s: %s", directory, e)
 
         return html_files
 
@@ -628,17 +628,17 @@ class SecurityFixAgent(SecurityFixToolBase):
         if os.path.isfile(target_path):
             files_to_process = [target_path]
         elif os.path.isdir(target_path):
-            logger.info("📂 Scanning directory: {target_path}")
+            logger.info("📂 Scanning directory: %s", target_path)
             files_to_process = self.scan_directory(target_path)
         else:
-            logger.error("Target path not found: %starget_path ")
+            logger.error("Target path not found: %s", target_path)
             return
 
         if not files_to_process:
             logger.info("❌ No HTML files found to process")
             return
 
-        logger.info("📋 Found {len(files_to_process)} HTML files to analyze")
+        logger.info("📋 Found %s HTML files to analyze", len(files_to_process))
 
         # Process each file
         results = []
@@ -652,22 +652,22 @@ class SecurityFixAgent(SecurityFixToolBase):
         report_path = self.save_report(report_content, os.path.dirname(target_path))
 
         if report_path:
-            logger.info("Security report saved: %sreport_path ")
+            logger.info("Security report saved: %s", report_path)
 
         # Print summary
-        sum(r.get("vulnerabilities_found", 0) for r in results)
+        total_vulnerabilities = sum(r.get("vulnerabilities_found", 0) for r in results)
         total_fixes = sum(r.get("fixes_applied", 0) for r in results)
 
         logger.info("=" * 50)
         logger.info("🎯 SUMMARY")
         logger.info("=" * 50)
-        logger.info("Files processed: {len(results)}")
-        logger.info("Vulnerabilities found: {total_vulnerabilities}")
-        logger.info("Fixes applied: {total_fixes}")
+        logger.info("Files processed: %s", len(results))
+        logger.info("Vulnerabilities found: %s", total_vulnerabilities)
+        logger.info("Fixes applied: %s", total_fixes)
 
         if total_fixes > 0:
             logger.info("Security fixes successfully applied!")
-            logger.info("📁 Backups created in: {self.backup_dir}")
+            logger.info("📁 Backups created in: %s", self.backup_dir)
         else:
             logger.info("✅ No vulnerabilities required fixing")
 


### PR DESCRIPTION
Closes #12678 (the log-interpolation half). The dead CLI flags in `performance_optimizer.py` are untouched — see below.

## Thinking Path

27 log calls across the two sanitizers never substituted their values, in the two shapes the issue describes. Fixing them turned up two defects the broken logging had been hiding, both of which matter more than the cosmetics.

**1. The `except` handlers have no `as e`.**

```python
except Exception:
    logger.error("Error processing file %sfile_path : %se ")
```

The exception object was never bound. Passing `e` as an argument — the obvious fix, and what the issue's suggested pattern implies — would raise `NameError` at the exact moment an error occurs, converting a logged failure into a crash inside the handler. The clauses now bind `as e`.

**2. `total_vulnerabilities` did not exist.**

```python
sum(r.get("vulnerabilities_found", 0) for r in results)   # result discarded
...
logger.info("Vulnerabilities found: {total_vulnerabilities}")
```

The assignment had been lost, so the summary computed the total and threw it away. Because the log line never substituted anything, nothing ever failed — the SUMMARY block simply could not report a real count. `flake8` F821 caught it the instant the log referenced the name for real. Assignment restored.

**Why not a scripted sweep.** I tried one first and reverted it. The payloads are not uniform — bare names, call expressions (`%slen(fixes_applied)`), and subscripted expressions (`{vuln['match'][:100]}`, which the issue does not list) — and a bare-identifier pattern silently mangles what it half-matches, in one case producing `logger.info("Applied %s(fixes_applied) …", len)`. These are explicit per-line edits.

## What Changed

`security_sanitizer.py` (14 sites) and `security_deep_sanitizer.py` (13 sites): all log calls converted to lazy `%`-formatting with real arguments; two `except Exception:` → `except Exception as e:`; `total_vulnerabilities` assignment restored in both.

## Verification

```
$ python3 -m py_compile security_sanitizer.py security_deep_sanitizer.py
BOTH COMPILE

$ python3 -m flake8 …/security_sanitizer.py …/security_deep_sanitizer.py
(clean — F821 on total_vulnerabilities is fixed, not suppressed)

$ grep -cE '%s[a-z_]+|logger\.[a-z]+\("[^"]*\{'  (both files)
0    (was 14 and 13)

import smoke: security_sanitizer imports OK / security_deep_sanitizer imports OK
```

33 insertions, 33 deletions — one line changed per site plus the two `except` clauses and two restored assignments.

## Not in this PR

The dead CLI flags (`--dry-run`, `--dev-mode`, `--replace-with-dev-logging` parsed and discarded in `performance_optimizer.py`). The issue offers "wire them in or remove them", and wiring `--dry-run` into `clean_project()`/`remove_console_logs()` is a behaviour change to a tool that rewrites source files — it deserves its own change and its own verification, not a ride-along with a logging fix. #12678 can stay open for it, or I can split it out.

## Model Used

claude-opus-5
