### PR TITLE
perf(http): route Telegram bot service and TTS client through the shared pool (#12979)

### DIFF
--- a/autobot-backend/services/telegram_bot_service.py
+++ b/autobot-backend/services/telegram_bot_service.py
@@ -14,9 +14,8 @@ AES-256-GCM field encryption (see autobot_shared.field_encryption).
 
 from typing import Any, Dict, Optional
 
-import aiohttp
-
 from autobot_shared.field_encryption import decrypt_field, encrypt_field
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 
@@ -111,17 +110,16 @@ class TelegramBotService:
         if reply_to_message_id:
             payload["reply_to_message_id"] = reply_to_message_id
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/sendMessage"
-            async with session.post(url, json=payload) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"Telegram sendMessage failed: {response.status} - {error_text}")
-                    response.raise_for_status()
+        url = f"{self.base_url}/sendMessage"
+        async with get_http_client().tracked_request("POST", url, json=payload) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                logger.error(f"Telegram sendMessage failed: {response.status} - {error_text}")
+                response.raise_for_status()
 
-                result = await response.json()
-                logger.info(f"Sent Telegram message to chat {chat_id}")
-                return result
+            result = await response.json()
+            logger.info(f"Sent Telegram message to chat {chat_id}")
+            return result
 
     async def set_webhook(self, webhook_url: str, secret_token: str) -> Dict[str, Any]:
         """
@@ -141,21 +139,20 @@ class TelegramBotService:
         if not self.bot_token or not self.base_url:
             raise ValueError("Telegram bot token not configured")
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/setWebhook"
-            payload = {
-                "url": webhook_url,
-                "secret_token": secret_token,
-            }
-            async with session.post(url, json=payload) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"Telegram setWebhook failed: {response.status} - {error_text}")
-                    response.raise_for_status()
+        url = f"{self.base_url}/setWebhook"
+        payload = {
+            "url": webhook_url,
+            "secret_token": secret_token,
+        }
+        async with get_http_client().tracked_request("POST", url, json=payload) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                logger.error(f"Telegram setWebhook failed: {response.status} - {error_text}")
+                response.raise_for_status()
 
-                result = await response.json()
-                logger.info(f"Set Telegram webhook to {webhook_url}")
-                return result
+            result = await response.json()
+            logger.info(f"Set Telegram webhook to {webhook_url}")
+            return result
 
     async def get_webhook_info(self) -> Dict[str, Any]:
         """
@@ -171,16 +168,15 @@ class TelegramBotService:
         if not self.bot_token or not self.base_url:
             raise ValueError("Telegram bot token not configured")
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/getWebhookInfo"
-            async with session.get(url) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"Telegram getWebhookInfo failed: {response.status} - {error_text}")
-                    response.raise_for_status()
+        url = f"{self.base_url}/getWebhookInfo"
+        async with get_http_client().tracked_request("GET", url) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                logger.error(f"Telegram getWebhookInfo failed: {response.status} - {error_text}")
+                response.raise_for_status()
 
-                result = await response.json()
-                return result
+            result = await response.json()
+            return result
 
     async def get_file(self, file_id: str) -> Dict[str, Any]:
         """
@@ -199,19 +195,18 @@ class TelegramBotService:
         if not self.bot_token or not self.base_url:
             raise ValueError("Telegram bot token not configured")
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/getFile"
-            payload = {"file_id": file_id}
-            async with session.post(url, json=payload) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"Telegram getFile failed: {response.status} - {error_text}")
-                    response.raise_for_status()
+        url = f"{self.base_url}/getFile"
+        payload = {"file_id": file_id}
+        async with get_http_client().tracked_request("POST", url, json=payload) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                logger.error(f"Telegram getFile failed: {response.status} - {error_text}")
+                response.raise_for_status()
 
-                result = await response.json()
-                if result.get("ok"):
-                    return result.get("result", {})
-                return {}
+            result = await response.json()
+            if result.get("ok"):
+                return result.get("result", {})
+            return {}
 
     async def download_file(self, file_path: str) -> bytes:
         """
