### PR TITLE
perf(http): route web_fetch + knowledge connectors through the shared pool (#12979)

### DIFF
--- a/autobot-backend/api/knowledge_connectors_auth_schema_test.py
+++ b/autobot-backend/api/knowledge_connectors_auth_schema_test.py
@@ -135,34 +135,29 @@ class _FakeAsyncResponse:
         return False
 
 
-class _FakeAiohttpSession:
-    """Replaces aiohttp.ClientSession — records auth material, never dials out."""
+class _FakeHttpClient:
+    """Replaces the shared pooled client — records auth material, never dials out.
+
+    Issue #12979 moved these connectors off per-request ``aiohttp.ClientSession``
+    onto ``autobot_shared.http_client``. The seam is now
+    ``get_http_client().tracked_request(method, url, **kwargs)``, which yields the
+    response, so the stub only needs that one entry point instead of the previous
+    per-verb ``get``/``post``/``request`` trio.
+    """
 
     def __init__(self, capture: dict, body: dict, status: int = 200) -> None:
         self._capture = capture
         self._body = body
         self._status = status
 
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *exc_info):
-        return False
-
-    def post(self, url, headers=None, json=None, **kwargs):
+    def tracked_request(self, method, url, headers=None, auth=None, **kwargs):
+        self._capture["method"] = method
         self._capture["headers"] = headers
-        return _FakeAsyncResponse(self._status, self._body)
-
-    def get(self, url, auth=None, **kwargs):
-        self._capture["auth"] = auth
-        return _FakeAsyncResponse(self._status, self._body)
-
-    def request(self, method, url, auth=None, json=None, **kwargs):
         self._capture["auth"] = auth
         return _FakeAsyncResponse(self._status, self._body)
 
 
-async def _create_via_api(request: CreateConnectorRequest, aiohttp_patch_target: str, fake_session):
+async def _create_via_api(request: CreateConnectorRequest, http_client_patch_target: str, fake_client):
     """Drive the real create_connector() handler with a stubbed secrets backend."""
     store = ConnectorCredentialStore(_FakeSecretsService())
     saved = {}
@@ -173,7 +168,7 @@ async def _create_via_api(request: CreateConnectorRequest, aiohttp_patch_target:
     with (
         patch.object(mod, "get_credential_store", return_value=store),
         patch.object(mod, "_save_connector", _fake_save),
-        patch(aiohttp_patch_target, return_value=fake_session),
+        patch(http_client_patch_target, return_value=fake_client),
     ):
         result = await mod.create_connector(request)
     return result, saved["cfg"]
@@ -183,14 +178,14 @@ async def _create_via_api(request: CreateConnectorRequest, aiohttp_patch_target:
 async def test_create_slack_schema_valid_credentials_authenticate():
     """A #12221-compliant Slack request round-trips the token through auth.test."""
     capture: dict = {}
-    fake_session = _FakeAiohttpSession(capture, {"ok": True}, 200)
+    fake_client = _FakeHttpClient(capture, {"ok": True}, 200)
     req = CreateConnectorRequest(
         connector_type="slack",
         name="Guard Slack",
         config={"token": _FAKE_BOT_CREDENTIAL, "channel_ids": ["C1"]},
     )
     try:
-        result, cfg = await _create_via_api(req, "knowledge.connectors.slack.aiohttp.ClientSession", fake_session)
+        result, cfg = await _create_via_api(req, "knowledge.connectors.slack.get_http_client", fake_client)
         assert result["connector_id"] == cfg.connector_id
         assert capture["headers"]["Authorization"] == "Bearer %s" % _FAKE_BOT_CREDENTIAL
         # The credential is encrypted at rest — never echoed in the public config.
@@ -203,7 +198,7 @@ async def test_create_slack_schema_valid_credentials_authenticate():
 async def test_create_confluence_schema_valid_credentials_authenticate():
     """A #12221-compliant Confluence request authenticates via BasicAuth(username, password)."""
     capture: dict = {}
-    fake_session = _FakeAiohttpSession(capture, {"results": []}, 200)
+    fake_client = _FakeHttpClient(capture, {"results": []}, 200)
     req = CreateConnectorRequest(
         connector_type="confluence",
         name="Guard Confluence",
@@ -215,7 +210,7 @@ async def test_create_confluence_schema_valid_credentials_authenticate():
         },
     )
     try:
-        result, cfg = await _create_via_api(req, "knowledge.connectors.confluence.aiohttp.ClientSession", fake_session)
+        result, cfg = await _create_via_api(req, "knowledge.connectors.confluence.get_http_client", fake_client)
         assert result["connector_id"] == cfg.connector_id
         assert capture["auth"].login == _FAKE_USERNAME
         assert capture["auth"].password == _FAKE_API_CREDENTIAL
@@ -228,7 +223,7 @@ async def test_create_confluence_schema_valid_credentials_authenticate():
 async def test_create_jira_schema_valid_credentials_authenticate():
     """A #12221-compliant Jira request authenticates via BasicAuth(username, password)."""
     capture: dict = {}
-    fake_session = _FakeAiohttpSession(capture, {"accountId": "u1"}, 200)
+    fake_client = _FakeHttpClient(capture, {"accountId": "u1"}, 200)
     req = CreateConnectorRequest(
         connector_type="jira",
         name="Guard Jira",
@@ -240,7 +235,7 @@ async def test_create_jira_schema_valid_credentials_authenticate():
         },
     )
     try:
-        result, cfg = await _create_via_api(req, "knowledge.connectors.jira.aiohttp.ClientSession", fake_session)
+        result, cfg = await _create_via_api(req, "knowledge.connectors.jira.get_http_client", fake_client)
         assert result["connector_id"] == cfg.connector_id
         assert capture["auth"].login == _FAKE_USERNAME
         assert capture["auth"].password == _FAKE_API_CREDENTIAL

--- a/autobot-backend/knowledge/connectors/audio_connector.py
+++ b/autobot-backend/knowledge/connectors/audio_connector.py
@@ -344,16 +344,17 @@ async def _download_direct_url(url: str, dest_dir: str) -> str:
     """Download a direct audio URL to dest_dir and return the local path."""
     import aiohttp
 
