### PR TITLE
perf(http): route communication/cloud/PM integrations and http_adapter through the shared pool (#12979)

### DIFF
--- a/autobot-backend/integrations/cloud_integration.py
+++ b/autobot-backend/integrations/cloud_integration.py
@@ -17,6 +17,7 @@ from urllib.parse import quote
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
 from integrations.base import (
@@ -235,15 +236,14 @@ class AWSIntegration(BaseIntegration):
         """Make HTTP request to AWS API."""
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers) as resp:
-                    text = await resp.text()
-                    body = self._parse_xml_response(text)
-                    return {
-                        "status_code": resp.status,
-                        "body": body,
-                        "headers": dict(resp.headers),
-                    }
+            async with get_http_client().tracked_request(method, url, headers=headers, timeout=timeout) as resp:
+                text = await resp.text()
+                body = self._parse_xml_response(text)
+                return {
+                    "status_code": resp.status,
+                    "body": body,
+                    "headers": dict(resp.headers),
+                }
         except aiohttp.ClientError as exc:
             self.logger.warning("AWS request to %s failed: %s", url, exc)
             return {"status_code": 0, "body": {}, "error": str(exc)}
@@ -428,14 +428,13 @@ class AzureIntegration(BaseIntegration):
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers) as resp:
-                    body = await resp.json()
-                    return {
-                        "status_code": resp.status,
-                        "body": body,
-                        "headers": dict(resp.headers),
-                    }
+            async with get_http_client().tracked_request(method, url, headers=headers, timeout=timeout) as resp:
+                body = await resp.json()
+                return {
+                    "status_code": resp.status,
+                    "body": body,
+                    "headers": dict(resp.headers),
+                }
         except aiohttp.ClientError as exc:
             self.logger.warning("Azure request to %s failed: %s", url, exc)
             return {"status_code": 0, "body": {}, "error": str(exc)}
@@ -598,14 +597,13 @@ class GCPIntegration(BaseIntegration):
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers) as resp:
-                    body = await resp.json()
-                    return {
-                        "status_code": resp.status,
-                        "body": body,
-                        "headers": dict(resp.headers),
-                    }
+            async with get_http_client().tracked_request(method, url, headers=headers, timeout=timeout) as resp:
+                body = await resp.json()
+                return {
+                    "status_code": resp.status,
+                    "body": body,
+                    "headers": dict(resp.headers),
+                }
         except aiohttp.ClientError as exc:
             self.logger.warning("GCP request to %s failed: %s", url, exc)
             return {"status_code": 0, "body": {}, "error": str(exc)}

