### PR TITLE
feat(research): findings->KB facts + grounded /research synthesis (#12622)

### DIFF
--- a/autobot-backend/async_chat_workflow.py
+++ b/autobot-backend/async_chat_workflow.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.ssot_config import config
 from constants.threshold_constants import TimingConstants
 from dependency_container import inject_services
 from knowledge.search import map_kb_result_to_dict
@@ -25,6 +26,13 @@ from llm_shared.models import ChatMessage, LLMResponse  # Phase 2D #3185
 from retry_mechanism import RetryConfig, RetryStrategy, with_retry
 
 logger = get_logger(__name__)
+
+# #12622: web-research facts are quarantined in a dedicated KB collection until
+# Phase 1's corroboration/promotion gate (#12623) reviews them, so general
+# chat/RAG must never surface them. ``$ne`` also matches facts that predate
+# this field entirely (no "collection" key), verified against the installed
+# ChromaDB via a standalone metadata-filter check.
+_RESEARCH_QUARANTINE_FILTER = {"collection": {"$ne": config.research_quarantine_collection}}
 
 # Performance optimization: O(1) lookup for message classification keywords (Issue #326)
 TERMINAL_KEYWORDS = {"terminal", "command", "bash", "shell", "run"}
@@ -224,7 +232,7 @@ class AsyncChatWorkflow:
             if kb is None:
                 logger.warning("Knowledge base unavailable; skipping search for query: %.80s", query)
                 return KnowledgeStatus.MISSING, []
-            raw: List[Dict[str, Any]] = await kb.search(query=query, top_k=5)
+            raw: List[Dict[str, Any]] = await kb.search(query=query, top_k=5, filters=_RESEARCH_QUARANTINE_FILTER)
             if not raw:
                 return KnowledgeStatus.MISSING, []
             results = [map_kb_result_to_dict(r) for r in raw]  # Issue #10740

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -599,6 +599,13 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["autoresearch"],
         "autoresearch",
     ),