+    from autobot_shared.http_client import get_http_client
+
     filename = os.path.basename(url.split("?")[0]) or "audio.mp3"
     dest_path = os.path.join(dest_dir, filename)
 
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url, timeout=aiohttp.ClientTimeout(total=300)) as resp:
-            if resp.status != 200:
-                raise RuntimeError(f"Failed to download {url}: HTTP {resp.status}")
-            with open(dest_path, "wb", encoding=None) as fh:  # type: ignore[call-overload]
-                async for chunk in resp.content.iter_chunked(65536):
-                    fh.write(chunk)
+    async with get_http_client().tracked_request("GET", url, timeout=aiohttp.ClientTimeout(total=300)) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Failed to download {url}: HTTP {resp.status}")
+        with open(dest_path, "wb", encoding=None) as fh:  # type: ignore[call-overload]
+            async for chunk in resp.content.iter_chunked(65536):
+                fh.write(chunk)
     return dest_path
 
 

--- a/autobot-backend/knowledge/connectors/confluence.py
+++ b/autobot-backend/knowledge/connectors/confluence.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 
 from autobot_shared.auth import BasicAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -225,14 +226,15 @@ class ConfluenceConnector(AbstractConnector):
         auth = aiohttp.BasicAuth(login=self._email, password=self._api_token)
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(url, auth=auth) as resp:
-                    if resp.status == 429:
-                        raise RetryableError("Confluence rate-limited", status_code=429)
-                    if resp.status >= 500:
-                        raise RetryableError("Confluence server error %d" % resp.status, status_code=resp.status)
-                    body = await resp.json(content_type=None)
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                "GET", url, auth=auth, timeout=timeout, suppress_error_log=True
+            ) as resp:
+                if resp.status == 429:
+                    raise RetryableError("Confluence rate-limited", status_code=429)
+                if resp.status >= 500:
+                    raise RetryableError("Confluence server error %d" % resp.status, status_code=resp.status)
+                body = await resp.json(content_type=None)
+                return {"status_code": resp.status, "body": body}
         except RetryableError:
             raise
         except aiohttp.ClientError as exc:

--- a/autobot-backend/knowledge/connectors/gdrive.py
+++ b/autobot-backend/knowledge/connectors/gdrive.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 
 from autobot_shared.auth import BearerAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector
@@ -621,47 +622,48 @@ class GoogleDriveConnector(AbstractConnector):
 
         try:
             timeout = aiohttp.ClientTimeout(total=60.0)  # Longer timeout for file downloads
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(
-                    method,
-                    url,
-                    headers=headers,
-                    json=json_data,
-                    params=params,
-                ) as resp:
-                    status_code = resp.status
+            async with get_http_client().tracked_request(
+                method,
+                url,
+                headers=headers,
+                json=json_data,
+                params=params,
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as resp:
+                status_code = resp.status
 
-                    # Handle no-content responses
-                    if status_code == 204:
-                        return {"status_code": 204, "body": {}}
+                # Handle no-content responses
+                if status_code == 204:
+                    return {"status_code": 204, "body": {}}
 
-                    if raw_content:
-                        content = await resp.read()
-                        return {
-                            "status_code": status_code,
-                            "content": content,
-                        }
-
-                    try:
-                        body = await resp.json()
-                    except aiohttp.ContentTypeError:
-                        body = {}
-
-                    # Log errors
-                    if status_code >= 400:
-                        error_msg = body.get("error", {}).get("message", "Unknown error")
-                        self.logger.warning(
-                            "Drive API request to %s failed: HTTP %d - %s",
-                            url,
-                            status_code,
-                            error_msg,
-                        )
-
+                if raw_content:
+                    content = await resp.read()
                     return {
                         "status_code": status_code,
-                        "body": body,
-                        "error": body.get("error", {}).get("message") if status_code >= 400 else None,
+                        "content": content,
                     }
+
+                try:
+                    body = await resp.json()
+                except aiohttp.ContentTypeError:
+                    body = {}
+
+                # Log errors
+                if status_code >= 400:
+                    error_msg = body.get("error", {}).get("message", "Unknown error")
+                    self.logger.warning(
+                        "Drive API request to %s failed: HTTP %d - %s",
+                        url,
+                        status_code,
+                        error_msg,
+                    )
+
+                return {
+                    "status_code": status_code,
+                    "body": body,
+                    "error": body.get("error", {}).get("message") if status_code >= 400 else None,
+                }
 
         except aiohttp.ClientError as exc:
             self.logger.error("Drive API request to %s failed: %s", url, exc)

--- a/autobot-backend/knowledge/connectors/gitlab.py
+++ b/autobot-backend/knowledge/connectors/gitlab.py
@@ -40,6 +40,7 @@ from urllib.parse import quote
 import aiohttp
 
 from autobot_shared.auth import ApiKeyAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -406,18 +407,19 @@ class GitLabConnector(AbstractConnector):
         headers = {"PRIVATE-TOKEN": self._token}
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(url, headers=headers) as resp:
-                    if resp.status == 429:
-                        raise RetryableError("GitLab rate-limited", status_code=429)
-                    if resp.status >= 500:
-                        raise RetryableError("GitLab server error %d" % resp.status, status_code=resp.status)
-                    content_type = resp.content_type or ""
-                    if "json" in content_type:
-                        body = await resp.json(content_type=None)
-                        return {"status_code": resp.status, "body": body}
-                    text = await resp.text(encoding="utf-8")
-                    return {"status_code": resp.status, "body_text": text}
+            async with get_http_client().tracked_request(
+                "GET", url, headers=headers, timeout=timeout, suppress_error_log=True
+            ) as resp:
+                if resp.status == 429:
+                    raise RetryableError("GitLab rate-limited", status_code=429)
+                if resp.status >= 500:
+                    raise RetryableError("GitLab server error %d" % resp.status, status_code=resp.status)
+                content_type = resp.content_type or ""
+                if "json" in content_type:
+                    body = await resp.json(content_type=None)
+                    return {"status_code": resp.status, "body": body}
+                text = await resp.text(encoding="utf-8")
+                return {"status_code": resp.status, "body_text": text}
         except RetryableError:
             raise
         except aiohttp.ClientError as exc:
@@ -766,18 +768,19 @@ class GiteaConnector(AbstractConnector):
         headers = {"Authorization": "token %s" % self._token}
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(url, headers=headers) as resp:
-                    if resp.status == 429:
-                        raise RetryableError("Gitea rate-limited", status_code=429)
-                    if resp.status >= 500:
-                        raise RetryableError("Gitea server error %d" % resp.status, status_code=resp.status)
-                    content_type = resp.content_type or ""
-                    if "json" in content_type:
-                        body = await resp.json(content_type=None)
-                        return {"status_code": resp.status, "body": body}
-                    text = await resp.text(encoding="utf-8")
-                    return {"status_code": resp.status, "body_text": text}
+            async with get_http_client().tracked_request(
+                "GET", url, headers=headers, timeout=timeout, suppress_error_log=True
+            ) as resp:
+                if resp.status == 429:
+                    raise RetryableError("Gitea rate-limited", status_code=429)
+                if resp.status >= 500:
+                    raise RetryableError("Gitea server error %d" % resp.status, status_code=resp.status)
+                content_type = resp.content_type or ""
+                if "json" in content_type:
+                    body = await resp.json(content_type=None)
+                    return {"status_code": resp.status, "body": body}
+                text = await resp.text(encoding="utf-8")
+                return {"status_code": resp.status, "body_text": text}
         except RetryableError:
             raise
         except aiohttp.ClientError as exc:

--- a/autobot-backend/knowledge/connectors/jira.py
+++ b/autobot-backend/knowledge/connectors/jira.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 
 from autobot_shared.auth import BasicAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -240,14 +241,15 @@ class JiraConnector(AbstractConnector):
         auth = aiohttp.BasicAuth(login=self._email, password=self._api_token)
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, auth=auth, json=json_data) as resp:
-                    if resp.status == 429:
-                        raise RetryableError("Jira rate-limited", status_code=429)
-                    if resp.status >= 500:
-                        raise RetryableError("Jira server error %d" % resp.status, status_code=resp.status)
-                    body = await resp.json(content_type=None)
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                method, url, auth=auth, json=json_data, timeout=timeout, suppress_error_log=True
+            ) as resp:
+                if resp.status == 429:
+                    raise RetryableError("Jira rate-limited", status_code=429)
+                if resp.status >= 500:
+                    raise RetryableError("Jira server error %d" % resp.status, status_code=resp.status)
+                body = await resp.json(content_type=None)
+                return {"status_code": resp.status, "body": body}
         except RetryableError:
             raise
         except aiohttp.ClientError as exc:

