### PR TITLE
fix(hot-reload): watch a module path that actually exists (#12975)

### DIFF
--- a/autobot-backend/utils/hot_reload_manager.py
+++ b/autobot-backend/utils/hot_reload_manager.py
@@ -23,7 +23,7 @@ from autobot_shared.logging_manager import get_logger
 logger = get_logger(__name__)
 
 # Issue #380: Module-level constants to avoid repeated Path computation
-_SRC_ROOT = Path(__file__).parent.parent  # src/
+_SRC_ROOT = Path(__file__).parent.parent  # the backend root (historically src/)
 _PROJECT_ROOT = _SRC_ROOT.parent  # project root
 
 # Issue #380: Module-level frozenset for valid source root directories
@@ -76,10 +76,16 @@ class HotReloadManager:
         self.watched_paths: Set[Path] = set()
         self.reload_lock = asyncio.Lock()
 
-        # Chat workflow specific modules to watch
-        # Note: Obsolete modules removed in Issue #567 archive cleanup
+        # Chat workflow specific modules to watch.
+        # Note: Obsolete modules removed in Issue #567 archive cleanup.
+        # These names are passed to importlib.import_module()/sys.modules, so
+        # they must be real importable paths. "src.async_chat_workflow" was a
+        # leftover from the old src/ layout -- src/async_chat_workflow.py does
+        # not exist, so the entry never matched and this module has silently
+        # never been hot-reloadable. The failure surfaces only as a
+        # "Module ... not registered" warning at reload time, never at startup.
         self.chat_workflow_modules = [
-            "src.async_chat_workflow",
+            "async_chat_workflow",
         ]
 
     async def start(self) -> None:

--- a/autobot-backend/utils/hot_reload_manager_watchlist_test.py
+++ b/autobot-backend/utils/hot_reload_manager_watchlist_test.py
@@ -1,0 +1,53 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Every hot-reload watch entry must name a real importable module.
+
+`chat_workflow_modules` entries are passed to `importlib.import_module()` and
+used as `sys.modules` keys, so a name that does not resolve can never be
+reloaded. `"src.async_chat_workflow"` was a leftover from the old `src/`
+layout — `src/async_chat_workflow.py` does not exist, so the entry never
+matched and that module was silently never hot-reloadable.
+
+The failure mode is why this needs a test rather than a fix alone: nothing
+reports it at startup. `reload_module()` only logs "Module ... not registered"
+if someone happens to trigger a reload, and `register_module` accepts any
+string, so a typo here is invisible until a developer wonders why their edits
+are not taking effect.
+"""
+
+import importlib.util
+
+import pytest
+
+from utils.hot_reload_manager import HotReloadManager
+
+
+def _watchlist():
+    return HotReloadManager().chat_workflow_modules
+
+
+def test_watchlist_is_not_empty():
+    """A silently-emptied list would make this suite vacuously pass."""
+    assert _watchlist(), "chat_workflow_modules is empty"
+
+
+@pytest.mark.parametrize("module_name", _watchlist())
+def test_watched_module_is_importable(module_name):
+    """importlib.import_module() is called with this exact string."""
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, ModuleNotFoundError, ValueError):
+        spec = None
+
+    assert spec is not None, (
+        f"hot-reload watches '{module_name}', which is not importable — "
+        "it can never be reloaded, and nothing reports that at startup"
+    )
+
+
+@pytest.mark.parametrize("module_name", _watchlist())
+def test_watched_module_has_no_stale_layout_prefix(module_name):
+    """The backend root was once `src/`; entries must not carry that prefix."""
+    assert not module_name.startswith("src."), (
+        f"'{module_name}' uses the retired src/ layout prefix"
+    )

--- a/autobot-backend/utils/hot_reload_manager_watchlist_test.py
+++ b/autobot-backend/utils/hot_reload_manager_watchlist_test.py
@@ -48,6 +48,4 @@ def test_watched_module_is_importable(module_name):
 @pytest.mark.parametrize("module_name", _watchlist())
 def test_watched_module_has_no_stale_layout_prefix(module_name):
     """The backend root was once `src/`; entries must not carry that prefix."""
-    assert not module_name.startswith("src."), (
-        f"'{module_name}' uses the retired src/ layout prefix"
-    )
+    assert not module_name.startswith("src."), f"'{module_name}' uses the retired src/ layout prefix"


### PR DESCRIPTION
Closes #12975. Found while measuring #12652's `AsyncChatWorkflow` references.

## Thinking Path

`hot_reload_manager.py` watched `"src.async_chat_workflow"`. That path does not exist — the module is `async_chat_workflow` at the backend root, and the `src.` prefix is a leftover from the retired `src/` layout (the `_SRC_ROOT` comment still carried the same stale assumption).

```
src.async_chat_workflow    importable=False
async_chat_workflow        importable=True
```

**Why it survived unnoticed** is the interesting part. These strings go straight into `importlib.import_module()` and `sys.modules`:

```python
del sys.modules[module_name]
new_module = importlib.import_module(module_name)
```

but nothing validates them. `register_module()` accepts any string, and `reload_module()` only logs `"Module ... not registered for hot reload"` — and only if a reload is actually triggered. There is no startup check, so the symptom is a developer's edits silently not taking effect, with no error to explain it.

That is the third instance today of the same shape: **a wrong path degrading into a silent no-op rather than an error** (#12782's `_resolve_env_path` returning a directory, #12969's doubled `STATIC_DIR`).

## What Changed

- `utils/hot_reload_manager.py`: the watch entry is now `"async_chat_workflow"`, with the reason recorded inline so the `src.` prefix is not restored by someone assuming the old layout.
- Corrected the stale `# src/` comment on `_SRC_ROOT`, which points at the backend root.

## Verification

```
$ python3 -m pytest utils/hot_reload_manager_watchlist_test.py -q
3 passed in 0.17s

$ python3 -m flake8 …
(clean)
```

The tests assert the property rather than the current value: every entry in `chat_workflow_modules` resolves via `find_spec`, and none carries the retired `src.` prefix. A third test pins that the list is non-empty, so silently emptying it cannot make the suite vacuously pass — the same guard I would want on any "check every item in a list" test.

## Scope

Developer-facing only: hot reload has never covered this module. Fixed because the cost is confusion rather than a visible failure, and the guard is cheap.

## Model Used

claude-opus-5