--- a/autobot-backend/integrations/communication_integration.py
+++ b/autobot-backend/integrations/communication_integration.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from integrations.base import (
     BaseIntegration,
@@ -157,11 +158,12 @@ class SlackIntegration(BaseIntegration):
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(url, headers=headers, data=form_data) as resp:
-                    result = await resp.json()
-                    self._check_slack_response(url, resp.status, result)
-                    return result
+            async with get_http_client().tracked_request(
+                "POST", url, headers=headers, data=form_data, timeout=timeout
+            ) as resp:
+                result = await resp.json()
+                self._check_slack_response(url, resp.status, result)
+                return result
         except asyncio.TimeoutError:
             self.logger.warning(
                 "Slack file upload to %s timed out (channel=%s)",
@@ -250,20 +252,20 @@ class SlackIntegration(BaseIntegration):
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                if method == "GET":
-                    async with session.get(url, headers=headers, params=data) as resp:
-                        result = await resp.json()
-                        self._check_slack_response(url, resp.status, result)
-                        if resp.status == 429:
-                            self._rate_limiter.apply_response_headers(self._token_key, dict(resp.headers))
-                        return result
-                async with session.post(url, headers=headers, json=data) as resp:
+            client = get_http_client()
+            if method == "GET":
+                async with client.tracked_request("GET", url, headers=headers, params=data, timeout=timeout) as resp:
                     result = await resp.json()
                     self._check_slack_response(url, resp.status, result)
                     if resp.status == 429:
                         self._rate_limiter.apply_response_headers(self._token_key, dict(resp.headers))
                     return result
+            async with client.tracked_request("POST", url, headers=headers, json=data, timeout=timeout) as resp:
+                result = await resp.json()
+                self._check_slack_response(url, resp.status, result)
+                if resp.status == 429:
+                    self._rate_limiter.apply_response_headers(self._token_key, dict(resp.headers))
+                return result
         except asyncio.TimeoutError:
             self.logger.warning("Slack request to %s timed out", url)
             return {"ok": False, "error": "timeout"}
@@ -401,10 +403,9 @@ class TeamsIntegration(BaseIntegration):
     async def _post_webhook(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Post message to Teams webhook."""
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(self.webhook_url, json=payload) as resp:
-                    status = resp.status
-                    return {"success": status == 200, "status_code": status}
+            async with get_http_client().tracked_request("POST", self.webhook_url, json=payload) as resp:
+                status = resp.status
+                return {"success": status == 200, "status_code": status}
         except aiohttp.ClientError as exc:
             self.logger.warning("Teams webhook failed: %s", exc)
             return {"success": False, "error": str(exc)}
@@ -418,10 +419,9 @@ class TeamsIntegration(BaseIntegration):
         """Make HTTP request to Microsoft Graph API."""
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers) as resp:
-                    body = await resp.json()
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(method, url, headers=headers, timeout=timeout) as resp:
+                body = await resp.json()
+                return {"status_code": resp.status, "body": body}
         except aiohttp.ClientError as exc:
             self.logger.warning("Teams Graph request to %s failed: %s", url, exc)
             return {"status_code": 0, "body": {}, "error": str(exc)}
@@ -571,10 +571,11 @@ class DiscordIntegration(BaseIntegration):
         """
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers, json=data, params=query_params) as resp:
-                    body = await resp.json()
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                method, url, headers=headers, json=data, params=query_params, timeout=timeout
+            ) as resp:
+                body = await resp.json()
+                return {"status_code": resp.status, "body": body}
         except aiohttp.ClientError as exc:
             self.logger.warning("Discord request to %s failed: %s", url, exc)
             return {"status_code": 0, "body": {}, "error": str(exc)}

--- a/autobot-backend/integrations/github_integration_test.py
+++ b/autobot-backend/integrations/github_integration_test.py
@@ -354,19 +354,15 @@ async def test_slack_make_request_429_applies_retry_after():
     resp.status = 429
     resp.headers = {"Retry-After": "30"}
     resp.json = AsyncMock(return_value=body)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
 
-    inner_cm = AsyncMock()
-    inner_cm.__aenter__ = AsyncMock(return_value=resp)
-    inner_cm.__aexit__ = AsyncMock(return_value=False)
+    # #12979: _make_slack_request routes through the shared pool's
+    # tracked_request() rather than constructing its own aiohttp.ClientSession.
+    mock_client = MagicMock()
+    mock_client.tracked_request = MagicMock(return_value=resp)
 
-    session = MagicMock()
-    session.post = MagicMock(return_value=inner_cm)
-
-    outer_cm = AsyncMock()
-    outer_cm.__aenter__ = AsyncMock(return_value=session)
-    outer_cm.__aexit__ = AsyncMock(return_value=False)
-
-    with patch("aiohttp.ClientSession", return_value=outer_cm):
+    with patch("integrations.communication_integration.get_http_client", return_value=mock_client):
         result = await slack._make_slack_request(
             "POST",
             "https://slack.com/api/chat.postMessage",

--- a/autobot-backend/integrations/project_management_integration.py
+++ b/autobot-backend/integrations/project_management_integration.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from integrations.base import (
     BaseIntegration,
@@ -280,12 +281,13 @@ class JiraIntegration(BaseIntegration):
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers, json=json_data) as resp:
-                    if resp.status == 204:
-                        return {"status_code": 204, "body": {}}
-                    body = await resp.json()
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                method, url, headers=headers, json=json_data, timeout=timeout
+            ) as resp:
+                if resp.status == 204:
+                    return {"status_code": 204, "body": {}}
+                body = await resp.json()
+                return {"status_code": resp.status, "body": body}
         except aiohttp.ClientError as exc:
             self.logger.warning("Jira request to %s failed: %s", url, exc)
             return {"status_code": 0, "error": str(exc)}
@@ -496,15 +498,15 @@ class TrelloIntegration(BaseIntegration):
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(
-                    method,
-                    url,
-                    params=params,
-                    json=data if method != "GET" else None,
-                ) as resp:
-                    body = await resp.json()
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                method,
+                url,
+                params=params,
+                json=data if method != "GET" else None,
+                timeout=timeout,
+            ) as resp:
+                body = await resp.json()
+                return {"status_code": resp.status, "body": body}
         except aiohttp.ClientError as exc:
             self.logger.warning("Trello request to %s failed: %s", url, exc)
             return {"status_code": 0, "error": str(exc)}
