### PR TITLE
refactor(slm-frontend): derive the security, credential and auth-token contracts from the generated schema (#13138)

### DIFF
--- a/autobot-slm-frontend/src/composables/useSlmApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.ts
@@ -52,10 +52,12 @@ import type {
   RestartAllServicesResponse,
   VNCCredentialCreate,
   VNCCredentialResponse,
+  VNCCredentialListResponse,
   VNCEndpointsResponse,
   VNCConnectionInfo,
   TLSCredentialCreate,
   TLSCredentialResponse,
+  TLSCredentialListResponse,
   TLSEndpointsResponse,
   TLSRenewResponse,
   TLSRotateResponse,
@@ -544,8 +546,8 @@ export function useSlmApi() {
     return response.data
   }
 
-  async function getNodeVncCredentials(nodeId: string): Promise<{ credentials: VNCCredentialResponse[]; total: number }> {
-    const response = await client.get<{ credentials: VNCCredentialResponse[]; total: number }>(
+  async function getNodeVncCredentials(nodeId: string): Promise<VNCCredentialListResponse> {
+    const response = await client.get<VNCCredentialListResponse>(
       `/nodes/${nodeId}/vnc-credentials`
     )
     return response.data
@@ -593,9 +595,9 @@ export function useSlmApi() {
     return response.data
   }
 
-  async function getNodeTlsCredentials(nodeId: string, includeInactive = false): Promise<{ credentials: TLSCredentialResponse[]; total: number }> {
+  async function getNodeTlsCredentials(nodeId: string, includeInactive = false): Promise<TLSCredentialListResponse> {
     const params = includeInactive ? '?include_inactive=true' : ''
-    const response = await client.get<{ credentials: TLSCredentialResponse[]; total: number }>(
+    const response = await client.get<TLSCredentialListResponse>(
       `/nodes/${nodeId}/tls-credentials${params}`
     )
     return response.data

--- a/autobot-slm-frontend/src/stores/auth.test.ts
+++ b/autobot-slm-frontend/src/stores/auth.test.ts
@@ -87,3 +87,73 @@ describe('authStore.completeMFALogin — verify-login transport contract (#12420
     expect(store.mfaPending).toBe(false)
   })
 })
+
+/**
+ * `POST /api/auth/login` declares the union `TokenResponse | MfaChallengeResponse`
+ * (`autobot-slm-backend/api/auth.py:81`). The store used to flatten both members
+ * into one all-optional hand-written interface, which made `access_token`
+ * optional everywhere and forced two `!` assertions on the live login path.
+ *
+ * Both contract members carry an `additionalProperties` catch-all, so the branch
+ * is chosen by a structural check on the discriminator rather than `in`. These
+ * tests pin that discrimination (#13138).
+ */
+describe('authStore.login — /api/auth/login response union (#13138)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    sessionStorage.clear()
+    localStorage.clear()
+    mockFetch.mockReset()
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  it('takes the token branch and authenticates when no MFA challenge is returned', async () => {
+    const store = useAuthStore()
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: 'plain-token', token: 'plain-token', token_type: 'bearer', expires_in: 3600 })
+    )
+    mockFetch.mockResolvedValueOnce(jsonResponse({ username: 'admin', is_admin: true }))
+
+    expect(await store.login('admin', 'pw')).toBe(true)
+    expect(store.token).toBe('plain-token')
+    expect(store.mfaPending).toBe(false)
+  })
+
+  it('takes the challenge branch without storing a token', async () => {
+    const store = useAuthStore()
+    mockFetch.mockResolvedValueOnce(jsonResponse({ requires_mfa: true, temp_token: 'temp-xyz' }))
+
+    expect(await store.login('admin', 'pw')).toBe(false)
+    expect(store.mfaPending).toBe(true)
+    expect(store.token).toBeNull()
+    expect(sessionStorage.getItem('slm_access_token')).toBeNull()
+    // Only the login call — no follow-up /api/auth/me while MFA is pending.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads access_token, not the mirrored token field', async () => {
+    // The SLM mirrors the JWT under `token` for clients written against the core
+    // backend (`autobot-slm-backend/models/schemas.py:31-48`). A divergent pair
+    // must resolve to `access_token`.
+    const store = useAuthStore()
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ access_token: 'canonical', token: 'mirror', token_type: 'bearer', expires_in: 3600 })
+    )
+    mockFetch.mockResolvedValueOnce(jsonResponse({ username: 'admin', is_admin: true }))
+
+    await store.login('admin', 'pw')
+    expect(store.token).toBe('canonical')
+  })
+
+  it('does not mistake requires_mfa:false for a challenge', async () => {
+    const store = useAuthStore()
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ requires_mfa: false, access_token: 'not-a-challenge', token_type: 'bearer', expires_in: 3600 })
+    )
+    mockFetch.mockResolvedValueOnce(jsonResponse({ username: 'admin', is_admin: true }))
+
+    expect(await store.login('admin', 'pw')).toBe(true)
+    expect(store.mfaPending).toBe(false)
+    expect(store.token).toBe('not-a-challenge')
+  })
+})

