### PR TITLE
fix(http): track active requests in monitoring test_connection sites (#12992)

### DIFF
--- a/autobot-backend/integrations/monitoring_integration.py
+++ b/autobot-backend/integrations/monitoring_integration.py
@@ -64,12 +64,19 @@ class DatadogIntegration(BaseIntegration):
             IntegrationHealth with connection status and details
         """
         try:
-            # `get()` returns (not yields) a ClientResponse; the `async with` is the
-            # connection-release point back into the shared pool and must be kept.
-            async with await get_http_client().get(
+            # `tracked_request()` owns the connection release AND the
+            # `_active_requests` slot (#12989/#12992); the raw `get()` form used
+            # here previously released the connection but leaked the counter.
+            # This site cannot use `get_json()` — it must inspect
+            # `response.status` and return a structured `IntegrationHealth`
+            # rather than raise. Failure is already logged and encoded below, so
+            # `suppress_error_log=True` avoids a duplicate ERROR from the manager.
+            async with get_http_client().tracked_request(
+                "GET",
                 f"{self.base_url}/validate",
                 headers=self._get_headers(),
                 timeout=aiohttp.ClientTimeout(total=10),
+                suppress_error_log=True,
             ) as response:
                 if response.status == 200:
                     data = await response.json()
@@ -273,12 +280,19 @@ class NewRelicIntegration(BaseIntegration):
             IntegrationHealth with connection status and details
         """
         try:
-            # `get()` returns (not yields) a ClientResponse; the `async with` is the
-            # connection-release point back into the shared pool and must be kept.
-            async with await get_http_client().get(
+            # `tracked_request()` owns the connection release AND the
+            # `_active_requests` slot (#12989/#12992); the raw `get()` form used
+            # here previously released the connection but leaked the counter.
+            # This site cannot use `get_json()` — it must inspect
+            # `response.status` and return a structured `IntegrationHealth`
+            # rather than raise. Failure is already logged and encoded below, so
+            # `suppress_error_log=True` avoids a duplicate ERROR from the manager.
+            async with get_http_client().tracked_request(
+                "GET",
                 f"{self.base_url}/applications.json",
                 headers=self._get_headers(),
                 timeout=aiohttp.ClientTimeout(total=10),
+                suppress_error_log=True,
             ) as response:
                 if response.status == 200:
                     data = await response.json()

--- a/autobot-backend/tests/test_raw_client_session_ceiling_12992.py
+++ b/autobot-backend/tests/test_raw_client_session_ceiling_12992.py
@@ -1,0 +1,159 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Guard: raw ``aiohttp.ClientSession(...)`` constructions must not grow (#12992).
+
+Issue #12979 is converting per-request ``aiohttp.ClientSession(...)`` sites in
+``autobot-backend/`` over to the shared pooled client
+(``autobot_shared.http_client.get_http_client()``). That sweep is not
+converging: two conversion batches landed, yet the remaining count came out
+*higher* than simple subtraction predicted, because unrelated PRs merged into
+``Dev_new_gui`` kept introducing new raw sessions while the batches were in
+flight. Every raw session opens its own connector, bypasses the shared pool's
+sizing/utilisation accounting, and re-creates the exact class of leak #12981
+and #12992 fixed.
+
+The sweep cannot finish while the backlog refills behind it. This test is the
+ratchet: it counts the constructions still present and asserts the count never
+*exceeds* the recorded ceiling, so the existing backlog stays green while any
+newly added raw session turns the suite red at the point it is introduced.
+
+Measured 2026-07-30 (#12992), on ``Dev_new_gui`` at ``352e07cc7``:
+**87** constructions across the walked tree.
+
+Unlike the ``xfail(strict=True)`` guard in
+``autobot-slm-backend/tests/test_update_all_applies_roles_12959.py`` — which
+marks a single binary gap — this is a monotonically decreasing budget, because
+the backlog is drained incrementally by #12979's batches rather than in one
+commit.
+
+Refs #12979, #12981, #12989, #12992.
+"""
+
+import ast
+import pathlib
+
+BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+#: Recorded ceiling on raw ``aiohttp.ClientSession(...)`` constructions in the
+#: walked tree. This number MUST ONLY EVER BE LOWERED. Converting sites to the
+#: shared pooled client (``get_http_client()``) is the only legitimate way to
+#: change it. If a change makes this test fail, the fix is to route the new
+#: call through the shared client — never to raise the ceiling. See #12979.
+#:
+#: HOW TO RE-MEASURE WHEN LOWERING THIS — two traps, both already hit once:
+#:
+#: 1. Do NOT use ``grep -c 'aiohttp.ClientSession('``. Grep reads 90 where this
+#:    test reads 87, because three matches are text rather than constructions:
+#:    a docstring example in ``code_analysis/scripts/analyze_performance.py``,
+#:    a ``print()`` string in ``code_analysis/scripts/analyze_performance_simple.py``,
+#:    and a regex replacement template in ``code_analysis/src/patch_generator.py``.
+#:    Trusting grep sets the ceiling 3 too high and silently buys slack for
+#:    three future raw sessions. Use ``raw_client_session_sites()`` below.
+#: 2. Re-measure against a tree freshly synced to ``origin/Dev_new_gui``
+#:    IMMEDIATELY BEFORE PUSHING. A count taken in a worktree is a snapshot of
+#:    that worktree: the first version of this file recorded 112, measured while
+#:    #12994 was still in flight. That PR merged and removed 25 constructions,
+#:    so the ceiling shipped ~25 too high — most of a conversion batch's worth
+#:    of slack — until it was caught in review. Sync, re-run, then push.
+MAX_RAW_CLIENT_SESSIONS = 87
+
+#: Directory names that are never part of the production surface being swept.
+EXCLUDED_DIR_NAMES = {"__pycache__", "tests", "test", ".pytest_cache", "node_modules"}
+
+#: Substring marking archived/vendored copies that are not live code.
+EXCLUDED_DIR_SUBSTRING = "archive"
+
+#: Files exempt from the ceiling. ``autobot_shared/http_client.py`` is the
+#: pooled client itself — constructing the shared session is precisely its job.
+#: Matched on the trailing path so a vendored/synced copy is exempt too.
+EXEMPT_SUFFIXES = (pathlib.Path("autobot_shared") / "http_client.py",)
+
+
+def _is_excluded(path: pathlib.Path) -> bool:
+    """True when *path* is a test, cache, or archived file rather than live code."""
+    for part in path.parts[:-1]:
+        if part in EXCLUDED_DIR_NAMES or EXCLUDED_DIR_SUBSTRING in part:
+            return True
+    name = path.name
+    return name.startswith("test_") or name.endswith("_test.py") or name == "conftest.py"
+
+
+def _is_exempt(path: pathlib.Path) -> bool:
+    """True when *path* is allowed to construct a raw session."""
+    return any(path.as_posix().endswith(suffix.as_posix()) for suffix in EXEMPT_SUFFIXES)
+
+
+def _count_constructions(source: str) -> int:
+    """Count ``ClientSession(...)`` call expressions in *source*.
+
+    Parsed with ``ast`` rather than grepped so that the same text appearing in a
+    docstring, comment, or code-generator replacement template (for example
+    ``code_analysis/src/patch_generator.py``) is not miscounted as a real
+    construction.
+    """
+    tree = ast.parse(source)
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "ClientSession":
+            count += 1
+        elif isinstance(func, ast.Name) and func.id == "ClientSession":
+            count += 1
+    return count
+
+
+def walk_backend_sources() -> list[pathlib.Path]:
+    """Return every live ``autobot-backend/`` Python file subject to the ceiling."""
+    return [path for path in sorted(BACKEND_ROOT.rglob("*.py")) if not _is_excluded(path) and not _is_exempt(path)]
+
+
+def raw_client_session_sites() -> dict[str, int]:
+    """Map each offending file (repo-relative) to its construction count."""
+    sites: dict[str, int] = {}
+    for path in walk_backend_sources():
+        count = _count_constructions(path.read_text(encoding="utf-8"))
+        if count:
+            sites[path.relative_to(BACKEND_ROOT.parent).as_posix()] = count
+    return sites
+
+
+def test_walker_scans_a_nonempty_tree():
+    """The walk must find real files, so the ceiling cannot pass vacuously.
+
+    Without this, a rename of ``autobot-backend/`` or a broadened exclusion rule
+    would silently reduce the walk to zero files and the ceiling assertion would
+    pass while checking nothing.
+    """
+    scanned = walk_backend_sources()
+    assert len(scanned) > 1000, (
+        f"Walker found only {len(scanned)} files under {BACKEND_ROOT}; "
+        "expected the full backend tree. The ceiling assertion is meaningless "
+        "against an empty or truncated walk — fix the walker, not this bound."
+    )
+    assert any(path.name == "monitoring_integration.py" for path in scanned), (
+        "Walker did not reach integrations/monitoring_integration.py — the walk "
+        "is not covering the backend package tree."
+    )
+
+
+def test_raw_client_sessions_do_not_exceed_ceiling():
+    """New raw ``aiohttp.ClientSession(...)`` sites must not be added (#12979).
+
+    Route the call through ``autobot_shared.http_client.get_http_client()``
+    instead — ``get_json()``/``post_json()`` for JSON, ``tracked_request()`` when
+    the raw response must be inspected. Do not raise ``MAX_RAW_CLIENT_SESSIONS``.
+    """
+    sites = raw_client_session_sites()
+    total = sum(sites.values())
+
+    assert total <= MAX_RAW_CLIENT_SESSIONS, (
+        f"{total} raw aiohttp.ClientSession(...) constructions found, exceeding the "
+        f"recorded ceiling of {MAX_RAW_CLIENT_SESSIONS} (#12992). New raw sessions "
+        "bypass the shared connection pool and its active-request accounting. "
+        "Use autobot_shared.http_client.get_http_client() — get_json()/post_json(), "
+        "or tracked_request() when the response object itself must be inspected. "
+        "The ceiling may only ever be LOWERED.\n"
+        "Current offenders:\n" + "\n".join(f"  {path}: {count}" for path, count in sorted(sites.items()))
+    )


### PR DESCRIPTION
Closes #12992

## Thinking Path

PR #12982 converted `monitoring_integration.py` before #12989 existed, so its two status-inspecting `test_connection()` sites used the recipe current at the time: `async with await get_http_client().get(...)`. The `async with` releases the **connection** correctly — but `get()` is `request()`, which increments `_active_requests` and delegates the success-path decrement to the caller. Neither site calls `decrement_active()`, so the counter only grew.

That is not cosmetic: `_active_requests` drives `utilization = _active_requests / _current_pool_size` in `_adjust_pool_size()` and gates the `_active_requests == 0` condition in `decrement_active()` that applies deferred session recreation. A monotonically rising counter pushes the pool toward `_pool_max` and makes deferred recreation unreachable. Datadog and New Relic health checks are polled, so it accrues continuously wherever those integrations are enabled.

These two sites cannot use the `*_json()` helpers — they must inspect `response.status` and return a structured `IntegrationHealth` rather than raise. They stay deliberate carve-outs; `tracked_request()` is exactly the primitive #12989 added for that shape, since it owns the counter as well as the response block.

Second, the #12979 sweep is not converging. Two conversion batches landed, yet the remaining raw-session count came out higher than subtraction predicted, because unrelated PRs merging into `Dev_new_gui` kept introducing new `aiohttp.ClientSession(...)` sites while the batches were in flight. A sweep cannot finish while the backlog refills behind it, so this PR adds a ratchet. Following the precedent of `autobot-slm-backend/tests/test_update_all_applies_roles_12959.py`, it is a pytest guard rather than a new CI workflow — but a monotonically decreasing budget rather than `xfail(strict=True)`, because the backlog drains incrementally across #12979's batches instead of in one commit.

## What Changed

**`autobot-backend/integrations/monitoring_integration.py`** — `DatadogIntegration.test_connection` and `NewRelicIntegration.test_connection` converted from `async with await get_http_client().get(...)` to `async with get_http_client().tracked_request("GET", ..., suppress_error_log=True)`. The `if response.status == 200:` / `else:` structured-error logic, the `IntegrationHealth` payloads, and both exception handlers are unchanged. `suppress_error_log=True` because both sites already log and encode the failure themselves, so the manager's default ERROR would duplicate it.

**`autobot-backend/tests/test_raw_client_session_ceiling_12992.py`** (new) — ratchet guarding the #12979 convergence problem:

- Walks `autobot-backend/` counting `ClientSession(...)` **call expressions**. Counted via `ast`, not grep, so the same text inside a docstring or a code-generator replacement template (e.g. `code_analysis/src/patch_generator.py:143`) is not miscounted — that alone is a 3-construction difference from a textual count.
- Excludes tests (`tests/` dirs, `test_*.py`, `*_test.py`, `conftest.py`), `__pycache__`, and any path segment containing `archive`.
- Exempts `autobot_shared/http_client.py` — constructing the pooled session is precisely its job. Matched on trailing path so a vendored/synced copy is exempt too.
- `MAX_RAW_CLIENT_SESSIONS = 87`, the count measured on this base (`352e07cc7`), with a comment stating the ceiling may only ever be **lowered**; the failure message names the offending files and points at `get_json()`/`post_json()`/`tracked_request()`.
- The ceiling constant carries a two-trap re-measurement note, both traps drawn from this PR's own history: (a) `grep -c` reads **90** where the AST reads **87**, because three matches are text not constructions — a docstring example in `analyze_performance.py`, a `print()` string in `analyze_performance_simple.py`, and a regex replacement template in `patch_generator.py` — so grep would set the ceiling 3 too high; (b) the ceiling must be re-measured against a tree freshly synced to `origin/Dev_new_gui` immediately before pushing. This PR first recorded **112**, measured while #12994 was in flight; that PR merged and removed 25 constructions, leaving the ceiling ~25 too high until review caught it. A count taken in a worktree is a snapshot of that worktree.
- `test_walker_scans_a_nonempty_tree` asserts the walk finds >1000 files and reaches `integrations/monitoring_integration.py`, so a rename or a broadened exclusion rule cannot reduce the walk to zero and let the ceiling pass vacuously.

## Verification

**The defect, measured.** Both `test_connection()` methods driven 5x each (10 requests) against a local aiohttp server, reading `connector._acquired_per_host` and `HTTPClientManager._active_requests`. The pre-fix run is the parent commit's file restored in place:

```
                                    requests  still-acquired  active_requests
before (parent commit), 200 served       10         0              10   <-- leak
before (parent commit), 503 served       10         0              10   <-- leak
after  (this PR),       200 served       10         0               0
after  (this PR),       503 served       10         0               0
```

Both the 200 and the non-2xx branch are exercised; connections were never the problem and stay at 0, and the counter now returns to 0.

**The guard fails on a new raw session.** Appending one `aiohttp.ClientSession()` to `autobot-backend/onboarding/doctor.py` and re-running (file restored afterwards, `git diff` clean):

```
AssertionError: 88 raw aiohttp.ClientSession(...) constructions found,
exceeding the recorded ceiling of 87 (#12992). ...
1 failed, 1 passed
```

**Suites.**

```
$ python3 -m pytest autobot-backend/tests/test_raw_client_session_ceiling_12992.py
2 passed in 12.06s

$ python3 -m pytest autobot-backend/integrations/ autobot-backend/tests/ -k "integration or http_client or monitoring"
1001 passed, 24 skipped, 5261 deselected in 51.23s

$ python3 -m pytest autobot_shared/ -k http
27 passed, 1117 deselected in 5.98s
```

**Static.** `black --check` (repo config, `line-length = 120`), `isort --check-only`, `flake8`, and `py_compile` all clean on both changed files.

The first push of the guard test was flake8-clean but Black-dirty, reddening the required `code-quality` check. `flake8` only enforces the 120-column limit; Black additionally *collapses* lines that fit within it, which is what it wanted here — a one-element tuple, a list comprehension, and an implicit-concat `+ "\n".join(...)`, none of them length violations. Lesson for this repo: **`flake8`-clean is not sufficient evidence that `code-quality` will pass — run `black --check` alongside it.**

Branch rebased onto `origin/Dev_new_gui` at `352e07cc7` (picking up #12991 and #12994) and re-measured there; `git rev-list --count HEAD..origin/Dev_new_gui` = 0 immediately before push. Task A's 10 → 0 result was re-confirmed post-rebase.

## Model Used

claude-opus-5
