### PR TITLE
fix(analytics): resolve nested router subpackages and honour what is actually mounted (#12956)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -109,6 +109,12 @@ _FOUR_ELEMENT_TUPLE_RE = re.compile(
     re.MULTILINE,
 )
 # Issue #552: Dynamic router loading pattern
+# #12956: names actually passed to include_router(), and the relative imports
+# that bind them to a submodule -- `from .costs import router as costs_router`.
+_INCLUDE_ROUTER_NAME_RE = re.compile(r"include_router\(\s*(\w+)")
+_RELATIVE_ROUTER_IMPORT_RE = re.compile(r"^from\s+\.(\w+)\s+import\s+router\s+as\s+(\w+)", re.MULTILINE)
+
+
 _DYNAMIC_ROUTER_TUPLE_RE = re.compile(
     r'\(\s*(\w+_router)\s*,\s*["\']([^"\']*)["\'],' r'\s*\[[^\]]*\]\s*,\s*["\'](\w+)["\']',
     re.MULTILINE,
@@ -741,9 +747,15 @@ class BackendEndpointScanner:
         the submodule's own prefix separately -- so only the package-level part
         belongs here.
 
-        Submodules are included only when the package actually mounts them via
-        ``include_router``: a helper module that defines no router contributes
-        no routes, and guessing otherwise is how phantom endpoints appear.
+        A submodule is included only when the package imports its router under
+        an alias AND mounts that exact alias via ``include_router``. #12956: the
+        previous check only confirmed the package mounted *something*, then
+        included every router-declaring module -- so a declared-but-unmounted
+        router still contributed routes, which the docstring already claimed it
+        would not.
+
+        Nested router subpackages recurse, so their modules resolve under their
+        own prefix rather than the parent's.
         """
         init_file = package / "__init__.py"
         init_content = init_file.read_text(encoding="utf-8", errors="ignore")
@@ -752,12 +764,28 @@ class BackendEndpointScanner:
             return {}
 
         served_prefix = f"{registry_prefix}{package_prefix}"
-        return {
-            py_file: served_prefix
-            for py_file in sorted(package.rglob("*.py"))
-            if not py_file.name.startswith("__")
-            and _APIROUTER_PREFIX_RE.search(py_file.read_text(encoding="utf-8", errors="ignore"))
-        }
+        mounted = set(_INCLUDE_ROUTER_NAME_RE.findall(init_content))
+        if not mounted:
+            return {}
+
+        files: Dict[Path, str] = {}
+        # #12956: walk one level and recurse, rather than rglob'ing the tree.
+        # rglob descended into nested router subpackages while the "__" filter
+        # removed the very __init__.py carrying their own prefix, so their
+        # modules were emitted under the PARENT's prefix -- inventing endpoints,
+        # the failure this whole change set exists to avoid.
+        for module_name, alias in _RELATIVE_ROUTER_IMPORT_RE.findall(init_content):
+            if alias not in mounted:
+                # Declared but never mounted: it serves nothing.
+                continue
+            module_file = (package / module_name).with_suffix(".py")
+            if module_file.is_file():
+                files[module_file] = served_prefix
+                continue
+            subpackage = package / module_name
+            if (subpackage / "__init__.py").is_file():
+                files.update(self._package_router_files(subpackage, served_prefix))
+        return files
 
     def _get_module_prefix(self, file_path: Path) -> str:
         """Get the API prefix for a given file based on router registry."""

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -219,7 +219,9 @@ class TestRegistryRoutersOutsideApi:
         backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
         pkg = self._make_package(
             backend,
-            'router = APIRouter(prefix="/llc")\nrouter.include_router(costs_router)\n',
+            'router = APIRouter(prefix="/llc")\n'
+            'from .costs import router as costs_router\n'
+            'router.include_router(costs_router)\n',
             {"costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/by-agent")\ndef c(): ...\n'},
         )
 
@@ -232,7 +234,9 @@ class TestRegistryRoutersOutsideApi:
         backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
         self._make_package(
             backend,
-            'router = APIRouter(prefix="/llc")\nrouter.include_router(costs_router)\n',
+            'router = APIRouter(prefix="/llc")\n'
+            'from .costs import router as costs_router\n'
+            'router.include_router(costs_router)\n',
             {"costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/by-agent")\ndef c(): ...\n'},
         )
 
@@ -245,7 +249,9 @@ class TestRegistryRoutersOutsideApi:
         backend = self._backend_with_registry(tmp_path, [("llc.api", "")])
         pkg = self._make_package(
             backend,
-            'router = APIRouter(prefix="/llc")\nrouter.include_router(costs_router)\n',
+            'router = APIRouter(prefix="/llc")\n'
+            'from .costs import router as costs_router\n'
+            'router.include_router(costs_router)\n',
             {
                 "costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/x")\ndef c(): ...\n',
                 "helpers.py": "def compute(): return 1\n",
@@ -378,3 +384,85 @@ class TestRouterAliasResolvesToItsModule:
         scanner._collect_router_prefixes()
 
         assert scanner._module_prefix_map.get("terminal") == "/api/terminal"
+
+
+class TestNestedRouterSubpackages:
+    """#12956: nested subpackages must resolve under their OWN prefix.
+
+    `rglob` walked the whole tree while the ``__``-prefix filter removed the
+    nested ``__init__.py`` carrying that subpackage's prefix, so its modules
+    were emitted under the PARENT's prefix — inventing endpoints, the exact
+    failure #12945 set out to prevent.
+    """
+
+    @staticmethod
+    def _pkg(root, rel, prefix, mounts, modules):
+        """Create a router package: its own prefix, what it mounts, its modules."""
+        pkg = root / rel
+        pkg.mkdir(parents=True, exist_ok=True)
+        imports = "".join(f"from .{m} import router as {m}_router\n" for m in mounts)
+        includes = "".join(f"router.include_router({m}_router)\n" for m in mounts)
+        (pkg / "__init__.py").write_text(
+            f'router = APIRouter(prefix="{prefix}")\n{imports}{includes}', encoding="utf-8"
+        )
+        for name, body in modules.items():
+            (pkg / f"{name}.py").write_text(body, encoding="utf-8")
+        return pkg
+
+    def _scanner(self, tmp_path, entries):
+        backend = tmp_path / "autobot-backend"
+        (backend / "api").mkdir(parents=True, exist_ok=True)
+        registry = backend / "initialization" / "router_registry"
+        registry.mkdir(parents=True, exist_ok=True)
+        lines = [f'    ("{m}", "{p}", ["t"], "x"),' for m, p in entries]
+        (registry / "feature_routers.py").write_text(
+            "ROUTER_CONFIGS = [\n" + "\n".join(lines) + "\n]\n", encoding="utf-8"
+        )
+        scanner = scanner_mod.BackendEndpointScanner(project_root=tmp_path)
+        scanner._collect_router_prefixes()
+        return scanner, backend
+
+    def test_nested_subpackage_uses_its_own_prefix(self, tmp_path):
+        scanner, backend = self._scanner(tmp_path, [("llc.api", "")])
+        pkg = self._pkg(
+            backend, "llc/api", "/llc", ["sub"],
+            {"sub": ""},  # placeholder, replaced by the subpackage below
+        )
+        (pkg / "sub.py").unlink()
+        self._pkg(
+            backend, "llc/api/sub", "/sub", ["b"],
+            {"b": 'router = APIRouter(prefix="/b")\n@router.get("/x")\ndef f(): ...\n'},
+        )
+
+        found = scanner._registry_router_files()
+
+        assert found == {pkg / "sub" / "b.py": "/api/llc/sub"}, found
+
+    def test_nested_module_route_gets_the_full_path(self, tmp_path):
+        _, backend = self._scanner(tmp_path, [("llc.api", "")])
+        pkg = self._pkg(backend, "llc/api", "/llc", ["sub"], {"sub": ""})
+        (pkg / "sub.py").unlink()
+        self._pkg(
+            backend, "llc/api/sub", "/sub", ["b"],
+            {"b": 'router = APIRouter(prefix="/b")\n@router.get("/x")\ndef f(): ...\n'},
+        )
+
+        paths = [e.path for e in scanner_mod.BackendEndpointScanner(project_root=tmp_path).scan_all_endpoints()]
+
+        assert "/api/llc/sub/b/x" in paths, paths
+
+    def test_declared_but_unmounted_router_is_excluded(self, tmp_path):
+        """#12956: the docstring claimed this; the code did not enforce it."""
+        scanner, backend = self._scanner(tmp_path, [("llc.api", "")])
+        pkg = self._pkg(
+            backend, "llc/api", "/llc", ["mounted"],
+            {
+                "mounted": 'router = APIRouter(prefix="/m")\n@router.get("/x")\ndef f(): ...\n',
+                "orphan": 'router = APIRouter(prefix="/o")\n@router.get("/y")\ndef g(): ...\n',
+            },
+        )
+
+        found = scanner._registry_router_files()
+
+        assert pkg / "orphan.py" not in found
+        assert pkg / "mounted.py" in found

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -220,8 +220,8 @@ class TestRegistryRoutersOutsideApi:
         pkg = self._make_package(
             backend,
             'router = APIRouter(prefix="/llc")\n'
-            'from .costs import router as costs_router\n'
-            'router.include_router(costs_router)\n',
+            "from .costs import router as costs_router\n"
+            "router.include_router(costs_router)\n",
             {"costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/by-agent")\ndef c(): ...\n'},
         )
 
@@ -235,8 +235,8 @@ class TestRegistryRoutersOutsideApi:
         self._make_package(
             backend,
             'router = APIRouter(prefix="/llc")\n'
-            'from .costs import router as costs_router\n'
-            'router.include_router(costs_router)\n',
+            "from .costs import router as costs_router\n"
+            "router.include_router(costs_router)\n",
             {"costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/by-agent")\ndef c(): ...\n'},
         )
 
@@ -250,8 +250,8 @@ class TestRegistryRoutersOutsideApi:
         pkg = self._make_package(
             backend,
             'router = APIRouter(prefix="/llc")\n'
-            'from .costs import router as costs_router\n'
-            'router.include_router(costs_router)\n',
+            "from .costs import router as costs_router\n"
+            "router.include_router(costs_router)\n",
             {
                 "costs.py": 'router = APIRouter(prefix="/costs")\n@router.get("/x")\ndef c(): ...\n',
                 "helpers.py": "def compute(): return 1\n",
@@ -425,12 +425,18 @@ class TestNestedRouterSubpackages:
     def test_nested_subpackage_uses_its_own_prefix(self, tmp_path):
         scanner, backend = self._scanner(tmp_path, [("llc.api", "")])
         pkg = self._pkg(
-            backend, "llc/api", "/llc", ["sub"],
+            backend,
+            "llc/api",
+            "/llc",
+            ["sub"],
             {"sub": ""},  # placeholder, replaced by the subpackage below
         )
         (pkg / "sub.py").unlink()
         self._pkg(
-            backend, "llc/api/sub", "/sub", ["b"],
+            backend,
+            "llc/api/sub",
+            "/sub",
+            ["b"],
             {"b": 'router = APIRouter(prefix="/b")\n@router.get("/x")\ndef f(): ...\n'},
         )
 
@@ -443,7 +449,10 @@ class TestNestedRouterSubpackages:
         pkg = self._pkg(backend, "llc/api", "/llc", ["sub"], {"sub": ""})
         (pkg / "sub.py").unlink()
         self._pkg(
-            backend, "llc/api/sub", "/sub", ["b"],
+            backend,
+            "llc/api/sub",
+            "/sub",
+            ["b"],
             {"b": 'router = APIRouter(prefix="/b")\n@router.get("/x")\ndef f(): ...\n'},
         )
 
@@ -455,7 +464,10 @@ class TestNestedRouterSubpackages:
         """#12956: the docstring claimed this; the code did not enforce it."""
         scanner, backend = self._scanner(tmp_path, [("llc.api", "")])
         pkg = self._pkg(
-            backend, "llc/api", "/llc", ["mounted"],
+            backend,
+            "llc/api",
+            "/llc",
+            ["mounted"],
             {
                 "mounted": 'router = APIRouter(prefix="/m")\n@router.get("/x")\ndef f(): ...\n',
                 "orphan": 'router = APIRouter(prefix="/o")\n@router.get("/y")\ndef g(): ...\n',


### PR DESCRIPTION
Closes #12956.

## Thinking Path

Both findings are against code I wrote in PR #12950, were reported on that PR by the `secreview` skill, and were not addressed before it merged. Both are correct, and both are the exact failure class #12945 existed to prevent — a submodule mapped to a prefix it is not served under, inventing endpoints that resurface as false "orphaned" findings.

**1. `rglob` + the `__` filter is self-defeating for nested packages.** `rglob` walked the entire tree while `not py_file.name.startswith("__")` removed the nested `__init__.py` carrying that subpackage's own prefix — so the only file that could have corrected the mapping was the one excluded. Now it walks one level and recurses, so a nested subpackage resolves under its own prefix.

Verified this is **latent rather than live**: `llc/api` has no nested router subpackages today, so nothing was actually mis-mapped on the current tree. The fix is preventive, which is why it needs the regression test the issue asks for — there is no live signal to catch it otherwise.

**2. The docstring described a check the code did not implement.** It claimed submodules are included "only when the package actually mounts them via `include_router`", while the code only confirmed the package mounted *something* and then included every router-declaring module. I chose to tighten the code rather than soften the claim, because the claim is the correct behaviour — a declared-but-unmounted router serves nothing.

## Measured effect

On indexed source `c5939a51-…`, against `app.openapi()`:

| | #12950 | this PR |
|---|---|---|
| router files outside `api/` | 28 | 36 |
| endpoints found | 2157 | 2220 |
| real routes matched | 1916 | **1960** (+44) |
| **scanned but not real** | **38** | **38** |
| missing findings | 290 | 244 |

Tightening the check **gained** 44 real routes rather than losing any, because binding alias→module finds submodules the old router-declaration filter missed — and the spurious count did not move, so nothing was invented.

## A note on the three failing fixtures

My #12950 tests broke under the tightened check. Their packages mounted `costs_router` **without** importing it:

```python
router = APIRouter(prefix="/llc")
router.include_router(costs_router)      # alias bound to nothing
```

No real registry does that — the live `llc/api/__init__.py` carries 30 `from .x import router as x_router` lines. The fixtures encoded a shape that cannot occur, so I corrected them rather than loosening the check to keep them passing. Worth flagging explicitly: a test that only passes against an impossible input was giving false assurance about the very behaviour under review.

## Verification

```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -q
30 passed in 1.49s

$ python3 -m pytest api/codebase_analytics/ -q
244 passed, 11 skipped in 5.43s

$ python3 -m flake8 …
(clean)
```

New tests: a nested subpackage resolving under its own prefix, its route's full served path end-to-end (`/api/llc/sub/b/x`), and a declared-but-unmounted router being excluded.

## Not a finding (recorded so it is not re-raised)

Per the issue: `joinpath(*module_path.split("."))` would let a `..` segment escape `backend_dir`, but the registry is code-controlled, not user input.

## Model Used

claude-opus-5
