### PR TITLE
fix(tests): re-baseline raw-ClientSession ceiling to 13, document new SSRF-pinned carve-out, wire guard into CI (#13041)

### DIFF
--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -99,3 +99,22 @@ jobs:
             echo "autobot-backend/tests/test_startup_imports.py with issue ref."
             exit 1
           }
+
+      # #13041: this guard has stdlib-only deps (ast/pathlib — no imports of
+      # backend modules) and was never collected by any CI workflow, letting
+      # the raw-ClientSession ceiling silently regress 12->13 unnoticed. This
+      # job already runs pytest against autobot-backend/tests/ with the full
+      # backend dependency set and is a required check, so it is the natural
+      # (smallest-blast-radius) place to add it rather than expanding #10691's
+      # broader "enable all backend tests in CI" scope.
+      - name: Run raw ClientSession ceiling guard
+        run: |
+          python -m pytest autobot-backend/tests/test_raw_client_session_ceiling_12992.py -v --tb=short || {
+            echo ""
+            echo "Raw aiohttp.ClientSession(...) ceiling guard FAILED (#12992/#13041)."
+            echo ""
+            echo "A new raw ClientSession site was added without routing it through"
+            echo "autobot_shared.http_client.get_http_client(), or without documenting"
+            echo "it as an intentional carve-out in the test's module docstring."
+            exit 1
+          }

--- a/autobot-backend/tests/test_raw_client_session_ceiling_12992.py
+++ b/autobot-backend/tests/test_raw_client_session_ceiling_12992.py
@@ -77,7 +77,7 @@ the true count at **12** — exactly the 10 documented carve-outs from batches
 2 newly-documented ``npu_pipeline/`` long-lived carve-outs found this batch.
 
 At 12, every remaining raw ``aiohttp.ClientSession(...)`` construction in
-``autobot-backend/`` is a **documented, intentional carve-out** — see the
+``autobot-backend/`` was a **documented, intentional carve-out** — see the
 "Remaining raw sites" list below. This sweep's convertible tail is drained;
 what is left is not unfinished work.
 
@@ -85,14 +85,36 @@ Unlike the ``xfail(strict=True)`` guard in
 ``autobot-slm-backend/tests/test_update_all_applies_roles_12959.py`` — which
 marks a single binary gap — this is a monotonically decreasing budget, because
 the backlog is drained incrementally by #12979's batches rather than in one
