### PR TITLE
fix(deploy): flush the TTS restart immediately so a later failure cannot swallow it (#12886)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1024,6 +1024,18 @@
       when: "'npu' in group_names"
       tags: [tts, tts-worker, deploy]
 
+    # Handlers normally flush at END of play, so ANY later task failure silently
+    # swallows the restart — and PLAY 2 has a known terminal failure in the
+    # browser tasks below (#12912). That is exactly what happened on the first
+    # successful delivery: tts-worker.py was written with the streaming route,
+    # the play then died at the browser wait, `restart tts-worker` never ran, and
+    # the worker kept serving 4-day-old code from memory. Flushing here makes TTS
+    # delivery independent of unrelated failures further down the play.
+    - name: "[PLAY 2] TTS | Apply pending TTS restart now, not at end of play (#12886)"
+      ansible.builtin.meta: flush_handlers
+      when: "'npu' in group_names"
+      tags: [tts, tts-worker, deploy]
+
     # ----- Browser Worker -----
     - name: "[PLAY 2] Browser | Deploy autobot-browser-worker"
       unarchive:

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -168,3 +168,37 @@ def test_playbook_passes_ansible_syntax_check() -> None:
     )
 
     assert result.returncode == 0, f"ansible rejected the playbook:\n{result.stderr[-1200:]}"
+
+
+def test_tts_restart_is_flushed_before_later_tasks_can_fail() -> None:
+    """The TTS restart must not be deferred to end of play (#12886).
+
+    Handlers normally flush at the end of a play, so any later failure swallows
+    them. PLAY 2 has a known terminal failure in the browser tasks (#12912), and
+    on the first successful delivery that is exactly what happened: the worker
+    file was written with the streaming route, the play died at the browser wait,
+    `restart tts-worker` never ran, and the worker kept serving days-old code
+    from memory. Delivery without restart is not delivery.
+    """
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+
+    for play in playbook:
+        tasks = play.get("tasks") or []
+        tts_idx = flush_idx = None
+        for i, task in enumerate(tasks):
+            inc = task.get("ansible.builtin.include_role") or task.get("include_role")
+            if isinstance(inc, dict) and inc.get("name") == "tts-worker":
+                tts_idx = i
+            meta = task.get("ansible.builtin.meta") or task.get("meta")
+            if meta == "flush_handlers" and tts_idx is not None and flush_idx is None:
+                flush_idx = i
+        if tts_idx is None:
+            continue
+        assert flush_idx is not None, (
+            "no flush_handlers after the tts-worker include — the restart would be "
+            "deferred to end of play and lost to any later failure (#12912)"
+        )
+        assert flush_idx > tts_idx, "flush_handlers must come AFTER the tts include"
+        return
+
+    raise AssertionError("no play contained the tts-worker include")


### PR DESCRIPTION
## Thinking Path

Third and final step of the #12886 delivery chain, found by checking the host rather than the recap.

After #13142 the TTS tasks finally ran clean (`ok=112`, no permission error) and the file genuinely landed:

```
/opt/autobot/autobot-tts-worker/tts-worker.py   mtime 20:43:14   grep -c 'synthesize/stream' -> 2
```

And the route was **still** 404. The service had not restarted since Jul 27 — four days — so it was serving old code from memory.

Cause: ansible flushes handlers at **end of play**. PLAY 2 has a known terminal failure in the browser tasks (#12912), so the play died there and the queued `restart tts-worker` was discarded. The notify fired; the queue never ran.

This is a general hazard, not a TTS quirk: while #12912 stands, *any* component in PLAY 2 whose restart is handler-driven silently fails to restart, no matter how correctly its files were deployed. Flushing right after the include makes this component's delivery independent of unrelated failures further down the play.

Had I trusted `changed=33` in the recap, this would have looked done.

## What Changed

**`playbooks/update-all-nodes.yml`** — `meta: flush_handlers` immediately after the tts-worker include, gated on the same `npu` group condition, with a comment recording the failure it prevents.

**`tests/test_updater_refreshes_tts_worker_12886.py`** — one test asserting a `flush_handlers` task follows the tts include in the same play, so the restart cannot silently revert to end-of-play.

## Verification

```
tests/test_updater_refreshes_tts_worker_12886.py .......
7 passed

ansible-playbook --syntax-check -i localhost, playbooks/update-all-nodes.yml
playbook: playbooks/update-all-nodes.yml
```

Acceptance is host-side and unproven until this merges: `/tts/synthesize/stream` served by the worker, and the #12959 probe's `tts-worker (#12886)` entry clearing. I will run the update and report the result either way — including if it still does not work.

## Model Used

Claude Opus 5 (`claude-opus-5`)

## Follow-up

Closes #12886 once the route is confirmed served on a host.

Refs #12912 — the browser blocker whose failure caused this; #12959 — general repair; #13132 — `/tts/clone-voice`, implemented nowhere.
