### PR TITLE
feat(secrets): migrate system_secrets into the unified System vault — importer + dual-read (#10088 Task 6a)

### DIFF
--- a/autobot-slm-backend/api/scim.py
+++ b/autobot-slm-backend/api/scim.py
@@ -9,9 +9,10 @@ RFC 7644 compliant endpoints for IdP-pushed user/group lifecycle.
 Mounts at /scim/v2 (registered without /api prefix so IdPs can reach it directly).
 
 Bearer-token auth: SCIM clients (Okta/Entra/Google) authenticate with the
-'scim_bearer_token' key from SystemSecret (AES-GCM encrypted at rest).
-The token is seeded once on first startup; admins retrieve it via the
-SLM secrets UI or CLI.
+'scim_bearer_token' key, read via services.system_secrets_vault (legacy
+SystemSecret first, unified System vault fallback — #10088 Task 6a). The
+token is seeded once on first startup; admins retrieve it via the SLM
+secrets UI or CLI.
 
 Group→role: delegates entirely to SSOService._sync_idp_groups_to_roles
 via _resolve_managed_roles + UserService.assign_role / revoke_role so
@@ -28,9 +29,8 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.database import SystemSecret
 from services.database import db_service
-from services.encryption import decrypt_data
+from services.system_secrets_vault import retrieve_secret
 from user_management.database import get_slm_session
 from user_management.models import Role, User, UserRole
 from user_management.services.base_service import TenantContext
@@ -66,16 +66,12 @@ async def _get_slm_db() -> AsyncSession:
 
 
 async def _load_scim_token() -> str | None:
-    """Load the SCIM bearer token from SystemSecret (main SLM DB, AES-GCM encrypted)."""
+    """Load the SCIM bearer token — legacy SystemSecret first, vault fallback (#10088 Task 6a)."""
     try:
         async with db_service.session() as db:
-            result = await db.execute(select(SystemSecret).where(SystemSecret.key == _SCIM_TOKEN_KEY))
-            row = result.scalar_one_or_none()
-            if row is None:
-                return None
-            return decrypt_data(row.encrypted_value)
+            return await retrieve_secret(db, _SCIM_TOKEN_KEY)
     except Exception:
-        logger.warning("Could not load SCIM bearer token from SystemSecret")
+        logger.warning("Could not load SCIM bearer token")
         return None
 
 

--- a/autobot-slm-backend/api/secrets.py
+++ b/autobot-slm-backend/api/secrets.py
@@ -29,8 +29,9 @@ from models.schemas import (
 from services.ansible_secrets import _SECRET_TO_DEPENDENT_ROLES
 from services.auth import require_permission
 from services.database import get_db
-from services.encryption import decrypt_data, encrypt_data
+from services.encryption import encrypt_data
 from services.hf_token_validator import probe_hf_token
+from services.system_secrets_vault import delete_vault_copy, retrieve_secret
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/secrets", tags=["secrets"])
@@ -141,15 +142,19 @@ async def get_secret_value(
     db: Annotated[AsyncSession, Depends(get_db)],
     _: Annotated[dict, Depends(require_permission(Permission.SECURITY_MANAGE))],
 ) -> dict:
-    """Get a decrypted secret value (admin only, for fleet provisioning)."""
-    result = await db.execute(select(SystemSecret).where(SystemSecret.key == key))
-    secret = result.scalar_one_or_none()
-    if not secret:
+    """Get a decrypted secret value (admin only, for fleet provisioning).
+
+    Legacy ``system_secrets`` first, unified System vault fallback (#10088
+    Task 6a) — a key imported by the vault migration and later pruned from
+    ``system_secrets`` stays reachable here.
+    """
+    value = await retrieve_secret(db, key)
+    if value is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Secret not found",
         )
-    return {"key": secret.key, "value": decrypt_data(secret.encrypted_value)}
+    return {"key": key, "value": value}
 
 
 @router.put("/{key}", response_model=SecretResponse)
@@ -192,7 +197,11 @@ async def delete_secret(
     db: Annotated[AsyncSession, Depends(get_db)],
     _: Annotated[dict, Depends(require_permission(Permission.SECURITY_MANAGE))],
 ) -> None:
-    """Delete a system secret (admin only)."""
+    """Delete a system secret (admin only).
+
+    Also deletes any imported vault copy (#10088 Task 6a) so a deleted
+    secret can never resurrect through the vault-fallback read path.
+    """
     result = await db.execute(select(SystemSecret).where(SystemSecret.key == key))
     secret = result.scalar_one_or_none()
     if not secret:
@@ -203,6 +212,7 @@ async def delete_secret(
 
     await db.delete(secret)
     await db.commit()
+    await delete_vault_copy(key)
     logger.info("System secret deleted: %s", key)
 
 

--- a/autobot-slm-backend/migrations/migrate_system_secrets_to_vault.py
+++ b/autobot-slm-backend/migrations/migrate_system_secrets_to_vault.py
@@ -1,0 +1,138 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Migration: import ``system_secrets`` rows into the unified-secrets System vault (#10088 Task 6a).
+
+This is a ONE-TIME, IDEMPOTENT data import. Safe to run multiple times — a
+second run finds every eligible key already present in the vault (by name)
+and reports it skipped.
+
+Not part of the schema ``migrations.runner`` list (same as the SSO vault
+migration, ``migrate_sso_to_unified_vault.py``) — it does not change any
+table, it only copies plaintext values into the (separate-service) vault.
+
+Skips two categories of key (see ``services.system_secrets_vault.is_migratable``):
+  - ``autobot_internal_api_key`` — the auth-bootstrap credential that gates
+    access to the vault itself; migrating it is a confused-deputy cycle.
+  - ``sso:provider:*`` — already migrated by the dedicated #10153 path.
+
+The legacy ``system_secrets`` row is NEVER deleted or modified by this
+script — ``api/secrets.py`` (today's SLM Secrets UI) stays the live write
+path until the owner decides how the two Secrets UIs unify (#10088 Task 6c).
+
+Prerequisites:
+    - AUTOBOT_INTERNAL_API_KEY (or SLM_SERVICE_KEY/SLM_SERVICE_ID) — vault auth.
+    - SLM_AUTHORITY_BASE_URL must point to a running autobot-backend.
+    - SLM_ENCRYPTION_KEY / SLM_SECRET_KEY for legacy decryption.
+
+Run:
+    python -m migrations.migrate_system_secrets_to_vault
+
+or with an explicit DB URL:
+    python -m migrations.migrate_system_secrets_to_vault postgresql+asyncpg://...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def _require_env() -> None:
+    """Abort with a clear message when required env vars are missing."""
+    missing = []
+    if not os.getenv("AUTOBOT_INTERNAL_API_KEY") and not (os.getenv("SLM_SERVICE_KEY") and os.getenv("SLM_SERVICE_ID")):
+        missing.append("AUTOBOT_INTERNAL_API_KEY (or SLM_SERVICE_KEY + SLM_SERVICE_ID) — vault auth")
+    if not any(os.getenv(v) for v in ("SLM_ENCRYPTION_KEY", "SLM_SECRET_KEY")):
+        missing.append("SLM_ENCRYPTION_KEY or SLM_SECRET_KEY (legacy decryption)")
+    if missing:
+        msg = "Migration aborted — missing configuration:\n" + "\n".join(f"  - {m}" for m in missing)
+        raise RuntimeError(msg)
+
+
+def _asyncpg_url(db_url: str) -> str:
+    """Normalize a sync ``postgresql://`` URL to the asyncpg driver for the async engine."""
+    if db_url.startswith("postgresql://"):
+        return db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return db_url
+
+
+async def _run(db_url: str) -> None:
+    """Async migration body."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    engine = create_async_engine(_asyncpg_url(db_url), echo=False)
+    async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session_maker() as session:
+        from models.database import SystemSecret
+        from services.system_secrets_vault import is_migratable, migrate_key_to_vault
+
+        result = await session.execute(select(SystemSecret.key))
+        keys = [row[0] for row in result.all()]
+        logger.info("Found %d system_secrets rows to consider", len(keys))
+
+        migrated = 0
+        skipped = 0
+        ineligible = 0
+        failed = 0
+
+        for key in keys:
+            if not is_migratable(key):
+                ineligible += 1
+                logger.info("key=%s: ineligible (irreducible or SSO-managed) — skipping", key)
+                continue
+            try:
+                did_migrate = await migrate_key_to_vault(session, key)
+            except Exception as exc:
+                logger.error("key=%s: migration failed: %s", key, type(exc).__name__)
+                failed += 1
+                continue
+            if did_migrate:
+                migrated += 1
+            else:
+                skipped += 1
+
+    await engine.dispose()
+    logger.info(
+        "Migration complete: migrated=%d skipped=%d ineligible=%d failed=%d",
+        migrated,
+        skipped,
+        ineligible,
+        failed,
+    )
+    if failed:
+        logger.warning("%d keys failed; re-run after fixing the above errors", failed)
+
+
+def migrate(db_url: str) -> None:
+    """Synchronous entry point (compatible with existing runner infrastructure)."""
+    _require_env()
+    asyncio.run(_run(db_url))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+    _require_env()
+
+    if len(sys.argv) > 1:
+        _db_url = sys.argv[1]
+    else:
+        try:
+            from migrations.runner import get_db_url
+
+            _db_url = get_db_url()
+        except ImportError:
+            from config import settings
+
+            _db_url = settings.database_url
+
+    logger.info("Starting system_secrets -> unified-vault import (db=%s)", _db_url.split("@")[-1])
+    migrate(_db_url)

--- a/autobot-slm-backend/migrations/migrate_system_secrets_to_vault_test.py
+++ b/autobot-slm-backend/migrations/migrate_system_secrets_to_vault_test.py
@@ -1,0 +1,181 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the system_secrets -> System vault import script (#10088 Task 6a).
+
+Real-load pattern (same technique as
+``user_management/services/sso_secrets_test.py`` /
+``services/system_secrets_vault_test.py``): swaps in the real sqlalchemy +
+product modules over an in-memory SQLite DB, with the System vault faked by
+an in-memory double patched onto the real, loaded ``vault_client`` module.
+
+Also manually verified end-to-end against a disposable local Postgres 16
+instance (private ``initdb``, not the shared host cluster) — see PR
+description for the run transcript: migrated hf_token + scim_bearer_token,
+skipped autobot_internal_api_key (irreducible), second run made zero
+additional vault writes, and the legacy ``system_secrets`` rows were
+untouched throughout.
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+_SLM_ROOT = Path(__file__).parent.parent
+for _p in (str(_SLM_ROOT), str(_SLM_ROOT.parent)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+os.environ.setdefault("SLM_ENCRYPTION_KEY", "unit-test-encryption-key-0123456789abcdef")
+os.environ.setdefault("AUTOBOT_INTERNAL_API_KEY", "unit-test-internal-api-key")
+
+_SWAP_KEYS = (
+    "models.database",
+    "services.encryption",
+    "services.system_secrets_vault",
+    "migrations.migrate_system_secrets_to_vault",
+    "user_management.services.vault_client",
+)
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or any(name == p or name.startswith(p + ".") for p in ("sqlalchemy", "aiosqlite"))
+
+
+def _load_real_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+class _FakeVault:
+    """In-memory double for the System vault's HTTP surface (name -> plaintext)."""
+
+    def __init__(self) -> None:
+        self.entries: dict[uuid.UUID, dict] = {}
+
+    def is_configured(self) -> bool:
+        return True
+
+    async def vault_create(self, name: str, secret_type: str, value: str) -> dict:
+        secret_id = uuid.uuid4()
+        self.entries[secret_id] = {"id": str(secret_id), "name": name, "value": value, "type": secret_type}
+        return self.entries[secret_id]
+
+    async def vault_list(self) -> list:
+        return list(self.entries.values())
+
+
+@pytest.fixture
+def migration_env(monkeypatch, tmp_path):
+    """Real-loaded modules + an in-memory SQLite DB seeded with system_secrets rows."""
+    orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+    for name in list(orig_modules):
+        del sys.modules[name]
+    try:
+        for name in ("sqlalchemy", "sqlalchemy.ext.asyncio", "sqlalchemy.orm", "sqlalchemy.dialects.sqlite.aiosqlite"):
+            importlib.import_module(name)
+
+        md = _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+        enc = _load_real_module("services.encryption", _SLM_ROOT / "services" / "encryption.py")
+        vc = _load_real_module(
+            "user_management.services.vault_client", _SLM_ROOT / "user_management" / "services" / "vault_client.py"
+        )
+        _load_real_module("services.system_secrets_vault", _SLM_ROOT / "services" / "system_secrets_vault.py")
+        mig = _load_real_module(
+            "migrations.migrate_system_secrets_to_vault",
+            _SLM_ROOT / "migrations" / "migrate_system_secrets_to_vault.py",
+        )
+
+        fv = _FakeVault()
+        monkeypatch.setattr(vc, "is_configured", fv.is_configured)
+        monkeypatch.setattr(vc, "vault_create", fv.vault_create)
+        monkeypatch.setattr(vc, "vault_list", fv.vault_list)
+
+        db_path = tmp_path / "system_secrets_migration_test.db"
+        db_url = f"sqlite+aiosqlite:///{db_path}"
+
+        import asyncio
+
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        async def _seed():
+            engine = create_async_engine(db_url, echo=False)  # canonical: ignore py-adhoc-db-engine
+            async with engine.begin() as conn:
+                await conn.run_sync(md.Base.metadata.create_all)
+            session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+            async with session_maker() as session:
+                session.add(md.SystemSecret(key="hf_token", encrypted_value=enc.encrypt_data("real-hf-token")))
+                session.add(
+                    md.SystemSecret(
+                        key="autobot_internal_api_key", encrypted_value=enc.encrypt_data("irreducible-value")
+                    )
+                )
+                session.add(
+                    md.SystemSecret(key="scim_bearer_token", encrypted_value=enc.encrypt_data("scim-token-value"))
+                )
+                await session.commit()
+            await engine.dispose()
+
+        asyncio.run(_seed())
+
+        yield mig, fv, db_url
+    finally:
+        for name in [name for name in sys.modules if _is_swap_key(name)]:
+            del sys.modules[name]
+        for name, mod in orig_modules.items():
+            sys.modules[name] = mod
+
+
+class TestMigrateSystemSecretsToVault:
+    def test_migrates_eligible_keys_only(self, migration_env):
+        mig, fv, db_url = migration_env
+        mig.migrate(db_url)
+
+        names = {e["name"] for e in fv.entries.values()}
+        assert names == {"hf_token", "scim_bearer_token"}
+        assert "autobot_internal_api_key" not in names
+
+    def test_second_run_is_a_noop(self, migration_env):
+        mig, fv, db_url = migration_env
+        mig.migrate(db_url)
+        count_after_first = len(fv.entries)
+
+        mig.migrate(db_url)
+        count_after_second = len(fv.entries)
+
+        assert count_after_first == count_after_second == 2
+
+    def test_migrated_values_match_source(self, migration_env):
+        mig, fv, db_url = migration_env
+        mig.migrate(db_url)
+
+        by_name = {e["name"]: e["value"] for e in fv.entries.values()}
+        assert by_name["hf_token"] == "real-hf-token"
+        assert by_name["scim_bearer_token"] == "scim-token-value"
+
+    def test_require_env_aborts_without_encryption_key(self, monkeypatch, migration_env):
+        mig, _fv, db_url = migration_env
+        monkeypatch.delenv("SLM_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("SLM_SECRET_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="SLM_ENCRYPTION_KEY or SLM_SECRET_KEY"):
+            mig.migrate(db_url)
+
+    def test_require_env_aborts_without_vault_auth(self, monkeypatch, migration_env):
+        mig, _fv, db_url = migration_env
+        monkeypatch.delenv("AUTOBOT_INTERNAL_API_KEY", raising=False)
+        monkeypatch.delenv("SLM_SERVICE_KEY", raising=False)
+        monkeypatch.delenv("SLM_SERVICE_ID", raising=False)
+
+        with pytest.raises(RuntimeError, match="vault auth"):
+            mig.migrate(db_url)

--- a/autobot-slm-backend/services/ansible_secrets.py
+++ b/autobot-slm-backend/services/ansible_secrets.py
@@ -58,27 +58,26 @@ async def fetch_deploy_secrets() -> dict[str, str]:
     infrastructure — any deploy path that needs to inject stored secrets as
     Ansible extra_vars should call this function.
 
+    Each key is resolved via ``system_secrets_vault.retrieve_secret``
+    (#10088 Task 6a): legacy ``system_secrets`` first, unified System vault
+    fallback. ``autobot_internal_api_key`` never reaches the vault path —
+    it is the auth-bootstrap credential ``vault_client`` uses to reach the
+    vault in the first place (confused-deputy guard; see
+    ``system_secrets_vault`` module docstring), and its legacy row is never
+    pruned, so the fallback is never exercised for it in practice.
+
     Returns an empty dict and logs a warning if the DB is unavailable — the
     deploy is allowed to proceed rather than being blocked by a secret-fetch
     failure.
     """
-    from sqlalchemy import select
-
-    from models.database import SystemSecret
     from services.database import db_service
-    from services.encryption import decrypt_data
+    from services.system_secrets_vault import retrieve_secret
 
     extra: dict[str, str] = {}
     try:
         async with db_service.session() as session:
-            result = await session.execute(
-                select(SystemSecret).where(SystemSecret.key.in_(list(_SECRET_TO_ANSIBLE_VAR.keys())))
-            )
-            for secret in result.scalars().all():
-                ansible_var = _SECRET_TO_ANSIBLE_VAR.get(secret.key)
-                if not ansible_var:
-                    continue
-                value = decrypt_data(secret.encrypted_value)
+            for key, ansible_var in _SECRET_TO_ANSIBLE_VAR.items():
+                value = await retrieve_secret(session, key)
                 if value:
                     extra[ansible_var] = value
     except Exception:

--- a/autobot-slm-backend/services/system_secrets_vault.py
+++ b/autobot-slm-backend/services/system_secrets_vault.py
@@ -1,0 +1,202 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Generic ``system_secrets`` -> unified-secrets System vault bridge (#10088 Task 6a).
+
+Same client/pattern as ``user_management.services.sso_secrets`` (#10153,
+PR #10498): the SLM Manager reaches the System vault over HTTP via
+``vault_client`` (HMAC / X-Internal-API-Key auth), never a direct import —
+the vault lives in a different service (autobot-backend) with its own DB.
+
+Unlike SSO secrets (one JSONB config column per provider to cache the vault
+UUID), ``SystemSecret`` rows are flat ``key -> encrypted_value`` pairs with no
+spare column to stash a vault id, so lookups always resolve by **name**
+(``vault_list()`` filtered by ``name == key``) rather than a cached UUID.
+
+Read ordering is LEGACY-FIRST, by design
+-----------------------------------------
+The legacy ``system_secrets`` CRUD (``api/secrets.py``, the current SLM
+Secrets UI) is left untouched by this task (Task 6c, unifying the two
+Secrets UIs, is a product decision for the owner — see #10088). Since that
+UI remains the live write path for arbitrary admin-managed keys, the legacy
+row is still the freshest copy; ``retrieve_secret`` therefore checks legacy
+first and only falls back to the vault for a key that has been imported and
+subsequently removed from ``system_secrets`` (so a migrated-then-pruned
+secret never becomes unreachable — the "no secret becomes unreachable
+mid-cutover" invariant, satisfied without introducing a second, divergent
+write path (no dual-write)).
+
+Irreducible keys are never migrated
+------------------------------------
+``autobot_internal_api_key`` is the credential ``vault_client`` itself uses
+to authenticate every call in this module (X-Internal-API-Key). Storing it
+*inside* the vault it unlocks is the exact confused-deputy cycle the #10088
+Appendix's "auth-bootstrap" classification exists to prevent — it is
+irreducible and MUST stay in ``system_secrets`` (or, per the Appendix, an
+env file) regardless of vault availability. ``sso:provider:*`` keys are
+already handled by the dedicated #10153 migration
+(``migrations/migrate_sso_to_unified_vault.py`` /
+``user_management.services.sso_secrets``) — skipped here to avoid a
+duplicate vault entry under the same name.
+
+Never log a secret value. Never expose one in an exception message.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+#: Auth-bootstrap credential — gates access to the vault this module talks to.
+#: Migrating it would create a confused-deputy cycle; see module docstring.
+IRREDUCIBLE_KEYS: frozenset[str] = frozenset({"autobot_internal_api_key"})  # nosec B105 - key name, not a credential
+
+#: SSO provider secrets already have a dedicated migration path (#10153).
+_SSO_KEY_PREFIX = "sso:provider:"
+
+#: Vault secret-type label for system_secrets rows imported by this module.
+_SECRET_TYPE = "system-secret"  # nosec B105 - type label, not a credential
+
+
+def is_migratable(key: str) -> bool:
+    """True when *key* is eligible to move into the System vault.
+
+    False for the auth-bootstrap key (irreducible, #10088 Appendix) and for
+    SSO provider fields (already migrated under a dedicated #10153 path).
+    """
+    return key not in IRREDUCIBLE_KEYS and not key.startswith(_SSO_KEY_PREFIX)
+
+
+async def _legacy_get(session: AsyncSession, key: str) -> str | None:
+    """Read+decrypt a legacy ``system_secrets`` row; ``None`` if absent."""
+    from models.database import SystemSecret
+    from services.encryption import decrypt_data
+
+    result = await session.execute(select(SystemSecret).where(SystemSecret.key == key))
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    return decrypt_data(row.encrypted_value)
+
+
+async def _find_vault_id_by_name(name: str) -> uuid.UUID | None:
+    """Scan the System vault listing for an entry named *name* (no cached id available)."""
+    from user_management.services.vault_client import VaultClientError, vault_list
+
+    try:
+        entries = await vault_list()
+    except VaultClientError:
+        return None
+    for entry in entries:
+        if entry.get("name") == name:
+            return uuid.UUID(entry["id"])
+    return None
+
+
+async def retrieve_secret(session: AsyncSession, key: str) -> str | None:
+    """Return the plaintext value of *key*, legacy-first (see module docstring).
+
+    Falls back to the System vault only when the legacy row is absent —
+    covers a key that was imported by :func:`migrate_key_to_vault` and later
+    pruned from ``system_secrets``. Returns ``None`` when the key exists
+    nowhere.
+    """
+    legacy_value = await _legacy_get(session, key)
+    if legacy_value is not None:
+        return legacy_value
+
+    if key in IRREDUCIBLE_KEYS:
+        return None  # never consult the vault for the auth-bootstrap key
+
+    from user_management.services.vault_client import (
+        VaultClientError,
+        VaultSecretNotFound,
+        is_configured,
+        vault_read,
+    )
+
+    if not is_configured():
+        return None
+
+    vault_id = await _find_vault_id_by_name(key)
+    if vault_id is None:
+        return None
+    try:
+        return await vault_read(vault_id)
+    except VaultSecretNotFound:
+        return None
+    except VaultClientError as exc:
+        logger.warning("system-secrets-vault: read failed key=%s: %s", key, type(exc).__name__)
+        return None
+
+
+async def delete_vault_copy(key: str) -> None:
+    """Delete *key*'s vault entry, if any (best-effort, never raises).
+
+    Called whenever the legacy row is deleted (``api/secrets.py``) so a
+    revoked/deleted secret can never resurrect through the vault-fallback
+    read path in :func:`retrieve_secret` — mirrors
+    ``SSOSecretsManager.delete_secrets`` deleting both copies (#10153).
+    """
+    if key in IRREDUCIBLE_KEYS:
+        return  # never touches the vault for the auth-bootstrap key
+
+    from user_management.services.vault_client import (
+        VaultClientError,
+        VaultSecretNotFound,
+        is_configured,
+        vault_delete,
+    )
+
+    if not is_configured():
+        return
+    vault_id = await _find_vault_id_by_name(key)
+    if vault_id is None:
+        return
+    try:
+        await vault_delete(vault_id)
+        logger.info("system-secrets-vault: deleted vault copy key=%s", key)
+    except VaultSecretNotFound:
+        pass  # already gone — idempotent
+    except VaultClientError as exc:
+        logger.warning("system-secrets-vault: delete failed key=%s: %s", key, type(exc).__name__)
+
+
+async def migrate_key_to_vault(session: AsyncSession, key: str) -> bool:
+    """Copy one ``system_secrets`` row into the System vault (idempotent).
+
+    Returns ``True`` when a vault write happened, ``False`` when the key is
+    ineligible, absent from the legacy table, already present in the vault,
+    or the vault is not configured. Never deletes the legacy row — the
+    existing CRUD (``api/secrets.py``) stays the live write path (#10088
+    Task 6c is undecided; see module docstring).
+    """
+    if not is_migratable(key):
+        return False
+
+    from user_management.services.vault_client import VaultClientError, is_configured, vault_create
+
+    if not is_configured():
+        return False
+
+    if await _find_vault_id_by_name(key) is not None:
+        logger.info("system-secrets-vault: migrate skip key=%s (already migrated)", key)
+        return False
+
+    plaintext = await _legacy_get(session, key)
+    if plaintext is None:
+        return False
+
+    try:
+        await vault_create(key, _SECRET_TYPE, plaintext)
+    except VaultClientError as exc:
+        logger.error("system-secrets-vault: migrate failed key=%s: %s", key, type(exc).__name__)
+        raise
+    logger.info("system-secrets-vault: migrated key=%s", key)
+    return True

--- a/autobot-slm-backend/services/system_secrets_vault_test.py
+++ b/autobot-slm-backend/services/system_secrets_vault_test.py
@@ -1,0 +1,334 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Integration tests for the system_secrets -> System vault bridge (#10088 Task 6a).
+
+The slm-backend root conftest stubs ``sqlalchemy`` / ``models.database`` /
+``services.encryption`` etc. as MagicMocks for api/* tests. Following the
+established real-load pattern
+(``user_management/services/sso_secrets_test.py``, #11737/#11794/#10153),
+this module swaps in the REAL sqlalchemy + product modules at import time,
+binds what it needs, then restores the stubs so sibling test files are
+unaffected.
+
+The System vault itself (a separate service, autobot-backend) is faked with
+an in-memory ``_FakeVault`` double patched onto the real, loaded
+``user_management.services.vault_client`` module — this exercises the
+actual name-lookup / create / read / delete logic in
+``system_secrets_vault.py`` without any live HTTP dependency.
+"""
+
+import contextlib
+import importlib
+import importlib.util
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+_SLM_ROOT = Path(__file__).parent.parent
+for _p in (str(_SLM_ROOT), str(_SLM_ROOT.parent)):  # slm root + repo root (autobot_shared)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+os.environ.setdefault("SLM_ENCRYPTION_KEY", "unit-test-encryption-key-0123456789abcdef")
+
+_SWAP_PREFIXES = ("sqlalchemy", "aiosqlite")
+_SWAP_KEYS = (
+    "models.database",
+    "services.encryption",
+    "services.system_secrets_vault",
+    "user_management.services.vault_client",
+)
+
+
+def _is_swap_key(name: str) -> bool:
+    return name in _SWAP_KEYS or any(name == p or name.startswith(p + ".") for p in _SWAP_PREFIXES)
+
+
+def _load_real_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+_orig_modules = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+for _name in list(_orig_modules):
+    del sys.modules[_name]
+try:
+    for _name in (
+        "sqlalchemy",
+        "sqlalchemy.ext.asyncio",
+        "sqlalchemy.orm",
+        "sqlalchemy.dialects.sqlite.aiosqlite",
+    ):
+        importlib.import_module(_name)
+
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    _real_md = _load_real_module("models.database", _SLM_ROOT / "models" / "database.py")
+    _real_enc = _load_real_module("services.encryption", _SLM_ROOT / "services" / "encryption.py")
+    _real_vc = _load_real_module(
+        "user_management.services.vault_client",
+        _SLM_ROOT / "user_management" / "services" / "vault_client.py",
+    )
+    _real_ssv = _load_real_module(
+        "services.system_secrets_vault",
+        _SLM_ROOT / "services" / "system_secrets_vault.py",
+    )
+
+    Base = _real_md.Base
+    SystemSecret = _real_md.SystemSecret
+    encrypt_data = _real_enc.encrypt_data
+    ssv = _real_ssv
+
+    _REAL_MODULES = {name: mod for name, mod in sys.modules.items() if _is_swap_key(name)}
+finally:
+    for _name in [name for name in sys.modules if _is_swap_key(name)]:
+        del sys.modules[_name]
+    for _name, _mod in _orig_modules.items():
+        sys.modules[_name] = _mod
+
+
+@contextlib.contextmanager
+def _real_modules_swapped():
+    saved = {name: sys.modules.get(name) for name in _REAL_MODULES}
+    sys.modules.update(_REAL_MODULES)
+    try:
+        yield
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)
+
+
+class _FakeVault:
+    """In-memory double for the System vault's HTTP surface (name -> plaintext)."""
+
+    def __init__(self) -> None:
+        self.entries: dict[uuid.UUID, dict] = {}
+        self.configured = True
+
+    def is_configured(self) -> bool:
+        return self.configured
+
+    async def vault_create(self, name: str, secret_type: str, value: str) -> dict:
+        secret_id = uuid.uuid4()
+        self.entries[secret_id] = {"id": str(secret_id), "name": name, "value": value, "type": secret_type}
+        return self.entries[secret_id]
+
+    async def vault_read(self, secret_id: uuid.UUID) -> str:
+        entry = self.entries.get(secret_id)
+        if entry is None:
+            raise _real_vc.VaultSecretNotFound(str(secret_id))
+        return entry["value"]
+
+    async def vault_list(self) -> list:
+        return list(self.entries.values())
+
+    async def vault_delete(self, secret_id: uuid.UUID) -> None:
+        self.entries.pop(secret_id, None)
+
+
+@pytest.fixture
+def fake_vault(monkeypatch):
+    """Patch the real, loaded vault_client's module-level functions with a fake."""
+    with _real_modules_swapped():
+        fv = _FakeVault()
+        monkeypatch.setattr(_real_vc, "is_configured", fv.is_configured)
+        monkeypatch.setattr(_real_vc, "vault_create", fv.vault_create)
+        monkeypatch.setattr(_real_vc, "vault_read", fv.vault_read)
+        monkeypatch.setattr(_real_vc, "vault_list", fv.vault_list)
+        monkeypatch.setattr(_real_vc, "vault_delete", fv.vault_delete)
+        yield fv
+
+
+@pytest.fixture
+async def async_session():
+    with _real_modules_swapped():
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session_maker = sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        async with async_session_maker() as session:
+            yield session
+        await engine.dispose()
+
+
+async def _add_legacy(session, key: str, value: str) -> None:
+    with _real_modules_swapped():
+        session.add(SystemSecret(key=key, encrypted_value=encrypt_data(value), category="system"))
+        await session.commit()
+
+
+class TestIsMigratable:
+    def test_irreducible_key_rejected(self):
+        with _real_modules_swapped():
+            assert ssv.is_migratable("autobot_internal_api_key") is False
+
+    def test_sso_prefixed_key_rejected(self):
+        with _real_modules_swapped():
+            assert ssv.is_migratable(f"sso:provider:{uuid.uuid4()}:client_secret") is False
+
+    def test_ordinary_key_accepted(self):
+        with _real_modules_swapped():
+            assert ssv.is_migratable("hf_token") is True
+
+
+class TestRetrieveSecret:
+    @pytest.mark.asyncio
+    async def test_legacy_first_when_present(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            await _add_legacy(async_session, "hf_token", "legacy-value")
+            # Also seed a DIFFERENT (stale) vault copy to prove legacy wins.
+            await fake_vault.vault_create("hf_token", "system-secret", "stale-vault-value")
+
+            value = await ssv.retrieve_secret(async_session, "hf_token")
+            assert value == "legacy-value"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_vault_when_legacy_absent(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            await fake_vault.vault_create("hf_token", "system-secret", "vault-only-value")
+            value = await ssv.retrieve_secret(async_session, "hf_token")
+            assert value == "vault-only-value"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_absent_everywhere(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            assert await ssv.retrieve_secret(async_session, "nonexistent_key") is None
+
+    @pytest.mark.asyncio
+    async def test_irreducible_key_never_reads_vault(self, async_session, fake_vault):
+        """Even if a vault entry somehow exists under this name, it must never be read."""
+        with _real_modules_swapped():
+            await fake_vault.vault_create("autobot_internal_api_key", "system-secret", "should-never-surface")
+            assert await ssv.retrieve_secret(async_session, "autobot_internal_api_key") is None
+
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_none_without_legacy(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            fake_vault.configured = False
+            assert await ssv.retrieve_secret(async_session, "hf_token") is None
+
+
+class TestMigrateKeyToVault:
+    @pytest.mark.asyncio
+    async def test_migrates_eligible_key(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            await _add_legacy(async_session, "hf_token", "the-hf-token")
+            migrated = await ssv.migrate_key_to_vault(async_session, "hf_token")
+            assert migrated is True
+            entries = await fake_vault.vault_list()
+            assert any(e["name"] == "hf_token" and e["value"] == "the-hf-token" for e in entries)
+
+    @pytest.mark.asyncio
+    async def test_second_run_is_a_noop(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            await _add_legacy(async_session, "hf_token", "the-hf-token")
+            first = await ssv.migrate_key_to_vault(async_session, "hf_token")
+            second = await ssv.migrate_key_to_vault(async_session, "hf_token")
+            assert first is True
+            assert second is False  # already migrated — no duplicate vault entry
+            entries = await fake_vault.vault_list()
+            assert len([e for e in entries if e["name"] == "hf_token"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_irreducible_key(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            await _add_legacy(async_session, "autobot_internal_api_key", "the-internal-key")
+            migrated = await ssv.migrate_key_to_vault(async_session, "autobot_internal_api_key")
+            assert migrated is False
+            assert await fake_vault.vault_list() == []
+
+    @pytest.mark.asyncio
+    async def test_skips_sso_prefixed_key(self, async_session, fake_vault):
+        provider_id = uuid.uuid4()
+        key = f"sso:provider:{provider_id}:client_secret"
+        with _real_modules_swapped():
+            await _add_legacy(async_session, key, "sso-secret-value")
+            migrated = await ssv.migrate_key_to_vault(async_session, key)
+            assert migrated is False
+            assert await fake_vault.vault_list() == []
+
+    @pytest.mark.asyncio
+    async def test_absent_legacy_key_not_migrated(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            migrated = await ssv.migrate_key_to_vault(async_session, "hf_token")
+            assert migrated is False
+
+    @pytest.mark.asyncio
+    async def test_vault_not_configured_skips(self, async_session, fake_vault):
+        with _real_modules_swapped():
+            await _add_legacy(async_session, "hf_token", "the-hf-token")
+            fake_vault.configured = False
+            migrated = await ssv.migrate_key_to_vault(async_session, "hf_token")
+            assert migrated is False
+
+
+class TestDeleteVaultCopy:
+    @pytest.mark.asyncio
+    async def test_revoked_secret_cannot_resurrect(self, async_session, fake_vault):
+        """Delete legacy + vault copy => retrieve_secret finds it nowhere (no resurrection)."""
+        with _real_modules_swapped():
+            await _add_legacy(async_session, "hf_token", "the-hf-token")
+            await ssv.migrate_key_to_vault(async_session, "hf_token")
+
+            # Simulate the legacy DELETE endpoint's row removal.
+            from sqlalchemy import delete as sa_delete
+
+            await async_session.execute(sa_delete(SystemSecret).where(SystemSecret.key == "hf_token"))
+            await async_session.commit()
+
+            # Without the dual-delete, this would resurrect via the vault fallback.
+            await ssv.delete_vault_copy("hf_token")
+
+            assert await ssv.retrieve_secret(async_session, "hf_token") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_vault_copy_is_idempotent(self, fake_vault):
+        with _real_modules_swapped():
+            await ssv.delete_vault_copy("never_existed")  # must not raise
+            await ssv.delete_vault_copy("never_existed")
+
+    @pytest.mark.asyncio
+    async def test_delete_vault_copy_never_touches_irreducible_key(self, fake_vault):
+        with _real_modules_swapped():
+            await fake_vault.vault_create("autobot_internal_api_key", "system-secret", "value")
+            await ssv.delete_vault_copy("autobot_internal_api_key")
+            # Entry untouched (guard returns before ever calling vault_delete).
+            entries = await fake_vault.vault_list()
+            assert any(e["name"] == "autobot_internal_api_key" for e in entries)
+
+
+class TestNoSecretValueLogged:
+    @pytest.mark.asyncio
+    async def test_migrate_logging_never_includes_secret_value(self, async_session, fake_vault, caplog):
+        with _real_modules_swapped():
+            secret_value = "super-secret-plaintext-marker-xyz"
+            await _add_legacy(async_session, "hf_token", secret_value)
+            with caplog.at_level("INFO"):
+                await ssv.migrate_key_to_vault(async_session, "hf_token")
+            for record in caplog.records:
+                assert secret_value not in record.getMessage()
+
+    @pytest.mark.asyncio
+    async def test_retrieve_logging_never_includes_secret_value(self, async_session, fake_vault, caplog):
+        with _real_modules_swapped():
+            secret_value = "another-secret-plaintext-marker-abc"
+            await fake_vault.vault_create("hf_token", "system-secret", secret_value)
+            with caplog.at_level("INFO"):
+                value = await ssv.retrieve_secret(async_session, "hf_token")
+            assert value == secret_value
+            for record in caplog.records:
+                assert secret_value not in record.getMessage()


### PR DESCRIPTION
## Thinking Path

Umbrella #10088 Task 6 ("SLM control plane (B)") bundles three different-nature changes: (a) `system_secrets` → System vault, (b) `node_credentials` → Node vault, (c) unify the two Secrets UIs. Per instructions, (c) is a product decision — audited only, not built. (a) and (b) were audited before writing anything.

**Inventory (`file:line`):**
- `autobot-slm-backend/models/database.py:665` `SystemSecret` (flat `key`→AES-GCM `encrypted_value`, admin-only). `models/database.py:696` `NodeCredential` (per-node VNC/SSH/TLS/RDP, Fernet).
- Readers/writers of `SystemSecret`: `api/secrets.py` (the SLM Secrets UI — generic CRUD, arbitrary keys), `api/scim.py:68` (`_load_scim_token`), `services/ansible_secrets.py:54` (`fetch_deploy_secrets`, injects stored secrets as Ansible extra_vars at deploy time), `main.py:495,515` (seeds `autobot_internal_api_key` / `scim_bearer_token` on first boot), and the already-migrated `sso:provider:*` fields (`user_management/services/sso_secrets.py`, #10153/PR #10498).
- Readers of `NodeCredential`: `services/vnc_credentials.py`, `services/rdp_credentials.py`, `services/tls_credentials.py` — all consumed via the SLM backend's own runtime API endpoints (`api/vnc.py`, `api/rdp.py`, `api/tls.py`), never by Ansible/deploy-time code directly (confirmed by repo-wide grep) — **no boot-time chicken-and-egg for node credentials**.

**How SLM reaches the vault:** confirmed via `sso_secrets.py`/`vault_client.py` (#10153) — the SLM Manager is a separate service (own DB, own process) and reaches the System vault over HTTP (`X-Internal-API-Key`/HMAC), never a direct import. Followed this exact, already-proven pattern rather than inventing a second one.

**A genuine bootstrap cycle, found and NOT worked around:** `autobot_internal_api_key` is stored today as a `system_secrets` row (`main.py:495` generates it on first boot; `api/secrets.py` lets an admin edit it), and its value is exactly what `vault_client.py`'s `X-Internal-API-Key` auth uses to reach the vault. Migrating this specific key into the System vault would be a confused-deputy cycle: the credential that unlocks the vault would live inside the vault it unlocks — the exact scenario the umbrella's Appendix classifies `AUTOBOT_INTERNAL_API_KEY` as **irreducible** (auth-bootstrap) to prevent. This key is explicitly excluded from migration (`IRREDUCIBLE_KEYS` denylist) and stays in `system_secrets` only, exactly as today.

**(b) scoped out — materially larger, not delivered:** the backend's `/api/v2/secrets` service-auth surface (`autobot-backend/api/envelope_secrets.py`, `services/secrets_coordinator.py`) is hard-restricted to the System vault only (`_require_system_vault`/`_assert_system_vault`) — there is **no service-auth Node-vault route today**, even though `VaultKind.NODE` and human-admin `authorize()` support already exist (Task 9.1/2.3). Building (b) would require new backend routes (`/api/v2/secrets/node/*`), a coordinator generalization across two repos, plus a per-credential-type encoding design (VNC password + extra_data JSON blob, TLS cert bundle, RDP password) with no existing precedent — a separate, larger PR. Delivering (a) only, per the "fully delivered or dropped" instruction.

**Scope narrowing followed exactly as instructed:** additive importer + dual-read only, no retirement. The audit found one real correctness need for write-path awareness: since the legacy `api/secrets.py` CRUD stays untouched (Task 6c undecided) and remains the sole write path, dual-read here is **legacy-first, vault-fallback** (not vault-first as SSO's pattern) — this avoids a staleness bug where a post-import edit via the still-live legacy UI would otherwise go unseen forever by a vault-first reader. Symmetrically, deleting the legacy row now also deletes any imported vault copy (mirrors `SSOSecretsManager.delete_secrets` deleting both) so a revoked secret can never resurrect through the vault fallback.

## What Changed

- **`autobot-slm-backend/services/system_secrets_vault.py`** (new) — generic bridge: `retrieve_secret` (legacy-first, vault fallback), `migrate_key_to_vault` (idempotent, per-key), `delete_vault_copy` (closes the resurrection gap), `is_migratable` (denylists `autobot_internal_api_key` and `sso:provider:*`, the latter already owned by #10153).
- **`autobot-slm-backend/migrations/migrate_system_secrets_to_vault.py`** (new) — standalone, idempotent one-time import script (same shape as `migrate_sso_to_unified_vault.py`); not part of the schema `migrations.runner` list, same as its SSO counterpart.
- **`api/scim.py`**, **`services/ansible_secrets.py`**, **`api/secrets.py`** (`get_secret_value`, `delete_secret`) — repointed at the new bridge. `autobot_internal_api_key` is never routed to the vault in any of these paths.
- `system_secrets` / `node_credentials` are untouched — no retirement, no dual-write.

## Verification

- `py_compile` / `flake8 --max-line-length=120` / `black --check --line-length=120` / `isort --check-only` / `pyflakes` / `bandit -c .bandit`: all clean on every touched/added file.
- 24 new tests (SQLite real-load pattern, same technique as `sso_secrets_test.py`), all passing: legacy-first read, vault fallback when legacy absent, irreducible key never reads/writes the vault, idempotent second migration run, **revoke-safety** (`test_revoked_secret_cannot_resurrect`: delete legacy + vault copy → unreachable everywhere), and two no-secret-value-in-logs assertions.
- Spun up a **disposable local Postgres 16** (private `initdb`, not the shared host cluster) and ran the real migration script end-to-end against it (vault HTTP faked, since no live autobot-backend in this environment): migrated `hf_token` + `scim_bearer_token`, correctly skipped `autobot_internal_api_key`, second run created zero additional vault entries, and all 3 legacy `system_secrets` rows remained present and unchanged (`SELECT key, category FROM system_secrets` — all 3 rows verified after both runs).
- `python -m pytest autobot-slm-backend/services/ autobot-slm-backend/migrations/ autobot-slm-backend/user_management/services/`: 221 passed (includes the 24 new). 4 pre-existing failures in `drift_checker_test.py` are unrelated to this change (confirmed via `git status` — file untouched — and root-caused to a missing sibling directory in this worktree, not secrets code).
- `autobot-backend/tests/test_raw_client_session_ceiling_12992.py`: still 2/2 passing (this PR touches no `autobot-backend/` files).
- `startup-import-smoke`'s own gate (`test_startup_imports.py`) only scans `autobot-backend/api` + `agents/`, so it doesn't cover SLM modules directly; equivalent coverage here is the real-module-load tests above plus the real-Postgres run, both of which exercise genuine imports of every touched module.

## Two-Secrets-UI unification — options for the owner (audited, not decided)

- **UI A — SLM Secrets UI** (`autobot-slm-backend/api/secrets.py` + `SecretsSettings.vue`): admin-only, generic key/value CRUD over `system_secrets`; reached from the SLM control-plane console. Exposes fleet-wide tokens (HF, SCIM bearer, internal API key, arbitrary admin-added keys) plus node VNC/SSH/TLS/RDP credential management (separate endpoints over `node_credentials`). No per-user secrets, no sharing model.
- **UI B — main-backend Secrets UI** (`autobot-backend/api/secrets.py` legacy store + `SecretsManager.vue`, being migrated to `/api/v2/secrets` under Tasks 2–5): per-user secret ownership with sharing (private/colleague/team/company), RBAC-governed, backed by the unified envelope store + vaults.
- **Option 1 — SLM UI becomes a filtered view of the unified UI.** Once (a)+(b) fully land, `SecretsSettings.vue` calls `/api/v2/secrets` scoped to `system`/`node` vaults (admin-only) instead of the SLM-local CRUD. Pro: truly one UI, one API. Con: requires (b) built first (Node-vault service route, currently absent) and a UI rewrite of `SecretsSettings.vue`.
- **Option 2 — Keep two entry points, one backing store.** Leave `SecretsSettings.vue` as the admin-facing "system/node" lens and `SecretsManager.vue` as the per-user lens, both reading/writing the same unified store via different scoped views (a role-based landing page, not a single component). Pro: smaller UI change, respects that admin fleet-ops and per-user secret sharing are genuinely different workflows. Con: "two UIs" technically persists, just both backed by one store — may not satisfy the umbrella's literal "unify into one" framing.
- **Option 3 — Full merge into a single Secrets page** with tabs/sections (System, Node, Mine, Shared, Company), gated by RBAC per section. Pro: closest to "one Secrets UI". Con: largest UI investment, blocked on (b) and on Task 7 (first-time-setup provider-key capture) to have real System-vault content to show.

No default recommended — trade-offs depend on how much of (b) and Task 7 the owner wants to land before touching the frontend.

## Discovered, not fixed (separate scope)

- `autobot_shared/legacy_secret_keys.py` (Task 1.3, LLC HKDF adapter) doesn't apply here — SLM's own `services/encryption.py` (AES-GCM, lightweight, no eager-import chain) is reused as-is, matching the SSO precedent; no new adapter needed.
- Pre-existing: `migrate_sso_to_unified_vault.py` has zero tests (confirmed via search) — not introduced by this PR, not fixed here (out of scope; flagged for awareness, not filed as a new issue since it's dormant scaffolding with no reported failure).

## Model Used

Sonnet 5
