### PR TITLE
refactor(slm-frontend): consume the generated OpenAPI contract in the SLM API composables (#12420)

### DIFF
--- a/autobot-slm-frontend/src/composables/useApiKeyApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useApiKeyApi.test.ts
@@ -81,12 +81,24 @@ describe('useApiKeyApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
     expect(mockDelete).toHaveBeenCalledWith('/api-keys/abc')
   })
 
-  it('getScopes GETs /api-keys/scopes', async () => {
-    mockGet.mockResolvedValue({ read: 'Read access' })
+  // The endpoint returns APIScopesResponse — `{ scopes: { ... } }` — not the
+  // bare map (autobot-slm-backend/api/api_keys.py:118-121). The composable used
+  // to type the response as the bare map and hand the envelope straight to the
+  // scope picker, which then rendered one bogus entry keyed `scopes`.
+  it('getScopes unwraps the APIScopesResponse envelope into a bare scope map', async () => {
+    mockGet.mockResolvedValue({
+      scopes: { 'chat:use': 'Send and receive chat messages' },
+    })
 
     const result = await useApiKeyApi().getScopes()
 
     expect(mockGet).toHaveBeenCalledWith('/api-keys/scopes')
-    expect(result).toEqual({ read: 'Read access' })
+    expect(result).toEqual({ 'chat:use': 'Send and receive chat messages' })
+  })
+
+  it('getScopes yields an empty map when the envelope carries no scopes', async () => {
+    mockGet.mockResolvedValue({})
+
+    expect(await useApiKeyApi().getScopes()).toEqual({})
   })
 })

--- a/autobot-slm-frontend/src/composables/useApiKeyApi.ts
+++ b/autobot-slm-frontend/src/composables/useApiKeyApi.ts
@@ -17,49 +17,24 @@
  * `/login` — matching the previous per-composable axios interceptor that called
  * `authStore.logout()`. Call sites therefore pass endpoints relative to the API
  * base and receive parsed JSON directly (no axios `.data`).
