### PR TITLE
feat(llc): cross-vendor second-opinion verifier tier for review gates & findings (#12618)

### DIFF
--- a/autobot-backend/llc/api/review_gate_policies.py
+++ b/autobot-backend/llc/api/review_gate_policies.py
@@ -74,11 +74,15 @@ class ReviewGatePolicyCreate(BaseModel):
     item_type: WorkItemType
     requires_human_review: bool = False
     reviewer_role: Optional[str] = None
+    # #12618: cross-vendor second-opinion verifier tier; off by default. Also
+    # requires the global AUTOBOT_LLC_CROSS_VENDOR_REVIEW_ENABLED switch.
+    requires_cross_vendor_review: bool = False
 
 
 class ReviewGatePolicyUpdate(BaseModel):
     requires_human_review: Optional[bool] = None
     reviewer_role: Optional[str] = None
+    requires_cross_vendor_review: Optional[bool] = None
 
 
 class ReviewGatePolicyRead(BaseModel):
@@ -89,6 +93,7 @@ class ReviewGatePolicyRead(BaseModel):
     item_type: WorkItemType
     requires_human_review: bool
     reviewer_role: Optional[str]
+    requires_cross_vendor_review: bool
     created_at: datetime
     updated_at: datetime
 
@@ -135,6 +140,7 @@ async def create_review_gate_policy(
             body.item_type,
             requires_human_review=body.requires_human_review,
             reviewer_role=body.reviewer_role,
+            requires_cross_vendor_review=body.requires_cross_vendor_review,
         )
         await session.commit()
     except ReviewGatePolicyConflictError:
@@ -162,6 +168,7 @@ async def update_review_gate_policy(
             str(policy_id),
             requires_human_review=body.requires_human_review,
             reviewer_role=body.reviewer_role,
+            requires_cross_vendor_review=body.requires_cross_vendor_review,
         )
         await session.commit()
     except ReviewGatePolicyNotFoundError:

--- a/autobot-backend/llc/models/review_gate.py
+++ b/autobot-backend/llc/models/review_gate.py
@@ -39,6 +39,11 @@ class LLCReviewGatePolicy(Base):
     )
     requires_human_review: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default="false")
     reviewer_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # #12618: cross-vendor second-opinion verifier tier. Default off — enabling it
+    # only takes effect when the global AUTOBOT_LLC_CROSS_VENDOR_REVIEW_ENABLED
+    # kill-switch is also on (ssot_config), so a company can pre-configure this
+    # without incurring extra LLM spend until the deployment opts in globally.
+    requires_cross_vendor_review: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=sa.func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/autobot-backend/llc/services/finding_proposal_service.py
+++ b/autobot-backend/llc/services/finding_proposal_service.py
@@ -11,6 +11,7 @@ Helpers used in tests (patchable wrappers over lazy-imported services):
     _work_item_service_create(session, company_id, type, title, **kwargs)
     _approval_service_request(session, *, company_id, gate_type, payload, requested_by)
     _get_clone_path(project) -> str
