### PR TITLE
feat(secrets): capture LLM provider keys at setup into the System vault (#10088 Task 7)

### DIFF
--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import threading
+import uuid
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Dict, List
@@ -53,6 +54,7 @@ from autobot_shared.time_utils import parse_utc_iso
 from middleware.proxy_utils import get_client_ip
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2
 from services.json_secrets_read import load_imported_json_secret
+from services.provider_key_vault import mirror_provider_key_best_effort
 from type_defs.common import Metadata
 
 logger = get_logger(__name__)
@@ -495,6 +497,22 @@ def audit_log(
     )
 
 
+async def _mirror_llm_provider_key(name: str, value: str, user: Dict | None) -> None:
+    """Best-effort System-vault mirror for an LLM-provider-key capture (#10088 Task 7).
+
+    No-op for any secret name that isn't a known LLM provider key (see
+    ``provider_key_vault.LLM_PROVIDER_KEY_NAMES``). Never raises -- a
+    dev/test environment without a configured vault root key must not turn a
+    successful legacy secret creation into a failed request.
+    """
+    raw_user_id = (user or {}).get("user_id")
+    try:
+        created_by = uuid.UUID(str(raw_user_id))
+    except (TypeError, ValueError):
+        created_by = uuid.UUID("00000000-0000-0000-0000-000000000000")
+    await mirror_provider_key_best_effort(name, value, created_by)
+
+
 async def _get_secret_dual_read(secret_id: str, chat_id: str | None) -> Dict | None:
     """Try the unified envelope store (#10088 Task 3 dual-read), else the legacy JSON file.
 
@@ -550,6 +568,9 @@ async def create_secret(
             session_id=None,
             outcome="success",
         )
+        # #10088 Task 7: mirror LLM-provider-key captures into the System vault
+        # (best-effort -- never turns a successful legacy write into a failure).
+        await _mirror_llm_provider_key(request.name, request.value, _user)
         return JSONResponse(
             status_code=201,
             content={

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -298,6 +298,30 @@ async def _init_database() -> None:
         raise
 
 
+async def _hydrate_llm_provider_keys() -> None:
+    """Hydrate LLM provider keys from the System vault (#10088 Task 7).
+
+    Runs once, synchronously, in Phase 1 (after the DB is initialised) so
+    ``llm_shared.provider_registry``'s lazy first population -- which can be
+    triggered by the very first request -- always sees a key captured only
+    via the setup wizard (never set as an env var). Env vars always win
+    (skipped entirely when set), so an Ansible-provisioned deployment is
+    unaffected. Best-effort: no root key configured (dev/test) or a DB error
+    must never block startup.
+    """
+    logger.info("[ 17%] Provider Keys: hydrating from System vault...")
+    try:
+        from services.provider_key_vault import hydrate_provider_keys_from_vault
+        from user_management.database import get_async_session_factory
+
+        async with get_async_session_factory()() as session:
+            hydrated = await hydrate_provider_keys_from_vault(session)
+        if hydrated:
+            logger.info("[ 17%] Provider Keys: hydrated %d key(s) from vault: %s", len(hydrated), hydrated)
+    except Exception as exc:
+        logger.debug("Provider-key vault hydration skipped (non-critical): %s", exc)
+
+
 async def _init_telemetry_and_redis() -> None:
     """Helper for initialize_critical_services. Ref: #1088.
 
@@ -466,6 +490,12 @@ async def initialize_critical_services(app: FastAPI):
             _init_database(),
             _init_telemetry_and_redis(),
         )
+
+        # --- Tier 1.5: LLM provider-key vault hydration (sequential, after DB) ---
+        # Must complete before Phase 1 returns -- llm_shared.provider_registry's
+        # first (lazy) population can be triggered by the very first request,
+        # so this cannot be deferred to Phase 2's background task (#10088 Task 7).
+        await _hydrate_llm_provider_keys()
 
         # --- Tier 2: chat service managers (parallel) ---
         # Issue #665: uses helpers

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -562,6 +562,7 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     from llm_shared.providers.openrouter import OpenRouterProvider
     from llm_shared.providers.vertexai import VertexAIProvider
     from llm_shared.providers.vllm_base import VLLMBaseProvider
+    from services.provider_key_vault import resolve_provider_key
 
     fallback: List[str] = []
 
@@ -577,8 +578,8 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     except Exception as exc:
         logger.debug("Ollama provider not registered: %s", exc)
 
-    # OpenAI — registered when API key is present
-    openai_key = config.openai_api_key
+    # OpenAI — registered when API key is present (env wins; else System vault, #10088 Task 7)
+    openai_key = resolve_provider_key("OPENAI_API_KEY", config.openai_api_key)
     if openai_key:
         openai_provider = OpenAIProvider(settings={"api_key": openai_key})
         registry.register(openai_provider)
@@ -586,8 +587,8 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     else:
         logger.debug("OPENAI_API_KEY not set — OpenAI provider not registered")
 
-    # Anthropic — registered when API key is present
-    anthropic_key = config.anthropic_api_key
+    # Anthropic — registered when API key is present (env wins; else System vault, #10088 Task 7)
+    anthropic_key = resolve_provider_key("ANTHROPIC_API_KEY", config.anthropic_api_key)
     if anthropic_key:
         anthropic_provider = AnthropicProvider(settings={"api_key": anthropic_key})
         registry.register(anthropic_provider)
@@ -595,8 +596,8 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     else:
         logger.debug("ANTHROPIC_API_KEY not set — Anthropic provider not registered")
 
-    # Groq — registered when API key is present
-    groq_key = config.groq_api_key
+    # Groq — registered when API key is present (env wins; else System vault, #10088 Task 7)
+    groq_key = resolve_provider_key("GROQ_API_KEY", config.groq_api_key)
     if groq_key:
         groq_provider = GroqProvider(settings={"api_key": groq_key})
         registry.register(groq_provider)
@@ -604,8 +605,8 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     else:
         logger.debug("GROQ_API_KEY not set — Groq provider not registered")
 
-    # Mistral — registered when API key is present (Issue #10549)
-    mistral_key = config.mistral_api_key
+    # Mistral — registered when API key is present (Issue #10549; env wins else vault, #10088 Task 7)
+    mistral_key = resolve_provider_key("MISTRAL_API_KEY", config.mistral_api_key)
     if mistral_key:
         mistral_provider = MistralProvider(
             settings={
@@ -634,7 +635,8 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
         custom_provider = CustomOpenAIProvider(
             settings={
                 "base_url": custom_url,
-                "api_key": config.custom_openai_api_key,
+                # env wins; else System vault (#10088 Task 7)
+                "api_key": resolve_provider_key("CUSTOM_OPENAI_API_KEY", config.custom_openai_api_key),
                 "default_model": config.custom_openai_default_model,
             }
         )
@@ -643,8 +645,8 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     else:
         logger.debug("CUSTOM_OPENAI_BASE_URL not set — custom OpenAI provider not registered")
 
-    # OpenRouter — registered when API key is present (Issue #4341)
-    openrouter_key = config.openrouter_api_key
+    # OpenRouter — registered when API key is present (Issue #4341; env wins else vault, #10088 Task 7)
+    openrouter_key = resolve_provider_key("OPENROUTER_API_KEY", config.openrouter_api_key)
     if openrouter_key:
         try:
             openrouter_provider = OpenRouterProvider(
@@ -660,8 +662,10 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     else:
         logger.debug("OPENROUTER_API_KEY not set — OpenRouter provider not registered")
 
-    # Nous Portal — registered when API key is present (Issue #4341)
-    nous_key = config.nous_api_key or config.hf_token or config.huggingface_api_token
+    # Nous Portal — registered when API key is present (Issue #4341; env wins else vault, #10088 Task 7)
+    nous_key = (
+        resolve_provider_key("NOUS_API_KEY", config.nous_api_key) or config.hf_token or config.huggingface_api_token
+    )
     if nous_key:
         try:
             nous_provider = NousPortalProvider(

--- a/autobot-backend/services/provider_key_vault.py
+++ b/autobot-backend/services/provider_key_vault.py
@@ -131,7 +131,7 @@ async def capture_provider_key(
             session,
             owner_vault=_SYSTEM_VAULT,
             name=name,
-            secret_type="api_key",
+            secret_type="api_key",  # nosec B106 - SecretType label, not a credential
             plaintext=plaintext.encode("utf-8"),
             created_by=created_by,
         )

--- a/autobot-backend/services/provider_key_vault.py
+++ b/autobot-backend/services/provider_key_vault.py
@@ -1,0 +1,191 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLM provider-key capture + vault-backed runtime resolution (#10088 Task 7).
+
+First-time-setup flow: an admin captures an LLM provider key (OpenAI,
+Anthropic, ...) through the API-key setup wizard
+(``autobot-frontend/src/components/settings/ApiKeySetupWizard.vue``), which
+posts to the legacy ``POST /api/secrets/`` endpoint (``api/secrets.py``) --
+today's *only* write path for these values, since ``SecretUpdateRequest`` has
+no ``value`` field (rotation is delete+recreate). This module adds two halves
+that endpoint never had:
+
+1. **Capture** (:func:`mirror_provider_key_best_effort`) -- mirrors a
+   provider-key value into the System vault at the moment it's created,
+   idempotently (create once, rotate on a later re-capture of the same
+   name). Scoped strictly to :data:`LLM_PROVIDER_KEY_NAMES` -- the generic
+   ``secrets.json`` -> envelope migration is Task 3's importer (`#13052`
+   notes nothing invokes it yet); this hook does not duplicate that work,
+   it only guarantees LLM provider keys specifically are never vault-blind.
+
+2. **Runtime resolution** (:func:`hydrate_provider_keys_from_vault` +
+   :func:`resolve_provider_key`) -- the actual runtime reader,
+   ``llm_shared.provider_registry._populate_default_providers``, only ever
+   read ``ssot_config`` (env vars) and never consulted the legacy secrets
+   store *or* the vault -- a value captured via the wizard was, until this
+   change, write-only (unreachable at runtime; the same class of defect
+   Task 5 hit for connector credentials). :func:`hydrate_provider_keys_from_vault`
+   runs once at startup (``initialization/lifespan.py``, Phase 1, after the
+   DB is initialised) and populates a process-lifetime cache consulted
+   *only* when the env var itself is unset, so an Ansible-provisioned
+   deployment's env vars remain authoritative and unaffected (dual-read,
+   env-first -- no provider key becomes unreachable mid-cutover).
+
+Never logs a secret value.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from models.secret import Secret
+
+logger = logging.getLogger(__name__)
+
+#: LLM provider API-key env-var names eligible for System-vault capture +
+#: resolution. Each name has a real runtime reader in
+#: ``llm_shared.provider_registry._populate_default_providers`` -- the actual
+#: LLM-call routing path (not the adapter-listing-only AdapterRegistry).
+#: HF_TOKEN is deliberately excluded: it is captured via a different flow
+#: (the SLM setup wizard's ``system_secrets``, already migrated by Task 6a).
+LLM_PROVIDER_KEY_NAMES: frozenset[str] = frozenset(
+    {
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "OPENROUTER_API_KEY",
+        "NOUS_API_KEY",
+        "CUSTOM_OPENAI_API_KEY",
+    }
+)
+
+_SYSTEM_VAULT = VaultRef(VaultKind.SYSTEM)
+
+#: Process-lifetime cache of provider keys hydrated from the System vault.
+#: Consulted only when the env var itself is unset (env wins). Never logged,
+#: never written back to os.environ (child-process env sanitization is a
+#: separate, pre-existing concern -- see services/execution/env_sanitizer.py).
+_hydrated_keys: dict[str, str] = {}
+
+
+def resolve_provider_key(env_var: str, config_value: str) -> str:
+    """Env var wins (today's authoritative source); else the vault-hydrated cache.
+
+    Called from ``llm_shared.provider_registry._populate_default_providers`` in
+    place of a bare ``config.<x>_api_key`` read, so a key captured only via the
+    setup wizard (never set as an env var) still resolves at runtime.
+    """
+    return config_value or _hydrated_keys.get(env_var, "")
+
+
+async def _find_system_secret_id(session: AsyncSession, name: str) -> uuid.UUID | None:
+    """Return the id of the active System-vault secret named *name*, if any."""
+    result = await session.execute(
+        select(Secret.id).where(
+            Secret.owner_vault == _SYSTEM_VAULT.to_str(),
+            Secret.name == name,
+            Secret.is_active.is_(True),
+        )
+    )
+    return result.scalars().first()
+
+
+async def capture_provider_key(
+    session: AsyncSession, *, name: str, plaintext: str, created_by: uuid.UUID, root_key: bytes | None = None
+) -> bool:
+    """Mirror an LLM-provider-key value into the System vault (idempotent).
+
+    Creates a new System-vault secret the first time *name* is captured;
+    rotates the value on a later re-capture (an admin legitimately changing a
+    key). No-op for any name outside :data:`LLM_PROVIDER_KEY_NAMES` -- this
+    hook is intentionally scoped to LLM provider keys, not a generic secrets
+    mirror. Raises on a genuine vault error; callers use
+    :func:`mirror_provider_key_best_effort` for the best-effort wrapper.
+    ``root_key`` defaults to loading ``AUTOBOT_SECRETS_ROOT_KEY`` (production
+    behaviour); tests pass an explicit key.
+    """
+    if name not in LLM_PROVIDER_KEY_NAMES:
+        return False
+    from services.envelope_secrets_service import EnvelopeSecretsService
+
+    service = EnvelopeSecretsService(root_key=root_key)
+    existing_id = await _find_system_secret_id(session, name)
+    if existing_id is not None:
+        await service.rotate_value(
+            session,
+            secret_id=existing_id,
+            new_plaintext=plaintext.encode("utf-8"),
+            actor_vaults={_SYSTEM_VAULT},
+        )
+    else:
+        await service.create(
+            session,
+            owner_vault=_SYSTEM_VAULT,
+            name=name,
+            secret_type="api_key",
+            plaintext=plaintext.encode("utf-8"),
+            created_by=created_by,
+        )
+    return True
+
+
+async def mirror_provider_key_best_effort(name: str, value: str, created_by: uuid.UUID) -> bool:
+    """Best-effort System-vault mirror for one legacy ``/api/secrets/`` capture.
+
+    Never raises: a dev/test environment with no root key configured, or any
+    DB error, must not turn a successful legacy ``secrets.json`` write into a
+    failed request. Returns True when the vault copy was written/updated.
+    """
+    if name not in LLM_PROVIDER_KEY_NAMES:
+        return False
+    try:
+        from user_management.database import get_async_session_factory
+
+        factory = get_async_session_factory()
+        async with factory() as session:
+            wrote = await capture_provider_key(session, name=name, plaintext=value, created_by=created_by)
+            if wrote:
+                await session.commit()
+            return wrote
+    except Exception as exc:  # noqa: BLE001 - vault is optional in dev/test; never break the caller
+        logger.warning("provider-key-vault: mirror failed name=%s: %s", name, type(exc).__name__)
+        return False
+
+
+async def hydrate_provider_keys_from_vault(session: AsyncSession, *, root_key: bytes | None = None) -> list[str]:
+    """Populate the process cache from the System vault for any unset env var.
+
+    Called once at FastAPI startup, after the DB is initialised. Env vars
+    always win (skipped entirely when already set) -- an Ansible-provisioned
+    deployment is byte-identical to before this change. Returns the list of
+    names actually hydrated (for startup logging -- never the values).
+    ``root_key`` defaults to loading ``AUTOBOT_SECRETS_ROOT_KEY`` (production
+    behaviour); tests pass an explicit key.
+    """
+    from services.envelope_secrets_service import EnvelopeSecretsService
+
+    service = EnvelopeSecretsService(root_key=root_key)
+    hydrated: list[str] = []
+    for name in LLM_PROVIDER_KEY_NAMES:
+        if os.environ.get(name):
+            continue  # env wins -- irreducible/authoritative today
+        secret_id = await _find_system_secret_id(session, name)
+        if secret_id is None:
+            continue
+        try:
+            value = await service.read(session, secret_id=secret_id, accessible_vaults={_SYSTEM_VAULT})
+        except Exception as exc:  # noqa: BLE001 - defensive, one bad row must not break the rest
+            logger.warning("provider-key-vault: hydrate failed name=%s: %s", name, type(exc).__name__)
+            continue
+        _hydrated_keys[name] = value.decode("utf-8")
+        hydrated.append(name)
+    return hydrated

--- a/autobot-backend/tests/migrations/test_provider_key_vault.py
+++ b/autobot-backend/tests/migrations/test_provider_key_vault.py
@@ -1,0 +1,178 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the LLM-provider-key vault capture + runtime resolution (#10088 / Task 7).
+
+Runs against a real, disposable Postgres (migration-gate) so the envelope
+crypto path (System-vault create/read/rotate) is exercised for real, not
+mocked. Verifies: a captured key lands in the System vault; a second capture
+of the same name is idempotent (rotates, not duplicates); the runtime
+resolver (:func:`resolve_provider_key`) actually returns the vault-hydrated
+value when the env var is unset; env vars always win over the vault; and no
+plaintext value is ever logged.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from services.envelope_secrets_service import EnvelopeSecretsService
+from services.provider_key_vault import (
+    LLM_PROVIDER_KEY_NAMES,
+    _hydrated_keys,
+    capture_provider_key,
+    hydrate_provider_keys_from_vault,
+    resolve_provider_key,
+)
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = bytes(range(32))
+_SYSTEM_VAULT = VaultRef(VaultKind.SYSTEM)
+_SENTINEL_USER = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _clear_hydration_cache():
+    """The process-lifetime hydration cache must not leak between tests."""
+    _hydrated_keys.clear()
+    yield
+    _hydrated_keys.clear()
+
+
+async def test_capture_lands_in_system_vault(session):
+    wrote = await capture_provider_key(
+        session, name="OPENAI_API_KEY", plaintext="sk-test-key-1", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+    assert wrote is True
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    secrets = await svc.list_for_vaults(session, accessible_vaults={_SYSTEM_VAULT})
+    assert len(secrets) == 1
+    assert secrets[0].name == "OPENAI_API_KEY"
+    value = await svc.read(session, secret_id=secrets[0].id, accessible_vaults={_SYSTEM_VAULT})
+    assert value == b"sk-test-key-1"
+
+
+async def test_second_capture_rotates_not_duplicates(session):
+    await capture_provider_key(
+        session, name="OPENAI_API_KEY", plaintext="sk-first", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+    await capture_provider_key(
+        session, name="OPENAI_API_KEY", plaintext="sk-second", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    secrets = await svc.list_for_vaults(session, accessible_vaults={_SYSTEM_VAULT})
+    assert len(secrets) == 1  # no duplicate row
+    value = await svc.read(session, secret_id=secrets[0].id, accessible_vaults={_SYSTEM_VAULT})
+    assert value == b"sk-second"  # updated, not stale
+
+
+async def test_non_provider_name_is_a_noop(session):
+    wrote = await capture_provider_key(
+        session, name="SOME_UNRELATED_SECRET", plaintext="whatever", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+    assert wrote is False
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    secrets = await svc.list_for_vaults(session, accessible_vaults={_SYSTEM_VAULT})
+    assert secrets == []
+
+
+async def test_hydrate_finds_vault_only_key(session, monkeypatch):
+    """A key with no env var set is discoverable via the System vault (dual-read)."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    await capture_provider_key(
+        session, name="ANTHROPIC_API_KEY", plaintext="claude-key-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    hydrated = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert "ANTHROPIC_API_KEY" in hydrated
+    # The runtime reader actually resolves through the new path (guards
+    # against a write-only vault, #10088's Task 5 defect class).
+    assert resolve_provider_key("ANTHROPIC_API_KEY", "") == "claude-key-value"
+
+
+async def test_hydrate_skips_when_env_var_already_set(session, monkeypatch):
+    """Env wins -- an Ansible-provisioned deployment is unaffected by the vault."""
+    monkeypatch.setenv("GROQ_API_KEY", "env-value")
+    await capture_provider_key(
+        session, name="GROQ_API_KEY", plaintext="vault-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    hydrated = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert "GROQ_API_KEY" not in hydrated  # env already set -- vault never even queried
+    # resolve_provider_key: env value always wins over anything in the cache.
+    assert resolve_provider_key("GROQ_API_KEY", "env-value") == "env-value"
+
+
+async def test_hydrate_is_idempotent_second_run_noop(session, monkeypatch):
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    await capture_provider_key(
+        session, name="MISTRAL_API_KEY", plaintext="mistral-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    first = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    second = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert first == second == ["MISTRAL_API_KEY"]
+    assert resolve_provider_key("MISTRAL_API_KEY", "") == "mistral-value"
+
+
+async def test_resolve_without_env_or_vault_returns_empty(session):
+    assert resolve_provider_key("OPENROUTER_API_KEY", "") == ""
+
+
+async def test_capture_never_logs_secret_value(session, caplog):
+    plaintext = "super-secret-plaintext-marker-xyz"
+    with caplog.at_level("DEBUG"):
+        await capture_provider_key(
+            session, name="OPENAI_API_KEY", plaintext=plaintext, created_by=_SENTINEL_USER, root_key=_ROOT
+        )
+        await session.commit()
+    assert plaintext not in caplog.text
+
+
+async def test_hydrate_never_logs_secret_value(session, caplog, monkeypatch):
+    monkeypatch.delenv("NOUS_API_KEY", raising=False)
+    plaintext = "another-secret-plaintext-marker-abc"
+    await capture_provider_key(
+        session, name="NOUS_API_KEY", plaintext=plaintext, created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    with caplog.at_level("DEBUG"):
+        await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert plaintext not in caplog.text
+
+
+def test_all_names_have_a_real_runtime_reader():
+    """Every name here must actually be consulted by provider_registry (no dead entries)."""
+    import inspect
+
+    from llm_shared import provider_registry
+
+    source = inspect.getsource(provider_registry._populate_default_providers)
+    for name in LLM_PROVIDER_KEY_NAMES:
+        assert name in source, f"{name} is declared but never resolved in _populate_default_providers"


### PR DESCRIPTION
## Thinking Path

Umbrella #10088 Task 7 says "LLM provider keys captured at setup → System vault
(admin-only); remove provider-key plaintext paths." Audit before implementing (per
task instructions) found the premise only half-matched reality:

- **Capture flow**: `autobot-frontend/src/components/settings/ApiKeySetupWizard.vue`
  captures `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` and posts to the legacy
  `POST /api/secrets/` (`autobot-backend/api/secrets.py:220-240`, the `secrets.json`
  file store). `SecretUpdateRequest` has no `value` field, so this create endpoint is
  the *only* write path for these values.
- **The generic Task-3 importer already covers legacy→vault migration in principle**
  (`services/json_secrets_importer.py`), but nothing invokes it in production — filed
  separately as **#13052**, not re-fixed here (per task instructions, "already filed,
  do not re-file"). Task 7 needed its own narrower, always-on capture hook rather than
  depending on that gap closing.
- **The real gap, and the one that matters**: the actual runtime reader for these keys,
  `llm_shared.provider_registry._populate_default_providers` (the LLM-call routing
  path used by chat/agents — not the adapter-listing-only `AdapterRegistry`), only
  ever read `ssot_config` env vars (`autobot_shared/ssot_config.py:281-282`) and never
  consulted the legacy secrets store *or* any vault. A key captured via the wizard was
  **write-only** — unreachable at runtime — the exact "dual-written but never
  dual-read" defect class Task 5 hit for connector credentials.
- **Boundary check (Appendix)**: provider keys are populated lazily on the registry's
  first access (a process-wide `gated_registry_singleton`), not at hard process
  bootstrap before the DB is reachable — confirmed movable, no Appendix correction
  needed.

## What Changed

- `autobot-backend/services/provider_key_vault.py` (new): idempotent capture of an
  LLM-provider-key value into the System vault the moment it's created (create once,
  rotate on a later re-capture — not a duplicate row), scoped strictly to
  `LLM_PROVIDER_KEY_NAMES` (OpenAI/Anthropic/Groq/Mistral/OpenRouter/Nous/Custom-OpenAI
  — the names with a real runtime reader). Also provides the vault-aware resolver
  (`resolve_provider_key`) and the startup hydration function
  (`hydrate_provider_keys_from_vault`) — env var always wins, vault is consulted only
  when it's unset, so an Ansible-provisioned deployment is byte-identical to before.
- `autobot-backend/api/secrets.py`: `create_secret` now calls a best-effort mirror hook
  after a successful legacy write. Never raises — a dev/test environment without
  `AUTOBOT_SECRETS_ROOT_KEY` configured must not turn a successful `secrets.json`
  write into a failed request.
- `autobot-backend/llm_shared/provider_registry.py`: `_populate_default_providers`
  resolves each provider key through `resolve_provider_key(env_var, config_value)`
  instead of a bare `config.<x>_api_key` read — this is the runtime-reader fix.
- `autobot-backend/initialization/lifespan.py`: new `_hydrate_llm_provider_keys()` runs
  once in Phase 1, right after the DB is initialised and before Phase 1 returns
  (`provider_registry`'s lazy population can be triggered by the very first request,
  so this can't be deferred to the Phase-2 background task). Best-effort; never blocks
  startup.

**Deliberately NOT removed in this PR**: the legacy `secrets.json` plaintext path and
its endpoints are untouched — scope narrowed per Task 7's instructions ("do NOT delete
plaintext fallbacks... land the vault path and dual-read; propose removal as a
separate, verifiable step"). Removal is a fast-follow once the vault path is proven in
a real deployment (flip on, verify a captured key resolves in production, then remove
the fallback in a dedicated PR).

**Not touched**: `HF_TOKEN` (already migrated by Task 6a's `system_secrets_vault.py` on
the SLM side — a different capture flow); the SLM `system_secrets` denylist
(`autobot_internal_api_key`) is untouched; no SLM-side files changed by this PR.

## Verification

- `py_compile` / `flake8 --max-line-length=120` / `black --check --line-length=120`: all clean.
- New tests: `autobot-backend/tests/migrations/test_provider_key_vault.py` (10 tests) —
  run for real against a disposable local Postgres (private `initdb`, not the shared
  host cluster): capture lands in the System vault; a second capture rotates (no
  duplicate row); a non-provider name is a no-op; `hydrate_provider_keys_from_vault`
  finds a vault-only key and `resolve_provider_key` returns it (the runtime-reader
  proof); env var always wins over the vault; hydration is idempotent (second run is a
  no-op); no plaintext value ever appears in logs (capture + hydrate); every declared
  name has a real caller in `_populate_default_providers` (guards a dead-entry drift).
  All 10 pass.
  ```
  10 passed in 52.73s
  ```
- Full migration-gate suite (139 tests) against the same disposable Postgres: all pass,
  no regression to Tasks 3/4/5/6's existing migration tests.
  ```
  139 passed, 25 deselected in 701.67s
  ```
- `cp`-swapped baseline diff (`tests/test_startup_imports.py` +
  `tests/test_raw_client_session_ceiling_12992.py`): 352 passed before, 352 passed
  after — identical set, no regression, no new raw `aiohttp.ClientSession` introduced.
- SLM-side: not applicable — this PR touches only `autobot-backend`; SLM's own
  provider-key capture (`HF_TOKEN`) was already migrated under Task 6a.

## Model Used

Sonnet 5