### PR TITLE
fix(deploy): wait on the port the browser worker binds, and deliver the backend unit (#12912, #12777)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -834,6 +834,16 @@
             migration_become: true
             migration_name_prefix: "[PLAY 2] Backend | "
 
+    # #12777/#12959: the unit template is role-owned and this play never rendered
+    # it, so the faulthandler fix stayed in the repo and never reached a host.
+    # Must precede the restart below so the new unit is what gets started.
+    - name: "[PLAY 2] Backend | Render systemd unit so role changes land (#12777)"
+      ansible.builtin.include_role:
+        name: backend
+        tasks_from: unit_only
+      when: "'backend' in group_names"
+      tags: [backend, systemd, unit]
+
     - name: "[PLAY 2] Backend | Restart service"
       systemd:
         name: autobot-backend
@@ -1172,10 +1182,18 @@
       failed_when: false
       tags: [browser, browser-worker, restart]
 
+    # #12912: waited on 3000, which nothing serves — autobot-playwright binds
+    # PLAYWRIGHT_PORT (9001, roles/browser/defaults/main.yml). On a live host
+    # 3000 is Grafana, bound to loopback only, so this timed out for 61s and
+    # failed PLAY 2 every single run — the terminal blocker that also swallowed
+    # other components' handlers.
+    #
+    # `| default(9001)` because role defaults are NOT in scope in a playbook
+    # task (the #12871 trap); this mirrors setup-browser-worker.yml.
     - name: "[PLAY 2] Browser | Wait for service to be ready"
       wait_for:
         host: "{{ ansible_host }}"
-        port: 3000
+        port: "{{ playwright_port | default(9001) }}"
         timeout: 60
         delay: 5
       delegate_to: localhost

--- a/autobot-slm-backend/ansible/roles/backend/tasks/unit_only.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/unit_only.yml
@@ -1,0 +1,43 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# GH#12777 / #12959: render the backend systemd unit with the role's defaults in
+# scope, so the builtin updater can deliver unit changes.
+#
+# The unit template is role-owned, and update-all-nodes.yml never rendered it —
+# it deploys backend *code* inline and applies the role only via
+# `tasks_from: env_only`. So #12777's faulthandler fix (Environment=
+# PYTHONFAULTHANDLER=1) sat in the template, merged and closed, while every
+# deployed host kept a unit without it. Confirmed on a live node: the template
+# had the line, `systemctl cat autobot-backend` did not.
+#
+# That mattered because the fix exists to diagnose a SIGABRT crash loop: without
+# it a fatal signal in a C extension unwinds with no stack, which is the whole
+# reason #12777 was filed.
+#
+# Same shape as env_only.yml (#12871): invoked via include_role so role defaults
+# land at role-default precedence and fill the unit's vars (backend_user,
+# backend_group, backend_install_dir, backend_code_dir, backend_host,
+# backend_port, backend_workers, backend_log_dir) without overriding anything a
+# caller passes as task vars.
+#
+# Deliberately does NOT restart. update-all-nodes.yml already has an explicit
+# "[PLAY 2] Backend | Restart service" task after this; adding a second restart
+# here would bounce the backend twice per update.
+---
+- name: "Backend | Render systemd unit from template (#12777)"
+  ansible.builtin.template:
+    src: autobot-backend.service.j2
+    dest: /etc/systemd/system/autobot-backend.service
+    mode: "0644"
+    owner: root
+    group: root
+  become: true
+  register: _backend_unit_rendered
+  tags: [backend, systemd, unit]
+
+- name: "Backend | Reload systemd after unit change (#12777)"
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+  when: _backend_unit_rendered.changed
+  tags: [backend, systemd, unit]

--- a/autobot-slm-backend/tests/test_updater_browser_port_and_backend_unit.py
+++ b/autobot-slm-backend/tests/test_updater_browser_port_and_backend_unit.py
@@ -64,9 +64,7 @@ def test_browser_wait_targets_the_port_the_worker_binds() -> None:
         "the browser wait still targets 3000 — nothing serves it; on a live host "
         "that is Grafana on loopback, and the wait fails PLAY 2 every run"
     )
-    assert "playwright_port" in port, (
-        "the wait should follow playwright_port rather than hardcode a number"
-    )
+    assert "playwright_port" in port, "the wait should follow playwright_port rather than hardcode a number"
     assert "9001" in port, "keep a literal fallback: role defaults are not in scope here"
 
 
@@ -76,8 +74,7 @@ def test_browser_wait_fallback_matches_the_role_default() -> None:
     declared = str(defaults["playwright_port"])
 
     assert declared in str(_browser_wait_task()["wait_for"]["port"]), (
-        f"role default playwright_port={declared} but the playbook falls back to "
-        "a different value — they must agree"
+        f"role default playwright_port={declared} but the playbook falls back to " "a different value — they must agree"
     )
 
 