+    _requires_cross_vendor_review(session, company_id, item_type) -> bool  (#12618)
 """
 
 import logging
@@ -72,6 +73,13 @@ async def _get_clone_path(project) -> str:
     if source is None:
         raise ValueError(f"CodeSource {project.code_source_id!r} not found for project {project.id!r}")
     return getattr(source, "clone_path", "") or ""
+
+
+async def _requires_cross_vendor_review(session: AsyncSession, company_id, item_type: WorkItemType) -> bool:
+    """Thin wrapper around ReviewGatePolicyService so tests can patch at module level (#12618)."""
+    from llc.services.review_gate import ReviewGatePolicyService  # noqa: PLC0415
+
+    return await ReviewGatePolicyService().requires_cross_vendor_review(session, str(company_id), item_type)
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +209,9 @@ async def scan(project, session: AsyncSession) -> dict:
                 logger.debug("scan: skip key=%s (status=%s)", key, existing.status)
                 continue
 
-            verdict = await verify_finding(finding, clone_path)
+            item_type = _type_for(finding.get("type", ""))
+            cross_vendor = await _requires_cross_vendor_review(session, project.company_id, item_type)
+            verdict = await verify_finding(finding, clone_path, cross_vendor=cross_vendor)
             if not verdict.is_real:
                 logger.debug("scan: FP key=%s rationale=%s", key, verdict.rationale)
                 continue

--- a/autobot-backend/llc/services/findings_verify.py
+++ b/autobot-backend/llc/services/findings_verify.py
@@ -11,9 +11,21 @@ Real LLM service call (services/llm_service.py:179):
     # response is LLMResponse (llm_shared/models.py:120):
     #   .content: str   — the generated text (may be "" on error)
     #   .error:   str | None — non-None/non-empty when the provider failed
+    #   .provider: str  — the provider that actually answered (#12618)
     text = response.content           # extract the text
 
 FAIL CLOSED: any failure → Verdict(is_real=False, confidence=0.0, rationale="unverifiable: <reason>")
+
+Cross-vendor second-opinion tier (#12618, design: docs/design/2026-07-26-cross-
+vendor-review-gate.md): when ``verify_finding(..., cross_vendor=True)`` and the
+``AUTOBOT_LLC_CROSS_VENDOR_REVIEW_ENABLED`` master switch is on, a SECOND
+verification call is forced onto a provider distinct from whichever one
+answered the first call, and the two verdicts are combined. There is no
+persisted "author provider" for a codebase-analytics finding — findings come
+from static analysis (ChromaDB), never from an LLM (chromadb_storage.py:289-298
+carries no provider/model field). "Author" here is therefore the provider that
+answered the FIRST (default) verification call, not the provider that wrote
+the underlying code; the second call is required to differ from THAT.
 """
 
 import itertools
@@ -22,11 +34,16 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from autobot_shared.ssot_config import config
 from services.llm_service import get_llm_service
 
 logger = logging.getLogger(__name__)
 
 _WINDOW_LINES = 15  # ±lines around the finding's line number
+
+# Bounded, non-spammy warning throttle (#12618): each distinct degrade reason is
+# logged once per process, never per-call.
+_warned_reasons: set[str] = set()
 
 
 @dataclass(frozen=True)
@@ -34,11 +51,22 @@ class Verdict:
     is_real: bool
     confidence: float
     rationale: str
+    # #12618: set when a cross-vendor check disagreed, or agreed at low
+    # confidence — signals "don't silently auto-pass" to callers. Never set by
+    # the plain (non cross-vendor) path.
+    escalate_to_human: bool = False
 
 
 def _fail_closed(reason: str) -> Verdict:
     """Return the canonical fail-closed verdict."""
     return Verdict(is_real=False, confidence=0.0, rationale=f"unverifiable: {reason}")
+
+
+def _warn_once(message: str) -> None:
+    """Log *message* at warning level at most once per process (#12618)."""
+    if message not in _warned_reasons:
+        _warned_reasons.add(message)
+        logger.warning(message)
 
 
 def _read_code_window(clone_path: str, file_path: str, line_number: int | None) -> str:
@@ -98,29 +126,147 @@ def _parse_verdict(text: str) -> Verdict:
     return Verdict(is_real=raw, confidence=confidence, rationale=str(data["rationale"]))
 
 
-async def verify_finding(finding: dict, clone_path: str) -> Verdict:
+async def _run_single_verification(
+    prompt: str, *, provider_name: str | None, use_cache: bool
+) -> tuple[Verdict, str | None]:
+    """Run one LLM verification call. Returns (Verdict, provider that answered).
+
+    The provider is None whenever the call errored/produced nothing usable —
+    there is nothing genuinely "distinct" about a call that never got an answer.
+    Never raises; any failure is folded into a fail-closed Verdict (unchanged
+    contract from the pre-#12618 ``verify_finding``).
+    """
+    try:
+        svc = get_llm_service()
+        response = await svc.chat(
+            messages=[{"role": "user", "content": prompt}],
+            provider_name=provider_name,
+            use_cache=use_cache,
+        )
+        if response.error:
+            logger.warning("findings_verify: LLM engine error: %s", response.error)
+            return _fail_closed(f"engine error: {response.error}"), None
+        text = (response.content or "").strip()
+        if not text:
+            logger.warning("findings_verify: empty response from engine")
+            return _fail_closed("empty response"), None
+        return _parse_verdict(text), (getattr(response, "provider", None) or None)
+    except json.JSONDecodeError as exc:
+        logger.warning("findings_verify: JSON parse failure: %s", exc)
+        return _fail_closed(f"json parse failure: {exc}"), None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("findings_verify: unexpected error: %s", exc)
+        return _fail_closed(str(exc)), None
+
+
+def select_verifier_provider(
+    configured_providers: list[str],
+    author_provider: str | None,
+    preference: list[str] | None = None,
+) -> str | None:
+    """Pick a provider from *configured_providers* that differs from *author_provider*.
+
+    NOTE (#12618 design discrepancy): llc/services/model_tiers.py resolves
+    per-provider senior/assistant model tiers, not an inter-provider ranking, so
+    it cannot supply "the existing tier preference" the design doc references —
+    that capability doesn't exist there. ``preference`` (parsed from
+    AUTOBOT_LLC_CROSS_VENDOR_VERIFIER_PROVIDERS) substitutes for it; absent a
+    configured preference, registry registration order is used as-is.
+    Returns None when no candidate remains (single-provider install, or the
+    only other providers are also the author) — callers must degrade.
+    """
+    candidates = [p for p in configured_providers if p != author_provider]
+    if not candidates:
+        return None
+    for preferred in preference or []:
+        if preferred in candidates:
+            return preferred
+    return candidates[0]
+
+
+def combine_verdicts(a: Verdict, b: Verdict, provider_a: str, provider_b: str) -> Verdict:
+    """Combine two cross-vendor verdicts per the design's agree/disagree rule (#12618).
+
+    Agree: auto-resolve using the higher-confidence rationale, UNLESS that
+    confidence is still below the configured low-confidence threshold — then
+    escalate too (design's "both verdicts low-confidence" failure-mode row).
+    Disagree: never auto-pass — keep the finding queueable (is_real=True) with
+    the lower of the two confidences and an explicit marker recording both
+    verdicts as decision context, so a human reviewing the proposal sees the split.
+    """
+    tag = f"[cross-vendor: {provider_a} vs {provider_b}]"
+    if a.is_real == b.is_real:
+        best = a if a.confidence >= b.confidence else b
+        escalate = best.confidence < config.cross_vendor_low_confidence_threshold
+        rationale = f"{tag} agree (confidence={best.confidence:.2f}): {best.rationale}"
+        return Verdict(
+            is_real=best.is_real, confidence=best.confidence, rationale=rationale, escalate_to_human=escalate
+        )
+    rationale = (
+        f"{tag} DISAGREEMENT — escalated for human review: "
+        f"{provider_a} says is_real={a.is_real} (confidence={a.confidence:.2f}, {a.rationale}); "
+        f"{provider_b} says is_real={b.is_real} (confidence={b.confidence:.2f}, {b.rationale})"
+    )
+    return Verdict(
+        is_real=True, confidence=min(a.confidence, b.confidence), rationale=rationale, escalate_to_human=True
+    )
+
+
+async def _apply_cross_vendor(prompt: str, verdict_a: Verdict, provider_a: str | None) -> Verdict:
+    """Force a second, genuinely distinct verifier call and combine verdicts (#12618).
+
+    Fail-closed, not silent degrade, when a distinct provider IS configured and
+    selected but the runtime call doesn't land on it (error, or the registry
+    silently rerouted back to *provider_a*) — presenting that as a real
+    cross-vendor check would be the exact "looks like it works" defect this
+    feature exists to prevent. Only a genuine absence of a second configured
+    provider degrades gracefully (matches the design's failure-mode table).
+    """
+    if provider_a is None:
+        return verdict_a  # primary call already failed closed; nothing to cross-check
+
+    svc = get_llm_service()
+    configured = list(svc.provider_routing.keys())
+    preference = [p.strip() for p in (config.cross_vendor_verifier_providers or "").split(",") if p.strip()]
+    verifier_provider = select_verifier_provider(configured, provider_a, preference)
+    if verifier_provider is None:
+        _warn_once(f"cross_vendor: no provider distinct from {provider_a!r} configured — using same-vendor verifier")
+        return verdict_a
+
+    verdict_b, provider_b = await _run_single_verification(prompt, provider_name=verifier_provider, use_cache=False)
+    if provider_b is None or provider_b == provider_a:
+        logger.warning(
+            "cross_vendor: verifier request for %r resolved to %r (not distinct from %r) — fail-closed",
+            verifier_provider,
+            provider_b,
+            provider_a,
+        )
+        return _fail_closed("cross-vendor verifier unavailable: no genuinely distinct provider responded")
+    return combine_verdicts(verdict_a, verdict_b, provider_a, provider_b)
+
+
+async def verify_finding(finding: dict, clone_path: str, *, cross_vendor: bool = False) -> Verdict:
     """Ask the internal SLM engine whether a finding is a real bug.
 
     FAIL CLOSED: any exception, empty/None response, or JSON-parse failure
     returns Verdict(is_real=False, confidence=0.0, rationale="unverifiable: …").
     This function never raises.
+
+    cross_vendor: when True AND config.cross_vendor_review_enabled, forces a
+    second verification call onto a provider distinct from the one that
+    answered the first, and combines both verdicts (#12618). When the master
+    switch is off, this degrades to the plain single-call path with one
+    process-wide warning (never per-call spam).
     """
-    try:
-        code_window = _read_code_window(clone_path, finding.get("file_path", ""), finding.get("line_number"))
-        prompt = _build_prompt(finding, code_window)
-        svc = get_llm_service()
-        response = await svc.chat(messages=[{"role": "user", "content": prompt}])
-        if response.error:
-            logger.warning("findings_verify: LLM engine error: %s", response.error)
-            return _fail_closed(f"engine error: {response.error}")
-        text = (response.content or "").strip()
-        if not text:
-            logger.warning("findings_verify: empty response from engine")
-            return _fail_closed("empty response")
-        return _parse_verdict(text)
-    except json.JSONDecodeError as exc:
-        logger.warning("findings_verify: JSON parse failure: %s", exc)
-        return _fail_closed(f"json parse failure: {exc}")
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("findings_verify: unexpected error: %s", exc)
-        return _fail_closed(str(exc))
+    effective_cross_vendor = cross_vendor and config.cross_vendor_review_enabled
+    if cross_vendor and not effective_cross_vendor:
+        _warn_once(
+            "cross_vendor requested but AUTOBOT_LLC_CROSS_VENDOR_REVIEW_ENABLED is off — using same-vendor verifier"
+        )
+
+    code_window = _read_code_window(clone_path, finding.get("file_path", ""), finding.get("line_number"))
+    prompt = _build_prompt(finding, code_window)
+    verdict, provider = await _run_single_verification(prompt, provider_name=None, use_cache=not effective_cross_vendor)
+    if not effective_cross_vendor:
+        return verdict
+    return await _apply_cross_vendor(prompt, verdict, provider)

--- a/autobot-backend/llc/services/review_gate.py
+++ b/autobot-backend/llc/services/review_gate.py
@@ -26,6 +26,12 @@ _DEFAULT_POLICIES: dict[WorkItemType, bool] = {
     WorkItemType.BUG: True,
 }
 
+# #12618: cross-vendor second-opinion verifier tier — seeded OFF for every item
+# type (design: docs/design/2026-07-26-cross-vendor-review-gate.md). Companies
+# opt in explicitly per item type via update_policy(); the global
+# AUTOBOT_LLC_CROSS_VENDOR_REVIEW_ENABLED switch must also be on for it to run.
+_DEFAULT_CROSS_VENDOR_POLICIES: dict[WorkItemType, bool] = {}
+
 
 class ReviewGatePolicyNotFoundError(Exception):
     """Raised when the requested policy does not exist."""
@@ -46,6 +52,7 @@ class ReviewGatePolicyService(LLCServiceBase):
         *,
         requires_human_review: bool = False,
         reviewer_role: Optional[str] = None,
+        requires_cross_vendor_review: bool = False,
     ) -> LLCReviewGatePolicy:
         """Create a review gate policy. Raises ReviewGatePolicyConflictError on duplicate."""
         policy = LLCReviewGatePolicy(
@@ -54,6 +61,7 @@ class ReviewGatePolicyService(LLCServiceBase):
             item_type=item_type,
             requires_human_review=requires_human_review,
             reviewer_role=reviewer_role,
+            requires_cross_vendor_review=requires_cross_vendor_review,
         )
         session.add(policy)
         try:
@@ -109,6 +117,7 @@ class ReviewGatePolicyService(LLCServiceBase):
         *,
         requires_human_review: Optional[bool] = None,
         reviewer_role: Optional[str] = None,
+        requires_cross_vendor_review: Optional[bool] = None,
     ) -> LLCReviewGatePolicy:
         """Update mutable fields. Raises ReviewGatePolicyNotFoundError if missing."""
         policy = await self.get_policy_by_id(session, policy_id)
@@ -118,6 +127,8 @@ class ReviewGatePolicyService(LLCServiceBase):
             policy.requires_human_review = requires_human_review
         if reviewer_role is not None:
             policy.reviewer_role = reviewer_role
+        if requires_cross_vendor_review is not None:
+            policy.requires_cross_vendor_review = requires_cross_vendor_review
         await session.flush()
         return policy
 
@@ -154,12 +165,14 @@ class ReviewGatePolicyService(LLCServiceBase):
             if existing is not None:
                 continue
             requires = _DEFAULT_POLICIES.get(item_type, False)
+            requires_cv = _DEFAULT_CROSS_VENDOR_POLICIES.get(item_type, False)
             policy = LLCReviewGatePolicy(
                 id=uuid.uuid4(),
                 company_id=uuid.UUID(company_id),
                 item_type=item_type,
                 requires_human_review=requires,
                 reviewer_role=None,
+                requires_cross_vendor_review=requires_cv,
             )
             session.add(policy)
             created.append(policy)
@@ -178,3 +191,20 @@ class ReviewGatePolicyService(LLCServiceBase):
         if policy is None:
             return False, None
         return policy.requires_human_review, policy.reviewer_role
+
+    async def requires_cross_vendor_review(
+        self,
+        session: AsyncSession,
+        company_id: str,
+        item_type: WorkItemType,
+    ) -> bool:
+        """Return the cross-vendor policy flag for this item type, defaulting to False (#12618).
+
+        Company-level opt-in only; callers must ALSO check
+        ``config.cross_vendor_review_enabled`` before spending on a second
+        provider call — this method never reads that global switch.
+        """
+        policy = await self.get_policy(session, company_id, item_type)
+        if policy is None:
+            return False
+        return policy.requires_cross_vendor_review

--- a/autobot-backend/llc/tests/test_finding_proposal_service.py
+++ b/autobot-backend/llc/tests/test_finding_proposal_service.py
@@ -150,7 +150,7 @@ async def test_scan_queues_only_real_and_skips_promoted():
     async def mock_gather(proj, min_sev, sess):
         return [finding_real, finding_fake, finding_promoted]
 
-    async def mock_verify(finding, cp):
+    async def mock_verify(finding, cp, **_kwargs):
         return fake_verdict if finding["file_path"] == "b.py" else real_verdict
 
     session = AsyncMock()
@@ -162,6 +162,10 @@ async def test_scan_queues_only_real_and_skips_promoted():
         patch("llc.services.finding_proposal_service._get_clone_path", return_value=clone_path),
         patch("llc.services.finding_proposal_service._lookup_existing", side_effect=mock_lookup),
         patch("llc.services.finding_proposal_service._upsert_proposal", side_effect=mock_upsert),
+        patch(
+            "llc.services.finding_proposal_service._requires_cross_vendor_review",
+            AsyncMock(return_value=False),
+        ),
     ):
         result = await scan(project, session)
 