@@ -734,10 +736,11 @@ class AsanaIntegration(BaseIntegration):
 
         try:
             timeout = aiohttp.ClientTimeout(total=30.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.request(method, url, headers=headers, json=json_data) as resp:
-                    body = await resp.json()
-                    return {"status_code": resp.status, "body": body}
+            async with get_http_client().tracked_request(
+                method, url, headers=headers, json=json_data, timeout=timeout
+            ) as resp:
+                body = await resp.json()
+                return {"status_code": resp.status, "body": body}
         except aiohttp.ClientError as exc:
             self.logger.warning("Asana request to %s failed: %s", url, exc)
             return {"status_code": 0, "error": str(exc)}

--- a/autobot-backend/llc/adapters/http_adapter.py
+++ b/autobot-backend/llc/adapters/http_adapter.py
@@ -26,6 +26,7 @@ import json
 
 import aiohttp
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 
 from ..models.enums import LLCRunStatus
@@ -50,10 +51,11 @@ class HttpAdapter:
         else:
             body = context
 
-        async with aiohttp.ClientSession(timeout=_DEFAULT_TIMEOUT) as session:
-            async with session.request(method, url, json=body, headers=headers) as resp:
-                resp.raise_for_status()
-                data = await resp.json()
+        async with get_http_client().tracked_request(
+            method, url, json=body, headers=headers, timeout=_DEFAULT_TIMEOUT
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
 
         run_id: str = data["run_id"]
         logger.info("HttpAdapter: invoked %s %s → run_id=%s", method, url, run_id)
@@ -64,12 +66,13 @@ class HttpAdapter:
         headers: dict = agent_config.get("headers", {})
 
         status_url = f"{base_url}/status/{run_id}"
-        async with aiohttp.ClientSession(timeout=_DEFAULT_TIMEOUT) as session:
-            async with session.get(status_url, headers=headers) as resp:
-                if resp.status == 404:
-                    return AdapterRunStatus(status=LLCRunStatus.FAILED, error="run not found")
-                resp.raise_for_status()
-                data = await resp.json()
+        async with get_http_client().tracked_request(
+            "GET", status_url, headers=headers, timeout=_DEFAULT_TIMEOUT
+        ) as resp:
+            if resp.status == 404:
+                return AdapterRunStatus(status=LLCRunStatus.FAILED, error="run not found")
+            resp.raise_for_status()
+            data = await resp.json()
 
         raw_status: str = data.get("status", "failed")
         # Map remote vocabulary to LLCRunStatus; "succeeded" accepted for compat.
@@ -94,7 +97,8 @@ class HttpAdapter:
         headers: dict = agent_config.get("headers", {})
 
         cancel_url = f"{base_url}/cancel/{run_id}"
-        async with aiohttp.ClientSession(timeout=_DEFAULT_TIMEOUT) as session:
-            async with session.post(cancel_url, headers=headers) as resp:
-                resp.raise_for_status()
+        async with get_http_client().tracked_request(
+            "POST", cancel_url, headers=headers, timeout=_DEFAULT_TIMEOUT
+        ) as resp:
+            resp.raise_for_status()
         logger.info("HttpAdapter: cancelled run_id=%s at %s", run_id, cancel_url)

--- a/autobot-backend/llc/adapters/tests/test_adapters.py
+++ b/autobot-backend/llc/adapters/tests/test_adapters.py
@@ -212,6 +212,14 @@ class TestProcessAdapter:
 
 
 def _mock_response(status_code: int, json_data: dict) -> MagicMock:
+    """Build a mock ``ClientResponse`` usable directly as its own async CM.
+
+    ``HTTPClientManager.tracked_request()`` yields the response under its own
+    ``async with``, so the mock returned by a patched ``tracked_request()``
+    call must itself support ``__aenter__``/``__aexit__`` (#12979: HttpAdapter
+    no longer constructs a raw session, so it routes through the shared
+    pool's ``tracked_request()`` instead of ``aiohttp.ClientSession()``).
+    """
     resp = MagicMock()
     resp.status = status_code
     resp.raise_for_status = MagicMock()
@@ -221,15 +229,12 @@ def _mock_response(status_code: int, json_data: dict) -> MagicMock:
     return resp
 
 
-def _mock_session(responses: list) -> MagicMock:
-    """Build a mock aiohttp session that returns each response in sequence."""
-    session = MagicMock()
-    session.__aenter__ = AsyncMock(return_value=session)
-    session.__aexit__ = AsyncMock(return_value=False)
-    session.request = MagicMock(side_effect=responses)
-    session.get = MagicMock(side_effect=responses)
-    session.post = MagicMock(side_effect=responses)
-    return session
+def _mock_http_client(responses: list) -> MagicMock:
+    """Build a mock ``HTTPClientManager`` whose ``tracked_request()`` returns
+    each response in sequence (#12979)."""
+    client = MagicMock()
+    client.tracked_request = MagicMock(side_effect=responses)
+    return client
 
 
 @pytest.mark.asyncio
@@ -238,7 +243,7 @@ class TestHttpAdapter:
         adapter = HttpAdapter()
         resp = _mock_response(200, {"run_id": "abc-123"})
 
-        with patch("aiohttp.ClientSession", return_value=_mock_session([resp])):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=_mock_http_client([resp])):
             run_id = await adapter.invoke({"url": "http://agent.local"}, {"task": "t1"})
 
         assert run_id == "abc-123"
@@ -247,7 +252,7 @@ class TestHttpAdapter:
         adapter = HttpAdapter()
         resp = _mock_response(200, {"run_id": "x"})
 
-        with patch("aiohttp.ClientSession", return_value=_mock_session([resp])):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=_mock_http_client([resp])):
             run_id = await adapter.invoke(
                 {
                     "url": "http://agent.local",
@@ -262,7 +267,7 @@ class TestHttpAdapter:
         adapter = HttpAdapter()
         resp = _mock_response(200, {"status": "running"})
 
-        with patch("aiohttp.ClientSession", return_value=_mock_session([resp])):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=_mock_http_client([resp])):
             result = await adapter.status({"url": "http://agent.local"}, "r1")
 
         assert result.status is LLCRunStatus.RUNNING
@@ -271,7 +276,7 @@ class TestHttpAdapter:
         adapter = HttpAdapter()
         resp = _mock_response(200, {"status": "completed", "exit_code": 0})
 
-        with patch("aiohttp.ClientSession", return_value=_mock_session([resp])):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=_mock_http_client([resp])):
             result = await adapter.status({"url": "http://agent.local"}, "r1")
 
         assert result.status is LLCRunStatus.COMPLETED
