### PR TITLE
fix(knowledge): exclude quarantined research facts at every reachable KB search site (#13009)

### DIFF
--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Tuple
 from autobot_shared.logging_manager import get_llm_logger
 from constants.model_constants import model_config
 from constants.ttl_constants import TTL_5_MINUTES
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge.search_components.bm25 import BM25Scorer
 from knowledge.search_components.reranking import (
     RerankWeights,
@@ -392,7 +393,9 @@ class AdvancedRAGOptimizer:
             # Use knowledge base's search method for semantic search
             # Issue #429: Fixed - was incorrectly calling get_fact(query=query)
             # get_fact() only accepts fact_id, not query. Use search() instead.
-            facts = await self.kb.search(query, top_k=limit)
+            # Issue #13009: reachable via RAGService -> ChatWorkflowManager on every
+            # chat turn -- must exclude quarantined research facts (#12622).
+            facts = await self.kb.search(query, top_k=limit, filters=RESEARCH_QUARANTINE_FILTER)
 
             semantic_results = []
             for i, fact in enumerate(facts[:limit]):

--- a/autobot-backend/advanced_rag_optimizer_test.py
+++ b/autobot-backend/advanced_rag_optimizer_test.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from advanced_rag_optimizer import AdvancedRAGOptimizer, SearchResult
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 
 
 class TestSemanticSearch:
@@ -41,7 +42,8 @@ class TestSemanticSearch:
         results = await optimizer._perform_semantic_search("test query", limit=10)
 
         # Verify kb.search was called (not get_fact)
-        mock_kb.search.assert_called_once_with("test query", top_k=10)
+        # Issue #13009: also verify the quarantine filter is applied (#12622).
+        mock_kb.search.assert_called_once_with("test query", top_k=10, filters=RESEARCH_QUARANTINE_FILTER)
 
         # Verify results are properly formatted
         assert len(results) == 2

--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -49,6 +49,7 @@ from constants.threshold_constants import TimingConstants
 from dependencies import get_config, get_knowledge_base
 from events.bus import PersistStrategy, get_event_bus
 from exceptions import InternalError, SubprocessError
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from monitoring.prometheus_metrics import get_metrics_manager
 from services.ai_stack_client import AIStackError, get_ai_stack_client
 from utils.response_helpers import create_success_response, handle_ai_stack_error
@@ -973,7 +974,8 @@ async def _enhance_context_with_kb(payload, knowledge_base) -> str | None:
         return payload.context
 
     try:
-        kb_results = await knowledge_base.search(query=payload.goal, top_k=5)
+        # Issue #13009: exclude quarantined research facts (#12622).
+        kb_results = await knowledge_base.search(query=payload.goal, top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
         if kb_results:
             kb_context = "\n".join([f"- {item.get('content', '')[:200]}..." for item in kb_results[:3]])
             return f"{payload.context or ''}\n\nRelevant knowledge:\n{kb_context}"
@@ -1152,7 +1154,12 @@ async def comprehensive_research_task(
         research_query = request_data.research_query
         if knowledge_base:
             try:
-                kb_results = await knowledge_base.search(query=request_data.research_query, top_k=3)
+                # Issue #13009: exclude quarantined research facts (#12622). This is a
+                # general multi-agent context-enhancement read, not the #12623
+                # corroboration/promotion gate, so quarantined facts must stay hidden.
+                kb_results = await knowledge_base.search(
+                    query=request_data.research_query, top_k=3, filters=RESEARCH_QUARANTINE_FILTER
+                )
                 if kb_results:
                     kb_context = "\n".join([f"- {item.get('content', '')[:150]}..." for item in kb_results])
                     research_query = f"{request_data.research_query}\n\nExisting" f"knowledge:\n{kb_context}"

--- a/autobot-backend/api/agent_test.py
+++ b/autobot-backend/api/agent_test.py
@@ -1,0 +1,58 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the research-quarantine filter fix at api/agent.py call sites (#13009).
+
+Proves the two general-purpose KB reads in this module -- goal-context
+enhancement and the "comprehensive research" multi-agent task (NOT the
+#12622/#12623 ResearchOrchestrator quarantine pipeline) -- now pass the
+shared exclusion filter into every ``knowledge_base.search()`` call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.agent import _enhance_context_with_kb, comprehensive_research_task
+from api.schemas_agent import ResearchTaskRequest
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
+
+
+class _Payload:
+    def __init__(self, goal: str, use_knowledge_base: bool = True, context: str | None = None):
+        self.goal = goal
+        self.use_knowledge_base = use_knowledge_base
+        self.context = context
+
+
+@pytest.mark.asyncio
+async def test_enhance_context_with_kb_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = [{"content": "fact"}]
+
+    await _enhance_context_with_kb(_Payload(goal="what is autobot"), mock_kb)
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
+
+
+@pytest.mark.asyncio
+async def test_comprehensive_research_task_applies_quarantine_filter():
+    """#13009: this endpoint is a general multi-agent task, not the #12622/#12623
+    quarantine pipeline itself -- it must NOT see quarantined facts."""
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = []
+
+    mock_ai_client = AsyncMock()
+    mock_ai_client.multi_agent_query.return_value = {"result": "ok"}
+
+    with patch("api.agent.get_ai_stack_client", AsyncMock(return_value=mock_ai_client)):
+        await comprehensive_research_task(
+            request_data=ResearchTaskRequest(research_query="what is autobot", include_web=False),
+            knowledge_base=mock_kb,
+            current_user={"user_id": "test-user"},
+        )
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=3, filters=RESEARCH_QUARANTINE_FILTER)

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -46,6 +46,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from dependencies import get_knowledge_base
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from services.ai_stack_client import AIStackError, get_ai_stack_client
 from type_defs.common import Metadata
 
@@ -126,7 +127,10 @@ async def rag_query(
     documents = request.documents
     if not documents and knowledge_base:
         try:
-            kb_results = await knowledge_base.search(query=request.query, top_k=request.max_results)
+            # Issue #13009: exclude quarantined research facts (#12622).
+            kb_results = await knowledge_base.search(
+                query=request.query, top_k=request.max_results, filters=RESEARCH_QUARANTINE_FILTER
+            )
             documents = kb_results if isinstance(kb_results, list) else []
         except Exception as e:
             logger.warning("Knowledge base search failed: %s", e)
@@ -214,7 +218,8 @@ async def chat(
     if request.use_knowledge_base and knowledge_base:
         try:
             # Search knowledge base for relevant context
-            kb_context = await knowledge_base.search(query=request.message, top_k=5)
+            # Issue #13009: exclude quarantined research facts (#12622).
+            kb_context = await knowledge_base.search(query=request.message, top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
             if kb_context:
                 kb_summary = "\n".join([f"- {item.get('content', '')[:200]}..." for item in kb_context[:3]])
                 enhanced_context = f"{request.context or ''}\n\nRelevant knowledge:\n{kb_summary}"
@@ -287,7 +292,10 @@ async def knowledge_search(
     # Local knowledge base search
     if knowledge_base:
         try:
-            local_results = await knowledge_base.search(query=query, top_k=max_results)
+            # Issue #13009: exclude quarantined research facts (#12622).
+            local_results = await knowledge_base.search(
+                query=query, top_k=max_results, filters=RESEARCH_QUARANTINE_FILTER
+            )
             results["local_kb"] = local_results
         except Exception as e:
             logger.warning("Local KB search failed: %s", e)

--- a/autobot-backend/api/ai_stack_integration_test.py
+++ b/autobot-backend/api/ai_stack_integration_test.py
@@ -1,0 +1,75 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the research-quarantine filter fix at api/ai_stack_integration.py (#13009).
+
+Three admin-gated but still general-purpose KB reads in this module must
+exclude quarantined research facts (#12622) the same way
+``async_chat_workflow.py::_execute_kb_search`` already does: admin auth is a
+different guarantee than the quarantine's "invisible until promoted".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.ai_stack_integration import chat, knowledge_search, rag_query
+from api.schemas_knowledge import ChatRequest, RAGQueryRequest
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
+
+
+def _fake_ai_client() -> AsyncMock:
+    client = AsyncMock()
+    client.rag_query.return_value = {"answer": "ok"}
+    client.chat_message.return_value = {"content": "ok"}
+    client.search_knowledge.return_value = {"results": []}
+    return client
+
+
+@pytest.mark.asyncio
+async def test_rag_query_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = []
+
+    with patch("api.ai_stack_integration.get_ai_stack_client", AsyncMock(return_value=_fake_ai_client())):
+        await rag_query(
+            request=RAGQueryRequest(query="what is autobot", max_results=10),
+            admin_check=True,
+            knowledge_base=mock_kb,
+        )
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=10, filters=RESEARCH_QUARANTINE_FILTER)
+
+
+@pytest.mark.asyncio
+async def test_chat_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = []
+
+    with patch("api.ai_stack_integration.get_ai_stack_client", AsyncMock(return_value=_fake_ai_client())):
+        await chat(
+            request=ChatRequest(message="what is autobot", use_knowledge_base=True),
+            admin_check=True,
+            knowledge_base=mock_kb,
+        )
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
+
+
+@pytest.mark.asyncio
+async def test_knowledge_search_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = []
+
+    with patch("api.ai_stack_integration.get_ai_stack_client", AsyncMock(return_value=_fake_ai_client())):
+        await knowledge_search(
+            query="what is autobot",
+            max_results=10,
+            admin_check=True,
+            knowledge_base=mock_kb,
+        )
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=10, filters=RESEARCH_QUARANTINE_FILTER)

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -62,6 +62,7 @@ from dependencies import get_config, get_knowledge_base
 
 # Import shared exception classes (Issue #292 - Eliminate duplicate code)
 from exceptions import get_exceptions_lazy
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 
 # CRITICAL SECURITY FIX: Import session ownership validation
 from security.session_ownership import validate_session_ownership
@@ -823,7 +824,9 @@ async def process_chat_message(
     citations: List[Citation] = []
     if message.use_knowledge_base and knowledge_base:
         try:
-            kb_hits = await knowledge_base.search(query=message.content, top_k=5)
+            # Issue #13009: exclude quarantined research facts (#12622) -- this
+            # citation path surfaces raw KB content directly in the response.
+            kb_hits = await knowledge_base.search(query=message.content, top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
             if kb_hits:
                 citations = _build_citations_from_kb_results(kb_hits)
                 logger.debug("[#10548] Attached %d citations to response in session %s", len(citations), session_id)
@@ -1879,7 +1882,8 @@ async def _enhance_with_knowledge_base(
 
     if message.use_knowledge_base and knowledge_base:
         try:
-            kb_results = await knowledge_base.search(query=message.content, top_k=5)
+            # Issue #13009: exclude quarantined research facts (#12622).
+            kb_results = await knowledge_base.search(query=message.content, top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
             if kb_results:
                 knowledge_sources = kb_results
                 kb_summary = "\n".join([f"- {item.get('content', '')[:300]}..." for item in kb_results[:3]])

--- a/autobot-backend/api/chat_test.py
+++ b/autobot-backend/api/chat_test.py
@@ -1,0 +1,72 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the research-quarantine filter fix at api/chat.py call sites (#13009).
+
+Two general-purpose chat surfaces in this module read the KB directly to
+build response context/citations: ``process_chat_message`` (#10548 RAG
+grounding, the primary ``/chat`` and ``/chat/message`` endpoints) and
+``_enhance_with_knowledge_base`` (the AI-Stack chat pipeline). Both must
+exclude quarantined research facts (#12622) the same way
+``async_chat_workflow.py::_execute_kb_search`` already does.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.chat import _enhance_with_knowledge_base, process_chat_message
+from api.schemas_chat import ChatMessage
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
+
+
+@pytest.mark.asyncio
+async def test_enhance_with_knowledge_base_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = [{"content": "fact"}]
+    message = ChatMessage(content="what is autobot", session_id="s1", use_knowledge_base=True)
+
+    await _enhance_with_knowledge_base(message, mock_kb)
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
+
+
+@pytest.mark.asyncio
+async def test_process_chat_message_citations_apply_quarantine_filter():
+    """#10548: this is the live RAG-grounding path on every /chat turn."""
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = []
+
+    message = ChatMessage(content="what is autobot", session_id="s1", use_knowledge_base=True)
+
+    with (
+        patch("api.chat._validate_session_id"),
+        patch("api.chat._validate_and_pin_provider"),
+        patch("api.chat._store_and_log_user_message", new=AsyncMock()),
+        patch("api.chat._get_chat_context", new=AsyncMock(return_value=[])),
+        patch("api.chat._build_llm_context", return_value=[]),
+        patch("api.chat._resolve_chat_reasoning_effort", new=AsyncMock(return_value="auto")),
+        patch(
+            "api.chat._generate_ai_response",
+            new=AsyncMock(return_value=({"content": "hi", "metadata": {}}, None)),
+        ),
+        patch("api.chat._store_and_log_ai_response", new=AsyncMock(return_value="msg-1")),
+        patch(
+            "api.chat.handle_message_completion",
+            new=AsyncMock(return_value={"summary_created": False, "warning_triggered": False}),
+        ),
+    ):
+        await process_chat_message(
+            message=message,
+            chat_history_manager=AsyncMock(),
+            llm_service=AsyncMock(),
+            memory_interface=AsyncMock(),
+            knowledge_base=mock_kb,
+            config={},
+            request_id="req-1",
+        )
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=5, filters=RESEARCH_QUARANTINE_FILTER)

--- a/autobot-backend/api/knowledge_ai_stack.py
+++ b/autobot-backend/api/knowledge_ai_stack.py
@@ -36,6 +36,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import utc_timestamp
 from dependencies import get_knowledge_base
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge_factory import get_or_create_knowledge_base
 from services.ai_stack_client import AIStackError, get_ai_stack_client
 from utils.response_helpers import (
@@ -337,9 +338,11 @@ async def rag_search(
         documents = request_data.documents
         if not documents and knowledge_base:
             try:
+                # Issue #13009: exclude quarantined research facts (#12622).
                 kb_results = await knowledge_base.search(
                     query=request_data.query,
                     top_k=15,  # Get more documents for RAG context
+                    filters=RESEARCH_QUARANTINE_FILTER,
                 )
                 documents = kb_results if isinstance(kb_results, list) else []
                 logger.info(f"Retrieved {len(documents)} documents from local KB for RAG")

--- a/autobot-backend/api/knowledge_ai_stack_test.py
+++ b/autobot-backend/api/knowledge_ai_stack_test.py
@@ -1,0 +1,39 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the research-quarantine filter fix at api/knowledge_ai_stack.py (#13009).
+
+``POST /search/rag`` is a general-purpose, authenticated RAG search that
+falls back to the local KB for documents -- it must exclude quarantined
+research facts (#12622) the same way
+``async_chat_workflow.py::_execute_kb_search`` already does.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.knowledge_ai_stack import rag_search
+from api.schemas_knowledge import AIStackRAGQueryRequest
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
+
+
+@pytest.mark.asyncio
+async def test_rag_search_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = []
+
+    mock_ai_client = AsyncMock()
+    mock_ai_client.rag_query.return_value = {"answer": "ok"}
+
+    with patch("api.knowledge_ai_stack.get_ai_stack_client", AsyncMock(return_value=mock_ai_client)):
+        await rag_search(
+            request_data=AIStackRAGQueryRequest(query="what is autobot"),
+            knowledge_base=mock_kb,
+            current_user={"user_id": "test-user"},
+        )
+
+    mock_kb.search.assert_called_once_with(query="what is autobot", top_k=15, filters=RESEARCH_QUARANTINE_FILTER)

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -36,6 +36,7 @@ from api.schemas_knowledge import (
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
 from knowledge_factory import get_or_create_knowledge_base
 
 logger = get_logger(__name__)
@@ -257,7 +258,8 @@ async def _search_facts(kb, query: str, top_k: int, result: dict) -> None:
         result: Result dict to populate
     """
     try:
-        fact_results = await kb.search(query, top_k=top_k)
+        # Issue #13009: exclude quarantined research facts (#12622).
+        fact_results = await kb.search(query, top_k=top_k, filters=RESEARCH_QUARANTINE_FILTER)
         if fact_results.get("results"):
             for fact in fact_results["results"]:
                 fact["source"] = "knowledge_base"
@@ -455,7 +457,8 @@ async def get_llm_context(req: Request, body: ContextRequest):
     # Search facts (Issue #315: use extracted helper)
     if kb is not None:
         try:
-            fact_results = await kb.search(body.query, top_k=5)
+            # Issue #13009: exclude quarantined research facts (#12622).
+            fact_results = await kb.search(body.query, top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
             total_length = _process_fact_results(
                 fact_results,
                 body.max_context_length,
@@ -681,7 +684,8 @@ async def _get_facts_for_graph(kb: Any, category_filter: str | None, max_facts: 
         return result.get("facts", []) if result.get("success") else []
     else:
         # Search for recent facts
-        result = await kb.search("*", top_k=max_facts)
+        # Issue #13009: exclude quarantined research facts (#12622).
+        result = await kb.search("*", top_k=max_facts, filters=RESEARCH_QUARANTINE_FILTER)
         return result.get("results", [])
 
 

--- a/autobot-backend/api/knowledge_search_aggregator_test.py
+++ b/autobot-backend/api/knowledge_search_aggregator_test.py
@@ -1,0 +1,61 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the research-quarantine filter fix at api/knowledge_search_aggregator.py (#13009).
+
+This module is documented as "the single entry point for all knowledge
+retrieval" (facts + graph + LLM context) -- all three unfiltered
+``kb.search()`` call sites found here must exclude quarantined research
+facts (#12622) the same way ``async_chat_workflow.py::_execute_kb_search``
+already does.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.knowledge_search_aggregator import _get_facts_for_graph, _search_facts, get_llm_context
+from api.schemas_knowledge import ContextRequest
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
+
+
+@pytest.mark.asyncio
+async def test_search_facts_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = {"results": []}
+    result: dict = {"sources_searched": []}
+
+    await _search_facts(mock_kb, "what is autobot", 5, result)
+
+    mock_kb.search.assert_called_once_with("what is autobot", top_k=5, filters=RESEARCH_QUARANTINE_FILTER)
+
+
+@pytest.mark.asyncio
+async def test_get_facts_for_graph_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = {"results": []}
+
+    await _get_facts_for_graph(mock_kb, category_filter=None, max_facts=25)
+
+    mock_kb.search.assert_called_once_with("*", top_k=25, filters=RESEARCH_QUARANTINE_FILTER)
+
+
+@pytest.mark.asyncio
+async def test_get_llm_context_applies_quarantine_filter():
+    mock_kb = AsyncMock()
+    mock_kb.search.return_value = {"results": []}
+
+    req = SimpleNamespace(app=None)
+    body = ContextRequest(query="what is autobot", include_documentation=False, include_relations=False)
+
+    with patch(
+        "api.knowledge_search_aggregator.get_or_create_knowledge_base",
+        AsyncMock(return_value=mock_kb),
+    ):
+        await get_llm_context(req, body)
+
+    mock_kb.search.assert_called_once_with("what is autobot", top_k=5, filters=RESEARCH_QUARANTINE_FILTER)

--- a/autobot-backend/async_chat_workflow.py
+++ b/autobot-backend/async_chat_workflow.py
@@ -17,22 +17,15 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
-from autobot_shared.ssot_config import config
 from constants.threshold_constants import TimingConstants
 from dependency_container import inject_services
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER as _RESEARCH_QUARANTINE_FILTER
 from knowledge.search import map_kb_result_to_dict
 from knowledge_base_factory import get_knowledge_base
 from llm_shared.models import ChatMessage, LLMResponse  # Phase 2D #3185
 from retry_mechanism import RetryConfig, RetryStrategy, with_retry
 
 logger = get_logger(__name__)
-
-# #12622: web-research facts are quarantined in a dedicated KB collection until
-# Phase 1's corroboration/promotion gate (#12623) reviews them, so general
-# chat/RAG must never surface them. ``$ne`` also matches facts that predate
-# this field entirely (no "collection" key), verified against the installed
-# ChromaDB via a standalone metadata-filter check.
-_RESEARCH_QUARANTINE_FILTER = {"collection": {"$ne": config.research_quarantine_collection}}
 
 # Performance optimization: O(1) lookup for message classification keywords (Issue #326)
 TERMINAL_KEYWORDS = {"terminal", "command", "bash", "shell", "run"}

--- a/autobot-backend/knowledge/quarantine.py
+++ b/autobot-backend/knowledge/quarantine.py
@@ -1,0 +1,35 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Research-quarantine KB search filter (#12622, #12623, #13009).
+
+``ResearchOrchestrator`` (#12622) lands web-research findings as KB facts
+tagged ``metadata.collection == config.research_quarantine_collection``.
+Those facts are quarantined -- invisible to every general-purpose chat/RAG
+read -- until the corroboration + promotion gate (#12623) reviews them and
+flips that metadata field.
+
+``async_chat_workflow.py::_execute_kb_search`` was the first call site fixed
+(#12622). #13009 audited every other ``kb.search()`` call site reachable
+from a general-purpose surface and found several more with the same gap;
+this module is the single shared filter so the exclusion is defined once
+instead of copy-pasted at each call site.
+
+The ``$ne`` operator also matches facts that predate the ``collection``
+field entirely (no key at all) -- verified against the installed ChromaDB
+(#12622) and against ``knowledge.backends.memory_adapter.InMemoryCollection``
+(#12623), so pre-existing facts stay visible.
+
+Research-internal readers (the corroboration/promotion gate itself --
+``services/claim_verifier.py``, ``services/research/orchestrator.py``,
+``services/research/planner.py``) must NOT use this filter: they exist to
+read the quarantine collection.
+"""
+
+from autobot_shared.ssot_config import config
+
+# Module-level constant (not a function): the filter is a static dict, cheap
+# to import and share; no per-call construction needed.
+RESEARCH_QUARANTINE_FILTER: dict = {"collection": {"$ne": config.research_quarantine_collection}}

--- a/autobot-backend/knowledge/quarantine_test.py
+++ b/autobot-backend/knowledge/quarantine_test.py
@@ -1,0 +1,72 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""End-to-end proof of the shared research-quarantine filter (#13009).
+
+#12622 introduced the quarantine ``{"collection": {"$ne": ...}}`` filter at a
+single call site (``async_chat_workflow.py::_execute_kb_search``). #13009
+audited every other reachable, general-purpose ``kb.search()`` call site,
+found several more with the same gap, and extracted the filter into this
+module so it is defined exactly once.
+
+This test proves the filter mechanism itself, the same way #13011's
+``services/research/quarantine_boundary_test.py`` proved it for the
+promotion gate: driving a real (non-mocked) ``InMemoryClient`` where-filter,
+not a mock. Per-call-site tests (in each touched module's test file) prove
+the filter is actually *passed* at each of the #13009 call sites; this test
+proves that, once passed, it actually excludes/includes the right facts.
+"""
+
+from __future__ import annotations
+
+from autobot_shared.ssot_config import config
+from knowledge.backends import InMemoryClient
+from knowledge.quarantine import RESEARCH_QUARANTINE_FILTER
+
+
+def _collection():
+    """A real (non-mocked) in-memory vector-store collection."""
+    return InMemoryClient().get_or_create_collection("quarantine_filter_test")
+
+
+class TestResearchQuarantineFilter:
+    """Real where-filter proof for the shared #13009 filter constant."""
+
+    def test_filter_derives_from_config_not_hardcoded(self):
+        """The filter must track the SSOT config constant (#12623), never a literal."""
+        assert RESEARCH_QUARANTINE_FILTER == {"collection": {"$ne": config.research_quarantine_collection}}
+
+    def test_quarantined_fact_is_excluded(self):
+        collection = _collection()
+        collection.add(
+            ids=["quarantined-fact"],
+            metadatas=[{"collection": config.research_quarantine_collection, "fact_id": "quarantined-fact"}],
+        )
+
+        visible = collection.get(where=RESEARCH_QUARANTINE_FILTER)
+
+        assert "quarantined-fact" not in visible["ids"]
+
+    def test_promoted_fact_is_included(self):
+        collection = _collection()
+        collection.add(
+            ids=["promoted-fact"],
+            metadatas=[{"collection": config.research_quarantine_collection, "fact_id": "promoted-fact"}],
+        )
+        before = collection.get(where=RESEARCH_QUARANTINE_FILTER)
+        assert "promoted-fact" not in before["ids"]
+
+        collection.update(ids=["promoted-fact"], metadatas=[{"collection": "general", "fact_id": "promoted-fact"}])
+
+        after = collection.get(where=RESEARCH_QUARANTINE_FILTER)
+        assert "promoted-fact" in after["ids"]
+
+    def test_legacy_fact_without_collection_field_stays_included(self):
+        """Facts predating #12622 (no 'collection' key at all) must not be hidden."""
+        collection = _collection()
+        collection.add(ids=["legacy-fact"], metadatas=[{"fact_id": "legacy-fact"}])
+
+        visible = collection.get(where=RESEARCH_QUARANTINE_FILTER)
+
+        assert "legacy-fact" in visible["ids"]


### PR DESCRIPTION
Closes #13009

## Thinking Path

Read #13009 + the two PRs that established the quarantine: #13010 (#12622, added the `{"collection": {"$ne": "research"}}` filter at `async_chat_workflow.py::_execute_kb_search`, the one confirmed-live chat-RAG surface at the time) and #13011 (#12623, the corroboration/promotion gate that later releases facts from quarantine).

Enumerated every reachable KB-read call site repo-wide (`kb.search()`/`knowledge_base.search()`, plus the raw `collection.query()` sites internal to the `knowledge/` package itself, which are the *implementation* of `kb.search()` and out of scope). Judged each for (a) general-purpose/chat vs. research-internal, (b) production reachability, (c) whether it already threads a caller-supplied `filters` argument.

**#13009's own 3 named candidates, resolved:**
- `ai_hardware_accelerator.py:834` (`_gpu_semantic_search`) — **not reachable**. Dispatched only via `AIHardwareAccelerator.process_task(task_type="semantic_search")`, and the only constructor of such a task, `accelerated_semantic_search()`, has zero callers anywhere in the repo.
- `utils/hybrid_search.py` (328/379/472, `HybridSearchEngine`) — **reachable but not a leak**. `get_hybrid_search_engine()` is only ever called from `utils/system_validator.py`'s diagnostic self-test, with hardcoded synthetic queries (`"Python programming tutorial"`, `"test query"`); the validator never surfaces fact `content` back to any response, only score/keyword-count presence.
- `advanced_rag_optimizer.py:395` (`_perform_semantic_search`) — **genuine, reachable, working leak**. Traced: `chat_workflow/manager.py::_init_knowledge_service` → `RAGService(kb)` → `AdvancedRAGOptimizer.advanced_search()` → `_perform_semantic_search()` → unfiltered `kb.search()`. `ChatWorkflowManager` is instantiated from `api/chat.py`'s live chat endpoints and `initialization/lifespan.py` — this is a second, parallel live chat-RAG surface alongside the one #12622 already fixed.

**11 more genuine, reachable, working sites found**, all general-purpose reads that must exclude quarantined facts (none are the #12622/#12623 research-internal corroboration path, which correctly keeps reading the quarantine collection unfiltered): `api/chat.py` (`process_chat_message` citations — #10548 RAG grounding on the primary `/chat`/`/chat/message` endpoints; `_enhance_with_knowledge_base` — AI-Stack chat pipeline), `api/agent.py` (`_enhance_context_with_kb` — goal-orchestration context; `comprehensive_research_task` — a general multi-agent task despite its name, not the quarantine pipeline), `api/ai_stack_integration.py` (`rag_query`/`chat`/`knowledge_search` — admin-gated, but the quarantine guarantee isn't "admin-only", it's "invisible until promoted"), `api/knowledge_ai_stack.py::rag_search`, and `api/knowledge_search_aggregator.py` (`_search_facts`/`get_llm_context`/`_get_facts_for_graph` — this module's own docstring calls it "the single entry point for all knowledge retrieval").

**Several apparent call sites turned out pre-existing broken or dead, independent of this issue** — fixing the quarantine there would be moot (no content is ever returned today) and is out of scope for #13009, so filed separately with file:line evidence: #13024 (stale `n_results`/`search_mode` kwargs no longer accepted by the canonical `KnowledgeBase.search()` signature, silently caught by broad `except` blocks — `agents/kb_librarian/librarian.py`, `agents/knowledge_retrieval_agent.py`, `api/chat_knowledge.py`, `services/grounded_agent.py`), #13025 (`KBLibrarianAgent.search_knowledge` passes `limit=` which triggers "Enhanced" mode returning a `Dict`, but the caller iterates it as a `List` — every non-empty search silently returns `[]`), #13026 (`api/knowledge_mcp.py`'s local KB singleton passes a `config_manager` kwarg `KnowledgeBase.__init__` doesn't accept — raises `TypeError` on first use), #13027 (`tools/tool_registry.py`'s singleton is never constructed with a `knowledge_base`, so the LLM tool-calling KB-search tool always reports "unavailable"), #13028 (dead code: `ai_hardware_accelerator._gpu_semantic_search` and `KnowledgeRetrievalAgent` have zero production callers).

## What Changed

- **New `knowledge/quarantine.py`**: extracted `RESEARCH_QUARANTINE_FILTER` from `async_chat_workflow.py`'s private module constant now that there are 12 real call sites (per #13009's own guidance: share the filter once there are 2+ sites, don't scatter copies). Reuses `config.research_quarantine_collection` (#12623's SSOT constant) — never a literal.
- Applied `filters=RESEARCH_QUARANTINE_FILTER` at all 12 confirmed-genuine sites: `advanced_rag_optimizer.py`, `api/chat.py` (×2), `api/agent.py` (×2), `api/ai_stack_integration.py` (×3), `api/knowledge_ai_stack.py`, `api/knowledge_search_aggregator.py` (×3).
- `async_chat_workflow.py` now imports the shared constant instead of defining its own private copy.
- Research-internal readers (`services/claim_verifier.py`, `services/research/orchestrator.py`, `services/research/planner.py`) were **not** touched — they exist to read the quarantine collection for corroboration.

## Verification

- `py_compile`, `flake8 --max-line-length=120`, `black --check --line-length=120`: clean on every touched/new file.
- **Central filter-mechanism proof** (`knowledge/quarantine_test.py`, 4 tests): drives a real (non-mocked) `InMemoryClient` where-filter, same pattern as #13011's `quarantine_boundary_test.py` — a quarantined fact is excluded, a promoted fact (metadata flipped) is included, a legacy fact with no `collection` field stays included, and the filter dict is asserted to derive from `config.research_quarantine_collection` (not hardcoded).
- **Per-site wiring proof** (11 new tests across `api/agent_test.py`, `api/chat_test.py`, `api/ai_stack_integration_test.py`, `api/knowledge_ai_stack_test.py`, `api/knowledge_search_aggregator_test.py`, plus 1 updated assertion in the pre-existing `advanced_rag_optimizer_test.py`): each calls the real function/route coroutine directly (no FastAPI TestClient needed — these are plain `async def`s; `Depends(...)` defaults are simply overridden with explicit mock kwargs) and asserts `kb.search(...)` was invoked with `filters=RESEARCH_QUARANTINE_FILTER`.
- **Research-internal regression proof**: reran `tests/services/test_claim_verifier.py`, `services/research/orchestrator_test.py`, `services/research/planner_test.py`, `services/research/quarantine_boundary_test.py`, `tests/unit/chat_workflow/test_async_chat_workflow_kb_search.py` — all still pass unmodified, confirming the promotion/corroboration gate still sees quarantined facts.
- `cp`-swapped baseline diff (not `git stash`, per worktree rules): swapped all 8 modified files back to pre-PR (`HEAD`), reran the same test set: 106 passed (pre-PR test file also reverted, so no false failure from the new `filters=` assertion). Restored PR files: 121 passed (106 + 15 new/updated). Identical baseline, zero regressions.
- `tests/test_startup_imports.py`: 350/350 passed, unchanged before/after.

## Model Used

Claude Sonnet 5