### PR TITLE
docs(research): stop a wrapped line beginning with an issue number (#13030)

### DIFF
--- a/docs/research/lean-hardware-model-loading.md
+++ b/docs/research/lean-hardware-model-loading.md
@@ -77,9 +77,9 @@ three and still lost end to end.
 
 ## 2. What AutoBot has today
 
-`autobot-backend/llm_shared/optimization/` (~12k LOC, 14 modules; issues #1946, #1952,
-#1964, #3104, #3140) is a layer-streaming inference stack whose stated purpose matches the target architecture
-above:
+`autobot-backend/llm_shared/optimization/` (~12k LOC, 14 modules) is a layer-streaming
+inference stack whose stated purpose matches the target architecture above. It originates
+from issues #1946, #1952, #1964, #3104 and #3140.
 
 > *"During batch/offline inference the entire model need not reside in VRAM simultaneously… Memory
 > requirements are therefore bounded by the largest single layer rather than the full model."*


### PR DESCRIPTION
Follow-up to #13040. Refs #13030.

## Thinking Path

#13040 claimed to fix a markdownlint MD018 warning in the audit doc. It did not — it only changed
*which* issue number led the wrapped line. The paragraph names five originating issues in sequence, so
any wrap point put one of them at the start of a line, where `#1946` reads as a malformed ATX heading.

Caught during the end-of-session verification sweep by re-grepping the merged file on the base branch
rather than trusting the earlier claim.

GitHub renders the line as plain text either way (CommonMark requires a space after `#` for a
heading), so nothing was visually wrong — but the warning is real and the previous commit message
asserted a fix that had not happened.

## What Changed

`docs/research/lean-hardware-model-loading.md` — restructured the §2 opening sentence so the
continuation line begins with a word rather than an issue number. Moved the issue list to the end of
the sentence and reflowed. No content change.

## Verification

```
$ grep -c '^#[0-9]' docs/research/lean-hardware-model-loading.md
0                      # was 1

$ grep -c '^## ' docs/research/lean-hardware-model-loading.md
5                      # headings intact
$ grep -c '^# '  docs/research/lean-hardware-model-loading.md
1

$ git diff --stat
 docs/research/lean-hardware-model-loading.md | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

Docs only. No code, config, or dependency changes.

## Model Used

Claude Opus 5 (1M context)
