### PR TITLE
refactor(user-management): design new canonical declarative base (#12647)

### DIFF
--- a/autobot-backend/user_management/models/api_key.py
+++ b/autobot-backend/user_management/models/api_key.py
@@ -15,9 +15,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.types import Uuid
 
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
@@ -46,7 +45,7 @@ class APIKey(Base):
     __tablename__ = "api_keys"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -68,7 +67,7 @@ class APIKey(Base):
 
     # Owner (always required)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -76,7 +75,7 @@ class APIKey(Base):
 
     # Optional team scope
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("teams.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
@@ -132,7 +131,7 @@ class APIKey(Base):
     )
 
     revoked_by: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )

--- a/autobot-backend/user_management/models/audit.py
+++ b/autobot-backend/user_management/models/audit.py
@@ -12,9 +12,8 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, Index, String, func
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy.types import Uuid
 
 from user_management.models.base import Base
 
@@ -30,14 +29,14 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Organization context (nullable for platform-level events)
     org_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("organizations.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
@@ -45,7 +44,7 @@ class AuditLog(Base):
 
     # Actor (who performed the action)
     user_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
@@ -67,7 +66,7 @@ class AuditLog(Base):
 
     # Resource ID affected
     resource_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         nullable=True,
     )
 

--- a/autobot-backend/user_management/models/base.py
+++ b/autobot-backend/user_management/models/base.py
@@ -2,123 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
+"""Re-export shim — the implementation now lives in autobot_shared (#12647).
+
+``models/base.py`` was the file gating the whole ``models/*`` de-fork: the
+backend and SLM declarative bases had genuinely different, deliberate
+designs (backend: timestamps baked into ``Base``, ``eager_defaults``,
+``AsyncAttrs``, generic ``Uuid``; SLM: opt-in ``TimestampMixin``,
+``postgresql.UUID``). The owner's 2026-07-31 decision on #12645/#12647 was to
+design a *new* canonical base preserving both sides' properties rather than
+adopt either fork — see ``autobot_shared/user_management/models/base.py`` for
+the property-by-property rationale. Kept as a shim, not deleted, so every
+existing ``from user_management.models.base import ...`` importer keeps
+working unchanged.
 """
-Base SQLAlchemy Models and Mixins
 