+    # Issue #12622: Research agent P0 — findings -> KB facts + grounded /research synthesis
+    (
+        "services.research.routes",
+        "/research",
+        ["research"],
+        "research",
+    ),
     # Issue #2165: Workflow export/import/sharing
     (
         "api.workflow_export",

--- a/autobot-backend/services/research/__init__.py
+++ b/autobot-backend/services/research/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Research agent (Phase 0): findings -> KB facts + grounded /research synthesis.
+
+Issue #12622 (child of umbrella #12621). See
+``docs/architecture/RESEARCH_AGENT_PRECISION_EFFICIENCY_DESIGN.md`` for the
+full architecture. This package composes existing KB/fetch/search modules
+into one bounded coordinator; it introduces no parallel store.
+"""

--- a/autobot-backend/services/research/extractor.py
+++ b/autobot-backend/services/research/extractor.py
@@ -1,0 +1,113 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Atomic-claim extraction from a fetched research page (#12622, design §4.5).
+
+Reuses the shared LLM service and the shared fence-tolerant JSON parser
+(``llm_shared.json_utils``) rather than inventing a new prompt-parsing layer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+from llm_shared.json_utils import extract_json_object
+
+from .models import ExtractedClaim
+
+logger = get_logger(__name__)
+
+# A claim must share at least this fraction of its distinctive (4+ char)
+# words with the source text to count as "supported" — a cheap, deterministic
+# anti-hallucination guard (design §4.5: "no claim invented that isn't
+# supported by the fetched text").
+_MIN_SUPPORT_OVERLAP = 0.5
+_WORD_RE = re.compile(r"[a-z0-9]{4,}")
+
+_EXTRACTION_SYSTEM_PROMPT = (
+    "You extract atomic factual claims from web page text for a research tool. "
+    "Rules: (1) every claim must be directly stated or clearly implied by the "
+    "given text — never add outside knowledge; (2) each claim is one "
+    "self-contained sentence; (3) assign a confidence 0.0-1.0 reflecting how "
+    "explicitly the text states it. Respond with ONLY a JSON object: "
+    '{"claims": [{"content": str, "confidence": float}, ...]}. '
+    "If the text contains no extractable factual claims, return an empty list."
+)
+
+
+def _build_extraction_messages(content: str) -> List[Dict[str, str]]:
+    """Build the chat messages for one claim-extraction call."""
+    return [
+        {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+        {"role": "user", "content": content},
+    ]
+
+
+def _distinctive_words(text: str) -> set:
+    """Return the lowercase 4+ char word set of *text* (cheap overlap key)."""
+    return set(_WORD_RE.findall(text.lower()))
+
+
+def _is_supported_by_source(claim_text: str, source_content: str) -> bool:
+    """Reject a claim whose wording has little overlap with the source text."""
+    claim_words = _distinctive_words(claim_text)
+    if not claim_words:
+        return False
+    source_words = _distinctive_words(source_content)
+    overlap = len(claim_words & source_words) / len(claim_words)
+    return overlap >= _MIN_SUPPORT_OVERLAP
+
+
+def _parse_claims_payload(raw_content: str) -> List[Dict[str, Any]]:
+    """Parse the LLM's JSON response into a list of raw claim dicts."""
+    try:
+        payload = extract_json_object(raw_content)
+    except json.JSONDecodeError:
+        logger.warning("extract_claims: LLM response was not valid JSON; skipping page")
+        return []
+    claims = payload.get("claims", [])
+    return claims if isinstance(claims, list) else []
+
+
+def _to_extracted_claim(raw: Dict[str, Any], url: str, doc_id: str) -> ExtractedClaim | None:
+    """Convert one raw claim dict to an ``ExtractedClaim``, or None if malformed."""
+    text = str(raw.get("content", "")).strip()
+    if not text:
+        return None
+    try:
+        confidence = float(raw.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+    return ExtractedClaim(content=text, confidence=confidence, source_url=url, source_doc_id=doc_id)
+
+
+async def extract_claims(
+    llm_service: Any,
+    content: str,
+    url: str,
+    source_doc_id: str,
+    max_content_chars: int,
+) -> List[ExtractedClaim]:
+    """Extract atomic, source-supported claims from one fetched page.
+
+    Truncates *content* to *max_content_chars* (token-ceiling budget, design
+    §4.1) before sending it to the LLM. Every returned claim has already
+    passed the ``_is_supported_by_source`` overlap guard.
+    """
+    truncated = content[:max_content_chars]
+    response = await llm_service.chat(messages=_build_extraction_messages(truncated), temperature=0.0)
+    if response.error:
+        logger.warning("extract_claims: LLM call failed for %s: %s", url, response.error)
+        return []
+
+    claims: List[ExtractedClaim] = []
+    for raw in _parse_claims_payload(response.content):
+        claim = _to_extracted_claim(raw, url, source_doc_id)
+        if claim is not None and _is_supported_by_source(claim.content, truncated):
+            claims.append(claim)
+    return claims

--- a/autobot-backend/services/research/extractor_test.py
+++ b/autobot-backend/services/research/extractor_test.py
@@ -1,0 +1,96 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for services.research.extractor (#12622).
+
+Covers the happy path, the anti-hallucination overlap guard, and the
+failure paths (LLM error, malformed JSON).
+"""
+
+from unittest.mock import AsyncMock
+
+from services.research.extractor import extract_claims
+
+_SOURCE_TEXT = (
+    "The Eiffel Tower was completed in 1889 for the World's Fair in Paris. "
+    "It stands 330 meters tall and was designed by engineer Gustave Eiffel."
+)
+
+
+def _mock_llm(content: str, error: str = "") -> AsyncMock:
+    llm = AsyncMock()
+    response = AsyncMock()
+    response.content = content
+    response.error = error
+    llm.chat = AsyncMock(return_value=response)
+    return llm
+
+
+class TestExtractClaims:
+    """Happy path + anti-hallucination guard."""
+
+    async def test_supported_claim_is_kept(self):
+        """A claim whose wording overlaps the source text is kept."""
+        llm = _mock_llm('{"claims": [{"content": "The Eiffel Tower was completed in 1889.", "confidence": 0.9}]}')
+
+        claims = await extract_claims(llm, _SOURCE_TEXT, "https://example.com/eiffel", "doc-1", 8000)
+
+        assert len(claims) == 1
+        assert claims[0].confidence == 0.9
+        assert claims[0].source_url == "https://example.com/eiffel"
+        assert claims[0].source_doc_id == "doc-1"
+
+    async def test_unsupported_claim_is_dropped(self):
+        """A claim with no wording overlap with the source is rejected (anti-hallucination)."""
+        llm = _mock_llm('{"claims": [{"content": "Bananas grow best in tropical climates.", "confidence": 0.9}]}')
+
+        claims = await extract_claims(llm, _SOURCE_TEXT, "https://example.com/eiffel", "doc-1", 8000)
+
+        assert claims == []
+
+    async def test_confidence_is_clamped(self):
+        """An out-of-range confidence value is clamped to [0, 1]."""
+        llm = _mock_llm('{"claims": [{"content": "The Eiffel Tower stands 330 meters tall.", "confidence": 5.0}]}')
+
+        claims = await extract_claims(llm, _SOURCE_TEXT, "https://example.com/eiffel", "doc-1", 8000)
+
+        assert claims[0].confidence == 1.0
+
+    async def test_content_truncated_to_budget(self):
+        """Only the first max_content_chars of the page are sent to the LLM."""
+        llm = _mock_llm('{"claims": []}')
+        long_text = "word " * 5000
+
+        await extract_claims(llm, long_text, "https://example.com/x", "doc-2", 100)
+
+        sent_content = llm.chat.await_args.kwargs["messages"][1]["content"]
+        assert len(sent_content) == 100
+
+
+class TestExtractClaimsFailurePaths:
+    """LLM failure and malformed-JSON paths must degrade to an empty list."""
+
+    async def test_llm_error_returns_empty(self):
+        """A non-empty response.error short-circuits to no claims."""
+        llm = _mock_llm("", error="model unavailable")
+
+        claims = await extract_claims(llm, _SOURCE_TEXT, "https://example.com/x", "doc-1", 8000)
+
+        assert claims == []
+
+    async def test_malformed_json_returns_empty(self):
+        """Non-JSON LLM output degrades to no claims instead of raising."""
+        llm = _mock_llm("this is not json at all")
+
+        claims = await extract_claims(llm, _SOURCE_TEXT, "https://example.com/x", "doc-1", 8000)
+
+        assert claims == []
+
+    async def test_empty_claim_content_is_skipped(self):
+        """A claim dict with empty/missing content is dropped, not crashed on."""
+        llm = _mock_llm('{"claims": [{"content": "", "confidence": 0.5}, {"confidence": 0.5}]}')
+
+        claims = await extract_claims(llm, _SOURCE_TEXT, "https://example.com/x", "doc-1", 8000)
+
+        assert claims == []

--- a/autobot-backend/services/research/models.py
+++ b/autobot-backend/services/research/models.py
@@ -1,0 +1,88 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Data shapes for the /research endpoint (#12622).
+
+Kept separate from ``orchestrator.py`` so the wire contract (request/response
++ internal claim/fact records) can be imported without pulling in the LLM /
+fetch / KB dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class ResearchRequest(BaseModel):
+    """``POST /research`` request body."""
+
+    question: str = Field(..., min_length=3, max_length=2000)
+    options: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Citation(BaseModel):
+    """One source citation backing a synthesized statement."""
+
+    fact_id: str
+    source_url: str = ""
+    source_doc_id: str = ""
+
+
+class ResearchFactOut(BaseModel):
+    """A KB fact produced or reused by this research run."""
+
+    fact_id: str
+    content: str
+    source_url: str = ""
+    confidence: float = 0.0
+
+
+class ResearchResponse(BaseModel):
+    """``POST /research`` response body — the full contract from #12622."""
+
+    answer: str
+    citations: List[Citation] = Field(default_factory=list)
+    facts: List[ResearchFactOut] = Field(default_factory=list)
+    # Phase 0 has no N-source corroborator (#12623 lands it) so this is
+    # structurally present but always empty until Phase 1's corroborator can
+    # populate it — never a silently-dropped feature.
+    contradictions: List[Dict[str, Any]] = Field(default_factory=list)
+    confidence: float = 0.0
+    sources_fetched: int = 0
+    facts_stored: int = 0
+
+
+@dataclass
+class ExtractedClaim:
+    """One atomic claim extracted from a fetched page, pre-KB-storage."""
+
+    content: str
+    confidence: float
+    source_url: str
+    source_doc_id: str
+
+
+@dataclass
+class StoredFact:
+    """A claim after landing in the KB (new or deduped to an existing fact)."""
+
+    fact_id: str
+    content: str
+    confidence: float
+    source_url: str
+    source_doc_id: str
+    is_new: bool
+
+
+@dataclass
+class ResearchBudget:
+    """Hard bounds for one orchestrator run (design doc §4.1 / §8 D5)."""
+
+    max_sources: int
+    max_content_chars: int
+    fetch_timeout_seconds: float
+    truncated_sources: List[str] = field(default_factory=list)

--- a/autobot-backend/services/research/orchestrator.py
+++ b/autobot-backend/services/research/orchestrator.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""ResearchOrchestrator (#12622, design §4.1) — the one new coordinator.
+
+Composes existing modules (never recreates them, design §6):
+  * ``agent_loop.search.registry`` — source discovery
+  * ``web_fetch.WebFetcher`` — fast-HTTP page fetch
+  * ``knowledge_base_factory.get_knowledge_base`` — the canonical KB facade
+  * ``services.research.extractor`` / ``synthesizer`` — the two new LLM steps
+
+Phase 0 scope only: a single bounded fetch round, no Planner sub-question
+loop (#12624) and no N-source corroboration (#12623) — both are later
+phases per the design doc's phasing table.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, List
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
+from knowledge_base_factory import get_knowledge_base
+from services.llm_service import get_llm_service
+
+from .extractor import extract_claims
+from .models import ExtractedClaim, ResearchBudget, ResearchFactOut, ResearchResponse, StoredFact
+from .synthesizer import synthesize_answer
+
+logger = get_logger(__name__)
+
+
+def _resolve_budget(options: dict) -> ResearchBudget:
+    """Build the run's budget, clamped to the configured hard caps (design §8 D5)."""
+    requested_sources = int(options.get("max_sources", config.research_max_sources))
+    return ResearchBudget(
+        max_sources=max(1, min(requested_sources, config.research_max_sources)),
+        max_content_chars=config.research_max_content_chars,
+        fetch_timeout_seconds=config.research_fetch_timeout_seconds,
+    )
+
+
+async def _discover_sources(question: str, max_sources: int) -> List[str]:
+    """Find candidate URLs for *question* via the shared search-provider registry."""
+    from agent_loop.search.registry import search as registry_search  # noqa: PLC0415
+
+    results = await registry_search(question, count=max_sources)
+    return [r.url for r in results if r.url]
+
+
+async def _fetch_source(url: str, timeout: float) -> Any:
+    """Fetch one URL, logging and swallowing per-source failures (budget §8 D5)."""
+    from web_fetch import RenderMode, WebFetcher  # noqa: PLC0415
+
+    try:
+        result = await WebFetcher.fetch(url, render=RenderMode.AUTO, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 — one bad source must not sink the run
+        logger.warning("ResearchOrchestrator: fetch failed for %s: %s", url, exc)
+        return None
+    return result if result.success and result.markdown.strip() else None
+
+
+def _claim_unique_key(url: str, claim_text: str) -> str:
+    """Stable dedup key: same (source, claim) across runs collapses to one fact."""
+    digest = hashlib.sha256(f"{url}::{claim_text.strip().lower()}".encode("utf-8")).hexdigest()
+    return f"research:{digest[:32]}"
+
+
+async def _store_source_document(kb: Any, url: str, title: str, markdown: str) -> str | None:
+    """Store the fetched page as the KB document of record (design §4.5)."""
+    metadata = {
+        "source_type": "web_research",
+        "url": url,
+        "title": title,
+        "collection": config.research_quarantine_collection,
+    }
+    result = await kb.add_document(content=markdown, metadata=metadata)
+    if result.get("status") not in ("success", "duplicate"):
+        logger.warning("ResearchOrchestrator: add_document failed for %s: %s", url, result)
+        return None
+    return result.get("fact_id")
+
+
+async def _store_claim(kb: Any, claim: ExtractedClaim) -> StoredFact | None:
+    """Land one extracted claim as a quarantined KB fact (design §5)."""
+    metadata = {
+        "collection": config.research_quarantine_collection,
+        "source_type": "web_research",
+        "url": claim.source_url,
+        "source_doc_id": claim.source_doc_id,
+        "confidence": claim.confidence,
+        "unique_key": _claim_unique_key(claim.source_url, claim.content),
+    }
+    result = await kb.store_fact(claim.content, metadata=metadata)
+    if result.get("status") not in ("success", "duplicate"):
+        logger.warning("ResearchOrchestrator: store_fact failed: %s", result)
+        return None
+    is_new = result.get("status") == "success"
+    return StoredFact(
+        fact_id=result["fact_id"],
+        content=claim.content,
+        confidence=claim.confidence,
+        source_url=claim.source_url,
+        source_doc_id=claim.source_doc_id,
+        is_new=is_new,
+    )
+
+
+class ResearchOrchestrator:
+    """Bundles fetch -> KB-fact landing -> grounded synthesis for one question."""
+
+    def __init__(self, llm_service: Any | None = None) -> None:
+        self._llm_service = llm_service
+
+    async def _llm(self) -> Any:
+        if self._llm_service is None:
+            self._llm_service = get_llm_service()
+        return self._llm_service
+
+    async def _land_page(self, kb: Any, url: str, budget: ResearchBudget) -> List[StoredFact]:
+        """Fetch one URL, extract claims, and land them as quarantined facts."""
+        fetch_result = await _fetch_source(url, budget.fetch_timeout_seconds)
+        if fetch_result is None:
+            return []
+        doc_id = await _store_source_document(kb, url, fetch_result.title, fetch_result.markdown)
+        if doc_id is None:
+            return []
+        llm = await self._llm()
+        claims = await extract_claims(llm, fetch_result.markdown, url, doc_id, budget.max_content_chars)
+        stored = [await _store_claim(kb, claim) for claim in claims]
+        return [fact for fact in stored if fact is not None]
+
+    async def research(self, question: str, options: dict | None = None) -> ResearchResponse:
+        """Run the bounded Phase-0 pipeline and return the full #12622 contract."""
+        budget = _resolve_budget(options or {})
+        kb = await get_knowledge_base()
+        if kb is None:
+            return ResearchResponse(answer="Knowledge base unavailable; cannot perform research.", confidence=0.0)
+
+        urls = await _discover_sources(question, budget.max_sources)
+        all_facts: List[StoredFact] = []
+        for url in urls:
+            all_facts.extend(await self._land_page(kb, url, budget))
+
+        llm = await self._llm()
+        synthesis = await synthesize_answer(llm, question, all_facts)
+        cited_ids = {c.fact_id for c in synthesis.citations}
+        facts_out = [
+            ResearchFactOut(fact_id=f.fact_id, content=f.content, source_url=f.source_url, confidence=f.confidence)
+            for f in all_facts
+            if f.fact_id in cited_ids
+        ]
+        return ResearchResponse(
+            answer=synthesis.answer,
+            citations=synthesis.citations,
+            facts=facts_out,
+            contradictions=[],
+            confidence=synthesis.confidence,
+            sources_fetched=len(urls),
+            facts_stored=len(all_facts),
+        )

--- a/autobot-backend/services/research/orchestrator_test.py
+++ b/autobot-backend/services/research/orchestrator_test.py
@@ -1,0 +1,164 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for services.research.orchestrator.ResearchOrchestrator (#12622).
+
+Mocks every composed dependency (search registry, WebFetcher, KB, extractor,
+synthesizer) so these tests exercise only the orchestrator's own wiring and
+budget/failure-path logic — not the composed modules themselves (already
+tested in their own colocated test files).
+"""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+# Force full (non-partial) module init before any test patches
+# "agent_loop.search.registry.search" — agent_loop/__init__.py pulls in a
+# heavy import chain, and patching a module mid-circular-import can silently
+# patch a stale partial module object instead of the one later imports see.
+import agent_loop.search.registry  # noqa: F401,E402
+import web_fetch  # noqa: F401,E402
+from services.research.models import ExtractedClaim, StoredFact
+from services.research.orchestrator import ResearchOrchestrator
+from services.research.synthesizer import SynthesisResult
+
+_MODULE = "services.research.orchestrator"
+
+
+@dataclass
+class _FakeSearchResult:
+    url: str
+
+
+@dataclass
+class _FakeFetchResult:
+    success: bool
+    markdown: str = ""
+    title: str = ""
+
+
+def _make_kb(store_fact_status: str = "success") -> AsyncMock:
+    kb = AsyncMock()
+    kb.add_document = AsyncMock(return_value={"status": "success", "fact_id": "doc-1"})
+    kb.store_fact = AsyncMock(return_value={"status": store_fact_status, "fact_id": "fact-1"})
+    return kb
+
+
+def _patch_common(kb, urls, fetch_result, claims, synthesis):
+    """Patch the four seams ResearchOrchestrator delegates to."""
+    return (
+        patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=kb)),
+        patch("agent_loop.search.registry.search", AsyncMock(return_value=[_FakeSearchResult(u) for u in urls])),
+        patch("web_fetch.WebFetcher.fetch", AsyncMock(return_value=fetch_result)),
+        patch(f"{_MODULE}.extract_claims", AsyncMock(return_value=claims)),
+        patch(f"{_MODULE}.synthesize_answer", AsyncMock(return_value=synthesis)),
+    )
+
+
+class TestResearchHappyPath:
+    """End-to-end happy path with every dependency mocked."""
+
+    async def test_full_pipeline_produces_contract_shape(self):
+        """One source -> one claim -> cited synthesis -> full response contract."""
+        kb = _make_kb()
+        claim = ExtractedClaim(content="X is Y.", confidence=0.8, source_url="https://a.example", source_doc_id="doc-1")
+        fact = StoredFact(
+            fact_id="fact-1",
+            content="X is Y.",
+            confidence=0.8,
+            source_url="https://a.example",
+            source_doc_id="doc-1",
+            is_new=True,
+        )
+        synthesis = SynthesisResult(answer="X is Y [F1].", citations=[], confidence=0.7)
+        # citations reference StoredFact ids the orchestrator itself built, so
+        # set the citation to match the fact the mocked _store_claim path returns.
+        from services.research.models import Citation
+
+        synthesis.citations = [Citation(fact_id="fact-1", source_url="https://a.example", source_doc_id="doc-1")]
+        fetch_result = _FakeFetchResult(success=True, markdown="X is Y because of Z.", title="Page A")
+
+        patches = _patch_common(kb, ["https://a.example"], fetch_result, [claim], synthesis)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await ResearchOrchestrator(llm_service=AsyncMock()).research("what is X?")
+
+        assert response.answer == "X is Y [F1]."
+        assert response.sources_fetched == 1
+        assert response.facts_stored == 1
+        assert len(response.facts) == 1
+        assert response.facts[0].fact_id == "fact-1"
+        assert response.contradictions == []
+        _ = fact  # documents the shape _store_claim would build; asserted via facts_stored above
+
+
+class TestResearchBudget:
+    """Budget clamping (design §8 D5)."""
+
+    async def test_max_sources_clamped_to_config_cap(self):
+        """A caller cannot request more sources than the configured hard cap."""
+        kb = _make_kb()
+        synthesis = SynthesisResult(answer="no facts", citations=[], confidence=0.0)
+        search_mock = AsyncMock(return_value=[])
+
+        with (
+            patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=kb)),
+            patch("agent_loop.search.registry.search", search_mock),
+            patch(f"{_MODULE}.synthesize_answer", AsyncMock(return_value=synthesis)),
+        ):
+            await ResearchOrchestrator(llm_service=AsyncMock()).research("q", {"max_sources": 999})
+
+        # config.research_max_sources default is 5 (see autobot_shared.ssot_config)
+        assert search_mock.await_args.kwargs["count"] == 5
+
+
+class TestResearchFailurePaths:
+    """A single bad source must never sink the whole run."""
+
+    async def test_kb_unavailable_returns_caveat_without_fetching(self):
+        """When the KB is unavailable, research() short-circuits before any fetch."""
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=None)):
+            response = await ResearchOrchestrator(llm_service=AsyncMock()).research("q")
+
+        assert "unavailable" in response.answer.lower()
+        assert response.facts_stored == 0
+
+    async def test_fetch_failure_yields_zero_facts_for_that_source(self):
+        """A failed fetch contributes no facts but the run still completes."""
+        kb = _make_kb()
+        synthesis = SynthesisResult(answer="no facts", citations=[], confidence=0.0)
+        failed_fetch = _FakeFetchResult(success=False)
+
+        patches = _patch_common(kb, ["https://bad.example"], failed_fetch, [], synthesis)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await ResearchOrchestrator(llm_service=AsyncMock()).research("q")
+
+        assert response.facts_stored == 0
+        assert response.sources_fetched == 1
+
+    async def test_add_document_failure_yields_zero_facts(self):
+        """A failed add_document skips claim extraction for that source entirely."""
+        kb = _make_kb()
+        kb.add_document = AsyncMock(return_value={"status": "error", "message": "boom"})
+        synthesis = SynthesisResult(answer="no facts", citations=[], confidence=0.0)
+        fetch_result = _FakeFetchResult(success=True, markdown="some text", title="t")
+
+        patches = _patch_common(kb, ["https://a.example"], fetch_result, [], synthesis)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await ResearchOrchestrator(llm_service=AsyncMock()).research("q")
+
+        assert response.facts_stored == 0
+        kb.store_fact.assert_not_awaited()
+
+    async def test_duplicate_claim_reuses_existing_fact_not_a_new_one(self):
+        """store_fact returning status=duplicate is treated as a landed (reused) fact."""
+        kb = _make_kb(store_fact_status="duplicate")
+        claim = ExtractedClaim(content="X is Y.", confidence=0.8, source_url="https://a.example", source_doc_id="doc-1")
+        synthesis = SynthesisResult(answer="no facts", citations=[], confidence=0.0)
+        fetch_result = _FakeFetchResult(success=True, markdown="X is Y.", title="t")
+
+        patches = _patch_common(kb, ["https://a.example"], fetch_result, [claim], synthesis)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await ResearchOrchestrator(llm_service=AsyncMock()).research("q")
+
+        assert response.facts_stored == 1

--- a/autobot-backend/services/research/routes.py
+++ b/autobot-backend/services/research/routes.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Research REST API (#12622).
+
+``POST /research`` — the first consumer of ``ResearchOrchestrator`` (owner
+decision, design doc §12). Mounted like ``services/autoresearch/routes.py``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from auth_middleware import get_current_user
+from autobot_shared.logging_manager import get_logger
+
+from .models import ResearchRequest, ResearchResponse
+from .orchestrator import ResearchOrchestrator
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["research"])
+
+_orchestrator: ResearchOrchestrator | None = None
+
+
+def _get_orchestrator(request: Request) -> ResearchOrchestrator:
+    """Get or create the process-wide ``ResearchOrchestrator`` singleton."""
+    global _orchestrator
+    app_orchestrator = getattr(request.app.state, "research_orchestrator", None)
+    if app_orchestrator is not None:
+        return app_orchestrator
+    if _orchestrator is None:
+        _orchestrator = ResearchOrchestrator()
+    request.app.state.research_orchestrator = _orchestrator
+    return _orchestrator
+
+
+@router.post("", response_model=ResearchResponse)
+async def run_research(
+    request: Request,
+    body: ResearchRequest,
+    _user: dict = Depends(get_current_user),
+) -> ResearchResponse:
+    """Run a bounded research pass and return a grounded, cited answer.
+
+    Findings land as quarantined KB facts (dedicated ``research`` collection,
+    not visible to general chat/RAG) while the response also carries a
+    directly-usable synthesized answer with inline citations.
+    """
+    orchestrator = _get_orchestrator(request)
+    try:
+        return await orchestrator.research(body.question, body.options)
+    except Exception as exc:  # noqa: BLE001 — user-facing 500, never a bare stack trace
+        logger.error("POST /research failed for question %.80s: %s", body.question, exc)
+        raise HTTPException(status_code=500, detail="Research request failed") from exc

--- a/autobot-backend/services/research/routes_test.py
+++ b/autobot-backend/services/research/routes_test.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Integration tests for POST /research (#12622).
+
+Builds a standalone FastAPI app mounting only ``services.research.routes``,
+overriding auth so these tests exercise the route wiring and error handling
+without a live auth backend. This is the same "app.include_router" shape
+production uses (see initialization/router_registry/feature_routers.py),
+so a passing test here demonstrates the route is genuinely reachable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from services.research.models import Citation, ResearchFactOut, ResearchResponse
+
+
+def _build_app(orchestrator: AsyncMock) -> TestClient:
+    """Build a FastAPI app with only the research router, auth overridden."""
+    from auth_middleware import get_current_user
+    from services.research.routes import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/research")
+    app.dependency_overrides[get_current_user] = lambda: {"username": "test-user", "role": "user"}
+    app.state.research_orchestrator = orchestrator
+    return TestClient(app)
+
+
+def _make_orchestrator(response: ResearchResponse) -> AsyncMock:
+    orchestrator = AsyncMock()
+    orchestrator.research = AsyncMock(return_value=response)
+    return orchestrator
+
+
+class TestPostResearch:
+    """POST /research request/response contract."""
+
+    def test_returns_full_contract_shape(self):
+        """A successful run returns the full #12622 response contract."""
+        response = ResearchResponse(
+            answer="X is Y [F1].",
+            citations=[Citation(fact_id="fact-1", source_url="https://a.example", source_doc_id="doc-1")],
+            facts=[
+                ResearchFactOut(fact_id="fact-1", content="X is Y.", source_url="https://a.example", confidence=0.8)
+            ],
+            contradictions=[],
+            confidence=0.7,
+            sources_fetched=1,
+            facts_stored=1,
+        )
+        client = _build_app(_make_orchestrator(response))
+
+        resp = client.post("/research", json={"question": "what is X?"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["answer"] == "X is Y [F1]."
+        assert body["citations"][0]["fact_id"] == "fact-1"
+        assert body["facts"][0]["fact_id"] == "fact-1"
+        assert body["contradictions"] == []
+        assert body["confidence"] == 0.7
+
+    def test_question_too_short_is_rejected(self):
+        """A sub-minimum-length question is rejected with 422 before the orchestrator runs."""
+        orchestrator = _make_orchestrator(ResearchResponse(answer=""))
+        client = _build_app(orchestrator)
+
+        resp = client.post("/research", json={"question": "hi"})
+
+        assert resp.status_code == 422
+        orchestrator.research.assert_not_awaited()
+
+    def test_missing_question_is_rejected(self):
+        """A request with no 'question' field is rejected with 422."""
+        client = _build_app(_make_orchestrator(ResearchResponse(answer="")))
+
+        resp = client.post("/research", json={})
+
+        assert resp.status_code == 422
+
+    def test_orchestrator_exception_returns_500_not_stack_trace(self):
+        """An unexpected orchestrator failure returns a clean 500, not a raw traceback."""
+        orchestrator = AsyncMock()
+        orchestrator.research = AsyncMock(side_effect=RuntimeError("boom"))
+        client = _build_app(orchestrator)
+
+        resp = client.post("/research", json={"question": "what is X?"})
+
+        assert resp.status_code == 500
+        assert "boom" not in resp.json()["detail"]
+
+    def test_route_requires_auth_dependency(self):
+        """The route is wired behind ``Depends(get_current_user)`` (not open).
+
+        Exact unauthenticated status code is auth_middleware's own contract
+        (covered by its test suite); this only asserts our route does not
+        bypass the dependency — an unauthenticated call must not reach the
+        orchestrator and must not succeed with 200.
+        """
+        from services.research.routes import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/research")
+        orchestrator = _make_orchestrator(ResearchResponse(answer=""))
+        app.state.research_orchestrator = orchestrator
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.post("/research", json={"question": "what is X?"})
+
+        assert resp.status_code != 200
+        orchestrator.research.assert_not_awaited()

--- a/autobot-backend/services/research/synthesizer.py
+++ b/autobot-backend/services/research/synthesizer.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Grounded LLM synthesis over KB facts (#12622, design §4.8).
+
+Every synthesized sentence must cite a fact id that was actually retrieved
+for this run; the anti-hallucinated-citation post-check drops any inline
+marker or structured citation the LLM invents.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+from llm_shared.json_utils import extract_json_object
+
+from .models import Citation, StoredFact
+
+logger = get_logger(__name__)
+
+_MARKER_RE = re.compile(r"\[F(\d+)\]")
+
+_SYNTHESIS_SYSTEM_PROMPT = (
+    "You answer a research question using ONLY the numbered facts provided. "
+    "Rules: (1) every sentence that states something from the facts must end "
+    "with one or more inline markers like [F1] or [F2,F3] referencing the "
+    "fact number(s) it relies on; (2) never state anything not supported by "
+    "a fact — omit it instead; (3) if facts disagree, say so explicitly and "
+    "list the conflicting fact numbers. Respond with ONLY a JSON object: "
+    '{"answer": str, "confidence": float 0.0-1.0}. confidence reflects how '
+    "well the available facts cover the question (low if facts are sparse)."
+)
+
+
+@dataclass
+class SynthesisResult:
+    """Grounded answer plus the citations that survived the post-check."""
+
+    answer: str
+    citations: List[Citation]
+    confidence: float
+
+
+def _build_facts_block(facts: List[StoredFact]) -> str:
+    """Render facts as a numbered block the LLM references via [F<n>]."""
+    lines = [f"[F{i + 1}] {fact.content}" for i, fact in enumerate(facts)]
+    return "\n".join(lines)
+
+
+def _build_synthesis_messages(question: str, facts: List[StoredFact]) -> List[Dict[str, str]]:
+    """Build the chat messages for one synthesis call."""
+    user_content = f"Question: {question}\n\nFacts:\n{_build_facts_block(facts)}"
+    return [
+        {"role": "system", "content": _SYNTHESIS_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+def _parse_synthesis_payload(raw_content: str) -> Dict[str, Any]:
+    """Parse the LLM's JSON response, tolerating malformed output."""
+    try:
+        return extract_json_object(raw_content)
+    except json.JSONDecodeError:
+        logger.warning("synthesize_answer: LLM response was not valid JSON")
+        return {}
+
+
+def _sanitize_answer_and_collect_citations(answer: str, facts: List[StoredFact]) -> tuple[str, List[Citation]]:
+    """Strip markers citing an out-of-range fact number; collect valid citations.
+
+    Anti-hallucinated-citation post-check (#12622 acceptance criteria):
+    every surviving ``[F<n>]`` marker maps to a fact that was actually
+    retrieved for this run.
+    """
+    valid_indices: set[int] = set()
+
+    def _replace(match: re.Match) -> str:
+        idx = int(match.group(1))
+        if 1 <= idx <= len(facts):
+            valid_indices.add(idx)
+            return match.group(0)
+        return ""
+
+    sanitized = _MARKER_RE.sub(_replace, answer)
+    citations = [_fact_to_citation(facts[i - 1]) for i in sorted(valid_indices)]
+    return sanitized, citations
+
+
+def _fact_to_citation(fact: StoredFact) -> Citation:
+    """Map a stored fact to its citation shape."""
+    return Citation(fact_id=fact.fact_id, source_url=fact.source_url, source_doc_id=fact.source_doc_id)
+
+
+async def synthesize_answer(llm_service: Any, question: str, facts: List[StoredFact]) -> SynthesisResult:
+    """Produce a grounded, cited answer from *facts*, or a caveat if none exist."""
+    if not facts:
+        return SynthesisResult(
+            answer="No facts were gathered for this question; unable to provide a grounded answer.",
+            citations=[],
+            confidence=0.0,
+        )
+
+    response = await llm_service.chat(messages=_build_synthesis_messages(question, facts), temperature=0.0)
+    if response.error:
+        logger.warning("synthesize_answer: LLM call failed: %s", response.error)
+        return SynthesisResult(answer="Synthesis failed; raw facts are available below.", citations=[], confidence=0.0)
+
+    payload = _parse_synthesis_payload(response.content)
+    raw_answer = str(payload.get("answer", "")).strip()
+    try:
+        raw_confidence = max(0.0, min(1.0, float(payload.get("confidence", 0.0))))
+    except (TypeError, ValueError):
+        raw_confidence = 0.0
+
+    sanitized_answer, citations = _sanitize_answer_and_collect_citations(raw_answer, facts)
+    if not citations:
+        return SynthesisResult(
+            answer="No cited claim survived verification; unable to provide a grounded answer.",
+            citations=[],
+            confidence=0.0,
+        )
+    return SynthesisResult(answer=sanitized_answer, citations=citations, confidence=raw_confidence)

--- a/autobot-backend/services/research/synthesizer_test.py
+++ b/autobot-backend/services/research/synthesizer_test.py
@@ -1,0 +1,101 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for services.research.synthesizer (#12622).
+
+Covers grounded synthesis, the anti-hallucinated-citation post-check, and
+the no-facts / all-facts-failed caveat paths.
+"""
+
+from unittest.mock import AsyncMock
+
+from services.research.models import StoredFact
+from services.research.synthesizer import synthesize_answer
+
+
+def _fact(fact_id: str, content: str) -> StoredFact:
+    return StoredFact(
+        fact_id=fact_id,
+        content=content,
+        confidence=0.7,
+        source_url=f"https://example.com/{fact_id}",
+        source_doc_id=f"doc-{fact_id}",
+        is_new=True,
+    )
+
+
+def _mock_llm(content: str, error: str = "") -> AsyncMock:
+    llm = AsyncMock()
+    response = AsyncMock()
+    response.content = content
+    response.error = error
+    llm.chat = AsyncMock(return_value=response)
+    return llm
+
+
+class TestSynthesizeAnswer:
+    """Grounded synthesis + anti-hallucinated-citation post-check."""
+
+    async def test_valid_marker_produces_citation(self):
+        """A [F1] marker referencing a real fact survives and is cited."""
+        facts = [_fact("abc", "The sky is blue.")]
+        llm = _mock_llm('{"answer": "The sky is blue [F1].", "confidence": 0.8}')
+
+        result = await synthesize_answer(llm, "What color is the sky?", facts)
+
+        assert result.answer == "The sky is blue [F1]."
+        assert len(result.citations) == 1
+        assert result.citations[0].fact_id == "abc"
+        assert result.confidence == 0.8
+
+    async def test_out_of_range_marker_is_stripped(self):
+        """A [F<n>] marker with no matching fact is stripped, not trusted."""
+        facts = [_fact("abc", "The sky is blue.")]
+        llm = _mock_llm('{"answer": "The sky is blue [F1]. Grass is green [F2].", "confidence": 0.9}')
+
+        result = await synthesize_answer(llm, "Tell me about colors", facts)
+
+        assert "[F2]" not in result.answer
+        assert "[F1]" in result.answer
+        assert len(result.citations) == 1
+
+    async def test_no_valid_citations_returns_caveat(self):
+        """An answer with zero surviving citations is replaced with a caveat."""
+        facts = [_fact("abc", "The sky is blue.")]
+        llm = _mock_llm('{"answer": "Grass is green [F9].", "confidence": 0.9}')
+
+        result = await synthesize_answer(llm, "What color is grass?", facts)
+
+        assert result.citations == []
+        assert result.confidence == 0.0
+        assert "verification" in result.answer.lower()
+
+    async def test_no_facts_returns_caveat_without_llm_call(self):
+        """Zero facts short-circuits to a caveat and never calls the LLM."""
+        llm = _mock_llm("")
+
+        result = await synthesize_answer(llm, "unanswerable question", [])
+
+        assert result.citations == []
+        assert result.confidence == 0.0
+        llm.chat.assert_not_awaited()
+
+    async def test_llm_error_returns_caveat(self):
+        """An LLM error degrades to a caveat instead of raising."""
+        facts = [_fact("abc", "The sky is blue.")]
+        llm = _mock_llm("", error="timeout")
+
+        result = await synthesize_answer(llm, "What color is the sky?", facts)
+
+        assert result.citations == []
+        assert result.confidence == 0.0
+
+    async def test_confidence_is_clamped(self):
+        """An out-of-range confidence value from the LLM is clamped to [0, 1]."""
+        facts = [_fact("abc", "The sky is blue.")]
+        llm = _mock_llm('{"answer": "The sky is blue [F1].", "confidence": 42}')
+
+        result = await synthesize_answer(llm, "What color is the sky?", facts)
+
+        assert result.confidence == 1.0

--- a/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_kb_search.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_kb_search.py
@@ -98,6 +98,25 @@ class TestExecuteKbSearch:
         assert status is KnowledgeStatus.MISSING
         assert results == []
 
+    async def test_quarantine_filter_excludes_research_collection(self, workflow):
+        """#12622: chat/RAG must exclude the quarantined 'research' collection.
+
+        Web-research facts are tagged metadata.collection="research" until
+        Phase 1's promotion gate reviews them; general chat search must never
+        surface them, so every call passes the quarantine exclusion filter.
+        """
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(return_value=[])
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            await workflow._execute_kb_search("what is autobot")
+
+        mock_kb.search.assert_awaited_once_with(
+            query="what is autobot",
+            top_k=5,
+            filters={"collection": {"$ne": "research"}},
+        )
+
     async def test_multiple_results_mapped_correctly(self, workflow):
         """Multiple results are mapped with correct keys."""
         from async_chat_workflow import KnowledgeStatus

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -47392,6 +47392,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/research": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run Research
+         * @description Run a bounded research pass and return a grounded, cited answer.
+         *
+         *     Findings land as quarantined KB facts (dedicated ``research`` collection,
+         *     not visible to general chat/RAG) while the response also carries a
+         *     directly-usable synthesized answer with inline citations.
+         */
+        post: operations["run_research_api_research_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workflow-export/export/{workflow_id}": {
         parameters: {
             query?: never;
@@ -60844,7 +60868,7 @@ export interface components {
              * Citations
              * @description Structured source citations from RAG retrieval. Non-empty only when grounding.grounded=True.
              */
-            citations?: components["schemas"]["Citation"][];
+            citations?: components["schemas"]["api__schemas_chat__Citation"][];
             /** @description Grounding transparency marker. grounded=False signals a model-only claim. */
             grounding?: components["schemas"]["GroundingStatus"] | null;
         } & {
@@ -61149,42 +61173,6 @@ export interface components {
          * @description Response for GET /circuit-breakers — opaque shape from manager.get_status().
          */
         CircuitBreakerStatusResponse: {
-            [key: string]: unknown;
-        };
-        /**
-         * Citation
-         * @description Structured source citation attached to a RAG-grounded response (#10548).
-         *
-         *     Propagated from retrieval (kb_results / RAGMetrics) through the response
-         *     builder to the API payload and rendered by CitationsDisplay.vue as chips.
-         */
-        Citation: {
-            /**
-             * Id
-             * @description Unique citation identifier (chunk/doc/graph-node id)
-             */
-            id: string;
-            /**
-             * Source Type
-             * @description Origin of this citation: 'doc' | 'chunk' | 'graph'
-             */
-            source_type: string;
-            /**
-             * Title
-             * @description Human-readable title or file name
-             */
-            title: string;
-            /**
-             * Uri
-             * @description Relative path or URI for deep-linking
-             */
-            uri?: string | null;
-            /**
-             * Score
-             * @description Retrieval relevance score (0–1)
-             */
-            score: number;
-        } & {
             [key: string]: unknown;
         };
         /**
@@ -88837,22 +88825,58 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** ResearchRequest */
-        ResearchRequest: {
-            /** Query */
-            query: string;
+        /**
+         * ResearchFactOut
+         * @description A KB fact produced or reused by this research run.
+         */
+        ResearchFactOut: {
+            /** Fact Id */
+            fact_id: string;
+            /** Content */
+            content: string;
             /**
-             * Research Depth
-             * @default comprehensive
+             * Source Url
+             * @default
              */
-            research_depth: string;
-            /** Sources */
-            sources?: string[] | null;
+            source_url: string;
             /**
-             * Include Web
-             * @default true
+             * Confidence
+             * @default 0
              */
-            include_web: boolean;
+            confidence: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ResearchResponse
+         * @description ``POST /research`` response body — the full contract from #12622.
+         */
+        ResearchResponse: {
+            /** Answer */
+            answer: string;
+            /** Citations */
+            citations?: components["schemas"]["services__research__models__Citation"][];
+            /** Facts */
+            facts?: components["schemas"]["ResearchFactOut"][];
+            /** Contradictions */
+            contradictions?: {
+                [key: string]: unknown;
+            }[];
+            /**
+             * Confidence
+             * @default 0
+             */
+            confidence: number;
+            /**
+             * Sources Fetched
+             * @default 0
+             */
+            sources_fetched: number;
+            /**
+             * Facts Stored
+             * @default 0
+             */
+            facts_stored: number;
         } & {
             [key: string]: unknown;
         };
@@ -101173,6 +101197,42 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * Citation
+         * @description Structured source citation attached to a RAG-grounded response (#10548).
+         *
+         *     Propagated from retrieval (kb_results / RAGMetrics) through the response
+         *     builder to the API payload and rendered by CitationsDisplay.vue as chips.
+         */
+        api__schemas_chat__Citation: {
+            /**
+             * Id
+             * @description Unique citation identifier (chunk/doc/graph-node id)
+             */
+            id: string;
+            /**
+             * Source Type
+             * @description Origin of this citation: 'doc' | 'chunk' | 'graph'
+             */
+            source_type: string;
+            /**
+             * Title
+             * @description Human-readable title or file name
+             */
+            title: string;
+            /**
+             * Uri
+             * @description Relative path or URI for deep-linking
+             */
+            uri?: string | null;
+            /**
+             * Score
+             * @description Retrieval relevance score (0–1)
+             */
+            score: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * TemplateSearchResponse
          * @description Response for GET /templates/search.
          */
@@ -101212,6 +101272,25 @@ export interface components {
              * @default false
              */
             include_embeddings: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ResearchRequest */
+        api__schemas_knowledge__ResearchRequest: {
+            /** Query */
+            query: string;
+            /**
+             * Research Depth
+             * @default comprehensive
+             */
+            research_depth: string;
+            /** Sources */
+            sources?: string[] | null;
+            /**
+             * Include Web
+             * @default true
+             */
+            include_web: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -101809,6 +101888,40 @@ export interface components {
             message: string;
             /** Training Started */
             training_started: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * Citation
+         * @description One source citation backing a synthesized statement.
+         */
+        services__research__models__Citation: {
+            /** Fact Id */
+            fact_id: string;
+            /**
+             * Source Url
+             * @default
+             */
+            source_url: string;
+            /**
+             * Source Doc Id
+             * @default
+             */
+            source_doc_id: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ResearchRequest
+         * @description ``POST /research`` request body.
+         */
+        services__research__models__ResearchRequest: {
+            /** Question */
+            question: string;
+            /** Options */
+            options?: {
+                [key: string]: unknown;
+            };
         } & {
             [key: string]: unknown;
         };
@@ -160594,7 +160707,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ResearchRequest"];
+                "application/json": components["schemas"]["api__schemas_knowledge__ResearchRequest"];
             };
         };
         responses: {
@@ -164064,6 +164177,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_research_api_research_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["services__research__models__ResearchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResearchResponse"];
                 };
             };
             /** @description Validation Error */

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1586,6 +1586,14 @@ class MiscConfig(BaseSettings):
     # ("true") with a 300s timeout; False/0 silently disabled HITL checkpoints.
     research_checkpoints_enabled: bool = Field(default=True, alias="AUTOBOT_RESEARCH_CHECKPOINTS_ENABLED")
     research_checkpoint_timeout: int = Field(default=300, alias="AUTOBOT_RESEARCH_CHECKPOINT_TIMEOUT")
+    # #12622: ResearchOrchestrator (/research) budget bounds — hard caps so a
+    # single request can never cascade into an unbounded fetch/LLM-call chain.
+    research_max_sources: int = Field(default=5, alias="AUTOBOT_RESEARCH_MAX_SOURCES")
+    research_max_content_chars: int = Field(default=8000, alias="AUTOBOT_RESEARCH_MAX_CONTENT_CHARS")
+    research_fetch_timeout_seconds: float = Field(default=15.0, alias="AUTOBOT_RESEARCH_FETCH_TIMEOUT_SECONDS")
+    # Quarantine collection name (design doc §5/§9): web-research facts land
+    # here, invisible to general chat/RAG, until Phase 1's promotion gate.
+    research_quarantine_collection: str = Field(default="research", alias="AUTOBOT_RESEARCH_QUARANTINE_COLLECTION")
     routing_model: str = Field(default="", alias="AUTOBOT_ROUTING_MODEL")
     run_jwt: str = Field(default="", alias="AUTOBOT_RUN_JWT")
     schema_dir: str = Field(default="", alias="AUTOBOT_SCHEMA_DIR")


### PR DESCRIPTION
## Thinking Path

Read #12622 + umbrella #12621 and the merged design doc (`docs/architecture/RESEARCH_AGENT_PRECISION_EFFICIENCY_DESIGN.md`, landed via PR #12643). Verified premise before coding:

- `services/research/` did not exist — nothing to duplicate.
- KB storage interface is canonical and singular: `knowledge_base_factory.get_knowledge_base()` returns the composed `KnowledgeBase` (Facts/Documents/Search/Collections mixins). `add_document()` internally calls `store_fact()` — "documents" and "facts" are the same Redis+Chroma record, differentiated only by metadata (`source_type`), matching the design's KB-native model claim.
- The real `/research` call path is a **standalone FastAPI router**, not `chat_workflow._dispatch_tool_call` or the (inert) `AgentLoop` — this matches the design's own owner decision ("first consumer: dedicated `/research` API endpoint"; chat/deep-research wiring is explicitly future work). Mounted exactly like `services/autoresearch/routes.py` via `initialization/router_registry/feature_routers.py`.
- Quarantine claim ("facts in `research` are NOT visible to general chat/RAG") was not yet true: the live chat-RAG injection path (`async_chat_workflow.py::_execute_kb_search`) calls `kb.search()` with no metadata filter, so a newly-landed `collection="research"` fact would otherwise leak into every chat turn. Verified empirically against the installed ChromaDB (1.5.5) that a `{"collection": {"$ne": "research"}}` filter correctly includes facts lacking the field entirely (pre-existing facts) while excluding quarantined ones — then wired that filter into `_execute_kb_search`.

Design vs issue: no discrepancies found: #12622's acceptance criteria map directly onto design §9 Phase 0 scope (no Planner loop, no N-source corroboration — both later phases, #12624/#12623).

## What Changed

**New `services/research/` package** (composes existing modules only, per design §6):
- `models.py` — wire contract: `ResearchRequest`/`ResearchResponse`/`Citation`/`ResearchFactOut`, plus internal `ExtractedClaim`/`StoredFact`/`ResearchBudget`.
- `extractor.py` — LLM atomic-claim extraction from a fetched page, with a deterministic anti-hallucination overlap guard (a claim must share ≥50% of its distinctive words with the source text or it's dropped).
- `synthesizer.py` — grounded LLM synthesis constrained to retrieved facts; every `[F<n>]` citation marker is post-checked against the actual fact set, invented markers are stripped, and an answer with zero surviving citations is replaced with an explicit caveat (anti-hallucinated-citation, per acceptance criteria).
- `orchestrator.py` — `ResearchOrchestrator`: the one new coordinator. Bounded pipeline (no Planner loop — Phase 2 per design): search-registry discovery → `WebFetcher` fetch → `KB.add_document` (source of record) → claim extraction → `KB.store_fact` (quarantined `research` collection, `unique_key`-deduped) → grounded synthesis. Budget (`max_sources`, `max_content_chars`, `fetch_timeout_seconds`) is clamped to new `autobot_shared.ssot_config` fields (never hardcoded): `AUTOBOT_RESEARCH_MAX_SOURCES` (default 5), `AUTOBOT_RESEARCH_MAX_CONTENT_CHARS` (8000), `AUTOBOT_RESEARCH_FETCH_TIMEOUT_SECONDS` (15), `AUTOBOT_RESEARCH_QUARANTINE_COLLECTION` (`research`).
- `routes.py` — `POST /research` behind `Depends(get_current_user)`, mounted at `/api/research` via `feature_routers.py` (same data-driven pattern as `/api/autoresearch`).

**Quarantine enforcement**: `async_chat_workflow.py::_execute_kb_search` now passes `filters={"collection": {"$ne": "research"}}` to `kb.search()`, so web-research facts stay invisible to the live chat-RAG path until Phase 1's promotion gate (#12623).

**`contradictions[]`** is structurally present in the response but always empty in this PR — there is no N-source corroborator yet (design §9 Phase 1, #12623); documented in `models.py` rather than silently omitted.

**Discovered (filed, not fixed here — different blast radius)**: #13009 — three other `kb.search()` call sites (`ai_hardware_accelerator.py:834`, `advanced_rag_optimizer.py:395`, `utils/hybrid_search.py:472`) call with no metadata filter and would also leak quarantined facts if/when they're reachable from a live general-chat surface; their production-reachability wasn't independently verified in this PR.

## Verification

- `py_compile`, `flake8 --max-line-length=120`, `black --check --line-length=120` (this repo's 120-col convention, not Black's 88 default): all clean on every new/touched file.
- New tests, including failure paths: 24 in `services/research/` (extractor: 7, synthesizer: 6, orchestrator: 6, routes: 5) + 1 new chat-workflow quarantine test — all pass.
- `cp`-swapped baseline diff (not `git stash`, per worktree rules): swapped in the pre-PR versions of `async_chat_workflow.py` / `ssot_config.py` / `feature_routers.py` and reran the **pre-existing** suites (`tests/unit/chat_workflow/` + `ssot_config_test.py`, 331 tests): baseline failed only the *new* quarantine test (expected — it asserts new behavior) with 330 passing; after restoring the PR's files, all 331 pass, 0 regressions.
- `tests/test_startup_imports.py`: 350/350 passed, unchanged before/after.
- **Reachability proof** (the key evidence for this issue): `initialization.router_registry.feature_routers.load_feature_routers()` run standalone — baseline (pre-PR) loads **121/121** feature routers with 0 failures; with this PR it loads **122/122** with 0 failures, and the load-result registry confirms `{"name": "research", "module": "services.research.routes", "loaded": True, "error": None}`, mounted at prefix `/research` (→ `/api/research` after `app_factory`'s `/api` prefix, same as every other feature router). This is the real, live call path — not `chat_workflow._dispatch_tool_call` and not the inert `AgentLoop`.

## Model Used

Claude Opus 4.8 (1M context)