### PR TITLE
fix(deploy): give the TTS worker an update path so its streaming route lands (#12886)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -993,6 +993,25 @@
         - npu_status.rc | default(0) != 0
       tags: [npu, npu-worker, restart]
 
+    # ----- TTS Worker -----
+    # #12886: the TTS worker had NO update path at all — it is excluded from
+    # per-component drift resolve (its deployed file is a rendered template, not
+    # a 1:1 sync) and this playbook never mentioned it. So every backend update
+    # advanced the caller while the worker stayed behind, and the streaming route
+    # the backend calls simply 404'd. That is the #12959 pattern: the fix existed
+    # in the role and had no route to the host.
+    #
+    # Applies the role's code_only task file — the service files that carry code
+    # changes — NOT the full role. Provisioning (service account, venv, torch and
+    # pocket-tts installs, gated-model pre-download) is slow, needs network, and
+    # must not re-run on a box that is already installed correctly.
+    - name: "[PLAY 2] TTS | Refresh deployed TTS worker service files (#12886)"
+      ansible.builtin.include_role:
+        name: tts-worker
+        tasks_from: code_only
+      when: "'npu' in group_names"
+      tags: [tts, tts-worker, deploy]
+
     # ----- Browser Worker -----
     - name: "[PLAY 2] Browser | Deploy autobot-browser-worker"
       unarchive:

--- a/autobot-slm-backend/ansible/roles/tts-worker/tasks/code_only.yml
+++ b/autobot-slm-backend/ansible/roles/tts-worker/tasks/code_only.yml
@@ -1,0 +1,51 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# The service files that carry code changes: the worker itself, its .env and its
+# systemd unit. Split out of main.yml (#12886) so the builtin updater can refresh
+# a deployed TTS worker without re-running provisioning.
+#
+# Everything main.yml does around these — creating the service account, building
+# the venv, pip-installing torch/pocket-tts, pre-downloading a gated HuggingFace
+# model — is provisioning work that must NOT run on every update. Those steps are
+# slow, need network, and can fail on a box that is already correctly installed.
+#
+# main.yml includes this file rather than repeating it, so there is exactly one
+# definition of "deploy the TTS service files". Copying the tasks into the
+# playbook instead is precisely the inline-vs-role duplication that left this
+# worker undeliverable in the first place (#12959).
+#
+# Handlers (`restart tts-worker`, `reload systemd`) live in the role, so this
+# file is only usable via include_role/import_role — which is intended.
+
+- name: "TTS Worker | Deploy tts-worker.py"
+  ansible.builtin.template:
+    src: tts-worker.py.j2
+    dest: "{{ tts_install_dir }}/tts-worker.py"
+    mode: "0755"
+    owner: "{{ tts_user }}"
+    group: "{{ tts_group }}"
+  notify: restart tts-worker
+  tags: ['tts', 'deploy']
+
+- name: "TTS Worker | Deploy .env file"
+  ansible.builtin.template:
+    src: tts-worker.env.j2
+    dest: "{{ tts_install_dir }}/.env"
+    mode: "0600"
+    owner: "{{ tts_user }}"
+    group: "{{ tts_group }}"
+  notify: restart tts-worker
+  tags: ['tts', 'deploy']
+
+- name: "TTS Worker | Deploy systemd service"
+  ansible.builtin.template:
+    src: autobot-tts-worker.service.j2
+    dest: /etc/systemd/system/autobot-tts-worker.service
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart tts-worker
+  tags: ['tts', 'deploy']

--- a/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
@@ -286,34 +286,11 @@
 # ============================================================
 # Deploy service files
 # ============================================================
-- name: "TTS Worker | Deploy tts-worker.py"
-  ansible.builtin.template:
-    src: tts-worker.py.j2
-    dest: "{{ tts_install_dir }}/tts-worker.py"
-    mode: "0755"
-    owner: "{{ tts_user }}"
-    group: "{{ tts_group }}"
-  notify: restart tts-worker
-  tags: ['tts', 'deploy']
-
-- name: "TTS Worker | Deploy .env file"
-  ansible.builtin.template:
-    src: tts-worker.env.j2
-    dest: "{{ tts_install_dir }}/.env"
-    mode: "0600"
-    owner: "{{ tts_user }}"
-    group: "{{ tts_group }}"
-  notify: restart tts-worker
-  tags: ['tts', 'deploy']
-
-- name: "TTS Worker | Deploy systemd service"
-  ansible.builtin.template:
-    src: autobot-tts-worker.service.j2
-    dest: /etc/systemd/system/autobot-tts-worker.service
-    mode: "0644"
-  notify:
-    - reload systemd
-    - restart tts-worker
+# #12886: these live in code_only.yml so the builtin updater can refresh a
+# deployed worker without re-running the provisioning above. Included here
+# rather than duplicated, so provisioning and update share one definition.
+- name: "TTS Worker | Deploy service files"
+  ansible.builtin.include_tasks: code_only.yml
   tags: ['tts', 'deploy']
 
 # ============================================================

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -94,17 +94,15 @@ def test_main_includes_code_only_rather_than_duplicating_it() -> None:
     """
     main = yaml.safe_load(_MAIN.read_text(encoding="utf-8"))
 
-    included = [
-        t.get("ansible.builtin.include_tasks") or t.get("include_tasks") for t in _iter_mappings(main)
-    ]
-    assert "code_only.yml" in [i for i in included if isinstance(i, str)], (
-        "roles/tts-worker/tasks/main.yml must include code_only.yml, not repeat its tasks"
-    )
+    included = [t.get("ansible.builtin.include_tasks") or t.get("include_tasks") for t in _iter_mappings(main)]
+    assert "code_only.yml" in [
+        i for i in included if isinstance(i, str)
+    ], "roles/tts-worker/tasks/main.yml must include code_only.yml, not repeat its tasks"
 
     main_text = _MAIN.read_text(encoding="utf-8")
-    assert "tts-worker.py.j2" not in main_text, (
-        "main.yml still renders tts-worker.py itself — that is a second definition"
-    )
+    assert (
+        "tts-worker.py.j2" not in main_text
+    ), "main.yml still renders tts-worker.py itself — that is a second definition"
 
 
 def test_streaming_route_is_actually_in_the_template() -> None:

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The builtin updater must refresh the deployed TTS worker (#12886).
+
+The TTS worker had no update path at all. It is excluded from per-component
+drift resolve (its deployed artifact is a rendered template, not a 1:1 sync of a
+repo directory) and ``update-all-nodes.yml`` never mentioned it. So every backend
+update advanced the caller while the worker stayed behind, and
+``/tts/synthesize/stream`` — which ``services/tts_client.py`` calls — 404'd on a
+host whose ``code_source`` was at origin tip.
+
+That is the #12959 shape: the route existed in the role's template and had no
+route to the host. These tests pin the wiring that closes it, and the property
+that makes the wiring safe — that the updater runs the *code* tasks only, never
+the provisioning half (service account, venv, torch/pocket-tts installs, gated
+HuggingFace model pre-download), which is slow, needs network, and must not
+re-run on an already-installed box.
+
+The companion guard ``test_update_all_applies_roles_12959.py`` deliberately still
+xfails after this: ``tasks_from`` is partial application, and a change to the
+role's provisioning half would still not land. This closes the code half only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_ANSIBLE = Path(__file__).resolve().parents[1] / "ansible"
+_PLAYBOOK = _ANSIBLE / "playbooks" / "update-all-nodes.yml"
+_ROLE = _ANSIBLE / "roles" / "tts-worker"
+_CODE_ONLY = _ROLE / "tasks" / "code_only.yml"
+_MAIN = _ROLE / "tasks" / "main.yml"
+
+#: Provisioning task substrings that must never run on an update path.
+_PROVISIONING_MARKERS = ("venv", "pip", "pre-download", "service account", "system group")
+
+
+def _iter_mappings(node):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_mappings(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_mappings(item)
+
+
+def _includes_of(role: str) -> list[dict]:
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+    found = []
+    for task in _iter_mappings(playbook):
+        inc = task.get("ansible.builtin.include_role") or task.get("include_role")
+        if isinstance(inc, dict) and inc.get("name") == role:
+            found.append(inc)
+    return found
+
+
+def test_updater_applies_the_tts_worker_role() -> None:
+    """Without this the worker is never touched by the builtin updater at all."""
+    includes = _includes_of("tts-worker")
+
+    assert includes, (
+        "update-all-nodes.yml does not apply the tts-worker role — "
+        "the worker would silently rot behind the backend again (#12886)"
+    )
+    assert any(inc.get("tasks_from") == "code_only" for inc in includes), (
+        "tts-worker must be applied via tasks_from=code_only; applying the full "
+        "role would re-run provisioning on every update"
+    )
+
+
+def test_code_only_carries_the_service_files_and_no_provisioning() -> None:
+    """The update path refreshes code, and must not re-provision the box."""
+    tasks = yaml.safe_load(_CODE_ONLY.read_text(encoding="utf-8"))
+    names = [t.get("name", "") for t in tasks]
+
+    assert any("tts-worker.py" in n for n in names), "the worker itself must be refreshed"
+    assert any("systemd service" in n for n in names), "the unit must be refreshed"
+
+    lowered = " ".join(names).lower()
+    for marker in _PROVISIONING_MARKERS:
+        assert marker not in lowered, f"provisioning task leaked into the update path: {marker}"
+
+
+def test_main_includes_code_only_rather_than_duplicating_it() -> None:
+    """One definition of 'deploy the TTS service files', used by both paths.
+
+    Copying the tasks into the playbook is exactly the inline-vs-role
+    duplication that made this component undeliverable (#12959).
+    """
+    main = yaml.safe_load(_MAIN.read_text(encoding="utf-8"))
+
+    included = [
+        t.get("ansible.builtin.include_tasks") or t.get("include_tasks") for t in _iter_mappings(main)
+    ]
+    assert "code_only.yml" in [i for i in included if isinstance(i, str)], (
+        "roles/tts-worker/tasks/main.yml must include code_only.yml, not repeat its tasks"
+    )
+
+    main_text = _MAIN.read_text(encoding="utf-8")
+    assert "tts-worker.py.j2" not in main_text, (
+        "main.yml still renders tts-worker.py itself — that is a second definition"
+    )
+
+
+def test_streaming_route_is_actually_in_the_template() -> None:
+    """Delivery is pointless if the artifact lacks the route that 404'd."""
+    template = (_ROLE / "templates" / "tts-worker.py.j2").read_text(encoding="utf-8")
+
+    assert "/tts/synthesize/stream" in template, (
+        "the route the backend calls is missing from the template — "
+        "wiring the updater would deliver a worker that still 404s"
+    )


### PR DESCRIPTION
## Thinking Path

Follows #13124 (the #12959 detection probe), which — on a live host — now reports exactly this:

```
tts-worker (#12886): TTS worker does not serve the streaming route the backend calls
```

That is the first of the three undelivered roles, picked deliberately: smallest surface, and the only one with a symptom a user actually hits (`TTS synthesis failed: TTS worker error 404`).

The worker had **no** route to a host. It is excluded from per-component drift resolve — reasonably, since its deployed artifact is a rendered template rather than a 1:1 sync of a repo directory — and `update-all-nodes.yml` contained zero TTS references. So the streaming route existed in the role's template while every update advanced the backend that calls it.

Two decisions worth stating:

**Why `tasks_from: code_only` and not the full role.** The role's `main.yml` creates a service account, builds a venv, pip-installs torch and pocket-tts, and pre-downloads a gated HuggingFace model. That is provisioning: slow, network-dependent, and capable of failing on a box that is already installed correctly. An update must refresh code, not re-provision. This mirrors the existing `backend` + `env_only` pattern rather than inventing a mechanism.

**Why `main.yml` includes `code_only.yml` instead of the playbook copying those tasks.** Copying them would create a second definition of "deploy the TTS service files" that is free to drift from the role — which is the precise inline-vs-role duplication that made this component undeliverable to begin with (#12959). One definition, two entry points.

Placed before the browser tasks, which currently end PLAY 2 at #12912.

## What Changed

**`roles/tts-worker/tasks/code_only.yml`** (new) — the three service files that carry code changes: `tts-worker.py`, its `.env`, and its systemd unit, with the existing handler notifications preserved.

**`roles/tts-worker/tasks/main.yml`** — the block those tasks came from is replaced by `include_tasks: code_only.yml`. No behaviour change to provisioning; the same tasks run in the same order.

**`playbooks/update-all-nodes.yml`** — PLAY 2 applies `tts-worker` via `tasks_from: code_only`, gated on the `npu` group (the group `deploy-full.yml` already uses to manage `autobot-tts-worker`).

**`tests/test_updater_refreshes_tts_worker_12886.py`** (new, 4 tests) — the updater applies the role via `code_only`; `code_only` carries the service files and no provisioning marker (venv / pip / pre-download / service account / system group); `main.yml` includes rather than duplicates, and no longer renders `tts-worker.py.j2` itself; and the template genuinely contains `/tts/synthesize/stream`, so delivery is not pointless.

## Verification

Mutation-checked — the two tests that pin the wiring fail against the pre-fix tree:

```
FAILED test_updater_applies_the_tts_worker_role
FAILED test_main_includes_code_only_rather_than_duplicating_it
2 failed, 2 passed
```

and pass after, with the guards:

```
tests/test_updater_refreshes_tts_worker_12886.py ....
tests/test_update_all_applies_roles_12959.py ........x.
tests/test_infrastructure_playbooks.py .....................
34 passed, 1 xfailed
```

`update-all-nodes.yml` parses (4 plays); `code_only.yml` 3 tasks; `main.yml` 25 tasks.

**#12960's guard deliberately still xfails.** `tasks_from` is partial application, and a change to the role's *provisioning* half would still not reach a host. That marker should stay until the roles are applied in full — this PR does not earn its removal, and weakening it to look complete would defeat its purpose.

## Model Used

Claude Opus 5 (`claude-opus-5`)

## Follow-up

Closes #12886 — the delivery half.

The other defect in that report, `/tts/clone-voice`, is split out as **#13132**: it is called by `services/tts_client.py:120` and `api/voice.py:253` but implemented nowhere in the tree, so it 404s regardless of deploy state. That is a missing implementation, not staleness, and closing it here would be the premature closure this whole thread has been about.

Refs #12959 — still open; this delivers one role, not the general repair.