--- a/autobot-slm-frontend/src/stores/auth.ts
+++ b/autobot-slm-frontend/src/stores/auth.ts
@@ -14,6 +14,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { createLogger } from '@/utils/debugUtils'
+import type { components } from '@/types/generated/api'
 
 const logger = createLogger('AuthStore')
 
@@ -22,22 +23,36 @@ interface User {
   isAdmin: boolean
 }
 
-interface TokenResponse {
-  access_token: string
-  token_type: string
-  expires_in: number
-}
+/**
+ * Token payload of `POST /api/auth/login`, `/api/auth/refresh` and
+ * `/api/mfa/verify-login`, derived from the generated OpenAPI contract
+ * (#13138). The hand-written copy omitted `token` — the SLM mirrors the JWT
+ * under both `access_token` and `token` so a client written against the core
+ * backend reads it too (autobot-slm-backend/models/schemas.py:31-48).
+ */
+type TokenResponse = components['schemas']['TokenResponse']
 
-interface MFALoginResponse {
-  requires_mfa?: boolean
-  temp_token?: string
-  access_token?: string
-  token_type?: string
-  expires_in?: number
-}
+/**
+ * MFA challenge branch of `POST /api/auth/login`, whose response model is the
+ * union `TokenResponse | MfaChallengeResponse` (autobot-slm-backend/api/auth.py:81).
+ * Modelled as the union rather than one flattened all-optional shape so the
+ * `requires_mfa` branch is the only place `temp_token` is readable.
+ */
+type MfaChallengeResponse = components['schemas']['MfaChallengeResponse']
+
+type LoginResponse = TokenResponse | MfaChallengeResponse
 
 interface LogoutResponse {
   logout_url?: string | null
+}
+
+/**
+ * Narrow the `/api/auth/login` union. Both members carry an
+ * `additionalProperties` catch-all in the contract, so a structural check on
+ * the discriminator is required rather than a bare `in` test.
+ */
+function isMfaChallenge(data: LoginResponse): data is MfaChallengeResponse {
+  return data.requires_mfa === true && typeof data.temp_token === 'string'
 }
 
 const TOKEN_KEY = 'slm_access_token'
