### PR TITLE
chore(vnc): pin noVNC to upstream v1.7.0 across all three deploy paths (#13069)

### DIFF
--- a/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
+++ b/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
@@ -29,8 +29,23 @@ services:
         export DEBIAN_FRONTEND=noninteractive
         if ! command -v supervisord &> /dev/null; then
           apt-get update -qq
-          apt-get install -y --no-install-recommends x11vnc xvfb novnc websockify supervisor
+          apt-get install -y --no-install-recommends x11vnc xvfb websockify supervisor curl ca-certificates
           apt-get clean && rm -rf /var/lib/apt/lists/*
+        fi
+
+        # #13069: noVNC pinned to an upstream release. The distro `novnc` package
+        # is 1.0.0 (2018) and predates VeNCrypt support (added in 1.4.0), which is
+        # what broke the deploy in #13060. Version and checksum are literals rather
+        # than shell vars because docker compose substitutes ${...} before the
+        # container sees it. Keep both in sync with
+        # autobot-slm-backend/ansible/roles/vnc/defaults/main.yml.
+        if [ ! -e /opt/novnc/vnc.html ]; then
+          curl -fsSL -o /tmp/novnc.tar.gz \
+            https://github.com/novnc/noVNC/archive/refs/tags/v1.7.0.tar.gz
+          echo 'b1003a11b6e6e8d8f7f5e5586daae7f8ca651d8aee0aa155ff9ac841c48f52c6  /tmp/novnc.tar.gz' | sha256sum -c -
+          tar xzf /tmp/novnc.tar.gz -C /opt
+          ln -sfn /opt/noVNC-1.7.0 /opt/novnc
+          rm -f /tmp/novnc.tar.gz
         fi
 
         # Create supervisor config directory
@@ -57,7 +72,9 @@ services:
         echo 'priority=200' >> /etc/supervisor/conf.d/autobot.conf
         echo '' >> /etc/supervisor/conf.d/autobot.conf
         echo '[program:novnc]' >> /etc/supervisor/conf.d/autobot.conf
-        echo 'command=/usr/share/novnc/utils/launch.sh --vnc localhost:5901 --listen 6080' >> /etc/supervisor/conf.d/autobot.conf
+        # #13069: upstream renamed utils/launch.sh to utils/novnc_proxy — the old
+        # path silently fails to start the proxy on any noVNC >= 1.2.0.
+        echo 'command=/opt/novnc/utils/novnc_proxy --vnc localhost:5901 --listen 6080' >> /etc/supervisor/conf.d/autobot.conf
         echo 'autostart=true' >> /etc/supervisor/conf.d/autobot.conf
         echo 'autorestart=true' >> /etc/supervisor/conf.d/autobot.conf
         echo 'priority=300' >> /etc/supervisor/conf.d/autobot.conf

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -68,7 +68,9 @@
         ports: [3000, 5900]
       vnc:
         services: ['vnc-server', 'vnc-websockify']
-        packages: ['tigervnc-standalone-server', 'x11vnc', 'websockify', 'novnc', 'xfce4', 'xfce4-terminal', 'dbus-x11']
+        # #13069: 'novnc' deliberately absent — the distro package is 1.0.0 (2018)
+        # and predates VeNCrypt. roles/vnc installs a pinned upstream release.
+        packages: ['tigervnc-standalone-server', 'x11vnc', 'websockify', 'xfce4', 'xfce4-terminal', 'dbus-x11']
         ports: [5900, 6080]
       slm-agent:
         services: ['slm-agent']

--- a/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
@@ -17,7 +17,23 @@ websockify_port: "{{ lookup('env', 'WEBSOCKIFY_PORT') | default('6080', true) }}
 websockify_enabled: "{{ lookup('env', 'WEBSOCKIFY_ENABLED') | default('true', true) }}"
 
 # noVNC installation
-novnc_path: /usr/share/novnc
+#
+# #13069: pinned to an explicit upstream release, NOT the distro package. Ubuntu
+# 22.04 ships `novnc 1:1.0.0-5` — upstream 1.0.0 is from 2018 and predates
+# VeNCrypt support (added in 1.4.0), which is what broke the deploy in #13060.
+# Bump novnc_version and novnc_archive_sha256 together to upgrade.
+#
+# The archive is the GitHub tag tarball: upstream publishes no release assets, so
+# the tag archive IS the distribution. It is self-contained — .gitmodules is empty
+# and vendor/pako is fully populated.
+novnc_version: "1.7.0"
+novnc_archive_sha256: b1003a11b6e6e8d8f7f5e5586daae7f8ca651d8aee0aa155ff9ac841c48f52c6
+
+# Versioned install root + stable symlink, so a rollback is a symlink flip.
+# novnc_path deliberately does NOT point at /usr/share/novnc: that directory is
+# dpkg-owned by the distro package, and replacing it with a symlink collides.
+novnc_install_root: "/opt/noVNC-{{ novnc_version }}"
+novnc_path: /opt/novnc
 
 # Security - password auto-generated to /etc/autobot/vnc-secrets.env
 #

--- a/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
@@ -24,12 +24,51 @@
       - tigervnc-tools
       - x11vnc
       - websockify
-      - novnc
       - xfce4
       - xfce4-terminal
       - dbus-x11
     state: present
   become: true
+
+# --- Pinned noVNC from upstream (#13069) ---
+# The distro `novnc` package is 1.0.0 (2018) on Ubuntu 22.04 — it predates
+# VeNCrypt support and caused the unreachable-server failure in #13060. Removed
+# so the packaged copy and the pinned copy cannot diverge.
+- name: Remove distro noVNC package (superseded by pinned upstream; #13069)
+  ansible.builtin.apt:
+    name: novnc
+    state: absent
+  become: true
+
+# Upstream publishes no release assets, so the tag archive is the distribution.
+# If GitHub ever re-compresses it the checksum fails loudly, which is the safe
+# failure mode — a mismatched archive is never installed.
+- name: Download noVNC {{ novnc_version }} tarball (#13069)
+  ansible.builtin.get_url:
+    url: "https://github.com/novnc/noVNC/archive/refs/tags/v{{ novnc_version }}.tar.gz"
+    dest: "/tmp/noVNC-{{ novnc_version }}.tar.gz"
+    checksum: "sha256:{{ novnc_archive_sha256 }}"
+    mode: "0644"
+  become: true
+
+- name: Unpack noVNC {{ novnc_version }} to versioned root (#13069)
+  ansible.builtin.unarchive:
+    src: "/tmp/noVNC-{{ novnc_version }}.tar.gz"
+    dest: /opt
+    remote_src: true
+    owner: root
+    group: root
+    creates: "{{ novnc_install_root }}/vnc.html"
+  become: true
+
+- name: Point {{ novnc_path }} at noVNC {{ novnc_version }} (#13069)
+  ansible.builtin.file:
+    src: "{{ novnc_install_root }}"
+    dest: "{{ novnc_path }}"
+    state: link
+    force: true
+  become: true
+  notify: restart websockify
 
 - name: Create VNC user if not exists
   ansible.builtin.user:


### PR DESCRIPTION
Closes #13069

## Thinking Path

Follow-up to #13060/#13061 on the principle that we should not be running old software. The VeNCrypt failure was the symptom; the cause was that every deploy path took whatever noVNC the distro froze.

```
$ apt-cache policy novnc
novnc:
  Installed: 1:1.0.0-5
  Candidate: 1:1.0.0-5
```

Upstream 1.0.0 is from **2018**. Current is **v1.7.0 (2026-04-28)** — eight years and seven minor releases behind. VeNCrypt support landed in 1.4.0, so the client physically could not negotiate what the server offered.

Rather than invent a new install mechanism, this reuses the pattern the repo already has for `node_exporter` / `prometheus` / `redis_exporter`: a `{{ X_version }}` var, `get_url` with a `checksum:`, then `unarchive`.

## What Changed

**Pinned install, checksum-verified.** `novnc_version: "1.7.0"` + `novnc_archive_sha256` in `roles/vnc/defaults/main.yml`. Upgrading is a two-line bump.

**Versioned root with a stable symlink** — `/opt/noVNC-1.7.0` with `/opt/novnc` pointing at it, so a rollback is a symlink flip and two versions can coexist during one.

**`novnc_path` moves from `/usr/share/novnc` to `/opt/novnc`.** `/usr/share/novnc` is dpkg-owned; Ansible's `file: state=link` will not replace a populated directory, so symlinking over it would collide with the package manager. Pointing at our own path sidesteps that entirely. `novnc_path` is only consumed by `websockify --web=`, so nothing else moves.

**The distro package is explicitly removed** (`state: absent`) so a packaged 1.0.0 and the pinned copy cannot diverge on a host that was provisioned before this change.

**All three install sites:**

| File | Change |
|---|---|
| `roles/vnc/tasks/main.yml` | `novnc` dropped from apt; pinned download + unpack + symlink added |
| `playbooks/enroll-node.yml` | `novnc` dropped from the `vnc` packages list |
| `docker-compose.playwright-vnc.yml` | apt `novnc` replaced with a checksummed fetch |

> [!NOTE]
> In the compose file the version and checksum are **literals, not shell variables**. Docker Compose performs `${...}` substitution before the container ever sees the script, so a shell var would have been silently emptied.

### Latent break fixed along the way

`docker-compose.playwright-vnc.yml` invoked `/usr/share/novnc/utils/launch.sh`. Upstream renamed that to `utils/novnc_proxy`, so on any noVNC ≥ 1.2.0 the supervisor program would have failed to start the proxy — a bug that only surfaces once you upgrade. Command updated in the same change.

## Verification

Simulated the exact install sequence end to end, then tried to break it.

```
=== 1. fresh download (no cache) ===                   download OK
=== 2. checksum gate — the literal in both files ===   novnc.tar.gz: OK
=== 3. unpack + symlink ===
=== 4. paths each consumer needs ===
  vnc.html                               OK
  vnc_lite.html                          OK
  utils/novnc_proxy                      OK
  core/rfb.js                            OK
  vendor/pako/lib/zlib/inflate.js        OK
=== 5. novnc_proxy executable (supervisor invokes it directly) ===
  executable OK
=== 6. NEGATIVE CONTROL — corrupted archive ===
  sha256sum: WARNING: 1 computed checksum did NOT match
  -> correctly REJECTED
```

**Archive completeness** — the concern with GitHub tag archives is missing submodules. `.gitmodules` is empty, and `vendor/pako` is fully populated including the real import target `lib/zlib/inflate.js`. Upstream publishes no release assets, so the tag archive *is* the distribution.

**Module graph resolves on disk** — all **34** assets referenced by `vnc.html` (scripts, styles, images, sounds) and every top-level `app/ui.js` import (`../core/rfb.js`, `../core/input/keyboard.js`, `./webutil.js`, …) exist in the unpacked tree.

**No consumer breaks** — every reference in the repo requests `/vnc.html`, which 1.7.0 still ships; `DesktopInterface.vue:320` uses `?autoconnect=true` and `autoconnect` is still supported (`password`, `host`, `port`, `path`, `encrypt`, `reconnect` too). Nothing references the removed `vnc_auto.html` or `novnc/include`.

**Static checks** — all 4 changed YAML files parse; `deploy.yml` passes `--syntax-check`; no apt-installed `novnc` remains anywhere outside the `state: absent` task.

## Deliberately Out of Scope

- **websockify** is stale too (apt `0.10.0+dfsg1-2build1`, upstream **0.13.0**) and it terminates TLS for the browser hop. It is a Python package needing a venv rather than a static unpack, so it is **#13070** to keep this PR testable on its own.
- `autobot-infrastructure/shared/scripts/` (`setup_browser_vnc.sh`, `browser-vnc-websockify.service`, `fix-vnc-desktop.sh`, `fix-vnc-wsl.sh`) hardcode `--web /usr/share/novnc`. They do not install the package, but they will serve a distro copy if one exists on that host. Recorded on #13069.

## Model Used

Claude Opus 5 (1M context)