--- a/autobot-backend/knowledge/connectors/nextcloud.py
+++ b/autobot-backend/knowledge/connectors/nextcloud.py
@@ -32,6 +32,7 @@ import aiohttp
 import defusedxml.ElementTree as ET
 
 from autobot_shared.auth import BasicAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -118,15 +119,16 @@ class NextcloudConnector(AbstractConnector):
     async def test_connection(self) -> bool:
         """Test WebDAV connection with OPTIONS request."""
         try:
-            async with aiohttp.ClientSession() as session:
-                auth = aiohttp.BasicAuth(self._username, self._password)
-                timeout = aiohttp.ClientTimeout(total=30.0)
-                async with session.options(self._webdav_base, auth=auth, timeout=timeout) as resp:
-                    if resp.status in (200, 204):
-                        self.logger.info("Nextcloud connection test successful: %s", self._webdav_base)
-                        return True
-                    self.logger.warning("Nextcloud test_connection failed: HTTP %d", resp.status)
-                    return False
+            auth = aiohttp.BasicAuth(self._username, self._password)
+            timeout = aiohttp.ClientTimeout(total=30.0)
+            async with get_http_client().tracked_request(
+                "OPTIONS", self._webdav_base, auth=auth, timeout=timeout, suppress_error_log=True
+            ) as resp:
+                if resp.status in (200, 204):
+                    self.logger.info("Nextcloud connection test successful: %s", self._webdav_base)
+                    return True
+                self.logger.warning("Nextcloud test_connection failed: HTTP %d", resp.status)
+                return False
         except Exception as exc:
             self.logger.error("Nextcloud test_connection error: %s", exc)
             return False
@@ -158,38 +160,37 @@ class NextcloudConnector(AbstractConnector):
         file_url = urljoin(self._webdav_base, encoded_path)
 
         try:
-            async with aiohttp.ClientSession() as session:
-                auth = aiohttp.BasicAuth(self._username, self._password)
-                timeout = aiohttp.ClientTimeout(total=300.0)
-                async with session.get(file_url, auth=auth, timeout=timeout) as resp:
-                    if resp.status == 200:
-                        content_bytes = await resp.read()
-                        content_type = resp.headers.get("Content-Type", "application/octet-stream")
+            auth = aiohttp.BasicAuth(self._username, self._password)
+            timeout = aiohttp.ClientTimeout(total=300.0)
+            async with get_http_client().tracked_request("GET", file_url, auth=auth, timeout=timeout) as resp:
+                if resp.status == 200:
+                    content_bytes = await resp.read()
+                    content_type = resp.headers.get("Content-Type", "application/octet-stream")
 
-                        # Decode text content
-                        try:
-                            content = content_bytes.decode("utf-8")
-                        except UnicodeDecodeError:
-                            # For binary files (PDF, DOCX), return as base64 or skip
-                            self.logger.warning("Binary content for %s - may need extraction", source_id)
-                            content = content_bytes.decode("utf-8", errors="replace")
+                    # Decode text content
+                    try:
+                        content = content_bytes.decode("utf-8")
+                    except UnicodeDecodeError:
+                        # For binary files (PDF, DOCX), return as base64 or skip
+                        self.logger.warning("Binary content for %s - may need extraction", source_id)
+                        content = content_bytes.decode("utf-8", errors="replace")
 
-                        await self._store_ts(
-                            source_id,
-                            resp.headers.get("Last-Modified", ""),
-                        )
+                    await self._store_ts(
+                        source_id,
+                        resp.headers.get("Last-Modified", ""),
+                    )
 
