### PR TITLE
perf(http): route utils/ health and model probes through the shared pool (#12979)

### DIFF
--- a/autobot-backend/utils/connection_utils.py
+++ b/autobot-backend/utils/connection_utils.py
@@ -346,9 +346,7 @@ class ConnectionTester:
                 "current_model": current_model,
                 "model_available": model_available,
                 "provider": provider,
-                "message": (
-                    f"Embedding model '{current_model}' " f"{'available' if model_available else 'not found'}"
-                ),
+                "message": (f"Embedding model '{current_model}' " f"{'available' if model_available else 'not found'}"),
             }
 
     @staticmethod

--- a/autobot-backend/utils/connection_utils.py
+++ b/autobot-backend/utils/connection_utils.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config as _ssot_config
@@ -67,10 +68,17 @@ class ConnectionTester:
                 ollama_endpoint = get_ollama_url()
                 ollama_check_url = f"{ollama_endpoint}/api/tags"
                 timeout = aiohttp.ClientTimeout(total=_ssot_config.timeout.health_check)
-                async with aiohttp.ClientSession(timeout=timeout) as session:
-                    async with session.get(ollama_check_url) as response:
-                        if response.status == 200:
-                            ollama_status = "connected"
+                # Issue #12979: shared pool instead of a per-probe session.
+                # suppress_error_log because this probe already swallows failure
+                # into a "disconnected" status and logs it at DEBUG below.
+                async with get_http_client().tracked_request(
+                    "GET",
+                    ollama_check_url,
+                    timeout=timeout,
+                    suppress_error_log=True,
+                ) as response:
+                    if response.status == 200:
+                        ollama_status = "connected"
             except Exception as e:
                 logger.debug("Ollama health check failed: %s", e)
 
@@ -168,33 +176,39 @@ class ConnectionTester:
             "stream": False,
         }
         gen_timeout = aiohttp.ClientTimeout(total=_ssot_config.timeout.llm)
-        async with aiohttp.ClientSession(timeout=gen_timeout) as session:
-            async with session.post(endpoint, json=test_payload) as resp:
-                if resp.status == 200:
-                    result = await resp.json()
-                    response_text = result.get("response", "No response text")
-                    test_response = (
-                        response_text[:100] + "..."
-                        if response_text and response_text != "No response text"
-                        else "No response"
-                    )
-                    return {
-                        "status": "connected",
-                        "message": f"Successfully connected to Ollama with model '{model}'",
-                        "endpoint": endpoint,
-                        "model": model,
-                        "current_model": model,
-                        "test_response": test_response,
-                    }
-                error_text = await resp.text()
+        # Issue #12979: shared pool. Status is inspected rather than raised on,
+        # so this keeps the explicit response block instead of post_json().
+        async with get_http_client().tracked_request(
+            "POST",
+            endpoint,
+            json=test_payload,
+            timeout=gen_timeout,
+        ) as resp:
+            if resp.status == 200:
+                result = await resp.json()
+                response_text = result.get("response", "No response text")
+                test_response = (
+                    response_text[:100] + "..."
+                    if response_text and response_text != "No response text"
+                    else "No response"
+                )
                 return {
-                    "status": "partial",
-                    "message": f"Connected to Ollama but model '{model}' failed to respond",
+                    "status": "connected",
+                    "message": f"Successfully connected to Ollama with model '{model}'",
                     "endpoint": endpoint,
                     "model": model,
                     "current_model": model,
-                    "error": error_text,
+                    "test_response": test_response,
                 }
+            error_text = await resp.text()
+            return {
+                "status": "partial",
+                "message": f"Connected to Ollama but model '{model}' failed to respond",
+                "endpoint": endpoint,
+                "model": model,
+                "current_model": model,
+                "error": error_text,
+            }
 
     @staticmethod
     async def test_ollama_connection() -> Metadata:
@@ -206,16 +220,19 @@ class ConnectionTester:
             check_url = endpoint.replace(PATH_OLLAMA_GENERATE, PATH_OLLAMA_TAGS)
             timeout = aiohttp.ClientTimeout(total=_ssot_config.timeout.http)
 
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(check_url) as response:
-                    if response.status != 200:
-                        return {
-                            "status": "disconnected",
-                            "message": f"Failed to connect to Ollama at {check_url}",
-                            "endpoint": endpoint,
-                            "status_code": response.status,
-                        }
-                    return await ConnectionTester._test_ollama_model(endpoint, model)
+            # Issue #12979: shared pool. The reachability probe releases its
+            # connection before the generation test runs, so the two requests
+            # do not hold two pooled slots at once.
+            async with get_http_client().tracked_request("GET", check_url, timeout=timeout) as response:
+                if response.status != 200:
+                    return {
+                        "status": "disconnected",
+                        "message": f"Failed to connect to Ollama at {check_url}",
+                        "endpoint": endpoint,
+                        "status_code": response.status,
+                    }
+
+            return await ConnectionTester._test_ollama_model(endpoint, model)
 
         except Exception as e:
             logger.error("Ollama connection test failed: %s", str(e))
