### PR TITLE
fix(config): env drift detector read the base directory, not the .env file (#12782)

### DIFF
--- a/autobot_shared/env_drift_detector.py
+++ b/autobot_shared/env_drift_detector.py
@@ -339,10 +339,14 @@ def _resolve_env_path(env_path: str | None) -> Path:
     for candidate in [current] + list(current.parents):
         if (candidate / ".env").exists():
             return candidate / ".env"
-    fallback = Path(
-        os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")
-    )  # ssot-config-exempt: bootstrap before config available / ".env"
-    return fallback
+    # ssot-config-exempt: bootstrap, before config is available.
+    # #12782: the `/ ".env"` join used to sit inside this trailing comment, so
+    # the fallback returned the DIRECTORY. _parse_env_file then failed with
+    # IsADirectoryError, swallowed it into an empty dict, and every SSOT key was
+    # reported missing -- "194 drifted, (194 SSOT keys, 0 .env keys)" on a host
+    # whose .env actually held 93 keys.
+    base = Path(os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot"))
+    return base / ".env"
 
 
 def _emit_drift_warnings(report: DriftReport) -> None:

--- a/autobot_shared/env_drift_detector_path_test.py
+++ b/autobot_shared/env_drift_detector_path_test.py
@@ -1,0 +1,61 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""`_resolve_env_path` must resolve to a FILE, never a directory (#12782).
+
+The fallback branch used to return the base directory, because the `/ ".env"`
+join had been absorbed into a trailing comment:
+
+    fallback = Path(
+        os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")
+    )  # ssot-config-exempt: bootstrap before config available / ".env"
+    return fallback
+
+`_parse_env_file` then hit `IsADirectoryError`, swallowed it into an empty dict
+(its `except OSError` path), and every SSOT key was reported missing. A live
+host showed "194 drifted, (194 SSOT keys, 0 .env keys)" while its `.env` held
+93 keys — the drift report was an artefact, not a measurement.
+"""
+
+import pathlib
+
+from autobot_shared import env_drift_detector as det
+
+
+def test_explicit_path_is_used_verbatim(tmp_path):
+    target = tmp_path / ".env"
+    target.write_text("A=1\n", encoding="utf-8")
+
+    assert det._resolve_env_path(str(target)) == target.resolve()
+
+
+def test_resolved_path_is_always_an_env_file(monkeypatch, tmp_path):
+    """The invariant that actually matters: never hand a directory to the parser."""
+    monkeypatch.setenv("AUTOBOT_BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(pathlib.Path, "exists", lambda self: False)
+
+    resolved = det._resolve_env_path(None)
+
+    assert resolved.name == ".env", f"resolved to {resolved}, which is not a .env file"
+
+
+def test_fallback_appends_env_to_the_base_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTOBOT_BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(pathlib.Path, "exists", lambda self: False)
+
+    assert det._resolve_env_path(None) == tmp_path / ".env"
+
+
+def test_parser_on_a_directory_yields_nothing(tmp_path):
+    """Guards the swallow: a directory must not silently parse as zero keys.
+
+    This is the behaviour that turned a path bug into a plausible-looking
+    "194 keys drifted" report, so it is pinned deliberately.
+    """
+    assert det._parse_env_file(tmp_path) == {}
+
+
+def test_parser_reads_a_real_env_file(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text('# c\nA=1\nB="two"\nC=3 # trailing\n\n', encoding="utf-8")
+
+    assert det._parse_env_file(env) == {"A": "1", "B": "two", "C": "3"}


### PR DESCRIPTION
Refs #12782. Fixes the cause of the 194-key drift report; the issue stays open for whatever real drift remains once the detector is measuring.

## Thinking Path

#12782 reads the warning `(194 SSOT keys, 0 .env keys)` as "the backend `.env` contributes nothing". Checking the live host first showed that is not what happened:

```
/opt/autobot/autobot-backend/.env   7075 bytes, 93 uppercase keys, mode 0600, autobot:autobot
detector                            0 .env keys
```

93 keys on disk, 0 counted. The confirming line was already sitting in the log:

```
env_drift_detector: cannot read /opt/autobot/autobot-backend: [Errno 21] Is a directory
```

The detector was handed the base **directory**. `_parse_env_file` raised `IsADirectoryError`, its `except OSError` swallowed it into an empty dict, and every SSOT key then compared against nothing and was reported `[MISSING]`.

The cause is a path join that ended up inside a trailing comment:

```python
fallback = Path(
    os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")
)  # ssot-config-exempt: bootstrap before config available / ".env"
return fallback
```

The `/ ".env"` is commented out. With `AUTOBOT_BASE_DIR=/opt/autobot/autobot-backend` that yields exactly the path in the error.

**So the 194 figure was an artefact of the empty side, not a measurement of drift.** A fix aimed at `.env` generation — the direction the issue points — would not have touched this.

## What Changed

`autobot_shared/env_drift_detector.py`: the fallback now joins `.env` outside the comment. The `ssot-config-exempt` marker is kept on its own line so it cannot swallow code again, with the failure recorded next to it.

`env_drift_detector_path_test.py` (new), 5 tests:
- explicit path passthrough
- **the resolved path is always a `.env` file, never a directory** — the invariant, which catches this class regardless of which branch produced it
- the fallback joins `.env` onto `AUTOBOT_BASE_DIR`
- a directory still parses to `{}` — pinning the swallow deliberately, so it stays visible rather than becoming load-bearing
- a real `.env` parses correctly (comments, quotes, inline comments)

## Verification

```
$ python3 -m pytest autobot_shared/env_drift_detector_path_test.py -q
5 passed in 0.20s

$ python3 -m pytest autobot_shared/ -q
1125 passed in 60.17s

$ python3 -m flake8 autobot_shared/env_drift_detector.py …_path_test.py
(clean)
```

## What this does not claim

I have not verified the corrected detector against the live host — that needs a deploy, and `autobot_shared` reaches hosts through the code-sync path rather than a role, so it should arrive normally (unlike the role-gated fixes tracked on #12959).

Once it is measuring the real file, the drift count will be whatever it actually is. **#12782 should stay open until that number is re-read** — the six empty-string settings it lists are a separate symptom, and their warnings no longer fire on the current boot, which is worth confirming rather than assuming.

## Model Used

claude-opus-5
