### PR TITLE
fix(deploy): run the TTS worker refresh with become (#12886)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1005,10 +1005,17 @@
     # changes — NOT the full role. Provisioning (service account, venv, torch and
     # pocket-tts installs, gated-model pre-download) is slow, needs network, and
     # must not re-run on a box that is already installed correctly.
+    # become is required and not inherited: this play sets no play-level become
+    # (unlike deploy-full.yml, which the role is normally applied under), and
+    # /opt/autobot/autobot-tts-worker is owned by the autobot-tts service
+    # account, not the autobot user ansible connects as. Without it the very
+    # first task fails "Destination /opt/autobot/autobot-tts-worker not
+    # writable" — the same wrong-user ownership class as #12872.
     - name: "[PLAY 2] TTS | Refresh deployed TTS worker service files (#12886)"
       ansible.builtin.include_role:
         name: tts-worker
         tasks_from: code_only
+      become: true
       when: "'npu' in group_names"
       tags: [tts, tts-worker, deploy]
 

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -113,3 +113,26 @@ def test_streaming_route_is_actually_in_the_template() -> None:
         "the route the backend calls is missing from the template — "
         "wiring the updater would deliver a worker that still 404s"
     )
+
+
+def test_tts_include_escalates_privilege() -> None:
+    """The include must run with become (#12886).
+
+    This play sets no play-level ``become`` — unlike deploy-full.yml, which the
+    role is normally applied under — and /opt/autobot/autobot-tts-worker is owned
+    by the autobot-tts service account, not the user ansible connects as. Without
+    it the first task dies with "Destination ... not writable" and the worker is
+    still never refreshed. Caught on a live run, not in review.
+    """
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+
+    for task in _iter_mappings(playbook):
+        inc = task.get("ansible.builtin.include_role") or task.get("include_role")
+        if isinstance(inc, dict) and inc.get("name") == "tts-worker":
+            assert task.get("become") is True, (
+                "the tts-worker include must set become: true — the deployed tree "
+                "is owned by a different service account"
+            )
+            return
+
+    raise AssertionError("no tts-worker include_role task found")


### PR DESCRIPTION
## Thinking Path

Follow-up to #13133, found by running the update on a live host immediately after merging it — not in review.

The wiring was right: the role is applied, and the task ran for the first time ever. It then failed on privilege:

```
TASK [[PLAY 2] TTS | Refresh deployed TTS worker service files (#12886)]
included: tts-worker for 00-SLM-Manager

TASK [tts-worker : TTS Worker | Deploy tts-worker.py]
fatal: FAILED! => {"msg": "Destination /opt/autobot/autobot-tts-worker not writable"}
```

Cause: `update-all-nodes.yml` sets **no play-level `become`**. `deploy-full.yml` — the playbook the tts-worker role is normally applied under — sets it at play level, so the role's tasks never needed their own. In PLAY 2 every component deploy sets `become: true` per task instead (e.g. `[PLAY 2] NPU | Deploy autobot-npu-worker`). My include didn't, and `/opt/autobot/autobot-tts-worker` is owned by the `autobot-tts` service account, not the user ansible connects as.

This is the same wrong-user ownership class as #12872, where the npu-worker rsync ran as `autobot` against an `autobot-npu`-owned tree.

Worth noting the failure moved rather than appeared: PLAY 2 previously died at the browser task (#12912). It now gets past NPU, runs the TTS refresh, and fails there — so this is the next step forward on the same play, not a regression.

## What Changed

**`playbooks/update-all-nodes.yml`** — the tts-worker include gains `become: true`, with a comment recording why it is required and not inherited.

**`tests/test_updater_refreshes_tts_worker_12886.py`** — one test asserting the include escalates, so this cannot regress silently.

## Verification

```
tests/test_updater_refreshes_tts_worker_12886.py .....
5 passed
```

The live evidence that motivated it is above: the exact ansible failure from the post-merge run. Delivery will be re-verified on the host after this merges — the #12959 probe reports `tts-worker (#12886)` as undelivered until `/tts/synthesize/stream` is actually served, so that entry flipping is the acceptance signal.

## Model Used

Claude Opus 5 (`claude-opus-5`)

## Follow-up

Closes #12886 — completes the delivery half begun in #13133.

`/tts/clone-voice` remains tracked separately as #13132 (implemented nowhere; 404s regardless of deploy state). Refs #12959, still open for the general repair.
