### PR TITLE
fix(http): balance _active_requests in response-consuming helpers (#12981)

### DIFF
--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -219,10 +219,18 @@ class HTTPClientManager:
             **kwargs: Additional arguments for aiohttp request
 
         Returns:
-            ClientResponse: The response object
+            ClientResponse: The response object. The active-request slot taken
+                by this call is **caller-owned** on the success path — the
+                caller MUST call ``decrement_active()`` once the response is
+                fully consumed. Failures decrement here, before raising.
 
         Note: For streaming responses, caller should use increment_active()/decrement_active()
         to prevent pool recreation during streaming.
+
+        Issue #12981: prefer ``tracked_request()`` (or the ``*_json()`` helpers
+        built on it) unless you genuinely need to hold a raw response open
+        beyond a single block — it balances the counter for you and therefore
+        cannot be forgotten.
         """
         # Check if pool adjustment needed (non-blocking)
         asyncio.create_task(self._adjust_pool_size())
@@ -335,17 +343,68 @@ class HTTPClientManager:
             logger.info("Applying deferred session recreation " f"(new pool size: {self._current_pool_size})")
             await self._create_session()
 
+    @asynccontextmanager
+    async def tracked_request(self, method: str, url: str, **kwargs) -> AsyncIterator[aiohttp.ClientResponse]:
+        """
+        Issue a request and yield a response whose active-request slot is
+        released automatically when the block exits.
+
+        Issue #12981: ``request()`` increments ``_active_requests`` on every
+        call but only decrements it on the failure path, delegating the
+        success-path decrement to the caller. Repo-wide, essentially no caller
+        honoured that contract, so the counter only ever grew — permanently
+        skewing ``_adjust_pool_size()`` utilisation and making the
+        ``_active_requests == 0`` gate in ``decrement_active()`` (deferred pool
+        recreation) unreachable.
+
+        This helper owns the FULL lifecycle — request, response body, and the
+        counter — so the decrement cannot be forgotten. Use it for any request
+        whose response is consumed within a single block; use ``request()``
+        plus an explicit ``decrement_active()`` only when the response must
+        outlive the block (streaming, #680).
+
+        Usage:
+            async with http_client.tracked_request("GET", url) as response:
+                response.raise_for_status()
+                data = await response.json()
+
+        Exception-safe: the counter is always decremented, even if the caller
+        raises. A failure inside ``request()`` itself decrements there, so the
+        slot is never released twice.
+        """
+        response = await self.request(method, url, **kwargs)
+        try:
+            async with response:
+                yield response
+        finally:
+            await self.decrement_active()
+
     async def get(self, url: str, **kwargs) -> aiohttp.ClientResponse:
-        """Convenience method for GET requests."""
+        """
+        Convenience method for GET requests.
+
+        Returns a raw caller-owned response: call ``decrement_active()`` when
+        it is fully consumed, or prefer ``tracked_request("GET", ...)`` which
+        balances the counter for you (#12981).
+        """
         return await self.request("GET", url, **kwargs)
 
     async def post(self, url: str, **kwargs) -> aiohttp.ClientResponse:
-        """Convenience method for POST requests."""
+        """
+        Convenience method for POST requests.
+
+        Returns a raw caller-owned response: call ``decrement_active()`` when
+        it is fully consumed, or prefer ``tracked_request("POST", ...)`` which
+        balances the counter for you (#12981).
+        """
         return await self.request("POST", url, **kwargs)
 
     async def get_json(self, url: str, **kwargs) -> Dict[str, Any]:
         """
         Make a GET request and return JSON response.
+
+        Owns the full request lifecycle, so the active-request counter is
+        balanced automatically (#12981).
 
         Args:
             url: Target URL
@@ -354,13 +413,16 @@ class HTTPClientManager:
         Returns:
             Dict containing the JSON response
         """
-        async with await self.get(url, **kwargs) as response:
+        async with self.tracked_request("GET", url, **kwargs) as response:
             response.raise_for_status()
             return await response.json()
 
     async def post_json(self, url: str, json_data: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         """
         Make a POST request with JSON data and return JSON response.
+
+        Owns the full request lifecycle, so the active-request counter is
+        balanced automatically (#12981).
 
         Args:
             url: Target URL
@@ -370,7 +432,7 @@ class HTTPClientManager:
         Returns:
             Dict containing the JSON response
         """
-        async with await self.post(url, json=json_data, **kwargs) as response:
+        async with self.tracked_request("POST", url, json=json_data, **kwargs) as response:
             response.raise_for_status()
             return await response.json()
 
@@ -532,14 +594,18 @@ async def example_usage() -> None:
     except aiohttp.ClientError as e:
         logger.error("Request failed: %s", e)
 
-    # Manual request with custom options
+    # Manual request with custom options. The raw-response path is
+    # caller-owned: balance the active-request counter in a finally (#12981),
+    # or use tracked_request() when the response fits in a single block.
     try:
-        async with await http_client.get(
-            "https://api.example.com/stream", timeout=aiohttp.ClientTimeout(total=60)
-        ) as response:
-            async for chunk in response.content.iter_chunked(1024):
-                # Process streaming data
-                pass
+        response = await http_client.get("https://api.example.com/stream", timeout=aiohttp.ClientTimeout(total=60))
+        try:
+            async with response:
+                async for chunk in response.content.iter_chunked(1024):
+                    # Process streaming data
+                    pass
+        finally:
+            await http_client.decrement_active()
     except Exception as e:
         logger.error("Streaming failed: %s", e)
 

--- a/autobot_shared/http_client_test.py
+++ b/autobot_shared/http_client_test.py
@@ -9,8 +9,10 @@ opt in (health probes) get the DEBUG downgrade.
 """
 
 import logging
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
 import pytest
 
 from autobot_shared.http_client import HTTPClientManager
@@ -118,3 +120,148 @@ async def test_tracked_session_decrements_on_exception():
                 raise RuntimeError("boom")
 
         assert client._active_requests == 0
+
+
+# ---------------------------------------------------------------------------
+# _active_requests must return to baseline after every completed request
+# (#12981)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal ClientResponse stand-in supporting `async with` and json()."""
+
+    def __init__(self, payload=None, status_exc=None):
+        self._payload = {"ok": True} if payload is None else payload
+        self._status_exc = status_exc
+        self.released = False
+
+    def raise_for_status(self):
+        """Raise the configured status error, mirroring ClientResponse."""
+        if self._status_exc is not None:
+            raise self._status_exc
+
+    async def json(self):
+        """Return the canned JSON payload."""
+        return self._payload
+
+    async def __aenter__(self):
+        """Enter the response context."""
+        return self
+
+    async def __aexit__(self, *_exc):
+        """Mark the connection released on context exit."""
+        self.released = True
+        return False
+
+
+@contextmanager
+def _patched_client(request_result):
+    """Yield the singleton client with its session/pool-adjust patched out.
+
+    ``request_result`` is used as the mocked ``session.request`` side_effect
+    when it is an exception, otherwise as its return_value.
+    """
+    client = HTTPClientManager()
+    fake_session = AsyncMock()
+    fake_session.closed = False
+    if isinstance(request_result, BaseException):
+        fake_session.request = AsyncMock(side_effect=request_result)
+    else:
+        fake_session.request = AsyncMock(return_value=request_result)
+    with (
+        patch.object(client, "get_session", AsyncMock(return_value=fake_session)),
+        patch.object(client, "_adjust_pool_size", AsyncMock(return_value=None)),
+    ):
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_get_json_returns_counter_to_baseline():
+    """A successful get_json() must not leak an active-request slot (#12981)."""
+    response = _FakeResponse({"value": 1})
+    with _patched_client(response) as client:
+        baseline = client._active_requests
+        assert await client.get_json("http://svc/data") == {"value": 1}
+        assert client._active_requests == baseline
+        assert response.released is True
+
+
+@pytest.mark.asyncio
+async def test_post_json_returns_counter_to_baseline():
+    """A successful post_json() must not leak an active-request slot (#12981)."""
+    response = _FakeResponse({"created": True})
+    with _patched_client(response) as client:
+        baseline = client._active_requests
+        assert await client.post_json("http://svc/submit", {"k": "v"}) == {"created": True}
+        assert client._active_requests == baseline
+
+
+@pytest.mark.asyncio
+async def test_failing_request_returns_counter_to_baseline():
+    """A transport failure must release the slot before propagating (#12981)."""
+    with _patched_client(ConnectionError("boom")) as client:
+        baseline = client._active_requests
+        with pytest.raises(ConnectionError):
+            await client.get_json("http://svc/down")
+        assert client._active_requests == baseline
+
+
+@pytest.mark.asyncio
+async def test_raise_for_status_failure_returns_counter_to_baseline():
+    """A non-2xx response consumed by get_json() must still release the slot."""
+    response = _FakeResponse(status_exc=aiohttp.ClientResponseError(None, (), status=500))
+    with _patched_client(response) as client:
+        baseline = client._active_requests
+        with pytest.raises(aiohttp.ClientResponseError):
+            await client.get_json("http://svc/error")
+        assert client._active_requests == baseline
+        assert response.released is True
+
+
+@pytest.mark.asyncio
+async def test_sequential_requests_do_not_accumulate():
+    """N sequential requests must leave the counter at baseline, not baseline+N.
+
+    This is the regression the issue reports: the counter grew monotonically,
+    permanently skewing pool utilisation and blocking deferred recreation.
+    """
+    with _patched_client(_FakeResponse()) as client:
+        baseline = client._active_requests
+        for _ in range(5):
+            await client.get_json("http://svc/data")
+        for _ in range(5):
+            await client.post_json("http://svc/data", {"k": "v"})
+        assert client._active_requests == baseline
+
+
+@pytest.mark.asyncio
+async def test_streaming_contract_unchanged_single_decrement():
+    """request() still hands the caller an un-decremented slot (#680 contract).
+
+    The raw-response path stays caller-owned: the slot is held until the
+    caller calls decrement_active() exactly once, returning it to baseline.
+    """
+    with _patched_client(_FakeResponse()) as client:
+        baseline = client._active_requests
+        response = await client.request("GET", "http://svc/stream")
+        try:
+            # Still held: pool recreation is correctly deferred mid-stream.
+            assert client._active_requests == baseline + 1
+        finally:
+            async with response:
+                pass
+            await client.decrement_active()
+        assert client._active_requests == baseline
+
+
+@pytest.mark.asyncio
+async def test_tracked_request_decrements_on_caller_exception():
+    """tracked_request() is exception-safe: the slot is released on raise."""
+    with _patched_client(_FakeResponse()) as client:
+        baseline = client._active_requests
+        with pytest.raises(RuntimeError):
+            async with client.tracked_request("GET", "http://svc/data"):
+                assert client._active_requests == baseline + 1
+                raise RuntimeError("boom")
+        assert client._active_requests == baseline


### PR DESCRIPTION
## Thinking Path

`HTTPClientManager.request()` increments `_active_requests` on every call but only decrements it on the failure path, delegating the success-path decrement to the caller. Repo-wide, exactly **one** production caller honoured that contract (`autobot-backend/chat_workflow/manager.py:2147`, a streaming path) against ~151 shared-client call sites. `get_json()` / `post_json()` consume the response internally and never decremented at all, so the counter only ever grew.

The counter is not cosmetic — it drives two live mechanisms:

1. **Pool auto-sizing** — `_adjust_pool_size()` computes `utilization = _active_requests / _current_pool_size`. A monotonically rising numerator pins utilisation above the 0.7 grow threshold permanently, so the pool ratchets toward `_pool_max` (200) regardless of real concurrency, and the `< 0.2` shrink branch becomes unreachable.
2. **Deferred pool recreation** — `_handle_pool_recreation()` defers recreation while `_active_requests > 0`, and only `decrement_active()` reaching `0` applies it. With a counter that never returns to zero, a pending pool resize is **never applied**.

It also makes `get_stats()["active_requests"]` and `utilization` wrong for anything reading them.

The fix had to avoid adding *more* caller obligations — a contract that ~151 call sites already ignore will keep being ignored. So the decrement moved into the helper that owns the full lifecycle, where it cannot be forgotten, rather than being spread across call sites. The raw-response path (`request()` / `get()` / `post()`) stays caller-owned exactly as documented, because streaming callers legitimately need the slot held past the initial request (#680).

## What Changed

Scope is `autobot_shared/http_client.py` + its test file. No call sites were converted.

- **New `tracked_request()` async context manager** — issues the request, yields the response inside `async with response`, and decrements in a `finally`. It owns request + response body + counter as one unit. Named for symmetry with the existing `tracked_session()`.
- **`get_json()` / `post_json()` now use it**, so both balance the counter automatically. These were the two internal response-consuming helpers; `get()`/`post()` return raw responses and remain caller-owned.
- **Docstrings made explicit** on `request()`, `get()`, and `post()`: the returned response is caller-owned on the success path and requires `decrement_active()`, with `tracked_request()` called out as the forget-proof alternative.
- **Fixed the in-file `example_usage()` streaming sample**, which demonstrated the unbalanced pattern (`async with await http_client.get(...)` with no decrement) and was effectively teaching the bug.

No double-decrement is possible: if `request()` itself raises, it decrements on its own error path and the `try` in `tracked_request()` is never entered.

## Verification

New tests fail on the old code and pass on the new — confirmed by temporarily restoring the old `get_json()` body:

```
FAILED test_get_json_returns_counter_to_baseline
FAILED test_raise_for_status_failure_returns_counter_to_baseline   assert 2 == 1
FAILED test_sequential_requests_do_not_accumulate                  assert 7 == 2
3 failed, 2 passed
```

`assert 7 == 2` is the reported regression exactly: 5 sequential `get_json()` calls left the counter 5 higher than baseline.

After the fix:

```
$ python3 -m pytest autobot_shared/http_client_test.py -q
11 passed in 0.85s
```

Seven tests added, covering every case: baseline restored after a successful `get_json()`, after a successful `post_json()`, after a transport failure, after a `raise_for_status()` failure mid-block, and after 10 sequential requests (baseline, not baseline+10). Plus `tracked_request()` exception-safety.

**Streaming contract asserted unchanged** — `test_streaming_contract_unchanged_single_decrement()` verifies `request()` still hands back an un-decremented slot (`baseline + 1` while held, so mid-stream pool recreation is still correctly deferred) and that one caller `decrement_active()` returns it to baseline.

Full suite, no regressions:

```
$ python3 -m pytest autobot_shared/ -q
1144 passed in 69.22s

# baseline, excluding the 7 new tests
1137 passed, 7 deselected in 49.28s
```

1137 baseline + 7 new = 1144. No pre-existing test changed state.

```
$ python3 -m flake8 autobot_shared/http_client.py autobot_shared/http_client_test.py
flake8 exit=0
```

The sole production `decrement_active()` caller (`chat_workflow/manager.py:2147`) is a streaming Ollama path built on raw `post()` — untouched by this change, and not at risk of double-decrementing.

## Model Used

claude-opus-5

Closes #12981