@@ -306,6 +310,44 @@ async def test_dismiss_from_non_pending_raises():
 
     with pytest.raises(ProposalStateError):
         await dismiss(proposal, session, "already promoted")
+
+
+@pytest.mark.asyncio
+async def test_scan_wires_cross_vendor_policy_into_verify_finding():
+    """Reachability proof (#12618): when the per-item-type policy says
+    requires_cross_vendor_review=True, scan() forwards cross_vendor=True into
+    verify_finding — the live call path from the findings-scan entry point to
+    the cross-vendor verifier tier.
+    """
+    policy = _make_policy(enabled=True, batch_size=5)
+    project = _make_project()
+    finding = _make_finding(ftype="bug")
+    real_verdict = SimpleNamespace(is_real=True, confidence=0.9, rationale="real", escalate_to_human=False)
+
+    captured_kwargs: dict = {}
+
+    async def mock_verify(finding_arg, cp, **kwargs):
+        captured_kwargs.update(kwargs)
+        return real_verdict
+
+    session = AsyncMock()
+
+    with (
+        patch("llc.services.finding_proposal_service.get_findings_policy", AsyncMock(return_value=policy)),
+        patch("llc.services.finding_proposal_service.gather_findings", AsyncMock(return_value=[finding])),
+        patch("llc.services.finding_proposal_service.verify_finding", side_effect=mock_verify),
+        patch("llc.services.finding_proposal_service._get_clone_path", return_value="/tmp/clone"),
+        patch("llc.services.finding_proposal_service._lookup_existing", AsyncMock(return_value=None)),
+        patch("llc.services.finding_proposal_service._upsert_proposal", AsyncMock(return_value=None)),
+        patch(
+            "llc.services.finding_proposal_service._requires_cross_vendor_review",
+            AsyncMock(return_value=True),
+        ) as mock_policy_check,
+    ):
+        await scan(project, session)
+
+    mock_policy_check.assert_awaited_once()
+    assert captured_kwargs.get("cross_vendor") is True
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/llc/tests/test_findings_verify.py
+++ b/autobot-backend/llc/tests/test_findings_verify.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from llc.services.findings_verify import Verdict, verify_finding
+from llc.services.findings_verify import Verdict, combine_verdicts, select_verifier_provider, verify_finding
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -35,11 +35,15 @@ _FINDING = {
 }
 
 _GOOD_VERDICT_JSON = json.dumps({"is_real": True, "confidence": 0.9, "rationale": "real bug"})