@@ -282,7 +287,7 @@ class TestHttpAdapter:
         adapter = HttpAdapter()
         resp = _mock_response(200, {"status": "succeeded", "exit_code": 0})
 
-        with patch("aiohttp.ClientSession", return_value=_mock_session([resp])):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=_mock_http_client([resp])):
             result = await adapter.status({"url": "http://agent.local"}, "r1")
 
         assert result.status is LLCRunStatus.COMPLETED
@@ -292,7 +297,7 @@ class TestHttpAdapter:
         resp = _mock_response(404, {})
         resp.raise_for_status = MagicMock()
 
-        with patch("aiohttp.ClientSession", return_value=_mock_session([resp])):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=_mock_http_client([resp])):
             result = await adapter.status({"url": "http://agent.local"}, "gone")
 
         assert result.status is LLCRunStatus.FAILED
@@ -302,7 +307,7 @@ class TestHttpAdapter:
         adapter = HttpAdapter()
         resp = _mock_response(200, {"status": "weird_value"})
 
-        with patch("aiohttp.ClientSession", return_value=_mock_session([resp])):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=_mock_http_client([resp])):
             result = await adapter.status({"url": "http://agent.local"}, "r2")
 
         assert result.status is LLCRunStatus.FAILED
@@ -310,21 +315,15 @@ class TestHttpAdapter:
     async def test_cancel_posts_to_cancel_endpoint(self) -> None:
         adapter = HttpAdapter()
         resp = _mock_response(200, {})
+        client = _mock_http_client([resp])
 
