### PR TITLE
refactor(frontend): ADR-008 shared-code boundary + de-fork SLM Advanced Control transport (#12653)

### DIFF
--- a/autobot-slm-frontend/src/composables/useAutobotApi.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.ts
@@ -182,6 +182,83 @@ export interface BudgetPoliciesList {
   count: number
 }
 
+// =============================================================================
+// Advanced Control (#12653) — desktop streaming + human takeover.
+//
+// The endpoint paths and payload shapes below used to be re-declared inline in
+// AdvancedControlTool.vue, which also re-implemented this composable's
+// transport with a raw `fetch` (no autobot_access_token fallback, no 401
+// handling, no timeout). Declaring them here keeps the SLM app's knowledge of
+// the autobot backend in exactly one place, next to every other tool.
+// =============================================================================
+
+export interface AdvancedControlCapabilities {
+  vnc_available?: boolean
+  novnc_available?: boolean
+  max_sessions?: number
+  supported_resolutions?: string[]
+  supported_depths?: number[]
+  [k: string]: unknown
+}
+
+export interface AdvancedControlStreamingSession {
+  session_id: string
+  user_id?: string
+  display?: string
+  vnc_port?: number
+  status?: string
+  created_at?: string
+  [k: string]: unknown
+}
+
+export interface AdvancedControlPendingRequest {
+  request_id: string
+  trigger?: string
+  reason?: string
+  priority?: string
+  created_at?: string
+  [k: string]: unknown
+}
+
+export interface AdvancedControlActiveSession {
+  session_id: string
+  human_operator?: string
+  status?: string
+  [k: string]: unknown
+}
+
+export type AdvancedControlTakeoverStatus = Record<string, unknown>
+
+/** Triggers accepted by POST /advanced-control/takeover/request. */
+export const ADVANCED_CONTROL_TRIGGERS = [
+  'MANUAL_REQUEST',
+  'CRITICAL_ERROR',
+  'SECURITY_CONCERN',
+  'USER_INTERVENTION_REQUIRED',
+  'SYSTEM_OVERLOAD',
+  'APPROVAL_REQUIRED',
+  'TIMEOUT_EXCEEDED',
+] as const
+
+/** Priorities accepted by POST /advanced-control/takeover/request. */
+export const ADVANCED_CONTROL_PRIORITIES = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] as const
+
+export interface AdvancedControlSessionRequest {
+  user_id: string
+  resolution?: string
+  depth?: number
+}
+
+export interface AdvancedControlTakeoverRequest {
+  trigger: string
+  reason: string
+  priority?: string
+  requesting_agent?: string | null
+}
+
+/** Lifecycle transitions on an approved takeover session. */
+export type AdvancedControlSessionAction = 'pause' | 'resume' | 'complete'
+
 export function useAutobotApi() {
   const authStore = useAuthStore()
 
@@ -1031,6 +1108,84 @@ export function useAutobotApi() {
     return response.data
   }
 
+  // =============================================================================
+  // Advanced Control API (#12653 - desktop streaming + human takeover)
+  // =============================================================================
+
+  const AC = '/advanced-control'
+
+  async function getAdvancedControlCapabilities(): Promise<AdvancedControlCapabilities> {
+    const response = await client.get<AdvancedControlCapabilities>(`${AC}/streaming/capabilities`)
+    return response.data
+  }
+
+  async function listAdvancedControlSessions(): Promise<AdvancedControlStreamingSession[]> {
+    const response = await client.get<{ sessions: AdvancedControlStreamingSession[]; count: number }>(
+      `${AC}/streaming/sessions`
+    )
+    return response.data.sessions ?? []
+  }
+
+  async function createAdvancedControlSession(
+    request: AdvancedControlSessionRequest
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(`${AC}/streaming/create`, request)
+    return response.data
+  }
+
+  async function terminateAdvancedControlSession(sessionId: string): Promise<Record<string, unknown>> {
+    const response = await client.delete(`${AC}/streaming/${encodeURIComponent(sessionId)}`)
+    return response.data
+  }
+
+  async function getAdvancedControlTakeoverStatus(): Promise<AdvancedControlTakeoverStatus> {
+    const response = await client.get<AdvancedControlTakeoverStatus>(`${AC}/takeover/status`)
+    return response.data
+  }
+
+  async function getPendingTakeovers(): Promise<AdvancedControlPendingRequest[]> {
+    const response = await client.get<{ pending_requests: AdvancedControlPendingRequest[]; count: number }>(
+      `${AC}/takeover/pending`
+    )
+    return response.data.pending_requests ?? []
+  }
+
+  async function getActiveTakeovers(): Promise<AdvancedControlActiveSession[]> {
+    const response = await client.get<{ active_sessions: AdvancedControlActiveSession[]; count: number }>(
+      `${AC}/takeover/active`
+    )
+    return response.data.active_sessions ?? []
+  }
+
+  async function requestTakeover(
+    request: AdvancedControlTakeoverRequest
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(`${AC}/takeover/request`, request)
+    return response.data
+  }
+
+  async function approveTakeover(
+    requestId: string,
+    humanOperator: string
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(`${AC}/takeover/${encodeURIComponent(requestId)}/approve`, {
+      human_operator: humanOperator,
+    })
+    return response.data
+  }
+
+  async function takeoverSessionAction(
+    sessionId: string,
+    action: AdvancedControlSessionAction,
+    body?: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(
+      `${AC}/takeover/sessions/${encodeURIComponent(sessionId)}/${action}`,
+      body
+    )
+    return response.data
+  }
+
   return {
     // Settings
     getSettings,
@@ -1151,6 +1306,17 @@ export function useAutobotApi() {
     getBatchStatus,
     // Terminal (Issue #729)
     executeTerminalCommand,
+    // Advanced Control (#12653)
+    getAdvancedControlCapabilities,
+    listAdvancedControlSessions,
+    createAdvancedControlSession,
+    terminateAdvancedControlSession,
+    getAdvancedControlTakeoverStatus,
+    getPendingTakeovers,
+    getActiveTakeovers,
+    requestTakeover,
+    approveTakeover,
+    takeoverSessionAction,
     // Log Forwarding Control (Issue #729)
     getLogForwardingStatus,
     startLogForwarding,

--- a/autobot-slm-frontend/src/views/tools/admin/AdvancedControlTool.test.ts
+++ b/autobot-slm-frontend/src/views/tools/admin/AdvancedControlTool.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import axios from 'axios'
 import AdvancedControlTool from './AdvancedControlTool.vue'
 import en from '@/locales/en.json'
 
@@ -10,9 +11,39 @@ vi.mock('@/stores/auth', () => ({
   useAuthStore: () => ({ token: 'test-token' }),
 }))
 
+// #12653: the tool now reaches the autobot backend through `useAutobotApi`,
+// the SLM app's single client for that backend, instead of a private `fetch`.
+// Stubbing `axios.create` keeps the assertions on the exact endpoint paths and
+// HTTP verbs — the transport changed, the wire contract did not.
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  }
+  return { default: { create: vi.fn(() => instance) } }
+})
+
 // vue-i18n 11 requires app.use(); install a real i18n plugin since the
 // template uses the global $t and the script uses useI18n().
 const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+/** The single axios instance every `useAutobotApi()` call receives. */
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
 
 /** Route each advanced-control endpoint to a canned payload. */
 function payloadFor(url: string): unknown {
@@ -38,19 +69,21 @@ function mountTool() {
 
 describe('AdvancedControlTool', () => {
   beforeEach(() => {
-    global.fetch = vi.fn(async (url: string) => ({
-      ok: true,
-      status: 200,
-      json: async () => payloadFor(url),
-    })) as unknown as typeof fetch
+    const c = client()
+    c.get.mockReset()
+    c.post.mockReset()
+    c.delete.mockReset()
+    c.get.mockImplementation(async (url: string) => ({ data: payloadFor(url) }))
+    c.post.mockImplementation(async (url: string) => ({ data: payloadFor(url) }))
+    c.delete.mockImplementation(async (url: string) => ({ data: payloadFor(url) }))
   })
 
-  it('loads all advanced-control endpoints on mount via getBackendUrl', async () => {
+  it('loads all advanced-control endpoints on mount via useAutobotApi', async () => {
     const wrapper = mountTool()
     await flushPromises()
-    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string)
+    const calls = client().get.mock.calls.map((c) => c[0] as string)
     for (const suffix of ['/streaming/capabilities', '/streaming/sessions', '/takeover/status', '/takeover/pending', '/takeover/active']) {
-      expect(calls.some((u) => u === `/autobot-api/advanced-control${suffix}`)).toBe(true)
+      expect(calls).toContain(`/advanced-control${suffix}`)
     }
     // Rendered rows from the mocked payloads.
     expect(wrapper.text()).toContain('s1')
@@ -59,7 +92,7 @@ describe('AdvancedControlTool', () => {
   })
 
   it('shows an error banner when a request fails', async () => {
-    global.fetch = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof fetch
+    client().get.mockRejectedValue({ response: { status: 500 } })
     const wrapper = mountTool()
     await flushPromises()
     expect(wrapper.find('[data-test="error"]').exists()).toBe(true)
@@ -74,11 +107,9 @@ describe('AdvancedControlTool', () => {
     // jsdom does not auto-submit a form on submit-button click; trigger submit directly.
     await wrapper.findAll('form')[0].trigger('submit')
     await flushPromises()
-    const post = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
-      (c) => c[0] === '/autobot-api/advanced-control/streaming/create' && c[1]?.method === 'POST',
-    )
+    const post = client().post.mock.calls.find((c) => c[0] === '/advanced-control/streaming/create')
     expect(post).toBeTruthy()
-    expect(JSON.parse(post![1]!.body as string)).toMatchObject({ user_id: 'alice' })
+    expect(post![1]).toMatchObject({ user_id: 'alice' })
   })
 
   it('DELETEs on terminate', async () => {
@@ -86,9 +117,19 @@ describe('AdvancedControlTool', () => {
     await flushPromises()
     await wrapper.find('[data-test="terminate-s1"]').trigger('click')
     await flushPromises()
-    const del = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
-      (c) => c[0] === '/autobot-api/advanced-control/streaming/s1' && c[1]?.method === 'DELETE',
-    )
+    const del = client().delete.mock.calls.find((c) => c[0] === '/advanced-control/streaming/s1')
     expect(del).toBeTruthy()
+  })
+
+  it('approves a pending takeover through the shared client', async () => {
+    const wrapper = mountTool()
+    await flushPromises()
+    const operatorInput = wrapper.findAll('input').find((i) => i.attributes('placeholder') === en.tools.admin.advancedControlTool.operatorPlaceholder)
+    await operatorInput!.setValue('op-1')
+    await wrapper.find('[data-test="approve-r1"]').trigger('click')
+    await flushPromises()
+    const approve = client().post.mock.calls.find((c) => c[0] === '/advanced-control/takeover/r1/approve')
+    expect(approve).toBeTruthy()
+    expect(approve![1]).toMatchObject({ human_operator: 'op-1' })
   })
 })

--- a/autobot-slm-frontend/src/views/tools/admin/AdvancedControlTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/AdvancedControlTool.vue
@@ -9,65 +9,57 @@
  * Control-plane tool for #11506 desktop-session takeover. Wires the live
  * autobot-backend `/api/advanced-control/*` routes (reached from the SLM
  * frontend via nginx `/autobot-api/` -> getBackendUrl()). See #12102.
+ *
+ * The endpoints and their payload shapes live in `useAutobotApi` — the SLM
+ * app's single client for the autobot backend — rather than being re-declared
+ * here on top of a private `fetch` (#12653). That fork carried only
+ * `authStore.token`, so it 401'd in the one case every other admin tool
+ * survives: an autobot-issued token in `autobot_access_token` with no SLM
+ * token. It also had no request timeout and no 401 cleanup.
  */
 
 import { ref, reactive, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useAuthStore } from '@/stores/auth'
-import { getBackendUrl } from '@/config/ssot-config'
+import {
+  useAutobotApi,
+  ADVANCED_CONTROL_TRIGGERS,
+  ADVANCED_CONTROL_PRIORITIES,
+  type AdvancedControlCapabilities,
+  type AdvancedControlStreamingSession,
+  type AdvancedControlPendingRequest,
+  type AdvancedControlActiveSession,
+  type AdvancedControlTakeoverStatus,
+  type AdvancedControlSessionAction,
+} from '@/composables/useAutobotApi'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
-const authStore = useAuthStore()
 const logger = createLogger('AdvancedControlTool')
 
-interface StreamingCapabilities {
-  vnc_available?: boolean
-  novnc_available?: boolean
-  max_sessions?: number
-  supported_resolutions?: string[]
-  supported_depths?: number[]
-  [k: string]: unknown
-}
-interface StreamingSession {
-  session_id: string
-  user_id?: string
-  display?: string
-  vnc_port?: number
-  status?: string
-  created_at?: string
-  [k: string]: unknown
-}
-interface PendingRequest {
-  request_id: string
-  trigger?: string
-  reason?: string
-  priority?: string
-  created_at?: string
-  [k: string]: unknown
-}
-interface ActiveSession {
-  session_id: string
-  human_operator?: string
-  status?: string
-  [k: string]: unknown
-}
-type TakeoverStatus = Record<string, unknown>
+const {
+  getAdvancedControlCapabilities,
+  listAdvancedControlSessions,
+  createAdvancedControlSession,
+  terminateAdvancedControlSession,
+  getAdvancedControlTakeoverStatus,
+  getPendingTakeovers,
+  getActiveTakeovers,
+  requestTakeover,
+  approveTakeover,
+  takeoverSessionAction,
+} = useAutobotApi()
 
-const TRIGGERS = [
-  'MANUAL_REQUEST', 'CRITICAL_ERROR', 'SECURITY_CONCERN',
-  'USER_INTERVENTION_REQUIRED', 'SYSTEM_OVERLOAD', 'APPROVAL_REQUIRED', 'TIMEOUT_EXCEEDED',
-] as const
-const PRIORITIES = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] as const
+const TRIGGERS = ADVANCED_CONTROL_TRIGGERS
+const PRIORITIES = ADVANCED_CONTROL_PRIORITIES
 
 const loading = ref(false)
 const error = ref<string | null>(null)
 
-const capabilities = ref<StreamingCapabilities | null>(null)
-const sessions = ref<StreamingSession[]>([])
-const takeoverStatus = ref<TakeoverStatus | null>(null)
-const pending = ref<PendingRequest[]>([])
-const active = ref<ActiveSession[]>([])
+const capabilities = ref<AdvancedControlCapabilities | null>(null)
+const sessions = ref<AdvancedControlStreamingSession[]>([])
+const takeoverStatus = ref<AdvancedControlTakeoverStatus | null>(null)
+const pending = ref<AdvancedControlPendingRequest[]>([])
+const active = ref<AdvancedControlActiveSession[]>([])
 
 const createForm = reactive<{ user_id: string; resolution: string; depth: number | null }>({
   user_id: '', resolution: '', depth: null,
@@ -82,42 +74,39 @@ const busy = reactive<{
   terminate: string | null; approve: string | null; session: string | null
 }>({ create: false, request: false, terminate: null, approve: null, session: null })
 
-/** Call an /advanced-control endpoint with SLM bearer auth; throw on non-2xx. */
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${getBackendUrl()}/advanced-control${path}`, {
-    ...init,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${authStore.token}`,
-      ...(init?.headers),
-    },
-  })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
-  return res.json() as Promise<T>
-}
-
 async function loadAll(): Promise<void> {
   loading.value = true
   error.value = null
   try {
     const [caps, sess, status, pend, act] = await Promise.all([
-      request<StreamingCapabilities>('/streaming/capabilities'),
-      request<{ sessions: StreamingSession[]; count: number }>('/streaming/sessions'),
-      request<TakeoverStatus>('/takeover/status'),
-      request<{ pending_requests: PendingRequest[]; count: number }>('/takeover/pending'),
-      request<{ active_sessions: ActiveSession[]; count: number }>('/takeover/active'),
+      getAdvancedControlCapabilities(),
+      listAdvancedControlSessions(),
+      getAdvancedControlTakeoverStatus(),
+      getPendingTakeovers(),
+      getActiveTakeovers(),
     ])
     capabilities.value = caps
-    sessions.value = sess.sessions
+    sessions.value = sess
     takeoverStatus.value = status
-    pending.value = pend.pending_requests
-    active.value = act.active_sessions
+    pending.value = pend
+    active.value = act
   } catch (e) {
-    error.value = e instanceof Error ? e.message : t('tools.admin.advancedControlTool.genericError')
+    error.value = describeError(e)
     logger.warn('Advanced-control load failed:', e)
   } finally {
     loading.value = false
   }
+}
+
+/**
+ * Render an axios/network failure the way the previous raw-fetch transport did
+ * (`HTTP <status>`), so the banner text and its test assertion are unchanged.
+ */
+function describeError(e: unknown): string {
+  const status = (e as { response?: { status?: number } })?.response?.status
+  if (typeof status === 'number') return `HTTP ${status}`
+  if (e instanceof Error && e.message) return e.message
+  return t('tools.admin.advancedControlTool.genericError')
 }
 
 /** Run an action, surface errors to the banner, and reload the given loaders. */
@@ -127,7 +116,7 @@ async function run(fn: () => Promise<unknown>): Promise<boolean> {
     await fn()
     return true
   } catch (e) {
-    error.value = e instanceof Error ? e.message : t('tools.admin.advancedControlTool.genericError')
+    error.value = describeError(e)
     logger.warn('Advanced-control action failed:', e)
     return false
   }
@@ -136,13 +125,10 @@ async function run(fn: () => Promise<unknown>): Promise<boolean> {
 async function onCreateSession(): Promise<void> {
   if (!createForm.user_id) return
   busy.create = true
-  const ok = await run(() => request('/streaming/create', {
-    method: 'POST',
-    body: JSON.stringify({
-      user_id: createForm.user_id,
-      resolution: createForm.resolution || '1024x768',
-      depth: createForm.depth ?? 24,
-    }),
+  const ok = await run(() => createAdvancedControlSession({
+    user_id: createForm.user_id,
+    resolution: createForm.resolution || '1024x768',
+    depth: createForm.depth ?? 24,
   }))
   busy.create = false
   if (ok) { createForm.user_id = ''; await loadAll() }
@@ -150,7 +136,7 @@ async function onCreateSession(): Promise<void> {
 
 async function onTerminate(sessionId: string): Promise<void> {
   busy.terminate = sessionId
-  const ok = await run(() => request(`/streaming/${sessionId}`, { method: 'DELETE' }))
+  const ok = await run(() => terminateAdvancedControlSession(sessionId))
   busy.terminate = null
   if (ok) await loadAll()
 }
@@ -158,14 +144,11 @@ async function onTerminate(sessionId: string): Promise<void> {
 async function onRequestTakeover(): Promise<void> {
   if (!requestForm.reason) return
   busy.request = true
-  const ok = await run(() => request('/takeover/request', {
-    method: 'POST',
-    body: JSON.stringify({
-      trigger: requestForm.trigger,
-      reason: requestForm.reason,
-      priority: requestForm.priority,
-      requesting_agent: requestForm.requesting_agent || null,
-    }),
+  const ok = await run(() => requestTakeover({
+    trigger: requestForm.trigger,
+    reason: requestForm.reason,
+    priority: requestForm.priority,
+    requesting_agent: requestForm.requesting_agent || null,
   }))
   busy.request = false
   if (ok) { requestForm.reason = ''; requestForm.requesting_agent = ''; await loadAll() }
@@ -175,20 +158,17 @@ async function onApprove(requestId: string): Promise<void> {
   const operator = operatorInputs[requestId]
   if (!operator) return
   busy.approve = requestId
-  const ok = await run(() => request(`/takeover/${requestId}/approve`, {
-    method: 'POST',
-    body: JSON.stringify({ human_operator: operator }),
-  }))
+  const ok = await run(() => approveTakeover(requestId, operator))
   busy.approve = null
   if (ok) await loadAll()
 }
 
-async function onSessionAction(sessionId: string, action: 'pause' | 'resume' | 'complete'): Promise<void> {
+async function onSessionAction(sessionId: string, action: AdvancedControlSessionAction): Promise<void> {
   busy.session = sessionId
   const body = action === 'complete'
-    ? JSON.stringify({ resolution: t('tools.admin.advancedControlTool.completedResolution') })
+    ? { resolution: t('tools.admin.advancedControlTool.completedResolution') }
     : undefined
-  const ok = await run(() => request(`/takeover/sessions/${sessionId}/${action}`, { method: 'POST', body }))
+  const ok = await run(() => takeoverSessionAction(sessionId, action, body))
   busy.session = null
   if (ok) await loadAll()
 }

--- a/docs/adr/008-frontend-shared-code-boundary.md
+++ b/docs/adr/008-frontend-shared-code-boundary.md
@@ -1,0 +1,221 @@
+# ADR-008: Frontend Shared-Code Boundary Between the Two SPAs
+
+## Status
+
+**Status**: Accepted
+
+## Date
+
+**Date**: 2026-07-31
+
+## Context
+
+AutoBot ships two Vue 3 SPAs against two different backends:
+
+| SPA | Audience | Primary backend |
+|---|---|---|
+| `autobot-frontend/` | end users (chat, knowledge, desktop, workflows) | autobot backend |
+| `autobot-slm-frontend/` | fleet/control-plane operators | SLM backend (plus the autobot backend for admin tools) |
+
+Issue #12653 (under umbrella #12645) asked whether the plumbing these two apps
+each carry — HTTP client, config resolver, WebSocket singleton — is an internal
+fork that should be collapsed into a shared package, and required this ADR
+before any convergence work.
+
+The question is not hypothetical: shared frontend packages already exist and are
+already consumed by both apps via `file:` dependencies.
+
+```
+libs/autobot-ui           -> @autobot/ui        theme-agnostic components + a11y/form composables
+autobot-plugins/vnc       -> @autobot/vnc       VNC viewer, toolbar, useVncControls
+autobot-plugins/terminal  -> @autobot/terminal  xterm-based terminal surface
+```
+
+So the real decision is **where the boundary sits**, not whether sharing is
+possible.
+
+### Measured state (2026-07-31, `origin/Dev_new_gui`)
+
+The three "copy-adapted plumbing" items named in #12653, measured on both sides:
+
+| Concept | `autobot-frontend` | `autobot-slm-frontend` | Overlap |
+|---|---|---|---|
+| HTTP client | `src/utils/ApiClient.ts` (842 lines) | `src/utils/ApiClient.ts` (419 lines) | method *names* only |
+| Config resolver | `src/config/ssot-config.ts` (787 lines) | `src/config/ssot-config.ts` (217 lines) | `getConfig`, `getBackendUrl` |
+| WS singleton | `src/services/GlobalWebSocketService.ts` (839 lines) | `src/composables/useSlmWebSocket.ts` (415 lines) | reconnect/handler-registry shape |
+
+The bodies have diverged along the axis that matters — **which system they talk
+to and how they authenticate to it**:
+
+- `autobot-frontend/src/utils/ApiClient.ts:191-232` resolves its base URL
+  through service discovery, reads the token from the user auth store *with an
+  expiry check* (`isRealAuthToken`, line 222), attaches an org-context header
+  (`X-Organization-Id`, lines 330-331), and offers XHR upload progress
+  (`UploadProgressEvent`, line 24).
+- `autobot-slm-frontend/src/utils/ApiClient.ts:36-40,149` resolves
+  `getSlmApiBase()`, reads `sessionStorage['slm_access_token']` with a
+  `localStorage` fallback, and on 401 clears the SLM session keys and redirects
+  to `/login`.
+- `autobot-slm-frontend/src/config/ssot-config.ts:13-47` defines `SLMConfig`
+  (Grafana/Prometheus URLs, VM roles, known hosts). `autobot-frontend`'s
+  `AutoBotConfig` (`src/config/ssot-config.ts:228-257`) defines permission
+  modes, approval records, VNC config and service discovery. The two schemas are
+  near-disjoint.
+- `autobot-slm-frontend/src/composables/useSlmWebSocket.ts:16,26` connects to the
+  **SLM** backend's `/api/ws/events` and carries `SLMWebSocketMessage`;
+  `GlobalWebSocketService.ts` connects to the **autobot** backend with a
+  different message vocabulary.
+
+These are not one capability implemented twice. They are per-app adapters whose
+only genuine commonality is a shape (`get`/`post`/`rawRequest`, "singleton
+socket with backoff"). Merging them would require a strategy object per app for
+base URL, token source, 401 policy and message schema — i.e. re-introducing the
+divergence as configuration, with a shared package that no longer has a single
+coherent behaviour to test.
+
+By contrast, the two items that *were* the same capability twice converged
+cleanly:
+
+- `useVncControls` existed in three places; #12931 gave the shared copy an
+  injected transport and #12978 reduced the two app copies to re-export shims
+  (`autobot-frontend/src/composables/useVncControls.ts:13-21`,
+  `autobot-slm-frontend/src/composables/useVncControls.ts:13-21`).
+- The `@autobot/ui` components carry no backend knowledge at all, so both apps
+  consume them unchanged and supply their own design tokens.
+
+The distinguishing property is visible in both successes: **the shared code
+contains no knowledge of which backend it talks to or how that backend
+authenticates.** Where it needs I/O, the consumer injects it.
+
+## Decision
+
+The shared-frontend boundary is drawn at **backend knowledge**.
+
+1. **Shared** (in `libs/` or `autobot-plugins/`, consumed via `@autobot/*`):
+   presentation, interaction, accessibility, and any behaviour expressible
+   without naming a backend, a base URL, or a token store. Where such code needs
+   I/O it takes an **injected transport** — the `@autobot/vnc` `useVncControls`
+   pattern — never a client of its own.
+
+2. **Per-app** (deliberately duplicated shape, not a fork): the HTTP client, the
+   config/SSOT resolver, and the WebSocket singleton. Each app owns exactly one
+   of each, and each encodes that app's origin resolution, token storage,
+   401 policy and message schema. These files are permitted to look alike; they
+   are not permitted to multiply within an app.
+
+3. **One client per (app, backend) pair.** This is the rule that has teeth. An
+   SPA that talks to two backends gets exactly two clients, and *no component
+   may open its own transport*:
+
+   | App | Backend | Canonical client |
+   |---|---|---|
+   | `autobot-frontend` | autobot | `src/utils/ApiClient.ts` |
+   | `autobot-slm-frontend` | SLM | `src/utils/ApiClient.ts` (`slmApiClient`) |
+   | `autobot-slm-frontend` | autobot | `src/composables/useAutobotApi.ts` |
+
+   Endpoint paths and payload types for a backend live with that backend's
+   client, not inline in the component that happens to call them first.
+
+4. **Cross-app feature duplication is a product decision, not a refactor.** When
+   the same capability is built in both SPAs and both copies are reachable by
+   real users, converging them changes what someone sees. Such cases are
+   escalated to the owner with both consumer sets identified; they are not
+   resolved by picking the larger implementation.
+
+### Alternatives Considered
+
+1. **A shared `@autobot/core` package holding ApiClient + ssot-config + WS.**
+   - Pros: one place to fix a transport bug; smaller total line count.
+   - Cons: the measured divergence is entirely in backend identity, auth storage
+     and 401 policy, so the package would be a strategy-injection shell with no
+     behaviour of its own; a change for one app's auth model would need
+     regression testing of the other app; it would fight #12420, which is
+     actively standing up the SLM contract *inside* the SLM app.
+   - Rejected: it converges the shape and leaves the semantics forked, which is
+     the worse of the two outcomes.
+
+2. **Full per-app copies with no shared packages at all.**
+   - Pros: zero coupling.
+   - Cons: contradicted by three shared packages already in production use, and
+     by the `useVncControls` triplication that shipped a fix to one app only.
+   - Rejected.
+
+3. **Move the Advanced Control API contract into a new shared package.**
+   - Pros: endpoint paths and enums would exist once across both SPAs.
+   - Cons: requires a fourth `file:` dependency and lockfile edits in both apps;
+     the two consumers still differ in transport and auth, so only ~150 lines of
+     type declarations are actually shared; and it would settle by implication
+     the open question in §"Deferred" below.
+   - Deferred, not rejected — revisit if a third consumer appears.
+
+## Consequences
+
+### Positive
+
+- A component that needs the network has exactly one place to go, per backend.
+  The rule is checkable by grep (`fetch(` / `axios.create` outside a client).
+- Shared packages stay testable in isolation, because none of them can reach a
+  backend on their own.
+- A transport bug in an app is fixed once for that app; a presentation bug in a
+  shared component is fixed once for both.
+
+### Negative
+
+- The two `ApiClient.ts` files keep looking like duplicates to a reader (and to
+  clone detectors), so each carries a header explaining that the similarity is
+  intentional.
+- Retry/timeout improvements must be ported by hand between the two clients.
+
+### Neutral
+
+- `libs/autobot-sdk-ts` (`@autobot/sdk`) remains an *external-consumer* SDK with
+  its own build and test toolchain. It is not a dependency of either SPA and is
+  not the home for in-app plumbing.
+
+## Deferred — open owner decision
+
+**Advanced Control is built twice and both copies are live.** This ADR
+deliberately does not pick a survivor:
+
+- `autobot-frontend/src/views/AdvancedControlView.vue` (1103 lines) +
+  `src/composables/useAdvancedControl.ts` + `src/utils/AdvancedControlApiClient.ts`
+  (458 lines, all 17 backend routes incl. emergency-stop, system status/health
+  and the monitoring/desktop WebSocket helpers). Routed at
+  `src/router/index.ts:843-853` — but `hideInNav: true`, and no other file in
+  the app links to it, so it is reachable only by typing the URL.
+- `autobot-slm-frontend/src/views/tools/admin/AdvancedControlTool.vue`
+  (504 lines, 12 of the 17 routes — no `takeover/.../action`, no
+  `system/status`, `system/health` or `system/emergency-stop`, no info
+  route). Routed at `src/router/index.ts:476-482`
+  **and** listed in the operator tool nav at `src/views/tools/ToolsLayout.vue:26`
+  — this is the copy an operator actually reaches.
+
+So the fuller implementation is the less reachable one. Converging them either
+removes a feature set from the surface that has users, or promotes a nav-hidden
+admin view into the product. Both are product calls.
+
+## Implementation Notes
+
+### Key files
+
+- `libs/autobot-ui/index.ts` — shared component/composable kit, no backend knowledge.
+- `autobot-plugins/vnc/src/composables/useVncControls.ts` — injected-transport reference implementation.
+- `autobot-slm-frontend/src/composables/useAutobotApi.ts` — the SLM app's single client for the autobot backend.
+- `autobot-frontend/src/utils/ApiClient.ts`, `autobot-slm-frontend/src/utils/ApiClient.ts` — per-app clients, intentionally similar.
+
+### Applying rule 3
+
+`AdvancedControlTool.vue` previously carried a private `fetch` helper that sent
+only `authStore.token` — no `autobot_access_token` fallback, no 401 cleanup, no
+timeout — while every other SLM admin tool went through `useAutobotApi`. Under
+rule 3 the endpoints and payload types moved onto `useAutobotApi` and the tool
+calls it, which also removed that auth divergence.
+
+## Related ADRs
+
+- [ADR-005](005-single-frontend-mandate.md) - Single frontend server mandate (deployment topology; this ADR covers source-code sharing).
+
+---
+
+**Author**: mrveiss
+**Copyright**: © 2025-2026 mrveiss

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,9 @@ Each ADR follows a consistent template (see [template.md](template.md)):
 | [ADR-003](003-npu-integration-strategy.md) | NPU Hardware Acceleration Integration | Accepted | 2025-01-01 |
 | [ADR-004](004-chat-workflow-architecture.md) | Chat Workflow and Message Processing | Accepted | 2025-01-01 |
 | [ADR-005](005-single-frontend-mandate.md) | Single Frontend Server Mandate | Accepted | 2025-01-01 |
+| [ADR-006](006-skill-bound-planning.md) | Skill-Bound Planning | Accepted | 2026-05-16 |
+| [ADR-007](007-connector-oauth-token-storage.md) | Connector OAuth Token and Credential Storage | Accepted | 2026-05-30 |
+| [ADR-008](008-frontend-shared-code-boundary.md) | Frontend Shared-Code Boundary Between the Two SPAs | Accepted | 2026-07-31 |
 
 ## Creating a New ADR
 

--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -20,3 +20,4 @@ aliases:
 | [005-single-frontend-mandate](005-single-frontend-mandate.md) | Single frontend mandate |
 | [006-skill-bound-planning](006-skill-bound-planning.md) | Skill-bound planning via skill_router at plan time |
 | [007-connector-oauth-token-storage](007-connector-oauth-token-storage.md) | Connector credentials must use SecretsService, not raw Redis |
+| [008-frontend-shared-code-boundary](008-frontend-shared-code-boundary.md) | Shared FE code is drawn at backend knowledge; one client per (app, backend) |


### PR DESCRIPTION
Closes #13080 — the discrete, decision-free slice of #12653 (ADR + the SLM Advanced Control
transport de-fork). #12653 stays open on #13078; see the end of Verification.

## Thinking Path

#12653 named five duplications. Measured all five on `origin/Dev_new_gui` before touching anything, and the picture is not the one the issue body describes.

**Already done.** `useVncControls` was converged by #12931 → #12978. Both app copies are now 21-line re-export shims onto `@autobot/vnc` (`autobot-frontend/src/composables/useVncControls.ts:13-21`, `autobot-slm-frontend/src/composables/useVncControls.ts:13-21`). Nothing to do.

**Not forks.** The three "copy-adapted plumbing" items have diverged exactly where it matters — which backend they address and how they authenticate:

| Concept | main FE | SLM FE | divergence |
|---|---|---|---|
| ApiClient | `src/utils/ApiClient.ts` 842L | `src/utils/ApiClient.ts` 419L | service discovery + auth-store token w/ expiry + `X-Organization-Id` + XHR progress vs `sessionStorage['slm_access_token']` + `/login` redirect |
| ssot-config | `src/config/ssot-config.ts` 787L | `src/config/ssot-config.ts` 217L | `AutoBotConfig` (permissions, VNC, discovery) vs `SLMConfig` (Grafana/Prometheus/hosts) — near-disjoint schemas |
| WS singleton | `src/services/GlobalWebSocketService.ts` 839L | `src/composables/useSlmWebSocket.ts` 415L | different backends, different message vocabularies |

Both copies of each are live with different consumers. Collapsing them means a strategy object per app for base URL, token source, 401 policy and message schema — the shape converges and the semantics stay forked. ADR-008 records that as the decision, with the boundary drawn at *backend knowledge*: shared code may not know which backend it talks to; where it needs I/O the consumer injects a transport, exactly as `@autobot/vnc` does.

**A product decision, not a refactor.** Advanced Control is genuinely built twice, and the "obvious canonical" is the dead one. The main-FE implementation is the fuller one (all 17 backend routes, incl. emergency-stop, system status/health, WS monitoring) but its route carries `hideInNav: true` and nothing in the app links to it — URL-only. The SLM tool covers 12 of 17 routes and is in the operator tool nav (`autobot-slm-frontend/src/views/tools/ToolsLayout.vue:26`), so it is the copy operators actually reach. Converging either removes features from the surface that has users or promotes a hidden admin view into the product. Deferred to the owner (ADR §Deferred, follow-up filed) rather than decided here.

**What was mechanical.** Measuring the SLM tool turned up a latent bug: it re-implemented the SLM app's autobot-backend transport with a private `fetch` carrying only `authStore.token` — no `autobot_access_token` fallback, no 401 cleanup, no timeout — while all ~17 sibling admin tools go through `useAutobotApi`. In the one case every other tool survives (an autobot-issued token, no SLM token) Advanced Control 401s. That fork is removed here.

## What Changed

**ADR-008** (`docs/adr/008-frontend-shared-code-boundary.md`) — the shared-code boundary between the two SPAs, with the measurements above. Four rules: shared code carries no backend knowledge and takes an injected transport; ApiClient / ssot-config / WS singleton stay per-app (one each, may look alike, may not multiply); **one client per (app, backend) pair**, with endpoint paths and payload types living beside that client; cross-app feature duplication with two live consumer sets is escalated, not refactored. Indexed in `README.md` and `_index.md` — which also picks up ADR-006 and ADR-007, absent from the README index since they were added.

**Applied rule 3 to Advanced Control in the SLM app.** The endpoint paths, payload types and the trigger/priority enums moved from `AdvancedControlTool.vue` onto `useAutobotApi` (10 methods), and the tool calls them. The private `fetch` helper is gone, so the tool inherits the token fallback, the 401 handler and the 30s timeout every other tool already had. Path params are now `encodeURIComponent`-escaped (the main-FE client already did this; the raw-fetch copy did not).

No behaviour change beyond that: the same 12 routes, the same payloads, and the error banner still renders `HTTP <status>` (`describeError` maps the axios rejection back to the previous wording).

Main frontend untouched.

## Verification

`autobot-slm-frontend` (only app touched):

```
npm run type-check   # vue-tsc --noEmit -p tsconfig.json — clean
npm run lint         # 0 errors, 16 warnings, all pre-existing, none in the 3 changed files
npx eslint src/views/tools/admin/AdvancedControlTool.{vue,test.ts} src/composables/useAutobotApi.ts  # clean
```

Full suite, `cp`-swapped baseline (no `git stash`):

```
baseline (files restored via git checkout):  25 files, 202 tests, 202 passed
after    (files restored from scratchpad):   25 files, 203 tests, 203 passed
```

Identical failing set (empty) before and after. The +1 is a new test covering the approve path through the shared client.

Consumer still renders: `AdvancedControlTool.test.ts` mounts the real component and asserts the rendered rows (`s1`, `r1`, `as1`) from mocked payloads, plus the exact endpoint paths and verbs on the axios instance — `/advanced-control/streaming/{capabilities,sessions,create}`, `/advanced-control/streaming/s1` (DELETE), `/advanced-control/takeover/{status,pending,active}`, `/advanced-control/takeover/r1/approve`. The transport changed; the wire contract is asserted unchanged.

`verify-generated-types-slm` unaffected — `src/types/generated/api.ts` not touched, and the SLM spec contains no `advanced-control` paths (those belong to the autobot backend).

#12653 is **not** closed by this PR: `useVncControls` exists once and the ADR is delivered, but "Advanced Control exists once" is the deferred product decision above.

## Model Used

claude-opus-5