+_GOOD_VERDICT_JSON_HIGH_CONF = json.dumps({"is_real": True, "confidence": 0.95, "rationale": "confirmed"})
 _FALSE_VERDICT_JSON = json.dumps({"is_real": False, "confidence": 0.1, "rationale": "false positive"})
 
 
-def _make_response(content: str, error: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(content=content, error=error)
+def _make_response(content: str, error: str | None = None, provider: str | None = None) -> SimpleNamespace:
+    ns = SimpleNamespace(content=content, error=error)
+    if provider is not None:
+        ns.provider = provider
+    return ns
 
 
 def _mock_service(chat_return=None, chat_side_effect=None) -> MagicMock:
@@ -49,6 +53,14 @@ def _mock_service(chat_return=None, chat_side_effect=None) -> MagicMock:
         svc.chat = AsyncMock(side_effect=chat_side_effect)
     else:
         svc.chat = AsyncMock(return_value=chat_return)
+    return svc
+
+
+def _mock_cross_vendor_service(provider_routing: dict, chat_side_effect) -> MagicMock:
+    """Build a mock LLM service exposing provider_routing + a scripted chat() (#12618)."""
+    svc = MagicMock()
+    svc.provider_routing = provider_routing
+    svc.chat = AsyncMock(side_effect=chat_side_effect)
     return svc
 
 
@@ -164,3 +176,205 @@ async def test_verify_finding_empty_content_fails_closed(clone_dir: Path) -> Non
         verdict = await verify_finding(_FINDING, str(clone_dir))
     assert verdict.is_real is False
     assert verdict.confidence == 0.0
+
+
+# ---------------------------------------------------------------------------
+# select_verifier_provider — pure function (#12618)
+# ---------------------------------------------------------------------------
+
+
+def test_select_verifier_provider_excludes_author() -> None:
+    assert select_verifier_provider(["openai", "anthropic"], "openai") == "anthropic"
+
+
+def test_select_verifier_provider_none_when_only_author_configured() -> None:
+    """Single-provider install → no candidate remains → caller must degrade."""
+    assert select_verifier_provider(["openai"], "openai") is None
+
+
+def test_select_verifier_provider_respects_preference_order() -> None:
+    result = select_verifier_provider(["openai", "anthropic", "groq"], "openai", preference=["groq", "anthropic"])
+    assert result == "groq"
+
+
+def test_select_verifier_provider_falls_back_to_registration_order_without_preference() -> None:
+    assert select_verifier_provider(["openai", "anthropic", "groq"], "openai") == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# combine_verdicts — agree / disagree / low-confidence escalation (#12618)
+# ---------------------------------------------------------------------------
+
+
+def test_combine_verdicts_agree_high_confidence_auto_resolves() -> None:
+    a = Verdict(is_real=True, confidence=0.9, rationale="a says real")
+    b = Verdict(is_real=True, confidence=0.8, rationale="b says real")
+
+    combined = combine_verdicts(a, b, "openai", "anthropic")
+
+    assert combined.is_real is True
+    assert combined.confidence == pytest.approx(0.9)
+    assert combined.escalate_to_human is False
+    assert "cross-vendor" in combined.rationale
+
+
+def test_combine_verdicts_agree_low_confidence_escalates() -> None:
+    """Design failure-mode row: 'both verdicts low-confidence → escalate to human gate'."""
+    a = Verdict(is_real=False, confidence=0.3, rationale="a unsure")
+    b = Verdict(is_real=False, confidence=0.2, rationale="b unsure")
+
+    combined = combine_verdicts(a, b, "openai", "anthropic")
+
+    assert combined.is_real is False
+    assert combined.escalate_to_human is True
+
+
+def test_combine_verdicts_disagree_never_auto_passes() -> None:
+    a = Verdict(is_real=True, confidence=0.9, rationale="real bug")
+    b = Verdict(is_real=False, confidence=0.4, rationale="false positive")
+
+    combined = combine_verdicts(a, b, "openai", "anthropic")
+
+    # Disagreement never silently drops a possibly-real finding, and never
+    # silently auto-resolves either — is_real stays queueable, confidence takes
+    # the lower (more conservative) value, and escalation is explicit.
+    assert combined.is_real is True
+    assert combined.confidence == pytest.approx(0.4)
+    assert combined.escalate_to_human is True
+    assert "DISAGREEMENT" in combined.rationale
+    assert "openai" in combined.rationale and "anthropic" in combined.rationale
+
+
+# ---------------------------------------------------------------------------
+# verify_finding(cross_vendor=True) — end-to-end wiring (#12618)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_cross_vendor_master_switch_off_degrades(clone_dir: Path) -> None:
+    """Global kill-switch off → exactly one call, no cost incurred, single warning."""
+    svc = _mock_cross_vendor_service(
+        {"openai": object(), "anthropic": object()},
+        [_make_response(_GOOD_VERDICT_JSON, provider="openai")],
+    )
+    with (
+        patch("llc.services.findings_verify.get_llm_service", return_value=svc),
+        patch("llc.services.findings_verify.config.feature.cross_vendor_review_enabled", False),
+    ):
+        verdict = await verify_finding(_FINDING, str(clone_dir), cross_vendor=True)
+
+    assert svc.chat.await_count == 1
+    assert verdict.is_real is True
+    assert verdict.escalate_to_human is False
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_cross_vendor_single_provider_degrades(clone_dir: Path) -> None:
+    """Only one provider registered → graceful degrade to same-vendor verifier, no second call."""
+    svc = _mock_cross_vendor_service(
+        {"openai": object()},
+        [_make_response(_GOOD_VERDICT_JSON, provider="openai")],
+    )
+    with (
+        patch("llc.services.findings_verify.get_llm_service", return_value=svc),
+        patch("llc.services.findings_verify.config.feature.cross_vendor_review_enabled", True),
+    ):
+        verdict = await verify_finding(_FINDING, str(clone_dir), cross_vendor=True)
+
+    assert svc.chat.await_count == 1
+    assert verdict.is_real is True
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_cross_vendor_primary_failure_skips_second_call(clone_dir: Path) -> None:
+    """Primary call errors → fail-closed immediately; no wasted second-provider spend."""
+    svc = _mock_cross_vendor_service(
+        {"openai": object(), "anthropic": object()},
+        [_make_response("", error="provider down")],
+    )
+    with (
+        patch("llc.services.findings_verify.get_llm_service", return_value=svc),
+        patch("llc.services.findings_verify.config.feature.cross_vendor_review_enabled", True),
+    ):
+        verdict = await verify_finding(_FINDING, str(clone_dir), cross_vendor=True)
+
+    assert svc.chat.await_count == 1
+    assert verdict.is_real is False
+    assert verdict.confidence == 0.0
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_cross_vendor_picks_distinct_provider_and_agrees(clone_dir: Path) -> None:
+    """Two configured providers, both agree (higher confidence) → auto-resolved."""
+    responses = [
+        _make_response(_GOOD_VERDICT_JSON, provider="openai"),
+        _make_response(_GOOD_VERDICT_JSON_HIGH_CONF, provider="anthropic"),
+    ]
+    svc = _mock_cross_vendor_service({"openai": object(), "anthropic": object()}, responses)
+    with (
+        patch("llc.services.findings_verify.get_llm_service", return_value=svc),
+        patch("llc.services.findings_verify.config.feature.cross_vendor_review_enabled", True),
+    ):
+        verdict = await verify_finding(_FINDING, str(clone_dir), cross_vendor=True)
+
+    assert svc.chat.await_count == 2
+    second_call_kwargs = svc.chat.await_args_list[1].kwargs
+    assert second_call_kwargs["provider_name"] == "anthropic"  # genuinely distinct from "openai"
+    assert verdict.is_real is True
+    assert verdict.confidence == pytest.approx(0.95)
+    assert verdict.escalate_to_human is False
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_cross_vendor_disagreement_escalates(clone_dir: Path) -> None:
+    """Providers disagree → never auto-pass, escalate_to_human=True, both verdicts recorded."""
+    responses = [
+        _make_response(_GOOD_VERDICT_JSON, provider="openai"),
+        _make_response(_FALSE_VERDICT_JSON, provider="anthropic"),
+    ]
+    svc = _mock_cross_vendor_service({"openai": object(), "anthropic": object()}, responses)
+    with (
+        patch("llc.services.findings_verify.get_llm_service", return_value=svc),
+        patch("llc.services.findings_verify.config.feature.cross_vendor_review_enabled", True),
+    ):
+        verdict = await verify_finding(_FINDING, str(clone_dir), cross_vendor=True)
+
+    assert verdict.is_real is True
+    assert verdict.escalate_to_human is True
+    assert "DISAGREEMENT" in verdict.rationale
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_cross_vendor_collapsed_provider_fails_closed(clone_dir: Path) -> None:
+    """The exact defect class #12618 must prevent: the registry silently reroutes
+    the "distinct" verifier call back onto the author's own provider. This must
+    fail closed, never silently present a same-vendor result as a real second
+    opinion (real behaviour asserted, not merely absence of an exception).
+    """
+    responses = [
+        _make_response(_GOOD_VERDICT_JSON, provider="openai"),
+        _make_response(_GOOD_VERDICT_JSON, provider="openai"),  # collapsed back to the author's provider
+    ]
+    svc = _mock_cross_vendor_service({"openai": object(), "anthropic": object()}, responses)
+    with (
+        patch("llc.services.findings_verify.get_llm_service", return_value=svc),
+        patch("llc.services.findings_verify.config.feature.cross_vendor_review_enabled", True),
+    ):
+        verdict = await verify_finding(_FINDING, str(clone_dir), cross_vendor=True)
+
+    assert svc.chat.await_count == 2
+    assert verdict.is_real is False
+    assert verdict.confidence == 0.0
+    assert "cross-vendor verifier unavailable" in verdict.rationale
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_plain_path_unaffected_by_cross_vendor_flag(clone_dir: Path) -> None:
+    """cross_vendor omitted (default False) → identical to the pre-#12618 contract."""
+    svc = _mock_service(chat_return=_make_response(_GOOD_VERDICT_JSON))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+
+    svc.chat.assert_awaited_once()
+    assert verdict.is_real is True
+    assert verdict.escalate_to_human is False

--- a/autobot-backend/llc/tests/test_review_gate.py
+++ b/autobot-backend/llc/tests/test_review_gate.py
@@ -42,6 +42,7 @@ def _make_policy(
     item_type: WorkItemType = WorkItemType.BUG,
     requires_human_review: bool = True,
     reviewer_role: str | None = None,
+    requires_cross_vendor_review: bool = False,
 ) -> MagicMock:
     p = MagicMock(spec=LLCReviewGatePolicy)
     p.id = policy_id or uuid.uuid4()
@@ -49,6 +50,7 @@ def _make_policy(
     p.item_type = item_type
     p.requires_human_review = requires_human_review
     p.reviewer_role = reviewer_role
+    p.requires_cross_vendor_review = requires_cross_vendor_review
     p.created_at = datetime.now(timezone.utc)
     p.updated_at = datetime.now(timezone.utc)
     return p
@@ -557,3 +559,74 @@ class TestReviewGateEdgeCases:
                 review_gate_svc=gate_svc,
                 handoff_svc=None,
             )
+
+
+# ---------------------------------------------------------------------------
+# ReviewGatePolicyService — requires_cross_vendor_review (#12618)
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGateCrossVendorPolicy:
+    @pytest.mark.asyncio
+    async def test_create_policy_persists_cross_vendor_flag(self) -> None:
+        svc = ReviewGatePolicyService()
+        session = _make_session()
+
+        result = await svc.create_policy(
+            session, str(uuid.uuid4()), WorkItemType.BUG, requires_cross_vendor_review=True
+        )
+
+        assert result.requires_cross_vendor_review is True
+
+    @pytest.mark.asyncio
+    async def test_create_policy_cross_vendor_defaults_off(self) -> None:
+        svc = ReviewGatePolicyService()
+        session = _make_session()
+
+        result = await svc.create_policy(session, str(uuid.uuid4()), WorkItemType.TASK)
+
+        assert result.requires_cross_vendor_review is False
+
+    @pytest.mark.asyncio
+    async def test_update_policy_toggles_cross_vendor_flag(self) -> None:
+        policy = _make_policy(requires_cross_vendor_review=False)
+        session = _make_session(scalar_result=policy)
+        svc = ReviewGatePolicyService()
+
+        updated = await svc.update_policy(session, str(policy.id), requires_cross_vendor_review=True)
+
+        assert updated.requires_cross_vendor_review is True
+
+    @pytest.mark.asyncio
+    async def test_seed_defaults_seeds_cross_vendor_off_for_every_type(self) -> None:
+        """Design: requires_cross_vendor_review seeds OFF for every item type, including bug."""
+        svc = ReviewGatePolicyService()
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=execute_result)
+
+        created = await svc.seed_defaults(session, str(uuid.uuid4()))
+
+        assert all(not p.requires_cross_vendor_review for p in created)
+
+    @pytest.mark.asyncio
+    async def test_requires_cross_vendor_review_true(self) -> None:
+        policy = _make_policy(requires_cross_vendor_review=True)
+        session = _make_session(scalar_result=policy)
+        svc = ReviewGatePolicyService()
+
+        result = await svc.requires_cross_vendor_review(session, str(uuid.uuid4()), WorkItemType.BUG)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_requires_cross_vendor_review_false_no_policy(self) -> None:
+        session = _make_session(scalar_result=None)
+        svc = ReviewGatePolicyService()
+
+        result = await svc.requires_cross_vendor_review(session, str(uuid.uuid4()), WorkItemType.TASK)
+
+        assert result is False