--- a/autobot-slm-backend/tests/test_updater_browser_port_and_backend_unit.py
+++ b/autobot-slm-backend/tests/test_updater_browser_port_and_backend_unit.py
@@ -1,0 +1,155 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""PLAY 2 must wait on the right port and deliver the backend unit (#12912, #12777).
+
+Two defects that together kept the builtin updater from ever succeeding:
+
+**#12912** — `[PLAY 2] Browser | Wait for service to be ready` waited on port
+3000. Nothing serves 3000: `autobot-playwright` binds `PLAYWRIGHT_PORT` (9001,
+``roles/browser/defaults/main.yml``), and on a live host 3000 is Grafana bound to
+loopback only. The wait timed out after 61 s and failed PLAY 2 on every run — the
+terminal blocker. It also swallowed other components' notify handlers, which is
+how the TTS worker kept serving stale code after its files had been delivered.
+
+**#12777** — the backend systemd unit is role-owned and this play never rendered
+it, so the faulthandler fix was merged, closed, and absent from every host. The
+template had ``Environment="PYTHONFAULTHANDLER=1"``; ``systemctl cat
+autobot-backend`` did not. It exists to make a SIGABRT crash loop diagnosable, so
+its absence defeated the entire point of the issue.
+
+Both are pinned here because both were invisible to the existing suite: the
+playbook parses fine either way, and only a live run exposed them.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_ANSIBLE = Path(__file__).resolve().parents[1] / "ansible"
+_PLAYBOOK = _ANSIBLE / "playbooks" / "update-all-nodes.yml"
+_BROWSER_DEFAULTS = _ANSIBLE / "roles" / "browser" / "defaults" / "main.yml"
+_UNIT_ONLY = _ANSIBLE / "roles" / "backend" / "tasks" / "unit_only.yml"
+_UNIT_TEMPLATE = _ANSIBLE / "roles" / "backend" / "templates" / "autobot-backend.service.j2"
+
+
+def _iter_mappings(node):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_mappings(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_mappings(item)
+
+
+def _browser_wait_task() -> dict:
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+    for task in _iter_mappings(playbook):
+        if "Browser | Wait for service" in str(task.get("name", "")):
+            return task
+    raise AssertionError("browser wait task not found")
+
+
+def test_browser_wait_targets_the_port_the_worker_binds() -> None:
+    """Waiting on 3000 is why PLAY 2 failed every run (#12912)."""
+    port = str(_browser_wait_task().get("wait_for", {}).get("port", ""))
+
+    assert "3000" not in port, (
+        "the browser wait still targets 3000 — nothing serves it; on a live host "
+        "that is Grafana on loopback, and the wait fails PLAY 2 every run"
+    )
+    assert "playwright_port" in port, (
+        "the wait should follow playwright_port rather than hardcode a number"
+    )
+    assert "9001" in port, "keep a literal fallback: role defaults are not in scope here"
+
+
+def test_browser_wait_fallback_matches_the_role_default() -> None:
+    """The inline fallback must not drift from roles/browser/defaults."""
+    defaults = yaml.safe_load(_BROWSER_DEFAULTS.read_text(encoding="utf-8"))
+    declared = str(defaults["playwright_port"])
+
+    assert declared in str(_browser_wait_task()["wait_for"]["port"]), (
+        f"role default playwright_port={declared} but the playbook falls back to "
+        "a different value — they must agree"
+    )
+
+
+def test_backend_unit_is_rendered_before_the_restart() -> None:
+    """Rendering after the restart would start the OLD unit (#12777)."""
+    playbook = yaml.safe_load(_PLAYBOOK.read_text(encoding="utf-8"))
+
+    for play in playbook:
+        tasks = play.get("tasks") or []
+        render_idx = restart_idx = None
+        for i, task in enumerate(tasks):
+            inc = task.get("ansible.builtin.include_role") or task.get("include_role")
+            if isinstance(inc, dict) and inc.get("name") == "backend":
+                if inc.get("tasks_from") == "unit_only":
+                    render_idx = i
+            svc = task.get("systemd") or task.get("ansible.builtin.systemd") or {}
+            if (
+                isinstance(svc, dict)
+                and svc.get("name") == "autobot-backend"
+                and svc.get("state") == "restarted"
+                and restart_idx is None
+            ):
+                restart_idx = i
+        if render_idx is None and restart_idx is None:
+            continue
+        assert render_idx is not None, (
+            "PLAY 2 never renders the backend unit — role-owned unit changes "
+            "(e.g. #12777's faulthandler) cannot reach a host"
+        )
+        if restart_idx is not None:
+            assert render_idx < restart_idx, (
+                "the unit must be rendered BEFORE the restart, else the restart "
+                "starts the old unit and the change only applies a run later"
+            )
+        return
+
+    raise AssertionError("neither a backend unit render nor a restart was found")
+
+
+def test_unit_only_renders_the_template_and_does_not_restart() -> None:
+    """It must reload systemd, and leave restarting to the play's own task."""
+    tasks = yaml.safe_load(_UNIT_ONLY.read_text(encoding="utf-8"))
+    blob = str(tasks)
+
+    assert "autobot-backend.service.j2" in blob, "the unit template must be rendered"
+    assert "daemon_reload" in blob, "systemd must be reloaded after a unit change"
+    assert "restarted" not in blob, (
+        "unit_only must not restart — the play already restarts the backend, and "
+        "a second restart would bounce it twice per update"
+    )
+
+
+def test_faulthandler_is_actually_in_the_unit_template() -> None:
+    """Delivery is pointless if the artifact lacks what #12777 shipped."""
+    assert "PYTHONFAULTHANDLER" in _UNIT_TEMPLATE.read_text(encoding="utf-8"), (
+        "the unit template lost the faulthandler setting — rendering it would "
+        "deliver a unit that still leaves a SIGABRT undiagnosable"
+    )
+
+
+def test_playbook_passes_ansible_syntax_check() -> None:
+    """Only ansible's parser catches semantically invalid task keywords."""
+    ansible = shutil.which("ansible-playbook")
+    if ansible is None:
+        pytest.skip("ansible-playbook not installed")
+
+    result = subprocess.run(
+        [ansible, "--syntax-check", "-i", "localhost,", str(_PLAYBOOK)],
+        capture_output=True,
+        text=True,
+        cwd=_ANSIBLE,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, f"ansible rejected the playbook:\n{result.stderr[-1200:]}"


### PR DESCRIPTION
## Thinking Path

Two defects that together stopped the builtin updater from ever reporting success. Batched because they are the same file, the same failure class (role-owned work not reaching a host), and the same acceptance signal — the #12959 probe going to zero and PLAY 2 finishing clean.

**#12912 — the terminal blocker.** PLAY 2 waited on port 3000 for 61 s and failed on every run. Nothing serves 3000: `autobot-playwright` binds `PLAYWRIGHT_PORT`, declared as `9001` in `roles/browser/defaults/main.yml`, and confirmed live (`node` pid on `0.0.0.0:9001`). On this host 3000 is Grafana, bound to loopback only — so the wait could never succeed even in principle.

This was not just noise. Ansible flushes handlers at end of play, so a play that dies here discards every queued restart — which is exactly why the TTS worker kept serving stale code in #12886 after its files had already been delivered. Fixing the port makes other components' restarts reachable again.

**#12777 — merged, closed, never delivered.** The backend systemd unit is role-owned and this play never rendered it. Verified on a live node: the template carries `Environment="PYTHONFAULTHANDLER=1"`, `systemctl cat autobot-backend` does not. That setting exists so a SIGABRT crash loop leaves a stack, so its absence defeated the point of the issue.

Ordering matters: the render must precede the existing restart, or the restart starts the old unit and the change only takes effect a run later. `unit_only.yml` deliberately does **not** restart — the play already has an explicit backend restart, and adding a second would bounce the backend twice per update.

**Deliberately out of scope: #12907.** Its consolidation task must run *after* the blockinfile that owns the managed block, so delivering it needs a `postgresql` role split rather than a task include — and it rewrites the exact credential file behind this week's DB outage (#12883). Different risk class; it gets its own PR rather than riding along here.

## What Changed

**`playbooks/update-all-nodes.yml`**
- the browser wait follows `{{ playwright_port | default(9001) }}`. The fallback is required because role defaults are not in scope in a playbook task — the #12871 trap — and mirrors `setup-browser-worker.yml`.
- new `[PLAY 2] Backend | Render systemd unit so role changes land (#12777)`, placed before the backend restart.

**`roles/backend/tasks/unit_only.yml`** (new) — renders `autobot-backend.service.j2` and reloads systemd only when it changed. Same shape as `env_only.yml`, so role defaults supply the unit's vars at role-default precedence without clobbering caller overrides.

**`tests/test_updater_browser_port_and_backend_unit.py`** (new, 6 tests) — the wait avoids 3000, follows `playwright_port`, and keeps a fallback that **matches the role default** (so the two cannot drift); the unit is rendered and rendered *before* the restart; `unit_only` reloads but does not restart; the template still contains `PYTHONFAULTHANDLER`; and the playbook passes `ansible --syntax-check`.

## Verification

Mutation-checked — reverting the playbook fails exactly the three wiring tests:

```
FAILED test_browser_wait_targets_the_port_the_worker_binds
FAILED test_browser_wait_fallback_matches_the_role_default
FAILED test_backend_unit_is_rendered_before_the_restart
3 failed, 3 passed
```

and with it restored, across the playbook/TTS/infrastructure suites:

```
44 passed, 1 xfailed
ansible-playbook --syntax-check -> playbook: playbooks/update-all-nodes.yml
```

Live state going in, from the #12959 probe (which already confirmed the TTS fix by clearing that entry):

```
2 of 3 role-owned change(s) never reached this host
  backend (#12777): backend unit lacks faulthandler
  postgresql (#12907): credential store still holds duplicate keys
```

Acceptance is host-side and unproven until this merges: `systemctl cat autobot-backend` containing `PYTHONFAULTHANDLER`, the probe dropping to `1 of 3` (postgresql only), and PLAY 2 completing without the browser timeout. I will run the update afterwards and report the outcome either way — including if it misses again, as it did three times on #12886.

## Model Used

Claude Opus 5 (`claude-opus-5`)

## Follow-up

Closes #12912, #12777.

Refs #12959 — after this, one role (postgresql) remains undelivered, so it stays open. #12907 to follow in its own PR.