-        session = MagicMock()
-        session.__aenter__ = AsyncMock(return_value=session)
-        session.__aexit__ = AsyncMock(return_value=False)
-        cancel_ctx = MagicMock()
-        cancel_ctx.__aenter__ = AsyncMock(return_value=resp)
-        cancel_ctx.__aexit__ = AsyncMock(return_value=False)
-        session.post = MagicMock(return_value=cancel_ctx)
-
-        with patch("aiohttp.ClientSession", return_value=session):
+        with patch("llc.adapters.http_adapter.get_http_client", return_value=client):
             await adapter.cancel({"url": "http://agent.local"}, "r3")
 
-        session.post.assert_called_once()
-        called_url = session.post.call_args[0][0]
-        assert called_url.endswith("/cancel/r3")
+        client.tracked_request.assert_called_once()
+        call_args = client.tracked_request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1].endswith("/cancel/r3")
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/skills/builtin/community_growth.py
+++ b/autobot-backend/skills/builtin/community_growth.py
@@ -14,8 +14,7 @@ import asyncio
 import json
 from typing import Any, Dict, List, Tuple
 
-import aiohttp
-
+from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import get_ollama_url
 from skills.base_skill import BaseSkill, SkillConfigField, SkillManifest
@@ -290,15 +289,14 @@ class CommunityGrowthSkill(BaseSkill):
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json={"text": content}) as resp:
-                data = await resp.json()
-                if resp.status == 201:
-                    tweet_id = data.get("data", {}).get("id", "")
-                    tweet_url = f"https://twitter.com/i/web/status/{tweet_id}"
-                    return {"success": True, "tweet_url": tweet_url}
-                error_msg = data.get("detail", f"HTTP {resp.status}")
-                return {"success": False, "error": error_msg}
+        async with get_http_client().tracked_request("POST", url, headers=headers, json={"text": content}) as resp:
+            data = await resp.json()
+            if resp.status == 201:
+                tweet_id = data.get("data", {}).get("id", "")
+                tweet_url = f"https://twitter.com/i/web/status/{tweet_id}"
+                return {"success": True, "tweet_url": tweet_url}
+            error_msg = data.get("detail", f"HTTP {resp.status}")
+            return {"success": False, "error": error_msg}
 
     async def _discord_notify(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Send a notification to a Discord webhook. Issue #1161."""
@@ -319,12 +317,11 @@ class CommunityGrowthSkill(BaseSkill):
         if embed_title:
             payload["embeds"] = [{"title": embed_title, "url": embed_url or ""}]
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(webhook_url, json=payload) as resp:
-                if resp.status in (200, 204):
-                    return {"success": True}
-                text = await resp.text()
-                return {"success": False, "error": f"HTTP {resp.status}: {text[:200]}"}
+        async with get_http_client().tracked_request("POST", webhook_url, json=payload) as resp:
+            if resp.status in (200, 204):
+                return {"success": True}
+            text = await resp.text()
+            return {"success": False, "error": f"HTTP {resp.status}: {text[:200]}"}
 
     async def _github_get_releases(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Fetch releases from a GitHub repository. Issue #1161."""
@@ -343,26 +340,25 @@ class CommunityGrowthSkill(BaseSkill):
             headers["Authorization"] = f"Bearer {token}"
 
         url = f"https://api.github.com/repos/{repo}/releases"
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=headers, params={"per_page": limit}) as resp:
-                if resp.status != 200:
-                    text = await resp.text()
-                    return {
-                        "success": False,
-                        "error": f"HTTP {resp.status}: {text[:200]}",
-                    }
-                data = await resp.json()
-                releases = [
-                    {
-                        "tag": r["tag_name"],
-                        "name": r["name"],
-                        "body": r.get("body", ""),
-                        "published_at": r["published_at"],
-                        "url": r["html_url"],
-                    }
-                    for r in data[:limit]
-                ]
-                return {"success": True, "releases": releases}
+        async with get_http_client().tracked_request("GET", url, headers=headers, params={"per_page": limit}) as resp:
+            if resp.status != 200:
+                text = await resp.text()
+                return {
+                    "success": False,
+                    "error": f"HTTP {resp.status}: {text[:200]}",
+                }
+            data = await resp.json()
+            releases = [
+                {
+                    "tag": r["tag_name"],
+                    "name": r["name"],
+                    "body": r.get("body", ""),
+                    "published_at": r["published_at"],
+                    "url": r["html_url"],
+                }
+                for r in data[:limit]
+            ]
+            return {"success": True, "releases": releases}
 
     # ------------------------------------------------------------------
     # LLM / template content generation
@@ -400,16 +396,15 @@ class CommunityGrowthSkill(BaseSkill):
             "options": {"num_predict": max_tokens},
         }
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(ollama_url, json=payload) as resp:
-                if resp.status != 200:
-                    return {"success": False, "error": f"Ollama HTTP {resp.status}"}
-                data = await resp.json()
-                return {
-                    "success": True,
-                    "content": data.get("response", ""),
-                    "tokens_used": data.get("eval_count", 0),
-                }
+        async with get_http_client().tracked_request("POST", ollama_url, json=payload) as resp:
+            if resp.status != 200:
+                return {"success": False, "error": f"Ollama HTTP {resp.status}"}
+            data = await resp.json()
+            return {
+                "success": True,
+                "content": data.get("response", ""),
+                "tokens_used": data.get("eval_count", 0),
+            }
 
     async def _fill_template(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Substitute variables into a template string. Issue #1161."""

--- a/autobot-backend/skills/builtin/community_growth_test.py
+++ b/autobot-backend/skills/builtin/community_growth_test.py
@@ -6,7 +6,7 @@
 Unit tests for CommunityGrowthSkill.
 
 Issue #1161: Tests cover all 8 tools across success, error, and dry_run paths.
-External APIs (PRAW, aiohttp) are mocked throughout.
+External APIs (PRAW, the shared pooled HTTP client) are mocked throughout.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -290,20 +290,16 @@ async def test_github_get_releases_success(skill: CommunityGrowthSkill):
             }
         ]
     )