@@ -232,16 +227,15 @@ class TelegramBotService:
 
         download_url = f"https://api.telegram.org/file/bot{self.bot_token}/{file_path}"
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(download_url) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"File download failed: {response.status} - {error_text}")
-                    response.raise_for_status()
+        async with get_http_client().tracked_request("GET", download_url) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                logger.error(f"File download failed: {response.status} - {error_text}")
+                response.raise_for_status()
 
-                content = await response.read()
-                logger.info(f"Downloaded file from Telegram: {file_path}")
-                return content
+            content = await response.read()
+            logger.info(f"Downloaded file from Telegram: {file_path}")
+            return content
 
     async def send_photo(
         self,
@@ -286,17 +280,16 @@ class TelegramBotService:
         if message_thread_id:
             payload["message_thread_id"] = message_thread_id
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/sendPhoto"
-            async with session.post(url, json=payload) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"Telegram sendPhoto failed: {response.status} - {error_text}")
-                    response.raise_for_status()
+        url = f"{self.base_url}/sendPhoto"
+        async with get_http_client().tracked_request("POST", url, json=payload) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                logger.error(f"Telegram sendPhoto failed: {response.status} - {error_text}")
+                response.raise_for_status()
 
-                result = await response.json()
-                logger.info(f"Sent photo to Telegram chat {chat_id}")
-                return result
+            result = await response.json()
+            logger.info(f"Sent photo to Telegram chat {chat_id}")
+            return result
 
     async def send_document(
         self,
@@ -341,17 +334,16 @@ class TelegramBotService:
         if message_thread_id:
             payload["message_thread_id"] = message_thread_id
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}/sendDocument"
-            async with session.post(url, json=payload) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"Telegram sendDocument failed: {response.status} - {error_text}")
-                    response.raise_for_status()
+        url = f"{self.base_url}/sendDocument"
+        async with get_http_client().tracked_request("POST", url, json=payload) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                logger.error(f"Telegram sendDocument failed: {response.status} - {error_text}")
+                response.raise_for_status()
 
