### PR TITLE
fix(frontend): SLM NodeStatus SSOT drift + CI-gate SLM generated types (#12662)

### DIFF
--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -1,7 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 #
-# Generated Types Freshness Gate (GH#10817)
+# Generated Types Freshness Gate (GH#10817, #12662)
 # autobot-frontend/src/types/generated/api.ts is generated from the backend
 # OpenAPI schema (`npm run gen:types`). Nothing gated its freshness, so it
 # silently drifted: #10746 hand-found 12 dead Enhanced* schemas, #10776
@@ -13,6 +13,15 @@
 # openapi-typescript, then `git diff --exit-code`. If it drifts, the diff is
 # non-empty and this gate goes red — run `npm run gen:types` against a running
 # backend and commit the result.
+#
+# #12662: a second job (verify-generated-types-slm) applies the identical
+# recipe to autobot-slm-frontend/src/types/generated/api.ts, generated from
+# autobot-slm-backend's OpenAPI schema via scripts/dump_openapi.py (no live
+# server needed — it imports `main.app` directly). Before this job existed,
+# the SLM generated file had zero CI freshness guard and had already drifted
+# 283 diff lines from the live backend schema (schema renames + new fields)
+# despite zero consumers importing it — see #12662 for the cross-language
+# NodeStatus drift this closes.
 #
 # Runs on GitHub-hosted ubuntu-latest (not the self-hosted runner) so it adds
 # no load to the single self-hosted runner.
@@ -51,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       types: ${{ steps.filter.outputs.types }}
+      slm_types: ${{ steps.filter.outputs.slm_types }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
@@ -62,6 +72,14 @@ jobs:
               - 'autobot-frontend/src/types/generated/api.ts'
               - 'autobot-frontend/package.json'
               - 'autobot-frontend/package-lock.json'
+              - 'scripts/audit_api_wiring.py'
+              - '**/requirements*.txt'
+              - '.github/workflows/verify-generated-types.yml'
+            slm_types:
+              - 'autobot-slm-backend/**/*.py'
+              - 'autobot-slm-frontend/src/types/generated/api.ts'
+              - 'autobot-slm-frontend/package.json'
+              - 'autobot-slm-frontend/package-lock.json'
               - 'scripts/audit_api_wiring.py'
               - '**/requirements*.txt'
               - '.github/workflows/verify-generated-types.yml'
@@ -127,3 +145,78 @@ jobs:
             exit 1
           fi
           echo "Generated types are fresh."
+
+  verify-generated-types-slm:
+    needs: changes
+    if: needs.changes.outputs.slm_types == 'true'
+    name: verify-generated-types-slm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-slm-backend/requirements*.txt
+
+      - name: Install SLM backend dependencies
+        # autobot-slm-backend/main.py needs its own requirements (croniter,
+        # authlib, ldap3, pysaml2, pyotp, ...) — see api-wiring.yml's identical
+        # note. dump_slm_openapi() imports `main.app` directly, same recipe as
+        # the API wiring audit's --dump-slm-openapi.
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r autobot-slm-backend/requirements.txt --prefer-binary
+
+      - name: Dump authoritative SLM OpenAPI schema
+        run: |
+          set -o pipefail
+          mkdir -p data logs static config autobot-slm-backend/data
+          export PYTHONPATH="$PWD:$PWD/autobot-slm-backend:${PYTHONPATH:-}"
+          if ! python scripts/audit_api_wiring.py --dump-slm-openapi slm_openapi.raw.json; then
+            echo "::error::SLM backend app.openapi() build failed — cannot verify generated types."
+            echo "This usually means the SLM backend does not import cleanly in CI (see startup-import-smoke)."
+            exit 1
+          fi
+          # --dump-slm-openapi adds an audit-only x-websocket-paths extension
+          # (same as backend's --dump-openapi). Strip it so the schema matches
+          # exactly what `npm run gen:types:openapi` (dump_openapi.py, no
+          # websocket union) produces locally.
+          python -c "
+          import json
+          s = json.load(open('slm_openapi.raw.json'))
+          s.pop('x-websocket-paths', None)
+          with open('autobot-slm-frontend/openapi.json', 'w', encoding='utf-8') as f:
+              json.dump(s, f, indent=2, sort_keys=True, ensure_ascii=False)
+              f.write('\n')
+          "
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-slm-frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: autobot-slm-frontend
+        run: npm ci
+
+      - name: Regenerate api.ts from authoritative schema
+        working-directory: autobot-slm-frontend
+        run: npx --no-install openapi-typescript openapi.json -o src/types/generated/api.ts --additional-properties
+
+      - name: Fail if generated types drifted
+        run: |
+          if ! git diff --exit-code autobot-slm-frontend/openapi.json autobot-slm-frontend/src/types/generated/api.ts; then
+            echo "::error::autobot-slm-frontend generated types are stale."
+            echo "The SLM backend OpenAPI schema changed but the committed generated types were not updated."
+            echo "Fix: run 'npm run gen:types:openapi && npm run gen:types' in autobot-slm-frontend and commit the result."
+            exit 1
+          fi
+          echo "SLM generated types are fresh."

--- a/autobot-slm-frontend/openapi.json
+++ b/autobot-slm-frontend/openapi.json
@@ -2862,6 +2862,22 @@
             "title": "Outdated Nodes",
             "type": "integer"
           },
+          "self_update_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Self Update Detail"
+          },
+          "self_update_incomplete": {
+            "default": false,
+            "title": "Self Update Incomplete",
+            "type": "boolean"
+          },
           "stale_components": {
             "default": [],
             "items": {
@@ -10937,7 +10953,7 @@
         "type": "object"
       },
       "ServiceActionRequest": {
-        "description": "Request for a service action.",
+        "description": "Request for a service action (start/stop/restart via orchestration).\n\nIssue #12755: canonicalized from the duplicate defined in\napi/orchestration.py — action is carried in the URL path, this body\nonly carries optional targeting/behavior flags.",
         "properties": {
           "force": {
             "default": false,
@@ -13445,7 +13461,7 @@
           },
           "users": {
             "items": {
-              "$ref": "#/components/schemas/user_management__schemas__user__UserResponse"
+              "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserResponse"
             },
             "title": "Users",
             "type": "array"
@@ -14347,6 +14363,248 @@
         "title": "RoleResponse",
         "type": "object"
       },
+      "autobot_shared__user_management__schemas__user__RoleResponse": {
+        "description": "Role information in responses.",
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_system": {
+            "default": false,
+            "title": "Is System",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "RoleResponse",
+        "type": "object"
+      },
+      "autobot_shared__user_management__schemas__user__UserCreate": {
+        "description": "Request model for creating a user.",
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name",
+            "title": "Display Name"
+          },
+          "email": {
+            "description": "User email address",
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Organization ID (uses current context if not provided)",
+            "title": "Org Id"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 8,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Password (8-128 characters, optional for SSO users)",
+            "title": "Password"
+          },
+          "role_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "List of role IDs to assign",
+            "title": "Role Ids"
+          },
+          "username": {
+            "description": "Username (3-100 characters, alphanumeric and underscores)",
+            "maxLength": 100,
+            "minLength": 3,
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "username"
+        ],
+        "title": "UserCreate",
+        "type": "object"
+      },
+      "autobot_shared__user_management__schemas__user__UserResponse": {
+        "description": "Response model for a single user.",
+        "properties": {
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bio"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_active": {
+            "default": true,
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "is_platform_admin": {
+            "default": false,
+            "title": "Is Platform Admin",
+            "type": "boolean"
+          },
+          "is_verified": {
+            "default": false,
+            "title": "Is Verified",
+            "type": "boolean"
+          },
+          "last_login_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Login At"
+          },
+          "mfa_enabled": {
+            "default": false,
+            "title": "Mfa Enabled",
+            "type": "boolean"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Org Id"
+          },
+          "preferences": {
+            "additionalProperties": true,
+            "title": "Preferences",
+            "type": "object"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__RoleResponse"
+            },
+            "title": "Roles",
+            "type": "array"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "username",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "UserResponse",
+        "type": "object"
+      },
       "models__schemas__FleetServiceStatus": {
         "description": "Service status across the fleet.",
         "properties": {
@@ -14531,248 +14789,6 @@
           "username",
           "is_active",
           "created_at"
-        ],
-        "title": "UserResponse",
-        "type": "object"
-      },
-      "user_management__schemas__user__RoleResponse": {
-        "description": "Role information in responses.",
-        "properties": {
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "is_system": {
-            "default": false,
-            "title": "Is System",
-            "type": "boolean"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ],
-        "title": "RoleResponse",
-        "type": "object"
-      },
-      "user_management__schemas__user__UserCreate": {
-        "description": "Request model for creating a user.",
-        "properties": {
-          "display_name": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Display name",
-            "title": "Display Name"
-          },
-          "email": {
-            "description": "User email address",
-            "format": "email",
-            "title": "Email",
-            "type": "string"
-          },
-          "org_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Organization ID (uses current context if not provided)",
-            "title": "Org Id"
-          },
-          "password": {
-            "anyOf": [
-              {
-                "maxLength": 128,
-                "minLength": 8,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Password (8-128 characters, optional for SSO users)",
-            "title": "Password"
-          },
-          "role_ids": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "List of role IDs to assign",
-            "title": "Role Ids"
-          },
-          "username": {
-            "description": "Username (3-100 characters, alphanumeric and underscores)",
-            "maxLength": 100,
-            "minLength": 3,
-            "title": "Username",
-            "type": "string"
-          }
-        },
-        "required": [
-          "email",
-          "username"
-        ],
-        "title": "UserCreate",
-        "type": "object"
-      },
-      "user_management__schemas__user__UserResponse": {
-        "description": "Response model for a single user.",
-        "properties": {
-          "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avatar Url"
-          },
-          "bio": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bio"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "email": {
-            "title": "Email",
-            "type": "string"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "is_active": {
-            "default": true,
-            "title": "Is Active",
-            "type": "boolean"
-          },
-          "is_platform_admin": {
-            "default": false,
-            "title": "Is Platform Admin",
-            "type": "boolean"
-          },
-          "is_verified": {
-            "default": false,
-            "title": "Is Verified",
-            "type": "boolean"
-          },
-          "last_login_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Login At"
-          },
-          "mfa_enabled": {
-            "default": false,
-            "title": "Mfa Enabled",
-            "type": "boolean"
-          },
-          "org_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Org Id"
-          },
-          "preferences": {
-            "additionalProperties": true,
-            "title": "Preferences",
-            "type": "object"
-          },
-          "roles": {
-            "items": {
-              "$ref": "#/components/schemas/user_management__schemas__user__RoleResponse"
-            },
-            "title": "Roles",
-            "type": "array"
-          },
-          "updated_at": {
-            "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
-          },
-          "username": {
-            "title": "Username",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "email",
-          "username",
-          "created_at",
-          "updated_at"
         ],
         "title": "UserResponse",
         "type": "object"
@@ -16394,7 +16410,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/user_management__schemas__user__UserCreate"
+                "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserCreate"
               }
             }
           },
