### PR TITLE
fix(skills): guard the Redis key decode in get_stale_skills (#12965)

### DIFF
--- a/autobot-backend/services/skill_management/skill_metrics.py
+++ b/autobot-backend/services/skill_management/skill_metrics.py
@@ -272,8 +272,16 @@ class SkillMetrics(AsyncRedisClientMixin):
 
         try:
             stale_keys = await redis.keys(f"{REDIS_SKILL_HEALTH_PREFIX}*:stale")
+            # The shared client is created with decode_responses=True, so keys
+            # arrive as str. Decoding unconditionally raised AttributeError on
+            # every call and the except below swallowed it into [] -- the caller
+            # saw "no stale skills", never an error. Guarded the same way as
+            # _iter_metric_keys and the duration parse above.
             return [
-                key.decode().replace(f"{REDIS_SKILL_HEALTH_PREFIX}", "").replace(":stale", "") for key in stale_keys
+                (key.decode() if isinstance(key, bytes) else key)
+                .replace(f"{REDIS_SKILL_HEALTH_PREFIX}", "")
+                .replace(":stale", "")
+                for key in stale_keys
             ]
         except Exception as e:
             logger.error("Failed to retrieve stale skills: %s", e)

--- a/autobot-backend/services/skill_management/skill_metrics_stale_decode_test.py
+++ b/autobot-backend/services/skill_management/skill_metrics_stale_decode_test.py
@@ -1,0 +1,54 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""`get_stale_skills` must handle str keys from a decode_responses client.
+
+The shared Redis client is created with ``decode_responses=True``, so ``keys()``
+returns ``str``. The comprehension called ``.decode()`` unconditionally, raising
+``AttributeError: 'str' object has no attribute 'decode'`` on every call — and
+the surrounding ``except Exception`` swallowed it into ``[]``.
+
+The caller therefore saw "no stale skills" rather than an error, while the live
+backend logged the failure 3612 times. Both halves are pinned here: the str path
+must work, and it must return the real skill ids rather than an empty list.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.skill_management import skill_metrics as sm
+
+PREFIX = sm.REDIS_SKILL_HEALTH_PREFIX
+
+
+def _metrics(keys):
+    inst = sm.SkillMetrics() if hasattr(sm, "SkillMetrics") else None
+    if inst is None:  # pragma: no cover - class name guard
+        pytest.skip("SkillMetrics not exported")
+    redis = AsyncMock()
+    redis.keys = AsyncMock(return_value=keys)
+    inst._get_redis = AsyncMock(return_value=redis)
+    return inst
+
+
+@pytest.mark.asyncio
+async def test_str_keys_are_handled(monkeypatch):
+    """decode_responses=True yields str — the live configuration."""
+    inst = _metrics([f"{PREFIX}alpha:stale", f"{PREFIX}beta:stale"])
+
+    assert sorted(await inst.get_stale_skills()) == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_bytes_keys_still_work():
+    """A client without decode_responses must not regress."""
+    inst = _metrics([f"{PREFIX}alpha:stale".encode(), f"{PREFIX}beta:stale".encode()])
+
+    assert sorted(await inst.get_stale_skills()) == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_no_stale_keys_returns_empty():
+    inst = _metrics([])
+
+    assert await inst.get_stale_skills() == []


### PR DESCRIPTION
Closes #12965.

## Thinking Path

Found by mining the live install's logs rather than working from a report — with the queue empty, the highest-signal source available was the box itself. This is the top error signature on it, **3612 occurrences**, and it was unfiled.

```
ERROR services.skill_management.skill_metrics:
  Failed to retrieve stale skills: 'str' object has no attribute 'decode'
```

The shared Redis client is created with `decode_responses=True`, so `keys()` returns `str` and the unconditional `.decode()` raises on every call.

**What makes it worth more than its one-line fix** is the swallow:

```python
except Exception as e:
    logger.error("Failed to retrieve stale skills: %s", e)
    return []
```

Callers see `[]` — "no stale skills" — which is a *plausible* answer, not an obviously broken one. So skill-staleness detection has never worked, nothing downstream could detect that, and the only evidence was 3612 log lines nobody was reading. The error also dominates `backend-error.log`, burying everything else in it.

The same file already gets this right twice (lines 148 and 157 use `x.decode() if isinstance(x, bytes) else x`), so line 276 was the outlier rather than the house style — which is why the fix matches the existing local pattern instead of introducing a new helper.

## What Changed

`services/skill_management/skill_metrics.py`: guarded the decode in `get_stale_skills`, matching the file's existing pattern, with the swallow's consequence recorded in a comment so the next reader knows why the guard matters.

`skill_metrics_stale_decode_test.py` (new), 3 tests: str keys (the live configuration), bytes keys (no regression for a client without `decode_responses`), and the empty case.

## Verification

```
$ python3 -m pytest services/skill_management/skill_metrics_stale_decode_test.py -q
3 passed in 0.46s

$ python3 -m flake8 …/skill_metrics.py …_stale_decode_test.py
(clean)
```

Not vacuous — the same comprehension against the pre-fix source raises:

```
PRE-FIX raises: 'str' object has no attribute 'decode'
```

## Note on the swallow

I left the `except Exception: … return []` in place. Narrowing it is a behaviour change for every caller that currently relies on the empty-list fallback, and it deserves its own consideration rather than riding along here. It is worth flagging though: this is the second time today a swallowed exception turned a hard failure into a plausible-looking empty result (the other being `env_drift_detector` reporting `0 .env keys`, #12964).

## Model Used

claude-opus-5