-Provides:
-- Base declarative class for all models (includes created_at/updated_at)
-- TenantMixin for multi-tenancy support
-- TimestampMixin kept as no-op alias for backward compatibility (#4300)
-"""
+from autobot_shared.user_management.models.base import (  # noqa: F401
+    Base,
+    SoftDeleteMixin,
+    TenantMixin,
+    TimestampMixin,
+)
 
-import uuid
-from datetime import datetime
-
-from sqlalchemy import DateTime, ForeignKey, func
-from sqlalchemy.ext.asyncio import AsyncAttrs
-from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
-from sqlalchemy.types import Uuid
-
-from autobot_shared.time_utils import now_utc
-
-
-class Base(AsyncAttrs, DeclarativeBase):
-    """Base class for all SQLAlchemy models.
-
-    Provides automatic created_at/updated_at timestamp columns to all models.
-    Models should inherit from Base only — do not inherit from TimestampMixin
-    separately, as it will cause metaclass conflicts (#4300).
-
-    #11684: mixes in ``AsyncAttrs`` so every model exposes ``awaitable_attrs`` —
-    greenlet-safe async access to un-loaded relationships/columns under an
-    AsyncSession. Purely additive (adds one accessor; no behavioral change).
-    """
-
-    # Timestamp columns provided to all models
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        nullable=False,
-    )
-
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        onupdate=func.now(),
-        nullable=False,
-    )
-
-    # Use UUID as default type annotation for id columns
-    type_annotation_map = {
-        uuid.UUID: Uuid(as_uuid=True),
-    }
-
-    # #12322: eagerly fetch server-side default/onupdate columns (e.g.
-    # ``updated_at``) via RETURNING on INSERT *and* UPDATE, for all models.
-    # SQLAlchemy's default ``eager_defaults="auto"`` only does this for INSERT,
-    # leaving onupdate columns expired after an UPDATE flush — a subsequent sync
-    # attribute read (e.g. Pydantic response serialization outside the greenlet
-    # context) then raises MissingGreenlet. This recurred twice (#12209 goals,
-    # #12309 companies), each patched with a per-call ``session.refresh``.
-    # Setting it here kills the whole class in one place and removes the extra
-    # per-write refresh SELECT (RETURNING is fetched inline with the UPDATE).
-    # Dialects without RETURNING (e.g. sqlite < 3.35) transparently fall back to
-    # a post-UPDATE SELECT, so the column is still populated — never expired.
-    # The other declarative bases were evaluated and are NOT susceptible to this
-    # class, so the fix only needs to live here: LLCBase (llc/models/activity.py)
-    # is append-only (no server-side onupdate), and SkillsBase (skills/models.py)
-    # uses a client-side ``onupdate`` assigned in Python (never expired post-flush).
-    __mapper_args__ = {"eager_defaults": True}
-
-
-class TimestampMixin:
-    """Backward compatibility alias for TimestampMixin.
-
-    NOTE: Do NOT use this in class definitions anymore. All models should
-    inherit from Base only. Base now includes created_at/updated_at columns
-    automatically. This class is kept only for backward compatibility with
-    imports/references (#4300).
-    """
-
-
-class TenantMixin:
-    """
-    Mixin for multi-tenant models.
-
-    Adds org_id foreign key that references the organizations table.
-    Models with this mixin are scoped to a specific organization.
-    """
-
-    @declared_attr
-    def org_id(cls) -> Mapped[uuid.UUID]:
-        return mapped_column(
-            Uuid(as_uuid=True),
-            ForeignKey("organizations.id", ondelete="CASCADE"),
-            nullable=False,
-            index=True,
-        )
-
-
-class SoftDeleteMixin:
-    """Mixin for soft delete support."""
-
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True,
-        default=None,
-    )
-
-    is_deleted: Mapped[bool] = mapped_column(
-        default=False,
-        nullable=False,
-    )
-
-    def soft_delete(self) -> None:
-        """Mark the record as deleted."""
-        self.is_deleted = True
-        self.deleted_at = now_utc()
-
-    def restore(self) -> None:
-        """Restore a soft-deleted record."""
-        self.is_deleted = False
-        self.deleted_at = None
+__all__ = ["Base", "TimestampMixin", "TenantMixin", "SoftDeleteMixin"]

--- a/autobot-backend/user_management/models/mfa.py
+++ b/autobot-backend/user_management/models/mfa.py
@@ -14,8 +14,8 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.types import Uuid
 
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
@@ -43,13 +43,13 @@ class UserMFA(Base):
     __tablename__ = "user_mfa"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         unique=True,

--- a/autobot-backend/user_management/models/organization.py
+++ b/autobot-backend/user_management/models/organization.py
@@ -14,9 +14,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.types import Uuid
 
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
@@ -45,7 +44,7 @@ class Organization(Base):
     __tablename__ = "organizations"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -106,7 +105,7 @@ class Organization(Base):
 
     # Sub-company hierarchy: nullable for root companies
     parent_org_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("organizations.id", ondelete="SET NULL"),
         nullable=True,
         index=True,

--- a/autobot-backend/user_management/models/role.py
+++ b/autobot-backend/user_management/models/role.py
@@ -12,8 +12,8 @@ import uuid
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.types import Uuid
 
 from autobot_shared.auth.permissions import SYSTEM_PERMISSIONS, SYSTEM_ROLES
 from user_management.models.base import Base
@@ -40,7 +40,7 @@ class Permission(Base):
     __tablename__ = "permissions"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -97,14 +97,14 @@ class Role(Base):
     __tablename__ = "roles"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Nullable org_id means system role
     org_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
@@ -179,13 +179,13 @@ class RolePermission(Base):
     __tablename__ = "role_permissions"
 
     role_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("roles.id", ondelete="CASCADE"),
         primary_key=True,
     )
 
     permission_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("permissions.id", ondelete="CASCADE"),
         primary_key=True,
     )
@@ -215,20 +215,20 @@ class UserRole(Base):
     __tablename__ = "user_roles"
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         primary_key=True,
     )
 
     role_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("roles.id", ondelete="CASCADE"),
         primary_key=True,
     )
 
     # Who assigned this role
     assigned_by: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )

--- a/autobot-backend/user_management/models/sso.py
+++ b/autobot-backend/user_management/models/sso.py
@@ -16,9 +16,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.types import Uuid
 
 from autobot_shared.ssot_constants import CategoryDefaults
 from autobot_shared.time_utils import now_utc
@@ -35,6 +34,7 @@ class SSOProviderType(str, Enum):
     # Enterprise SSO
     LDAP = "ldap"
     ACTIVE_DIRECTORY = "active_directory"
+    OKTA = "okta"
     SAML = "saml"
     MICROSOFT_ENTRA = "microsoft_entra"
     GOOGLE_WORKSPACE = "google_workspace"
@@ -56,14 +56,14 @@ class SSOProvider(Base):
     __tablename__ = "sso_providers"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Organization (nullable for global/social providers)
     org_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
@@ -152,6 +152,7 @@ class SSOProvider(Base):
         return self.provider_type in (
             SSOProviderType.LDAP.value,
             SSOProviderType.ACTIVE_DIRECTORY.value,
+            SSOProviderType.OKTA.value,
             SSOProviderType.SAML.value,
             SSOProviderType.MICROSOFT_ENTRA.value,
             SSOProviderType.GOOGLE_WORKSPACE.value,
@@ -173,20 +174,20 @@ class UserSSOLink(Base):
     __tablename__ = "user_sso_links"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
     provider_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("sso_providers.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/autobot-backend/user_management/models/team.py
+++ b/autobot-backend/user_management/models/team.py
@@ -14,9 +14,8 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.types import Uuid
 
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base, TenantMixin
@@ -51,7 +50,7 @@ class Team(Base, TenantMixin):
     __tablename__ = "teams"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -149,20 +148,20 @@ class TeamMembership(Base):
     __tablename__ = "team_memberships"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     team_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("teams.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/autobot-backend/user_management/models/user.py
+++ b/autobot-backend/user_management/models/user.py
@@ -13,9 +13,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.types import Uuid
 
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
@@ -69,14 +68,14 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Organization association (nullable for platform admins in provider mode)
     org_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True),
+        UUID(as_uuid=True),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=True,
         index=True,

--- a/autobot-slm-backend/migrations/add_role_permission_audit_log_timestamps.py
+++ b/autobot-slm-backend/migrations/add_role_permission_audit_log_timestamps.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Migration: Add created_at/updated_at to role_permissions and audit_logs
+
+Issue #12647 — the new canonical ``user_management`` declarative base bakes
+``created_at``/``updated_at`` into ``Base`` unconditionally (matching the
+backend's existing, already-migrated design), rather than making them
+opt-in via ``TimestampMixin``. SLM's ``RolePermission`` and ``AuditLog``
+models never opted into ``TimestampMixin`` and have no matching columns in
+the live SLM database, so they gain ORM-mapped ``updated_at`` (and, for
+``role_permissions``, ``created_at`` too) under the new base.
+
+This mirrors the backend's own #10636 fix for the identical drift
+("Base gives every model both created_at and updated_at, but ... some
+tables [were] created without updated_at") — same idempotent,
+guard-checked, forward-only, no-data-loss pattern, applied here because SLM
+has its own separate database and never received that migration.
+
+Run: python3 -m migrations.add_role_permission_audit_log_timestamps
+"""
+
+import logging
+import sys
+
+from migrations.utils import add_column_if_not_exists, get_connection
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+_TIMESTAMP_COLUMN = "TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()"
+
+
+def migrate(db_url: str) -> None:
+    """Add missing created_at/updated_at columns (#12647, mirrors #10636)."""
+    logger.info("Running migration: add_role_permission_audit_log_timestamps")
+
+    conn = get_connection(db_url)
+    cursor = conn.cursor()
+
+    add_column_if_not_exists(cursor, "role_permissions", "created_at", _TIMESTAMP_COLUMN)
+    add_column_if_not_exists(cursor, "role_permissions", "updated_at", _TIMESTAMP_COLUMN)
+    add_column_if_not_exists(cursor, "audit_logs", "updated_at", _TIMESTAMP_COLUMN)
+
+    conn.commit()
+    conn.close()
+
+    logger.info("Migration complete: added created_at/updated_at to role_permissions, audit_logs")
+
+
+if __name__ == "__main__":
+    from migrations.runner import get_db_url
+
+    db_url = sys.argv[1] if len(sys.argv) > 1 else get_db_url()
+    migrate(db_url)

--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -69,6 +69,11 @@ MIGRATIONS = [
     # Issue #11303: per-component async drift/resolve job tracking table so job
     # status survives the SLM backend restarting itself during a self-resolve.
     "add_component_sync_jobs_table",
+    # Issue #12647: the new canonical user_management declarative base bakes
+    # created_at/updated_at into Base unconditionally (matching the backend's
+    # already-migrated design). role_permissions and audit_logs never opted
+    # into TimestampMixin, so they need the columns added — mirrors #10636.
+    "add_role_permission_audit_log_timestamps",
 ]
 
 

--- a/autobot-slm-backend/user_management/models/api_key.py
+++ b/autobot-slm-backend/user_management/models/api_key.py
@@ -9,21 +9,22 @@ Long-lived API keys for programmatic access.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from user_management.models.base import Base, TimestampMixin
+from autobot_shared.time_utils import now_utc
+from user_management.models.base import Base
 
 if TYPE_CHECKING:
     from user_management.models.team import Team
     from user_management.models.user import User
 
 
-class APIKey(Base, TimestampMixin):
+class APIKey(Base):
     """
     API Key model.
 
@@ -153,7 +154,7 @@ class APIKey(Base, TimestampMixin):
         """Check if the key has expired."""
         if self.expires_at is None:
             return False
-        return datetime.now(timezone.utc) > self.expires_at
+        return now_utc() > self.expires_at
 
     @property
     def is_revoked(self) -> bool:
@@ -167,13 +168,13 @@ class APIKey(Base, TimestampMixin):
 
     def record_usage(self) -> None:
         """Record a usage of this API key."""
-        self.last_used_at = datetime.now(timezone.utc)
+        self.last_used_at = now_utc()
         self.usage_count += 1
 
     def revoke(self, revoked_by_user_id: uuid.UUID | None = None) -> None:
         """Revoke the API key."""
         self.is_active = False
-        self.revoked_at = datetime.now(timezone.utc)
+        self.revoked_at = now_utc()
         self.revoked_by = revoked_by_user_id
 
     def has_scope(self, scope: str) -> bool:

--- a/autobot-slm-backend/user_management/models/base.py
+++ b/autobot-slm-backend/user_management/models/base.py
@@ -2,87 +2,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
+"""Re-export shim — the implementation now lives in autobot_shared (#12647).
+
+``models/base.py`` was the file gating the whole ``models/*`` de-fork: the
+backend and SLM declarative bases had genuinely different, deliberate
+designs (backend: timestamps baked into ``Base``, ``eager_defaults``,
+``AsyncAttrs``, generic ``Uuid``; SLM: opt-in ``TimestampMixin``,
+``postgresql.UUID``). The owner's 2026-07-31 decision on #12645/#12647 was to
+design a *new* canonical base preserving both sides' properties rather than
+adopt either fork — see ``autobot_shared/user_management/models/base.py`` for
+the property-by-property rationale. Kept as a shim, not deleted, so every
+existing ``from user_management.models.base import ...`` importer keeps
+working unchanged.
+
+Note: timestamps are now baked into ``Base`` (matching backend's prior
+design) rather than opt-in via ``TimestampMixin``. SLM model classes that
+still spell out ``(Base, TimestampMixin)`` keep working unchanged —
+``TimestampMixin`` is a no-op alias, so combining it with ``Base`` maps the
+same columns once, not twice. The two SLM models that never opted into
+``TimestampMixin`` (``RolePermission``, ``AuditLog``) now expect
+``updated_at`` (and, for ``RolePermission``, ``created_at``) — see the
+accompanying migration.
 """
-Base SQLAlchemy Models and Mixins
 
-Provides:
-- Base declarative class for all models
-- TimestampMixin for created_at/updated_at
-- TenantMixin for multi-tenancy support
-"""
+from autobot_shared.user_management.models.base import (  # noqa: F401
+    Base,
+    SoftDeleteMixin,
+    TenantMixin,
+    TimestampMixin,
+)
 
-import uuid
-from datetime import datetime, timezone
-
-from sqlalchemy import DateTime, ForeignKey, func
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
-
-
-class Base(DeclarativeBase):
-    """Base class for all SQLAlchemy models."""
-
-    # Use UUID as default type annotation for id columns
-    type_annotation_map = {
-        uuid.UUID: UUID(as_uuid=True),
-    }
-
-
-class TimestampMixin:
-    """Mixin that adds created_at and updated_at timestamps."""
-
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        nullable=False,
-    )
-
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        onupdate=func.now(),
-        nullable=False,
-    )
-
-
-class TenantMixin:
-    """
-    Mixin for multi-tenant models.
-
-    Adds org_id foreign key that references the organizations table.
-    Models with this mixin are scoped to a specific organization.
-    """
-
-    @declared_attr
-    def org_id(cls) -> Mapped[uuid.UUID]:
-        return mapped_column(
-            UUID(as_uuid=True),
-            ForeignKey("organizations.id", ondelete="CASCADE"),
-            nullable=False,
-            index=True,
-        )
-
-
-class SoftDeleteMixin:
-    """Mixin for soft delete support."""
-
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True,
-        default=None,
-    )
-
-    is_deleted: Mapped[bool] = mapped_column(
-        default=False,
-        nullable=False,
-    )
-
-    def soft_delete(self) -> None:
-        """Mark the record as deleted."""
-        self.is_deleted = True
-        self.deleted_at = datetime.now(timezone.utc)
-
-    def restore(self) -> None:
-        """Restore a soft-deleted record."""
-        self.is_deleted = False
-        self.deleted_at = None
+__all__ = ["Base", "TimestampMixin", "TenantMixin", "SoftDeleteMixin"]

--- a/autobot-slm-backend/user_management/models/mfa.py
+++ b/autobot-slm-backend/user_management/models/mfa.py
@@ -9,7 +9,7 @@ Supports TOTP-based 2FA with backup codes.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -17,7 +17,8 @@ from sqlalchemy import Boolean, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from user_management.models.base import Base, TimestampMixin
+from autobot_shared.time_utils import now_utc
+from user_management.models.base import Base
 
 if TYPE_CHECKING:
     from user_management.models.user import User
@@ -31,7 +32,7 @@ class MFAMethod(str, Enum):
     SMS = "sms"  # Future support
 
 
-class UserMFA(Base, TimestampMixin):
+class UserMFA(Base):
     """
     User MFA configuration.
 
@@ -110,9 +111,9 @@ class UserMFA(Base, TimestampMixin):
 
     def record_verification(self) -> None:
         """Record a successful MFA verification."""
-        self.last_verified_at = datetime.now(timezone.utc)
+        self.last_verified_at = now_utc()
 
     def use_backup_code(self) -> None:
         """Record usage of a backup code."""
         self.backup_codes_remaining = max(0, self.backup_codes_remaining - 1)
-        self.last_verified_at = datetime.now(timezone.utc)
+        self.last_verified_at = now_utc()

--- a/autobot-slm-backend/user_management/models/organization.py
+++ b/autobot-slm-backend/user_management/models/organization.py
@@ -10,14 +10,15 @@ In multi_company and provider modes, each organization is isolated.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from user_management.models.base import Base, TimestampMixin
+from autobot_shared.time_utils import now_utc
+from user_management.models.base import Base
 
 if TYPE_CHECKING:
     from user_management.models.role import Role
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
     from user_management.models.user import User
 
 
-class Organization(Base, TimestampMixin):
+class Organization(Base):
     """
     Organization/Tenant model.
 
@@ -133,7 +134,7 @@ class Organization(Base, TimestampMixin):
 
     def soft_delete(self) -> None:
         """Soft delete the organization."""
-        self.deleted_at = datetime.now(timezone.utc)
+        self.deleted_at = now_utc()
         self.is_active = False
 
     def get_setting(self, key: str, default=None):

--- a/autobot-slm-backend/user_management/models/role.py
+++ b/autobot-slm-backend/user_management/models/role.py
@@ -16,14 +16,14 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from autobot_shared.auth.permissions import SYSTEM_PERMISSIONS, SYSTEM_ROLES
-from user_management.models.base import Base, TimestampMixin
+from user_management.models.base import Base
 
 if TYPE_CHECKING:
     from user_management.models.organization import Organization
     from user_management.models.user import User
 
 
-class Permission(Base, TimestampMixin):
+class Permission(Base):
     """
     Permission model.
 
@@ -85,7 +85,7 @@ class Permission(Base, TimestampMixin):
         return f"{resource}:{action}"
 
 
-class Role(Base, TimestampMixin):
+class Role(Base):
     """
     Role model.
 
@@ -205,7 +205,7 @@ class RolePermission(Base):
         return f"<RolePermission(role_id={self.role_id}, permission_id={self.permission_id})>"
 
 
-class UserRole(Base, TimestampMixin):
+class UserRole(Base):
     """
     User-Role assignment table.
 

--- a/autobot-slm-backend/user_management/models/sso.py
+++ b/autobot-slm-backend/user_management/models/sso.py
@@ -11,7 +11,7 @@ Supports multiple SSO providers:
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -19,7 +19,9 @@ from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from user_management.models.base import Base, TimestampMixin
+from autobot_shared.ssot_constants import CategoryDefaults
+from autobot_shared.time_utils import now_utc
+from user_management.models.base import Base
 
 if TYPE_CHECKING:
     from user_management.models.organization import Organization
@@ -43,7 +45,7 @@ class SSOProviderType(str, Enum):
     GITHUB = "github"
 
 
-class SSOProvider(Base, TimestampMixin):
+class SSOProvider(Base):
     """
     SSO Provider configuration.
 
@@ -114,7 +116,7 @@ class SSOProvider(Base, TimestampMixin):
     default_role: Mapped[str | None] = mapped_column(
         String(100),
         nullable=True,
-        default="user",
+        default=CategoryDefaults.ROLE_USER,
     )
 
     # Group/team mapping configuration
@@ -152,6 +154,7 @@ class SSOProvider(Base, TimestampMixin):
         return self.provider_type in (
             SSOProviderType.LDAP.value,
             SSOProviderType.ACTIVE_DIRECTORY.value,
+            SSOProviderType.OKTA.value,
             SSOProviderType.SAML.value,
             SSOProviderType.MICROSOFT_ENTRA.value,
             SSOProviderType.GOOGLE_WORKSPACE.value,
@@ -162,7 +165,7 @@ class SSOProvider(Base, TimestampMixin):
         return self.config.get(key, default)
 
 
-class UserSSOLink(Base, TimestampMixin):
+class UserSSOLink(Base):
     """
     Link between a user and an SSO provider.
 
@@ -239,4 +242,4 @@ class UserSSOLink(Base, TimestampMixin):
 
     def record_login(self) -> None:
         """Record a login via this SSO link."""
-        self.last_login_at = datetime.now(timezone.utc)
+        self.last_login_at = now_utc()

--- a/autobot-slm-backend/user_management/models/team.py
+++ b/autobot-slm-backend/user_management/models/team.py
@@ -9,7 +9,7 @@ Teams belong to organizations and contain users with specific roles.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -17,7 +17,8 @@ from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstr
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from user_management.models.base import Base, TenantMixin, TimestampMixin
+from autobot_shared.time_utils import now_utc
+from user_management.models.base import Base, TenantMixin
 
 if TYPE_CHECKING:
     from user_management.models.api_key import APIKey
@@ -33,7 +34,7 @@ class TeamRole(str, Enum):
     MEMBER = "member"
 
 
-class Team(Base, TenantMixin, TimestampMixin):
+class Team(Base, TenantMixin):
     """
     Team model.
 
@@ -115,7 +116,7 @@ class Team(Base, TenantMixin, TimestampMixin):
 
     def soft_delete(self) -> None:
         """Soft delete the team."""
-        self.deleted_at = datetime.now(timezone.utc)
+        self.deleted_at = now_utc()
 
     @property
     def member_count(self) -> int:
@@ -137,7 +138,7 @@ class Team(Base, TenantMixin, TimestampMixin):
         return self.get_members_by_role(TeamRole.ADMIN)
 
 
-class TeamMembership(Base, TimestampMixin):
+class TeamMembership(Base):
     """
     Team membership model.
 
@@ -175,7 +176,7 @@ class TeamMembership(Base, TimestampMixin):
     # When the user joined the team
     joined_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
+        default=now_utc,
         nullable=False,
     )
 

--- a/autobot-slm-backend/user_management/models/user.py
+++ b/autobot-slm-backend/user_management/models/user.py
@@ -9,14 +9,15 @@ Core user model with authentication, profile, and tenant association.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from user_management.models.base import Base, TimestampMixin
+from autobot_shared.time_utils import now_utc
+from user_management.models.base import Base
 
 if TYPE_CHECKING:
     from user_management.models.api_key import APIKey
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
     from user_management.models.team import TeamMembership
 
 
-class User(Base, TimestampMixin):
+class User(Base):
     """
     User model.
 
@@ -196,7 +197,7 @@ class User(Base, TimestampMixin):
 
     def soft_delete(self) -> None:
         """Soft delete the user."""
-        self.deleted_at = datetime.now(timezone.utc)
+        self.deleted_at = now_utc()
         self.is_active = False
 
     def get_preference(self, key: str, default=None):
@@ -229,9 +230,9 @@ class User(Base, TimestampMixin):
 
     def record_login(self) -> None:
         """Record a successful login."""
-        self.last_login_at = datetime.now(timezone.utc)
+        self.last_login_at = now_utc()
 
     def verify_email(self) -> None:
         """Mark email as verified."""
         self.is_verified = True
-        self.email_verified_at = datetime.now(timezone.utc)
+        self.email_verified_at = now_utc()

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -196,21 +196,43 @@ class RedisConnectionManager:
         - Comprehensive statistics
 
         Refactored for Issue #620.
+
+        #12647: ``_init_configurations`` resolves the Redis host via
+        ``NetworkConstants.REDIS_VM_IP``, which — when no config-manager or env
+        value is set — goes through ``ConfigRegistry.get()``'s Redis-backed
+        cache tier, which constructs a Redis client, which constructs *this
+        same singleton* to look up its own host. ``__new__`` correctly returns
+        the same (not-yet-initialized) instance, but Python still calls
+        ``__init__`` again on it — and the OLD ``_initialized`` guard is set
+        only at the very end, so the re-entrant call saw no guard and reran
+        every init step from scratch, recursing without bound (confirmed via a
+        captured traceback: RedisConnectionManager() -> _load_redis_config ->
+        NetworkConstants.REDIS_VM_IP -> ConfigRegistry.get -> _get_redis ->
+        get_redis_client -> RedisConnectionManager() again). Marking
+        "initializing" BEFORE running any init step lets the re-entrant call
+        return immediately instead; its caller (ConfigRegistry._get_redis,
+        already wrapped in a broad except) then degrades to the env/registry-
+        defaults tier exactly as the "graceful fallback chain" docstring
+        promises, rather than blowing the stack.
         """
-        if hasattr(self, "_initialized"):
+        if hasattr(self, "_initialized") or getattr(self, "_initializing", False):
             return
+        self._initializing = True
 
-        # Initialize all subsystems using helper methods. Issue #620.
-        self._init_pool_and_client_storage()
-        self._init_circuit_breaker_state()
-        self._init_tcp_keepalive_options()
-        self._init_connection_tracking()
-        self._init_configurations()
-        self._init_statistics_tracking()
-        self._init_cleanup_configuration()
+        try:
+            # Initialize all subsystems using helper methods. Issue #620.
+            self._init_pool_and_client_storage()
+            self._init_circuit_breaker_state()
+            self._init_tcp_keepalive_options()
+            self._init_connection_tracking()
+            self._init_configurations()
+            self._init_statistics_tracking()
+            self._init_cleanup_configuration()
 
-        self._initialized = True
-        logger.info("Enhanced Redis Connection Manager initialized with consolidated features")
+            self._initialized = True
+            logger.info("Enhanced Redis Connection Manager initialized with consolidated features")
+        finally:
+            self._initializing = False
 
     def _init_pool_and_client_storage(self) -> None:
         """

--- a/autobot_shared/user_management/__init__.py
+++ b/autobot_shared/user_management/__init__.py
@@ -20,40 +20,52 @@ Movers so far:
 
 Each fork keeps a re-export shim so existing importers are untouched — the
 fork is removed, not the callers.
+
+#12647 (follow-up): the re-exports below are lazy (PEP 562 module
+``__getattr__``, mirroring ``autobot_shared/__init__.py``'s own pattern) —
+NOT for style, but because eager imports here previously coupled every
+submodule of this package together. Merely importing
+``autobot_shared.user_management.models.base`` (SQLAlchemy + time_utils only)
+forced Python to first execute this package's ``__init__.py`` in full,
+which eagerly imported ``schemas.user`` — whose ``EmailStr`` fields need
+``email_validator`` at class-definition time. That pulled ``email_validator``
+into `import models`'s chain (via the models/base.py shim) for the first
+time, breaking ``migration-gate``'s deliberately thin dependency set (the
+same defect class as the ``jsonschema`` coupling PR #13053 fixed). Lazy
+attribute resolution keeps each submodule's dependency footprint scoped to
+callers that actually touch it.
 """
 
-from autobot_shared.user_management.base_service import (  # noqa: F401
-    BaseService,
-    TenantContext,
-)
-from autobot_shared.user_management.models.base import (  # noqa: F401
-    Base,
-    SoftDeleteMixin,
-    TenantMixin,
-    TimestampMixin,
-)
-from autobot_shared.user_management.schemas.user import (  # noqa: F401
-    PasswordChange,
-    RoleResponse,
-    UserCreate,
-    UserListResponse,
-    UserLogin,
-    UserResponse,
-    UserUpdate,
-)
+_LAZY_IMPORTS = {
+    "BaseService": (".base_service", "BaseService"),
+    "TenantContext": (".base_service", "TenantContext"),
+    "Base": (".models.base", "Base"),
+    "TimestampMixin": (".models.base", "TimestampMixin"),
+    "TenantMixin": (".models.base", "TenantMixin"),
+    "SoftDeleteMixin": (".models.base", "SoftDeleteMixin"),
+    "RoleResponse": (".schemas.user", "RoleResponse"),
+    "UserCreate": (".schemas.user", "UserCreate"),
+    "UserUpdate": (".schemas.user", "UserUpdate"),
+    "UserResponse": (".schemas.user", "UserResponse"),
+    "UserListResponse": (".schemas.user", "UserListResponse"),
+    "UserLogin": (".schemas.user", "UserLogin"),
+    "PasswordChange": (".schemas.user", "PasswordChange"),
+}
 
-__all__ = [
-    "BaseService",
-    "TenantContext",
-    "Base",
-    "TimestampMixin",
-    "TenantMixin",
-    "SoftDeleteMixin",
-    "RoleResponse",
-    "UserCreate",
-    "UserUpdate",
-    "UserResponse",
-    "UserListResponse",
-    "UserLogin",
-    "PasswordChange",
-]
+__all__ = list(_LAZY_IMPORTS)
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        mod = importlib.import_module(module_path, __name__)
+        val = getattr(mod, attr_name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY_IMPORTS))

--- a/autobot_shared/user_management/__init__.py
+++ b/autobot_shared/user_management/__init__.py
@@ -12,6 +12,11 @@ Movers so far:
 - `schemas.user` (#12647) — identical apart from Pydantic v1/v2 config style;
   no SQLAlchemy dependency, so it does not need the declarative-base decision
   gating the model files.
+- `models.base` (#12647) — the declarative base itself, resolving the
+  backend/SLM design fork per the owner's 2026-07-31 decision: a new
+  canonical base preserving both sides' properties (AsyncAttrs +
+  eager_defaults from backend; postgresql.UUID typing from SLM), not an
+  adoption of either fork.
 
 Each fork keeps a re-export shim so existing importers are untouched — the
 fork is removed, not the callers.
@@ -20,6 +25,12 @@ fork is removed, not the callers.
 from autobot_shared.user_management.base_service import (  # noqa: F401
     BaseService,
     TenantContext,
+)
+from autobot_shared.user_management.models.base import (  # noqa: F401
+    Base,
+    SoftDeleteMixin,
+    TenantMixin,
+    TimestampMixin,
 )
 from autobot_shared.user_management.schemas.user import (  # noqa: F401
     PasswordChange,
@@ -34,6 +45,10 @@ from autobot_shared.user_management.schemas.user import (  # noqa: F401
 __all__ = [
     "BaseService",
     "TenantContext",
+    "Base",
+    "TimestampMixin",
+    "TenantMixin",
+    "SoftDeleteMixin",
     "RoleResponse",
     "UserCreate",
     "UserUpdate",

--- a/autobot_shared/user_management/models/__init__.py
+++ b/autobot_shared/user_management/models/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical user_management declarative base (#12647).
+
+Home for the new declarative base that reconciles the backend/SLM
+``models/base.py`` fork per the owner's 2026-07-31 decision on #12645/#12647:
+design a new canonical base that deliberately preserves both sides'
+properties, rather than adopting either fork wholesale. See ``base.py`` for
+the property-by-property rationale.
+"""
+
+from autobot_shared.user_management.models.base import (  # noqa: F401
+    Base,
+    SoftDeleteMixin,
+    TenantMixin,
+    TimestampMixin,
+)
+
+__all__ = [
+    "Base",
+    "TimestampMixin",
+    "TenantMixin",
+    "SoftDeleteMixin",
+]

--- a/autobot_shared/user_management/models/base.py
+++ b/autobot_shared/user_management/models/base.py
@@ -1,0 +1,167 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Canonical Base SQLAlchemy Models and Mixins (#12647)
+
+``user_management/models/base.py`` was forked across ``autobot-backend`` and
+``autobot-slm-backend`` with two different, deliberate designs:
+
+- **Backend** — ``Base(AsyncAttrs, DeclarativeBase)`` with ``created_at`` /
+  ``updated_at`` baked directly into ``Base`` (every subclass gets them for
+  free), ``eager_defaults=True`` (#12322), and ``AsyncAttrs`` (#11684) for
+  greenlet-safe ``awaitable_attrs``. Backend's ``Base`` is also the
+  declarative base for ~40 non-``user_management`` model files
+  (``llc/models/*``, ``models/*.py``, ``canvas/models.py``), so its
+  timestamp behaviour cannot change without touching all of them.
+- **SLM** — plain ``Base(DeclarativeBase)`` with a *separate*
+  ``TimestampMixin`` that models opt into per-table, and
+  ``sqlalchemy.dialects.postgresql.UUID`` for UUID columns.
+
+Per the owner's 2026-07-31 decision on #12645/#12647, this is a **new**
+canonical base, not an adoption of either fork:
+
+1. ``AsyncAttrs`` and ``eager_defaults=True`` are preserved (the properties
+   #4300/#11684 exist to protect).
+2. The UUID column type is SLM's ``sqlalchemy.dialects.postgresql.UUID``, not
+   backend's ``sqlalchemy.types.Uuid``. In SQLAlchemy 2.0, ``postgresql.UUID``
+   is itself a subclass of the generic ``Uuid`` (``Emulated`` /
+   ``NativeForEmulated``), so it compiles to the *same* native ``UUID`` DDL on
+   Postgres and falls back to the same CHAR(32) emulation SQLite already used
+   under the generic type — verified by compiling ``CREATE TABLE`` under both
+   dialects. No migration is needed for this part of the change on either
+   side.
+3. Timestamps stay **baked into Base**, unconditionally, matching backend's
+   existing (already-migrated, #10636-hardened) design — *not* switched to an
+   opt-in mixin. Backend's ``Base`` backs ~40 non-``user_management`` models
+   that rely on this today; making timestamps opt-in would silently drop
+   ``created_at``/``updated_at`` ORM mapping from all of them. ``TimestampMixin``
+   is kept as the no-op backward-compatibility alias backend already uses
+   (#4300) — SLM's model files that spell out ``(Base, TimestampMixin)``
+   keep working unchanged, since Base already supplies the same columns.
+
+The one place this is *not* free: SLM's ``RolePermission`` and ``AuditLog``
+models never opted into a ``TimestampMixin`` and have no ``updated_at``
+column in the live SLM database (``AuditLog`` also lacks a matching
+``created_at`` server-side column only via a locally-declared field, which is
+unaffected). Baking timestamps into ``Base`` means these two SLM models start
+expecting ``updated_at`` (and, for ``RolePermission``, ``created_at`` too).
+This is the exact drift the backend itself hit and fixed in #10636 ("Base
+gives every model both created_at and updated_at, but ... some tables [were]
+created without updated_at") — the SLM migration added alongside this change
+mirrors that already-shipped, idempotent, forward-safe pattern.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
+
+from autobot_shared.time_utils import now_utc
+
+
+class Base(AsyncAttrs, DeclarativeBase):
+    """Base class for all ``user_management`` SQLAlchemy models.
+
+    Provides automatic ``created_at``/``updated_at`` timestamp columns to all
+    models (backend's design, #4300) — do not inherit from ``TimestampMixin``
+    separately; it is a no-op alias kept only for backward compatibility.
+
+    ``AsyncAttrs`` (#11684) mixes in ``awaitable_attrs`` — greenlet-safe async
+    access to un-loaded relationships/columns under an ``AsyncSession``.
+
+    UUID columns use ``sqlalchemy.dialects.postgresql.UUID`` (SLM's existing
+    typing) rather than the generic ``sqlalchemy.types.Uuid`` — see module
+    docstring: same compiled DDL on Postgres and SQLite, no migration implied
+    by the type itself.
+    """
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Use UUID as default type annotation for id columns
+    type_annotation_map = {
+        uuid.UUID: UUID(as_uuid=True),
+    }
+
+    # #12322: eagerly fetch server-side default/onupdate columns (e.g.
+    # ``updated_at``) via RETURNING on INSERT *and* UPDATE, for all models.
+    # SQLAlchemy's default ``eager_defaults="auto"`` only does this for INSERT,
+    # leaving onupdate columns expired after an UPDATE flush — a subsequent sync
+    # attribute read (e.g. Pydantic response serialization outside the greenlet
+    # context) then raises MissingGreenlet. This recurred twice (#12209 goals,
+    # #12309 companies), each patched with a per-call ``session.refresh``.
+    # Setting it here kills the whole class in one place and removes the extra
+    # per-write refresh SELECT (RETURNING is fetched inline with the UPDATE).
+    # Dialects without RETURNING (e.g. sqlite < 3.35) transparently fall back to
+    # a post-UPDATE SELECT, so the column is still populated — never expired.
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class TimestampMixin:
+    """Backward compatibility alias for TimestampMixin.
+
+    NOTE: Do NOT use this in class definitions anymore. All models should
+    inherit from Base only. Base now includes created_at/updated_at columns
+    automatically. This class is kept only for backward compatibility with
+    imports/references (#4300), and so SLM's existing ``(Base, TimestampMixin)``
+    class declarations keep working unchanged (#12647): Base already supplies
+    the same columns, so combining both is a no-op, not a duplicate mapping.
+    """
+
+
+class TenantMixin:
+    """
+    Mixin for multi-tenant models.
+
+    Adds org_id foreign key that references the organizations table.
+    Models with this mixin are scoped to a specific organization.
+    """
+
+    @declared_attr
+    def org_id(cls) -> Mapped[uuid.UUID]:
+        return mapped_column(
+            UUID(as_uuid=True),
+            ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+
+
+class SoftDeleteMixin:
+    """Mixin for soft delete support."""
+
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+
+    is_deleted: Mapped[bool] = mapped_column(
+        default=False,
+        nullable=False,
+    )
+
+    def soft_delete(self) -> None:
+        """Mark the record as deleted."""
+        self.is_deleted = True
+        self.deleted_at = now_utc()
+
+    def restore(self) -> None:
+        """Restore a soft-deleted record."""
+        self.is_deleted = False
+        self.deleted_at = None

--- a/autobot_shared/user_management/models/base_test.py
+++ b/autobot_shared/user_management/models/base_test.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The shared declarative base is the single implementation (#12647).
+
+``models/base.py`` was the file gating the whole ``user_management``
+``models/*`` de-fork: backend and SLM had genuinely different declarative
+bases. The owner's 2026-07-31 decision was a *new* canonical base, not an
+adoption of either fork — see ``base.py`` for the property-by-property
+rationale.
+
+These pin the property that matters — both backends resolve to the SAME
+class objects, not merely equivalent ones. Two same-named classes are not
+interchangeable (the trap #12913 fixed for CircuitState), so identity is the
+assertion, not behaviour.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+from autobot_shared.user_management.models.base import (
+    Base,
+    SoftDeleteMixin,
+    TenantMixin,
+    TimestampMixin,
+)
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SHIMS = {
+    "backend": _ROOT / "autobot-backend/user_management/models/base.py",
+    "slm": _ROOT / "autobot-slm-backend/user_management/models/base.py",
+}
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("backend", sorted(_SHIMS))
+def test_shim_exists(backend):
+    assert _SHIMS[backend].is_file(), f"{backend} shim missing"
+
+
+@pytest.mark.parametrize("backend", sorted(_SHIMS))
+def test_shim_resolves_to_the_shared_classes(backend):
+    """Same objects, not same-named twins — see #12913."""
+    module = _load(_SHIMS[backend], f"shim_{backend}")
+
+    assert module.Base is Base
+    assert module.TimestampMixin is TimestampMixin
+    assert module.TenantMixin is TenantMixin
+    assert module.SoftDeleteMixin is SoftDeleteMixin
+
+
+def test_both_backends_share_one_implementation():
+    a = _load(_SHIMS["backend"], "shim_a")
+    b = _load(_SHIMS["slm"], "shim_b")
+
+    assert a.Base is b.Base
+    assert a.TimestampMixin is b.TimestampMixin
+    assert a.TenantMixin is b.TenantMixin
+
+
+def test_package_reexports_the_public_surface():
+    import autobot_shared.user_management as pkg
+
+    assert pkg.Base is Base
+    assert pkg.TimestampMixin is TimestampMixin
+    assert pkg.TenantMixin is TenantMixin
+    assert pkg.SoftDeleteMixin is SoftDeleteMixin
+
+
+def test_base_preserves_asyncattrs_and_eager_defaults():
+    """#4300 / #11684 rationale must survive the new canonical base."""
+    from sqlalchemy.ext.asyncio import AsyncAttrs
+
+    assert issubclass(Base, AsyncAttrs)
+    assert Base.__mapper_args__ == {"eager_defaults": True}
+
+
+def test_base_preserves_slm_uuid_typing():
+    """SLM's postgresql.UUID typing must not silently change (#12647)."""
+    import uuid
+
+    from sqlalchemy.dialects.postgresql import UUID as PgUUID
+
+    mapped_type = Base.type_annotation_map[uuid.UUID]
+    assert isinstance(mapped_type, PgUUID)
+
+
+def test_base_provides_timestamps_unconditionally():
+    """Matches backend's existing (#10636-hardened) design: every subclass
+    gets created_at/updated_at without re-declaring them."""
+    assert "created_at" in Base.__dict__
+    assert "updated_at" in Base.__dict__
+
+
+def test_timestamp_mixin_is_a_noop():
+    """Combining (Base, TimestampMixin) must not double-map columns (#4300)."""
+    assert not hasattr(TimestampMixin, "created_at")
+    assert not hasattr(TimestampMixin, "updated_at")


### PR DESCRIPTION
## Thinking Path

#12647's 9 gated model files (`models/base.py`, `models/__init__.py`, `user`, `organization`, `role`, `sso`, `team`, `api_key`, `audit`, `mfa`) were blocked on the declarative-base decision the owner made on 2026-07-31: design a **new** canonical base preserving both forks' properties, rejecting the two adopt-one-side options.

Audited all 9 files fresh on `origin/Dev_new_gui` before writing anything (per the issue's Phase 1 instruction) — all 9 were still genuinely divergent (none pre-converged, unlike prior slices of this issue that turned out already done). `config.py`/`database.py` re-confirmed **not** forks (single vs dual Postgres engine by design, per the 2026-07-29/07-30 audit trail).

Key design findings, each changing the shape of the fix:
- `postgresql.UUID` is a subclass of the generic `Uuid` in SQLAlchemy 2.0 (`Emulated`/`NativeForEmulated`) — compiles to identical DDL on Postgres *and* SQLite (verified by compiling `CREATE TABLE` under both dialects). Adopting SLM's UUID typing at the base level needs **no migration**.
- Backend's `Base` is the declarative base for ~40 non-`user_management` models (`llc/models/*`, `models/*.py`, `canvas/models.py`), not just the 9 gated files. Making timestamps opt-in-via-mixin (SLM's current shape) would have silently dropped `created_at`/`updated_at` ORM mapping from all 40+. So the canonical base keeps backend's "timestamps baked into `Base` unconditionally" design instead — the *lower*-blast-radius choice, not the "adopt backend" choice; the UUID typing and `AsyncAttrs`/`eager_defaults` still come from the explicit preservation list.
- Consequence: SLM's `RolePermission` and `AuditLog` never opted into a `TimestampMixin` and have no `updated_at` column in the live SLM DB. Under the new base they now expect it — the exact drift the backend itself hit and fixed in #10636. Added a mirrored, idempotent SLM migration for this.

## What Changed

- **New canonical base** — `autobot_shared/user_management/models/base.py`: `Base(AsyncAttrs, DeclarativeBase)` with `eager_defaults=True` and `AsyncAttrs` (#4300/#11684, preserved), `postgresql.UUID` typing (SLM's typing, preserved), timestamps baked in unconditionally (backend's existing, #10636-hardened design). `TimestampMixin` stays a no-op alias so SLM's `(Base, TimestampMixin)` declarations keep working unchanged.
- **Shims** — both backends' `user_management/models/base.py` re-export from `autobot_shared`, following the `base_service` (#12972) / `schemas.user` (#13007) precedent. Identity test (`base_test.py`) asserts both shims resolve to the *same* class objects, not same-named twins (#12913's lesson).
- **Backend's 8 model files** — converged explicit `sqlalchemy.types.Uuid` → `sqlalchemy.dialects.postgresql.UUID` (matching the new base, zero DDL change); added `SSOProviderType.OKTA` (SLM already had it — union-of-features).
- **SLM's 8 model files** — dropped the now-redundant `TimestampMixin` from class bases; adopted `now_utc()` in place of inline `datetime.now(timezone.utc)`; fixed `is_enterprise()` (SLM had `OKTA` in the enum but never in the enterprise check); adopted the shared `CategoryDefaults.ROLE_USER` constant over a literal `"user"`.
- **SLM migration** — `add_role_permission_audit_log_timestamps.py`, idempotent/guard-checked, mirrors the backend's own #10636 fix exactly; wired into `migrations/runner.py`.

After this, `role.py`, `team.py`, `api_key.py`, `mfa.py`, `sso.py`, `audit.py` are identical between backends except cosmetic typing style (`Optional[X]` vs `X | None`) and SLM's more accurate `SystemSecret` doc comment in `sso.py` — both legitimate, left as-is. `user.py` and `organization.py` keep backend's activity-tracking relationships and LLC/PM-sync extension columns respectively — real per-side features, not fork residue. `models/__init__.py` needed no changes (its divergence — `RetentionPolicy` + sibling `models` import — is asymmetric feature import, not a fork, matching the umbrella's established pattern for `__init__.py` files).

**Scope call, surfaced for review:** only `models/base.py` was relocated to `autobot_shared` as a true single canonical file. The other 8 stayed two-per-backend (now byte-identical except legitimate content) rather than also being physically relocated, because `organization.py`/`user.py` genuinely can't move (real per-side columns/relationships), and relocating the other 6 would add cross-module `relationship()` string-resolution and `TYPE_CHECKING` import-path risk I can't verify without running the app. `role.py`/`team.py`/`api_key.py`/`mfa.py`/`sso.py`/`audit.py` are now excellent, low-risk candidates for a follow-up move mirroring `base_service.py`.

## Verification

Static only, per the execution constraint (no service/pytest execution):
- `py_compile` on every changed file — clean.
- `flake8 --max-line-length=120` on every changed file — clean.
- `black --check --line-length=120` / `isort --check-only` — clean.
- Manually verified (Python REPL, no app code) that `sqlalchemy.dialects.postgresql.UUID` subclasses the generic `Uuid` and compiles identical `CREATE TABLE` DDL under both `postgresql` and `sqlite` dialects in the pinned SQLAlchemy 2.0.49.
- `git grep` swept the codebase for any read of `RolePermission.created_at/.updated_at` or `AuditLog.updated_at` before dropping their old implicit-Base mapping story — no hits.
- Confirmed via `diff` that role/team/api_key/mfa/sso/audit model files are now identical (or differ only in already-documented legitimate ways) between backends.

**Unverified, pending CI:** `startup-import-smoke` (350-module import graph — this is exactly a declarative-base change, the class most likely to break at import time in ways static analysis can't catch) and `migration-gate` (`autobot-backend/tests/migrations/`, though no backend migration file changed). The new SLM migration (`add_role_permission_audit_log_timestamps.py`) is **not covered by any required CI gate** — SLM's migration runner is a custom Python script system, not Alembic, and `migration-gate` only exercises `autobot-backend/tests/migrations/`. Its correctness rests on structurally mirroring the backend's already-shipped, working `#10636` fix, not on an executed test. Flagging this explicitly per the task's instruction to be honest about what test execution can't cover here.

Closes #12647

## Model Used

Sonnet 5 (claude-sonnet-5)