### PR TITLE
test(ssot): parity guards for the hand-mirrored permission and port tables (#13073, #13074)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'autobot-frontend/**'
       - '.github/workflows/frontend-test.yml'
+      # Canonical source for the cross-language parity guard (#13073, #13074):
+      # a port/enum edit here with no frontend edit must still run the suite.
+      - 'autobot_shared/ssot_config.py'
   pull_request:
     # 'Dev_*' covers the Dev_new_gui integration branch — every frontend PR
     # merges here, so the suite must run pre-merge, not only post-merge on the
@@ -52,6 +55,8 @@ jobs:
             frontend:
               - 'autobot-frontend/**'
               - '.github/workflows/frontend-test.yml'
+              # See the push paths above (#13073, #13074).
+              - 'autobot_shared/ssot_config.py'
 
   # Job 1: Unit and Integration Tests
   unit-tests:

--- a/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-parity.spec.ts
@@ -1,0 +1,224 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Cross-language SSOT parity guard.
+ * =================================
+ *
+ * `autobot_shared/ssot_config.py` is canonical for several vocabularies that
+ * the frontend cannot import at runtime, so `src/config/ssot-config.ts`
+ * hand-mirrors them.  Both mirrors below measured *zero* drift when their
+ * issues were filed — the point of this file is not to fix drift but to make
+ * the next divergence fail CI instead of rotting silently, which is exactly
+ * how #12662's items drifted.
+ *
+ * Covered:
+ *   #13073 - PermissionMode / PermissionAction value vocabularies.
+ *   #13074 - PortConfig literal default values.
+ *
+ * Mechanism: this reads the *Python source text* and extracts the declarations
+ * with anchored regexes.  It deliberately does not execute Python, import
+ * `ssot_config.py`, or read a committed generated fixture — a fixture would be
+ * a third copy free to drift on its own, and a Python-side test would not run
+ * in CI (the backend suite runs only for `tests/migrations/` and the import
+ * smoke, #10691).  The frontend unit job already checks out the whole repo, so
+ * the canonical file is on disk here.
+ *
+ * Ports specifically cannot ride the OpenAPI codegen pipeline at all: they are
+ * env-driven config defaults and never appear in any API response schema.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+import {
+  PERMISSION_MODES,
+  PERMISSION_ACTIONS,
+  PORT_DEFAULTS,
+} from '../ssot-config'
+
+const PYTHON_SSOT_RELATIVE = join('autobot_shared', 'ssot_config.py')
+
+/**
+ * Locate the canonical Python config by walking up from the working directory.
+ *
+ * `import.meta.url` is not usable here: under the jsdom environment it is an
+ * `http://` URL, not a `file://` one.  Walking up keeps the lookup independent
+ * of whether vitest was invoked from `autobot-frontend/` or the repo root.
+ */
+function findPythonSsotPath(): string {
+  let dir = resolve(process.cwd())
+  for (;;) {
+    const candidate = join(dir, PYTHON_SSOT_RELATIVE)
+    if (existsSync(candidate)) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  throw new Error(
+    `Could not locate ${PYTHON_SSOT_RELATIVE} above ${process.cwd()} — this parity guard requires a full repo checkout, not a frontend-only one.`,
+  )
+}
+
+const PYTHON_SSOT_PATH = findPythonSsotPath()
+
+function readPythonSsot(): string {
+  const source = readFileSync(PYTHON_SSOT_PATH, 'utf-8')
+  if (source.length === 0) {
+    throw new Error(`Canonical Python config is empty: ${PYTHON_SSOT_PATH}`)
+  }
+  return source
+}
+
+/**
+ * Return the indented body of a top-level `class <name>(...)`.
+ *
+ * Throws when the class is gone — a rename must fail loudly rather than let
+ * every assertion below pass vacuously against an empty extraction.
+ */
+function pythonClassBody(source: string, className: string): string {
+  const lines = source.split('\n')
+  const start = lines.findIndex((line) =>
+    new RegExp(`^class ${className}\\(`).test(line),
+  )
+  if (start === -1) {
+    throw new Error(
+      `class ${className} not found in ${PYTHON_SSOT_PATH} — it was renamed or removed; update this parity test alongside it.`,
+    )
+  }
+  const body: string[] = []
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) break
+    body.push(lines[i])
+  }
+  return body.join('\n')
+}
+
+/** Extract the string values of a `class X(str, Enum)`, in declaration order. */
+function pythonEnumValues(source: string, className: string): string[] {
+  const body = pythonClassBody(source, className)
+  const values: string[] = []
+  const member = /^ {4}([A-Z][A-Z0-9_]*)\s*=\s*"([^"]*)"/gm
+  let match: RegExpExecArray | null
+  while ((match = member.exec(body)) !== null) values.push(match[2])
+  if (values.length === 0) {
+    throw new Error(
+      `Parsed zero members out of Python enum ${className} — the declaration shape changed; fix this parser rather than trusting an empty comparison.`,
+    )
+  }
+  return values
+}
+
+/** Extract `name: int = Field(default=N, ...)` pairs from `class PortConfig`. */
+function pythonPortDefaults(source: string): Record<string, number> {
+  const body = pythonClassBody(source, 'PortConfig')
+  const defaults: Record<string, number> = {}
+  const field = /^ {4}([a-z][a-z0-9_]*)\s*:\s*int\s*=\s*Field\(\s*default=(\d+)/gm
+  let match: RegExpExecArray | null
+  while ((match = field.exec(body)) !== null) {
+    defaults[match[1]] = Number(match[2])
+  }
+  if (Object.keys(defaults).length === 0) {
+    throw new Error(
+      'Parsed zero ports out of Python PortConfig — the declaration shape changed; fix this parser rather than trusting an empty comparison.',
+    )
+  }
+  return defaults
+}
+
+/**
+ * Ports that legitimately exist on one side only.
+ *
+ * Python-only: backend-internal services the main frontend never addresses
+ * directly. TS-only: a frontend-to-frontend link with no Python analog.
+ * Anything appearing on one side that is *not* listed here is unmirrored
+ * drift and fails below.
+ */
+const PYTHON_ONLY_PORTS = ['chromadb', 'tts', 'chrome_cdp'] as const
+const TS_ONLY_PORTS = ['slmAdmin'] as const
+
+describe('Python source parser (self-check)', () => {
+  it('reads the canonical Python config off disk', () => {
+    expect(readPythonSsot()).toContain('class PortConfig(BaseSettings):')
+  })
+
+  it('throws instead of returning nothing when a class is missing', () => {
+    expect(() => pythonClassBody(readPythonSsot(), 'NoSuchClass')).toThrow(
+      /not found/,
+    )
+  })
+
+  it('extracts a non-empty result from each declaration it parses', () => {
+    const source = readPythonSsot()
+    expect(pythonEnumValues(source, 'PermissionMode').length).toBeGreaterThan(0)
+    expect(pythonEnumValues(source, 'PermissionAction').length).toBeGreaterThan(0)
+    expect(Object.keys(pythonPortDefaults(source)).length).toBeGreaterThan(0)
+  })
+})
+
+describe('SSOT parity: permission vocabulary (#13073)', () => {
+  it('PermissionMode matches autobot_shared/ssot_config.py value for value', () => {
+    expect([...PERMISSION_MODES]).toEqual(
+      pythonEnumValues(readPythonSsot(), 'PermissionMode'),
+    )
+  })
+
+  it('PermissionAction matches autobot_shared/ssot_config.py value for value', () => {
+    expect([...PERMISSION_ACTIONS]).toEqual(
+      pythonEnumValues(readPythonSsot(), 'PermissionAction'),
+    )
+  })
+})
+
+describe('SSOT parity: port defaults (#13074)', () => {
+  it('every overlapping port default matches the Python literal', () => {
+    const pythonPorts = pythonPortDefaults(readPythonSsot())
+    const overlapping = Object.keys(PORT_DEFAULTS).filter(
+      (name) => name in pythonPorts,
+    )
+    expect(overlapping.length).toBeGreaterThan(0)
+
+    const tsSide = Object.fromEntries(
+      overlapping.map((name) => [
+        name,
+        PORT_DEFAULTS[name as keyof typeof PORT_DEFAULTS],
+      ]),
+    )
+    const pythonSide = Object.fromEntries(
+      overlapping.map((name) => [name, pythonPorts[name]]),
+    )
+    expect(tsSide).toEqual(pythonSide)
+  })
+
+  it('no new Python-only port appears without being mirrored or allow-listed', () => {
+    const pythonPorts = pythonPortDefaults(readPythonSsot())
+    const unmirrored = Object.keys(pythonPorts).filter(
+      (name) =>
+        !(name in PORT_DEFAULTS) &&
+        !(PYTHON_ONLY_PORTS as readonly string[]).includes(name),
+    )
+    expect(unmirrored).toEqual([])
+  })
+
+  it('no new TS-only port appears without being mirrored or allow-listed', () => {
+    const pythonPorts = pythonPortDefaults(readPythonSsot())
+    const unmirrored = Object.keys(PORT_DEFAULTS).filter(
+      (name) =>
+        !(name in pythonPorts) &&
+        !(TS_ONLY_PORTS as readonly string[]).includes(name),
+    )
+    expect(unmirrored).toEqual([])
+  })
+
+  it('each allow-listed one-sided port is still genuinely one-sided', () => {
+    const pythonPorts = pythonPortDefaults(readPythonSsot())
+    for (const name of PYTHON_ONLY_PORTS) {
+      expect(pythonPorts).toHaveProperty(name)
+      expect(PORT_DEFAULTS).not.toHaveProperty(name)
+    }
+    for (const name of TS_ONLY_PORTS) {
+      expect(PORT_DEFAULTS).toHaveProperty(name)
+      expect(pythonPorts).not.toHaveProperty(name)
+    }
+  })
+})

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -83,6 +83,32 @@ export interface PortConfig {
 }
 
 /**
+ * Literal fallback port values, used when no `VITE_*_PORT` env var is set.
+ *
+ * These are hand-mirrored from `PortConfig` in `autobot_shared/ssot_config.py`
+ * and there is no schema to generate them from (ports never appear in any
+ * OpenAPI response), so `src/config/__tests__/ssot-parity.spec.ts` parses the
+ * Python source and asserts this table still matches it (#13074).
+ *
+ * Exported as a runtime value (not inlined into the `getEnvNumber` calls) so
+ * that parity test has something env-independent to compare against.
+ */
+export const PORT_DEFAULTS = {
+  backend: 8001,
+  frontend: 5173,
+  redis: 6379,
+  ollama: 11434,
+  vnc: 6080,
+  browser: 9001,
+  aistack: 8080,
+  npu: 8081,
+  prometheus: 9090,
+  grafana: 3000,
+  slm: 8000,
+  slmAdmin: 5174,
+} as const satisfies PortConfig;
+
+/**
  * LLM model configuration.
  */
 export interface LLMConfig {
@@ -147,17 +173,25 @@ export interface FeatureConfig {
 /**
  * Permission modes matching backend PermissionMode enum.
  */
-export type PermissionMode =
-  | 'default'
-  | 'acceptEdits'
-  | 'plan'
-  | 'dontAsk'
-  | 'bypassPermissions';
+export const PERMISSION_MODES = [
+  'default',
+  'acceptEdits',
+  'plan',
+  'dontAsk',
+  'bypassPermissions',
+] as const;
+
+export type PermissionMode = (typeof PERMISSION_MODES)[number];
 
 /**
  * Permission actions matching backend PermissionAction enum.
+ *
+ * Order-significant: both tables are asserted against the Python enums by
+ * `src/config/__tests__/ssot-parity.spec.ts` (#13073).
  */
-export type PermissionAction = 'allow' | 'ask' | 'deny';
+export const PERMISSION_ACTIONS = ['allow', 'ask', 'deny'] as const;
+
+export type PermissionAction = (typeof PERMISSION_ACTIONS)[number];
 
 /**
  * Permission rule interface.
@@ -378,18 +412,18 @@ function buildConfig(): AutoBotConfig {
 
   // Service ports
   const port: PortConfig = {
-    backend: getEnvNumber('VITE_BACKEND_PORT', 8001),
-    frontend: getEnvNumber('VITE_FRONTEND_PORT', 5173),
-    redis: getEnvNumber('VITE_REDIS_PORT', 6379),
-    ollama: getEnvNumber('VITE_OLLAMA_PORT', 11434),
-    vnc: getEnvNumber('VITE_DESKTOP_VNC_PORT', 6080),
-    browser: getEnvNumber('VITE_BROWSER_PORT', 9001),
-    aistack: getEnvNumber('VITE_AI_STACK_PORT', 8080),
-    npu: getEnvNumber('VITE_NPU_WORKER_PORT', 8081),
-    prometheus: getEnvNumber('VITE_PROMETHEUS_PORT', 9090),
-    grafana: getEnvNumber('VITE_GRAFANA_PORT', 3000),
-    slm: getEnvNumber('VITE_SLM_PORT', 8000),
-    slmAdmin: getEnvNumber('VITE_SLM_ADMIN_PORT', 5174),
+    backend: getEnvNumber('VITE_BACKEND_PORT', PORT_DEFAULTS.backend),
+    frontend: getEnvNumber('VITE_FRONTEND_PORT', PORT_DEFAULTS.frontend),
+    redis: getEnvNumber('VITE_REDIS_PORT', PORT_DEFAULTS.redis),
+    ollama: getEnvNumber('VITE_OLLAMA_PORT', PORT_DEFAULTS.ollama),
+    vnc: getEnvNumber('VITE_DESKTOP_VNC_PORT', PORT_DEFAULTS.vnc),
+    browser: getEnvNumber('VITE_BROWSER_PORT', PORT_DEFAULTS.browser),
+    aistack: getEnvNumber('VITE_AI_STACK_PORT', PORT_DEFAULTS.aistack),
+    npu: getEnvNumber('VITE_NPU_WORKER_PORT', PORT_DEFAULTS.npu),
+    prometheus: getEnvNumber('VITE_PROMETHEUS_PORT', PORT_DEFAULTS.prometheus),
+    grafana: getEnvNumber('VITE_GRAFANA_PORT', PORT_DEFAULTS.grafana),
+    slm: getEnvNumber('VITE_SLM_PORT', PORT_DEFAULTS.slm),
+    slmAdmin: getEnvNumber('VITE_SLM_ADMIN_PORT', PORT_DEFAULTS.slmAdmin),
   };
 
   // LLM configuration

--- a/autobot-frontend/src/stores/usePermissionStore.ts
+++ b/autobot-frontend/src/stores/usePermissionStore.ts
@@ -19,52 +19,26 @@ import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { getApiBase } from '@/config/ssot-config'
+import type {
+  PermissionMode,
+  PermissionAction,
+  PermissionRule,
+  ApprovalRecord,
+  PermissionStatus,
+} from '@/config/ssot-config'
 
 const logger = createLogger('usePermissionStore')
 
-// Permission modes matching backend PermissionMode enum
-export type PermissionMode =
-  | 'default'
-  | 'acceptEdits'
-  | 'plan'
-  | 'dontAsk'
-  | 'bypassPermissions'
-
-// Permission actions matching backend PermissionAction enum
-export type PermissionAction = 'allow' | 'ask' | 'deny'
-
-// Permission rule interface
-export interface PermissionRule {
-  tool: string
-  pattern: string
-  action: PermissionAction
-  description: string
-}
-
-// Approval record interface
-export interface ApprovalRecord {
-  pattern: string
-  tool: string
-  risk_level: string
-  user_id: string
-  created_at: number
-  original_command: string
-  comment?: string
-}
-
-// Permission status interface
-export interface PermissionStatus {
-  enabled: boolean
-  mode: PermissionMode
-  approval_memory_enabled: boolean
-  approval_memory_ttl_days: number
-  rules_file: string
-  rules_count: {
-    allow: number
-    ask: number
-    deny: number
-    total: number
-  }
+// Permission vocabulary is defined once, in `@/config/ssot-config` (the mirror
+// of `autobot_shared/ssot_config.py`).  These were previously re-declared here
+// verbatim, giving the same app two copies of one union (#13073); they are now
+// re-exported so every existing `usePermissionStore` type import keeps working.
+export type {
+  PermissionMode,
+  PermissionAction,
+  PermissionRule,
+  ApprovalRecord,
+  PermissionStatus,
 }
 
 // API response types


### PR DESCRIPTION
## Thinking Path

Both issues are cross-language SSOT drift items deferred from #12662, and both measured **zero drift**. So the deliverable is a guard, not a fix — restoring sync without one just resets the clock, which is the reasoning that made #12662's `NodeStatus` fix worth doing.

Re-measured both before writing anything:

- **#13073** — `PermissionMode` (`default`/`acceptEdits`/`plan`/`dontAsk`/`bypassPermissions`) and `PermissionAction` (`allow`/`ask`/`deny`) at `autobot_shared/ssot_config.py:1045`/`1064` still match `autobot-frontend/src/config/ssot-config.ts:150`/`160` exactly. Both in-app duplications still present: the dead `adminOnlyModes` at `ssot-config.ts:217`, and `usePermissionStore.ts:26-34` re-declaring the same unions.
- **#13074** — all 11 overlapping ports still match value for value; the 3 Python-only (`chromadb`, `tts`, `chrome_cdp`) and 1 TS-only (`slmAdmin`) entries are each still legitimately one-sided.

**The crux was how a JS test can read the Python side.** Four candidates were considered:

| Mechanism | Verdict |
|---|---|
| Import `ssot_config.py` from vitest | Impossible — different runtime. |
| Committed generated fixture | Rejected — a fixture is a *third* copy, free to drift on its own. |
| Python-side test | Rejected — the backend suite does not run in CI outside `tests/migrations/` and the import smoke (#10691), so the guard would never fire. |
| **Parse the Python source text** | **Chosen** — the canonical file is the thing being read, no execution, and the frontend job already does a full-repo checkout. |

Ports additionally cannot ride the OpenAPI codegen pipeline at all: they are env-driven config defaults and never appear in any response schema, so there is nothing for `openapi-typescript` to generate from. #13074 itself recommends value-parity instead of generation.

A guard that only fires when someone edits the frontend is half a guard — drift is far likelier to be introduced by editing the Python. `frontend-test.yml` was path-filtered to `autobot-frontend/**`, so a Python-only edit hit the `unit-tests-skip` shim and reported green without running anything. That filter is widened here.

## What Changed

**`autobot-frontend/src/config/ssot-config.ts`** — gave the mirrors a runtime handle to compare against. The permission unions were type-only (erased at runtime) and the port defaults were literals inlined into `getEnvNumber` calls, so neither was reachable by a test:

- `PERMISSION_MODES` / `PERMISSION_ACTIONS` const tuples, with `PermissionMode` / `PermissionAction` derived via `(typeof X)[number]`. The exported types are identical to before.
- `PORT_DEFAULTS` (`as const satisfies PortConfig`), now referenced by each `getEnvNumber(..., PORT_DEFAULTS.x)` call. Env-independent, so the test compares literals rather than whatever the environment resolved to.

**`autobot-frontend/src/stores/usePermissionStore.ts`** — collapsed the verbatim second declaration of `PermissionMode`, `PermissionAction`, `PermissionRule`, `ApprovalRecord` and `PermissionStatus` into re-exports from `@/config/ssot-config`. Re-exported rather than removed, so every existing type import of the store keeps resolving.

**`autobot-frontend/src/config/__tests__/ssot-parity.spec.ts`** (new, 9 tests) — parses the canonical Python and asserts parity:

- Permission vocabularies match value for value, **order included** (order drives mode pickers).
- Every overlapping port default matches its Python literal.
- Any *new* one-sided port on either side fails, unless added to the named `PYTHON_ONLY_PORTS` / `TS_ONLY_PORTS` allow-lists — this is what catches "added a port to Python, forgot the frontend".
- The allow-listed entries are re-checked as still genuinely one-sided.
- Parsers throw on a missing class or a zero-member extraction, so a Python shape change fails loudly instead of silently comparing two empty sets.

**`.github/workflows/frontend-test.yml`** — added `autobot_shared/ssot_config.py` to both the `push` paths and the `changes` job filter, so a Python-only edit actually runs this guard.

## Verification

Ran locally in a worktree freshly branched off `origin/Dev_new_gui`. No application code was executed — frontend tooling only.

**Suite delta** (full `vitest run`, pristine baseline captured before any edit):

| | Test files | Tests | Failures |
|---|---|---|---|
| Baseline (`origin/Dev_new_gui`) | 177 passed | 2256 passed, 1 skipped | 0 |
| After | 178 passed | 2265 passed, 1 skipped | 0 |

Delta is exactly `+1` file / `+9` tests — the new spec. Identical (empty) failing set on both sides.

- `npm run type-check` — clean.
- `npm run lint` (oxlint + eslint) — clean.
- `vue-tsc -p tsconfig.vitest.json` — 209 pre-existing errors across other test files, **zero** in any file touched here. Not a CI gate (`type-check` uses `tsconfig.app.json`, which excludes tests); left untouched.

**Non-vacuity — perturbed each side in turn, then restored:**

Python side (`grafana` 3000 to 3999, `PLAN` `"plan"` to `"planning"`):

```
x PermissionMode matches ...   - "planning"  + "plan"
x every overlapping port ...   - "grafana": 3999  + "grafana": 3000
Tests  2 failed | 7 passed (9)
```

TS side (`npu` 8081 to 8085, `'bypassPermissions'` to `'bypass'`):

```
x PermissionMode matches ...   - "bypassPermissions"  + "bypass"
x every overlapping port ...   - "npu": 8081  + "npu": 8085
Tests  2 failed | 7 passed (9)
```

Unmirrored new Python port (`newservice: int = Field(default=7777, ...)`):

```
x no new Python-only port appears without being mirrored or allow-listed
  expected [ 'newservice' ] to deeply equal []
Tests  1 failed | 8 passed (9)
```

After restoring both files, `git diff --exit-code autobot_shared/ssot_config.py` is clean and the spec is `9 passed (9)`. The guard fails in both directions and on one-sided additions — it is not the TS side checking itself.

**Not verified, stated plainly:** no Python test was added and the backend suite was not run — it does not run in CI outside `tests/migrations/` and the import smoke (#10691), which is precisely why the guard lives on the vitest side. `autobot_shared/ssot_config.py` is unmodified by this PR.

**Left alone deliberately:** the dead `adminOnlyModes` field (`ssot-config.ts:217`) is **not** removed. Its whole enclosing `PermissionConfig` interface has zero consumers repo-wide, and the frontend has no admin-only-mode list anywhere, so there is nothing to wire it into without inventing a consumer. Per this project's never-delete-code rule it stays; flagged for the owner instead.

`PermissionMode` drift remains presentational, not a privilege gate — every `/api/permissions/*` endpoint re-derives the caller's real role server-side via `check_admin_permission` and never trusts a frontend-supplied hint. That analysis from #13073 was re-confirmed and is unchanged by this PR.

Closes #13073
Closes #13074

## Model Used

claude-opus-5
