### PR TITLE
fix(ansible/vnc): offer VncAuth so clients can connect, give VNC its own TLS key, stop provisioning on unselected hosts (#13060)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -343,10 +343,14 @@ role_redis_active: >-
      (inventory_hostname in (groups.get('redis', []) | default([]))) or
      (inventory_hostname in (groups.get('database', []) | default([]))) }}
 
+# #13060: NO groups['main'] / groups['backend'] fallback. Those clauses pulled the
+# full desktop stack (tigervnc, x11vnc, novnc, websockify, xfce4) onto every backend
+# and main host, including ones that never selected the role. Activation is explicit,
+# matching role_xrdp_active below.
+# Migration: a backend/main host that relied on implicit activation must now list
+# 'vnc' in node_roles (or join vnc_nodes) to keep its desktop provisioned.
 role_vnc_active: >-
   {{ ('vnc' in (node_roles | default([]))) or
-     (inventory_hostname in (groups.get('main', []) | default([]))) or
-     (inventory_hostname in (groups.get('backend', []) | default([]))) or
      (inventory_hostname in (groups.get('vnc_nodes', []) | default([]))) }}
 
 role_xrdp_active: >-

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -68,10 +68,14 @@ role_redis_active: >-
      (inventory_hostname in (groups.get('redis', []) | default([]))) or
      (inventory_hostname in (groups.get('database', []) | default([]))) }}
 
+# #13060: NO groups['main'] / groups['backend'] fallback. Those clauses pulled the
+# full desktop stack (tigervnc, x11vnc, novnc, websockify, xfce4) onto every backend
+# and main host, including ones that never selected the role. Activation is explicit,
+# matching role_xrdp_active below.
+# Migration: a backend/main host that relied on implicit activation must now list
+# 'vnc' in node_roles (or join vnc_nodes) to keep its desktop provisioned.
 role_vnc_active: >-
   {{ ('vnc' in (node_roles | default([]))) or
-     (inventory_hostname in (groups.get('main', []) | default([]))) or
-     (inventory_hostname in (groups.get('backend', []) | default([]))) or
      (inventory_hostname in (groups.get('vnc_nodes', []) | default([]))) }}
 
 role_xrdp_active: >-

--- a/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
@@ -20,8 +20,28 @@ websockify_enabled: "{{ lookup('env', 'WEBSOCKIFY_ENABLED') | default('true', tr
 novnc_path: /usr/share/novnc
 
 # Security - password auto-generated to /etc/autobot/vnc-secrets.env
-vnc_security_type: "{{ lookup('env', 'VNC_SECURITY_TYPE') | default('VeNCrypt', true) }}"
+#
+# #13060: VncAuth is what this role actually provisions — `vncpasswd -f` (see
+# tasks/main.yml) writes a VncAuth-format password file. TLSVnc and X509Vnc are
+# VeNCrypt sub-types that wrap that same VncAuth challenge for native viewers
+# able to negotiate them.
+#
+# Do NOT set this to bare "VeNCrypt": that names only the wrapper and leaves the
+# sub-type list empty, so NO client completes the handshake — not even a
+# VeNCrypt-capable one. It also locks out noVNC < 1.4.0 (the `novnc` apt package
+# ships 1.0.0 on some releases), which has no VeNCrypt support at all.
+#
+# VncAuth on the raw RFB hop is safe here: websockify terminates TLS for the
+# browser (see vnc-websockify.service.j2) and connects to VNC over loopback.
+vnc_security_type: "{{ lookup('env', 'VNC_SECURITY_TYPE') | default('VncAuth,TLSVnc,X509Vnc', true) }}"
 vnc_always_shared: "{{ lookup('env', 'VNC_ALWAYS_SHARED') | default('0', true) }}"
+
+# #13060: dedicated VNC keypair, read by BOTH the X509Vnc security type (Xvnc,
+# running as vnc_user) and websockify --ssl-only (also vnc_user). The shared node
+# key at /etc/autobot/certs/server-key.pem is root:root 0600 and is consumed by
+# nginx, Redis and PostgreSQL, so it must not be opened up to vnc_user.
+vnc_tls_cert: /etc/autobot/certs/vnc-cert.pem
+vnc_tls_key: /etc/autobot/certs/vnc-key.pem
 
 # Service management
 vnc_service_name: vnc-server

--- a/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
@@ -97,7 +97,11 @@
   become: true
   when: vnc_password_result.stdout | length > 0
 
-# --- TLS cert verification for websockify (#1962) ---
+# --- Node-level TLS cert (#1962) ---
+# Shared node keypair, also provisioned by roles/backend and setup-internal-ca.
+# Kept here so a vnc-only node still ends up with one. It stays root:root 0600
+# because nginx, Redis and PostgreSQL consume it — VNC gets its own pair below
+# rather than widening access to this key (#13060).
 - name: Ensure TLS cert directory exists
   ansible.builtin.file:
     path: /etc/autobot/certs
@@ -125,6 +129,36 @@
     chmod 0600 /etc/autobot/certs/server-key.pem
   become: true
   when: tls_cert_check.results | selectattr('stat.exists', 'equalto', false) | list | length > 0
