### PR TITLE
perf(http): route CI/CD and VCS integrations through the shared pool (#12979)

### DIFF
--- a/autobot-backend/integrations/cicd_integration.py
+++ b/autobot-backend/integrations/cicd_integration.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from integrations.base import (
     BaseIntegration,
@@ -41,22 +42,25 @@ class JenkinsIntegration(BaseIntegration):
             IntegrationHealth with status and details
         """
         try:
-            async with aiohttp.ClientSession(auth=self.auth) as session:
-                async with session.get(
-                    f"{self.base_url}/api/json", timeout=aiohttp.ClientTimeout(total=10)
-                ) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        return IntegrationHealth(
-                            status=IntegrationStatus.HEALTHY,
-                            message="Connected to Jenkins successfully",
-                            details={"version": data.get("version")},
-                        )
+            async with get_http_client().tracked_request(
+                "GET",
+                f"{self.base_url}/api/json",
+                auth=self.auth,
+                timeout=aiohttp.ClientTimeout(total=10),
+                suppress_error_log=True,
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
                     return IntegrationHealth(
-                        status=IntegrationStatus.UNHEALTHY,
-                        message=f"Jenkins returned status {response.status}",
-                        details={},
+                        status=IntegrationStatus.HEALTHY,
+                        message="Connected to Jenkins successfully",
+                        details={"version": data.get("version")},
                     )
+                return IntegrationHealth(
+                    status=IntegrationStatus.UNHEALTHY,
+                    message=f"Jenkins returned status {response.status}",
+                    details={},
+                )
         except Exception:
             logger.exception("Jenkins connection test failed")
             return IntegrationHealth(
@@ -114,42 +118,40 @@ class JenkinsIntegration(BaseIntegration):
 
     async def _list_jobs(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List all Jenkins jobs."""
-        async with aiohttp.ClientSession(auth=self.auth) as session:
-            async with session.get(f"{self.base_url}/api/json?tree=jobs[name,url,color]") as response:
-                response.raise_for_status()
-                data = await response.json()
-                return {"jobs": data.get("jobs", [])}
+        data = await get_http_client().get_json(
+            f"{self.base_url}/api/json?tree=jobs[name,url,color]",
+            auth=self.auth,
+        )
+        return {"jobs": data.get("jobs", [])}
 
     async def _get_build_status(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Get Jenkins build status."""
         job_name = params["job_name"]
         build_number = params["build_number"]
         url = f"{self.base_url}/job/{job_name}/{build_number}/api/json"
-        async with aiohttp.ClientSession(auth=self.auth) as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                return await response.json()
+        return await get_http_client().get_json(url, auth=self.auth)
 
     async def _trigger_build(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Trigger Jenkins build."""
         job_name = params["job_name"]
         build_params = params.get("parameters", {})
         url = f"{self.base_url}/job/{job_name}/buildWithParameters"
-        async with aiohttp.ClientSession(auth=self.auth) as session:
-            async with session.post(url, json=build_params) as response:
-                response.raise_for_status()
-                return {"status": "triggered", "job_name": job_name}
+        # Not post_json(): Jenkins answers buildWithParameters with an empty
+        # 201 body, so decoding JSON here would raise on the success path.
+        async with get_http_client().tracked_request("POST", url, json=build_params, auth=self.auth) as response:
+            response.raise_for_status()
+            return {"status": "triggered", "job_name": job_name}
 
     async def _get_build_log(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Get Jenkins build log."""
         job_name = params["job_name"]
         build_number = params["build_number"]
         url = f"{self.base_url}/job/{job_name}/{build_number}/consoleText"
-        async with aiohttp.ClientSession(auth=self.auth) as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                log = await response.text()
-                return {"log": log, "job_name": job_name, "build_number": build_number}
+        # Console output is plain text, so this reads text() rather than json().
+        async with get_http_client().tracked_request("GET", url, auth=self.auth) as response:
+            response.raise_for_status()
+            log = await response.text()
+            return {"log": log, "job_name": job_name, "build_number": build_number}
 
 
 class GitLabCIIntegration(BaseIntegration):
@@ -173,23 +175,25 @@ class GitLabCIIntegration(BaseIntegration):
             IntegrationHealth with status and details
         """
         try:
-            async with aiohttp.ClientSession(headers=self.headers) as session:
-                async with session.get(
-                    f"{self.base_url}/api/v4/version",
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        return IntegrationHealth(
-                            status=IntegrationStatus.HEALTHY,
-                            message="Connected to GitLab successfully",
-                            details={"version": data.get("version")},
-                        )
+            async with get_http_client().tracked_request(
+                "GET",
+                f"{self.base_url}/api/v4/version",
+                headers=self.headers,
+                timeout=aiohttp.ClientTimeout(total=10),
+                suppress_error_log=True,
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
                     return IntegrationHealth(
-                        status=IntegrationStatus.UNHEALTHY,
-                        message=f"GitLab returned status {response.status}",
-                        details={},
+                        status=IntegrationStatus.HEALTHY,
+                        message="Connected to GitLab successfully",
+                        details={"version": data.get("version")},
                     )
+                return IntegrationHealth(
+                    status=IntegrationStatus.UNHEALTHY,
+                    message=f"GitLab returned status {response.status}",
+                    details={},
+                )
         except Exception:
             logger.exception("GitLab connection test failed")
             return IntegrationHealth(
@@ -253,42 +257,30 @@ class GitLabCIIntegration(BaseIntegration):
         """List GitLab pipelines."""
         project_id = params["project_id"]
         url = f"{self.base_url}/api/v4/projects/{project_id}/pipelines"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                pipelines = await response.json()
-                return {"pipelines": pipelines}
+        pipelines = await get_http_client().get_json(url, headers=self.headers)
+        return {"pipelines": pipelines}
 
     async def _get_pipeline_status(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Get GitLab pipeline status."""
         project_id = params["project_id"]
         pipeline_id = params["pipeline_id"]
         url = f"{self.base_url}/api/v4/projects/{project_id}/pipelines/{pipeline_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                return await response.json()
+        return await get_http_client().get_json(url, headers=self.headers)
 
     async def _trigger_pipeline(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Trigger GitLab pipeline."""
         project_id = params["project_id"]
         ref = params["ref"]
         url = f"{self.base_url}/api/v4/projects/{project_id}/pipeline"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.post(url, json={"ref": ref}) as response:
-                response.raise_for_status()
-                return await response.json()
+        return await get_http_client().post_json(url, {"ref": ref}, headers=self.headers)
 
     async def _list_jobs(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List GitLab pipeline jobs."""
         project_id = params["project_id"]
         pipeline_id = params["pipeline_id"]
         url = f"{self.base_url}/api/v4/projects/{project_id}/pipelines/{pipeline_id}/jobs"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                jobs = await response.json()
-                return {"jobs": jobs}
+        jobs = await get_http_client().get_json(url, headers=self.headers)
+        return {"jobs": jobs}
 
 
 class CircleCIIntegration(BaseIntegration):
@@ -312,20 +304,25 @@ class CircleCIIntegration(BaseIntegration):
             IntegrationHealth with status and details
         """
         try:
-            async with aiohttp.ClientSession(headers=self.headers) as session:
-                async with session.get(f"{self.base_url}/me", timeout=aiohttp.ClientTimeout(total=10)) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        return IntegrationHealth(
-                            status=IntegrationStatus.HEALTHY,
-                            message="Connected to CircleCI successfully",
-                            details={"user": data.get("name")},
-                        )
+            async with get_http_client().tracked_request(
+                "GET",
+                f"{self.base_url}/me",
+                headers=self.headers,
+                timeout=aiohttp.ClientTimeout(total=10),
+                suppress_error_log=True,
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
                     return IntegrationHealth(
-                        status=IntegrationStatus.UNHEALTHY,
-                        message=f"CircleCI returned status {response.status}",
-                        details={},
+                        status=IntegrationStatus.HEALTHY,
+                        message="Connected to CircleCI successfully",
+                        details={"user": data.get("name")},
                     )
+                return IntegrationHealth(
+                    status=IntegrationStatus.UNHEALTHY,
+                    message=f"CircleCI returned status {response.status}",
+                    details={},
+                )
         except Exception:
             logger.exception("CircleCI connection test failed")
             return IntegrationHealth(
@@ -383,20 +380,14 @@ class CircleCIIntegration(BaseIntegration):
         """List CircleCI pipelines."""
         project_slug = params["project_slug"]
         url = f"{self.base_url}/project/{project_slug}/pipeline"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                data = await response.json()
-                return {"pipelines": data.get("items", [])}
+        data = await get_http_client().get_json(url, headers=self.headers)
+        return {"pipelines": data.get("items", [])}
 
     async def _get_workflow_status(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Get CircleCI workflow status."""
         workflow_id = params["workflow_id"]
         url = f"{self.base_url}/workflow/{workflow_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                return await response.json()
+        return await get_http_client().get_json(url, headers=self.headers)
 
     async def _trigger_pipeline(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Trigger CircleCI pipeline."""
@@ -404,7 +395,4 @@ class CircleCIIntegration(BaseIntegration):
         branch = params.get("branch", "main")
         url = f"{self.base_url}/project/{project_slug}/pipeline"
         payload = {"branch": branch}
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.post(url, json=payload) as response:
-                response.raise_for_status()
-                return await response.json()
+        return await get_http_client().post_json(url, payload, headers=self.headers)

--- a/autobot-backend/integrations/version_control_integration.py
+++ b/autobot-backend/integrations/version_control_integration.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from integrations.base import (
@@ -42,24 +43,25 @@ class GitLabIntegration(BaseIntegration):
             IntegrationHealth with connection status
         """
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"{self.base_url}/user",
-                    headers=self.headers,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ) as response:
-                    if response.status == 200:
-                        user_data = await response.json()
-                        return IntegrationHealth(
-                            status=IntegrationStatus.HEALTHY,
-                            message=f"Connected as {user_data.get('username')}",
-                            last_checked=now_utc(),
-                        )
+            async with get_http_client().tracked_request(
+                "GET",
+                f"{self.base_url}/user",
+                headers=self.headers,
+                timeout=aiohttp.ClientTimeout(total=10),
+                suppress_error_log=True,
+            ) as response:
+                if response.status == 200:
+                    user_data = await response.json()
                     return IntegrationHealth(
-                        status=IntegrationStatus.UNHEALTHY,
-                        message=f"API returned status {response.status}",
+                        status=IntegrationStatus.HEALTHY,
+                        message=f"Connected as {user_data.get('username')}",
                         last_checked=now_utc(),
                     )
+                return IntegrationHealth(
+                    status=IntegrationStatus.UNHEALTHY,
+                    message=f"API returned status {response.status}",
+                    last_checked=now_utc(),
+                )
         except Exception as e:
             logger.error("GitLab connection test failed: %s", str(e))
             return IntegrationHealth(
@@ -143,16 +145,13 @@ class GitLabIntegration(BaseIntegration):
         if "visibility" in params:
             query_params["visibility"] = params["visibility"]
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                f"{self.base_url}/projects",
-                headers=self.headers,
-                params=query_params,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as response:
-                response.raise_for_status()
-                projects = await response.json()
-                return {"projects": projects, "count": len(projects)}
+        projects = await get_http_client().get_json(
+            f"{self.base_url}/projects",
+            headers=self.headers,
+            params=query_params,
+            timeout=aiohttp.ClientTimeout(total=30),
+        )
+        return {"projects": projects, "count": len(projects)}
 
     async def _list_merge_requests(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List merge requests for a project.
@@ -169,17 +168,14 @@ class GitLabIntegration(BaseIntegration):
             "scope": params.get("scope", "all"),
         }
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/projects/{project_id}/merge_requests"
-            async with session.get(
-                url,
-                headers=self.headers,
-                params=query_params,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as response:
-                response.raise_for_status()
-                merge_requests = await response.json()
-                return {"merge_requests": merge_requests, "count": len(merge_requests)}
+        url = f"{self.base_url}/projects/{project_id}/merge_requests"
+        merge_requests = await get_http_client().get_json(
+            url,
+            headers=self.headers,
+            params=query_params,
+            timeout=aiohttp.ClientTimeout(total=30),
+        )
+        return {"merge_requests": merge_requests, "count": len(merge_requests)}
 
     async def _list_branches(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List branches for a project.
@@ -195,17 +191,14 @@ class GitLabIntegration(BaseIntegration):
         if "search" in params:
             query_params["search"] = params["search"]
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/projects/{project_id}/repository/branches"
-            async with session.get(
-                url,
-                headers=self.headers,
-                params=query_params,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as response:
-                response.raise_for_status()
-                branches = await response.json()
-                return {"branches": branches, "count": len(branches)}
+        url = f"{self.base_url}/projects/{project_id}/repository/branches"
+        branches = await get_http_client().get_json(
+            url,
+            headers=self.headers,
+            params=query_params,
+            timeout=aiohttp.ClientTimeout(total=30),
+        )
+        return {"branches": branches, "count": len(branches)}
 
     async def _get_commit_info(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Get detailed commit information.
@@ -219,12 +212,9 @@ class GitLabIntegration(BaseIntegration):
         project_id = params["project_id"]
         commit_sha = params["commit_sha"]
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/projects/{project_id}" f"/repository/commits/{commit_sha}"
-            async with session.get(url, headers=self.headers, timeout=aiohttp.ClientTimeout(total=30)) as response:
-                response.raise_for_status()
-                commit = await response.json()
-                return {"commit": commit}
+        url = f"{self.base_url}/projects/{project_id}" f"/repository/commits/{commit_sha}"
+        commit = await get_http_client().get_json(url, headers=self.headers, timeout=aiohttp.ClientTimeout(total=30))
+        return {"commit": commit}
 
     async def _compare_branches(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Compare two branches.
@@ -238,17 +228,14 @@ class GitLabIntegration(BaseIntegration):
         project_id = params["project_id"]
         query_params = {"from": params["from_branch"], "to": params["to_branch"]}
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/projects/{project_id}/repository/compare"
-            async with session.get(
-                url,
-                headers=self.headers,
-                params=query_params,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as response:
-                response.raise_for_status()
-                comparison = await response.json()
-                return {"comparison": comparison}
+        url = f"{self.base_url}/projects/{project_id}/repository/compare"
+        comparison = await get_http_client().get_json(
+            url,
+            headers=self.headers,
+            params=query_params,
+            timeout=aiohttp.ClientTimeout(total=30),
+        )
+        return {"comparison": comparison}
 
 
 class BitbucketIntegration(BaseIntegration):
@@ -281,6 +268,20 @@ class BitbucketIntegration(BaseIntegration):
             self.auth = aiohttp.BasicAuth(username, config.api_key)
             self.headers = {}
 
+    def _request_kwargs(self, timeout: int) -> Dict[str, Any]:
+        """Build the per-request kwargs shared by every Bitbucket call.
+
+        Args:
+            timeout: Total request timeout in seconds
+
+        Returns:
+            Request kwargs including headers, timeout and optional basic auth
+        """
+        kwargs: Dict[str, Any] = {"headers": self.headers, "timeout": timeout}
+        if hasattr(self, "auth"):
+            kwargs["auth"] = self.auth
+        return kwargs
+
     async def test_connection(self) -> IntegrationHealth:
         """Test Bitbucket API connection.
 
@@ -288,24 +289,22 @@ class BitbucketIntegration(BaseIntegration):
             IntegrationHealth with connection status
         """
         try:
-            async with aiohttp.ClientSession() as session:
-                kwargs = {"headers": self.headers, "timeout": 10}
-                if hasattr(self, "auth"):
-                    kwargs["auth"] = self.auth
-
-                async with session.get(f"{self.base_url}/user", **kwargs) as response:
-                    if response.status == 200:
-                        user_data = await response.json()
-                        return IntegrationHealth(
-                            status=IntegrationStatus.HEALTHY,
-                            message=(f"Connected as {user_data.get('username')}"),
-                            last_checked=now_utc(),
-                        )
+            kwargs = self._request_kwargs(timeout=10)
+            async with get_http_client().tracked_request(
+                "GET", f"{self.base_url}/user", suppress_error_log=True, **kwargs
+            ) as response:
+                if response.status == 200:
+                    user_data = await response.json()
                     return IntegrationHealth(
-                        status=IntegrationStatus.UNHEALTHY,
-                        message=f"API returned status {response.status}",
+                        status=IntegrationStatus.HEALTHY,
+                        message=(f"Connected as {user_data.get('username')}"),
                         last_checked=now_utc(),
                     )
+                return IntegrationHealth(
+                    status=IntegrationStatus.UNHEALTHY,
+                    message=f"API returned status {response.status}",
+                    last_checked=now_utc(),
+                )
         except Exception as e:
             logger.error("Bitbucket connection test failed: %s", str(e))
             return IntegrationHealth(
@@ -377,19 +376,12 @@ class BitbucketIntegration(BaseIntegration):
         if not workspace:
             raise ValueError("Workspace is required")
 
-        async with aiohttp.ClientSession() as session:
-            kwargs = {"headers": self.headers, "timeout": 30}
-            if hasattr(self, "auth"):
-                kwargs["auth"] = self.auth
-
-            url = f"{self.base_url}/repositories/{workspace}"
-            async with session.get(url, **kwargs) as response:
-                response.raise_for_status()
-                data = await response.json()
-                return {
-                    "repositories": data.get("values", []),
-                    "count": len(data.get("values", [])),
-                }
+        url = f"{self.base_url}/repositories/{workspace}"
+        data = await get_http_client().get_json(url, **self._request_kwargs(timeout=30))
+        return {
+            "repositories": data.get("values", []),
+            "count": len(data.get("values", [])),
+        }
 
     async def _list_pull_requests(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List pull requests for a repository.
@@ -407,21 +399,15 @@ class BitbucketIntegration(BaseIntegration):
         repo_slug = params["repo_slug"]
         state = params.get("state", "OPEN")
 
-        async with aiohttp.ClientSession() as session:
-            kwargs = {"headers": self.headers, "timeout": 30}
-            if hasattr(self, "auth"):
-                kwargs["auth"] = self.auth
+        url = f"{self.base_url}/repositories/{workspace}/" f"{repo_slug}/pullrequests"
+        kwargs = self._request_kwargs(timeout=30)
+        kwargs["params"] = {"state": state}
 
-            url = f"{self.base_url}/repositories/{workspace}/" f"{repo_slug}/pullrequests"
-            kwargs["params"] = {"state": state}
-
-            async with session.get(url, **kwargs) as response:
-                response.raise_for_status()
-                data = await response.json()
-                return {
-                    "pull_requests": data.get("values", []),
-                    "count": len(data.get("values", [])),
-                }
+        data = await get_http_client().get_json(url, **kwargs)
+        return {
+            "pull_requests": data.get("values", []),
+            "count": len(data.get("values", [])),
+        }
 
     async def _list_branches(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List branches for a repository.
@@ -438,19 +424,12 @@ class BitbucketIntegration(BaseIntegration):
 
         repo_slug = params["repo_slug"]
 
-        async with aiohttp.ClientSession() as session:
-            kwargs = {"headers": self.headers, "timeout": 30}
-            if hasattr(self, "auth"):
-                kwargs["auth"] = self.auth
-
-            url = f"{self.base_url}/repositories/{workspace}/" f"{repo_slug}/refs/branches"
-            async with session.get(url, **kwargs) as response:
-                response.raise_for_status()
-                data = await response.json()
-                return {
-                    "branches": data.get("values", []),
-                    "count": len(data.get("values", [])),
-                }
+        url = f"{self.base_url}/repositories/{workspace}/" f"{repo_slug}/refs/branches"
+        data = await get_http_client().get_json(url, **self._request_kwargs(timeout=30))
+        return {
+            "branches": data.get("values", []),
+            "count": len(data.get("values", [])),
+        }
 
     async def _get_commit_info(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Get detailed commit information.
@@ -468,13 +447,6 @@ class BitbucketIntegration(BaseIntegration):
         repo_slug = params["repo_slug"]
         commit_hash = params["commit_hash"]
 
-        async with aiohttp.ClientSession() as session:
-            kwargs = {"headers": self.headers, "timeout": 30}
-            if hasattr(self, "auth"):
-                kwargs["auth"] = self.auth
-
-            url = f"{self.base_url}/repositories/{workspace}/" f"{repo_slug}/commit/{commit_hash}"
-            async with session.get(url, **kwargs) as response:
-                response.raise_for_status()
-                commit = await response.json()
-                return {"commit": commit}
+        url = f"{self.base_url}/repositories/{workspace}/" f"{repo_slug}/commit/{commit_hash}"
+        commit = await get_http_client().get_json(url, **self._request_kwargs(timeout=30))
+        return {"commit": commit}


### PR DESCRIPTION
## Thinking Path

Batch 3 of #12979, following the pilot (`monitoring_integration.py`, #12982) and the utils batch (#12991). The two densest remaining clusters in `autobot-backend/` were `integrations/cicd_integration.py` (14 sites) and `integrations/version_control_integration.py` (11).

Both are API-client modules written against documented remote APIs, so the prediction carried into this batch was that the split would swing back toward the safe `get_json()` shape — unlike the utils batch, which was 8/8 the careful shape because probe code turns unreachable services into status strings rather than raising. That held: 18 of 25 sites were the safe shape.

Classification was done per-site by reading what each branch actually reads, not by grepping for `raise_for_status()`. That mattered twice, and in both cases the grep-based triage would have been wrong:

- `JenkinsIntegration._trigger_build()` is a POST **with** `raise_for_status()` that returns `{"status": "triggered", ...}` without reading the body. Real Jenkins answers `buildWithParameters` with an empty `201`, so `post_json()` would have raised on the *success* path. Verified directly against a server returning that exact response:

  ```
  post_json RAISED ContentTypeError: 201, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8'
  tracked_request -> status 201 | site returns {'status': 'triggered', ...}
  ```

- `JenkinsIntegration._get_build_log()` has `raise_for_status()` but reads `text()` — Jenkins console output is plain text.

`tracked_request()` is used for the careful shape rather than the older `async with await client.get(...)` form, per the #12989 amendment: the older form releases the connection but leaves `_active_requests` permanently incremented.

## What Changed

`autobot-backend/integrations/cicd_integration.py`: 14 `aiohttp.ClientSession(` → **0**
`autobot-backend/integrations/version_control_integration.py`: 11 → **0**

| shape | count | conversion |
|---|---|---|
| `raise_for_status()` + `json()`, GET | 16 | `get_json()` |
| `raise_for_status()` + `json()`, POST | 2 | `post_json()` |
| inspects `response.status` → structured `IntegrationHealth` | 5 | `tracked_request()` |
| `raise_for_status()` + `text()` | 1 | `tracked_request()` |
| POST + `raise_for_status()`, body never read | 1 | `tracked_request()` |

18 safe / 7 careful — the inverse of the utils batch, as expected for integration clients. No site fell outside these shapes.

Session-level configuration moved to per-request kwargs, which the manager forwards unchanged: `ClientSession(auth=...)` → `auth=`, `ClientSession(headers=...)` → `headers=`. The manager additionally merges W3C trace context into those headers, which the raw per-request sessions were missing entirely.

The five `test_connection()` sites pass `suppress_error_log=True`. Each already catches the exception, logs it itself, and encodes the failure as `IntegrationStatus.UNHEALTHY` — the manager's default ERROR log would only duplicate a message the call site already emits.

`BitbucketIntegration._request_kwargs()` was extracted: the identical `{"headers": ..., "timeout": ...}` + `if hasattr(self, "auth")` block appeared at five call sites, and collapsing the surrounding `async with` blocks would otherwise have left it duplicated five times inline.

## Verification

**Static**

```
py_compile          : OK (both files)
flake8 --count      : 0
black --check       : 2 files would be left unchanged

grep -c "aiohttp.ClientSession(" cicd_integration.py            : 14 -> 0
grep -c "aiohttp.ClientSession(" version_control_integration.py : 11 -> 0
```

**Exercised against a local aiohttp server** — all 25 converted sites (26 calls; Bitbucket `test_connection` run once per auth mode) on both the success and the failure branch, 52 requests total:

```
requests issued        : 52
pooled idle conns      : 1
still-acquired         : 0
active_requests counter: 0
```

52 requests over **one** connection, zero still acquired, counter balanced — the leak assertion established in the pilot and reused per batch.

Behaviour preserved on the failure branch. The status-inspecting sites still return structured health rather than raising:

```
jenkins.test_connection            -> unhealthy | Jenkins returned status 503
gitlabci.test_connection           -> unhealthy | GitLab returned status 503
circleci.test_connection           -> unhealthy | CircleCI returned status 503
gitlab.test_connection             -> unhealthy | API returned status 503
bitbucket.test_connection (basic)  -> unhealthy | API returned status 503
bitbucket.test_connection (bearer) -> unhealthy | API returned status 503
```

…while the 18 `*_json()` sites raise `ClientResponseError` on 503, exactly as `raise_for_status()` did before. On the success branch every site returned its previous shape, including the two carve-outs:

```
jenkins._trigger_build   -> {'status': 'triggered', 'job_name': 'j'}      (empty 201 body)
jenkins._get_build_log   -> {'log': 'build log line 1\nline 2\n', ...}    (text/plain)
```

**Existing tests** — baseline taken by `cp`-swapping the origin files in, never `git stash`:

```
origin    : 186 passed, 1 warning in 1.82s
converted : 186 passed, 1 warning in 1.63s
```

No test exercises these two modules directly; the suite covers the shared `BaseIntegration` contract, which both files still satisfy.

## Discovered, filed separately

- **#12992** — the two `test_connection()` sites converted in the pilot (#12982) still use the pre-#12989 `async with await get_http_client().get(...)` form, which releases the connection but leaks the counter. Measured: 10 requests → `still-acquired 0`, `active_requests 10`. Not fixed here — different file, outside this batch's scope, and it blocked nothing converted in this PR.
- **#12993** — `integration_unknown_action_contract_test.py` discovers subclasses via a CWD-relative `Path("autobot-backend/integrations")`, so the suite fails from `autobot-backend/` and passes from the repo root. Surfaced while taking the test baseline; confirmed pre-existing on `origin/Dev_new_gui`.

## Model Used

claude-opus-5