-                result = await response.json()
-                logger.info(f"Sent document to Telegram chat {chat_id}")
-                return result
+            result = await response.json()
+            logger.info(f"Sent document to Telegram chat {chat_id}")
+            return result
 
     async def verify_token(self) -> bool:
         """
@@ -364,15 +356,14 @@ class TelegramBotService:
             return False
 
         try:
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.base_url}/getMe"
-                async with session.get(url) as response:
-                    if response.status == 200:
-                        result = await response.json()
-                        if result.get("ok"):
-                            bot_info = result.get("result", {})
-                            logger.info(f"Telegram bot verified: @{bot_info.get('username')}")
-                            return True
+            url = f"{self.base_url}/getMe"
+            async with get_http_client().tracked_request("GET", url) as response:
+                if response.status == 200:
+                    result = await response.json()
+                    if result.get("ok"):
+                        bot_info = result.get("result", {})
+                        logger.info(f"Telegram bot verified: @{bot_info.get('username')}")
+                        return True
             return False
         except Exception as exc:
             logger.error(f"Failed to verify Telegram bot token: {exc}")

--- a/autobot-backend/services/tts_client.py
+++ b/autobot-backend/services/tts_client.py
@@ -21,6 +21,7 @@ from collections.abc import AsyncIterator
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config, get_config
 
@@ -47,11 +48,13 @@ class TTSClient:
         """Return True if the TTS worker health check passes."""
         try:
             timeout = aiohttp.ClientTimeout(total=HEALTH_TIMEOUT)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(f"{self.base_url}/health") as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        return data.get("model_loaded", False)
+            client = get_http_client()
+            async with client.tracked_request(
+                "GET", f"{self.base_url}/health", timeout=timeout, suppress_error_log=True
+            ) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    return data.get("model_loaded", False)
         except Exception as e:
             logger.debug("TTS worker health check failed: %s", e)
         return False
@@ -59,18 +62,20 @@ class TTSClient:
     async def synthesize(self, text: str, voice_id: str = "", language: str = "") -> bytes:
         """Send text to TTS worker and return WAV bytes."""
         timeout = aiohttp.ClientTimeout(total=SYNTHESIS_TIMEOUT)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            data = aiohttp.FormData()
-            data.add_field("text", text)
-            if voice_id:
-                data.add_field("voice_id", voice_id)
-            if language:
-                data.add_field("language", language)
-            async with session.post(f"{self.base_url}/tts/synthesize", data=data) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    raise RuntimeError(f"TTS worker error {resp.status}: {body}")
-                return await resp.read()
+        data = aiohttp.FormData()
+        data.add_field("text", text)
+        if voice_id:
+            data.add_field("voice_id", voice_id)
+        if language:
+            data.add_field("language", language)
+        client = get_http_client()
+        async with client.tracked_request(
+            "POST", f"{self.base_url}/tts/synthesize", data=data, timeout=timeout
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"TTS worker error {resp.status}: {body}")
+            return await resp.read()
 
     async def synthesize_stream(self, text: str, voice_id: str = "", language: str = "") -> AsyncIterator[bytes]:
         """Stream TTS audio from the worker as individually-decodable WAV chunks (#12501).
@@ -83,54 +88,60 @@ class TTSClient:
         instead of waiting for the whole utterance.
         """
         timeout = aiohttp.ClientTimeout(total=SYNTHESIS_TIMEOUT)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            data = aiohttp.FormData()
-            data.add_field("text", text)
-            if voice_id:
-                data.add_field("voice_id", voice_id)
-            if language:
-                data.add_field("language", language)
-            async with session.post(f"{self.base_url}/tts/synthesize/stream", data=data) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    raise RuntimeError(f"TTS worker error {resp.status}: {body}")
-                while True:
-                    try:
-                        header = await resp.content.readexactly(4)
-                    except asyncio.IncompleteReadError:
-                        break
-                    chunk_len = int.from_bytes(header, "big")
-                    try:
-                        yield await resp.content.readexactly(chunk_len)
-                    except asyncio.IncompleteReadError as e:
-                        raise RuntimeError("TTS stream truncated mid-chunk") from e
+        data = aiohttp.FormData()
+        data.add_field("text", text)
+        if voice_id:
+            data.add_field("voice_id", voice_id)
+        if language:
+            data.add_field("language", language)
+        client = get_http_client()
+        async with client.tracked_request(
+            "POST", f"{self.base_url}/tts/synthesize/stream", data=data, timeout=timeout
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"TTS worker error {resp.status}: {body}")
+            while True:
+                try:
+                    header = await resp.content.readexactly(4)
+                except asyncio.IncompleteReadError:
+                    break
+                chunk_len = int.from_bytes(header, "big")
+                try:
+                    yield await resp.content.readexactly(chunk_len)
+                except asyncio.IncompleteReadError as e:
+                    raise RuntimeError("TTS stream truncated mid-chunk") from e
 
     async def clone_voice(self, text: str, reference_audio: bytes) -> bytes:
         """Send text + reference audio to TTS worker; returns WAV bytes."""
         timeout = aiohttp.ClientTimeout(total=SYNTHESIS_TIMEOUT)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            data = aiohttp.FormData()
-            data.add_field("text", text)
-            data.add_field(
-                "reference_audio",
-                reference_audio,
-                filename="reference.wav",
-                content_type="audio/wav",
-            )
-            async with session.post(f"{self.base_url}/tts/clone-voice", data=data) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    raise RuntimeError(f"TTS worker error {resp.status}: {body}")
-                return await resp.read()
+        data = aiohttp.FormData()
+        data.add_field("text", text)
+        data.add_field(
+            "reference_audio",
+            reference_audio,
+            filename="reference.wav",
+            content_type="audio/wav",
+        )
+        client = get_http_client()
+        async with client.tracked_request(
+            "POST", f"{self.base_url}/tts/clone-voice", data=data, timeout=timeout
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"TTS worker error {resp.status}: {body}")
+            return await resp.read()
 
     async def list_voices(self) -> list[dict]:
         """List available voice profiles from TTS worker."""
         timeout = aiohttp.ClientTimeout(total=HEALTH_TIMEOUT)
         try:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(f"{self.base_url}/voices") as resp:
-                    if resp.status == 200:
-                        return await resp.json()
+            client = get_http_client()
+            async with client.tracked_request(
+                "GET", f"{self.base_url}/voices", timeout=timeout, suppress_error_log=True
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
         except Exception as e:
             logger.warning("Failed to list voices: %s", e)
         return []
@@ -138,28 +149,30 @@ class TTSClient:
     async def create_voice(self, name: str, audio_bytes: bytes, filename: str = "ref.wav") -> dict:
         """Create a voice profile from reference audio."""
         timeout = aiohttp.ClientTimeout(total=SYNTHESIS_TIMEOUT)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            data = aiohttp.FormData()
-            data.add_field("name", name)
-            data.add_field(
-                "audio",
-                audio_bytes,
-                filename=filename,
-                content_type="audio/wav",
-            )
-            async with session.post(f"{self.base_url}/voices/create", data=data) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    raise RuntimeError(f"Voice create error {resp.status}: {body}")
-                return await resp.json()
+        data = aiohttp.FormData()
+        data.add_field("name", name)
+        data.add_field(
+            "audio",
+            audio_bytes,
+            filename=filename,
+            content_type="audio/wav",
+        )
+        client = get_http_client()
+        async with client.tracked_request("POST", f"{self.base_url}/voices/create", data=data, timeout=timeout) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"Voice create error {resp.status}: {body}")
+            return await resp.json()
 
     async def delete_voice(self, voice_id: str) -> bool:
         """Delete a voice profile."""
         timeout = aiohttp.ClientTimeout(total=HEALTH_TIMEOUT)
         try:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.delete(f"{self.base_url}/voices/{voice_id}") as resp:
-                    return resp.status == 200
+            client = get_http_client()
+            async with client.tracked_request(
+                "DELETE", f"{self.base_url}/voices/{voice_id}", timeout=timeout, suppress_error_log=True
+            ) as resp:
+                return resp.status == 200
         except Exception as e:
             logger.warning("Failed to delete voice %s: %s", voice_id, e)
         return False

--- a/autobot-backend/services/tts_client_test.py
+++ b/autobot-backend/services/tts_client_test.py
@@ -4,10 +4,16 @@
 # Author: mrveiss
 """Tests for TTSClient.synthesize_stream (#12501).
 
-Mocks aiohttp.ClientSession so no real network/worker is required — same
-pattern as tests/utils/test_traced_http_client.py. Exercises the client
-side of the worker's length-prefixed streaming wire format:
-``[4-byte big-endian length][WAV bytes]`` repeated back to back.
+Mocks the shared pooled HTTP client so no real network/worker is required.
+Exercises the client side of the worker's length-prefixed streaming wire
+format: ``[4-byte big-endian length][WAV bytes]`` repeated back to back.
+
+Issue #12979 moved TTSClient off per-request ``aiohttp.ClientSession`` onto
+``autobot_shared.http_client``. The seam is now
+``get_http_client().tracked_request(method, url, **kwargs)``, which yields the
+response, so the stub targets that entry point instead of ``aiohttp.ClientSession``
+-- patching the latter would no longer intercept anything and the test would
+dial out for real.
 """
 
 import asyncio
@@ -43,33 +49,37 @@ def _framed(chunks: list) -> bytes:
     return out
 
 
-def _make_mock_session(body: bytes, status: int = 200) -> MagicMock:
-    """Return a MagicMock standing in for aiohttp.ClientSession with one POST response."""
+def _make_mock_http_client(body: bytes, status: int = 200) -> MagicMock:
+    """Return a MagicMock standing in for the shared pooled HTTP client.
+
+    ``get_http_client().tracked_request(...)`` is an ``@asynccontextmanager``
+    call, so the mock's return value must itself be the async context manager
+    (``__aenter__``/``__aexit__``) that yields the response -- ``tracked_request``
+    is not awaited by callers, only entered via ``async with``.
+    """
     mock_resp = MagicMock()
     mock_resp.status = status
     mock_resp.content = _FakeStreamReader(body)
     mock_resp.text = AsyncMock(return_value="error body")
 
-    mock_post_cm = MagicMock()
-    mock_post_cm.__aenter__ = AsyncMock(return_value=mock_resp)
-    mock_post_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_request_cm = MagicMock()
+    mock_request_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_request_cm.__aexit__ = AsyncMock(return_value=False)
 
-    mock_session = MagicMock()
-    mock_session.post = MagicMock(return_value=mock_post_cm)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=False)
-    return mock_session
+    mock_client = MagicMock()
+    mock_client.tracked_request = MagicMock(return_value=mock_request_cm)
+    return mock_client
 
 
 @pytest.mark.asyncio
 async def test_synthesize_stream_yields_multiple_chunks():
     """synthesize_stream yields each WAV chunk from the framed HTTP body in order."""
     chunks = [b"RIFF-chunk-one", b"RIFF-chunk-two", b"RIFF-chunk-three"]
-    session = _make_mock_session(_framed(chunks))
+    mock_client = _make_mock_http_client(_framed(chunks))
 
-    with patch("aiohttp.ClientSession", return_value=session):
-        client = TTSClient()
-        received = [c async for c in client.synthesize_stream("hello world", voice_id="alba")]
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
+        received = [c async for c in tts_client.synthesize_stream("hello world", voice_id="alba")]
 
     assert received == chunks
 
@@ -77,12 +87,12 @@ async def test_synthesize_stream_yields_multiple_chunks():
 @pytest.mark.asyncio
 async def test_synthesize_stream_raises_on_non_200():
     """synthesize_stream raises RuntimeError when the worker returns a non-200 status."""
-    session = _make_mock_session(b"", status=500)
+    mock_client = _make_mock_http_client(b"", status=500)
 
-    with patch("aiohttp.ClientSession", return_value=session):
-        client = TTSClient()
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
         with pytest.raises(RuntimeError, match="TTS worker error 500"):
-            async for _ in client.synthesize_stream("hello"):
+            async for _ in tts_client.synthesize_stream("hello"):
                 pass
 
 
@@ -90,22 +100,22 @@ async def test_synthesize_stream_raises_on_non_200():
 async def test_synthesize_stream_raises_on_truncated_chunk():
     """A length prefix promising more bytes than are sent raises, instead of silently truncating audio."""
     body = (100).to_bytes(4, "big") + b"short"
-    session = _make_mock_session(body)
+    mock_client = _make_mock_http_client(body)
 
-    with patch("aiohttp.ClientSession", return_value=session):
-        client = TTSClient()
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
         with pytest.raises(RuntimeError, match="truncated mid-chunk"):
-            async for _ in client.synthesize_stream("hello"):
+            async for _ in tts_client.synthesize_stream("hello"):
                 pass
 
 
 @pytest.mark.asyncio
 async def test_synthesize_stream_empty_body_yields_nothing():
     """An empty response body (zero chunks) yields nothing and does not raise."""
-    session = _make_mock_session(b"")
+    mock_client = _make_mock_http_client(b"")
 
-    with patch("aiohttp.ClientSession", return_value=session):
-        client = TTSClient()
-        received = [c async for c in client.synthesize_stream("hello")]
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
+        received = [c async for c in tts_client.synthesize_stream("hello")]
 
     assert received == []

--- a/autobot-slm-backend/tests/services/tts_contract_test.py
+++ b/autobot-slm-backend/tests/services/tts_contract_test.py
@@ -25,15 +25,30 @@ _REPO_ROOT = Path(__file__).parent.parent.parent.parent
 _CLIENT = _REPO_ROOT / "autobot-backend" / "services" / "tts_client.py"
 _TEMPLATE = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "tts-worker" / "templates" / "tts-worker.py.j2"
 
-# ``async with session.post(f"{self.base_url}/tts/synthesize", data=data)``
-_CLIENT_CALL = re.compile(r"session\.(get|post|delete|put|patch)\(\s*f?\"\{self\.base_url\}(/[^\"]*)\"")
+# ``async with session.post(f"{self.base_url}/tts/synthesize", data=data)`` — pre-#12979 raw session shape.
+_CLIENT_CALL_RAW_SESSION = re.compile(r"session\.(get|post|delete|put|patch)\(\s*f?\"\{self\.base_url\}(/[^\"]*)\"")
+# ``client.tracked_request("POST", f"{self.base_url}/tts/synthesize", ...)`` — #12979 pooled-client shape.
+# ``\s*`` spans the newline in the multi-line call form the pooled conversion uses.
+_CLIENT_CALL_POOLED = re.compile(
+    r"tracked_request\(\s*\"(GET|POST|DELETE|PUT|PATCH)\"\s*,\s*f\"\{self\.base_url\}(/[^\"]*)\""
+)
 # ``@app.post("/tts/synthesize")``
 _WORKER_ROUTE = re.compile(r"@app\.(get|post|delete|put|patch)\(\"([^\"]+)\"")
 
 
 def _client_calls() -> set[tuple[str, str]]:
-    """(method, path) pairs the backend's TTS client issues against the worker."""
-    return {(m.lower(), p) for m, p in _CLIENT_CALL.findall(_CLIENT.read_text(encoding="utf-8"))}
+    """(method, path) pairs the backend's TTS client issues against the worker.
+
+    Issue #12979 moved ``tts_client.py`` off per-request ``session.<verb>(...)``
+    onto ``get_http_client().tracked_request(method, url, ...)`` — a different
+    source shape carrying the same (method, path) contract. Both regexes are
+    checked so the extraction survives the migration instead of silently
+    reading zero calls (see ``test_sources_are_present``).
+    """
+    text = _CLIENT.read_text(encoding="utf-8")
+    raw = {(m.lower(), p) for m, p in _CLIENT_CALL_RAW_SESSION.findall(text)}
+    pooled = {(m.lower(), p) for m, p in _CLIENT_CALL_POOLED.findall(text)}
+    return raw | pooled
 
 
 def _worker_routes() -> set[tuple[str, str]]:


### PR DESCRIPTION
## Thinking Path

Batch 5 of #12979. Per the consolidated batch recipe on the issue: classify every site by reading it (do not grep-and-sweep), because the `*_json()` vs `tracked_request()` split has swung 82%/0%/72%/0% across the first four batches and is a property of the module's *contract*, not the codebase.

Scope: the two dense single files named in the task — `autobot-backend/services/telegram_bot_service.py` (8 sites) and `autobot-backend/services/tts_client.py` (7 sites) — 15 sites total, at the ~15 target, so no third area was added.

Read every site in both files:
- **Telegram (8/8 `tracked_request()`):** every method reads `error_text = await response.text()` on the non-2xx branch *before* raising, specifically to log the response body — `get_json()`/`post_json()` would raise `ClientResponseError` immediately and drop that log detail, a behaviour change in exactly the place batch 3's `_trigger_build()` finding warned about (raise_for_status-shaped code that isn't a `*_json()` candidate once you look at what it actually reads). `download_file()` reads raw `bytes()`. `verify_token()` inspects `status == 200` and returns a bool sentinel, never raising.
- **TTS client (7/7 `tracked_request()`):** `is_available()`/`list_voices()`/`delete_voice()` swallow failure into a debug/warning log plus a sentinel (`bool`/`[]`); `synthesize()`/`clone_voice()`/`create_voice()` read raw `bytes()` or raise a custom `RuntimeError` with the response body already read via `text()`; `synthesize_stream()` streams length-prefixed chunks from `resp.content.readexactly()` inside the response block.

No site in either file uses `raise_for_status()`, a custom `connector=`, returns a session, or is long-lived — so this batch has zero RAW carve-outs, unlike batch 4's SSRF-pinned connector.

`synthesize_stream()` is a genuine streaming case: the `tracked_request()` `async with` block spans every `yield` in the generator body. This works because `async with` remains active across `await`/`yield` points in an async generator — the block exits (and the counter decrements) whichever way the generator ends, exhausted normally or closed early by the caller giving up on the stream.

## What Changed

- `autobot-backend/services/telegram_bot_service.py`: 8 raw `aiohttp.ClientSession()` → 0, all via `get_http_client().tracked_request(method, url, ...)`. Removed the now-unused `import aiohttp`.
- `autobot-backend/services/tts_client.py`: 7 raw `aiohttp.ClientSession(timeout=...)` → 0, all via `tracked_request()`. `is_available()`, `list_voices()`, and `delete_voice()` pass `suppress_error_log=True` since each already downgrades the failure to a debug/warning log plus a sentinel — the pooled client's default ERROR log would otherwise turn an expected condition (TTS worker not running) into noise on a poll loop.
- `autobot-backend/services/tts_client_test.py`: retargeted from `patch("aiohttp.ClientSession", ...)` to `patch("services.tts_client.get_http_client", ...)`, since the code no longer touches `aiohttp.ClientSession` at the call site. The fake client's `tracked_request()` returns the same async-context-manager mock the old fake session's `.post()` returned.
- `autobot-slm-backend/tests/services/tts_contract_test.py`: a **second, non-mock test seam**, found by exercising rather than by the repo-wide `patch(.*ClientSession` grep. This is a static regex contract test (#12886) that parses `tts_client.py`'s source for the `session.<verb>(f"{self.base_url}/path")` shape to confirm every backend call is served by the worker template. The regex didn't match the new `tracked_request("VERB", f"{self.base_url}/path", ...)` shape and went 8 failed / 1 passed. Added a second regex for the pooled shape alongside the original (not a replacement), so a future raw-session call site is still caught by the same test.
- `telegram_bot_service.py` has no direct unit test exercising its HTTP methods (`api/telegram_bot_test.py` covers webhook wiring and command handling only), so there was no seam to retarget there.

## Verification

**(a) py_compile, flake8, black --check --line-length=120** — all clean on the 4 changed files.

**(b) Local aiohttp server exercise** — all 15 converted sites driven on success *and* failure branches against a real local server (29 exercised paths, 0 unexpected):
```
exercised paths       : 29
unexpected            : 0  []
server-side requests  : 29
still-acquired        : 0
active_requests       : 0
ALL ASSERTIONS PASSED
```

**(c) Baseline vs after (cp-swapped origin/Dev_new_gui, never git stash)** — repo-wide `grep -rn 'patch(.*ClientSession'` confirmed the only mock-based seam for these two modules is `tts_client_test.py` (fixed above); the regex-based seam in `tts_contract_test.py` was caught by running it, not by that grep, which is why "exercise every path" and "diff against baseline" both matter independently. Curated regression scope (both files' direct tests plus every caller's test file: `api/telegram_bot_test.py`, `api/voice_stream_test.py`, `tests/test_voice_503_guard.py`, `integrations/protocols_conformance_test.py`, `tests/services/notification_service_test.py`, `autobot-slm-backend/tests/services/tts_contract_test.py`):
```
baseline (origin/Dev_new_gui): 119 passed, 0 failed
after this branch:             119 passed, 0 failed
```
A full `autobot-backend/` suite run was attempted for both states but hung indefinitely on a pre-existing, unrelated `security/security_api_e2e_test.py` before reaching `services/` alphabetically — confirmed pre-existing since it hung identically with the baseline (origin) files in place. The curated scope above stands in for it; it covers every known caller of the two converted modules.

**(d) Ceiling guard** — `autobot-backend/tests/test_raw_client_session_ceiling_12992.py` does **not exist on this branch's base** (`origin/Dev_new_gui` @ `352e07cc7`); it ships in still-open PR #12996, which currently has 10 red required checks (SAST, api-wiring, code-quality, smoke-test, etc.) and is not close to merging. There is therefore no ceiling constant in this PR to lower. Using that test's own AST-walker logic (copied, not modified) as a standalone script for measurement only: **87 on `origin/Dev_new_gui` @ `352e07cc7` → 72 on this branch, exactly −15** (the 15 sites converted here). Whoever finishes #12996 will re-measure against whatever tip it rebases onto, per that file's own "re-measure immediately before push" rule — this PR does not need to (and cannot, since the file isn't part of its diff) touch it.

## Model Used

Claude Sonnet 5