+
+# --- Dedicated VNC keypair (#13060) ---
+# Xvnc (for the X509Vnc security type) and websockify (--ssl-only) both run as
+# {{ vnc_user }} and must be able to read this key. Previously websockify pointed
+# at the shared node key above, which is root:root 0600 — so the --ssl-only unit
+# could never start.
+- name: Generate dedicated VNC TLS keypair (#13060)
+  ansible.builtin.command:
+    cmd: >-
+      openssl req -x509 -newkey rsa:2048 -nodes
+      -keyout {{ vnc_tls_key }}
+      -out {{ vnc_tls_cert }}
+      -days 3650
+      -subj /CN={{ inventory_hostname }}.autobot.internal
+    creates: "{{ vnc_tls_key }}"
+  become: true
+
+- name: Restrict VNC TLS keypair to the VNC user (#13060)
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: "{{ vnc_user }}"
+    group: "{{ vnc_group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - {path: "{{ vnc_tls_cert }}", mode: "0644"}
+    - {path: "{{ vnc_tls_key }}", mode: "0600"}
+  become: true
+  notify:
+    - restart vnc-server
+    - restart websockify
 
 - name: Deploy VNC xstartup script
   ansible.builtin.template:

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-config.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-config.j2
@@ -12,5 +12,10 @@ depth={{ vnc_depth }}
 SecurityTypes={{ vnc_security_type }}
 localhost=no
 
+# X509 material for the X509Vnc security type (#13060). Dedicated VNC keypair —
+# readable by {{ vnc_user }}, unlike the shared root:root 0600 node key.
+X509Cert={{ vnc_tls_cert }}
+X509Key={{ vnc_tls_key }}
+
 # Performance settings
 AlwaysShared={{ vnc_always_shared | default(0) }}

--- a/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
+++ b/autobot-slm-backend/ansible/roles/vnc/templates/vnc-websockify.service.j2
@@ -15,9 +15,12 @@ User={{ vnc_user }}
 Group={{ vnc_group }}
 
 # Calculate VNC port from display number (5900 + display)
+# #13060: use the dedicated VNC keypair. This unit runs as {{ vnc_user }}, which
+# cannot read the shared node key (/etc/autobot/certs/server-key.pem, root:root
+# 0600) — with that key, --ssl-only websockify failed to start.
 ExecStart=/usr/bin/websockify --web={{ novnc_path }} \
-    --cert=/etc/autobot/certs/server-cert.pem \
-    --key=/etc/autobot/certs/server-key.pem \
+    --cert={{ vnc_tls_cert }} \
+    --key={{ vnc_tls_key }} \
     --ssl-only \
     0.0.0.0:{{ websockify_port }} localhost:{{ 5900 + vnc_display | int }}
 

--- a/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
@@ -117,7 +117,8 @@ all:
       ansible_connection: local
       node_roles: []
       expected_role_backend_active: true   # via groups['main']
-      expected_role_vnc_active: true       # via groups['main']
+      # #13060: VNC is NOT implied by groups['main'] — activation is explicit.
+      expected_role_vnc_active: false
       expected_role_frontend_active: false
       expected_role_slm_active: false
 

--- a/autobot-slm-backend/ansible/tests/inventory_dynamic/test_role_facts.yml
+++ b/autobot-slm-backend/ansible/tests/inventory_dynamic/test_role_facts.yml
@@ -117,7 +117,8 @@ all:
       ansible_connection: local
       node_roles: []
       expected_role_backend_active: true   # via groups['main']
-      expected_role_vnc_active: true       # via groups['main']
+      # #13060: VNC is NOT implied by groups['main'] — activation is explicit.
+      expected_role_vnc_active: false
       expected_role_frontend_active: false
       expected_role_slm_active: false
 


### PR DESCRIPTION
Closes #13060

## Thinking Path

Started from a live deploy symptom: the server offered **VeNCrypt only (type 19)** while the `novnc` apt package ships **1.0.0**, which supports `std_vnc_auth` / `tight_auth` / `xvp_auth` — VeNCrypt only arrived in noVNC 1.4.0.

The obvious read is "upgrade noVNC". That would not have fixed it. Tracing the config chain showed the role sets `SecurityTypes=VeNCrypt`, which names the VeNCrypt *wrapper* without any sub-type (`TLSVnc` / `X509Vnc` / `Plain`), leaving the sub-type list empty — so even a VeNCrypt-capable client has nothing to negotiate. The role also provisions a **VncAuth** password (`vncpasswd -f`), so it was configuring a security type that never reads the credentials it creates.

Confirming it as divergence rather than intent: **every other VNC launcher in the repo already uses VncAuth** — `api/vnc_manager.py:143`, `browser-vnc.service:18`, `setup_browser_vnc.sh:57`, `fix-vnc-desktop.sh:58`, and `docs/guides/vision-vnc-ui-testing.md:2316`. The Ansible role was the lone outlier.

That also explains any intermittency: starting VNC through the backend API passes `-SecurityTypes VncAuth,TLSVnc` on the CLI and works, while the systemd unit passes none — so `~/.vnc/config` wins at boot and the server comes up unreachable.

Two further defects surfaced while fixing this and are folded in, per the fix-what-you-find rule.

## What Changed

**1. Security type — `VeNCrypt` → `VncAuth,TLSVnc,X509Vnc`**

`roles/vnc/defaults/main.yml`. noVNC connects via plain VncAuth; native viewers can negotiate the TLS-wrapped sub-types. VncAuth on the raw RFB hop is safe here because websockify already terminates TLS for the browser and reaches VNC over loopback, and `register-credentials.yml` registers the **websockify port**, not the raw RFB port.

**2. Dedicated VNC TLS keypair**

`vnc-websockify.service.j2` runs as `{{ vnc_user }}` but pointed `--cert/--key` at `/etc/autobot/certs/server-key.pem` — documented `root:root 0600` in `setup-internal-ca.yml:435` and chmodded `0600` with no chown by this role. An unprivileged user cannot read it, so the `--ssl-only` unit could never start.

Fixed with a dedicated pair (`vnc-cert.pem` / `vnc-key.pem`) owned by `vnc_user`, rather than loosening the shared node key that nginx, Redis and PostgreSQL also consume. The same pair backs the new `X509Vnc` type. Node-level cert generation is left in place — a vnc-only node still needs one.

**3. `role_vnc_active` — explicit selection only**

Reported from the field: the VNC stack landed on a host with no `vnc` in `node_roles`. Both duplicated copies (`playbooks/vars/role_active_facts.yml`, `inventory/group_vars/all.yml`) had `groups['main']` and `groups['backend']` fallbacks, pulling in tigervnc, x11vnc, novnc, websockify and **xfce4**. VNC was the outlier — `role_xrdp_active`, defined immediately below, has no such fallback. Both now gate on `'vnc' in node_roles` or `vnc_nodes` membership.

> [!IMPORTANT]
> **Migration.** A backend/main host that relied on implicit activation must now list `vnc` in its `node_roles` (or join `vnc_nodes`) to keep its desktop provisioned. This matters where `api/vnc_manager.py:85` pgreps for `Xtigervnc` on the canonical display.

## Verification

**Role-active-facts tests — both loading paths, all 9 synthetic hosts, `failed=0`:**

```
# group_vars path
ansible-playbook -i tests/inventory/test_role_facts.yml tests/playbooks/test_role_active_facts.yml
test-ai-stack-and-llm            : ok=4    failed=0
test-backend-short-name          : ok=3    failed=0
test-browser-legacy-name         : ok=3    failed=0
test-dedicated-slm-manager       : ok=10   failed=0
test-empty-roles-via-group       : ok=4    failed=0
test-frontend-prefixed           : ok=3    failed=0
test-no-roles-defined            : ok=10   failed=0
test-npu-and-tts                 : ok=4    failed=0
test-single-host-slm-and-backend : ok=10   failed=0

# vars_files path (dynamic inventory, no group_vars) — same 9 hosts, failed=0
ansible-playbook -i tests/inventory_dynamic/test_role_facts.yml \
                 tests/playbooks/test_role_active_facts_no_group_vars.yml
```

**Negative control** — proves the flipped expectation is a live assertion, not a silently-skipped one:

```
$ ansible-playbook ... -e 'role_vnc_active=true'
fatal: [test-empty-roles-via-group]: FAILED! =>
  "test-empty-roles-via-group: role_vnc_active=true, expected=False (node_roles=[])"
fatal: [test-backend-short-name]: FAILED! =>
  "test-backend-short-name: role_vnc_active=true, expected=False (node_roles=['backend'])"
```

**Rendered templates:**

```
# vnc-config
SecurityTypes=VncAuth,TLSVnc,X509Vnc
X509Cert=/etc/autobot/certs/vnc-cert.pem
X509Key=/etc/autobot/certs/vnc-key.pem

# vnc-websockify.service   (User=autobot — matches the key owner)
ExecStart=/usr/bin/websockify --web=/usr/share/novnc \
    --cert=/etc/autobot/certs/vnc-cert.pem \
    --key=/etc/autobot/certs/vnc-key.pem \
    --ssl-only \
    0.0.0.0:6080 localhost:5901
```

**Syntax / YAML:** `ansible-playbook --syntax-check deploy.yml` passes; all 6 changed YAML files parse.

**openssl argv smoke test** (exact string the `command` module shlex-splits):

```
subject=CN = node.autobot.internal
notAfter=Jul 27 17:03:50 2036 GMT
RSA key ok
```

## Notes

`vncpasswd -f` writes a **VncAuth** password, and the RFB VncAuth scheme truncates to **8 characters** — so the ~16-char generated secret in `/etc/autobot/vnc-secrets.env` yields ~47 bits of effective strength regardless of its length. That is inherent to VncAuth, not introduced here, and is a further reason the TLS sub-types stay in the offer list. Noted on #13060 rather than expanded into this PR.

## Model Used

Claude Opus 5 (1M context)
