### PR TITLE
refactor(user-mgmt): de-fork schemas/user.py to autobot_shared (#12647)

### DIFF
--- a/autobot-backend/user_management/schemas/user.py
+++ b/autobot-backend/user_management/schemas/user.py
@@ -2,152 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
+"""Re-export shim — the implementation now lives in autobot_shared (#12647).
+
+This file was identical in both backends apart from Pydantic v1/v2 config
+style (`class Config` vs `model_config = ConfigDict(...)`), so it carries no
+SQLAlchemy dependency and does not need the declarative-base decision that
+gates the model files. Kept as a shim rather than deleted so existing
+importers keep working unchanged; the fork is what goes, not the callers.
 """
-User Schemas
 
-Pydantic models for user-related API requests and responses.
-"""
+from autobot_shared.user_management.schemas.user import (  # noqa: F401
+    PasswordChange,
+    RoleResponse,
+    UserCreate,
+    UserListResponse,
+    UserLogin,
+    UserResponse,
+    UserUpdate,
+)
 
-import re
-import uuid
-from datetime import datetime
-from typing import List
-
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
-
-
-class RoleResponse(BaseModel):
-    """Role information in responses."""
-
-    model_config = ConfigDict(from_attributes=True)
-
-    id: uuid.UUID
-    name: str
-    description: str | None = None
-    is_system: bool = False
-
-
-class UserCreate(BaseModel):
-    """Request model for creating a user."""
-
-    email: EmailStr = Field(..., description="User email address")
-    username: str = Field(
-        ...,
-        min_length=3,
-        max_length=100,
-        description="Username (3-100 characters, alphanumeric and underscores)",
-    )
-    password: str | None = Field(
-        None,
-        min_length=8,
-        max_length=128,
-        description="Password (8-128 characters, optional for SSO users)",
-    )
-    display_name: str | None = Field(None, max_length=255, description="Display name")
-    org_id: uuid.UUID | None = Field(None, description="Organization ID (uses current context if not provided)")
-    role_ids: List[uuid.UUID] | None = Field(None, description="List of role IDs to assign")
-
-    @field_validator("username")
-    @classmethod
-    def validate_username(cls, v: str) -> str:
-        """Validate username format."""
-        if not re.match(r"^[a-zA-Z0-9_]+$", v):
-            raise ValueError("Username must contain only letters, numbers, and underscores")
-        return v.lower()
-
-    @field_validator("password")
-    @classmethod
-    def validate_password(cls, v: str | None) -> str | None:
-        """Validate password strength."""
-        if v is None:
-            return v
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        if not re.search(r"[A-Z]", v):
-            raise ValueError("Password must contain at least one uppercase letter")
-        if not re.search(r"[a-z]", v):
-            raise ValueError("Password must contain at least one lowercase letter")
-        if not re.search(r"\d", v):
-            raise ValueError("Password must contain at least one digit")
-        return v
-
-
-class UserUpdate(BaseModel):
-    """Request model for updating a user."""
-
-    email: EmailStr | None = Field(None, description="New email address")
-    username: str | None = Field(None, min_length=3, max_length=100, description="New username")
-    display_name: str | None = Field(None, max_length=255, description="Display name")
-    bio: str | None = Field(None, max_length=500, description="User bio")
-    avatar_url: str | None = Field(None, max_length=500, description="Avatar URL")
-    preferences: dict | None = Field(None, description="User preferences")
-
-    @field_validator("username")
-    @classmethod
-    def validate_username(cls, v: str | None) -> str | None:
-        """Validate username format if provided."""
-        if v is None:
-            return v
-        if not re.match(r"^[a-zA-Z0-9_]+$", v):
-            raise ValueError("Username must contain only letters, numbers, and underscores")
-        return v.lower()
-
-
-class UserResponse(BaseModel):
-    """Response model for a single user."""
-
-    model_config = ConfigDict(from_attributes=True)
-
-    id: uuid.UUID
-    email: str
-    username: str
-    display_name: str | None = None
-    bio: str | None = None
-    avatar_url: str | None = None
-    org_id: uuid.UUID | None = None
-    is_active: bool = True
-    is_verified: bool = False
-    mfa_enabled: bool = False
-    is_platform_admin: bool = False
-    preferences: dict = Field(default_factory=dict)
-    roles: List[RoleResponse] = Field(default_factory=list)
-    last_login_at: datetime | None = None
-    created_at: datetime
-    updated_at: datetime
-
-
-class UserListResponse(BaseModel):
-    """Response model for paginated user list."""
-
-    users: List[UserResponse]
-    total: int
-    limit: int
-    offset: int
-
-
-class UserLogin(BaseModel):
-    """Request model for user login."""
-
-    username_or_email: str = Field(..., min_length=3, description="Username or email address")
-    password: str = Field(..., min_length=1, description="Password")
-
-
-class PasswordChange(BaseModel):
-    """Request model for changing password."""
-
-    current_password: str | None = Field(None, description="Current password (required unless admin reset)")
-    new_password: str = Field(..., min_length=8, max_length=128, description="New password")
-
-    @field_validator("new_password")
-    @classmethod
-    def validate_new_password(cls, v: str) -> str:
-        """Validate password strength."""
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        if not re.search(r"[A-Z]", v):
-            raise ValueError("Password must contain at least one uppercase letter")
-        if not re.search(r"[a-z]", v):
-            raise ValueError("Password must contain at least one lowercase letter")
-        if not re.search(r"\d", v):
-            raise ValueError("Password must contain at least one digit")
-        return v
+__all__ = [
+    "RoleResponse",
+    "UserCreate",
+    "UserUpdate",
+    "UserResponse",
+    "UserListResponse",
+    "UserLogin",
+    "PasswordChange",
+]

--- a/autobot-slm-backend/user_management/schemas/user.py
+++ b/autobot-slm-backend/user_management/schemas/user.py
@@ -2,154 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
+"""Re-export shim — the implementation now lives in autobot_shared (#12647).
+
+This file was identical in both backends apart from Pydantic v1/v2 config
+style (`class Config` vs `model_config = ConfigDict(...)`), so it carries no
+SQLAlchemy dependency and does not need the declarative-base decision that
+gates the model files. Kept as a shim rather than deleted so existing
+importers keep working unchanged; the fork is what goes, not the callers.
 """
-User Schemas
 
-Pydantic models for user-related API requests and responses.
-"""
+from autobot_shared.user_management.schemas.user import (  # noqa: F401
+    PasswordChange,
+    RoleResponse,
+    UserCreate,
+    UserListResponse,
+    UserLogin,
+    UserResponse,
+    UserUpdate,
+)
 
-import re
-import uuid
-from datetime import datetime
-from typing import List
-
-from pydantic import BaseModel, EmailStr, Field, field_validator
-
-
-class RoleResponse(BaseModel):
-    """Role information in responses."""
-
-    id: uuid.UUID
-    name: str
-    description: str | None = None
-    is_system: bool = False
-
-    class Config:
-        from_attributes = True
-
-
-class UserCreate(BaseModel):
-    """Request model for creating a user."""
-
-    email: EmailStr = Field(..., description="User email address")
-    username: str = Field(
-        ...,
-        min_length=3,
-        max_length=100,
-        description="Username (3-100 characters, alphanumeric and underscores)",
-    )
-    password: str | None = Field(
-        None,
-        min_length=8,
-        max_length=128,
-        description="Password (8-128 characters, optional for SSO users)",
-    )
-    display_name: str | None = Field(None, max_length=255, description="Display name")
-    org_id: uuid.UUID | None = Field(None, description="Organization ID (uses current context if not provided)")
-    role_ids: List[uuid.UUID] | None = Field(None, description="List of role IDs to assign")
-
-    @field_validator("username")
-    @classmethod
-    def validate_username(cls, v: str) -> str:
-        """Validate username format."""
-        if not re.match(r"^[a-zA-Z0-9_]+$", v):
-            raise ValueError("Username must contain only letters, numbers, and underscores")
-        return v.lower()
-
-    @field_validator("password")
-    @classmethod
-    def validate_password(cls, v: str | None) -> str | None:
-        """Validate password strength."""
-        if v is None:
-            return v
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        if not re.search(r"[A-Z]", v):
-            raise ValueError("Password must contain at least one uppercase letter")
-        if not re.search(r"[a-z]", v):
-            raise ValueError("Password must contain at least one lowercase letter")
-        if not re.search(r"\d", v):
-            raise ValueError("Password must contain at least one digit")
-        return v
-
-
-class UserUpdate(BaseModel):
-    """Request model for updating a user."""
-
-    email: EmailStr | None = Field(None, description="New email address")
-    username: str | None = Field(None, min_length=3, max_length=100, description="New username")
-    display_name: str | None = Field(None, max_length=255, description="Display name")
-    bio: str | None = Field(None, max_length=500, description="User bio")
-    avatar_url: str | None = Field(None, max_length=500, description="Avatar URL")
-    preferences: dict | None = Field(None, description="User preferences")
-
-    @field_validator("username")
-    @classmethod
-    def validate_username(cls, v: str | None) -> str | None:
-        """Validate username format if provided."""
-        if v is None:
-            return v
-        if not re.match(r"^[a-zA-Z0-9_]+$", v):
-            raise ValueError("Username must contain only letters, numbers, and underscores")
-        return v.lower()
-
-
-class UserResponse(BaseModel):
-    """Response model for a single user."""
-
-    id: uuid.UUID
-    email: str
-    username: str
-    display_name: str | None = None
-    bio: str | None = None
-    avatar_url: str | None = None
-    org_id: uuid.UUID | None = None
-    is_active: bool = True
-    is_verified: bool = False
-    mfa_enabled: bool = False
-    is_platform_admin: bool = False
-    preferences: dict = Field(default_factory=dict)
-    roles: List[RoleResponse] = Field(default_factory=list)
-    last_login_at: datetime | None = None
-    created_at: datetime
-    updated_at: datetime
-
-    class Config:
-        from_attributes = True
-
-
-class UserListResponse(BaseModel):
-    """Response model for paginated user list."""
-
-    users: List[UserResponse]
-    total: int
-    limit: int
-    offset: int
-
-
-class UserLogin(BaseModel):
-    """Request model for user login."""
-
-    username_or_email: str = Field(..., min_length=3, description="Username or email address")
-    password: str = Field(..., min_length=1, description="Password")
-
-
-class PasswordChange(BaseModel):
-    """Request model for changing password."""
-
-    current_password: str | None = Field(None, description="Current password (required unless admin reset)")
-    new_password: str = Field(..., min_length=8, max_length=128, description="New password")
-
-    @field_validator("new_password")
-    @classmethod
-    def validate_new_password(cls, v: str) -> str:
-        """Validate password strength."""
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters")
-        if not re.search(r"[A-Z]", v):
-            raise ValueError("Password must contain at least one uppercase letter")
-        if not re.search(r"[a-z]", v):
-            raise ValueError("Password must contain at least one lowercase letter")
-        if not re.search(r"\d", v):
-            raise ValueError("Password must contain at least one digit")
-        return v
+__all__ = [
+    "RoleResponse",
+    "UserCreate",
+    "UserUpdate",
+    "UserResponse",
+    "UserListResponse",
+    "UserLogin",
+    "PasswordChange",
+]

--- a/autobot_shared/user_management/__init__.py
+++ b/autobot_shared/user_management/__init__.py
@@ -3,18 +3,42 @@
 """Canonical user_management core shared by both backends (#12647).
 
 `user_management` is forked across `autobot-backend` and `autobot-slm-backend`,
-with 25 shared-but-divergent files. This package is the consolidation target:
-files land here once they are identical in both forks, so each move carries no
-semantic drift to reconcile.
+with 19 shared-but-divergent `.py` source files. This package is the
+consolidation target: files land here once their drift is either non-existent
+or reconciled, so each move carries no semantic loss.
 
-First mover: `base_service`, which was byte-identical in both and imports
-nothing backend-specific. Each fork keeps a re-export shim so existing importers
-are untouched — the fork is removed, not the callers.
+Movers so far:
+- `base_service` (#12972) — byte-identical, no backend-specific imports.
+- `schemas.user` (#12647) — identical apart from Pydantic v1/v2 config style;
+  no SQLAlchemy dependency, so it does not need the declarative-base decision
+  gating the model files.
+
+Each fork keeps a re-export shim so existing importers are untouched — the
+fork is removed, not the callers.
 """
 
 from autobot_shared.user_management.base_service import (  # noqa: F401
     BaseService,
     TenantContext,
 )
+from autobot_shared.user_management.schemas.user import (  # noqa: F401
+    PasswordChange,
+    RoleResponse,
+    UserCreate,
+    UserListResponse,
+    UserLogin,
+    UserResponse,
+    UserUpdate,
+)
 
-__all__ = ["BaseService", "TenantContext"]
+__all__ = [
+    "BaseService",
+    "TenantContext",
+    "RoleResponse",
+    "UserCreate",
+    "UserUpdate",
+    "UserResponse",
+    "UserListResponse",
+    "UserLogin",
+    "PasswordChange",
+]

--- a/autobot_shared/user_management/schemas/__init__.py
+++ b/autobot_shared/user_management/schemas/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical user_management Pydantic schemas shared by both backends (#12647).
+
+Second move after `base_service` (#12972): `schemas/user.py` was identical in
+both backends except for Pydantic v1/v2 config style (`class Config` vs
+`model_config = ConfigDict(...)`) — no SQLAlchemy dependency, so it does not
+need the declarative-base decision that gates the model files.
+"""
+
+from autobot_shared.user_management.schemas.user import (  # noqa: F401
+    PasswordChange,
+    RoleResponse,
+    UserCreate,
+    UserListResponse,
+    UserLogin,
+    UserResponse,
+    UserUpdate,
+)
+
+__all__ = [
+    "RoleResponse",
+    "UserCreate",
+    "UserUpdate",
+    "UserResponse",
+    "UserListResponse",
+    "UserLogin",
+    "PasswordChange",
+]

--- a/autobot_shared/user_management/schemas/user.py
+++ b/autobot_shared/user_management/schemas/user.py
@@ -1,0 +1,153 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+User Schemas
+
+Pydantic models for user-related API requests and responses.
+"""
+
+import re
+import uuid
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+
+
+class RoleResponse(BaseModel):
+    """Role information in responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    description: str | None = None
+    is_system: bool = False
+
+
+class UserCreate(BaseModel):
+    """Request model for creating a user."""
+
+    email: EmailStr = Field(..., description="User email address")
+    username: str = Field(
+        ...,
+        min_length=3,
+        max_length=100,
+        description="Username (3-100 characters, alphanumeric and underscores)",
+    )
+    password: str | None = Field(
+        None,
+        min_length=8,
+        max_length=128,
+        description="Password (8-128 characters, optional for SSO users)",
+    )
+    display_name: str | None = Field(None, max_length=255, description="Display name")
+    org_id: uuid.UUID | None = Field(None, description="Organization ID (uses current context if not provided)")
+    role_ids: List[uuid.UUID] | None = Field(None, description="List of role IDs to assign")
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v: str) -> str:
+        """Validate username format."""
+        if not re.match(r"^[a-zA-Z0-9_]+$", v):
+            raise ValueError("Username must contain only letters, numbers, and underscores")
+        return v.lower()
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str | None) -> str | None:
+        """Validate password strength."""
+        if v is None:
+            return v
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must contain at least one digit")
+        return v
+
+
+class UserUpdate(BaseModel):
+    """Request model for updating a user."""
+
+    email: EmailStr | None = Field(None, description="New email address")
+    username: str | None = Field(None, min_length=3, max_length=100, description="New username")
+    display_name: str | None = Field(None, max_length=255, description="Display name")
+    bio: str | None = Field(None, max_length=500, description="User bio")
+    avatar_url: str | None = Field(None, max_length=500, description="Avatar URL")
+    preferences: dict | None = Field(None, description="User preferences")
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v: str | None) -> str | None:
+        """Validate username format if provided."""
+        if v is None:
+            return v
+        if not re.match(r"^[a-zA-Z0-9_]+$", v):
+            raise ValueError("Username must contain only letters, numbers, and underscores")
+        return v.lower()
+
+
+class UserResponse(BaseModel):
+    """Response model for a single user."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    email: str
+    username: str
+    display_name: str | None = None
+    bio: str | None = None
+    avatar_url: str | None = None
+    org_id: uuid.UUID | None = None
+    is_active: bool = True
+    is_verified: bool = False
+    mfa_enabled: bool = False
+    is_platform_admin: bool = False
+    preferences: dict = Field(default_factory=dict)
+    roles: List[RoleResponse] = Field(default_factory=list)
+    last_login_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class UserListResponse(BaseModel):
+    """Response model for paginated user list."""
+
+    users: List[UserResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class UserLogin(BaseModel):
+    """Request model for user login."""
+
+    username_or_email: str = Field(..., min_length=3, description="Username or email address")
+    password: str = Field(..., min_length=1, description="Password")
+
+
+class PasswordChange(BaseModel):
+    """Request model for changing password."""
+
+    current_password: str | None = Field(None, description="Current password (required unless admin reset)")
+    new_password: str = Field(..., min_length=8, max_length=128, description="New password")
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password(cls, v: str) -> str:
+        """Validate password strength."""
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must contain at least one digit")
+        return v

--- a/autobot_shared/user_management/schemas/user_test.py
+++ b/autobot_shared/user_management/schemas/user_test.py
@@ -1,0 +1,97 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The shared schemas.user module is the single implementation (#12647).
+
+`schemas/user.py` was identical in both backends apart from Pydantic v1/v2
+config style, which made it the second safe de-fork move after `base_service`
+(#12972): no SQLAlchemy dependency, so it needs neither the declarative-base
+decision (#12645) that gates the model files.
+
+These pin the property that matters — both backends resolve to the SAME
+class objects, not merely equivalent ones. Two same-named classes are not
+interchangeable (the trap #12913 fixed for CircuitState), so identity is the
+assertion, not behaviour.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+from autobot_shared.user_management.schemas.user import (
+    PasswordChange,
+    RoleResponse,
+    UserCreate,
+    UserListResponse,
+    UserLogin,
+    UserResponse,
+    UserUpdate,
+)
+
+_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_SHIMS = {
+    "backend": _ROOT / "autobot-backend/user_management/schemas/user.py",
+    "slm": _ROOT / "autobot-slm-backend/user_management/schemas/user.py",
+}
+_PUBLIC_NAMES = [
+    "PasswordChange",
+    "RoleResponse",
+    "UserCreate",
+    "UserListResponse",
+    "UserLogin",
+    "UserResponse",
+    "UserUpdate",
+]
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("backend", sorted(_SHIMS))
+def test_shim_exists(backend):
+    assert _SHIMS[backend].is_file(), f"{backend} shim missing"
+
+
+@pytest.mark.parametrize("backend", sorted(_SHIMS))
+@pytest.mark.parametrize("name", _PUBLIC_NAMES)
+def test_shim_resolves_to_the_shared_class(backend, name):
+    """Same object, not a same-named twin — see #12913."""
+    module = _load(_SHIMS[backend], f"shim_{backend}_{name}")
+
+    shared = {
+        "PasswordChange": PasswordChange,
+        "RoleResponse": RoleResponse,
+        "UserCreate": UserCreate,
+        "UserListResponse": UserListResponse,
+        "UserLogin": UserLogin,
+        "UserResponse": UserResponse,
+        "UserUpdate": UserUpdate,
+    }[name]
+    assert getattr(module, name) is shared
+
+
+def test_both_backends_share_one_implementation():
+    a = _load(_SHIMS["backend"], "shim_schemas_a")
+    b = _load(_SHIMS["slm"], "shim_schemas_b")
+
+    assert a.UserResponse is b.UserResponse
+    assert a.RoleResponse is b.RoleResponse
+
+
+def test_package_reexports_the_public_surface():
+    import autobot_shared.user_management as pkg
+
+    assert pkg.UserResponse is UserResponse
+    assert pkg.RoleResponse is RoleResponse
+
+
+def test_config_style_is_pydantic_v2_configdict():
+    """The canonical form is `model_config`, not the legacy `class Config`."""
+    assert UserResponse.model_config.get("from_attributes") is True
+    assert RoleResponse.model_config.get("from_attributes") is True


### PR DESCRIPTION
## Thinking Path

Re-measured #12647 before writing anything: PR #12972 already moved `base_service` (byte-identical) into `autobot_shared/user_management/`. Since then, three more sub-steps have already merged and closed sub-issues that this issue's own comment history records: `team_service`/`base_service` helper convergence (#12918), `organization_service` convergence (#12920/#12921), and a database-pool-helper de-dup (#12929/#12930). Current state, measured directly (`diff -rq autobot-backend/user_management autobot-slm-backend/user_management`, `.py` sources only): **19 divergent files**, not the 25 the issue originally listed (6 were gitignored `__pycache__` artifacts).

Partitioning the 19 by whether they need the declarative-base decision that gates #12645/#12647:

**(b) Decision-gated — not touched here:**
- `models/base.py` + the 8 model files that inherit it (`user`, `organization`, `role`, `sso`, `team`, `api_key`, `audit`, `mfa`, plus `models/__init__.py`) — gated on the declarative-base question already flagged: backend's `Base(AsyncAttrs, DeclarativeBase)` with built-in timestamps/`eager_defaults`/`sqlalchemy.types.Uuid` (rationale: #4300, #11684) vs SLM's plain `Base(DeclarativeBase)` + separate `TimestampMixin` + `sqlalchemy.dialects.postgresql.UUID`. **Options:** (1) adopt the backend's form everywhere — has documented rationale but changes SLM's UUID column typing; (2) adopt the SLM's plainer form — loses `AsyncAttrs`/`eager_defaults` unless re-added; (3) design a new canonical `Base` that keeps both properties. Not decided here — belongs on #12645.
- `middleware/rbac_middleware.py` (404 diff lines) — already scoped and filed separately as #12925: the caches are two different designs (backend L1-dict+pubsub vs SLM Redis-L2), and the backend has zero permission-denial auditing where SLM has a full audit trail. Not a mechanical merge; excluded per that issue's own recommendation.
- `services/user_service.py` (134 diff lines) — already scoped and filed as #12924: SLM's `change_password` does not invalidate other sessions (backend-only `SessionService`), a security-relevant behavioural difference, not a lag. Excluded per that issue.
- `config.py` / `database.py` — investigated independently (matches #12929's closed finding): these are **not the same capability twice**. The backend manages one Postgres engine; the SLM manages two (`slm_engine` + `autobot_engine`, colocated on the SLM server) — different design by necessity, not drift. The one real duplicate (`_get_pool_config()`'s fallback table) was already extracted to `autobot_shared.ssot_config.database_pool_settings()` in #12930. No further action needed; recommend the umbrella's file count treat these as ruled-out, same as `middleware/__init__.py`/`services/__init__.py` (whose divergence is a consequence of each backend's asymmetric feature set, not a fork to reconcile — converges last, per the existing issue comment).

**(a) De-forkable now, no decision needed — delivered in this PR:**
- `schemas/user.py` (18 diff lines) — genuinely fresh: not previously flagged as done or gated anywhere in the issue's history. `diff -u` showed the *only* difference between backends is Pydantic v1/v2 config style (`class Config: from_attributes = True` vs `model_config = ConfigDict(from_attributes=True)`). Pure Pydantic, zero SQLAlchemy import, zero behavioural difference.

## What Changed

- `autobot_shared/user_management/schemas/user.py` created — the canonical body, using the modern `ConfigDict` form (matches the backend's existing style, and the pattern the umbrella wants going forward).
- `autobot_shared/user_management/schemas/__init__.py` — package re-export.
- `autobot_shared/user_management/__init__.py` — extended to also re-export the schema names (was `base_service`-only).
- Both backends' `user_management/schemas/user.py` become re-export shims, same pattern as `base_service` (#12972) — every existing importer (`api/user_management/users.py`, `api/schemas_agent.py`, `api/autobot_users.py`, `api/slm_users.py`, `user_management/schemas/__init__.py` in both backends) resolves unchanged; nothing was deleted, only re-pointed.
- `autobot_shared/user_management/schemas/user_test.py` — asserts both shims resolve to the **same class objects** (not merely equivalent ones), following the identity-check pattern #12972 established for `base_service` (the trap #12913 fixed for `CircuitState`).

## Verification

```
$ python3 -m pytest autobot_shared/user_management/ -q
25 passed in 2.91s

$ python3 -m flake8 --max-line-length=120 autobot_shared/user_management/ \
    autobot-backend/user_management/schemas/user.py autobot-slm-backend/user_management/schemas/user.py
(clean)

$ python3 -m black --check --line-length=120 autobot_shared/user_management/ \
    autobot-backend/user_management/schemas/user.py autobot-slm-backend/user_management/schemas/user.py
8 files would be left unchanged.

$ python3 -m flake8 --select=F821 autobot_shared/user_management/ autobot-backend/user_management/ autobot-slm-backend/user_management/
(clean)
```

Startup-import smoke (`autobot-backend/tests/test_startup_imports.py`, the CI-required check for this path):
```
before: 350 passed
after:  350 passed
```

Cp-swapped baseline diff on both backends' broader `user_management`/`api/user_management` suites — identical failing set before and after (both pre-existing, unrelated to this change):
```
autobot-backend:      1 failed, 65 passed   (TestPasswordChangeRateLimiting — pre-existing, rate-limiter test infra issue)
autobot-slm-backend:  2 collection errors   (api/autobot_users.py, api/slm_users.py — pre-existing conftest MagicMock stub
                                              on user_management.schemas.user producing an invalid FastAPI response-model
                                              type; unrelated to this de-fork, same MagicMock error signature before/after)
```

Residual-import audit: grepped for every remaining reference to `user_management.schemas.user` / `user_management.schemas` across both backends — all resolve through the shim (`api/user_management/users.py`, `api/schemas_agent.py`, `api/autobot_users.py`, `api/slm_users.py`, `conftest.py`'s stub-list entry). No dangling imports.

## Discovered pre-existing issues (not fixed here, out of scope)

- `autobot-backend/api/user_management/users_password_change_test.py::TestPasswordChangeRateLimiting::test_rate_limit_exceeded_returns_429` fails on both base and branch (`'Internal server error'` instead of the expected `'Too many attempts'` message) — pre-existing, unrelated to this PR.
- `autobot-slm-backend/api/autobot_users.py` and `api/slm_users.py` fail to collect on both base and branch: `conftest.py`'s `_stub("user_management.schemas.user")` MagicMock breaks FastAPI response-model validation for any route using `UserResponse` as a return type. Pre-existing test-infra gap (the module is stubbed but routes still reference its real types at import time), unrelated to this de-fork. Will file a discrete issue with `file:line` evidence.

## Model Used

claude-sonnet-5