### PR TITLE
fix(web_fetch): pin SSRF guard connect target in fetcher.py + link/pipeline.py (#13019)

### DIFF
--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -30,6 +30,17 @@ This module retains ownership of:
 
 None of these helpers are removed; they are kept here to preserve all call
 sites intact (see issue #7401 caller audit).
+
+SSRF (#13019): ``_fetch_and_parse``'s BeautifulSoup fallback previously had
+no enforcement of its own — ``_is_public_url_async`` only gated the Jina
+fast-path attempt, so a non-public URL simply skipped Jina and fell through
+to an UNGUARDED direct connect. It now routes through
+``autobot_shared.security.ssrf_guard.pinned_request_with_redirects``, which
+independently resolves + pins every hop (including redirects) before
+connecting, unconditionally — closing both the missing-gate bug and the
+check-then-connect TOCTOU in one fix. ``_try_jina`` is unaffected: its
+connect target is always the fixed, trusted ``r.jina.ai`` host (the caller's
+``url`` is only embedded in the request path), so pinning it is a no-op.
 """
 
 import ipaddress
@@ -40,6 +51,7 @@ from typing import Any, Dict, List
 from urllib.parse import urljoin
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from knowledge.query_sanitizer import sanitize_document as _sanitize_document
 from media.core.pipeline import BasePipeline
 from media.core.types import MediaInput, MediaType, ProcessingResult
@@ -67,6 +79,15 @@ _JINA_TIMEOUT = aiohttp.ClientTimeout(total=5) if _AIOHTTP_AVAILABLE else None
 _MAX_CONTENT_LENGTH = 1_000_000  # 1 MB cap on HTML download
 _USER_AGENT = "AutoBot/1.0 (media-pipeline)"
 _JINA_BASE_URL = "https://r.jina.ai/"
+
+
+def _resolve_max_redirects() -> int:
+    """Return max redirect hops for the pinned fallback fetch from env var (default 5)."""
+    raw = config.misc.web_fetch_max_redirects
+    return raw if raw else 5
+
+
+_MAX_REDIRECTS: int = _resolve_max_redirects()
 
 # SSRF guard constants moved with the implementation to
 # ``autobot_shared.url_safety`` (#7477): _PRIVATE_TLDS, _IPV6_ULA,
@@ -206,7 +227,15 @@ class LinkPipeline(BasePipeline):
         }
 
     async def _fetch_and_parse(self, url: str, metadata: Dict) -> Dict[str, Any]:
-        """Fetch URL — tries Jina Reader fast-path first, falls back to BeautifulSoup."""
+        """Fetch URL — tries Jina Reader fast-path first, falls back to BeautifulSoup.
+
+        The fallback fetch is SSRF-guarded unconditionally (#13019): it no
+        longer relies on the ``_is_public_url_async`` check above (which only
+        ever gated the Jina attempt, not this path) — every real connection
+        is resolved + pinned per hop by ``pinned_request_with_redirects``, so
+        a non-public or DNS-rebound URL is rejected here even when Jina was
+        skipped.
+        """
         # Fast-path: Jina Reader (public URLs only, 5-second timeout).
         # DNS resolution runs in a thread to avoid blocking the event loop.
         if await self._is_public_url_async(url):
@@ -221,11 +250,16 @@ class LinkPipeline(BasePipeline):
         # Callers may pass metadata={"allow_self_signed": True} to opt-in to skipping
         # cert verification for known-safe internal URLs.
         ssl_context = False if metadata.get("allow_self_signed") else None
-        try:
-            from autobot_shared.http_client import get_http_client
+        from autobot_shared.security.ssrf_guard import SSRFError, pinned_request_with_redirects
 
-            async with get_http_client().tracked_request(
-                "GET", url, headers=headers, timeout=_DEFAULT_TIMEOUT, allow_redirects=True, ssl=ssl_context
+        try:
+            async with pinned_request_with_redirects(
+                "GET",
+                url,
+                headers=headers,
+                timeout=_DEFAULT_TIMEOUT,
+                max_redirects=_MAX_REDIRECTS,
+                ssl=ssl_context,
             ) as response:
                 final_url = str(response.url)
                 content_type = response.headers.get("Content-Type", "")
@@ -240,6 +274,9 @@ class LinkPipeline(BasePipeline):
                 )
             return self._parse_html(raw_html, final_url, content_type, metadata)
 
+        except SSRFError as exc:
+            logger.warning("Link pipeline fetch blocked by SSRF guard for %s: %s", url, exc)
+            return self._error_result(url, "blocked by SSRF guard", metadata)
         except aiohttp.ClientConnectorError as exc:
             logger.warning("Link pipeline connection error: %s", exc)
             return self._error_result(url, f"Connection error: {exc}", metadata)

--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -9,6 +9,7 @@
 """Unit tests for LinkPipeline."""
 
 import socket
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -158,18 +159,32 @@ class TestLinkPipelineErrorHandling:
         assert result["processing_status"] == "error"
 
 
-class TestLinkPipelineHttp:
-    """Tests for HTTP fetch path.
+def _make_fake_pinned_request(mock_response):
+    """Build a fake ``pinned_request_with_redirects`` async-CM factory + a calls log.
 
-    #12979: _fetch_and_parse() now routes through the shared pool's
-    get_http_client().tracked_request() instead of a private ClientSession,
-    so these tests patch the singleton manager's tracked_request() (which
-    returns the response object directly, itself the async context manager)
-    rather than aiohttp.ClientSession.
+    #13019: ``_fetch_and_parse()``'s fallback fetch now routes through
+    ``ssrf_guard.pinned_request_with_redirects`` (lazily imported inside the
+    method) instead of the shared pool's ``get_http_client().tracked_request``,
+    so pure functional tests (success / error-status / TLS passthrough) patch
+    this factory directly rather than doing real DNS + fake aiohttp plumbing;
+    the SSRF-specific hostile tests below (``TestLinkPipelineFetchSSRFPinning``)
+    mock real DNS instead and exercise the genuine guard.
     """
+    calls = []
+
+    @asynccontextmanager
+    async def _fake(method, url, **kwargs):
+        calls.append({"method": method, "url": url, "kwargs": kwargs})
+        yield mock_response
+
+    return _fake, calls
+
+
+class TestLinkPipelineHttp:
+    """Tests for HTTP fetch path (#13019: pinned_request_with_redirects)."""
 
     def _make_mock_response(self, url, status=200):
-        """Helper: build a mock response for tracked_request() fetch tests."""
+        """Helper: build a mock response for the pinned-fetch tests."""
         mock_response = AsyncMock()
         mock_response.url = url
         mock_response.headers = {"Content-Type": "text/html"}
@@ -181,85 +196,76 @@ class TestLinkPipelineHttp:
 
     @pytest.mark.asyncio
     async def test_fetch_success(self):
-        from autobot_shared.http_client import get_http_client
         from media.link import pipeline as pl
 
         pipe = LinkPipeline()
         mock_response = self._make_mock_response("https://example.com")
         _parsed = {"type": "link_fetch", "confidence": 0.9, "url": "https://example.com"}
-        manager = get_http_client()
+        fake_pinned, calls = _make_fake_pinned_request(mock_response)
 
         with (
             patch("media.link.pipeline._AIOHTTP_AVAILABLE", True),
             patch("media.link.pipeline._BS4_AVAILABLE", True),
-            patch.object(manager, "tracked_request", return_value=mock_response) as mock_tracked_request,
+            patch("autobot_shared.security.ssrf_guard.pinned_request_with_redirects", fake_pinned),
             patch.object(pipe, "_parse_html", return_value=_parsed),
             patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
         ):
             result = await pipe._fetch_and_parse("https://example.com", {})
 
-            assert result["type"] == "link_fetch"
-            assert result["confidence"] > 0
-            # Default path must verify TLS certs (ssl=None, not ssl=False)
-            mock_tracked_request.assert_called_once_with(
-                "GET",
-                "https://example.com",
-                headers={"User-Agent": pl._USER_AGENT},
-                timeout=pl._DEFAULT_TIMEOUT,
-                allow_redirects=True,
-                ssl=None,
-            )
+        assert result["type"] == "link_fetch"
+        assert result["confidence"] > 0
+        # Default path must verify TLS certs (ssl=None, not ssl=False)
+        assert len(calls) == 1
+        assert calls[0]["method"] == "GET"
+        assert calls[0]["url"] == "https://example.com"
+        assert calls[0]["kwargs"] == {
+            "headers": {"User-Agent": pl._USER_AGENT},
+            "timeout": pl._DEFAULT_TIMEOUT,
+            "max_redirects": pl._MAX_REDIRECTS,
+            "ssl": None,
+        }
 
     @pytest.mark.asyncio
     async def test_fetch_default_verifies_tls(self):
         """ssl=None (cert verification) is used when allow_self_signed is absent."""
-        from autobot_shared.http_client import get_http_client
-
         pipe = LinkPipeline()
         mock_response = self._make_mock_response("https://example.com")
         _parsed = {"type": "link_fetch", "confidence": 0.9}
-        manager = get_http_client()
+        fake_pinned, calls = _make_fake_pinned_request(mock_response)
 
         with (
             patch("media.link.pipeline._AIOHTTP_AVAILABLE", True),
             patch("media.link.pipeline._BS4_AVAILABLE", True),
-            patch.object(manager, "tracked_request", return_value=mock_response) as mock_tracked_request,
+            patch("autobot_shared.security.ssrf_guard.pinned_request_with_redirects", fake_pinned),
             patch.object(pipe, "_parse_html", return_value=_parsed),
             patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
         ):
             await pipe._fetch_and_parse("https://example.com", {})
 
-            _call_kwargs = mock_tracked_request.call_args.kwargs
-            assert _call_kwargs.get("ssl") is None, "Default fetch must NOT disable cert verification"
+        assert calls[0]["kwargs"].get("ssl") is None, "Default fetch must NOT disable cert verification"
 
     @pytest.mark.asyncio
     async def test_fetch_allow_self_signed_disables_tls(self):
         """ssl=False is used only when metadata allow_self_signed=True is explicitly set."""
-        from autobot_shared.http_client import get_http_client
-
         pipe = LinkPipeline()
         mock_response = self._make_mock_response("https://internal.example.com")
         _parsed = {"type": "link_fetch", "confidence": 0.9}
-        manager = get_http_client()
+        fake_pinned, calls = _make_fake_pinned_request(mock_response)
 
         with (
             patch("media.link.pipeline._AIOHTTP_AVAILABLE", True),
             patch("media.link.pipeline._BS4_AVAILABLE", True),
-            patch.object(manager, "tracked_request", return_value=mock_response) as mock_tracked_request,
+            patch("autobot_shared.security.ssrf_guard.pinned_request_with_redirects", fake_pinned),
             patch.object(pipe, "_parse_html", return_value=_parsed),
             patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
         ):
             await pipe._fetch_and_parse("https://internal.example.com", {"allow_self_signed": True})
 
-            _call_kwargs = mock_tracked_request.call_args.kwargs
-            assert _call_kwargs.get("ssl") is False, "allow_self_signed=True must set ssl=False"
+        assert calls[0]["kwargs"].get("ssl") is False, "allow_self_signed=True must set ssl=False"
 
     @pytest.mark.asyncio
     async def test_fetch_http_error(self):
-        from autobot_shared.http_client import get_http_client
-
         pipe = LinkPipeline()
-        manager = get_http_client()
 
         mock_response = AsyncMock()
         mock_response.url = "https://example.com/404"
@@ -268,17 +274,96 @@ class TestLinkPipelineHttp:
         mock_response.status = 404
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=False)
+        fake_pinned, _calls = _make_fake_pinned_request(mock_response)
 
         with (
             patch("media.link.pipeline._AIOHTTP_AVAILABLE", True),
             patch("media.link.pipeline._BS4_AVAILABLE", True),
-            patch.object(manager, "tracked_request", return_value=mock_response),
+            patch("autobot_shared.security.ssrf_guard.pinned_request_with_redirects", fake_pinned),
             patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
         ):
             result = await pipe._fetch_and_parse("https://example.com/404", {})
 
         assert result["processing_status"] == "error"
         assert "404" in result["error"]
+
+
+class TestLinkPipelineFetchSSRFPinning:
+    """Hostile-path tests for the fallback fetch's SSRF pinning (#13019).
+
+    Mocks real DNS at ``autobot_shared.url_safety.socket.getaddrinfo`` — never
+    the guard itself. Prior to this fix, ``_is_public_url_async`` only gated
+    the Jina attempt; a non-public URL simply skipped Jina and fell through to
+    an UNGUARDED direct connect (see ``test_fetch_skips_jina_when_hostname_resolves_to_private_ip``
+    below for the old, now-corrected, expectation). These tests prove the
+    fallback fetch is blocked unconditionally, not just the Jina attempt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_private_ip_literal_blocked_end_to_end(self):
+        pipe = LinkPipeline()
+        with patch("aiohttp.ClientSession") as mock_session_cls:
+            result = await pipe._fetch_and_parse("http://10.0.0.5/admin", {})
+        assert result["processing_status"] == "error"
+        mock_session_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dns_rebind_public_at_precheck_private_at_connect_blocked(self):
+        """Public at the Jina pre-check, private by the time the pinned connect
+        happens — must still be refused end-to-end through ``_fetch_and_parse``."""
+        pipe = LinkPipeline()
+        public_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        private_infos = [(2, 1, 6, "", ("10.0.0.9", 0))]
+
+        with (
+            patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
+            patch(
+                "autobot_shared.url_safety.socket.getaddrinfo",
+                side_effect=[public_infos, private_infos],
+            ),
+            patch("aiohttp.ClientSession") as mock_session_cls,
+        ):
+            result = await pipe._fetch_and_parse("https://rebind.example.com/page", {})
+
+        assert result["processing_status"] == "error"
+        mock_session_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_internal_rejected_outright(self):
+        """A public site that 302s to a private address is rejected, not followed."""
+        pipe = LinkPipeline()
+        real_getaddrinfo = socket.getaddrinfo
+
+        def _fake_getaddrinfo(host, *args, **kwargs):
+            if host == "open-redirect.example.com":
+                return [(2, 1, 6, "", ("93.184.216.34", 0))]
+            return real_getaddrinfo(host, *args, **kwargs)
+
+        redirect_resp = MagicMock()
+        redirect_resp.status = 302
+        redirect_resp.headers = {"Location": "http://10.0.0.5/internal"}
+        redirect_resp.release = AsyncMock(return_value=None)
+        responses = [redirect_resp]
+
+        class _FakeSession:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def request(self, method, url, **kwargs):
+                return responses.pop(0)
+
+            async def close(self):
+                pass
+
+        with (
+            patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
+            patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=_fake_getaddrinfo),
+            patch("aiohttp.ClientSession", _FakeSession),
+        ):
+            result = await pipe._fetch_and_parse("https://open-redirect.example.com/go", {})
+
+        assert result["processing_status"] == "error"
+        assert responses == []
 
 
 class TestLinkPipelineJina:
@@ -340,29 +425,31 @@ class TestLinkPipelineJina:
 
     @pytest.mark.asyncio
     async def test_fetch_skips_jina_when_hostname_resolves_to_private_ip(self):
-        """SSRF guard: hostname resolving to RFC1918 must skip Jina fast-path."""
-        from autobot_shared.http_client import get_http_client
+        """SSRF guard: hostname resolving to RFC1918 must skip Jina fast-path.
 
+        #13019: the fallback fetch is now ALSO blocked (previously it fell
+        through to an unguarded direct connect — see
+        ``TestLinkPipelineFetchSSRFPinning`` for the dedicated regression
+        tests). Jina must never even be attempted either way.
+        """
         pipe = LinkPipeline()
-        bs4_result = {"type": "link_fetch", "confidence": 0.9, "url": "https://intranet.attacker/"}
         jina_mock = AsyncMock(return_value="should-not-be-called")
 
         with (
             patch.object(pipe, "_try_jina", new=jina_mock),
-            patch.object(pipe, "_parse_html", return_value=bs4_result),
-            patch.object(get_http_client(), "tracked_request", return_value=self._make_mock_bs4_response()),
+            patch("aiohttp.ClientSession") as mock_session_cls,
             _mock_getaddrinfo("10.0.0.5"),
         ):
             result = await pipe._fetch_and_parse("https://intranet.attacker/", {})
 
         jina_mock.assert_not_called()
         assert result.get("source") != "jina"
+        assert result["processing_status"] == "error"
+        mock_session_cls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_jina_non200_falls_back_to_beautifulsoup(self):
         """Non-200 Jina response triggers BeautifulSoup fallback."""
-        from autobot_shared.http_client import get_http_client
-
         pipe = LinkPipeline()
         mock_session = self._make_jina_mock_session(status=429)
 
@@ -376,9 +463,10 @@ class TestLinkPipelineJina:
             jina_result = await pipe._try_jina("https://example.com")
             assert jina_result is None
 
+        fake_pinned, _calls = _make_fake_pinned_request(self._make_mock_bs4_response())
         with (
             patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
-            patch.object(get_http_client(), "tracked_request", return_value=self._make_mock_bs4_response()),
+            patch("autobot_shared.security.ssrf_guard.pinned_request_with_redirects", fake_pinned),
             patch.object(pipe, "_parse_html", return_value=bs4_result),
         ):
             result = await pipe._fetch_and_parse("https://example.com", {})
@@ -389,19 +477,13 @@ class TestLinkPipelineJina:
     @pytest.mark.asyncio
     async def test_jina_timeout_falls_back_to_beautifulsoup(self):
         """Jina timeout triggers BeautifulSoup fallback."""
-        import aiohttp as _aiohttp
-
-        from autobot_shared.http_client import get_http_client
-
         pipe = LinkPipeline()
         bs4_result = {"type": "link_fetch", "confidence": 0.9, "url": "https://example.com"}
-
-        async def _raise_timeout(*args, **kwargs):
-            raise _aiohttp.ServerTimeoutError()
+        fake_pinned, _calls = _make_fake_pinned_request(self._make_mock_bs4_response())
 
         with (
             patch.object(pipe, "_try_jina", new=AsyncMock(return_value=None)),
-            patch.object(get_http_client(), "tracked_request", return_value=self._make_mock_bs4_response()),
+            patch("autobot_shared.security.ssrf_guard.pinned_request_with_redirects", fake_pinned),
             patch.object(pipe, "_parse_html", return_value=bs4_result),
         ):
             result = await pipe._fetch_and_parse("https://example.com", {})
@@ -542,7 +624,7 @@ class TestLinkPipelineJina:
             assert not await pipe._is_public_url_async("https://intranet.attacker/")
 
     def _make_mock_bs4_response(self, status=200):
-        """Helper: mock response for the BS4-fallback tracked_request() path."""
+        """Helper: mock response for the pinned BS4-fallback fetch path."""
         mock_response = AsyncMock()
         mock_response.url = "https://example.com"
         mock_response.headers = {"Content-Type": "text/html"}

--- a/autobot-backend/tests/unit/web_fetch/test_fetcher.py
+++ b/autobot-backend/tests/unit/web_fetch/test_fetcher.py
@@ -5,7 +5,7 @@
 """Tests for web_fetch.fetcher — render mode selection, SPA detection, fallback chain."""
 
 import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -13,6 +13,7 @@ from web_fetch.fetcher import (
     WebFetcher,
     _circuit_is_open,
     _domain_circuit,
+    _fetch_bs4,
     _record_domain_failure,
     _record_domain_success,
 )
@@ -91,6 +92,133 @@ class TestSSRFGuard:
             result = await WebFetcher.fetch("http://10.0.0.1/page")
         assert result.success is False
         assert result.error_code == ERR_SSRF_BLOCKED
+
+
+class TestFetchBS4SSRFPinning:
+    """Hostile-path tests for ``_fetch_bs4``'s pinned-redirect fetch (#13019).
+
+    Mocks real DNS at ``autobot_shared.url_safety.socket.getaddrinfo`` — never
+    the guard itself — mirroring ``api/tests/test_provider_auth_ssrf.py`` /
+    ``tests/content_reach/test_http_pinned_get.py``. ``_is_public_url`` is
+    NOT mocked in these tests so the real pre-check + real pinned connect
+    both run, proving the fix holds end-to-end.
+    """
+
+    @pytest.mark.asyncio
+    async def test_blocks_private_ip_literal_no_network_call(self) -> None:
+        with patch("aiohttp.ClientSession") as mock_session_cls:
+            html, status = await _fetch_bs4("http://10.0.0.5/secret", timeout=5.0)
+        assert (html, status) == (None, None)
+        mock_session_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_blocks_link_local_metadata_no_network_call(self) -> None:
+        with patch("aiohttp.ClientSession") as mock_session_cls:
+            html, status = await _fetch_bs4("http://169.254.169.254/latest/meta-data/", timeout=5.0)
+        assert (html, status) == (None, None)
+        mock_session_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_blocks_dns_rebind_public_at_precheck_private_at_connect(self) -> None:
+        """A hostname that is public at the ``_is_public_url`` pre-check but
+        resolves to a private address by the time the pinned connect happens
+        must still be refused — the classic validate-then-forget TOCTOU.
+        """
+        public_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        private_infos = [(2, 1, 6, "", ("10.0.0.9", 0))]
+
+        with (
+            patch(
+                "autobot_shared.url_safety.socket.getaddrinfo",
+                side_effect=[public_infos, private_infos],
+            ),
+            patch("aiohttp.ClientSession") as mock_session_cls,
+        ):
+            html, status = await _fetch_bs4("https://rebind.example.com/page", timeout=5.0)
+
+        assert (html, status) == (None, None)
+        mock_session_cls.assert_not_called()
+
+    @staticmethod
+    def _fake_getaddrinfo_for(public_hosts: dict):
+        """Real DNS pass-through except for hostnames explicitly mapped to a
+        canned answer — so literal-IP redirect targets (e.g. ``10.0.0.5``,
+        which needs NO DNS at all) are resolved for real, not via a blanket
+        mock that would misreport them as public.
+        """
+        import socket as _socket
+
+        real_getaddrinfo = _socket.getaddrinfo
+
+        def _fake(host, *args, **kwargs):
+            if host in public_hosts:
+                return public_hosts[host]
+            return real_getaddrinfo(host, *args, **kwargs)
+
+        return _fake
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_internal_rejected_outright(self) -> None:
+        """A public site that 302s to a private address is rejected, not followed."""
+        fake_dns = self._fake_getaddrinfo_for({"open-redirect.example.com": [(2, 1, 6, "", ("93.184.216.34", 0))]})
+
+        redirect_resp = MagicMock()
+        redirect_resp.status = 302
+        redirect_resp.headers = {"Location": "http://10.0.0.5/internal"}
+        redirect_resp.release = AsyncMock(return_value=None)
+        responses = [redirect_resp]
+
+        class _FakeSession:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def request(self, method, url, **kwargs):
+                return responses.pop(0)
+
+            async def close(self):
+                pass
+
+        with (
+            patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=fake_dns),
+            patch("aiohttp.ClientSession", _FakeSession),
+        ):
+            html, status = await _fetch_bs4("https://open-redirect.example.com/go", timeout=5.0)
+
+        assert (html, status) == (None, None)
+        # Only the first (legitimate) hop connected; hop 2 was blocked pre-connect.
+        assert responses == []
+
+    @pytest.mark.asyncio
+    async def test_genuinely_public_url_succeeds(self) -> None:
+        """A real public host fetches successfully through the pinned path."""
+        fake_dns = self._fake_getaddrinfo_for({"real.example.com": [(2, 1, 6, "", ("93.184.216.34", 0))]})
+
+        ok_resp = MagicMock()
+        ok_resp.status = 200
+
+        async def _iter_chunked(_size):
+            yield b"<html><body>hi</body></html>"
+
+        ok_resp.content.iter_chunked = MagicMock(side_effect=lambda n: _iter_chunked(n))
+
+        class _FakeSession:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def request(self, method, url, **kwargs):
+                return ok_resp
+
+            async def close(self):
+                pass
+
+        with (
+            patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=fake_dns),
+            patch("aiohttp.ClientSession", _FakeSession),
+        ):
+            html, status = await _fetch_bs4("https://real.example.com/page", timeout=5.0)
+
+        assert status == 200
+        assert "hi" in html
 
 
 class TestCircuitBreaker:

--- a/autobot-backend/web_fetch/fetcher.py
+++ b/autobot-backend/web_fetch/fetcher.py
@@ -15,6 +15,21 @@ Render decision tree (RenderMode.AUTO):
 SSRF guards delegate to ``autobot_shared.url_safety.is_public_url_async``
 (extracted in #7477 to break the ``pipeline.py`` ↔ ``fetcher.py`` cycle).
 Jina circuit breaker from media.link.pipeline is reused via _try_jina / _record_*.
+
+SSRF TOCTOU (#13019): ``_fetch_bs4`` connects directly to the caller-supplied
+``url`` and previously did so via the shared pooled ``get_http_client()``
+session after only a check-then-forget ``_is_public_url`` validation — DNS
+could re-resolve to a private address between the check and the real
+connect. It now routes through
+``autobot_shared.security.ssrf_guard.pinned_request_with_redirects``, which
+independently resolves + pins EVERY hop (including redirects) so validation
+and connection can never diverge. ``_fetch_jina_impl`` and
+``_fetch_playwright`` are NOT affected: the actual TCP connection they make
+is always to a fixed, trusted proxy (``r.jina.ai`` — the caller's ``url`` is
+only embedded in the *request path*, never the connect target) or to our own
+in-cluster Playwright service, so pinning ``url`` there would be a no-op —
+the ``_is_public_url`` check on those paths remains a defense-in-depth guard
+against asking a third party to fetch on our behalf, not a TOCTOU fix.
 """
 
 from __future__ import annotations
@@ -25,6 +40,7 @@ from urllib.parse import urlparse
 
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from web_fetch.cache import WEB_FETCH_MAX_BYTES, get_cached_result, set_cached_result
 from web_fetch.extractors import _MIN_CONTENT_CHARS, extract_markdown, is_spa_content
 
@@ -74,7 +90,15 @@ _CIRCUIT_COOLDOWN = 60.0
 
 _JINA_BASE_URL = "https://r.jina.ai/"
 _USER_AGENT = "AutoBot/1.0 (web-fetch)"
-_MAX_REDIRECTS = 5
+
+
+def _resolve_max_redirects() -> int:
+    """Return max redirect hops for the pinned BS4 fetch from env var (default 5)."""
+    raw = config.misc.web_fetch_max_redirects
+    return raw if raw else 5
+
+
+_MAX_REDIRECTS: int = _resolve_max_redirects()
 
 
 def _get_domain_sem(netloc: str) -> asyncio.Semaphore:
@@ -157,7 +181,7 @@ async def _fetch_jina_impl(url: str, timeout: float) -> str | None:
 
 
 async def _fetch_bs4(url: str, timeout: float) -> tuple[str | None, int | None]:
-    """Fetch raw HTML via aiohttp. Returns (html, status_code) or (None, None).
+    """Fetch raw HTML. Returns (html, status_code) or (None, None).
 
     Single round-trip (#7459): streams the response body in 64 KiB chunks,
     enforces ``WEB_FETCH_MAX_BYTES``, and returns ``("", status)`` for empty
@@ -167,24 +191,23 @@ async def _fetch_bs4(url: str, timeout: float) -> tuple[str | None, int | None]:
 
     SSRF guard is enforced inline (defense in depth) so any caller —
     including ``WebFetcher.fetch_raw_html`` which intentionally bypasses
-    the public ``fetch()`` pipeline — cannot reach private IPs.
+    the public ``fetch()`` pipeline — cannot reach private IPs. The actual
+    connect goes through ``ssrf_guard.pinned_request_with_redirects`` (#13019)
+    instead of the shared pooled client, so the resolved address validated is
+    the address connected to on every hop, including redirects.
     """
     import aiohttp
+
+    from autobot_shared.security.ssrf_guard import SSRFError, pinned_request_with_redirects
 
     if not await _is_public_url(url):
         return None, None
 
     headers = {"User-Agent": _USER_AGENT}
+    aio_timeout = aiohttp.ClientTimeout(total=timeout)
     try:
-        aio_timeout = aiohttp.ClientTimeout(total=timeout)
-        async with get_http_client().tracked_request(
-            "GET",
-            url,
-            headers=headers,
-            timeout=aio_timeout,
-            allow_redirects=True,
-            max_redirects=_MAX_REDIRECTS,
-            suppress_error_log=True,
+        async with pinned_request_with_redirects(
+            "GET", url, headers=headers, timeout=aio_timeout, max_redirects=_MAX_REDIRECTS
         ) as resp:
             content = b""
             async for chunk in resp.content.iter_chunked(65536):
@@ -195,8 +218,8 @@ async def _fetch_bs4(url: str, timeout: float) -> tuple[str | None, int | None]:
                 return "", resp.status
             html = content.decode("utf-8", errors="replace")
             return html, resp.status
-    except aiohttp.TooManyRedirects:
-        logger.debug("Too many redirects for %s", url)
+    except SSRFError as exc:
+        logger.warning("web_fetch BS4 fetch blocked by SSRF guard for %s: %s", url, exc)
         return None, None
     except Exception as exc:
         logger.debug("BS4 fetch failed for %s: %s", url, exc)

--- a/autobot_shared/security/ssrf_guard.py
+++ b/autobot_shared/security/ssrf_guard.py
@@ -18,6 +18,10 @@ Public API
   that connects to the pre-resolved IP
 - :func:`fetch_safe_url` — full SSRF-safe HTTP GET: resolve → pin → fetch,
   with allow_redirects=False enforced
+- :func:`pinned_request_with_redirects` — like :func:`pinned_connector` but
+  follows redirects, independently re-resolving + re-pinning EACH hop, for
+  callers (``web_fetch``, ``media/link/pipeline``, #13019) that genuinely
+  need redirect-following and cannot accept ``allow_redirects=False``
 
 Dependencies: stdlib + aiohttp only (no autobot-* imports).
 """
@@ -25,7 +29,9 @@ Dependencies: stdlib + aiohttp only (no autobot-* imports).
 from __future__ import annotations
 
 import socket
-from urllib.parse import urlparse
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+from urllib.parse import urljoin, urlparse
 
 import aiohttp
 import aiohttp.abc
@@ -123,6 +129,64 @@ async def pinned_connector(url: str) -> aiohttp.TCPConnector:
     return aiohttp.TCPConnector(resolver=resolver, use_dns_cache=False)
 
 
+@asynccontextmanager
+async def pinned_request_with_redirects(
+    method: str,
+    url: str,
+    *,
+    headers: dict | None = None,
+    timeout: aiohttp.ClientTimeout | None = None,
+    max_redirects: int = 5,
+    ssl: Any = None,
+) -> AsyncIterator[aiohttp.ClientResponse]:
+    """SSRF-safe request that follows redirects, re-pinning EACH hop (#13019).
+
+    A single ``pinned_connector(url)`` + ``allow_redirects=True`` would be
+    unsafe: :func:`safe_aiohttp_resolver` returns a resolver that maps ANY
+    hostname to the *first* hop's pinned IP, so a cross-host redirect would
+    either connect to the wrong server or (worse) silently reuse the original
+    IP for a hostname it was never resolved for. This function instead issues
+    each hop with ``allow_redirects=False`` through its OWN fresh
+    :func:`pinned_connector`, so a redirect ``Location`` is independently
+    resolved and safety-checked before it is ever connected to — a redirect
+    to a private/loopback/link-local/rebound address raises
+    :class:`SSRFError` instead of being followed, exactly like the initial
+    URL would be.
+
+    Bounded by *max_redirects*: an exhausted chain raises :class:`SSRFError`
+    (distinguishable from a natural network failure) rather than silently
+    truncating.
+
+    Yields the terminal response with its body still open for the caller to
+    stream; the owning session for that final hop is closed when the
+    ``async with`` block exits (including on error). Intermediate hops close
+    their own sessions immediately after reading the ``Location`` header.
+    """
+    current_url = url
+    for _ in range(max_redirects + 1):
+        connector = await pinned_connector(current_url)
+        session = aiohttp.ClientSession(connector=connector, timeout=timeout)
+        try:
+            resp = await session.request(method, current_url, headers=headers, allow_redirects=False, ssl=ssl)
+        except Exception:
+            await session.close()
+            raise
+
+        location = resp.headers.get("Location") if 300 <= resp.status < 400 else None
+        if location is None:
+            try:
+                yield resp
+            finally:
+                await session.close()
+            return
+
+        await resp.release()
+        await session.close()
+        current_url = urljoin(current_url, location)
+
+    raise SSRFError(f"exceeded max_redirects={max_redirects} while fetching {url!r}")
+
+
 async def fetch_safe_url(
     url: str,
     *,
@@ -197,4 +261,11 @@ async def fetch_safe_url(
     return status, body[:max_bytes], content_type
 
 
-__all__ = ["SSRFError", "resolve_safe_ip", "safe_aiohttp_resolver", "pinned_connector", "fetch_safe_url"]
+__all__ = [
+    "SSRFError",
+    "resolve_safe_ip",
+    "safe_aiohttp_resolver",
+    "pinned_connector",
+    "pinned_request_with_redirects",
+    "fetch_safe_url",
+]

--- a/autobot_shared/security/ssrf_guard_test.py
+++ b/autobot_shared/security/ssrf_guard_test.py
@@ -18,6 +18,7 @@ Covers all threat categories the shared module must block:
 
 from __future__ import annotations
 
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -26,6 +27,7 @@ from autobot_shared.security.ssrf_guard import (
     SSRFError,
     fetch_safe_url,
     pinned_connector,
+    pinned_request_with_redirects,
     resolve_safe_ip,
     safe_aiohttp_resolver,
 )
@@ -291,3 +293,205 @@ async def test_fetch_safe_url_returns_status_body_content_type() -> None:
     assert status == 200
     assert body == b'{"ok":true}'
     assert ct == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# pinned_request_with_redirects — per-hop pinned redirect following (#13019)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_session_class(responses):
+    """Return a fake ``aiohttp.ClientSession`` class + a shared *calls* log.
+
+    Each instantiation pulls the next canned response from *responses* on
+    ``.request()``; ``.close()`` is a no-op. Mirrors the real API surface
+    ``pinned_request_with_redirects`` actually uses (``request`` + ``close``),
+    not ``get`` + ``async with session`` like ``fetch_safe_url``'s tests.
+    """
+    calls = []
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            self._init_kwargs = kwargs
+            calls.append({"connector": kwargs.get("connector")})
+
+        async def request(self, method, url, **kwargs):
+            calls[-1].update({"method": method, "url": url, "kwargs": kwargs})
+            return responses.pop(0)
+
+        async def close(self):
+            calls[-1]["closed"] = True
+
+    return _FakeSession, calls
+
+
+def _make_fake_response(status, headers=None):
+    resp = MagicMock()
+    resp.status = status
+    resp.headers = headers or {}
+    resp.release = AsyncMock(return_value=None)
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_blocks_private_ip_no_network_call() -> None:
+    """A private-IP-literal URL is blocked before any session is created."""
+    with patch("aiohttp.ClientSession") as mock_session_cls:
+        with pytest.raises(SSRFError):
+            async with pinned_request_with_redirects("GET", "http://10.0.0.5/secret"):
+                pass
+    mock_session_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_blocks_localhost_no_network_call() -> None:
+    with patch("aiohttp.ClientSession") as mock_session_cls:
+        with pytest.raises(SSRFError):
+            async with pinned_request_with_redirects("GET", "http://localhost:8080/x"):
+                pass
+    mock_session_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_blocks_link_local_metadata_no_network_call() -> None:
+    with patch("aiohttp.ClientSession") as mock_session_cls:
+        with pytest.raises(SSRFError):
+            async with pinned_request_with_redirects("GET", "http://169.254.169.254/latest/meta-data/"):
+                pass
+    mock_session_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_blocks_dns_rebind_to_private_address() -> None:
+    """Public-looking hostname that resolves to a private IP at connect time is refused.
+
+    Exercises the REAL ``resolve_safe_ip`` guard via mocked DNS (never mocking
+    the guard itself) — the classic validate-then-forget rebind shape.
+    """
+    fake_infos = [(2, 1, 6, "", ("10.0.0.9", 0))]
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        patch("aiohttp.ClientSession") as mock_session_cls,
+    ):
+        with pytest.raises(SSRFError):
+            async with pinned_request_with_redirects("GET", "https://rebind.example.com/page"):
+                pass
+    mock_session_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_no_redirect_returns_response() -> None:
+    """A plain 200 is yielded as-is; session is closed on context exit."""
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    fake_cls, calls = _make_fake_session_class([_make_fake_response(200, {"Content-Type": "text/html"})])
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        async with pinned_request_with_redirects("GET", "https://real.example.com/page") as resp:
+            assert resp.status == 200
+
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://real.example.com/page"
+    assert calls[0]["kwargs"]["allow_redirects"] is False
+    assert calls[0].get("closed") is True
+
+    # The connector actually used for the connect is pinned to the resolved
+    # IP literal while Host/TLS SNI (the resolver's "hostname" field) still
+    # preserve the original hostname — i.e. validation and connect target
+    # are the same address, but the vhost/cert identity is unchanged.
+    resolver_result = await calls[0]["connector"]._resolver.resolve("real.example.com", 443)
+    assert resolver_result[0]["host"] == "93.184.216.34"
+    assert resolver_result[0]["hostname"] == "real.example.com"
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_follows_redirect_with_per_hop_pin() -> None:
+    """A same-origin 302 is followed; the second hop is independently resolved + pinned."""
+    per_hop_infos = [
+        [(2, 1, 6, "", ("93.184.216.34", 0))],  # hop 1: real.example.com
+        [(2, 1, 6, "", ("8.8.4.4", 0))],  # hop 2: real2.example.com
+    ]
+    fake_cls, calls = _make_fake_session_class(
+        [
+            _make_fake_response(302, {"Location": "https://real2.example.com/final"}),
+            _make_fake_response(200, {"Content-Type": "text/html"}),
+        ]
+    )
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=per_hop_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        async with pinned_request_with_redirects("GET", "https://real.example.com/start") as resp:
+            assert resp.status == 200
+
+    assert len(calls) == 2
+    assert calls[0]["url"] == "https://real.example.com/start"
+    assert calls[1]["url"] == "https://real2.example.com/final"
+    # Each hop gets its OWN connector pinned to that hop's resolved IP.
+    assert calls[0]["connector"] is not calls[1]["connector"]
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_rejects_redirect_to_private_ip() -> None:
+    """A redirect Location pointing at a private IP literal is rejected outright, never followed.
+
+    Only hop 1's hostname needs DNS mocked; hop 2 is an IP literal that the
+    REAL (unmocked) resolver parses directly — verifying the private-IP
+    rejection is genuine, not an artifact of a blanket DNS mock.
+    """
+    real_getaddrinfo = socket.getaddrinfo
+
+    def _fake_getaddrinfo(host, *args, **kwargs):
+        if host == "open-redirect.example.com":
+            return [(2, 1, 6, "", ("93.184.216.34", 0))]
+        return real_getaddrinfo(host, *args, **kwargs)
+
+    fake_cls, calls = _make_fake_session_class([_make_fake_response(302, {"Location": "http://10.0.0.5/internal"})])
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", side_effect=_fake_getaddrinfo),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        with pytest.raises(SSRFError):
+            async with pinned_request_with_redirects("GET", "https://open-redirect.example.com/go"):
+                pass
+
+    # Only the first (legitimate) hop actually connected; the second was blocked pre-connect.
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_exceeds_max_redirects_raises() -> None:
+    """A redirect chain longer than max_redirects raises SSRFError, not a silent truncation."""
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    responses = [_make_fake_response(302, {"Location": f"https://real.example.com/hop{i}"}) for i in range(5)]
+    fake_cls, calls = _make_fake_session_class(responses)
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        with pytest.raises(SSRFError, match="exceeded max_redirects"):
+            async with pinned_request_with_redirects("GET", "https://real.example.com/start", max_redirects=2):
+                pass
+
+    # max_redirects=2 allows hops 0,1,2 (3 attempts) before giving up.
+    assert len(calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_pinned_request_with_redirects_passes_ssl_kwarg_through() -> None:
+    fake_infos = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    fake_cls, calls = _make_fake_session_class([_make_fake_response(200)])
+
+    with (
+        patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos),
+        patch("aiohttp.ClientSession", fake_cls),
+    ):
+        async with pinned_request_with_redirects("GET", "https://real.example.com/x", ssl=False):
+            pass
+
+    assert calls[0]["kwargs"]["ssl"] is False

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1693,6 +1693,9 @@ class MiscConfig(BaseSettings):
     weak_cache_size: int = Field(default=0, alias="AUTOBOT_WEAK_CACHE_SIZE")
     web_fetch_cache_ttl: str = Field(default="", alias="AUTOBOT_WEB_FETCH_CACHE_TTL")
     web_fetch_max_bytes: int = Field(default=0, alias="AUTOBOT_WEB_FETCH_MAX_BYTES")
+    # #13019: bounds redirect-hop count for the pinned-redirect SSRF fetch path
+    # shared by web_fetch/fetcher.py and media/link/pipeline.py.
+    web_fetch_max_redirects: int = Field(default=0, alias="AUTOBOT_WEB_FETCH_MAX_REDIRECTS")
     celery_broker_url: str = Field(default="", alias="CELERY_BROKER_URL")
     celery_result_backend: str = Field(default="", alias="CELERY_RESULT_BACKEND")
     ci: str = Field(default="", alias="CI")


### PR DESCRIPTION
Closes #13019

## Thinking Path

Phase 1 verified each claim in #13019 against source and corrected two of them before touching code:

1. **`web_fetch/fetcher.py` — confirmed, but only for `_fetch_bs4`.** `_fetch_bs4` really does check `_is_public_url(url)` then connect separately (previously via the shared pooled `get_http_client()` session) — a genuine DNS-rebind TOCTOU. **Correction:** `_fetch_jina_impl` does NOT share this defect. Its actual TCP connect target is always the fixed, trusted `r.jina.ai` host — the caller's `url` is only embedded in the *request path* (`https://r.jina.ai/{url}`), never the connect target — so pinning it would be a no-op. Same for `_fetch_playwright` (connects to our own in-cluster Playwright service, not `url`, mirroring PR #13020's Playwright/yt-dlp scope-narrowing). Reachability: `WebFetcher.fetch`/`fetch_raw_html` is called from `chat_workflow/tool_handler.py`, `api/knowledge_scrape.py`, `api/knowledge_mcp.py`, `api/knowledge_extract.py`, `tools/tool_registry.py`, `services/research/orchestrator.py`, `knowledge/connectors/web_crawler.py` — broad, caller-controlled-URL exposure, not admin-only.
2. **`media/link/pipeline.py` — confirmed, and WORSE than reported.** `_fetch_and_parse`'s `_is_public_url_async(url)` check only ever gated the **Jina** attempt — if it returned `False`, the code fell through *unconditionally* to the BeautifulSoup fallback fetch with **zero** SSRF enforcement (an existing test, `test_fetch_skips_jina_when_hostname_resolves_to_private_ip`, explicitly asserted this: it mocked DNS to a private IP and still expected the BS4 fetch to proceed). This isn't merely a TOCTOU window — it's a missing gate. Fixed by making the pinned fetch unconditional, which closes both issues in one change. **Reachability correction:** `LinkPipeline`/`MediaPipelineManager` currently has **no production caller** — `api/knowledge_scrape.py` and friends call `web_fetch.WebFetcher` directly; `process_url()` is referenced only from its own test file. So severity here is "latent, not actively exploitable" rather than the issue's "Medium" — fixed anyway per the project's "never delete code — wire it in" stance, since #12979 already actively maintains this file.
3. **HTTP stack: both modules are aiohttp**, unlike `content_reach` (httpx). `media/link/pipeline.py` is also on the shared pooled client from #12979 for Jina, but Jina's fixed connect target means pooling there is unaffected by this fix. The existing aiohttp `ssrf_guard.pinned_connector` is reused as-is (aiohttp's own resolver only maps one hostname → one pinned IP, so a naive `pinned_connector(url)` + `allow_redirects=True` would silently misroute any cross-host redirect) — no httpx helper was needed, so nothing was promoted from `content_reach/_http.py`.
4. Both fetch paths need genuine redirect-following (BS4 defaults follow up to 5/10 hops today — real-world URLs redirect constantly); simply disabling redirects (the `fetch_safe_url`/`api/knowledge.py` precedent) would be a real functionality regression, so a new shared primitive, `ssrf_guard.pinned_request_with_redirects`, independently resolves + pins **every** hop (including redirects), rejecting a redirect to a private/rebound address outright instead of following it.

## What Changed

**`autobot_shared/security/ssrf_guard.py`** — new `pinned_request_with_redirects(method, url, ...)`: an async context manager that issues each hop with `allow_redirects=False` through its own fresh `pinned_connector`, re-validating the `Location` before ever connecting to it. Bounded by `max_redirects` (`SSRFError` on exhaustion, not silent truncation).

**`autobot_shared/ssot_config.py`** — new `web_fetch_max_redirects` field (`AUTOBOT_WEB_FETCH_MAX_REDIRECTS`, default 5) shared by both call sites.

**`web_fetch/fetcher.py`** — `_fetch_bs4` now routes through `pinned_request_with_redirects` instead of the shared pooled client; `SSRFError` is logged distinctly (`"blocked by SSRF guard"`) from a natural fetch failure. `_MAX_REDIRECTS` is now config-sourced instead of a hardcoded literal.

**`media/link/pipeline.py`** — `_fetch_and_parse`'s fallback now routes through `pinned_request_with_redirects` unconditionally (closing the missing-gate bug), preserving the existing `ssl=` passthrough for `allow_self_signed`. New `_MAX_REDIRECTS` module constant, same config field.

**Not changed (by design):** `_fetch_jina_impl`/`_try_jina` and `_fetch_playwright` — see correction #1 above.

## Verification

```
python3 -m py_compile <7 changed files>                      # OK
python3 -m flake8 --max-line-length=120 <7 changed files>    # 0
python3 -m black --check --line-length=120 <7 changed files> # unchanged

pytest tests/content_reach/ tests/unit/web_fetch/ media/link/pipeline_test.py \
       autobot_shared/security/ssrf_guard_test.py tests/test_startup_imports.py -q
  743 passed (393 non-startup + 350 startup-import-smoke)
  cp-swapped baseline (origin/Dev_new_gui content restored via cp, not stash):
    startup-import-smoke: 350/350 both sides, unchanged
    PR #13020's content_reach tests: still green, unchanged
```

New/changed hostile-path tests (mock real DNS at `autobot_shared.url_safety.socket.getaddrinfo`, never the guard — mirrors `api/tests/test_provider_auth_ssrf.py` / PR #13020's `test_http_pinned_get.py`):

- `autobot_shared/security/ssrf_guard_test.py` — `pinned_request_with_redirects`: blocks private IP / localhost / link-local metadata pre-connect; DNS-rebind (public hostname resolving private at connect); follows a legitimate cross-host redirect with independent per-hop pinning (asserts each hop gets its OWN connector); **rejects a redirect to a private IP literal outright**; exceeds-`max_redirects` raises `SSRFError` rather than truncating silently; verifies the connector's pinned resolver targets the IP literal while `hostname` (Host/SNI) preserves the original name.
- `tests/unit/web_fetch/test_fetcher.py` (`TestFetchBS4SSRFPinning`, 5 tests) — private IP literal, link-local metadata, DNS-rebind (public at `_is_public_url` pre-check / private at pinned connect), redirect-to-internal rejected outright, and a genuinely public URL still succeeds end-to-end.
- `media/link/pipeline_test.py` (`TestLinkPipelineFetchSSRFPinning`, 3 tests) — same private-IP/DNS-rebind/redirect-to-internal cases exercised through `_fetch_and_parse` itself, proving the previously-missing gate now blocks the fallback fetch unconditionally, not just Jina. The 7 pre-existing functional tests for the old `get_http_client().tracked_request()` shape were rewired onto the new pinned-fetch factory (mocked directly for pure functional assertions — TLS passthrough, HTTP-error status, success) rather than duplicating DNS-mocking plumbing into every test.

## Discovered (filed separately, not in scope here)

- #13021 — `media/link/pipeline.py:67`'s `_MAX_CONTENT_LENGTH` (1 MB cap) is declared but never enforced; unbounded body read in the same fallback fetch (resource-exhaustion class, distinct from SSRF).

## Model Used

Claude Sonnet 5