### PR TITLE
feat(secrets): repoint connector OAuth token reads at the unified envelope store (#10088 Task 5)

### DIFF
--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -233,11 +233,19 @@ class ConnectorCredentialStore:
         Raises PermissionError on owner mismatch, LookupError when the secret is
         missing or holds no refresh token while the access token is expired.
         Propagates RuntimeError from the token endpoint on a failed refresh.
+
+        When the vault-read flag is on, the vault envelope store is tried first
+        (matching :meth:`load`'s expand-phase read-first behaviour, #10088 Task 5) —
+        OAuth-managed connector tokens follow the same cutover path as static creds.
         """
-        secret = await asyncio.get_running_loop().run_in_executor(
-            None,
-            lambda: self._svc.get_secret(secret_id=secret_id, include_value=True, accessed_by=owner_id),
-        )
+        secret = None
+        if _vault_read_enabled():
+            secret = await load_imported_credential(secret_id, owner_id)
+        if secret is None:
+            secret = await asyncio.get_running_loop().run_in_executor(
+                None,
+                lambda: self._svc.get_secret(secret_id=secret_id, include_value=True, accessed_by=owner_id),
+            )
         if secret is None:
             raise LookupError(f"OAuth secret {secret_id!r} not found or expired")
         stored_owner = secret.get("created_by") or ""

--- a/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_read.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_read.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Routing tests for the ConnectorCredentialStore vault-read flag (#10088 / Task 3c-2).
+"""Routing tests for the ConnectorCredentialStore vault-read flag (#10088 / Task 3c-2, Task 5).
 
 Verifies the expand-phase feature flag: off → SQLite only (byte-identical to before);
 on → vault envelope store first with SQLite fallback. The vault core itself is exercised
-against Postgres in tests/migrations/test_credential_store_unified_read.py.
+against Postgres in tests/migrations/test_credential_store_read.py. get_access_token
+(OAuth-managed connector tokens) follows the same read-first routing as load() (Task 5).
 """
 
 import json
@@ -72,3 +73,62 @@ async def test_load_flag_on_falls_back_when_not_imported(monkeypatch):
     svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
     out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
     assert out == {"host": "h", "token": "sqlite"} and svc.get_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# get_access_token — OAuth "connector tokens" follow the same read-first cutover
+# as load() (#10088 Task 5: repoint the bridge so OAuth tokens aren't left behind).
+# ---------------------------------------------------------------------------
+
+
+async def test_get_access_token_flag_off_uses_sqlite_only(monkeypatch):
+    monkeypatch.setattr(cs, "_vault_read_enabled", lambda: False)
+
+    async def _boom(*a, **k):
+        raise AssertionError("vault path must not be consulted when flag is off")
+
+    monkeypatch.setattr(cs, "load_imported_credential", _boom)
+    svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"access_token": "sqlite-token"})})
+    token = await ConnectorCredentialStore(svc).get_access_token("sid", "u1")
+    assert token == "sqlite-token" and svc.get_calls == 1
+
+
+async def test_get_access_token_flag_on_prefers_vault(monkeypatch):
+    monkeypatch.setattr(cs, "_vault_read_enabled", lambda: True)
+
+    async def _vault(secret_id, owner_id):
+        return {"created_by": owner_id, "value": json.dumps({"access_token": "vault-token"})}
+
+    monkeypatch.setattr(cs, "load_imported_credential", _vault)
+    svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"access_token": "sqlite-token"})})
+    token = await ConnectorCredentialStore(svc).get_access_token("sid", "u1")
+    assert token == "vault-token" and svc.get_calls == 0  # SQLite untouched
+
+
+async def test_get_access_token_flag_on_falls_back_when_not_imported(monkeypatch):
+    monkeypatch.setattr(cs, "_vault_read_enabled", lambda: True)
+
+    async def _none(secret_id, owner_id):
+        return None
+
+    monkeypatch.setattr(cs, "load_imported_credential", _none)
+    svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"access_token": "sqlite-token"})})
+    token = await ConnectorCredentialStore(svc).get_access_token("sid", "u1")
+    assert token == "sqlite-token" and svc.get_calls == 1
+
+
+async def test_get_access_token_vault_path_never_logs_secret_value(monkeypatch, caplog):
+    monkeypatch.setattr(cs, "_vault_read_enabled", lambda: True)
+    plaintext = "super-secret-access-value-xyz"
+
+    async def _vault(secret_id, owner_id):
+        return {"created_by": owner_id, "value": json.dumps({"access_token": plaintext})}
+
+    monkeypatch.setattr(cs, "load_imported_credential", _vault)
+    svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"access_token": "unused"})})
+
+    with caplog.at_level("DEBUG"):
+        token = await ConnectorCredentialStore(svc).get_access_token("sid", "u1")
+
+    assert token == plaintext
+    assert plaintext not in caplog.text


### PR DESCRIPTION
## Thinking Path

Audited before implementing, per the umbrella's own pattern (Task 3 and Task 4 both
found the task text stale in different directions).

**`ConnectorCredentialStore`** (`autobot-backend/knowledge/connectors/credential_store.py:54`)
already bridges `ConnectorConfig` ↔ `SecretsService` (the legacy SQLite store), exactly as
Task 5's text describes. What the umbrella calls `UnifiedSecretsService` does not exist under
that name anywhere in the codebase — the canonical service Task 2.2 actually shipped as is
`EnvelopeSecretsService` (`services/envelope_secrets_service.py:61`), reached via the
`services/credential_read.py` / `services/credential_write.py` helpers.

**Most of the "repoint" is already done.** PRs #10327 and #10334 (Task 3c-2, already merged)
gave `store()`/`load()`/`rotate()`/`revoke()`/`store_oauth()` expand-phase dual-read
(`AUTOBOT_SECRETS_UNIFIED_READ`) and dual-write (`AUTOBOT_SECRETS_UNIFIED_WRITE`) against the
envelope store, both default-off, plus a reconciliation sweep (#10340) that closed the
revoke-resurrection gate. `load()` already tries the vault first and falls back to SQLite.

**The one gap:** `get_access_token()` — the OAuth-managed connector token read path (used by
connectors configured via the OAuth authorization-code flow, e.g. gitlab/gdrive/onedrive OAuth
apps, reached from `api/knowledge_connectors.py::_oauth_full_config` →
`_cfg_with_credentials`, called from background sync, connection-test and rotation) — was
never given the same read-first routing as `load()`. It's dual-*written* (via `store_oauth`
and the post-refresh `update_secret`) but only ever *read* from legacy SQLite, even with the
read flag on. Since Task 5's own text is "repoint the bridge... so **connector tokens** follow
the store into the unified envelope," and OAuth tokens are literally that, this is the real,
non-duplicative scope left for Task 5's connector half.

**Reachability confirmed:** every enterprise connector (`slack.py`, `confluence.py`, `jira.py`,
`gitlab.py`/`gitea`, `notion.py`, `gdrive.py`, `onedrive.py`) declares `auth_schema()` and is
routed uniformly through `ConnectorCredentialStore` via `api/knowledge_connectors.py` — there
is no per-connector credential path to separately repoint.

**SSO half (#9501) is a distinct deliverable that is already fully done**, under a different,
already-completed sub-task of this same umbrella (**#10153**, merged PR #10498, plus
#10492/#10503/#10436/#10437). `autobot-slm-backend/user_management/services/sso_secrets.py`
already stores SSO client secrets in the unified System vault via an HMAC-authenticated HTTP
client (`vault_client.py`), with a legacy `SystemSecret`-table fallback during rollout — the
exact "adopt the system vault / shared crypto" Task 5 asks for. Not redone here; no new PR
needed for that half.

## What Changed

- `knowledge/connectors/credential_store.py` — `get_access_token()` now tries the vault
  envelope store first (via the already-tested `load_imported_credential` helper, matching
  `load()`'s exact routing) and falls back to SQLite when not yet imported or the flag is off.
  Byte-identical behaviour when `AUTOBOT_SECRETS_UNIFIED_READ` is off (untouched default).
- `tests/unit/knowledge/connectors/test_credential_store_read.py` — routing tests for
  `get_access_token` (flag off → SQLite only; flag on → vault-first; flag on + not-imported →
  SQLite fallback) plus a no-log-leak assertion, mirroring the existing `load()` tests.

No new importer, no new migration, no dual-write change (already covered), no retirement of
any store.

## Verification

- `py_compile`, `flake8 --max-line-length=120`, `black --check --line-length=120`,
  `isort --check-only --profile black --line-length 120` — all clean on both changed files.
- `pytest tests/unit/knowledge/connectors/test_credential_store_read.py` — 8/8 passed
  (5 new: 3 routing + 1 no-log-leak, plus the pre-existing 3 for `load()`... actually 8 total).
- `pytest knowledge/connectors/tests/test_credential_store.py tests/unit/knowledge/connectors/`
  — 95 passed / 4 pre-existing failures, **identical before and after** via a `cp`-swapped
  baseline (the 4 failures are unrelated `gitlab.py` mock-attribute test rot, `_store_ts`,
  pre-existing on `Dev_new_gui`).
- Real disposable local Postgres 16 provisioned (own throwaway cluster + data dir, not the
  shared host cluster) and the **full `migration-gate` suite run for real**:
  `tests/migrations/` — **129 passed, 25 deselected, 0 failed** (654s), including
  `test_credential_store_read.py` (4/4 — the Postgres-level core the routing reuses, seeded
  with a `connector_oauth_token`-typed secret), `test_credential_mirror.py` (4/4) and
  `test_credential_reconcile.py` (4/4).
- `tests/test_startup_imports.py` — 350/350 passed (unchanged; no new imports were added,
  only a new call site to an already-imported helper).
- `tests/test_raw_client_session_ceiling_12992.py` — 2/2 passed (unaffected — no raw
  `ClientSession` usage touched).
- No credential value reaches logs: `test_get_access_token_vault_path_never_logs_secret_value`
  asserts a plaintext token value never appears in `caplog.text` through the new code path,
  matching the pattern Tasks 3 and 4 established.
- Isolation: the new code path reuses the exact owner-scoped `VaultRef(VaultKind.USER,
  owner_id)` lookup already Postgres-proven in `test_credential_store_read.py`
  (`test_returns_none_on_owner_mismatch`); no new isolation logic was introduced.

**Deliberately not done (scope narrowing, consistent with Tasks 3/4):** no store retirement,
no new dual-write, no changes to `rotate()` (which reads its pre-mutation state from the
SQLite canonical store by design — the expand-phase invariant is that writes go through the
canonical store first and mirror out, while only pure reads try the vault first). SSO half
already delivered elsewhere, not duplicated.

## Model Used

Claude Opus 5 (claude-opus-5)