### PR TITLE
fix(deploy): escalate the TTS include via apply, not a bare become (#12886)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1015,7 +1015,12 @@
       ansible.builtin.include_role:
         name: tts-worker
         tasks_from: code_only
-      become: true
+        # `become` is NOT a valid task keyword on include_role (a dynamic
+        # include) — ansible rejects the whole playbook with "'become' is not a
+        # valid attribute for a IncludeRole", which breaks every self-update.
+        # `apply` is how privilege is handed to the included tasks.
+        apply:
+          become: true
       when: "'npu' in group_names"
       tags: [tts, tts-worker, deploy]
 

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -137,8 +137,7 @@ def test_tts_include_escalates_privilege() -> None:
         inc = task.get("ansible.builtin.include_role") or task.get("include_role")
         if isinstance(inc, dict) and inc.get("name") == "tts-worker":
             assert task.get("become") is None, (
-                "bare `become:` on include_role makes ansible reject the whole "
-                "playbook — use apply: {become: true}"
+                "bare `become:` on include_role makes ansible reject the whole " "playbook — use apply: {become: true}"
             )
             assert (inc.get("apply") or {}).get("become") is True, (
                 "the tts-worker include must escalate via apply: {become: true} — "
@@ -168,6 +167,4 @@ def test_playbook_passes_ansible_syntax_check() -> None:
         timeout=180,
     )
 
-    assert result.returncode == 0, (
-        f"ansible rejected the playbook:\n{result.stderr[-1200:]}"
-    )
+    assert result.returncode == 0, f"ansible rejected the playbook:\n{result.stderr[-1200:]}"

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -23,6 +23,8 @@ role's provisioning half would still not land. This closes the code half only.
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -116,23 +118,56 @@ def test_streaming_route_is_actually_in_the_template() -> None:
 
 
 def test_tts_include_escalates_privilege() -> None:
-    """The include must run with become (#12886).
+    """The include must escalate, via ``apply`` (#12886).
 
     This play sets no play-level ``become`` — unlike deploy-full.yml, which the
     role is normally applied under — and /opt/autobot/autobot-tts-worker is owned
     by the autobot-tts service account, not the user ansible connects as. Without
-    it the first task dies with "Destination ... not writable" and the worker is
-    still never refreshed. Caught on a live run, not in review.
+    escalation the first task dies "Destination ... not writable".
+
+    It must be ``apply: {become: true}``, NOT a bare ``become:`` task keyword:
+    ``become`` is not valid on include_role, and ansible rejects the ENTIRE
+    playbook with "'become' is not a valid attribute for a IncludeRole" — which
+    breaks every self-update, not just this task. Both mistakes were made on a
+    live host before this test existed.
     """
     playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
 
     for task in _iter_mappings(playbook):
         inc = task.get("ansible.builtin.include_role") or task.get("include_role")
         if isinstance(inc, dict) and inc.get("name") == "tts-worker":
-            assert task.get("become") is True, (
-                "the tts-worker include must set become: true — the deployed tree "
-                "is owned by a different service account"
+            assert task.get("become") is None, (
+                "bare `become:` on include_role makes ansible reject the whole "
+                "playbook — use apply: {become: true}"
+            )
+            assert (inc.get("apply") or {}).get("become") is True, (
+                "the tts-worker include must escalate via apply: {become: true} — "
+                "the deployed tree is owned by a different service account"
             )
             return
 
     raise AssertionError("no tts-worker include_role task found")
+
+
+def test_playbook_passes_ansible_syntax_check() -> None:
+    """Validate with ansible itself, not just a YAML parse (#12886).
+
+    A YAML-valid playbook can still be semantically invalid — a bare `become:`
+    on include_role parses fine and then breaks every self-update at run time.
+    Only ansible's own parser catches that class, so gate on it here.
+    """
+    ansible = shutil.which("ansible-playbook")
+    if ansible is None:
+        pytest.skip("ansible-playbook not installed")
+
+    result = subprocess.run(
+        [ansible, "--syntax-check", "-i", "localhost,", str(_PLAYBOOK)],
+        capture_output=True,
+        text=True,
+        cwd=_ANSIBLE,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, (
+        f"ansible rejected the playbook:\n{result.stderr[-1200:]}"
+    )


### PR DESCRIPTION
## Thinking Path

Hotfix for a regression I introduced in #13136.

That PR added `become: true` as a **task keyword** on `include_role`. It is not valid there, and ansible rejects the whole playbook rather than just the task:

```
ERROR! 'become' is not a valid attribute for a IncludeRole
```

So after #13136 merged, **every self-update failed at parse time** — the transient unit exited `4/NOPERMISSION` with no plays run at all. That is strictly worse than the permission error it was meant to fix: #13136 broke one task, this broke the entire updater.

Escalation for a dynamic include belongs in `apply`, which hands the keyword to the included tasks.

**Why it got through review and CI.** The tests I added parse the playbook as YAML and assert structure. `become:` in that position is perfectly valid YAML — it is only invalid to ansible's own parser. Nothing in the suite ran ansible. That is the actual gap, so this adds a `--syntax-check` test rather than just correcting the keyword.

Found by running the update on a live host immediately after merging #13136 — the second time in this sequence that a live run caught what review did not.

## What Changed

**`playbooks/update-all-nodes.yml`** — the tts-worker include escalates via `apply: {become: true}`, with a comment naming the failure mode so the bare form is not reintroduced.

**`tests/test_updater_refreshes_tts_worker_12886.py`**
- the privilege test now asserts `apply.become is True` **and** that a bare `become` is absent, since the bare form is the one that breaks everything;
- new `test_playbook_passes_ansible_syntax_check` runs `ansible-playbook --syntax-check`, skipping cleanly when ansible is unavailable.

## Verification

The syntax gate reproduces the exact failure against the bad form and passes against this one:

```
# bare become:
ERROR! 'become' is not a valid attribute for a IncludeRole
  line 1014, column 7

# apply: {become: true}
playbook: playbooks/update-all-nodes.yml          (syntax-check clean)
```

```
tests/test_updater_refreshes_tts_worker_12886.py ......
6 passed
```

Delivery is still unproven on the host: the streaming route is not served yet, and `/opt/autobot/autobot-tts-worker/tts-worker.py` is dated 2026-07-16 with no `synthesize/stream`. The #12959 probe reports `tts-worker (#12886)` as undelivered, and that entry flipping is the acceptance signal — I will re-run the update after this merges and report the result either way.

## Model Used

Claude Opus 5 (`claude-opus-5`)

## Follow-up

Closes #12886 once delivery is confirmed on a host.

Refs #12959 (general repair, still open) and #13132 (`/tts/clone-voice`, implemented nowhere).
