### PR TITLE
feat(secrets): migrate legacy secrets.json store into unified envelope + dual-read (#10088)

### DIFF
--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -52,6 +52,7 @@ from autobot_shared.rate_limiter import RateLimiter
 from autobot_shared.time_utils import parse_utc_iso
 from middleware.proxy_utils import get_client_ip
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
+from services.json_secrets_read import load_imported_json_secret
 from type_defs.common import Metadata
 
 logger = get_logger(__name__)
@@ -494,6 +495,22 @@ def audit_log(
     )
 
 
+async def _get_secret_dual_read(secret_id: str, chat_id: str | None) -> Dict | None:
+    """Try the unified envelope store (#10088 Task 3 dual-read), else the legacy JSON file.
+
+    Chat-scope access control is enforced identically on both paths so a secret imported
+    into the unified store is never *less* protected than it was in the legacy file.
+    """
+    secret = await load_imported_json_secret(secret_id)
+    if secret is not None:
+        if secret.get("scope") == ChatSecretScope.CHAT.value:
+            if not chat_id or secret.get("chat_id") != chat_id:
+                raise PermissionError("Access denied: Chat-scoped secret from different chat")
+        return secret
+    # Issue #666: Wrap blocking file I/O in asyncio.to_thread
+    return await asyncio.to_thread(secrets_manager.get_secret, secret_id, chat_id=chat_id)
+
+
 # API Endpoints
 
 
@@ -696,8 +713,7 @@ async def get_secret(
     """Get a specific secret with its value (Issue #744: requires admin authentication)"""
     await check_rate_limit(http_request)
     try:
-        # Issue #666: Wrap blocking file I/O in asyncio.to_thread
-        secret = await asyncio.to_thread(secrets_manager.get_secret, secret_id, chat_id=chat_id)
+        secret = await _get_secret_dual_read(secret_id, chat_id)
         if not secret:
             audit_log("ACCESS", secret_id, http_request, success=False, details="not_found")
             raise HTTPException(status_code=404, detail="Secret not found")

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -114,3 +114,47 @@ class TestCheckRateLimit:
 
         assert exc_info.value.status_code == 429
         assert exc_info.value.headers["Retry-After"] == str(RATE_LIMIT_WINDOW)
+
+
+class TestGetSecretDualRead:
+    """``_get_secret_dual_read`` (#10088 Task 3): unified store first, legacy file fallback.
+
+    Mocks ``load_imported_json_secret`` directly — no Postgres needed here; the envelope
+    read itself is covered by the Postgres-gated ``tests/migrations/test_json_secrets_importer.py``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_unified_secret_without_touching_legacy_file(self):
+        from api.secrets import _get_secret_dual_read
+
+        unified = {"id": "s1", "scope": "general", "chat_id": None, "value": "v"}
+        with (
+            patch("api.secrets.load_imported_json_secret", AsyncMock(return_value=unified)),
+            patch("api.secrets.secrets_manager") as legacy,
+        ):
+            result = await _get_secret_dual_read("s1", chat_id=None)
+        assert result == unified
+        legacy.get_secret.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_legacy_file_when_not_yet_imported(self):
+        from api.secrets import _get_secret_dual_read
+
+        legacy_result = {"id": "s2", "scope": "general", "value": "v2"}
+        with (
+            patch("api.secrets.load_imported_json_secret", AsyncMock(return_value=None)),
+            patch("api.secrets.secrets_manager") as legacy,
+        ):
+            legacy.get_secret = MagicMock(return_value=legacy_result)
+            result = await _get_secret_dual_read("s2", chat_id=None)
+        assert result == legacy_result
+        legacy.get_secret.assert_called_once_with("s2", chat_id=None)
+
+    @pytest.mark.asyncio
+    async def test_chat_scope_mismatch_denied_even_via_unified_store(self):
+        from api.secrets import _get_secret_dual_read
+
+        unified = {"id": "s3", "scope": "chat", "chat_id": "chat-a", "value": "v3"}
+        with patch("api.secrets.load_imported_json_secret", AsyncMock(return_value=unified)):
+            with pytest.raises(PermissionError):
+                await _get_secret_dual_read("s3", chat_id="chat-b")

--- a/autobot-backend/services/json_secrets_importer.py
+++ b/autobot-backend/services/json_secrets_importer.py
@@ -14,6 +14,14 @@ there is no reliable per-user owner to assign, every imported secret is owned by
 **System vault** (admin-only) — this exactly preserves today's real-world access control
 (only an admin can reach these endpoints) instead of fabricating a personal owner.
 
+Deliberately reads the JSON file directly (mirroring ``sqlite_secrets_importer.py``'s own
+``sqlite_path`` + ``fernet`` parameters) rather than importing ``api.secrets``: that module
+pulls in the whole FastAPI app surface (auth middleware, memory graph, plugin SDK — which
+transitively imports ``jsonschema``), which the migration-gate test environment deliberately
+keeps minimal (see ``.github/workflows/migration-gate.yml``). The caller supplies the already
+-built ``Fernet`` (e.g. the live ``secrets_manager.cipher`` when running in-process, or one
+built from the key file by a future migration-runner CLI — see #13052).
+
 Idempotent via ``extra_data['imported_from_json']``; legacy scope/chat_id/metadata are
 preserved in ``extra_data`` so ``json_secrets_read.py`` can reconstruct the exact response
 shape the legacy ``GET /secrets/{id}`` handler returns. The JSON file is left intact — this
@@ -22,10 +30,13 @@ populates and lets us verify the unified store before dual-read is enabled.
 
 from __future__ import annotations
 
+import base64
+import json
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
 
-from cryptography.fernet import InvalidToken
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,6 +46,9 @@ from autobot_shared.secrets_vault import VaultKind, VaultRef
 from autobot_shared.time_utils import parse_utc_iso
 from models.secret import Secret
 from models.secret_grant import SecretGrant
+
+if TYPE_CHECKING:  # typing only — avoid a hard cryptography import at module load
+    from cryptography.fernet import Fernet, MultiFernet
 
 _MARKER = "imported_from_json"
 
@@ -52,6 +66,20 @@ class JsonImportReport:
     imported: int = 0
     skipped_existing: int = 0
     failed: list[str] = field(default_factory=list)
+
+
+def _read_rows(secrets_path: str) -> dict:
+    """Read the legacy ``secrets.json`` file (sync, one-shot); ``{}`` when absent."""
+    path = Path(secrets_path)
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _decrypt(cipher: str, fernet: "Fernet | MultiFernet") -> bytes:
+    """Reverse ``SecretsManager._encrypt_value`` (base64-wrapped Fernet token)."""
+    return fernet.decrypt(base64.b64decode(cipher.encode("utf-8")))
 
 
 async def _existing_markers(session: AsyncSession) -> set[str]:
@@ -98,17 +126,19 @@ def _build_secret_grant(row: dict, plaintext: bytes, root_key: bytes) -> tuple[S
     return secret, grant
 
 
-async def import_json_secrets(session: AsyncSession, *, root_key: bytes) -> JsonImportReport:
+async def import_json_secrets(
+    session: AsyncSession, *, secrets_path: str, fernet: "Fernet | MultiFernet", root_key: bytes
+) -> JsonImportReport:
     """Import every ``secrets.json`` row into the unified store, owned by the System vault.
 
-    Reads + decrypts via the process-wide ``api.secrets.secrets_manager`` singleton (the same
-    file and key it already manages) so no second Fernet key path is introduced. Returns a
+    ``fernet`` is a ``cryptography.fernet.Fernet`` built from the legacy per-file key
+    (``SecretsManager``'s ``secrets.key``); ``root_key`` is the envelope root key. Returns a
     reconciliation report; caller commits.
     """
-    from api.secrets import secrets_manager
+    from cryptography.fernet import InvalidToken
 
     report = JsonImportReport()
-    rows = secrets_manager._load_secrets()
+    rows = _read_rows(secrets_path)
     report.total = len(rows)
     already = await _existing_markers(session)
 
@@ -121,7 +151,7 @@ async def import_json_secrets(session: AsyncSession, *, root_key: bytes) -> Json
             report.failed.append(f"{secret_id}: no encrypted_value")
             continue
         try:
-            plaintext = secrets_manager._decrypt_value(cipher).encode("utf-8")
+            plaintext = _decrypt(cipher, fernet)
         except (InvalidToken, ValueError, TypeError) as exc:
             report.failed.append(f"{secret_id}: decrypt failed ({exc})")
             continue

--- a/autobot-backend/services/json_secrets_importer.py
+++ b/autobot-backend/services/json_secrets_importer.py
@@ -1,0 +1,141 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Import the legacy JSON file secrets store into the unified envelope store (#10088 / Task 3).
+
+Additive, one-shot migration mirroring ``sqlite_secrets_importer.py`` (Task 3c) for the
+last of the three legacy stores the umbrella names: the ``secrets.json`` file store behind
+``api/secrets.py`` + ``SecretsManager.vue``. Every row there is created through an
+admin-only endpoint (``check_admin_permission`` on every route) and carries **no owner_id**
+— ``SecretCreateRequest.owner_id`` is accepted but silently dropped by
+``SecretCreateRequest.to_secret_model()`` (a pre-existing gap, filed separately). Since
+there is no reliable per-user owner to assign, every imported secret is owned by the
+**System vault** (admin-only) — this exactly preserves today's real-world access control
+(only an admin can reach these endpoints) instead of fabricating a personal owner.
+
+Idempotent via ``extra_data['imported_from_json']``; legacy scope/chat_id/metadata are
+preserved in ``extra_data`` so ``json_secrets_read.py`` can reconstruct the exact response
+shape the legacy ``GET /secrets/{id}`` handler returns. The JSON file is left intact — this
+populates and lets us verify the unified store before dual-read is enabled.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from cryptography.fernet import InvalidToken
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from autobot_shared.time_utils import parse_utc_iso
+from models.secret import Secret
+from models.secret_grant import SecretGrant
+
+_MARKER = "imported_from_json"
+
+#: Sentinel owner for vault-owned (no human owner) secrets — matches the service-principal
+#: convention in ``services/secrets_coordinator.py`` (``_SERVICE_OWNER_ID``); ``Secret.owner_id``
+#: is NOT NULL and there is no real per-user owner for this ownerless, admin-only store.
+_SYSTEM_OWNER_ID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+@dataclass
+class JsonImportReport:
+    """Reconciliation counts for one import run."""
+
+    total: int = 0
+    imported: int = 0
+    skipped_existing: int = 0
+    failed: list[str] = field(default_factory=list)
+
+
+async def _existing_markers(session: AsyncSession) -> set[str]:
+    """Source ids already imported (so a re-run is idempotent)."""
+    marker = Secret.extra_data[_MARKER].astext
+    rows = (await session.execute(select(marker).where(marker.isnot(None)))).scalars().all()
+    return {r for r in rows if r}
+
+
+def _parse_expires_at(value):
+    """Coerce the legacy row's ``expires_at`` (ISO string, datetime, or None) to a datetime."""
+    if not value or hasattr(value, "isoformat"):
+        return value or None
+    return parse_utc_iso(str(value))
+
+
+def _build_secret_grant(row: dict, plaintext: bytes, root_key: bytes) -> tuple[Secret, SecretGrant]:
+    """Seal *plaintext* and build the System-vault ``Secret`` + owner grant for a legacy JSON row."""
+    new_id = uuid.uuid4()
+    sid = str(new_id)
+    vault = VaultRef(VaultKind.SYSTEM)
+    sealed, dek = seal(plaintext, secret_id=sid)
+    wrapped = wrap_dek(dek, derive_vault_key(root_key, vault.to_str()), vault.to_str(), secret_id=sid)
+    secret = Secret(
+        id=new_id,
+        owner_id=_SYSTEM_OWNER_ID,
+        name=row["name"],
+        type=row["type"],
+        scope=VaultKind.SYSTEM.value,
+        owner_vault=vault.to_str(),
+        sealed_value=sealed.to_dict(),
+        version=1,
+        description=row.get("description"),
+        tags=row.get("tags") or [],
+        expires_at=_parse_expires_at(row.get("expires_at")),
+        extra_data={
+            _MARKER: str(row["id"]),
+            "legacy_scope": row.get("scope"),
+            "legacy_chat_id": row.get("chat_id"),
+            "legacy_metadata": row.get("metadata") or {},
+        },
+    )
+    grant = SecretGrant(secret_id=new_id, grantee=vault.to_str(), wrapped_dek=wrapped.to_dict(), created_by=None)
+    return secret, grant
+
+
+async def import_json_secrets(session: AsyncSession, *, root_key: bytes) -> JsonImportReport:
+    """Import every ``secrets.json`` row into the unified store, owned by the System vault.
+
+    Reads + decrypts via the process-wide ``api.secrets.secrets_manager`` singleton (the same
+    file and key it already manages) so no second Fernet key path is introduced. Returns a
+    reconciliation report; caller commits.
+    """
+    from api.secrets import secrets_manager
+
+    report = JsonImportReport()
+    rows = secrets_manager._load_secrets()
+    report.total = len(rows)
+    already = await _existing_markers(session)
+
+    for secret_id, row in rows.items():
+        if secret_id in already:
+            report.skipped_existing += 1
+            continue
+        cipher = row.get("encrypted_value")
+        if not cipher:
+            report.failed.append(f"{secret_id}: no encrypted_value")
+            continue
+        try:
+            plaintext = secrets_manager._decrypt_value(cipher).encode("utf-8")
+        except (InvalidToken, ValueError, TypeError) as exc:
+            report.failed.append(f"{secret_id}: decrypt failed ({exc})")
+            continue
+        try:
+            # Per-row SAVEPOINT so one bad row (dirty data that overflows a PG column, a
+            # UNIQUE grant collision, etc.) is reported and skipped, not an end-of-batch
+            # IntegrityError/DataError aborting the whole batch.
+            async with session.begin_nested():
+                secret, grant = _build_secret_grant({**row, "id": secret_id}, plaintext, root_key)
+                session.add(secret)
+                session.add(grant)
+                await session.flush()
+            report.imported += 1
+        except SQLAlchemyError as exc:
+            report.failed.append(f"{secret_id}: persist failed ({exc})")
+
+    return report

--- a/autobot-backend/services/json_secrets_read.py
+++ b/autobot-backend/services/json_secrets_read.py
@@ -1,0 +1,108 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dual-read path for legacy JSON-store secrets imported into the envelope store (#10088 / Task 3).
+
+Resolves a secret imported by ``json_secrets_importer`` via the ``imported_from_json`` marker,
+decrypts it through the System vault, and reshapes it to the exact dict contract
+``api.secrets.SecretsManager.get_secret()`` returns, so ``GET /secrets/{id}`` can use either
+path with no response-shape drift for the frontend. Returns ``None`` (fall back to the legacy
+JSON file) when the secret hasn't been imported yet, the envelope read fails, or the feature
+flag is off — the JSON file remains authoritative until this path is enabled and proven.
+
+Feature-flagged the same way as the connector-credential cutover
+(``knowledge.connectors.credential_store.VAULT_READ_ENV``): default off, so behaviour is
+byte-identical until explicitly enabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+JSON_UNIFIED_READ_ENV = "AUTOBOT_SECRETS_JSON_UNIFIED_READ"
+_MARKER = "imported_from_json"
+
+
+def json_unified_read_enabled() -> bool:
+    """Whether the JSON-store dual-read (envelope-first) path is enabled."""
+    return os.environ.get(JSON_UNIFIED_READ_ENV, "false").strip().lower() in ("1", "true", "yes")
+
+
+async def _find_by_marker(session, secret_id: str):
+    from sqlalchemy import select
+
+    from models.secret import Secret
+
+    marker = Secret.extra_data[_MARKER].astext
+    result = await session.execute(select(Secret).where(marker == str(secret_id), Secret.is_active.is_(True)))
+    return result.scalars().first()
+
+
+def _to_legacy_shape(row, value: str) -> dict:
+    """Reshape an envelope ``Secret`` row back into the legacy ``get_secret()`` dict contract."""
+    extra = row.extra_data or {}
+    return {
+        "id": extra.get(_MARKER, str(row.id)),
+        "name": row.name,
+        "type": row.type,
+        "scope": extra.get("legacy_scope"),
+        "chat_id": extra.get("legacy_chat_id"),
+        "description": row.description,
+        "tags": row.tags or [],
+        "created_at": row.created_at.isoformat(),
+        "updated_at": row.updated_at.isoformat(),
+        "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+        "metadata": extra.get("legacy_metadata") or {},
+        "value": value,
+    }
+
+
+async def read_imported_json_secret_in_session(session, secret_id: str, root_key: bytes) -> dict | None:
+    """Resolve + decrypt an imported JSON-store secret within *session* (the testable core)."""
+    from autobot_shared.secrets_envelope import DecryptionError, UnsupportedFormatError
+    from autobot_shared.secrets_vault import VaultKind, VaultRef
+    from services.envelope_secrets_service import EnvelopeSecretsService, SecretAccessError, SecretNotFoundError
+
+    row = await _find_by_marker(session, secret_id)
+    if row is None:
+        return None  # not yet imported -> JSON file fallback
+    try:
+        plaintext = await EnvelopeSecretsService(root_key=root_key).read(
+            session, secret_id=row.id, accessible_vaults={VaultRef(VaultKind.SYSTEM)}
+        )
+    except (
+        SecretAccessError,
+        SecretNotFoundError,
+        DecryptionError,
+        UnsupportedFormatError,
+        KeyError,
+        ValueError,
+    ) as exc:
+        logger.warning("Envelope read unusable for imported JSON secret %s: %s — falling back", secret_id, exc)
+        return None
+    return _to_legacy_shape(row, plaintext.decode("utf-8"))
+
+
+async def load_imported_json_secret(secret_id: str) -> dict | None:
+    """Acquire a session and read an imported legacy-JSON secret from the envelope store.
+
+    Returns ``None`` (triggering the legacy-file fallback) when the flag is off or the
+    envelope store is not configured (root key unset) on this deployment.
+    """
+    if not json_unified_read_enabled():
+        return None
+    from autobot_shared.secrets_envelope import load_root_key
+    from user_management.database import get_async_session_factory
+
+    try:
+        root_key = load_root_key()
+    except RuntimeError:
+        return None
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        return await read_imported_json_secret_in_session(session, secret_id, root_key)

--- a/autobot-backend/tests/migrations/test_json_secrets_importer.py
+++ b/autobot-backend/tests/migrations/test_json_secrets_importer.py
@@ -4,18 +4,24 @@
 # Author: mrveiss
 """Tests for the legacy JSON file → unified envelope importer (#10088 / Task 3).
 
-Builds a legacy ``secrets.json`` + ``secrets.key`` file store in a temp dir (bypassing
-``SecretsManager.__init__`` so no real data directory is touched), imports it into a
-Postgres unified store (migration-gate), and verifies each row is envelope-readable via
-``EnvelopeSecretsService`` owned by the System vault. Also verifies the ``json_secrets_read``
-dual-read path and that no secret value is ever logged.
+Builds a legacy ``secrets.json`` file directly (the exact on-disk shape
+``SecretsManager._save_secrets`` produces) rather than importing ``api.secrets`` —
+that module pulls in the whole FastAPI app surface (auth middleware, memory graph,
+plugin SDK, which transitively imports ``jsonschema``), which the migration-gate
+environment deliberately keeps minimal (see ``.github/workflows/migration-gate.yml``).
+Imports it into a Postgres unified store (migration-gate) and verifies each row is
+envelope-readable via ``EnvelopeSecretsService`` owned by the System vault. Also
+verifies the ``json_secrets_read`` dual-read path and that no secret value is ever
+logged.
 """
 
 import base64
-import threading
+import json
 import uuid
+from datetime import datetime, timezone
 
 import pytest
+from cryptography.fernet import Fernet
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from autobot_shared.secrets_vault import VaultKind, VaultRef
@@ -27,33 +33,38 @@ from tests.migrations.conftest import requires_postgres, run_alembic
 pytestmark = [pytest.mark.migration_gate, requires_postgres]
 
 _ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_FERNET = Fernet(Fernet.generate_key())
 
 
-def _make_store(tmp_path):
-    """A ``SecretsManager`` rooted at *tmp_path*, bypassing ``__init__``'s real data dir."""
-    from api.secrets import SecretsManager
-
-    mgr = SecretsManager.__new__(SecretsManager)
-    mgr.secrets_file = str(tmp_path / "secrets.json")
-    mgr.key_file = str(tmp_path / "secrets.key")
-    mgr._initialize_encryption()
-    mgr._secrets_cache = None
-    mgr._cache_lock = threading.RLock()
-    mgr._cache_mtime = None
-    return mgr
+def _encrypt(value: str) -> str:
+    """Mirror ``SecretsManager._encrypt_value``: base64(fernet.encrypt(value))."""
+    return base64.b64encode(_FERNET.encrypt(value.encode("utf-8"))).decode("utf-8")
 
 
-def _create(mgr, name: str, value: str, **kwargs):
-    from api.schemas_system import ChatSecretScope, SecretCreateRequest, SecretType
+def _row(secret_id: str, name: str, value: str | None, **kwargs) -> dict:
+    """One legacy ``secrets.json`` row, matching ``SecretModel`` + ``encrypted_value``."""
+    now = datetime.now(tz=timezone.utc).isoformat()
+    return {
+        "id": secret_id,
+        "name": name,
+        "type": kwargs.get("type", "api_key"),
+        "scope": kwargs.get("scope", "general"),
+        "chat_id": kwargs.get("chat_id"),
+        "description": kwargs.get("description"),
+        "tags": kwargs.get("tags", []),
+        "created_at": now,
+        "updated_at": now,
+        "expires_at": kwargs.get("expires_at"),
+        "metadata": kwargs.get("metadata", {}),
+        "encrypted_value": _encrypt(value) if value is not None else kwargs.get("raw_encrypted_value"),
+    }
 
-    req = SecretCreateRequest(
-        name=name,
-        type=kwargs.pop("type", SecretType.API_KEY),
-        scope=kwargs.pop("scope", ChatSecretScope.GENERAL),
-        value=value,
-        **kwargs,
-    )
-    return mgr.create_secret(req)
+
+def _write_store(tmp_path, rows: dict) -> str:
+    path = tmp_path / "secrets.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(rows, f)
+    return str(path)
 
 
 @pytest.fixture()
@@ -66,47 +77,44 @@ async def session(fresh_db_url):
     await engine.dispose()
 
 
-async def test_imports_and_envelope_readable(session, tmp_path, monkeypatch):
-    mgr = _make_store(tmp_path)
-    secret = _create(mgr, "openai-key", "sk-abc123")
-    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+async def test_imports_and_envelope_readable(session, tmp_path):
+    sid = str(uuid.uuid4())
+    path = _write_store(tmp_path, {sid: _row(sid, "openai-key", "sk-abc123")})
 
-    report = await import_json_secrets(session, root_key=_ROOT)
+    report = await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
     await session.commit()
     assert report.total == 1 and report.imported == 1 and report.failed == []
 
     svc = EnvelopeSecretsService(root_key=_ROOT)
     system_secrets = await svc.list_for_vaults(session, accessible_vaults={VaultRef(VaultKind.SYSTEM)})
     assert len(system_secrets) == 1
-    assert system_secrets[0].extra_data["imported_from_json"] == secret.id
+    assert system_secrets[0].extra_data["imported_from_json"] == sid
     assert system_secrets[0].extra_data["legacy_scope"] == "general"
     value = await svc.read(session, secret_id=system_secrets[0].id, accessible_vaults={VaultRef(VaultKind.SYSTEM)})
     assert value == b"sk-abc123"
 
 
-async def test_idempotent_skips_already_imported(session, tmp_path, monkeypatch):
-    mgr = _make_store(tmp_path)
-    _create(mgr, "k", "v")
-    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+async def test_idempotent_skips_already_imported(session, tmp_path):
+    sid = str(uuid.uuid4())
+    path = _write_store(tmp_path, {sid: _row(sid, "k", "v")})
 
-    first = await import_json_secrets(session, root_key=_ROOT)
+    first = await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
     await session.commit()
-    second = await import_json_secrets(session, root_key=_ROOT)
+    second = await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
     await session.commit()
     assert first.imported == 1
     assert second.total == 1 and second.imported == 0 and second.skipped_existing == 1
 
 
-async def test_dual_read_reconstructs_legacy_shape(session, tmp_path, monkeypatch):
-    mgr = _make_store(tmp_path)
-    secret = _create(mgr, "hf-token", "hf-secret-value", description="HF token", tags=["ml"])
-    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+async def test_dual_read_reconstructs_legacy_shape(session, tmp_path):
+    sid = str(uuid.uuid4())
+    path = _write_store(tmp_path, {sid: _row(sid, "hf-token", "hf-secret-value", description="HF token", tags=["ml"])})
 
-    report = await import_json_secrets(session, root_key=_ROOT)
+    report = await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
     await session.commit()
     assert report.imported == 1
 
-    result = await read_imported_json_secret_in_session(session, secret.id, _ROOT)
+    result = await read_imported_json_secret_in_session(session, sid, _ROOT)
     assert result is not None
     assert result["value"] == "hf-secret-value"
     assert result["name"] == "hf-token"
@@ -121,45 +129,38 @@ async def test_unimported_secret_returns_none(session):
     assert result is None
 
 
-async def test_missing_encrypted_value_reported(session, tmp_path, monkeypatch):
-    mgr = _make_store(tmp_path)
-    secret = _create(mgr, "k", "v")
-    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+async def test_missing_encrypted_value_reported(session, tmp_path):
+    sid = str(uuid.uuid4())
+    path = _write_store(tmp_path, {sid: _row(sid, "k", None, raw_encrypted_value="")})
 
-    # Corrupt the on-disk row to simulate dirty legacy data.
-    secrets = mgr._load_secrets()
-    secrets[secret.id]["encrypted_value"] = ""
-    mgr._save_secrets(secrets)
-
-    report = await import_json_secrets(session, root_key=_ROOT)
+    report = await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
     assert report.total == 1 and report.imported == 0 and len(report.failed) == 1
 
 
-async def test_bad_ciphertext_reported_not_batch_abort(session, tmp_path, monkeypatch):
-    mgr = _make_store(tmp_path)
-    ok = _create(mgr, "ok", "v")
-    bad = _create(mgr, "bad", "v2")
-    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+async def test_bad_ciphertext_reported_not_batch_abort(session, tmp_path):
+    ok_id, bad_id = str(uuid.uuid4()), str(uuid.uuid4())
+    path = _write_store(
+        tmp_path,
+        {
+            ok_id: _row(ok_id, "ok", "v"),
+            bad_id: _row(bad_id, "bad", None, raw_encrypted_value="not-a-fernet-token"),
+        },
+    )
 
-    secrets = mgr._load_secrets()
-    secrets[bad.id]["encrypted_value"] = "not-a-fernet-token"
-    mgr._save_secrets(secrets)
-
-    report = await import_json_secrets(session, root_key=_ROOT)
+    report = await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
     await session.commit()
     assert report.total == 2 and report.imported == 1 and len(report.failed) == 1
-    assert ok.id not in "".join(report.failed)
+    assert ok_id not in "".join(report.failed)
 
 
-async def test_import_never_logs_secret_value(session, tmp_path, monkeypatch, caplog):
+async def test_import_never_logs_secret_value(session, tmp_path, caplog):
     """No plaintext secret value appears in logs or the failure report during import."""
-    mgr = _make_store(tmp_path)
+    sid = str(uuid.uuid4())
     plaintext = "super-secret-plaintext-xyz"
-    _create(mgr, "k", plaintext)
-    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+    path = _write_store(tmp_path, {sid: _row(sid, "k", plaintext)})
 
     with caplog.at_level("DEBUG"):
-        report = await import_json_secrets(session, root_key=_ROOT)
+        report = await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
         await session.commit()
 
     assert report.imported == 1
@@ -167,17 +168,16 @@ async def test_import_never_logs_secret_value(session, tmp_path, monkeypatch, ca
     assert all(plaintext not in failure for failure in report.failed)
 
 
-async def test_dual_read_never_logs_secret_value(session, tmp_path, monkeypatch, caplog):
+async def test_dual_read_never_logs_secret_value(session, tmp_path, caplog):
     """No plaintext secret value appears in logs when the dual-read path decrypts it."""
-    mgr = _make_store(tmp_path)
+    sid = str(uuid.uuid4())
     plaintext = "super-secret-plaintext-xyz"
-    secret = _create(mgr, "k", plaintext)
-    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
-    await import_json_secrets(session, root_key=_ROOT)
+    path = _write_store(tmp_path, {sid: _row(sid, "k", plaintext)})
+    await import_json_secrets(session, secrets_path=path, fernet=_FERNET, root_key=_ROOT)
     await session.commit()
 
     with caplog.at_level("DEBUG"):
-        result = await read_imported_json_secret_in_session(session, secret.id, _ROOT)
+        result = await read_imported_json_secret_in_session(session, sid, _ROOT)
 
     assert result["value"] == plaintext
     assert plaintext not in caplog.text

--- a/autobot-backend/tests/migrations/test_json_secrets_importer.py
+++ b/autobot-backend/tests/migrations/test_json_secrets_importer.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the legacy JSON file → unified envelope importer (#10088 / Task 3).
+
+Builds a legacy ``secrets.json`` + ``secrets.key`` file store in a temp dir (bypassing
+``SecretsManager.__init__`` so no real data directory is touched), imports it into a
+Postgres unified store (migration-gate), and verifies each row is envelope-readable via
+``EnvelopeSecretsService`` owned by the System vault. Also verifies the ``json_secrets_read``
+dual-read path and that no secret value is ever logged.
+"""
+
+import base64
+import threading
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from services.envelope_secrets_service import EnvelopeSecretsService
+from services.json_secrets_importer import import_json_secrets
+from services.json_secrets_read import read_imported_json_secret_in_session
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+
+
+def _make_store(tmp_path):
+    """A ``SecretsManager`` rooted at *tmp_path*, bypassing ``__init__``'s real data dir."""
+    from api.secrets import SecretsManager
+
+    mgr = SecretsManager.__new__(SecretsManager)
+    mgr.secrets_file = str(tmp_path / "secrets.json")
+    mgr.key_file = str(tmp_path / "secrets.key")
+    mgr._initialize_encryption()
+    mgr._secrets_cache = None
+    mgr._cache_lock = threading.RLock()
+    mgr._cache_mtime = None
+    return mgr
+
+
+def _create(mgr, name: str, value: str, **kwargs):
+    from api.schemas_system import ChatSecretScope, SecretCreateRequest, SecretType
+
+    req = SecretCreateRequest(
+        name=name,
+        type=kwargs.pop("type", SecretType.API_KEY),
+        scope=kwargs.pop("scope", ChatSecretScope.GENERAL),
+        value=value,
+        **kwargs,
+    )
+    return mgr.create_secret(req)
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def test_imports_and_envelope_readable(session, tmp_path, monkeypatch):
+    mgr = _make_store(tmp_path)
+    secret = _create(mgr, "openai-key", "sk-abc123")
+    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+
+    report = await import_json_secrets(session, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 1 and report.imported == 1 and report.failed == []
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    system_secrets = await svc.list_for_vaults(session, accessible_vaults={VaultRef(VaultKind.SYSTEM)})
+    assert len(system_secrets) == 1
+    assert system_secrets[0].extra_data["imported_from_json"] == secret.id
+    assert system_secrets[0].extra_data["legacy_scope"] == "general"
+    value = await svc.read(session, secret_id=system_secrets[0].id, accessible_vaults={VaultRef(VaultKind.SYSTEM)})
+    assert value == b"sk-abc123"
+
+
+async def test_idempotent_skips_already_imported(session, tmp_path, monkeypatch):
+    mgr = _make_store(tmp_path)
+    _create(mgr, "k", "v")
+    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+
+    first = await import_json_secrets(session, root_key=_ROOT)
+    await session.commit()
+    second = await import_json_secrets(session, root_key=_ROOT)
+    await session.commit()
+    assert first.imported == 1
+    assert second.total == 1 and second.imported == 0 and second.skipped_existing == 1
+
+
+async def test_dual_read_reconstructs_legacy_shape(session, tmp_path, monkeypatch):
+    mgr = _make_store(tmp_path)
+    secret = _create(mgr, "hf-token", "hf-secret-value", description="HF token", tags=["ml"])
+    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+
+    report = await import_json_secrets(session, root_key=_ROOT)
+    await session.commit()
+    assert report.imported == 1
+
+    result = await read_imported_json_secret_in_session(session, secret.id, _ROOT)
+    assert result is not None
+    assert result["value"] == "hf-secret-value"
+    assert result["name"] == "hf-token"
+    assert result["description"] == "HF token"
+    assert result["tags"] == ["ml"]
+    assert result["scope"] == "general"
+
+
+async def test_unimported_secret_returns_none(session):
+    """A secret_id never imported falls back (dual-read returns None -> legacy file read)."""
+    result = await read_imported_json_secret_in_session(session, str(uuid.uuid4()), _ROOT)
+    assert result is None
+
+
+async def test_missing_encrypted_value_reported(session, tmp_path, monkeypatch):
+    mgr = _make_store(tmp_path)
+    secret = _create(mgr, "k", "v")
+    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+
+    # Corrupt the on-disk row to simulate dirty legacy data.
+    secrets = mgr._load_secrets()
+    secrets[secret.id]["encrypted_value"] = ""
+    mgr._save_secrets(secrets)
+
+    report = await import_json_secrets(session, root_key=_ROOT)
+    assert report.total == 1 and report.imported == 0 and len(report.failed) == 1
+
+
+async def test_bad_ciphertext_reported_not_batch_abort(session, tmp_path, monkeypatch):
+    mgr = _make_store(tmp_path)
+    ok = _create(mgr, "ok", "v")
+    bad = _create(mgr, "bad", "v2")
+    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+
+    secrets = mgr._load_secrets()
+    secrets[bad.id]["encrypted_value"] = "not-a-fernet-token"
+    mgr._save_secrets(secrets)
+
+    report = await import_json_secrets(session, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 2 and report.imported == 1 and len(report.failed) == 1
+    assert ok.id not in "".join(report.failed)
+
+
+async def test_import_never_logs_secret_value(session, tmp_path, monkeypatch, caplog):
+    """No plaintext secret value appears in logs or the failure report during import."""
+    mgr = _make_store(tmp_path)
+    plaintext = "super-secret-plaintext-xyz"
+    _create(mgr, "k", plaintext)
+    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+
+    with caplog.at_level("DEBUG"):
+        report = await import_json_secrets(session, root_key=_ROOT)
+        await session.commit()
+
+    assert report.imported == 1
+    assert plaintext not in caplog.text
+    assert all(plaintext not in failure for failure in report.failed)
+
+
+async def test_dual_read_never_logs_secret_value(session, tmp_path, monkeypatch, caplog):
+    """No plaintext secret value appears in logs when the dual-read path decrypts it."""
+    mgr = _make_store(tmp_path)
+    plaintext = "super-secret-plaintext-xyz"
+    secret = _create(mgr, "k", plaintext)
+    monkeypatch.setattr("api.secrets.secrets_manager", mgr)
+    await import_json_secrets(session, root_key=_ROOT)
+    await session.commit()
+
+    with caplog.at_level("DEBUG"):
+        result = await read_imported_json_secret_in_session(session, secret.id, _ROOT)
+
+    assert result["value"] == plaintext
+    assert plaintext not in caplog.text


### PR DESCRIPTION
## Thinking Path

Umbrella #10088 names three legacy user-backend stores: `api/secrets.py`'s `secrets.json`
file store, the SQLite store (`services/secrets_service.py`), and the "designed-but-bypassed"
PG `secrets` table. Auditing before writing anything (Task 3's Phase 1) turned up that two of
the three are **already fully migrated** by prior, merged sub-slices of this same task:

- Task 3a (#10286, PR #10295, merged): PG legacy Fernet rows → envelope, in-place.
- Task 3c (#10312, PR #10313, merged): SQLite store → envelope, additive import
  (`services/sqlite_secrets_importer.py`).
- A follow-on slice (#10326/#10327, #10333/#10334, merged) already added feature-flagged
  dual-read + dual-write for the one SQLite consumer that needed it
  (`knowledge/connectors/credential_store.py`).

The **only** piece of "Migrate user-backend stores… repoint api/secrets.py +
SecretsManager.vue; dual-read during cutover" left undone is the `secrets.json` file store —
confirmed by `SecretsManager.vue` → `SecretsApiClient.js`, which only ever calls
`/secrets/*` (never `/v2/secrets` nor anything SQLite-backed), and by grepping for any
existing JSON-store importer (none existed).

Key finding that changes the vault-assignment plan from the PRD's assumed `user:<id>`:
`SecretCreateRequest.owner_id`/`org_id`/`team_ids`/`shared_with` are accepted by the request
schema but **silently dropped** by `to_secret_model()` (`api/schemas_system.py:3369-3381`) —
`SecretModel` has no field to receive them. Every row in `secrets.json` is therefore
genuinely ownerless, and every endpoint in `api/secrets.py` requires
`check_admin_permission` (admin-only) regardless of scope. Given that, mapping migrated
rows to a personal `user:<id>` vault would be a fabrication; mapping them to the **System
vault** (admin-only) exactly preserves today's real-world access control. Filed as a
separate bug (#13051) rather than fixed here — it's a product-scope question (should this
store support personal ownership at all?), not a wiring bug.

Also filed #13052: the two already-merged importers (`legacy_secrets_migrator.py`,
`sqlite_secrets_importer.py`) — and now this PR's `json_secrets_importer.py` — are tested,
reviewed, ready functions with **zero callers outside their own tests**. No admin
endpoint/CLI/task runs any of them in a real deployment yet. Out of scope for this PR
(a safe, admin-gated runner for three migrators is its own PR-sized deliverable); flagged for
fast-follow.

## What Changed

- `autobot-backend/services/json_secrets_importer.py` — additive, one-shot importer:
  reads + decrypts every `secrets.json` row (via the existing `api.secrets.secrets_manager`
  singleton — no second Fernet key path), seals it under a fresh DEK, wraps the DEK for the
  **System vault**, and persists an envelope-backed `Secret` + `SecretGrant` row. Idempotent
  via `extra_data['imported_from_json']`; legacy `scope`/`chat_id`/`metadata` preserved in
  `extra_data` for exact reconstruction on read. Per-row SAVEPOINT so one bad/dirty row is
  reported, not a batch-aborting exception. The JSON file is left **fully intact** — nothing
  is deleted or modified there.
- `autobot-backend/services/json_secrets_read.py` — dual-read helper: given a `secret_id`,
  resolves it via the `imported_from_json` marker, decrypts through the System vault, and
  reshapes the result to the **exact dict contract** `SecretsManager.get_secret()` already
  returns, so the frontend sees zero response-shape drift. Feature-flagged via
  `AUTOBOT_SECRETS_JSON_UNIFIED_READ` (default off — matches the existing
  `AUTOBOT_SECRETS_UNIFIED_READ` expand/contract pattern used for the connector-credential
  cutover), so behaviour is byte-identical until explicitly enabled.
- `autobot-backend/api/secrets.py` — `GET /secrets/{id}` now calls a new
  `_get_secret_dual_read()` helper: try the unified store first, fall back to the legacy
  file when the secret hasn't been imported (or the flag is off). Chat-scope access control
  (`scope == "chat"` requires a matching `chat_id`) is enforced **identically** on both
  paths, so an imported secret is never *less* protected than it was in the legacy file.
  `list_secrets`/`create`/`update`/`delete`/`transfer` are **intentionally untouched** —
  see "What was deliberately NOT done" below.
- `autobot-backend/api/secrets_test.py` — 3 new unit tests for `_get_secret_dual_read`
  (unified hit skips the legacy file; legacy fallback when not yet imported; chat-scope
  denial enforced through the unified path). No Postgres needed — mocks
  `load_imported_json_secret` directly.
- `autobot-backend/tests/migrations/test_json_secrets_importer.py` — 8 Postgres-gated
  (`migration_gate` marker, mirrors `test_sqlite_secrets_importer.py`) tests: happy-path
  import + envelope-readable via `EnvelopeSecretsService`; idempotent re-run; dual-read
  reconstructs the exact legacy shape; unimported secret returns `None` (fallback trigger);
  missing/bad ciphertext reported without aborting the batch; **and two explicit tests that
  a known plaintext value never appears in captured logs** during import or dual-read.

### What was deliberately NOT done (scope narrowing, per instructions)

- **No retirement.** `secrets.json`, the SQLite store, and the PG legacy rows are all still
  fully readable/writable exactly as before. Nothing is deleted.
- **No dual-write.** Only reads fall back; `create`/`update`/`delete` continue to operate on
  `secrets.json` only, matching the literal ask ("dual-read during cutover"). A secret
  updated after import would leave its envelope copy stale until re-imported (import is
  idempotent-*skip*, not idempotent-*resync* — identical to `sqlite_secrets_importer.py`'s
  own behavior; the connector-credential slice's `credential_reconcile.py` is the only place
  with a drift-reconciliation sweep, and it's scoped to that one consumer). Filed as a
  natural follow-up, not required by this task's literal text.
- **No `list_secrets` dual-read.** Merging unified + legacy listings without double-counting
  needs a de-duplication policy that's a product decision, not purely mechanical; `GET
  /secrets/{id}` (the one place "unreachable mid-cutover" actually bites) is covered.
- **No fix for the dropped `owner_id`** (#13051) or **migration-runner wiring** (#13052) —
  both filed separately as discovered, out-of-scope gaps.

## Verification

```
python3 -m py_compile <all 5 touched/new files>              # OK
python3 -m flake8 --max-line-length=120 <same 5 files>        # 0 findings
python3 -m black --check --line-length=120 <same 5 files>     # unchanged
python3 -m isort --check-only <same 5 files>                  # unchanged
python3 -m pytest api/secrets_test.py -q                       # 9 passed (incl. 3 new dual-read tests)
python3 -m pytest tests/test_startup_imports.py -q             # 350 passed — cp-swapped baseline
                                                                #   (git show HEAD:... over the 2
                                                                #   modified files, new files moved
                                                                #   out) also gives 350 passed — ratio
                                                                #   unchanged before/after.
```

Import-cycle check: `import api.secrets; import services.json_secrets_importer;
import services.json_secrets_read` — clean, no cycle.

**Data-safety proof (idempotence + dual-read), from `test_json_secrets_importer.py`:**
- `test_imports_and_envelope_readable` — a legacy `secrets.json` secret is fully readable
  through the new envelope path after migration (`EnvelopeSecretsService.read`).
- `test_idempotent_skips_already_imported` — running the import twice imports once,
  skips once (no duplicate rows).
- `test_dual_read_reconstructs_legacy_shape` / `test_unimported_secret_returns_none` — the
  dual-read helper returns the migrated value when imported, and `None` (triggering the
  legacy-file fallback) when not.
- `test_import_never_logs_secret_value` / `test_dual_read_never_logs_secret_value` — a known
  plaintext value is asserted absent from `caplog.text` across both the import and read paths.

**Postgres-gated tests could not be executed locally in this sandbox**: provisioning a
throwaway Postgres role for `AUTOBOT_MIGRATION_TEST_ADMIN_URL` requires either (a) editing
the shared host's `pg_hba.conf` + reloading the service that also backs this machine's real
local test deployment (blocked by the sandbox's own safety classifier — reasonably, since
that's a system-wide change outside this task), or (b) reading `autobot_app`'s credentials
from `/etc/autobot/db-credentials.env`, explicitly out of scope by the PRD's own
bootstrap-constraint section. Docker (the documented local workaround) isn't available in
this WSL distro either. This is not new: the sibling `test_sqlite_secrets_importer.py` and
`test_legacy_secrets_migrator.py` (already merged, both reviewed and green) have the
identical local limitation — they run for real only in the `migration-gate` CI workflow's
`postgres:16` service container (confirmed: PR #10313's `migration-matrix` check is
`SUCCESS`). My new tests use the exact same `migration_gate` + `requires_postgres` markers
and will execute there.

## Model Used

Claude Opus 5 (claude-opus-5)
