### PR TITLE
fix(scripts): resolve run_agent.sh paths from the script, not the live install (#13092)

### DIFF
--- a/run_agent.sh
+++ b/run_agent.sh
@@ -4,6 +4,31 @@
 
 # Script to run the AutoBot application with backend and frontend components
 
+# Refuse to run as root. Everything below writes __pycache__, logs and build
+# artifacts into the project tree; under sudo those become root-owned and can no
+# longer be removed by the owning user — which also breaks `git worktree remove`
+# and leaves a half-deleted worktree behind (#13092). The handful of operations
+# that genuinely need elevation call sudo explicitly themselves.
+if [ "$(id -u)" -eq 0 ]; then
+    echo "❌ Do not run this script as root (or through sudo)."
+    echo "   It writes build artifacts into the project tree; as root they become"
+    echo "   root-owned and undeletable by your user."
+    echo "   The steps that need elevation invoke sudo on their own."
+    exit 1
+fi
+
+# Resolve the project root from THIS script's location rather than a hard-coded
+# install path. An explicit AUTOBOT_PROJECT_ROOT still wins. A deployed install
+# resolves to its own directory automatically, so behaviour there is unchanged;
+# previously, running from a checkout or worktree operated on the live install
+# instead — including `rm -rf` of its frontend node_modules (#13092).
+PROJECT_ROOT="${AUTOBOT_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+if [ ! -d "$PROJECT_ROOT" ]; then
+    echo "❌ Project root does not exist: $PROJECT_ROOT"
+    exit 1
+fi
+echo "📁 Project root: $PROJECT_ROOT"
+
 # Parse command line arguments
 TEST_MODE=false
 START_ALL_CONTAINERS=false
@@ -203,11 +228,11 @@ fi
 echo "Starting Playwright Service Docker container..."
 
 # Ensure playwright-server.js exists and is a file
-if [ ! -f "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/playwright-server.js" ]; then
+if [ ! -f "$PROJECT_ROOT/playwright-server.js" ]; then
     echo "⚠️  playwright-server.js not found in project root. Checking for it..."
-    if [ -f "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/tests/playwright-server.js" ]; then
+    if [ -f "$PROJECT_ROOT/tests/playwright-server.js" ]; then
         echo "📋 Copying playwright-server.js from tests directory..."
-        cp "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/tests/playwright-server.js" "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/playwright-server.js"
+        cp "$PROJECT_ROOT/tests/playwright-server.js" "$PROJECT_ROOT/playwright-server.js"
     else
         echo "❌ playwright-server.js not found. Playwright container cannot start."
         echo "   Please ensure playwright-server.js exists in the project root."
@@ -304,10 +329,10 @@ echo "Existing Vite server terminated."
 # Start frontend (Vite with Vue)
 echo "Starting Vite frontend server..."
 echo "Cleaning frontend build artifacts and cache..."
-rm -rf ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/autobot-slm-frontend/node_modules ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/autobot-slm-frontend/.vite
-cd ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}/autobot-slm-frontend && npm install --force && npm run build && npm run dev &
+rm -rf "$PROJECT_ROOT/autobot-slm-frontend/node_modules" "$PROJECT_ROOT/autobot-slm-frontend/.vite"
+cd "$PROJECT_ROOT/autobot-slm-frontend" && npm install --force && npm run build && npm run dev &
 FRONTEND_PID=$!
-cd ${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}
+cd "$PROJECT_ROOT" || exit 1
 
 # Check if frontend started successfully
 sleep 5


### PR DESCRIPTION
Closes #13092.

## Thinking Path

Found while reconciling stale git worktrees: one worktree held 147 root-owned files (`autobot-slm-backend/**/__pycache__`, `logs/`, `config/`) that made it undeletable and broke `git worktree remove` mid-operation, leaving `fatal: not a git repository` on every later worktree command.

Tracing what could produce them led to `run_agent.sh`. It starts uvicorn unprivileged, so root ownership means the whole script had been run under `sudo`. Reading it surfaced the larger problem: the script never resolves its own location. Every path came from `${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}`, so with no env set it targets the **live install** no matter where it is invoked from.

That makes two independent failure modes, so both are fixed here rather than only the one that was observed:

1. Running from a checkout `rm -rf`s the live install's frontend `node_modules` and `.vite`, then builds and serves from the live install — contradicting the standing rule that the codebase is the source of truth and `/opt/autobot/` is never touched directly.
2. Running under `sudo` poisons the tree with root-owned build artifacts.

Deriving the root from `BASH_SOURCE` is correct in both locations at once: in a checkout it resolves to that checkout, and in a deployed install the script sits at the install root and resolves there automatically — so deployed behaviour is unchanged without special-casing.

## What Changed

`run_agent.sh` only:

- `PROJECT_ROOT` is resolved from the script's own directory; an explicit `AUTOBOT_PROJECT_ROOT` still takes precedence, and a non-existent root now fails fast instead of proceeding.
- All five call sites switched from the inline `${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}` default to `"$PROJECT_ROOT"` (playwright-server checks and copy, frontend clean/build, final `cd`).
- Added a root guard: the script exits non-zero with an explanation if run as root. The operations that genuinely need elevation (`lsof`, `kill`, `netstat`, `usermod`) still call `sudo` themselves and are unaffected.
- Quoted every expansion in the destructive `rm -rf` and `cd` lines; the final `cd` now has an `|| exit 1`.

No behaviour change for a correctly deployed install, and no change to the container, backend, or NPU startup logic.

## Verification

Syntax:

```
$ bash -n run_agent.sh
OK
```

The new header exercised in isolation (the full script starts servers, so only the resolution and guard logic were run):

| Case | Result |
|---|---|
| Run from the worktree, no env | `📁 Project root: …/.worktrees/issue-13092` — resolves to the checkout, not the install |
| `AUTOBOT_PROJECT_ROOT=/tmp` | `📁 Project root: /tmp` — explicit override still wins |
| Invoked from a different cwd | resolves to the script's directory, not the caller's cwd |
| `AUTOBOT_PROJECT_ROOT=/nope/missing` | `❌ Project root does not exist` — exit 1 |
| `id -u` stubbed to 0 | root guard fires — exit 1 |

Before/after on the destructive line, evaluated from a worktree with no env set:

```
old:  rm -rf /opt/autobot/code_source/autobot-slm-frontend/node_modules   <- live install
new:  rm -rf /home/.../.worktrees/issue-13092/autobot-slm-frontend/node_modules
```

Remaining `AUTOBOT_PROJECT_ROOT:-` occurrences: 1, the intentional override on the resolution line.

## Model Used

Claude Opus 5
