### PR TITLE
fix(slm): declare aiohttp in requirements.txt (#13118)

### DIFF
--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -39,8 +39,16 @@ websockets>=16.1.1,<17       # Issue #3098: relaxed from >=16.0 (#10386): slm_cl
 # Ansible integration
 ansible-runner>=2.4.3
 
-# HTTP client (for health checks)
-httpx>=0.28.1
+# HTTP clients
+httpx>=0.28.1  # health checks, general async HTTP calls
+# Async HTTP client — genuine runtime dependency, not an optional extra:
+# user_management/services/vault_client.py (SSO/system-secrets vault HTTP
+# calls), services/a2a_card_fetcher.py, services/reconciler.py's node health
+# check, and autobot_shared/retry_mechanism.py's network-retry helper all
+# import it (lazily, at call time) — a fresh install was already broken the
+# first time any of those code paths ran; this was just never surfaced
+# until CI started building the app to verify generated types (#13118).
+aiohttp>=3.14.3  # SECURITY UPDATE — matches autobot-backend/requirements.txt pin
 
 # System metrics
 psutil>=7.2.2


### PR DESCRIPTION
## Thinking Path

`#13118` diagnosed `verify-generated-types-slm` failing on `Dev_new_gui` with `No module named 'aiohttp'`, citing `main.py:20 → api/__init__.py:18 → api/code_sync.py:36` as the exact import chain (reproduced locally against an earlier commit).

Re-checking that chain against the current `Dev_new_gui` tip: `api/code_sync.py` itself no longer imports `aiohttp` at all — grepping the file and its full transitive module-level import graph (built with a custom AST-based static tracer covering module/class/if/try scope, not just function bodies, 148 files reachable from `main.py`) finds zero eager `aiohttp` imports anywhere in that specific chain. The issue's line citation against `code_sync.py:36` is stale for the current tree.

Widening the search past `code_sync.py` to every file reachable from `main.py` (not just the one chain quoted in the issue) surfaces 4 real, lazy (function-scoped) `import aiohttp` call sites used for genuine production features:
- `autobot-slm-backend/user_management/services/vault_client.py:38` — SSO/system-secrets vault HTTP calls
- `autobot-slm-backend/services/a2a_card_fetcher.py:48,155` — A2A agent-card fetch
- `autobot-slm-backend/services/reconciler.py:1419-1436` (`_http_health_check`) — node health checks
- `autobot_shared/retry_mechanism.py:508-521` (`retry_network_operation`) — shared network-retry helper

Because these are lazy (deferred to call time), the app **builds** without `aiohttp` installed — which is why my static trace of the reachable-at-import-time graph is clean — but any one of these 4 code paths would `ImportError` the first time it actually ran in production (e.g. an admin viewing a vault-backed secret, an A2A card fetch, a node health-check poll). This is a real fresh-install bug independent of CI.

Given the fix-decision framework in this task:
- **Option 1 (declare the dependency)** is correct: aiohttp backs 4 genuine, non-optional production features, not one narrow optional path.
- **Option 2 (make it lazier)** is already the status quo at every call site and doesn't fix anything — the package is still missing, just the crash moves from CI to a user's browser.
- **Option 3 (route through `autobot_shared/http_client.py`, the canonical client `#12979` migrated ~120 `autobot-backend` sites onto)** is the *architecturally* correct long-term fix, but is a 4-site behavioral migration (timeout/pooling semantics change) out of scope for a dependency-declaration bug fix — filed as `#13134` instead of bundling into this PR.

I could not pinpoint the exact frame CI's build step crashes on without executing the app (barred by this task's execution constraint), but since the underlying package is genuinely missing and genuinely needed by reachable code, declaring it resolves the class of failure regardless of which exact frame triggers it in CI.

## What Changed

- `autobot-slm-backend/requirements.txt`: added `aiohttp>=3.14.3` (same floor as `autobot-backend/requirements.txt`'s existing pin, for cross-backend consistency), with a comment documenting the 4 real call sites and why it isn't optional. Split the "HTTP client (for health checks)" comment so it doesn't misattribute `aiohttp` usage to `httpx` (the actual health-check code path uses `aiohttp`, not `httpx`).

## Verification

- Only `autobot-slm-backend/requirements.txt` changed — no `.py` files touched, so `py_compile`/`flake8`/`black`/`isort` don't apply.
- Static AST-based import-graph trace (custom script, 148 files reachable from `autobot-slm-backend/main.py`, covering module/class/if/try scope): confirms no OTHER undeclared module-level 3rd-party import is reachable (`torchmetrics`, mentioned as a possible follow-on in #13118, does not appear anywhere in the SLM backend or `autobot_shared`).
- Per this task's execution constraint, I did not run the SLM backend, `dump_openapi.py`, or pytest locally — **`verify-generated-types-slm` going green is pending CI on this PR.**
- Filed `#13134` for converging the 4 ad-hoc `aiohttp.ClientSession` sites onto the canonical `autobot_shared/http_client.py` (the `#12979` pattern), plus the requirements.txt comment/code mismatch — out of scope here.

Closes #13118

## Model Used

Claude Sonnet 5