+ *
+ * Contract types (#12420 Phase 3): every request/response shape below is
+ * DERIVED from the generated OpenAPI schema (`@/types/generated/api`), which is
+ * produced from the SLM backend's own Pydantic models and CI-guarded by
+ * `verify-generated-types-slm`. Do not hand-declare these — a backend schema
+ * change must surface here as a type error, not as a silent runtime mismatch.
+ * Re-run `npm run gen:types:openapi && npm run gen:types` after a backend change.
  */
 
 import slmApiClient from '@/utils/ApiClient'
+import type { components } from '@/types/generated/api'
 
-export interface APIKeyCreate {
-  name: string
-  description?: string
-  scopes: string[]
-  expires_days?: number
-}
-
-export interface APIKeyCreateResponse {
-  id: string
-  key: string
-  key_prefix: string
-  name: string
-  scopes: string[]
-  expires_at: string | null
-  created_at: string
-}
-
-export interface APIKeyResponse {
-  id: string
-  key_prefix: string
-  name: string
-  description: string | null
-  scopes: string[]
-  is_active: boolean
-  expires_at: string | null
-  last_used_at: string | null
-  usage_count: number
-  created_at: string
-}
-
-export interface APIKeyListResponse {
-  keys: APIKeyResponse[]
-  total: number
-}
-
-export interface APIKeyUpdate {
-  name?: string
-  description?: string
-}
+export type APIKeyCreate = components['schemas']['APIKeyCreate']
+export type APIKeyCreateResponse = components['schemas']['APIKeyCreateResponse']
+export type APIKeyResponse = components['schemas']['APIKeyResponse']
+export type APIKeyListResponse = components['schemas']['APIKeyListResponse']
+export type APIKeyUpdate = components['schemas']['APIKeyUpdate']
+export type APIScopesResponse = components['schemas']['APIScopesResponse']
 
 export function useApiKeyApi() {
   async function createKey(data: APIKeyCreate): Promise<APIKeyCreateResponse> {
@@ -85,8 +60,27 @@ export function useApiKeyApi() {
     await slmApiClient.delete(`/api-keys/${keyId}`)
   }
 
+  /**
+   * Available API-key scopes as a `{ scope: description }` map.
+   *
+   * The endpoint returns an ENVELOPE — `APIScopesResponse { scopes: dict }`
+   * (`autobot-slm-backend/api/api_keys.py:118-121`) — not the bare map. This
+   * composable previously typed the response as `Record<string, string>` and
+   * returned it unwrapped, so the scope picker in SecuritySettings.vue iterated
+   * the envelope and rendered a single bogus entry keyed `scopes`. Wiring the
+   * generated contract exposed that; unwrap here so callers keep the bare map.
+   *
+   * The backend declares `scopes` as an untyped `dict`, so the generated value
+   * type is `unknown`; the values are scope descriptions, normalised to string.
+   */
   async function getScopes(): Promise<Record<string, string>> {
-    return slmApiClient.get<Record<string, string>>('/api-keys/scopes')
+    const response = await slmApiClient.get<APIScopesResponse>('/api-keys/scopes')
+    return Object.fromEntries(
+      Object.entries(response.scopes ?? {}).map(([scope, description]) => [
+        scope,
+        String(description),
+      ])
+    )
   }
 
   return {

--- a/autobot-slm-frontend/src/composables/useLlmConfigApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useLlmConfigApi.test.ts
@@ -55,7 +55,12 @@ describe('useLlmConfigApi — migrated onto slmApiClient (#12420 Phase 2)', () =
   })
 
   it('testConnection POSTs the request to /settings/admin/llm/test', async () => {
-    const request = { provider: 'openai', api_key: 'k' }
+    const request = {
+      provider: 'openai',
+      api_key: 'k',
+      endpoint: 'https://api.openai.test',
+      model: 'gpt-4',
+    }
     mockPost.mockResolvedValue({ success: true })
 
     await useLlmConfigApi().testConnection(request)

--- a/autobot-slm-frontend/src/composables/useLlmConfigApi.ts
+++ b/autobot-slm-frontend/src/composables/useLlmConfigApi.ts
@@ -16,59 +16,24 @@
  * `/login` — matching the previous per-composable axios interceptor that called
  * `authStore.logout()`. Call sites therefore pass endpoints relative to the API
  * base and receive parsed JSON directly (no axios `.data`).
+ *
+ * Contract types (#12420 Phase 3): the request/response shapes below are DERIVED
+ * from the generated OpenAPI schema (`@/types/generated/api`), which is produced
+ * from the SLM backend's own Pydantic models and CI-guarded by
+ * `verify-generated-types-slm`. Do not hand-declare them — a backend schema
+ * change must surface here as a type error, not as a silent runtime mismatch.
  */
 
 import slmApiClient from '@/utils/ApiClient'
+import type { components } from '@/types/generated/api'
 
-export interface LLMProviderConfig {
-  name: string
-  enabled: boolean
-  api_key: string
-  endpoint: string
-  model: string
-  temperature: number
-  max_tokens: number
-}
-
-export interface LLMConfig {
-  active_provider: string
-  providers: LLMProviderConfig[]
-  ollama_host: string
-  ollama_port: number
-  gpu_models: string[]
-  cpu_models: string[]
-  max_loaded_models: number
-  num_parallel: number
-  keep_alive: string
-  flash_attention: boolean
-  kv_cache_type: string
-}
-
-export interface LLMConfigResponse {
-  config: LLMConfig
-  message: string
-}
-
-export interface LLMTestRequest {
-  provider: string
-  endpoint?: string
-  api_key?: string
-  model?: string
-}
-
-export interface LLMTestResponse {
-  success: boolean
-  message: string
-  provider: string
-  latency_ms: number | null
-}
-
-export interface LLMApplyResponse {
-  success: boolean
-  message: string
-  node_count: number
-  output: string | null
-}
+export type LLMProviderConfig = components['schemas']['LLMProviderConfig']
+export type LLMConfig = components['schemas']['LLMConfig']
+export type LLMConfigResponse = components['schemas']['LLMConfigResponse']
+export type LLMTestRequest = components['schemas']['LLMTestRequest']
+export type LLMTestResponse = components['schemas']['LLMTestResponse']
+export type LLMApplyRequest = components['schemas']['LLMApplyRequest']
+export type LLMApplyResponse = components['schemas']['LLMApplyResponse']
 
 export function useLlmConfigApi() {
   async function getConfig(): Promise<LLMConfigResponse> {
@@ -86,9 +51,8 @@ export function useLlmConfigApi() {
   }
 
   async function applyToFleet(nodeIds?: string[]): Promise<LLMApplyResponse> {
-    return slmApiClient.post<LLMApplyResponse>('/settings/admin/llm/apply', {
-      node_ids: nodeIds || null,
-    })
+    const body: LLMApplyRequest = { node_ids: nodeIds || null }
+    return slmApiClient.post<LLMApplyResponse>('/settings/admin/llm/apply', body)
   }
 
   return {

--- a/autobot-slm-frontend/src/composables/useMfaApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useMfaApi.test.ts
@@ -73,14 +73,17 @@ describe('useMfaApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
     expect(result).toEqual({ success: true, message: 'ok' })
   })
 
-  it('verifyLogin POSTs code + temp_token to /mfa/verify-login', async () => {
+  // The backend binds `temp_token` from the QUERY string (a bare `str` argument
+  // beside the Pydantic body model, autobot-slm-backend/api/mfa.py:96-99) — the
+  // generated contract lists it under `parameters.query`. Sending it in the body
+  // (the previous behaviour) makes the backend 422 on the missing query param.
+  it('verifyLogin sends temp_token as a query parameter and only `code` in the body', async () => {
     mockPost.mockResolvedValue({ success: true, message: 'ok', access_token: 't' })
 
     const result = await useMfaApi().verifyLogin('123456', 'temp-abc')
 
-    expect(mockPost).toHaveBeenCalledWith('/mfa/verify-login', {
+    expect(mockPost).toHaveBeenCalledWith('/mfa/verify-login?temp_token=temp-abc', {
       code: '123456',
-      temp_token: 'temp-abc',
     })
     expect(result.access_token).toBe('t')
   })

--- a/autobot-slm-frontend/src/composables/useMfaApi.ts
+++ b/autobot-slm-frontend/src/composables/useMfaApi.ts
@@ -14,25 +14,31 @@
  * resolves the base URL via `getSlmApiBase()` and injects the SLM bearer token
  * (same `slm_access_token` storage the auth store reads), so call sites pass
  * endpoints relative to the API base and receive parsed JSON directly.
+ *
+ * Contract types (#12420 Phase 3): the request/response shapes below are DERIVED
+ * from the generated OpenAPI schema (`@/types/generated/api`), which is produced
+ * from the SLM backend's own Pydantic models and CI-guarded by
+ * `verify-generated-types-slm`. Do not hand-declare them — a backend schema
+ * change must surface here as a type error, not as a silent runtime mismatch.
  */
 
 import slmApiClient from '@/utils/ApiClient'
 import { useAuthStore } from '@/stores/auth'
 import { createAuthGuard } from '@/utils/slmAuthGuard'
+import type { components } from '@/types/generated/api'
 
-export interface MFASetupResponse {
-  secret: string
-  otpauth_uri: string
-  backup_codes: string[]
-}
+export type MFASetupResponse = components['schemas']['MFASetupResponse']
+export type MFAStatusResponse = components['schemas']['MFAStatusResponse']
+export type MFAVerifyRequest = components['schemas']['MFAVerifyRequest']
+export type MFADisableRequest = components['schemas']['MFADisableRequest']
+export type BackupCodesResponse = components['schemas']['BackupCodesResponse']
 
-export interface MFAStatusResponse {
-  enabled: boolean
-  method: string
-  backup_codes_remaining: number
-  last_verified_at: string | null
-}
-
+/**
+ * `POST /mfa/verify-login` and `/mfa/verify-setup` declare no response_model on
+ * the backend, so the generated response type is an untyped object and there is
+ * no schema to derive from — these two shapes stay hand-declared until the
+ * backend types the endpoints.
+ */
 export interface MFAVerifyResponse {
   success: boolean
   message: string
@@ -56,28 +62,43 @@ export function useMfaApi() {
   async function verifySetup(
     code: string
   ): Promise<{ success: boolean; message: string }> {
+    const body: MFAVerifyRequest = { code }
     return withAuthGuard(() =>
       slmApiClient.post<{ success: boolean; message: string }>(
         '/mfa/verify-setup',
-        { code }
+        body
       )
     )
   }
 
+  /**
+   * Verify the MFA code during login.
+   *
+   * `temp_token` is a QUERY parameter, not a body field: the backend declares it
+   * as a bare `str` argument alongside the Pydantic body model
+   * (`autobot-slm-backend/api/mfa.py:96-99`), which FastAPI binds from the query
+   * string — the generated contract confirms it
+   * (`operations.verify_mfa_login_api_mfa_verify_login_post.parameters.query`).
+   * It used to be sent in the JSON body, which the backend rejects with a 422
+   * for the missing required query parameter.
+   */
   async function verifyLogin(
     code: string,
     tempToken: string
   ): Promise<MFAVerifyResponse> {
+    const body: MFAVerifyRequest = { code }
+    const query = new URLSearchParams({ temp_token: tempToken })
     return withAuthGuard(() =>
-      slmApiClient.post<MFAVerifyResponse>('/mfa/verify-login', {
-        code,
-        temp_token: tempToken,
-      })
+      slmApiClient.post<MFAVerifyResponse>(
+        `/mfa/verify-login?${query.toString()}`,
+        body
+      )
     )
   }
 
   async function disableMFA(password: string): Promise<void> {
-    await withAuthGuard(() => slmApiClient.post('/mfa/disable', { password }))
+    const body: MFADisableRequest = { password }
+    await withAuthGuard(() => slmApiClient.post('/mfa/disable', body))
   }
 
   async function getMFAStatus(): Promise<MFAStatusResponse> {
@@ -88,11 +109,10 @@ export function useMfaApi() {
 
   async function regenerateBackupCodes(
     password: string
-  ): Promise<{ backup_codes: string[] }> {
+  ): Promise<BackupCodesResponse> {
+    const body: MFADisableRequest = { password }
     return withAuthGuard(() =>
-      slmApiClient.post<{ backup_codes: string[] }>('/mfa/backup-codes', {
-        password,
-      })
+      slmApiClient.post<BackupCodesResponse>('/mfa/backup-codes', body)
     )
   }
 

--- a/autobot-slm-frontend/src/composables/useSecretsApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSecretsApi.test.ts
@@ -46,7 +46,7 @@ describe('useSecretsApi — migrated onto slmApiClient (#12420 Phase 2)', () => 
   })
 
   it('createSecret POSTs the payload to /secrets', async () => {
-    const payload = { key: 'HF_TOKEN', value: 'x' }
+    const payload = { key: 'HF_TOKEN', value: 'x', category: 'system' }
     mockPost.mockResolvedValue({ id: 1 })
 
     await useSecretsApi().createSecret(payload)

--- a/autobot-slm-frontend/src/composables/useSecretsApi.ts
+++ b/autobot-slm-frontend/src/composables/useSecretsApi.ts
@@ -15,43 +15,30 @@
  * redirect to `/login`) — matching the previous axios interceptor that called
  * `authStore.logout()`. Call sites pass endpoints relative to the API base and
  * receive parsed JSON directly.
+ *
+ * Contract types (#12420 Phase 3): the request/response shapes below are DERIVED
+ * from the generated OpenAPI schema (`@/types/generated/api`), which is produced
+ * from the SLM backend's own Pydantic models and CI-guarded by
+ * `verify-generated-types-slm`. Do not hand-declare them — a backend schema
+ * change must surface here as a type error, not as a silent runtime mismatch.
  */
 
 import slmApiClient from '@/utils/ApiClient'
+import type { components } from '@/types/generated/api'
 
-export interface SecretCreate {
-  key: string
-  value: string
-  category?: string
-  description?: string
-}
+export type SecretCreate = components['schemas']['SecretCreate']
+export type SecretUpdate = components['schemas']['SecretUpdate']
+export type SecretResponse = components['schemas']['SecretResponse']
+export type ApplySecretsRequest = components['schemas']['ApplySecretsRequest']
+export type ApplySecretsResult = components['schemas']['ApplySecretsResponse']
 
-export interface SecretUpdate {
-  value?: string
-  category?: string
-  description?: string
-}
-
-export interface SecretResponse {
-  id: number
-  key: string
-  category: string
-  description: string | null
-  created_at: string
-  updated_at: string
-}
-
+/**
+ * `GET /secrets/dependent-roles` returns an untyped `dict` (the backend
+ * declares no response_model), so there is no generated schema to derive from —
+ * this shape stays hand-declared until the backend types the endpoint.
+ */
 export interface DependentRolesMapping {
   mapping: Record<string, string[]>
-}
-
-export interface ApplySecretsResult {
-  success: boolean
-  key: string
-  dependent_roles: string[]
-  target_node_ids: string[]
-  output: string
-  returncode: number
 }
 
 export function useSecretsApi() {
@@ -82,7 +69,8 @@ export function useSecretsApi() {
   }
 
   async function applySecret(key: string): Promise<ApplySecretsResult> {
-    return slmApiClient.post<ApplySecretsResult>('/secrets/apply', { key })
+    const body: ApplySecretsRequest = { key }
+    return slmApiClient.post<ApplySecretsResult>('/secrets/apply', body)
   }
 
   return {

--- a/autobot-slm-frontend/src/composables/useSlmUserApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmUserApi.ts
@@ -17,76 +17,36 @@
  * `authStore.logout()`. Query parameters (skip/limit) are serialised onto the
  * endpoint since the canonical client takes a relative path, not an axios
  * `params` object; call sites receive parsed JSON directly.
+ *
+ * Contract types (#12420 Phase 3): the request/response shapes below are DERIVED
+ * from the generated OpenAPI schema (`@/types/generated/api`), which is produced
+ * from the SLM backend's own Pydantic models and CI-guarded by
+ * `verify-generated-types-slm`. Do not hand-declare them — a backend schema
+ * change must surface here as a type error, not as a silent runtime mismatch.
  */
 
 import slmApiClient from '@/utils/ApiClient'
+import type { components } from '@/types/generated/api'
 
 // =============================================================================
-// Type Definitions
+// Type Definitions — derived from the generated OpenAPI contract
 // =============================================================================
 
-export interface RoleResponse {
-  id: string
-  name: string
-  description: string | null
-  is_system: boolean
-}
+// Both /slm-users and /autobot-users serve the `autobot_shared` user schemas
+// (the generated names are FastAPI's disambiguation of two same-named models).
+export type RoleResponse =
+  components['schemas']['autobot_shared__user_management__schemas__user__RoleResponse']
+export type SlmUserResponse =
+  components['schemas']['autobot_shared__user_management__schemas__user__UserResponse']
+export type SlmUserListResponse = components['schemas']['UserListResponse']
+export type CreateUserPayload =
+  components['schemas']['autobot_shared__user_management__schemas__user__UserCreate']
+export type PasswordChange = components['schemas']['PasswordChange']
 
-export interface SlmUserResponse {
-  id: string
-  email: string
-  username: string
-  display_name: string | null
-  bio: string | null
-  avatar_url: string | null
-  org_id: string | null
-  is_active: boolean
-  is_verified: boolean
-  mfa_enabled: boolean
-  is_platform_admin: boolean
-  preferences: Record<string, unknown>
-  roles: RoleResponse[]
-  last_login_at: string | null
-  created_at: string
-  updated_at: string
-}
-
-export interface SlmUserListResponse {
-  users: SlmUserResponse[]
-  total: number
-  limit: number
-  offset: number
-}
-
-export interface TeamResponse {
-  id: string
-  name: string
-  description: string | null
-  organization_id: string | null
-  created_at: string
-  updated_at: string
-}
-
-export interface TeamListResponse {
-  teams: TeamResponse[]
-  total: number
-  limit: number
-  offset: number
-}
-
-export interface CreateUserPayload {
-  email: string
-  username: string
-  password: string
-  display_name?: string
-  role_ids?: string[]
-}
-
-export interface CreateTeamPayload {
-  name: string
-  description?: string
-  organization_id?: string
-}
+export type TeamResponse = components['schemas']['TeamResponse']
+export type TeamListResponse = components['schemas']['TeamListResponse']
+export type CreateTeamPayload = components['schemas']['TeamCreate']
+export type TeamMemberAdd = components['schemas']['TeamMemberAdd']
 
 // Serialise pagination params onto the endpoint (the canonical client takes a
 // relative path, not an axios `params` object).
@@ -116,7 +76,8 @@ export function useSlmUserApi() {
   }
 
   async function changeSlmUserPassword(userId: string, newPassword: string): Promise<void> {
-    await slmApiClient.post(`/slm-users/${userId}/change-password`, { new_password: newPassword })
+    const body: PasswordChange = { new_password: newPassword }
+    await slmApiClient.post(`/slm-users/${userId}/change-password`, body)
   }
 
   // ===========================================================================
@@ -136,7 +97,8 @@ export function useSlmUserApi() {
   }
 
   async function changeAutobotUserPassword(userId: string, newPassword: string): Promise<void> {
-    await slmApiClient.post(`/autobot-users/${userId}/change-password`, { new_password: newPassword })
+    const body: PasswordChange = { new_password: newPassword }
+    await slmApiClient.post(`/autobot-users/${userId}/change-password`, body)
   }
 
   // ===========================================================================
@@ -160,10 +122,8 @@ export function useSlmUserApi() {
     userId: string,
     role = 'member'
   ): Promise<void> {
-    await slmApiClient.post(`/autobot-teams/${teamId}/members`, {
-      user_id: userId,
-      role,
-    })
+    const body: TeamMemberAdd = { user_id: userId, role }
+    await slmApiClient.post(`/autobot-teams/${teamId}/members`, body)
   }
 
   async function removeTeamMember(teamId: string, userId: string): Promise<void> {

--- a/autobot-slm-frontend/src/composables/useSsoApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSsoApi.test.ts
@@ -63,7 +63,15 @@ describe('useSsoApi — migrated onto slmApiClient (#12420 Phase 2)', () => {
   })
 
   it('createProvider POSTs the payload to /sso-providers', async () => {
-    const payload = { provider_type: 'oauth2', name: 'g', config: {} }
+    const payload = {
+      provider_type: 'oauth2',
+      name: 'g',
+      config: {},
+      is_active: true,
+      is_social: false,
+      allow_user_creation: true,
+      default_role: 'user',
+    }
     mockPost.mockResolvedValue({ id: '1' })
 
     await useSsoApi().createProvider(payload)

--- a/autobot-slm-frontend/src/composables/useSsoApi.ts
+++ b/autobot-slm-frontend/src/composables/useSsoApi.ts
@@ -20,65 +20,37 @@
  * 401 there is a credential failure, not a rejected session), so the SSO login
  * flow methods that hit `/auth/sso/**` wrap their call in `withAuthGuard` to
  * preserve the historic "logout on 401" behavior explicitly.
+ *
+ * Contract types (#12420 Phase 3): the request/response shapes below are DERIVED
+ * from the generated OpenAPI schema (`@/types/generated/api`), which is produced
+ * from the SLM backend's own Pydantic models and CI-guarded by
+ * `verify-generated-types-slm`. Do not hand-declare them — a backend schema
+ * change must surface here as a type error, not as a silent runtime mismatch.
  */
 
 import slmApiClient from '@/utils/ApiClient'
 import { useAuthStore } from '@/stores/auth'
 import { createAuthGuard } from '@/utils/slmAuthGuard'
+import type { components } from '@/types/generated/api'
 
 // =============================================================================
-// Type Definitions
+// Type Definitions — derived from the generated OpenAPI contract
 // =============================================================================
 
-export interface SSOProviderResponse {
-  id: string
-  org_id: string | null
-  provider_type: string
-  name: string
-  is_active: boolean
-  is_social: boolean
-  allow_user_creation: boolean
-  default_role: string | null
-  group_mapping: Record<string, string>
-  last_sync_at: string | null
-  created_at: string
-  updated_at: string
-}
+export type SSOProviderResponse = components['schemas']['SSOProviderResponse']
+export type SSOProviderListResponse = components['schemas']['SSOProviderListResponse']
+export type SSOProviderCreate = components['schemas']['SSOProviderCreate']
+export type SSOProviderUpdate = components['schemas']['SSOProviderUpdate']
+export type SSOLoginInitResponse = components['schemas']['SSOLoginInitResponse']
+export type SSOTestResponse = components['schemas']['SSOTestResponse']
+export type SSOProviderHealthResponse = components['schemas']['SSOProviderHealthResponse']
+export type LDAPLoginRequest = components['schemas']['LDAPLoginRequest']
 
-export interface SSOProviderListResponse {
-  providers: SSOProviderResponse[]
-  total: number
-}
-
-export interface SSOProviderCreate {
-  provider_type: string
-  name: string
-  config: Record<string, unknown>
-  org_id?: string
-  is_active?: boolean
-  is_social?: boolean
-  allow_user_creation?: boolean
-  default_role?: string
-  group_mapping?: Record<string, string>
-}
-
-export interface SSOProviderUpdate {
-  name?: string
-  config?: Record<string, unknown>
-  is_active?: boolean
-  allow_user_creation?: boolean
-  default_role?: string
-  group_mapping?: Record<string, string>
-}
-
-export interface SSOLoginInitResponse {
-  provider_id: string
-  provider_type: string
-  provider_name: string
-  redirect_url: string
-  state: string | null
-}
-
+/**
+ * `GET /auth/sso/providers` and `POST /auth/sso/ldap/login` declare no
+ * response_model on the backend, so there is no generated schema to derive from
+ * — these two shapes stay hand-declared until the backend types the endpoints.
+ */
 export interface ActiveProvider {
   id: string
   name: string
@@ -86,25 +58,10 @@ export interface ActiveProvider {
   is_social: boolean
 }
 
-export interface SSOTestResponse {
-  success: boolean
-  message: string
-  details?: Record<string, unknown>
-}
-
 interface LDAPLoginResponse {
   access_token: string
   token_type: string
   expires_in: number
-}
-
-export interface SSOProviderHealthResponse {
-  provider_id: string
-  name: string
-  success_count: number
-  failure_count: number
-  last_success_at: string | null
-  health_status: 'healthy' | 'warning' | 'error' | 'unknown'
 }
 
 // =============================================================================
@@ -193,12 +150,13 @@ export function useSsoApi() {
     username: string,
     password: string
   ): Promise<LDAPLoginResponse> {
+    const body: LDAPLoginRequest = {
+      provider_id: providerId,
+      username,
+      password,
+    }
     return withAuthGuard(() =>
-      slmApiClient.post<LDAPLoginResponse>('/auth/sso/ldap/login', {
-        provider_id: providerId,
-        username,
-        password,
-      })
+      slmApiClient.post<LDAPLoginResponse>('/auth/sso/ldap/login', body)
     )
   }
 

--- a/autobot-slm-frontend/src/composables/useTimezone.ts
+++ b/autobot-slm-frontend/src/composables/useTimezone.ts
@@ -55,8 +55,12 @@ export function ensureTimezone(): Promise<void> {
 /**
  * Format an ISO date string using the fleet-configured timezone.
  * Falls back to browser locale if timezone is not yet loaded.
+ *
+ * Accepts `undefined` as well as `null`: the generated OpenAPI contract models
+ * nullable backend timestamps as optional (`expires_at?: string | null`), so
+ * call sites forward possibly-absent values here (#12420).
  */
-export function formatDateTime(dateStr: string | null): string {
+export function formatDateTime(dateStr: string | null | undefined): string {
   if (!dateStr) return 'Never'
   const date = new Date(dateStr)
   if (isNaN(date.getTime())) return dateStr

--- a/autobot-slm-frontend/src/stores/auth.test.ts
+++ b/autobot-slm-frontend/src/stores/auth.test.ts
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Auth store — MFA login transport contract (#12420).
+ *
+ * `POST /api/mfa/verify-login` binds `temp_token` from the QUERY string: the
+ * backend declares it as a bare `str` argument beside the Pydantic body model
+ * (`autobot-slm-backend/api/mfa.py:96-99`), which FastAPI treats as a query
+ * parameter, and the generated OpenAPI contract lists it under
+ * `operations.verify_mfa_login_api_mfa_verify_login_post.parameters.query`.
+ *
+ * The store used to send it in the JSON body, so the backend rejected every MFA
+ * login with a 422 for the missing required query parameter. These tests drive
+ * the full mfa-pending → verify flow and pin the request shape so it cannot
+ * regress into the body again.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useAuthStore } from './auth'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockFetch = vi.fn()
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+describe('authStore.completeMFALogin — verify-login transport contract (#12420)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    sessionStorage.clear()
+    localStorage.clear()
+    mockFetch.mockReset()
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  /** Drive `login()` so the store holds a temp token, then verify the MFA code. */
+  async function loginThenVerify(tempToken: string, code: string): Promise<boolean> {
+    const store = useAuthStore()
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ requires_mfa: true, temp_token: tempToken })
+    )
+    await store.login('admin', 'pw')
+
+    // verify-login, then the fetchCurrentUser() follow-up call.
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: 'final-token', token_type: 'bearer', expires_in: 3600 })
+    )
+    mockFetch.mockResolvedValueOnce(jsonResponse({ username: 'admin', is_admin: true }))
+    return store.completeMFALogin(code)
+  }
+
+  it('sends temp_token as a query parameter, not a body field', async () => {
+    await loginThenVerify('temp-abc', '123456')
+
+    const [url, init] = mockFetch.mock.calls[1]
+    expect(url).toContain('/api/mfa/verify-login?temp_token=temp-abc')
+    expect(JSON.parse(init.body)).toEqual({ code: '123456' })
+    expect(JSON.parse(init.body)).not.toHaveProperty('temp_token')
+  })
+
+  it('URL-encodes a temp token containing query-unsafe characters', async () => {
+    await loginThenVerify('a+b/c=d', '123456')
+
+    const [url] = mockFetch.mock.calls[1]
+    expect(url).toContain('temp_token=a%2Bb%2Fc%3Dd')
+  })
+
+  it('stores the returned access token and clears the pending MFA state', async () => {
+    const store = useAuthStore()
+    const result = await loginThenVerify('temp-abc', '123456')
+
+    expect(result).toBe(true)
+    expect(store.token).toBe('final-token')
+    expect(sessionStorage.getItem('slm_access_token')).toBe('final-token')
+    expect(store.mfaPending).toBe(false)
+  })
+})

--- a/autobot-slm-frontend/src/stores/auth.ts
+++ b/autobot-slm-frontend/src/stores/auth.ts
@@ -113,11 +113,21 @@ export const useAuthStore = defineStore('auth', () => {
     loading.value = true
     error.value = null
     try {
-      const response = await fetch(`${getApiUrl()}/api/mfa/verify-login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code, temp_token: mfaTempToken.value }),
-      })
+      // `temp_token` is a QUERY parameter, not a body field: the backend
+      // declares it as a bare `str` argument beside the Pydantic body model
+      // (autobot-slm-backend/api/mfa.py:96-99), which FastAPI binds from the
+      // query string. The generated contract confirms it under
+      // `parameters.query`. Sending it in the body 422s on the missing
+      // required query parameter, blocking MFA login entirely (#12420).
+      const query = new URLSearchParams({ temp_token: mfaTempToken.value })
+      const response = await fetch(
+        `${getApiUrl()}/api/mfa/verify-login?${query.toString()}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        }
+      )
       if (!response.ok) {
         const data = await response.json()
         throw new Error(data.detail || 'MFA verification failed')

--- a/autobot-slm-frontend/src/views/settings/SecuritySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/SecuritySettings.vue
@@ -216,7 +216,7 @@ function copyToClipboard(text: string): void {
   setTimeout(() => (success.value = null), 3000)
 }
 
-function formatDate(dateStr: string | null): string {
+function formatDate(dateStr: string | null | undefined): string {
   return formatDateTime(dateStr)
 }
 

--- a/autobot-slm-frontend/src/views/settings/admin/SSOSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/SSOSettings.vue
@@ -306,6 +306,9 @@ async function saveProvider(): Promise<void> {
         is_active: formData.is_active,
         allow_user_creation: formData.allow_user_creation,
         default_role: formData.default_role,
+        // Neither form collects `is_social`; the contract requires it, so state
+        // the backend default explicitly rather than relying on omission.
+        is_social: false,
         config,
       }
       await api.createProvider(createData)

--- a/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
@@ -512,7 +512,7 @@ async function refreshActiveTab(): Promise<void> {
   else await loadTeams()
 }
 
-function formatDate(dateStr: string | null): string {
+function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return 'Never'
   return formatDateTime(dateStr)
 }

--- a/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
@@ -451,6 +451,9 @@ async function createSsoProvider(): Promise<void> {
       is_active: newProviderForm.is_active,
       allow_user_creation: newProviderForm.allow_user_creation,
       default_role: newProviderForm.default_role,
+      // This form does not collect `is_social`; the contract requires it, so
+      // state the backend default explicitly rather than relying on omission.
+      is_social: false,
     }
 
     await ssoApi.createProvider(payload)


### PR DESCRIPTION
Closes #13141 — the discrete, fully-delivered slice of #12420 (recommendation 3, for the composables already on `slmApiClient`).

#12420 itself stays OPEN: its remainder is tracked by #13138 (114 hand-typed shapes still shadowing a generated schema), #13140 (~52 call sites still bypassing the client, blocking the lint rule) and #13139 (5 backend endpoints with no `response_model`). Partial delivery never closes the parent.

## Thinking Path

#12420 was filed when the SLM frontend had no HTTP-client abstraction and no type generation at all. Both premises are now stale, so the first step was to re-measure rather than re-implement.

**What the issue claimed vs. what is true on `Dev_new_gui` (`f27b1b0b2`):**

| Issue claim | Measured today |
|---|---|
| "0 client classes (no ApiClient at all)" | `SlmApiClient` exists — `autobot-slm-frontend/src/utils/ApiClient.ts:69`, singleton at `:417`, imported by ~20 modules |
| "no `gen:types` script" | `package.json` has `gen:types:openapi` + `gen:types` + `verify:types` (landed in #13075) |
| "`src/types/generated/` DOES NOT EXIST" | `src/types/generated/api.ts` exists, 309 schemas, CI-guarded by `verify-generated-types-slm` |
| "51/167 files raw-fetch" | 197 source files; ~40 SLM-backend raw-`fetch` sites remain (recommendation 2, partly done) |
| "23 hand-typed responses" | 411 hand-declared types, **120** of which shadow a generated schema by exact name |
| "record as an ADR" | done — ADR-008 (#13077) |

So recommendations 1 (type generation) and 5 (ADR) are complete, 2 (one transport client) is largely complete, and the untouched gap is **recommendation 3: nothing actually consumed the generated contract.** Exactly one symbol did — `NodeStatus` at `src/types/slm.ts:21`. 308 schemas were dead weight while 120 hand-declared interfaces shadowed them, free to drift with nothing to catch it — precisely the failure mode the issue predicted.

This PR closes that gap for the composables already routed through the canonical client, so `vue-tsc` (a required check via `slm-frontend-check.yml`) now fails when the SLM backend's schema moves.

Endpoint→schema mappings were read out of the generated `operations` block, not guessed, which is how the two defects below surfaced.

**Not in scope (deliberate):** ADR-008 fixes one client per (app, backend) pair, so the SLM's `ApiClient` stays separate from the main frontend's. The 7 components carrying a forked **autobot-backend** transport are #13079 — a different backend — and are untouched here.

## What Changed

**Contract types derived from `components['schemas'][...]` (7 composables, 39 types):**

| File | Types |
|---|---|
| `useApiKeyApi.ts` | `APIKeyCreate`, `APIKeyCreateResponse`, `APIKeyResponse`, `APIKeyListResponse`, `APIKeyUpdate`, `APIScopesResponse` |
| `useSecretsApi.ts` | `SecretCreate`, `SecretUpdate`, `SecretResponse`, `ApplySecretsRequest`, `ApplySecretsResult`→`ApplySecretsResponse` |
| `useLlmConfigApi.ts` | `LLMProviderConfig`, `LLMConfig`, `LLMConfigResponse`, `LLMTestRequest`, `LLMTestResponse`, `LLMApplyRequest`, `LLMApplyResponse` |
| `useMfaApi.ts` | `MFASetupResponse`, `MFAStatusResponse`, `MFAVerifyRequest`, `MFADisableRequest`, `BackupCodesResponse` |
| `useSsoApi.ts` | `SSOProviderResponse`, `SSOProviderListResponse`, `SSOProviderCreate`, `SSOProviderUpdate`, `SSOLoginInitResponse`, `SSOTestResponse`, `SSOProviderHealthResponse`, `LDAPLoginRequest` |
| `useSlmUserApi.ts` | `RoleResponse`, `SlmUserResponse`, `SlmUserListResponse`, `CreateUserPayload`, `PasswordChange`, `TeamResponse`, `TeamListResponse`, `CreateTeamPayload`, `TeamMemberAdd` |

Request bodies that were untyped object literals (`applyToFleet`, `disableMFA`, `loginWithLDAP`, both `change*Password`, `addTeamMember`, `applySecret`) are now typed against their contract schema, so a renamed backend field becomes a compile error instead of a silently ignored payload.

Shapes whose endpoints declare **no** `response_model` cannot be derived and stay hand-declared with a comment saying why: `DependentRolesMapping`, `MFAVerifyResponse`, `ActiveProvider`, `LDAPLoginResponse`.

**Two genuine defects the contract exposed, fixed here:**

1. **The API-key scope picker was unusable.** `GET /api-keys/scopes` returns the envelope `APIScopesResponse { scopes }` (`autobot-slm-backend/api/api_keys.py:118-121`), but `useApiKeyApi.getScopes()` typed it as the bare map and returned it unwrapped. `SecuritySettings.vue:715` then ran `v-for="(description, scope) in availableScopes"` over the envelope, rendering exactly one bogus checkbox keyed `scopes` — no real scope was ever selectable when creating an API key. Now unwrapped. The existing test mocked the wrong shape (`{ read: 'Read access' }`), validating the frontend's mistaken assumption rather than the backend; it is replaced with two tests against the real envelope.

2. **SLM MFA login could never complete.** `POST /api/mfa/verify-login` binds `temp_token` from the **query string** — the backend declares it as a bare `str` beside the Pydantic body model (`autobot-slm-backend/api/mfa.py:96-99`), which FastAPI treats as a query parameter, and the generated contract lists it under `operations.verify_mfa_login_api_mfa_verify_login_post.parameters.query`. Both call sites sent it in the JSON body, so the backend rejected every attempt with a 422 for the missing required query parameter. Fixed in `stores/auth.ts:112` (`completeMFALogin`, the live login path) and in `useMfaApi.verifyLogin`. A new `src/stores/auth.test.ts` drives the full mfa-pending → verify flow and pins the request shape, including URL-encoding of query-unsafe token characters.

**Consumer adjustments the contract required:**
- `formatDateTime` (`useTimezone.ts`) and the two local `formatDate` wrappers accept `undefined` as well as `null` — generated nullable timestamps are optional (`expires_at?: string | null`). All three bodies already handled absent values.
- The two SSO provider-create payloads state `is_social: false` explicitly. The contract requires the field and neither form collects it, so this pins the backend default rather than relying on omission — identical wire semantics.

## Verification

Run in `autobot-slm-frontend/`.

**Before** (pristine `origin/Dev_new_gui`, swapped in with `cp` from `git archive` — never `git stash`):
```
npm run type-check  -> clean
npm run test:unit   -> Test Files 25 passed (25) | Tests 203 passed (203)
npm run lint        -> 16 problems (0 errors, 16 warnings)
```

**After:**
```
npm run type-check  -> clean
npm run test:unit   -> Test Files 26 passed (26) | Tests 207 passed (207)
npm run lint        -> 16 problems (0 errors, 16 warnings)
```

+4 tests: 3 new in `stores/auth.test.ts`, +1 from splitting the `getScopes` test.

Lint findings were diffed line-for-line between the `cp`-swapped baseline tree and the final tree — **identical 18-line finding set**, so no pre-existing warning was masked and none was added.

`verify-generated-types-slm` still holds: `git diff --exit-code src/types/generated/api.ts` is clean. The generated file was read but never edited, and no regeneration was needed because no backend schema changed.

Per the #13090 execution constraint no AutoBot application code was run — no backend, no SLM backend, no schema dump. The contract was read from the committed generated artefact and cross-checked against backend source.

## Model Used

claude-opus-5