-                        return ContentResult(
-                            source_id=source_id,
-                            content=content,
-                            content_type=content_type,
-                            metadata={"url": file_url},
-                        )
-                    elif resp.status == 404:
-                        self.logger.warning("File not found: %s", file_url)
-                        return None
-                    else:
-                        raise RetryableError(f"WebDAV GET failed: HTTP {resp.status}", resp.status)
+                    return ContentResult(
+                        source_id=source_id,
+                        content=content,
+                        content_type=content_type,
+                        metadata={"url": file_url},
+                    )
+                elif resp.status == 404:
+                    self.logger.warning("File not found: %s", file_url)
+                    return None
+                else:
+                    raise RetryableError(f"WebDAV GET failed: HTTP {resp.status}", resp.status)
         except aiohttp.ClientError as exc:
             self.logger.error("WebDAV GET error for %s: %s", source_id, exc)
             raise RetryableError(str(exc))
@@ -252,32 +253,32 @@ class NextcloudConnector(AbstractConnector):
         sources: List[SourceInfo] = []
 
         try:
-            async with aiohttp.ClientSession() as session:
-                auth = aiohttp.BasicAuth(self._username, self._password)
-                timeout = aiohttp.ClientTimeout(total=60.0)
-                headers = {
-                    "Content-Type": "application/xml",
-                    "Depth": "infinity",  # Recursive listing
-                }
+            auth = aiohttp.BasicAuth(self._username, self._password)
+            timeout = aiohttp.ClientTimeout(total=60.0)
+            headers = {
+                "Content-Type": "application/xml",
+                "Depth": "infinity",  # Recursive listing
+            }
 
-                async with session.request(
-                    "PROPFIND",
-                    folder_url,
-                    auth=auth,
-                    headers=headers,
-                    data=propfind_body,
-                    timeout=timeout,
-                ) as resp:
-                    if resp.status != 207:  # Multi-Status
-                        self.logger.warning(
-                            "WebDAV PROPFIND failed for %s: HTTP %d",
-                            folder_path,
-                            resp.status,
-                        )
-                        return sources
+            async with get_http_client().tracked_request(
+                "PROPFIND",
+                folder_url,
+                auth=auth,
+                headers=headers,
+                data=propfind_body,
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as resp:
+                if resp.status != 207:  # Multi-Status
+                    self.logger.warning(
+                        "WebDAV PROPFIND failed for %s: HTTP %d",
+                        folder_path,
+                        resp.status,
+                    )
+                    return sources
 
-                    xml_data = await resp.text()
-                    sources = self._parse_propfind_response(xml_data)
+                xml_data = await resp.text()
+                sources = self._parse_propfind_response(xml_data)
 
         except Exception as exc:
             self.logger.error("WebDAV PROPFIND error for %s: %s", folder_path, exc)

--- a/autobot-backend/knowledge/connectors/notion.py
+++ b/autobot-backend/knowledge/connectors/notion.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List
 import aiohttp
 
 from autobot_shared.auth import BearerAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.notion_utils import extract_title as _extract_title
 from autobot_shared.time_utils import now_utc, parse_utc_iso
@@ -267,10 +268,11 @@ class NotionConnector(AbstractConnector):
         }
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers, json=json_data) as resp:
-                    body = await resp.json(content_type=None)
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                method, url, headers=headers, json=json_data, timeout=timeout, suppress_error_log=True
+            ) as resp:
+                body = await resp.json(content_type=None)
+                return {"status_code": resp.status, "body": body}
         except aiohttp.ClientError as exc:
             self.logger.warning("Notion request to %s failed: %s", url, exc)
             return {"status_code": 0, "error": str(exc)}

--- a/autobot-backend/knowledge/connectors/oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/oauth_flow.py
@@ -171,6 +171,14 @@ async def _post_token(token_url: str, payload: dict, *, connector: aiohttp.BaseC
     from ``ssrf_guard.pinned_connector``), the session connects to the
     pre-resolved public IP so the token POST cannot be DNS-rebound to a private
     address between validation and connect. The session owns and closes it.
