### PR TITLE
docs+fix(tests): backend suite triage step 2 — group by root cause, fix trivial items (#10691)

### DIFF
--- a/autobot-backend/tests/integration/test_mobile_pairing.py
+++ b/autobot-backend/tests/integration/test_mobile_pairing.py
@@ -38,6 +38,28 @@ from user_management.models.base import Base
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
 
+@pytest.fixture(autouse=True)
+def _test_encryption_service(monkeypatch):
+    """Provide a REAL EncryptionService with an injected test master key (#11687).
+
+    ``MobileDevice.device_token`` encrypts/decrypts through the module-level
+    ``get_encryption_service()`` singleton, which requires
+    ``AUTOBOT_ENCRYPTION_KEY`` — absent in the hermetic test env (ssot config
+    reads env once at import, so setting the variable here would be too late).
+    Injecting the key keeps the real AES-GCM round-trip under test (same
+    pattern already used by the sibling test_mobile_push.py).
+    """
+    import encryption_service as enc_mod
+
+    svc = enc_mod.EncryptionService(master_key="integration-test-master-key-0123456789abcdef")
+    monkeypatch.setattr(enc_mod, "get_encryption_service", lambda: svc)
+    # device_jwt.py's _secret() reads DEVICE_JWT_SECRET fresh from os.environ
+    # on every call (no import-time caching, unlike the encryption key above),
+    # so a plain monkeypatch.setenv is sufficient — same convention already
+    # used by services/device_jwt_test.py.
+    monkeypatch.setenv("DEVICE_JWT_SECRET", "test-secret-32-chars-minimum-len")
+
+
 @pytest.fixture
 async def test_db_engine():
     """Create an in-memory test database engine."""
@@ -49,7 +71,11 @@ async def test_db_engine():
     )
 
     async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+        # #11834: scope create_all to the tables under test — whole-metadata
+        # create_all breaks under whole-dir order when earlier tests import
+        # llc models whose Postgres '::jsonb' server_defaults sqlite rejects
+        # (same fix already applied in the sibling test_mobile_push.py).
+        await conn.run_sync(lambda sync_conn: Base.metadata.create_all(sync_conn, tables=[MobileDevice.__table__]))
 
     yield engine
 
@@ -155,7 +181,9 @@ async def test_generate_qr_challenge_token(test_client, redis_client, test_user)
     key = _redis_challenge_key(data["challenge_token"])
     stored_user_id = redis_client.get(key)
     assert stored_user_id is not None
-    assert stored_user_id.decode() == test_user["id"]
+    # get_redis_client() is configured with decode_responses=True (see
+    # autobot_shared/redis_management/config.py), so values are already str.
+    assert stored_user_id == test_user["id"]
 
     # Verify TTL is set correctly
     ttl = redis_client.ttl(key)

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1581,15 +1581,18 @@ def test_resolve_pg_db_url_prefers_autobot_database_url() -> None:
     assert result == "postgresql://u:p@host/db"
 
 
-def test_resolve_pg_db_url_falls_back_to_database_url() -> None:
+def test_resolve_pg_db_url_falls_back_to_database_url(monkeypatch) -> None:
     """DATABASE_URL is used when AUTOBOT_DATABASE_URL is absent (#11431)."""
+    monkeypatch.delenv("AUTOBOT_DATABASE_URL", raising=False)
     env_vars = {"DATABASE_URL": "postgresql://u:p@host/db"}
     result = _resolve_pg_db_url(env_vars)
     assert result == "postgresql://u:p@host/db"
 
 
-def test_resolve_pg_db_url_assembles_from_component_vars() -> None:
+def test_resolve_pg_db_url_assembles_from_component_vars(monkeypatch) -> None:
     """AUTOBOT_POSTGRES_* vars are assembled into a URL when no full URL exists (#11431)."""
