### PR TITLE
feat(secrets): registration API for secret_dependencies (#10088 Task 8.2)

### DIFF
--- a/autobot-backend/api/envelope_secrets.py
+++ b/autobot-backend/api/envelope_secrets.py
@@ -210,10 +210,26 @@ class SecretAccessOut(BaseModel):
         )
 
 
+class RegisterDependencyBody(BaseModel):
+    """(#10088 Task 8.2) A consumer that depends on the secret."""
+
+    dependent_kind: str
+    dependent_id: str
+    company_id: uuid.UUID | None = None
+
+
 class DependentOut(BaseModel):
     dependent_kind: str
     dependent_id: str
     company_id: str | None
+
+    @classmethod
+    def of_one(cls, dep) -> "DependentOut":
+        return cls(
+            dependent_kind=dep.dependent_kind,
+            dependent_id=dep.dependent_id,
+            company_id=str(dep.company_id) if dep.company_id else None,
+        )
 
 
 class SecretDependenciesOut(BaseModel):
@@ -222,17 +238,7 @@ class SecretDependenciesOut(BaseModel):
 
     @classmethod
     def of(cls, secret_id: uuid.UUID, deps) -> "SecretDependenciesOut":
-        return cls(
-            secret_id=str(secret_id),
-            dependents=[
-                DependentOut(
-                    dependent_kind=d.dependent_kind,
-                    dependent_id=d.dependent_id,
-                    company_id=str(d.company_id) if d.company_id else None,
-                )
-                for d in deps
-            ],
-        )
+        return cls(secret_id=str(secret_id), dependents=[DependentOut.of_one(d) for d in deps])
 
 
 @router.post("", response_model=SecretMetadata, status_code=status.HTTP_201_CREATED)
