### PR TITLE
feat(research): topic-based source routing + data-driven search sources (#12625)

### DIFF
--- a/autobot-backend/agent_loop/search/base.py
+++ b/autobot-backend/agent_loop/search/base.py
@@ -58,6 +58,15 @@ class WebSearchProvider(ABC):
 
     provider_name: str = "base"
 
+    # Topics (one of the CATEGORY_* constants above) this provider specializes
+    # in, for ``services.research.router`` to prefer it over the general
+    # fallback chain (#12625, design §4.4). Empty means "no specialization" —
+    # the provider is only ever tried in its normal fallback-chain position.
+    # Existing providers (SearXNG/Brave/content_reach) declare none: `category`
+    # only ever shaped their *query* (design §4.4 is new provider-*selection*,
+    # not the pre-existing query-category hint).
+    supported_categories: tuple[str, ...] = ()
+
     def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
         """Store provider settings (credentials, instance URL, options)."""
         self.settings: Dict[str, Any] = settings or {}

--- a/autobot-backend/agent_loop/search/config_declared_provider.py
+++ b/autobot-backend/agent_loop/search/config_declared_provider.py
@@ -1,0 +1,255 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Data-driven search-source definitions (#12625, design §4.7).
+
+Lets a non-code contributor add a simple, credential-less search source by
+declaring a URL + a single query parameter + a declarative JSON response-parse
+rule in ``config/research_sources.yaml`` — no Python subclass required.
+Complex-auth sources stay Python classes (design §4.7, e.g. ``BraveSearchProvider``):
+this mechanism intentionally supports only GET + one query parameter and plain
+dict/list JSON traversal — never arbitrary code execution (no eval/Jinja).
+
+SSRF (#6533/#12278): a config-declared ``base_url`` is fetched by the server on
+every search — a server-side request forgery surface by construction. Every
+request goes through the SAME layered guard the repo's other outbound-URL
+sinks use (``api/provider_auth.py``, ``api/marketplace_sources.py``,
+``content_reach/_url_guard.py``, ``knowledge/connectors/oauth_flow.py``,
+``skills/external_importer.py``):
+
+1. Scheme + hostname validated at config-load time (catches an authoring
+   mistake before it ever reaches a request).
+2. The host is re-resolved and the connector pinned to that IP via
+   :func:`autobot_shared.security.ssrf_guard.pinned_connector` on **every**
+   call (never cached) — the pre-resolved public IP defeats a DNS-rebind
+   between the safety check and the socket connect (#12278).
+3. The runtime query is passed **only** through aiohttp's ``params=`` dict,
+   never string-interpolated into the URL, so a hostile query value can never
+   alter the outbound request's scheme, host, or port.
+4. Redirects are disabled (``allow_redirects=False``); any 3xx response is
+   rejected outright rather than followed (mirrors
+   ``autobot_shared.security.ssrf_guard.fetch_safe_url`` /
+   ``api/marketplace_sources.py``).
+
+Deliberately **not** routed through the shared pooled
+``autobot_shared.http_client`` (#12979): a pinned connector is a
+session-level object the pool would silently discard on reuse, reopening the
+DNS-rebind hole #12278 closed — same carve-out category as
+``knowledge/connectors/oauth_flow.py`` / ``skills/external_importer.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import aiohttp
+import yaml
+
+from agent_loop.search.base import DEFAULT_RESULT_COUNT, SearchResult, WebSearchProvider
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "config", "research_sources.yaml")
+_ALLOWED_SCHEMES = ("http", "https")
+
+# Module-level constants (never inline literals): request timeout when a
+# source definition omits ``timeout_seconds``, and a hard response-size cap
+# so a misbehaving/malicious source can't exhaust memory.
+_DEFAULT_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+
+
+@dataclass
+class SourceDefinition:
+    """One config-declared search source (design §4.7)."""
+
+    name: str
+    category: str
+    base_url: str
+    query_param: str
+    extra_params: Dict[str, str] = field(default_factory=dict)
+    result_path: str = ""
+    title_field: str = "title"
+    url_field: str = "url"
+    snippet_field: str = ""
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+
+
+def _validate_definition(raw: Dict[str, Any]) -> Optional[SourceDefinition]:
+    """Build one ``SourceDefinition`` from a raw config dict, or None if malformed/unsafe.
+
+    Never raises: a bad entry is logged and skipped so one malformed source
+    can never take down the others or block startup.
+    """
+    name = str(raw.get("name", "")).strip()
+    base_url = str(raw.get("base_url", "")).strip()
+    query_param = str(raw.get("query_param", "")).strip()
+    category = str(raw.get("category", "")).strip()
+    if not (name and base_url and query_param and category):
+        logger.warning("research_sources.yaml: skipping incomplete source entry: %r", raw)
+        return None
+    parsed = urlparse(base_url)
+    if parsed.scheme not in _ALLOWED_SCHEMES or not parsed.hostname:
+        logger.warning("research_sources.yaml: skipping source %r — unsafe base_url %r", name, base_url)
+        return None
+    return SourceDefinition(
+        name=name,
+        category=category,
+        base_url=base_url,
+        query_param=query_param,
+        extra_params={str(k): str(v) for k, v in (raw.get("extra_params") or {}).items()},
+        result_path=str(raw.get("result_path", "")),
+        title_field=str(raw.get("title_field", "title")),
+        url_field=str(raw.get("url_field", "url")),
+        snippet_field=str(raw.get("snippet_field", "")),
+        timeout_seconds=float(raw.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS)),
+    )
+
+
+def load_source_definitions(config_path: Optional[str] = None) -> List[SourceDefinition]:
+    """Load + validate every source declared in ``research_sources.yaml``.
+
+    Never raises: a missing file, empty file, or malformed entry degrades to
+    an empty/partial list — matches
+    ``agent_loop.search.registry._populate_default_providers`` (population
+    failures are logged, never block startup).
+    """
+    path = config_path or _DEFAULT_CONFIG_PATH
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw_config = yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        logger.debug("research_sources.yaml not found at %s — no config-declared sources", path)
+        return []
+    except Exception as exc:  # noqa: BLE001 — a broken config file must never block startup
+        logger.warning("research_sources.yaml: failed to load %s: %s", path, exc)
+        return []
+    raw_sources = raw_config.get("sources", [])
+    if not isinstance(raw_sources, list):
+        return []
+    return [d for d in (_validate_definition(raw) for raw in raw_sources) if d is not None]
+
+
+def _dig(payload: Any, dotted_path: str) -> Any:
+    """Traverse *payload* by a dotted key path (pure dict access — no eval/exec)."""
+    node = payload
+    if not dotted_path:
+        return node
+    for part in dotted_path.split("."):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+    return node
+
+
+def _item_field(item: Dict[str, Any], dotted_path: str) -> str:
+    """Extract one string field from a result item via a dotted path (or top-level key)."""
+    if not dotted_path:
+        return ""
+    value = _dig(item, dotted_path)
+    return str(value) if value is not None else ""
+
+
+class ConfigDeclaredSearchProvider(WebSearchProvider):
+    """A ``WebSearchProvider`` backed entirely by one data-driven ``SourceDefinition``.
+
+    No credentials, no per-source Python subclass. See the module docstring
+    for the SSRF guarantees every ``search()`` call enforces.
+    """
+
+    def __init__(self, definition: SourceDefinition) -> None:
+        """Bind this provider instance to one config-declared source."""
+        super().__init__(settings={})
+        self.provider_name = definition.name
+        self.supported_categories = (definition.category,)
+        self._definition = definition
+
+    async def is_available(self) -> bool:
+        """Cheap pre-check only — the authoritative, DNS-rebind-safe check is
+        the fresh ``pinned_connector`` resolve inside ``search()`` itself.
+        """
+        from autobot_shared.url_safety import is_public_url_async  # noqa: PLC0415
+
+        return await is_public_url_async(self._definition.base_url)
+
+    async def _pinned_session_kwargs(self) -> Dict[str, Any]:
+        """Resolve-once + pin the connector to base_url — fresh on every call (#12278)."""
+        from autobot_shared.security.ssrf_guard import pinned_connector  # noqa: PLC0415
+
+        connector = await pinned_connector(self._definition.base_url)
+        timeout = aiohttp.ClientTimeout(total=self._definition.timeout_seconds)
+        return {"connector": connector, "timeout": timeout}
+
+    def _build_params(self, query: str) -> Dict[str, str]:
+        """Runtime query goes ONLY into the params dict — never string-built into the URL."""
+        params = dict(self._definition.extra_params)
+        params[self._definition.query_param] = query
+        return params
+
+    def _parse_results(self, payload: Any, count: int) -> List[SearchResult]:
+        """Declarative dict/list traversal — no code execution on the response."""
+        items = _dig(payload, self._definition.result_path)
+        if not isinstance(items, list):
+            return []
+        results: List[SearchResult] = []
+        for item in items[:count]:
+            if not isinstance(item, dict):
+                continue
+            url = _item_field(item, self._definition.url_field)
+            if not url:
+                continue
+            results.append(
+                SearchResult(
+                    title=_item_field(item, self._definition.title_field),
+                    url=url,
+                    snippet=_item_field(item, self._definition.snippet_field),
+                    source=self._definition.name,
+                )
+            )
+        return results
+
+    async def search(
+        self,
+        query: str,
+        *,
+        category: Optional[str] = None,
+        count: int = DEFAULT_RESULT_COUNT,
+    ) -> List[SearchResult]:
+        """Query the config-declared source; raise on any unsafe/failed request
+        so the registry's fallback chain takes over (design: "preserve
+        graceful fallback").
+        """
+        from autobot_shared.security.ssrf_guard import SSRFError  # noqa: PLC0415
+
+        try:
+            session_kwargs = await self._pinned_session_kwargs()
+        except SSRFError as exc:
+            raise RuntimeError(f"source {self._definition.name!r} blocked by SSRF guard: {exc}") from exc
+
+        async with aiohttp.ClientSession(**session_kwargs) as session:
+            async with session.get(
+                self._definition.base_url,
+                params=self._build_params(query),
+                allow_redirects=False,  # a redirect to an internal address must never be followed (#12278)
+            ) as resp:
+                if 300 <= resp.status < 400:
+                    raise RuntimeError(
+                        f"source {self._definition.name!r} returned a redirect (HTTP {resp.status}); "
+                        "redirects are rejected by the SSRF guard"
+                    )
+                if resp.status != 200:
+                    raise RuntimeError(f"source {self._definition.name!r} returned HTTP {resp.status}")
+                body = await resp.content.read(_MAX_RESPONSE_BYTES + 1)
+
+        try:
+            payload = json.loads(body[:_MAX_RESPONSE_BYTES].decode("utf-8", errors="replace"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"source {self._definition.name!r} returned invalid JSON: {exc}") from exc
+
+        return self._parse_results(payload, count)

--- a/autobot-backend/agent_loop/search/config_declared_provider_test.py
+++ b/autobot-backend/agent_loop/search/config_declared_provider_test.py
@@ -1,0 +1,237 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit + SSRF-hostile-path tests for ConfigDeclaredSearchProvider (#12625).
+
+The DNS-mocking technique (patching ``autobot_shared.url_safety.socket.getaddrinfo``)
+mirrors ``api/tests/test_provider_auth_ssrf.py`` — ``asyncio``'s default
+``loop.getaddrinfo`` runs the very same ``socket.getaddrinfo`` in an executor,
+so this exercises the REAL ``ssrf_guard.pinned_connector`` / ``resolve_safe_ip``
+guard rather than mocking it away.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_loop.search.config_declared_provider import (
+    ConfigDeclaredSearchProvider,
+    SourceDefinition,
+    _validate_definition,
+    load_source_definitions,
+)
+
+
+def _definition(**overrides) -> SourceDefinition:
+    base = dict(
+        name="test_source",
+        category="academic",
+        base_url="https://docs.example.com/api/search",
+        query_param="q",
+        extra_params={"format": "json"},
+        result_path="results",
+        title_field="title",
+        url_field="url",
+        snippet_field="summary",
+    )
+    base.update(overrides)
+    return SourceDefinition(**base)
+
+
+class _FakeContent:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def read(self, _n: int) -> bytes:
+        return self._body
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body: bytes = b"", headers: dict | None = None) -> None:
+        self.status = status
+        self.content = _FakeContent(body)
+        self.headers = headers or {}
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+class _FakeSession:
+    """Records the exact get(url, params=...) call shape for SSRF assertions."""
+
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.captured_url: str | None = None
+        self.captured_kwargs: dict | None = None
+
+    def get(self, url: str, **kwargs):
+        self.captured_url = url
+        self.captured_kwargs = kwargs
+        return self._response
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+def _fake_connector():
+    return object()
+
+
+class TestSourceDefinitionLoading:
+    """Data-driven loading (#12625 acceptance: "add a source via config only")."""
+
+    def test_load_source_definitions_missing_file_returns_empty(self, tmp_path):
+        assert load_source_definitions(str(tmp_path / "nope.yaml")) == []
+
+    def test_load_source_definitions_parses_valid_entry(self, tmp_path):
+        config = tmp_path / "research_sources.yaml"
+        config.write_text(
+            "sources:\n"
+            "  - name: docs_source\n"
+            "    category: code\n"
+            "    base_url: https://docs.example.com/search\n"
+            "    query_param: q\n"
+            "    result_path: results\n",
+            encoding="utf-8",
+        )
+        defs = load_source_definitions(str(config))
+        assert len(defs) == 1
+        assert defs[0].name == "docs_source"
+        assert defs[0].category == "code"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            {"name": "", "category": "code", "base_url": "https://x.example/a", "query_param": "q"},
+            {"name": "x", "category": "", "base_url": "https://x.example/a", "query_param": "q"},
+            {"name": "x", "category": "code", "base_url": "", "query_param": "q"},
+            {"name": "x", "category": "code", "base_url": "https://x.example/a", "query_param": ""},
+            {"name": "x", "category": "code", "base_url": "ftp://x.example/a", "query_param": "q"},
+            {"name": "x", "category": "code", "base_url": "not-a-url", "query_param": "q"},
+        ],
+    )
+    def test_validate_definition_rejects_malformed_or_unsafe_entries(self, raw):
+        assert _validate_definition(raw) is None
+
+
+class TestConfigDeclaredProviderRequestSafety:
+    """Requests never string-interpolate the runtime query into the URL (#12625)."""
+
+    async def test_search_passes_query_only_through_params_never_the_url(self):
+        """A query crafted to look like a host/scheme change must stay a params value."""
+        hostile_query = "http://evil.example.com/@docs.example.com"
+        response = _FakeResponse(200, json.dumps({"results": []}).encode("utf-8"))
+        session = _FakeSession(response)
+
+        with (
+            patch("autobot_shared.security.ssrf_guard.pinned_connector", AsyncMock(return_value=_fake_connector())),
+            patch("aiohttp.ClientSession", return_value=session),
+        ):
+            provider = ConfigDeclaredSearchProvider(_definition())
+            await provider.search(hostile_query, count=5)
+
+        # The outbound request target is ALWAYS the declared base_url — the
+        # hostile value can only ever land inside params, never the URL itself.
+        assert session.captured_url == "https://docs.example.com/api/search"
+        assert session.captured_kwargs["params"]["q"] == hostile_query
+        assert session.captured_kwargs["allow_redirects"] is False
+
+    async def test_search_rejects_redirect_response_without_following_it(self):
+        """A 3xx response (e.g. redirecting to an internal address) must be rejected outright."""
+        response = _FakeResponse(302, headers={"Location": "http://169.254.169.254/latest/meta-data/"})
+        session = _FakeSession(response)
+
+        with (
+            patch("autobot_shared.security.ssrf_guard.pinned_connector", AsyncMock(return_value=_fake_connector())),
+            patch("aiohttp.ClientSession", return_value=session),
+        ):
+            provider = ConfigDeclaredSearchProvider(_definition())
+            with pytest.raises(RuntimeError, match="redirect"):
+                await provider.search("q", count=5)
+
+    async def test_search_parses_declarative_result_path_and_fields(self):
+        payload = {
+            "results": [
+                {"title": "Doc A", "url": "https://docs.example.com/a", "summary": "About A"},
+                {"title": "Doc B", "url": "https://docs.example.com/b", "summary": "About B"},
+            ]
+        }
+        response = _FakeResponse(200, json.dumps(payload).encode("utf-8"))
+        session = _FakeSession(response)
+
+        with (
+            patch("autobot_shared.security.ssrf_guard.pinned_connector", AsyncMock(return_value=_fake_connector())),
+            patch("aiohttp.ClientSession", return_value=session),
+        ):
+            provider = ConfigDeclaredSearchProvider(_definition())
+            results = await provider.search("q", count=5)
+
+        assert [r.url for r in results] == ["https://docs.example.com/a", "https://docs.example.com/b"]
+        assert results[0].title == "Doc A"
+        assert results[0].snippet == "About A"
+        assert results[0].source == "test_source"
+
+
+class TestConfigDeclaredProviderSSRFHostileCases:
+    """Hostile base_url cases — real ssrf_guard/url_safety DNS resolution, not mocked away."""
+
+    async def test_is_available_false_for_internal_ip_base_url(self):
+        provider = ConfigDeclaredSearchProvider(_definition(base_url="http://10.0.0.5/search"))
+        assert await provider.is_available() is False
+
+    async def test_is_available_false_for_localhost_base_url(self):
+        provider = ConfigDeclaredSearchProvider(_definition(base_url="http://localhost:8080/search"))
+        assert await provider.is_available() is False
+
+    async def test_is_available_false_for_link_local_metadata_base_url(self):
+        provider = ConfigDeclaredSearchProvider(_definition(base_url="http://169.254.169.254/search"))
+        assert await provider.is_available() is False
+
+    async def test_search_raises_when_base_url_resolves_to_private_address(self):
+        """DNS-rebind case: a benign-looking hostname resolves to a private IP at request time."""
+        fake_infos = [(2, 1, 6, "", ("10.0.0.9", 0))]
+        provider = ConfigDeclaredSearchProvider(_definition(base_url="https://rebind.example.com/search"))
+
+        with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+            with pytest.raises(RuntimeError, match="SSRF guard"):
+                await provider.search("q", count=5)
+
+    async def test_search_raises_when_base_url_resolves_to_loopback(self):
+        fake_infos = [(2, 1, 6, "", ("127.0.0.1", 0))]
+        provider = ConfigDeclaredSearchProvider(_definition(base_url="https://sneaky.example.com/search"))
+
+        with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+            with pytest.raises(RuntimeError, match="SSRF guard"):
+                await provider.search("q", count=5)
+
+    async def test_search_raises_when_base_url_resolves_to_metadata_address(self):
+        fake_infos = [(2, 1, 6, "", ("169.254.169.254", 0))]
+        provider = ConfigDeclaredSearchProvider(_definition(base_url="https://sneaky.example.com/search"))
+
+        with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+            with pytest.raises(RuntimeError, match="SSRF guard"):
+                await provider.search("q", count=5)
+
+    async def test_search_succeeds_when_base_url_resolves_to_public_address(self):
+        fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        response = _FakeResponse(200, json.dumps({"results": []}).encode("utf-8"))
+        session = _FakeSession(response)
+        provider = ConfigDeclaredSearchProvider(_definition(base_url="https://real.example.com/search"))
+
+        with (
+            patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+            patch("aiohttp.ClientSession", return_value=session),
+        ):
+            results = await provider.search("q", count=5)
+
+        assert results == []

--- a/autobot-backend/agent_loop/search/registry.py
+++ b/autobot-backend/agent_loop/search/registry.py
@@ -124,10 +124,29 @@ def _populate_default_providers(registry: SearchProviderRegistry) -> None:
     else:
         logger.debug("BRAVE_SEARCH_API_KEY not set — Brave search provider not registered")
 
+    _populate_config_declared_sources(registry)
+
     from agent_loop.search.content_reach_provider import ContentReachSearchProvider
 
     registry.register(ContentReachSearchProvider())
     logger.debug("Registered content_reach as fallback web-search provider")
+
+
+def _populate_config_declared_sources(registry: SearchProviderRegistry) -> None:
+    """Register data-driven sources declared in config/research_sources.yaml (#12625, design §4.7).
+
+    Extends this canonical registry rather than a parallel one: each declared
+    source becomes an ordinary ``WebSearchProvider`` registration, so it
+    shares the exact same credential-gating-free registration path, fallback
+    chain, and ``services.research.router`` topic-preference lookup as every
+    other provider. An empty/missing config file registers nothing (never
+    blocks startup).
+    """
+    from agent_loop.search.config_declared_provider import ConfigDeclaredSearchProvider, load_source_definitions
+
+    for definition in load_source_definitions():
+        registry.register(ConfigDeclaredSearchProvider(definition))
+        logger.debug("Registered config-declared search source %r (category=%s)", definition.name, definition.category)
 
 
 def _warn_if_topic_search_degraded(registry: SearchProviderRegistry) -> None:

--- a/autobot-backend/config/research_sources.yaml
+++ b/autobot-backend/config/research_sources.yaml
@@ -1,0 +1,50 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Data-driven search sources (#12625, design §4.7). Loaded by
+# agent_loop.search.config_declared_provider.load_source_definitions() and
+# registered into the shared SearchProviderRegistry alongside the built-in
+# providers — no Python code required to add one.
+#
+# Every source must:
+#   - use a fixed http(s) base_url (validated at load time; anything else is
+#     skipped with a warning — never blocks startup)
+#   - accept the runtime search text via exactly one query parameter
+#     (query_param) — it is ALWAYS passed through aiohttp's params=, never
+#     string-built into the URL, so it can never change the request's host,
+#     scheme, or port
+#   - return JSON; result_path/title_field/url_field/snippet_field are plain
+#     dotted dict/list paths into that JSON (no code execution)
+#
+# Fields:
+#   name             unique provider name (also the fallback-chain entry)
+#   category         topic this source specializes in (matched by
+#                    services.research.router.infer_topic — see
+#                    config/research_topics.yaml for the topic keyword lists)
+#   base_url         fixed http(s) endpoint fetched on every search
+#   query_param      name of the query-string parameter carrying the search text
+#   extra_params     (optional) fixed extra query-string parameters
+#   result_path      (optional) dotted path to the list of result items in the
+#                    JSON response; "" means the response body IS that list
+#   title_field      (optional, default "title") dotted path within each item
+#   url_field        (optional, default "url") dotted path within each item
+#   snippet_field    (optional) dotted path within each item
+#   timeout_seconds  (optional, default 15.0) per-request timeout
+#
+# No sources are declared by default — this file intentionally ships empty
+# so no external endpoint is fetched without an explicit, reviewed opt-in.
+# Example (illustrative only — uncomment and adapt to add a real source):
+#
+# sources:
+#   - name: example_docs
+#     category: code
+#     base_url: "https://example-docs.invalid/api/search"
+#     query_param: "q"
+#     extra_params:
+#       format: "json"
+#     result_path: "results"
+#     title_field: "title"
+#     url_field: "url"
+#     snippet_field: "summary"
+
+sources: []

--- a/autobot-backend/config/research_topics.yaml
+++ b/autobot-backend/config/research_topics.yaml
@@ -1,0 +1,36 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Keyword -> topic map used by services.research.router.infer_topic (#12625).
+# Extend this file (no code change) to teach the Source Router new topics;
+# a source declared in config/research_sources.yaml can then set its
+# `category` to one of these keys so a matching sub-question routes to it
+# ahead of the general-web fallback.
+#
+# A sub-question's topic is the first key whose keyword list contains a
+# substring match against the (lower-cased) sub-question text; no match
+# defaults to "general" (the unchanged registry fallback order).
+topics:
+  academic:
+    - study
+    - research
+    - paper
+    - journal
+    - theorem
+    - hypothesis
+    - experiment
+  code:
+    - code
+    - function
+    - library
+    - programming
+    - framework
+    - compile
+    - syntax
+  news:
+    - news
+    - today
+    - yesterday
+    - breaking
+    - announced
+    - latest

--- a/autobot-backend/services/research/orchestrator.py
+++ b/autobot-backend/services/research/orchestrator.py
@@ -5,7 +5,8 @@
 """ResearchOrchestrator (#12622, design §4.1) — the one new coordinator.
 
 Composes existing modules (never recreates them, design §6):
-  * ``agent_loop.search.registry`` — source discovery
+  * ``services.research.router`` — topic-based source routing over the
+    shared ``agent_loop.search.registry`` (#12625)
   * ``web_fetch.WebFetcher`` — fast-HTTP page fetch
   * ``knowledge_base_factory.get_knowledge_base`` — the canonical KB facade
   * ``services.research.extractor`` / ``synthesizer`` — the two new LLM steps
@@ -55,10 +56,15 @@ def _resolve_budget(options: dict) -> ResearchBudget:
 
 
 async def _discover_sources(question: str, max_sources: int) -> List[str]:
-    """Find candidate URLs for *question* via the shared search-provider registry."""
-    from agent_loop.search.registry import search as registry_search  # noqa: PLC0415
+    """Find candidate URLs for *question* via topic-routed search (#12625).
 
-    results = await registry_search(question, count=max_sources)
+    Delegates to ``services.research.router.route_search``, which prefers a
+    specialized provider for the question's inferred topic and otherwise
+    preserves the registry's unchanged default fallback order.
+    """
+    from services.research.router import route_search  # noqa: PLC0415
+
+    results = await route_search(question, count=max_sources)
     return [r.url for r in results if r.url]
 
 

--- a/autobot-backend/services/research/router.py
+++ b/autobot-backend/services/research/router.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Source Router (#12625, design §4.4) — topic-based provider selection.
+
+Maps a sub-question's inferred topic to a preferred provider in the existing
+``SearchProviderRegistry`` (``agent_loop/search/registry.py``): a specialized
+source (config-declared or a Python provider that declares
+``supported_categories``) is preferred when one is registered for that topic;
+otherwise the registry's normal credential-gated, graceful-fallback provider
+order is used unchanged (design: "Preserve the registry's credential-gating
++ graceful fallback"). This module never re-implements that logic — it only
+supplies the registry's existing ``provider=`` preferred-candidate parameter.
+
+Topic-inference scope note (#12625 premise finding): the merged Planner
+(#12624, PR #13014) does not tag sub-questions with a topic —
+``services.research.planner.SubQuestion`` carries only ``text`` /
+``expected_value``. Expanding the Planner's LLM decomposition prompt to also
+classify topic is out of scope here (a larger, already-merged/tested module,
+and an LLM round-trip per sub-question the design's efficiency goal argues
+against). Design §4.4 asks the Router to map a sub-question's *inferred*
+topic to providers — this module does that inference itself, cheaply and
+deterministically (keyword match, see ``config/research_topics.yaml``), which
+is a legitimate, narrower reading of "inferred" than "pre-tagged by the
+Planner". See the discovered-gap issue filed alongside this PR for wiring
+topic-tagging into the Planner directly.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Tuple
+
+import yaml
+
+from agent_loop.search.base import CATEGORY_ACADEMIC, CATEGORY_CODE, CATEGORY_GENERAL, CATEGORY_NEWS, SearchResult
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_TOPICS_CONFIG = os.path.join(os.path.dirname(__file__), "..", "..", "config", "research_topics.yaml")
+
+# Built-in fallback when config/research_topics.yaml is missing/empty/malformed
+# (never blocks startup — matches agent_loop.search.registry's population style).
+_BUILTIN_TOPIC_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    CATEGORY_ACADEMIC: ("study", "research", "paper", "journal", "theorem", "hypothesis", "experiment"),
+    CATEGORY_CODE: ("code", "function", "library", "programming", "framework", "compile", "syntax"),
+    CATEGORY_NEWS: ("news", "today", "yesterday", "breaking", "announced", "latest"),
+}
+
+_topic_keywords_cache: Optional[Dict[str, Tuple[str, ...]]] = None
+
+
+def _load_topic_keywords(config_path: Optional[str] = None) -> Dict[str, Tuple[str, ...]]:
+    """Load the topic->keyword map from ``research_topics.yaml`` (never raises)."""
+    path = config_path or _DEFAULT_TOPICS_CONFIG
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        return _BUILTIN_TOPIC_KEYWORDS
+    except Exception as exc:  # noqa: BLE001 — a broken config file must never block startup
+        logger.warning("research_topics.yaml: failed to load %s: %s", path, exc)
+        return _BUILTIN_TOPIC_KEYWORDS
+    topics = raw.get("topics", {})
+    if not isinstance(topics, dict) or not topics:
+        return _BUILTIN_TOPIC_KEYWORDS
+    parsed = {
+        str(topic): tuple(str(w).lower() for w in words)
+        for topic, words in topics.items()
+        if isinstance(words, list) and words
+    }
+    return parsed or _BUILTIN_TOPIC_KEYWORDS
+
+
+def _topic_keywords() -> Dict[str, Tuple[str, ...]]:
+    """Return the process-wide topic->keyword map, loading it once lazily."""
+    global _topic_keywords_cache
+    if _topic_keywords_cache is None:
+        _topic_keywords_cache = _load_topic_keywords()
+    return _topic_keywords_cache
+
+
+def infer_topic(text: str) -> str:
+    """Infer a coarse topic for *text* from keyword substring match.
+
+    Deterministic and never raises — an unmatched or empty question always
+    degrades to ``CATEGORY_GENERAL`` (the unchanged default fallback path).
+    """
+    lowered = text.lower()
+    for topic, keywords in _topic_keywords().items():
+        if any(keyword in lowered for keyword in keywords):
+            return topic
+    return CATEGORY_GENERAL
+
+
+def _preferred_provider_for_topic(topic: str) -> Optional[str]:
+    """Return the first registered provider whose ``supported_categories``
+    contains *topic*, or None (the registry's default order applies unchanged).
+    """
+    if topic == CATEGORY_GENERAL:
+        return None
+
+    from agent_loop.search.registry import get_search_registry  # noqa: PLC0415
+
+    registry = get_search_registry()
+    for name in registry.list_providers():
+        provider = registry.get_provider(name)
+        if provider is not None and topic in getattr(provider, "supported_categories", ()):
+            return name
+    return None
+
+
+async def route_search(query: str, *, count: int) -> List[SearchResult]:
+    """Route *query* to its specialized provider (if any) via the shared registry.
+
+    Registry credential-gating + graceful per-provider fallback (#9022/#9023)
+    are entirely unchanged: this only supplies the *preferred* provider name.
+    ``SearchProviderRegistry.search`` still tries the full fallback chain if
+    the preferred provider is unavailable or errors, and falls back to the
+    default order untouched when no specialization matches (design: "default
+    to general web when nothing matches").
+    """
+    from agent_loop.search.registry import search as registry_search  # noqa: PLC0415
+
+    topic = infer_topic(query)
+    preferred = _preferred_provider_for_topic(topic)
+    if preferred:
+        logger.debug("router.route_search: topic=%r routed to specialized provider=%r", topic, preferred)
+    return await registry_search(query, provider=preferred, category=topic, count=count)

--- a/autobot-backend/services/research/router_test.py
+++ b/autobot-backend/services/research/router_test.py
@@ -1,0 +1,209 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for services.research.router (#12625).
+
+Uses a REAL ``SearchProviderRegistry`` instance (not a mock of it) so these
+tests exercise the registry's own credential-gating + graceful-fallback logic
+end-to-end through the router, proving the design requirement ("Preserve the
+registry's credential-gating + graceful fallback") rather than assuming it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List, Optional
+from unittest.mock import AsyncMock, patch
+
+import agent_loop.search.registry  # noqa: F401 — force full (non-partial) module init, see orchestrator_test.py
+from agent_loop.search.base import CATEGORY_GENERAL, SearchResult, WebSearchProvider
+from agent_loop.search.config_declared_provider import ConfigDeclaredSearchProvider, load_source_definitions
+from agent_loop.search.registry import SearchProviderRegistry
+from services.research.router import infer_topic, route_search
+
+
+class _FakeProvider(WebSearchProvider):
+    """A minimal, in-test WebSearchProvider — no network, fully controllable."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        categories: tuple = (),
+        available: bool = True,
+        results: Optional[List[SearchResult]] = None,
+        error: Optional[Exception] = None,
+    ) -> None:
+        super().__init__(settings={})
+        self.provider_name = name
+        self.supported_categories = categories
+        self._available = available
+        self._results = results or []
+        self._error = error
+        self.search_calls: List[str] = []
+
+    async def is_available(self) -> bool:
+        return self._available
+
+    async def search(self, query: str, *, category: Optional[str] = None, count: int = 10) -> List[SearchResult]:
+        self.search_calls.append(query)
+        if self._error:
+            raise self._error
+        return self._results
+
+
+def _registry(*providers: WebSearchProvider) -> SearchProviderRegistry:
+    reg = SearchProviderRegistry()
+    for provider in providers:
+        reg.register(provider)
+    return reg
+
+
+class TestInferTopic:
+    """Keyword-based inference (config/research_topics.yaml + built-in fallback)."""
+
+    def test_academic_keyword_infers_academic_topic(self):
+        assert infer_topic("What does this research paper conclude about gravity?") == "academic"
+
+    def test_code_keyword_infers_code_topic(self):
+        assert infer_topic("How do I use this library's function signature?") == "code"
+
+    def test_news_keyword_infers_news_topic(self):
+        assert infer_topic("What is today's breaking news on the election?") == "news"
+
+    def test_unmatched_question_defaults_to_general(self):
+        assert infer_topic("What color is the sky?") == CATEGORY_GENERAL
+
+
+class TestRouteSearchPrefersSpecialist:
+    """Acceptance: "fewer wasted general-web queries on specialized topics"."""
+
+    async def test_specialized_provider_is_used_and_general_is_not_queried(self):
+        specialist_results = [SearchResult(title="Paper", url="https://scholar.example/paper")]
+        specialist = _FakeProvider("scholar", categories=("academic",), results=specialist_results)
+        general = _FakeProvider("content_reach", results=[SearchResult(title="Web", url="https://web.example")])
+
+        with patch("agent_loop.search.registry.get_search_registry", return_value=_registry(general, specialist)):
+            results = await route_search("What does this research paper conclude?", count=5)
+
+        assert [r.url for r in results] == ["https://scholar.example/paper"]
+        assert specialist.search_calls == ["What does this research paper conclude?"]
+        assert general.search_calls == []  # no wasted general-web query
+
+
+class TestRouteSearchFallback:
+    """Acceptance: default to general web when nothing matches; fallback preserved."""
+
+    async def test_falls_back_to_general_web_when_no_specialist_registered(self):
+        general = _FakeProvider("content_reach", results=[SearchResult(title="Web", url="https://web.example")])
+
+        with patch("agent_loop.search.registry.get_search_registry", return_value=_registry(general)):
+            results = await route_search("What does this research paper conclude?", count=5)
+
+        assert [r.url for r in results] == ["https://web.example"]
+        assert general.search_calls == ["What does this research paper conclude?"]
+
+    async def test_credential_gated_specialist_unavailable_falls_back_gracefully(self):
+        """A specialist that is registered but not credentialed (is_available=False)
+        must never block the run — the registry's fallback chain takes over."""
+        unavailable_specialist = _FakeProvider("scholar", categories=("academic",), available=False)
+        general = _FakeProvider("content_reach", results=[SearchResult(title="Web", url="https://web.example")])
+
+        with patch(
+            "agent_loop.search.registry.get_search_registry",
+            return_value=_registry(general, unavailable_specialist),
+        ):
+            results = await route_search("What does this research paper conclude?", count=5)
+
+        assert [r.url for r in results] == ["https://web.example"]
+        assert unavailable_specialist.search_calls == []  # never called — was skipped as unavailable
+
+    async def test_specialist_error_falls_back_to_next_provider(self):
+        """A specialist that errors mid-search must not sink the whole run (graceful fallback)."""
+        erroring_specialist = _FakeProvider("scholar", categories=("academic",), error=RuntimeError("unreachable"))
+        general = _FakeProvider("content_reach", results=[SearchResult(title="Web", url="https://web.example")])
+
+        with patch(
+            "agent_loop.search.registry.get_search_registry",
+            return_value=_registry(general, erroring_specialist),
+        ):
+            results = await route_search("What does this research paper conclude?", count=5)
+
+        assert [r.url for r in results] == ["https://web.example"]
+
+    async def test_no_providers_registered_returns_empty_list(self):
+        with patch("agent_loop.search.registry.get_search_registry", return_value=_registry()):
+            results = await route_search("anything", count=5)
+        assert results == []
+
+
+class TestConfigDeclaredSourceEndToEndRouting:
+    """Acceptance: "A new simple source can be added via config only (no Python),
+    and the router picks it up" — proven end-to-end: YAML -> SourceDefinition ->
+    ConfigDeclaredSearchProvider -> registered -> routed by topic, zero Python
+    subclass authored for the source itself."""
+
+    async def test_yaml_declared_source_is_routed_to_by_topic(self, tmp_path):
+        config = tmp_path / "research_sources.yaml"
+        config.write_text(
+            "sources:\n"
+            "  - name: docs_source\n"
+            "    category: code\n"
+            "    base_url: https://docs.example.com/search\n"
+            "    query_param: q\n"
+            "    result_path: results\n",
+            encoding="utf-8",
+        )
+        definitions = load_source_definitions(str(config))
+        assert len(definitions) == 1  # config-only source loaded, no Python class written for it
+
+        config_source = ConfigDeclaredSearchProvider(definitions[0])
+        general = _FakeProvider("content_reach", results=[SearchResult(title="Web", url="https://web.example")])
+        payload = {"results": [{"title": "Docs", "url": "https://docs.example.com/x", "summary": "s"}]}
+
+        with (
+            patch("agent_loop.search.registry.get_search_registry", return_value=_registry(general, config_source)),
+            patch("autobot_shared.url_safety.is_public_url_async", AsyncMock(return_value=True)),
+            patch("autobot_shared.security.ssrf_guard.pinned_connector", AsyncMock(return_value=object())),
+            patch("aiohttp.ClientSession") as fake_session_cls,
+        ):
+            fake_session_cls.return_value = _FakeAiohttpSession(200, json.dumps(payload).encode("utf-8"))
+            results = await route_search("How do I use this library's function?", count=5)
+
+        assert [r.url for r in results] == ["https://docs.example.com/x"]
+        assert general.search_calls == []  # config-declared specialist satisfied it; no general-web fallback needed
+
+
+class _FakeAiohttpContent:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def read(self, _n: int) -> bytes:
+        return self._body
+
+
+class _FakeAiohttpResponse:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self.content = _FakeAiohttpContent(body)
+
+    async def __aenter__(self) -> "_FakeAiohttpResponse":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+class _FakeAiohttpSession:
+    def __init__(self, status: int, body: bytes) -> None:
+        self._response = _FakeAiohttpResponse(status, body)
+
+    def get(self, *_args, **_kwargs):
+        return self._response
+
+    async def __aenter__(self) -> "_FakeAiohttpSession":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False


### PR DESCRIPTION
Closes #12625

## Thinking Path

Every prior child of umbrella #12621 shipped with a wrong technical pointer, so Phase 1 was a premise audit, not implementation:

1. **`SearchProviderRegistry` interface** (`autobot-backend/agent_loop/search/registry.py:31-96`) — confirmed real: credential-gating is auto-population from `ssot_config` (empty credential = provider never registered), graceful fallback is `_ordered_candidates(preferred)` + a try/except loop in `search()` that moves to the next candidate on any exception. Both are **unchanged** by this PR.
2. **Existing topic/capability metadata** — `agent_loop/search/base.py` already has `CATEGORY_GENERAL/NEWS/CODE/ACADEMIC` + a `category` param threaded into `SearchProviderRegistry.search()` and into SearXNG/Brave — but that only shapes the *query* sent to whichever provider is already selected (e.g. SearXNG maps it to its own `categories=` param). No provider declares which categories it *specializes in*, and the registry doesn't select providers by category. This PR adds one new attribute, `WebSearchProvider.supported_categories`, for exactly that (provider-*selection*, not query-shaping).
3. **Data-driven source mechanism audit** — `api/marketplace_sources.py` is a full-catalog-URL registry (JSON catalog fetch, not a per-query URL-template+parse source); `knowledge/connectors/` are Python classes; `plugin_sdk/` is manifest-driven but for plugins, not search sources. No pre-existing URL-template+parse mechanism for search sources — this genuinely doesn't exist yet.
4. **Planner topic-tagging** — the issue's "Depends on" line says the merged Planner (#12624/PR #13014) "produces the topic-tagged sub-questions the router consumes." It doesn't: `services/research/planner.py`'s `SubQuestion` carries only `text`/`expected_value`; the decompose prompt never asks for a topic. **This is the wrong pointer for #12625.** Rather than expand the already-merged, tested Planner's LLM prompt (larger blast radius, an extra LLM round-trip per sub-question, contrary to the design's own efficiency goal), the Router infers the topic itself — cheap, deterministic keyword match, config-declared in `config/research_topics.yaml`. Filed the gap as #13015 (low priority; today's keyword router works).

Given #3, the "data-driven source" half is a genuine new SSRF surface (config-declared `base_url` fetched by the server on every search). Made it safe by reusing the canonical `autobot_shared.security.ssrf_guard.pinned_connector` (the same helper `api/provider_auth.py`, `knowledge/connectors/oauth_flow.py`, and `skills/external_importer.py` use) rather than writing a new validator, and by architecturally preventing the runtime query from ever reaching the URL string (see Verification).

## What Changed

**Source Router** (`services/research/router.py`, new):
- `infer_topic(text)` — keyword match against `config/research_topics.yaml` (built-in fallback if the file is missing), defaults to `CATEGORY_GENERAL`.
- `route_search(query, count=...)` — infers the topic, looks up the first registered provider whose `supported_categories` contains it, and calls the **existing** `SearchProviderRegistry.search(..., provider=preferred, category=topic, ...)` — the registry's own credential-gating + graceful fallback loop is untouched; `route_search` only supplies the preferred name.
- `ResearchOrchestrator._discover_sources` now delegates to `route_search` instead of calling the registry directly. All 14 pre-existing orchestrator tests pass unmodified (they patch `agent_loop.search.registry.search`, which the router still resolves through at call time).

**Data-driven source definitions** (`agent_loop/search/config_declared_provider.py`, new):
- `SourceDefinition` (name, category, base_url, query_param, extra_params, result_path, title/url/snippet field paths, timeout) loaded + validated from `config/research_sources.yaml` (ships empty by default — no external endpoint is fetched without an explicit, reviewed opt-in; format documented via comments).
- `ConfigDeclaredSearchProvider(WebSearchProvider)` wraps one definition; registered into the canonical `SearchProviderRegistry` via a new `_populate_config_declared_sources()` step in `agent_loop/search/registry.py` (same registry, same fallback chain — not a parallel registry).
- `WebSearchProvider.supported_categories: tuple[str, ...] = ()` added to `agent_loop/search/base.py` (one attribute; existing providers declare none, so their behavior is unchanged).

**SSRF (the critical part):**
- Reuses `autobot_shared.security.ssrf_guard.pinned_connector` — resolved fresh (never cached) on every `search()` call, so a DNS-rebind between calls is always caught.
- Redirects disabled (`allow_redirects=False`); any 3xx response is rejected outright, mirroring `api/marketplace_sources.py`'s established pattern.
- The runtime query is passed **only** through aiohttp's `params=` dict — never string-interpolated into the URL — so a hostile query value cannot alter the outbound request's scheme, host, or port.
- Response parsing is pure dict/list dotted-path traversal (no `eval`/templating on the response).
- Deliberately **not** routed through the shared pooled `autobot_shared.http_client` (#12979): a pinned connector is a session-level object the pool would silently discard, reopening the DNS-rebind hole #12278 closed — same carve-out as `knowledge/connectors/oauth_flow.py`.

**Quarantine boundary preserved:** config-declared sources only ever return `SearchResult` URLs, which flow through the *unchanged* `_discover_sources` → `_fetch_source` → `_store_source_document`/`_store_claim` path in `orchestrator.py` — every fact landed via this route still gets `collection: config.research_quarantine_collection` and must pass the #12623 promotion gate exactly like every other source. No new write path to the KB was added.

**Discovered gap filed, not fixed here (different scope):** #13015 — Planner doesn't tag sub-question topics as the design assumed.

## Verification

```
python3 -m py_compile <changed files>          # OK
python3 -m flake8 --max-line-length=120 <changed files>   # 0
python3 -m black --check --line-length=120 <changed files> # unchanged
pytest tests/test_startup_imports.py services/research/ agent_loop/search/ -q
  # before this PR (cp-swapped baseline via origin/Dev_new_gui content): 398 passed, 0 failed
  # after this PR:                                                     426 passed, 0 failed
  # (350 startup-import-smoke unchanged both sides; +27 net new tests, 0 regressions,
  #  restored files diffed byte-identical to pre-swap after restoring)
```

New tests (27):
- `agent_loop/search/config_declared_provider_test.py` (18) — YAML loading/validation, request-safety (query confined to `params=`, never the URL), redirect rejection, declarative parsing, and the full hostile-URL set: internal IP, localhost, link-local metadata (169.254.169.254), DNS-rebind-to-private/loopback/metadata at request time (real `ssrf_guard`/`url_safety` DNS mocked the same way as `api/tests/test_provider_auth_ssrf.py`, not mocked away).
- `services/research/router_test.py` (10) — topic inference; specialized-provider preference with **zero** general-web calls (the "fewer wasted queries" acceptance criterion); falls back to general web when no specialist matches; credential-gated-unavailable specialist falls back gracefully; erroring specialist falls back gracefully; end-to-end YAML-only source → routed by the router with no Python subclass authored for the source.

## Model Used

Claude Sonnet 5
