### PR TITLE
fix(content_reach): pin SSRF guard connect target to close robots.txt redirect + TOCTOU gaps (#13017)

### DIFF
--- a/autobot-backend/content_reach/_http.py
+++ b/autobot-backend/content_reach/_http.py
@@ -6,16 +6,66 @@
 
 Encapsulates the injected-client-vs-async-with branch so backends stay DRY.
 Error handling (httpx.HTTPError → BackendError) remains the caller's responsibility.
+
+SSRF (#13017): the production (no injected client) path validates a URL with
+``content_reach._url_guard.ensure_public_url`` and then connects separately —
+classic TOCTOU, since DNS can change between the check and the connect. This
+module closes that gap the same way ``pinned_connector`` does for aiohttp
+call sites (``agent_loop/search/config_declared_provider.py``): resolve the
+host to a public IP literal once, then connect directly to that IP (Host
+header + TLS SNI preserved via httpx's ``extensions={"sni_hostname": ...}``)
+so the address validated is the address connected to. The injected-client
+test path is unaffected — tests bypass real network entirely.
 """
 
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
 # Default HTTP timeout in seconds — shared across all httpx-backed backends.
 _HTTP_TIMEOUT = 15.0
+
+
+def _pin_host(url: str, safe_ip: str) -> str:
+    """Return *url* with its host literal replaced by *safe_ip* (port preserved, IPv6 bracketed)."""
+    parsed = urlparse(url)
+    netloc = f"[{safe_ip}]" if ":" in safe_ip else safe_ip
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+async def _pinned_get(
+    url: str,
+    *,
+    headers: dict[str, str] | None,
+    params: dict[str, Any] | None,
+    timeout: float,
+) -> httpx.Response:
+    """SSRF-safe GET: resolve *url*'s host to a public IP and connect to that literal address.
+
+    Raises ``autobot_shared.security.ssrf_guard.SSRFError`` if the host is
+    missing or resolves to a non-public address (defeats DNS-rebind TOCTOU
+    between ``ensure_public_url`` and the fetch — #13017).
+    """
+    from autobot_shared.security.ssrf_guard import SSRFError, resolve_safe_ip
+
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        raise SSRFError(f"URL has no hostname: {url!r}")
+
+    safe_ip = await resolve_safe_ip(host)
+    pinned_url = _pin_host(url, safe_ip)
+    req_headers = dict(headers or {})
+    req_headers.setdefault("Host", host)
+    extensions = {"sni_hostname": host} if parsed.scheme == "https" else {}
+
+    async with httpx.AsyncClient(timeout=timeout) as c:
+        return await c.get(pinned_url, headers=req_headers, params=params, extensions=extensions)
 
 
 async def http_get(
@@ -26,20 +76,20 @@ async def http_get(
     params: dict[str, Any] | None = None,
     timeout: float = _HTTP_TIMEOUT,
 ) -> httpx.Response:
-    """GET *url* with an optional injected client or a short-lived AsyncClient.
+    """GET *url* with an optional injected client or a pinned short-lived AsyncClient.
 
-    If *client* is not None, uses it directly (test injection path).
-    Otherwise opens a fresh AsyncClient, issues the request, and closes it.
-    Callers must wrap this with ``try/except httpx.HTTPError`` as appropriate.
+    If *client* is not None, uses it directly (test injection path) — unchanged.
+    Otherwise resolves the host to a safe IP and connects to that literal
+    address (see :func:`_pinned_get`) so validation and connection cannot
+    diverge (#13017). Callers must wrap this with ``try/except httpx.HTTPError``
+    (network errors) and ``SSRFError`` (guard rejections) as appropriate.
     """
-    kwargs: dict[str, Any] = {}
-    if headers is not None:
-        kwargs["headers"] = headers
-    if params is not None:
-        kwargs["params"] = params
-
     if client is not None:
+        kwargs: dict[str, Any] = {}
+        if headers is not None:
+            kwargs["headers"] = headers
+        if params is not None:
+            kwargs["params"] = params
         return await client.get(url, timeout=timeout, **kwargs)
 
-    async with httpx.AsyncClient(timeout=timeout) as c:
-        return await c.get(url, **kwargs)
+    return await _pinned_get(url, headers=headers, params=params, timeout=timeout)

--- a/autobot-backend/content_reach/_url_guard.py
+++ b/autobot-backend/content_reach/_url_guard.py
@@ -12,6 +12,12 @@ Public API
   Fail-open on robots-fetch errors (log warning + allow).
 
 Both functions must be awaited BEFORE any httpx/browser/caption call.
+
+The robots.txt fetch itself is SSRF-guarded (#13017): it connects through
+``autobot_shared.security.ssrf_guard.pinned_connector`` (never a bare
+``aiohttp.ClientSession()``) with redirects disabled, so a public domain
+cannot answer with a 3xx to an internal address and have it followed. A guard
+rejection is logged distinctly from a natural network failure.
 """
 
 from __future__ import annotations
@@ -52,16 +58,36 @@ def _extract_domain(url: str) -> str:
 
 
 async def _fetch_robots_text(domain: str) -> str:
-    """Fetch robots.txt for domain; return empty string on any error (fail-open)."""
+    """Fetch robots.txt for domain via a pinned connector; fail-open on network errors.
+
+    A blocked-by-guard fetch (private/rebound address, or a redirect to one) is
+    logged distinctly from a natural network failure so it can never hide
+    behind an indistinguishable "fetch failed" warning (#13017).
+    """
     import aiohttp
+
+    from autobot_shared.security.ssrf_guard import SSRFError, pinned_connector
 
     robots_url = f"{domain}/robots.txt"
     try:
-        timeout = aiohttp.ClientTimeout(total=_ROBOTS_FETCH_TIMEOUT)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(robots_url, timeout=timeout, allow_redirects=True) as resp:
+        connector = await pinned_connector(robots_url)
+    except SSRFError as exc:
+        logger.warning("content_reach robots.txt fetch blocked by SSRF guard for %s: %s", domain, exc)
+        return ""
+
+    timeout = aiohttp.ClientTimeout(total=_ROBOTS_FETCH_TIMEOUT)
+    try:
+        async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+            async with session.get(robots_url, allow_redirects=False) as resp:
                 if resp.status == 200:
                     return await resp.text(encoding="utf-8", errors="replace")
+                if 300 <= resp.status < 400:
+                    logger.warning(
+                        "content_reach robots.txt fetch for %s got redirect (HTTP %s); "
+                        "rejected outright by SSRF guard",
+                        domain,
+                        resp.status,
+                    )
         return ""
     except Exception as exc:
         logger.warning("content_reach robots.txt fetch failed for %s: %s", domain, exc)

--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from autobot_shared.security.ssrf_guard import SSRFError
 from content_reach._http import http_get
 from content_reach._url_guard import ensure_public_url
 from content_reach.backends.browser import BrowserBackend
@@ -74,6 +75,9 @@ class RedditJsonBackend(ContentBackend):
             except httpx.HTTPError as exc:
                 logger.debug("RedditJsonBackend: HTTP error for %r: %s", url, exc)
                 raise BackendError(str(exc)) from exc
+            except SSRFError as exc:
+                logger.warning("RedditJsonBackend: blocked by SSRF guard at connect time for %r: %s", url, exc)
+                raise BackendError(str(exc)) from exc
         else:
             try:
                 response = await http_get(
@@ -84,6 +88,9 @@ class RedditJsonBackend(ContentBackend):
                 )
             except httpx.HTTPError as exc:
                 logger.debug("RedditJsonBackend: HTTP error for query %r: %s", request.query, exc)
+                raise BackendError(str(exc)) from exc
+            except SSRFError as exc:
+                logger.warning("RedditJsonBackend: blocked by SSRF guard at connect time: %s", exc)
                 raise BackendError(str(exc)) from exc
 
         if response.status_code != 200:
@@ -154,6 +161,9 @@ class HnAlgoliaBackend(ContentBackend):
             )
         except httpx.HTTPError as exc:
             logger.debug("HnAlgoliaBackend: HTTP error for query %r: %s", request.query, exc)
+            raise BackendError(str(exc)) from exc
+        except SSRFError as exc:
+            logger.warning("HnAlgoliaBackend: blocked by SSRF guard at connect time: %s", exc)
             raise BackendError(str(exc)) from exc
 
         if response.status_code != 200:

--- a/autobot-backend/content_reach/sources/web_page.py
+++ b/autobot-backend/content_reach/sources/web_page.py
@@ -17,6 +17,7 @@ import asyncio
 import httpx
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.ssrf_guard import SSRFError
 from content_reach._http import http_get
 from content_reach._url_guard import ensure_public_url, ensure_robots_allowed
 from content_reach.backends.browser import BrowserBackend
@@ -84,6 +85,8 @@ class TrafilaturaBackend(ContentBackend):
             response = await http_get(request.url, client=self._client)
         except httpx.HTTPError as exc:
             raise BackendError(f"TrafilaturaBackend: HTTP error fetching {request.url!r}: {exc}") from exc
+        except SSRFError as exc:
+            raise BackendError(f"TrafilaturaBackend: blocked by SSRF guard at connect time: {exc}") from exc
 
         html = response.text
         text = await asyncio.to_thread(_trafilatura_extract, html)
@@ -139,6 +142,8 @@ class JinaReaderBackend(ContentBackend):
             response = await http_get(url, client=self._client, headers=headers)
         except httpx.HTTPError as exc:
             raise BackendError(f"JinaReaderBackend: HTTP error fetching {request.url!r}: {exc}") from exc
+        except SSRFError as exc:
+            raise BackendError(f"JinaReaderBackend: blocked by SSRF guard at connect time: {exc}") from exc
 
         if response.status_code != 200:
             logger.debug(

--- a/autobot-backend/content_reach/sources/youtube.py
+++ b/autobot-backend/content_reach/sources/youtube.py
@@ -17,6 +17,7 @@ import re
 import httpx
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.ssrf_guard import SSRFError
 from content_reach._http import http_get
 from content_reach._url_guard import ensure_public_url
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
@@ -202,6 +203,13 @@ class YtDlpCaptionBackend(ContentBackend):
                 exc,
             )
             raise BackendError(f"YtDlpCaptionBackend: HTTP error fetching captions: {exc}") from exc
+        except SSRFError as exc:
+            logger.warning(
+                "YtDlpCaptionBackend: caption track blocked by SSRF guard at connect time for %r: %s",
+                request.url,
+                exc,
+            )
+            raise BackendError(f"YtDlpCaptionBackend: blocked by SSRF guard at connect time: {exc}") from exc
 
         text = _caption_raw_to_text(response.text, ext)
 

--- a/autobot-backend/tests/content_reach/test_http_pinned_get.py
+++ b/autobot-backend/tests/content_reach/test_http_pinned_get.py
@@ -1,0 +1,164 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Hostile-path tests for content_reach._http's pinned-connect fix (#13017).
+
+The DNS-mocking technique (patching ``autobot_shared.url_safety.socket.getaddrinfo``)
+mirrors ``api/tests/test_provider_auth_ssrf.py`` / ``config_declared_provider_test.py``
+— asyncio's default ``loop.getaddrinfo`` runs the very same ``socket.getaddrinfo``
+in an executor, so this exercises the REAL ``ssrf_guard.resolve_safe_ip`` guard
+rather than mocking it away.
+
+Structure:
+  1. _pin_host — pure URL-rewrite unit tests (IPv4/IPv6/port)
+  2. _pinned_get / http_get(client=None) — hostile cases: internal IP, localhost,
+     link-local metadata, DNS-rebind; and the successful-pin path (Host + SNI
+     preserved, connect target is the resolved IP literal)
+  3. http_get(client=...) — injected-client path is unaffected by pinning
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from autobot_shared.security.ssrf_guard import SSRFError
+from content_reach._http import _pin_host, http_get
+
+# ---------------------------------------------------------------------------
+# 1. _pin_host — pure unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_pin_host_replaces_ipv4_host_preserves_path_query():
+    pinned = _pin_host("https://example.com/a/b?x=1", "93.184.216.34")
+    assert pinned == "https://93.184.216.34/a/b?x=1"
+
+
+def test_pin_host_preserves_port():
+    pinned = _pin_host("https://example.com:8443/page", "93.184.216.34")
+    assert pinned == "https://93.184.216.34:8443/page"
+
+
+def test_pin_host_brackets_ipv6_literal():
+    pinned = _pin_host("http://example.com/page", "2606:2800:220:1:248:1893:25c8:1946")
+    assert pinned == "http://[2606:2800:220:1:248:1893:25c8:1946]/page"
+
+
+# ---------------------------------------------------------------------------
+# 2. http_get(client=None) — the production, pinned-connect path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_get_blocks_internal_ip_no_network_call():
+    """An outright-internal-IP URL is blocked before any httpx call is made."""
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        with pytest.raises(SSRFError):
+            await http_get("http://10.0.0.5/secret", client=None)
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_get_blocks_localhost_no_network_call():
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        with pytest.raises(SSRFError):
+            await http_get("http://localhost:8080/x", client=None)
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_get_blocks_link_local_metadata_no_network_call():
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        with pytest.raises(SSRFError):
+            await http_get("http://169.254.169.254/latest/meta-data/", client=None)
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_get_blocks_dns_rebind_to_private_address():
+    """A benign-looking hostname that resolves to a private IP at connect time is refused.
+
+    This is the exact defect-2 shape: a URL that would pass a validate-then-forget
+    check must still be caught because resolution happens fresh at connect time.
+    """
+    fake_infos = [(2, 1, 6, "", ("10.0.0.9", 0))]
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get,
+    ):
+        with pytest.raises(SSRFError):
+            await http_get("https://rebind.example.com/page", client=None)
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_get_blocks_dns_rebind_to_loopback():
+    fake_infos = [(2, 1, 6, "", ("127.0.0.1", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        with pytest.raises(SSRFError):
+            await http_get("https://sneaky.example.com/page", client=None)
+
+
+@pytest.mark.asyncio
+async def test_http_get_blocks_dns_rebind_to_metadata():
+    fake_infos = [(2, 1, 6, "", ("169.254.169.254", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        with pytest.raises(SSRFError):
+            await http_get("https://sneaky2.example.com/page", client=None)
+
+
+@pytest.mark.asyncio
+async def test_http_get_pins_connect_target_and_preserves_host_sni():
+    """A genuinely public host connects to the resolved IP with Host + SNI preserved."""
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["host_header"] = request.headers.get("host")
+        captured["sni_hostname"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, text="ok")
+
+    class _MockTransportClient(httpx.AsyncClient):
+        """Forces every real ``httpx.AsyncClient(...)`` construction in the
+        code under test onto a MockTransport bound to *handler*, so we can
+        assert on the exact outbound request without touching the network.
+        """
+
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            super().__init__(*args, **kwargs)
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        patch("content_reach._http.httpx.AsyncClient", _MockTransportClient),
+    ):
+        response = await http_get("https://real.example.com/robots.txt", client=None)
+
+    assert response.status_code == 200
+    assert captured["url"] == "https://93.184.216.34/robots.txt"
+    assert captured["host_header"] == "real.example.com"
+    assert captured["sni_hostname"] == "real.example.com"
+
+
+# ---------------------------------------------------------------------------
+# 3. http_get(client=...) — injected-client (test) path is unaffected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_get_injected_client_bypasses_pinning():
+    """When a client is injected, http_get uses it directly — no DNS resolution at all."""
+    mock_response = httpx.Response(200, text="ok")
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+
+    with patch("autobot_shared.security.ssrf_guard.resolve_safe_ip", new_callable=AsyncMock) as mock_resolve:
+        response = await http_get("http://10.0.0.5/whatever", client=mock_client)
+
+    assert response is mock_response
+    mock_resolve.assert_not_called()

--- a/autobot-backend/tests/content_reach/test_url_guard.py
+++ b/autobot-backend/tests/content_reach/test_url_guard.py
@@ -19,6 +19,8 @@ Structure:
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -594,18 +596,23 @@ async def test_robots_cache_under_max_not_cleared(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_robots_fetch_error_logs_at_warning(monkeypatch, caplog):
-    """_fetch_robots_text logs at WARNING (not DEBUG) on fetch failure."""
+    """_fetch_robots_text logs at WARNING (not DEBUG) on a natural network failure.
+
+    Real DNS is mocked (not the guard) per the ``config_declared_provider_test.py``
+    pattern: the domain resolves to a public IP so ``pinned_connector`` succeeds,
+    then the aiohttp session itself raises — this is a benign network failure,
+    distinct from a guard rejection (see test_robots_fetch_blocked_by_ssrf_guard_*).
+    """
     import logging
+
+    import aiohttp
 
     import content_reach._url_guard as guard_mod
 
-    async def _boom(domain: str) -> str:
-        raise RuntimeError("firewall blocked robots.txt")
-
-    # We need to trigger the real except path, so monkeypatch aiohttp to raise.
-    import aiohttp
-
     class _FailSession:
+        def __init__(self, *a, **kw):
+            pass
+
         async def __aenter__(self):
             return self
 
@@ -622,10 +629,153 @@ async def test_robots_fetch_error_logs_at_warning(monkeypatch, caplog):
         async def __aexit__(self, *a):
             pass
 
-    monkeypatch.setattr(aiohttp, "ClientSession", lambda: _FailSession())
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    monkeypatch.setattr(aiohttp, "ClientSession", _FailSession)
 
-    with caplog.at_level(logging.WARNING, logger="content_reach._url_guard"):
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        caplog.at_level(logging.WARNING, logger="content_reach._url_guard"),
+    ):
         text = await guard_mod._fetch_robots_text("http://example.com")
 
     assert text == ""
     assert any("robots.txt fetch failed" in r.message for r in caplog.records if r.levelno == logging.WARNING)
+
+
+# ---------------------------------------------------------------------------
+# 13. robots.txt fetch is SSRF-guarded (#13017) — hostile cases, real DNS mocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robots_fetch_blocked_by_ssrf_guard_dns_rebind(caplog):
+    """A domain that resolves to a private address must be blocked, and logged distinctly."""
+    import logging
+
+    import content_reach._url_guard as guard_mod
+
+    fake_infos = [(2, 1, 6, "", ("10.0.0.9", 0))]
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        caplog.at_level(logging.WARNING, logger="content_reach._url_guard"),
+    ):
+        text = await guard_mod._fetch_robots_text("http://rebind.example.com")
+
+    assert text == ""
+    assert any(
+        "blocked by SSRF guard" in r.message for r in caplog.records if r.levelno == logging.WARNING
+    ), "a guard rejection must be logged distinctly from a natural fetch failure"
+
+
+@pytest.mark.asyncio
+async def test_robots_fetch_blocked_by_ssrf_guard_loopback():
+    """A domain resolving to loopback must be blocked."""
+    import content_reach._url_guard as guard_mod
+
+    fake_infos = [(2, 1, 6, "", ("127.0.0.1", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        text = await guard_mod._fetch_robots_text("http://sneaky.example.com")
+    assert text == ""
+
+
+@pytest.mark.asyncio
+async def test_robots_fetch_blocked_by_ssrf_guard_metadata():
+    """A domain resolving to the cloud metadata address must be blocked."""
+    import content_reach._url_guard as guard_mod
+
+    fake_infos = [(2, 1, 6, "", ("169.254.169.254", 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        text = await guard_mod._fetch_robots_text("http://sneaky2.example.com")
+    assert text == ""
+
+
+@pytest.mark.asyncio
+async def test_robots_fetch_rejects_redirect_to_internal_address(monkeypatch, caplog):
+    """A public domain answering robots.txt with a 302 to an internal address must NOT be followed.
+
+    This is the exact vector in defect 1 of #13017: allow_redirects must be
+    False, and any 3xx must be rejected outright rather than followed.
+    """
+    import logging
+
+    import aiohttp
+
+    import content_reach._url_guard as guard_mod
+
+    class _RedirectResp:
+        status = 302
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _RedirectSession:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        def get(self, url, *, allow_redirects, **kw):
+            assert allow_redirects is False, "robots.txt fetch must never follow redirects"
+            return _RedirectResp()
+
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    monkeypatch.setattr(aiohttp, "ClientSession", _RedirectSession)
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        caplog.at_level(logging.WARNING, logger="content_reach._url_guard"),
+    ):
+        text = await guard_mod._fetch_robots_text("http://public-domain.example.com")
+
+    assert text == ""
+    assert any(
+        "redirect" in r.message and "rejected" in r.message for r in caplog.records if r.levelno == logging.WARNING
+    )
+
+
+@pytest.mark.asyncio
+async def test_robots_fetch_pins_connector_for_public_domain():
+    """A genuinely public domain resolves, is pinned, and its robots.txt is returned on 200."""
+    import content_reach._url_guard as guard_mod
+
+    class _OkResp:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def text(self, encoding="utf-8", errors="replace"):
+            return "User-agent: *\nDisallow: /admin"
+
+    class _OkSession:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        def get(self, url, *, allow_redirects, **kw):
+            assert allow_redirects is False
+            return _OkResp()
+
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        patch("aiohttp.ClientSession", _OkSession),
+    ):
+        text = await guard_mod._fetch_robots_text("https://real.example.com")
+
+    assert "Disallow: /admin" in text


### PR DESCRIPTION
Closes #13017

## Thinking Path

Phase 1 verified both defects and corrected one premise before touching code:

1. **Defect 1 confirmed exactly as reported.** `content_reach/_url_guard.py:54-68`'s `_fetch_robots_text` really did open a bare `aiohttp.ClientSession()` with `allow_redirects=True`, and `domain` really derives from a caller-supplied URL via `_extract_domain` (line 48). Reachability confirmed: `_fetch_robots_text` → `_get_robots_parser` → `ensure_robots_allowed`, imported by `content_reach/backends/browser.py:21` and `content_reach/sources/web_page.py:21` — both take `request.url` straight from the caller, so this is real caller-controlled-URL exposure, not inert/admin-only code.
2. **Defect 2 confirmed, but the fix shape needed correcting.** `ensure_public_url` (delegates to `autobot_shared.url_safety.is_public_url_async`) validates and returns; every caller then connects separately. The issue suggested routing straight onto `pinned_connector` (the aiohttp primitive PR #13016 established) — but `content_reach`'s own httpx fetch seam, `content_reach/_http.py`, is httpx-based, and `pinned_connector` returns an `aiohttp.TCPConnector`. There is no existing httpx-compatible pinning helper anywhere in the repo (verified: no `sni_hostname`/custom-transport usage exists outside test doubles). Built one: `content_reach/_http.py._pinned_get` resolves the host via `ssrf_guard.resolve_safe_ip`, connects to the literal IP, and preserves the original `Host` header + TLS SNI via httpx's `extensions={"sni_hostname": ...}` — verified empirically (`httpcore`'s connection layer passes `sni_hostname` to `ssl.wrap_socket(server_hostname=...)`, which both sets SNI and verifies the certificate against the *original* hostname, while the TCP socket connects to the pinned IP).
3. **Scope-narrowing discovery, reported rather than silently expanded.** Two `ensure_public_url` callers hand the URL to a *different* subsystem's own network stack — `BrowserBackend`/`BrowserSearchBackend` (Playwright, via `research_browser_manager.research_url()`) and `YtDlpCaptionBackend`'s first check (yt-dlp's own `extract_info()`). Pinning our own aiohttp/httpx connector does nothing for those — Playwright and yt-dlp do their own DNS resolution. Closing that residual TOCTOU needs Playwright route-interception or yt-dlp proxy/socket options: a different-shaped, larger-blast-radius change. Filed separately as #13018 rather than folded in or silently left unfixed. Also found the identical validate-then-connect pattern (unrelated in scope) in `web_fetch/fetcher.py` and `media/link/pipeline.py` — filed as #13019.

## What Changed

**`content_reach/_url_guard.py`** — `_fetch_robots_text` now resolves via `autobot_shared.security.ssrf_guard.pinned_connector` before ever opening a session, with `allow_redirects=False`; any 3xx is rejected outright and logged distinctly (`"...rejected outright by SSRF guard"`) from a natural network failure (`"...fetch failed"`). A guard rejection during connector resolution is likewise logged distinctly (`"...blocked by SSRF guard"`). Fail-open is preserved for genuine network errors — deliberate existing policy (a broken robots endpoint must not block content), now no longer indistinguishable from a blocked fetch.

**`content_reach/_http.py`** — new `_pin_host` (pure URL-rewrite: swaps the host for a resolved IP literal, preserves port, brackets IPv6) and `_pinned_get` (resolve-then-connect-to-literal with Host + SNI preservation). `http_get(client=None)` — the production path — now routes through `_pinned_get` instead of a plain `httpx.AsyncClient(url)`. The injected-client test path (`client=...`, used by every existing content_reach backend test) is completely unchanged.

**`content_reach/sources/web_page.py` / `reddit.py` / `youtube.py`** — each `http_get` call site now also catches `SSRFError` (raised by the new pinned path) alongside the existing `httpx.HTTPError`, converting it to the same `BackendError` contract callers already expect, with a `logger.warning` distinguishing a guard rejection from an HTTP-level failure. This closes the TOCTOU for every real TCP connection `content_reach` makes via its shared httpx seam: `TrafilaturaBackend`, `JinaReaderBackend`, `RedditJsonBackend` (both url-mode and search-mode), `HnAlgoliaBackend`, and `YtDlpCaptionBackend`'s caption-track fetch.

**Not changed (by design, see Thinking Path #3):** `BrowserBackend`/`BrowserSearchBackend`'s Playwright navigation and `YtDlpCaptionBackend`'s `extract_info()` call keep their existing `ensure_public_url` pre-check (still a valid fail-fast filter) — the residual gap there is filed as #13018.

## Verification

```
python3 -m py_compile <7 changed files>                     # OK
python3 -m flake8 --max-line-length=120 <7 changed files>   # 0
python3 -m black --check --line-length=120 <7 changed files> # unchanged

pytest tests/content_reach/ tests/test_startup_imports.py -q
  before (cp-swapped baseline via origin/Dev_new_gui content): 479 passed, 0 failed
  after this PR:                                              495 passed, 0 failed
  (350 startup-import-smoke unchanged both sides; +16 net new tests, 0 regressions,
   restored files diffed byte-identical to pre-swap after restoring)
```

New/changed hostile-path tests (mock real DNS via `autobot_shared.url_safety.socket.getaddrinfo`, not the guard — mirrors `api/tests/test_provider_auth_ssrf.py` / `config_declared_provider_test.py`):

- `tests/content_reach/test_url_guard.py` — robots.txt fetch blocked for a domain that DNS-resolves to a private/loopback/link-local-metadata address; **a public domain whose robots.txt answers 302 to an internal address is rejected outright and logged distinctly** (the exact defect-1 vector); a genuinely public domain still gets its robots.txt on 200; the pre-existing natural-network-failure test updated to mock real DNS instead of skipping past the new pinned-connector call.
- `tests/content_reach/test_http_pinned_get.py` (new, 11 tests) — `_pin_host` unit tests (IPv4/IPv6/port); `http_get(client=None)` blocked for internal IP / localhost / link-local metadata; **DNS-rebind test**: a hostname resolving to a private/loopback/metadata address at connect time is refused even though nothing upstream re-validates it; a successful pin verified end-to-end via `httpx.MockTransport` — asserts the actual connect target is the resolved IP literal while `Host` header and TLS `sni_hostname` extension both preserve the original hostname; injected-client path confirmed to skip DNS resolution entirely (`resolve_safe_ip` never called).

## Model Used

Claude Sonnet 5