### PR TITLE
fix(monitoring): render RFC3339 with one Z so Prometheus range queries stop 400ing (#12967)

### DIFF
--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -15,6 +15,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
 import aiohttp
+
+from autobot_shared.time_utils import to_rfc3339
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -146,8 +148,8 @@ async def _query_prometheus_range(
         http_client = get_http_client()
         params = {
             "query": query,
-            "start": start.isoformat() + "Z",
-            "end": end.isoformat() + "Z",
+            "start": to_rfc3339(start),
+            "end": to_rfc3339(end),
             "step": step,
         }
         async with await http_client.get(

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -15,8 +15,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
 import aiohttp
-
-from autobot_shared.time_utils import to_rfc3339
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -64,6 +62,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import get_config
+from autobot_shared.time_utils import to_rfc3339
 from config.registry import ConfigRegistry
 
 # Issue #474: Import ServiceURLs for AlertManager integration

--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -9,6 +9,8 @@ Data validation models for NPU worker management and load balancing.
 """
 
 from datetime import datetime
+
+from autobot_shared.time_utils import to_rfc3339
 from enum import Enum
 from typing import Any, Dict, List
 
@@ -235,7 +237,9 @@ class NPUWorkerDetails(BaseModel):
             "performance_metrics": self.metrics.model_dump() if self.metrics else {},
             "priority": self.config.priority,
             "weight": self.config.weight,
-            "last_heartbeat": (self.status.last_heartbeat.isoformat() + "Z" if self.status.last_heartbeat else ""),
+            # #12967: last_heartbeat is `datetime | None` with no naive constraint,
+            # so an aware producer would emit a doubled zone (+00:00Z) here.
+            "last_heartbeat": (to_rfc3339(self.status.last_heartbeat) if self.status.last_heartbeat else ""),
             "created_at": "",  # Not tracked in current model
         }
 

--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -9,15 +9,13 @@ Data validation models for NPU worker management and load balancing.
 """
 
 from datetime import datetime
-
-from autobot_shared.time_utils import to_rfc3339
 from enum import Enum
 from typing import Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from autobot_shared.ssot_config import config as _ssot_config
-from autobot_shared.time_utils import now_utc
+from autobot_shared.time_utils import now_utc, to_rfc3339
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import CategoryDefaults
 

--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -79,6 +79,29 @@ def now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def to_rfc3339(value: datetime) -> str:
+    """Render *value* as RFC3339 with a single ``Z`` suffix.
+
+    Appending ``"Z"`` to ``isoformat()`` is only correct for a NAIVE UTC
+    datetime. On an aware one the offset is already present, so the result
+    carries a doubled zone -- ``2026-07-29T13:23:29+00:00Z`` -- which strict
+    parsers reject. Prometheus answered every such range query with HTTP 400
+    (#12967), and because the caller only logged a warning the graphs simply
+    came back empty.
+
+    Naive input is treated as UTC, matching :func:`parse_utc_iso`.
+
+    Args:
+        value: Aware or naive datetime.
+
+    Returns:
+        RFC3339 string ending in exactly one ``Z``.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def parse_utc_iso(value: str) -> datetime:
     """Parse an ISO-8601 timestamp string and return a tz-aware UTC datetime.
 

--- a/autobot_shared/time_utils_rfc3339_test.py
+++ b/autobot_shared/time_utils_rfc3339_test.py
@@ -1,0 +1,51 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""`to_rfc3339` must emit exactly one zone designator (#12967).
+
+`isoformat() + "Z"` is correct only for a naive UTC datetime. On an aware one
+the offset is already there, so the result carries a doubled zone
+(`+00:00Z`). Prometheus rejected every range query built that way with HTTP
+400, and because the caller only logged a warning the graphs came back empty
+instead of erroring.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from autobot_shared.time_utils import to_rfc3339
+
+AWARE = datetime(2026, 7, 29, 13, 23, 29, tzinfo=timezone.utc)
+NAIVE = datetime(2026, 7, 29, 13, 23, 29)
+
+
+@pytest.mark.parametrize("value", [AWARE, NAIVE])
+def test_never_emits_a_doubled_zone(value):
+    """The exact defect: '+00:00Z' is not valid RFC3339."""
+    rendered = to_rfc3339(value)
+
+    assert "+00:00" not in rendered
+    assert rendered.count("Z") == 1
+    assert rendered.endswith("Z")
+
+
+def test_aware_utc_renders_with_z():
+    assert to_rfc3339(AWARE) == "2026-07-29T13:23:29Z"
+
+
+def test_naive_is_treated_as_utc():
+    """Matches parse_utc_iso's convention, so a round trip is stable."""
+    assert to_rfc3339(NAIVE) == "2026-07-29T13:23:29Z"
+
+
+def test_non_utc_offset_is_converted_not_relabelled():
+    """A +02:00 time must shift, not just get its suffix swapped."""
+    berlin = datetime(2026, 7, 29, 15, 23, 29, tzinfo=timezone(timedelta(hours=2)))
+
+    assert to_rfc3339(berlin) == "2026-07-29T13:23:29Z"
+
+
+def test_output_is_parseable_back():
+    from autobot_shared.time_utils import parse_utc_iso
+
+    assert parse_utc_iso(to_rfc3339(AWARE)) == AWARE


### PR DESCRIPTION
Closes #12967.

## Thinking Path

Found by scanning the live install's logs — 1592 occurrences, the second-most-frequent signature after #12965, and unfiled.

```
api.monitoring - WARNING - Prometheus range query failed: 400
```

**Prometheus is healthy** (`systemctl is-active` → active, listening on `*:9090`), so a 400 is it rejecting the request as malformed, not failing to serve it.

`api/monitoring.py:149-150` appended `"Z"` to `isoformat()`, while the caller at `:587` supplies `datetime.now(timezone.utc)` — aware. On an aware datetime the offset is already present:

```
aware isoformat + "Z"  ->  2026-07-29T13:23:29.512853+00:00Z   <- invalid RFC3339
naive isoformat + "Z"  ->  2026-07-29T13:23:29.512966Z         <- what the code assumed
```

The `+ "Z"` was correct for the naive datetime the caller presumably used to pass. Nothing failed loudly when that changed, because the non-200 branch only logs a warning — so range graphs came back **empty rather than erroring**, which is why this ran for 1592 iterations without being noticed.

**Why a shared helper rather than two inline fixes.** "Append Z" is correct exactly when the datetime is naive, and that assumption is invisible at the call site and easy to reintroduce. Putting it in `autobot_shared.time_utils` beside `parse_utc_iso` gives one place that encodes the rule, and the two functions now round-trip.

Grepping for the construct found a **third** site: `models/npu_models.py:238` does the same on `last_heartbeat`, which is typed `datetime | None` with no naive constraint — so an aware producer emits the same malformed value, and its own schema example advertises the `Z` form. Fixed too; no doubled-zone sites remain in `autobot-backend/` or `autobot_shared/`.

## What Changed

- `autobot_shared/time_utils.py`: added `to_rfc3339()`. Naive input is treated as UTC (matching `parse_utc_iso`); aware input is **converted**, not relabelled.
- `api/monitoring.py`: `start`/`end` use it.
- `models/npu_models.py`: `last_heartbeat` uses it.

## Verification

```
$ python3 -m pytest autobot_shared/time_utils_rfc3339_test.py -q
6 passed in 0.20s

$ python3 -m pytest autobot_shared/ -q
1131 passed in 54.88s

$ python3 -m flake8 (all three files)
(clean)

$ grep -rn 'isoformat() + "Z"' autobot-backend/ autobot_shared/   # excl. tests
0
```

Tests pin the defect itself — never emits `+00:00`, exactly one trailing `Z` — for both aware and naive input, plus a non-UTC offset being **converted** rather than having its suffix swapped (a `+02:00` time must shift by two hours, not merely gain a `Z`), and a `parse_utc_iso` round trip.

## Not verified

That the live queries now return 200 — that needs a deploy. `autobot_shared/` and `api/` reach hosts via the code-sync path rather than an Ansible role, so unlike the role-gated fixes on #12959 this should arrive normally. The check afterwards is simply that the warning stops accumulating.

## Model Used

claude-opus-5