-commit.
+commit. It can still rise by exactly one when a *new* carve-out is added
+deliberately elsewhere in the codebase (see #13041 below) — the ratchet only
+forbids *undocumented, unreviewed* growth.
 
-Remaining raw sites (12, all carve-outs — see #12979 comments for detail):
+#13041 (2026-07-30): #12625's PR #13016 added
+``agent_loop/search/config_declared_provider.py``, a 13th raw site, without
+updating this ceiling or this inventory — exactly the "backlog refill" failure
+mode warned about above, except the new site is itself a legitimate carve-out
+rather than a reversion. Re-measured with the same AST walker against
+``origin/Dev_new_gui`` at ``a2f788889``: **13**, confirmed by an independent
+manual read of every offender. Investigating #13041's own claim that
+``orchestration/dag_executor.py`` and ``services/slm_client.py`` were *also*
+new/undocumented: both were already present in the custom-TLS bullet below
+(and in ``MAX_RAW_CLIENT_SESSIONS``'s history above) since batch 8 (#13006) —
+that part of #13041's premise was incorrect; only
+``config_declared_provider.py`` is new. Its raw session pins a
+``TCPConnector`` via ``autobot_shared.security.ssrf_guard.pinned_connector()``
+fresh on every call (agent_loop/search/config_declared_provider.py:183-187,
+235) — same DNS-rebind-safety shape as ``knowledge/connectors/oauth_flow.py``
+and ``skills/external_importer.py``. Pooling it would silently discard the
+pinned connector and reopen the #12278 DNS-rebinding hole, so it stays raw and
+the ceiling rises to 13 to record it as a carve-out rather than a violation.
+
+Remaining raw sites (13, all carve-outs — see #12979 comments for detail):
 
 * SSRF-pinned ``connector=`` (pooling would silently drop the pin —
   DNS-rebinding regression no test catches): ``api/provider_auth.py`` (2),
   ``api/marketplace_sources.py``, ``content_reach/_url_guard.py``,
-  ``knowledge/connectors/oauth_flow.py``, ``skills/external_importer.py``.
+  ``knowledge/connectors/oauth_flow.py``, ``skills/external_importer.py``,
+  ``agent_loop/search/config_declared_provider.py`` (#12625/#13016, #13041).
 * Long-lived (session outlives a single call, reused across sequential or
   concurrent requests on the same instance): ``services/npu_client.py``,
   ``services/npu_pipeline/dispatcher.py``, ``services/npu_pipeline/npu_client.py``,
@@ -100,7 +122,7 @@ Remaining raw sites (12, all carve-outs — see #12979 comments for detail):
 * Custom non-default TLS/SSL context the pool cannot express per-request:
   ``services/slm_client.py``, ``orchestration/dag_executor.py``.
 
-Refs #12979, #12981, #12989, #12992.
+Refs #12979, #12981, #12989, #12992, #13041.
 """
 
 import ast
@@ -147,7 +169,16 @@ BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[1]
 #:    carve-outs on inspection) land the true count at 12 — every remaining
 #:    site is now a documented carve-out (see the module docstring's
 #:    "Remaining raw sites" list).
-MAX_RAW_CLIENT_SESSIONS = 12
+#:    #13041 (2026-07-30): #12625's PR #13016 added a 13th raw site
+#:    (``agent_loop/search/config_declared_provider.py``) without touching this
+#:    constant or the inventory below. Re-measured against ``origin/Dev_new_gui``
+#:    at ``a2f788889``: still 13, confirmed by AST walker and manual read of the
+#:    new site — it is a genuine SSRF-pinned-connector carve-out (#12278), not a
+#:    reversion, so the ceiling rises by exactly one rather than the site being
+#:    converted. See the module docstring's #13041 note for the full
+#:    investigation, including which of #13041's claimed offenders were already
+#:    documented.
+MAX_RAW_CLIENT_SESSIONS = 13
 
 #: Directory names that are never part of the production surface being swept.
 EXCLUDED_DIR_NAMES = {"__pycache__", "tests", "test", ".pytest_cache", "node_modules"}


### PR DESCRIPTION
## Thinking Path
`test_raw_client_session_ceiling_12992.py` was failing on `origin/Dev_new_gui` (13 raw `aiohttp.ClientSession(...)` sites vs. a recorded ceiling of 12). Re-measured with the test's own AST walker (never `grep -c` — it over/under-counts on string literals) against a tree freshly synced to `origin/Dev_new_gui` at `a2f788889`: confirmed **13**, same offender list #13041 reported.

Investigated each of #13041's three claimed "new, undocumented" offenders individually before touching anything:
- `agent_loop/search/config_declared_provider.py` — genuinely new (added by PR #13016 / #12625) and genuinely undocumented. Read the file: its raw session pins a `TCPConnector` via `autobot_shared.security.ssrf_guard.pinned_connector()` fresh on every call (`config_declared_provider.py:183-187,235`) — the same SSRF-pinned-connector shape already carved out for `oauth_flow.py` / `external_importer.py`. Pooling it would silently drop the pin and reopen the #12278 DNS-rebinding hole. **This site must stay raw; it is a legitimate carve-out, not a violation.**
- `orchestration/dag_executor.py` and `services/slm_client.py` — checked git history of the test file: both were already listed in the module docstring's "custom non-default TLS/SSL context" bullet since batch 8 landed the 12-ceiling (#13006). **#13041's claim that these two are new/undocumented is incorrect** — only `config_declared_provider.py` is new.

So the fix is: raise the ceiling to the measured, correct value (13) and document the one genuinely new carve-out — not convert `config_declared_provider.py` to the pooled client, which would be a security regression.

Root cause of *why this regressed unnoticed*: the guard has never been collected by any CI workflow. `autobot-backend/tests/**` only appears in `migration-gate.yml` (migrations subdir only) and `startup-import-smoke.yml` (only `test_startup_imports.py`); the required "Unit & Integration Tests" check (`frontend-test.yml`) is entirely frontend. That gap is tracked separately as #10691 (evidence already posted there) — out of scope for a "smallest sound fix" PR to broaden. Within this PR's blast radius, the guard has zero non-stdlib dependencies (`ast`/`pathlib` only, no backend-module imports) and `startup-import-smoke.yml`'s job already installs the full backend dependency set and is a required check — the natural, low-risk place to add exactly this one test.

## What Changed
- `autobot-backend/tests/test_raw_client_session_ceiling_12992.py`: `MAX_RAW_CLIENT_SESSIONS` 12 → 13; module docstring's "Remaining raw sites" inventory updated to add `agent_loop/search/config_declared_provider.py` under the SSRF-pinned-connector category with its reasoning and refs (#12625/#13016/#13041); `MAX_RAW_CLIENT_SESSIONS`'s re-measurement history comment and the module docstring both record the #13041 investigation, including which of its claimed offenders were already documented.
- `.github/workflows/startup-import-smoke.yml`: added a second step to the existing `startup-import-smoke` job (which already installs the full backend dep set and runs backend pytest, and is a required check) that runs `test_raw_client_session_ceiling_12992.py`, so a future regression fails CI instead of silently landing again.
- Did **not** touch `config_declared_provider.py`, `dag_executor.py`, or `slm_client.py` — all three stay raw by design.
- Did **not** attempt to broaden backend test coverage in CI beyond this one guard — that is #10691's scope.

## Verification
- Re-measured with the AST walker against `origin/Dev_new_gui` @ `a2f788889`: 13 constructions, offender list matches #13041 exactly.
- `pytest autobot-backend/tests/test_raw_client_session_ceiling_12992.py -v`: 2 passed (walker-sanity + ceiling).
- Negative case: temporarily set `MAX_RAW_CLIENT_SESSIONS` back to 12 in the working tree and re-ran — reproduced #13041's exact `AssertionError: 13 raw ... exceeding ... 12` failure with the same offender list, then reverted to 13. Confirms the ratchet trips at ceiling+1.
- `py_compile` / `flake8 --max-line-length=120` / `black --check --line-length=120` on the changed test file: all clean.
- CI-wiring evidence: built a Python 3.14 venv (matches the workflow's `actions/setup-python` version), installed `requirements-ci.txt` + `pytest` + editable `autobot_shared` (the exact steps the job runs), then ran `pytest autobot-backend/tests/test_startup_imports.py autobot-backend/tests/test_raw_client_session_ceiling_12992.py` together and standalone — the ceiling guard collects and passes cleanly in both cases (`2 passed`), confirming the new workflow step actually executes the test rather than repeating the "silently never collected" failure mode #13041 is about.
- Startup-import smoke ratio: unchanged — the new step is a separate, independent `pytest` invocation appended after the existing `test_startup_imports.py` step; `test_startup_imports.py` itself was not modified (350/350 passing locally against available deps, same as before this change).

## Model Used
Sonnet