### PR TITLE
fix(analytics): separate fallback-derived findings from actionable missing endpoints (#12745)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -1188,6 +1188,7 @@ class EndpointMatcher:
         self,
         used_endpoints: List[EndpointUsageItem],
         missing_endpoints: List[EndpointMismatchItem],
+        low_confidence_endpoints: List[EndpointMismatchItem],
     ) -> Set[int]:
         """
         Match API calls to backend endpoints.
@@ -1229,14 +1230,27 @@ class EndpointMatcher:
                     break
 
             if not matched and not call.is_dynamic and self._is_reportable_call(call.path):
-                missing_endpoints.append(
+                # #12745: method=="UNKNOWN" marks a finding from the standalone-
+                # path fallback -- the line held an "/api/..." string but matched
+                # no structured call pattern, so this may be a comment, constant
+                # or cache-key map rather than a call. Measured 89% false against
+                # app.openapi() versus 25% for pattern-matched calls, so these are
+                # reported separately instead of drowning the actionable ones.
+                # Separated, never dropped: suppression is how #12894 hid 29 real
+                # findings behind a label.
+                low_confidence = call.method == "UNKNOWN"
+                (low_confidence_endpoints if low_confidence else missing_endpoints).append(
                     EndpointMismatchItem(
-                        type="missing",
+                        type="low_confidence" if low_confidence else "missing",
                         method=call.method,
                         path=call.path,
                         file_path=call.file_path,
                         line_number=call.line_number,
-                        details="Called but no backend endpoint found",
+                        details=(
+                            "Path literal with no recognised call pattern — verify before acting"
+                            if low_confidence
+                            else "Called but no backend endpoint found"
+                        ),
                     )
                 )
 
@@ -1316,6 +1330,7 @@ class EndpointMatcher:
         """
         used_endpoints: List[EndpointUsageItem] = []
         missing_endpoints: List[EndpointMismatchItem] = []
+        low_confidence_endpoints: List[EndpointMismatchItem] = []
 
         # #12745: with an empty endpoint map every call matches nothing, so the
         # report claimed 2400 missing endpoints of which 97.4% actually existed.
@@ -1325,7 +1340,9 @@ class EndpointMatcher:
             return self._empty_scan_analysis()
 
         # Match calls to endpoints (Issue #665: uses helper)
-        used_endpoint_ids = self._match_calls_to_endpoints(used_endpoints, missing_endpoints)
+        used_endpoint_ids = self._match_calls_to_endpoints(
+            used_endpoints, missing_endpoints, low_confidence_endpoints
+        )
 
         # Find orphaned endpoints (Issue #665: uses helper)
         orphaned_endpoints = self._find_orphaned_endpoints(used_endpoint_ids)
@@ -1346,6 +1363,8 @@ class EndpointMatcher:
             api_calls=self.calls,
             orphaned=orphaned_endpoints,
             missing=missing_endpoints,
+            low_confidence=low_confidence_endpoints,
+            low_confidence_endpoints=len(low_confidence_endpoints),
             used=used_endpoints,
             scan_timestamp=datetime.now(tz=timezone.utc).isoformat(),
         )

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -1340,9 +1340,7 @@ class EndpointMatcher:
             return self._empty_scan_analysis()
 
         # Match calls to endpoints (Issue #665: uses helper)
-        used_endpoint_ids = self._match_calls_to_endpoints(
-            used_endpoints, missing_endpoints, low_confidence_endpoints
-        )
+        used_endpoint_ids = self._match_calls_to_endpoints(used_endpoints, missing_endpoints, low_confidence_endpoints)
 
         # Find orphaned endpoints (Issue #665: uses helper)
         orphaned_endpoints = self._find_orphaned_endpoints(used_endpoint_ids)

--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner_test.py
@@ -478,3 +478,54 @@ class TestNestedRouterSubpackages:
 
         assert pkg / "orphan.py" not in found
         assert pkg / "mounted.py" in found
+
+
+class TestLowConfidenceSplit:
+    """#12745: fallback-derived findings are separated, never dropped.
+
+    A line containing "/api/..." that matches no structured call pattern still
+    produces a finding, with method="UNKNOWN". Measured 89% false against
+    app.openapi() (214/240) versus 25% for pattern-matched calls, because any
+    /api/ string qualifies — a comment, a constant, a cache-key map (#12381).
+    """
+
+    @staticmethod
+    def _match(calls):
+        matcher = scanner_mod.EndpointMatcher([], calls)
+        missing, low = [], []
+        matcher._match_calls_to_endpoints([], missing, low)
+        return missing, low
+
+    @staticmethod
+    def _call(method):
+        return scanner_mod.FrontendAPICallItem(
+            method=method,
+            path="/api/does-not-exist",
+            file_path="src/x.ts",
+            line_number=1,
+            context="ctx",
+            is_dynamic=False,
+        )
+
+    def test_unknown_method_goes_to_low_confidence(self):
+        missing, low = self._match([self._call("UNKNOWN")])
+
+        assert missing == []
+        assert [i.type for i in low] == ["low_confidence"]
+
+    def test_resolved_method_stays_in_missing(self):
+        missing, low = self._match([self._call("GET")])
+
+        assert [i.type for i in missing] == ["missing"]
+        assert low == []
+
+    def test_nothing_is_dropped(self):
+        """Both buckets together must account for every reportable call."""
+        missing, low = self._match([self._call("UNKNOWN"), self._call("POST")])
+
+        assert len(missing) + len(low) == 2
+
+    def test_low_confidence_finding_says_why(self):
+        _, low = self._match([self._call("UNKNOWN")])
+
+        assert "verify" in (low[0].details or "").lower()

