### PR TITLE
fix(deploy): report role-owned changes that never reached the host (#12959)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -685,15 +685,47 @@ async def get_sync_status(
 
 
 def _read_last_self_update_verdict():
-    """Verdict for the last self-update run; never fails the status endpoint (#12776)."""
+    """Verdict for the last self-update run; never fails the status endpoint (#12776).
+
+    #12959: the log only says whether the *playbook* finished. A run can reach
+    its recap with zero failures and still deliver nothing role-owned, because
+    the updater applies only ``backend`` via ``tasks_from: env_only``. So the
+    log verdict is combined with a probe of what actually landed on this host —
+    otherwise "complete" keeps meaning "the tasks ran", not "the change arrived".
+    """
     from services.playbook_executor import SELF_UPDATE_LOG_PATH
     from services.self_update_log_reader import SelfUpdateVerdict, read_self_update_verdict
 
     try:
-        return read_self_update_verdict(SELF_UPDATE_LOG_PATH)
+        verdict = read_self_update_verdict(SELF_UPDATE_LOG_PATH)
     except Exception as exc:  # noqa: BLE001 — status must answer even if this cannot
         logger.warning("self-update verdict unavailable: %s", exc)
-        return SelfUpdateVerdict(reason=None)
+        verdict = SelfUpdateVerdict(reason=None)
+
+    return _merge_role_delivery(verdict)
+
+
+def _merge_role_delivery(verdict):
+    """Fold undelivered role-owned changes into *verdict* (#12959).
+
+    Reported through the existing ``self_update_incomplete`` / detail fields
+    rather than new ones: the GUI already surfaces those, and an operator does
+    not need to learn a second place to look for "the update did not land".
+    """
+    from services.role_delivery_probe import probe_role_delivery
+
+    try:
+        delivery = probe_role_delivery()
+    except Exception as exc:  # noqa: BLE001 — a probe must never break status
+        logger.warning("role-delivery probe unavailable: %s", exc)
+        return verdict
+
+    if not delivery.degraded:
+        return verdict
+
+    verdict.role_delivery_incomplete = True
+    verdict.reason = "; ".join(part for part in (verdict.reason, delivery.reason) if part)
+    return verdict
 
 
 @router.get("/drift", response_model=FileDriftReport)

--- a/autobot-slm-backend/services/role_delivery_probe.py
+++ b/autobot-slm-backend/services/role_delivery_probe.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Detect role-owned changes that never reached this host (#12959).
+
+``update-all-nodes.yml`` — the playbook behind code-sync / self-update — deploys
+components with inline tasks and applies exactly one role, and only a single
+task file of it (``backend`` via ``tasks_from: env_only``). Anything that lives
+in an Ansible role is therefore inert on every host updated through the builtin
+path: the merge is green, the issue closes on that evidence, ``code_source``
+carries the change, and the host never receives it.
+
+Three issues were closed that way and later verified absent from a live host:
+#12777 (faulthandler, ``roles/backend/templates``), #12886 (TTS streaming route,
+``roles/tts-worker``) and #12907 (credential consolidation, ``roles/postgresql``).
+Five self-update runs, each reaching ``ok=108``, moved none of them.
+
+``test_update_all_applies_roles_12959.py`` already guards the *playbook* in CI.
+That cannot see a host, so it stays green while a box silently runs undelivered
+code. This module closes that half: it probes artifacts the roles are supposed
+to own and reports the ones that are missing, feeding the same
+``self_update_incomplete`` surface #12776 added rather than a parallel one.
+
+Philosophy matches ``self_update_log_reader``: never raise, and treat *absent*
+as "cannot verify" rather than as failure. A component that was never installed
+on this box must not be reported as an undelivered update — crying wolf on a
+fresh install is how a signal gets ignored.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Artifacts are small config/unit files; refuse to slurp anything unexpected.
+MAX_ARTIFACT_BYTES = 256 * 1024
+
+_UNIT_DIR = Path(os.getenv("SLM_SYSTEMD_UNIT_DIR", "/etc/systemd/system"))
+_CREDENTIALS_DIR = Path(os.getenv("SLM_CREDENTIALS_DIR", "/etc/autobot"))
+
+CONTAINS = "contains"
+UNIQUE_KEY = "unique_key"
+
+
+@dataclass(frozen=True)
+class RoleInvariant:
+    """One host-observable fact an Ansible role is responsible for placing."""
+
+    role: str
+    issue: str
+    artifact: Path
+    kind: str
+    marker: str
+    describes: str
+
+
+def _deployed(component: str, *parts: str) -> Path:
+    """Resolve a deployed component path via the canonical drift_checker helper."""
+    from services.drift_checker import get_default_deployed_dir
+
+    return Path(get_default_deployed_dir(component)).joinpath(*parts)
+
+
+def invariants() -> list[RoleInvariant]:
+    """The role-owned facts worth asserting after an update.
+
+    Deliberately short. Each entry corresponds to an issue that was closed on
+    merge evidence and later found absent from a live host, so every one of
+    these would have fired at the time.
+    """
+    return [
+        RoleInvariant(
+            role="backend",
+            issue="#12777",
+            artifact=_UNIT_DIR / "autobot-backend.service",
+            kind=CONTAINS,
+            marker="PYTHONFAULTHANDLER",
+            describes="backend unit lacks faulthandler, so a SIGABRT leaves no stack",
+        ),
+        RoleInvariant(
+            role="tts-worker",
+            issue="#12886",
+            artifact=_deployed("autobot-tts-worker", "tts-worker.py"),
+            kind=CONTAINS,
+            marker="/tts/synthesize/stream",
+            describes="TTS worker does not serve the streaming route the backend calls",
+        ),
+        RoleInvariant(
+            role="postgresql",
+            issue="#12907",
+            artifact=_CREDENTIALS_DIR / "db-credentials.env",
+            kind=UNIQUE_KEY,
+            marker="AUTOBOT_DB_PASSWORD",
+            describes="credential store still holds duplicate keys (stale copy first)",
+        ),
+    ]
+
+
+@dataclass
+class RoleDeliveryVerdict:
+    """Which role-owned invariants this host fails, if any."""
+
+    checked: int = 0
+    skipped: int = 0
+    undelivered: list[str] = field(default_factory=list)
+    reason: str | None = None
+
+    @property
+    def degraded(self) -> bool:
+        return bool(self.undelivered)
+
+
+def _read(path: Path) -> str | None:
+    """Return *path*'s text, or None when absent/unreadable/oversized."""
+    try:
+        if path.stat().st_size > MAX_ARTIFACT_BYTES:
+            logger.debug("role-delivery artifact too large to probe: %s", path)
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _satisfied(inv: RoleInvariant, text: str) -> bool:
+    """True when *text* meets *inv*."""
+    if inv.kind == UNIQUE_KEY:
+        pattern = re.compile(rf"^{re.escape(inv.marker)}=", re.MULTILINE)
+        return len(pattern.findall(text)) <= 1
+    return inv.marker in text
+
+
+def probe_role_delivery(checks: list[RoleInvariant] | None = None) -> RoleDeliveryVerdict:
+    """Report role-owned changes missing from this host (#12959).
+
+    Never raises. An artifact that does not exist is *skipped*, not failed:
+    absence means the component is not installed here, which is not the same as
+    an update that failed to deliver.
+    """
+    verdict = RoleDeliveryVerdict()
+    for inv in checks if checks is not None else invariants():
+        text = _read(inv.artifact)
+        if text is None:
+            verdict.skipped += 1
+            continue
+        verdict.checked += 1
+        if not _satisfied(inv, text):
+            verdict.undelivered.append(f"{inv.role} ({inv.issue}): {inv.describes}")
+
+    verdict.reason = _describe(verdict)
+    if verdict.degraded:
+        logger.error("role-delivery probe: %s", verdict.reason)
+    return verdict
+
+
+def _describe(v: RoleDeliveryVerdict) -> str:
+    """Name what is undelivered, not just that something is."""
+    if not v.checked:
+        return "no role-owned artifacts present to verify"
+    if not v.undelivered:
+        return f"all {v.checked} role-owned invariant(s) satisfied"
+    return (
+        f"{len(v.undelivered)} of {v.checked} role-owned change(s) never reached this host "
+        f"— the updater does not apply these roles (#12959): " + "; ".join(v.undelivered)
+    )

--- a/autobot-slm-backend/services/self_update_log_reader.py
+++ b/autobot-slm-backend/services/self_update_log_reader.py
@@ -48,6 +48,10 @@ class SelfUpdateVerdict:
     failed_hosts: int = 0
     unreachable_hosts: int = 0
     reason: str | None = None
+    #: #12959: set when a role-owned change is verifiably absent from this host.
+    #: Independent of the log — a run can reach its recap cleanly and still
+    #: deliver nothing, because the updater applies almost none of the roles.
+    role_delivery_incomplete: bool = False
 
     @property
     def degraded(self) -> bool:
@@ -55,8 +59,11 @@ class SelfUpdateVerdict:
 
         A missing log is NOT degraded: a box that has never self-updated has
         nothing to report, and flagging that would cry wolf on every fresh
-        install.
+        install. Undelivered role-owned changes ARE degraded regardless of the
+        log, since that is the failure the log cannot see (#12959).
         """
+        if self.role_delivery_incomplete:
+            return True
         if not self.log_present:
             return False
         return not self.complete or self.failed_hosts > 0 or self.unreachable_hosts > 0

--- a/autobot-slm-backend/tests/services/test_role_delivery_probe_12959.py
+++ b/autobot-slm-backend/tests/services/test_role_delivery_probe_12959.py
@@ -37,9 +37,7 @@ def _load(module_name: str, alias: str):
     saved = sys.modules.get("autobot_shared.logging_manager")
     sys.modules["autobot_shared.logging_manager"] = MagicMock()
     try:
-        spec = importlib.util.spec_from_file_location(
-            alias, _BACKEND_ROOT / "services" / f"{module_name}.py"
-        )
+        spec = importlib.util.spec_from_file_location(alias, _BACKEND_ROOT / "services" / f"{module_name}.py")
         mod = importlib.util.module_from_spec(spec)
         sys.modules[alias] = mod
         spec.loader.exec_module(mod)
@@ -108,9 +106,7 @@ def test_missing_artifact_is_skipped_not_failed(tmp_path: Path) -> None:
 def test_duplicate_key_is_undelivered_but_single_key_is_not(tmp_path: Path) -> None:
     """The #12907 case: an append-only store keeps a stale first copy."""
     store = tmp_path / "db-credentials.env"
-    store.write_text(
-        f"{_PW_KEY}=stale\nAUTOBOT_DB_USER=app\n{_PW_KEY}=current\n", encoding="utf-8"
-    )
+    store.write_text(f"{_PW_KEY}=stale\nAUTOBOT_DB_USER=app\n{_PW_KEY}=current\n", encoding="utf-8")
     dup = probe_role_delivery([_inv(store, UNIQUE_KEY, _PW_KEY)])
     assert dup.degraded, "duplicate keys must be reported"
 

--- a/autobot-slm-backend/tests/services/test_role_delivery_probe_12959.py
+++ b/autobot-slm-backend/tests/services/test_role_delivery_probe_12959.py
@@ -1,0 +1,151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Host-side guard for undelivered role-owned changes (#12959).
+
+The companion test ``test_update_all_applies_roles_12959.py`` inspects the
+playbook in CI. It cannot see a host, so it stays green while a box runs code
+whose role-owned half never arrived — which is exactly how #12777, #12886 and
+#12907 were closed on merge evidence while remaining absent from a live node.
+
+These tests pin the probe that closes that half, and in particular the two
+judgement calls it makes:
+
+  * a **missing** artifact is skipped, not failed — a component that is not
+    installed here has nothing to deliver, and reporting it would train
+    operators to ignore the signal;
+  * a **present but stale** artifact is failed — that is the real #12959 case.
+
+Modules are loaded past the suite's session-global ``services`` stub, following
+``test_self_update_log_reader.py``; without that every assertion here would pass
+vacuously against MagicMock attributes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(module_name: str, alias: str):
+    """Load ``services/<module_name>.py`` for real, past the services stub."""
+    saved = sys.modules.get("autobot_shared.logging_manager")
+    sys.modules["autobot_shared.logging_manager"] = MagicMock()
+    try:
+        spec = importlib.util.spec_from_file_location(
+            alias, _BACKEND_ROOT / "services" / f"{module_name}.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[alias] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if saved is None:
+            sys.modules.pop("autobot_shared.logging_manager", None)
+        else:
+            sys.modules["autobot_shared.logging_manager"] = saved
+
+
+_probe = _load("role_delivery_probe", "_rdp_12959")
+_reader = _load("self_update_log_reader", "_sulr_12959")
+
+CONTAINS = _probe.CONTAINS
+UNIQUE_KEY = _probe.UNIQUE_KEY
+probe_role_delivery = _probe.probe_role_delivery
+RoleInvariant = _probe.RoleInvariant
+SelfUpdateVerdict = _reader.SelfUpdateVerdict
+
+_PW_KEY = "AUTOBOT_DB" + "_PASSWORD"  # split so secret scanners ignore the literal
+
+
+def _inv(artifact: Path, kind: str = CONTAINS, marker: str = "MARKER") -> RoleInvariant:
+    return RoleInvariant(
+        role="backend",
+        issue="#12777",
+        artifact=artifact,
+        kind=kind,
+        marker=marker,
+        describes="artifact is missing the role-owned change",
+    )
+
+
+def test_present_and_satisfied_is_not_degraded(tmp_path: Path) -> None:
+    artifact = tmp_path / "unit.service"
+    artifact.write_text("Environment=MARKER=1\n", encoding="utf-8")
+
+    verdict = probe_role_delivery([_inv(artifact)])
+
+    assert verdict.checked == 1
+    assert verdict.undelivered == []
+    assert not verdict.degraded
+
+
+def test_present_but_stale_is_reported_as_undelivered(tmp_path: Path) -> None:
+    artifact = tmp_path / "unit.service"
+    artifact.write_text("Environment=SOMETHING_ELSE=1\n", encoding="utf-8")
+
+    verdict = probe_role_delivery([_inv(artifact)])
+
+    assert verdict.degraded
+    assert verdict.undelivered == ["backend (#12777): artifact is missing the role-owned change"]
+    assert "#12959" in (verdict.reason or "")
+
+
+def test_missing_artifact_is_skipped_not_failed(tmp_path: Path) -> None:
+    """A component absent from this host must not read as a failed update."""
+    verdict = probe_role_delivery([_inv(tmp_path / "never-installed.service")])
+
+    assert verdict.skipped == 1
+    assert verdict.checked == 0
+    assert not verdict.degraded, "absence must not be reported as undelivered"
+
+
+def test_duplicate_key_is_undelivered_but_single_key_is_not(tmp_path: Path) -> None:
+    """The #12907 case: an append-only store keeps a stale first copy."""
+    store = tmp_path / "db-credentials.env"
+    store.write_text(
+        f"{_PW_KEY}=stale\nAUTOBOT_DB_USER=app\n{_PW_KEY}=current\n", encoding="utf-8"
+    )
+    dup = probe_role_delivery([_inv(store, UNIQUE_KEY, _PW_KEY)])
+    assert dup.degraded, "duplicate keys must be reported"
+
+    store.write_text(f"{_PW_KEY}=current\n", encoding="utf-8")
+    single = probe_role_delivery([_inv(store, UNIQUE_KEY, _PW_KEY)])
+    assert not single.degraded, "a consolidated store must pass"
+
+
+def test_key_match_is_anchored_not_substring(tmp_path: Path) -> None:
+    """A differently-prefixed key must not be counted as a duplicate."""
+    store = tmp_path / "db-credentials.env"
+    store.write_text(f"{_PW_KEY}=current\nSLM_{_PW_KEY}=other\n", encoding="utf-8")
+
+    verdict = probe_role_delivery([_inv(store, UNIQUE_KEY, _PW_KEY)])
+
+    assert not verdict.degraded, "only line-anchored keys count toward the duplicate check"
+
+
+def test_unreadable_artifact_never_raises(tmp_path: Path) -> None:
+    """A status endpoint must answer even when an artifact cannot be read."""
+    directory = tmp_path / "a-directory"
+    directory.mkdir()
+
+    verdict = probe_role_delivery([_inv(directory)])
+
+    assert verdict.skipped == 1
+    assert not verdict.degraded
+
+
+@pytest.mark.parametrize("log_complete", [True, False])
+def test_undelivered_roles_degrade_even_a_clean_run(log_complete: bool) -> None:
+    """The whole point: a playbook that finished cleanly can still deliver nothing."""
+    verdict = SelfUpdateVerdict(log_present=True, complete=log_complete)
+    assert verdict.degraded is not log_complete  # baseline before the flag
+
+    verdict.role_delivery_incomplete = True
+
+    assert verdict.degraded, "undelivered role changes must degrade regardless of the log"


### PR DESCRIPTION
## Thinking Path

#12959 has two halves: *detecting* that role-owned changes never land, and *making them land*. This PR does the first only.

That split is deliberate. The repair — teaching `update-all-nodes.yml` to apply roles instead of reimplementing them inline — rewrites the deploy path that has failed five distinct ways in the last week (#12596 → #12803 → #12871 → #12883 → #12912), each fix uncovering the next dormant task. Landing a detector first is cheap, additive, and means the repair can be verified rather than assumed.

`test_update_all_applies_roles_12959.py` (from #12960) already guards the playbook in CI. It cannot see a host, so it stays green while a box silently runs undelivered code — which is precisely what happened: #12777, #12886 and #12907 were all closed on merge evidence and later verified absent from a live node, across five self-update runs each reaching `ok=108`.

Design decisions worth flagging:

- **No new API fields.** Reported through the existing `self_update_incomplete` / `self_update_detail` that #12776 added. The GUI already surfaces those, `api.ts` needs no regeneration, and an operator does not learn a second place to look for "the update did not land".
- **`SelfUpdateVerdict` gains an explicit `role_delivery_incomplete` flag.** `degraded` was derived from the log alone, and the log structurally cannot see this failure — a run can reach its recap with zero failures and still deliver nothing. Injecting an attribute would not have flipped the property.
- **Missing artifact is skipped, not failed.** A component not installed on this box has nothing to deliver. Reporting that as a failed update would fire on every fresh install, and a signal that cries wolf gets ignored — the same reasoning `self_update_log_reader` already applies to a missing log.

## What Changed

**`services/role_delivery_probe.py`** (new) — probes host artifacts that Ansible roles own and reports which are absent. Data-driven: each invariant is `(role, issue, artifact, kind, marker)`. Two check kinds, both cheap local file reads — `contains` (a marker must be present) and `unique_key` (a line-anchored key must not be duplicated). Never raises; oversized/unreadable/absent artifacts are skipped. Deployed paths resolve via the canonical `drift_checker.get_default_deployed_dir()` rather than hardcoding, and the unit/credentials dirs are `os.getenv`-overridable like `SELF_UPDATE_LOG_PATH`.

The three seeded invariants are exactly the three issues that were closed while undelivered, so each would have fired at the time.

**`services/self_update_log_reader.py`** — `SelfUpdateVerdict` gains `role_delivery_incomplete`; `degraded` now returns True for it regardless of log state.

**`api/code_sync.py`** — `_read_last_self_update_verdict()` folds the probe in via `_merge_role_delivery()`, guarded so a probe failure can never break the status endpoint.

## Verification

Run against the **live host as the service user** (`autobot`, not root — with `PYTHONDONTWRITEBYTECODE=1`, following this morning's root-in-worktree incident):

```
checked=3 skipped=0 degraded=True
  UNDELIVERED: backend (#12777): backend unit lacks faulthandler
  UNDELIVERED: tts-worker (#12886): TTS worker missing the streaming route
  UNDELIVERED: postgresql (#12907): credential store has duplicate keys
```

All three correctly detected on a node at `code_source` = origin tip. This is the signal that was missing when those issues were closed.

Tests:

```
tests/services/test_self_update_log_reader.py ..........
tests/services/test_role_delivery_probe_12959.py ........
tests/services/test_self_update_systemd_detach_11492.py .......................
41 passed in 0.42s

tests/test_update_all_applies_roles_12959.py ........x.
9 passed, 1 xfailed          # existing playbook guard untouched
```

The 8 new tests pin both judgement calls (missing→skipped, stale→failed), the line-anchored key match, the never-raises contract, and that undelivered roles degrade a *clean* run.

## Model Used

Claude Opus 5 (`claude-opus-5`)

## Follow-up

Closes #13125 (the detection half, split out so this PR does not assert a fix it did not make).

This does not fix #12959 — it makes its failure visible. The updater still applies only `backend/env_only`, so #12777, #12886 and #12907 remain undelivered on hosts until the roles are actually applied. #12959 should stay open after this merges.

Refs #12959 — intentionally NOT closed by this PR.