+    mock_inner_resp.__aenter__ = AsyncMock(return_value=mock_inner_resp)
+    mock_inner_resp.__aexit__ = AsyncMock(return_value=False)
 
-    request_cm = MagicMock()
-    request_cm.__aenter__ = AsyncMock(return_value=mock_inner_resp)
-    request_cm.__aexit__ = AsyncMock(return_value=False)
+    # #12979: routes through the shared pool's tracked_request() rather than
+    # constructing its own aiohttp.ClientSession, so the response mock is
+    # returned directly by a patched get_http_client().
+    mock_client = MagicMock()
+    mock_client.tracked_request = MagicMock(return_value=mock_inner_resp)
 
-    mock_session = MagicMock()
-    mock_session.get.return_value = request_cm
-
-    session_cm = MagicMock()
-    session_cm.__aenter__ = AsyncMock(return_value=mock_session)
-    session_cm.__aexit__ = AsyncMock(return_value=False)
-
-    with patch("skills.builtin.community_growth.aiohttp.ClientSession") as mock_cs:
-        mock_cs.return_value = session_cm
+    with patch("skills.builtin.community_growth.get_http_client", return_value=mock_client):
         result = await skill.execute("github_get_releases", {"repo": "mrveiss/AutoBot-AI", "limit": 1})
 
     assert result["success"] is True
@@ -335,20 +331,15 @@ async def test_llm_draft_content_success(skill: CommunityGrowthSkill):
             "eval_count": 42,
         }
     )
+    mock_inner_resp.__aenter__ = AsyncMock(return_value=mock_inner_resp)
+    mock_inner_resp.__aexit__ = AsyncMock(return_value=False)
 
-    request_cm = MagicMock()
-    request_cm.__aenter__ = AsyncMock(return_value=mock_inner_resp)
-    request_cm.__aexit__ = AsyncMock(return_value=False)
+    # #12979: routes through the shared pool's tracked_request() rather than
+    # constructing its own aiohttp.ClientSession.
+    mock_client = MagicMock()
+    mock_client.tracked_request = MagicMock(return_value=mock_inner_resp)
 