@@ -88,16 +103,16 @@ export const useAuthStore = defineStore('auth', () => {
         throw new Error(data.detail || 'Login failed')
       }
 
-      const data: MFALoginResponse = await response.json()
+      const data: LoginResponse = await response.json()
 
-      if (data.requires_mfa && data.temp_token) {
+      if (isMfaChallenge(data)) {
         mfaPending.value = true
         mfaTempToken.value = data.temp_token
         return false
       }
 
-      token.value = data.access_token!
-      sessionStorage.setItem(TOKEN_KEY, data.access_token!)
+      token.value = data.access_token
+      sessionStorage.setItem(TOKEN_KEY, data.access_token)
 
       await fetchCurrentUser()
       return true

--- a/autobot-slm-frontend/src/types/api-responses.ts
+++ b/autobot-slm-frontend/src/types/api-responses.ts
@@ -11,6 +11,8 @@
  * definitions locally.  Issue #3196.
  */
 
+import type { components } from './generated/api'
+
 // =============================================================================
 // Replication
 // =============================================================================
@@ -62,107 +64,53 @@ export interface RestartAllServicesResponse {
 
 // =============================================================================
 // VNC Credentials (Issue #725)
+//
+// Derived from the generated OpenAPI contract (#13138) — response models of
+// autobot-slm-backend/api/vnc.py.
 // =============================================================================
 
-export interface VNCCredentialCreate {
-  vnc_type?: 'desktop' | 'browser' | 'custom'
-  name?: string
-  password: string
-  port?: number
-  display_number?: number
-  vnc_port?: number
-  websockify_enabled?: boolean
-}
+/** Request body of POST `/nodes/{node_id}/vnc/credentials` (vnc.py:48). */
+export type VNCCredentialCreate = components['schemas']['VNCCredentialCreate']
 
-export interface VNCCredentialResponse {
-  id: number
-  credential_id: string
-  node_id: string
-  vnc_type: string | null
-  name: string | null
-  port: number | null
-  display_number: number | null
-  vnc_port: number | null
-  websockify_enabled: boolean
-  is_active: boolean
-  last_used: string | null
-  created_at: string
-  updated_at: string
-  websocket_url: string | null
-}
+/** Response model of the VNC credential endpoints (vnc.py:48, :115, :139). */
+export type VNCCredentialResponse = components['schemas']['VNCCredentialResponse']
 
-export interface VNCEndpointResponse {
-  credential_id: string
-  node_id: string
-  hostname: string
-  ip_address: string
-  vnc_type: string
-  name: string | null
-  port: number
-  websocket_url: string
-  is_active: boolean
-}
+/** Response model of GET `/nodes/{node_id}/vnc/credentials` (vnc.py:82). */
+export type VNCCredentialListResponse = components['schemas']['VNCCredentialListResponse']
 
-export interface VNCEndpointsResponse {
-  endpoints: VNCEndpointResponse[]
-  total: number
-}
+/** Entry of the fleet-wide VNC endpoint list (vnc.py:227). */
+export type VNCEndpointResponse = components['schemas']['VNCEndpointResponse']
 
-export interface VNCConnectionInfo {
-  credential_id: string
-  node_id: string
-  vnc_type: string
-  host: string
-  port: number
-  display_number: number
-  websocket_url: string
-  connection_token: string | null
-  token_expires_at: string | null
-}
+/** Response model of GET `/vnc/endpoints` (vnc.py:227). */
+export type VNCEndpointsResponse = components['schemas']['VNCEndpointsResponse']
+
+/** Response model of POST `/vnc/credentials/{credential_id}/connect` (vnc.py:187). */
+export type VNCConnectionInfo = components['schemas']['VNCConnectionInfo']
 
 // =============================================================================
 // TLS Credentials (Issue #725)
+//
+// Derived from the generated OpenAPI contract (#13138) — response models of
+// autobot-slm-backend/api/tls.py. `TLSCredentialResponse` carries `ca_cert`
+// and `server_cert` (public certificate data; the private key is never
+// returned — models/schemas.py:1352-1368), both of which the hand-written
+// declaration omitted.
 // =============================================================================
 
-export interface TLSCredentialCreate {
-  name?: string
-  ca_cert: string
-  server_cert: string
-  server_key: string
-  common_name?: string
-  expires_at?: string
-}
+/** Request body of POST `/nodes/{node_id}/tls/credentials` (tls.py:68). */
+export type TLSCredentialCreate = components['schemas']['TLSCredentialCreate']
 
-export interface TLSCredentialResponse {
-  id: number
-  credential_id: string
-  node_id: string
-  name: string | null
-  common_name: string | null
-  expires_at: string | null
-  fingerprint: string | null
-  is_active: boolean
-  created_at: string
-  updated_at: string
-}
+/** Response model of the TLS credential endpoints (tls.py:68, :138, :160). */
+export type TLSCredentialResponse = components['schemas']['TLSCredentialResponse']
 
-export interface TLSEndpointResponse {
-  credential_id: string
-  node_id: string
-  hostname: string
-  ip_address: string
-  name: string | null
-  common_name: string | null
-  expires_at: string | null
-  is_active: boolean
-  days_until_expiry: number | null
-}
+/** Response model of GET `/nodes/{node_id}/tls/credentials` (tls.py:101). */
+export type TLSCredentialListResponse = components['schemas']['TLSCredentialListResponse']
 
-export interface TLSEndpointsResponse {
-  endpoints: TLSEndpointResponse[]
-  total: number
-  expiring_soon: number
-}
+/** Entry of the fleet-wide TLS endpoint list (tls.py:282). */
+export type TLSEndpointResponse = components['schemas']['TLSEndpointResponse']
+
+/** Response model of GET `/tls/endpoints` and `/tls/expiring` (tls.py:282, :305). */
+export type TLSEndpointsResponse = components['schemas']['TLSEndpointsResponse']
 
 export interface TLSRenewResponse {
   success: boolean
@@ -533,124 +481,23 @@ export interface ResolveResponse {
 
 // =============================================================================
 // Security (Issue #813)
+//
+// Single-sourced from `types/slm.ts` (#13138): these eight shapes were
+// hand-declared identically here and there, so one backend change had two
+// places to drift from. `types/slm.ts` now derives them from the generated
+// OpenAPI contract; this module re-exports so existing importers keep working.
 // =============================================================================
 
-export interface SecurityEventResponse {
-  id: number
-  event_id: string
-  timestamp: string
-  event_type: string
-  severity: string
-  category: string | null
-  source_ip: string | null
-  source_user: string | null
-  source_node_id: string | null
-  target_resource: string | null
-  target_node_id: string | null
-  title: string
-  description: string | null
-  threat_indicator: string | null
-  threat_score: number | null
-  mitre_technique: string | null
-  is_acknowledged: boolean
-  acknowledged_by: string | null
-  acknowledged_at: string | null
-  is_resolved: boolean
-  resolved_by: string | null
-  resolved_at: string | null
-  resolution_notes: string | null
-  created_at: string
-}
-
-export interface SecurityOverviewResponse {
-  security_score: number
-  active_threats: number
-  failed_logins_24h: number
-  policy_violations: number
-  total_events_24h: number
-  critical_events: number
-  certificates_expiring: number
-  recent_events: SecurityEventResponse[]
-}
-
-export interface AuditLogResponse {
-  id: number
-  log_id: string
-  timestamp: string
-  user_id: string | null
-  username: string | null
-  ip_address: string | null
-  category: string
-  action: string
-  resource_type: string | null
-  resource_id: string | null
-  description: string | null
-  request_method: string | null
-  request_path: string | null
-  response_status: number | null
-  success: boolean
-  error_message: string | null
-  created_at: string
-}
-
-export interface AuditLogListResponse {
-  logs: AuditLogResponse[]
-  total: number
-  page: number
-  per_page: number
-}
-
-export interface SecurityEventListResponse {
-  events: SecurityEventResponse[]
-  total: number
-  page: number
-  per_page: number
-  unacknowledged_count: number
-  critical_count: number
-}
-
-export interface ThreatSummary {
-  total_threats: number
-  critical: number
-  high: number
-  medium: number
-  low: number
-  acknowledged: number
-  resolved: number
-  by_type: Record<string, number>
-  by_source_ip: Record<string, number>
-  trend_24h: Array<Record<string, unknown>>
-}
-
-export interface SecurityPolicyResponse {
-  id: number
-  policy_id: string
-  name: string
-  description: string | null
-  category: string
-  policy_type: string
-  rules: unknown[]
-  parameters: Record<string, unknown>
-  applies_to_nodes: unknown[]
-  applies_to_roles: unknown[]
-  status: string
-  is_enforced: boolean
-  last_evaluated: string | null
-  compliance_score: number | null
-  violations_count: number
-  version: number
-  created_by: string | null
-  updated_by: string | null
-  created_at: string
-  updated_at: string
-}
-
-export interface SecurityPolicyListResponse {
-  policies: SecurityPolicyResponse[]
-  total: number
-  page: number
-  per_page: number
-}
+export type {
+  SecurityEventResponse,
+  SecurityOverviewResponse,
+  AuditLogResponse,
+  AuditLogListResponse,
+  SecurityEventListResponse,
+  ThreatSummary,
+  SecurityPolicyResponse,
+  SecurityPolicyListResponse,
+} from './slm'
 
 // =============================================================================
 // Fleet Certificates (Issue #926 Phase 7)

--- a/autobot-slm-frontend/src/types/slm.ts
+++ b/autobot-slm-frontend/src/types/slm.ts
@@ -701,121 +701,33 @@ export interface ExternalAgentCard {
 
 // =============================================================================
 // Security API Response Types (Issue #3184)
+//
+// Derived from the generated OpenAPI contract (#13138). Every shape below is
+// the response model of a `/security/*` endpoint in
+// autobot-slm-backend/api/security.py, so `vue-tsc` now fails when the backend
+// schema moves instead of the drift reaching a security dashboard unnoticed.
 // =============================================================================
 
-export interface SecurityEventResponse {
-  id: number
-  event_id: string
-  timestamp: string
-  event_type: string
-  severity: string
-  category: string | null
-  source_ip: string | null
-  source_user: string | null
-  source_node_id: string | null
-  target_resource: string | null
-  target_node_id: string | null
-  title: string
-  description: string | null
-  threat_indicator: string | null
-  threat_score: number | null
-  mitre_technique: string | null
-  is_acknowledged: boolean
-  acknowledged_by: string | null
-  acknowledged_at: string | null
-  is_resolved: boolean
-  resolved_by: string | null
-  resolved_at: string | null
-  resolution_notes: string | null
-  created_at: string
-}
+/** Response model of GET/POST `/security/events*` (security.py:530, :549, :577). */
+export type SecurityEventResponse = components['schemas']['SecurityEventResponse']
 
-export interface SecurityOverviewResponse {
-  security_score: number
-  active_threats: number
-  failed_logins_24h: number
-  policy_violations: number
-  total_events_24h: number
-  critical_events: number
-  certificates_expiring: number
-  recent_events: SecurityEventResponse[]
-}
+/** Response model of GET `/security/overview` (security.py:191). */
+export type SecurityOverviewResponse = components['schemas']['SecurityOverviewResponse']
 
-export interface AuditLogResponse {
-  id: number
-  log_id: string
-  timestamp: string
-  user_id: string | null
-  username: string | null
-  ip_address: string | null
-  category: string
-  action: string
-  resource_type: string | null
-  resource_id: string | null
-  description: string | null
-  request_method: string | null
-  request_path: string | null
-  response_status: number | null
-  success: boolean
-  error_message: string | null
-  created_at: string
-}
+/** Response model of GET `/security/audit-logs/{log_id}` (security.py:292). */
+export type AuditLogResponse = components['schemas']['AuditLogResponse']
 
-export interface AuditLogListResponse {
-  logs: AuditLogResponse[]
-  total: number
-  page: number
-  per_page: number
-}
+/** Response model of GET `/security/audit-logs` (security.py:231). */
+export type AuditLogListResponse = components['schemas']['AuditLogListResponse']
 
-export interface SecurityEventListResponse {
-  events: SecurityEventResponse[]
-  total: number
-  page: number
-  per_page: number
-  unacknowledged_count: number
-  critical_count: number
-}
+/** Response model of GET `/security/events` (security.py:376). */
+export type SecurityEventListResponse = components['schemas']['SecurityEventListResponse']
 
-export interface ThreatSummary {
-  total_threats: number
-  critical: number
-  high: number
-  medium: number
-  low: number
-  acknowledged: number
-  resolved: number
-  by_type: Record<string, number>
-  by_source_ip: Record<string, number>
-  trend_24h: Array<Record<string, unknown>>
-}
+/** Response model of GET `/security/events/summary` (security.py:456). */
+export type ThreatSummary = components['schemas']['ThreatSummary']
 
-export interface SecurityPolicyResponse {
-  id: number
-  policy_id: string
-  name: string
-  description: string | null
-  category: string
-  policy_type: string
-  rules: unknown[]
-  parameters: Record<string, unknown>
-  applies_to_nodes: unknown[]
-  applies_to_roles: unknown[]
-  status: string
-  is_enforced: boolean
-  last_evaluated: string | null
-  compliance_score: number | null
-  violations_count: number
-  version: number
-  created_by: string | null
-  updated_by: string | null
-  created_at: string
-  updated_at: string
-}
+/** Response model of GET/PATCH `/security/policies/{policy_id}` (security.py:696, :715). */
+export type SecurityPolicyResponse = components['schemas']['SecurityPolicyResponse']
 
-export interface SecurityPolicyListResponse {
-  policies: SecurityPolicyResponse[]
-  total: number
-  page: number
-  per_page: number
-}
+/** Response model of GET `/security/policies` (security.py:617). */
+export type SecurityPolicyListResponse = components['schemas']['SecurityPolicyListResponse']

--- a/autobot-slm-frontend/src/views/SecurityView.vue
+++ b/autobot-slm-frontend/src/views/SecurityView.vue
@@ -412,8 +412,10 @@ async function uploadTlsCertificate() {
   }
 }
 
-function formatExpiryStatus(daysUntil: number | null): { text: string; class: string } {
-  if (daysUntil === null) return { text: 'Unknown', class: 'bg-gray-100 text-gray-700' }
+// `days_until_expiry` is nullable AND optional in the contract
+// (TLSEndpointResponse, tls.py:282) — accept both absent and null.
+function formatExpiryStatus(daysUntil: number | null | undefined): { text: string; class: string } {
+  if (daysUntil == null) return { text: 'Unknown', class: 'bg-gray-100 text-gray-700' }
   if (daysUntil <= 0) return { text: 'Expired', class: 'bg-red-100 text-red-700' }
   if (daysUntil <= 7) return { text: `${daysUntil}d`, class: 'bg-red-100 text-red-700' }
   if (daysUntil <= 30) return { text: `${daysUntil}d`, class: 'bg-yellow-100 text-yellow-700' }
@@ -640,12 +642,12 @@ const scoreColor = computed(() => {
           <div class="px-6 py-4 border-b border-gray-200">
             <h2 class="text-lg font-semibold">{{ $t('securityView.recentSecurityEvents') }}</h2>
           </div>
-          <div v-if="overview.recent_events.length === 0" class="p-6 text-center text-gray-500">
+          <div v-if="!overview.recent_events?.length" class="p-6 text-center text-gray-500">
             {{ $t('securityView.noRecentSecurityEvents') }}
           </div>
           <div v-else class="divide-y divide-gray-200">
             <div
-              v-for="event in overview.recent_events"
+              v-for="event in overview.recent_events ?? []"
               :key="event.event_id"
               class="px-6 py-4 flex items-center justify-between"
             >


### PR DESCRIPTION
Closes #13147 — the discrete, fully-delivered security/auth slice of #13138.

**#13138 itself stays OPEN**: ~77 shapes remain, enumerated below, and the credential write paths are blocked on #13145. Partial delivery never closes the parent.

## Thinking Path

**The count in the issue is wrong, and so was my first attempt at it.** The issue says 114 collisions remain. Reproducing the scan on pristine `Dev_new_gui` with a name-level regex reproduced ~109 — but both figures are inflated. A pattern like `^\s*(?:export\s+)?(interface|type)\s+(\w+)` also matches the *members of a type-only import*:

```ts
import {
  useMfaApi,
  type MFASetupResponse,   // <- counted as a declaration
} from '@/composables/useMfaApi'
```

Requiring a real declaration body (`interface X … {` or `type X … =`) gives the true figure:

| | pristine `Dev_new_gui` (5a4c3a4ae) |
|---|---|
| generated schemas | 309 |
| hand-declared type/interface names | 414 |
| exact-name collisions | 129 |
| — already derived by #13137 | 35 |
| — **still hand-written** | **94** |

35, not 39, because four of #13137's shapes have no `response_model` and stayed hand-declared by design.

**Not every collision is drift — three are worse than drift.** `usePrometheusMetrics.ts` declares `DashboardOverview` and `SystemMetrics`, and two components declare `LogEntry`, whose names match a wire schema but whose *contents* are deliberate client-side view-models built by remapping that same endpoint's response — `usePrometheusMetrics.ts:224-241` maps `/monitoring/dashboard` (whose response model really is `DashboardOverview`, `autobot-slm-backend/api/monitoring.py:704`) into a different shape, and `LogViewer.vue:113-127` maps `severity`→`level`. Deriving those would be actively wrong; they need renaming. They are called out here so the remaining batches do not derive them blindly.

**Prioritised by risk, not alphabetically.** The groups, highest first:

1. **Credential *write* paths** — `NodeCreate`, `NodeUpdate`, `ConnectionTestRequest`. Genuine disagreement, and it turned out to be a live defect. **Filed as #13145, deferred here** (below).
2. **Auth token + security read models** — `TokenResponse`, the eight `/security/*` shapes, VNC/TLS credential shapes. **Delivered here.**
3. Shape-changing but non-security — envelope-vs-bare and enum widening across `useCodeSync`, `useOrchestration`, `useRoles`. Deferred.
4. Monitoring/observability read models in `types/api-responses.ts` — the long tail. Deferred.

## What Changed

**18 shapes derived from `components['schemas'][…]`** (94 → 77 by the same scan; `SecurityView.vue:43`'s local re-alias of the now-derived `ThreatSummary` still counts against the total but satisfies the issue's "collapse to one exported alias").

| File | Types |
|---|---|
| `types/slm.ts` | `SecurityEventResponse`, `SecurityEventListResponse`, `SecurityOverviewResponse`, `SecurityPolicyResponse`, `SecurityPolicyListResponse`, `AuditLogResponse`, `AuditLogListResponse`, `ThreatSummary` |
| `types/api-responses.ts` | `VNCCredentialCreate`, `VNCCredentialResponse`, `VNCEndpointResponse`, `VNCEndpointsResponse`, `VNCConnectionInfo`, `TLSCredentialCreate`, `TLSCredentialResponse`, `TLSEndpointResponse`, `TLSEndpointsResponse` |
| `stores/auth.ts` | `TokenResponse`, `MfaChallengeResponse` |

Each alias carries the `file:line` of the backend endpoint whose `response_model` it is, so the mapping is checkable rather than assumed.

**Double declarations collapsed.** All eight `/security/*` shapes were hand-declared *identically* in both `types/slm.ts:706-821` and `types/api-responses.ts:538-653` — one backend change had two places to drift from, and only the `types/slm.ts` copy had any importer. `types/slm.ts` now owns the derivation and `types/api-responses.ts` re-exports it, so both import paths keep working from one definition.

**Drift the derivation exposed and corrected:**

- `TokenResponse` omitted `token`. The SLM mirrors the JWT under both `access_token` and `token` so a client written against the core backend reads it (`autobot-slm-backend/models/schemas.py:31-48`); the hand-written copy documented only half the contract.
- `TLSCredentialResponse` omitted `ca_cert` and `server_cert` — public certificate data the endpoint returns and the UI could never reach (`autobot-slm-backend/models/schemas.py:1352-1368`).
- `VNCCredentialCreate` and `TLSCredentialCreate` both omitted `extra_data`.
- `SecurityOverviewResponse.recent_events` was declared non-null but is `default_factory=list` server-side (`autobot-slm-backend/models/schemas.py:1601`), so the contract makes it optional. `SecurityView.vue:643` read `.length` off it unguarded — a crash on any response that omits it. Now `?? []` / optional-chained.
- `TLSEndpointResponse.days_until_expiry` is nullable **and** optional; `formatExpiryStatus` accepted only `number | null` and tested `=== null`, so an absent value fell through to the "expired" branch. Now `== null`.
- The same "declared non-null, actually optional" tail across ~30 timestamp/count fields in the security models — resolved by derivation, no consumer change needed.

**`/api/auth/login` is a union, and was modelled as a flattened blob.** Its `response_model` is `TokenResponse | MfaChallengeResponse` (`autobot-slm-backend/api/auth.py:81`), but `stores/auth.ts` declared one all-optional `MFALoginResponse` merging both. That made `access_token` optional on the success branch and forced two `!` assertions on the live login path (`stores/auth.ts:99-100`). Now the real union plus an `isMfaChallenge` type guard; the assertions are gone. Both contract members carry an `additionalProperties` catch-all, so the guard checks the discriminator structurally rather than with `in`.

**Inline envelopes replaced by their schemas.** `getNodeVncCredentials` / `getNodeTlsCredentials` re-typed their `{ credentials, total }` return inline; both are real schemas (`VNCCredentialListResponse`, `TLSCredentialListResponse`) — the exact shape of the #13137 scope-picker defect, avoided here.

### Deferred, with reasons

- **`NodeCreate` / `NodeUpdate` / `ConnectionTestRequest` → #13145.** The derivation surfaced that the Edit-Node modal PATCHes nine fields the backend's `NodeUpdate` does not declare (`autobot-slm-backend/models/schemas.py:172-179` vs `AddNodeModal.vue:1123-1141`). Pydantic's default `extra="ignore"` drops them, the request 200s and the UI reports success — so "Deploy PKI certificates", "Re-run enrollment tasks" and every SSH credential edit are no-ops, and validation *forces* an SSH password to enable them. `ssh_key` is likewise dropped on register and on connection-test. Deriving these types would turn the surplus fields into compile errors whose only silent fix is deleting UI controls — a product decision, so it is filed rather than taken. Per the task constraint the server contract is left untouched.
- **Groups 3 and 4** (~77 shapes) — deliberately not attempted; partial delivery never closes an issue here.
- **`DashboardOverview`, `SystemMetrics`, `LogEntry` ×2** — must be *renamed*, not derived (above).
- `formatExpiryStatus` returns hardcoded `'Unknown'`/`'Expired'` (`SecurityView.vue:416-417`). Already in scope of #12732; not re-filed and not fixed here, to keep this diff to contract derivation.

## Verification

Run in `autobot-slm-frontend/`.

**Before** — pristine `origin/Dev_new_gui` `src/` swapped in with `cp` from `git archive` (never `git stash`):
```
npm run type-check  -> clean
npm run test:unit   -> Test Files 26 passed (26) | Tests 207 passed (207)
npm run lint        -> 16 problems (0 errors, 16 warnings)
```

**After:**
```
npm run type-check  -> clean
npm run test:unit   -> Test Files 26 passed (26) | Tests 211 passed (211)
npm run lint        -> 16 problems (0 errors, 16 warnings)
```

+4 tests: a new `describe` in `stores/auth.test.ts` pinning the login-union discrimination — token branch authenticates, challenge branch stores no token and makes no follow-up `/api/auth/me` call, `access_token` wins over the mirrored `token`, and `requires_mfa: false` is not mistaken for a challenge.

Lint findings were diffed line-for-line between the `cp`-swapped baseline tree and the final tree — **identical 18-line finding set**, so no pre-existing warning was masked and none was added.

`verify-generated-types-slm` still holds: `git diff --exit-code src/types/generated/api.ts` is clean. The generated file was read but never edited, and no regeneration was needed because no backend schema changed.

Branch rebased onto `163933b75` after `origin/Dev_new_gui` moved mid-work; `type-check` re-run green on the rebased tip.

Per the #13090 execution constraint no AutoBot application code was run — no backend, no SLM backend, no schema dump, no ad-hoc Postgres/Redis. Every contract claim above was read from the committed generated artefact and cross-checked against backend source at the cited `file:line`.

## Model Used

claude-opus-5
