### PR TITLE
fix(content_reach): re-validate SSRF guard immediately before Playwright navigate (#13018)

### DIFF
--- a/autobot-backend/content_reach/backends/browser.py
+++ b/autobot-backend/content_reach/backends/browser.py
@@ -68,12 +68,27 @@ class BrowserBackend(ContentBackend):
 
         return await self._navigate(request)
 
+    @staticmethod
+    def _raise_for_failed_result(result: dict, url: str) -> None:
+        """Raise BackendError for a failed research_url result, distinguishing
+        an SSRF-guard rejection (#13018 -- see research_browser_manager's
+        navigate_to re-check, tagged ``blocked_by_guard``) from any other
+        research_url failure, instead of one generic message for both.
+        """
+        if result.get("blocked_by_guard"):
+            raise BackendError(f"BrowserBackend: blocked by SSRF guard at navigate time for {url!r}")
+        error = result.get("error", "unknown error")
+        raise BackendError(f"BrowserBackend: research_url failed for {url!r}: {error}")
+
     async def _navigate(self, request: ContentRequest) -> ContentResult:
         """Issue the browser navigation call and map result to ContentResult.
 
         Guards (SSRF/robots) are NOT re-checked here — callers must run them
         before calling _navigate (BrowserBackend.fetch does; BrowserSearchBackend
         runs SSRF-only before delegating here, skipping robots for search results).
+        research_url's navigate_to re-validates the SSRF guard immediately
+        before Playwright's own DNS resolution as a compensating control
+        (#13018 -- narrows, does not close, that TOCTOU window).
         """
         manager = _get_manager()
         result = await manager.research_url(
@@ -83,7 +98,7 @@ class BrowserBackend(ContentBackend):
         )
 
         if not result.get("success"):
-            raise BackendError(f"BrowserBackend: research_url returned success=False for {request.url!r}")
+            self._raise_for_failed_result(result, request.url)
 
         content = result.get("content") or {}
         text = content.get("text_content", "")

--- a/autobot-backend/content_reach/sources/youtube.py
+++ b/autobot-backend/content_reach/sources/youtube.py
@@ -178,6 +178,18 @@ class YtDlpCaptionBackend(ContentBackend):
 
         _ytdlp_extract_info owns the yt_dlp import check and raises BackendError
         when yt_dlp is unavailable, so no separate guard is needed here.
+
+        Issue #13018: ensure_public_url below is a genuine SSRF guard, but
+        yt-dlp's extract_info() performs its own DNS resolution when it fetches
+        request.url, so the check is stale by connect time (DNS-rebind TOCTOU).
+        Unlike the browser path (research_browser_manager.navigate_to), there is
+        no intervening network work here to narrow away -- the to_thread call
+        already runs immediately after the check -- and yt-dlp exposes no hook
+        to veto its own connection's resolved address. Closing this needs either
+        an egress-validating proxy (yt-dlp accepts a `proxy` option) or a
+        yt-dlp-networking-internals wrapper; both are deployment/architecture
+        decisions, not made yet (see #13018 discussion). This remains an open,
+        documented gap, not a closed one.
         """
         await ensure_public_url(request.url)
 

--- a/autobot-backend/research_browser_manager.py
+++ b/autobot-backend/research_browser_manager.py
@@ -5,6 +5,21 @@
 """
 Research Browser Manager
 Handles Playwright browser automation for research tasks with user interaction support
+
+Issue #13018: Playwright performs its own DNS resolution when ``page.goto()``
+navigates, so an earlier SSRF check by a caller (e.g. content_reach's
+``ensure_public_url``) can be stale by the time Playwright actually connects
+(DNS-rebind TOCTOU). There is no Playwright primitive equivalent to the
+aiohttp/httpx connector-pinning used elsewhere in the codebase (route
+interception rewrites the request URL, which breaks TLS SNI for virtually
+every modern HTTPS origin; Chromium's ``--host-resolver-rules`` is a
+launch-time-only flag and this browser is a long-lived, possibly remote CDP
+session shared across navigations, so it cannot be re-pinned per request).
+Closing the gap fully needs an egress-validating proxy in front of the
+browser -- a deployment decision, not yet made (see #13018 discussion).
+``ResearchBrowserSession.navigate_to`` re-validates the URL immediately
+before ``page.goto`` as a compensating control: this narrows the window to
+this one call, it does NOT close it.
 """
 
 import asyncio
@@ -18,6 +33,7 @@ import aiofiles
 
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
+from autobot_shared.url_safety import is_public_url_async
 from config.manager import get_config_manager
 
 try:
@@ -265,10 +281,42 @@ class ResearchBrowserSession:
             },
         )
 
+    async def _reject_if_dns_rebound(self, url: str) -> Dict[str, Any] | None:
+        """Return a blocked-response dict if url is no longer public, else None.
+
+        Issue #13018: re-checks immediately before page.goto, the closest point
+        we control to Playwright's own DNS resolution. Narrows -- does not
+        close -- the DNS-rebind TOCTOU window (see module docstring). A
+        rejection here is marked ``blocked_by_guard`` so callers (notably
+        ``ResearchBrowserManager.research_url``) can distinguish it from a
+        natural navigation failure and must not blindly retry unguarded.
+        """
+        if await is_public_url_async(url):
+            return None
+        logger.warning(
+            "research_browser_manager: navigation to %s blocked by SSRF guard "
+            "immediately before page.goto (#13018 mitigation -- narrows, does "
+            "not close, the Playwright DNS-rebind TOCTOU)",
+            url,
+        )
+        return {
+            "success": False,
+            "error": "blocked by SSRF guard: non-public address",
+            "blocked_by_guard": True,
+        }
+
     async def navigate_to(self, url: str, wait_for_load: bool = True) -> Dict[str, Any]:
-        """Navigate to a URL and return page information."""
+        """Navigate to a URL and return page information.
+
+        Re-validates url immediately before page.goto (#13018 mitigation) --
+        see _reject_if_dns_rebound.
+        """
         if not self.page:
             return {"success": False, "error": "Browser not initialized"}
+
+        blocked = await self._reject_if_dns_rebound(url)
+        if blocked:
+            return blocked
 
         try:
             self.current_url = url
@@ -543,6 +591,10 @@ class ResearchBrowserManager:
         Research a URL with automatic fallbacks.
 
         Issue #620: Refactored to use extracted helper methods.
+        Issue #13018: a navigate_to() rejection marked ``blocked_by_guard`` is
+        returned as-is -- it must NOT fall through to the MHTML fallback,
+        which does its own unguarded page.goto() and would otherwise silently
+        bypass the SSRF re-check.
         """
         try:
             session = await self._get_or_create_session(conversation_id)
@@ -551,6 +603,8 @@ class ResearchBrowserManager:
 
             nav_result = await session.navigate_to(url)
             if not nav_result["success"]:
+                if nav_result.get("blocked_by_guard"):
+                    return nav_result
                 return await self._try_mhtml_fallback(session, url)
 
             if nav_result.get("interaction_required"):

--- a/autobot-backend/research_browser_manager_test.py
+++ b/autobot-backend/research_browser_manager_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Hostile-path tests for research_browser_manager's DNS-rebind mitigation (#13018).
+
+Playwright performs its own DNS resolution inside page.goto(); an earlier SSRF
+check by a caller (e.g. content_reach.ensure_public_url) can be stale by the
+time Playwright actually connects. ``ResearchBrowserSession.navigate_to`` now
+re-validates immediately before page.goto as a compensating control (narrows,
+does not close, the TOCTOU window — see the module docstring in
+research_browser_manager.py).
+
+The DNS-mocking technique (patching ``autobot_shared.url_safety.socket.getaddrinfo``)
+mirrors ``api/tests/test_provider_auth_ssrf.py`` / PR #13020's
+``tests/content_reach/test_http_pinned_get.py`` — it exercises the REAL
+``is_public_url_async`` guard rather than mocking the guard away.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from research_browser_manager import ResearchBrowserManager, ResearchBrowserSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_with_page() -> ResearchBrowserSession:
+    """Build a session with a mock Playwright page (no real browser)."""
+    session = ResearchBrowserSession(session_id="s1", conversation_id="c1")
+    session.page = MagicMock()
+    session.page.goto = AsyncMock()
+    session.page.title = AsyncMock(return_value="Title")
+    session.page.content = AsyncMock(return_value="<html></html>")
+    session.page.evaluate = AsyncMock(return_value=None)
+    return session
+
+
+def _dns(ip: str):
+    """Return a patch context targeting the real getaddrinfo used by is_public_url_async."""
+    fake_infos = [(2, 1, 6, "", (ip, 0))]
+    return patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos)
+
+
+# ---------------------------------------------------------------------------
+# navigate_to — blocked cases: page.goto must NEVER be called
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_blocks_private_ip_no_goto_call():
+    session = _make_session_with_page()
+    with _dns("10.0.0.5"):
+        result = await session.navigate_to("https://internal.example/")
+    assert result["success"] is False
+    assert result["blocked_by_guard"] is True
+    session.page.goto.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_blocks_loopback_no_goto_call():
+    session = _make_session_with_page()
+    with _dns("127.0.0.1"):
+        result = await session.navigate_to("https://loopback.example/")
+    assert result["success"] is False
+    assert result["blocked_by_guard"] is True
+    session.page.goto.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_blocks_link_local_metadata_no_goto_call():
+    """169.254.169.254 — cloud-metadata endpoint must be blocked."""
+    session = _make_session_with_page()
+    with _dns("169.254.169.254"):
+        result = await session.navigate_to("https://metadata.example/")
+    assert result["success"] is False
+    assert result["blocked_by_guard"] is True
+    session.page.goto.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_blocks_dns_rebind_between_earlier_check_and_navigate():
+    """A URL that passed an earlier (public) check but rebinds to a private
+    address by the time navigate_to runs is still rejected — this is the
+    exact vector #13018 documents: navigate_to re-checks independently of
+    whatever the caller checked earlier."""
+    session = _make_session_with_page()
+    # Simulate: caller's earlier ensure_public_url check saw a public IP...
+    with _dns("93.184.216.34"):
+        from autobot_shared.url_safety import is_public_url_async
+
+        assert await is_public_url_async("https://rebind.example/") is True
+    # ...but by navigate_to time, DNS has rebound to a private address.
+    with _dns("10.1.2.3"):
+        result = await session.navigate_to("https://rebind.example/")
+    assert result["success"] is False
+    assert result["blocked_by_guard"] is True
+    session.page.goto.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# navigate_to — success case: a genuinely public address navigates normally
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_allows_public_ip_and_calls_goto():
+    session = _make_session_with_page()
+    with _dns("93.184.216.34"):
+        result = await session.navigate_to("https://example.com/", wait_for_load=False)
+    assert result["success"] is True
+    assert "blocked_by_guard" not in result
+    session.page.goto.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# research_url() — a guard rejection must NOT fall through to the unguarded
+# MHTML fallback (that fallback does its own raw page.goto with no re-check).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_research_url_returns_blocked_result_without_mhtml_fallback(monkeypatch):
+    manager = ResearchBrowserManager()
+    session = _make_session_with_page()
+
+    async def _fake_get_or_create_session(conversation_id: str):
+        return session
+
+    monkeypatch.setattr(manager, "_get_or_create_session", _fake_get_or_create_session)
+
+    fallback_mock = AsyncMock(side_effect=AssertionError("MHTML fallback must not run for a guard rejection"))
+    monkeypatch.setattr(manager, "_try_mhtml_fallback", fallback_mock)
+
+    with _dns("10.0.0.9"):
+        result = await manager.research_url("c1", "https://internal.example/")
+
+    assert result["success"] is False
+    assert result["blocked_by_guard"] is True
+    fallback_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_research_url_still_falls_back_on_natural_navigation_failure(monkeypatch):
+    """Regression guard: a non-guard navigation failure must still reach the
+    existing MHTML fallback path (#13018's gating must not swallow it)."""
+    manager = ResearchBrowserManager()
+    session = _make_session_with_page()
+    session.page.goto = AsyncMock(side_effect=RuntimeError("net::ERR_CONNECTION_RESET"))
+
+    async def _fake_get_or_create_session(conversation_id: str):
+        return session
+
+    monkeypatch.setattr(manager, "_get_or_create_session", _fake_get_or_create_session)
+
+    fallback_mock = AsyncMock(return_value={"success": True, "status": "mhtml_fallback"})
+    monkeypatch.setattr(manager, "_try_mhtml_fallback", fallback_mock)
+
+    with _dns("93.184.216.34"):
+        result = await manager.research_url("c1", "https://example.com/")
+
+    fallback_mock.assert_awaited_once()
+    assert result == {"success": True, "status": "mhtml_fallback"}

--- a/autobot-backend/tests/content_reach/backends/test_browser.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser.py
@@ -98,14 +98,32 @@ async def test_browser_fetch_raises_without_url(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_browser_fetch_raises_on_unsuccessful(monkeypatch):
-    stub_manager = _StubManager({"success": False})
+    stub_manager = _StubManager({"success": False, "error": "Failed to create browser session"})
     import content_reach.backends.browser as browser_mod
 
     monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
 
     backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
     request = ContentRequest(url="https://example.com")
-    with pytest.raises(BackendError):
+    with pytest.raises(BackendError, match="Failed to create browser session"):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_browser_fetch_distinguishes_guard_rejection_from_generic_failure(monkeypatch):
+    """Issue #13018: a navigate_to guard rejection (blocked_by_guard=True) must
+    raise a distinctly-worded BackendError, not the generic navigation-failure
+    message used for other research_url failures."""
+    stub_manager = _StubManager(
+        {"success": False, "error": "blocked by SSRF guard: non-public address", "blocked_by_guard": True}
+    )
+    import content_reach.backends.browser as browser_mod
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+
+    backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
+    request = ContentRequest(url="https://example.com")
+    with pytest.raises(BackendError, match="blocked by SSRF guard at navigate time"):
         await backend.fetch(request)
 
 


### PR DESCRIPTION
## Thinking Path

Phase 1 established, with evidence, that a full close of #13018 is not reachable without an architecture decision, then implemented the one honest partial mitigation available without one.

1. **Reachability confirmed real, not inert.** `content_reach`'s `CONTENT_REACH_SCHEMA` tool is registered directly in `chat_workflow/tool_handler.py`'s dispatcher with a caller/LLM-controlled `url` field for `source in {web_page, youtube, reddit, social}` — all of which fall back to `BrowserBackend` (Playwright) or `YtDlpCaptionBackend` (yt-dlp). Not admin-only, not orphaned.
2. **Playwright constraint mechanisms, checked against this deployment's actual topology:** `research_browser_manager.py` connects over CDP to a **remote, long-lived Chrome process on a dedicated `browser` VM** (`ssot_config.chrome_cdp_url`, launched by an ansible role running a Node.js `playwright-server.js`), reused across many navigations per conversation session. Of the candidate mechanisms:
   - `page.route()`/request interception can rewrite the request URL to an IP literal, but doing so changes the TLS SNI sent for the connection — breaking certificate validation/vhost routing for virtually every modern SNI-vhosted HTTPS origin. Not viable.
   - Chromium's `--host-resolver-rules="MAP host ip"` is the correct per-host DNS-pin primitive (preserves SNI/Host like our aiohttp/httpx pinning) — but it is a **launch-time-only** flag on a process we don't control the launch of from this codebase, and this browser is long-lived/shared across concurrent navigations to different hosts, so it can't be re-pinned per-request without relaunching per navigation (defeats session reuse, large blast radius, a deployment change to the `browser` ansible role).
   - The only mechanism that reaches parity with our own connector-pinning is routing the browser context's traffic through an **egress-validating proxy** we build and operate (Playwright's per-context `proxy` option) — a new service, with its own deployment/placement/access-control questions.
3. **yt-dlp, same conclusion.** `YtDlpCaptionBackend.fetch`'s first call hands `request.url` to `yt_dlp.YoutubeDL.extract_info()`, which performs its own resolution via yt-dlp's internal networking stack. yt-dlp accepts a `proxy` option (same egress-proxy answer as Playwright) but has no hook to veto a specific connection's resolved address inline.
4. **Partial mitigation, evaluated honestly per the issue's own item 4:** re-validating immediately before the actual handoff to the other subsystem narrows (does not close) the window. For the browser path there IS a real window to narrow — `ensure_robots_allowed`'s own network round-trip, plus session-acquisition/browser-launch time, both happen between the original `ensure_public_url` check and Playwright's actual `page.goto()`. For yt-dlp's caption-track `fetch()`, the check already runs immediately adjacent to the `to_thread` handoff — there is no further narrowing available in code without the same architecture decision.

**Conclusion:** full closure needs an architecture decision (egress-validating proxy, or restructuring how/where the browser service is launched) that this PR does not make. The one honest, non-architectural improvement — re-validating right before Playwright's actual DNS resolution — is implemented here as a documented, narrows-not-closes compensating control. #13018 stays open; the architecture options are reported on the issue, not picked.

## What Changed

**`research_browser_manager.py`** — `ResearchBrowserSession.navigate_to()` now calls a new `_reject_if_dns_rebound(url)` immediately before `page.goto()`, the closest point this codebase controls to Playwright's own connection. A rejection returns `{"success": False, "error": "blocked by SSRF guard: non-public address", "blocked_by_guard": True}` and is logged distinctly from a natural navigation failure. `ResearchBrowserManager.research_url()` now checks `blocked_by_guard` and returns that result as-is instead of falling through to `_try_mhtml_fallback` — which does its own **unguarded** `page.goto()` and would otherwise silently bypass the re-check. This benefits every caller of `navigate_to`/`research_url`, not just `content_reach` (also `api/research_browser.py`, `api/scrape_templates.py`).

**`content_reach/backends/browser.py`** — `BrowserBackend._navigate` now distinguishes a `blocked_by_guard` result (raises `"blocked by SSRF guard at navigate time"`) from any other `research_url` failure (raises `"research_url failed for {url}: {error}"`, no longer swallowing the reason into one generic message).

**`content_reach/sources/youtube.py`** — documentation-only: explains why `YtDlpCaptionBackend.fetch`'s check cannot be narrowed further without the same architecture decision (yt-dlp has no connect-time veto hook, and the check already runs immediately before the `to_thread` handoff).

**Not changed (by design):** no proxy, no browser-deployment change — those are the architecture decision this PR does not make.

## Verification

```
python3 -m py_compile research_browser_manager.py research_browser_manager_test.py \
  content_reach/backends/browser.py content_reach/sources/youtube.py \
  tests/content_reach/backends/test_browser.py                              # OK
python3 -m flake8 --max-line-length=120 <same files>                        # 0
python3 -m black --check --line-length=120 <same files>                     # unchanged

pytest tests/test_startup_imports.py tests/content_reach/ research_browser_manager_test.py -q
  baseline (cp-swapped origin/Dev_new_gui content, not stash): 495 passed, 0 failed
  after this PR:                                                503 passed, 0 failed
  (startup-import-smoke: 350/350 unchanged both sides; +8 net new tests, 0 regressions)
```

New hostile-path tests (mock real DNS at `autobot_shared.url_safety.socket.getaddrinfo`, never the guard itself — mirrors `api/tests/test_provider_auth_ssrf.py` / PR #13020's `test_http_pinned_get.py`):

- `research_browser_manager_test.py` (new, 7 tests) — `navigate_to` blocks private IP / loopback / link-local metadata with `page.goto` never called; **DNS-rebind test**: a URL that an earlier `is_public_url_async` check saw as public is still rejected by `navigate_to` when DNS has since rebound to a private address; a genuinely public address still navigates and calls `page.goto` once; `research_url()` returns a `blocked_by_guard` rejection as-is without invoking the unguarded MHTML fallback (regression-asserted via a fallback mock that raises if called); a **non**-guard navigation failure still reaches the existing MHTML fallback (guards the gating didn't overreach).
- `tests/content_reach/backends/test_browser.py` — new test asserting a `blocked_by_guard` result raises the distinctly-worded `BackendError`, not the generic message; existing failure test updated to assert the (no-longer-swallowed) error text.

## Model Used

Claude Sonnet 5