### PR TITLE
feat(llc): per-agent performance scorecard surfaced in sprint retrospectives (#12619)

### DIFF
--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -28,6 +28,9 @@ Routes:
   GET /llc/sprints/{sprint_id}/capacity         — assigned story-point totals
   GET /llc/projects/{project_id}/velocity       — velocity history for N closed sprints
   GET /llc/sprints/{sprint_id}/burndown         — day-by-day burndown series
+
+  Agent scorecard (GH#12619):
+  GET /llc/sprints/{sprint_id}/agent-scorecard  — per-agent success rate/throughput/spend
 """
 
 import uuid
@@ -49,6 +52,7 @@ from ..kb.collections import KbCollectionManager
 from ..models.enums import ApprovalType, SprintStatus, WorkItemRelationType, WorkItemStatus
 from ..models.sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
 from ..models.work_item import LLCWorkItem, LLCWorkItemRelation
+from ..services.agent_scorecard import AgentScorecardService
 from ..services.approval import ApprovalNotFoundError, ApprovalService, ApprovalStateError
 from ..services.disposal_policy import get_disposal_policy
 from ..services.project_disposal import dispose
@@ -1152,3 +1156,61 @@ async def get_sprint_summary(
         status=sprint.status,
         kb_summary=sprint.kb_summary,
     )
+
+
+# ------------------------------------------------------------------ Agent scorecard (GH#12619)
+
+_scorecard_svc = AgentScorecardService()
+
+
+class AgentScoreResponse(BaseModel):
+    org_node_id: str
+    agent_id: Optional[str]
+    agent_name: str
+    work_items_total: int
+    work_items_done: int
+    throughput: int
+    runs_total: Optional[int]
+    runs_terminal: Optional[int]
+    runs_completed: Optional[int]
+    success_rate: Optional[float]
+    reliability_score: Optional[float]
+    low_sample: Optional[bool]
+    spend_lifetime_usd: Optional[float]
+    tokens_spent_lifetime: Optional[int]
+    spend_window: str
+
+
+class SprintScorecardResponse(BaseModel):
+    sprint_id: str
+    sprint_name: str
+    run_window_available: bool
+    run_window_start: Optional[str]
+    run_window_end: Optional[str]
+    scores: List[AgentScoreResponse]
+
+
+@router.get("/sprints/{sprint_id}/agent-scorecard", response_model=SprintScorecardResponse)
+async def get_sprint_agent_scorecard(
+    sprint_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> SprintScorecardResponse:
+    """Return the per-agent success-rate/throughput/spend scorecard for a sprint (GH#12619).
+
+    Success rate is time-windowed against the sprint's dates (heartbeat runs
+    have no sprint FK — see ``AgentScorecardService`` docstring) and spend is
+    a lifetime total, not sprint-scoped (GH#13067) — both are labeled
+    explicitly in the response rather than implied to be exact.
+    """
+    sprint = (await session.execute(select(LLCSprint).where(LLCSprint.id == sprint_id))).scalar_one_or_none()
+    # IDOR guard (#10148).
+    if sprint is None or str(sprint.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    try:
+        scorecard = await _scorecard_svc.build(session, sprint_id)
+    except SprintNotFound as exc:
+        logger.error("Exception in API handler: %s", exc, exc_info=True)
+        raise HTTPException(status_code=404, detail="Internal server error") from exc
+    return SprintScorecardResponse(**scorecard.to_dict())

--- a/autobot-backend/llc/config/__init__.py
+++ b/autobot-backend/llc/config/__init__.py
@@ -53,9 +53,24 @@ DEFAULT_STREAMING_WATCHDOG_TIMEOUT = int(os.environ.get("LLC_STREAMING_WATCHDOG_
 # can never drift (GH#9777).
 AGENT_API_KEY_PLACEHOLDER = "<injected-at-runtime>"
 
+# Agent scorecard aggregation (GH#12619).
+# Minimum terminal (non-queued/running) heartbeat runs an agent must have in a
+# sprint window before its reliability score is treated as statistically
+# meaningful. Below this, the score is still returned but flagged
+# ``low_sample=True`` so callers don't rank a 2-run agent above a 200-run one
+# on a raw ratio alone.
+SCORECARD_MIN_RUNS_FOR_CONFIDENT_RANKING = int(os.environ.get("LLC_SCORECARD_MIN_RUNS_FOR_CONFIDENT_RANKING", "5"))
+
+# Z-score for the Wilson score interval lower bound used as the low-n-aware
+# "reliability_score" (1.96 = 95% confidence). Higher = more conservative
+# (shrinks harder toward 0 for small sample sizes).
+SCORECARD_WILSON_Z_SCORE = float(os.environ.get("LLC_SCORECARD_WILSON_Z_SCORE", "1.96"))
+
 __all__ = [
     "AGENT_API_BASE_URL",
     "AGENT_API_KEY_PLACEHOLDER",
     "DEFAULT_BUDGET_LIMIT",
     "DEFAULT_STREAMING_WATCHDOG_TIMEOUT",
+    "SCORECARD_MIN_RUNS_FOR_CONFIDENT_RANKING",
+    "SCORECARD_WILSON_Z_SCORE",
 ]

--- a/autobot-backend/llc/kb/sprint_summarizer.py
+++ b/autobot-backend/llc/kb/sprint_summarizer.py
@@ -12,8 +12,10 @@ On sprint close:
   5. Archive the sprint collection via KbCollectionManager.
 """
 
+from __future__ import annotations
+
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,6 +25,14 @@ from llm_shared.types import LLMType
 
 from ..kb.collections import KbCollectionManager
 from ..models.sprint import LLCSprint
+
+if TYPE_CHECKING:
+    # Deferred to avoid a circular import: llc.services.__init__ imports
+    # sprint_autoclose, which imports this module — a module-level import
+    # here of anything under ``llc.services`` would try to re-enter this
+    # partially-initialized module. Actual runtime use is via lazy imports
+    # inside the functions below (GH#12619).
+    from ..services.agent_scorecard import AgentScore, SprintScorecard
 
 logger = get_logger(__name__)
 
@@ -126,11 +136,52 @@ class SprintKbSummarizer:
         finally:
             await self._km.archive_collection(KbCollectionManager.SPRINT_PREFIX, sprint_id)
 
-        if summary_text and session is not None and sprint is not None:
-            sprint.kb_summary = summary_text  # type: ignore[attr-defined]
+        scorecard_section = await self._build_agent_scorecard_section(sprint_id, session)
+        final_summary = self._combine_summary(summary_text, scorecard_section)
+
+        if final_summary and session is not None and sprint is not None:
+            sprint.kb_summary = final_summary  # type: ignore[attr-defined]
             await session.flush()
 
         return summary_text
+
+    # ------------------------------------------------------------------
+    # Agent scorecard (GH#12619)
+    # ------------------------------------------------------------------
+
+    async def _build_agent_scorecard_section(
+        self,
+        sprint_id: uuid.UUID,
+        session: Optional[AsyncSession],
+    ) -> Optional[str]:
+        """Build the rendered per-agent scorecard section, or None if unavailable.
+
+        Best-effort: a scorecard aggregation failure must never block sprint
+        close / KB merge, so any error is logged and swallowed here.
+        """
+        if session is None:
+            return None
+        # Lazy import — see the module-level TYPE_CHECKING note above.
+        from ..services.agent_scorecard import AgentScorecardService
+        from ..services.sprint_planning import SprintNotFound
+
+        try:
+            scorecard = await AgentScorecardService().build(session, sprint_id)
+        except SprintNotFound:
+            logger.warning("Sprint %s vanished before scorecard aggregation; skipping", sprint_id)
+            return None
+        except Exception:
+            logger.error("Agent scorecard aggregation failed for sprint %s", sprint_id, exc_info=True)
+            return None
+        if not scorecard.scores:
+            return None
+        return render_agent_scorecard(scorecard)
+
+    def _combine_summary(self, summary_text: Optional[str], scorecard_section: Optional[str]) -> Optional[str]:
+        """Merge the Learnings summary and the scorecard section; either may be absent."""
+        if summary_text and scorecard_section:
+            return f"{summary_text}\n\n{scorecard_section}"
+        return summary_text or scorecard_section
 
     # ------------------------------------------------------------------
     # Helpers
@@ -302,4 +353,45 @@ class SprintKbSummarizer:
         return summary_text
 
 
-__all__ = ["SprintKbSummarizer"]
+def render_agent_scorecard(scorecard: SprintScorecard) -> str:
+    """Render a ``SprintScorecard`` as a markdown section for the retro summary.
+
+    Component signals (raw run/work-item counts) are shown alongside the
+    composite ``reliability_score`` so the derivation stays inspectable
+    rather than presenting a single opaque number.
+    """
+    header = [
+        "## Agent Scorecard",
+        "",
+        "| Agent | Runs (terminal) | Success rate | Reliability (low-n aware) | Work items done | Spend (lifetime) |",
+        "|---|---|---|---|---|---|",
+    ]
+    rows = [_render_scorecard_row(score) for score in scorecard.scores]
+    return "\n".join(header + rows + ["", _render_scorecard_footnote(scorecard)])
+
+
+def _render_scorecard_row(score: AgentScore) -> str:
+    """Render one ``AgentScore`` as a markdown table row."""
+    success = f"{score.success_rate:.1%}" if score.success_rate is not None else "n/a"
+    reliability = f"{score.reliability_score:.2f}" if score.reliability_score is not None else "n/a"
+    runs = str(score.runs_terminal) if score.runs_terminal is not None else "n/a"
+    if score.low_sample:
+        runs = f"{runs} (low-n)"
+    spend = f"${score.spend_lifetime_usd:.2f}" if score.spend_lifetime_usd is not None else "n/a"
+    name = score.agent_id or score.agent_name
+    return f"| {name} | {runs} | {success} | {reliability} | {score.work_items_done} | {spend} |"
+
+
+def _render_scorecard_footnote(scorecard: SprintScorecard) -> str:
+    """Explain the run-window / spend-window caveats so the derivation is inspectable."""
+    if scorecard.run_window_available:
+        window = (
+            f"Run window (approximate — time-windowed, not FK-linked; GH#12619): "
+            f"{scorecard.run_window_start} to {scorecard.run_window_end}."
+        )
+    else:
+        window = "Run-based metrics unavailable — sprint has no start_date."
+    return f"{window} Spend is a lifetime total (not sprint-windowed) — see GH#13067."
+
+
+__all__ = ["SprintKbSummarizer", "render_agent_scorecard"]

--- a/autobot-backend/llc/services/agent_scorecard.py
+++ b/autobot-backend/llc/services/agent_scorecard.py
@@ -1,0 +1,334 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""AgentScorecardService — per-agent performance scorecard for a sprint (GH#12619).
+
+Aggregates rows the LLC already writes into a per-agent scorecard: success
+rate, throughput, and spend. No new data collection.
+
+Two schema realities shape this aggregation (see design doc
+``docs/design/2026-07-26-agent-scored-retrospectives.md`` and the GH#12619
+premise check for full detail):
+
+1. ``LLCHeartbeatRun.work_item_id`` is never populated by any writer, so runs
+   cannot be joined to a sprint via FK. Runs are instead attributed to a
+   sprint by time-windowing ``started_at`` against the sprint's
+   ``start_date``/``end_date`` — an approximation, surfaced explicitly via
+   ``run_window_available``/``run_window_start``/``run_window_end`` rather
+   than hidden inside a silent join.
+2. Agent identity is dual-keyspace (GH#10032): ``llc_work_items.assignee_agent_id``
+   is the ``AgentOrgNode`` UUID PK; ``llc_heartbeat_runs.agent_id`` and
+   ``llc_agent_budgets.agent_id`` are the logical slug. Sprint-agent
+   enumeration goes through work items (UUID space), then crosses over to the
+   slug via ``AgentOrgNode`` before querying runs/budgets.
+
+Spend has no per-event or time-stamped record (GH#13067 — the
+``llc_cost_events`` table backing ``/costs/by-agent-model`` was never
+migrated and is dead code) so it is sourced from the lifetime aggregate on
+``llc_agent_budgets`` and labeled ``spend_window="lifetime"`` rather than
+implied to be sprint-scoped.
+"""
+
+import math
+import uuid
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timezone
+from typing import Dict, List, Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.logging_manager import get_logger
+from models.agent_org import AgentOrgNode
+
+from ..config import SCORECARD_MIN_RUNS_FOR_CONFIDENT_RANKING, SCORECARD_WILSON_Z_SCORE
+from ..models.budget import LLCAgentBudget
+from ..models.enums import LLCRunStatus, WorkItemStatus
+from ..models.heartbeat_run import LLCHeartbeatRun
+from ..models.sprint import LLCSprint
+from ..models.work_item import LLCWorkItem
+from .base import LLCServiceBase
+from .sprint_planning import SprintNotFound
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class AgentScore:
+    """Per-agent scorecard row for one sprint."""
+
+    org_node_id: str
+    agent_id: Optional[str]
+    agent_name: str
+
+    work_items_total: int
+    work_items_done: int
+    throughput: int
+
+    runs_total: Optional[int]
+    runs_terminal: Optional[int]
+    runs_completed: Optional[int]
+    success_rate: Optional[float]
+    reliability_score: Optional[float]
+    low_sample: Optional[bool]
+
+    spend_lifetime_usd: Optional[float]
+    tokens_spent_lifetime: Optional[int]
+    spend_window: str = "lifetime"
+
+    def to_dict(self) -> dict:
+        return {
+            "org_node_id": self.org_node_id,
+            "agent_id": self.agent_id,
+            "agent_name": self.agent_name,
+            "work_items_total": self.work_items_total,
+            "work_items_done": self.work_items_done,
+            "throughput": self.throughput,
+            "runs_total": self.runs_total,
+            "runs_terminal": self.runs_terminal,
+            "runs_completed": self.runs_completed,
+            "success_rate": self.success_rate,
+            "reliability_score": self.reliability_score,
+            "low_sample": self.low_sample,
+            "spend_lifetime_usd": self.spend_lifetime_usd,
+            "tokens_spent_lifetime": self.tokens_spent_lifetime,
+            "spend_window": self.spend_window,
+        }
+
+
+@dataclass
+class SprintScorecard:
+    """Scorecard for every agent who worked a given sprint."""
+
+    sprint_id: str
+    sprint_name: str
+    run_window_available: bool
+    run_window_start: Optional[str]
+    run_window_end: Optional[str]
+    scores: List[AgentScore] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "sprint_id": self.sprint_id,
+            "sprint_name": self.sprint_name,
+            "run_window_available": self.run_window_available,
+            "run_window_start": self.run_window_start,
+            "run_window_end": self.run_window_end,
+            "scores": [s.to_dict() for s in self.scores],
+        }
+
+
+def _wilson_lower_bound(successes: int, total: int, z: float) -> float:
+    """Wilson score interval lower bound — a low-n-aware success rate.
+
+    Shrinks toward 0 as ``total`` shrinks, so a 1/1 agent does not outrank a
+    180/200 agent the way a raw ratio would. Standard formula (used e.g. by
+    Reddit/HN ranking); no external dependency required.
+    """
+    if total == 0:
+        return 0.0
+    phat = successes / total
+    z2 = z * z
+    denom = 1 + z2 / total
+    center = phat + z2 / (2 * total)
+    margin = z * math.sqrt((phat * (1 - phat) + z2 / (4 * total)) / total)
+    return max(0.0, (center - margin) / denom)
+
+
+class AgentScorecardService(LLCServiceBase):
+    """Read-only aggregation of per-agent success rate, throughput, and spend."""
+
+    async def build(self, session: AsyncSession, sprint_id: uuid.UUID) -> SprintScorecard:
+        """Build the scorecard for every agent assigned work in ``sprint_id``."""
+        sprint = await self._load_sprint(session, sprint_id)
+        roster = await self._enumerate_sprint_agents(session, sprint_id)
+
+        window_start, window_end = self._resolve_run_window(sprint)
+        window_available = window_start is not None
+
+        if not roster:
+            return SprintScorecard(
+                sprint_id=str(sprint_id),
+                sprint_name=sprint.name,
+                run_window_available=window_available,
+                run_window_start=window_start.isoformat() if window_start else None,
+                run_window_end=window_end.isoformat() if window_end else None,
+                scores=[],
+            )
+
+        nodes = await self._resolve_agent_nodes(session, list(roster.keys()))
+        slugs = [node.agent_id for node in nodes.values()]
+
+        run_stats = (
+            await self._aggregate_heartbeat_runs(session, sprint.company_id, slugs, window_start, window_end)
+            if window_available
+            else {}
+        )
+        budget_stats = await self._aggregate_budgets(session, slugs)
+
+        scores = [
+            self._assemble_score(org_node_id, counts, nodes.get(org_node_id), run_stats, budget_stats, window_available)
+            for org_node_id, counts in roster.items()
+        ]
+        scores.sort(key=lambda s: s.agent_name)
+
+        return SprintScorecard(
+            sprint_id=str(sprint_id),
+            sprint_name=sprint.name,
+            run_window_available=window_available,
+            run_window_start=window_start.isoformat() if window_start else None,
+            run_window_end=window_end.isoformat() if window_end else None,
+            scores=scores,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _load_sprint(self, session: AsyncSession, sprint_id: uuid.UUID) -> LLCSprint:
+        result = await session.execute(select(LLCSprint).where(LLCSprint.id == sprint_id))
+        sprint = result.scalar_one_or_none()
+        if sprint is None:
+            raise SprintNotFound(f"Sprint {sprint_id} not found")
+        return sprint
+
+    async def _enumerate_sprint_agents(
+        self, session: AsyncSession, sprint_id: uuid.UUID
+    ) -> Dict[uuid.UUID, Dict[str, int]]:
+        """Return {assignee_agent_id: {work_items_total, work_items_done}}.
+
+        Mirrors ``SprintPlanningService.get_capacity`` — an agent is "in" a
+        sprint iff they are the primary assignee of at least one work item
+        with that ``sprint_id``.
+        """
+        stmt = select(LLCWorkItem.assignee_agent_id, LLCWorkItem.status).where(
+            LLCWorkItem.sprint_id == sprint_id,
+            LLCWorkItem.assignee_agent_id.is_not(None),
+        )
+        result = await session.execute(stmt)
+
+        roster: Dict[uuid.UUID, Dict[str, int]] = {}
+        for agent_id, status in result.all():
+            counts = roster.setdefault(agent_id, {"work_items_total": 0, "work_items_done": 0})
+            counts["work_items_total"] += 1
+            if status == WorkItemStatus.DONE.value:
+                counts["work_items_done"] += 1
+        return roster
+
+    async def _resolve_agent_nodes(
+        self, session: AsyncSession, org_node_ids: List[uuid.UUID]
+    ) -> Dict[uuid.UUID, AgentOrgNode]:
+        """Cross the UUID keyspace (work items) to the slug keyspace (runs/budgets), GH#10032."""
+        result = await session.execute(select(AgentOrgNode).where(AgentOrgNode.id.in_(org_node_ids)))
+        return {node.id: node for node in result.scalars().all()}
+
+    def _resolve_run_window(self, sprint: LLCSprint) -> tuple[Optional[datetime], Optional[datetime]]:
+        """Return (start, end) UTC datetimes for time-windowing runs, or (None, None).
+
+        Runs have no sprint FK (see module docstring) so this window is an
+        approximation, not a join guarantee. Unavailable when the sprint has
+        no ``start_date``.
+        """
+        if sprint.start_date is None:
+            return None, None
+        start = datetime.combine(sprint.start_date, time.min, tzinfo=timezone.utc)
+        end_date: date = sprint.end_date or datetime.now(timezone.utc).date()
+        end = datetime.combine(end_date, time.max, tzinfo=timezone.utc)
+        return start, end
+
+    async def _aggregate_heartbeat_runs(
+        self,
+        session: AsyncSession,
+        company_id: uuid.UUID,
+        slugs: List[str],
+        window_start: datetime,
+        window_end: datetime,
+    ) -> Dict[str, Dict[str, int]]:
+        """Return {agent_slug: {status: count}} for runs in the sprint's time window."""
+        if not slugs:
+            return {}
+        stmt = (
+            select(
+                LLCHeartbeatRun.agent_id,
+                LLCHeartbeatRun.status,
+                func.count().label("n"),
+            )
+            .where(
+                LLCHeartbeatRun.company_id == company_id,
+                LLCHeartbeatRun.agent_id.in_(slugs),
+                LLCHeartbeatRun.started_at >= window_start,
+                LLCHeartbeatRun.started_at <= window_end,
+            )
+            .group_by(LLCHeartbeatRun.agent_id, LLCHeartbeatRun.status)
+        )
+        result = await session.execute(stmt)
+
+        by_slug: Dict[str, Dict[str, int]] = {}
+        for slug, status, n in result.all():
+            by_slug.setdefault(slug, {})[status] = n
+        return by_slug
+
+    async def _aggregate_budgets(self, session: AsyncSession, slugs: List[str]) -> Dict[str, LLCAgentBudget]:
+        """Return {agent_slug: LLCAgentBudget} — lifetime spend, not sprint-windowed."""
+        if not slugs:
+            return {}
+        result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id.in_(slugs)))
+        return {row.agent_id: row for row in result.scalars().all()}
+
+    def _assemble_score(
+        self,
+        org_node_id: uuid.UUID,
+        counts: Dict[str, int],
+        node: Optional[AgentOrgNode],
+        run_stats: Dict[str, Dict[str, int]],
+        budget_stats: Dict[str, LLCAgentBudget],
+        window_available: bool,
+    ) -> AgentScore:
+        slug = node.agent_id if node else None
+        name = node.name if node else f"unresolved-{org_node_id}"
+
+        # None (not 0) when the run window itself is unavailable (no sprint
+        # dates) — distinct from a measured zero-run agent within a real window.
+        runs_total = runs_terminal = runs_completed = None
+        success_rate = reliability_score = low_sample = None
+        if slug is not None and window_available:
+            status_counts = run_stats.get(slug, {})
+            runs_total, runs_terminal, runs_completed = self._summarize_run_counts(status_counts)
+            if runs_terminal > 0:
+                success_rate = runs_completed / runs_terminal
+                reliability_score = _wilson_lower_bound(runs_completed, runs_terminal, SCORECARD_WILSON_Z_SCORE)
+                low_sample = runs_terminal < SCORECARD_MIN_RUNS_FOR_CONFIDENT_RANKING
+
+        budget = budget_stats.get(slug) if slug else None
+        return AgentScore(
+            org_node_id=str(org_node_id),
+            agent_id=slug,
+            agent_name=name,
+            work_items_total=counts["work_items_total"],
+            work_items_done=counts["work_items_done"],
+            throughput=counts["work_items_done"],
+            runs_total=runs_total,
+            runs_terminal=runs_terminal,
+            runs_completed=runs_completed,
+            success_rate=success_rate,
+            reliability_score=reliability_score,
+            low_sample=low_sample,
+            spend_lifetime_usd=float(budget.budget_spent) if budget else None,
+            tokens_spent_lifetime=budget.tokens_spent if budget else None,
+        )
+
+    def _summarize_run_counts(self, status_counts: Dict[str, int]) -> tuple[int, int, int]:
+        """Collapse {status: count} into (total, terminal, completed) using the canonical classifier."""
+        total = sum(status_counts.values())
+        terminal = 0
+        completed = 0
+        for status, n in status_counts.items():
+            if LLCRunStatus(status).is_terminal():
+                terminal += n
+                if status == LLCRunStatus.COMPLETED.value:
+                    completed += n
+        return total, terminal, completed
+
+
+__all__ = ["AgentScore", "AgentScorecardService", "SprintScorecard"]

--- a/autobot-backend/llc/tests/test_agent_scorecard.py
+++ b/autobot-backend/llc/tests/test_agent_scorecard.py
@@ -1,0 +1,253 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for AgentScorecardService — per-agent scorecard aggregation (GH#12619)."""
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.models.enums import LLCRunStatus, WorkItemStatus
+from llc.models.sprint import LLCSprint
+from llc.services.agent_scorecard import AgentScorecardService, _wilson_lower_bound
+from llc.services.sprint_planning import SprintNotFound
+
+_SPRINT_ID = uuid.uuid4()
+_COMPANY_ID = uuid.uuid4()
+_AGENT_A_NODE = uuid.uuid4()
+_AGENT_B_NODE = uuid.uuid4()
+
+
+def _patch_obj(obj, attr, new):
+    return patch.object(obj, attr, new=new)
+
+
+def _make_sprint(**kwargs) -> LLCSprint:
+    defaults = {
+        "id": _SPRINT_ID,
+        "company_id": _COMPANY_ID,
+        "name": "Sprint 1",
+        "start_date": date(2026, 6, 1),
+        "end_date": date(2026, 6, 14),
+    }
+    defaults.update(kwargs)
+    obj = MagicMock(spec=LLCSprint)
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _agent_org_node(node_id, slug, name):
+    node = MagicMock()
+    node.id = node_id
+    node.agent_id = slug
+    node.name = name
+    return node
+
+
+def _agent_budget(slug, spent, tokens):
+    row = MagicMock()
+    row.agent_id = slug
+    row.budget_spent = Decimal(str(spent))
+    row.tokens_spent = tokens
+    return row
+
+
+def _execute_result(*, scalar_one_or_none=None, all_rows=None, scalars_all=None):
+    """Build a MagicMock mimicking a SQLAlchemy Result for one canned response."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar_one_or_none
+    result.all.return_value = all_rows or []
+    if scalars_all is not None:
+        result.scalars.return_value.all.return_value = scalars_all
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Pure math — Wilson lower bound + terminal-status classification
+# ---------------------------------------------------------------------------
+
+
+def test_wilson_lower_bound_penalizes_small_sample():
+    """A 2/2 agent must not outrank a 180/200 agent on raw ratio alone."""
+    small_n = _wilson_lower_bound(successes=2, total=2, z=1.96)
+    large_n = _wilson_lower_bound(successes=180, total=200, z=1.96)
+
+    assert small_n < large_n, "low-n perfect ratio should score below high-n near-perfect ratio"
+    assert small_n < 1.0  # raw ratio would be 1.0; the lower bound must shrink it
+
+
+def test_wilson_lower_bound_zero_total_is_zero():
+    assert _wilson_lower_bound(successes=0, total=0, z=1.96) == 0.0
+
+
+def test_summarize_run_counts_uses_canonical_terminal_classifier():
+    svc = AgentScorecardService()
+    status_counts = {
+        LLCRunStatus.QUEUED.value: 3,
+        LLCRunStatus.RUNNING.value: 1,
+        LLCRunStatus.COMPLETED.value: 8,
+        LLCRunStatus.FAILED.value: 2,
+    }
+    total, terminal, completed = svc._summarize_run_counts(status_counts)
+    assert total == 14
+    assert terminal == 10  # excludes QUEUED + RUNNING (GH#9777 is_terminal())
+    assert completed == 8
+
+
+# ---------------------------------------------------------------------------
+# build() orchestration — mocked data-access boundaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_zero_run_agent_is_none_not_zero_or_error():
+    """Design AC: zero-run agent gets success_rate=None, not a ZeroDivisionError or omission."""
+    svc = AgentScorecardService()
+    sprint = _make_sprint()
+    node = _agent_org_node(_AGENT_B_NODE, "agent-b", "Agent Bravo")
+    roster = {_AGENT_B_NODE: {"work_items_total": 1, "work_items_done": 0}}
+
+    with (
+        _patch_obj(svc, "_load_sprint", AsyncMock(return_value=sprint)),
+        _patch_obj(svc, "_enumerate_sprint_agents", AsyncMock(return_value=roster)),
+        _patch_obj(svc, "_resolve_agent_nodes", AsyncMock(return_value={_AGENT_B_NODE: node})),
+        _patch_obj(svc, "_aggregate_heartbeat_runs", AsyncMock(return_value={})),
+        _patch_obj(svc, "_aggregate_budgets", AsyncMock(return_value={})),
+    ):
+        scorecard = await svc.build(AsyncMock(), _SPRINT_ID)
+
+    assert len(scorecard.scores) == 1
+    score = scorecard.scores[0]
+    assert score.runs_total == 0  # measured zero — the agent was in-window with no runs
+    assert score.success_rate is None  # not 0.0 — avoids punishing idle agents
+    assert score.reliability_score is None
+    assert score.low_sample is None
+    assert score.spend_lifetime_usd is None  # no budget row
+
+
+@pytest.mark.asyncio
+async def test_build_empty_roster_returns_no_scores_not_an_error():
+    svc = AgentScorecardService()
+    sprint = _make_sprint()
+    with (
+        _patch_obj(svc, "_load_sprint", AsyncMock(return_value=sprint)),
+        _patch_obj(svc, "_enumerate_sprint_agents", AsyncMock(return_value={})),
+    ):
+        scorecard = await svc.build(AsyncMock(), _SPRINT_ID)
+    assert scorecard.scores == []
+
+
+@pytest.mark.asyncio
+async def test_build_run_window_unavailable_without_start_date():
+    """No sprint.start_date → run metrics are None (unknown), never 0 (measured)."""
+    svc = AgentScorecardService()
+    sprint = _make_sprint(start_date=None)
+    node = _agent_org_node(_AGENT_A_NODE, "agent-a", "Agent Alpha")
+    roster = {_AGENT_A_NODE: {"work_items_total": 3, "work_items_done": 2}}
+
+    with (
+        _patch_obj(svc, "_load_sprint", AsyncMock(return_value=sprint)),
+        _patch_obj(svc, "_enumerate_sprint_agents", AsyncMock(return_value=roster)),
+        _patch_obj(svc, "_resolve_agent_nodes", AsyncMock(return_value={_AGENT_A_NODE: node})),
+        _patch_obj(svc, "_aggregate_budgets", AsyncMock(return_value={})),
+    ):
+        scorecard = await svc.build(AsyncMock(), _SPRINT_ID)
+
+    assert scorecard.run_window_available is False
+    score = scorecard.scores[0]
+    assert score.runs_total is None
+    assert score.success_rate is None
+    assert score.throughput == 2  # work-item completion is independent of the run window
+
+
+@pytest.mark.asyncio
+async def test_build_low_sample_flag_below_configured_threshold():
+    svc = AgentScorecardService()
+    sprint = _make_sprint()
+    node = _agent_org_node(_AGENT_A_NODE, "agent-a", "Agent Alpha")
+    roster = {_AGENT_A_NODE: {"work_items_total": 1, "work_items_done": 1}}
+    run_stats = {"agent-a": {LLCRunStatus.COMPLETED.value: 2}}  # 2 terminal runs < default threshold (5)
+
+    with (
+        _patch_obj(svc, "_load_sprint", AsyncMock(return_value=sprint)),
+        _patch_obj(svc, "_enumerate_sprint_agents", AsyncMock(return_value=roster)),
+        _patch_obj(svc, "_resolve_agent_nodes", AsyncMock(return_value={_AGENT_A_NODE: node})),
+        _patch_obj(svc, "_aggregate_heartbeat_runs", AsyncMock(return_value=run_stats)),
+        _patch_obj(svc, "_aggregate_budgets", AsyncMock(return_value={})),
+    ):
+        scorecard = await svc.build(AsyncMock(), _SPRINT_ID)
+
+    score = scorecard.scores[0]
+    assert score.success_rate == 1.0
+    assert score.low_sample is True  # flagged despite a perfect ratio
+    assert score.reliability_score < 1.0  # Wilson bound shrinks it below the raw ratio
+
+
+@pytest.mark.asyncio
+async def test_build_sprint_not_found_raises():
+    svc = AgentScorecardService()
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_execute_result(scalar_one_or_none=None))
+    with pytest.raises(SprintNotFound):
+        await svc.build(session, uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end aggregation against a sequenced mock session (real SQL-building code)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_full_aggregation_against_real_queries():
+    """Exercises the real query-building methods (not mocked), matching call order in build()."""
+    svc = AgentScorecardService()
+    sprint = _make_sprint()
+
+    node_a = _agent_org_node(_AGENT_A_NODE, "agent-a", "Agent Alpha")
+    node_b = _agent_org_node(_AGENT_B_NODE, "agent-b", "Agent Bravo")
+
+    roster_rows = [
+        (_AGENT_A_NODE, WorkItemStatus.DONE.value),
+        (_AGENT_A_NODE, WorkItemStatus.IN_PROGRESS.value),
+        (_AGENT_B_NODE, WorkItemStatus.DONE.value),
+    ]
+    run_rows = [
+        ("agent-a", LLCRunStatus.COMPLETED.value, 180),
+        ("agent-a", LLCRunStatus.FAILED.value, 20),
+        # agent-b has no heartbeat runs at all — zero-run case
+    ]
+    budget_rows = [_agent_budget("agent-a", "12.50", 500_000)]
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[
+            _execute_result(scalar_one_or_none=sprint),  # _load_sprint
+            _execute_result(all_rows=roster_rows),  # _enumerate_sprint_agents
+            _execute_result(scalars_all=[node_a, node_b]),  # _resolve_agent_nodes
+            _execute_result(all_rows=run_rows),  # _aggregate_heartbeat_runs
+            _execute_result(scalars_all=budget_rows),  # _aggregate_budgets
+        ]
+    )
+
+    scorecard = await svc.build(session, _SPRINT_ID)
+
+    by_agent = {s.agent_id: s for s in scorecard.scores}
+    assert set(by_agent) == {"agent-a", "agent-b"}
+
+    a = by_agent["agent-a"]
+    assert a.work_items_total == 2 and a.work_items_done == 1
+    assert a.runs_terminal == 200 and a.runs_completed == 180
+    assert a.success_rate == pytest.approx(0.9)
+    assert a.spend_lifetime_usd == pytest.approx(12.50)
+    assert a.tokens_spent_lifetime == 500_000
+
+    b = by_agent["agent-b"]
+    assert b.work_items_total == 1 and b.work_items_done == 1
+    assert b.runs_total == 0
+    assert b.success_rate is None
+    assert b.spend_lifetime_usd is None

--- a/autobot-backend/llc/tests/test_sprint_summarizer.py
+++ b/autobot-backend/llc/tests/test_sprint_summarizer.py
@@ -167,7 +167,7 @@ async def test_llm_failure_falls_back_to_direct_merge(summarizer, km_mock):
     with (
         patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(None, project_id))),
         patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=docs)),
-        patch.object(summarizer, "_direct_merge", new=AsyncMock()) as dm,
+        patch.object(summarizer, "_direct_merge", new=AsyncMock()),
         patch.object(summarizer, "_llm_summarize_and_index", new=AsyncMock(return_value=_SENTINEL)) as lsi,
     ):
         result = await summarizer.summarize_and_merge(sprint_id, session=MagicMock())
@@ -426,3 +426,153 @@ async def test_llm_index_uses_upsert_for_idempotency(summarizer, km_mock):
     dst_col.upsert.assert_called_once()
     call_kwargs = dst_col.upsert.call_args.kwargs
     assert call_kwargs["ids"] == [f"sprint_summary:{sprint_id}"]
+
+
+# ---------------------------------------------------------------------------
+# Agent scorecard integration (GH#12619) — proves the retro surface actually
+# receives the data: SprintAutoCloseService.execute_close ->
+# SprintKbSummarizer.summarize_and_merge -> sprint.kb_summary, read by
+# GET /sprints/{id}/summary and GET /sprints/{id}/agent-scorecard.
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_score(**kwargs):
+    from llc.services.agent_scorecard import AgentScore
+
+    defaults = {
+        "org_node_id": str(uuid.uuid4()),
+        "agent_id": "agent-a",
+        "agent_name": "Agent Alpha",
+        "work_items_total": 3,
+        "work_items_done": 2,
+        "throughput": 2,
+        "runs_total": 10,
+        "runs_terminal": 10,
+        "runs_completed": 9,
+        "success_rate": 0.9,
+        "reliability_score": 0.7,
+        "low_sample": False,
+        "spend_lifetime_usd": 4.20,
+        "tokens_spent_lifetime": 12_000,
+    }
+    defaults.update(kwargs)
+    return AgentScore(**defaults)
+
+
+def _make_scorecard(scores):
+    from llc.services.agent_scorecard import SprintScorecard
+
+    return SprintScorecard(
+        sprint_id=str(uuid.uuid4()),
+        sprint_name="Sprint 1",
+        run_window_available=True,
+        run_window_start="2026-06-01T00:00:00+00:00",
+        run_window_end="2026-06-14T23:59:59.999999+00:00",
+        scores=scores,
+    )
+
+
+def test_render_agent_scorecard_includes_component_signals_and_caveats():
+    """The composite reliability_score must appear alongside raw component counts."""
+    from llc.kb.sprint_summarizer import render_agent_scorecard
+
+    scorecard = _make_scorecard([_make_agent_score()])
+    rendered = render_agent_scorecard(scorecard)
+
+    assert "## Agent Scorecard" in rendered
+    assert "agent-a" in rendered
+    assert "90.0%" in rendered  # raw success rate
+    assert "0.70" in rendered  # composite reliability score, shown alongside
+    assert "GH#12619" in rendered  # run-window caveat
+    assert "GH#13067" in rendered  # spend-window caveat
+
+
+def test_render_agent_scorecard_zero_run_agent_shows_na_not_zero():
+    from llc.kb.sprint_summarizer import render_agent_scorecard
+
+    zero_run = _make_agent_score(
+        runs_total=0, runs_terminal=0, runs_completed=0, success_rate=None, reliability_score=None, low_sample=None
+    )
+    rendered = render_agent_scorecard(_make_scorecard([zero_run]))
+    assert "n/a" in rendered
+
+
+@pytest.mark.asyncio
+async def test_summarize_and_merge_writes_scorecard_section_even_with_no_docs(summarizer, km_mock):
+    """A sprint with an empty KB collection must still get its scorecard persisted."""
+    sprint_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    sprint_mock = MagicMock()
+    sprint_mock.kb_summary = None
+    session_mock = MagicMock()
+    session_mock.flush = AsyncMock()
+
+    scorecard = _make_scorecard([_make_agent_score()])
+    fake_svc = MagicMock()
+    fake_svc.build = AsyncMock(return_value=scorecard)
+
+    with (
+        patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(sprint_mock, project_id))),
+        patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=[])),
+        patch("llc.services.agent_scorecard.AgentScorecardService", return_value=fake_svc),
+    ):
+        result = await summarizer.summarize_and_merge(sprint_id, session=session_mock)
+
+    assert result is None  # Learnings text unchanged — no docs to summarize
+    assert sprint_mock.kb_summary is not None
+    assert "Agent Scorecard" in sprint_mock.kb_summary
+    fake_svc.build.assert_awaited_once_with(session_mock, sprint_id)
+
+
+@pytest.mark.asyncio
+async def test_summarize_and_merge_combines_learnings_and_scorecard(summarizer, km_mock):
+    """Both sections must appear when there is Learnings text AND scorecard data."""
+    sprint_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    docs = _make_docs(5)
+    sprint_mock = MagicMock()
+    session_mock = MagicMock()
+    session_mock.flush = AsyncMock()
+
+    scorecard = _make_scorecard([_make_agent_score()])
+    fake_svc = MagicMock()
+    fake_svc.build = AsyncMock(return_value=scorecard)
+
+    with (
+        patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(sprint_mock, project_id))),
+        patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=docs)),
+        patch.object(summarizer, "_direct_merge", new=AsyncMock()),
+        patch("llc.services.agent_scorecard.AgentScorecardService", return_value=fake_svc),
+    ):
+        result = await summarizer.summarize_and_merge(sprint_id, session=session_mock)
+
+    assert result == "[direct-merged: 5 docs]"
+    assert "[direct-merged: 5 docs]" in sprint_mock.kb_summary
+    assert "Agent Scorecard" in sprint_mock.kb_summary
+
+
+@pytest.mark.asyncio
+async def test_scorecard_section_degrades_gracefully_on_sprint_not_found(summarizer, km_mock):
+    """A sprint-close race (sprint vanishes) must not crash the KB merge."""
+    from llc.services.sprint_planning import SprintNotFound
+
+    sprint_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    docs = _make_docs(5)
+    sprint_mock = MagicMock()
+    session_mock = MagicMock()
+    session_mock.flush = AsyncMock()
+
+    fake_svc = MagicMock()
+    fake_svc.build = AsyncMock(side_effect=SprintNotFound("gone"))
+
+    with (
+        patch.object(summarizer, "_load_sprint_context", new=AsyncMock(return_value=(sprint_mock, project_id))),
+        patch.object(summarizer, "_fetch_documents", new=AsyncMock(return_value=docs)),
+        patch.object(summarizer, "_direct_merge", new=AsyncMock()),
+        patch("llc.services.agent_scorecard.AgentScorecardService", return_value=fake_svc),
+    ):
+        result = await summarizer.summarize_and_merge(sprint_id, session=session_mock)
+
+    assert result == "[direct-merged: 5 docs]"
+    assert sprint_mock.kb_summary == "[direct-merged: 5 docs]"  # Learnings persisted; scorecard silently omitted

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -50289,6 +50289,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/sprints/{sprint_id}/agent-scorecard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sprint Agent Scorecard
+         * @description Return the per-agent success-rate/throughput/spend scorecard for a sprint (GH#12619).
+         *
+         *     Success rate is time-windowed against the sprint's dates (heartbeat runs
+         *     have no sprint FK — see ``AgentScorecardService`` docstring) and spend is
+         *     a lifetime total, not sprint-scoped (GH#13067) — both are labeled
+         *     explicitly in the response rather than implied to be exact.
+         */
+        get: operations["get_sprint_agent_scorecard_api_llc_sprints__sprint_id__agent_scorecard_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/work-items": {
         parameters: {
             query?: never;
@@ -54641,6 +54666,41 @@ export interface components {
          * @description Request body for POST /heartbeat/{agent_id}/resume (GH#6476).
          */
         AgentResumeRequest: Record<string, never>;
+        /** AgentScoreResponse */
+        AgentScoreResponse: {
+            /** Org Node Id */
+            org_node_id: string;
+            /** Agent Id */
+            agent_id: string | null;
+            /** Agent Name */
+            agent_name: string;
+            /** Work Items Total */
+            work_items_total: number;
+            /** Work Items Done */
+            work_items_done: number;
+            /** Throughput */
+            throughput: number;
+            /** Runs Total */
+            runs_total: number | null;
+            /** Runs Terminal */
+            runs_terminal: number | null;
+            /** Runs Completed */
+            runs_completed: number | null;
+            /** Success Rate */
+            success_rate: number | null;
+            /** Reliability Score */
+            reliability_score: number | null;
+            /** Low Sample */
+            low_sample: boolean | null;
+            /** Spend Lifetime Usd */
+            spend_lifetime_usd: number | null;
+            /** Tokens Spent Lifetime */
+            tokens_spent_lifetime: number | null;
+            /** Spend Window */
+            spend_window: string;
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * AgentStatusData
          * @description data payload for GET /agent/agents/status.
@@ -93821,6 +93881,23 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** SprintScorecardResponse */
+        SprintScorecardResponse: {
+            /** Sprint Id */
+            sprint_id: string;
+            /** Sprint Name */
+            sprint_name: string;
+            /** Run Window Available */
+            run_window_available: boolean;
+            /** Run Window Start */
+            run_window_start: string | null;
+            /** Run Window End */
+            run_window_end: string | null;
+            /** Scores */
+            scores: components["schemas"]["AgentScoreResponse"][];
         } & {
             [key: string]: unknown;
         };
@@ -169440,6 +169517,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SprintSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_sprint_agent_scorecard_api_llc_sprints__sprint_id__agent_scorecard_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sprint_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SprintScorecardResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Closes #12619

## Thinking Path

The sprint retrospective summarises *work product*, not *agent performance over time*. The per-agent signal already exists (`llc/models/heartbeat_run.py` run records, `llc/api/costs.py` per-agent spend) but is never aggregated, so there is no way to see which specialist agents are reliable versus regressing across sprints.

This adds a per-agent scorecard aggregating that existing signal — no schema change, purely additive aggregation over rows and columns that already exist.

## What Changed

- `llc/services/agent_scorecard.py` (new) — `AgentScorecardService`, aggregating per-agent success rate, throughput and spend for a sprint.
- `llc/kb/sprint_summarizer.py` — `_build_agent_scorecard_section()` renders the scorecard into the retrospective summary (`:139-140`), returning `None` rather than failing when data is unavailable.
- `llc/api/sprints.py` — `GET /llc/sprints/{sprint_id}/agent-scorecard` read API.
- `llc/config/__init__.py` — env-sourced thresholds/weights, no literals.
- Tests: `llc/tests/test_agent_scorecard.py`, `llc/tests/test_sprint_summarizer.py`.

## Verification

- `py_compile` clean on all changed files; `black --check --line-length=120` — 6 files unchanged; `flake8 --max-line-length=120` — 0 findings.
- `llc/tests/test_agent_scorecard.py` + `llc/tests/test_sprint_summarizer.py`: **31 passed**.
- `tests/test_startup_imports.py`: **350/350**, unchanged.
- Reachability proven, not asserted — two live surfaces: the read endpoint at `llc/api/sprints.py:1193`, and the retrospective section wired at `llc/kb/sprint_summarizer.py:139-140`.
- No migration: the change is aggregation over existing rows, so there is no schema forward-safety concern.

**Disclosure:** the implementing agent hit a usage limit immediately after committing and before reporting its own verification. The three commits were complete and the tree clean; the verification above was run independently against the pushed branch rather than taken on trust. Two things the agent did not report and which a reviewer should therefore weigh directly: how it handles **low-sample agents** (an agent with two runs must not outrank one with two hundred on a ratio alone), and whether the aggregation window is inspectable. Both are visible in `agent_scorecard.py` and covered by `test_agent_scorecard.py`, but they were not independently argued in a report.

## Model Used

claude-opus-5