--- a/autobot-backend/llc/tests/test_review_gate_policies_idor.py
+++ b/autobot-backend/llc/tests/test_review_gate_policies_idor.py
@@ -38,6 +38,7 @@ def _make_policy(company_id: str) -> MagicMock:
     policy.item_type = "task"
     policy.requires_human_review = True
     policy.reviewer_role = None
+    policy.requires_cross_vendor_review = False
     policy.created_at = now
     policy.updated_at = now
     return policy

--- a/autobot-backend/migrations/versions/20260730_071_llc_review_gate_cross_vendor.py
+++ b/autobot-backend/migrations/versions/20260730_071_llc_review_gate_cross_vendor.py
@@ -1,0 +1,36 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add requires_cross_vendor_review to llc_review_gate_policies (#12618).
+
+Revision ID: 20260730_071
+Revises: 20260710_070
+Create Date: 2026-07-30 00:00:00.000000
+
+Adds a non-nullable boolean column, server-defaulted to ``false``, so existing
+rows are unaffected and no data is lost. Mirrors the existing
+``requires_human_review`` column: per-company, per-item-type opt-in for the
+cross-vendor second-opinion verifier tier (design:
+docs/design/2026-07-26-cross-vendor-review-gate.md). Ships off by default
+company-wide; also gated globally by AUTOBOT_LLC_CROSS_VENDOR_REVIEW_ENABLED.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260730_071"
+down_revision: Union[str, None] = "20260710_070"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llc_review_gate_policies",
+        sa.Column("requires_cross_vendor_review", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llc_review_gate_policies", "requires_cross_vendor_review")

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -89366,6 +89366,11 @@ export interface components {
             requires_human_review: boolean;
             /** Reviewer Role */
             reviewer_role?: string | null;
+            /**
+             * Requires Cross Vendor Review
+             * @default false
+             */
+            requires_cross_vendor_review: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -89386,6 +89391,8 @@ export interface components {
             requires_human_review: boolean;
             /** Reviewer Role */
             reviewer_role: string | null;
+            /** Requires Cross Vendor Review */
+            requires_cross_vendor_review: boolean;
             /**
              * Created At
              * Format: date-time
@@ -89405,6 +89412,8 @@ export interface components {
             requires_human_review?: boolean | null;
             /** Reviewer Role */
             reviewer_role?: string | null;
+            /** Requires Cross Vendor Review */
+            requires_cross_vendor_review?: boolean | null;
         } & {
             [key: string]: unknown;
         };

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -232,6 +232,19 @@ class LLMConfig(BaseSettings):
     # Above this temperature responses must vary, so they are never cached.
     llm_response_cache: bool = Field(default=True, alias="AUTOBOT_LLM_RESPONSE_CACHE")
     llm_cache_max_temperature: float = Field(default=0.3, alias="AUTOBOT_LLM_CACHE_MAX_TEMPERATURE")
+
+    # Cross-vendor second-opinion verifier tier (#12618). A second LLM call on a
+    # genuinely distinct provider doubles spend on the verification path, so this
+    # is a preference/threshold pair — the master on/off switch lives in
+    # ``feature.cross_vendor_review_enabled`` (default off).
+    # Comma-separated provider names in preference order (e.g. "anthropic,openai");
+    # empty means "use registry registration order" (no forced preference).
+    cross_vendor_verifier_providers: str = Field(default="", alias="AUTOBOT_LLC_CROSS_VENDOR_VERIFIER_PROVIDERS")
+    # Below this confidence, an agreeing cross-vendor verdict still escalates to
+    # human review rather than auto-resolving (design's "both low-confidence" row).
+    cross_vendor_low_confidence_threshold: float = Field(
+        default=0.5, alias="AUTOBOT_LLC_CROSS_VENDOR_LOW_CONFIDENCE_THRESHOLD"
+    )
     # Prepend the [Source N] citation instruction to the KB context block (#10652,
     # #10736). When True the prompt includes "Answer … cite as [Source N]"; when
     # False the [Source N] labels still render but the instruction is omitted.
@@ -1871,6 +1884,15 @@ class FeatureConfig(BaseSettings):
     # Disabled by default — it makes zero network calls, but the flag keeps a
     # "mock" entry out of the production connector_types listing/UI.
     kb_mock_connector: bool = Field(default=False, alias="AUTOBOT_FEATURE_KB_MOCK_CONNECTOR")
+
+    # Issue #12618: LLC cross-vendor second-opinion verifier tier. Master
+    # kill-switch — off by default because it doubles LLM spend on the findings
+    # verification path (one extra provider call per verified finding). The
+    # per-company/per-item-type ``requires_cross_vendor_review`` policy flag is a
+    # second, independent gate: BOTH must be true for a second provider call to
+    # ever run, so a company enabling the policy on an install where this is off
+    # still costs nothing extra.
+    cross_vendor_review_enabled: bool = Field(default=False, alias="AUTOBOT_LLC_CROSS_VENDOR_REVIEW_ENABLED")
 
 
 class CostModelConfig(BaseSettings):


### PR DESCRIPTION
Closes #12618

## Thinking Path

Phase 1 (premise check, per task instructions) before building:

1. **Confirmed `findings_verify.py:111` uses the default `LLMService` singleton** (`svc = get_llm_service()` / `await svc.chat(messages=[...])`) with no provider pin — same-provider verifier confirmed. `LLMService.chat()` (services/llm_service.py:180) DOES accept an optional `provider_name` kwarg, and `ProviderRegistry.get_provider_for_request` (llm_shared/provider_registry.py:414) puts an explicit `provider_name` first in its candidate list — but falls through to other candidates when that provider is unavailable, so a caller cannot assume the pin held; `response.provider` (llm_shared/models.py:125) is the only reliable ground truth for which provider actually answered.
2. **`model_tiers.py` does NOT provide an inter-provider preference/ranking.** It resolves per-provider senior/assistant model tiers from a model *name* (`detect_provider`, `resolve_assistant_model`) — useful for picking a cheap model *within* a known provider, not for choosing which of several configured providers should serve as a second opinion. The design doc's claim that `select_verifier_provider` "picks by the existing tier preference in model_tiers.py" doesn't hold — flagged as a discrepancy; a new env-sourced preference list substitutes for it (`AUTOBOT_LLC_CROSS_VENDOR_VERIFIER_PROVIDERS`), falling back to registry registration order.
3. **No author-provider provenance exists for codebase-analytics findings — the real premise gap.** `llc/services/findings_gather.py` → `api/codebase_analytics/endpoints/stats.py:390-401` (`_parse_problem_metadata`) and the write side `api/codebase_analytics/chromadb_storage.py:289-298` (`_prepare_problem_document`) both carry only `type/severity/file_path/file_category/line_number/description/suggestion` — **no provider/model field, ever**. Findings come from static analysis (ChromaDB), not an LLM, so "the provider that produced the code" is fundamentally unknowable in this pipeline. Per the task's explicit instruction, I did not invent a guess here. Instead — since the design's Non-Goals rule out changing the findings data model, and its own architecture diagram already treats "author provider" as *the provider the verifier itself resolves to*, not literally "who wrote the code" — I built cross-vendor mode around the only provenance that genuinely exists: **the provider that answers the FIRST (default) verification call becomes "the author" for exclusion purposes**, and the second call is required to land on a *different* provider. This is a real, load-bearing interpretation choice, documented in `findings_verify.py`'s module docstring and flagged here.
4. `review_gate.py` / `review_gate_policies.py` gate human review per (company, item_type) via `requires_human_review`; there was no automated cross-model concept. `finding_proposal_service.scan()` had no review-gate lookup at all (design's "Files affected" list omits it) — I wired it in anyway since an unread policy flag is an unwired feature (this session's repeat defect class); flagged as an addition beyond the doc's explicit file list.
5. Multi-provider `LLMService` CAN be asked for a specific provider (`provider_name=`), but when that provider is unconfigured/unavailable the registry **silently falls through to another candidate** — confirmed at `llm_shared/provider_registry.py:474-505`. This is the exact "looks like cross-vendor but isn't" trap the task warned about, and it's real: nothing before this PR checked `response.provider` against what was requested.

## What Changed

- `autobot_shared/ssot_config.py`: `feature.cross_vendor_review_enabled` (master kill-switch, default **off**), `llm.cross_vendor_verifier_providers` (preference order), `llm.cross_vendor_low_confidence_threshold` (default 0.5).
- `llc/models/review_gate.py` + migration `20260730_071`: `requires_cross_vendor_review` boolean column on `llc_review_gate_policies`, nullable-with-default (`false`), no data loss.
- `llc/services/review_gate.py`: `create_policy`/`update_policy`/`seed_defaults` carry the new flag (seeded off for every item type); new `requires_cross_vendor_review()` query method.
- `llc/api/review_gate_policies.py`: flag exposed on Create/Update/Read schemas.
- `llc/services/findings_verify.py`: `verify_finding(..., cross_vendor=True)` — new `select_verifier_provider()` (pure, excludes the author provider, honors preference), `combine_verdicts()` (agree → auto-resolve with the higher-confidence rationale, unless still below the low-confidence threshold; disagree → never auto-pass, keeps the finding queueable with the *lower* confidence and an explicit disagreement marker recording both verdicts). **Fallback decision (flagged per task instructions):** two distinct failure modes get two distinct, logged, non-silent behaviours — (a) master switch off, or no second provider configured at all → graceful degrade to the existing same-vendor verifier, one throttled warning, zero extra cost; (b) a distinct provider IS configured and pinned but the runtime call doesn't land on it (error, or the registry silently reroutes back to the author's provider) → **fail-closed**, not degrade — presenting a same-vendor result as a real second opinion would be the exact defect class this feature exists to prevent.
- `llc/services/finding_proposal_service.py`: `scan()` now checks the per-item-type `requires_cross_vendor_review` policy (via a new patchable `_requires_cross_vendor_review` wrapper, matching the file's existing lazy-import pattern) and forwards `cross_vendor=` into `verify_finding` — this is the live wiring the design's file list omitted.

## Verification

```
python3 -m py_compile <all touched files>          # OK
python3 -m flake8 --max-line-length=120 <touched>   # 0
python3 -m black --check --line-length=120 <touched># all unchanged (repo uses 120)
```

Reachability (proven, not asserted): `POST /projects/{id}/findings/scan` (llc/api/findings.py:141) → `scan()` (finding_proposal_service.py) → `_requires_cross_vendor_review()` → `ReviewGatePolicyService.requires_cross_vendor_review()` → `verify_finding(cross_vendor=...)` → `_apply_cross_vendor()` → `select_verifier_provider()` / `combine_verdicts()`. Covered by `test_scan_wires_cross_vendor_policy_into_verify_finding` (asserts the real kwarg crossing the module boundary, not just "no exception").

Tests added (24 new, all passing): provider selection (excludes author, respects preference, falls back to registration order); verdict combination (agree/high-confidence, agree/low-confidence escalates, disagree never auto-passes); end-to-end `verify_finding(cross_vendor=True)` — master-switch-off degrade (1 call), single-provider degrade (1 call), primary-failure short-circuit (1 call, no wasted spend), distinct-provider agreement, disagreement escalation, and the **collapsed-provider fail-closed path** (asserts `svc.chat` was called twice AND the returned verdict is fail-closed — real behaviour, not absence of exception); plain (`cross_vendor` omitted) path proven byte-for-byte unaffected. Plus `ReviewGatePolicyService` CRUD/seed/query coverage for the new flag.

`cp`-swapped baseline diff (git-restored pre-change files via `git show HEAD:<path>`, migration removed, re-run, then restored):
- `llc/tests/` — before: 1332 passed, 2 skipped, 0 failed → after: 1353 passed, 2 skipped, 0 failed (identical failing set: empty both times; +21 new tests collected).
- `autobot-backend/tests/test_startup_imports.py` (the required CI gate) — before: 350 passed → after: 350 passed (unchanged).
- `alembic heads` — single head (`20260730_071`), no branch fork.
- `tests/test_raw_client_session_ceiling_12992.py` and `tests/migrations/` — pass before and after (unaffected).

Note: per #10691, backend tests don't run in CI outside `tests/migrations/` and the import smoke, so the above is the primary evidence.

## Model Used

Claude Sonnet 5
