### PR TITLE
refactor(slm-frontend): derive the monitoring long tail from the generated schema (#13138)

### DIFF
--- a/autobot-slm-frontend/src/components/DeploymentLogViewer.vue
+++ b/autobot-slm-frontend/src/components/DeploymentLogViewer.vue
@@ -18,7 +18,14 @@ import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('DeploymentLogViewer')
 
-interface LogEntry {
+/**
+ * A message received on the deployment log WebSocket — NOT an HTTP response.
+ *
+ * Renamed from `LogEntry` in #13138: it collided with the generated
+ * `components['schemas']['LogEntry']` (api/monitoring.py:128) despite sharing
+ * no field with it (`type`/`log_type`, and a `Date` rather than an ISO string).
+ */
+interface DeploymentLogMessage {
   type: string
   log_type: string
   message: string
@@ -36,7 +43,7 @@ const emit = defineEmits<{
   statusChange: [status: string]
 }>()
 
-const logs = ref<LogEntry[]>([])
+const logs = ref<DeploymentLogMessage[]>([])
 const status = ref<string>('connecting')
 const progress = ref<number>(0)
 const error = ref<string | null>(null)

--- a/autobot-slm-frontend/src/components/DeploymentWizard.vue
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.vue
@@ -7,12 +7,21 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { useFleetStore } from '@/stores/fleet'
 import { getSlmApiBase } from '@/config/ssot-config'
-import type { SLMNode, NodeRole } from '@/types/slm'
+import type { SLMNode, NodeRole, RoleInfo, RoleListResponse } from '@/types/slm'
 
-interface RoleInfo {
-  name: string
-  description: string
-  category: string
+/**
+ * The subset of `RoleInfo` this wizard renders.
+ *
+ * Replaces the hand-written `RoleInfo` copy removed in #13138. It stays a
+ * projection rather than the full derived `RoleInfo` because the offline
+ * fallback below is built from `NODE_ROLE_METADATA`, which cannot supply
+ * `ansible_role` or `required` — a full `RoleInfo` there would be a lie. The
+ * member types are derived, so a contract rename still breaks the build.
+ */
+type WizardRoleChoice = {
+  name: RoleInfo['name']
+  description: RoleInfo['description']
+  category: RoleInfo['category']
   dependencies: string[]
 }
 
@@ -33,7 +42,7 @@ const selectedNodeId = ref<string>('')
 const selectedRoles = ref<string[]>([])
 const isDeploying = ref(false)
 const deployError = ref<string | null>(null)
-const roles = ref<RoleInfo[]>([])
+const roles = ref<WizardRoleChoice[]>([])
 const isLoadingRoles = ref(false)
 
 // For manual IP input when no nodes exist
@@ -57,7 +66,7 @@ const canProceedStep2 = computed(() => selectedRoles.value.length > 0)
 
 // Group roles by category
 const rolesByCategory = computed(() => {
-  const groups: Record<string, RoleInfo[]> = {}
+  const groups: Record<string, WizardRoleChoice[]> = {}
   for (const role of roles.value) {
     if (!groups[role.category]) {
       groups[role.category] = []
@@ -101,8 +110,15 @@ async function fetchRoles(): Promise<void> {
       },
     })
     if (response.ok) {
-      const data = await response.json()
-      roles.value = data.roles
+      const data = (await response.json()) as RoleListResponse
+      // #13138: `dependencies` is `default_factory=list` server-side and so
+      // optional in the contract — normalise it, the template reads `.length`.
+      roles.value = data.roles.map((role) => ({
+        name: role.name,
+        description: role.description,
+        category: role.category,
+        dependencies: role.dependencies ?? [],
+      }))
     }
   } catch (e) {
     // Use default roles from node-roles constants if API fails

--- a/autobot-slm-frontend/src/components/InfrastructureWizard.vue
+++ b/autobot-slm-frontend/src/components/InfrastructureWizard.vue
@@ -13,31 +13,10 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import { getSlmApiBase } from '@/config/ssot-config'
+import type { PlaybookInfo, PlaybookExecution } from '@/types/slm'
 
 const logger = createLogger('InfrastructureWizard')
 
-interface PlaybookInfo {
-  id: string
-  name: string
-  description: string
-  category: string
-  playbook_file: string
-  target_hosts: string[]
-  variables: Record<string, unknown>
-  estimated_duration: string
-  requires_confirmation: boolean
-}
-
-interface PlaybookExecution {
-  execution_id: string
-  playbook_id: string
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
-  started_at: string | null
-  completed_at: string | null
-  output: string[]
-  error: string | null
-  triggered_by: string
-}
 
 const props = defineProps<{
   visible: boolean

--- a/autobot-slm-frontend/src/components/fleet/NPUDetailsPanel.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUDetailsPanel.vue
@@ -35,7 +35,10 @@ const success = ref<string | null>(null)
 const liveMetrics = ref<NPUWorkerMetrics | null>(null)
 const showConfigSection = ref(false)
 
-const workerConfig = reactive<NPUWorkerConfig>({
+// #13138: `assigned_models` is `default_factory=list` server-side and therefore
+// OPTIONAL in the contract, but this form always keeps a concrete array so the
+// checkbox list and `toggleModel` have something to index.
+const workerConfig = reactive<NPUWorkerConfig & { assigned_models: string[] }>({
   priority: 1,
   weight: 1,
   max_concurrent: 1,
@@ -78,7 +81,8 @@ const tempColor = computed(() => {
 async function loadWorkerConfig(): Promise<void> {
   const cfg = await fleetStore.fetchNpuWorkerConfig(props.node.node_id)
   if (cfg) {
-    Object.assign(workerConfig, cfg)
+    // The response may omit `assigned_models` entirely — keep the array.
+    Object.assign(workerConfig, cfg, { assigned_models: cfg.assigned_models ?? [] })
   }
 }
 

--- a/autobot-slm-frontend/src/components/fleet/NPUPerformanceMetrics.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUPerformanceMetrics.vue
@@ -51,15 +51,19 @@ function utilizationTextColor(pct: number): string {
   return 'text-green-600'
 }
 
-function temperatureColor(temp: number | null): string {
-  if (temp === null) return 'text-gray-400'
+// #13138: `temperature_celsius` is optional AND nullable in the contract
+// (`temperature_celsius?: float | None`), so an absent reading arrives as
+// `undefined`, not `null` — a `=== null` test alone let it fall through to the
+// "cool" branch and render `undefined°C`.
+function temperatureColor(temp: number | null | undefined): string {
+  if (temp === null || temp === undefined) return 'text-gray-400'
   if (temp > 75) return 'text-red-600'
   if (temp >= 60) return 'text-yellow-600'
   return 'text-green-600'
 }
 
-function temperatureDisplay(temp: number | null): string {
-  if (temp === null) return 'N/A'
+function temperatureDisplay(temp: number | null | undefined): string {
+  if (temp === null || temp === undefined) return 'N/A'
   return `${temp.toFixed(1)}\u00B0C`
 }
 

--- a/autobot-slm-frontend/src/components/fleet/NodeServicesPanel.vue
+++ b/autobot-slm-frontend/src/components/fleet/NodeServicesPanel.vue
@@ -142,7 +142,9 @@ function getStatusClasses(status: ServiceStatus): { bg: string; text: string; do
   return classes[status] || classes.unknown
 }
 
-function formatBytes(bytes: number | null): string {
+// #13138: `memory_bytes` is optional AND nullable in the contract; the body
+// already handled `undefined`, only the signature disagreed.
+function formatBytes(bytes: number | null | undefined): string {
   if (bytes === null || bytes === undefined) return '-'
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`

--- a/autobot-slm-frontend/src/composables/useNodeServices.ts
+++ b/autobot-slm-frontend/src/composables/useNodeServices.ts
@@ -53,7 +53,8 @@ export function useNodeServices(nodeId: MaybeRef<string>) {
         name: s.service_name,
         status: s.status as Service['status'],
         pid: s.main_pid ?? undefined,
-        memory_mb: s.memory_bytes !== null ? s.memory_bytes / 1024 / 1024 : undefined,
+        // #13138: `memory_bytes` is optional AND nullable in the contract.
+        memory_mb: s.memory_bytes != null ? s.memory_bytes / 1024 / 1024 : undefined,
         category: s.category,
       }))
       return services.value

--- a/autobot-slm-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-slm-frontend/src/composables/usePrometheusMetrics.ts
@@ -23,7 +23,18 @@ const API_BASE = getSlmApiBase()
 
 // ===== Type Definitions =====
 
-export interface SystemMetrics {
+/**
+ * Host-level metrics as this composable presents them — a client-side
+ * VIEW-MODEL, not a wire shape.
+ *
+ * Renamed from `SystemMetrics` in #13138: it collided with the generated
+ * `components['schemas']['SystemMetrics']` (the `/health/metrics` response,
+ * autobot-slm-backend/api/health.py:59) while sharing almost nothing with it —
+ * `fetchDashboard` below synthesises every field from `/monitoring/dashboard`'s
+ * `fleet_metrics` averages, and `timestamp` here is `Date.now()`, not an ISO
+ * string. Deriving it would have been actively harmful.
+ */
+export interface SystemMetricsViewModel {
   cpu_percent: number
   memory_percent: number
   disk_percent: number
@@ -94,8 +105,17 @@ export interface OptimizationRecommendation {
   expected_improvement: string
 }
 
-export interface DashboardOverview {
-  system_metrics?: SystemMetrics
+/**
+ * Dashboard shape this composable exposes — a client-side VIEW-MODEL.
+ *
+ * Renamed from `DashboardOverview` in #13138: it collided with the generated
+ * `components['schemas']['DashboardOverview']` (api/monitoring.py:118), which
+ * `fetchDashboard` deliberately REMAPS into this shape (see the mapping right
+ * below). The real wire model is derived, under its own name, in
+ * `types/api-responses.ts`.
+ */
+export interface DashboardViewModel {
+  system_metrics?: SystemMetricsViewModel
   gpu_metrics?: GPUMetrics
   npu_metrics?: NPUMetrics
   hardware_acceleration?: Record<string, boolean>
@@ -183,7 +203,7 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
   }
 
   // State
-  const dashboard = ref<DashboardOverview | null>(null)
+  const dashboard = ref<DashboardViewModel | null>(null)
   const services = ref<ServicesSummary | null>(null)
   const alerts = ref<AlertsSummary | null>(null)
   const recommendations = ref<OptimizationRecommendation[]>([])

--- a/autobot-slm-frontend/src/constants/node-roles.ts
+++ b/autobot-slm-frontend/src/constants/node-roles.ts
@@ -171,6 +171,16 @@ export const NODE_ROLE_METADATA: Record<NodeRole, RoleMetadata> = {
     category: 'remote-access',
     tools: ['tigervnc-standalone-server', 'websockify', 'novnc', 'x11vnc'],
   },
+  // #13138: present in role_registry.py `_INFRA_ROLES` (:372) and therefore
+  // returned by GET /deployments/roles, but missing from this mirror — so the
+  // role rendered with no label and no description wherever it appeared.
+  'docker': {
+    name: 'docker',
+    displayName: 'Docker',
+    description: 'Container runtime for hybrid Docker deployments',
+    category: 'infrastructure',
+    tools: ['docker', 'docker-compose'],
+  },
 }
 
 /**

--- a/autobot-slm-frontend/src/types/api-responses.ts
+++ b/autobot-slm-frontend/src/types/api-responses.ts
@@ -37,13 +37,38 @@ export interface SyncVerifyResponse {
 
 // =============================================================================
 // Services — Restart All (Issue #725)
+//
+// Derived from the generated OpenAPI contract (#13138) — request/response
+// models of POST `/nodes/{node_id}/services/restart-all`
+// (autobot-slm-backend/api/services.py:932).
 // =============================================================================
 
-export interface RestartAllServicesRequest {
-  category?: 'autobot' | 'system' | 'all'
-  exclude_services?: string[]
+/**
+ * Request body of POST `/nodes/{node_id}/services/restart-all`
+ * (models/schemas.py:897).
+ *
+ * `Partial<>` because both fields carry a server-side default (`category=None`,
+ * `exclude_services=[]`) and openapi-typescript emits defaulted fields as
+ * REQUIRED — correct for a response, backwards for a request body.
+ *
+ * The intersected `category` keeps the literal union: the contract widens it to
+ * `string` because OpenAPI cannot express `pattern="^(autobot|system|all)$"`
+ * (models/schemas.py:900), but sending anything else is a guaranteed 422.
+ */
+export type RestartAllServicesRequest = Partial<
+  components['schemas']['RestartAllServicesRequest']
+> & {
+  category?: 'autobot' | 'system' | 'all' | null
 }
 
+/**
+ * Element of `RestartAllServicesResponse.results`.
+ *
+ * Hand-written on purpose: the response model types `results` as a bare
+ * `List[Dict]` (models/schemas.py:920), so the contract can only say
+ * `{ [key: string]: unknown }[]`. The real keys are built at
+ * api/services.py:892-897 and always include `is_slm_agent`.
+ */
 export interface RestartServiceResult {
   service_name: string
   success: boolean
@@ -51,16 +76,15 @@ export interface RestartServiceResult {
   is_slm_agent: boolean
 }
 
-export interface RestartAllServicesResponse {
-  node_id: string
-  success: boolean
-  message: string
-  total_services: number
-  successful_restarts: number
-  failed_restarts: number
-  results: RestartServiceResult[]
-  slm_agent_restarted: boolean
-}
+/**
+ * Response model of POST `/nodes/{node_id}/services/restart-all`
+ * (models/schemas.py:911), with `results` pinned to the shape the endpoint
+ * actually builds.
+ */
+export type RestartAllServicesResponse =
+  components['schemas']['RestartAllServicesResponse'] & {
+    results?: RestartServiceResult[]
+  }
 
 // =============================================================================
 // VNC Credentials (Issue #725)
@@ -175,155 +199,73 @@ export interface TLSEnableResponse {
 
 // =============================================================================
 // Monitoring (Issue #729)
+//
+// Derived from the generated OpenAPI contract (#13138) — response models of
+// autobot-slm-backend/api/monitoring.py. The local names are kept as aliases
+// of the differently-named schemas so existing importers stay untouched.
+//
+// NOTE for future passes: the same three names — `DashboardOverview`,
+// `SystemMetrics` and `LogEntry` — are ALSO declared in
+// `composables/usePrometheusMetrics.ts`, `views/monitoring/LogViewer.vue` and
+// `components/DeploymentLogViewer.vue`. Those are client-side VIEW-MODELS that
+// deliberately remap these endpoints; they must never be derived. They were
+// renamed in #13138 so the collision cannot come back.
 // =============================================================================
 
-export interface FleetMetricsNode {
-  node_id: string
-  hostname: string
-  ip_address: string
-  status: string
-  cpu_percent: number
-  memory_percent: number
-  disk_percent: number
-  last_heartbeat: string | null
-  services_running: number
-  services_failed: number
-}
+/** Entry of `FleetMetricsResponse.nodes` — `NodeMetrics` (monitoring.py:53). */
+export type FleetMetricsNode = components['schemas']['NodeMetrics']
 
-export interface FleetMetrics {
-  total_nodes: number
-  online_nodes: number
-  degraded_nodes: number
-  offline_nodes: number
-  avg_cpu_percent: number
-  avg_memory_percent: number
-  avg_disk_percent: number
-  total_services: number
-  running_services: number
-  failed_services: number
-  nodes: FleetMetricsNode[]
-  timestamp: string
-}
+/**
+ * Response model of GET `/monitoring/metrics/fleet` — `FleetMetricsResponse`
+ * (monitoring.py:68). `timestamp` is `default_factory`, hence optional here.
+ */
+export type FleetMetrics = components['schemas']['FleetMetricsResponse']
 
-export interface AlertItem {
-  alert_id: string
-  severity: string
-  category: string
-  message: string
-  node_id: string | null
-  hostname: string | null
-  timestamp: string
-  acknowledged: boolean
-}
+/** Entry of `AlertsResponse.alerts` (monitoring.py:85). */
+export type AlertItem = components['schemas']['AlertItem']
 
-export interface AlertsResponse {
-  total_count: number
-  critical_count: number
-  warning_count: number
-  info_count: number
-  alerts: AlertItem[]
-}
+/** Response model of GET `/monitoring/alerts` (monitoring.py:98). */
+export type AlertsResponse = components['schemas']['AlertsResponse']
 
-export interface MonitoringSystemHealth {
-  overall_status: string
-  health_score: number
-  components: Record<string, string>
-  issues: string[]
-  last_check: string
-}
+/**
+ * Response model of GET `/monitoring/health` — `SystemHealthResponse`
+ * (monitoring.py:108). `last_check` is `default_factory`, hence optional.
+ */
+export type MonitoringSystemHealth = components['schemas']['SystemHealthResponse']
 
-export interface DashboardOverview {
-  fleet_metrics: FleetMetrics
-  recent_alerts: AlertItem[]
-  recent_deployments: number
-  active_maintenance: number
-  health_summary: MonitoringSystemHealth
-}
+/** Response model of GET `/monitoring/dashboard` (monitoring.py:118). */
+export type DashboardOverview = components['schemas']['DashboardOverview']
 
-export interface LogEntry {
-  event_id: string
-  node_id: string
-  hostname: string
-  event_type: string
-  severity: string
-  message: string
-  timestamp: string
-}
+/** Entry of `LogsResponse.logs` (monitoring.py:128). */
+export type LogEntry = components['schemas']['LogEntry']
 
-export interface LogsResponse {
-  logs: LogEntry[]
-  total: number
-  page: number
-  per_page: number
-}
+/** Response model of GET `/monitoring/logs` (monitoring.py:140). */
+export type LogsResponse = components['schemas']['LogsResponse']
 
 // Application-log viewer (Issue #11302) — tails allowlisted on-node log files
 // (backend-error.log, celery-error.log, etc.) via GET /monitoring/app-logs.
-export interface AppLogEntry {
-  line_number: number
-  timestamp: string | null
-  severity: string | null
-  message: string
-}
 
-export interface AppLogsResponse {
-  entries: AppLogEntry[]
-  total: number
-  page: number
-  per_page: number
-  node_id: string
-  service: string
-}
+/** Entry of `AppLogsResponse.entries` (monitoring.py:149). */
+export type AppLogEntry = components['schemas']['AppLogEntry']
+
+/** Response model of GET `/monitoring/app-logs` (monitoring.py:158). */
+export type AppLogsResponse = components['schemas']['AppLogsResponse']
 
 // =============================================================================
 // Blue-Green Deployments (Issue #726 Phase 3)
+//
+// Single-sourced from `types/slm.ts` (#13138): these three shapes were declared
+// here AND there for the same wire models, and `DeploymentsView.vue` bridged
+// the two copies with an `as BlueGreenDeployment[]` cast — so a divergence
+// would have been silently cast away. `types/slm.ts` now derives them from the
+// generated contract; these are aliases so existing importers keep working.
 // =============================================================================
 
-export interface BlueGreenDeploymentApi {
-  id: number
-  bg_deployment_id: string
-  blue_node_id: string
-  blue_roles: string[]
-  green_node_id: string
-  green_original_roles: string[]
-  borrowed_roles: string[]
-  purge_on_complete: boolean
-  deployment_type: string
-  health_check_url: string | null
-  health_check_interval: number
-  health_check_timeout: number
-  auto_rollback: boolean
-  status: string
-  progress_percent: number
-  current_step: string | null
-  error: string | null
-  started_at: string | null
-  switched_at: string | null
-  completed_at: string | null
-  rollback_at: string | null
-  triggered_by: string | null
-  created_at: string
-  updated_at: string
-}
-
-export interface BlueGreenCreate {
-  blue_node_id: string
-  green_node_id: string
-  roles: string[]
-  deployment_type?: string
-  health_check_url?: string
-  health_check_interval?: number
-  health_check_timeout?: number
-  auto_rollback?: boolean
-  purge_on_complete?: boolean
-}
-
-export interface BlueGreenListResponse {
-  deployments: BlueGreenDeploymentApi[]
-  total: number
-  page: number
-  per_page: number
-}
+export type {
+  BlueGreenDeployment as BlueGreenDeploymentApi,
+  BlueGreenDeploymentCreate as BlueGreenCreate,
+  BlueGreenListResponse,
+} from './slm'
 
 // =============================================================================
 // NPU Management (Issue #255)
@@ -341,143 +283,93 @@ export interface NPURoleResponse {
   detection_triggered?: boolean
 }
 
-export interface NPUDetectionResponse {
-  success: boolean
-  message: string
-  node_id: string
-  capabilities: import('./slm').NPUNodeStatus['capabilities'] | null
-}
+/**
+ * Response model of POST `/npu/nodes/{node_id}/detect` (api/npu.py).
+ * `capabilities` is the derived `NPUCapabilities` (types/slm.ts), narrowed
+ * there to the `NPUDeviceType` union the detector actually emits.
+ */
+export type NPUDetectionResponse =
+  components['schemas']['NPUDetectionResponse'] & {
+    capabilities?: import('./slm').NPUCapabilities | null
+  }
 
 // =============================================================================
 // Error Monitoring (Issue #563)
 // =============================================================================
 
-export interface ErrorStatistics {
-  total_errors: number
-  errors_24h: number
-  errors_7d: number
-  errors_30d: number
-  resolved_count: number
-  unresolved_count: number
-  error_rate_per_hour: number
+/**
+ * Response model of GET `/errors/statistics` (api/errors.py:37).
+ *
+ * `trend` is a bare `str` in the contract, but `_calculate_error_trend`
+ * (api/errors.py:245-273) returns exactly one of three literals on every path,
+ * so the union is a real guarantee and is kept by intersection.
+ */
+export type ErrorStatistics = components['schemas']['ErrorStatistics'] & {
   trend: 'increasing' | 'decreasing' | 'stable'
 }
 
-export interface RecentError {
-  event_id: string
-  node_id: string
-  hostname: string
-  event_type: string
-  severity: string
-  message: string
-  timestamp: string
-  resolved: boolean
-  resolved_at: string | null
-  resolved_by: string | null
-}
+/** Entry of `RecentErrorsResponse.errors` (api/errors.py:50). */
+export type RecentError = components['schemas']['RecentError']
 
-export interface RecentErrorsResponse {
-  errors: RecentError[]
-  total: number
-  page: number
-  per_page: number
-}
+/** Response model of GET `/errors/recent` (api/errors.py:65). */
+export type RecentErrorsResponse = components['schemas']['RecentErrorsResponse']
 
-export interface CategoryBreakdown {
-  category: string
-  count: number
-  percentage: number
-}
+/** Entry of `CategoriesResponse.categories` (api/errors.py:74). */
+export type CategoryBreakdown = components['schemas']['CategoryBreakdown']
 
-export interface CategoriesResponse {
-  categories: CategoryBreakdown[]
-  total: number
-}
+/** Response model of GET `/errors/categories` (api/errors.py:82). */
+export type CategoriesResponse = components['schemas']['CategoriesResponse']
 
-export interface ComponentBreakdown {
-  node_id: string
-  hostname: string
-  count: number
-  percentage: number
-}
+/** Entry of `ComponentsResponse.components` (api/errors.py:89). */
+export type ComponentBreakdown = components['schemas']['ComponentBreakdown']
 
-export interface ComponentsResponse {
-  components: ComponentBreakdown[]
-  total: number
-}
+/** Response model of GET `/errors/components` (api/errors.py:98). */
+export type ComponentsResponse = components['schemas']['ComponentsResponse']
 
-export interface ErrorHealthResponse {
+/**
+ * Response model of GET `/errors/health` (api/errors.py:105).
+ *
+ * `status` is a bare `str` in the contract; `get_error_health`
+ * (api/errors.py:509-518) assigns exactly one of three literals on every
+ * branch, so the union is kept by intersection.
+ */
+export type ErrorHealthResponse = components['schemas']['ErrorHealthResponse'] & {
   status: 'healthy' | 'warning' | 'critical'
-  error_rate_current: number
-  error_rate_threshold_warning: number
-  error_rate_threshold_critical: number
-  recent_critical_count: number
-  message: string
 }
 
-export interface MetricsSummary {
-  total_errors: number
-  unresolved_errors: number
-  critical_errors: number
-  error_rate_per_hour: number
-  mean_time_to_resolve_hours: number | null
-  top_error_type: string | null
-  most_affected_node: string | null
-}
+/** Response model of GET `/errors/metrics/summary` (api/errors.py:116). */
+export type MetricsSummary = components['schemas']['MetricsSummary']
 
-export interface TimelinePoint {
-  timestamp: string
-  count: number
-  critical: number
-  error: number
-}
+/** Entry of `TimelineResponse.timeline` (api/errors.py:128). */
+export type TimelinePoint = components['schemas']['TimelinePoint']
 
-export interface TimelineResponse {
-  timeline: TimelinePoint[]
-  interval: string
-  start: string
-  end: string
-}
+/** Response model of GET `/errors/metrics/timeline` (api/errors.py:137). */
+export type TimelineResponse = components['schemas']['TimelineResponse']
 
-export interface TopError {
-  event_type: string
-  message: string
-  count: number
-  last_occurred: string
-  affected_nodes: string[]
-}
+/** Entry of `TopErrorsResponse.errors` (api/errors.py:146). */
+export type TopError = components['schemas']['TopError']
 
-export interface TopErrorsResponse {
-  errors: TopError[]
-}
+/** Response model of GET `/errors/metrics/top-errors` (api/errors.py:156). */
+export type TopErrorsResponse = components['schemas']['TopErrorsResponse']
 
-export interface AlertThresholdConfig {
-  warning_threshold: number
-  critical_threshold: number
-  retention_days: number
-}
+/**
+ * Request body of POST `/errors/metrics/alert-threshold` (api/errors.py:162).
+ * All three fields are genuinely required — they carry `ge`/`le` bounds but no
+ * default — so a plain alias is correct here, not `Partial`.
+ */
+export type AlertThresholdConfig = components['schemas']['AlertThresholdConfig']
 
-export interface AlertThresholdResponse extends AlertThresholdConfig {
-  updated: boolean
-}
+/** Response model of POST `/errors/metrics/alert-threshold` (api/errors.py:170). */
+export type AlertThresholdResponse = components['schemas']['AlertThresholdResponse']
 
-export interface CleanupResponse {
-  deleted_count: number
-  retention_days: number
-  message: string
-}
+/** Response model of POST `/errors/metrics/cleanup` (api/errors.py:179). */
+export type CleanupResponse = components['schemas']['CleanupResponse']
 
-export interface ClearResponse {
-  deleted_count: number
-  message: string
-}
+/** Response model of POST `/errors/clear` (api/errors.py:187). */
+export type ClearResponse = components['schemas']['ClearResponse']
 
-export interface ResolveResponse {
-  event_id: string
-  resolved: boolean
-  resolved_at: string
-  resolved_by: string
-}
+/** Response model of POST `/errors/metrics/resolve/{event_id}` (api/errors.py:201). */
+export type ResolveResponse = components['schemas']['ResolveResponse']
 
 // =============================================================================
 // Security (Issue #813)
@@ -541,9 +433,8 @@ export interface WizardStatusResponse {
 // Generic action response (used across multiple endpoints)
 // =============================================================================
 
-export interface ActionResponse {
-  action: string
-  success: boolean
-  message: string
-  resource_id?: string
-}
+/**
+ * Shared action envelope (`ActionResponse`, models/schemas.py). `resource_id`
+ * is optional AND nullable in the contract.
+ */
+export type ActionResponse = components['schemas']['ActionResponse']

--- a/autobot-slm-frontend/src/types/slm.ts
+++ b/autobot-slm-frontend/src/types/slm.ts
@@ -741,6 +741,37 @@ export interface ExternalAgentCard {
 }
 
 // =============================================================================
+// Infrastructure Playbooks (Issue #1177)
+//
+// Derived from the generated OpenAPI contract (#13138) — response models of
+// autobot-slm-backend/api/infrastructure.py. `PlaybookInfo` was declared
+// identically in `components/InfrastructureWizard.vue` and
+// `views/InfrastructureView.vue`, so one backend change had two places to
+// drift from; both now import this single definition.
+// =============================================================================
+
+/**
+ * Response element of GET `/infrastructure/playbooks`
+ * (api/infrastructure.py:54).
+ *
+ * Both hand-written copies omitted `tags`, and typed `category` as a bare
+ * `string` where the contract has the `PlaybookCategory` enum.
+ */
+export type PlaybookInfo = components['schemas']['PlaybookInfo']
+
+/** Playbook category enum (api/infrastructure.py:33). */
+export type PlaybookCategory = components['schemas']['PlaybookCategory']
+
+/**
+ * Playbook run state (api/infrastructure.py:69). `output` is
+ * `default_factory=list` and therefore optional in the contract.
+ */
+export type PlaybookExecution = components['schemas']['PlaybookExecution']
+
+/** Playbook execution status enum (api/infrastructure.py:44). */
+export type PlaybookStatus = components['schemas']['PlaybookStatus']
+
+// =============================================================================
 // Security API Response Types (Issue #3184)
 //
 // Derived from the generated OpenAPI contract (#13138). Every shape below is

--- a/autobot-slm-frontend/src/types/slm.ts
+++ b/autobot-slm-frontend/src/types/slm.ts
@@ -20,6 +20,15 @@ import type { components } from './generated/api'
  */
 export type NodeStatus = components['schemas']['NodeStatus']
 
+/**
+ * Role names the SLM fleet can assign.
+ *
+ * Mirror of `DEFAULT_ROLES` in
+ * autobot-slm-backend/services/role_registry.py:416 — the registry is the
+ * source of truth and `constants/node-roles.ts` carries the matching metadata.
+ * `'docker'` (`_INFRA_ROLES`, role_registry.py:372) was missing from this union
+ * until #13138; `GET /deployments/roles` has always returned it.
+ */
 export type NodeRole =
   | 'slm-backend'
   | 'slm-frontend'
@@ -41,6 +50,7 @@ export type NodeRole =
   | 'autobot_shared'
   | 'slm-agent'
   | 'vnc'
+  | 'docker'
 
 export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
 
@@ -218,25 +228,42 @@ export interface NodeUpdateCheckResponse {
 export type RoleCategory = 'core' | 'data' | 'application' | 'ai' | 'automation' | 'observability' | 'remote-access' | 'infrastructure'
 
 /**
- * Available role information from backend
+ * Available role information — response element of GET `/deployments/roles`
+ * (`RoleInfo`, models/schemas.py:421). Derived from the generated contract
+ * (#13138).
+ *
+ * The hand-written declaration omitted `ansible_role` entirely
+ * (schemas.py:427) — the playbook the role maps to — so the UI could not reach
+ * it.
+ *
+ * `name` and `category` are widened to `str` by the contract but stay narrowed
+ * here: `_build_available_roles` (api/deployments.py:149-171) copies
+ * `reg["name"]` out of `role_registry.DEFAULT_ROLES`, which
+ * `constants/node-roles.ts` is documented to mirror, and every `category` comes
+ * from `_ROLE_UI_META` (deployments.py:44-147) or the `"core"` default — both
+ * sets match these unions exactly. Deriving them surfaced the one real gap:
+ * `'docker'` was missing from `NodeRole`.
+ *
+ * `dependencies` is NOT narrowed back to `NodeRole[]`: the builder passes
+ * `dependencies=[]` unconditionally (deployments.py:166), so the old claim
+ * described a field the endpoint never populates.
  */
-export interface RoleInfo {
+export type RoleInfo = components['schemas']['RoleInfo'] & {
   name: NodeRole
-  description: string
   category: RoleCategory
-  required: boolean
-  degraded_without: string[]
-  dependencies: NodeRole[]
-  variables: Record<string, unknown>
-  tools: string[]
 }
 
 /**
- * Response for listing available roles
+ * Response model of GET `/deployments/roles` (models/schemas.py:435).
+ *
+ * NOTE (#13138) — the narrowed member comes FIRST in these list envelopes on
+ * purpose. `A[] & B[]` keeps both `map` signatures and TypeScript resolves the
+ * callback against the first one, so `base & { items: Narrow[] }` silently
+ * types the callback parameter as the WIDE element (that is how
+ * `useNodeServices.ts` ended up mapping `category` as `string`). Writing
+ * `{ items: Narrow[] } & base` picks the narrowed element.
  */
-export interface RoleListResponse {
-  roles: RoleInfo[]
-}
+export type RoleListResponse = { roles: RoleInfo[] } & components['schemas']['RoleListResponse']
 
 /**
  * PKI certificate status for a node
@@ -367,20 +394,25 @@ export interface MaintenanceWindow {
   updated_at: string
 }
 
-export interface MaintenanceWindowCreate {
-  node_id?: string
-  start_time: string
-  end_time: string
-  reason?: string
-  auto_drain?: boolean
-  suppress_alerts?: boolean
-  suppress_remediation?: boolean
+/**
+ * Request body of POST `/maintenance/windows` — `MaintenanceWindowCreate`.
+ * Derived from the generated contract (#13138).
+ *
+ * `Partial<>` because `auto_drain`, `suppress_alerts` and `suppress_remediation`
+ * all carry server-side defaults and openapi-typescript emits defaulted fields
+ * as REQUIRED — backwards for a request body. The two genuinely mandatory
+ * fields are re-required by indexed access so they stay derived.
+ */
+export type MaintenanceWindowCreate = Partial<
+  components['schemas']['MaintenanceWindowCreate']
+> & {
+  start_time: components['schemas']['MaintenanceWindowCreate']['start_time']
+  end_time: components['schemas']['MaintenanceWindowCreate']['end_time']
 }
 
-export interface MaintenanceWindowListResponse {
-  windows: MaintenanceWindow[]
-  total: number
-}
+/** Response model of GET `/maintenance/windows`. */
+export type MaintenanceWindowListResponse = { windows: MaintenanceWindow[] } &
+  components['schemas']['MaintenanceWindowListResponse']
 
 export interface SLMWebSocketMessage {
   type: 'health_update' | 'deployment_status' | 'backup_status' | 'node_status' | 'remediation_event' | 'service_status' | 'rollback_event'
@@ -398,16 +430,10 @@ export interface FleetSummary {
 }
 
 /**
- * Per-node update summary from fleet update check (#682)
+ * Per-node update summary from the fleet update check (#682), derived from the
+ * generated contract (#13138).
  */
-export interface NodeUpdateSummary {
-  node_id: string
-  hostname: string
-  system_updates: number
-  code_update_available: boolean
-  code_status: string
-  total_updates: number
-}
+export type NodeUpdateSummary = components['schemas']['NodeUpdateSummary']
 
 /**
  * Fleet-wide update summary response (#682)
@@ -427,29 +453,29 @@ export type ServiceStatus = 'running' | 'stopped' | 'failed' | 'unknown'
 
 export type ServiceCategory = 'autobot' | 'system'
 
-export interface NodeService {
-  id: number
-  node_id: string
-  service_name: string
+/**
+ * A systemd unit tracked on a node — the `ServiceResponse` model
+ * (autobot-slm-backend/models/schemas.py), derived from the generated contract
+ * (#13138). The hand-written declaration was missing `endpoint_path`, `port`,
+ * `protocol` and `is_discoverable`.
+ *
+ * `status` and `category` are widened to `string` by the contract but kept as
+ * unions here: `category` is written only through `ServiceCategoryUpdate`,
+ * which pins `pattern="^(autobot|system)$"`, and `status` is written only from
+ * the `ServiceStatus` enum. Issue #1019: `extra_data` may include
+ * `error_message` for failed services.
+ */
+export type NodeService = components['schemas']['ServiceResponse'] & {
   status: ServiceStatus
   category: ServiceCategory
-  enabled: boolean
-  description: string | null
-  active_state: string | null
-  sub_state: string | null
-  main_pid: number | null
-  memory_bytes: number | null
-  // Issue #1019: extra_data may include error_message for failed services
-  extra_data: Record<string, unknown>
-  last_checked: string | null
-  created_at: string
-  updated_at: string
 }
 
-export interface ServiceListResponse {
-  services: NodeService[]
-  total: number
-}
+/**
+ * Response model of GET `/nodes/{node_id}/services` (#13138). The intersection
+ * keeps `services` pinned to `NodeService`, whose `status`/`category` literal
+ * unions the contract widens to `string`.
+ */
+export type ServiceListResponse = { services: NodeService[] } & components['schemas']['ServiceListResponse']
 
 export interface ServiceActionResponse {
   action: string
@@ -460,12 +486,8 @@ export interface ServiceActionResponse {
   job_id?: string
 }
 
-export interface ServiceLogsResponse {
-  service_name: string
-  node_id: string
-  logs: string
-  lines_returned: number
-}
+/** Response model of GET `/nodes/{node_id}/services/{name}/logs` (#13138). */
+export type ServiceLogsResponse = components['schemas']['ServiceLogsResponse']
 
 export interface FleetServiceStatus {
   service_name: string
@@ -494,6 +516,16 @@ export interface FleetServicesResponse {
 // Blue-Green Deployment Types (Issue #726 Phase 3)
 // =============================================================================
 
+/**
+ * Blue-green deployment lifecycle status.
+ *
+ * The contract widens `status` to `str`; the real value set is the
+ * `BlueGreenStatus` enum (models/database.py:573-586), which the column
+ * default and every assignment site draw from. `'monitoring'` is the
+ * post-deployment health-watch state added by Issue #726 Phase 3
+ * (services/blue_green.py:780) and was missing from this union — a deployment
+ * sitting in it fell through every bucket of `bgStats` in `DeploymentsView`.
+ */
 export type BlueGreenStatus =
   | 'pending'
   | 'borrowing'
@@ -501,56 +533,49 @@ export type BlueGreenStatus =
   | 'verifying'
   | 'switching'
   | 'active'
+  | 'monitoring'
   | 'rolling_back'
   | 'rolled_back'
   | 'completed'
   | 'failed'
 
-export interface BlueGreenDeployment {
-  id: number
-  bg_deployment_id: string
-  blue_node_id: string
-  blue_roles: string[]
-  green_node_id: string
-  green_original_roles: string[]
-  borrowed_roles: string[]
-  purge_on_complete: boolean
-  deployment_type: 'upgrade' | 'migration' | 'failover'
-  health_check_url: string | null
-  health_check_interval: number
-  health_check_timeout: number
-  auto_rollback: boolean
+/**
+ * `deployment_type` value set — a bare `str` column with an `upgrade` default
+ * and an enumerating comment (models/database.py:617).
+ */
+export type BlueGreenDeploymentType = 'upgrade' | 'migration' | 'failover'
+
+/**
+ * Response model of the blue-green endpoints — `BlueGreenResponse`
+ * (autobot-slm-backend/api/blue_green.py). Derived from the generated contract
+ * (#13138); the intersection keeps the two literal unions the schema widens to
+ * `string`.
+ */
+export type BlueGreenDeployment = components['schemas']['BlueGreenResponse'] & {
   status: BlueGreenStatus
-  progress_percent: number
-  current_step: string | null
-  error: string | null
-  started_at: string | null
-  switched_at: string | null
-  completed_at: string | null
-  rollback_at: string | null
-  triggered_by: string | null
-  created_at: string
-  updated_at: string
+  deployment_type: BlueGreenDeploymentType
 }
 
-export interface BlueGreenDeploymentCreate {
-  blue_node_id: string
-  green_node_id: string
-  roles: string[]
-  deployment_type?: 'upgrade' | 'migration' | 'failover'
-  health_check_url?: string
-  health_check_interval?: number
-  health_check_timeout?: number
-  auto_rollback?: boolean
-  purge_on_complete?: boolean
+/**
+ * Request body of POST `/blue-green` — `BlueGreenCreate`.
+ *
+ * `Partial<>` because every optional knob carries a server-side default and
+ * openapi-typescript emits defaulted fields as REQUIRED, which is backwards for
+ * a request body; the three genuinely mandatory fields are re-required by
+ * indexed access so they stay derived.
+ */
+export type BlueGreenDeploymentCreate = Partial<
+  components['schemas']['BlueGreenCreate']
+> & {
+  blue_node_id: components['schemas']['BlueGreenCreate']['blue_node_id']
+  green_node_id: components['schemas']['BlueGreenCreate']['green_node_id']
+  roles: components['schemas']['BlueGreenCreate']['roles']
+  deployment_type?: BlueGreenDeploymentType
 }
 
-export interface BlueGreenListResponse {
-  deployments: BlueGreenDeployment[]
-  total: number
-  page: number
-  per_page: number
-}
+/** Response model of GET `/blue-green` (paginated list). */
+export type BlueGreenListResponse = { deployments: BlueGreenDeployment[] } &
+  components['schemas']['BlueGreenListResponse']
 
 export interface EligibleNode {
   node_id: string
@@ -561,15 +586,19 @@ export interface EligibleNode {
   status: string
 }
 
-export interface EligibleNodesResponse {
-  nodes: EligibleNode[]
-  total: number
-}
+/** Response model of GET `/blue-green/eligible-nodes` (#13138). */
+export type EligibleNodesResponse = { nodes: EligibleNode[] } &
+  components['schemas']['EligibleNodesResponse']
 
-export interface RolePurgeRequest {
-  node_id: string
-  roles: string[]
-  force?: boolean
+/**
+ * Request body of the role-purge endpoint (#13138). `force` carries a
+ * server-side default, so `Partial<>` + re-required mandatory fields.
+ */
+export type RolePurgeRequest = Partial<
+  components['schemas']['RolePurgeRequest']
+> & {
+  node_id: components['schemas']['RolePurgeRequest']['node_id']
+  roles: components['schemas']['RolePurgeRequest']['roles']
 }
 
 // =============================================================================
@@ -580,13 +609,19 @@ export type NPUDeviceType = 'intel-npu' | 'nvidia-gpu' | 'amd-gpu' | 'unknown'
 
 export type NPULoadBalancingStrategy = 'round-robin' | 'least-loaded' | 'model-affinity'
 
-export interface NPUCapabilities {
-  models: string[]
-  maxConcurrent: number
-  memoryGB: number
-  deviceType: NPUDeviceType
-  utilization: number
-}
+/**
+ * NPU device capabilities reported by detection (#13138).
+ *
+ * `deviceType` is deliberately NOT narrowed back to `NPUDeviceType`: it is
+ * copied verbatim out of an external NPU worker's `/health` payload
+ * (`data.get("deviceType", "unknown")`, api/npu.py:83), so nothing constrains
+ * it to the four known values. All three renderers already fall through to the
+ * raw string for an unknown device (NPUNodeCard.vue:50,
+ * NPUWorkerMonitor.vue:97, NPUDetailsPanel.vue:54), so the union was an
+ * unverifiable claim the UI never relied on. `NPUDeviceType` stays exported as
+ * the set of values that get a friendly label.
+ */
+export type NPUCapabilities = components['schemas']['NPUCapabilities']
 
 export interface NPUNodeStatus {
   node_id: string
@@ -598,10 +633,19 @@ export interface NPUNodeStatus {
   detectionError?: string
 }
 
-export interface NPULoadBalancingConfig {
-  strategy: NPULoadBalancingStrategy
-  modelAffinity: Record<string, string[]>
-}
+/**
+ * NPU load-balancing configuration (#13138).
+ *
+ * `strategy` is a bare `str` on the model (models/schemas.py:2115), but the
+ * value set is enumerated by `NPULoadBalancingStrategy`
+ * (models/schemas.py:2078-2085) and matches this union exactly, so the
+ * narrowing is kept by intersection. `modelAffinity` is `default_factory=dict`,
+ * hence optional in the contract.
+ */
+export type NPULoadBalancingConfig =
+  components['schemas']['NPULoadBalancingConfig'] & {
+    strategy: NPULoadBalancingStrategy
+  }
 
 export interface NPUModelInfo {
   name: string
@@ -613,20 +657,12 @@ export interface NPUModelInfo {
 
 // NPU Metrics & Config Types (Issue #590 - NPU Dashboard Improvements)
 
-export interface NPUWorkerMetrics {
-  node_id: string
-  utilization: number
-  temperature_celsius: number | null
-  inference_count: number
-  avg_latency_ms: number
-  throughput_rps: number
-  queue_depth: number
-  memory_used_gb: number
-  memory_total_gb: number
-  uptime_seconds: number
-  error_count: number
-  timestamp: string | null
-}
+/**
+ * Per-worker NPU metrics (#13138). `temperature_celsius` and `timestamp` are
+ * optional AND nullable in the contract; the hand-written declaration required
+ * both to be present.
+ */
+export type NPUWorkerMetrics = components['schemas']['NPUWorkerMetrics']
 
 export interface NPUFleetMetrics {
   total_nodes: number
@@ -639,13 +675,17 @@ export interface NPUFleetMetrics {
   node_metrics: NPUWorkerMetrics[]
 }
 
-export interface NPUWorkerConfig {
-  priority: number
-  weight: number
-  max_concurrent: number
+/**
+ * Configuration for an individual NPU worker (models/schemas.py:2196), derived
+ * from the generated contract (#13138).
+ *
+ * `failure_action` is a bare `str` with only a `retry` default server-side
+ * (schemas.py:2202); its sole construction site is the four-option `<select>`
+ * at `components/fleet/NPUDetailsPanel.vue:383-386`, so the union is a real
+ * frontend-side guarantee and is kept by intersection.
+ */
+export type NPUWorkerConfig = components['schemas']['NPUWorkerConfig'] & {
   failure_action: 'retry' | 'failover' | 'skip' | 'alert'
-  max_retries: number
-  assigned_models: string[]
 }
 
 // =============================================================================
@@ -673,24 +713,25 @@ export interface ExternalAgent {
   updated_at: string | null
 }
 
-export interface ExternalAgentCreate {
-  name: string
-  base_url: string
-  description?: string
-  tags?: string[]
-  enabled?: boolean
-  ssl_verify?: boolean
-  api_key?: string
+/**
+ * Request body of POST `/external-agents` (#13138).
+ *
+ * `Partial<>` because `enabled`, `ssl_verify` and `tags` carry server-side
+ * defaults that openapi-typescript emits as REQUIRED — backwards for a request
+ * body; `name` and `base_url` are re-required by indexed access.
+ */
+export type ExternalAgentCreate = Partial<
+  components['schemas']['ExternalAgentCreate']
+> & {
+  name: components['schemas']['ExternalAgentCreate']['name']
+  base_url: components['schemas']['ExternalAgentCreate']['base_url']
 }
 
-export interface ExternalAgentUpdate {
-  name?: string
-  description?: string
-  tags?: string[]
-  enabled?: boolean
-  ssl_verify?: boolean
-  api_key?: string
-}
+/**
+ * Request body of PATCH `/external-agents/{id}` (#13138) — every field is a
+ * nullable override, so a plain alias is correct here.
+ */
+export type ExternalAgentUpdate = components['schemas']['ExternalAgentUpdate']
 
 export interface ExternalAgentCard {
   id: number

--- a/autobot-slm-frontend/src/views/DeploymentsView.blueGreen.test.ts
+++ b/autobot-slm-frontend/src/views/DeploymentsView.blueGreen.test.ts
@@ -1,0 +1,161 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Issue #13138 — a blue-green deployment in the `monitoring` status showed up
+ * in NO stat tile at all.
+ *
+ * `BlueGreenStatus` (types/slm.ts) omitted `'monitoring'`, the post-deployment
+ * health-watch state the backend sets at services/blue_green.py:780 and holds
+ * for up to `post_deploy_monitor_duration` seconds. `bgStats.active` tested a
+ * hard-coded list that did not include it, `completed`/`failed`/`rolledBack`
+ * did not match either, and `getStatusClass` fell through to the neutral gray
+ * default — so a deployment being actively health-watched simply vanished from
+ * the dashboard, and its badge claimed nothing was happening.
+ *
+ * Deriving `BlueGreenDeployment` from the generated contract restored the
+ * fields the health-watch reports (`health_failures`,
+ * `health_failure_threshold`, `monitoring_started_at`,
+ * `post_deploy_monitor_duration`), which the hand-written type omitted
+ * entirely.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref, computed } from 'vue'
+import en from '@/locales/en.json'
+import type { BlueGreenDeployment, BlueGreenStatus } from '@/types/slm'
+
+function makeBgDeployment(status: BlueGreenStatus): BlueGreenDeployment {
+  return {
+    id: 1,
+    bg_deployment_id: 'bg-1',
+    blue_node_id: 'node-blue',
+    blue_roles: ['backend'],
+    green_node_id: 'node-green',
+    green_original_roles: [],
+    borrowed_roles: ['backend'],
+    purge_on_complete: true,
+    deployment_type: 'upgrade',
+    health_check_url: null,
+    health_check_interval: 10,
+    health_check_timeout: 300,
+    health_failure_threshold: 3,
+    health_failures: 0,
+    monitoring_started_at: '2026-07-31T12:00:00Z',
+    post_deploy_monitor_duration: 1800,
+    auto_rollback: true,
+    status,
+    progress_percent: 100,
+    current_step: 'post-deploy monitoring',
+    error: null,
+    started_at: '2026-07-31T11:00:00Z',
+    switched_at: '2026-07-31T11:59:00Z',
+    completed_at: null,
+    rollback_at: null,
+    triggered_by: 'admin',
+    created_at: '2026-07-31T11:00:00Z',
+    updated_at: '2026-07-31T12:00:00Z',
+  }
+}
+
+let bgDeploymentsImpl: BlueGreenDeployment[] = []
+
+vi.mock('@/composables/useSlmApi', () => ({
+  useSlmApi: () => ({
+    getDeployments: vi.fn().mockResolvedValue([]),
+    getBlueGreenDeployments: vi.fn(async () => ({
+      deployments: bgDeploymentsImpl,
+      total: bgDeploymentsImpl.length,
+      page: 1,
+      per_page: 20,
+    })),
+    getRoleOwners: vi.fn().mockResolvedValue({}),
+  }),
+}))
+
+vi.mock('@/composables/useSlmWebSocket', () => ({
+  useSlmWebSocket: () => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    subscribeAll: vi.fn(),
+    onDeploymentStatus: vi.fn(),
+    onRollbackEvent: vi.fn(),
+  }),
+}))
+
+vi.mock('@/stores/fleet', () => ({
+  useFleetStore: () => ({
+    nodeList: computed(() => []),
+    roles: ref([]),
+    fetchNodes: vi.fn().mockResolvedValue(undefined),
+    fetchRoles: vi.fn().mockResolvedValue(undefined),
+    getNode: vi.fn().mockReturnValue(undefined),
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {}, params: {} }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}))
+
+import DeploymentsView from './DeploymentsView.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+/**
+ * The blue-green "Active" tile. Two `text-blue-600` stat numbers exist —
+ * standard `inProgress` first, then blue-green `active` — and `v-show` keeps
+ * both in the DOM, so take the last.
+ */
+function activeTileCount(wrapper: VueWrapper): string {
+  const tiles = wrapper.findAll('p.text-2xl.font-bold.text-blue-600')
+  return tiles.length > 0 ? tiles[tiles.length - 1].text() : ''
+}
+
+async function mountWith(status: BlueGreenStatus) {
+  bgDeploymentsImpl = [makeBgDeployment(status)]
+  const wrapper = mount(DeploymentsView, { global: { plugins: [i18n] } })
+  await flushPromises()
+  return wrapper
+}
+
+describe('DeploymentsView blue-green stats (#13138)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    bgDeploymentsImpl = []
+  })
+
+  it('counts a deployment in post-deploy monitoring as active', async () => {
+    const wrapper = await mountWith('monitoring')
+    expect(activeTileCount(wrapper)).toBe('1')
+  })
+
+  it('gives the monitoring status the in-flight badge, not the neutral default', async () => {
+    const wrapper = await mountWith('monitoring')
+    expect(wrapper.html()).toContain('bg-blue-100 text-blue-800')
+  })
+
+  it('still counts the pre-existing in-flight statuses', async () => {
+    for (const status of [
+      'borrowing',
+      'deploying',
+      'verifying',
+      'switching',
+      'active',
+    ] as BlueGreenStatus[]) {
+      const wrapper = await mountWith(status)
+      expect(activeTileCount(wrapper)).toBe('1')
+    }
+  })
+
+  it('does not count a terminal status as active', async () => {
+    const wrapper = await mountWith('completed')
+    expect(activeTileCount(wrapper)).toBe('0')
+  })
+})

--- a/autobot-slm-frontend/src/views/DeploymentsView.vue
+++ b/autobot-slm-frontend/src/views/DeploymentsView.vue
@@ -572,7 +572,9 @@ function getStatusIcon(status: string): string {
   }
 }
 
-function formatDateTime(isoString: string | null): string {
+// #13138: the blue-green timestamps are optional AND nullable in the contract,
+// so an absent value arrives as `undefined`.
+function formatDateTime(isoString: string | null | undefined): string {
   if (!isoString) return '-'
   return formatDateTimeTz(isoString)
 }

--- a/autobot-slm-frontend/src/views/DeploymentsView.vue
+++ b/autobot-slm-frontend/src/views/DeploymentsView.vue
@@ -16,7 +16,7 @@ import { useSlmWebSocket } from '@/composables/useSlmWebSocket'
 import { useFleetStore } from '@/stores/fleet'
 import { formatDateTime as formatDateTimeTz } from '@/composables/useTimezone'
 import { createLogger } from '@/utils/debugUtils'
-import type { Deployment, BlueGreenDeployment, BlueGreenDeploymentCreate, NodeRole } from '@/types/slm'
+import type { Deployment, BlueGreenDeployment, BlueGreenDeploymentCreate, BlueGreenStatus, NodeRole } from '@/types/slm'
 
 const logger = createLogger('DeploymentsView')
 const api = useSlmApi()
@@ -196,10 +196,24 @@ const roleCategories = computed(() => {
   return categories
 })
 
+/** Blue-green statuses that mean "still running" (types/slm.ts BlueGreenStatus). */
+const IN_FLIGHT_BG_STATUSES: BlueGreenStatus[] = [
+  'borrowing',
+  'deploying',
+  'verifying',
+  'switching',
+  'active',
+  'monitoring',
+]
+
 // Blue-green stats
 const bgStats = computed(() => ({
   total: bgDeployments.value.length,
-  active: bgDeployments.value.filter(d => ['borrowing', 'deploying', 'verifying', 'switching', 'active'].includes(d.status)).length,
+  // #13138: 'monitoring' is the post-deploy health-watch state
+  // (services/blue_green.py:780, up to `post_deploy_monitor_duration` seconds).
+  // It was in none of these buckets, so a deployment sitting in it vanished
+  // from every tile.
+  active: bgDeployments.value.filter(d => IN_FLIGHT_BG_STATUSES.includes(d.status)).length,
   completed: bgDeployments.value.filter(d => d.status === 'completed').length,
   failed: bgDeployments.value.filter(d => d.status === 'failed').length,
   rolledBack: bgDeployments.value.filter(d => d.status === 'rolled_back').length,
@@ -332,7 +346,7 @@ async function fetchBgDeployments(): Promise<void> {
   isLoadingBg.value = true
   try {
     const response = await api.getBlueGreenDeployments()
-    bgDeployments.value = response.deployments as BlueGreenDeployment[]
+    bgDeployments.value = response.deployments
   } catch (err) {
     logger.error('Failed to fetch blue-green deployments:', err)
   } finally {
@@ -551,6 +565,7 @@ function getStatusClass(status: string): string {
     case 'borrowing':
     case 'deploying':
     case 'verifying':
+    case 'monitoring':
     case 'switching': return 'bg-blue-100 text-blue-800'
     case 'pending': return 'bg-yellow-100 text-yellow-800'
     case 'failed': return 'bg-red-100 text-red-800'

--- a/autobot-slm-frontend/src/views/InfrastructureView.vue
+++ b/autobot-slm-frontend/src/views/InfrastructureView.vue
@@ -13,21 +13,11 @@
 import { ref, computed, onMounted } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import { getSlmApiBase } from '@/config/ssot-config'
+import type { PlaybookInfo } from '@/types/slm'
 
 const logger = createLogger('InfrastructureView')
 import InfrastructureWizard from '@/components/InfrastructureWizard.vue'
 
-interface PlaybookInfo {
-  id: string
-  name: string
-  description: string
-  category: string
-  playbook_file: string
-  target_hosts: string[]
-  variables: Record<string, unknown>
-  estimated_duration: string
-  requires_confirmation: boolean
-}
 
 
 const showWizard = ref(false)

--- a/autobot-slm-frontend/src/views/SetupWizardView.vue
+++ b/autobot-slm-frontend/src/views/SetupWizardView.vue
@@ -591,7 +591,17 @@ const allNodesEnrolled = computed(() =>
 
 // ── Role assignment ───────────────────────────────────────────────────────
 
-interface RoleInfo {
+/**
+ * A role checkbox in the wizard — a client-side VIEW-MODEL, not a wire shape.
+ *
+ * Renamed from `RoleInfo` in #13138: it collided with the generated
+ * `components['schemas']['RoleInfo']` (models/schemas.py:421) while declaring a
+ * `display_name` the contract does not have — `loadRoles` below builds it from
+ * `description` (the backend already folds the registry's `display_name` into
+ * `description` at api/deployments.py:157-160). Deriving it would have swapped
+ * a working local shape for an unrelated wire shape.
+ */
+interface WizardRoleOption {
   name: string
   display_name: string
   required: boolean
@@ -601,7 +611,7 @@ interface RoleInfo {
 const INFRA_ROLES = ['autobot_shared', 'slm-agent']
 const SLM_ROLES = ['slm-backend', 'slm-frontend', 'slm-database', 'slm-monitoring']
 
-const availableRoles = ref<RoleInfo[]>([])
+const availableRoles = ref<WizardRoleOption[]>([])
 const nodeRoles = ref<Record<string, string[]>>({})
 const savingRoles = ref(false)
 
@@ -609,7 +619,7 @@ const requiredRoles = computed(() => availableRoles.value.filter(r => r.required
 const optionalRoles = computed(() => availableRoles.value.filter(r => !r.required))
 
 /** Roles visible for a given node: unassigned or assigned to this node (#1455). */
-function rolesForNode(nodeId: string, roles: RoleInfo[]): RoleInfo[] {
+function rolesForNode(nodeId: string, roles: WizardRoleOption[]): WizardRoleOption[] {
   return roles.filter(r => {
     const assignedTo = nodes.value.find(
       n => n.node_id !== nodeId && (nodeRoles.value[n.node_id] || []).includes(r.name)
@@ -679,11 +689,11 @@ const DEPLOYMENT_GROUPS: DeploymentGroup[] = [
  */
 function groupedRolesForNode(
   nodeId: string,
-  roles: RoleInfo[],
-): Array<{ label: string; description: string; roles: RoleInfo[] }> {
+  roles: WizardRoleOption[],
+): Array<{ label: string; description: string; roles: WizardRoleOption[] }> {
   const visible = rolesForNode(nodeId, roles)
   const placed = new Set<string>()
-  const result: Array<{ label: string; description: string; roles: RoleInfo[] }> = []
+  const result: Array<{ label: string; description: string; roles: WizardRoleOption[] }> = []
 
   for (const group of DEPLOYMENT_GROUPS) {
     const matched = visible.filter(r => group.roles.includes(r.name))

--- a/autobot-slm-frontend/src/views/monitoring/LogViewer.vue
+++ b/autobot-slm-frontend/src/views/monitoring/LogViewer.vue
@@ -20,7 +20,16 @@ import type { AppLogEntry } from '@/types/api-responses'
 const logger = createLogger('LogViewer')
 const { t } = useI18n()
 
-interface LogEntry {
+/**
+ * Row rendered by this viewer — a client-side VIEW-MODEL, not a wire shape.
+ *
+ * Renamed from `LogEntry` in #13138: it collided with the generated
+ * `components['schemas']['LogEntry']` (api/monitoring.py:128) while
+ * deliberately remapping it — `severityToLevel` below turns `severity` into
+ * `level` and `hostname`/`event_type` into `source`. Deriving it would have
+ * replaced a working local shape with an unrelated wire shape.
+ */
+interface LogRow {
   timestamp: string
   level: 'debug' | 'info' | 'warning' | 'error' | 'critical'
   source: string
@@ -37,7 +46,7 @@ type LogSubTab = 'fleetEvents' | 'appLogs'
 const activeSubTab = ref<LogSubTab>('fleetEvents')
 
 // State
-const logs = ref<LogEntry[]>([])
+const logs = ref<LogRow[]>([])
 const isLoading = ref(false)
 const isAutoRefresh = ref(true)
 const searchQuery = ref('')
@@ -110,7 +119,7 @@ function formatDate(ts: string): string {
   })
 }
 
-const severityToLevel: Record<string, LogEntry['level']> = {
+const severityToLevel: Record<string, LogRow['level']> = {
   debug: 'debug',
   info: 'info',
   warning: 'warning',

--- a/autobot-slm-frontend/src/views/settings/GeneralSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/GeneralSettings.vue
@@ -14,6 +14,11 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useDarkMode } from '@/composables/useAccessibility'
+// #13138: derived from the generated contract — the response model of
+// GET/PUT `/settings/time` (autobot-slm-backend/api/settings.py:37).
+import type { components } from '@/types/generated/api'
+
+type TimeConfig = components['schemas']['TimeConfig']
 
 const darkMode = useDarkMode()
 
@@ -24,10 +29,6 @@ interface Setting {
   description: string | null
 }
 
-interface TimeConfig {
-  timezone: string
-  ntp_servers: string[]
-}
 
 const router = useRouter()
 const authStore = useAuthStore()


### PR DESCRIPTION
Closes #13161 — the monitoring long-tail slice of #13138. **#13138 itself stays OPEN**: 4 shapes remain, 3 of them still blocked on #13145 and the 4th an alias-of-derived counting artifact. Partial delivery never closes the parent.

## Thinking Path

Fourth slice of #13138, after #13137 (39), #13146 (18) and #13152 (23). Target was the monitoring long tail — `types/api-responses.ts` (~30) and the rest of `types/slm.ts` (~20).

Measured on the tip with the three rules the prior slices established (require a declaration body · exclude `import { type X }` · a name counts as remaining if **any** declaration lacks a `components['schemas'][…]` body): **309 schemas, 422 hand-declared names, 132 collisions, 78 derived, 54 still hand-written.** One unit above the 53 reported by slice 3: `ThreatSummary` at `SecurityView.vue:43` is `type ThreatSummary = ThreatSummaryType`, an alias of the derived import — remaining by the strict per-name rule, already correct in substance. Effective 53, so the count reproduces.

Treated every disagreement as a finding and established which side was wrong before making it compile. Four defects fell out, all with the server right.

**Two more view-models found, exactly where the brief predicted.** The four already known (`DashboardOverview`/`SystemMetrics` in `usePrometheusMetrics.ts`, `LogEntry` ×2) plus a fifth: `RoleInfo` at `SetupWizardView.vue:594` declares a `display_name` the contract does not have — `loadRoles` builds it from `description`, because the backend already folds the registry's `display_name` into `description` (`api/deployments.py:157-160`). Deriving it would have swapped a working local shape for an unrelated wire shape. All five are **renamed**, not derived, so the collision cannot come back. A sixth candidate, `RoleInfo` at `DeploymentWizard.vue:12`, is a straight projection rather than a remap, so it drops its copy for one with derived member types.

## What Changed

**53 → 4 remaining.** 50 shapes derived; 3 of the 4 left are blocked on #13145, the 4th is the `ThreatSummary` alias.

### Defects found (server right in every case)

**1. A blue-green deployment in post-deploy monitoring showed no state at all.** `BlueGreenStatus` omitted `'monitoring'` — the health-watch state set at `services/blue_green.py:780` and held for up to `post_deploy_monitor_duration` seconds (default 1800). It matched **none** of the four `bgStats` buckets (`DeploymentsView.vue:202-205`) and fell through `getStatusClass` to the neutral gray default, so a deployment being actively health-watched vanished from every tile and its badge claimed nothing was happening. The hand-written type also had no `health_failures`, `health_failure_threshold`, `monitoring_started_at` or `post_deploy_monitor_duration`, so there was nothing to render even had it been counted. 4 new tests, confirmed failing against the pre-fix view.

**2. `NodeRole` was missing `'docker'`.** `constants/node-roles.ts` states "Source of truth: `role_registry.py:DEFAULT_ROLES`" and "Keep in sync", but the registry has 21 roles and the union had 20 — `docker` (`_INFRA_ROLES`, `role_registry.py:372`) has always been returned by `GET /deployments/roles`. `Record<NodeRole, RoleMetadata>` forced the matching metadata entry once the union was corrected.

**3. `PlaybookInfo` was declared identically twice** (`InfrastructureWizard.vue:19`, `InfrastructureView.vue:20`) — one backend change, two places to drift from. Same class as the `/security/*` duplicate in #13146. Both omitted `tags` and typed `category` as a bare `string` where the contract has the `PlaybookCategory` enum.

**4. `BlueGreenDeployment` / `BlueGreenCreate` / `BlueGreenListResponse` were each declared twice** for the same wire models, in `types/slm.ts` and `types/api-responses.ts`, with `DeploymentsView.vue:335` bridging them via `as BlueGreenDeployment[]` — so a divergence would have been silently cast away. Now one derivation plus aliases, and the cast is gone.

### Fields the frontend type could not reach

`RoleInfo.ansible_role` · `NodeService.endpoint_path` / `port` / `protocol` / `is_discoverable` · `BlueGreenCreate.health_failure_threshold` / `post_deploy_monitor_duration` (so the New Blue-Green modal could never configure post-deploy monitoring) · `PlaybookInfo.tags`.

### Optional-and-nullable, declared required

`temperature_celsius` (`NPUPerformanceMetrics.vue:54,61` tested only `=== null`, so an absent reading rendered `undefined°C` in the "cool" colour), `memory_bytes` (`NodeServicesPanel.vue:145` — the body already handled `undefined`, only the signature disagreed; `useNodeServices.ts:56` used `!== null`), the blue-green timestamps (`DeploymentsView.vue:575`), `RecentError.resolved_at` / `resolved_by`, `MetricsSummary`'s three nullables, `FleetMetricsResponse.timestamp`, `SystemHealthResponse.last_check`, `AlertItem.node_id` / `hostname`, `PlaybookExecution.output`. `NPUWorkerConfig.assigned_models` is `default_factory=list` and so omittable — `toggleModel` indexed it unguarded, now normalised at the load site.

### Widening, resolved per type

| Case | Types | Resolution |
|---|---|---|
| Constrained in a way the schema cannot express | `RestartAllServicesRequest.category` (`pattern="^(autobot\|system\|all)$"`), `NodeService.category` | derive, keep the union |
| Unconstrained but exhaustively enumerable | `ErrorStatistics.trend` (3 branches, `errors.py:245-273`), `ErrorHealthResponse.status` (3 branches, `:509-518`), `BlueGreenStatus`, `NPULoadBalancingConfig.strategy` (enum at `schemas.py:2078-2085`), `RoleInfo.name`/`category` | derive, keep the union, cite the sites |
| Frontend-side guarantee | `NPUWorkerConfig.failure_action` — sole construction site is the four-option `<select>` at `NPUDetailsPanel.vue:383-386` | derive, keep the union |
| Frontend claim unverifiable | `NPUCapabilities.deviceType` — copied verbatim out of an external worker's `/health` payload (`api/npu.py:83`); all three renderers already fall back to the raw string | **widened** |
| Frontend claim describes a field the endpoint never populates | `RoleInfo.dependencies` (`deployments.py:166` passes `[]` unconditionally) | **widened** |

### Bare `dict` server-side

`RestartAllServicesResponse.results` is `List[Dict]` (`schemas.py:920`), so the contract can only say `{ [key: string]: unknown }[]`. Derived for the scalars and intersected to pin `RestartServiceResult`, whose keys are built at `api/services.py:892-897` and always include the `is_slm_agent` the UI reads.

### A third trap for the next slice

`Omit`/`Pick` collapse (#13152) and `required`-means-defaulted (#13152) both held. A new one: **`A[] & B[]` keeps both `map` signatures and TypeScript resolves the callback against the first**, so `base & { items: Narrow[] }` silently types the callback parameter as the WIDE element — that is exactly how `useNodeServices.ts:52` ended up mapping `category` as `string` with no error at the definition site. Writing `{ items: Narrow[] } & base` picks the narrowed element. All list envelopes here use that order, and the rule is recorded on `RoleListResponse`.

### Deferred, with reasons

- **Blocked on #13145** — `NodeCreate`, `NodeUpdate`, `ConnectionTestRequest`. Unchanged; a product decision.
- **`ThreatSummary`** (`SecurityView.vue:43`) — `type ThreatSummary = ThreatSummaryType`, an alias of the derived import inside a block of five such aliases. Correct in substance; renaming it churns the file for a measurement artifact.
- **`BlueGreenCreate`'s two new knobs** are now reachable but get no UI control here — that is a feature, not contract derivation.

## Verification

All measured in a worktree synced to `Dev_new_gui`, rebased onto `a1fc379d7` mid-work after another session pushed #13153, then re-verified.

- `npm run type-check` — clean (`vue-tsc --noEmit -p tsconfig.json`, no output).
- `npx vitest run` — **27 files / 219 tests passed**, up from 26 / 215 (+4 blue-green tests). Baseline taken against a `cp`-swapped pristine `src/` restored from `git archive`, never `git stash`.
- The 4 new tests **fail against the pre-fix view**, confirmed by swapping the pristine `DeploymentsView.vue` back in: `expected '0' to be '1'` for the active tile, and `expected … to contain 'bg-blue-100 text-blue-800'` for the badge. The two regression tests (pre-existing in-flight statuses, terminal status) pass both before and after.
- `npm run lint` — **16 problems, 0 errors, 16 warnings**, identical to the pristine baseline apart from one line-number shift in `DeploymentWizard.vue` (107 → 123) caused by an added doc comment: same file, same rule, same finding.
- `git diff --exit-code src/types/generated/api.ts` — clean, so `verify-generated-types-slm` holds.
- Remaining count re-measured with the same scan: **309 schemas, 428 hand-declared names, 132 collisions, 128 derived, 4 still hand-written.**
- No AutoBot application code was run (#13090) — frontend tooling only, no backend, no schema dump, no Postgres/Redis, no `sudo`.

## Model Used

claude-opus-5
