### PR TITLE
fix(deps): bump transitive @hono/node-server to 2.0.12 in MCP lockfiles (#12274)

### DIFF
--- a/.mcp/package-lock.json
+++ b/.mcp/package-lock.json
@@ -13,12 +13,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package-lock.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package-lock.json
@@ -467,12 +467,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/package-lock.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/package-lock.json
@@ -546,6 +546,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1008,18 +1020,6 @@
         "zod": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {


### PR DESCRIPTION
## Thinking Path

Issue #12274 tracked 16 Dependabot alerts across `hono` and `@hono/node-server` in four manifests. Reconciling against the live alert API first showed the issue body is **partly stale**:

- **Only 3 alerts are still open**, all for `@hono/node-server` (`< 2.0.5`, first patched `2.0.5`, medium):
  - `#1056` — `.mcp/package-lock.json`
  - `#1062` — `autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package-lock.json`
  - `#1068` — `autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/package-lock.json`
- **`hono` itself has no open alerts** — the 12 `hono` rows in the issue table have since closed (`hono` already resolves to `4.12.31` in every lockfile). The issue title is therefore half stale.
- **`mcp-task-manager-server` no longer exists** in the tree, so its 4 alerts have no manifest to patch.

Root cause: `@hono/node-server` is **transitive only** — no `package.json` in the repo declares it. It arrives via `@modelcontextprotocol/sdk`, and the installed SDK `1.30.0` already declares `"@hono/node-server": "^1.19.9 || ^2.0.5"`. The patched range was **already permitted**; the lockfiles had simply resolved to the `1.x` side of the `||`. So no SDK bump and no `package.json` change is warranted — this is a pure lockfile re-resolution.

Fix applied per directory with `npm update @hono/node-server --package-lock-only`, which touches only the lockfile and leaves `node_modules` and `package.json` alone.

## What Changed

Three lockfiles, `@hono/node-server` only:

| Lockfile | Before | After |
|---|---|---|
| `.mcp/package-lock.json` | `1.19.13` | `2.0.12` |
| `autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package-lock.json` | `1.19.13` | `2.0.12` |
| `autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/package-lock.json` | `1.19.15` | `2.0.12` |

Notes:

- No `package.json` was modified — `@hono/node-server` stays transitive.
- In `mcp-structured-thinking` the entry moved from the nested `node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server` to the hoisted top-level `node_modules/@hono/node-server`; nothing else depended on the nested copy, so this is npm de-duplicating, not a scope change. That accounts for the larger line count in that file.
- `1.x -> 2.x` is a **major** bump of a transitive dep. The only manifest-visible change is `engines.node`: `>=18.14.1` -> `>=20`. CI runs Node 22 and these MCP tools declare no `engines` of their own, so nothing is excluded.
- `hono` is **unchanged** at `4.12.31` in all three lockfiles, and satisfies the new `peerDependencies: { "hono": "^4" }`.

## Verification

Open alerts before the change (live API, filtered to hono packages):

```
$ gh api "repos/mrveiss/AutoBot-AI/dependabot/alerts?state=open&per_page=100" \
    --jq '.[] | select(.dependency.package.name|test("hono")) | {n,pkg,mf,vuln,patched}'
{"mf":".../mcp-structured-thinking/package-lock.json","n":1068,"patched":"2.0.5","pkg":"@hono/node-server","vuln":"< 2.0.5"}
{"mf":".../mcp-autobot-tracker/package-lock.json",    "n":1062,"patched":"2.0.5","pkg":"@hono/node-server","vuln":"< 2.0.5"}
{"mf":".mcp/package-lock.json",                       "n":1056,"patched":"2.0.5","pkg":"@hono/node-server","vuln":"< 2.0.5"}
```

Resulting versions — all `>= 2.0.5`:

```
$ grep -A2 '"node_modules/@hono/node-server"' <each lockfile>
.mcp/package-lock.json:15:                              "version": "2.0.12"
.../mcp-autobot-tracker/package-lock.json:469:          "version": "2.0.12"
.../mcp-structured-thinking/package-lock.json:549:      "version": "2.0.12"
```

Diff is confined to the three lockfiles:

```
$ git diff --stat HEAD~1
 .mcp/package-lock.json                             |  8 ++++----
 .../tools/mcp-autobot-tracker/package-lock.json    |  8 ++++----
 .../mcp-structured-thinking/package-lock.json      | 24 +++++++++++-----------
 3 files changed, 20 insertions(+), 20 deletions(-)
```

Every added/removed line mentioning `hono` belongs to the `@hono/node-server` block — the `node_modules/hono` entry itself is untouched:

```
$ git diff -U0 HEAD~1 | grep -E '^[+-]' | grep -i hono | sort -u
+    "node_modules/@hono/node-server": {
+      "resolved": ".../@hono/node-server/-/node-server-2.0.12.tgz",
+        "hono": "^4"
-    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
-      "resolved": ".../@hono/node-server/-/node-server-1.19.13.tgz",
-      "resolved": ".../@hono/node-server/-/node-server-1.19.15.tgz",
-        "hono": "^4"
```

Dependency tree still resolves cleanly, **no peer warnings and no `ERESOLVE`** in any of the three packages:

```
$ npm install --package-lock-only --dry-run   # .mcp
up to date in 570ms
$ npm install --package-lock-only --dry-run   # mcp-autobot-tracker
up to date in 817ms
$ npm install --package-lock-only --dry-run   # mcp-structured-thinking
up to date in 2s

$ npm ls --package-lock-only --all            # .mcp
├─┬ @hono/node-server@2.0.12
│ └── hono@4.12.31 deduped
└── hono@4.12.31
```

`git status` confirms no `package.json` was staged:

```
M  .mcp/package-lock.json
M  autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package-lock.json
M  autobot-infrastructure/shared/mcp/tools/mcp-structured-thinking/package-lock.json
```

### #12276 is NOT covered

Checked as requested. #12276 tracks `protobufjs` (alert `#1027`, `autobot-frontend/package-lock.json`) and `@babel/core` (alert `#907`, `mcp-structured-thinking/package-lock.json`) — disjoint packages and, for protobufjs, a different manifest entirely. Nothing in this PR touches either. It stays open.

Closes #12274

## Model Used

claude-opus-5
