### PR TITLE
docs(research): stop a wrapped line beginning with an issue number (#13055)

### DIFF
--- a/docs/research/lean-hardware-model-loading.md
+++ b/docs/research/lean-hardware-model-loading.md
@@ -77,9 +77,9 @@ three and still lost end to end.
 
 ## 2. What AutoBot has today
 
-`autobot-backend/llm_shared/optimization/` (~12k LOC, 14 modules; issues #1946, #1952,
-#1964, #3104, #3140) is a layer-streaming inference stack whose stated purpose matches the target architecture
-above:
+`autobot-backend/llm_shared/optimization/` (~12k LOC, 14 modules) is a layer-streaming
+inference stack whose stated purpose matches the target architecture above. It originates
+from issues #1946, #1952, #1964, #3104 and #3140.
 
 > *"During batch/offline inference the entire model need not reside in VRAM simultaneously… Memory
 > requirements are therefore bounded by the largest single layer rather than the full model."*


### PR DESCRIPTION
Closes #13055. Follow-up to #13040; refs #13030.

## Thinking Path

#13040 carried a commit claiming to fix a markdownlint MD018 warning. It did not — it changed *which*
issue number led the wrapped line. The paragraph names five issues in sequence, so any wrap point put
one of them at a line start, where `#1946` reads as a malformed ATX heading.

Caught in the end-of-session sweep by re-grepping the merged file on the base branch rather than
trusting the earlier claim.

A first attempt at this fix went out on a branch named `issue-13030-lint`. The PR-issue gate derives
the issue from the branch name and demanded `closes #13030` — but #13030 is an umbrella with six open
children, and `Closes` on it would auto-close the umbrella when `Dev_new_gui` promotes to `main`.
Rather than satisfy the gate with a false closure keyword, the defect was filed discretely as #13055
and rebranched. That PR (#13054) is closed unmerged; its branch is deleted.

## What Changed

`docs/research/lean-hardware-model-loading.md` — restructured the §2 opening sentence so the
continuation line begins with a word. The issue list moved to the end of the sentence. No content
change.

## Verification

```
$ grep -c '^#[0-9]' docs/research/lean-hardware-model-loading.md
0                      # was 1

$ grep -c '^## ' docs/research/lean-hardware-model-loading.md
5                      # headings intact

$ git diff --stat
 docs/research/lean-hardware-model-loading.md | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

Docs only. No code, config, or dependency changes.

## Model Used

Claude Opus 5 (1M context)
