### PR TITLE
refactor(user-management): move byte-identical base_service to autobot_shared (#12647)

### DIFF
--- a/autobot-backend/user_management/services/base_service.py
+++ b/autobot-backend/user_management/services/base_service.py
@@ -2,126 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
+"""Re-export shim — the implementation now lives in autobot_shared (#12647).
+
+This file was byte-identical in both backends, so it was the safe first move in
+#12645's user_management de-fork: no drift to reconcile, and nothing here is
+backend-specific. Kept as a shim rather than deleted so the 12 existing
+importers keep working unchanged; the fork is what goes, not the callers.
 """
-Base Service Class
 
-Provides tenant context management and common service patterns.
-"""
+from autobot_shared.user_management.base_service import (  # noqa: F401
+    BaseService,
+    TenantContext,
+)
 
-import uuid
-from dataclasses import dataclass
-
-from sqlalchemy import Select, select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from autobot_shared.logging_manager import get_logger
-
-logger = get_logger(__name__)
-
-
-@dataclass
-class TenantContext:
-    """
-    Tenant context for multi-tenancy operations.
-
-    In single_company mode, org_id is the implicit organization.
-    In multi_company/provider modes, org_id is set from JWT/session.
-    """
-
-    org_id: uuid.UUID | None = None
-    user_id: uuid.UUID | None = None
-    is_platform_admin: bool = False
-
-    @property
-    def is_authenticated(self) -> bool:
-        """Check if context has an authenticated user."""
-        return self.user_id is not None
-
-    @property
-    def is_org_scoped(self) -> bool:
-        """Check if context has organization scope."""
-        return self.org_id is not None
-
-
-class BaseService:
-    """
-    Base service class with tenant context support.
-
-    All tenant-scoped services should inherit from this.
-    """
-
-    def __init__(self, session: AsyncSession, context: TenantContext | None = None):
-        """
-        Initialize service with database session and tenant context.
-
-        Args:
-            session: Async SQLAlchemy session
-            context: Optional tenant context for multi-tenancy
-        """
-        self.session = session
-        self.context = context or TenantContext()
-
-    def apply_tenant_filter(self, query: Select, model_class) -> Select:
-        """
-        Apply tenant filter to query if organization-scoped.
-
-        Args:
-            query: SQLAlchemy select query
-            model_class: Model class with org_id column
-
-        Returns:
-            Filtered query
-        """
-        if self.context.org_id and hasattr(model_class, "org_id"):
-            return query.where(model_class.org_id == self.context.org_id)
-        return query
-
-    async def _get_by_id(self, model_class, entity_id: uuid.UUID):
-        """
-        Get entity by ID with tenant filtering.
-
-        Args:
-            model_class: SQLAlchemy model class
-            entity_id: Entity UUID
-
-        Returns:
-            Entity instance or None
-        """
-        query = select(model_class).where(model_class.id == entity_id)
-        query = self.apply_tenant_filter(query, model_class)
-
-        result = await self.session.execute(query)
-        return result.scalar_one_or_none()
-
-    async def _soft_delete(self, entity) -> bool:
-        """
-        Soft delete an entity if it has soft delete support.
-
-        Args:
-            entity: Entity instance with soft_delete method
-
-        Returns:
-            True if deleted
-        """
-        if hasattr(entity, "soft_delete"):
-            entity.soft_delete()
-            await self.session.flush()
-            return True
-        return False
-
-    def _require_org_context(self):
-        """Raise error if no organization context is set."""
-        if not self.context.org_id:
-            raise ValueError(
-                "Organization context required for this operation. " "Ensure deployment mode supports multi-tenancy."
-            )
-
-    def _require_auth_context(self):
-        """Raise error if no authenticated user context."""
-        if not self.context.user_id:
-            raise ValueError("Authenticated user context required for this operation.")
-
-    def _require_platform_admin(self):
-        """Raise error if current user is not a platform admin."""
-        if not self.context.is_platform_admin:
-            raise PermissionError("Platform admin privileges required for this operation.")
+__all__ = ["BaseService", "TenantContext"]

--- a/autobot-slm-backend/user_management/services/base_service.py
+++ b/autobot-slm-backend/user_management/services/base_service.py
@@ -2,126 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
+"""Re-export shim — the implementation now lives in autobot_shared (#12647).
+
+This file was byte-identical in both backends, so it was the safe first move in
+#12645's user_management de-fork: no drift to reconcile, and nothing here is
+backend-specific. Kept as a shim rather than deleted so the 12 existing
+importers keep working unchanged; the fork is what goes, not the callers.
 """
-Base Service Class
 
-Provides tenant context management and common service patterns.
-"""
+from autobot_shared.user_management.base_service import (  # noqa: F401
+    BaseService,
+    TenantContext,
+)
 
-import uuid
-from dataclasses import dataclass
-
-from sqlalchemy import Select, select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from autobot_shared.logging_manager import get_logger
-
-logger = get_logger(__name__)
-
-
-@dataclass
-class TenantContext:
-    """
-    Tenant context for multi-tenancy operations.
-
-    In single_company mode, org_id is the implicit organization.
-    In multi_company/provider modes, org_id is set from JWT/session.
-    """
-
-    org_id: uuid.UUID | None = None
-    user_id: uuid.UUID | None = None
-    is_platform_admin: bool = False
-
-    @property
-    def is_authenticated(self) -> bool:
-        """Check if context has an authenticated user."""
-        return self.user_id is not None
-
-    @property
-    def is_org_scoped(self) -> bool:
-        """Check if context has organization scope."""
-        return self.org_id is not None
-
-
-class BaseService:
-    """
-    Base service class with tenant context support.
-
-    All tenant-scoped services should inherit from this.
-    """
-
-    def __init__(self, session: AsyncSession, context: TenantContext | None = None):
-        """
-        Initialize service with database session and tenant context.
-
-        Args:
-            session: Async SQLAlchemy session
-            context: Optional tenant context for multi-tenancy
-        """
-        self.session = session
-        self.context = context or TenantContext()
-
-    def apply_tenant_filter(self, query: Select, model_class) -> Select:
-        """
-        Apply tenant filter to query if organization-scoped.
-
-        Args:
-            query: SQLAlchemy select query
-            model_class: Model class with org_id column
-
-        Returns:
-            Filtered query
-        """
-        if self.context.org_id and hasattr(model_class, "org_id"):
-            return query.where(model_class.org_id == self.context.org_id)
-        return query
-
-    async def _get_by_id(self, model_class, entity_id: uuid.UUID):
-        """
-        Get entity by ID with tenant filtering.
-
-        Args:
-            model_class: SQLAlchemy model class
-            entity_id: Entity UUID
-
-        Returns:
-            Entity instance or None
-        """
-        query = select(model_class).where(model_class.id == entity_id)
-        query = self.apply_tenant_filter(query, model_class)
-
-        result = await self.session.execute(query)
-        return result.scalar_one_or_none()
-
-    async def _soft_delete(self, entity) -> bool:
-        """
-        Soft delete an entity if it has soft delete support.
-
-        Args:
-            entity: Entity instance with soft_delete method
-
-        Returns:
-            True if deleted
-        """
-        if hasattr(entity, "soft_delete"):
-            entity.soft_delete()
-            await self.session.flush()
-            return True
-        return False
-
-    def _require_org_context(self):
-        """Raise error if no organization context is set."""
-        if not self.context.org_id:
-            raise ValueError(
-                "Organization context required for this operation. " "Ensure deployment mode supports multi-tenancy."
-            )
-
-    def _require_auth_context(self):
-        """Raise error if no authenticated user context."""
-        if not self.context.user_id:
-            raise ValueError("Authenticated user context required for this operation.")
-
-    def _require_platform_admin(self):
-        """Raise error if current user is not a platform admin."""
-        if not self.context.is_platform_admin:
-            raise PermissionError("Platform admin privileges required for this operation.")
+__all__ = ["BaseService", "TenantContext"]

--- a/autobot_shared/user_management/__init__.py
+++ b/autobot_shared/user_management/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical user_management core shared by both backends (#12647).
+
+`user_management` is forked across `autobot-backend` and `autobot-slm-backend`,
+with 25 shared-but-divergent files. This package is the consolidation target:
+files land here once they are identical in both forks, so each move carries no
+semantic drift to reconcile.
+
+First mover: `base_service`, which was byte-identical in both and imports
+nothing backend-specific. Each fork keeps a re-export shim so existing importers
+are untouched — the fork is removed, not the callers.
+"""
+
+from autobot_shared.user_management.base_service import (  # noqa: F401
+    BaseService,
+    TenantContext,
+)
+
+__all__ = ["BaseService", "TenantContext"]

--- a/autobot_shared/user_management/base_service.py
+++ b/autobot_shared/user_management/base_service.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Base Service Class
+
+Provides tenant context management and common service patterns.
+"""
+
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class TenantContext:
+    """
+    Tenant context for multi-tenancy operations.
+
+    In single_company mode, org_id is the implicit organization.
+    In multi_company/provider modes, org_id is set from JWT/session.
+    """
+
+    org_id: uuid.UUID | None = None
+    user_id: uuid.UUID | None = None
+    is_platform_admin: bool = False
+
+    @property
+    def is_authenticated(self) -> bool:
+        """Check if context has an authenticated user."""
+        return self.user_id is not None
+
+    @property
+    def is_org_scoped(self) -> bool:
+        """Check if context has organization scope."""
+        return self.org_id is not None
+
+
+class BaseService:
+    """
+    Base service class with tenant context support.
+
+    All tenant-scoped services should inherit from this.
+    """
+
+    def __init__(self, session: AsyncSession, context: TenantContext | None = None):
+        """
+        Initialize service with database session and tenant context.
+
+        Args:
+            session: Async SQLAlchemy session
+            context: Optional tenant context for multi-tenancy
+        """
+        self.session = session
+        self.context = context or TenantContext()
+
+    def apply_tenant_filter(self, query: Select, model_class) -> Select:
+        """
+        Apply tenant filter to query if organization-scoped.
+
+        Args:
+            query: SQLAlchemy select query
+            model_class: Model class with org_id column
+
+        Returns:
+            Filtered query
+        """
+        if self.context.org_id and hasattr(model_class, "org_id"):
+            return query.where(model_class.org_id == self.context.org_id)
+        return query
+
+    async def _get_by_id(self, model_class, entity_id: uuid.UUID):
+        """
+        Get entity by ID with tenant filtering.
+
+        Args:
+            model_class: SQLAlchemy model class
+            entity_id: Entity UUID
+
+        Returns:
+            Entity instance or None
+        """
+        query = select(model_class).where(model_class.id == entity_id)
+        query = self.apply_tenant_filter(query, model_class)
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def _soft_delete(self, entity) -> bool:
+        """
+        Soft delete an entity if it has soft delete support.
+
+        Args:
+            entity: Entity instance with soft_delete method
+
+        Returns:
+            True if deleted
+        """
+        if hasattr(entity, "soft_delete"):
+            entity.soft_delete()
+            await self.session.flush()
+            return True
+        return False
+
+    def _require_org_context(self):
+        """Raise error if no organization context is set."""
+        if not self.context.org_id:
+            raise ValueError(
+                "Organization context required for this operation. " "Ensure deployment mode supports multi-tenancy."
+            )
+
+    def _require_auth_context(self):
+        """Raise error if no authenticated user context."""
+        if not self.context.user_id:
+            raise ValueError("Authenticated user context required for this operation.")
+
+    def _require_platform_admin(self):
+        """Raise error if current user is not a platform admin."""
+        if not self.context.is_platform_admin:
+            raise PermissionError("Platform admin privileges required for this operation.")

--- a/autobot_shared/user_management/base_service_test.py
+++ b/autobot_shared/user_management/base_service_test.py
@@ -1,0 +1,63 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The shared base_service is the single implementation (#12647).
+
+`user_management` is forked across both backends with 25 shared-but-divergent
+files. `base_service` was byte-identical in both, which made it the safe first
+move: nothing to reconcile.
+
+These pin the property that matters — both backends resolve to the SAME class
+objects, not merely equivalent ones. Two same-named classes are not
+interchangeable (the trap #12913 fixed for CircuitState), so identity is the
+assertion, not behaviour.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+from autobot_shared.user_management.base_service import BaseService, TenantContext
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SHIMS = {
+    "backend": _ROOT / "autobot-backend/user_management/services/base_service.py",
+    "slm": _ROOT / "autobot-slm-backend/user_management/services/base_service.py",
+}
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("backend", sorted(_SHIMS))
+def test_shim_exists(backend):
+    assert _SHIMS[backend].is_file(), f"{backend} shim missing"
+
+
+@pytest.mark.parametrize("backend", sorted(_SHIMS))
+def test_shim_resolves_to_the_shared_class(backend):
+    """Same object, not a same-named twin — see #12913."""
+    module = _load(_SHIMS[backend], f"shim_{backend}")
+
+    assert module.BaseService is BaseService
+    assert module.TenantContext is TenantContext
+
+
+def test_both_backends_share_one_implementation():
+    a = _load(_SHIMS["backend"], "shim_a")
+    b = _load(_SHIMS["slm"], "shim_b")
+
+    assert a.BaseService is b.BaseService
+
+
+def test_package_reexports_the_public_surface():
+    import autobot_shared.user_management as pkg
+
+    assert pkg.BaseService is BaseService
+    assert pkg.TenantContext is TenantContext


### PR DESCRIPTION
Refs #12647, part of #12645. First step of the user_management de-fork — the one file with no drift to reconcile. The issue stays open.

## Thinking Path

#12647's difficulty is semantic drift: 25 shared-but-divergent files, with real behavioural differences in `user_service`, `rbac_middleware` and the models. Its own recommendation is to sub-step, starting with `models/base` + `base_service`.

Measuring that sub-step first changed its size:

```console
$ diff autobot-backend/.../services/base_service.py autobot-slm-backend/.../services/base_service.py
(0 diff lines — byte-identical)

$ diff .../models/base.py .../models/base.py
64 diff lines
```

The issue lists `base_service` as 6 diff lines; it is now **0**. So half of sub-step (a) is a move with *nothing to reconcile* — no drift, no feature union to decide, no risk of losing either side's behaviour. Its imports are `uuid`, `dataclasses`, `sqlalchemy` and `autobot_shared.logging_manager` — nothing backend-specific, so it is portable as-is.

`models/base.py` (64 diff lines) is left alone: that one carries the declarative-base question this issue and #12645 both flag, and it is the decision I should not make unilaterally.

## What Changed

- `autobot_shared/user_management/` created as the consolidation target #12647 names, with `base_service.py` moved in verbatim.
- Each backend keeps a **re-export shim** at the original path, so all 12 existing importers are untouched. The fork is removed, not the callers — same pattern as `auth_rbac` re-exporting `is_admin_role` (#12948).

## Verification

```
$ python3 -m pytest autobot_shared/user_management/base_service_test.py -q
6 passed in 2.18s

$ python3 -m pytest autobot_shared/ -q
1137 passed in 37.28s

$ python3 -m flake8 (shared package + both shims)
(clean)

import smoke: user_management.services.{base_service,user_service,organization_service}  3/3
```

The tests assert both shims resolve to the **same class objects**, not merely equivalent ones:

```python
assert module.BaseService is BaseService
assert a.BaseService is b.BaseService
```

That identity check is the point. Two same-named classes are not interchangeable — the trap #12913 fixed for `CircuitState` and #12932 records for the memory graph — so a "de-fork" that left two equivalent-but-distinct classes would reintroduce exactly the defect this umbrella exists to remove.

## Why the issue stays open

This is 1 of 25 divergent files, deliberately the easiest. What remains is the actual work: `models/base.py` (64 lines, gated on the declarative-base decision), `rbac_middleware.py` (331), `database.py` (440), `config.py` (241), `user_service.py` (111), and the rest — each needing drift reconciled under the issue's "union of features, zero loss" contract.

The value here is establishing the target package and the shim pattern, so subsequent moves are mechanical rather than architectural.

## Model Used

claude-opus-5