@@ -444,6 +450,64 @@ async def secret_dependencies(
     except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
         raise _mapped(exc)
     return SecretDependenciesOut.of(secret_id, deps)
+
+
+@router.post("/{secret_id}/dependencies", response_model=DependentOut, status_code=status.HTTP_201_CREATED)
+async def register_secret_dependency(
+    secret_id: uuid.UUID,
+    body: RegisterDependencyBody,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> DependentOut:
+    """Register that a service/agent/workflow depends on this secret (#10088 Task 8.2).
+
+    Idempotent — registering the same ``(dependent_kind, dependent_id)`` twice returns the
+    existing row rather than erroring. Seeds the rotation/revocation impact list surfaced by
+    ``GET /{secret_id}/dependencies``.
+    """
+    user_id, perms = who
+    try:
+        dep = await coordinator.register_dependency(
+            session,
+            user_id=user_id,
+            permissions=perms,
+            secret_id=secret_id,
+            dependent_kind=body.dependent_kind,
+            dependent_id=body.dependent_id,
+            company_id=body.company_id,
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
+        raise _mapped(exc)
+    return DependentOut.of_one(dep)
+
+
+@router.delete("/{secret_id}/dependencies/{dependent_kind}/{dependent_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def unregister_secret_dependency(
+    secret_id: uuid.UUID,
+    dependent_kind: str,
+    dependent_id: str,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> None:
+    """Drop a registered dependency (#10088 Task 8.2). 404 if no such row exists."""
+    user_id, perms = who
+    try:
+        removed = await coordinator.unregister_dependency(
+            session,
+            user_id=user_id,
+            permissions=perms,
+            secret_id=secret_id,
+            dependent_kind=dependent_kind,
+            dependent_id=dependent_id,
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+    if not removed:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"no dependency {dependent_kind}:{dependent_id} on {secret_id}")
 
 
 @router.put("/{secret_id}", response_model=SecretMetadata)

--- a/autobot-backend/services/secrets_coordinator.py
+++ b/autobot-backend/services/secrets_coordinator.py
@@ -23,6 +23,8 @@ Authorization model
   the DEK via your ``actor_vaults``).
 - **revoke** — ``authorize("revoke", owner_vault)``.
 - **rotate** / **delete** — ``authorize("write", owner_vault)``.
+- **register_dependency** / **unregister_dependency** (#10088 Task 8.2) —
+  ``authorize("write", owner_vault)``: metadata about the secret, not a grant on it.
 
 Every mutation authorizes against the secret's **owner vault** (the authority
 that owns it), not the grantee — sharing with company B is gated by your rights
@@ -131,6 +133,59 @@ class SecretsCoordinator:
         if not authorize(facts, "share", owner):
             raise SecretAccessError(f"not authorized to view dependencies for secret {secret_id}")
         return await SecretDependencyService().what_depends_on(session, secret_id=secret_id)
+
+    async def register_dependency(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        permissions: set[str],
+        secret_id: uuid.UUID,
+        dependent_kind: str,
+        dependent_id: str,
+        company_id: uuid.UUID | None = None,
+    ) -> SecretDependency:
+        """Record that *dependent_kind:dependent_id* consumes *secret_id* (#10088 Task 8.2).
+
+        Gated the same as ``create``/``rotate``/``delete`` — ``write`` authority on the secret's
+        owner vault — because this is metadata about the secret, not a grant on it: the caller
+        needs no ability to *read* the value, only to manage the secret. Idempotent (delegates to
+        :meth:`SecretDependencyService.register`); invalid ``dependent_kind`` raises ``ValueError``.
+        """
+        facts = await self._facts(session, user_id, permissions)
+        owner = await self._owner_vault(session, secret_id)  # raises SecretNotFoundError when absent
+        if not authorize(facts, "write", owner):
+            raise SecretAccessError(f"not authorized to register dependencies for secret {secret_id}")
+        dep = await SecretDependencyService().register(
+            session,
+            secret_id=secret_id,
+            dependent_kind=dependent_kind,
+            dependent_id=dependent_id,
+            company_id=company_id,
+            created_by=user_id,
+        )
+        if dep is None:  # pragma: no cover — concurrent unregister raced the read-back
+            raise SecretNotFoundError(f"dependency {dependent_kind}:{dependent_id} vanished during registration")
+        return dep
+
+    async def unregister_dependency(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        permissions: set[str],
+        secret_id: uuid.UUID,
+        dependent_kind: str,
+        dependent_id: str,
+    ) -> int:
+        """Drop a dependency row. Same ``write`` gate as :meth:`register_dependency`."""
+        facts = await self._facts(session, user_id, permissions)
+        owner = await self._owner_vault(session, secret_id)  # raises SecretNotFoundError when absent
+        if not authorize(facts, "write", owner):
+            raise SecretAccessError(f"not authorized to unregister dependencies for secret {secret_id}")
+        return await SecretDependencyService().unregister(
+            session, secret_id=secret_id, dependent_kind=dependent_kind, dependent_id=dependent_id
+        )
 
     async def share(
         self,

--- a/autobot-backend/tests/migrations/test_secret_dependencies.py
+++ b/autobot-backend/tests/migrations/test_secret_dependencies.py
@@ -124,3 +124,69 @@ async def test_coordinator_describe_dependencies_authz(session):
 
     with pytest.raises(SecretNotFoundError):
         await coord.describe_dependencies(session, user_id=_OWNER, permissions=set(), secret_id=uuid.uuid4())
+
+
+async def test_coordinator_register_dependency_idempotent_and_authz(session):
+    from services.envelope_secrets_service import SecretAccessError, SecretNotFoundError
+    from services.secrets_coordinator import SecretsCoordinator
+
+    coord = SecretsCoordinator(service=EnvelopeSecretsService(root_key=_ROOT))
+    owner = VaultRef(VaultKind.USER, str(_OWNER))
+    secret = await coord.create(
+        session, user_id=_OWNER, permissions=set(), owner_vault=owner, name="x", secret_type="password", plaintext=b"v"
+    )
+    await session.commit()
+
+    dep = await coord.register_dependency(
+        session,
+        user_id=_OWNER,
+        permissions=set(),
+        secret_id=secret.id,
+        dependent_kind="agent",
+        dependent_id="researcher",
+    )
+    await session.commit()
+    again = await coord.register_dependency(
+        session,
+        user_id=_OWNER,
+        permissions=set(),
+        secret_id=secret.id,
+        dependent_kind="agent",
+        dependent_id="researcher",
+    )
+    assert again.id == dep.id  # idempotent through the coordinator, not just the service
+
+    deps = await coord.describe_dependencies(session, user_id=_OWNER, permissions=set(), secret_id=secret.id)
+    assert [(d.dependent_kind, d.dependent_id) for d in deps] == [("agent", "researcher")]
+
+    # A stranger (no write authority on the owner vault) may not register a dependency.
+    with pytest.raises(SecretAccessError):
+        await coord.register_dependency(
+            session,
+            user_id=uuid.uuid4(),
+            permissions=set(),
+            secret_id=secret.id,
+            dependent_kind="agent",
+            dependent_id="intruder",
+        )
+
+    with pytest.raises(SecretNotFoundError):
+        await coord.register_dependency(
+            session,
+            user_id=_OWNER,
+            permissions=set(),
+            secret_id=uuid.uuid4(),
+            dependent_kind="agent",
+            dependent_id="x",
+        )
+
+    removed = await coord.unregister_dependency(
+        session,
+        user_id=_OWNER,
+        permissions=set(),
+        secret_id=secret.id,
+        dependent_kind="agent",
+        dependent_id="researcher",
+    )
+    assert removed == 1
+    assert await coord.describe_dependencies(session, user_id=_OWNER, permissions=set(), secret_id=secret.id) == []

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -32133,8 +32133,36 @@ export interface paths {
          */
         get: operations["secret_dependencies_api_v2_secrets__secret_id__dependencies_get"];
         put?: never;
-        post?: never;
+        /**
+         * Register Secret Dependency
+         * @description Register that a service/agent/workflow depends on this secret (#10088 Task 8.2).
+         *
+         *     Idempotent — registering the same ``(dependent_kind, dependent_id)`` twice returns the
+         *     existing row rather than erroring. Seeds the rotation/revocation impact list surfaced by
+         *     ``GET /{secret_id}/dependencies``.
+         */
+        post: operations["register_secret_dependency_api_v2_secrets__secret_id__dependencies_post"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/secrets/{secret_id}/dependencies/{dependent_kind}/{dependent_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Unregister Secret Dependency
+         * @description Drop a registered dependency (#10088 Task 8.2). 404 if no such row exists.
+         */
+        delete: operations["unregister_secret_dependency_api_v2_secrets__secret_id__dependencies__dependent_kind___dependent_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -88460,6 +88488,20 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * RegisterDependencyBody
+         * @description (#10088 Task 8.2) A consumer that depends on the secret.
+         */
+        RegisterDependencyBody: {
+            /** Dependent Kind */
+            dependent_kind: string;
+            /** Dependent Id */
+            dependent_id: string;
+            /** Company Id */
+            company_id?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * RegisterTargetRequest
          * @description Register an agent as an optimization target at runtime.
          *
@@ -144189,6 +144231,72 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SecretDependenciesOut"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_secret_dependency_api_v2_secrets__secret_id__dependencies_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                secret_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterDependencyBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DependentOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unregister_secret_dependency_api_v2_secrets__secret_id__dependencies__dependent_kind___dependent_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                secret_id: string;
+                dependent_kind: string;
+                dependent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
Closes #13064

## Thinking Path

Audited the whole of Task 8 (umbrella #10088) before touching anything, per the
FIFO-backlog instruction, because the umbrella still shows Task 8 entirely
unchecked and Task 9 flagged as a dependency-edge prerequisite.

**Task 9 blocker check (does NOT block 8.2):** `secrets_authz.authorize()` has
an explicit marker — `# agent / service principals are refined in Task 9.2;
default closed` (`autobot-backend/services/secrets_authz.py:117`) — confirming
Task 9.2 (agent/service → *effective principal for RBAC*) is genuinely
incomplete for the **access** side of the graph. But `secret_dependencies`
does not need an authenticated agent/service principal: `dependent_kind`/
`dependent_id` are descriptive strings naming *what* depends on a secret
(`models/secret_dependency.py:44-54`), not a vault/principal to authorize
against. The only identity the registration API needs is the *caller doing
the registering*, and that's already solved — `principal` (user RBAC,
`api/envelope_secrets.py:60`) and, separately, `service_principal` (HMAC /
`X-Internal-API-Key`, `api/envelope_secrets.py:72`, landed via #10478) already
resolve callers today. **Task 9 does not block 8.2.**

**8.1 audit (already done):** `secret_grants.grantee` stores a `VaultRef`
string (`kind:id`) — migration `20260614_057_secrets_envelope_store.py:86-97`
— so every grant already carries grantee principal-type/id (folded into Task
2's schema exactly as the PRD says). `services/secrets_access_audit.py`
(`describe_secret_access`, merged PR #10344) expands `team:`/`role:`/
`company:` grants through the membership tables into effective member users —
the RBAC-expansion the PRD calls for. Org coords concretely present: only
`company_id` (LLC company) — no `project_id`/`sprint_id`/`team_id` columns
exist on any secrets table today; `agent_id`/`service_id` are folded into the
generic `dependent_kind`/`dependent_id` pair rather than separate columns.

**8.2 audit (mostly already done, one real gap):** grep found the model,
migration 061, and `SecretDependencyService` (register/what_depends_on/
secrets_for_dependent/unregister) already merged — under the umbrella's
earlier task numbering, PRs #10375/#10381 built exactly what current 8.2
describes, plus a `GET /{secret_id}/dependencies` query endpoint (arguably
8.4 scope, shipped early). **Gap:** no HTTP path to *register* a dependency —
`SecretDependencyService.register`/`unregister` were only callable
in-process. Filed and closed by this PR: #13064.

Designed against real seed shapes rather than an imagined one: checked
`AGENT_SECRET_MAPPINGS` (`services/agent_secrets_integration.py:53`, keyed by
`agent_type` string like `"interactive_terminal"`) and the workflow
`${secrets.NAME}` reference format (`services/workflow_secret_service.py`,
`services/workflow_automation/executor.py`) — both fit `dependent_kind`/
`dependent_id` as plain strings, so 8.3's future seeders need no model change.

**No migration in this PR** — 061 already has everything 8.2's model needs
(FK CASCADE, unique constraint for idempotency, optional `company_id`).
Adding new schema for the reason above would be speculative ahead of 8.3.

## What Changed

- `SecretsCoordinator.register_dependency` / `.unregister_dependency`
  (`autobot-backend/services/secrets_coordinator.py`) — same `write`-authority
  gate on the secret's owner vault as `create`/`rotate`/`delete` (registering a
  dependency is secret metadata, not a grant, so it doesn't need `share`).
- `POST /api/v2/secrets/{secret_id}/dependencies` and
  `DELETE /api/v2/secrets/{secret_id}/dependencies/{dependent_kind}/{dependent_id}`
  (`autobot-backend/api/envelope_secrets.py`) — thin FastAPI shells over the
  coordinator, same exception-mapping pattern as every other route in the
  router.
- Filed issue #13064 tracking this specific gap (closed by this PR).

## Verification

- `py_compile` / `flake8 --max-line-length=120` / `black --check --line-length=120` — clean on all 3 changed files.
- Coordinator-level tests (real Postgres, migration-gate pattern,
  `tests/migrations/test_secret_dependencies.py`):
  register → read-back via `describe_dependencies`; idempotent through the
  coordinator (not just the service); unauthorized caller → `SecretAccessError`;
  unknown secret → `SecretNotFoundError`; unregister removes exactly one row.
  `6 passed` (was 5 before this PR — pre-existing model/service/migration
  tests unaffected).
- Ran against a disposable local Postgres (`initdb` private cluster, port
  5499) — did not touch the shared host cluster's `pg_hba.conf`.
- `cp`-swapped baseline diff: reverted the 3 changed files via `git checkout
  --`, ran `test_secret_dependencies.py` + `test_raw_client_session_ceiling_12992.py`
  + `test_startup_imports.py` → `357 passed`; restored via `cp`, reran →
  `358 passed` (the one new test). Identical failing set (0) before/after.
- Startup import smoke (`tests/test_startup_imports.py`) and the raw-`ClientSession`
  ceiling guard (`tests/test_raw_client_session_ceiling_12992.py`) both included
  in the before/after run above — unaffected.

## Model Used

Claude Sonnet 5
