### PR TITLE
feat(knowledge): correct auth-field docs + pagination tests for enterprise connectors (#10538)

### DIFF
--- a/autobot-backend/knowledge/connectors/confluence_test.py
+++ b/autobot-backend/knowledge/connectors/confluence_test.py
@@ -89,6 +89,28 @@ class TestConfluenceConnectorDiscovery:
         assert sources[0].source_id == "confluence:test-confluence-1:page:111"
         assert sources[0].name == "Runbook"
 
+    @pytest.mark.asyncio
+    async def test_discover_sources_paginates(self, confluence_config):
+        """_list_pages() must follow multiple `start` batches until a short page (#10538)."""
+        connector = ConfluenceConnector(confluence_config)
+        connector._page_size = 1
+        page1 = {"results": [{"id": "111", "title": "Page One", "version": {"when": "2026-01-01T00:00:00.000Z"}}]}
+        page2 = {"results": [{"id": "222", "title": "Page Two", "version": {"when": "2026-01-02T00:00:00.000Z"}}]}
+        page3 = {"results": []}
+        with patch.object(connector, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = [
+                {"status_code": 200, "body": page1},
+                {"status_code": 200, "body": page2},
+                {"status_code": 200, "body": page3},
+            ]
+            sources = await connector.discover_sources()
+
+        assert mock_get.call_count == 3
+        assert {s.source_id for s in sources} == {
+            "confluence:test-confluence-1:page:111",
+            "confluence:test-confluence-1:page:222",
+        }
+
 
 class TestConfluenceConnectorFetchContent:
     @pytest.mark.asyncio

--- a/autobot-backend/knowledge/connectors/jira_test.py
+++ b/autobot-backend/knowledge/connectors/jira_test.py
@@ -105,6 +105,33 @@ class TestJiraConnectorDiscovery:
         assert sources[0].source_id == "jira:test-jira-1:issue:ABC-1"
         assert sources[0].name == "Fix the bug"
 
+    @pytest.mark.asyncio
+    async def test_discover_sources_paginates(self, jira_config):
+        """_search() must follow startAt batches until total is reached (#10538)."""
+        connector = JiraConnector(jira_config)
+        connector._page_size = 1
+
+        def _issue(key: str, updated: str) -> dict:
+            return {
+                "key": key,
+                "fields": {"summary": key, "project": {"key": "ABC"}, "updated": updated},
+            }
+
+        page1 = {"total": 2, "issues": [_issue("ABC-1", "2026-01-01T00:00:00.000+0000")]}
+        page2 = {"total": 2, "issues": [_issue("ABC-2", "2026-01-02T00:00:00.000+0000")]}
+        with patch.object(connector, "_post", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = [
+                {"status_code": 200, "body": page1},
+                {"status_code": 200, "body": page2},
+            ]
+            sources = await connector.discover_sources()
+
+        assert mock_post.call_count == 2
+        assert {s.source_id for s in sources} == {
+            "jira:test-jira-1:issue:ABC-1",
+            "jira:test-jira-1:issue:ABC-2",
+        }
+
 
 class TestJiraConnectorFetchContent:
     @pytest.mark.asyncio

--- a/autobot-backend/knowledge/connectors/slack_test.py
+++ b/autobot-backend/knowledge/connectors/slack_test.py
@@ -87,6 +87,33 @@ class TestSlackConnectorDiscovery:
         assert sources[0].source_id == "slack:test-slack-1:channel:C123:ts:1000.001"
         assert "hello" in sources[0].name
 
+    @pytest.mark.asyncio
+    async def test_discover_sources_paginates(self, slack_config):
+        """_history() must follow `response_metadata.next_cursor` until exhausted (#10538)."""
+        connector = SlackConnector(slack_config)
+        page1 = {
+            "ok": True,
+            "messages": [{"ts": "1000.001", "user": "U1", "text": "hello"}],
+            "response_metadata": {"next_cursor": "cursor-2"},
+        }
+        page2 = {
+            "ok": True,
+            "messages": [{"ts": "1000.002", "user": "U1", "text": "world"}],
+            "response_metadata": {"next_cursor": ""},
+        }
+        with patch.object(connector, "_slack_post", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = [
+                {"status_code": 200, "body": page1},
+                {"status_code": 200, "body": page2},
+            ]
+            sources = await connector.discover_sources()
+
+        assert mock_post.call_count == 2
+        assert {s.source_id for s in sources} == {
+            "slack:test-slack-1:channel:C123:ts:1000.001",
+            "slack:test-slack-1:channel:C123:ts:1000.002",
+        }
+
 
 class TestSlackConnectorFetchContent:
     @pytest.mark.asyncio

--- a/docs/knowledge-base/enterprise-connectors-setup.md
+++ b/docs/knowledge-base/enterprise-connectors-setup.md
@@ -9,9 +9,9 @@ that ingest **Slack** channel/thread history, **Confluence** wiki pages and
 `kb.search`.
 
 All connector types, config fields and API endpoints below are cited to the
-exact source lines they are read from. No credentials are invented — where a
-field's handling is ambiguous, that is called out explicitly (see
-[Known limitation: auth-field mismatch](#known-limitation-auth-field-mismatch)).
+exact source lines they are read from. No credentials are invented, and the
+config keys documented here are the ones the connectors actually read — see
+[Auth-field alignment](#auth-field-alignment) for how that is kept true.
 
 ## Important: disabled by default in production
 
@@ -59,38 +59,38 @@ production connector-type listing (`mock.py:24-30`).
 ### Slack
 
 The Slack connector calls the Slack Web API with a bearer bot token
-(`autobot-backend/knowledge/connectors/slack.py:251-257`).
+(`autobot-backend/knowledge/connectors/slack.py:257-263`).
 
 - Create a Slack app and a **bot token** (`xoxb-...`) with the
   `channels:history`, `groups:history` and `channels:read` scopes
   (`slack.py:20-22`).
-- Collect the **channel IDs** you want ingested (`slack.py:23`).
+- Collect the **channel IDs** you want ingested (`slack.py:26`).
 - The token is verified via `auth.test`; history is read via
   `conversations.history` / `conversations.replies`
-  (`slack.py:106-108`, `:220`, `:241`).
+  (`slack.py:114`, `:226`, `:247`).
 
 ### Confluence (Atlassian Cloud)
 
 The Confluence connector uses HTTP Basic auth (account email + API token)
-against the Confluence REST API (`confluence.py:64-67`, `:220-223`).
+against the Confluence REST API (`confluence.py:67-70`, `:223-242`).
 
 - Create an **Atlassian API token** at your Atlassian account security page.
 - Note your Atlassian **account email** (used as the Basic-auth login).
 - Determine the site **base URL including `/wiki`**, e.g.
   `https://your-domain.atlassian.net/wiki` (`confluence.py:18-19`).
-- Collect the **space keys** to sync (`confluence.py:22`).
+- Collect the **space keys** to sync (`confluence.py:27`).
 
 ### Jira (Atlassian Cloud)
 
 The Jira connector uses the same Atlassian API-token + email Basic auth against
-the Jira REST API v3 (`jira.py:66-69`, `:231-234`).
+the Jira REST API v3 (`jira.py:73-76`, `:238-257`).
 
 - Reuse (or create) an **Atlassian API token**.
 - Note your Atlassian **account email**.
 - Determine the site **base URL without `/wiki`**, e.g.
   `https://your-domain.atlassian.net` (`jira.py:18-19`).
-- Collect the **project keys** to sync (`jira.py:22`), or supply an explicit
-  `jql` override (`jira.py:23-24`).
+- Collect the **project keys** to sync (`jira.py:27`), or supply an explicit
+  `jql` override (`jira.py:28-29`).
 
 ## Step 3 — Connector config fields
 
@@ -102,33 +102,43 @@ connector's `__init__` reads**, with defaults, cited to source.
 
 | Key | Required | Default | Source |
 |---|---|---|---|
-| `bot_token` | yes | `""` | `slack.py:95` |
-| `channel_ids` | yes | `[]` | `slack.py:96` |
-| `sync_threads` | no | `True` | `slack.py:97` |
-| `oldest` | no | `"0"` | `slack.py:98` |
-| `page_size` | no | `200` | `slack.py:99` |
-| `slack_api_base` | no (testing) | `https://slack.com/api` | `slack.py:100` |
+| `token` | yes | `""` | `slack.py:101` |
+| `channel_ids` | yes | `[]` | `slack.py:102` |
+| `sync_threads` | no | `True` | `slack.py:103` |
+| `oldest` | no | `"0"` | `slack.py:104` |
+| `page_size` | no | `200` | `slack.py:105` |
+| `slack_api_base` | no (testing) | `https://slack.com/api` | `slack.py:106` |
+
+`token` is the canonical `BearerAuth` field (`connector_auth.py:18-23`) — see
+[Auth-field alignment](#auth-field-alignment).
 
 ### Confluence config keys
 
 | Key | Required | Default | Source |
 |---|---|---|---|
-| `base_url` | yes | `""` | `confluence.py:89` |
-| `email` | yes | `""` | `confluence.py:87` |
-| `api_token` | yes | `""` | `confluence.py:88` |
-| `space_keys` | yes | `[]` | `confluence.py:90` |
-| `page_size` | no | `25` | `confluence.py:91` |
+| `base_url` | yes | `""` | `confluence.py:92` |
+| `username` | yes | `""` | `confluence.py:90` |
+| `password` | yes | `""` | `confluence.py:91` |
+| `space_keys` | yes | `[]` | `confluence.py:93` |
+| `page_size` | no | `25` | `confluence.py:94` |
+
+`username`/`password` are the canonical `BasicAuth` fields
+(`connector_auth.py:37-43`) — `username` holds the Atlassian account email and
+`password` holds the API token.
 
 ### Jira config keys
 
 | Key | Required | Default | Source |
 |---|---|---|---|
-| `base_url` | yes | `""` | `jira.py:93` |
-| `email` | yes | `""` | `jira.py:91` |
-| `api_token` | yes | `""` | `jira.py:92` |
-| `project_keys` | yes | `[]` | `jira.py:94` |
-| `jql` | no (overrides project keys) | `""` | `jira.py:95` |
-| `page_size` | no | `50` | `jira.py:96` |
+| `base_url` | yes | `""` | `jira.py:100` |
+| `username` | yes | `""` | `jira.py:98` |
+| `password` | yes | `""` | `jira.py:99` |
+| `project_keys` | yes | `[]` | `jira.py:101` |
+| `jql` | no (overrides project keys) | `""` | `jira.py:102` |
+| `page_size` | no | `50` | `jira.py:103` |
+
+Same `BasicAuth` mapping as Confluence: `username` = Atlassian account email,
+`password` = API token.
 
 ## Step 4 — Register a connector and run the first sync
 
@@ -157,8 +167,7 @@ only persists on success (`knowledge_connectors.py:395-482`). A failed
 connection test returns **400** and the connector is not saved
 (`knowledge_connectors.py:467-478`).
 
-Slack example (see the auth-field caveat in
-[Known limitation](#known-limitation-auth-field-mismatch) before running):
+Slack example:
 
 ```bash
 curl -s -X POST https://<backend-host>/api/knowledge_base/connectors \
@@ -167,7 +176,7 @@ curl -s -X POST https://<backend-host>/api/knowledge_base/connectors \
         "connector_type": "slack",
         "name": "Engineering Slack",
         "config": {
-          "bot_token": "<SLACK_BOT_TOKEN>",
+          "token": "<SLACK_BOT_TOKEN>",
           "channel_ids": ["C0123456789"]
         }
       }'
@@ -183,8 +192,8 @@ curl -s -X POST https://<backend-host>/api/knowledge_base/connectors \
         "name": "Team Wiki",
         "config": {
           "base_url": "https://your-domain.atlassian.net/wiki",
-          "email": "<ATLASSIAN_EMAIL>",
-          "api_token": "<ATLASSIAN_API_TOKEN>",
+          "username": "<ATLASSIAN_EMAIL>",
+          "password": "<ATLASSIAN_API_TOKEN>",
           "space_keys": ["ENG", "OPS"]
         }
       }'
@@ -200,8 +209,8 @@ curl -s -X POST https://<backend-host>/api/knowledge_base/connectors \
         "name": "Delivery Tracker",
         "config": {
           "base_url": "https://your-domain.atlassian.net",
-          "email": "<ATLASSIAN_EMAIL>",
-          "api_token": "<ATLASSIAN_API_TOKEN>",
+          "username": "<ATLASSIAN_EMAIL>",
+          "password": "<ATLASSIAN_API_TOKEN>",
           "project_keys": ["ABC", "XYZ"]
         }
       }'
@@ -257,53 +266,52 @@ override `sync()` and runs the identical inherited pipeline offline
   curl -s -X GET https://<backend-host>/api/knowledge_base/connectors/health
   ```
 
-Change-detection checkpoints are stored in Redis (knowledge DB): Slack keys
-under `connector:slack:ts:` (`slack.py:50`, `:298-309`), Confluence under
-`connector:confluence:ts:` (`confluence.py:45`, `:264-275`), Jira under
-`connector:jira:ts:` (`jira.py:47`, `:275-286`), each with a 30-day TTL.
+Change-detection checkpoints are stored in Redis (knowledge DB) via the shared
+`_load_ts()` / `_store_ts()` helpers on `AbstractConnector`
+(`base.py:272-291`, `:293-308` — extracted from six byte-identical
+per-connector copies in #12659). The default key prefix is
+`connector:<connector_type>:ts:` (`base.py:268-269`) — i.e.
+`connector:slack:ts:`, `connector:confluence:ts:`, `connector:jira:ts:` — each
+with a 30-day TTL (`base.py:52`).
 
-## Known limitation: auth-field mismatch
+## Auth-field alignment
 
-The credential-handling layer and the connector bodies currently read
-**different config keys**. Operators must understand this before registering a
-production connector:
+The credential-handling layer and the connector bodies read the **same**
+config keys, so the examples above are the correct, currently-working request
+shape:
 
 - The create endpoint validates the request `config` against the connector's
   declared `auth_schema()` and requires those schema fields to be present
   (`knowledge_connectors.py:423`, validation logic
-  `autobot_shared/auth/connector_auth.py:78-84`). It then extracts the
+  `autobot_shared/auth/connector_auth.py:68-84`). It then extracts the
   schema's sensitive fields into the encrypted credential store and strips them
   from the stored config (`credential_store.py:82-84`).
 - Slack declares `BearerAuth`, whose sensitive/required field is `token`
-  (`slack.py:72-75`; `connector_auth.py:18-23`) — but `SlackConnector.__init__`
-  reads `bot_token` (`slack.py:95`).
+  (`slack.py:78-81`; `connector_auth.py:18-23`) — `SlackConnector.__init__`
+  reads the same `token` key (`slack.py:101`).
 - Confluence and Jira declare `BasicAuth`, whose fields are `username` and
-  `password` (`confluence.py:64-67`, `jira.py:66-69`;
-  `connector_auth.py:36-43`) — but their `__init__` methods read `email` and
-  `api_token` (`confluence.py:87-88`, `jira.py:91-92`).
+  `password` (`confluence.py:67-70`, `jira.py:73-76`;
+  `connector_auth.py:37-43`) — their `__init__` methods read the same
+  `username`/`password` keys (`confluence.py:90-91`, `jira.py:98-99`).
 
-Practical consequence: a request that satisfies the connector docstrings
-(`bot_token` / `email` + `api_token`) does **not** satisfy auth-schema
-validation, and vice-versa. The mapping between the declared auth schema and the
-keys the connector actually reads is **not resolved in the current code**. This
-is why these connectors remain disabled by default and Issue #10538 stays open
-for the live-credential wiring. Do not treat the examples above as a guaranteed
-working recipe until this mapping is finalized; validate against your target
-build and coordinate with the credential-wiring work before enabling in
-production.
+This alignment was fixed in #12225 (tracked from #12221), which renamed the
+per-connector reads to match the declared schema; prior to that fix, a request
+that satisfied the connector docstrings (`bot_token` / `email` + `api_token`)
+would not have satisfied auth-schema validation. That mismatch no longer
+exists in the current code.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Where to look |
 |---|---|---|
 | `422` on create, type "not registered" | `kb_enterprise_connectors` flag off on that node | `knowledge_connectors.py:81-87`, `:409-414` |
-| `422` "Auth config invalid" | Missing auth-schema field (`token` / `username` + `password`) | `knowledge_connectors.py:423`; `connector_auth.py:78-84` |
-| `400` "Connection test failed" | Bad/expired token, wrong `base_url`, no channel/space/project access | `test_connection` per connector (`slack.py:106-112`, `confluence.py:97-103`, `jira.py:102-108`) |
-| Empty sync (no facts) | Wrong `channel_ids` / `space_keys` / `project_keys`, or `oldest`/`jql` filters out everything | `slack.py:114-121`, `confluence.py:105-112`, `jira.py:110-113` |
-| Sync slows / stalls under load | Upstream `HTTP 429` rate limiting is retried as `RetryableError` | `slack.py:262-263`, `confluence.py:228-229`, `jira.py:239-240` |
-| Upstream `5xx` errors | Retried as `RetryableError`; `4xx` (non-429) are logged and skipped | `slack.py:264-265`, `confluence.py:230-231`, `jira.py:241-242` |
+| `422` "Auth config invalid" | Missing auth-schema field (`token` / `username` + `password`) | `knowledge_connectors.py:423`; `connector_auth.py:68-84` |
+| `400` "Connection test failed" | Bad/expired token, wrong `base_url`, no channel/space/project access | `test_connection` per connector (`slack.py:112-118`, `confluence.py:100-106`, `jira.py:109-115`) |
+| Empty sync (no facts) | Wrong `channel_ids` / `space_keys` / `project_keys`, or `oldest`/`jql` filters out everything | `slack.py:120-127`, `confluence.py:108-115`, `jira.py:117-120` |
+| Sync slows / stalls under load | Upstream `HTTP 429` rate limiting is retried as `RetryableError` | `slack.py:274-275`, `confluence.py:232-233`, `jira.py:247-248` |
+| Upstream `5xx` errors | Retried as `RetryableError`; `4xx` (non-429) are logged and skipped | `slack.py:276-277`, `confluence.py:234-235`, `jira.py:249-250` |
 | Confluence `404`/empty on valid space | `base_url` missing the `/wiki` suffix | `confluence.py:18-19` |
-| Jira returns nothing for known project | `base_url` wrongly includes `/wiki`, or `jql` override shadows `project_keys` | `jira.py:18-19`, `:169-177` |
+| Jira returns nothing for known project | `base_url` wrongly includes `/wiki`, or `jql` override shadows `project_keys` | `jira.py:18-19`, `:176-184` |
 
 ## Reference
 


### PR DESCRIPTION
## Thinking Path

Audited #10538 before writing anything, per instructions. The Slack/Confluence/Jira KB
ingestion connectors already exist, fully implemented, in
`autobot-backend/knowledge/connectors/{slack,confluence,jira}.py`, delivered across five
already-merged PRs: #12189 (scaffold), #12199 (offline mock/replay connector + fixtures),
#12219 (operator setup guide), #12225 (auth-schema/credential-key alignment, closing #12221),
plus later cross-cutting refactors #12659 (shared `_load_ts`/`_store_ts` extraction) and
#12979/#12999 (pooled HTTP client migration). All three connectors implement the exact same
`AbstractConnector` contract as every other connector in the family (`base.py`) — `auth_schema()`,
`output_schema()`, `{"status_code","body"}` HTTP-result shape, `_load_ts`/`_store_ts` checkpointing,
`get_http_client().tracked_request()` for outbound HTTP (no raw `aiohttp.ClientSession`) — and are
reachable end-to-end: `knowledge/connectors/__init__.py` imports them behind the
`kb_enterprise_connectors` feature flag, `api/knowledge_connectors.py`'s `_SUPPORTED_TYPES` lists
`slack`/`confluence`/`jira`, and `GET /knowledge_base/connector_types` /
`POST /knowledge_base/connectors` operate on whatever `ConnectorRegistry` has registered. 69
existing offline tests (mocked HTTP, real assertions on content/metadata, auth-failure paths, and
the feature-flag gating) were green before this PR and remain green after.

So there was no connector left to build. Digging into *why* the issue was still open (owner's own
comments on the issue thread), the remaining ask was live-credential validation against real Slack/
Confluence/Jira tenants — which the owner separately clarified (2026-07-24 comment) is a per-install
operator task using the secrets manager, not something dev/CI does. That leaves the issue's code-side
acceptance criteria fully met, but two real gaps surfaced during the audit that a straight "close, no
changes" would have left behind:

1. **The operator setup guide had gone stale.** PR #12225 (auth-key alignment) landed *after* PR
   #12219 (the setup guide) and renamed the connector's config-read keys (`bot_token`->`token`,
   `email`/`api_token`->`username`/`password`) to match the declared `auth_schema()` — but the guide
   was never updated. It still told operators to send the old, now-rejected field names, still
   described the mismatch as unresolved, and still said "Issue #10538 stays open for the
   live-credential wiring" — which is exactly backwards now that #12225 fixed it. An operator
   following the guide today would get `422`s.
2. **No pagination test.** All three APIs paginate (`response_metadata.next_cursor` for Slack,
   `start` offset for Confluence, `startAt`/`total` for Jira) and the connector code handles it, but
   the offline test suite only ever mocked a single page.

Both are small, directly in-scope fixes for #10538's own deliverable, so I fixed them here rather
than filing follow-ups, per the "fix pre-existing issues discovered along the way" rule.

## What Changed

- `docs/knowledge-base/enterprise-connectors-setup.md`: corrected every config-key table, curl
  example, and source-line citation to the current, post-#12225/#12659 code (`token` /
  `username`+`password` instead of `bot_token` / `email`+`api_token`; Redis checkpoints now cited to
  the shared `base.py` helpers instead of removed per-connector copies). Replaced the "Known
  limitation: auth-field mismatch" section with an "Auth-field alignment" section documenting that
  #12225 resolved it.
- `autobot-backend/knowledge/connectors/{slack,confluence,jira}_test.py`: added one multi-page
  pagination test per connector, each driving `discover_sources()` through a real multi-call
  sequence (2-3 mocked pages) and asserting every page's sources were collected — not merely that no
  exception was raised.
- No connector code changes — nothing to build; see the audit above.
- Filed #13041 for an unrelated, pre-existing regression discovered while running the verification
  suite: `test_raw_client_session_ceiling_12992` is currently red on `Dev_new_gui` (13 raw
  `aiohttp.ClientSession` sites vs. the recorded ceiling of 12) due to 3 undocumented new raw
  sessions in `agent_loop/search/config_declared_provider.py`, `orchestration/dag_executor.py`, and
  `services/slm_client.py` — none touched by this PR, filed separately per convention.

## Verification

Full offline connector suite (69 tests, unaffected + 3 new pagination tests = 72 net after adding,
47 shown for the 3 touched files):

```
knowledge/connectors/slack_test.py       .............. (14 incl. new pagination test)
knowledge/connectors/confluence_test.py  ............... (15 incl. new pagination test)
knowledge/connectors/jira_test.py        .................. (18 incl. new pagination test)
============================== 47 passed in 1.13s ==============================
```

Full connector-family suite (unaffected files) still green:
```
knowledge/connectors/{slack,confluence,jira}_test.py
knowledge/connectors/mock_test.py
knowledge/connectors/connectors_init_gating_test.py
============================= 69 passed in 10.25s ==============================
```

`flake8 --max-line-length=120` and `black --check --line-length=120` on the 3 touched test files: clean.

Registration/reachability proof (no code path added — confirming the existing one):
- `autobot-backend/api/knowledge_connectors.py:84-86` lists `slack`/`confluence`/`jira` in
  `_SUPPORTED_TYPES`.
- `autobot-backend/knowledge/connectors/__init__.py:85-88` imports (and therefore
  `@ConnectorRegistry.register`s) all three behind `kb_enterprise_connectors`.
- `GET /knowledge_base/connector_types` (`knowledge_connectors.py:346-369`) and
  `POST /knowledge_base/connectors` (`:401-482`) operate on `ConnectorRegistry.registered_types()` /
  `.create()` dynamically — no hardcoded connector list to update.

Baseline diff: `test_raw_client_session_ceiling_12992` fails identically before and after this PR
(13 vs. ceiling 12, same offender list — none in `knowledge/connectors/`, confirming this PR didn't
touch the ratchet). Pre-existing, filed as #13041.

Startup import smoke: unaffected — this PR touches only test files and docs, no importable modules
changed.

## Model Used

Claude Sonnet 5