@@ -16405,7 +16421,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/user_management__schemas__user__UserResponse"
+                  "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserResponse"
                 }
               }
             },
@@ -16494,7 +16510,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/user_management__schemas__user__UserResponse"
+                  "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserResponse"
                 }
               }
             },
@@ -16551,7 +16567,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/user_management__schemas__user__UserResponse"
+                  "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserResponse"
                 }
               }
             },
@@ -29662,7 +29678,7 @@
     },
     "/api/secrets/{key}": {
       "delete": {
-        "description": "Delete a system secret (admin only).",
+        "description": "Delete a system secret (admin only).\n\nAlso deletes any imported vault copy (#10088 Task 6a) so a deleted\nsecret can never resurrect through the vault-fallback read path.",
         "operationId": "delete_secret_api_secrets__key__delete",
         "parameters": [
           {
@@ -29805,7 +29821,7 @@
     },
     "/api/secrets/{key}/value": {
       "get": {
-        "description": "Get a decrypted secret value (admin only, for fleet provisioning).",
+        "description": "Get a decrypted secret value (admin only, for fleet provisioning).\n\nLegacy ``system_secrets`` first, unified System vault fallback (#10088\nTask 6a) — a key imported by the vault migration and later pruned from\n``system_secrets`` stays reachable here.",
         "operationId": "get_secret_value_api_secrets__key__value_get",
         "parameters": [
           {
@@ -31972,7 +31988,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/user_management__schemas__user__UserCreate"
+                "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserCreate"
               }
             }
           },
@@ -31983,7 +31999,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/user_management__schemas__user__UserResponse"
+                  "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserResponse"
                 }
               }
             },
@@ -32072,7 +32088,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/user_management__schemas__user__UserResponse"
+                  "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserResponse"
                 }
               }
             },