@@ -312,27 +329,27 @@ class ConnectionTester:
         tags_url = f"{ollama_host}/api/tags"
         timeout = aiohttp.ClientTimeout(total=_ssot_config.timeout.connect)
 
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(tags_url) as response:
-                if response.status != 200:
-                    return {
-                        "connected": False,
-                        "current_model": current_model,
-                        "provider": provider,
-                        "message": f"Cannot connect to Ollama at {ollama_host}",
-                    }
-                data = await response.json()
-                available_models = [model["name"] for model in data.get("models", [])]
-                model_available = current_model in available_models if current_model else False
+        # Issue #12979: shared pool; status is inspected, so the response block stays.
+        async with get_http_client().tracked_request("GET", tags_url, timeout=timeout) as response:
+            if response.status != 200:
                 return {
-                    "connected": True,
+                    "connected": False,
                     "current_model": current_model,
-                    "model_available": model_available,
                     "provider": provider,
-                    "message": (
-                        f"Embedding model '{current_model}' " f"{'available' if model_available else 'not found'}"
-                    ),
+                    "message": f"Cannot connect to Ollama at {ollama_host}",
                 }
+            data = await response.json()
+            available_models = [model["name"] for model in data.get("models", [])]
+            model_available = current_model in available_models if current_model else False
+            return {
+                "connected": True,
+                "current_model": current_model,
+                "model_available": model_available,
+                "provider": provider,
+                "message": (
+                    f"Embedding model '{current_model}' " f"{'available' if model_available else 'not found'}"
+                ),
+            }
 
     @staticmethod
     async def _get_embedding_status() -> Metadata:
@@ -499,13 +516,20 @@ class ModelManager:
             ollama_url = f"{ollama_host}/api/tags"
 
             timeout = aiohttp.ClientTimeout(total=_ssot_config.timeout.http)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(ollama_url) as response:
-                    if response.status != 200:
-                        return []
-                    ollama_data = await response.json()
-                    raw_models = ollama_data.get("models", [])
-                    return [ModelManager._parse_ollama_model(model) for model in raw_models]
+            # Issue #12979: shared pool. suppress_error_log because this path
+            # already rate-limits its own failure warning below to avoid spam
+            # when Ollama is not running.
+            async with get_http_client().tracked_request(
+                "GET",
+                ollama_url,
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as response:
+                if response.status != 200:
+                    return []
+                ollama_data = await response.json()
+                raw_models = ollama_data.get("models", [])
+                return [ModelManager._parse_ollama_model(model) for model in raw_models]
         except Exception as e:
             ModelManager._log_ollama_warning_if_needed(e)
             return []

--- a/autobot-backend/utils/hardware_metrics.py
+++ b/autobot-backend/utils/hardware_metrics.py
@@ -23,6 +23,7 @@ import aiohttp
 import psutil
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import TTL_1_HOUR
 
@@ -370,10 +371,17 @@ class HardwarePerformanceMonitor:
             ssot_config = get_config()
 
             timeout = aiohttp.ClientTimeout(total=5.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(f"http://{ssot_config.vm.npu_worker}:8081/stats") as response:
-                    if response.status == 200:
-                        return await response.json()
+            # Issue #12979: shared pool. suppress_error_log because the NPU
+            # worker is optional and this collector already swallows failure
+            # into an empty result.
+            async with get_http_client().tracked_request(
+                "GET",
+                f"http://{ssot_config.vm.npu}:8081/stats",
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as response:
+                if response.status == 200:
+                    return await response.json()
 
             return {}
         except Exception:
@@ -591,10 +599,16 @@ class HardwarePerformanceMonitor:
             start_time = time.time()
 
             timeout = aiohttp.ClientTimeout(total=2.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(f"http://{ssot_config.vm.main}:8001/api/health") as response:
-                    if response.status == 200:
-                        return round((time.time() - start_time) * 1000, 1)  # Convert to ms
+            # Issue #12979: shared pool. suppress_error_log because a failed
+            # probe is reported as the 999.0 sentinel below, not as an error.
+            async with get_http_client().tracked_request(
+                "GET",
+                f"http://{ssot_config.vm.main}:8001/api/health",
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as response:
+                if response.status == 200:
+                    return round((time.time() - start_time) * 1000, 1)  # Convert to ms
 
             return 999.0  # High latency if failed
         except Exception:
@@ -648,13 +662,13 @@ class HardwarePerformanceMonitor:
             {"name": "Redis", "host": ssot_config.vm.redis, "port": 6379, "path": None},
             {
                 "name": "AI Stack",
-                "host": ssot_config.vm.ai_stack,
+                "host": ssot_config.vm.aistack,
                 "port": 8080,
                 "path": "/health",
             },
             {
                 "name": "NPU Worker",
-                "host": ssot_config.vm.npu_worker,
+                "host": ssot_config.vm.npu,
                 "port": 8081,
                 "path": "/health",
             },
@@ -702,14 +716,20 @@ class HardwarePerformanceMonitor:
 
         try:
             timeout = aiohttp.ClientTimeout(total=5.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(f"http://{host}:{port}{path}") as response:
-                    if response.status == 200:
-                        return "healthy"
-                    elif 200 <= response.status < 400:
-                        return "degraded"
-                    else:
-                        return "critical"
+            # Issue #12979: shared pool. suppress_error_log because an
+            # unreachable service is already reported as "critical" below.
+            async with get_http_client().tracked_request(
+                "GET",
+                f"http://{host}:{port}{path}",
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as response:
+                if response.status == 200:
+                    return "healthy"
+                elif 200 <= response.status < 400:
+                    return "degraded"
+                else:
+                    return "critical"
         except Exception:
             return "critical"
 


### PR DESCRIPTION
Batch 2 of #12979, following the merged pilot (#12982, `integrations/monitoring_integration.py`). Not a closing PR — ~108 sites remain.

## Thinking Path

**Area chosen: `autobot-backend/utils/`** — `connection_utils.py` (5 sites) and `hardware_metrics.py` (3 sites).

Both candidates named on the issue were counted before choosing:

| candidate | sites | note |
|---|---|---|
| `web_fetch/` (fetcher, robots, site_mapper) | 4 | spread one-per-file; one passes session-level `headers=` |
| `utils/` | 8 production (+2 in diagnostic scripts) | two files, one uniform shape |

`utils/` won on three grounds:

1. **Highest value per site.** These are not one-shot calls. `get_fast_health_status()` is a cached-every-30s health endpoint, `_check_http_service_status()` runs once per service per collection cycle (6 services), and `HardwarePerformanceMonitor` polls on a 5s interval. A per-request session on a 5s poll loop is the exact cost the pool exists to remove — `web_fetch` fetches are comparatively rare and long.
2. **Uniform shape, so the whole batch is the trap-prone form.** All 8 inspect `response.status` and return a structured result; **zero** matched the `raise_for_status()` + `json()` shape. That makes this a good batch to re-run the pilot's leak assertion against, since every single site had to keep an explicit response block.
3. **Cohesive and self-contained** — two modules, one concern (service reachability probing), no shared helpers with the rest of the tree.

**Deviation from the recipe, deliberate.** The issue's recipe says the status-inspecting shape becomes `async with await client.get(...)`. That recipe predates #12989. `client.get()` releases the *connection* under `async with`, but it still leaves `_active_requests` permanently incremented — the exact defect #12981 described and #12989 fixed for `get_json`/`post_json`. `tracked_request()` is the API #12989 added for precisely this shape: it owns the response block *and* balances the counter. Every converted site uses it. Using the literal recipe here would have re-introduced the counter leak this batch was sequenced to wait for.

**Log-level preservation.** `request()` logs failures at ERROR by default. Five of the eight sites currently swallow failure deliberately — into a `"disconnected"` status, an empty dict, a `999.0` latency sentinel, or a rate-limited warning that exists specifically to stop Ollama-not-running spam. Converting those without `suppress_error_log=True` would have turned a quiet, expected condition into per-probe ERROR noise on a 5s loop. The three sites whose callers already log at ERROR keep the default.

## What Changed

`aiohttp.ClientSession(` count, before -> after:

| file | before | after |
|---|---|---|
| `autobot-backend/utils/connection_utils.py` | 5 | **0** |
| `autobot-backend/utils/hardware_metrics.py` | 3 | **0** |

Per-shape split across the 8 sites:

| shape | count | conversion |
|---|---|---|
| `raise_for_status()` + `json()`, GET | **0** | — |
| `raise_for_status()` + `json()`, POST | **0** | — |
| inspects `response.status`, returns structured result | **8** (7 GET + 1 POST) | `tracked_request(...)` |

No site fell outside these categories. The single POST (`_test_ollama_model`) reads JSON on 200 and `text()` on non-200, so it is a status-inspecting site despite being a POST — `post_json()` would have raised instead of returning the `"partial"` result.

`aiohttp` remains imported in both files: `ClientTimeout` is still constructed at every site and passed through as a per-call kwarg.

One structural change beyond substitution: `test_ollama_connection()` used to call `_test_ollama_model()` from *inside* the reachability probe's response block. The probe now closes its block before the generation test runs, so the two requests no longer hold two pooled slots at once.

### Pre-existing bug fixed (#12990)

`hardware_metrics.py` read three `VMConfig` attributes that do not exist — `vm.npu_worker` and `vm.ai_stack`, where the fields are `npu` and `aistack`. Two silent failures resulted:

- `_get_npu_worker_stats()` was **permanently dead** — the `AttributeError` was swallowed by its `except Exception: return {}`, so the NPU worker was never contacted.
- `_get_service_configs()` **raised**, killing `collect_service_performance_metrics()` for all six services, not just AI Stack.

Fixed here rather than deferred because one of the three lines is a line this PR edits, and the conversion at that site was otherwise unverifiable — the request never fired. Repo-wide grep confirms `hardware_metrics.py` was the only file with the wrong names. Full write-up in #12990.

## Verification

**Syntax and lint — clean on both changed files:**

```
$ python3 -m py_compile autobot-backend/utils/connection_utils.py autobot-backend/utils/hardware_metrics.py
py_compile OK
$ python3 -m flake8 autobot-backend/utils/connection_utils.py autobot-backend/utils/hardware_metrics.py
flake8 exit=0
```

**Session-count grep, after:**

```
autobot-backend/utils/connection_utils.py:0
autobot-backend/utils/hardware_metrics.py:0
```

**Leak assertion — the pilot's method, reused.** All 8 converted sites were exercised against a local `aiohttp` test server through the real shared pool, on both the success and the failure branch, then `connector._acquired_per_host` was read:

```
--- exercised call sites ---
  hm._get_npu_worker_stats: {'npu': 'stats'}
  hm._measure_network_latency: 4.9
  hm._check_http_service_status 200: 'healthy'
  hm._check_http_service_status 204: 'degraded'
  hm._check_http_service_status 500: 'critical'
  cu.get_fast_health_status: 'connected'
  cu._test_ollama_model 200: 'connected'
  cu.test_ollama_connection: 'connected'
  cu._check_ollama_embedding 200: True
  cu.ModelManager._get_ollama_models: [{'name': 'm1', 'type': 'ollama', ...}]
  cu.get_fast_health_status 500: 'disconnected'
  cu.test_ollama_connection 500: 'disconnected'
  cu._check_ollama_embedding 500: False
  cu.ModelManager._get_ollama_models 500: []
  cu._test_ollama_model 500: 'partial'

--- pool state ---
  requests issued        : 16
  pooled idle conns      : 1
  still-acquired         : 0
  active_requests counter: 0

PASS: no leaked connections, counter balanced
```

**16 requests, 1 pooled connection, 0 still-acquired** — every request reused the same connection and every one released it. The counter reading 0 rather than 16 is the #12989 fix working through `tracked_request()`; the literal `client.get()` recipe would have left it at 16.

**Behaviour preserved on the error branches.** The bottom five lines above are the non-2xx runs: `'disconnected'`, `'disconnected'`, `False`, `[]`, `'partial'` — all structured returns, no raises. A uniform `get_json()` sweep would have raised at all five. That is 8 in 8 here, against 2 in 11 in the pilot.

**Existing tests — no regression:**

```
baseline (origin/Dev_new_gui files swapped in):  14 passed in 1.06s
after conversion:                                14 passed in 0.95s
```

(`utils/connection_utils_test.py` — 14 tests. `utils/hardware_metrics_test.py` collects 0 items, before and after.)

## Remaining work on #12979

This is batch 2. Roughly **108** raw constructions remain outside the 7 long-lived ones and the returned-session case at `voice_processing/providers/cloud/base.py:73`. Densest remaining clusters:

```
integrations/cicd_integration.py           14
integrations/version_control_integration.py 11
services/telegram_bot_service.py            8
services/tts_client.py                      7
integrations/communication_integration.py   5
web_fetch/ (fetcher, robots, site_mapper)   4
```

**One recipe amendment for later batches:** the `raise_for_status()` vs `response.status` triage grep mis-classifies a site that reads `json()` on 200 and `text()` on non-200 — it looks like a JSON site but is a status site. Check what the non-2xx branch *reads*, not only whether `raise_for_status()` is absent.

## Model Used

claude-opus-5