+
+    Issue #12979 — deliberately NOT converted to the shared pooled client.
+    A connector is a *session*-level object: the pooled ``HTTPClientManager``
+    owns one shared ``TCPConnector`` for all callers and ``session.request()``
+    accepts no per-request connector override. Routing this call through the
+    pool would silently drop the caller's pinned connector and reopen the
+    DNS-rebinding hole closed in #12278, so the per-request session here buys
+    a security property that connection reuse cannot replace.
     """
     timeout = aiohttp.ClientTimeout(total=_TOKEN_REQUEST_TIMEOUT)
     session_kwargs: dict = {"timeout": timeout}

--- a/autobot-backend/knowledge/connectors/onedrive.py
+++ b/autobot-backend/knowledge/connectors/onedrive.py
@@ -36,6 +36,7 @@ from urllib.parse import quote
 import aiohttp
 
 from autobot_shared.auth import BearerAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from knowledge.connectors.base import AbstractConnector
@@ -560,59 +561,63 @@ class OneDriveConnector(AbstractConnector):
 
         try:
             timeout = aiohttp.ClientTimeout(total=60.0)  # Longer timeout for file downloads
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(
-                    method,
-                    url,
-                    headers=headers,
-                    json=json_data,
-                    params=params,
-                ) as resp:
-                    status_code = resp.status
+            client = get_http_client()
+            async with client.tracked_request(
+                method,
+                url,
+                headers=headers,
+                json=json_data,
+                params=params,
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as resp:
+                status_code = resp.status
 
-                    # Handle redirects for download URLs
-                    if status_code in (301, 302, 303, 307, 308):
-                        location = resp.headers.get("Location")
-                        if location and raw_content:
-                            # Follow redirect for file download
-                            async with session.get(location) as redirect_resp:
-                                content = await redirect_resp.read()
-                                return {
-                                    "status_code": redirect_resp.status,
-                                    "content": content,
-                                }
+                # Handle redirects for download URLs
+                if status_code in (301, 302, 303, 307, 308):
+                    location = resp.headers.get("Location")
+                    if location and raw_content:
+                        # Follow redirect for file download
+                        async with client.tracked_request(
+                            "GET", location, timeout=timeout, suppress_error_log=True
+                        ) as redirect_resp:
+                            content = await redirect_resp.read()
+                            return {
+                                "status_code": redirect_resp.status,
+                                "content": content,
+                            }
 
-                    # Handle no-content responses
-                    if status_code == 204:
-                        return {"status_code": 204, "body": {}}
+                # Handle no-content responses
+                if status_code == 204:
+                    return {"status_code": 204, "body": {}}
 
-                    if raw_content:
-                        content = await resp.read()
-                        return {
-                            "status_code": status_code,
-                            "content": content,
-                        }
-
-                    try:
-                        body = await resp.json()
-                    except aiohttp.ContentTypeError:
-                        body = {}
-
-                    # Log errors
-                    if status_code >= 400:
-                        error_msg = body.get("error", {}).get("message", "Unknown error")
-                        self.logger.warning(
-                            "Graph API request to %s failed: HTTP %d - %s",
-                            url,
-                            status_code,
-                            error_msg,
-                        )
-
+                if raw_content:
+                    content = await resp.read()
                     return {
                         "status_code": status_code,
-                        "body": body,
-                        "error": body.get("error", {}).get("message") if status_code >= 400 else None,
+                        "content": content,
                     }
+
+                try:
+                    body = await resp.json()
+                except aiohttp.ContentTypeError:
+                    body = {}
+
+                # Log errors
+                if status_code >= 400:
+                    error_msg = body.get("error", {}).get("message", "Unknown error")
+                    self.logger.warning(
+                        "Graph API request to %s failed: HTTP %d - %s",
+                        url,
+                        status_code,
+                        error_msg,
+                    )
+
+                return {
+                    "status_code": status_code,
+                    "body": body,
+                    "error": body.get("error", {}).get("message") if status_code >= 400 else None,
+                }
 
         except aiohttp.ClientError as exc:
             self.logger.error("Graph API request to %s failed: %s", url, exc)

--- a/autobot-backend/knowledge/connectors/slack.py
+++ b/autobot-backend/knowledge/connectors/slack.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 
 from autobot_shared.auth import BearerAuth
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from knowledge.connectors.base import AbstractConnector, RetryableError
@@ -262,14 +263,20 @@ class SlackConnector(AbstractConnector):
         }
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(url, headers=headers, json=json_data or {}) as resp:
-                    if resp.status == 429:
-                        raise RetryableError("Slack rate-limited", status_code=429)
-                    if resp.status >= 500:
-                        raise RetryableError("Slack server error %d" % resp.status, status_code=resp.status)
-                    body = await resp.json(content_type=None)
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                "POST",
+                url,
+                headers=headers,
+                json=json_data or {},
+                timeout=timeout,
+                suppress_error_log=True,
+            ) as resp:
+                if resp.status == 429:
+                    raise RetryableError("Slack rate-limited", status_code=429)
+                if resp.status >= 500:
+                    raise RetryableError("Slack server error %d" % resp.status, status_code=resp.status)
+                body = await resp.json(content_type=None)
+                return {"status_code": resp.status, "body": body}
         except RetryableError:
             raise
         except aiohttp.ClientError as exc:

--- a/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py
@@ -77,12 +77,18 @@ def _mock_response(status: int, payload: Any, content_type: str = "application/j
     return resp
 
 
-def _mock_session(response: MagicMock) -> MagicMock:
-    session = MagicMock()
-    session.get = MagicMock(return_value=response)
-    session.__aenter__ = AsyncMock(return_value=session)
-    session.__aexit__ = AsyncMock(return_value=False)
-    return session
+def _mock_http_client(response: MagicMock) -> MagicMock:
+    """Stub the shared pooled client used by the connector (Issue #12979).
+
+    These connectors no longer build a per-request ``aiohttp.ClientSession``;
+    they call ``get_http_client().tracked_request(method, url, **kwargs)``,
+    which yields the response. Patching ``aiohttp.ClientSession`` therefore no
+    longer intercepts anything — the stub has to target that seam instead, or
+    the test dials out for real.
+    """
+    client = MagicMock()
+    client.tracked_request = MagicMock(return_value=response)
+    return client
 
 
 # ---------------------------------------------------------------------------
@@ -151,8 +157,8 @@ def test_issue_to_text_pr_flag():
 async def test_gitlab_test_connection_ok():
     connector = GitLabConnector(_gl_config())
     resp = _mock_response(200, {"id": 1, "username": "bot"})
-    session = _mock_session(resp)
-    with patch("aiohttp.ClientSession", return_value=session):
+    client = _mock_http_client(resp)
+    with patch("knowledge.connectors.gitlab.get_http_client", return_value=client):
         result = await connector.test_connection()
     assert result is True
 
@@ -161,8 +167,8 @@ async def test_gitlab_test_connection_ok():
 async def test_gitlab_test_connection_fail():
     connector = GitLabConnector(_gl_config())
     resp = _mock_response(401, {"message": "401 Unauthorized"})
-    session = _mock_session(resp)
-    with patch("aiohttp.ClientSession", return_value=session):
+    client = _mock_http_client(resp)
+    with patch("knowledge.connectors.gitlab.get_http_client", return_value=client):
         result = await connector.test_connection()
     assert result is False
 
@@ -327,8 +333,8 @@ async def test_gitlab_fetch_content_bad_source_id():
 async def test_gitea_test_connection_ok():
     connector = GiteaConnector(_gitea_config())
     resp = _mock_response(200, {"id": 1, "login": "alice"})
-    session = _mock_session(resp)
-    with patch("aiohttp.ClientSession", return_value=session):
+    client = _mock_http_client(resp)
+    with patch("knowledge.connectors.gitlab.get_http_client", return_value=client):
         result = await connector.test_connection()
     assert result is True
 
@@ -337,8 +343,8 @@ async def test_gitea_test_connection_ok():
 async def test_gitea_test_connection_fail():
     connector = GiteaConnector(_gitea_config())
     resp = _mock_response(401, {"message": "Unauthorized"})
-    session = _mock_session(resp)
-    with patch("aiohttp.ClientSession", return_value=session):
+    client = _mock_http_client(resp)
+    with patch("knowledge.connectors.gitlab.get_http_client", return_value=client):
         result = await connector.test_connection()
     assert result is False
 

--- a/autobot-backend/web_fetch/fetcher.py
+++ b/autobot-backend/web_fetch/fetcher.py
@@ -23,6 +23,7 @@ import asyncio
 import time
 from urllib.parse import urlparse
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from web_fetch.cache import WEB_FETCH_MAX_BYTES, get_cached_result, set_cached_result
 from web_fetch.extractors import _MIN_CONTENT_CHARS, extract_markdown, is_spa_content
@@ -141,10 +142,15 @@ async def _fetch_jina_impl(url: str, timeout: float) -> str | None:
     jina_url = f"{_JINA_BASE_URL}{url}"
     try:
         aio_timeout = aiohttp.ClientTimeout(total=timeout)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(jina_url, timeout=aio_timeout, allow_redirects=True) as resp:
-                if resp.status == 200:
-                    return await resp.text(encoding="utf-8", errors="replace")
+        async with get_http_client().tracked_request(
+            "GET",
+            jina_url,
+            timeout=aio_timeout,
+            allow_redirects=True,
+            suppress_error_log=True,
+        ) as resp:
+            if resp.status == 200:
+                return await resp.text(encoding="utf-8", errors="replace")
     except Exception as exc:
         logger.debug("Jina fetch failed for %s: %s", url, exc)
     return None
@@ -171,22 +177,24 @@ async def _fetch_bs4(url: str, timeout: float) -> tuple[str | None, int | None]:
     headers = {"User-Agent": _USER_AGENT}
     try:
         aio_timeout = aiohttp.ClientTimeout(total=timeout)
-        async with aiohttp.ClientSession(headers=headers) as session:
-            async with session.get(
-                url,
-                timeout=aio_timeout,
-                allow_redirects=True,
-                max_redirects=_MAX_REDIRECTS,
-            ) as resp:
-                content = b""
-                async for chunk in resp.content.iter_chunked(65536):
-                    content += chunk
-                    if len(content) > WEB_FETCH_MAX_BYTES:
-                        return None, None  # too large
-                if not content:
-                    return "", resp.status
-                html = content.decode("utf-8", errors="replace")
-                return html, resp.status
+        async with get_http_client().tracked_request(
+            "GET",
+            url,
+            headers=headers,
+            timeout=aio_timeout,
+            allow_redirects=True,
+            max_redirects=_MAX_REDIRECTS,
+            suppress_error_log=True,
+        ) as resp:
+            content = b""
+            async for chunk in resp.content.iter_chunked(65536):
+                content += chunk
+                if len(content) > WEB_FETCH_MAX_BYTES:
+                    return None, None  # too large
+            if not content:
+                return "", resp.status
+            html = content.decode("utf-8", errors="replace")
+            return html, resp.status
     except aiohttp.TooManyRedirects:
         logger.debug("Too many redirects for %s", url)
         return None, None

--- a/autobot-backend/web_fetch/robots.py
+++ b/autobot-backend/web_fetch/robots.py
@@ -17,6 +17,7 @@ import asyncio
 import urllib.robotparser
 from urllib.parse import urlparse
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -51,10 +52,15 @@ async def _fetch_robots_text(domain: str, timeout: float = 10.0) -> str:
 
         robots_url = f"{domain}/robots.txt"
         aio_timeout = aiohttp.ClientTimeout(total=timeout)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(robots_url, timeout=aio_timeout, allow_redirects=True) as resp:
-                if resp.status == 200:
-                    return await resp.text(encoding="utf-8", errors="replace")
+        async with get_http_client().tracked_request(
+            "GET",
+            robots_url,
+            timeout=aio_timeout,
+            allow_redirects=True,
+            suppress_error_log=True,
+        ) as resp:
+            if resp.status == 200:
+                return await resp.text(encoding="utf-8", errors="replace")
         return ""
     except Exception as exc:
         logger.debug("robots.txt fetch failed for %s: %s", domain, exc)

--- a/autobot-backend/web_fetch/site_mapper.py
+++ b/autobot-backend/web_fetch/site_mapper.py
@@ -25,6 +25,7 @@ import xml.etree.ElementTree as ET  # nosec B405 — sitemap XML from crawled UR
 from typing import List
 from urllib.parse import urlparse
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -69,12 +70,17 @@ async def _fetch_xml(url: str) -> str | None:
         import aiohttp
 
         timeout = aiohttp.ClientTimeout(total=_SITEMAP_TIMEOUT)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=timeout, allow_redirects=True) as resp:
-                if resp.status == 200:
-                    return await resp.text(encoding="utf-8", errors="replace")
-        logger.debug("sitemap fetch HTTP %s for %s", resp.status, url)
-        return None
+        async with get_http_client().tracked_request(
+            "GET",
+            url,
+            timeout=timeout,
+            allow_redirects=True,
+            suppress_error_log=True,
+        ) as resp:
+            if resp.status == 200:
+                return await resp.text(encoding="utf-8", errors="replace")
+            logger.debug("sitemap fetch HTTP %s for %s", resp.status, url)
+            return None
     except Exception as exc:
         logger.debug("sitemap fetch error for %s: %s", url, exc)
         return None


### PR DESCRIPTION
Batch 4 of the #12979 per-request-session conversion. Refs #12979 (deliberately not `Closes` — the issue covers a much larger tail; see #12995 for why the PR-links gate is red).

Previous batches: #12982 (monitoring), #12991 (utils), #12994 (cicd + version control).

## Thinking Path

**Scope choice.** `web_fetch/` was assigned (4 sites). For the second area I surveyed with

```
grep -rn "aiohttp.ClientSession(" --include=*.py autobot-backend | grep -v test
```

and picked **`knowledge/connectors/`** — 13 sites across 11 files, and, unlike the other dense clusters (`telegram_bot_service.py` 8, `tts_client.py` 7), it is a *directory* with a single concern: every file is an outbound client to a third-party knowledge source, all built on the same `{"status_code": ..., "body": ...}` return contract. One concern, one review lens, one failure mode to reason about. Total batch: **17 raw constructions in 13 files.**

**Classification, not sweeping.** Every site was read and classified individually, applying the four triage rules accumulated over batches 1-3. The result is unusual and worth stating up front:

| shape | pilot (11) | utils (8) | cicd/vc (25) | **this batch (17)** |
|---|---|---|---|---|
| `raise_for_status()` + `json()`, GET → `get_json()` | 7 | 0 | 16 | **0** |
| `raise_for_status()` + `json()`, POST → `post_json()` | 2 | 0 | 2 | **0** |
| inspects status / reads text or bytes → `tracked_request()` | 2 | 8 | 6 | **16** |
| must stay a raw session | 0 | 0 | 0 | **1** |

**Not one site in this batch was a `*_json()` candidate.** Not a single `raise_for_status()` call exists anywhere in the 17. That is not an accident of style: these connectors exist to *report* a remote's health and payload to a sync scheduler, so every one of them converts a non-2xx into a structured return (`{"status_code": 404, "body": {...}}`) or a typed `RetryableError` on 429/5xx. `get_json()` would have replaced that contract with a raised `ClientResponseError` at every call site simultaneously.

This is the third distinct ratio in four batches (82% → 0% → 72% → 0% safe). The "count per file, never extrapolate" rule from batch 2 continues to be the load-bearing one.

**Triage rule 3 fired again, in a new place.** Batch 3 found that the *presence* of `raise_for_status()` does not imply a `*_json()` candidate (`_trigger_build`, empty 201). This batch found sites where the body is genuinely bimodal at runtime: `gitlab._gl_get()` and `gitea._gitea_get()` branch on `resp.content_type` and read **`json()` or `text()` depending on the response**. GitLab's raw-file endpoints answer `text/plain`; the API answers JSON. Either helper would be wrong half the time — `tracked_request()` is the only correct shape.

**One site is not convertible, and that is a security property rather than an oversight.**

`knowledge/connectors/oauth_flow.py::_post_token()` accepts an SSRF-pinned `aiohttp.TCPConnector` from its caller (`api/provider_auth.py` passes one built by `ssrf_guard.pinned_connector`) so the OAuth token POST connects to the *pre-resolved* public IP and cannot be DNS-rebound between validation and connect — the hole closed by #12278. A connector is a **session**-level object: `HTTPClientManager` owns exactly one for all callers, and `session.request()` has no per-request connector override. Routing this through the pool would silently discard the caller's pinned connector and reopen that hole. Left as a raw per-request session with an in-code comment stating why, per the issue's "Done when: remaining raw constructions each have a stated reason".

**Log-level discipline (batch 2's rule 3).** 14 of the 16 converted sites swallow or sentinel-encode expected failures — into `""`, `None`, `(None, None)`, `[]`, `False`, or `{"status_code": 0, ...}` — and already log at their own chosen level. Those pass `suppress_error_log=True` so a connector probing an unreachable service does not also emit an `ERROR` from the HTTP layer. The two that genuinely propagate (`nextcloud.fetch_content` → `RetryableError`, `audio._download_direct_url` → `RuntimeError`) keep the default `ERROR`, since there the failure really is an error.

**Timeout semantics were checked, not assumed.** The shared session is built with `ClientTimeout(total=30, connect=5, sock_read=10)`. A per-request `timeout=` in aiohttp **replaces** the session timeout wholesale rather than merging, so a site passing `ClientTimeout(total=300)` (Nextcloud file download, audio download) keeps its long transfer window instead of inheriting `sock_read=10`. All 17 converted requests pass an explicit `timeout=`, so none silently acquires the shared session's stricter socket deadline. This was the one way the conversion could have changed failure characteristics on large downloads; it does not.

## What Changed

`aiohttp.ClientSession(` constructions, per file, before → after:

| file | before | after |
|---|---|---|
| `web_fetch/fetcher.py` | 2 | **0** |
| `web_fetch/robots.py` | 1 | **0** |
| `web_fetch/site_mapper.py` | 1 | **0** |
| `knowledge/connectors/nextcloud.py` | 3 | **0** |
| `knowledge/connectors/gitlab.py` | 2 | **0** |
| `knowledge/connectors/confluence.py` | 1 | **0** |
| `knowledge/connectors/slack.py` | 1 | **0** |
| `knowledge/connectors/jira.py` | 1 | **0** |
| `knowledge/connectors/notion.py` | 1 | **0** |
| `knowledge/connectors/gdrive.py` | 1 | **0** |
| `knowledge/connectors/onedrive.py` | 1 | **0** |
| `knowledge/connectors/audio_connector.py` | 1 | **0** |
| `knowledge/connectors/oauth_flow.py` | 1 | **1** (documented, see above) |
| **total** | **17** | **1** |

16 converted, all via `tracked_request()` — which owns the response block *and* balances `_active_requests` (#12981/#12989), so neither the connection nor the counter can leak. 17 `tracked_request()` call sites result, because `onedrive._graph_request()` issues a nested follow-up request inside the outer block; both are tracked and both release.

Non-obvious conversions worth a reviewer's eye:

- **`web_fetch/fetcher.py::_fetch_bs4`** — the only site with session-level `headers=`; moved to per-request `headers=`, which additionally gains OTel trace propagation (`request()` merges rather than overwrites). Streams the body in 64 KiB chunks *inside* the tracked block, so the `WEB_FETCH_MAX_BYTES` early-return still releases the connection.
- **`nextcloud.py`** — `OPTIONS` and `PROPFIND` (WebDAV) go through `tracked_request(method, ...)` unchanged; arbitrary method strings are supported.
- **`site_mapper.py::_fetch_xml`** — the non-200 `logger.debug` previously ran *after* the `async with` blocks had exited, relying on `resp` outliving the block. Moved inside the block; same output, no reliance on a released response.

## Verification

**Static.** `py_compile` and `flake8` clean on all 13 changed files.

**Behavioural — every converted path, both branches, against a local aiohttp server.**

A harness drives all 16 converted sites on success *and* failure (2xx, 204, 404, 429, 500, empty body, oversized body, non-JSON body, JSON-under-`text/plain`, redirect, redirect loop, and connection-refused), then reads the pool's internals:

```
exercised paths             : 73   unexpected: 0
server-side requests served : 62
pooled idle conns           : 1
still-acquired              : 0
active_requests counter     : 0
```

**62 requests over one connection**, zero connections still acquired, counter balanced at zero — the leak assertion from batch 1 and the counter assertion from batch 2, both clean.

Error-path contracts confirmed unchanged (a `get_json()` sweep would have broken every one of these):

```
confluence._get 404       -> {'status_code': 404, 'body': {'error': ...}}
confluence._get 429/500   -> RetryableError (rate-limited / server error 500)
slack._slack_post 500     -> RetryableError; conn-refused -> {'ok': False, 'error': ...}
jira._get / _post 404     -> {'status_code': 404, 'body': ...}
gitlab._gl_get text body  -> {'status_code': 200, 'body_text': 'HELLO-TEXT'}
gdrive  non-JSON 200      -> {'status_code': 200, 'body': {}, 'error': None}
nextcloud.test_connection -> True / False / False (204 / 404 / refused)
nextcloud.fetch_content   -> content / None / RetryableError (200 / 404 / 500)
audio._download_direct_url-> file written / RuntimeError / ClientConnectorError
web_fetch _fetch_bs4      -> ('',200) empty | (None,None) oversized | (None,None) refused
web_fetch _fetch_bs4      -> (None,None) on redirect loop (TooManyRedirects branch)
```

The last line is worth calling out: `_fetch_bs4` catches `aiohttp.TooManyRedirects` specifically. `HTTPClientManager.request()` wraps every exception (to count it and log it) and re-raises, so that except clause still matches — verified against a server serving an endless redirect chain rather than assumed from reading.

**Existing tests.** Baseline taken by `cp`-swapping the `origin/Dev_new_gui` files back in (never `git stash` — it is shared across worktrees), same selection both times:

```
autobot-backend/tests/unit/web_fetch/
autobot-backend/knowledge/connectors/
autobot-backend/tests/unit/knowledge/connectors/
autobot-backend/api/knowledge_connectors_auth_schema_test.py
```

| | baseline (origin files) | after |
|---|---|---|
| passed | 554 + 6 | 560 |
| failed | 11 | 11 |

Same 11 failures before and after — 6 Redis-backed scheduler/resilience tests, 4 from the `_store_ts` rot described below, and 1 web-crawler checkpoint test.

### The conversion moved a test seam, and the first run caught it

This is the finding worth carrying into the next batch. The after-run initially came back **14 failed / 551 passed against a baseline of 11 / 554** — three *new* failures, in `test_gitlab_connector.py`:

```
FAILED test_gitlab_test_connection_ok
FAILED test_gitea_test_connection_ok
FAILED test_gitea_test_connection_fail
```

Cause: those tests stub HTTP with `patch("aiohttp.ClientSession", return_value=session)`. Once the connector calls `get_http_client().tracked_request(...)` instead, that patch intercepts nothing and **the test dials out for real**:

```
socket.gaierror: [Errno -5] No address associated with hostname
WARNING GitLab request to https://gitlab.example.com/api/v4/user failed:
        Cannot connect to host gitlab.example.com:443
```

Two things make this worth more than a one-line fix:

1. **A separate test file, outside the obvious selection, had the same seam.** `api/knowledge_connectors_auth_schema_test.py` patches `knowledge.connectors.slack.aiohttp.ClientSession` (and `.confluence.`, `.jira.`) — the #12221 credential guard, which asserts a decrypted token actually reaches the outbound call. It went 6 passed → 3 failed and would have been missed entirely by the `knowledge/connectors/` + `tests/unit/` selection. Verified pre-existing-green by `cp`-swapping origin back in (6 passed), then re-broken, then fixed.

2. **One of the broken tests still "passed".** `test_gitlab_test_connection_fail` asserts `result is False`; the un-stubbed real DNS lookup fails, the connector sentinel-encodes that as `status_code: 0`, and `False` is duly returned. It went green for entirely the wrong reason and would never have flagged the lost stub. A green suite was not evidence here — only the *diff against the baseline* was.

Both files now stub the pooled seam instead, with a comment stating why:

```python
client.tracked_request = MagicMock(return_value=response)
patch("knowledge.connectors.gitlab.get_http_client", return_value=client)
```

**Recommended addition to the batch recipe:** before converting a module, grep the whole test tree — not just its neighbouring test file — for `patch(".*aiohttp.ClientSession"` naming that module. Any hit is a stub that will silently stop intercepting, and some of them will fail open rather than fail loudly.

**Remaining raw constructions, measured not subtracted.** Per batch 3's correction, the count is taken against this branch rather than derived from a stale headline — and by AST rather than grep, because `aiohttp.ClientSession(` also appears inside docstrings and string literals:

```
AST (non-test, autobot-backend), origin/Dev_new_gui : 87   (grep says 90)
AST (non-test, autobot-backend), this branch        : 71   (grep says 74)
```

Exactly -16, matching the 16 conversions. grep over-counts by 3 in both directions — `aiohttp.ClientSession(` also occurs inside docstrings and string literals — so the AST figure is the one to track.

Test-only changes in this PR (no production behaviour):

- `autobot-backend/tests/unit/knowledge/connectors/test_gitlab_connector.py` — `_mock_session()` → `_mock_http_client()`, 4 patch targets retargeted.
- `autobot-backend/api/knowledge_connectors_auth_schema_test.py` — `_FakeAiohttpSession` → `_FakeHttpClient`, 3 patch targets retargeted. The per-verb `get`/`post`/`request` trio collapses to a single `tracked_request`, and the credential assertions are unchanged, so the #12221 guard still guards the same thing.

## Discoveries filed

**#12997** — `OneDriveConnector._graph_request()` carries a manual `301/302/303/307/308` branch that can never execute: the preceding request does not disable redirects, so aiohttp resolves them internally and the site only ever sees the final status. Verified against the **pre-conversion** file (`uses shared pool: False`) to confirm it is pre-existing rather than introduced here:

```
result      : {'status_code': 200, 'content': b'BINARYPAYLOA'}
server hits : [('redirect-endpoint', ...), ('raw-endpoint', None)]
VERDICT: manual 3xx branch reachable == False
```

Not fixed here: it does not block verifying any converted line (the branch is preserved verbatim), and choosing between "delete it" and "make it reachable and correct" is a behaviour decision for the connector, not a side effect of a pooling change.

**#12998** — 4 GitLab/Gitea connector tests patch `knowledge.connectors.gitlab._store_ts`, a module-level helper that #12659 folded into `AbstractConnector`. `mock.patch` raises `AttributeError` at setup, so those four have had no coverage since #12659 landed. They are 4 of the 11 pre-existing failures in the baseline above. Not fixed here even though this PR touches the same file — mixing an unrelated stub relocation into the pooling diff would blur what this change is answerable for.

## Model Used

claude-opus-5
