### PR TITLE
fix(deploy): restart the TTS worker explicitly, not via notify handler (#12886)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1024,17 +1024,27 @@
       when: "'npu' in group_names"
       tags: [tts, tts-worker, deploy]
 
-    # Handlers normally flush at END of play, so ANY later task failure silently
-    # swallows the restart — and PLAY 2 has a known terminal failure in the
-    # browser tasks below (#12912). That is exactly what happened on the first
-    # successful delivery: tts-worker.py was written with the streaming route,
-    # the play then died at the browser wait, `restart tts-worker` never ran, and
-    # the worker kept serving 4-day-old code from memory. Flushing here makes TTS
-    # delivery independent of unrelated failures further down the play.
-    - name: "[PLAY 2] TTS | Apply pending TTS restart now, not at end of play (#12886)"
-      ansible.builtin.meta: flush_handlers
+    # Restart explicitly rather than via the role's notify handler, matching how
+    # every other component in this play is restarted (NPU, Browser, backend).
+    #
+    # Handlers are wrong here for two compounding reasons, both observed on a
+    # live host (#12886):
+    #   1. they flush at END of play, and PLAY 2 has a known terminal failure in
+    #      the browser tasks below (#12912) — so the queued restart was discarded
+    #      and the worker kept serving 4-day-old code;
+    #   2. once the file is already current, the template task reports `ok` and
+    #      never notifies at all — so a host that received the file but missed
+    #      the restart stays stale forever, with nothing left to trigger it.
+    #
+    # An unconditional restart is idempotent in effect and cannot be swallowed.
+    - name: "[PLAY 2] TTS | Restart service"
+      systemd:
+        name: autobot-tts-worker
+        state: restarted
+      become: true
       when: "'npu' in group_names"
-      tags: [tts, tts-worker, deploy]
+      failed_when: false
+      tags: [tts, tts-worker, restart]
 
     # ----- Browser Worker -----
     - name: "[PLAY 2] Browser | Deploy autobot-browser-worker"

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1037,13 +1037,18 @@
     #      the restart stays stale forever, with nothing left to trigger it.
     #
     # An unconditional restart is idempotent in effect and cannot be swallowed.
+    # Deliberately NOT `failed_when: false`, unlike the NPU/Browser restarts
+    # above. This whole issue exists because a worker kept serving stale code
+    # while the update reported success — swallowing a failed restart here would
+    # reintroduce exactly that: the file lands, the process never reloads, and
+    # nothing says so. A restart that cannot complete is a real failure and
+    # should be visible.
     - name: "[PLAY 2] TTS | Restart service"
       systemd:
         name: autobot-tts-worker
         state: restarted
       become: true
       when: "'npu' in group_names"
-      failed_when: false
       tags: [tts, tts-worker, restart]
 
     # ----- Browser Worker -----

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -211,3 +211,27 @@ def test_tts_service_is_restarted_explicitly() -> None:
         return
 
     raise AssertionError("no play contained the tts-worker include")
+
+
+def test_tts_restart_does_not_fail_open() -> None:
+    """A failed TTS restart must surface, not be swallowed (#12886).
+
+    Flagged by security review as fail-open state drift. `failed_when: false`
+    would mean the file lands, the process never reloads, the play reports
+    success and nothing says otherwise — the precise silent-non-delivery failure
+    this issue is about. The NPU/Browser restarts above do swallow errors; that
+    convention is not appropriate for the task whose entire purpose is proving
+    the worker actually reloaded.
+    """
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+
+    for task in _iter_mappings(playbook):
+        svc = task.get("systemd") or task.get("ansible.builtin.systemd") or {}
+        if isinstance(svc, dict) and svc.get("name") == "autobot-tts-worker":
+            assert task.get("failed_when") is not False, (
+                "the TTS restart must not fail open — a swallowed restart failure "
+                "leaves the worker serving stale code with the update green"
+            )
+            return
+
+    raise AssertionError("no autobot-tts-worker restart task found")

--- a/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
+++ b/autobot-slm-backend/tests/test_updater_refreshes_tts_worker_12886.py
@@ -170,35 +170,44 @@ def test_playbook_passes_ansible_syntax_check() -> None:
     assert result.returncode == 0, f"ansible rejected the playbook:\n{result.stderr[-1200:]}"
 
 
-def test_tts_restart_is_flushed_before_later_tasks_can_fail() -> None:
-    """The TTS restart must not be deferred to end of play (#12886).
+def test_tts_service_is_restarted_explicitly() -> None:
+    """The worker must be restarted by a task, not a notify handler (#12886).
 
-    Handlers normally flush at the end of a play, so any later failure swallows
-    them. PLAY 2 has a known terminal failure in the browser tasks (#12912), and
-    on the first successful delivery that is exactly what happened: the worker
-    file was written with the streaming route, the play died at the browser wait,
-    `restart tts-worker` never ran, and the worker kept serving days-old code
-    from memory. Delivery without restart is not delivery.
+    Two failures made handler-driven restart unusable here, both seen on a live
+    host. Handlers flush at END of play, and PLAY 2 dies at the browser tasks
+    (#12912), so the queued restart was discarded and the worker served 4-day-old
+    code. Then, once the file was already current, the template reported `ok` and
+    never notified at all — leaving a host that had the file but not the restart
+    permanently stale, with nothing left to trigger it.
+
+    Delivering a file without restarting the process is not delivery.
     """
     playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
 
     for play in playbook:
         tasks = play.get("tasks") or []
-        tts_idx = flush_idx = None
+        tts_idx = restart_idx = None
         for i, task in enumerate(tasks):
             inc = task.get("ansible.builtin.include_role") or task.get("include_role")
             if isinstance(inc, dict) and inc.get("name") == "tts-worker":
                 tts_idx = i
-            meta = task.get("ansible.builtin.meta") or task.get("meta")
-            if meta == "flush_handlers" and tts_idx is not None and flush_idx is None:
-                flush_idx = i
+            svc = task.get("systemd") or task.get("ansible.builtin.systemd") or {}
+            if (
+                isinstance(svc, dict)
+                and svc.get("name") == "autobot-tts-worker"
+                and svc.get("state") == "restarted"
+                and tts_idx is not None
+                and restart_idx is None
+            ):
+                restart_idx = i
         if tts_idx is None:
             continue
-        assert flush_idx is not None, (
-            "no flush_handlers after the tts-worker include — the restart would be "
-            "deferred to end of play and lost to any later failure (#12912)"
+        assert restart_idx is not None, (
+            "no explicit autobot-tts-worker restart after the include — a notify "
+            "handler is lost to end-of-play failures and never fires when the "
+            "file is already current"
         )
-        assert flush_idx > tts_idx, "flush_handlers must come AFTER the tts include"
+        assert restart_idx > tts_idx, "the restart must come AFTER the include"
         return
 
     raise AssertionError("no play contained the tts-worker include")


### PR DESCRIPTION
## Thinking Path

Supersedes the approach in #13143, which did not work. Verified on the host rather than from the recap.

State after #13143 merged and an update ran: the file is correct on disk, the route is still 404.

```
/opt/autobot/autobot-tts-worker/tts-worker.py   grep -c 'synthesize/stream' -> 2
autobot-tts-worker  ExecMainStartTimestamp = Mon 2026-07-27 17:51:27
```

Four days old. The worker had the new file and was serving old code from memory.

Handler-driven restart fails here for two compounding reasons:

1. **Handlers flush at end of play.** PLAY 2 dies at the browser tasks (#12912), so the queued `restart tts-worker` was discarded — that was the #13143 diagnosis, and `meta: flush_handlers` was the right fix *for that*.
2. **`flush_handlers` still did nothing**, because by then the file was already current from the prior run. The template task reported `ok`, so it never notified, so nothing was queued to flush. A host that received the file but missed the restart is stuck permanently — there is no longer any change to trigger it.

(2) is the part I got wrong in #13143: I fixed when handlers run without asking whether a handler would fire at all.

So restart explicitly, matching the convention every other component in this play already follows — NPU, Browser and backend all use `systemd: state=restarted` with `become: true` and `failed_when: false`. Unconditional, so it cannot be swallowed by a later failure and does not depend on a changed-file signal.

## What Changed

**`playbooks/update-all-nodes.yml`** — the `meta: flush_handlers` task from #13143 is replaced by an explicit `[PLAY 2] TTS | Restart service` task, mirroring the NPU restart exactly, with a comment recording both failure modes.

**`tests/test_updater_refreshes_tts_worker_12886.py`** — the flush assertion is replaced by one requiring an explicit `autobot-tts-worker` restart task ordered after the include.

## Verification

```
tests/test_updater_refreshes_tts_worker_12886.py .......
7 passed

ansible-playbook --syntax-check -i localhost, playbooks/update-all-nodes.yml
playbook: playbooks/update-all-nodes.yml
```

Still unproven on the host, which is the only acceptance that counts: `/tts/synthesize/stream` served, `ExecMainStartTimestamp` recent, and the #12959 probe's `tts-worker (#12886)` entry clearing. I will run the update after merge and report the outcome either way — this is the third attempt at this delivery, and I would rather report another miss than claim success from a green recap.

## Model Used

Claude Opus 5 (`claude-opus-5`)

## Follow-up

Closes #12886 once the route is confirmed served.

Refs #12912 (browser blocker — its failure is what exposed the handler problem), #12959, #13132.
