### PR TITLE
feat(research): N-source corroboration + contradiction surfacing + KB promotion gate (#12623)

### DIFF
--- a/autobot-backend/knowledge/backends/memory_adapter.py
+++ b/autobot-backend/knowledge/backends/memory_adapter.py
@@ -43,8 +43,26 @@ def _cosine_distance(a: Sequence[float], b: Sequence[float]) -> float:
     return 1.0 - (num / (da * db))
 
 
+def _match_field(actual: Any, expected: Any) -> bool:
+    """Match one metadata field against a plain value or a single-key operator dict.
+
+    Issue #12623: extended from bare equality to also support ``$ne`` (the
+    operator the chat-RAG quarantine filter — #12622 — and this repo's
+    knowledge base use to exclude the ``research`` collection). Missing
+    metadata (``actual is None``) matches ``$ne`` — same "absent field passes"
+    semantics verified empirically against real ChromaDB in #13010.
+    """
+    if isinstance(expected, dict):
+        if "$ne" in expected:
+            return actual != expected["$ne"]
+        if "$eq" in expected:
+            return actual == expected["$eq"]
+        return False  # unsupported operator -> fail-safe: no match
+    return actual == expected
+
+
 def _match_where(meta: Metadata | None, where: Where | None) -> bool:
-    """Minimal ``where`` filter: equality on top-level keys only.
+    """Minimal ``where`` filter: equality plus ``$ne``/``$eq`` on top-level keys.
 
     Full ChromaDB where syntax (``$and``, ``$or``, ``$in`` ...) is out of
     scope for the in-memory fake — tests that need it should use ChromaDB
@@ -52,10 +70,9 @@ def _match_where(meta: Metadata | None, where: Where | None) -> bool:
     """
     if not where:
         return True
-    if meta is None:
-        return False
     for key, expected in where.items():
-        if meta.get(key) != expected:
+        actual = meta.get(key) if meta is not None else None
+        if not _match_field(actual, expected):
             return False
     return True
 

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -1129,6 +1129,29 @@ class FactsMixin:
         await self._mark_vectorization_succeeded(fact_id)
         logger.info("Re-vectorized updated fact %s", fact_id)
 
+    async def _sync_fact_metadata_in_chromadb(self, fact_id: str, metadata: Dict[str, Any]) -> None:
+        """Push a metadata-only change through to the ChromaDB vector store.
+
+        Issue #12623: ``update_fact`` previously only synced ChromaDB when
+        *content* changed (via ``_revectorize_fact``); a metadata-only update
+        (e.g. the promotion gate flipping ``collection``) silently left the
+        stale metadata in the vector store, so a ChromaDB-filtered search
+        (like the chat-RAG quarantine filter, #12622) would never see the
+        change. Uses ``collection.update()`` directly — no re-embedding
+        needed since the text is unchanged, so this is cheap.
+        """
+        if not self.vector_store:
+            return
+        from knowledge.utils import sanitize_metadata_for_chromadb as _sanitize
+
+        sanitized = _sanitize(metadata)
+        sanitized["fact_id"] = fact_id
+        try:
+            await asyncio.to_thread(self.vector_store._collection.update, ids=[fact_id], metadatas=[sanitized])
+            logger.debug("Synced metadata-only update to ChromaDB for fact %s", fact_id)
+        except Exception as exc:
+            logger.warning("Could not sync metadata-only update to ChromaDB for fact %s: %s", fact_id, exc)
+
     async def _refresh_content_hash(self, fact_id: str, old_content: str, new_content: str) -> None:
         """Refresh content_hash dedup key when content changes. Issue #1375."""
         if old_content:
@@ -1181,6 +1204,11 @@ class FactsMixin:
 
             if content is not None and self.vector_store:
                 await self._revectorize_fact(fact_id, decoded["content"], current_metadata)
+            elif metadata is not None and self.vector_store:
+                # Issue #12623: content unchanged but metadata changed (e.g. the
+                # promotion gate) — still must propagate to ChromaDB or a
+                # metadata-filtered search never observes the change.
+                await self._sync_fact_metadata_in_chromadb(fact_id, current_metadata)
 
             return {"status": "success", "fact_id": fact_id, "action": "updated"}
 

--- a/autobot-backend/knowledge/facts_metadata_sync_test.py
+++ b/autobot-backend/knowledge/facts_metadata_sync_test.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for Issue #12623 — ``update_fact`` metadata-only updates must
+sync ChromaDB, not just Redis.
+
+Before this fix, ``update_fact(fact_id, metadata=...)`` (no ``content``
+argument) only re-synced the vector store when *content* also changed
+(``_revectorize_fact``). A pure metadata change — e.g. the #12623 promotion
+gate flipping ``collection`` from ``research`` to the general value — was
+written to Redis but silently never reached ChromaDB, so any
+ChromaDB-filtered search (like the #12622 chat-RAG quarantine filter) would
+still see the stale metadata and the fact would remain invisible even after
+"promotion".
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge.facts import FactsMixin
+
+
+class _KB(FactsMixin):
+    """Minimal FactsMixin host with the collaborators update_fact touches."""
+
+    def __init__(self, existing_metadata: dict):
+        self.ensure_initialized = MagicMock()
+        self.redis_client = MagicMock()
+        self.redis_client.exists.return_value = True
+        self.redis_client.hgetall.return_value = {
+            b"content": b"unchanged content",
+            b"metadata": json.dumps(existing_metadata).encode("utf-8"),
+            b"timestamp": b"2026-01-01T00:00:00+00:00",
+        }
+        self.vector_store = MagicMock()
+        self.vector_store._collection = MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_metadata_only_update_syncs_chromadb():
+    """A metadata-only update() call must push the change to ChromaDB too."""
+    kb = _KB({"collection": "research", "fact_id": "fact-1"})
+
+    result = await kb.update_fact("fact-1", metadata={"collection": "general"})
+
+    assert result["status"] == "success"
+    kb.vector_store._collection.update.assert_called_once()
+    call_kwargs = kb.vector_store._collection.update.call_args.kwargs
+    assert call_kwargs["ids"] == ["fact-1"]
+    assert call_kwargs["metadatas"][0]["collection"] == "general"
+
+
+@pytest.mark.asyncio
+async def test_content_update_still_uses_revectorize_not_metadata_sync():
+    """A content change re-embeds via _revectorize_fact — the metadata-only
+    path must NOT also fire (would be a redundant/duplicate vector-store write)."""
+    kb = _KB({"collection": "research", "fact_id": "fact-1"})
+    kb._revectorize_fact = AsyncMock()
+    kb._sync_fact_metadata_in_chromadb = AsyncMock()
+
+    await kb.update_fact("fact-1", content="new content", metadata={"collection": "general"})
+
+    kb._revectorize_fact.assert_awaited_once()
+    kb._sync_fact_metadata_in_chromadb.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_vector_store_skips_sync_without_error():
+    """A KB with no vector store configured must not raise on metadata update."""
+    kb = _KB({"collection": "research"})
+    kb.vector_store = None
+
+    result = await kb.update_fact("fact-1", metadata={"collection": "general"})
+
+    assert result["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_chromadb_sync_failure_does_not_fail_the_update():
+    """A ChromaDB error during the metadata sync must not surface as an update failure."""
+    kb = _KB({"collection": "research"})
+    kb.vector_store._collection.update.side_effect = RuntimeError("chroma unreachable")
+
+    result = await kb.update_fact("fact-1", metadata={"collection": "general"})
+
+    assert result["status"] == "success"

--- a/autobot-backend/services/claim_verifier.py
+++ b/autobot-backend/services/claim_verifier.py
@@ -26,9 +26,11 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Tuple
+from urllib.parse import urlparse
 
 from autobot_shared.logging_manager import get_llm_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_config import config
 from constants.ttl_constants import TTL_7_DAYS
 from services.knowledge_grounding_models import (
     Claim,
@@ -46,6 +48,17 @@ _CACHE_KEY_PREFIX = "verified_claim"
 _RESEARCH_AGENT_TIMEOUT = 30.0  # seconds
 _RAG_CONFIDENCE_THRESHOLD = 0.7
 _MIN_RAG_CONFIDENCE = 0.5
+
+# ---------------------------------------------------------------------------
+# N-source corroboration (#12623) — every tunable sourced from ssot_config,
+# never hardcoded. K = minimum independent agreeing sources before a claim
+# can ever be marked verified; single-source claims are never promoted.
+# ---------------------------------------------------------------------------
+_CORROBORATION_MIN_SOURCES: int = config.research_corroboration_min_sources
+_CORROBORATION_CONFIDENCE_BASE: float = config.research_corroboration_confidence_base
+_CORROBORATION_CONFIDENCE_PER_SOURCE: float = config.research_corroboration_confidence_per_source
+_CORROBORATION_CONFIDENCE_CAP: float = config.research_corroboration_confidence_cap
+_CORROBORATION_CLASSIFY_TIMEOUT_SECONDS: float = config.research_corroboration_classify_timeout_seconds
 
 
 class VerificationStatus(str, Enum):
@@ -118,6 +131,110 @@ class VerifiedClaim:
         }
 
 
+class SourceAgreement(str, Enum):
+    """Verdict from adversarial agreement classification of one candidate source."""
+
+    AGREE = "agree"
+    CONTRADICT = "contradict"
+    UNRELATED = "unrelated"
+
+
+@dataclass
+class CorroborationResult:
+    """Outcome of N-source corroboration for one material claim (#12623)."""
+
+    claim_text: str
+    independent_agree_count: int
+    contradicting_sources: List[KBSource] = field(default_factory=list)
+    confidence: float = 0.0
+    verified: bool = False
+    requires_human_review: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization / API response shaping."""
+        return {
+            "claim_text": self.claim_text,
+            "independent_agree_count": self.independent_agree_count,
+            "contradicting_sources": [s.source_id for s in self.contradicting_sources],
+            "confidence": self.confidence,
+            "verified": self.verified,
+            "requires_human_review": self.requires_human_review,
+        }
+
+
+# Adversarial refutation-prompt pattern (ported from the second-model
+# devil's-advocate check in agent_loop/pre_action_verifier.py — no
+# "deep-research" skill with this pattern exists in the codebase; verified
+# during #12623 premise-check). Framed as "what evidence would contradict
+# this claim?" per the design doc, applied to a candidate source instead of
+# a proposed action.
+_CORROBORATION_SYSTEM_PROMPT = (
+    "You are an adversarial fact-checker. Your ONLY job is to find whether the "
+    "candidate source text CONTRADICTS the claim below. Actively look for "
+    "evidence against the claim rather than assuming agreement — do not be "
+    "swayed by superficial phrasing similarity."
+)
+
+_CORROBORATION_USER_TMPL = """\
+## Claim
+{claim_text}
+
+## Candidate source text
+{source_text}
+
+## Your task
+What evidence in the source above would contradict this claim, if any? \
+Respond with EXACTLY this format (no extra text):
+
+AGREEMENT: <AGREE|CONTRADICT|UNRELATED>
+RATIONALE: <one sentence>
+"""
+
+
+def _build_corroboration_prompt(claim_text: str, source_text: str) -> tuple[str, str]:
+    """Return (system_prompt, user_prompt) for one agreement-classification call."""
+    user = _CORROBORATION_USER_TMPL.format(claim_text=claim_text, source_text=source_text[:2000])
+    return _CORROBORATION_SYSTEM_PROMPT, user
+
+
+def _parse_agreement(raw: str) -> SourceAgreement:
+    """Extract the AGREEMENT verdict from the LLM response, defaulting to UNRELATED."""
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.upper().startswith("AGREEMENT:"):
+            value = stripped[len("AGREEMENT:") :].strip().upper()
+            try:
+                return SourceAgreement(value.lower())
+            except ValueError:
+                return SourceAgreement.UNRELATED
+    return SourceAgreement.UNRELATED
+
+
+def _source_domain(url: str | None) -> str | None:
+    """Return the netloc of *url*, or None if unusable (treated as non-independent)."""
+    if not url:
+        return None
+    try:
+        netloc = urlparse(url).netloc
+        return netloc or None
+    except ValueError:
+        return None
+
+
+def _dedupe_independent_sources(claim_url: str | None, candidates: List[KBSource]) -> List[KBSource]:
+    """Keep at most one source per distinct domain, excluding the claim's own domain."""
+    claim_domain = _source_domain(claim_url)
+    seen: set[str] = set()
+    independent: List[KBSource] = []
+    for src in candidates:
+        domain = _source_domain(src.url)
+        if domain is None or domain == claim_domain or domain in seen:
+            continue
+        seen.add(domain)
+        independent.append(src)
+    return independent
+
+
 class ClaimVerifier:
     """
     Verifies claims using KB RAG search and research agent escalation.
@@ -130,21 +247,129 @@ class ClaimVerifier:
        c) Otherwise, escalate to research agent
        d) Return whichever source has higher confidence
     3. CONTRADICTS claims return to ConflictResolver (not handled here)
+
+    #12623: also provides N-source corroboration (``corroborate``) for
+    material claims produced by the research orchestrator — a distinct
+    workflow from single-claim ``verify()`` above, extending this same
+    class per the issue's "extend, do not fork" requirement.
     """
 
-    def __init__(self, knowledge_base: Any, research_agent_service: Any | None = None) -> None:
+    def __init__(
+        self,
+        knowledge_base: Any,
+        research_agent_service: Any | None = None,
+        llm_service: Any | None = None,
+    ) -> None:
         """
         Initialize claim verifier.
 
         Args:
             knowledge_base: KnowledgeBase instance for RAG searches
             research_agent_service: Optional research agent service for escalation
+            llm_service: Optional LLM service for N-source corroboration (#12623);
+                lazily resolved via ``services.llm_service.get_llm_service`` when absent.
         """
         self.kb = knowledge_base
         self.research_agent_service = research_agent_service
+        self._llm_service = llm_service
         self._cache: Dict[str, Tuple[VerifiedClaim, float]] = {}
         self._cache_lock = asyncio.Lock()
         logger.info("ClaimVerifier initialized")
+
+    async def _llm(self) -> Any:
+        """Lazily resolve the LLM service used for corroboration classification."""
+        if self._llm_service is None:
+            from services.llm_service import get_llm_service
+
+            self._llm_service = get_llm_service()
+        return self._llm_service
+
+    async def classify_agreement(self, claim_text: str, source_text: str) -> SourceAgreement:
+        """Adversarially classify whether *source_text* agrees with or contradicts *claim_text*.
+
+        Fails conservatively (UNRELATED — no corroboration credit, no contradiction
+        flag either) on any LLM error or timeout, so a broken verifier can never
+        wrongly promote or wrongly block a claim.
+        """
+        llm = await self._llm()
+        system_prompt, user_prompt = _build_corroboration_prompt(claim_text, source_text)
+        try:
+            response = await asyncio.wait_for(
+                llm.chat(
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    temperature=0.0,
+                ),
+                timeout=_CORROBORATION_CLASSIFY_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            logger.warning("classify_agreement: LLM call failed (%s) — treating as UNRELATED", exc)
+            return SourceAgreement.UNRELATED
+        if getattr(response, "error", None):
+            logger.warning("classify_agreement: LLM error: %s — treating as UNRELATED", response.error)
+            return SourceAgreement.UNRELATED
+        return _parse_agreement(response.content or "")
+
+    async def _classify_all(self, claim_text: str, sources: List[KBSource]) -> tuple[int, List[KBSource]]:
+        """Classify every independent source; return (agree_count, contradicting_sources)."""
+        verdicts = await asyncio.gather(*(self.classify_agreement(claim_text, s.text) for s in sources))
+        agree_count = sum(1 for v in verdicts if v == SourceAgreement.AGREE)
+        contradicting = [s for s, v in zip(sources, verdicts) if v == SourceAgreement.CONTRADICT]
+        return agree_count, contradicting
+
+    def _score_corroboration(self, claim_text: str, agree_count: int) -> CorroborationResult:
+        """Build the verified-and-scored result once contradictions are ruled out."""
+        if agree_count < _CORROBORATION_MIN_SOURCES:
+            return CorroborationResult(claim_text=claim_text, independent_agree_count=agree_count)
+        extra_sources = agree_count - _CORROBORATION_MIN_SOURCES
+        confidence = min(
+            _CORROBORATION_CONFIDENCE_CAP,
+            _CORROBORATION_CONFIDENCE_BASE + _CORROBORATION_CONFIDENCE_PER_SOURCE * extra_sources,
+        )
+        return CorroborationResult(
+            claim_text=claim_text,
+            independent_agree_count=agree_count,
+            confidence=confidence,
+            verified=True,
+        )
+
+    async def corroborate(
+        self,
+        claim_text: str,
+        candidate_sources: List[KBSource],
+        claim_url: str | None = None,
+    ) -> CorroborationResult:
+        """N-source corroboration for one material claim (#12623).
+
+        Gathers independent (distinct-domain) candidate sources, adversarially
+        classifies each against the claim, and either raises confidence on
+        agreement (never below the configured K-source floor — single-source
+        claims are never verified) or flags a contradiction for human review.
+        """
+        independent = _dedupe_independent_sources(claim_url, candidate_sources)
+        if len(independent) < _CORROBORATION_MIN_SOURCES:
+            logger.debug(
+                "corroborate: only %d independent source(s) for claim (K=%d) — staying quarantined",
+                len(independent),
+                _CORROBORATION_MIN_SOURCES,
+            )
+            return CorroborationResult(claim_text=claim_text, independent_agree_count=len(independent))
+
+        agree_count, contradicting = await self._classify_all(claim_text, independent)
+        if contradicting:
+            logger.warning(
+                "corroborate: %d contradicting source(s) found for claim — flagging for human review",
+                len(contradicting),
+            )
+            return CorroborationResult(
+                claim_text=claim_text,
+                independent_agree_count=agree_count,
+                contradicting_sources=contradicting,
+                requires_human_review=True,
+            )
+        return self._score_corroboration(claim_text, agree_count)
 
     def _build_cache_key(self, claim: Claim) -> str:
         """Build cache key for a claim (based on claim text hash)."""

--- a/autobot-backend/services/research/orchestrator.py
+++ b/autobot-backend/services/research/orchestrator.py
@@ -9,20 +9,24 @@ Composes existing modules (never recreates them, design §6):
   * ``web_fetch.WebFetcher`` — fast-HTTP page fetch
   * ``knowledge_base_factory.get_knowledge_base`` — the canonical KB facade
   * ``services.research.extractor`` / ``synthesizer`` — the two new LLM steps
+  * ``services.claim_verifier.ClaimVerifier.corroborate`` — N-source
+    corroboration + promotion gate (#12623)
 
-Phase 0 scope only: a single bounded fetch round, no Planner sub-question
-loop (#12624) and no N-source corroboration (#12623) — both are later
-phases per the design doc's phasing table.
+Phase 0 scope: a single bounded fetch round, no Planner sub-question loop
+(#12624 — later phase). #12623 adds the corroboration/promotion step below.
 """
 
 from __future__ import annotations
 
 import hashlib
-from typing import Any, List
+from datetime import datetime, timezone
+from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from knowledge_base_factory import get_knowledge_base
+from services.claim_verifier import ClaimVerifier, CorroborationResult
+from services.knowledge_grounding_models import KBSource
 from services.llm_service import get_llm_service
 
 from .extractor import extract_claims
@@ -108,6 +112,80 @@ async def _store_claim(kb: Any, claim: ExtractedClaim) -> StoredFact | None:
     )
 
 
+def _kb_result_to_source(result: dict) -> KBSource:
+    """Map a raw ``kb.search()`` result dict to a ``KBSource`` (#12623)."""
+    metadata = result.get("metadata") or {}
+    return KBSource(
+        source_id=metadata.get("fact_id", result.get("node_id", result.get("doc_id", ""))),
+        source_type=metadata.get("source_type", "document"),
+        text=result.get("content", ""),
+        confidence=result.get("score", 0.0),
+        age_days=metadata.get("age_days", 0.0),
+        url=metadata.get("url"),
+    )
+
+
+async def _gather_candidate_sources(kb: Any, fact: StoredFact) -> List[KBSource]:
+    """Search the quarantine collection for other facts that might corroborate *fact*."""
+    raw = await kb.search(
+        query=fact.content,
+        top_k=config.research_corroboration_search_top_k,
+        filters={"collection": config.research_quarantine_collection},
+    )
+    sources = [_kb_result_to_source(r) for r in (raw or [])]
+    return [s for s in sources if s.source_id and s.source_id != fact.fact_id]
+
+
+async def _promote_fact(kb: Any, fact: StoredFact, result: CorroborationResult) -> None:
+    """Promote a corroborated fact out of quarantine (#12623, one-way trust boundary).
+
+    Reversible/auditable: records the evidence count and confidence that
+    justified promotion rather than silently moving the fact.
+    """
+    await kb.update_fact(
+        fact.fact_id,
+        metadata={
+            "collection": config.research_promoted_collection,
+            "verification_status": "verified",
+            "requires_human_review": False,
+            "promoted_at": datetime.now(tz=timezone.utc).isoformat(),
+            "promotion_confidence": result.confidence,
+            "promotion_evidence_count": result.independent_agree_count,
+        },
+    )
+    logger.info(
+        "ResearchOrchestrator: promoted fact %s (confidence=%.2f, sources=%d)",
+        fact.fact_id,
+        result.confidence,
+        result.independent_agree_count,
+    )
+
+
+async def _flag_contradiction(kb: Any, fact: StoredFact, result: CorroborationResult) -> dict:
+    """Record a contradiction: fact->fact relation(s) + human-review flag; never promoted."""
+    for source in result.contradicting_sources:
+        await kb.create_fact_relation(
+            fact.fact_id,
+            source.source_id,
+            "contradicts",
+            metadata={"detected_by": "research_corroborator"},
+        )
+    await kb.update_fact(
+        fact.fact_id,
+        metadata={"verification_status": "disputed", "requires_human_review": True},
+    )
+    logger.warning(
+        "ResearchOrchestrator: fact %s disputed by %d source(s) — staying quarantined",
+        fact.fact_id,
+        len(result.contradicting_sources),
+    )
+    return {
+        "fact_id": fact.fact_id,
+        "content": fact.content,
+        "contradicting_fact_ids": [s.source_id for s in result.contradicting_sources],
+    }
+
+
 class ResearchOrchestrator:
     """Bundles fetch -> KB-fact landing -> grounded synthesis for one question."""
 
@@ -132,6 +210,30 @@ class ResearchOrchestrator:
         stored = [await _store_claim(kb, claim) for claim in claims]
         return [fact for fact in stored if fact is not None]
 
+    async def _corroborate_material_facts(
+        self, kb: Any, material_facts: List[StoredFact]
+    ) -> tuple[List[dict], Dict[str, float]]:
+        """N-source corroboration + promotion gate for cited (material) facts only (#12623).
+
+        Cost control: only claims the synthesizer actually asserted are worth
+        the corroboration LLM calls (design: "verify only asserted claims").
+        Returns (contradiction records for ``contradictions[]``, confidence
+        overrides for promoted facts so ``facts[].confidence`` in the response
+        reflects the corroboration outcome per the acceptance criteria).
+        """
+        verifier = ClaimVerifier(knowledge_base=kb, llm_service=await self._llm())
+        contradictions: List[dict] = []
+        confidence_overrides: Dict[str, float] = {}
+        for fact in material_facts:
+            candidates = await _gather_candidate_sources(kb, fact)
+            result = await verifier.corroborate(fact.content, candidates, claim_url=fact.source_url)
+            if result.verified:
+                await _promote_fact(kb, fact, result)
+                confidence_overrides[fact.fact_id] = result.confidence
+            elif result.requires_human_review:
+                contradictions.append(await _flag_contradiction(kb, fact, result))
+        return contradictions, confidence_overrides
+
     async def research(self, question: str, options: dict | None = None) -> ResearchResponse:
         """Run the bounded Phase-0 pipeline and return the full #12622 contract."""
         budget = _resolve_budget(options or {})
@@ -147,16 +249,22 @@ class ResearchOrchestrator:
         llm = await self._llm()
         synthesis = await synthesize_answer(llm, question, all_facts)
         cited_ids = {c.fact_id for c in synthesis.citations}
+        material_facts = [f for f in all_facts if f.fact_id in cited_ids]
+        contradictions, confidence_overrides = await self._corroborate_material_facts(kb, material_facts)
         facts_out = [
-            ResearchFactOut(fact_id=f.fact_id, content=f.content, source_url=f.source_url, confidence=f.confidence)
-            for f in all_facts
-            if f.fact_id in cited_ids
+            ResearchFactOut(
+                fact_id=f.fact_id,
+                content=f.content,
+                source_url=f.source_url,
+                confidence=confidence_overrides.get(f.fact_id, f.confidence),
+            )
+            for f in material_facts
         ]
         return ResearchResponse(
             answer=synthesis.answer,
             citations=synthesis.citations,
             facts=facts_out,
-            contradictions=[],
+            contradictions=contradictions,
             confidence=synthesis.confidence,
             sources_fetched=len(urls),
             facts_stored=len(all_facts),

--- a/autobot-backend/services/research/orchestrator_test.py
+++ b/autobot-backend/services/research/orchestrator_test.py
@@ -42,6 +42,12 @@ def _make_kb(store_fact_status: str = "success") -> AsyncMock:
     kb = AsyncMock()
     kb.add_document = AsyncMock(return_value={"status": "success", "fact_id": "doc-1"})
     kb.store_fact = AsyncMock(return_value={"status": store_fact_status, "fact_id": "fact-1"})
+    # #12623: the corroboration step always calls kb.search() for material
+    # facts — default to "no corroborating sources found" so pre-#12623
+    # tests (which don't care about corroboration) stay quarantined/inert.
+    kb.search = AsyncMock(return_value=[])
+    kb.update_fact = AsyncMock(return_value={"status": "success"})
+    kb.create_fact_relation = AsyncMock(return_value={"success": True})
     return kb
 
 
@@ -162,3 +168,117 @@ class TestResearchFailurePaths:
             response = await ResearchOrchestrator(llm_service=AsyncMock()).research("q")
 
         assert response.facts_stored == 1
+
+
+# ---------------------------------------------------------------------------
+# N-source corroboration + promotion gate wiring (#12623)
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_with_agreement(verdict: str) -> AsyncMock:
+    """LLM mock whose .chat() always returns a fixed agreement verdict."""
+    from types import SimpleNamespace
+
+    llm = AsyncMock()
+    llm.chat = AsyncMock(return_value=SimpleNamespace(content=f"AGREEMENT: {verdict}\nRATIONALE: r", error=None))
+    return llm
+
+
+def _corroborating_search_result(fact_id: str, url: str, content: str = "corroborating") -> dict:
+    return {
+        "content": content,
+        "score": 0.85,
+        "metadata": {"fact_id": fact_id, "url": url, "source_type": "web_research"},
+        "node_id": fact_id,
+        "doc_id": fact_id,
+    }
+
+
+class TestResearchCorroborationAndPromotion:
+    """Full pipeline: a cited fact with corroborating/contradicting sources."""
+
+    async def test_corroborated_material_fact_is_promoted(self):
+        """A material fact with >=K independent agreeing sources is promoted out of quarantine."""
+        kb = _make_kb()
+        kb.search = AsyncMock(
+            return_value=[
+                _corroborating_search_result("fact-2", "https://b.example/page"),
+                _corroborating_search_result("fact-3", "https://c.example/page"),
+            ]
+        )
+        claim = ExtractedClaim(content="X is Y.", confidence=0.8, source_url="https://a.example", source_doc_id="doc-1")
+        synthesis = SynthesisResult(answer="X is Y [F1].", citations=[], confidence=0.7)
+        from services.research.models import Citation
+
+        synthesis.citations = [Citation(fact_id="fact-1", source_url="https://a.example", source_doc_id="doc-1")]
+        fetch_result = _FakeFetchResult(success=True, markdown="X is Y because of Z.", title="Page A")
+
+        patches = _patch_common(kb, ["https://a.example"], fetch_result, [claim], synthesis)
+        llm = _make_llm_with_agreement("AGREE")
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await ResearchOrchestrator(llm_service=llm).research("what is X?")
+
+        assert response.contradictions == []
+        kb.update_fact.assert_awaited_once()
+        call_kwargs = kb.update_fact.await_args
+        assert call_kwargs.args[0] == "fact-1"
+        promoted_metadata = call_kwargs.kwargs["metadata"]
+        assert promoted_metadata["collection"] != "research"
+        assert promoted_metadata["verification_status"] == "verified"
+
+        # Acceptance criterion: response confidence/facts[] reflect the
+        # corroboration outcome (evidence-based), not the original
+        # extraction-time confidence the LLM claim extractor guessed.
+        assert len(response.facts) == 1
+        assert response.facts[0].confidence == promoted_metadata["promotion_confidence"]
+        assert response.facts[0].confidence != claim.confidence
+
+    async def test_contradicted_material_fact_stays_quarantined(self):
+        """A material fact with a disagreeing independent source is flagged, never promoted."""
+        kb = _make_kb()
+        kb.search = AsyncMock(
+            return_value=[
+                _corroborating_search_result("fact-2", "https://b.example/page"),
+                _corroborating_search_result("fact-3", "https://c.example/page"),
+            ]
+        )
+        claim = ExtractedClaim(content="X is Y.", confidence=0.8, source_url="https://a.example", source_doc_id="doc-1")
+        synthesis = SynthesisResult(answer="X is Y [F1].", citations=[], confidence=0.7)
+        from services.research.models import Citation
+
+        synthesis.citations = [Citation(fact_id="fact-1", source_url="https://a.example", source_doc_id="doc-1")]
+        fetch_result = _FakeFetchResult(success=True, markdown="X is Y because of Z.", title="Page A")
+
+        patches = _patch_common(kb, ["https://a.example"], fetch_result, [claim], synthesis)
+        llm = _make_llm_with_agreement("CONTRADICT")
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await ResearchOrchestrator(llm_service=llm).research("what is X?")
+
+        assert len(response.contradictions) == 1
+        assert response.contradictions[0]["fact_id"] == "fact-1"
+        kb.create_fact_relation.assert_any_await(
+            "fact-1", "fact-2", "contradicts", metadata={"detected_by": "research_corroborator"}
+        )
+        update_metadata = kb.update_fact.await_args.kwargs["metadata"]
+        assert update_metadata["requires_human_review"] is True
+        # promotion metadata must never be written for a disputed fact
+        assert "collection" not in update_metadata
+
+    async def test_below_threshold_material_fact_stays_quarantined_no_promotion(self):
+        """Fewer than K independent sources -> quarantined, no update_fact/relation calls at all."""
+        kb = _make_kb()
+        kb.search = AsyncMock(return_value=[])  # no corroborating sources found
+        claim = ExtractedClaim(content="X is Y.", confidence=0.8, source_url="https://a.example", source_doc_id="doc-1")
+        synthesis = SynthesisResult(answer="X is Y [F1].", citations=[], confidence=0.7)
+        from services.research.models import Citation
+
+        synthesis.citations = [Citation(fact_id="fact-1", source_url="https://a.example", source_doc_id="doc-1")]
+        fetch_result = _FakeFetchResult(success=True, markdown="X is Y because of Z.", title="Page A")
+
+        patches = _patch_common(kb, ["https://a.example"], fetch_result, [claim], synthesis)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await ResearchOrchestrator(llm_service=AsyncMock()).research("what is X?")
+
+        assert response.contradictions == []
+        kb.update_fact.assert_not_awaited()
+        kb.create_fact_relation.assert_not_awaited()

--- a/autobot-backend/services/research/quarantine_boundary_test.py
+++ b/autobot-backend/services/research/quarantine_boundary_test.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""End-to-end proof of the #12622/#12623 quarantine boundary.
+
+Both the chat-RAG quarantine filter (``async_chat_workflow.py::_execute_kb_search``,
+#12622) and this PR's promotion gate (``knowledge/facts.py::update_fact`` /
+``_sync_fact_metadata_in_chromadb``) rely on ONE real enforcement point: a
+vector-store ``where`` filter ``{"collection": {"$ne": "research"}}`` evaluated
+against the store's own metadata.
+
+Real ChromaDB cannot be used directly in this test suite — ``conftest.py``
+globally stubs the ``chromadb`` package (it hangs at import time without a
+local server, see conftest.py's stub block), so ``chromadb.PersistentClient``
+would silently return a ``MagicMock``. Instead this test drives
+``knowledge.backends.InMemoryClient`` — the repo's designated real (not
+mocked) where-filter implementation for exactly this scenario (its module
+docstring: "tests that need [operator filters] should ... extend this
+helper" — done here by adding ``$ne`` support to ``_match_where``, #12623) —
+and separately proves the *production* ChromaDB call shape
+(``vector_store._collection.update(ids=, metadatas=)``) is invoked correctly
+by ``FactsMixin._sync_fact_metadata_in_chromadb``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from knowledge.backends import InMemoryClient
+from knowledge.facts import FactsMixin
+
+_QUARANTINE_FILTER = {"collection": {"$ne": "research"}}
+
+
+def _collection():
+    """A real (non-mocked) in-memory vector-store collection."""
+    return InMemoryClient().get_or_create_collection("quarantine_boundary_test")
+
+
+class TestQuarantineBoundaryEndToEnd:
+    """Real where-filter proof that quarantine/promotion actually gates visibility."""
+
+    def test_below_threshold_fact_is_excluded_from_chat_rag_path(self):
+        """A quarantined (never-promoted) fact must never surface via the filter."""
+        collection = _collection()
+        collection.add(
+            ids=["quarantined-fact"],
+            metadatas=[{"collection": "research", "fact_id": "quarantined-fact"}],
+        )
+
+        visible = collection.get(where=_QUARANTINE_FILTER)
+
+        assert "quarantined-fact" not in visible["ids"]
+
+    def test_promoted_fact_is_reachable_from_chat_rag_path(self):
+        """A promoted fact (collection flipped to the general value) becomes visible."""
+        collection = _collection()
+        collection.add(
+            ids=["promoted-fact"],
+            metadatas=[{"collection": "research", "fact_id": "promoted-fact"}],
+        )
+
+        # Sanity: still quarantined before promotion.
+        before = collection.get(where=_QUARANTINE_FILTER)
+        assert "promoted-fact" not in before["ids"]
+
+        # Promotion gate flips only metadata (#12623's fix to
+        # knowledge/facts.py::update_fact — no re-embedding needed).
+        collection.update(
+            ids=["promoted-fact"],
+            metadatas=[{"collection": "general", "fact_id": "promoted-fact", "verification_status": "verified"}],
+        )
+
+        after = collection.get(where=_QUARANTINE_FILTER)
+        assert "promoted-fact" in after["ids"]
+
+    def test_preexisting_facts_without_collection_field_stay_visible(self):
+        """A fact predating the quarantine feature (no 'collection' key) is unaffected."""
+        collection = _collection()
+        collection.add(
+            ids=["legacy-fact"],
+            metadatas=[{"fact_id": "legacy-fact"}],
+        )
+
+        visible = collection.get(where=_QUARANTINE_FILTER)
+
+        assert "legacy-fact" in visible["ids"]
+
+    def test_metadata_only_update_fact_helper_reproduces_promotion(self):
+        """The exact production path: FactsMixin._sync_fact_metadata_in_chromadb.
+
+        Proves the fix to the pre-existing ``update_fact`` gap (#12623): a
+        metadata-only change (no content change) previously never reached
+        ChromaDB, which would have silently defeated the promotion gate.
+        """
+        collection = _collection()
+        collection.add(
+            ids=["gap-fact"],
+            metadatas=[{"collection": "research", "fact_id": "gap-fact"}],
+        )
+
+        class _FakeVectorStore:
+            _collection = collection
+
+        mixin = FactsMixin()
+        mixin.vector_store = _FakeVectorStore()
+
+        asyncio.run(
+            mixin._sync_fact_metadata_in_chromadb(
+                "gap-fact", {"collection": "general", "verification_status": "verified"}
+            )
+        )
+
+        after = collection.get(where=_QUARANTINE_FILTER)
+        assert "gap-fact" in after["ids"]
+
+    def test_contradicted_fact_never_promoted_stays_quarantined(self):
+        """A disputed fact (#12623 contradiction path) is never promoted — stays quarantined."""
+        collection = _collection()
+        collection.add(
+            ids=["disputed-fact"],
+            metadatas=[{"collection": "research", "fact_id": "disputed-fact"}],
+        )
+
+        # The contradiction path (orchestrator._flag_contradiction) only ever
+        # sets verification_status/requires_human_review — it must never
+        # touch "collection".
+        collection.update(
+            ids=["disputed-fact"],
+            metadatas=[
+                {
+                    "collection": "research",
+                    "fact_id": "disputed-fact",
+                    "verification_status": "disputed",
+                    "requires_human_review": True,
+                }
+            ],
+        )
+
+        visible = collection.get(where=_QUARANTINE_FILTER)
+        assert "disputed-fact" not in visible["ids"]

--- a/autobot-backend/tests/services/test_claim_verifier.py
+++ b/autobot-backend/tests/services/test_claim_verifier.py
@@ -19,6 +19,7 @@ import pytest
 from services.claim_verifier import (
     ClaimVerifier,
     ResearchStatus,
+    SourceAgreement,
     VerificationStatus,
 )
 from services.knowledge_grounding_models import (
@@ -915,3 +916,138 @@ class TestEdgeCases:
 
         # Should use RAG result (0.6 > 0.0)
         assert result.source == "kb_rag"
+
+
+# ---------------------------------------------------------------------------
+# N-source corroboration + promotion gate (#12623)
+# ---------------------------------------------------------------------------
+
+
+def _source(source_id: str, url: str, text: str = "corroborating text") -> KBSource:
+    """Build a minimal KBSource for corroboration tests."""
+    return KBSource(source_id=source_id, source_type="web_research", text=text, confidence=0.8, age_days=0.0, url=url)
+
+
+def _llm_response(content: str, error: str | None = None):
+    """Build a fake LLM chat() response with .content/.error attributes."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(content=content, error=error)
+
+
+@pytest.fixture
+def mock_llm_service():
+    """Create a mock LLM service returning a chat() response object."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def corroborating_verifier(mock_knowledge_base, mock_llm_service):
+    """ClaimVerifier wired with an explicit LLM service for corroboration tests."""
+    return ClaimVerifier(mock_knowledge_base, llm_service=mock_llm_service)
+
+
+class TestClassifyAgreement:
+    """Unit tests for the adversarial agreement-classification prompt call."""
+
+    @pytest.mark.asyncio
+    async def test_parses_agree_verdict(self, corroborating_verifier, mock_llm_service):
+        mock_llm_service.chat.return_value = _llm_response("AGREEMENT: AGREE\nRATIONALE: matches claim")
+        verdict = await corroborating_verifier.classify_agreement("The sky is blue.", "The sky appears blue.")
+        assert verdict == SourceAgreement.AGREE
+
+    @pytest.mark.asyncio
+    async def test_parses_contradict_verdict(self, corroborating_verifier, mock_llm_service):
+        mock_llm_service.chat.return_value = _llm_response("AGREEMENT: CONTRADICT\nRATIONALE: opposite claim")
+        verdict = await corroborating_verifier.classify_agreement("X is Y.", "X is definitely not Y.")
+        assert verdict == SourceAgreement.CONTRADICT
+
+    @pytest.mark.asyncio
+    async def test_llm_error_fails_conservative_unrelated(self, corroborating_verifier, mock_llm_service):
+        mock_llm_service.chat.return_value = _llm_response("", error="provider unavailable")
+        verdict = await corroborating_verifier.classify_agreement("X is Y.", "some text")
+        assert verdict == SourceAgreement.UNRELATED
+
+    @pytest.mark.asyncio
+    async def test_llm_exception_fails_conservative_unrelated(self, corroborating_verifier, mock_llm_service):
+        mock_llm_service.chat.side_effect = RuntimeError("timeout")
+        verdict = await corroborating_verifier.classify_agreement("X is Y.", "some text")
+        assert verdict == SourceAgreement.UNRELATED
+
+
+class TestCorroborate:
+    """Unit tests for ClaimVerifier.corroborate (N-source corroboration + promotion gate)."""
+
+    @pytest.mark.asyncio
+    async def test_single_source_never_verified(self, corroborating_verifier):
+        """Acceptance criterion: single-source claims are never marked verified."""
+        sources = [_source("f1", "https://a.example/page")]
+        result = await corroborating_verifier.corroborate("X is Y.", sources, claim_url="https://origin.example/x")
+
+        assert result.verified is False
+        assert result.confidence == 0.0
+        assert result.requires_human_review is False
+
+    @pytest.mark.asyncio
+    async def test_no_independent_sources_never_verified(self, corroborating_verifier):
+        """Zero candidate sources -> quarantined, no LLM call made."""
+        result = await corroborating_verifier.corroborate("X is Y.", [], claim_url="https://origin.example/x")
+        assert result.verified is False
+        assert result.independent_agree_count == 0
+
+    @pytest.mark.asyncio
+    async def test_same_domain_sources_not_independent(self, corroborating_verifier, mock_llm_service):
+        """Two sources from the same domain as the claim's own origin count as one/zero."""
+        sources = [
+            _source("f1", "https://origin.example/other-page"),
+            _source("f2", "https://origin.example/yet-another"),
+        ]
+        result = await corroborating_verifier.corroborate("X is Y.", sources, claim_url="https://origin.example/x")
+
+        assert result.verified is False
+        mock_llm_service.chat.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_agreement_promotes_with_confidence(self, corroborating_verifier, mock_llm_service):
+        """K independent agreeing sources -> verified with the configured base confidence."""
+        mock_llm_service.chat.return_value = _llm_response("AGREEMENT: AGREE\nRATIONALE: consistent")
+        sources = [
+            _source("f1", "https://b.example/page"),
+            _source("f2", "https://c.example/page"),
+        ]
+        result = await corroborating_verifier.corroborate("X is Y.", sources, claim_url="https://origin.example/x")
+
+        assert result.verified is True
+        assert result.independent_agree_count == 2
+        assert result.confidence > 0.0
+        assert result.requires_human_review is False
+
+    @pytest.mark.asyncio
+    async def test_extra_sources_increase_confidence(self, corroborating_verifier, mock_llm_service):
+        """More agreeing independent sources beyond K raises confidence further."""
+        mock_llm_service.chat.return_value = _llm_response("AGREEMENT: AGREE\nRATIONALE: consistent")
+        sources = [
+            _source("f1", "https://b.example/page"),
+            _source("f2", "https://c.example/page"),
+            _source("f3", "https://d.example/page"),
+        ]
+        result_2 = await corroborating_verifier.corroborate(
+            "X is Y.", sources[:2], claim_url="https://origin.example/x"
+        )
+        result_3 = await corroborating_verifier.corroborate("X is Y.", sources, claim_url="https://origin.example/x")
+
+        assert result_3.confidence > result_2.confidence
+
+    @pytest.mark.asyncio
+    async def test_contradiction_flags_for_review_and_blocks_promotion(self, corroborating_verifier, mock_llm_service):
+        """A disagreeing independent source -> requires_human_review, never verified."""
+        mock_llm_service.chat.return_value = _llm_response("AGREEMENT: CONTRADICT\nRATIONALE: opposes claim")
+        sources = [
+            _source("f1", "https://b.example/page"),
+            _source("f2", "https://c.example/page"),
+        ]
+        result = await corroborating_verifier.corroborate("X is Y.", sources, claim_url="https://origin.example/x")
+
+        assert result.verified is False
+        assert result.requires_human_review is True
+        assert len(result.contradicting_sources) == 2

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1594,6 +1594,37 @@ class MiscConfig(BaseSettings):
     # Quarantine collection name (design doc §5/§9): web-research facts land
     # here, invisible to general chat/RAG, until Phase 1's promotion gate.
     research_quarantine_collection: str = Field(default="research", alias="AUTOBOT_RESEARCH_QUARANTINE_COLLECTION")
+    # #12623: N-source corroboration + promotion gate. Every tunable number is
+    # a config field (never a literal in services/claim_verifier.py or
+    # services/research/orchestrator.py). K = minimum independent agreeing
+    # sources before a claim can ever be marked verified — single-source
+    # claims are never promoted regardless of confidence (design §9 Phase 1).
+    research_corroboration_min_sources: int = Field(default=2, alias="AUTOBOT_RESEARCH_CORROBORATION_MIN_SOURCES")
+    # Confidence assigned when exactly K independent sources agree.
+    research_corroboration_confidence_base: float = Field(
+        default=0.75, alias="AUTOBOT_RESEARCH_CORROBORATION_CONFIDENCE_BASE"
+    )
+    # Confidence increment per additional agreeing independent source beyond K.
+    research_corroboration_confidence_per_source: float = Field(
+        default=0.05, alias="AUTOBOT_RESEARCH_CORROBORATION_CONFIDENCE_PER_SOURCE"
+    )
+    # Hard cap so confidence never reaches false certainty (1.0).
+    research_corroboration_confidence_cap: float = Field(
+        default=0.95, alias="AUTOBOT_RESEARCH_CORROBORATION_CONFIDENCE_CAP"
+    )
+    # Minimum corroboration confidence required to promote a fact out of quarantine.
+    research_promotion_confidence_threshold: float = Field(
+        default=0.75, alias="AUTOBOT_RESEARCH_PROMOTION_CONFIDENCE_THRESHOLD"
+    )
+    # Collection metadata value written on promoted facts (must differ from
+    # ``research_quarantine_collection`` so the chat-RAG ``$ne`` filter admits it).
+    research_promoted_collection: str = Field(default="general", alias="AUTOBOT_RESEARCH_PROMOTED_COLLECTION")
+    # How many candidate corroborating facts to retrieve per material claim.
+    research_corroboration_search_top_k: int = Field(default=5, alias="AUTOBOT_RESEARCH_CORROBORATION_SEARCH_TOP_K")
+    # Timeout for the adversarial agreement-classification LLM call.
+    research_corroboration_classify_timeout_seconds: float = Field(
+        default=20.0, alias="AUTOBOT_RESEARCH_CORROBORATION_CLASSIFY_TIMEOUT_SECONDS"
+    )
     routing_model: str = Field(default="", alias="AUTOBOT_ROUTING_MODEL")
     run_jwt: str = Field(default="", alias="AUTOBOT_RUN_JWT")
     schema_dir: str = Field(default="", alias="AUTOBOT_SCHEMA_DIR")


### PR DESCRIPTION
Closes #12623

## Thinking Path

Read #12623 + umbrella #12621, the merged design doc (PR #12643), and the just-merged PR #13010 (#12622) before writing code. Verified every premise:

- **`ClaimVerifier.verify()` at `services/claim_verifier.py:365`** is a real 2-source arbitration (KB-RAG vs research-agent, "whichever has higher confidence" wins) — extended it in place rather than forking, per the issue's explicit requirement.
- **KB `contradicts` relation exists**: `knowledge/relations.py:43` (`KB_RELATION_TYPES`), created via `create_fact_relation()`. **`requires_human_review` exists** as a result-object field (`VerifiedClaim`, `ConflictResolutionResult`, `GroundedResponse`, LLC `review_gate`) but had never been a *fact metadata* field — reused the same name for the new fact-level flag rather than inventing a new one.
- **The "deep-research skill" refutation-prompt pattern the issue says to port does not exist.** No skill by that name has prompt logic; `autobot-backend/skills/builtin/research/SKILL.md` is an unrelated `/research` slash-command skill, and `onboarding/presets.py`'s `"deep-research"` entry is just a starter-preset system prompt with no refutation logic. The actual adversarial refutation-prompt pattern in this codebase lives in `agent_loop/pre_action_verifier.py` (`_VERIFIER_SYSTEM`/structured-response parsing/fail-open) — ported *that* pattern instead, applied to a candidate source vs. a claim rather than an action vs. safety.
- **Promotion mechanism**: confirmed via #13010 that `add_document()`/`store_fact()` share one Redis+Chroma record differentiated by `metadata["collection"]`. "Promotion" is a metadata flip (`collection: "research"` → the general value), not a data move. **Discovered along the way**: `knowledge/facts.py::update_fact()` only re-synced ChromaDB when *content* also changed (`_revectorize_fact`) — a metadata-only update (exactly what promotion needs) was written to Redis but silently never reached the vector store, which would have made every "promoted" fact stay invisible to chat/RAG. Fixed in-scope since it directly gates this issue's acceptance criteria.

## What Changed

- **`autobot_shared/ssot_config.py`**: 7 new config fields — corroboration K (`AUTOBOT_RESEARCH_CORROBORATION_MIN_SOURCES`, default 2), confidence-formula base/per-source/cap, promotion threshold, promoted-collection name, search top-k, classify timeout. Nothing hardcoded in the logic below.
- **`services/claim_verifier.py`** (extended, not forked): `SourceAgreement` enum, `CorroborationResult`, and `ClaimVerifier.corroborate()` — dedupes candidate sources to one per distinct domain (excluding the claim's own domain), adversarially classifies each via the ported refutation prompt, and either raises confidence on ≥K agreement or flags a contradiction. Single-source claims are never verified (hard floor, not just a threshold artifact).
- **`services/research/orchestrator.py`**: after synthesis picks material (cited) facts, `_corroborate_material_facts()` runs corroboration against candidates found via `kb.search()` in the quarantine collection. Verified → `_promote_fact()` flips `collection` to the general value with an auditable trail (`promoted_at`, `promotion_confidence`, `promotion_evidence_count`) — reversible/auditable, never silent. Contradicted → `_flag_contradiction()` records a `contradicts` KB relation + `requires_human_review=True`; never promoted. `facts[].confidence` and `contradictions[]` in the response now reflect the corroboration outcome, not just extraction-time confidence.
- **`knowledge/facts.py`**: `update_fact()` now syncs metadata-only changes to ChromaDB via a new `_sync_fact_metadata_in_chromadb()` (cheap `collection.update()`, no re-embedding) — fixes the promotion-visibility gap above.
- **`knowledge/backends/memory_adapter.py`**: extended `_match_where` with `$ne`/`$eq` operator support (its own docstring said to extend it for exactly this) so the quarantine boundary can be proven against a real, non-mocked where-filter implementation without needing live ChromaDB (which `conftest.py` globally stubs in this test suite).

## Verification

- `py_compile`, `flake8 --max-line-length=120`, `black --check --line-length=120` (120-col, not Black's 88 default): clean on every touched/new file.
- New tests incl. failure paths: 10 in `test_claim_verifier.py` (agreement/contradiction/below-threshold/same-domain-not-independent/LLM-fail-open), 3 in `orchestrator_test.py` (promoted/contradicted/below-threshold wiring, including a confidence-reflects-corroboration assertion), 4 in `knowledge/facts_metadata_sync_test.py` (the ChromaDB-sync fix + its failure/no-vector-store paths), 5 in `services/research/quarantine_boundary_test.py`.
- **Quarantine boundary proven end-to-end, not described**: `quarantine_boundary_test.py` drives a real (non-mocked) `InMemoryCollection` where-filter — a below-threshold/quarantined fact is excluded by `{"collection": {"$ne": "research"}}`, a promoted fact (metadata flipped) becomes reachable, a pre-existing fact with no `collection` field stays visible, a disputed/contradicted fact stays excluded, and the exact production call path (`FactsMixin._sync_fact_metadata_in_chromadb`) reproduces the same result.
- **`cp`-swapped baseline diff** (not `git stash`, per worktree rules): swapped all 7 modified files back to their pre-PR (`HEAD`) versions, moved the 2 new test files aside, and reran the same 6-suite sweep: 38 failed (all pre-existing `[chromadb]`-parametrized cases — global chromadb stub in `conftest.py`, unrelated to this change) / 128 passed. After restoring: **identical 38 failing test names**, 150 passed (22 new). Zero regressions.
- `tests/test_startup_imports.py`: 350/350 passed, unchanged before/after.
- Broader sweep across `services/` + `knowledge/` (3898 tests, ~11 min): every file this PR touches or adds (`services/research/{orchestrator,extractor,synthesizer,routes,quarantine_boundary}_test.py`) is 100% green; the 90 failures/52 errors present are in unrelated modules (redis-service e2e needing a live `backend_url` fixture, npu_pipeline dispatcher, rag_service_kb_synthesis, etc.) — confirmed pre-existing/environmental, not caused by this change.

## Model Used

Claude Sonnet 5