+    monkeypatch.delenv("AUTOBOT_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     env_vars = {
         "AUTOBOT_POSTGRES_HOST": "db.internal",
         "AUTOBOT_POSTGRES_PORT": "5432",
@@ -1890,20 +1893,23 @@ def test_resolve_pg_db_url_byte_identical_autobot_database_url_in_os_environ() -
     assert result == "postgresql://env_u:env_p@envhost/envdb"
 
 
-def test_resolve_pg_db_url_byte_identical_database_url_fallback() -> None:
+def test_resolve_pg_db_url_byte_identical_database_url_fallback(monkeypatch) -> None:
     """DATABASE_URL in env_vars → returned as-is (unchanged)."""
+    monkeypatch.delenv("AUTOBOT_DATABASE_URL", raising=False)
     env_vars = {"DATABASE_URL": "postgresql://u2:p2@host2/db2"}
     result = _resolve_pg_db_url(env_vars)
     assert result == "postgresql://u2:p2@host2/db2"
 
 
-def test_resolve_pg_db_url_byte_identical_component_vars_no_password() -> None:
+def test_resolve_pg_db_url_byte_identical_component_vars_no_password(monkeypatch) -> None:
     """AUTOBOT_POSTGRES_* without password → 'user@host:port/db' (no colon before @).
 
     Before (#11466 inline code):
         auth = f"{user}@"  # pw is falsy
         return f"postgresql://{auth}{host}:{port}/{db}"
     """
+    monkeypatch.delenv("AUTOBOT_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     env_vars = {
         "AUTOBOT_POSTGRES_HOST": "pg-host",
         "AUTOBOT_POSTGRES_PORT": "5432",
@@ -1914,13 +1920,15 @@ def test_resolve_pg_db_url_byte_identical_component_vars_no_password() -> None:
     assert result == "postgresql://autobot_app@pg-host:5432/autobot_users"
 
 
-def test_resolve_pg_db_url_byte_identical_component_vars_with_password() -> None:
+def test_resolve_pg_db_url_byte_identical_component_vars_with_password(monkeypatch) -> None:
     """AUTOBOT_POSTGRES_* with password → 'user:pw@host:port/db'.
 
     Before (#11466 inline code):
         auth = f"{user}:{pw}@"  # pw is truthy
         return f"postgresql://{auth}{host}:{port}/{db}"
     """
+    monkeypatch.delenv("AUTOBOT_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     env_vars = {
         "AUTOBOT_POSTGRES_HOST": "pg-host",
         "AUTOBOT_POSTGRES_PORT": "5433",
@@ -1941,6 +1949,8 @@ def test_resolve_pg_db_url_byte_identical_component_vars_defaults() -> None:
         port = ... os.environ.get("AUTOBOT_POSTGRES_PORT", "5432")
     """
     clear_keys = {
+        "AUTOBOT_DATABASE_URL",
+        "DATABASE_URL",
         "AUTOBOT_POSTGRES_PORT",
         "AUTOBOT_POSTGRES_USER",
         "AUTOBOT_POSTGRES_PASSWORD",
@@ -1977,8 +1987,10 @@ def test_resolve_pg_db_url_byte_identical_nothing_set_returns_empty() -> None:
     assert result == ""
 
 
-def test_resolve_pg_db_url_env_vars_takes_precedence_over_os_environ() -> None:
+def test_resolve_pg_db_url_env_vars_takes_precedence_over_os_environ(monkeypatch) -> None:
     """env_vars takes precedence over os.environ for AUTOBOT_POSTGRES_* keys."""
+    monkeypatch.delenv("AUTOBOT_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     os.environ["AUTOBOT_POSTGRES_HOST"] = "os-environ-host"
     try:
         result = _resolve_pg_db_url({"AUTOBOT_POSTGRES_HOST": "env-vars-host"})

--- a/docs/audit/backend-test-baseline-10691-step2.md
+++ b/docs/audit/backend-test-baseline-10691-step2.md
@@ -1,0 +1,259 @@
+# Backend test triage — step 2 (#10691)
+
+**Purpose.** Per the owner's decision on #10691, step 1 (measure the true
+baseline) was completed in `docs/audit/backend-test-baseline-10691.md` (PR
+#13088) and the namespace-pollution fix in
+`docs/audit/backend-test-namespace-pollution-13084.md` (PR #13109, merged as
+`6be4e8260`). This document is **step 2: triage the post-#13109 failure
+surface into fix-now vs quarantine-with-issue**, and it recommends whether
+the suite can now be flipped to a required gate.
+
+## Environment (independently reproduced, matching prior sessions' methodology)
+
+- Fresh worktree off `origin/Dev_new_gui` at `6be4e8260` (post-#13109),
+  Python 3.10.12, system pytest 9.0.2 / pytest-asyncio 1.3.0 / pytest-cov
+  7.1.0 / pytest-xdist 3.8.0 / fakeredis 2.36.2 — no ad-hoc installs.
+- **Disposable local Postgres 16** — private `initdb` cluster, own data dir,
+  own Unix socket (`/tmp/pg10691sock`), listening only on `127.0.0.1:55432`.
+  The shared host cluster and `pg_hba.conf` were never touched;
+  `/etc/autobot/db-credentials.env` was never read.
+- **Disposable local Redis** — a second `redis-server` on `127.0.0.1:63790`
+  with its own data dir. The real shared `redis-stack` instance on `:6379`
+  was confirmed unchanged (943 keys, before and after every run).
+- `config/config.yaml` created to match `ci.yml`'s setup step exactly;
+  **sha256 `e125bf80...` confirmed byte-identical before the first run and
+  after every run performed** (the #13083 corruption vector this session
+  guarded against explicitly).
+- No `sudo`, no root-owned files, no application service run as root.
+
+## Reproducible invocation (matches `.github/workflows/ci.yml`'s two-invocation split exactly)
+
+```
+python -m pytest autobot-backend autobot_shared autobot-tts-worker repo_tests \
+  -n auto --dist loadscope \
+  -m "not integration and not slow and not distributed and not performance" \
+  --cov=autobot-backend --cov=autobot_shared --cov-report= --tb=short \
+  --continue-on-collection-errors -q
+
+python -m pytest autobot-slm-backend \
+  -n auto --dist loadscope \
+  -m "not integration and not slow and not distributed and not performance" \
+  --cov=autobot-slm-backend --cov-report= --tb=short \
+  --continue-on-collection-errors -q
+```
+
+## Headline numbers
+
+| | Invocation 1 (backend/shared/tts/repo) | Invocation 2 (slm-backend) | Combined |
+|---|---:|---:|---:|
+| Failed | 855 | 21 | **876** |
+| Passed | 18,233 | 1,504 | **19,737** |
+| Skipped | 2,440 | 1 | 2,441 |
+| xfailed | 2 | 1 | 3 |
+| Errors | 104 | 1 | **105** |
+| Wall-clock | 1,706.5s | 185.7s | **1,892.2s (~31.5 min)** |
+
+**Comparison to the #13109 PR's own measurement** (874 failed / 76 errors /
+14 collection errors / 19,749 passed, ~1,031s): failed matches almost
+exactly (+2, normal repo drift); **errors are +29 higher** (105 vs 76). All
+of that delta is explained below — it is not unexplained noise:
+
+- **+19** — `autobot-backend/tests/integration/test_mobile_pairing.py` errored
+  at setup on **100% of its 19 tests** in this session (bucket A, fixed
+  below). Whether this is new drift since the #13109 measurement or an
+  environment-order sensitivity not hit in that session is not fully
+  reconciled, but it reproduced deterministically across every run this
+  session performed.
+- **+27 minus 2 already inside the errors bucket in both sessions** — the
+  `global_config_manager` test-rot cluster (#13112) contributes 27 setup
+  errors; a small residual is attributable to normal ordering/timing drift.
+
+Collection errors matched exactly: **14** (12 `tools.lint` + 1 `cachetools`
++ 1 `test_apply_secrets.py`), same as #13109's measurement.
+
+**Config checksum and shared Redis dbsize were reconfirmed unchanged after
+every run in this session, including the fixes below.**
+
+## Order-dependence confirmation (bucket D) — two runs, not one
+
+A `--last-failed` re-run of exactly the failing/erroring set from the run
+above (`--tb=line`, same disposable environment):
+
+| | Invocation 1 re-run | Invocation 2 re-run |
+|---|---:|---:|
+| Result | 771 failed, 67 passed, 80 errors (170.3s) | 14 failed, 1 error (105.7s, no flips — all match already-known/filed causes) |
+
+Of invocation 1's 67 flips, **19 are the `test_mobile_pairing.py` fix landing
+mid-session** (not flakiness — a genuine fix), leaving **~48 confirmed
+order-dependent flips** with zero code change, consistent in magnitude with
+the #13088 baseline's own 56-flip measurement. This is the same
+worker/collection-order sensitivity already documented for #13084 — not
+classic timing-based flake.
+
+## Root-cause grouping (the deliverable) — by count, largest first
+
+| Root cause | Count | Bucket | Status |
+|---|---:|---|---|
+| **`code_intelligence` self-poisoning conftest stub** — 11 submodules stubbed as `MagicMock` in `autobot-backend/conftest.py` are ALSO collected as their own test files; `--import-mode=importlib` returns the stub instead of re-importing the real module | **453** (433 in `code_intelligence/*_test.py` + 20 in `api/merge_conflict_resolution_test.py`, a consumer of one poisoned submodule) | A (systemic) | **Filed #13111**, not fixed (11-module removal needs individual full-suite verification per module) |
+| `security_layer.global_config_manager` / `knowledge_base.global_config_manager` — symbol removed, tests still `patch()` it | 27 | C (test rot) | **Filed #13112** |
+| `asyncio.get_event_loop().run_until_complete()` in sync `def test_...()` — legacy pattern only fails when no async test primed the worker's loop first | 23 | A + D | **Filed #13113** |
+| ChromaDB `[chromadb]`-parametrized tests — need a live ChromaDB instance (port 8100 convention) | 38 | B | Documented (not filed — env-dependent, per task scope) |
+| `drift_checker_test.py` invariants stale relative to #12450's component migration | 4 | C (test rot) | **Filed #13114** (security-relevant list, needs owner confirmation before editing assertions) |
+| `tools.lint` not importable (`repo_tests/lint/canonical/**`) | 12 | config gap | Already filed **#13086** |
+| `ConfigManager(config_file=...)` removed kwarg | 7 | C | Already filed **#13087** |
+| GitLab connector `_store_ts` removed by #12659 | 8 | C | Already filed **#12998** |
+| `services.token_denylist` patches nonexistent `get_redis_client` (real export: `get_async_redis_client`) — incl. `test_auth_logout.py`'s identical pattern | 10 | C | Already filed **#13106** |
+| `test_apply_secrets.py` collection error (`services.system_secrets_vault` never stubbed) | 1 | config gap | Already filed **#13108** |
+| Playwright browser binary not installed (`chromium_headless_shell`) | 10 | B | Documented (needs `playwright install chromium` as a CI step, or an `importorskip`/skip guard — not present today) |
+| `fixture 'backend_url' not found` — needs a live running backend | 13 | B | Documented (carried over from owner's 2026-07-03 scoping) |
+| `fixture 'host_id' not found` + IaC `ConnectionError` (NameResolutionError to a real host) | 2 + 7 | B | Documented — needs a live IaC test host/network, or these tests should mock instead |
+| `TestUnifiedMultiModalSystem` — audio/vision models (Whisper, Wav2Vec2) not loaded | 12 | B | Documented (GPU/model-weight dependent) |
+| `services/redis_service_management_e2e_test.py` — needs live redis-management/VM service | 10 | B | Documented |
+| Missing optional dep `cachetools` (no `importorskip` guard) | 1 (collection) + 2 (runtime references) | B | Documented, per "missing optional dep is itself a bucket-B finding" rule — no ad-hoc install performed |
+| **Fixed this session** — `test_mobile_pairing.py` (SQLite DDL scope + missing encryption/JWT-secret fixtures + stale bytes/str `.decode()`) | 19 (all were errors → all now pass) | A (genuine defect) | **Fixed** |
+| **Fixed this session** — `_resolve_pg_db_url` env-isolation gap (`test_code_sync_deploy_bugs.py`) | 7 | A (test hygiene) | **Fixed** |
+| Long tail — remaining `code_intelligence`-adjacent (`mcp/mcp_cache_test.py` TestMCPToolCache, 14), security API assertions, MCP registry, config registry, IaC/webhook/security edge cases, and dozens of 1-6-count single-cluster failures across `pki/`, `services/`, `security/`, `api/` not individually traced this session | ~**312** (981 total − everything else above) | mixed A/B/C, unclassified | **Needs a further per-cluster pass** — not attempted exhaustively per task scope ("874 failures will not be 874 distinct causes... group aggressively", not "triage all 981 individually") |
+
+Total accounted (981 = 876 failed + 105 errors, includes the 14 collection
+errors as a subset): 453 + 27 + 23 + 38 + 4 + 12 + 7 + 8 + 10 + 1 + 10 + 13 +
+9 + 12 + 10 + 3 + 26 (fixed) + ~312 (tail) = 981.
+
+## What was fixed in this PR (trivial, mechanical, verified)
+
+### 1. `autobot-backend/tests/integration/test_mobile_pairing.py` — 19 setup errors → 0
+
+Three gaps, each already solved identically in the sibling file
+`test_mobile_push.py` (same `TEST_DB_URL`, same `MobileDevice` import) or in
+`services/device_jwt_test.py` (same secret convention) — this file simply
+never received those fixes:
+
+1. `test_db_engine`'s `Base.metadata.create_all` created **every** model
+   registered on the shared declarative base, including `llc/models/approval.py:54`'s
+   Postgres-only `server_default=sa.text("'{}'::jsonb")`, which SQLite's
+   dialect cannot parse (`unrecognized token: ":"`). Scoped to
+   `tables=[MobileDevice.__table__]`, exactly matching `test_mobile_push.py`'s
+   `#11834` fix.
+2. Missing `_test_encryption_service` autouse fixture (copied verbatim from
+   `test_mobile_push.py`) — `MobileDevice.device_token` requires
+   `AUTOBOT_ENCRYPTION_KEY` via a real `EncryptionService`, absent in the
+   hermetic test env (#11687).
+3. Missing `DEVICE_JWT_SECRET` env var (copied from `services/device_jwt_test.py`'s
+   established `monkeypatch`/`os.environ` convention) — `device_jwt.py:_secret()`
+   reads it fresh on every call (no caching), so a plain `monkeypatch.setenv`
+   is sufficient and safe.
+4. `test_generate_qr_challenge_token` called `.decode()` on a Redis GET
+   result, but `get_redis_client()` is configured with `decode_responses=True`
+   (`autobot_shared/redis_management/config.py:61`), so the value is already
+   `str` — stale test rot, one-line fix.
+
+Verified: `19 passed` (was `19 errored` — 100% of the file). No other file
+touched.
+
+### 2. `autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py` — 7 failures → 0
+
+`_resolve_pg_db_url()`'s "byte-identical" and "assembles from component
+vars" tests pass an explicit `env_vars` dict, but the function itself falls
+back to the **real** `os.environ.get("AUTOBOT_DATABASE_URL", ...)` for step
+1 of its resolution order (`api/code_sync.py:1765`). 7 of these tests never
+cleared `AUTOBOT_DATABASE_URL`/`DATABASE_URL` from the ambient environment
+before asserting fallback-to-component-vars behaviour — unlike the sibling
+test `test_resolve_pg_db_url_byte_identical_nothing_set_returns_empty` in
+the same file, which does. Any environment that legitimately exports
+`AUTOBOT_DATABASE_URL` (a live deployment's env file, or — as here — this
+suite's own disposable-Postgres provisioning for other DB-dependent tests)
+breaks these 7 tests regardless of the codebase being correct. Fixed by
+adding `monkeypatch.delenv(...)` (or extending the existing manual
+backup/restore `clear_keys` set) to each, matching the established sibling
+pattern exactly.
+
+Verified: `89 passed` (was `82 passed, 7 failed`) — including a direct
+re-run with the exact polluting env vars this session used for the live-DB
+tests, proving the fix holds under the real reproduction conditions, not
+just in isolation.
+
+## Issues filed this session
+
+| Issue | Bucket | Count | Summary |
+|---|---|---:|---|
+| [#13111](https://github.com/mrveiss/AutoBot-AI/issues/13111) | A (systemic) | 453 | `code_intelligence` conftest self-poisoning — the single largest root cause (51.8% of the 874-failure surface) |
+| [#13112](https://github.com/mrveiss/AutoBot-AI/issues/13112) | C | 27 | `global_config_manager` patch target removed from `security_layer`/`knowledge_base` |
+| [#13113](https://github.com/mrveiss/AutoBot-AI/issues/13113) | A + D | 23 | Legacy `asyncio.get_event_loop().run_until_complete()` in sync tests, order-dependent |
+| [#13114](https://github.com/mrveiss/AutoBot-AI/issues/13114) | C | 4 | `drift_checker_test.py` invariants stale relative to #12450 |
+
+Already-filed issues confirmed present in this session's reproduction, not
+re-filed: #13086, #13087, #12998, #13106, #13108.
+
+## Bucket B — environment-dependent (documented, no mass skip markers added)
+
+Per the task's explicit instruction, **no skip markers were mass-added**.
+For each of the following, the recommended mechanism is noted; none were
+applied in this PR since doing so is itself a design decision (which
+service to provision in CI vs. which marker convention to use) outside
+"trivial and mechanical":
+
+| Need | Count | Recommended mechanism |
+|---|---:|---|
+| Live ChromaDB (port 8100) | 38 | CI-provisioned service container, or `@pytest.mark.integration` |
+| Playwright browser binary | 10 | `playwright install chromium` as a CI step, or `pytest.importorskip`-equivalent runtime skip |
+| Live running backend (`backend_url` fixture) | 13 | Carried over from owner's 2026-07-03 scoping — needs the same disposition decision |
+| Live IaC test host / network | 9 | Either provision a stub host in CI, or these tests should mock the host client instead of hitting real DNS |
+| Audio/vision ML models (Whisper, Wav2Vec2) not loaded | 12 | GPU/model-weight dependent — mark `@pytest.mark.slow` or provide lightweight test doubles |
+| Live redis-management / VM service | 10 | `@pytest.mark.integration`, needs a real multi-VM or VM-simulation harness |
+| Missing optional dep `cachetools` | 1 collection + 2 runtime | Already the correct pattern per project convention (`pytest.importorskip`) — not yet applied to `security/enterprise/threat_detection/` |
+
+## Verification
+
+- `autobot-backend/tests/migrations/` and `test_startup_imports.py` (350) —
+  not re-run in full this session (unchanged by this PR's two test-file-only
+  edits); no code outside test files was touched.
+- `python -m py_compile` on both modified files: clean.
+- `black --check --line-length=120`, `isort --check-only --settings-path=.`,
+  `flake8 --config=.flake8` on both modified files: clean.
+- `config/config.yaml` sha256 `e125bf80...` confirmed byte-identical before
+  the first run and after every run this session, including both fix
+  verifications.
+- Shared production Redis `dbsize` (943) confirmed unchanged before and
+  after every run.
+- Disposable Postgres/Redis only; shared cluster and `pg_hba.conf` untouched;
+  no `sudo`, no root-owned files, no service run as root.
+- `autobot-backend/tests/integration/test_mobile_pairing.py`: 19 passed
+  (was 19 errored).
+- `autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py`: 89 passed
+  (was 82 passed, 7 failed).
+
+## Verdict on flipping the gate to required (owner's step 4)
+
+**Not yet — three things block it, in priority order:**
+
+1. **#13111 must land first.** At 453 of 874 (51.8%), this single
+   mechanism dominates the failure surface so completely that no other
+   triage signal is trustworthy until it's fixed and the suite re-measured.
+   Fixing it requires per-module verification (11 submodules × a full-suite
+   run each), which is real, non-trivial work — but it is the single
+   highest-leverage next step by a wide margin, exactly as #13084 was for
+   step 1.
+2. **The four already-filed test-rot issues (#13112, #13086, #13087,
+   #12998, #13106 — ~59 failures) and #13113 (23, order-dependent) should
+   land** before re-measuring, since they are independent of #13111 and
+   individually small enough to fix safely.
+3. **Bucket B needs an explicit owner decision** on which environment
+   dependencies (ChromaDB, Playwright, live backend, live IaC host,
+   ML models, redis-management VM — ~92 tests total) get a CI-provisioned
+   service vs. an explicit `@pytest.mark.integration`/skip marker with a
+   filed issue. Left undecided, these ~92 will permanently red a required
+   gate with no actionable owner.
+
+**Once #13111 lands**, the remaining surface drops from 981 to an estimated
+~500 (981 − 453 − 26 already fixed here), overwhelmingly the already-filed
+issues above plus the ~312-item long tail this session did not individually
+trace. That is the point at which a genuine re-measurement (mirroring the
+#13084→#13109 pattern exactly) becomes worthwhile — attempting it now would
+just re-measure the same 453-failure noise floor.
+
+**Wall-clock**: 1,892s (~31.5 min) measured this session vs. #13109's 1,031s
+(~17.2 min) on the same disposable-environment methodology — this session's
+box was under more load; the two-invocation split itself did not regress
+(confirmed by #13109's own before/after). The wall-clock question (step
+3/4's "runtime acceptable on the singleton runner" gate) cannot be answered
+definitively from a dev-box measurement either way and still needs a real
+advisory-job run on the actual self-hosted runner.


### PR DESCRIPTION
## Thinking Path

Step 2 of the owner's #10691 decision: measure the post-#13109 failure
surface, group it by root cause with counts (not a flat list), fix only
trivial/mechanical items, and file everything else. Reproduced the exact
per-backend split invocation `.github/workflows/ci.yml` uses, on a
disposable local Postgres/Redis (never the shared cluster), with
`config/config.yaml` checksummed before/after every run per the #13083
lesson. Confirmed order-dependence across two runs (`--last-failed`
re-run) rather than asserting flakiness from a single pass.

## What Changed

- **Fixed** `autobot-backend/tests/integration/test_mobile_pairing.py` —
  19/19 tests errored at setup (100% of the file) due to three gaps already
  solved identically in sibling files (`test_mobile_push.py`,
  `device_jwt_test.py`) that this file simply never received: unscoped
  `Base.metadata.create_all()` hitting a Postgres-only `::jsonb` server
  default on SQLite, a missing test encryption-key fixture, and a missing
  `DEVICE_JWT_SECRET` env var. Also fixed one stale `bytes.decode()` call
  against a `str`-returning Redis client. All 19 now pass.
- **Fixed** `autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py` —
  7 of `_resolve_pg_db_url`'s tests didn't isolate `AUTOBOT_DATABASE_URL`/
  `DATABASE_URL` from the ambient environment (unlike a sibling test in the
  same file), so any environment that legitimately exports those vars
  (including this suite's own disposable-Postgres provisioning) broke them
  regardless of correct code. Added the missing isolation.
- **Filed 4 new issues** for genuine defects too large/risky for this PR:
  - #13111 — `code_intelligence` conftest self-poisoning: **453 of 874
    failures (51.8%)**, by far the largest single mechanism found. 11
    submodules are stubbed as `MagicMock` for OTHER tests' benefit but are
    ALSO collected as their own test targets, so they test themselves as a
    mock.
  - #13112 — `global_config_manager` patch target removed from
    `security_layer`/`knowledge_base` (27 failures, test rot).
  - #13113 — legacy `asyncio.get_event_loop().run_until_complete()` in 23
    sync test functions across ~20 files, order-dependent on worker state.
  - #13114 — `drift_checker_test.py` invariants stale relative to #12450's
    component migration (4 failures, security-relevant list — needs owner
    sign-off before editing assertions).
- **Documented** (not filed as new, per task scope) the bucket-B
  environment-dependent surface: live ChromaDB (38), Playwright browser
  binary (10), live backend/IaC/redis-management fixtures (~32), ML models
  (12) — with recommended CI mechanisms, no mass skip markers added.
- Full by-root-cause grouping with counts:
  `docs/audit/backend-test-baseline-10691-step2.md`.

## Verification

- `test_mobile_pairing.py`: 19 passed (was 19 errored).
- `test_code_sync_deploy_bugs.py`: 89 passed (was 82 passed, 7 failed) —
  re-verified with the exact polluting env vars this session used.
- `python -m py_compile`, `black --check --line-length=120`,
  `isort --check-only --settings-path=.`, `flake8 --config=.flake8` on both
  modified files: clean.
- `config/config.yaml` sha256 `e125bf80...` byte-identical before the first
  run and after every run this session (disposable Postgres 16 + disposable
  Redis; shared cluster and `pg_hba.conf` untouched; shared Redis `dbsize`
  943 unchanged throughout; no `sudo`, no root-owned files).
- Order-dependence confirmed across two runs (`--last-failed` re-run: ~48
  confirmed flips after excluding this session's own fix).

**Gate verdict**: not ready to flip to required yet. #13111 (51.8% of the
surface) must land first — no other triage signal is trustworthy while one
mechanism dominates this completely. See the doc's "Verdict" section for
the full sequencing recommendation.

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5)


Closes #10691

(Note: #10691 is a 4-step umbrella per the owner's decision comment; this PR delivers step 2 — measure + triage — only. Steps 3 (advisory job) and 4 (flip to required) remain and should be tracked as follow-up before the umbrella is considered fully resolved. This merge targets `Dev_new_gui`, which does not auto-close on merge per this repo's workflow — the umbrella should be reopened or re-scoped by the owner if steps 3/4 are still needed as separate tracked work.)