-    mock_session = MagicMock()
-    mock_session.post.return_value = request_cm
-
-    session_cm = MagicMock()
-    session_cm.__aenter__ = AsyncMock(return_value=mock_session)
-    session_cm.__aexit__ = AsyncMock(return_value=False)
-
-    with patch("skills.builtin.community_growth.aiohttp.ClientSession") as mock_cs:
-        mock_cs.return_value = session_cm
+    with patch("skills.builtin.community_growth.get_http_client", return_value=mock_client):
         result = await skill.execute(
             "llm_draft_content",
             {"prompt": "Write about AutoBot", "format": "reddit_post"},

--- a/autobot-backend/tests/test_raw_client_session_ceiling_12992.py
+++ b/autobot-backend/tests/test_raw_client_session_ceiling_12992.py
@@ -18,7 +18,13 @@ ratchet: it counts the constructions still present and asserts the count never
 newly added raw session turns the suite red at the point it is introduced.
 
 Measured 2026-07-30 (#12992), on ``Dev_new_gui`` at ``352e07cc7``:
-**87** constructions across the walked tree.
+**87** constructions across the walked tree. That measurement was already stale
+by the time it merged — batches #12991/#12994/#12999 had converted sites
+against a moving base — and read **71** by the time batch 6 (communication,
+community_growth, cloud, project_management, http_adapter integrations)
+started. Batch 6 removed 18 sites, landing at **53** (re-measured against
+``origin/Dev_new_gui`` immediately before push, per the note on
+``MAX_RAW_CLIENT_SESSIONS`` below).
 
 Unlike the ``xfail(strict=True)`` guard in
 ``autobot-slm-backend/tests/test_update_all_applies_roles_12959.py`` — which
@@ -55,7 +61,11 @@ BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
 #:    #12994 was still in flight. That PR merged and removed 25 constructions,
 #:    so the ceiling shipped ~25 too high — most of a conversion batch's worth
 #:    of slack — until it was caught in review. Sync, re-run, then push.
-MAX_RAW_CLIENT_SESSIONS = 87
+#:    Batch 6 hit the SAME trap in the opposite direction: this constant was
+#:    still 87 on ``origin/Dev_new_gui`` (stale from #12996) while the true
+#:    count had already fallen to 71 via #12991/#12994/#12999. Batch 6's own
+#:    conversion of 18 sites brought it to 53.
+MAX_RAW_CLIENT_SESSIONS = 53
 
 #: Directory names that are never part of the production surface being swept.
 EXCLUDED_DIR_NAMES = {"__pycache__", "tests", "test", ".pytest_cache", "node_modules"}


### PR DESCRIPTION
## Thinking Path

Batch 6 of #12979 (per the consolidated recipe + per-batch deltas already on the issue): the five densest remaining files as of batch 5's comment, none colliding with in-flight PR #13000 (telegram/tts). Read and classified every one of the 18 sites individually rather than sweeping on a signal — the recipe's own history shows the `*_json()`/`tracked_request()` ratio is unpredictable per-module (82%/0%/72%/0%/0% across the first five batches).

All 18 sites in this batch turned out to belong to the same shape: every one reads `response.status` and/or the body manually (structured error objects, sentinel results, or an empty-body branch before `json()`), so **zero** matched the `raise_for_status()+json()` `get_json()`/`post_json()` shape — a sixth data point for "count per file, never extrapolate."

`llc/adapters/http_adapter.py` got the extra scrutiny the task called for (an adapter may legitimately need to own its session lifetime). Its `_DEFAULT_TIMEOUT = ClientTimeout(total=None, connect=30)` looked like a candidate for a RAW carve-out, but `HTTPClientManager.request()` forwards `timeout=` straight to `session.request()` as a per-request override (confirmed in the issue's step-1 comment), so passing it as a kwarg to `tracked_request()` reproduces the exact behaviour. No connector=, no returned session, nothing long-lived — all three sites convert cleanly.

## What Changed

**Converted (18 sites, all `tracked_request()`):**
- `autobot-backend/integrations/communication_integration.py` (5) — Slack `_upload_file`/`_make_slack_request` (GET+POST), Teams `_post_webhook`/`_make_teams_request`, Discord `_make_discord_request`. All inspect `resp.status` for custom error handling (Slack: 429/5xx vs body-encoded `ok:false`; Teams/Discord: structured `{status_code, body}`).
- `autobot-backend/skills/builtin/community_growth.py` (4) — Twitter `_twitter_post` (checks `status==201`), Discord `_discord_notify` (200/204 vs `text()` on failure), GitHub `_github_get_releases` (200 list vs `text()` on failure), Ollama `_llm_draft_content` (200 vs sentinel). `import aiohttp` removed — no longer used in the file.
- `autobot-backend/integrations/cloud_integration.py` (3) — AWS `_make_aws_request` (reads `text()` → XML parse), Azure/GCP `_make_azure_request`/`_make_gcp_request` (read `json()`, return `status_code` alongside body — no `raise_for_status()`).
- `autobot-backend/integrations/project_management_integration.py` (3) — Jira `_jira_request` (204-empty-body branch before `json()`), Trello `_trello_request`, Asana `_asana_request` (all return `{status_code, body}` without raising).
- `autobot-backend/llc/adapters/http_adapter.py` (3) — `invoke()` (raises via `raise_for_status()` but dynamic HTTP method, so kept as `tracked_request()` + explicit `raise_for_status()` rather than `post_json()`, which only supports POST), `status()` (404 → structured `AdapterRunStatus`, the same "body never read for one branch" trap as batch 3's Jenkins finding), `cancel()` (POST + `raise_for_status()`, body never read at all — same shape as `JenkinsIntegration._trigger_build()`).

**RAW carve-outs:** none in this batch. `_DEFAULT_TIMEOUT`'s `total=None` is expressible as a per-request `timeout=` kwarg (see Thinking Path); no `connector=`, no returned-session, no long-lived construction among the 18.

**Test seams retargeted (3 files, 11 sites)** — found via `grep -rn 'patch(.*ClientSession'` across the whole repo, not just the touched directories, per the recipe:
- `autobot-backend/skills/builtin/community_growth_test.py` — 2 tests patched `skills.builtin.community_growth.aiohttp.ClientSession`; since `import aiohttp` is now gone from the module, this would have raised `AttributeError` at patch setup (not silently passed through). Retargeted to patch `get_http_client` and mock `tracked_request()`.
- `autobot-backend/llc/adapters/tests/test_adapters.py` — 8 `TestHttpAdapter` tests patched the global `aiohttp.ClientSession`; retargeted to patch `llc.adapters.http_adapter.get_http_client`.
- `autobot-backend/integrations/github_integration_test.py` — one test (`test_slack_make_request_429_applies_retry_after`) exercises `SlackIntegration._make_slack_request` from a file that shares no name with `communication_integration.py`; without the fix it would have dialled `https://slack.com/api/chat.postMessage` for real.

**Guard ceiling lowered:** `autobot-backend/tests/test_raw_client_session_ceiling_12992.py` `MAX_RAW_CLIENT_SESSIONS` 87 → 53. The 87 was already stale on `origin/Dev_new_gui` (three earlier batches had landed against it without the constant being updated); AST-measured actual before this batch was 71, and 71 − 18 = 53, confirmed by re-running the walker.

## Verification

**Static (all four required):**
```
py_compile   : OK, all 9 changed files
flake8       : 0 findings, all 9 files
black --check --line-length=120 : all 9 files unchanged
```

**Local-server exercise** (all 18 converted paths, success + failure branches, against a local `aiohttp.web` server — 39 requests):
```
exercised checks : 40   unexpected: 0
still-acquired   : 0
active_requests  : 0
```
Two sites with hardcoded external URLs (Twitter, GitHub releases — can't be safely redirected without editing production source) were verified via an equivalent-shape direct call through `get_http_client().tracked_request()` using the identical kwargs the converted method uses, rather than end-to-end, to avoid dialling the real internet.

**Test-seam diff against a `cp`-swapped baseline** (never `git stash`, per policy) — curated regression scope: both converted-file test files, `protocols_conformance_test.py`, `github_integration_test.py`, the `integration_unknown_action_contract_test.py` CWD-sensitive suite (#12993, run from repo root), and the two LLC scheduler test files that reference these integrations/adapters under full mocks:
```
baseline (origin/Dev_new_gui, cp-swapped) : 199 passed / 0 failed
after (this branch)                        : 199 passed / 0 failed
```
Identical pass set both times — the 11 retargeted mocks are exercised in that same 199, not held out.

**Ceiling guard:**
```
AST count, origin/Dev_new_gui (this branch's base) : 71
AST count, this branch (18 sites converted)        : 53
MAX_RAW_CLIENT_SESSIONS 87 → 53
```
Confirmed the negative case: monkeypatching the constant to `52` (ceiling−1) trips the assertion as expected. Branch was fetched against `origin/Dev_new_gui` immediately before push and found NOT behind (merge-base == origin tip), so 53 is current, not stale.

Closes nothing directly (#12979 stays open — repo-wide non-`autobot-backend` scope, and the gate-vs-sweep question, are both still open per the issue).

## Model Used

Claude Opus 4.5 (Sonnet 5)