### PR TITLE
feat(secrets): migrate LLC company secrets — importer + dual-read (#10088)

### DIFF
--- a/autobot-backend/llc/services/secret.py
+++ b/autobot-backend/llc/services/secret.py
@@ -17,26 +17,32 @@ argument. API routes must verify that the calling agent's company_id matches
 the requested company_id before invoking service methods.
 """
 
-import base64
 import logging
 import os
 import uuid
-from typing import List
+from typing import List, Optional
 
 from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.legacy_secret_keys import derive_llc_company_fernet
 from autobot_shared.time_utils import now_utc
 from llc.models.secret import LLCSecret
+from services.llc_secrets_read import llc_unified_read_enabled, read_imported_llc_secret_in_session
 
 from .base import LLCServiceBase
 
 logger = logging.getLogger(__name__)
 
 _ENV_MASTER_KEY = "LLC_SECRET_MASTER_KEY"
+
+# Backward-compatible alias: the per-company HKDF+Fernet derivation now lives in
+# autobot_shared.legacy_secret_keys (#10088 / Task 1.3 + Task 4) so migration
+# importers can reuse it without pulling in llc/services/__init__.py's eager
+# import of every concrete LLC service. Existing tests import this name
+# directly from this module, so it stays a re-export rather than moving away.
+_derive_fernet_key = derive_llc_company_fernet
 
 
 class SecretNotFound(Exception):
@@ -53,25 +59,6 @@ class SecretAccessDenied(Exception):
 
     def __init__(self, agent_company_id: str, secret_company_id: str) -> None:
         super().__init__(f"Agent company {agent_company_id} cannot access secrets of {secret_company_id}")
-
-
-def _derive_fernet_key(master_key_bytes: bytes, company_id: str) -> Fernet:
-    """Derive a Fernet instance whose key is company-specific.
-
-    Uses HKDF-SHA256 to stretch master_key_bytes into 32 bytes, keyed to
-    company_id so that each company has a distinct encryption key.
-    The 32 output bytes are URL-safe-base64-encoded to satisfy Fernet's
-    requirement of a 44-character key string.
-    """
-    hkdf = HKDF(
-        algorithm=hashes.SHA256(),
-        length=32,
-        salt=None,
-        info=company_id.encode("utf-8"),
-    )
-    derived = hkdf.derive(master_key_bytes)
-    fernet_key = base64.urlsafe_b64encode(derived)
-    return Fernet(fernet_key)
 
 
 class SecretService(LLCServiceBase):
@@ -169,9 +156,32 @@ class SecretService(LLCServiceBase):
         """Return the decrypted plaintext for the named secret.
 
         Raises SecretNotFound if the secret does not exist or is revoked.
+
+        Dual-read (#10088 / Task 4): when ``AUTOBOT_SECRETS_LLC_UNIFIED_READ`` is
+        enabled, tries the unified envelope store first (see
+        ``services.llc_secrets_read``) — only for the row ``_fetch_active`` just
+        proved exists and is not revoked, so a revoked/absent secret can never
+        stale-resurrect through the unified copy. Falls back to the legacy
+        per-company Fernet decrypt on any miss, disabled flag, or unusable root key.
         """
         secret = await self._fetch_active(session, company_id, name)
+        if llc_unified_read_enabled():
+            unified = await self._unified_get(session, secret, company_id)
+            if unified is not None:
+                return unified
         return self._fernet(company_id).decrypt(secret.value).decode("utf-8")
+
+    async def _unified_get(self, session: AsyncSession, secret: LLCSecret, company_id: str) -> Optional[str]:
+        """Best-effort unified-store read for an already-resolved active secret row."""
+        from autobot_shared.secrets_envelope import load_root_key
+
+        try:
+            root_key = load_root_key()
+        except RuntimeError:
+            return None
+        return await read_imported_llc_secret_in_session(
+            session, source_id=str(secret.id), company_id=company_id, root_key=root_key
+        )
 
     async def revoke(
         self,

--- a/autobot-backend/llc/tests/test_secrets.py
+++ b/autobot-backend/llc/tests/test_secrets.py
@@ -265,6 +265,94 @@ async def test_set_raises_on_missing_master_key() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Dual-read wiring (#10088 / Task 4): get() consults the unified envelope
+# store only when the flag is on, and only for a row _fetch_active already
+# proved active — so a revoked/absent secret can never stale-resurrect
+# through it. These are mock-based (no Postgres) because they exercise
+# llc.services.secret directly; the standalone dual-read helper itself is
+# proven against real Postgres in tests/migrations/test_llc_secrets_read.py.
+# ---------------------------------------------------------------------------
+
+_ENV_UNIFIED_READ = "AUTOBOT_SECRETS_LLC_UNIFIED_READ"
+
+
+@pytest.mark.asyncio
+async def test_get_returns_unified_value_when_dual_read_enabled() -> None:
+    row = _make_secret_row(plaintext="legacy-plaintext")
+    session = _make_session(row=row)
+
+    with (
+        patch.dict(os.environ, {_ENV_KEY: _MASTER_KEY, _ENV_UNIFIED_READ: "true"}),
+        patch("autobot_shared.secrets_envelope.load_root_key", return_value=b"0" * 32),
+        patch(
+            "llc.services.secret.read_imported_llc_secret_in_session",
+            new=AsyncMock(return_value="unified-plaintext"),
+        ) as unified,
+    ):
+        svc = SecretService()
+        result = await svc.get(session, _COMPANY_A, "db_password")
+
+    assert result == "unified-plaintext"
+    unified.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_falls_back_to_legacy_when_unified_read_misses() -> None:
+    plaintext = "legacy-only-value"
+    row = _make_secret_row(plaintext=plaintext)
+    session = _make_session(row=row)
+
+    with (
+        patch.dict(os.environ, {_ENV_KEY: _MASTER_KEY, _ENV_UNIFIED_READ: "true"}),
+        patch("autobot_shared.secrets_envelope.load_root_key", return_value=b"0" * 32),
+        patch(
+            "llc.services.secret.read_imported_llc_secret_in_session",
+            new=AsyncMock(return_value=None),  # not yet imported
+        ),
+    ):
+        svc = SecretService()
+        result = await svc.get(session, _COMPANY_A, "db_password")
+
+    assert result == plaintext
+
+
+@pytest.mark.asyncio
+async def test_get_never_consults_unified_store_when_flag_disabled() -> None:
+    plaintext = "legacy-only-value"
+    row = _make_secret_row(plaintext=plaintext)
+    session = _make_session(row=row)
+
+    env = {k: v for k, v in os.environ.items() if k != _ENV_UNIFIED_READ}
+    env[_ENV_KEY] = _MASTER_KEY
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("llc.services.secret.read_imported_llc_secret_in_session", new=AsyncMock()) as unified,
+    ):
+        svc = SecretService()
+        result = await svc.get(session, _COMPANY_A, "db_password")
+
+    assert result == plaintext
+    unified.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_revoked_secret_never_reaches_unified_store() -> None:
+    """The hard data-safety invariant: _fetch_active raises before dual-read is ever attempted,
+    so a revoked/absent legacy secret can never stale-resurrect through the unified copy."""
+    session = _make_session(row=None)  # simulates the SQL filter excluding the revoked row
+
+    with (
+        patch.dict(os.environ, {_ENV_KEY: _MASTER_KEY, _ENV_UNIFIED_READ: "true"}),
+        patch("llc.services.secret.read_imported_llc_secret_in_session", new=AsyncMock()) as unified,
+    ):
+        svc = SecretService()
+        with pytest.raises(SecretNotFound):
+            await svc.get(session, _COMPANY_A, "revoked-key")
+
+    unified.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Module-level constant (keep in sync with services/secret.py)
 # ---------------------------------------------------------------------------
 

--- a/autobot-backend/services/llc_secrets_importer.py
+++ b/autobot-backend/services/llc_secrets_importer.py
@@ -1,0 +1,156 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Import LLC company secrets into the unified envelope store (#10088 / Task 4).
+
+Additive, one-shot migration mirroring ``sqlite_secrets_importer.py`` /
+``json_secrets_importer.py`` (Task 3): reads active rows from the legacy
+``llc_secrets`` table (``llc.models.secret.LLCSecret`` / ``llc.services.secret.
+SecretService``, per-company HKDF+Fernet), decrypts each with its
+company-derived Fernet key, and **creates** a new envelope-backed row owned by
+that LLC company's vault (``company:<company_id>`` — ``VaultKind.COMPANY``).
+
+Unlike the JSON/SQLite stores, ``llc_secrets`` already lives in the same
+PostgreSQL database as the unified ``secrets`` table, so this importer reads
+it through the same ``AsyncSession`` rather than a separate file/connection.
+
+Owner mapping: an LLC secret has no single human owner — ``created_by_
+agent_id`` names an *agent*, not a ``user_management`` user, and the umbrella
+governs company vaults by LLC membership, not by a personal owner. The
+envelope ``Secret.owner_id`` column is NOT NULL with no FK, so imported rows
+use the same sentinel service-owner UUID as other vault-owned (non-personal)
+imports (see ``services/secrets_coordinator.py``'s ``_SERVICE_OWNER_ID`` and
+``json_secrets_importer.py``'s ``_SYSTEM_OWNER_ID``).
+
+Only **active** (``revoked_at IS NULL``) rows are imported — a revoked legacy
+secret has no live reader and importing it would let a stale copy resurrect
+through the unified store. ``(company_id, name)`` is unique in ``llc_secrets``
+and reactivation reuses the same row id, so the marker keyed on the legacy
+row's id is stable across revoke/re-set cycles.
+
+Idempotent via ``extra_data['imported_from_llc_secrets']`` (the legacy row's
+UUID). Run inside one transaction and ``commit()`` the session once
+afterwards, exactly like the other two importers. ``llc_secrets`` and
+``llc/services/secret.py`` are left fully intact — this populates the unified
+store so the dual-read path (``services/llc_secrets_read.py``) can serve reads
+from it while ``llc_secrets`` stays authoritative for writes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.legacy_secret_keys import derive_llc_company_fernet
+from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from llc.models.secret import LLCSecret
+from models.secret import Secret, SecretType
+from models.secret_grant import SecretGrant
+
+_MARKER = "imported_from_llc_secrets"
+
+#: Sentinel owner for vault-owned (no human owner) secrets — matches the
+#: convention in ``services/secrets_coordinator.py`` (``_SERVICE_OWNER_ID``) and
+#: ``json_secrets_importer.py`` (``_SYSTEM_OWNER_ID``); ``Secret.owner_id`` is
+#: NOT NULL and an LLC company secret has no single per-user owner.
+_COMPANY_OWNER_ID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+@dataclass
+class LlcImportReport:
+    """Reconciliation counts for one import run."""
+
+    total: int = 0
+    imported: int = 0
+    skipped_existing: int = 0
+    failed: list[str] = field(default_factory=list)
+
+
+async def _read_active_rows(session: AsyncSession) -> list[LLCSecret]:
+    """Return active (non-revoked) llc_secrets rows, ordered for deterministic runs."""
+    result = await session.execute(
+        select(LLCSecret).where(LLCSecret.revoked_at.is_(None)).order_by(LLCSecret.company_id, LLCSecret.name)
+    )
+    return list(result.scalars().all())
+
+
+async def _existing_markers(session: AsyncSession) -> set[str]:
+    """Source (legacy) row ids already imported (so a re-run is idempotent)."""
+    marker = Secret.extra_data[_MARKER].astext
+    rows = (await session.execute(select(marker).where(marker.isnot(None)))).scalars().all()
+    return {r for r in rows if r}
+
+
+def _build_secret_grant(row: LLCSecret, plaintext: bytes, root_key: bytes) -> tuple[Secret, SecretGrant]:
+    """Seal *plaintext* and build the Company-vault ``Secret`` + owner grant for a legacy row."""
+    new_id = uuid.uuid4()
+    sid = str(new_id)
+    vault = VaultRef(VaultKind.COMPANY, row.company_id)
+    sealed, dek = seal(plaintext, secret_id=sid)
+    wrapped = wrap_dek(dek, derive_vault_key(root_key, vault.to_str()), vault.to_str(), secret_id=sid)
+    secret = Secret(
+        id=new_id,
+        owner_id=_COMPANY_OWNER_ID,
+        name=row.name,
+        type=SecretType.OTHER.value,
+        scope=VaultKind.COMPANY.value,
+        owner_vault=vault.to_str(),
+        sealed_value=sealed.to_dict(),
+        version=1,
+        extra_data={
+            _MARKER: str(row.id),
+            "legacy_company_id": row.company_id,
+            "legacy_version": row.version,
+            "legacy_created_by_agent_id": row.created_by_agent_id,
+        },
+    )
+    grant = SecretGrant(secret_id=new_id, grantee=vault.to_str(), wrapped_dek=wrapped.to_dict(), created_by=None)
+    return secret, grant
+
+
+async def import_llc_secrets(session: AsyncSession, *, master_key: bytes, root_key: bytes) -> LlcImportReport:
+    """Import every active ``llc_secrets`` row into the unified store, owned by its Company vault.
+
+    ``master_key`` is the raw ``LLC_SECRET_MASTER_KEY`` bytes (the same input
+    ``llc.services.secret.SecretService._get_master_key()`` reads from env); each
+    row is decrypted with its own company-derived Fernet key, mirroring the live
+    service exactly. ``root_key`` is the envelope root key
+    (``AUTOBOT_SECRETS_ROOT_KEY``). Returns a reconciliation report; caller commits.
+    """
+    from cryptography.fernet import InvalidToken
+
+    report = LlcImportReport()
+    rows = await _read_active_rows(session)
+    report.total = len(rows)
+    already = await _existing_markers(session)
+
+    for row in rows:
+        src = str(row.id)
+        if src in already:
+            report.skipped_existing += 1
+            continue
+        try:
+            plaintext = derive_llc_company_fernet(master_key, row.company_id).decrypt(row.value)
+        except (InvalidToken, ValueError, TypeError) as exc:
+            report.failed.append(f"{src}: decrypt failed ({exc})")
+            continue
+        try:
+            # Per-row SAVEPOINT so one bad row (a UNIQUE grant collision, dirty
+            # data that overflows a PG column, etc.) is reported and skipped
+            # without aborting the whole batch.
+            async with session.begin_nested():
+                secret, grant = _build_secret_grant(row, plaintext, root_key)
+                session.add(secret)
+                session.add(grant)
+                await session.flush()
+            report.imported += 1
+        except SQLAlchemyError as exc:
+            report.failed.append(f"{src}: persist failed ({exc})")
+
+    return report

--- a/autobot-backend/services/llc_secrets_read.py
+++ b/autobot-backend/services/llc_secrets_read.py
@@ -1,0 +1,81 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dual-read path for LLC company secrets imported into the envelope store (#10088 / Task 4).
+
+Resolves a secret imported by ``llc_secrets_importer`` via its
+``imported_from_llc_secrets`` marker and decrypts it through the secret's
+Company vault (``company:<company_id>``), so ``SecretService.get()`` can serve
+either path with no response-shape drift for its callers. Returns ``None``
+(fall back to the legacy ``llc_secrets`` Fernet decrypt) when the secret hasn't
+been imported yet, the envelope read fails, or the feature flag is off — the
+legacy table remains authoritative until this path is enabled and proven.
+
+Correctness note (revoke safety): callers MUST resolve and revocation-check the
+legacy ``llc_secrets`` row first (``SecretService._fetch_active`` already does
+this) and only then call this module with that row's id. A revoked/absent
+legacy row therefore never reaches — and can never stale-resurrect through —
+this dual-read path.
+
+Feature-flagged the same way as the JSON-store cutover
+(``services.json_secrets_read.JSON_UNIFIED_READ_ENV``): default off, so
+behaviour is byte-identical until explicitly enabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+LLC_UNIFIED_READ_ENV = "AUTOBOT_SECRETS_LLC_UNIFIED_READ"
+_MARKER = "imported_from_llc_secrets"
+
+
+def llc_unified_read_enabled() -> bool:
+    """Whether the LLC-secrets dual-read (envelope-first) path is enabled."""
+    return os.environ.get(LLC_UNIFIED_READ_ENV, "false").strip().lower() in ("1", "true", "yes")
+
+
+async def _find_by_marker(session, source_id: str):
+    from sqlalchemy import select
+
+    from models.secret import Secret
+
+    marker = Secret.extra_data[_MARKER].astext
+    result = await session.execute(select(Secret).where(marker == str(source_id), Secret.is_active.is_(True)))
+    return result.scalars().first()
+
+
+async def read_imported_llc_secret_in_session(
+    session, *, source_id: str, company_id: str, root_key: bytes
+) -> str | None:
+    """Resolve + decrypt an imported LLC company secret within *session* (the testable core).
+
+    ``source_id`` is the legacy ``llc_secrets`` row's id, already resolved and
+    revocation-checked by the caller (see the module docstring).
+    """
+    from autobot_shared.secrets_envelope import DecryptionError, UnsupportedFormatError
+    from autobot_shared.secrets_vault import VaultKind, VaultRef
+    from services.envelope_secrets_service import EnvelopeSecretsService, SecretAccessError, SecretNotFoundError
+
+    row = await _find_by_marker(session, source_id)
+    if row is None:
+        return None  # not yet imported -> legacy llc_secrets fallback
+    try:
+        plaintext = await EnvelopeSecretsService(root_key=root_key).read(
+            session, secret_id=row.id, accessible_vaults={VaultRef(VaultKind.COMPANY, company_id)}
+        )
+    except (
+        SecretAccessError,
+        SecretNotFoundError,
+        DecryptionError,
+        UnsupportedFormatError,
+        KeyError,
+        ValueError,
+    ) as exc:
+        logger.warning("Envelope read unusable for imported LLC secret %s: %s — falling back", source_id, exc)
+        return None
+    return plaintext.decode("utf-8")

--- a/autobot-backend/tests/migrations/test_llc_secrets_importer.py
+++ b/autobot-backend/tests/migrations/test_llc_secrets_importer.py
@@ -1,0 +1,192 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the LLC company secrets → unified envelope importer (#10088 / Task 4).
+
+Unlike the JSON/SQLite importers, ``llc_secrets`` already lives in the same
+Postgres database as the unified store, so these tests insert legacy
+``LLCSecret`` rows directly (through the ORM, against the same migration-built
+schema) rather than standing up a separate file/connection, then import them
+and verify each is envelope-readable via ``EnvelopeSecretsService`` owned by
+its Company vault. Also verifies company isolation and that no secret value is
+ever logged.
+
+Deliberately imports ``autobot_shared.legacy_secret_keys`` (not
+``llc.services.secret``) to build the legacy ciphertext: importing
+``llc.services.secret`` transitively executes ``llc/services/__init__.py``,
+which eagerly imports every concrete LLC service (including KB/RAG modules
+that reach ``llm_shared`` and attempt live Redis connections at import time) —
+exactly the heavyweight coupling this migration-gate suite must stay clear of
+(see the umbrella's Task 4 discovery; filed separately).
+"""
+
+import base64
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.legacy_secret_keys import derive_llc_company_fernet
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from llc.models.secret import LLCSecret
+from services.envelope_secrets_service import EnvelopeSecretsService, SecretAccessError
+from services.llc_secrets_importer import import_llc_secrets
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_MASTER_KEY = b"llc-migration-test-master-key-32b"
+_COMPANY_A = "company-aaa"
+_COMPANY_B = "company-bbb"
+
+
+def _make_row(company_id: str, name: str, plaintext: str, agent: str = "agent-001", revoked: bool = False) -> LLCSecret:
+    ciphertext = derive_llc_company_fernet(_MASTER_KEY, company_id).encrypt(plaintext.encode("utf-8"))
+    from autobot_shared.time_utils import now_utc
+
+    return LLCSecret(
+        id=uuid.uuid4(),
+        company_id=company_id,
+        name=name,
+        value=ciphertext,
+        version=1,
+        created_by_agent_id=agent,
+        revoked_at=now_utc() if revoked else None,
+    )
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def test_imports_and_envelope_readable(session):
+    row = _make_row(_COMPANY_A, "db-password", "s3cr3t-value")
+    session.add(row)
+    await session.flush()
+
+    report = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 1 and report.imported == 1 and report.failed == []
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    company_secrets = await svc.list_for_vaults(session, accessible_vaults={VaultRef(VaultKind.COMPANY, _COMPANY_A)})
+    assert len(company_secrets) == 1
+    assert company_secrets[0].extra_data["imported_from_llc_secrets"] == str(row.id)
+    assert company_secrets[0].extra_data["legacy_company_id"] == _COMPANY_A
+    value = await svc.read(
+        session, secret_id=company_secrets[0].id, accessible_vaults={VaultRef(VaultKind.COMPANY, _COMPANY_A)}
+    )
+    assert value == b"s3cr3t-value"
+
+
+async def test_idempotent_skips_already_imported(session):
+    row = _make_row(_COMPANY_A, "k", "v")
+    session.add(row)
+    await session.flush()
+
+    first = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+    second = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+    assert first.imported == 1
+    assert second.total == 1 and second.imported == 0 and second.skipped_existing == 1
+
+
+async def test_revoked_secret_not_imported(session):
+    active = _make_row(_COMPANY_A, "active-key", "v1")
+    revoked = _make_row(_COMPANY_A, "revoked-key", "v2", revoked=True)
+    session.add_all([active, revoked])
+    await session.flush()
+
+    report = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 1 and report.imported == 1
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    company_secrets = await svc.list_for_vaults(session, accessible_vaults={VaultRef(VaultKind.COMPANY, _COMPANY_A)})
+    assert [s.name for s in company_secrets] == ["active-key"]
+
+
+async def test_company_isolation_no_cross_company_read(session):
+    """Company B holds no grant for Company A's imported secret — proves isolation."""
+    row_a = _make_row(_COMPANY_A, "a-secret", "a-value")
+    row_b = _make_row(_COMPANY_B, "b-secret", "b-value")
+    session.add_all([row_a, row_b])
+    await session.flush()
+
+    await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    a_secrets = await svc.list_for_vaults(session, accessible_vaults={VaultRef(VaultKind.COMPANY, _COMPANY_A)})
+    assert len(a_secrets) == 1
+
+    with pytest.raises(SecretAccessError):
+        await svc.read(session, secret_id=a_secrets[0].id, accessible_vaults={VaultRef(VaultKind.COMPANY, _COMPANY_B)})
+
+
+async def test_bad_ciphertext_reported_not_batch_abort(session):
+    ok_row = _make_row(_COMPANY_A, "ok", "v")
+    bad_row = _make_row(_COMPANY_A, "bad", "v")
+    bad_row.value = b"not-a-fernet-token"
+    session.add_all([ok_row, bad_row])
+    await session.flush()
+
+    report = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 2 and report.imported == 1 and len(report.failed) == 1
+    assert str(ok_row.id) not in "".join(report.failed)
+
+
+async def test_wrong_company_key_reported_not_batch_abort(session):
+    """A row decrypted with a *different* company's derived key never wraps as ciphertext-valid
+    for its own company — this exercises the same decrypt-failure path as bit-corrupted data."""
+    good = _make_row(_COMPANY_A, "good", "v1")
+    cross = _make_row(_COMPANY_B, "cross", "v2")
+    # Simulate dirty data: this row's declared company_id doesn't match the key used to encrypt it.
+    cross.value = derive_llc_company_fernet(_MASTER_KEY, _COMPANY_A).encrypt(b"v2")
+    session.add_all([good, cross])
+    await session.flush()
+
+    report = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 2 and report.imported == 1 and len(report.failed) == 1
+
+
+async def test_import_never_logs_secret_value(session, caplog):
+    plaintext = "super-secret-plaintext-xyz"
+    row = _make_row(_COMPANY_A, "k", plaintext)
+    session.add(row)
+    await session.flush()
+
+    with caplog.at_level("DEBUG"):
+        report = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+        await session.commit()
+
+    assert report.imported == 1
+    assert plaintext not in caplog.text
+    assert all(plaintext not in failure for failure in report.failed)
+
+
+async def test_legacy_fernet_still_readable(session):
+    """The legacy row and its Fernet ciphertext are untouched by the import (no retirement)."""
+    row = _make_row(_COMPANY_A, "k", "still-here")
+    session.add(row)
+    await session.flush()
+
+    await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+
+    # The legacy row's own cipher must still decrypt via the exact same derivation the
+    # live SecretService uses -- proves llc_secrets was left fully intact, not migrated
+    # in-place or retired.
+    plaintext = derive_llc_company_fernet(_MASTER_KEY, _COMPANY_A).decrypt(row.value)
+    assert plaintext == b"still-here"

--- a/autobot-backend/tests/migrations/test_llc_secrets_read.py
+++ b/autobot-backend/tests/migrations/test_llc_secrets_read.py
@@ -1,0 +1,119 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the LLC company secrets dual-read module (#10088 / Task 4).
+
+Exercises ``services.llc_secrets_read`` directly against a Postgres-backed
+unified store. Deliberately builds legacy rows via ``autobot_shared.
+legacy_secret_keys`` rather than ``llc.services.secret.SecretService``:
+importing that module transitively executes ``llc/services/__init__.py``,
+which eagerly imports every concrete LLC service (KB/RAG modules that reach
+``llm_shared`` and attempt live Redis connections at import time) — exactly
+the heavyweight coupling this migration-gate suite must stay clear of (see
+the umbrella's Task 4 discovery; filed separately as a pre-existing bug).
+
+The ``SecretService.get()`` wiring itself (which calls this module only after
+its own revoke-check, so a revoked/absent legacy secret never reaches the
+unified store) is proven with mocks in ``llc/tests/test_secrets.py`` — that
+suite already imports ``llc.services.secret`` for its own purposes and is not
+part of the migration-gate path.
+"""
+
+import base64
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.legacy_secret_keys import derive_llc_company_fernet
+from llc.models.secret import LLCSecret
+from services.llc_secrets_importer import import_llc_secrets
+from services.llc_secrets_read import llc_unified_read_enabled, read_imported_llc_secret_in_session
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_MASTER_KEY = b"llc-migration-test-master-key-32b"
+_COMPANY = "company-read-test"
+
+
+def _make_row(company_id: str, name: str, plaintext: str) -> LLCSecret:
+    ciphertext = derive_llc_company_fernet(_MASTER_KEY, company_id).encrypt(plaintext.encode("utf-8"))
+    return LLCSecret(
+        id=uuid.uuid4(), company_id=company_id, name=name, value=ciphertext, version=1, created_by_agent_id="agent-1"
+    )
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def test_dual_read_serves_imported_secret(session):
+    row = _make_row(_COMPANY, "api-key", "legacy-plaintext")
+    session.add(row)
+    await session.flush()
+
+    report = await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+    assert report.imported == 1
+
+    value = await read_imported_llc_secret_in_session(
+        session, source_id=str(row.id), company_id=_COMPANY, root_key=_ROOT
+    )
+    assert value == "legacy-plaintext"
+
+
+async def test_unimported_secret_returns_none(session):
+    """A source id never imported falls back (dual-read returns None -> legacy Fernet decrypt)."""
+    result = await read_imported_llc_secret_in_session(
+        session, source_id=str(uuid.uuid4()), company_id=_COMPANY, root_key=_ROOT
+    )
+    assert result is None
+
+
+async def test_wrong_company_vault_denied(session):
+    """A grantee from a different company vault cannot open the imported secret."""
+    row = _make_row(_COMPANY, "api-key", "legacy-plaintext")
+    session.add(row)
+    await session.flush()
+    await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+
+    result = await read_imported_llc_secret_in_session(
+        session, source_id=str(row.id), company_id="some-other-company", root_key=_ROOT
+    )
+    assert result is None  # SecretAccessError caught internally -> fall back, never raise
+
+
+async def test_dual_read_never_logs_secret_value(session, caplog):
+    plaintext = "super-secret-plaintext-xyz"
+    row = _make_row(_COMPANY, "logged-key", plaintext)
+    session.add(row)
+    await session.flush()
+    await import_llc_secrets(session, master_key=_MASTER_KEY, root_key=_ROOT)
+    await session.commit()
+
+    with caplog.at_level("DEBUG"):
+        value = await read_imported_llc_secret_in_session(
+            session, source_id=str(row.id), company_id=_COMPANY, root_key=_ROOT
+        )
+
+    assert value == plaintext
+    assert plaintext not in caplog.text
+
+
+def test_env_helper_reads_flag_case_insensitively(monkeypatch):
+    monkeypatch.setenv("AUTOBOT_SECRETS_LLC_UNIFIED_READ", "True")
+    assert llc_unified_read_enabled() is True
+    monkeypatch.setenv("AUTOBOT_SECRETS_LLC_UNIFIED_READ", "0")
+    assert llc_unified_read_enabled() is False
+    monkeypatch.delenv("AUTOBOT_SECRETS_LLC_UNIFIED_READ", raising=False)
+    assert llc_unified_read_enabled() is False

--- a/autobot_shared/legacy_secret_keys.py
+++ b/autobot_shared/legacy_secret_keys.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Legacy per-store key-derivation adapters, read-only for migration (#10088 / Task 1.3).
+
+The umbrella's Task 1.3 calls for "legacy-key adapters (Fernet
+``AUTOBOT_SECRETS_KEY``, LLC HKDF, SLM AES-GCM, field-encryption) read-only for
+migration" — a shared, database-free home for the exact key-derivation math a
+legacy store used, so a migration importer can decrypt its rows without
+importing the live service module (and, transitively, its whole package).
+
+``derive_llc_company_fernet`` is the LLC HKDF adapter: it reproduces
+``llc.services.secret``'s per-company Fernet derivation byte-for-byte
+(HKDF-SHA256 keyed on ``company_id``, URL-safe-base64-encoded to a 44-char
+Fernet key). ``llc.services.secret`` itself delegates to this function (kept
+as the single source of truth) rather than duplicating the math, so the two
+can never drift.
+
+Deliberately depends on nothing but ``cryptography`` — no SQLAlchemy, no
+``llc.*``, no FastAPI — so migration modules can import it without pulling in
+``llc/services/__init__.py``'s eager import of every concrete LLC service
+(itself a real, separately-tracked coupling risk; see the umbrella's Task 4
+discovery).
+"""
+
+from __future__ import annotations
+
+import base64
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+
+def derive_llc_company_fernet(master_key: bytes, company_id: str) -> Fernet:
+    """Derive a Fernet instance whose key is specific to *company_id*.
+
+    Uses HKDF-SHA256 to stretch *master_key* into 32 bytes, keyed to
+    *company_id* so each LLC company has a distinct encryption key. The 32
+    output bytes are URL-safe-base64-encoded to satisfy Fernet's requirement
+    of a 44-character key string.
+    """
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=company_id.encode("utf-8"),
+    )
+    derived = hkdf.derive(master_key)
+    fernet_key = base64.urlsafe_b64encode(derived)
+    return Fernet(fernet_key)


### PR DESCRIPTION
## Thinking Path

Umbrella #10088 Task 4 ("Migrate LLC company secrets") audited before writing anything, per the umbrella's own pattern (Tasks 3a/3c were already done by earlier sessions before anyone looked). This time Task 4 really was greenfield: `#10075`/`#10076` (cited by the task text) turned out to be unrelated model-drift bugs (duplicate index declaration, enum label order) already fixed — not migration-content work.

Inventory (`file:line`):
- `autobot-backend/llc/models/secret.py:18` — `LLCSecret`: per-company HKDF-derived Fernet ciphertext, `(company_id, name)` unique, soft-delete via `revoked_at`.
- `autobot-backend/llc/services/secret.py` — `SecretService.set/get/revoke/list`; `_derive_fernet_key` (HKDF-SHA256 keyed on `company_id`) was the one piece of crypto math worth reusing.
- `autobot-backend/llc/api/secrets.py` — `/llc/secrets/{company_id}` REST surface (list/set/get/revoke); untouched, no wire-format change.
- `autobot-backend/llc/models/api_key.py` — `llc_agent_api_keys` (`LLCApiKey`): SHA-256 hash of a bearer token, not a secret store — kept untouched, exactly as the task specifies.

Confirmed `derive_vault_key` already accepts arbitrary vault ids (Task 9.1, `VaultRef(VaultKind.COMPANY, company_id).to_str()` → `company:<id>`), and `services/secrets_authz.py` already resolves a company's KEK/access via `PrincipalFacts.company_roles` (LLC `MembershipRole`) — no new permission system needed, matching the umbrella's lock.

**Scope narrowing followed exactly as instructed:** additive importer + dual-read only. No retirement, no dual-write (the audit found no correctness reason to add one — `llc_secrets` stays the only write path).

**A real coupling bug surfaced while building the importer** (the same class that broke Task 3's first CI run): reusing `llc.services.secret._derive_fernet_key` from a migration module transitively executes `llc/services/__init__.py`, which eagerly imports all 13 concrete LLC services — two of which reach `llm_shared` (hardware probing + mock LLM provider init) and several of which attempt live Redis connections, purely as import side effects. Fixed by extracting the HKDF+Fernet derivation into a dependency-free `autobot_shared/legacy_secret_keys.py` adapter (the umbrella's own Task 1.3, "LLC HKDF legacy-key adapter", previously unstarted) that both the live service and the importer now share — `llc.services.secret._derive_fernet_key` becomes a backward-compatible alias so existing tests are untouched. The eager-import issue itself is pre-existing and out of scope for Task 4; filed separately as #13057.

## What Changed

- **`autobot_shared/legacy_secret_keys.py`** (new) — `derive_llc_company_fernet(master_key, company_id)`, the per-company HKDF-SHA256 → Fernet-key derivation, moved out of `llc/services/secret.py` so migration code can reuse it without pulling in the whole LLC service package.
- **`autobot-backend/llc/services/secret.py`** — `_derive_fernet_key` now a re-export of the shared function (no behavior change); `get()` gains dual-read: after `_fetch_active()` proves the row exists and is not revoked, tries the unified envelope store (flag `AUTOBOT_SECRETS_LLC_UNIFIED_READ`, default off) and falls back to the legacy per-company Fernet decrypt on any miss/disabled-flag/unusable-root-key.
- **`autobot-backend/services/llc_secrets_importer.py`** (new) — additive, idempotent import of active (`revoked_at IS NULL`) `llc_secrets` rows into the unified envelope store, owned by that row's Company vault (`company:<company_id>`). Revoked rows are never imported. Marker `extra_data['imported_from_llc_secrets']` (the legacy row's id) makes re-runs a no-op. Per-row SAVEPOINT so one bad row is reported, not batch-aborting.
- **`autobot-backend/services/llc_secrets_read.py`** (new) — resolves an imported secret by its legacy-row marker and decrypts it through `EnvelopeSecretsService` with `accessible_vaults={VaultRef(COMPANY, company_id)}`. Returns `None` (triggering fallback) on any miss/access/decrypt failure.
- **`llc_secrets` is untouched** — model, service, API, `llc_agent_api_keys` all unchanged in shape and behavior when the flag is off (verified byte-identical below).
- Tests: `autobot-backend/tests/migrations/test_llc_secrets_importer.py`, `test_llc_secrets_read.py` (Postgres-gated, migration-gate) + 4 new mock-based wiring tests in `autobot-backend/llc/tests/test_secrets.py` proving the `get()` integration (these deliberately import `llc.services.secret` directly, so they stay out of the migration-gate path to avoid the #13057 coupling).

## Verification

- `py_compile` / `flake8 --max-line-length=120` / `black --check --line-length=120` / `isort --check-only --profile black`: all clean on every touched/added file.
- Confirmed (via a `builtins.__import__` guard) that `services.llc_secrets_importer` and `services.llc_secrets_read` import cleanly with **zero** noise/side effects (no Redis attempts, no `llm_shared` probing, no `jsonschema`) — unlike `llc.services.secret` itself, which still triggers the pre-existing #13057 issue when imported directly (not made worse by this PR).
- Spun up a disposable local Postgres 16 (isolated `initdb` instance, not the shared host cluster) and ran the new migration-gate tests for real: **13/13 passed** — `test_imports_and_envelope_readable`, `test_idempotent_skips_already_imported`, `test_revoked_secret_not_imported`, `test_company_isolation_no_cross_company_read` (company B raises `SecretAccessError` reading company A's imported secret), `test_bad_ciphertext_reported_not_batch_abort`, `test_wrong_company_key_reported_not_batch_abort`, `test_import_never_logs_secret_value`, `test_legacy_fernet_still_readable` (legacy row + Fernet cipher still decrypts after import — nothing retired), plus the dual-read module's own 5 tests (serves imported secret, unimported → `None` fallback, wrong-company vault denied, no secret value logged, env-flag parsing).
- `llc/tests/test_secrets.py`: 16/16 pass (12 pre-existing + 4 new), including the critical **revoke-safety proof**: `test_get_revoked_secret_never_reaches_unified_store` mocks the dual-read helper and asserts it is **never called** when the row is revoked/absent — `_fetch_active()` raises `SecretNotFound` first, so a revoked legacy secret can never stale-resurrect through an already-imported unified copy, even with the flag on.
- Startup-import-smoke ratio: **350/350 before and after** (`cp`-swapped `llc/services/secret.py` back to the `origin/Dev_new_gui` version, re-ran, restored).
- Discovered and filed separately (not fixed here, per scope): **#13057** — `llc/services/__init__.py` eagerly imports all 13 concrete LLC services, so importing any single one pulls in `llm_shared` + live Redis connection attempts.

## Model Used

Sonnet 5
