### PR TITLE
fix: config-save test corruption + skills DB self-deadlock (#13082, #13083)

### DIFF
--- a/autobot-backend/skills/db.py
+++ b/autobot-backend/skills/db.py
@@ -37,12 +37,26 @@ class _SkillsEngineManager:
         return self._engine
 
     def get_session_factory(self) -> async_sessionmaker[AsyncSession]:
-        """Return the singleton session factory, constructing it on first call."""
+        """Return the singleton session factory, constructing it on first call.
+
+        Issue #13082: ``self.get()`` performs its own complete, thread-safe
+        double-checked-locking construction using this same ``self._lock``.
+        Calling it *while already holding* ``self._lock`` (as this method
+        previously did, passing it as the ``bind=`` argument from inside the
+        ``with self._lock:`` block) re-enters a non-reentrant
+        ``threading.Lock`` on the same thread — an unconditional self-deadlock
+        the very first time this is called before the engine has been warmed
+        up (no other invariant requires the two constructions to be atomic
+        with each other; each is already independently safe). Fetching the
+        engine *before* acquiring the lock removes the nested acquisition
+        entirely instead of papering over it with a reentrant lock.
+        """
         if self._session_factory is None:
+            engine = self.get()
             with self._lock:
                 if self._session_factory is None:
                     self._session_factory = async_sessionmaker(
-                        bind=self.get(),
+                        bind=engine,
                         class_=AsyncSession,
                         expire_on_commit=False,
                         autocommit=False,

--- a/autobot-backend/skills/db_test.py
+++ b/autobot-backend/skills/db_test.py
@@ -1,0 +1,53 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression test for the skills DB engine manager (Issue #13082).
+
+Reproduces the self-deadlock: ``get_session_factory()`` previously acquired
+its own non-reentrant ``threading.Lock`` and, while still holding it, called
+``get()``, which tried to acquire the *same* lock again on the same thread.
+On the very first call in a process (before ``initialization/lifespan.py``
+has warmed up the engine), this was an unconditional self-deadlock with no
+timeout anywhere in the path. Reproduced against the real, unmocked path via
+``skills/governance_test.py::test_semi_auto_requires_review`` (#10691
+baseline audit).
+"""
+
+import threading
+
+from skills.db import _SkillsEngineManager
+
+# Generous but bounded: a genuine deadlock never returns, so any finite
+# timeout proves the hang; this just avoids a slow CI run on the passing path.
+_DEADLOCK_DETECTION_TIMEOUT_SECONDS = 5
+
+
+def test_get_session_factory_does_not_deadlock_on_cold_start():
+    """First-ever call to get_session_factory() must return, not hang.
+
+    Uses a *fresh* manager instance (not the module-level singleton, which
+    other tests may have already warmed up) to reliably reproduce the
+    cold-start condition: both ``_engine`` and ``_session_factory`` are
+    ``None`` when ``get_session_factory()`` acquires ``self._lock`` and
+    (previously) re-entered it via ``self.get()``.
+    """
+    manager = _SkillsEngineManager()
+    result: dict = {}
+
+    def call_get_session_factory() -> None:
+        try:
+            result["factory"] = manager.get_session_factory()
+        except Exception as e:  # pragma: no cover - defensive, not the bug under test
+            result["error"] = e
+
+    thread = threading.Thread(target=call_get_session_factory, daemon=True)
+    thread.start()
+    thread.join(timeout=_DEADLOCK_DETECTION_TIMEOUT_SECONDS)
+
+    assert not thread.is_alive(), (
+        "get_session_factory() deadlocked (Issue #13082): the non-reentrant "
+        "threading.Lock was re-entered on the same thread via self.get()."
+    )
+    assert "error" not in result, f"Unexpected error: {result.get('error')}"
+    assert result["factory"] is not None

--- a/autobot-backend/utils/thread_safety_test.py
+++ b/autobot-backend/utils/thread_safety_test.py
@@ -184,54 +184,87 @@ class TestConfigServiceFileLocking:
         assert ConfigService._config_write_lock is not None
 
     @pytest.mark.asyncio
-    async def test_concurrent_config_saves(self):
-        """Test that concurrent config saves don't corrupt file"""
-        import tempfile
-        from pathlib import Path
+    async def test_concurrent_config_saves(self, monkeypatch, tmp_path):
+        """Test that concurrent config saves don't corrupt the real config.yaml.
 
-        from config import unified_config_manager
+        Issue #13083: the previous version patched ``base_config_file`` on the
+        object returned by ``from config import unified_config_manager``. That
+        works in isolation, but ``ConfigService._save_config_to_file`` reads a
+        module-global name (``services.config_service.unified_config_manager``)
+        bound once, at import time, to whatever ``config.__getattr__`` returned
+        *then*. If anything ever replaces ``sys.modules["config"]`` later in the
+        same process — confirmed here: ``autobot-slm-backend``'s own, unrelated
+        ``config`` concept is stubbed unconditionally via
+        ``sys.modules["config"] = MagicMock()`` by
+        ``autobot-slm-backend/tests/api/test_auth_logout.py`` and
+        ``autobot-slm-backend/tests/services/test_token_denylist.py`` with no
+        guard and no restore (the cross-backend namespace-collision class
+        tracked by #13084) — then a *later* ``from config import
+        unified_config_manager`` resolves to a throwaway MagicMock instead of
+        the real singleton ``ConfigService`` actually uses. Patching that
+        MagicMock's ``base_config_file`` is then silently inert: the redirect
+        never takes effect and every concurrent save lands on the developer's
+        real, unpatched ``config/config.yaml`` (reproduced 3/3 by the #10691
+        baseline audit).
+
+        Fix: patch the attribute directly on ``services.config_service`` (the
+        actual consumer), bypassing the ``config`` package/its ``__getattr__``
+        entirely, and assert identity immediately after patching so any future
+        regression of this seam fails the test loudly instead of writing to
+        the real file.
+        """
+        import services.config_service as config_service_module
         from services.config_service import ConfigService
+
+        class _FakeConfigManager:
+            """Minimal test double exposing only what `_save_config_to_file` reads."""
+
+            def __init__(self, base_config_file):
+                self.base_config_file = base_config_file
+
+        test_file = tmp_path / "test_config.yaml"
+        fake_manager = _FakeConfigManager(test_file)
+
+        # Patch the real consumer, not a name reachable only via `config`'s
+        # module-level __getattr__ (which is exactly what a same-named module
+        # elsewhere in the process can silently hijack — see #13084).
+        monkeypatch.setattr(config_service_module, "unified_config_manager", fake_manager)
+
+        # Fail loudly, before any write, if this seam is ever broken.
+        assert config_service_module.unified_config_manager is fake_manager
+        assert config_service_module.unified_config_manager.base_config_file == test_file
 
         errors = []
         save_count = {"count": 0}
 
-        # Create temp directory for test
-        with tempfile.TemporaryDirectory() as tmpdir:
-            test_file = Path(tmpdir) / "test_config.yaml"
-
-            # Patch the config file path
-            original_path = unified_config_manager.base_config_file
-
+        def save_config(i):
             try:
-                unified_config_manager.base_config_file = test_file
+                config = {"test_key": f"value_{i}", "iteration": i}
+                ConfigService._save_config_to_file(config)
+                save_count["count"] += 1
+            except Exception as e:
+                errors.append(e)
 
-                def save_config(i):
-                    try:
-                        config = {"test_key": f"value_{i}", "iteration": i}
-                        ConfigService._save_config_to_file(config)
-                        save_count["count"] += 1
-                    except Exception as e:
-                        errors.append(e)
+        # Run 10 concurrent saves
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(save_config, i) for i in range(10)]
+            for f in futures:
+                f.result()
 
-                # Run 10 concurrent saves
-                with ThreadPoolExecutor(max_workers=10) as executor:
-                    futures = [executor.submit(save_config, i) for i in range(10)]
-                    for f in futures:
-                        f.result()
+        assert len(errors) == 0, f"Errors during concurrent saves: {errors}"
+        assert save_count["count"] == 10
 
-                assert len(errors) == 0, f"Errors during concurrent saves: {errors}"
-                assert save_count["count"] == 10
+        # Verify the redirect actually took effect (would previously raise
+        # FileNotFoundError here because the writes went to the real file).
+        assert test_file.exists(), "concurrent saves did not land in the redirected temp file"
 
-                # Verify file is valid YAML (not corrupted)
-                import yaml
+        # Verify file is valid YAML (not corrupted)
+        import yaml
 
-                with open(test_file, "r") as f:
-                    data = yaml.safe_load(f)
-                    assert "test_key" in data
-                    assert "iteration" in data
-
-            finally:
-                unified_config_manager.base_config_file = original_path
+        with open(test_file, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+            assert "test_key" in data
+            assert "iteration" in data
 
 
 class TestExistingLockVerification:


### PR DESCRIPTION
## Thinking Path

The #10691 baseline audit (`docs/audit/backend-test-baseline-10691.md`) flagged
two CRITICAL, confirmed-reproducible defects. Both looked deceptively correct
on read, so each was reproduced empirically before touching code, per the
task's explicit "find the actual mechanism, do not guess" instruction.

**#13083.** `test_concurrent_config_saves` patches
`unified_config_manager.base_config_file` via `from config import
unified_config_manager`. In isolation this works (verified: same object
`id()` on both the test side and `services.config_service`'s own binding).
Reproducing under a **full-suite collection** (`pytest -k
test_concurrent_config_saves --continue-on-collection-errors`, matching the
audit's own invocation) instead reliably corrupted the real
`config/config.yaml` and left the test's own assertions failing with
`FileNotFoundError` on the temp file. Root-caused to
`autobot-slm-backend/tests/api/test_auth_logout.py:50-55` and
`autobot-slm-backend/tests/services/test_token_denylist.py:40-45`, which
unconditionally do `sys.modules["config"] = MagicMock()` with no guard and no
restore — an unrelated, same-named `config` concept from the SLM backend
(the same cross-backend namespace-collision class as #13084). Once that runs
earlier in the same worker process, `services.config_service`'s own
`unified_config_manager` binding (captured once, at its own import time,
*before* the clobber) still points to the real singleton, but the test's own
**later** `from config import unified_config_manager` resolves to the
MagicMock instead — so patching it is silently inert, and every concurrent
save lands on the real file.

**#13082.** `_SkillsEngineManager.get_session_factory()` acquires
`self._lock`, then — while still holding it — calls `self.get()`, which tries
to acquire the *same* non-reentrant `threading.Lock` again on the same
thread. `self.get()` already has its own complete, independently thread-safe
double-checked-locking construction using that same lock, so the nested
acquisition was pure redundancy, not a required invariant — it only ever
manifests as a deadlock on the very first cold call, before
`initialization/lifespan.py` has warmed the engine, exactly matching the
audit's `governance_test.py::test_semi_auto_requires_review` repro.

## What Changed

- `autobot-backend/utils/thread_safety_test.py`: `test_concurrent_config_saves`
  now uses `monkeypatch.setattr` to patch
  `services.config_service.unified_config_manager` directly (the actual
  consumer) with a minimal test double, bypassing the `config` package's
  `__getattr__` entirely, plus an identity assertion immediately after
  patching so any future regression of this seam fails loudly instead of
  writing to the real file. Switched to pytest's `tmp_path` fixture
  (auto-restoring, no manual `try/finally`).
- `autobot-backend/skills/db.py`: `get_session_factory()` now fetches the
  engine via `self.get()` **before** acquiring `self._lock`, removing the
  nested/self-deadlocking acquisition instead of swapping in an `RLock`
  (which would have papered over the redundant nesting rather than removing
  it — no invariant actually requires the two constructions to be atomic
  with each other).
- `autobot-backend/skills/db_test.py` (new): regression test reproducing the
  deadlock against a fresh `_SkillsEngineManager` instance via a
  bounded-timeout background thread; confirmed failing (thread still alive
  after 5s) against the pre-fix code and passing against the fix.
- Filed **#13094** (separate, out-of-scope, pre-existing): two
  `TracingService`-related tests in the same file resolve `TracingService` as
  a `MagicMock` under certain collection orders — confirmed identical failing
  set before and after this PR via a `cp`-swapped baseline of the untouched
  file; almost certainly the same conftest-stub-leak class already tracked by
  #13084.

## Verification

- `py_compile`, `flake8 --max-line-length=120`, `black --check
  --line-length=120`: clean on all 3 touched/added files.
- **#13083**: backed up `config/config.yaml` (checksum-verified) before every
  run. Reproduced corruption 2/2 times pre-fix via
  `pytest -k test_concurrent_config_saves --continue-on-collection-errors`
  (252 collection errors, matching the audit's own count) — real file ended
  up containing `iteration: 9` / `test_key: value_9` (the test's own content)
  and the test itself failed with `FileNotFoundError` on the temp path. Same
  invocation post-fix: test **passes**, `config/config.yaml` checksum
  **identical** before/after
  (`8bdcbb891d4ba064370cabbbeef818ee34e810b6c1c88b31e814de56a3187554`).
  Restored the file after every attempt; final state confirmed byte-identical
  to the pre-session backup.
- **#13082**: new regression test confirmed deadlocking (thread still alive
  after the 5s bounded join) against the pre-fix `db.py` (via a `cp`-swapped
  copy, not `git stash`), and passing against the fix. The previously
  deadlock-deselected `governance_test.py::test_semi_auto_requires_review`
  now passes standalone in 0.18s.
- `tests/test_startup_imports.py`: 350 passed, 0 failed (unaffected by this
  change — same ratio as an untouched baseline).
- `cp`-swapped baseline diff (`utils/thread_safety_test.py`, unrelated
  `TracingService` classes untouched by this diff): identical 2-failure set
  before and after — filed as #13094, not fixed here (out of scope, same
  root-cause class as #13084).

## Model Used

Claude Sonnet 5