@@ -32129,7 +32145,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/user_management__schemas__user__UserResponse"
+                  "$ref": "#/components/schemas/autobot_shared__user_management__schemas__user__UserResponse"
                 }
               }
             },

--- a/autobot-slm-frontend/src/components/DeploymentWizard.vue
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.vue
@@ -327,7 +327,7 @@ function getCategoryIcon(category: string): string {
                   <span
                     :class="[
                       'px-2 py-1 text-xs font-medium rounded-full',
-                      node.status === 'healthy'
+                      node.status === 'online'
                         ? 'bg-green-100 text-green-800'
                         : node.status === 'offline'
                           ? 'bg-gray-100 text-gray-800'

--- a/autobot-slm-frontend/src/components/fleet/AssignNPURoleModal.vue
+++ b/autobot-slm-frontend/src/components/fleet/AssignNPURoleModal.vue
@@ -38,7 +38,7 @@ const selectedNode = computed(() => {
 const eligibleNodes = computed(() => {
   // Filter to nodes that are online and don't already have npu-worker role
   return props.availableNodes.filter(n =>
-    (n.status === 'online' || n.status === 'healthy') &&
+    n.status === 'online' &&
     !n.roles.includes('npu-worker')
   )
 })

--- a/autobot-slm-frontend/src/components/fleet/NPUNodeCard.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUNodeCard.vue
@@ -26,13 +26,11 @@ const emit = defineEmits<{
 const statusColor = computed(() => {
   switch (props.node.status) {
     case 'online':
-    case 'healthy':
       return 'bg-green-100 text-green-800'
     case 'degraded':
       return 'bg-yellow-100 text-yellow-800'
     case 'offline':
     case 'error':
-    case 'unhealthy':
       return 'bg-red-100 text-red-800'
     default:
       return 'bg-gray-100 text-gray-800'

--- a/autobot-slm-frontend/src/components/fleet/NPUWorkerMonitor.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUWorkerMonitor.vue
@@ -37,9 +37,7 @@ let refreshTimer: ReturnType<typeof setInterval> | null = null
 const npuNodes = computed(() => fleetStore.npuNodes)
 
 const onlineCount = computed(() => {
-  return npuNodes.value.filter(
-    n => n.status === 'online' || n.status === 'healthy'
-  ).length
+  return npuNodes.value.filter(n => n.status === 'online').length
 })
 
 const avgUtilization = computed(() => {
@@ -56,7 +54,6 @@ function nodeMetrics(nodeId: string): NPUWorkerMetrics | undefined {
 function nodeStatusIndicator(node: SLMNode): string {
   switch (node.status) {
     case 'online':
-    case 'healthy':
       return 'bg-green-500'
     case 'degraded':
       return 'bg-yellow-500'
@@ -68,14 +65,12 @@ function nodeStatusIndicator(node: SLMNode): string {
 function nodeStatusLabel(node: SLMNode): string {
   switch (node.status) {
     case 'online':
-    case 'healthy':
       return 'Online'
     case 'degraded':
       return 'Degraded'
     case 'offline':
       return 'Offline'
     case 'error':
-    case 'unhealthy':
       return 'Error'
     default:
       return node.status
@@ -110,13 +105,13 @@ function currentTask(nodeId: string): string {
 }
 
 function connectionStatus(node: SLMNode): string {
-  if (node.status === 'online' || node.status === 'healthy') return 'Connected'
+  if (node.status === 'online') return 'Connected'
   if (node.status === 'degraded') return 'Unstable'
   return 'Disconnected'
 }
 
 function connectionColor(node: SLMNode): string {
-  if (node.status === 'online' || node.status === 'healthy') {
+  if (node.status === 'online') {
     return 'text-green-600'
   }
   if (node.status === 'degraded') return 'text-yellow-600'

--- a/autobot-slm-frontend/src/components/fleet/NPUWorkersTab.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUWorkersTab.vue
@@ -75,9 +75,7 @@ const avgUtilization = computed(() => {
 })
 
 const healthyNpuNodes = computed(() => {
-  return npuNodes.value.filter(n =>
-    n.status === 'online' || n.status === 'healthy'
-  ).length
+  return npuNodes.value.filter(n => n.status === 'online').length
 })
 
 // Methods

--- a/autobot-slm-frontend/src/components/fleet/NodeCard.test.ts
+++ b/autobot-slm-frontend/src/components/fleet/NodeCard.test.ts
@@ -48,18 +48,14 @@ describe('NodeCard enroll/recovery action (#12477)', () => {
     expect(btn.text()).toContain(en.fleet.nodeCard.enrollNode)
   })
 
-  it('shows the Enroll action for registered nodes', async () => {
-    expect((await mountCard('registered')).find('[data-test="enroll-action"]').exists()).toBe(true)
-  })
-
   it('exposes the recovery action labelled "Recover Connection" for degraded nodes', async () => {
     const btn = (await mountCard('degraded')).find('[data-test="enroll-action"]')
     expect(btn.exists()).toBe(true)
     expect(btn.text()).toContain(en.fleet.nodeCard.recoverConnection)
   })
 
-  it('exposes the recovery action for offline, unhealthy and error nodes', async () => {
-    for (const status of ['offline', 'unhealthy', 'error'] as NodeStatus[]) {
+  it('exposes the recovery action for offline and error nodes', async () => {
+    for (const status of ['offline', 'error'] as NodeStatus[]) {
       const btn = (await mountCard(status)).find('[data-test="enroll-action"]')
       expect(btn.exists()).toBe(true)
       expect(btn.text()).toContain(en.fleet.nodeCard.recoverConnection)
@@ -74,7 +70,7 @@ describe('NodeCard enroll/recovery action (#12477)', () => {
     expect(events![0]).toEqual(['enroll', 'node-1'])
   })
 
-  it('does not show the enroll/recovery action for healthy nodes', async () => {
-    expect((await mountCard('healthy')).find('[data-test="enroll-action"]').exists()).toBe(false)
+  it('does not show the enroll/recovery action for online nodes', async () => {
+    expect((await mountCard('online')).find('[data-test="enroll-action"]').exists()).toBe(false)
   })
 })

--- a/autobot-slm-frontend/src/components/fleet/NodeCard.vue
+++ b/autobot-slm-frontend/src/components/fleet/NodeCard.vue
@@ -30,14 +30,11 @@ const showMenu = ref(false)
 const statusClass = computed(() => {
   switch (props.node.status) {
     case 'online': return 'bg-green-500'
-    case 'healthy': return 'bg-green-500'
     case 'degraded': return 'bg-yellow-500'
-    case 'unhealthy': return 'bg-red-500'
     case 'offline': return 'bg-gray-400'
     case 'error': return 'bg-red-500'
     case 'enrolling': return 'bg-blue-500 animate-pulse'
     case 'pending': return 'bg-gray-400'
-    case 'registered': return 'bg-gray-400'
     case 'decommissioned': return 'bg-gray-300'
     default: return 'bg-gray-400'
   }
@@ -63,19 +60,18 @@ const lastSeen = computed(() => {
 })
 
 const canEnroll = computed(() => {
-  return props.node.status === 'registered' || props.node.status === 'pending'
+  return props.node.status === 'pending'
 })
 
-// #12477: A degraded/offline/unhealthy/error node has a broken connection the
-// operator must be able to re-establish. The POST /nodes/{id}/enroll endpoint
-// has no status guard and re-runs the enrollment flow (reinstalls the key via
-// an SSH password), so recovery reuses the same 'enroll' action. This is
+// #12477: A degraded/offline/error node has a broken connection the operator
+// must be able to re-establish. The POST /nodes/{id}/enroll endpoint has no
+// status guard and re-runs the enrollment flow (reinstalls the key via an
+// SSH password), so recovery reuses the same 'enroll' action. This is
 // distinct from the decommissioned-only 'reenroll' endpoint, which rejects any
 // non-decommissioned node.
 const canRecover = computed(() => {
   return (
     props.node.status === 'degraded' ||
-    props.node.status === 'unhealthy' ||
     props.node.status === 'offline' ||
     props.node.status === 'error'
   )

--- a/autobot-slm-frontend/src/composables/useFleetHealth.ts
+++ b/autobot-slm-frontend/src/composables/useFleetHealth.ts
@@ -41,13 +41,13 @@ export function useFleetHealth() {
 
     for (const node of nodes.value.values()) {
       switch (node.status) {
-        case 'healthy':
+        case 'online':
           healthy++
           break
         case 'degraded':
           degraded++
           break
-        case 'unhealthy':
+        case 'error':
           unhealthy++
           break
         case 'offline':
@@ -93,9 +93,9 @@ export function useFleetHealth() {
     const node = nodes.value.get(nodeId)
     if (node) {
       node.health = health
-      node.status = health.status === 'healthy' ? 'healthy' :
+      node.status = health.status === 'healthy' ? 'online' :
                     health.status === 'degraded' ? 'degraded' :
-                    health.status === 'unhealthy' ? 'unhealthy' : 'offline'
+                    health.status === 'unhealthy' ? 'error' : 'offline'
       nodes.value.set(nodeId, { ...node })
     }
   }

--- a/autobot-slm-frontend/src/stores/fleet.ts
+++ b/autobot-slm-frontend/src/stores/fleet.ts
@@ -89,13 +89,11 @@ export const useFleetStore = defineStore('fleet', () => {
     for (const node of nodes.value.values()) {
       switch (node.status) {
         case 'online':
-        case 'healthy':
           healthy++
           break
         case 'degraded':
           degraded++
           break
-        case 'unhealthy':
         case 'error':
           unhealthy++
           break
@@ -310,9 +308,9 @@ export const useFleetStore = defineStore('fleet', () => {
     const node = nodes.value.get(nodeId)
     if (node) {
       node.health = health
-      node.status = health.status === 'healthy' ? 'healthy' :
+      node.status = health.status === 'healthy' ? 'online' :
                     health.status === 'degraded' ? 'degraded' :
-                    health.status === 'unhealthy' ? 'unhealthy' : 'offline'
+                    health.status === 'unhealthy' ? 'error' : 'offline'
       nodes.value.set(nodeId, { ...node })
     }
   }

--- a/autobot-slm-frontend/src/types/generated/api.ts
+++ b/autobot-slm-frontend/src/types/generated/api.ts
@@ -5128,6 +5128,9 @@ export interface paths {
         /**
          * Delete Secret
          * @description Delete a system secret (admin only).
+         *
+         *     Also deletes any imported vault copy (#10088 Task 6a) so a deleted
+         *     secret can never resurrect through the vault-fallback read path.
          */
         delete: operations["delete_secret_api_secrets__key__delete"];
         options?: never;
@@ -5145,6 +5148,10 @@ export interface paths {
         /**
          * Get Secret Value
          * @description Get a decrypted secret value (admin only, for fleet provisioning).
+         *
+         *     Legacy ``system_secrets`` first, unified System vault fallback (#10088
+         *     Task 6a) — a key imported by the vault migration and later pruned from
+         *     ``system_secrets`` stays reachable here.
          */
         get: operations["get_secret_value_api_secrets__key__value_get"];
         put?: never;
@@ -8100,6 +8107,13 @@ export interface components {
              * @default 0
              */
             outdated_nodes: number;
+            /** Self Update Detail */
+            self_update_detail?: string | null;
+            /**
+             * Self Update Incomplete
+             * @default false
+             */
+            self_update_incomplete: boolean;
             /**
              * Stale Components
              * @default []
@@ -12102,7 +12116,11 @@ export interface components {
         };
         /**
          * ServiceActionRequest
-         * @description Request for a service action.
+         * @description Request for a service action (start/stop/restart via orchestration).
+         *
+         *     Issue #12755: canonicalized from the duplicate defined in
+         *     api/orchestration.py — action is carried in the URL path, this body
+         *     only carries optional targeting/behavior flags.
          */
         ServiceActionRequest: {
             /**
@@ -13411,7 +13429,7 @@ export interface components {
             /** Total */
             total: number;
             /** Users */
-            users: components["schemas"]["user_management__schemas__user__UserResponse"][];
+            users: components["schemas"]["autobot_shared__user_management__schemas__user__UserResponse"][];
         } & {
             [key: string]: unknown;
         };
@@ -13783,6 +13801,130 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * RoleResponse
+         * @description Role information in responses.
+         */
+        autobot_shared__user_management__schemas__user__RoleResponse: {
+            /** Description */
+            description?: string | null;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Is System
+             * @default false
+             */
+            is_system: boolean;
+            /** Name */
+            name: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * UserCreate
+         * @description Request model for creating a user.
+         */
+        autobot_shared__user_management__schemas__user__UserCreate: {
+            /**
+             * Display Name
+             * @description Display name
+             */
+            display_name?: string | null;
+            /**
+             * Email
+             * Format: email
+             * @description User email address
+             */
+            email: string;
+            /**
+             * Org Id
+             * @description Organization ID (uses current context if not provided)
+             */
+            org_id?: string | null;
+            /**
+             * Password
+             * @description Password (8-128 characters, optional for SSO users)
+             */
+            password?: string | null;
+            /**
+             * Role Ids
+             * @description List of role IDs to assign
+             */
+            role_ids?: string[] | null;
+            /**
+             * Username
+             * @description Username (3-100 characters, alphanumeric and underscores)
+             */
+            username: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * UserResponse
+         * @description Response model for a single user.
+         */
+        autobot_shared__user_management__schemas__user__UserResponse: {
+            /** Avatar Url */
+            avatar_url?: string | null;
+            /** Bio */
+            bio?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Display Name */
+            display_name?: string | null;
+            /** Email */
+            email: string;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Is Active
+             * @default true
+             */
+            is_active: boolean;
+            /**
+             * Is Platform Admin
+             * @default false
+             */
+            is_platform_admin: boolean;
+            /**
+             * Is Verified
+             * @default false
+             */
+            is_verified: boolean;
+            /** Last Login At */
+            last_login_at?: string | null;
+            /**
+             * Mfa Enabled
+             * @default false
+             */
+            mfa_enabled: boolean;
+            /** Org Id */
+            org_id?: string | null;
+            /** Preferences */
+            preferences?: {
+                [key: string]: unknown;
+            };
+            /** Roles */
+            roles?: components["schemas"]["autobot_shared__user_management__schemas__user__RoleResponse"][];
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Username */
+            username: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * FleetServiceStatus
          * @description Service status across the fleet.
          */
@@ -13879,130 +14021,6 @@ export interface components {
             is_admin: boolean;
             /** Last Login */
             last_login?: string | null;
-            /** Username */
-            username: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /**
-         * RoleResponse
-         * @description Role information in responses.
-         */
-        user_management__schemas__user__RoleResponse: {
-            /** Description */
-            description?: string | null;
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /**
-             * Is System
-             * @default false
-             */
-            is_system: boolean;
-            /** Name */
-            name: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /**
-         * UserCreate
-         * @description Request model for creating a user.
-         */
-        user_management__schemas__user__UserCreate: {
-            /**
-             * Display Name
-             * @description Display name
-             */
-            display_name?: string | null;
-            /**
-             * Email
-             * Format: email
-             * @description User email address
-             */
-            email: string;
-            /**
-             * Org Id
-             * @description Organization ID (uses current context if not provided)
-             */
-            org_id?: string | null;
-            /**
-             * Password
-             * @description Password (8-128 characters, optional for SSO users)
-             */
-            password?: string | null;
-            /**
-             * Role Ids
-             * @description List of role IDs to assign
-             */
-            role_ids?: string[] | null;
-            /**
-             * Username
-             * @description Username (3-100 characters, alphanumeric and underscores)
-             */
-            username: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /**
-         * UserResponse
-         * @description Response model for a single user.
-         */
-        user_management__schemas__user__UserResponse: {
-            /** Avatar Url */
-            avatar_url?: string | null;
-            /** Bio */
-            bio?: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Display Name */
-            display_name?: string | null;
-            /** Email */
-            email: string;
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /**
-             * Is Active
-             * @default true
-             */
-            is_active: boolean;
-            /**
-             * Is Platform Admin
-             * @default false
-             */
-            is_platform_admin: boolean;
-            /**
-             * Is Verified
-             * @default false
-             */
-            is_verified: boolean;
-            /** Last Login At */
-            last_login_at?: string | null;
-            /**
-             * Mfa Enabled
-             * @default false
-             */
-            mfa_enabled: boolean;
-            /** Org Id */
-            org_id?: string | null;
-            /** Preferences */
-            preferences?: {
-                [key: string]: unknown;
-            };
-            /** Roles */
-            roles?: components["schemas"]["user_management__schemas__user__RoleResponse"][];
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
             /** Username */
             username: string;
         } & {
@@ -15043,7 +15061,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["user_management__schemas__user__UserCreate"];
+                "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserCreate"];
             };
         };
         responses: {
@@ -15053,7 +15071,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["user_management__schemas__user__UserResponse"];
+                    "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15084,7 +15102,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["user_management__schemas__user__UserResponse"];
+                    "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15148,7 +15166,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["user_management__schemas__user__UserResponse"];
+                    "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserResponse"];
                 };
             };
             /** @description Validation Error */
@@ -23940,7 +23958,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["user_management__schemas__user__UserCreate"];
+                "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserCreate"];
             };
         };
         responses: {
@@ -23950,7 +23968,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["user_management__schemas__user__UserResponse"];
+                    "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserResponse"];
                 };
             };
             /** @description Validation Error */
@@ -23981,7 +23999,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["user_management__schemas__user__UserResponse"];
+                    "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserResponse"];
                 };
             };
             /** @description Validation Error */
@@ -24045,7 +24063,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["user_management__schemas__user__UserResponse"];
+                    "application/json": components["schemas"]["autobot_shared__user_management__schemas__user__UserResponse"];
                 };
             };
             /** @description Validation Error */

--- a/autobot-slm-frontend/src/types/slm.ts
+++ b/autobot-slm-frontend/src/types/slm.ts
@@ -7,7 +7,18 @@
  * SLM Type Definitions
  */
 
-export type NodeStatus = 'registered' | 'pending' | 'enrolling' | 'healthy' | 'degraded' | 'unhealthy' | 'offline' | 'maintenance' | 'online' | 'error' | 'decommissioned'
+import type { components } from './generated/api'
+
+/**
+ * Node status — derived from the generated OpenAPI type (#12662), which is
+ * itself generated from the backend's canonical `NodeStatus` enum
+ * (autobot-slm-backend/models/database.py). Do not hand-declare this union;
+ * it drifted to 11 hand-invented values ('registered', 'healthy',
+ * 'unhealthy') that the backend has never emitted before #12662 fixed it.
+ * Re-run `npm run gen:types:openapi && npm run gen:types` after a backend
+ * enum change — `verify-generated-types-slm` (CI) fails if this drifts.
+ */
+export type NodeStatus = components['schemas']['NodeStatus']
 
 export type NodeRole =
   | 'slm-backend'


### PR DESCRIPTION
Closes #12662

## Thinking Path

#12662 named four cross-language vocabulary drifts (NodeStatus, node-role, permission modes/actions, ports). Per the parent umbrella's own track record ("every issue examined has had at least one wrong pointer"), I measured each independently before touching code rather than trusting the counts in the issue body.

**Measured, own count:**
1. **`NodeStatus` — confirmed diverged, live bug.** Backend `autobot-slm-backend/models/database.py:35` has 8 values (`pending`/`enrolling`/`online`/`degraded`/`offline`/`error`/`maintenance`/`decommissioned`). Frontend `autobot-slm-frontend/src/types/slm.ts:10` had 11 — 3 invented (`registered`, `healthy`, `unhealthy`) that the backend has **never** emitted (grepped the entire SLM backend for `"registered"`: zero hits). Every switch/comparison against those 3 values was consequently dead code on real data.
2. **Node-role registry** — backend `DEFAULT_ROLES` has 21 role names, frontend `NodeRole`/`node-roles.ts` has 20 — missing `"docker"`. Deferred: split to #13072 with the reason it can't ride the existing OpenAPI pipeline as-is (role names are plain `str` fields, not an `Enum`/`Literal`, so `openapi-typescript` can't render them as a literal union without a backend typing change).
3. **Permission modes/actions** — **zero value drift today** (`PermissionMode`/`PermissionAction` match exactly between `autobot_shared/ssot_config.py` and `autobot-frontend/src/config/ssot-config.ts`). Investigated whether the frontend gate is a privilege boundary: it is not — every `/api/permissions/*` endpoint independently re-derives the caller's real role via `check_admin_permission` (JWT-based), not any frontend-supplied hint, so a values-drift here would be a UI-only mismatch, not a security defect. Deferred to #13073 with a concrete path to ride the *other* existing generator (`gen_frontend_types.py`, dataclass/enum-based, already CI-gated) plus two discovered in-app duplications (dead `adminOnlyModes` field, `usePermissionStore.ts` re-declaring the same union a second time).
4. **Port defaults** — zero drift on the 11 overlapping ports; the 3 Python-only and 1 TS-only port are each legitimately one-sided (unused by main-FE / frontend-to-frontend routing), not bugs. Not carriable by OpenAPI codegen at all (ports aren't in any response schema). Deferred to #13074 with a value-parity-test recommendation instead.

**Generation infrastructure check:** the SLM frontend already has `openapi-typescript` codegen (`gen:types`, a committed `src/types/generated/api.ts`) since #12420 Phase 0 — but with **zero CI freshness gate** and **zero consumers**. Confirmed the checked-in file had drifted 283 diff lines from the live backend schema. Rather than hand-correcting `NodeStatus` (which resets the clock until the next drift), I wired the existing pipeline: CI-gated it and made `NodeStatus` derive from it directly.

## What Changed

**Delivered (complete):**
- `.github/workflows/verify-generated-types.yml`: new `verify-generated-types-slm` job, mirroring the existing main-FE job exactly — dumps the SLM backend's authoritative OpenAPI schema via `scripts/audit_api_wiring.py --dump-slm-openapi` (the same mechanism `api-wiring.yml` already uses, no live server needed), strips the audit-only `x-websocket-paths` extension, regenerates `api.ts`, fails on `git diff`. Verified the exact CI shell recipe reproduces the committed files byte-for-byte.
- Regenerated `autobot-slm-frontend/openapi.json` and `src/types/generated/api.ts` against the current backend schema so the new gate starts green.
- `autobot-slm-frontend/src/types/slm.ts`: `NodeStatus` now derives from `components['schemas']['NodeStatus']` (the generated type) instead of a hand-declared 11-value union.
- Fixed every consumer the corrected type surfaced as a TS2367/TS2322 compile error: `NodeCard.vue`, `NPUNodeCard.vue`, `NPUWorkerMonitor.vue`, `NPUWorkersTab.vue`, `AssignNPURoleModal.vue`, `DeploymentWizard.vue` (dead `'healthy'`/`'unhealthy'` checks → real equivalents `'online'`/`'error'`); `stores/fleet.ts`'s **live** `updateNodeHealth()` no longer writes the invented values into `node.status` at runtime (a real bug: a WS health update previously set `node.status` to a value nothing else recognized); `useFleetHealth.ts` (deprecated, zero callers) updated the same way to keep compiling.
- `NodeCard.test.ts`: dropped the `'registered'`/`'unhealthy'` cases (unreachable with real data, already covered by `'pending'`/`'offline'`+`'error'`), repointed the `'healthy'` assertion at `'online'`.

**Deferred (filed, not built — each with file:line evidence and a concrete path):**
- #13072 — node-role registry (`'docker'` missing from `NodeRole`); needs a backend typing decision to ride codegen.
- #13073 — permission modes/actions; no live drift, presentational only, extends a *different* existing generator.
- #13074 — port defaults; no live drift, not codegen-able (no schema), needs a value-parity test instead.

## Verification

- `vue-tsc --noEmit -p tsconfig.json`: clean (0 errors) — was 5 TS2367/TS2322 errors before the consumer fixes.
- `vitest run` (full `autobot-slm-frontend` suite): 202/202 passing, 25/25 files.
- `eslint .`: 0 errors, 16 pre-existing warnings (0 new, none in changed files beyond one pre-existing unrelated warning in `DeploymentWizard.vue`).
- CI-recipe parity: extracted the exact multi-step shell script the new workflow job runs (via `yaml.safe_load`) and executed it standalone against a fresh `dump_slm_openapi()` output — produced a byte-identical `openapi.json` and `api.ts` to what's committed here (`diff` exit 0).
- Anti-drift guard: `verify-generated-types-slm` fails `git diff --exit-code` if `NodeStatus` (or anything else in the SLM OpenAPI schema) drifts again — the same mechanism that's protected `autobot-frontend`'s generated types since #10817.

## Model Used

Claude Opus 4.5 (Sonnet 5)