### PR TITLE
fix(auto-tools): make --dry-run actually skip writes (#12678)

### DIFF
--- a/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
+++ b/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
@@ -394,6 +394,25 @@ class ConsoleLogCleaner(ConsoleLogToolBase):
             json.dump(self.report, f, indent=2)
         print(f"📊 JSON report saved to: {json_report_path}")  # noqa: print
 
+    def _apply_cli_args(self, args: argparse.Namespace) -> None:
+        """Receive the flags declared in :meth:`_extra_cli_args` (#12678).
+
+        ``--dry-run`` is honoured by ``ConsoleLogToolBase.process_file``, which
+        reports what would change without writing. ``--dev-mode`` and
+        ``--replace-with-dev-logging`` are still accepted but not implemented --
+        they are recorded here so the gap is visible in one place rather than
+        silently discarded at the parser.
+        """
+        super()._apply_cli_args(args)
+        self.dev_mode = bool(getattr(args, "dev_mode", False))
+        self.replace_with_dev_logging = bool(getattr(args, "replace_with_dev_logging", False))
+        if self.dry_run:
+            print("🔎 Dry run: no files will be modified")  # noqa: print
+        for unimplemented in ("dev_mode", "replace_with_dev_logging"):
+            if getattr(self, unimplemented):
+                flag = unimplemented.replace("_", "-")
+                print(f"⚠️  --{flag} is accepted but not yet implemented (#12678)")  # noqa: print
+
     @classmethod
     def _extra_cli_args(cls, parser: argparse.ArgumentParser) -> None:
         """Hook for ``ConsoleLogToolBase.cli_main``: cleanup-specific flags."""

--- a/autobot-backend/code_analysis/auto-tools/tool_base.py
+++ b/autobot-backend/code_analysis/auto-tools/tool_base.py
@@ -171,10 +171,15 @@ class ConsoleLogToolBase:
             modified_content, count = self._transform_content(original_content, file_path)
 
             if count > 0:
-                self.create_backup(file_path)
+                # #12678: --dry-run must not touch the tree. Guarded here rather
+                # than at each call site because this is the only writer, so a
+                # future tool cannot bypass it by accident. The count is still
+                # reported, so a dry run says what it *would* change.
+                if not getattr(self, "dry_run", False):
+                    self.create_backup(file_path)
 
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(modified_content)
+                    with open(file_path, "w", encoding="utf-8") as f:
+                        f.write(modified_content)
 
                 self.report[self.REPORT_COUNT_KEY] += count
                 return True
@@ -193,6 +198,16 @@ class ConsoleLogToolBase:
     def run_project(self, target_dir: str = None) -> Dict[str, Any]:
         """Hook: invoke this tool's project-wide pass (convert_project/clean_project)."""
         raise NotImplementedError
+
+    def _apply_cli_args(self, args: argparse.Namespace) -> None:
+        """Receive the parsed CLI args (#12678).
+
+        ``--dry-run`` is handled here rather than per-tool because the code that
+        honours it -- :meth:`process_file` -- lives on this base. A subclass that
+        forgot to wire it would otherwise silently write while reporting a dry
+        run. Subclasses adding their own flags should call ``super()`` first.
+        """
+        self.dry_run = bool(getattr(args, "dry_run", False))
 
     @classmethod
     def _extra_cli_args(cls, parser: argparse.ArgumentParser) -> None:
@@ -216,6 +231,9 @@ class ConsoleLogToolBase:
         args = parser.parse_args()
 
         instance = cls(args.project_path, args.backup_dir)
+        # #12678: extra flags declared via _extra_cli_args were parsed and then
+        # discarded here, so a tool could not read its own options.
+        instance._apply_cli_args(args)
 
         if args.target_dir:
             target_path = Path(args.project_path) / args.target_dir

--- a/autobot-backend/code_analysis/auto-tools/tool_base_dry_run_test.py
+++ b/autobot-backend/code_analysis/auto-tools/tool_base_dry_run_test.py
@@ -1,0 +1,106 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""`--dry-run` must not modify the tree (#12678).
+
+`ConsoleLogToolBase` rewrites source files in place. The CLI accepted
+``--dry-run`` and discarded it — `cli_main` never handed the parsed args to the
+instance — so the flag a user would most reasonably trust before letting a tool
+rewrite their tree did nothing.
+
+These assert on **file bytes**, not on a reported counter: a dry run that
+reports "0 modified" while still writing would pass a counter-based test and be
+worse than the honest no-op it replaced.
+"""
+
+import argparse
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_DIR = pathlib.Path(__file__).parent
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tool_base = _load("tool_base")
+
+DIRTY = "function f() {\n  console.log('x');\n  return 1;\n}\n"
+
+
+@pytest.fixture
+def js_file(tmp_path):
+    path = tmp_path / "app.js"
+    path.write_text(DIRTY, encoding="utf-8")
+    return path
+
+
+class _Cleaner(tool_base.ConsoleLogToolBase):
+    """Minimal concrete tool: strips the console.log line."""
+
+    REPORT_COUNT_KEY = "console_logs_removed"
+
+    def __init__(self, project_path, backup_dir=None):
+        # The base declares no __init__; it reads these attributes directly.
+        self.project_root = pathlib.Path(project_path)
+        self.backup_dir = pathlib.Path(backup_dir or (self.project_root / "backups"))
+        self.report = {self.REPORT_COUNT_KEY: 0}
+
+    def _transform_content(self, content, file_path):
+        lines = [ln for ln in content.splitlines(keepends=True) if "console.log" not in ln]
+        removed = len(content.splitlines()) - len(lines)
+        return "".join(lines), removed
+
+
+def test_dry_run_leaves_the_file_byte_identical(js_file, tmp_path):
+    tool = _Cleaner(str(tmp_path))
+    tool._apply_cli_args(argparse.Namespace(dry_run=True))
+
+    changed = tool.process_file(js_file)
+
+    assert changed is True, "a dry run should still report that it would change the file"
+    assert js_file.read_text(encoding="utf-8") == DIRTY, "dry run modified the file"
+
+
+def test_dry_run_still_reports_what_it_would_change(js_file, tmp_path):
+    tool = _Cleaner(str(tmp_path))
+    tool._apply_cli_args(argparse.Namespace(dry_run=True))
+
+    tool.process_file(js_file)
+
+    assert tool.report["console_logs_removed"] == 1
+
+
+def test_dry_run_creates_no_backup(js_file, tmp_path):
+    tool = _Cleaner(str(tmp_path))
+    tool._apply_cli_args(argparse.Namespace(dry_run=True))
+
+    tool.process_file(js_file)
+    backups = [p for p in tmp_path.rglob("*") if p.is_file() and p != js_file]
+
+    assert backups == [], f"dry run wrote {backups}"
+
+
+def test_without_dry_run_the_file_is_rewritten(js_file, tmp_path):
+    tool = _Cleaner(str(tmp_path))
+
+    tool.process_file(js_file)
+
+    assert "console.log" not in js_file.read_text(encoding="utf-8")
+
+
+def test_apply_cli_args_defaults_to_writing(js_file, tmp_path):
+    """A tool that declares no flags must keep its previous behaviour."""
+    tool = _Cleaner(str(tmp_path))
+    tool._apply_cli_args(argparse.Namespace())
+
+    tool.process_file(js_file)
+
+    assert "console.log" not in js_file.read_text(encoding="utf-8")


### PR DESCRIPTION
Refs #12678 — the dead-CLI-flags half. `--dry-run` is now real; the other two are still unimplemented but no longer silent.

## Thinking Path

The flags were not merely unread, they were **unreachable**. `ConsoleLogToolBase.cli_main` parses them and then hands the instance only two values:

```python
cls._extra_cli_args(parser)
args = parser.parse_args()
instance = cls(args.project_path, args.backup_dir)   # the rest is dropped here
```

So `ConsoleLogCleaner` could not read `args.dry_run` even if it tried. That matters more than a normal dead flag: this tool **rewrites source files in place**, and `--dry-run` is precisely the flag a user would trust before letting it loose on a tree. Accepted-and-ignored is worse than absent.

**Where the flag is honoured was the real design decision.** My first cut set `dry_run` in `ConsoleLogCleaner._apply_cli_args`. The tests caught the hole immediately — the file was still rewritten — because the base's no-op hook meant any tool that did not re-implement it wrote anyway. `process_file` is the *single writer* and lives on the base, so the base now owns the default: a subclass cannot silently write while reporting a dry run. That inverted the safe direction; leaving it in the subclass made correctness opt-in.

## What Changed

- `tool_base.py`: added the `_apply_cli_args(self, args)` seam, called immediately after the instance is constructed, mirroring `_extra_cli_args` / `_print_cli_summary`. It sets `self.dry_run` from the parsed args. `process_file` skips the backup **and** the write when set, while still counting — so a dry run reports what it *would* change.
- `performance_optimizer.py`: overrides the seam, calls `super()` first, and prints an explicit warning that `--dev-mode` and `--replace-with-dev-logging` are accepted but not implemented, so the remaining gap is visible at the point of use rather than buried in the parser.

## Verification

```
$ python3 -m pytest tool_base_dry_run_test.py -q
5 passed in 0.30s

$ python3 -m flake8 tool_base.py tool_base_dry_run_test.py
(clean)
```

The tests assert on **file bytes**, deliberately:

- `--dry-run` leaves the file byte-identical
- `--dry-run` still reports the count it would have applied
- `--dry-run` creates no backup file
- without the flag, the file *is* rewritten (so the guard cannot pass by doing nothing)
- a tool declaring no flags keeps its previous behaviour

A counter-based test would have passed a dry run that reported "0 modified" while still writing — which is the failure mode worth guarding here.

## Pre-existing, not touched

`performance_optimizer.py:264` has an F841 (`indent` assigned, never used), present on `origin/Dev_new_gui`. I left it: the surrounding comment says "Look for preceding whitespace to maintain formatting", so an unused `indent` suggests indentation handling was never finished. Deleting the variable would silence the lint and hide that. Worth its own look.

## Still open on #12678

`--dev-mode` and `--replace-with-dev-logging` — each needs fixtures asserting which console calls survive and in what form, which is a different piece of work from making the tree safe from an unimplemented `--dry-run`.

## Model Used

claude-opus-5