--- a/autobot-backend/api/codebase_analytics/models.py
+++ b/autobot-backend/api/codebase_analytics/models.py
@@ -121,6 +121,16 @@ class APIEndpointAnalysis(BaseModel):
     orphaned: List[EndpointMismatchItem]
     missing: List[EndpointMismatchItem]
     used: List[EndpointUsageItem]
+    # #12745: findings derived from the scanner's standalone-path fallback --
+    # a line containing "/api/..." that matched no structured call pattern, so
+    # the HTTP method is UNKNOWN. Measured 89% false (214/240) against
+    # app.openapi(), versus 25% for pattern-matched calls, because any /api/
+    # string qualifies: a comment, a constant, a cache-key map (#12381).
+    # Kept and reported separately rather than dropped -- suppressing findings
+    # is how #12894 hid 29 real ones -- but out of `missing`, which is what
+    # users act on.
+    low_confidence: List[EndpointMismatchItem] = []
+    low_confidence_endpoints: int = 0
     scan_timestamp: str
     # #12745: set when the backend route scan produced nothing. In that state
     # every frontend call looks "missing" (2400 of them on a real source), which


### PR DESCRIPTION
Refs #12745 — addresses criteria 1, 3 and 4. The issue stays open; see below.

## Thinking Path

Tracing the `UNKNOWN` methods showed that two of this issue's acceptance criteria are the **same defect**.

`FrontendAPICallScanner` has a fallback: a line containing `/api/...` that matches none of `_API_CALL_PATTERNS` still emits a finding, with `method="UNKNOWN"`. That value is not a parsing shortfall — it marks a finding the scanner could not confirm is a call at all. A comment, a constant, or a cache-key map qualifies (the documented #12381 false-positive class).

Splitting the 244 findings by that marker, against `app.openapi()`:

```
method=UNKNOWN : 214/240 = 89% false
method known   :   1/4   = 25% false
```

So the unresolved method (criterion 3) and the false-positive rate (criterion 4) have one cause, and "97% false positives" is what happens when both sets are presented as equally actionable.

**Separated, not suppressed.** Dropping the weak set would hide genuine calls the patterns do not yet recognise — the #12894 failure mode, where 29 real findings sat behind a reassuring label. This follows the precedent already shipped in `scripts/audit_api_wiring.py` (#12941): report the confident set as findings, and the weak set separately with its nature stated.

## What Changed

- `models.py`: `APIEndpointAnalysis` gains `low_confidence: List[EndpointMismatchItem] = []` and `low_confidence_endpoints: int = 0`. Both default, so existing consumers are unaffected.
- `api_endpoint_scanner.py`: `_match_calls_to_endpoints` routes `method == "UNKNOWN"` findings to the new bucket, typed `low_confidence`, with the detail *"Path literal with no recognised call pattern — verify before acting"*.

## Verification

```
$ python3 -m pytest api/codebase_analytics/api_endpoint_scanner_test.py -q
34 passed in 0.76s          (30 pre-existing + 4 new)

$ python3 -m pytest api/codebase_analytics/ -q
248 passed, 11 skipped      (was 244 passed / 11 skipped)

$ python3 -m flake8 …
(clean)
```

Measured on the live indexed source `c5939a51-…`:

| bucket | items | false | rate |
|---|---|---|---|
| `missing` | **4** | 1 | 25% |
| `low_confidence` | 240 | 214 | 89% |
| **total** | **244** | | *unchanged — nothing dropped* |

Against the acceptance criteria:

- **1** — missing count is now **4**, i.e. "single/low-double digits". Met.
- **3** — the `method` half is explained: `UNKNOWN` is the fallback marker, and those findings are now labelled as such. (`file_path` was already populated on all 244 — the earlier `file: "?"` report is a serialization-layer concern, not the scanner.)
- **4** — one false positive remains in the actionable bucket, down from ~2400.

A test pins that both buckets together still account for every reportable call, so a future change cannot quietly drop the weak set.

## Why the issue stays open

Criterion 2 was met earlier (#12944/#12946/#12945/#12953/#12956 took the scan from 0 to 2220 endpoints). What remains is genuine: **the 240 low-confidence findings are still 89% false**, and reducing that means teaching the scanner more call patterns so fewer calls fall back — tracked with its own baseline on #12953. This change makes the report honest about what it knows; it does not yet make the scanner know more.

## Model Used

claude-opus-5
