### PR TITLE
refactor(slm-frontend): route the getSlmApiBase() call sites through slmApiClient (#13140)

### DIFF
--- a/autobot-slm-frontend/src/components/DeploymentWizard.test.ts
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.test.ts
@@ -1,0 +1,128 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * DeploymentWizard — the fallback that never ran (#13140).
+ *
+ * `fetchRoles` was written with a `catch` that rebuilds the role list from
+ * `NODE_ROLE_METADATA` "if API fails", but the success path was guarded by
+ * `if (response.ok)` with NO else. A `fetch` only rejects on a network-level
+ * failure, so an HTTP failure — a 500 from the deployment service, a 403 from
+ * a role the operator lacks, a 502 from the proxy — fell straight through both
+ * branches: `roles` stayed EMPTY, the fallback written for exactly that case
+ * never ran, and the wizard's role picker rendered blank with no explanation.
+ *
+ * Routing the call through `slmApiClient.get()` makes an HTTP failure a
+ * rejection, so the existing fallback finally does its job. That is a
+ * deliberate behaviour change, asserted here rather than assumed.
+ *
+ * The same call also built `Bearer ${sessionStorage.getItem(...)}`
+ * unconditionally — the literal `Bearer null` with no session.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import DeploymentWizard from './DeploymentWizard.vue'
+import en from '@/locales/en.json'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ params: {}, query: {} }),
+}))
+
+const TOKEN_KEY = 'slm_access_token'
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+type WizardVm = { roles: { name: string }[]; fetchRoles: () => Promise<void> }
+
+/**
+ * The wizard also loads the fleet on mount. Route by URL so only
+ * `/deployments/roles` is under test and the fleet store gets the shape it
+ * expects rather than a role payload.
+ */
+function routeFetch(rolesResponse: () => Response) {
+  return vi.fn((url: string) => {
+    if (String(url).includes('/deployments/roles')) {
+      return Promise.resolve(rolesResponse())
+    }
+    return Promise.resolve(jsonResponse({ nodes: [] }))
+  })
+}
+
+function mountWizard() {
+  return mount(DeploymentWizard, {
+    props: { visible: true },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('DeploymentWizard role transport', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+    setActivePinia(createPinia())
+    fetchMock = routeFetch(() => jsonResponse({ roles: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/deployments', href: '' } as unknown as Location,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('falls back to the built-in role metadata when the role fetch is rejected', async () => {
+    // Pre-change this left `roles` empty and the picker blank.
+    fetchMock = routeFetch(() => jsonResponse({ detail: 'deployment service down' }, 500))
+    vi.stubGlobal('fetch', fetchMock)
+    const wrapper = mountWizard()
+    const vm = wrapper.vm as unknown as WizardVm
+
+    await vi.waitFor(() => expect(vm.roles.length).toBeGreaterThan(0), { timeout: 9000 })
+    expect(vm.roles.every((r) => typeof r.name === 'string' && r.name.length > 0)).toBe(true)
+  })
+
+  it('sends NO Authorization header when there is no session, not "Bearer null"', async () => {
+    mountWizard()
+    await flushPromises()
+
+    const call = fetchMock.mock.calls.find((c) => String(c[0]).includes('/deployments/roles'))!
+    expect((call[1].headers as Record<string, string>).Authorization).toBeUndefined()
+  })
+
+  it('resolves the role list against the API base with the stored bearer and a timeout', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'deploy-token')
+    mountWizard()
+    await flushPromises()
+
+    const call = fetchMock.mock.calls.find((c) => String(c[0]).includes('/deployments/roles'))!
+    expect(call[0]).toBe('/api/deployments/roles')
+    expect((call[1].headers as Record<string, string>).Authorization).toBe('Bearer deploy-token')
+    expect((call[1] as RequestInit).signal).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/autobot-slm-frontend/src/components/DeploymentWizard.vue
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.vue
@@ -6,7 +6,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { useFleetStore } from '@/stores/fleet'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
 import type { SLMNode, NodeRole, RoleInfo, RoleListResponse } from '@/types/slm'
 
 /**
@@ -104,22 +104,24 @@ async function loadData(): Promise<void> {
 async function fetchRoles(): Promise<void> {
   isLoadingRoles.value = true
   try {
-    const response = await fetch(`${getSlmApiBase()}/deployments/roles`, {
-      headers: {
-        Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
-      },
-    })
-    if (response.ok) {
-      const data = (await response.json()) as RoleListResponse
-      // #13138: `dependencies` is `default_factory=list` server-side and so
-      // optional in the contract — normalise it, the template reads `.length`.
-      roles.value = data.roles.map((role) => ({
-        name: role.name,
-        description: role.description,
-        category: role.category,
-        dependencies: role.dependencies ?? [],
-      }))
-    }
+    // Was `Bearer ${sessionStorage.getItem(...)}` built unconditionally — the
+    // literal `Bearer null` with no session; the client omits the header when
+    // there is no token and adds the base URL, a timeout and 401 handling.
+    //
+    // BEHAVIOUR CHANGE, deliberate: a non-OK response used to be dropped by
+    // `if (response.ok)` with no else, leaving `roles` EMPTY and the wizard's
+    // role picker blank — the NODE_ROLE_METADATA fallback below only ran when
+    // `fetch` itself threw. `get()` rejects on a non-OK too, so the fallback
+    // that was written for exactly this case now actually runs (#13140).
+    const data = await slmApiClient.get<RoleListResponse>('/deployments/roles')
+    // #13138: `dependencies` is `default_factory=list` server-side and so
+    // optional in the contract — normalise it, the template reads `.length`.
+    roles.value = data.roles.map((role) => ({
+      name: role.name,
+      description: role.description,
+      category: role.category,
+      dependencies: role.dependencies ?? [],
+    }))
   } catch (e) {
     // Use default roles from node-roles constants if API fails
     const { NODE_ROLE_METADATA } = await import('@/constants/node-roles')

--- a/autobot-slm-frontend/src/components/InfrastructureWizard.vue
+++ b/autobot-slm-frontend/src/components/InfrastructureWizard.vue
@@ -12,7 +12,8 @@
 
 import { ref, computed, watch, onMounted } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
+import { PLAYBOOK_EXECUTE_TIMEOUT_MS, POLLED_READ_MAX_RETRIES } from '@/constants/api-timeouts'
 import type { PlaybookInfo, PlaybookExecution } from '@/types/slm'
 
 const logger = createLogger('InfrastructureWizard')
@@ -109,18 +110,18 @@ function stopPolling(): void {
 async function loadPlaybooks(): Promise<void> {
   isLoadingPlaybooks.value = true
   try {
-    const response = await fetch(`${getSlmApiBase()}/infrastructure/playbooks`, {
-      headers: {
-        Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
-      },
-    })
-    if (response.ok) {
-      const data = await response.json()
-      playbooks.value = data.playbooks
-    } else {
-      logger.error('Failed to load playbooks:', response.statusText)
-    }
+    // All four calls here built `Bearer ${sessionStorage.getItem(...)}`
+    // UNCONDITIONALLY, sending the literal `Bearer null` with no session. The
+    // client reads the same key (with a localStorage fallback) and omits the
+    // header when there is no token, and supplies the base URL, a timeout and
+    // the 401 handling these calls had none of (#13140).
+    const data = await slmApiClient.get<{ playbooks: PlaybookInfo[] }>(
+      '/infrastructure/playbooks'
+    )
+    playbooks.value = data.playbooks
   } catch (e) {
+    // A non-OK response used to be logged in an else branch and a thrown one
+    // here; `get()` rejects on both, so there is now one failure path.
     logger.error('Error loading playbooks:', e)
   } finally {
     isLoadingPlaybooks.value = false
@@ -134,16 +135,16 @@ async function execute(): Promise<void> {
   executeError.value = null
 
   try {
-    const response = await fetch(`${getSlmApiBase()}/infrastructure/execute`, {
+    // `rawRequest` keeps the `error.detail` body surfaced in `executeError`.
+    // Registering a run resolves the inventory, so it gets the longer playbook
+    // budget rather than the client's 30s default.
+    const response = await slmApiClient.rawRequest('/infrastructure/execute', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
-      },
-      body: JSON.stringify({
+      timeout: PLAYBOOK_EXECUTE_TIMEOUT_MS,
+      body: {
         playbook_id: selectedPlaybookId.value,
         variables: customVariables.value,
-      }),
+      },
     })
 
     if (!response.ok) {
@@ -173,21 +174,20 @@ function startStatusPolling(executionId: string): void {
 
 async function pollExecutionStatus(executionId: string): Promise<void> {
   try {
-    const response = await fetch(`${getSlmApiBase()}/infrastructure/executions/${executionId}`, {
-      headers: {
-        Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
-      },
-    })
+    // `POLLED_READ_MAX_RETRIES`: this runs on a 1s interval, and the client's
+    // default GET retry (3 attempts, ~3s of exponential backoff) would leave
+    // several ticks in flight at once and make the reported status lag the run
+    // it describes. A failed tick is retried by the next tick, not in-place.
+    const data = await slmApiClient.get<{ execution: PlaybookExecution }>(
+      `/infrastructure/executions/${executionId}`,
+      { maxRetries: POLLED_READ_MAX_RETRIES }
+    )
+    currentExecution.value = data.execution
 
-    if (response.ok) {
-      const data = await response.json()
-      currentExecution.value = data.execution
-
-      // Stop polling when execution is complete
-      if (isExecutionComplete.value) {
-        stopPolling()
-        emit('executed', executionId)
-      }
+    // Stop polling when execution is complete
+    if (isExecutionComplete.value) {
+      stopPolling()
+      emit('executed', executionId)
     }
   } catch (e) {
     logger.error('Error polling execution status:', e)
@@ -198,21 +198,11 @@ async function cancelExecution(): Promise<void> {
   if (!currentExecution.value) return
 
   try {
-    const response = await fetch(
-      `${getSlmApiBase()}/infrastructure/executions/${currentExecution.value.execution_id}/cancel`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
-        },
-      }
+    const data = await slmApiClient.post<{ execution: PlaybookExecution }>(
+      `/infrastructure/executions/${currentExecution.value.execution_id}/cancel`
     )
-
-    if (response.ok) {
-      const data = await response.json()
-      currentExecution.value = data.execution
-      stopPolling()
-    }
+    currentExecution.value = data.execution
+    stopPolling()
   } catch (e) {
     logger.error('Error cancelling execution:', e)
   }

--- a/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
+++ b/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
@@ -16,12 +16,11 @@
 
 import { ref, computed } from 'vue'
 import { useFleetStore } from '@/stores/fleet'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
+import { REMOTE_EXEC_TIMEOUT_MS } from '@/constants/api-timeouts'
 import { useNodeServices } from '@/composables/useNodeServices'
 
 const fleetStore = useFleetStore()
-const authStore = useAuthStore()
 
 // Tool definitions - reduced to 3 unique tools per Issue #737
 // Removed: network-test (use NodeCard "Test"), health-check (use NodeLifecyclePanel),
@@ -127,15 +126,15 @@ async function runRedisCommand(): Promise<void> {
     }
 
     // Execute via SSH
-    const response = await fetch(`${getSlmApiBase()}/nodes/${targetNode.node_id}/exec`, {
+    // `rawRequest` keeps the `err.detail` body this panel renders; the client
+    // adds the base URL, the storage-backed bearer (`getAuthHeaders()` returned
+    // `{}` for an unhydrated token ref and sent the request anonymous), the 401
+    // handler and a timeout. `/exec` runs a command over SSH, so it takes the
+    // long remote-exec budget rather than the client's 30s default (#13140).
+    const response = await slmApiClient.rawRequest(`/nodes/${targetNode.node_id}/exec`, {
       method: 'POST',
-      headers: {
-        ...authStore.getAuthHeaders(),
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        command: `redis-cli ${redisCommand.value}`,
-      }),
+      timeout: REMOTE_EXEC_TIMEOUT_MS,
+      body: { command: `redis-cli ${redisCommand.value}` },
     })
 
     if (!response.ok) {
@@ -163,15 +162,10 @@ async function runShellCommand(): Promise<void> {
   result.value = null
 
   try {
-    const response = await fetch(`${getSlmApiBase()}/nodes/${selectedNode.value}/exec`, {
+    const response = await slmApiClient.rawRequest(`/nodes/${selectedNode.value}/exec`, {
       method: 'POST',
-      headers: {
-        ...authStore.getAuthHeaders(),
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        command: shellCommand.value,
-      }),
+      timeout: REMOTE_EXEC_TIMEOUT_MS,
+      body: { command: shellCommand.value },
     })
 
     if (!response.ok) {

--- a/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
+++ b/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
@@ -127,10 +127,12 @@ async function runRedisCommand(): Promise<void> {
 
     // Execute via SSH
     // `rawRequest` keeps the `err.detail` body this panel renders; the client
-    // adds the base URL, the storage-backed bearer (`getAuthHeaders()` returned
-    // `{}` for an unhydrated token ref and sent the request anonymous), the 401
-    // handler and a timeout. `/exec` runs a command over SSH, so it takes the
-    // long remote-exec budget rather than the client's 30s default (#13140).
+    // adds the base URL, the bearer, the 401 handler and a timeout.
+    // `getAuthHeaders()` returned `{}` whenever the store's `token` ref was
+    // null, and that ref is seeded from storage once at store construction —
+    // so a token that landed later (another tab, another store instance) left
+    // the command dispatched with no credential. `/exec` runs over SSH, so it
+    // takes the long remote-exec budget, not the 30s default (#13140).
     const response = await slmApiClient.rawRequest(`/nodes/${targetNode.node_id}/exec`, {
       method: 'POST',
       timeout: REMOTE_EXEC_TIMEOUT_MS,

--- a/autobot-slm-frontend/src/composables/usePerformanceMonitoring.ts
+++ b/autobot-slm-frontend/src/composables/usePerformanceMonitoring.ts
@@ -13,13 +13,9 @@
 
 import { ref, onMounted, onUnmounted } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
 
 const logger = createLogger('usePerformanceMonitoring')
-
-// SLM Admin uses the local SLM backend API
-const API_BASE = getSlmApiBase()
 
 // ===== Type Definitions =====
 
@@ -109,8 +105,6 @@ export function usePerformanceMonitoring(options: {
 } = {}) {
   const { autoFetch = false, pollInterval = 30000 } = options
 
-  const authStore = useAuthStore()
-
   // State
   const overview = ref<PerformanceOverview | null>(null)
   const traces = ref<TraceItem[]>([])
@@ -123,31 +117,30 @@ export function usePerformanceMonitoring(options: {
   let pollingInterval: ReturnType<typeof setInterval> | null = null
 
   /**
-   * Build auth headers for API requests.
-   */
-  function getHeaders(): Record<string, string> {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    }
-    if (authStore.token) {
-      headers.Authorization = `Bearer ${authStore.token}`
-    }
-    return headers
-  }
-
-  /**
-   * Perform an authenticated API request and return parsed JSON.
+   * Perform one authenticated SLM request and return parsed JSON.
    *
-   * Helper for all fetch functions (Issue #752).
+   * Helper for all fetch functions (Issue #752), routed through the canonical
+   * client in #13140. It calls `slmApiClient.rawRequest` and NOT the client's
+   * `get`/`post`/... helpers, deliberately: rawRequest is the single seam that
+   * contributes the `getSlmApiBase()` origin, the bearer token (read from
+   * storage per request rather than from a reactive ref that may never have
+   * been hydrated), the request timeout and the 401 handler — while leaving
+   * this function's two behaviours that callers depend on intact:
+   *
+   *   * the `HTTP <n>: <raw body text>` error message, which every catch block
+   *     below surfaces to the user verbatim (the helpers re-shape it from the
+   *     parsed JSON, changing what the UI shows);
+   *   * single-shot dispatch. `get()` would retry a 5xx three times with
+   *     exponential backoff, and `startPolling()` re-issues `fetchOverview`
+   *     every `pollInterval` — a retried tick would overlap the next one.
+   *
+   * `endpoint` is relative to the API base, e.g. '/performance/slos'.
    */
   async function apiRequest<T>(
-    url: string,
-    options: RequestInit = {}
+    endpoint: string,
+    options: { method?: string; body?: unknown } = {}
   ): Promise<T> {
-    const response = await fetch(url, {
-      ...options,
-      headers: { ...getHeaders(), ...(options.headers as Record<string, string>) },
-    })
+    const response = await slmApiClient.rawRequest(endpoint, options)
     if (!response.ok) {
       const body = await response.text().catch(() => '')
       throw new Error(`HTTP ${response.status}: ${body || response.statusText}`)
@@ -164,9 +157,7 @@ export function usePerformanceMonitoring(options: {
     loading.value = true
     error.value = null
     try {
-      const data = await apiRequest<PerformanceOverview>(
-        `${API_BASE}/performance/overview`
-      )
+      const data = await apiRequest<PerformanceOverview>('/performance/overview')
       overview.value = data
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch overview'
@@ -189,7 +180,7 @@ export function usePerformanceMonitoring(options: {
       if (params.per_page !== undefined) query.set('per_page', String(params.per_page))
 
       const queryStr = query.toString()
-      const url = `${API_BASE}/performance/traces${queryStr ? `?${queryStr}` : ''}`
+      const url = `/performance/traces${queryStr ? `?${queryStr}` : ''}`
       const data = await apiRequest<{ traces: TraceItem[]; total: number }>(url)
       traces.value = data.traces ?? []
       traceTotal.value = data.total ?? 0
@@ -204,9 +195,7 @@ export function usePerformanceMonitoring(options: {
 
   async function fetchTraceDetail(traceId: string): Promise<TraceDetail | null> {
     try {
-      return await apiRequest<TraceDetail>(
-        `${API_BASE}/performance/traces/${traceId}`
-      )
+      return await apiRequest<TraceDetail>(`/performance/traces/${traceId}`)
     } catch (err) {
       logger.error(`Failed to fetch trace ${traceId}:`, err)
       error.value = err instanceof Error ? err.message : 'Failed to fetch trace detail'
@@ -218,9 +207,7 @@ export function usePerformanceMonitoring(options: {
     loading.value = true
     error.value = null
     try {
-      const data = await apiRequest<{ slos: SLODefinition[] }>(
-        `${API_BASE}/performance/slos`
-      )
+      const data = await apiRequest<{ slos: SLODefinition[] }>('/performance/slos')
       slos.value = data.slos ?? []
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch SLOs'
@@ -235,10 +222,12 @@ export function usePerformanceMonitoring(options: {
     slo: Omit<SLODefinition, 'slo_id' | 'current_compliance'>
   ): Promise<SLODefinition | null> {
     try {
-      const created = await apiRequest<SLODefinition>(
-        `${API_BASE}/performance/slos`,
-        { method: 'POST', body: JSON.stringify(slo) }
-      )
+      // `body` is handed over unserialised: rawRequest JSON-stringifies it
+      // (and would double-encode a pre-stringified string).
+      const created = await apiRequest<SLODefinition>('/performance/slos', {
+        method: 'POST',
+        body: slo,
+      })
       await fetchSLOs()
       return created
     } catch (err) {
@@ -250,10 +239,7 @@ export function usePerformanceMonitoring(options: {
 
   async function deleteSLO(sloId: string): Promise<boolean> {
     try {
-      await apiRequest<void>(
-        `${API_BASE}/performance/slos/${sloId}`,
-        { method: 'DELETE' }
-      )
+      await apiRequest<void>(`/performance/slos/${sloId}`, { method: 'DELETE' })
       await fetchSLOs()
       return true
     } catch (err) {
@@ -267,9 +253,7 @@ export function usePerformanceMonitoring(options: {
     loading.value = true
     error.value = null
     try {
-      const data = await apiRequest<{ rules: AlertRule[] }>(
-        `${API_BASE}/performance/alerts/rules`
-      )
+      const data = await apiRequest<{ rules: AlertRule[] }>('/performance/alerts/rules')
       alertRules.value = data.rules ?? []
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch alert rules'
@@ -284,10 +268,10 @@ export function usePerformanceMonitoring(options: {
     rule: Omit<AlertRule, 'rule_id' | 'last_triggered'>
   ): Promise<AlertRule | null> {
     try {
-      const created = await apiRequest<AlertRule>(
-        `${API_BASE}/performance/alerts/rules`,
-        { method: 'POST', body: JSON.stringify(rule) }
-      )
+      const created = await apiRequest<AlertRule>('/performance/alerts/rules', {
+        method: 'POST',
+        body: rule,
+      })
       await fetchAlertRules()
       return created
     } catch (err) {
@@ -302,10 +286,10 @@ export function usePerformanceMonitoring(options: {
     updates: Partial<AlertRule>
   ): Promise<AlertRule | null> {
     try {
-      const updated = await apiRequest<AlertRule>(
-        `${API_BASE}/performance/alerts/rules/${ruleId}`,
-        { method: 'PUT', body: JSON.stringify(updates) }
-      )
+      const updated = await apiRequest<AlertRule>(`/performance/alerts/rules/${ruleId}`, {
+        method: 'PUT',
+        body: updates,
+      })
       await fetchAlertRules()
       return updated
     } catch (err) {
@@ -317,10 +301,7 @@ export function usePerformanceMonitoring(options: {
 
   async function deleteAlertRule(ruleId: string): Promise<boolean> {
     try {
-      await apiRequest<void>(
-        `${API_BASE}/performance/alerts/rules/${ruleId}`,
-        { method: 'DELETE' }
-      )
+      await apiRequest<void>(`/performance/alerts/rules/${ruleId}`, { method: 'DELETE' })
       await fetchAlertRules()
       return true
     } catch (err) {

--- a/autobot-slm-frontend/src/composables/usePrometheusMetrics.test.ts
+++ b/autobot-slm-frontend/src/composables/usePrometheusMetrics.test.ts
@@ -1,0 +1,171 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * usePrometheusMetrics — metrics transport behaviour (#13140).
+ *
+ * This composable is the largest of the `getSlmApiBase()` group (9 call sites)
+ * and the one with the most to lose from a mechanical swap, because every read
+ * in it is issued from a 30s polling loop. What is asserted here is what the
+ * raw `fetch` sites did NOT do:
+ *
+ *   * the request carried NO `Authorization` header whenever the auth store's
+ *     reactive `token` ref was unhydrated, because `getHeaders()` read
+ *     `authStore.token` — even with a live session sitting in storage;
+ *   * no request had a timeout, so a hung SLM backend pinned a poll tick open
+ *     indefinitely;
+ *
+ * and what must NOT change now that the client is in the path:
+ *
+ *   * a polled read stays single-shot — `slmApiClient.get()` otherwise retries
+ *     a 5xx three times with ~3s of exponential backoff, which inside a poll
+ *     loop stacks ticks on top of each other;
+ *   * `/performance/metrics/prometheus` is still read as TEXT, not parsed as
+ *     JSON — it returns the Prometheus exposition format.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { usePrometheusMetrics } from './usePrometheusMetrics'
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+const TOKEN_KEY = 'slm_access_token'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { 'content-type': 'text/plain' } })
+}
+
+/** The composable is used outside a component here, so lifecycle hooks no-op. */
+function metrics() {
+  return usePrometheusMetrics({ autoFetch: false, pollInterval: 0 })
+}
+
+function lastInit(mock: ReturnType<typeof vi.fn>): RequestInit {
+  return mock.mock.calls[mock.mock.calls.length - 1][1] as RequestInit
+}
+
+function headerOf(init: RequestInit, name: string): string | undefined {
+  return (init.headers as Record<string, string>)[name]
+}
+
+describe('usePrometheusMetrics transport', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+    setActivePinia(createPinia())
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/monitoring', href: '' } as unknown as Location,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('sends the stored bearer even though the auth store ref was never hydrated', async () => {
+    // The session exists in storage but no `useAuthStore()` has read it into
+    // its reactive `token` ref — exactly the state a fresh page load is in
+    // while the store is still constructing. `getHeaders()` returned no
+    // Authorization header here and the poll went out anonymous.
+    sessionStorage.setItem(TOKEN_KEY, 'poll-token')
+    fetchMock.mockResolvedValue(jsonResponse({ fleet_metrics: {}, health_summary: {} }))
+
+    await metrics().fetchDashboard()
+
+    expect(headerOf(lastInit(fetchMock), 'Authorization')).toBe('Bearer poll-token')
+  })
+
+  it('gives every polled read an abort signal, so a hung backend cannot pin a tick open', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'poll-token')
+    fetchMock.mockResolvedValue(jsonResponse({ fleet_metrics: {}, health_summary: {} }))
+
+    await metrics().fetchDashboard()
+
+    expect(lastInit(fetchMock).signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('keeps a polled read single-shot on a 500 rather than retrying inside the tick', async () => {
+    // Regression guard on POLL_OPTS, not a pre-change defect: the raw fetch
+    // did not retry either. Dropping `maxRetries` would silently turn one
+    // 30s tick into three attempts with ~3s of backoff.
+    sessionStorage.setItem(TOKEN_KEY, 'poll-token')
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'boom' }, 500))
+
+    const m = metrics()
+    await m.fetchFleetMetrics()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(m.error.value).toContain('500')
+  })
+
+  it('reports a failed dashboard read instead of leaving the panel silently stale', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'poll-token')
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'dashboard down' }, 503))
+
+    const m = metrics()
+    await m.fetchDashboard()
+
+    expect(m.isConnected.value).toBe(false)
+    expect(m.error.value).toContain('dashboard down')
+  })
+
+  it('resolves endpoints against the SLM API base', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'poll-token')
+    fetchMock.mockResolvedValue(jsonResponse({ nodes: [] }))
+
+    await metrics().fetchNPUDetails()
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/npu/nodes')
+  })
+
+  it('reads the Prometheus export as text, not as JSON', async () => {
+    // `get()` would call response.json() and reject on the exposition format —
+    // this read keeps the Response object on purpose.
+    sessionStorage.setItem(TOKEN_KEY, 'poll-token')
+    const exposition = '# HELP slm_up\nslm_up 1\n'
+    fetchMock.mockResolvedValue(textResponse(exposition))
+
+    const m = metrics()
+    await m.fetchPrometheusExport()
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/performance/metrics/prometheus')
+    expect(m.prometheusExport.value).toBe(exposition)
+    expect(m.error.value).toBeNull()
+  })
+
+  it('clears the session and redirects when a poll is rejected as unauthorised', async () => {
+    // The raw sites dropped a 401: `if (response.ok)` with no else left the
+    // panel rendering stale numbers against a dead session.
+    sessionStorage.setItem(TOKEN_KEY, 'expired-token')
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'Not authenticated' }, 401))
+
+    await metrics().fetchAlerts()
+
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBeNull()
+    expect(window.location.href).toBe('/login')
+  })
+})

--- a/autobot-slm-frontend/src/composables/usePrometheusMetrics.test.ts
+++ b/autobot-slm-frontend/src/composables/usePrometheusMetrics.test.ts
@@ -11,9 +11,12 @@
  * in it is issued from a 30s polling loop. What is asserted here is what the
  * raw `fetch` sites did NOT do:
  *
- *   * the request carried NO `Authorization` header whenever the auth store's
- *     reactive `token` ref was unhydrated, because `getHeaders()` read
- *     `authStore.token` — even with a live session sitting in storage;
+ *   * the request carried NO `Authorization` header for any token that landed
+ *     in storage AFTER the auth store was constructed. `getHeaders()` read
+ *     `authStore.token`, and that ref is seeded from storage exactly once
+ *     (`stores/auth.ts:66`) — so a login in another tab, or a refresh done
+ *     through a different store instance, left the poll going out anonymous
+ *     against a session that was demonstrably present;
  *   * no request had a timeout, so a hung SLM backend pinned a poll tick open
  *     indefinitely;
  *
@@ -29,6 +32,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { usePrometheusMetrics } from './usePrometheusMetrics'
+import { useAuthStore } from '@/stores/auth'
 
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
 
@@ -86,11 +90,14 @@ describe('usePrometheusMetrics transport', () => {
     })
   })
 
-  it('sends the stored bearer even though the auth store ref was never hydrated', async () => {
-    // The session exists in storage but no `useAuthStore()` has read it into
-    // its reactive `token` ref — exactly the state a fresh page load is in
-    // while the store is still constructing. `getHeaders()` returned no
-    // Authorization header here and the poll went out anonymous.
+  it('sends a bearer that reached storage after the auth store was constructed', async () => {
+    // Construct the store with NO session, then write the token — the shape of
+    // a login in another tab, or of a refresh performed through a different
+    // store instance. `authStore.token` is seeded from storage once, at
+    // construction, so it is still null here and `getHeaders()` produced no
+    // Authorization header at all: the poll went out anonymous against a
+    // session that plainly exists. The client re-reads storage per request.
+    useAuthStore()
     sessionStorage.setItem(TOKEN_KEY, 'poll-token')
     fetchMock.mockResolvedValue(jsonResponse({ fleet_metrics: {}, health_summary: {} }))
 

--- a/autobot-slm-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-slm-frontend/src/composables/usePrometheusMetrics.ts
@@ -13,13 +13,33 @@
 
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
+import { POLLED_READ_MAX_RETRIES } from '@/constants/api-timeouts'
 
 const logger = createLogger('usePrometheusMetrics')
 
-// SLM Admin uses the local SLM backend API
-const API_BASE = getSlmApiBase()
+/**
+ * Every read below goes through `slmApiClient` (#13140), which owns the
+ * `getSlmApiBase()` origin, the bearer token, the request timeout and the 401
+ * handler. Three things changed at this seam and were decided, not inherited:
+ *
+ *  1. The bearer used to be built from `authStore.token`, a reactive ref
+ *     hydrated once at store construction; when it was null the header was
+ *     silently omitted and the request went out anonymous. The client reads
+ *     sessionStorage (localStorage fallback) per request instead, so a session
+ *     restored or refreshed elsewhere is picked up.
+ *  2. `get()` retries a 5xx three times with exponential backoff (~3s). These
+ *     are POLLED reads on a 30s tick, so every one passes
+ *     `POLLED_READ_MAX_RETRIES` — a failed tick is retried by the NEXT tick
+ *     rather than by holding the current one open.
+ *  3. A non-OK response used to be dropped by `if (response.ok)` with no else
+ *     in `fetchServices`/`fetchAlerts`/`fetchNPUDetails`. `get()` throws, so the
+ *     surrounding catch now runs: the same rendered outcome (state left stale),
+ *     but the failure is logged instead of vanishing.
+ */
+
+/** Polled read options — single-shot, see note 2 above. */
+const POLL_OPTS = { maxRetries: POLLED_READ_MAX_RETRIES } as const
 
 // ===== Type Definitions =====
 
@@ -184,23 +204,47 @@ export interface UsePrometheusMetricsOptions {
   useWebSocket?: boolean
 }
 
+/**
+ * Transport-local wire shapes for the four endpoints whose responses this
+ * composable REMAPS rather than assigns. They exist only to type the
+ * `slmApiClient.get<T>()` calls that replace an untyped `response.json()`;
+ * deriving and naming them from the generated contract is #13138's scope and is
+ * deliberately not widened here.
+ */
+interface DashboardWire {
+  fleet_metrics?: {
+    avg_cpu_percent?: number
+    avg_memory_percent?: number
+    avg_disk_percent?: number
+    total_services?: number
+  }
+  health_summary?: {
+    overall_status?: string
+    health_score?: number
+    issues?: string[]
+  }
+}
+
+interface MonitoringHealthWire {
+  overall_status?: string
+  health_score?: number
+}
+
+interface MonitoringAlertsWire {
+  total_count?: number
+  critical_count?: number
+  warning_count?: number
+  alerts?: Record<string, unknown>[]
+}
+
+interface NpuNodesWire {
+  nodes?: Record<string, unknown>[]
+}
+
 // ===== Composable Implementation =====
 
 export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) {
   const { autoFetch = true, pollInterval = 30000 } = options
-
-  const authStore = useAuthStore()
-
-  // Helper to get auth headers
-  function getHeaders(): Record<string, string> {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    }
-    if (authStore.token) {
-      headers.Authorization = `Bearer ${authStore.token}`
-    }
-    return headers
-  }
 
   // State
   const dashboard = ref<DashboardViewModel | null>(null)
@@ -243,40 +287,33 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchDashboard(): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/monitoring/dashboard`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        const data = await response.json()
-        // Map SLM dashboard response to expected format
-        dashboard.value = {
-          system_metrics: {
-            cpu_percent: data.fleet_metrics?.avg_cpu_percent ?? 0,
-            memory_percent: data.fleet_metrics?.avg_memory_percent ?? 0,
-            disk_percent: data.fleet_metrics?.avg_disk_percent ?? 0,
-            network_bytes_sent: 0,
-            network_bytes_recv: 0,
-            process_count: data.fleet_metrics?.total_services ?? 0,
-            timestamp: Date.now(),
-          },
-          analysis: {
-            overall_health: data.health_summary?.overall_status ?? 'unknown',
-            performance_score: data.health_summary?.health_score ?? 0,
-            bottlenecks: data.health_summary?.issues ?? [],
-            resource_utilization: {
-              cpu: data.fleet_metrics?.avg_cpu_percent ?? 0,
-              memory: data.fleet_metrics?.avg_memory_percent ?? 0,
-              disk: data.fleet_metrics?.avg_disk_percent ?? 0,
-            },
-          },
+      const data = await slmApiClient.get<DashboardWire>('/monitoring/dashboard', POLL_OPTS)
+      // Map SLM dashboard response to expected format
+      dashboard.value = {
+        system_metrics: {
+          cpu_percent: data.fleet_metrics?.avg_cpu_percent ?? 0,
+          memory_percent: data.fleet_metrics?.avg_memory_percent ?? 0,
+          disk_percent: data.fleet_metrics?.avg_disk_percent ?? 0,
+          network_bytes_sent: 0,
+          network_bytes_recv: 0,
+          process_count: data.fleet_metrics?.total_services ?? 0,
           timestamp: Date.now(),
-        }
-        lastUpdate.value = new Date()
-        error.value = null
-        isConnected.value = true
-      } else {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+        },
+        analysis: {
+          overall_health: data.health_summary?.overall_status ?? 'unknown',
+          performance_score: data.health_summary?.health_score ?? 0,
+          bottlenecks: data.health_summary?.issues ?? [],
+          resource_utilization: {
+            cpu: data.fleet_metrics?.avg_cpu_percent ?? 0,
+            memory: data.fleet_metrics?.avg_memory_percent ?? 0,
+            disk: data.fleet_metrics?.avg_disk_percent ?? 0,
+          },
+        },
+        timestamp: Date.now(),
       }
+      lastUpdate.value = new Date()
+      error.value = null
+      isConnected.value = true
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch dashboard'
       logger.error('Failed to fetch dashboard:', err)
@@ -287,24 +324,19 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchServices(): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/monitoring/health`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        const data = await response.json()
-        // Map SLM health response to services format
-        services.value = {
-          total_services: 0,
-          healthy_services: 0,
-          degraded_services: 0,
-          critical_services: 0,
-          overall_status: data.overall_status === 'healthy' ? 'healthy' :
-                          data.overall_status === 'degraded' ? 'degraded' : 'critical',
-          health_percentage: data.health_score,
-          services: [],
-        }
-        error.value = null
+      const data = await slmApiClient.get<MonitoringHealthWire>('/monitoring/health', POLL_OPTS)
+      // Map SLM health response to services format
+      services.value = {
+        total_services: 0,
+        healthy_services: 0,
+        degraded_services: 0,
+        critical_services: 0,
+        overall_status: data.overall_status === 'healthy' ? 'healthy' :
+                        data.overall_status === 'degraded' ? 'degraded' : 'critical',
+        health_percentage: data.health_score ?? 0,
+        services: [],
       }
+      error.value = null
     } catch (err) {
       logger.error('Failed to fetch services:', err)
     }
@@ -312,31 +344,26 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchAlerts(): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/monitoring/alerts`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        const data = await response.json()
-        alerts.value = {
-          total_count: data.total_count ?? 0,
-          critical_count: data.critical_count ?? 0,
-          warning_count: data.warning_count ?? 0,
-          alerts: (data.alerts ?? []).map((a: Record<string, unknown>) => {
-            // Normalize backend 'error' severity → 'high' so it matches
-            // the frontend severity breakdown (critical/high/warning/info). (#995)
-            const rawSeverity = String(a.severity ?? 'info')
-            const severity = rawSeverity === 'error' ? 'high' : rawSeverity
-            return {
-              category: String(a.category ?? ''),
-              severity,
-              message: String(a.message ?? ''),
-              recommendation: '',
-              timestamp: new Date(String(a.timestamp ?? '')).getTime(),
-            }
-          }),
-        }
-        error.value = null
+      const data = await slmApiClient.get<MonitoringAlertsWire>('/monitoring/alerts', POLL_OPTS)
+      alerts.value = {
+        total_count: data.total_count ?? 0,
+        critical_count: data.critical_count ?? 0,
+        warning_count: data.warning_count ?? 0,
+        alerts: (data.alerts ?? []).map((a: Record<string, unknown>) => {
+          // Normalize backend 'error' severity → 'high' so it matches
+          // the frontend severity breakdown (critical/high/warning/info). (#995)
+          const rawSeverity = String(a.severity ?? 'info')
+          const severity = rawSeverity === 'error' ? 'high' : rawSeverity
+          return {
+            category: String(a.category ?? ''),
+            severity,
+            message: String(a.message ?? ''),
+            recommendation: '',
+            timestamp: new Date(String(a.timestamp ?? '')).getTime(),
+          }
+        }) as PerformanceAlert[],
       }
+      error.value = null
     } catch (err) {
       logger.error('Failed to fetch alerts:', err)
     }
@@ -362,24 +389,19 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
   async function fetchNPUDetails(): Promise<void> {
     // Issue #835 - query actual NPU node status from SLM backend
     try {
-      const response = await fetch(`${API_BASE}/npu/nodes`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        const data = await response.json()
-        const nodes = data.nodes || []
-        if (nodes.length > 0) {
-          const activeNodes = nodes.filter(
-            (n: Record<string, unknown>) => n.status === 'online'
-          )
-          npuDetails.value = {
-            available: activeNodes.length > 0,
-            utilization_percent: 0,
-            acceleration_ratio: 0,
-            inference_count: activeNodes.length,
-          }
-          return
+      const data = await slmApiClient.get<NpuNodesWire>('/npu/nodes', POLL_OPTS)
+      const nodes = data.nodes || []
+      if (nodes.length > 0) {
+        const activeNodes = nodes.filter(
+          (n: Record<string, unknown>) => n.status === 'online'
+        )
+        npuDetails.value = {
+          available: activeNodes.length > 0,
+          utilization_percent: 0,
+          acceleration_ratio: 0,
+          inference_count: activeNodes.length,
         }
+        return
       }
     } catch (err) {
       logger.error('Failed to fetch NPU details:', err)
@@ -417,15 +439,11 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchFleetMetrics(): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/monitoring/metrics/fleet`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        fleetMetrics.value = await response.json()
-        error.value = null
-      } else {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-      }
+      fleetMetrics.value = await slmApiClient.get<FleetMetricsDetailed>(
+        '/monitoring/metrics/fleet',
+        POLL_OPTS
+      )
+      error.value = null
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch fleet metrics'
       logger.error('Failed to fetch fleet metrics:', err)
@@ -435,16 +453,12 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchNodeMetricsDetailed(nodeId: string): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/monitoring/metrics/node/${nodeId}`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        const data = await response.json()
-        nodeMetrics.value.set(nodeId, data)
-        error.value = null
-      } else {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-      }
+      const data = await slmApiClient.get<NodeMetricsDetailed>(
+        `/monitoring/metrics/node/${nodeId}`,
+        POLL_OPTS
+      )
+      nodeMetrics.value.set(nodeId, data)
+      error.value = null
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch node metrics'
       logger.error(`Failed to fetch node metrics for ${nodeId}:`, err)
@@ -454,15 +468,11 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchPerformanceOverview(): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/performance/overview`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        performanceOverview.value = await response.json()
-        error.value = null
-      } else {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-      }
+      performanceOverview.value = await slmApiClient.get<PerformanceOverview>(
+        '/performance/overview',
+        POLL_OPTS
+      )
+      error.value = null
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch performance overview'
       logger.error('Failed to fetch performance overview:', err)
@@ -472,15 +482,11 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchNPUFleetMetrics(): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/npu/metrics`, {
-        headers: getHeaders(),
-      })
-      if (response.ok) {
-        npuFleetMetrics.value = await response.json()
-        error.value = null
-      } else {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-      }
+      npuFleetMetrics.value = await slmApiClient.get<NPUFleetMetrics>(
+        '/npu/metrics',
+        POLL_OPTS
+      )
+      error.value = null
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch NPU fleet metrics'
       logger.error('Failed to fetch NPU fleet metrics:', err)
@@ -490,9 +496,12 @@ export function usePrometheusMetrics(options: UsePrometheusMetricsOptions = {}) 
 
   async function fetchPrometheusExport(): Promise<void> {
     try {
-      const response = await fetch(`${API_BASE}/performance/metrics/prometheus`, {
-        headers: getHeaders(),
-      })
+      // `rawRequest`, NOT `get()`: this endpoint returns the Prometheus text
+      // exposition format, and `get()` parses the body as JSON. This is the one
+      // read in this composable with a genuine transport reason to keep the
+      // Response object — it still takes the base URL, bearer, timeout and 401
+      // handling from the client (#13140).
+      const response = await slmApiClient.rawRequest('/performance/metrics/prometheus')
       if (response.ok) {
         prometheusExport.value = await response.text()
         error.value = null

--- a/autobot-slm-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-slm-frontend/src/composables/usePrometheusMetrics.ts
@@ -23,11 +23,14 @@ const logger = createLogger('usePrometheusMetrics')
  * `getSlmApiBase()` origin, the bearer token, the request timeout and the 401
  * handler. Three things changed at this seam and were decided, not inherited:
  *
- *  1. The bearer used to be built from `authStore.token`, a reactive ref
- *     hydrated once at store construction; when it was null the header was
- *     silently omitted and the request went out anonymous. The client reads
- *     sessionStorage (localStorage fallback) per request instead, so a session
- *     restored or refreshed elsewhere is picked up.
+ *  1. The bearer used to be built from `authStore.token`. That ref is seeded
+ *     from storage ONCE, at store construction (`stores/auth.ts:66`), so it is
+ *     correct for a page that loaded with a session already in place and stale
+ *     for every token that lands afterwards — a login in another tab, or a
+ *     refresh performed through a different store instance. When it was null
+ *     `getHeaders()` omitted the header silently and the poll went out
+ *     anonymous. The client re-reads sessionStorage (localStorage fallback) on
+ *     every request, so there is no window in which the two disagree.
  *  2. `get()` retries a 5xx three times with exponential backoff (~3s). These
  *     are POLLED reads on a 30s tick, so every one passes
  *     `POLLED_READ_MAX_RETRIES` — a failed tick is retried by the NEXT tick

--- a/autobot-slm-frontend/src/composables/useSlmWebSocket.ts
+++ b/autobot-slm-frontend/src/composables/useSlmWebSocket.ts
@@ -16,6 +16,8 @@ import { ref, onUnmounted } from 'vue'
 import type { SLMWebSocketMessage, NodeHealth } from '@/types/slm'
 import { getConfig } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
+import { slmApiClient } from '@/utils/ApiClient'
+import { HEALTH_PROBE_TIMEOUT_MS } from '@/constants/api-timeouts'
 
 const logger = createLogger('SlmWebSocket')
 
@@ -185,8 +187,21 @@ function doDisconnect(): void {
 
 async function checkBackendHealth(): Promise<boolean> {
   try {
-    const resp = await fetch(`${config.apiBaseUrl}/api/health`, {
-      signal: AbortSignal.timeout(3000),
+    // This was the fourth way this app spelled the SLM API base:
+    // `${config.apiBaseUrl}/api/health`, hand-built here instead of taken from
+    // `getSlmApiBase()` (which is exactly `config.apiBaseUrl + '/api'`). The
+    // two agree today, so this is convergence rather than a fix — but it
+    // removes the copy that would have to be found again the next time the
+    // co-located prefix moves (#13140, #2829).
+    //
+    // `rawRequest`, NOT `get()`: this is a liveness pre-flight that gates the
+    // reconnect backoff below. It must stay single-shot (`get()` retries a 5xx
+    // three times, holding the reconnect timer open for seconds) and it must
+    // keep its own short budget rather than the client's 30s default — hence
+    // the explicit `HEALTH_PROBE_TIMEOUT_MS`, which also replaces the
+    // hard-coded 3000 this call carried.
+    const resp = await slmApiClient.rawRequest('/health', {
+      timeout: HEALTH_PROBE_TIMEOUT_MS,
     })
     return resp.ok
   } catch {

--- a/autobot-slm-frontend/src/constants/api-timeouts.ts
+++ b/autobot-slm-frontend/src/constants/api-timeouts.ts
@@ -1,0 +1,56 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Request timeouts for SLM endpoints that outlive the client default (#13140).
+ *
+ * `slmApiClient` applies `VITE_SLM_API_TIMEOUT_MS` (30s default) to every
+ * request. That budget is right for a CRUD read, but the raw `fetch` sites this
+ * issue migrates had NO timeout at all, so a handful of them were relying on
+ * being able to run longer than 30s. Handing those the default would abort a
+ * workflow that works today — a regression dressed up as a refactor. They get
+ * an explicit, named, env-sourced budget instead of a magic number at the call
+ * site.
+ */
+
+/** Parse an env var as a positive integer, falling back when unset/invalid. */
+function timeoutFromEnv(name: string, fallbackMs: number): number {
+  const raw = import.meta.env[name]
+  const parsed = raw != null && raw !== '' ? parseInt(String(raw), 10) : NaN
+  return Number.isNaN(parsed) || parsed <= 0 ? fallbackMs : parsed
+}
+
+/**
+ * `POST /nodes/{id}/exec` and the node connection/health probes run SSH or an
+ * ansible ad-hoc command against a fleet node and block until it finishes.
+ * Five minutes matches the ansible-runner ceiling these endpoints sit behind.
+ */
+export const REMOTE_EXEC_TIMEOUT_MS = timeoutFromEnv('VITE_SLM_REMOTE_EXEC_TIMEOUT_MS', 300_000)
+
+/**
+ * `POST /infrastructure/execute` kicks off a playbook run. The call returns as
+ * soon as the execution is registered (status is then polled), but registration
+ * itself involves inventory resolution on a cold cache.
+ */
+export const PLAYBOOK_EXECUTE_TIMEOUT_MS = timeoutFromEnv(
+  'VITE_SLM_PLAYBOOK_EXEC_TIMEOUT_MS',
+  120_000
+)
+
+/**
+ * The WebSocket reconnect loop's liveness pre-flight (`useSlmWebSocket`). It
+ * gates an exponential backoff, so it must fail FAST rather than hold the
+ * reconnect timer open for the full default budget.
+ */
+export const HEALTH_PROBE_TIMEOUT_MS = timeoutFromEnv('VITE_SLM_HEALTH_PROBE_TIMEOUT_MS', 3_000)
+
+/**
+ * Reads issued from a polling loop must not retry: `slmApiClient.get()` retries
+ * a 5xx three times with exponential backoff (~3s), which for a 1s status poll
+ * means overlapping in-flight requests and a status stream that lags behind the
+ * run it is reporting on. Polled reads pass this so a tick is single-shot and
+ * the next tick is the retry.
+ */
+export const POLLED_READ_MAX_RETRIES = 1

--- a/autobot-slm-frontend/src/locales/en.json
+++ b/autobot-slm-frontend/src/locales/en.json
@@ -1115,6 +1115,7 @@
       "alertsRecommendations": "Alerts & Recommendations",
       "allSeverities": "All Severities",
       "clearAllValue0": "Clear All ({value0})",
+      "clearFailed": "Failed to clear alerts: {message}",
       "critical": "Critical",
       "expectedImprovement": "Expected improvement:",
       "filterBySeverity": "Filter by severity:",

--- a/autobot-slm-frontend/src/views/AgentsView.vue
+++ b/autobot-slm-frontend/src/views/AgentsView.vue
@@ -12,8 +12,8 @@
 
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useAuthStore } from '@/stores/auth'
-import config, { getSlmApiBase } from '@/config/ssot-config'
+import config from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
 import ExternalAgentsView from '@/views/ExternalAgentsView.vue'
 import OrgChartTab from '@/components/agents/OrgChartTab.vue'
 import ConfigHistoryTab from '@/components/agents/ConfigHistoryTab.vue'
@@ -45,7 +45,6 @@ const CUSTOM_VALUE = '__custom__'
 
 const route = useRoute()
 const router = useRouter()
-const authStore = useAuthStore()
 
 // Active tab — route-based (#1404, #1405, #1406: added admin tabs)
 type AgentTab = 'local-agents' | 'external-agents' | 'org-chart' | 'config-history' | 'processes'
@@ -100,11 +99,14 @@ async function fetchAgents() {
   loading.value = true
   error.value = null
   try {
-    const response = await fetch(`${getSlmApiBase()}/agents`, {
-      headers: { Authorization: `Bearer ${authStore.token}` },
-    })
-    if (!response.ok) throw new Error(`Failed to fetch agents: ${response.status}`)
-    const data = await response.json()
+    // The three calls in this view built `Bearer ${authStore.token}`
+    // UNCONDITIONALLY, so with no session they sent the literal string
+    // `Bearer null` — a malformed credential rather than an absent one. The
+    // client omits the header when there is no token, which also lets its 401
+    // handler tell "session rejected" (clear + redirect to /login) apart from
+    // "never had one" (log only); it reads the token from storage per request
+    // rather than from a ref hydrated once at store construction (#13140).
+    const data = await slmApiClient.get<{ agents?: Agent[] }>('/agents')
     agents.value = data.agents || []
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to fetch agents'
@@ -115,12 +117,11 @@ async function fetchAgents() {
 
 async function fetchNodes() {
   try {
-    const response = await fetch(`${getSlmApiBase()}/nodes`, {
-      headers: { Authorization: `Bearer ${authStore.token}` },
-    })
-    if (!response.ok) return
-    const data = await response.json()
-    nodes.value = (data.nodes || data || []).filter(
+    // A non-OK response used to `return` silently; `get()` rejects, so it now
+    // lands in the catch below — the same outcome (fall back to Custom mode)
+    // reached by one code path instead of two.
+    const data = await slmApiClient.get<{ nodes?: FleetNode[] }>('/nodes')
+    nodes.value = (data.nodes || []).filter(
       (n: FleetNode) => n.status === 'online',
     )
   } catch {
@@ -174,15 +175,7 @@ async function saveAgent() {
       llm_temperature: editForm.value.llm_temperature,
       is_active: editForm.value.is_active,
     }
-    const response = await fetch(`${getSlmApiBase()}/agents/${selectedAgent.value.agent_id}`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${authStore.token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    })
-    if (!response.ok) throw new Error(`Failed to update agent: ${response.status}`)
+    await slmApiClient.put(`/agents/${selectedAgent.value.agent_id}`, payload)
     await fetchAgents()
     const updated = agents.value.find(
       (a) => a.agent_id === selectedAgent.value?.agent_id,

--- a/autobot-slm-frontend/src/views/AgentsView.vue
+++ b/autobot-slm-frontend/src/views/AgentsView.vue
@@ -104,8 +104,10 @@ async function fetchAgents() {
     // `Bearer null` — a malformed credential rather than an absent one. The
     // client omits the header when there is no token, which also lets its 401
     // handler tell "session rejected" (clear + redirect to /login) apart from
-    // "never had one" (log only); it reads the token from storage per request
-    // rather than from a ref hydrated once at store construction (#13140).
+    // "never had one" (log only); and it reads the token from storage per
+    // request rather than from a ref seeded there once, at store construction
+    // (`stores/auth.ts:66`), which goes stale the moment a token lands in
+    // storage through any other path (#13140).
     const data = await slmApiClient.get<{ agents?: Agent[] }>('/agents')
     agents.value = data.agents || []
   } catch (err) {

--- a/autobot-slm-frontend/src/views/InfrastructureView.test.ts
+++ b/autobot-slm-frontend/src/views/InfrastructureView.test.ts
@@ -1,0 +1,143 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * InfrastructureView — the `Bearer null` group (#13140).
+ *
+ * Seven of this issue's call sites built their credential like this:
+ *
+ *     Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`
+ *
+ * unconditionally — `InfrastructureWizard` ×4, `InfrastructureView` ×1,
+ * `DeploymentWizard` ×1 (and `AgentsView` ×3 with `authStore.token`). With no
+ * session `getItem` returns `null`, template interpolation stringifies it, and
+ * the request went out with the literal header `Bearer null`: a MALFORMED
+ * credential rather than an absent one, which a backend is entitled to treat
+ * differently from an anonymous request, and which made the resulting 401
+ * indistinguishable from a genuinely expired session.
+ *
+ * This view is the smallest member of that group, so it carries the assertion
+ * for all of them. Also asserted: the non-OK response that `if (response.ok)`
+ * with no `else` used to drop now reaches the catch, and the endpoint resolves
+ * against the API base.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import InfrastructureView from './InfrastructureView.vue'
+import en from '@/locales/en.json'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ params: {}, query: {} }),
+}))
+
+const TOKEN_KEY = 'slm_access_token'
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function mountView() {
+  return mount(InfrastructureView, {
+    global: {
+      plugins: [i18n],
+      stubs: { InfrastructureWizard: true },
+    },
+  })
+}
+
+describe('InfrastructureView playbook transport', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+    setActivePinia(createPinia())
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ playbooks: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/infrastructure', href: '' } as unknown as Location,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('sends NO Authorization header when there is no session, not "Bearer null"', async () => {
+    mountView()
+    await flushPromises()
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  it('sends the stored bearer when a session exists', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'infra-token')
+    mountView()
+    await flushPromises()
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer infra-token')
+  })
+
+  it('resolves the playbook list against the API base and applies a timeout', async () => {
+    mountView()
+    await flushPromises()
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/infrastructure/playbooks')
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('retries a 5xx page load, then fails without touching the session', async () => {
+    // Two things pinned here. First: a 500 used to be dropped by
+    // `if (response.ok)` with no else, so the view rendered "no playbooks" for
+    // a dead backend exactly as it did for a genuinely empty list; it now
+    // travels the error path. Second: this is a page LOAD, not a poll, so it
+    // deliberately keeps `get()`'s default retry — a transient 5xx recovers on
+    // its own — which is why `isLoading` is still true immediately after the
+    // first attempt and only settles once the back-off is spent.
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'inventory unavailable' }, 500))
+    const wrapper = mountView()
+    const vm = wrapper.vm as unknown as { playbooks: unknown[]; isLoading: boolean }
+    await flushPromises()
+
+    expect(vm.isLoading).toBe(true)
+    await vi.waitFor(() => expect(vm.isLoading).toBe(false), { timeout: 9000 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(vm.playbooks).toEqual([])
+    // A 500 is not a session rejection: the client must not clear or redirect.
+    expect(window.location.href).toBe('')
+  })
+
+  it('clears the session and redirects when the playbook load is unauthorised', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'expired-token')
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'Not authenticated' }, 401))
+    mountView()
+    await flushPromises()
+
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBeNull()
+    expect(window.location.href).toBe('/login')
+  })
+})

--- a/autobot-slm-frontend/src/views/InfrastructureView.vue
+++ b/autobot-slm-frontend/src/views/InfrastructureView.vue
@@ -12,7 +12,7 @@
 
 import { ref, computed, onMounted } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
 import type { PlaybookInfo } from '@/types/slm'
 
 const logger = createLogger('InfrastructureView')
@@ -42,15 +42,15 @@ onMounted(() => {
 async function loadPlaybooks(): Promise<void> {
   isLoading.value = true
   try {
-    const response = await fetch(`${getSlmApiBase()}/infrastructure/playbooks`, {
-      headers: {
-        Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
-      },
-    })
-    if (response.ok) {
-      const data = await response.json()
-      playbooks.value = data.playbooks
-    }
+    // Was `Bearer ${sessionStorage.getItem(...)}` built unconditionally — the
+    // literal `Bearer null` with no session. The client omits the header when
+    // there is no token and adds the base URL, a timeout and 401 handling; a
+    // non-OK response, previously dropped by `if (response.ok)` with no else,
+    // now reaches the catch below (#13140).
+    const data = await slmApiClient.get<{ playbooks: PlaybookInfo[] }>(
+      '/infrastructure/playbooks'
+    )
+    playbooks.value = data.playbooks
   } catch (e) {
     logger.error('Error loading playbooks:', e)
   } finally {

--- a/autobot-slm-frontend/src/views/RolesView.vue
+++ b/autobot-slm-frontend/src/views/RolesView.vue
@@ -129,10 +129,13 @@ const healthClass = computed(() => {
  * `rawRequest`, not the `get`/`post`/... helpers, so the `body.detail` message
  * this view renders in `errorMessage` survives (the helpers flatten it into
  * `HTTP <n>: <msg>`) and so writes stay single-shot. The client supplies the
- * base URL, the bearer read from storage — replacing
- * `authStore.getAuthHeaders()`, which returned `{}` and sent the request
- * ANONYMOUS whenever the store's reactive `token` ref was unhydrated — the
- * request timeout, and the 401 handler.
+ * base URL, the bearer, the request timeout and the 401 handler.
+ *
+ * The bearer replaces `authStore.getAuthHeaders()`, which returns `{}` when the
+ * store's `token` ref is null. That ref is seeded from storage once, at store
+ * construction (`stores/auth.ts:66`), so a token that lands later is invisible
+ * to it and the request went out anonymous; the client re-reads storage on
+ * every call.
  *
  * `path` stays relative to the API base, exactly as callers already pass it,
  * and `body` is handed over unserialised (rawRequest JSON-stringifies it).

--- a/autobot-slm-frontend/src/views/RolesView.vue
+++ b/autobot-slm-frontend/src/views/RolesView.vue
@@ -13,12 +13,11 @@
 
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useAuthStore } from '@/stores/auth'
 import { createLogger } from '@/utils/debugUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
+import { REMOTE_EXEC_TIMEOUT_MS } from '@/constants/api-timeouts'
 
 const logger = createLogger('RolesView')
-const authStore = useAuthStore()
 const { t } = useI18n()
 
 // Types
@@ -124,13 +123,26 @@ const healthClass = computed(() => {
   }[fleetHealth.value.health] ?? 'bg-gray-100 text-gray-600'
 })
 
-// API helper
-async function apiFetch<T>(path: string, options?: RequestInit): Promise<T | null> {
+/**
+ * API helper — one request through the canonical client (#13140).
+ *
+ * `rawRequest`, not the `get`/`post`/... helpers, so the `body.detail` message
+ * this view renders in `errorMessage` survives (the helpers flatten it into
+ * `HTTP <n>: <msg>`) and so writes stay single-shot. The client supplies the
+ * base URL, the bearer read from storage — replacing
+ * `authStore.getAuthHeaders()`, which returned `{}` and sent the request
+ * ANONYMOUS whenever the store's reactive `token` ref was unhydrated — the
+ * request timeout, and the 401 handler.
+ *
+ * `path` stays relative to the API base, exactly as callers already pass it,
+ * and `body` is handed over unserialised (rawRequest JSON-stringifies it).
+ */
+async function apiFetch<T>(
+  path: string,
+  options: { method?: string; body?: unknown; timeout?: number } = {}
+): Promise<T | null> {
   try {
-    const response = await fetch(`${getSlmApiBase()}${path}`, {
-      ...options,
-      headers: { 'Content-Type': 'application/json', ...authStore.getAuthHeaders(), ...options?.headers },
-    })
+    const response = await slmApiClient.rawRequest(path, options)
     if (!response.ok) {
       const body = await response.json().catch(() => ({}))
       throw new Error(body.detail || `HTTP ${response.status}`)
@@ -225,7 +237,7 @@ async function saveRole(): Promise<void> {
   if (editingRole.value) {
     const result = await apiFetch<RoleDefinition>(
       `/roles/${editingRole.value}`,
-      { method: 'PUT', body: JSON.stringify(payload) }
+      { method: 'PUT', body: payload }
     )
     if (result) {
       successMessage.value = t('rolesView.roleUpdated', { name: result.name })
@@ -236,7 +248,7 @@ async function saveRole(): Promise<void> {
   } else {
     const result = await apiFetch<RoleDefinition>(
       '/roles',
-      { method: 'POST', body: JSON.stringify(payload) }
+      { method: 'POST', body: payload }
     )
     if (result) {
       successMessage.value = t('rolesView.roleCreated', { name: result.name })
@@ -290,7 +302,13 @@ async function executeMigrate(): Promise<void> {
 
   const result = await apiFetch<{ success: boolean; output: string; playbook: string }>(
     `/roles/${migratingRole.value.name}/migrate`,
-    { method: 'POST', body: JSON.stringify({ target_node_id: targetNodeId.value }) }
+    // Runs an ansible playbook against the target node — the client's 30s
+    // default would abort a migration that completes fine today.
+    {
+      method: 'POST',
+      body: { target_node_id: targetNodeId.value },
+      timeout: REMOTE_EXEC_TIMEOUT_MS,
+    }
   )
 
   migrateLoading.value = false

--- a/autobot-slm-frontend/src/views/ToolsView.test.ts
+++ b/autobot-slm-frontend/src/views/ToolsView.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * ToolsView — remote-exec transport behaviour (#13140).
+ *
+ * ToolsView is the representative of the group that built its headers from
+ * `authStore.getAuthHeaders()`, which returns `{}` for an unhydrated `token`
+ * ref, so the request went out ANONYMOUS while a live session sat in storage.
+ * It is also the group with a genuine timeout hazard: every tool here runs a
+ * command over SSH against a fleet node, so it must NOT inherit the client's
+ * 30s default — a long ansible run that completes fine today would abort.
+ *
+ * Asserted end to end at the component boundary:
+ *
+ *   * the bearer is attached from storage without the store ref being hydrated;
+ *   * the request carries an abort signal (there was no timeout at all before);
+ *   * the SSH-backed endpoints get the long remote-exec budget, not the default;
+ *   * the endpoint path, method and JSON payload are unchanged;
+ *   * the backend's `detail` error body is still what the operator is shown.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import ToolsView from './ToolsView.vue'
+import { useFleetStore } from '@/stores/fleet'
+import { REMOTE_EXEC_TIMEOUT_MS } from '@/constants/api-timeouts'
+import en from '@/locales/en.json'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ params: {}, query: {} }),
+}))
+
+const TOKEN_KEY = 'slm_access_token'
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+const NODE = {
+  node_id: 'node-a',
+  ip_address: '10.0.0.9',
+  ssh_user: 'autobot',
+  ssh_port: 22,
+  auth_method: 'key',
+  status: 'online',
+  roles: ['redis'],
+}
+
+/**
+ * The view loads nodes on mount through the fleet store; seed the store's node
+ * map directly so its own transport is not part of what this suite asserts.
+ */
+function seedFleet() {
+  const fleet = useFleetStore()
+  ;(fleet.nodes as unknown as Map<string, typeof NODE>).set(NODE.node_id, NODE)
+}
+
+async function mountTools() {
+  const wrapper = mount(ToolsView, { global: { plugins: [i18n] } })
+  // Let the on-mount `fleetStore.fetchNodes()` settle FIRST — it replaces the
+  // node map wholesale, so seeding before it would be overwritten.
+  await flushPromises()
+  seedFleet()
+  await flushPromises()
+  return wrapper
+}
+
+/** Find the request this suite is about, ignoring any fleet-store traffic. */
+function callTo(mock: ReturnType<typeof vi.fn>, path: string) {
+  const call = mock.mock.calls.find((c) => String(c[0]).includes(path))
+  expect(call, `no request to ${path}`).toBeDefined()
+  return { url: String(call![0]), init: call![1] as RequestInit }
+}
+
+describe('ToolsView remote-exec transport', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+    setActivePinia(createPinia())
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ nodes: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/tools', href: '' } as unknown as Location,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('attaches the stored bearer to an exec although the store ref is unhydrated', async () => {
+    // `authStore.getAuthHeaders()` returned `{}` in exactly this state, so the
+    // command was dispatched to the fleet with no credential at all.
+    sessionStorage.setItem(TOKEN_KEY, 'tools-token')
+    const wrapper = await mountTools()
+
+    fetchMock.mockResolvedValue(jsonResponse({ output: 'PONG' }))
+    const vm = wrapper.vm as unknown as {
+      redisCommand: string
+      runRedisCommand: () => Promise<void>
+    }
+    vm.redisCommand = 'PING'
+    await vm.runRedisCommand()
+    await flushPromises()
+
+    const { init } = callTo(fetchMock, '/nodes/node-a/exec')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tools-token')
+  })
+
+  it('sends the exec to the API base with the same method and payload', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'tools-token')
+    const wrapper = await mountTools()
+
+    fetchMock.mockResolvedValue(jsonResponse({ output: 'PONG' }))
+    const vm = wrapper.vm as unknown as {
+      redisCommand: string
+      runRedisCommand: () => Promise<void>
+    }
+    vm.redisCommand = 'PING'
+    await vm.runRedisCommand()
+    await flushPromises()
+
+    const { url, init } = callTo(fetchMock, '/nodes/node-a/exec')
+    expect(url).toBe('/api/nodes/node-a/exec')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ command: 'redis-cli PING' })
+  })
+
+  it('gives an SSH-backed exec the long budget, not the client default', async () => {
+    // A raw fetch had no timeout; the client's 30s default would abort a long
+    // ansible run. The abort must therefore fire on the remote-exec budget.
+    vi.useFakeTimers()
+    try {
+      sessionStorage.setItem(TOKEN_KEY, 'tools-token')
+      const wrapper = mount(ToolsView, { global: { plugins: [i18n] } })
+      await flushPromises()
+      seedFleet()
+      await flushPromises()
+
+      let captured: AbortSignal | undefined
+      fetchMock.mockImplementation((_u: string, init: RequestInit) => {
+        captured = init.signal as AbortSignal
+        return new Promise(() => {}) // never settles — the timeout must abort it
+      })
+
+      const vm = wrapper.vm as unknown as {
+        ansibleCommand: string
+        selectedNode: string
+        runAnsibleCommand: () => Promise<void>
+      }
+      vm.selectedNode = 'node-a'
+      vm.ansibleCommand = 'uptime'
+      vm.runAnsibleCommand()
+      await Promise.resolve()
+
+      expect(captured).toBeInstanceOf(AbortSignal)
+      // Still alive well past the 30s default the client would have applied.
+      vi.advanceTimersByTime(30_000 + 1_000)
+      expect(captured!.aborted).toBe(false)
+      // Aborted once the remote-exec budget is spent.
+      vi.advanceTimersByTime(REMOTE_EXEC_TIMEOUT_MS)
+      expect(captured!.aborted).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("still shows the backend's detail message when an exec is rejected", async () => {
+    // `rawRequest` rather than `post()` exists for this: `post()` would have
+    // flattened the body into `HTTP 502: ...` and the operator would never see
+    // what the backend actually said.
+    sessionStorage.setItem(TOKEN_KEY, 'tools-token')
+    const wrapper = await mountTools()
+
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'node unreachable' }, 502))
+    const vm = wrapper.vm as unknown as {
+      redisCommand: string
+      selectTool: (id: string) => void
+      runRedisCommand: () => Promise<void>
+    }
+    // Open the Redis panel so the error region is actually rendered.
+    vm.selectTool('redis-cli')
+    vm.redisCommand = 'PING'
+    await vm.runRedisCommand()
+    await flushPromises()
+
+    expect(wrapper.get('[role="alert"]').text()).toContain('node unreachable')
+  })
+
+  it('clears the session and redirects when an exec is rejected as unauthorised', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'expired-token')
+    const wrapper = await mountTools()
+
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'Not authenticated' }, 401))
+    const vm = wrapper.vm as unknown as {
+      redisCommand: string
+      runRedisCommand: () => Promise<void>
+    }
+    vm.redisCommand = 'PING'
+    await vm.runRedisCommand()
+    await flushPromises()
+
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBeNull()
+    expect(window.location.href).toBe('/login')
+  })
+})

--- a/autobot-slm-frontend/src/views/ToolsView.test.ts
+++ b/autobot-slm-frontend/src/views/ToolsView.test.ts
@@ -7,15 +7,21 @@
  * ToolsView — remote-exec transport behaviour (#13140).
  *
  * ToolsView is the representative of the group that built its headers from
- * `authStore.getAuthHeaders()`, which returns `{}` for an unhydrated `token`
- * ref, so the request went out ANONYMOUS while a live session sat in storage.
+ * `authStore.getAuthHeaders()`, which returns `{}` when the store's `token`
+ * ref is null. That ref is seeded from storage exactly once, at store
+ * construction (`stores/auth.ts:66`), so any token that lands afterwards — a
+ * login in another tab, a refresh through a different store instance — is
+ * invisible to it and the SSH command was dispatched to a fleet node with no
+ * credential at all.
+ *
  * It is also the group with a genuine timeout hazard: every tool here runs a
  * command over SSH against a fleet node, so it must NOT inherit the client's
  * 30s default — a long ansible run that completes fine today would abort.
  *
  * Asserted end to end at the component boundary:
  *
- *   * the bearer is attached from storage without the store ref being hydrated;
+ *   * the bearer is attached for a token that reached storage after the store
+ *     was constructed;
  *   * the request carries an abort signal (there was no timeout at all before);
  *   * the SSH-backed endpoints get the long remote-exec budget, not the default;
  *   * the endpoint path, method and JSON payload are unchanged;
@@ -28,6 +34,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import ToolsView from './ToolsView.vue'
 import { useFleetStore } from '@/stores/fleet'
+import { useAuthStore } from '@/stores/auth'
 import { REMOTE_EXEC_TIMEOUT_MS } from '@/constants/api-timeouts'
 import en from '@/locales/en.json'
 
@@ -111,9 +118,12 @@ describe('ToolsView remote-exec transport', () => {
     })
   })
 
-  it('attaches the stored bearer to an exec although the store ref is unhydrated', async () => {
+  it('attaches a bearer that reached storage after the auth store was constructed', async () => {
+    // Construct the store with NO session, then write the token — a login in
+    // another tab, or a refresh through a different store instance.
     // `authStore.getAuthHeaders()` returned `{}` in exactly this state, so the
     // command was dispatched to the fleet with no credential at all.
+    useAuthStore()
     sessionStorage.setItem(TOKEN_KEY, 'tools-token')
     const wrapper = await mountTools()
 

--- a/autobot-slm-frontend/src/views/ToolsView.vue
+++ b/autobot-slm-frontend/src/views/ToolsView.vue
@@ -18,11 +18,10 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFleetStore } from '@/stores/fleet'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { slmApiClient } from '@/utils/ApiClient'
+import { REMOTE_EXEC_TIMEOUT_MS } from '@/constants/api-timeouts'
 
 const fleetStore = useFleetStore()
-const authStore = useAuthStore()
 const { t } = useI18n()
 
 // Tool definitions - all tools integrated into SLM (Issue #729)
@@ -115,18 +114,23 @@ async function runNetworkTest(): Promise<void> {
   result.value = null
 
   try {
-    const response = await fetch(`${getSlmApiBase()}/nodes/test-connection`, {
+    // `rawRequest` (not `post`) keeps the `err.detail` error body this panel
+    // renders. The client contributes the base URL, the bearer read from
+    // storage — replacing `authStore.getAuthHeaders()`, which returned `{}` and
+    // sent the request ANONYMOUS whenever the store's reactive `token` ref was
+    // unhydrated — the 401 handler, and, new here, a timeout. Every tool on
+    // this view opens an SSH session to a fleet node, so they take the long
+    // remote-exec budget rather than the client's 30s default, which would
+    // abort a command that completes fine today (#13140).
+    const response = await slmApiClient.rawRequest('/nodes/test-connection', {
       method: 'POST',
-      headers: {
-        ...authStore.getAuthHeaders(),
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+      timeout: REMOTE_EXEC_TIMEOUT_MS,
+      body: {
         ip_address: selectedNodeDetails.value?.ip_address,
         ssh_user: selectedNodeDetails.value?.ssh_user || 'autobot',
         ssh_port: selectedNodeDetails.value?.ssh_port || 22,
         auth_method: selectedNodeDetails.value?.auth_method || 'key',
-      }),
+      },
     })
 
     if (!response.ok) {
@@ -160,9 +164,10 @@ async function runHealthCheck(): Promise<void> {
   result.value = null
 
   try {
-    const response = await fetch(`${getSlmApiBase()}/nodes/${selectedNode.value}/health`, {
-      headers: authStore.getAuthHeaders(),
-    })
+    const response = await slmApiClient.rawRequest(
+      `/nodes/${selectedNode.value}/health`,
+      { timeout: REMOTE_EXEC_TIMEOUT_MS }
+    )
 
     if (!response.ok) {
       throw new Error(t('toolsView.healthCheckFailed'))
@@ -195,9 +200,9 @@ async function getServiceLogs(): Promise<void> {
   result.value = null
 
   try {
-    const response = await fetch(
-      `${getSlmApiBase()}/nodes/${selectedNode.value}/services/${selectedService.value}/logs?lines=${logLines.value}`,
-      { headers: authStore.getAuthHeaders() }
+    const response = await slmApiClient.rawRequest(
+      `/nodes/${selectedNode.value}/services/${selectedService.value}/logs?lines=${logLines.value}`,
+      { timeout: REMOTE_EXEC_TIMEOUT_MS }
     )
 
     if (!response.ok) {
@@ -225,12 +230,9 @@ async function serviceAction(action: 'start' | 'stop' | 'restart'): Promise<void
   result.value = null
 
   try {
-    const response = await fetch(
-      `${getSlmApiBase()}/nodes/${selectedNode.value}/services/${selectedService.value}/${action}`,
-      {
-        method: 'POST',
-        headers: authStore.getAuthHeaders(),
-      }
+    const response = await slmApiClient.rawRequest(
+      `/nodes/${selectedNode.value}/services/${selectedService.value}/${action}`,
+      { method: 'POST', timeout: REMOTE_EXEC_TIMEOUT_MS }
     )
 
     if (!response.ok) {
@@ -269,15 +271,10 @@ async function runRedisCommand(): Promise<void> {
     }
 
     // Execute via ansible ad-hoc
-    const response = await fetch(`${getSlmApiBase()}/nodes/${targetNode.node_id}/exec`, {
+    const response = await slmApiClient.rawRequest(`/nodes/${targetNode.node_id}/exec`, {
       method: 'POST',
-      headers: {
-        ...authStore.getAuthHeaders(),
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        command: `redis-cli ${redisCommand.value}`,
-      }),
+      timeout: REMOTE_EXEC_TIMEOUT_MS,
+      body: { command: `redis-cli ${redisCommand.value}` },
     })
 
     if (!response.ok) {
@@ -305,15 +302,10 @@ async function runAnsibleCommand(): Promise<void> {
   result.value = null
 
   try {
-    const response = await fetch(`${getSlmApiBase()}/nodes/${selectedNode.value}/exec`, {
+    const response = await slmApiClient.rawRequest(`/nodes/${selectedNode.value}/exec`, {
       method: 'POST',
-      headers: {
-        ...authStore.getAuthHeaders(),
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        command: ansibleCommand.value,
-      }),
+      timeout: REMOTE_EXEC_TIMEOUT_MS,
+      body: { command: ansibleCommand.value },
     })
 
     if (!response.ok) {

--- a/autobot-slm-frontend/src/views/ToolsView.vue
+++ b/autobot-slm-frontend/src/views/ToolsView.vue
@@ -115,13 +115,19 @@ async function runNetworkTest(): Promise<void> {
 
   try {
     // `rawRequest` (not `post`) keeps the `err.detail` error body this panel
-    // renders. The client contributes the base URL, the bearer read from
-    // storage — replacing `authStore.getAuthHeaders()`, which returned `{}` and
-    // sent the request ANONYMOUS whenever the store's reactive `token` ref was
-    // unhydrated — the 401 handler, and, new here, a timeout. Every tool on
-    // this view opens an SSH session to a fleet node, so they take the long
-    // remote-exec budget rather than the client's 30s default, which would
-    // abort a command that completes fine today (#13140).
+    // renders. The client contributes the base URL, the bearer, the 401
+    // handler, and — new here — a timeout.
+    //
+    // On the bearer: `authStore.getAuthHeaders()` returns `{}` when the store's
+    // `token` ref is null, and that ref is seeded from storage ONCE, at store
+    // construction (`stores/auth.ts:66`). A token that lands afterwards — a
+    // login in another tab, a refresh through a different store instance — is
+    // invisible to it, and the command was then dispatched to a fleet node with
+    // no credential at all. The client re-reads storage per request.
+    //
+    // On the timeout: every tool here opens an SSH session to a fleet node, so
+    // they take the long remote-exec budget rather than the client's 30s
+    // default, which would abort a command that completes fine today (#13140).
     const response = await slmApiClient.rawRequest('/nodes/test-connection', {
       method: 'POST',
       timeout: REMOTE_EXEC_TIMEOUT_MS,

--- a/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.test.ts
+++ b/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.test.ts
@@ -1,0 +1,159 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * AlertsMonitor — the discarded DELETE response (#13140).
+ *
+ * "Clear all alerts" is the only DESTRUCTIVE action among this issue's 30
+ * `getSlmApiBase()` sites, and it was the worst-handled: the call was written
+ * `await fetch(url, { method: 'DELETE', headers })` with the Response never
+ * bound to anything. A 401, a 403 or a 500 was therefore indistinguishable
+ * from success — `refresh()` re-rendered the very same alerts and the operator,
+ * who had just confirmed a "this cannot be undone" dialog, was left to infer
+ * from an unchanged list that nothing had happened.
+ *
+ * The bearer was also built from `authStore.token`, a ref hydrated once at
+ * store construction, so with a session only in storage the destructive call
+ * went out anonymous.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import AlertsMonitor from './AlertsMonitor.vue'
+import en from '@/locales/en.json'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ params: {}, query: {} }),
+}))
+
+const TOKEN_KEY = 'slm_access_token'
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+const ALERTS = {
+  total_count: 2,
+  critical_count: 1,
+  warning_count: 1,
+  alerts: [
+    { category: 'cpu', severity: 'critical', message: 'cpu hot', timestamp: '2026-01-01T00:00:00Z' },
+    { category: 'disk', severity: 'warning', message: 'disk low', timestamp: '2026-01-01T00:00:00Z' },
+  ],
+}
+
+/** Route each endpoint independently so only the DELETE is made to fail. */
+function routeFetch(deleteResponse: () => Response) {
+  return vi.fn((url: string, init: RequestInit = {}) => {
+    if (init.method === 'DELETE') return Promise.resolve(deleteResponse())
+    if (String(url).includes('/monitoring/alerts')) {
+      return Promise.resolve(jsonResponse(ALERTS))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+function mountMonitor() {
+  return mount(AlertsMonitor, { global: { plugins: [i18n] } })
+}
+
+async function clearAll(wrapper: ReturnType<typeof mountMonitor>) {
+  const vm = wrapper.vm as unknown as { clearAlerts: () => Promise<void> }
+  await vm.clearAlerts()
+  await flushPromises()
+}
+
+describe('AlertsMonitor clear-all transport', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+    setActivePinia(createPinia())
+    vi.stubGlobal('confirm', vi.fn(() => true))
+
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { pathname: '/monitoring/alerts', href: '' } as unknown as Location,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('tells the operator when a confirmed clear was rejected', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'alerts-token')
+    fetchMock = routeFetch(() => jsonResponse({ detail: 'alert store read-only' }, 500))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mountMonitor()
+    await flushPromises()
+    await clearAll(wrapper)
+
+    const banner = wrapper.get('[data-testid="clear-alerts-error"]')
+    expect(banner.text()).toContain('alert store read-only')
+  })
+
+  it('reports nothing when the clear succeeds', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'alerts-token')
+    fetchMock = routeFetch(() => new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mountMonitor()
+    await flushPromises()
+    await clearAll(wrapper)
+
+    expect(wrapper.find('[data-testid="clear-alerts-error"]').exists()).toBe(false)
+  })
+
+  it('sends the stored bearer on the destructive call, and to the API base', async () => {
+    // `authStore.token` was null in this state, so the DELETE went out with no
+    // credential at all.
+    sessionStorage.setItem(TOKEN_KEY, 'alerts-token')
+    fetchMock = routeFetch(() => new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mountMonitor()
+    await flushPromises()
+    await clearAll(wrapper)
+
+    const del = fetchMock.mock.calls.find((c) => (c[1] as RequestInit).method === 'DELETE')!
+    expect(del[0]).toBe('/api/monitoring/alerts')
+    expect((del[1].headers as Record<string, string>).Authorization).toBe('Bearer alerts-token')
+    expect((del[1] as RequestInit).signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('does not clear alerts at all when the confirmation is declined', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'alerts-token')
+    fetchMock = routeFetch(() => new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('confirm', vi.fn(() => false))
+
+    const wrapper = mountMonitor()
+    await flushPromises()
+    await clearAll(wrapper)
+
+    expect(
+      fetchMock.mock.calls.some((c) => (c[1] as RequestInit).method === 'DELETE')
+    ).toBe(false)
+  })
+})

--- a/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
+++ b/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
@@ -131,9 +131,10 @@ async function clearAlerts() {
   isClearing.value = true
   clearError.value = null
   try {
-    // The bearer was built from `authStore.token`, a ref hydrated once at
-    // store construction; the client reads it from storage per request. It
-    // also supplies the base URL, a timeout and 401 handling (#13140).
+    // The bearer was built from `authStore.token`, a ref seeded from storage
+    // once at store construction, so a token that landed later left this
+    // DESTRUCTIVE call with no credential; the client re-reads storage per
+    // request. It also supplies the base URL, a timeout and 401 handling.
     //
     // BEHAVIOUR CHANGE, deliberate: the previous `await fetch(...)` discarded
     // its Response entirely, so a rejected clear (401/403/500) reported

--- a/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
+++ b/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
@@ -11,8 +11,10 @@
 
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { usePrometheusMetrics } from '@/composables/usePrometheusMetrics'
-import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+import { slmApiClient } from '@/utils/ApiClient'
+
+const logger = createLogger('AlertsMonitor')
 
 const {
   alerts,
@@ -22,8 +24,8 @@ const {
   isLoading,
 } = usePrometheusMetrics({ autoFetch: false })
 
-const authStore = useAuthStore()
 const isClearing = ref(false)
+const clearError = ref<string | null>(null)
 
 // State
 const activeTab = ref<'alerts' | 'recommendations'>('alerts')
@@ -127,11 +129,23 @@ function isAcknowledged(index: number): boolean {
 async function clearAlerts() {
   if (!confirm('Clear all active alerts? This cannot be undone.')) return
   isClearing.value = true
+  clearError.value = null
   try {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    if (authStore.token) headers.Authorization = `Bearer ${authStore.token}`
-    await fetch(`${getSlmApiBase()}/monitoring/alerts`, { method: 'DELETE', headers })
+    // The bearer was built from `authStore.token`, a ref hydrated once at
+    // store construction; the client reads it from storage per request. It
+    // also supplies the base URL, a timeout and 401 handling (#13140).
+    //
+    // BEHAVIOUR CHANGE, deliberate: the previous `await fetch(...)` discarded
+    // its Response entirely, so a rejected clear (401/403/500) reported
+    // NOTHING — `refresh()` just re-rendered the same alerts and the operator
+    // was left to infer that the destructive action they had confirmed had
+    // silently done nothing. `delete()` rejects, and this catch surfaces it
+    // rather than letting it escape as an unhandled rejection.
+    await slmApiClient.delete('/monitoring/alerts')
     await refresh()
+  } catch (e) {
+    logger.error('Failed to clear alerts:', e)
+    clearError.value = e instanceof Error ? e.message : String(e)
   } finally {
     isClearing.value = false
   }
@@ -185,6 +199,16 @@ onUnmounted(() => {
           {{ $t('monitoring.alertsMonitor.refresh') }}
         </button>
       </div>
+    </div>
+
+    <!-- Clear failure — a discarded DELETE response used to report nothing -->
+    <div
+      v-if="clearError"
+      role="alert"
+      data-testid="clear-alerts-error"
+      class="mb-6 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700"
+    >
+      {{ $t('monitoring.alertsMonitor.clearFailed', { message: clearError }) }}
     </div>
 
     <!-- Summary Cards -->


### PR DESCRIPTION
Second slice of #13140, after PR #13169 (`824f4576b`) converted the 23 sites that resolved their base URL through `stores/auth.ts:getApiUrl()`. This one takes the **30 sites that already call `getSlmApiBase()`** — every remaining SLM-backend `fetch` in the app. **#13140 stays open** (definition-of-done item 4, the ESLint rule, is not landed here), so this PR deliberately carries no `Closes` keyword; the advisory PR-link gate is left red as the honest signal for partial delivery (#12995).

## Thinking Path

**Re-measured first.** 50 raw `fetch(` sites in `autobot-slm-frontend/src` (tests excluded), down from the 73 the first slice measured:

| target | count | disposition |
|---|---|---|
| SLM backend via `getSlmApiBase()` | **30** | this PR — all of them |
| autobot backend via `getBackendUrl()` | 17 | **#13079**, a different backend per ADR-008 — untouched |
| external (Prometheus `/-/healthy`, Grafana `/api/health`) | 2 | legitimately raw |
| `utils/ApiClient.ts:221` | 1 | the client itself |

**Not every site should become a `get()`.** Two have a genuine transport reason to keep the `Response` object, and use `rawRequest` rather than the JSON helpers:

- `usePrometheusMetrics.fetchPrometheusExport` reads `/performance/metrics/prometheus`, which returns the **Prometheus text exposition format**. `get()` calls `response.json()` and would reject on it.
- `useSlmWebSocket.checkBackendHealth` is a **liveness pre-flight that gates the reconnect backoff**. It must stay single-shot and keep a short budget, not the client's 30s default.

A third class keeps `rawRequest` because the *rendered* error must not change: `ToolsView` (6), `FleetToolsTab` (2), `RolesView.apiFetch`, `InfrastructureWizard.execute` and `usePerformanceMonitoring.apiRequest` all surface the backend's `detail` body (or, for `usePerformanceMonitoring`, its own `HTTP <n>: <raw body text>` string) directly to the operator. `post()`/`get()` would flatten those into `HTTP <n>: <msg>`.

**Behaviour changes were decided, not inherited.** Four seams needed a call rather than a swap; each is described below and asserted in a test.

## What Changed

### The retry hazard `get()` introduces

`slmApiClient.get()` retries a non-4xx three times with exponential backoff (~3s). That is right for a page load and wrong inside a poll, so a new `POLLED_READ_MAX_RETRIES` is passed by:

- `usePrometheusMetrics` — all 8 JSON reads, on a 30s tick;
- `InfrastructureWizard.pollExecutionStatus` — **a 1s interval**, where the default would leave several ticks in flight at once and make the reported status lag the run it describes.

`usePerformanceMonitoring.apiRequest` routes through `rawRequest` for the same reason (plus its error-string contract) — `startPolling()` re-issues `fetchOverview` on a timer.

Page loads (`InfrastructureView`, `DeploymentWizard`, `AgentsView`, `RolesView`) keep the default retry on purpose; a transient 5xx recovers on its own.

### The timeout hazard `get()` introduces

These sites had **no timeout at all**, and several deliberately run longer than 30s. Handing them the client default would abort a workflow that works today — a regression dressed as a refactor. New `src/constants/api-timeouts.ts` gives them explicit, named, env-sourced budgets instead of magic numbers at the call site:

- `REMOTE_EXEC_TIMEOUT_MS` (5 min) — `POST /nodes/{id}/exec` ×4, node health, service start/stop/restart, service logs, connection test, `POST /roles/{name}/migrate` (all SSH/ansible-backed);
- `PLAYBOOK_EXECUTE_TIMEOUT_MS` (2 min) — `POST /infrastructure/execute`;
- `HEALTH_PROBE_TIMEOUT_MS` (3s) — the WS reconnect pre-flight, replacing a hard-coded `3000`.

### Two defects fixed on the way

**`Bearer null` — 7 sites.** `InfrastructureWizard` ×4, `InfrastructureView`, `DeploymentWizard` built ``Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}` `` **unconditionally**; `AgentsView` ×3 did the same with `authStore.token`. With no session the interpolation stringifies `null` and the literal header `Bearer null` went out — a *malformed* credential rather than an absent one, which also made the resulting 401 indistinguishable from a genuinely expired session. The client omits the header entirely, which lets `handleUnauthorized` tell "session rejected" (clear + redirect) apart from "never had one" (log only).

**A fallback that never ran.** `DeploymentWizard.fetchRoles` has a `catch` that rebuilds the role list from `NODE_ROLE_METADATA` "if API fails" — but the success path was `if (response.ok)` with **no else**, and `fetch` only rejects at the network level. So an HTTP failure fell through both branches: `roles` stayed empty, the wizard's role picker rendered blank, and the fallback written for exactly that case never executed. `get()` rejects on a non-OK, so it now does.

### A destructive action that reported nothing

`AlertsMonitor.clearAlerts` was `await fetch(url, { method: 'DELETE', headers })` with the `Response` never bound. A 401/403/500 was indistinguishable from success: `refresh()` re-rendered the same alerts and the operator, having just confirmed a "this cannot be undone" dialog, was left to infer from an unchanged list that nothing had happened. It now catches and renders the failure (one new `en` key, `monitoring.alertsMonitor.clearFailed`; no bare `@` added).

### A fourth base-URL spelling retired

`useSlmWebSocket.ts:188` hand-built `${config.apiBaseUrl}/api/health`. That is *exactly* `getSlmApiBase()`, so the two agree today — this is convergence, not a fix, but it removes the copy that would need finding again the next time the co-located prefix moves (#2829).

### One claim corrected mid-PR

The first two commits asserted that `authStore.getAuthHeaders()` sent requests anonymous "whenever a session sat in storage". **That overstates it** — `stores/auth.ts:66` seeds the ref from sessionStorage with a localStorage fallback, so a page that *loads* with a session is fine. The two bearer tests passing against pre-change sources is what exposed it. The real defect is narrower and still real: the seed happens **once, at store construction**, so a token reaching storage afterwards (login in another tab, refresh through a different store instance) is invisible to the ref. Commit 3 corrects every comment and reshapes both tests to construct the store *before* writing the token — the scenario that actually diverges.

## Verification

Against a `cp`-swapped pristine baseline at `824f4576b` with an identical failing set (zero).

| | before | after |
|---|---|---|
| `npm run test:unit` | 29 files / 260 tests, 0 failures | **34 files / 284 tests, 0 failures** |
| `npm run type-check` | clean | **clean** |
| `npm run lint` | 0 errors / 16 warnings | **0 errors / 16 warnings** (same pre-existing set) |

**Non-vacuity.** Pristine sources `cp`-swapped back with the 24 new tests left in place: **16 of 24 fail**, each on the specific defect it names.

```
x sends a bearer that reached storage after the auth store was constructed
    expected undefined to be 'Bearer poll-token'
x attaches a bearer that reached storage after the auth store was constructed
    expected undefined to be 'Bearer tools-token'
x sends NO Authorization header when there is no session, not "Bearer null"   (x2)
    expected 'Bearer null' to be undefined
x gives every polled read an abort signal ...                                 (x4)
    expected undefined to be an instance of AbortSignal
x clears the session and redirects when ... unauthorised                      (x3)
    expected 'expired-token' to be null
x tells the operator when a confirmed clear was rejected
    Unable to get [data-testid="clear-alerts-error"] within: <div class="p-6">
x falls back to the built-in role metadata when the role fetch is rejected
    expected 0 to be greater than 0
x reports a failed dashboard read instead of leaving the panel silently stale
    expected 'HTTP 503: ' to contain 'dashboard down'
x retries a 5xx page load, then fails without touching the session
    expected false to be true
```

The 8 that pass on both sides are stated as regression guards, not defect proofs: endpoint paths, the JSON payload shape, `POLL_OPTS` staying single-shot, the Prometheus export still being read as text, and a declined confirmation still sending nothing.

Assertions are on what reaches the wire — the `Authorization` header value, the request URL, the method and parsed body, `init.signal instanceof AbortSignal`, and (with fake timers) that the abort fires *after* 31s and only once `REMOTE_EXEC_TIMEOUT_MS` is spent — not that a client method was called.

**Deferred, and why**

- **The ESLint rule** (#13140 DoD item 4) forbidding `fetch(`/`axios.create` outside the client. It cannot land while the 17 `getBackendUrl()` sites (#13079) and the 3 private axios instances remain.
- **The 3 private axios instances** (`useOrchestration`, `useOrchestrationManagement`, `useExternalAgents`) — they belong with `slmApiCompat`, which is a different shape of change.
- `getApiUrl()` in `stores/auth.ts` remains for its two display-only consumers (`APISettings.vue:25`, `BackendSettings.vue:63,277`), which report host origin rather than API base — unchanged from the first slice.

After this PR, **zero** SLM-backend raw `fetch` calls remain in `autobot-slm-frontend/src`.

## Model Used

claude-opus-4-6-20260213
