### PR TITLE
refactor(slm-frontend): route the 17 raw-fetch autobot-backend calls through useAutobotApi (#13079)

### DIFF
--- a/autobot-slm-frontend/src/components/RedisServicePanel.test.ts
+++ b/autobot-slm-frontend/src/components/RedisServicePanel.test.ts
@@ -1,0 +1,128 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — RedisServicePanel reaches the autobot backend through
+ * `useAutobotApi` instead of a private `fetch` that sent only
+ * `Bearer ${authStore.token}` (no `autobot_access_token` fallback, no 401
+ * cleanup, and — for a panel that polls every 10s — no timeout at all).
+ *
+ * `useAutobotApi` adds a 30s timeout but performs no retries, so a slow
+ * backend cannot stack retry attempts inside the 10s poll interval; the test
+ * below pins the poll cadence to one request per tick.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import axios from 'axios'
+import RedisServicePanel from './RedisServicePanel.vue'
+import en from '@/locales/en.json'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ token: 'test-token' }),
+}))
+
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: () => undefined },
+      response: { use: () => undefined },
+    },
+  }
+  return { default: { create: () => instance } }
+})
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> }
+
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
+
+const STATUS = {
+  status: 'running' as const,
+  uptime_seconds: 3600,
+  memory_used_bytes: 1048576,
+  memory_peak_bytes: 2097152,
+  connected_clients: 4,
+  last_checked: '2026-01-01T00:00:00Z',
+}
+
+type Vm = {
+  redisStatus: typeof STATUS | null
+  errorMessage: string | null
+  performAction: (action: 'start' | 'stop' | 'restart') => Promise<void>
+}
+
+function mountPanel(): Vm {
+  return mount(RedisServicePanel, { global: { plugins: [i18n] } }).vm as unknown as Vm
+}
+
+describe('RedisServicePanel transport (#13079)', () => {
+  beforeEach(() => {
+    const c = client()
+    c.get.mockReset()
+    c.post.mockReset()
+    c.get.mockResolvedValue({ data: STATUS, status: 200 })
+    c.post.mockResolvedValue({ data: { success: true }, status: 200 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('GETs /redis-service/status on mount and stores the payload', async () => {
+    const vm = mountPanel()
+    await flushPromises()
+
+    expect(client().get.mock.calls[0][0]).toBe('/redis-service/status')
+    expect(vm.redisStatus).toEqual(STATUS)
+  })
+
+  it('POSTs /redis-service/{action} and refreshes the status once', async () => {
+    const vm = mountPanel()
+    await flushPromises()
+    client().get.mockClear()
+
+    await vm.performAction('restart')
+    await flushPromises()
+
+    expect(client().post.mock.calls[0][0]).toBe('/redis-service/restart')
+    expect(client().get.mock.calls.map((c) => c[0])).toEqual(['/redis-service/status'])
+  })
+
+  it('surfaces the backend detail when an action is refused', async () => {
+    const vm = mountPanel()
+    await flushPromises()
+    client().post.mockRejectedValue({ response: { data: { detail: 'redis unit is masked' } } })
+
+    await vm.performAction('stop')
+    await flushPromises()
+
+    expect(vm.errorMessage).toBe('redis unit is masked')
+  })
+
+  it('issues exactly one status request per 10s poll tick (no stacked retries)', async () => {
+    vi.useFakeTimers()
+    mountPanel()
+    await flushPromises()
+    client().get.mockClear()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(client().get.mock.calls.map((c) => c[0])).toEqual([
+      '/redis-service/status',
+      '/redis-service/status',
+      '/redis-service/status',
+    ])
+  })
+})

--- a/autobot-slm-frontend/src/components/RedisServicePanel.vue
+++ b/autobot-slm-frontend/src/components/RedisServicePanel.vue
@@ -15,38 +15,32 @@
 
 import { ref, onMounted, onUnmounted } from 'vue'
 import { formatBytes } from '@/utils/formatHelpers'
-import { getBackendUrl } from '@/config/ssot-config'
 import i18n from '@/i18n'
-import { useAuthStore } from '@/stores/auth'
 import { createLogger } from '@/utils/debugUtils'
+import {
+  useAutobotApi,
+  autobotApiErrorMessage,
+  type RedisServiceAction,
+  type RedisServiceStatus,
+} from '@/composables/useAutobotApi'
 
 const t = i18n.global.t.bind(i18n.global)
 
 const logger = createLogger('RedisServicePanel')
-const authStore = useAuthStore()
+const api = useAutobotApi()
 
 // -----------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------
 
-interface RedisStatus {
-  status: 'running' | 'stopped' | 'unknown'
-  uptime_seconds: number | null
-  memory_used_bytes: number | null
-  memory_peak_bytes: number | null
-  connected_clients: number | null
-  last_checked: string | null
-  error?: string
-}
-
 // -----------------------------------------------------------------------
 // State
 // -----------------------------------------------------------------------
 
-const redisStatus = ref<RedisStatus | null>(null)
+const redisStatus = ref<RedisServiceStatus | null>(null)
 const isLoading = ref(true)
 const isActionInProgress = ref(false)
-const currentAction = ref<'start' | 'stop' | 'restart' | null>(null)
+const currentAction = ref<RedisServiceAction | null>(null)
 const errorMessage = ref<string | null>(null)
 const successMessage = ref<string | null>(null)
 const showStopConfirm = ref(false)
@@ -56,10 +50,6 @@ let pollInterval: ReturnType<typeof setInterval> | null = null
 // -----------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------
-
-function authHeaders(): Record<string, string> {
-  return { Authorization: `Bearer ${authStore.token}` }
-}
 
 function formatUptime(seconds: number | null): string {
   if (seconds === null || seconds === undefined) return '-'
@@ -92,13 +82,7 @@ function statusTextClass(status: string | undefined): string {
 
 async function fetchStatus(): Promise<void> {
   try {
-    const response = await fetch(`${getBackendUrl()}/redis-service/status`, {
-      headers: authHeaders(),
-    })
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`)
-    }
-    redisStatus.value = await response.json()
+    redisStatus.value = await api.getRedisServiceStatus()
     errorMessage.value = null
   } catch (err) {
     logger.error('Failed to fetch Redis status:', err)
@@ -108,7 +92,7 @@ async function fetchStatus(): Promise<void> {
   }
 }
 
-async function performAction(action: 'start' | 'stop' | 'restart'): Promise<void> {
+async function performAction(action: RedisServiceAction): Promise<void> {
   if (isActionInProgress.value) return
   isActionInProgress.value = true
   currentAction.value = action
@@ -116,21 +100,14 @@ async function performAction(action: 'start' | 'stop' | 'restart'): Promise<void
   successMessage.value = null
 
   try {
-    const response = await fetch(`${getBackendUrl()}/redis-service/${action}`, {
-      method: 'POST',
-      headers: authHeaders(),
-    })
-    if (!response.ok) {
-      const body = await response.json().catch(() => ({}))
-      throw new Error(body.detail ?? `HTTP ${response.status}`)
-    }
+    await api.performRedisServiceAction(action)
     successMessage.value = t('redisServicePanel.actionSucceeded', { action })
     // Refresh status after action
     await fetchStatus()
     setTimeout(() => { successMessage.value = null }, 4000)
   } catch (err) {
     logger.error(`Failed to ${action} Redis service:`, err)
-    errorMessage.value = err instanceof Error ? err.message : t('redisServicePanel.actionFailed', { action })
+    errorMessage.value = autobotApiErrorMessage(err, t('redisServicePanel.actionFailed', { action }))
   } finally {
     isActionInProgress.value = false
     currentAction.value = null

--- a/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.test.ts
+++ b/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.test.ts
@@ -1,0 +1,140 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — ConfigHistoryTab reaches the autobot backend through
+ * `useAutobotApi` instead of a private `fetch` that sent only
+ * `Bearer ${authStore.token}` (no `autobot_access_token` fallback, no 401
+ * cleanup, no timeout).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import axios from 'axios'
+import ConfigHistoryTab from './ConfigHistoryTab.vue'
+import en from '@/locales/en.json'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ token: 'test-token' }),
+}))
+
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: () => undefined },
+      response: { use: () => undefined },
+    },
+  }
+  return { default: { create: () => instance } }
+})
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> }
+
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
+
+const REVISION = {
+  id: 'rev-9',
+  entity_type: 'agent',
+  entity_id: 'orchestrator',
+  before_config: { retries: 1 },
+  after_config: { retries: 3 },
+  changed_keys: ['retries'],
+  source: 'api',
+  created_by: 'ops',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+type Vm = {
+  entityType: string
+  entityId: string
+  revisions: unknown[]
+  error: string | null
+  fetchRevisions: () => Promise<void>
+  rollback: (id: string) => Promise<void>
+}
+
+function mountTab(): Vm {
+  return mount(ConfigHistoryTab, { global: { plugins: [i18n] } }).vm as unknown as Vm
+}
+
+describe('ConfigHistoryTab transport (#13079)', () => {
+  beforeEach(() => {
+    const c = client()
+    c.get.mockReset()
+    c.post.mockReset()
+    c.get.mockResolvedValue({ data: [REVISION], status: 200 })
+    c.post.mockResolvedValue({ data: { success: true }, status: 200 })
+  })
+
+  it('GETs /config-revisions/{type}/{id} with the limit', async () => {
+    const vm = mountTab()
+    vm.entityType = 'agent'
+    vm.entityId = 'orchestrator'
+
+    await vm.fetchRevisions()
+    await flushPromises()
+
+    expect(client().get.mock.calls[0][0]).toBe('/config-revisions/agent/orchestrator?limit=50')
+    expect(vm.revisions).toHaveLength(1)
+  })
+
+  it('makes no request until an entity id is supplied', async () => {
+    const vm = mountTab()
+    vm.entityId = ''
+
+    await vm.fetchRevisions()
+
+    expect(client().get).not.toHaveBeenCalled()
+  })
+
+  it('POSTs the rollback path and reloads the timeline', async () => {
+    const vm = mountTab()
+    vm.entityType = 'agent'
+    vm.entityId = 'orchestrator'
+    await vm.fetchRevisions()
+    client().get.mockClear()
+
+    await vm.rollback('rev-9')
+    await flushPromises()
+
+    expect(client().post.mock.calls[0][0]).toBe(
+      '/config-revisions/agent/orchestrator/rev-9/rollback',
+    )
+    expect(client().get.mock.calls[0][0]).toBe('/config-revisions/agent/orchestrator?limit=50')
+  })
+
+  it('surfaces the backend detail when a rollback is refused', async () => {
+    const vm = mountTab()
+    vm.entityType = 'agent'
+    vm.entityId = 'orchestrator'
+    client().post.mockRejectedValue({ response: { data: { detail: 'revision is not rollbackable' } } })
+
+    await vm.rollback('rev-9')
+
+    expect(vm.error).toBe('revision is not rollbackable')
+  })
+
+  it('surfaces the backend detail when the timeline load fails', async () => {
+    const vm = mountTab()
+    vm.entityType = 'agent'
+    vm.entityId = 'orchestrator'
+    client().get.mockRejectedValue({ response: { data: { detail: 'no such entity' } } })
+
+    await vm.fetchRevisions()
+
+    expect(vm.error).toBe('no such entity')
+    expect(vm.revisions).toEqual([])
+  })
+})

--- a/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.vue
+++ b/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.vue
@@ -6,30 +6,25 @@
  * Config History Tab (#1404)
  *
  * Timeline of configuration revisions with diff view and rollback.
- * Uses /autobot-api proxy to main backend.
+ *
+ * #13079: reaches the autobot backend through `useAutobotApi`, the SLM app's
+ * single client for that backend, instead of a private `fetch` that sent only
+ * `Bearer ${authStore.token}` (no `autobot_access_token` fallback, no 401
+ * cleanup, no timeout).
  */
 
-import { computed, ref, watch } from 'vue'
-import { useAuthStore } from '@/stores/auth'
-import { getBackendUrl } from '@/config/ssot-config'
+import { ref, watch } from 'vue'
+import {
+  useAutobotApi,
+  autobotApiErrorMessage,
+  type ConfigRevision,
+} from '@/composables/useAutobotApi'
 
-interface Revision {
-  id: string
-  entity_type: string
-  entity_id: string
-  before_config: Record<string, unknown> | null
-  after_config: Record<string, unknown>
-  changed_keys: string[]
-  source: string
-  created_by: string
-  created_at: string | null
-}
-
-const authStore = useAuthStore()
-const revisions = ref<Revision[]>([])
+const api = useAutobotApi()
+const revisions = ref<ConfigRevision[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
-const selectedRevision = ref<Revision | null>(null)
+const selectedRevision = ref<ConfigRevision | null>(null)
 const showRollbackConfirm = ref(false)
 const rollbackLoading = ref(false)
 
@@ -43,25 +38,15 @@ const entityTypes = [
 
 const systemEntities = ['settings', 'config', 'backend']
 
-const headers = computed(() => ({
-  Authorization: `Bearer ${authStore.token}`,
-  'Content-Type': 'application/json',
-}))
-
 async function fetchRevisions() {
   if (!entityType.value || !entityId.value) return
   loading.value = true
   error.value = null
   selectedRevision.value = null
   try {
-    const res = await fetch(
-      `${getBackendUrl()}/config-revisions/${entityType.value}/${entityId.value}?limit=50`,
-      { headers: headers.value },
-    )
-    if (!res.ok) throw new Error(`Failed to load revisions: ${res.status}`)
-    revisions.value = await res.json()
+    revisions.value = await api.getConfigRevisions(entityType.value, entityId.value, 50)
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load revisions'
+    error.value = autobotApiErrorMessage(err, 'Failed to load revisions')
     revisions.value = []
   } finally {
     loading.value = false
@@ -71,25 +56,18 @@ async function fetchRevisions() {
 async function rollback(revisionId: string) {
   rollbackLoading.value = true
   try {
-    const res = await fetch(
-      `${getBackendUrl()}/config-revisions/${entityType.value}/${entityId.value}/${revisionId}/rollback`,
-      { method: 'POST', headers: headers.value },
-    )
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      throw new Error(data.detail || `Rollback failed: ${res.status}`)
-    }
+    await api.rollbackConfigRevision(entityType.value, entityId.value, revisionId)
     showRollbackConfirm.value = false
     selectedRevision.value = null
     await fetchRevisions()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Rollback failed'
+    error.value = autobotApiErrorMessage(err, 'Rollback failed')
   } finally {
     rollbackLoading.value = false
   }
 }
 
-function selectRevision(rev: Revision) {
+function selectRevision(rev: ConfigRevision) {
   selectedRevision.value = selectedRevision.value?.id === rev.id ? null : rev
   showRollbackConfirm.value = false
 }

--- a/autobot-slm-frontend/src/components/agents/OrgChartTab.test.ts
+++ b/autobot-slm-frontend/src/components/agents/OrgChartTab.test.ts
@@ -1,0 +1,179 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — OrgChartTab reaches the autobot backend through `useAutobotApi`.
+ *
+ * The tab used to own a private `fetch` with an `Authorization:
+ * Bearer ${authStore.token}` header computed inline, so it lost the
+ * `autobot_access_token` fallback, the 401 cleanup and the 30s timeout that
+ * `useAutobotApi` applies (asserted in useAutobotApi.test.ts).
+ *
+ * Stubbing `axios.create` keeps these assertions on the wire contract: the
+ * exact endpoint paths and verbs, and the per-panel degradation the old
+ * `fetch`-with-`res.ok` checks provided — `fetch` never rejects on a non-2xx,
+ * so one failing detail panel must still leave the other two populated.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import axios from 'axios'
+import OrgChartTab from './OrgChartTab.vue'
+import en from '@/locales/en.json'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ token: 'test-token' }),
+}))
+
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: () => undefined },
+      response: { use: () => undefined },
+    },
+  }
+  return { default: { create: () => instance } }
+})
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> }
+
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
+
+const NODE = {
+  agent_id: 'orchestrator',
+  name: 'Orchestrator',
+  org_role: 'manager',
+  title: 'Lead',
+  capabilities: 'planning',
+  direct_reports_count: 1,
+  children: [],
+}
+
+function payloadFor(url: string): unknown {
+  if (url.endsWith('/agents/org')) return [NODE]
+  if (url.endsWith('/reports')) return [{ agent_id: 'worker', name: 'Worker', org_role: 'worker' }]
+  if (url.endsWith('/activity')) {
+    return { manager_id: 'orchestrator', total_delegated: 3, by_status: { completed: 3 } }
+  }
+  if (url.includes('/delegations')) {
+    return [
+      {
+        id: 'd1',
+        delegator_id: 'orchestrator',
+        assignee_id: 'worker',
+        task_description: 'ship it',
+        status: 'completed',
+        escalated_to: null,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ]
+  }
+  return { success: true }
+}
+
+function urlsOf(fn: ReturnType<typeof vi.fn>): string[] {
+  return fn.mock.calls.map((c) => c[0] as string)
+}
+
+describe('OrgChartTab transport (#13079)', () => {
+  beforeEach(() => {
+    const c = client()
+    c.get.mockReset()
+    c.post.mockReset()
+    c.get.mockImplementation(async (url: string) => ({ data: payloadFor(url), status: 200 }))
+    c.post.mockImplementation(async (url: string) => ({ data: payloadFor(url), status: 200 }))
+  })
+
+  it('loads the org tree from /agents/org on mount', async () => {
+    const wrapper = mount(OrgChartTab, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(urlsOf(client().get)).toContain('/agents/org')
+    expect(wrapper.text()).toContain('Orchestrator')
+  })
+
+  it('fans out to reports, activity and delegations when a node is selected', async () => {
+    const wrapper = mount(OrgChartTab, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    await (wrapper.vm as unknown as { selectNode: (n: unknown) => Promise<void> }).selectNode(NODE)
+    await flushPromises()
+
+    const urls = urlsOf(client().get)
+    expect(urls).toContain('/agents/orchestrator/reports')
+    expect(urls).toContain('/agents/orchestrator/activity')
+    expect(urls).toContain('/agents/orchestrator/delegations?role=delegator&limit=10')
+  })
+
+  it('keeps the surviving detail panels when one of the three calls fails', async () => {
+    const wrapper = mount(OrgChartTab, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    client().get.mockImplementation(async (url: string) => {
+      if (url.endsWith('/reports')) throw new Error('boom')
+      return { data: payloadFor(url), status: 200 }
+    })
+
+    const vm = wrapper.vm as unknown as {
+      selectNode: (n: unknown) => Promise<void>
+      directReports: unknown[]
+      activity: unknown
+      delegations: unknown[]
+    }
+    await vm.selectNode(NODE)
+    await flushPromises()
+
+    expect(vm.directReports).toEqual([])
+    expect(vm.activity).not.toBeNull()
+    expect(vm.delegations).toHaveLength(1)
+  })
+
+  it('POSTs a delegation and surfaces the backend detail on failure', async () => {
+    const wrapper = mount(OrgChartTab, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as {
+      selectNode: (n: unknown) => Promise<void>
+      submitDelegation: () => Promise<void>
+      delegateForm: { assignee_id: string; task_description: string }
+      delegateError: string | null
+    }
+    await vm.selectNode(NODE)
+    vm.delegateForm.assignee_id = 'worker'
+    vm.delegateForm.task_description = 'ship it'
+
+    await vm.submitDelegation()
+    await flushPromises()
+
+    const [url, body] = client().post.mock.calls[0] as [string, unknown]
+    expect(url).toBe('/agents/orchestrator/delegate')
+    expect(body).toEqual({ assignee_id: 'worker', task_description: 'ship it' })
+
+    client().post.mockRejectedValue({ response: { data: { detail: 'not a manager' } } })
+    await vm.submitDelegation()
+    await flushPromises()
+
+    expect(vm.delegateError).toBe('not a manager')
+  })
+
+  it('shows the backend detail when the tree load fails', async () => {
+    client().get.mockRejectedValue({ response: { data: { detail: 'org registry offline' } } })
+
+    const wrapper = mount(OrgChartTab, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('org registry offline')
+  })
+})

--- a/autobot-slm-frontend/src/components/agents/OrgChartTab.vue
+++ b/autobot-slm-frontend/src/components/agents/OrgChartTab.vue
@@ -6,114 +6,75 @@
  * Agent Org Chart Tab (#1405)
  *
  * Tree visualization of agent hierarchy with delegation controls.
- * Uses /autobot-api proxy to main backend.
+ *
+ * #13079: reaches the autobot backend through `useAutobotApi`, the SLM app's
+ * single client for that backend, instead of a private `fetch` that sent only
+ * `Bearer ${authStore.token}` (no `autobot_access_token` fallback, no 401
+ * cleanup, no timeout).
  */
 
-import { computed, onMounted, ref } from 'vue'
-import { useAuthStore } from '@/stores/auth'
-import { getBackendUrl } from '@/config/ssot-config'
+import { onMounted, ref } from 'vue'
+import {
+  useAutobotApi,
+  autobotApiErrorMessage,
+  type AgentActivitySummary,
+  type AgentDelegation,
+  type AgentDirectReport,
+  type AgentOrgNode,
+} from '@/composables/useAutobotApi'
 import OrgTreeNode from './OrgTreeNode.vue'
 
-interface OrgNode {
-  agent_id: string
-  name: string
-  org_role: string
-  title: string | null
-  capabilities: string | null
-  direct_reports_count: number
-  children: OrgNode[]
-}
-
-interface Delegation {
-  id: string
-  delegator_id: string
-  assignee_id: string
-  task_description: string
-  status: string
-  escalated_to: string | null
-  created_at: string | null
-}
-
-interface ActivitySummary {
-  manager_id: string
-  total_delegated: number
-  by_status: Record<string, number>
-}
-
-const authStore = useAuthStore()
-const tree = ref<OrgNode[]>([])
+const api = useAutobotApi()
+const tree = ref<AgentOrgNode[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
-const selectedNode = ref<OrgNode | null>(null)
-const directReports = ref<{ agent_id: string; name: string; org_role: string }[]>([])
-const activity = ref<ActivitySummary | null>(null)
-const delegations = ref<Delegation[]>([])
+const selectedNode = ref<AgentOrgNode | null>(null)
+const directReports = ref<AgentDirectReport[]>([])
+const activity = ref<AgentActivitySummary | null>(null)
+const delegations = ref<AgentDelegation[]>([])
 const showDelegateForm = ref(false)
 const delegateForm = ref({ assignee_id: '', task_description: '' })
 const delegateError = ref<string | null>(null)
-
-const headers = computed(() => ({
-  Authorization: `Bearer ${authStore.token}`,
-  'Content-Type': 'application/json',
-}))
 
 async function fetchTree() {
   loading.value = true
   error.value = null
   try {
-    const res = await fetch(`${getBackendUrl()}/agents/org`, { headers: headers.value })
-    if (!res.ok) throw new Error(`Failed to load org tree: ${res.status}`)
-    tree.value = await res.json()
+    tree.value = await api.getAgentOrgTree()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load org tree'
+    error.value = autobotApiErrorMessage(err, 'Failed to load org tree')
   } finally {
     loading.value = false
   }
 }
 
-async function selectNode(node: OrgNode) {
+async function selectNode(node: AgentOrgNode) {
   selectedNode.value = node
   showDelegateForm.value = false
   delegateError.value = null
-  try {
-    const [reportsRes, activityRes, delegationsRes] = await Promise.all([
-      fetch(`${getBackendUrl()}/agents/${node.agent_id}/reports`, { headers: headers.value }),
-      fetch(`${getBackendUrl()}/agents/${node.agent_id}/activity`, { headers: headers.value }),
-      fetch(`${getBackendUrl()}/agents/${node.agent_id}/delegations?role=delegator&limit=10`, {
-        headers: headers.value,
-      }),
-    ])
-    directReports.value = reportsRes.ok ? await reportsRes.json() : []
-    activity.value = activityRes.ok ? await activityRes.json() : null
-    delegations.value = delegationsRes.ok ? await delegationsRes.json() : []
-  } catch {
-    directReports.value = []
-    activity.value = null
-    delegations.value = []
-  }
+  // `allSettled`, not `all`: the raw `fetch` this replaced never rejected on a
+  // non-2xx, so one failing panel left the other two populated. Keep that
+  // per-panel degradation rather than blanking the whole detail pane.
+  const [reports, summary, recent] = await Promise.allSettled([
+    api.getAgentDirectReports(node.agent_id),
+    api.getAgentActivity(node.agent_id),
+    api.getAgentDelegations(node.agent_id, { role: 'delegator', limit: 10 }),
+  ])
+  directReports.value = reports.status === 'fulfilled' ? reports.value : []
+  activity.value = summary.status === 'fulfilled' ? summary.value : null
+  delegations.value = recent.status === 'fulfilled' ? recent.value : []
 }
 
 async function submitDelegation() {
   if (!selectedNode.value) return
   delegateError.value = null
   try {
-    const res = await fetch(
-      `${getBackendUrl()}/agents/${selectedNode.value.agent_id}/delegate`,
-      {
-        method: 'POST',
-        headers: headers.value,
-        body: JSON.stringify(delegateForm.value),
-      },
-    )
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      throw new Error(data.detail || `Failed: ${res.status}`)
-    }
+    await api.delegateAgentTask(selectedNode.value.agent_id, delegateForm.value)
     delegateForm.value = { assignee_id: '', task_description: '' }
     showDelegateForm.value = false
     await selectNode(selectedNode.value)
   } catch (err) {
-    delegateError.value = err instanceof Error ? err.message : 'Delegation failed'
+    delegateError.value = autobotApiErrorMessage(err, 'Delegation failed')
   }
 }
 

--- a/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.test.ts
+++ b/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.test.ts
@@ -1,0 +1,174 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — ProcessMonitorTab reaches the autobot backend through
+ * `useAutobotApi` instead of a private `fetch` that sent only
+ * `Bearer ${authStore.token}` (no `autobot_access_token` fallback, no 401
+ * cleanup, no timeout).
+ *
+ * The live-log WebSocket is deliberately NOT migrated — `useAutobotApi` is an
+ * HTTP client and has no socket equivalent — so these tests also pin that the
+ * plain-text log body still arrives verbatim rather than JSON-parsed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import axios from 'axios'
+import ProcessMonitorTab from './ProcessMonitorTab.vue'
+import en from '@/locales/en.json'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ token: 'test-token' }),
+}))
+
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: () => undefined },
+      response: { use: () => undefined },
+    },
+  }
+  return { default: { create: () => instance } }
+})
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> }
+
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
+
+const PROCESS = {
+  id: 'p1',
+  agent_id: 'orchestrator',
+  task_id: null,
+  command: '/usr/bin/python3',
+  args: ['script.py'],
+  status: 'completed',
+  exit_code: 0,
+  signal: null,
+  log_excerpt: 'done',
+  log_path: null,
+  timeout_seconds: 300,
+  started_at: '2026-01-01T00:00:00Z',
+  completed_at: '2026-01-01T00:00:10Z',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+type Vm = {
+  agentId: string
+  statusFilter: string
+  fullLog: string | null
+  error: string | null
+  fetchProcesses: () => Promise<void>
+  fetchFullLog: (id: string) => Promise<void>
+  signalProcess: (id: string, sig: string) => Promise<void>
+  spawnProcess: () => Promise<void>
+  spawnForm: { agent_id: string; command: string; args: string; timeout_seconds: number }
+}
+
+function mountTab(): { vm: Vm } {
+  const wrapper = mount(ProcessMonitorTab, { global: { plugins: [i18n] } })
+  return { vm: wrapper.vm as unknown as Vm }
+}
+
+describe('ProcessMonitorTab transport (#13079)', () => {
+  beforeEach(() => {
+    const c = client()
+    c.get.mockReset()
+    c.post.mockReset()
+    c.get.mockResolvedValue({ data: { processes: [PROCESS] }, status: 200 })
+    c.post.mockResolvedValue({ data: { success: true }, status: 200 })
+  })
+
+  it('GETs /agents/{id}/processes with the limit and the selected status filter', async () => {
+    const { vm } = mountTab()
+    vm.agentId = 'orchestrator'
+    vm.statusFilter = 'running'
+
+    await vm.fetchProcesses()
+    await flushPromises()
+
+    expect(client().get.mock.calls[0][0]).toBe(
+      '/agents/orchestrator/processes?limit=50&status=running',
+    )
+  })
+
+  it('omits the status filter when "All" is selected', async () => {
+    const { vm } = mountTab()
+    vm.agentId = 'orchestrator'
+    vm.statusFilter = ''
+
+    await vm.fetchProcesses()
+
+    expect(client().get.mock.calls[0][0]).toBe('/agents/orchestrator/processes?limit=50')
+  })
+
+  it('requests the log as text and stores it verbatim', async () => {
+    client().get.mockResolvedValue({ data: 'stdout line\nstderr line', status: 200 })
+    const { vm } = mountTab()
+
+    await vm.fetchFullLog('p1')
+
+    const [url, config] = client().get.mock.calls[0] as [string, { responseType: string }]
+    expect(url).toBe('/processes/p1/logs')
+    expect(config.responseType).toBe('text')
+    expect(vm.fullLog).toBe('stdout line\nstderr line')
+  })
+
+  it('keeps the "Failed to load log" placeholder when the log request rejects', async () => {
+    client().get.mockRejectedValue(new Error('gone'))
+    const { vm } = mountTab()
+
+    await vm.fetchFullLog('p1')
+
+    expect(vm.fullLog).toBe('Failed to load log')
+  })
+
+  it('POSTs the signal name and surfaces the backend detail on failure', async () => {
+    const { vm } = mountTab()
+    vm.agentId = 'orchestrator'
+
+    await vm.signalProcess('p1', 'SIGKILL')
+
+    expect(client().post.mock.calls[0].slice(0, 2)).toEqual([
+      '/processes/p1/signal',
+      { signal: 'SIGKILL' },
+    ])
+
+    client().post.mockRejectedValue({ response: { data: { detail: 'process already exited' } } })
+    await vm.signalProcess('p1', 'SIGTERM')
+
+    expect(vm.error).toBe('process already exited')
+  })
+
+  it('POSTs the spawn payload with args split into a list', async () => {
+    const { vm } = mountTab()
+    vm.agentId = 'orchestrator'
+    vm.spawnForm.command = '/usr/bin/python3'
+    vm.spawnForm.args = 'script.py --flag'
+    vm.spawnForm.timeout_seconds = 120
+
+    await vm.spawnProcess()
+
+    expect(client().post.mock.calls[0].slice(0, 2)).toEqual([
+      '/processes/spawn',
+      {
+        agent_id: 'orchestrator',
+        command: '/usr/bin/python3',
+        args: ['script.py', '--flag'],
+        timeout_seconds: 120,
+      },
+    ])
+  })
+})

--- a/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
+++ b/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
@@ -6,31 +6,24 @@
  * Process Monitor Tab (#1406)
  *
  * Table of background processes with status, logs, and signal controls.
- * Uses /autobot-api proxy to main backend.
+ *
+ * #13079: the REST calls reach the autobot backend through `useAutobotApi`,
+ * the SLM app's single client for that backend, instead of a private `fetch`
+ * that sent only `Bearer ${authStore.token}` (no `autobot_access_token`
+ * fallback, no 401 cleanup, no timeout). The live-log WebSocket below stays on
+ * the native transport — `useAutobotApi` is HTTP-only and a socket has no
+ * equivalent there.
  */
 
-import { computed, ref } from 'vue'
-import { useAuthStore } from '@/stores/auth'
+import { ref } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
+import {
+  useAutobotApi,
+  autobotApiErrorMessage,
+  type ProcessRun,
+} from '@/composables/useAutobotApi'
 
-interface ProcessRun {
-  id: string
-  agent_id: string
-  task_id: string | null
-  command: string
-  args: string[]
-  status: string
-  exit_code: number | null
-  signal: string | null
-  log_excerpt: string | null
-  log_path: string | null
-  timeout_seconds: number
-  started_at: string | null
-  completed_at: string | null
-  created_at: string | null
-}
-
-const authStore = useAuthStore()
+const api = useAutobotApi()
 const processes = ref<ProcessRun[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
@@ -51,11 +44,6 @@ const spawnForm = ref({
   timeout_seconds: 300,
 })
 
-const headers = computed(() => ({
-  Authorization: `Bearer ${authStore.token}`,
-  'Content-Type': 'application/json',
-}))
-
 async function fetchProcesses() {
   if (!agentId.value) return
   loading.value = true
@@ -63,14 +51,12 @@ async function fetchProcesses() {
   selectedProcess.value = null
   fullLog.value = null
   try {
-    let url = `${getBackendUrl()}/agents/${agentId.value}/processes?limit=50`
-    if (statusFilter.value) url += `&status=${statusFilter.value}`
-    const res = await fetch(url, { headers: headers.value })
-    if (!res.ok) throw new Error(`Failed to load processes: ${res.status}`)
-    const data = await res.json()
-    processes.value = data.processes || []
+    processes.value = await api.getAgentProcesses(agentId.value, {
+      limit: 50,
+      status: statusFilter.value || undefined,
+    })
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load processes'
+    error.value = autobotApiErrorMessage(err, 'Failed to load processes')
     processes.value = []
   } finally {
     loading.value = false
@@ -80,10 +66,7 @@ async function fetchProcesses() {
 async function fetchFullLog(processId: string) {
   fullLogLoading.value = true
   try {
-    const res = await fetch(`${getBackendUrl()}/processes/${processId}/logs`, {
-      headers: headers.value,
-    })
-    fullLog.value = res.ok ? await res.text() : 'Failed to load log'
+    fullLog.value = await api.getProcessLogs(processId)
   } catch {
     fullLog.value = 'Failed to load log'
   } finally {
@@ -138,47 +121,28 @@ function streamLogs(processId: string) {
 
 async function signalProcess(processId: string, sig: string) {
   try {
-    const res = await fetch(`${getBackendUrl()}/processes/${processId}/signal`, {
-      method: 'POST',
-      headers: headers.value,
-      body: JSON.stringify({ signal: sig }),
-    })
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      throw new Error(data.detail || `Signal failed: ${res.status}`)
-    }
+    await api.signalProcess(processId, sig)
     showKillConfirm.value = null
     await fetchProcesses()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Signal failed'
+    error.value = autobotApiErrorMessage(err, 'Signal failed')
   }
 }
 
 async function spawnProcess() {
   error.value = null
   try {
-    const payload = {
+    await api.spawnProcess({
       agent_id: spawnForm.value.agent_id || agentId.value,
       command: spawnForm.value.command,
-      args: spawnForm.value.args
-        ? spawnForm.value.args.split(' ').filter(Boolean)
-        : [],
+      args: spawnForm.value.args ? spawnForm.value.args.split(' ').filter(Boolean) : [],
       timeout_seconds: spawnForm.value.timeout_seconds,
-    }
-    const res = await fetch(`${getBackendUrl()}/processes/spawn`, {
-      method: 'POST',
-      headers: headers.value,
-      body: JSON.stringify(payload),
     })
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      throw new Error(data.detail || `Spawn failed: ${res.status}`)
-    }
     showSpawnForm.value = false
     spawnForm.value = { agent_id: '', command: '', args: '', timeout_seconds: 300 }
     await fetchProcesses()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Spawn failed'
+    error.value = autobotApiErrorMessage(err, 'Spawn failed')
   }
 }
 

--- a/autobot-slm-frontend/src/composables/useAutobotApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.test.ts
@@ -1,0 +1,334 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — the transport contract seven SLM components used to re-implement.
+ *
+ * OrgChartTab, ProcessMonitorTab, ConfigHistoryTab, RedisServicePanel,
+ * UserManagementSettings, CacheSettings and BackendSettings each built their
+ * own `fetch` against `getBackendUrl()` that sent only
+ * `Bearer ${authStore.token}`. With an autobot-issued token and no SLM token
+ * those views 401'd while every tool on this client worked (proven in #13077
+ * for AdvancedControlTool).
+ *
+ * These tests exercise the REAL interceptors registered by `useAutobotApi` —
+ * `axios.create` is stubbed with an instance that records the callbacks, which
+ * are then invoked directly. They assert the three properties the raw-`fetch`
+ * forks were losing (localStorage token fallback, 401 cleanup, 30s timeout),
+ * plus the exact path and verb of every endpoint moved onto the client.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const BACKEND = 'http://autobot.example/autobot-api'
+
+type Headers = Record<string, unknown>
+type RequestConfig = { headers: Headers }
+
+const h = vi.hoisted(() => {
+  const state = {
+    createConfig: null as Record<string, unknown> | null,
+    requestInterceptor: null as ((c: RequestConfig) => RequestConfig) | null,
+    responseErrorInterceptor: null as ((e: unknown) => Promise<unknown>) | null,
+    token: null as string | null,
+  }
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      // Plain functions, not vi.fn: the suite runs with `mockReset: true`,
+      // which would strip a vi.fn implementation before the tests execute.
+      request: {
+        use: (fn: (c: RequestConfig) => RequestConfig) => {
+          state.requestInterceptor = fn
+        },
+      },
+      response: {
+        use: (_ok: unknown, err: (e: unknown) => Promise<unknown>) => {
+          state.responseErrorInterceptor = err
+        },
+      },
+    },
+  }
+  return { state, instance }
+})
+
+vi.mock('axios', () => ({
+  default: {
+    create: (config: Record<string, unknown>) => {
+      h.state.createConfig = config
+      return h.instance
+    },
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({ getBackendUrl: () => BACKEND }))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    get token() {
+      return h.state.token
+    },
+  }),
+}))
+
+import { useAutobotApi, autobotApiErrorMessage } from './useAutobotApi'
+
+/** Run the recorded request interceptor over a bare config. */
+function applyRequestInterceptor(): Headers {
+  useAutobotApi()
+  const config: RequestConfig = { headers: {} }
+  return h.state.requestInterceptor!(config).headers
+}
+
+function lastCall(fn: ReturnType<typeof vi.fn>): unknown[] {
+  return fn.mock.calls[fn.mock.calls.length - 1] as unknown[]
+}
+
+describe('useAutobotApi transport contract (#13079)', () => {
+  beforeEach(() => {
+    h.state.token = null
+    h.state.createConfig = null
+    localStorage.clear()
+    h.instance.get.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.post.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.put.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.patch.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.delete.mockResolvedValue({ data: {}, status: 200 })
+  })
+
+  it('resolves the base URL from getBackendUrl() and applies a 30s timeout', () => {
+    useAutobotApi()
+
+    expect(h.state.createConfig?.baseURL).toBe(BACKEND)
+    expect(h.state.createConfig?.timeout).toBe(30000)
+  })
+
+  it('sends the SLM bearer token when the auth store holds one', () => {
+    h.state.token = 'slm-token'
+
+    expect(applyRequestInterceptor().Authorization).toBe('Bearer slm-token')
+  })
+
+  it('falls back to the autobot_access_token in localStorage — the #13079 defect', () => {
+    // This is precisely the case the private `fetch` forks got wrong: an
+    // autobot-issued token present, no SLM token, so they sent
+    // `Bearer null` / `Bearer undefined` and the backend replied 401.
+    h.state.token = null
+    localStorage.setItem('autobot_access_token', 'autobot-token')
+
+    expect(applyRequestInterceptor().Authorization).toBe('Bearer autobot-token')
+  })
+
+  it('sends no Authorization header when neither token exists', () => {
+    expect(applyRequestInterceptor().Authorization).toBeUndefined()
+  })
+
+  it('clears the stale autobot_access_token on a 401 and still rejects', async () => {
+    useAutobotApi()
+    localStorage.setItem('autobot_access_token', 'expired-token')
+
+    const err = { response: { status: 401 } }
+    await expect(h.state.responseErrorInterceptor!(err)).rejects.toBe(err)
+    expect(localStorage.getItem('autobot_access_token')).toBeNull()
+  })
+
+  it('keeps the token on a non-401 failure', async () => {
+    useAutobotApi()
+    localStorage.setItem('autobot_access_token', 'good-token')
+
+    await expect(
+      h.state.responseErrorInterceptor!({ response: { status: 500 } }),
+    ).rejects.toBeTruthy()
+    expect(localStorage.getItem('autobot_access_token')).toBe('good-token')
+  })
+})
+
+describe('useAutobotApi endpoints moved off raw fetch (#13079)', () => {
+  beforeEach(() => {
+    h.state.token = 'slm-token'
+    localStorage.clear()
+    h.instance.get.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.post.mockResolvedValue({ data: {}, status: 200 })
+  })
+
+  describe('agent org chart (#1405)', () => {
+    it('GETs /agents/org', async () => {
+      const tree = [{ agent_id: 'a1', name: 'A', org_role: 'manager' }]
+      h.instance.get.mockResolvedValue({ data: tree, status: 200 })
+
+      await expect(useAutobotApi().getAgentOrgTree()).resolves.toEqual(tree)
+      expect(lastCall(h.instance.get)[0]).toBe('/agents/org')
+    })
+
+    it('GETs /agents/{id}/reports', async () => {
+      await useAutobotApi().getAgentDirectReports('a1')
+
+      expect(lastCall(h.instance.get)[0]).toBe('/agents/a1/reports')
+    })
+
+    it('GETs /agents/{id}/activity', async () => {
+      await useAutobotApi().getAgentActivity('a1')
+
+      expect(lastCall(h.instance.get)[0]).toBe('/agents/a1/activity')
+    })
+
+    it('GETs /agents/{id}/delegations with the role + limit query', async () => {
+      h.instance.get.mockResolvedValue({ data: [], status: 200 })
+
+      await useAutobotApi().getAgentDelegations('a1', { role: 'delegator', limit: 10 })
+
+      expect(lastCall(h.instance.get)[0]).toBe('/agents/a1/delegations?role=delegator&limit=10')
+    })
+
+    it('POSTs the delegation body to /agents/{id}/delegate', async () => {
+      const body = { assignee_id: 'a2', task_description: 'do it' }
+
+      await useAutobotApi().delegateAgentTask('a1', body)
+
+      expect(lastCall(h.instance.post).slice(0, 2)).toEqual(['/agents/a1/delegate', body])
+    })
+  })
+
+  describe('agent processes (#1406)', () => {
+    it('GETs /agents/{id}/processes with limit and status, unwrapping .processes', async () => {
+      h.instance.get.mockResolvedValue({ data: { processes: [{ id: 'p1' }] }, status: 200 })
+
+      const rows = await useAutobotApi().getAgentProcesses('a1', { limit: 50, status: 'running' })
+
+      expect(lastCall(h.instance.get)[0]).toBe('/agents/a1/processes?limit=50&status=running')
+      expect(rows).toEqual([{ id: 'p1' }])
+    })
+
+    it('omits the status filter when none is selected', async () => {
+      h.instance.get.mockResolvedValue({ data: { processes: [] }, status: 200 })
+
+      await useAutobotApi().getAgentProcesses('a1', { limit: 50, status: undefined })
+
+      expect(lastCall(h.instance.get)[0]).toBe('/agents/a1/processes?limit=50')
+    })
+
+    it('requests the log body as text so axios does not JSON-parse it', async () => {
+      h.instance.get.mockResolvedValue({ data: 'line one\nline two', status: 200 })
+
+      const log = await useAutobotApi().getProcessLogs('p1')
+
+      const [url, config] = lastCall(h.instance.get) as [string, { responseType: string }]
+      expect(url).toBe('/processes/p1/logs')
+      expect(config.responseType).toBe('text')
+      expect(log).toBe('line one\nline two')
+    })
+
+    it('POSTs the signal name to /processes/{id}/signal', async () => {
+      await useAutobotApi().signalProcess('p1', 'SIGKILL')
+
+      expect(lastCall(h.instance.post).slice(0, 2)).toEqual([
+        '/processes/p1/signal',
+        { signal: 'SIGKILL' },
+      ])
+    })
+
+    it('POSTs the spawn payload to /processes/spawn', async () => {
+      const payload = { agent_id: 'a1', command: '/bin/true', args: ['-x'], timeout_seconds: 300 }
+
+      await useAutobotApi().spawnProcess(payload)
+
+      expect(lastCall(h.instance.post).slice(0, 2)).toEqual(['/processes/spawn', payload])
+    })
+  })
+
+  describe('config revisions (#1404)', () => {
+    it('GETs /config-revisions/{type}/{id} with the limit', async () => {
+      h.instance.get.mockResolvedValue({ data: [], status: 200 })
+
+      await useAutobotApi().getConfigRevisions('agent', 'orchestrator', 50)
+
+      expect(lastCall(h.instance.get)[0]).toBe('/config-revisions/agent/orchestrator?limit=50')
+    })
+
+    it('POSTs the rollback path', async () => {
+      await useAutobotApi().rollbackConfigRevision('agent', 'orchestrator', 'rev-9')
+
+      expect(lastCall(h.instance.post)[0]).toBe(
+        '/config-revisions/agent/orchestrator/rev-9/rollback',
+      )
+    })
+  })
+
+  describe('Redis service, RBAC and cache admin', () => {
+    it('GETs /redis-service/status', async () => {
+      await useAutobotApi().getRedisServiceStatus()
+
+      expect(lastCall(h.instance.get)[0]).toBe('/redis-service/status')
+    })
+
+    it('POSTs /redis-service/{action}', async () => {
+      await useAutobotApi().performRedisServiceAction('restart')
+
+      expect(lastCall(h.instance.post)[0]).toBe('/redis-service/restart')
+    })
+
+    it('GETs /settings/rbac/status', async () => {
+      await useAutobotApi().getRbacStatus()
+
+      expect(lastCall(h.instance.get)[0]).toBe('/settings/rbac/status')
+    })
+
+    it('POSTs the RBAC bootstrap body to /settings/rbac/initialize', async () => {
+      const body = { create_admin: true, admin_username: 'ops' }
+
+      await useAutobotApi().initializeRbac(body)
+
+      expect(lastCall(h.instance.post).slice(0, 2)).toEqual(['/settings/rbac/initialize', body])
+    })
+
+    it('POSTs /cache/redis/clear/{database}', async () => {
+      await useAutobotApi().clearRedisDatabase('sessions')
+
+      expect(lastCall(h.instance.post)[0]).toBe('/cache/redis/clear/sessions')
+    })
+  })
+
+  describe('health probe', () => {
+    it('reports a 2xx backend as reachable', async () => {
+      h.instance.get.mockResolvedValue({ data: {}, status: 200 })
+
+      await expect(useAutobotApi().probeBackendHealth()).resolves.toEqual({ ok: true, status: 200 })
+      expect(lastCall(h.instance.get)[0]).toBe('/health')
+    })
+
+    it('accepts every status so a 401 cannot log the operator out', async () => {
+      h.instance.get.mockResolvedValue({ data: {}, status: 401 })
+
+      const result = await useAutobotApi().probeBackendHealth()
+
+      const [, config] = lastCall(h.instance.get) as [string, { validateStatus: (s: number) => boolean }]
+      // validateStatus never rejects -> the response error interceptor that
+      // removes `autobot_access_token` is never reached by the probe.
+      expect(config.validateStatus(401)).toBe(true)
+      expect(config.validateStatus(503)).toBe(true)
+      expect(result).toEqual({ ok: false, status: 401 })
+    })
+  })
+})
+
+describe('autobotApiErrorMessage (#13079)', () => {
+  it('surfaces the FastAPI detail string the raw fetch call sites showed', () => {
+    const err = { response: { data: { detail: 'agent is not a manager' } } }
+
+    expect(autobotApiErrorMessage(err, 'fallback')).toBe('agent is not a manager')
+  })
+
+  it('falls back to the Error message when there is no detail body', () => {
+    expect(autobotApiErrorMessage(new Error('Network Error'), 'fallback')).toBe('Network Error')
+  })
+
+  it('falls back to the supplied default for a non-Error rejection', () => {
+    expect(autobotApiErrorMessage('nope', 'Rollback failed')).toBe('Rollback failed')
+  })
+})

--- a/autobot-slm-frontend/src/composables/useAutobotApi.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.ts
@@ -259,6 +259,148 @@ export interface AdvancedControlTakeoverRequest {
 /** Lifecycle transitions on an approved takeover session. */
 export type AdvancedControlSessionAction = 'pause' | 'resume' | 'complete'
 
+// =============================================================================
+// Agent org chart / processes / config revisions / Redis service / RBAC (#13079)
+//
+// The endpoint paths and payload shapes below used to be re-declared inline in
+// OrgChartTab.vue, ProcessMonitorTab.vue, ConfigHistoryTab.vue,
+// RedisServicePanel.vue, UserManagementSettings.vue, CacheSettings.vue and
+// BackendSettings.vue. Each of those files also re-implemented this
+// composable's transport with a raw `fetch` that sent only
+// `Bearer ${authStore.token}` — no `autobot_access_token` fallback, no 401
+// cleanup, no timeout, no shared base-URL resolution. Declaring them here keeps
+// the SLM app's knowledge of the autobot backend in exactly one place
+// (ADR-008 decision rule 3), as `AdvancedControlTool.vue` already does.
+// =============================================================================
+
+/** Node of the agent hierarchy returned by GET /agents/org (#1405). */
+export interface AgentOrgNode {
+  agent_id: string
+  name: string
+  org_role: string
+  title: string | null
+  capabilities: string | null
+  direct_reports_count: number
+  children: AgentOrgNode[]
+}
+
+/** Entry of GET /agents/{id}/reports (#1405). */
+export interface AgentDirectReport {
+  agent_id: string
+  name: string
+  org_role: string
+}
+
+/** Entry of GET /agents/{id}/delegations (#1405). */
+export interface AgentDelegation {
+  id: string
+  delegator_id: string
+  assignee_id: string
+  task_description: string
+  status: string
+  escalated_to: string | null
+  created_at: string | null
+}
+
+/** GET /agents/{id}/activity (#1405). */
+export interface AgentActivitySummary {
+  manager_id: string
+  total_delegated: number
+  by_status: Record<string, number>
+}
+
+/** Body of POST /agents/{id}/delegate (#1405). */
+export interface AgentDelegationRequest {
+  assignee_id: string
+  task_description: string
+}
+
+/** Row of GET /agents/{id}/processes (#1406). */
+export interface ProcessRun {
+  id: string
+  agent_id: string
+  task_id: string | null
+  command: string
+  args: string[]
+  status: string
+  exit_code: number | null
+  signal: string | null
+  log_excerpt: string | null
+  log_path: string | null
+  timeout_seconds: number
+  started_at: string | null
+  completed_at: string | null
+  created_at: string | null
+}
+
+/** Body of POST /processes/spawn (#1406). */
+export interface ProcessSpawnRequest {
+  agent_id: string
+  command: string
+  args: string[]
+  timeout_seconds: number
+}
+
+/** Entry of GET /config-revisions/{entityType}/{entityId} (#1404). */
+export interface ConfigRevision {
+  id: string
+  entity_type: string
+  entity_id: string
+  before_config: Record<string, unknown> | null
+  after_config: Record<string, unknown>
+  changed_keys: string[]
+  source: string
+  created_by: string
+  created_at: string | null
+}
+
+/** GET /redis-service/status (#3381). */
+export interface RedisServiceStatus {
+  status: 'running' | 'stopped' | 'unknown'
+  uptime_seconds: number | null
+  memory_used_bytes: number | null
+  memory_peak_bytes: number | null
+  connected_clients: number | null
+  last_checked: string | null
+  error?: string
+}
+
+/** Lifecycle verbs accepted by POST /redis-service/{action} (#3381). */
+export type RedisServiceAction = 'start' | 'stop' | 'restart'
+
+/** GET /settings/rbac/status. */
+export interface RbacStatus {
+  initialized: boolean
+  message: string
+}
+
+/** Body of POST /settings/rbac/initialize. */
+export interface RbacInitializeRequest {
+  create_admin: boolean
+  admin_username: string
+}
+
+/** Outcome of the GET /health reachability probe behind "Test connection". */
+export interface BackendHealthProbe {
+  ok: boolean
+  status: number
+}
+
+/**
+ * Unwrap the FastAPI `{ "detail": "..." }` error body (#13079).
+ *
+ * The raw-`fetch` call sites this client replaced read `detail` off the parsed
+ * body and showed it to the operator. Axios rejects with a generic
+ * "Request failed with status code 500" message instead, so the detail has to
+ * be pulled off `error.response.data` explicitly to keep the same error shape.
+ */
+export function autobotApiErrorMessage(err: unknown, fallback: string): string {
+  const detail = (err as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
+  if (typeof detail === 'string' && detail.length > 0) return detail
+  if (err instanceof Error && err.message.length > 0) return err.message
+  return fallback
+}
+
 export function useAutobotApi() {
   const authStore = useAuthStore()
 
@@ -1186,6 +1328,170 @@ export function useAutobotApi() {
     return response.data
   }
 
+  // =============================================================================
+  // Agent Org Chart (#1405 / #13079)
+  // =============================================================================
+
+  async function getAgentOrgTree(): Promise<AgentOrgNode[]> {
+    const response = await client.get<AgentOrgNode[]>('/agents/org')
+    return response.data ?? []
+  }
+
+  async function getAgentDirectReports(agentId: string): Promise<AgentDirectReport[]> {
+    const response = await client.get<AgentDirectReport[]>(
+      `/agents/${encodeURIComponent(agentId)}/reports`
+    )
+    return response.data ?? []
+  }
+
+  async function getAgentActivity(agentId: string): Promise<AgentActivitySummary> {
+    const response = await client.get<AgentActivitySummary>(
+      `/agents/${encodeURIComponent(agentId)}/activity`
+    )
+    return response.data
+  }
+
+  async function getAgentDelegations(
+    agentId: string,
+    options?: { role?: string; limit?: number }
+  ): Promise<AgentDelegation[]> {
+    const params = new URLSearchParams()
+    if (options?.role) params.append('role', options.role)
+    if (options?.limit !== undefined) params.append('limit', String(options.limit))
+    const query = params.toString()
+    const response = await client.get<AgentDelegation[]>(
+      `/agents/${encodeURIComponent(agentId)}/delegations${query ? `?${query}` : ''}`
+    )
+    return response.data ?? []
+  }
+
+  async function delegateAgentTask(
+    agentId: string,
+    request: AgentDelegationRequest
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(`/agents/${encodeURIComponent(agentId)}/delegate`, request)
+    return response.data
+  }
+
+  // =============================================================================
+  // Agent Processes (#1406 / #13079)
+  // =============================================================================
+
+  async function getAgentProcesses(
+    agentId: string,
+    options?: { limit?: number; status?: string }
+  ): Promise<ProcessRun[]> {
+    const params = new URLSearchParams()
+    params.append('limit', String(options?.limit ?? 50))
+    if (options?.status) params.append('status', options.status)
+    const response = await client.get<{ processes: ProcessRun[] }>(
+      `/agents/${encodeURIComponent(agentId)}/processes?${params}`
+    )
+    return response.data?.processes ?? []
+  }
+
+  /**
+   * Process logs are served as plain text, not JSON. `responseType: 'text'`
+   * disables axios' default JSON parsing so the body arrives verbatim — the
+   * raw `fetch` this replaced used `response.text()` for the same reason.
+   */
+  async function getProcessLogs(processId: string): Promise<string> {
+    const response = await client.get<string>(
+      `/processes/${encodeURIComponent(processId)}/logs`,
+      { responseType: 'text' }
+    )
+    return response.data
+  }
+
+  async function signalProcess(
+    processId: string,
+    signal: string
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(`/processes/${encodeURIComponent(processId)}/signal`, {
+      signal,
+    })
+    return response.data
+  }
+
+  async function spawnProcess(request: ProcessSpawnRequest): Promise<Record<string, unknown>> {
+    const response = await client.post('/processes/spawn', request)
+    return response.data
+  }
+
+  // =============================================================================
+  // Config Revisions (#1404 / #13079)
+  // =============================================================================
+
+  async function getConfigRevisions(
+    entityType: string,
+    entityId: string,
+    limit: number = 50
+  ): Promise<ConfigRevision[]> {
+    const response = await client.get<ConfigRevision[]>(
+      `/config-revisions/${encodeURIComponent(entityType)}/${encodeURIComponent(entityId)}?limit=${limit}`
+    )
+    return response.data ?? []
+  }
+
+  async function rollbackConfigRevision(
+    entityType: string,
+    entityId: string,
+    revisionId: string
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(
+      `/config-revisions/${encodeURIComponent(entityType)}/${encodeURIComponent(entityId)}/${encodeURIComponent(revisionId)}/rollback`
+    )
+    return response.data
+  }
+
+  // =============================================================================
+  // Redis Service control (#3381 / #13079)
+  // =============================================================================
+
+  async function getRedisServiceStatus(): Promise<RedisServiceStatus> {
+    const response = await client.get<RedisServiceStatus>('/redis-service/status')
+    return response.data
+  }
+
+  async function performRedisServiceAction(
+    action: RedisServiceAction
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(`/redis-service/${action}`)
+    return response.data
+  }
+
+  // =============================================================================
+  // RBAC bootstrap + Redis cache admin (#13079)
+  // =============================================================================
+
+  async function getRbacStatus(): Promise<RbacStatus> {
+    const response = await client.get<RbacStatus>('/settings/rbac/status')
+    return response.data
+  }
+
+  async function initializeRbac(request: RbacInitializeRequest): Promise<{ message?: string }> {
+    const response = await client.post<{ message?: string }>('/settings/rbac/initialize', request)
+    return response.data
+  }
+
+  async function clearRedisDatabase(database: string): Promise<Record<string, unknown>> {
+    const response = await client.post(`/cache/redis/clear/${encodeURIComponent(database)}`)
+    return response.data
+  }
+
+  /**
+   * Reachability probe behind the "Test connection" control (#13079).
+   *
+   * `validateStatus` accepts every status code so the probe reports
+   * "reachable but rejected" rather than throwing, and — critically — never
+   * trips the response interceptor that clears `autobot_access_token`: a
+   * connectivity diagnostic must not be able to log the operator out.
+   */
+  async function probeBackendHealth(): Promise<BackendHealthProbe> {
+    const response = await client.get('/health', { validateStatus: () => true })
+    return { ok: response.status >= 200 && response.status < 300, status: response.status }
+  }
+
   return {
     // Settings
     getSettings,
@@ -1317,6 +1623,28 @@ export function useAutobotApi() {
     requestTakeover,
     approveTakeover,
     takeoverSessionAction,
+    // Agent Org Chart (#1405 / #13079)
+    getAgentOrgTree,
+    getAgentDirectReports,
+    getAgentActivity,
+    getAgentDelegations,
+    delegateAgentTask,
+    // Agent Processes (#1406 / #13079)
+    getAgentProcesses,
+    getProcessLogs,
+    signalProcess,
+    spawnProcess,
+    // Config Revisions (#1404 / #13079)
+    getConfigRevisions,
+    rollbackConfigRevision,
+    // Redis Service control (#3381 / #13079)
+    getRedisServiceStatus,
+    performRedisServiceAction,
+    // RBAC bootstrap + Redis cache admin + health probe (#13079)
+    getRbacStatus,
+    initializeRbac,
+    clearRedisDatabase,
+    probeBackendHealth,
     // Log Forwarding Control (Issue #729)
     getLogForwardingStatus,
     startLogForwarding,

--- a/autobot-slm-frontend/src/views/settings/BackendSettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/BackendSettings.test.ts
@@ -1,0 +1,121 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — BackendSettings' "Test connection" probe.
+ *
+ * The probe was the one raw `fetch` here that was deliberately
+ * unauthenticated, so converting it needed care: routing a diagnostic through
+ * a client whose response interceptor clears `autobot_access_token` on a 401
+ * would let "check whether the backend is up" log the operator out.
+ *
+ * `probeBackendHealth` therefore passes `validateStatus: () => true`, so the
+ * request never rejects and the interceptor is never reached. These tests pin
+ * that: a 401 backend reports "failed" (not reachable-and-authorised) while
+ * the token in localStorage survives.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import axios from 'axios'
+import BackendSettings from './BackendSettings.vue'
+import en from '@/locales/en.json'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ token: 'test-token', getApiUrl: () => 'https://slm.example' }),
+}))
+
+vi.mock('@/utils/slmSettingsApi', () => ({
+  listSettings: vi.fn(async () => []),
+  upsertSetting: vi.fn(async () => true),
+}))
+
+vi.mock('axios', () => {
+  // The real response interceptor is registered here so the probe can be shown
+  // NOT to trip it: `validateStatus` keeps a 401 on the success path.
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: () => undefined },
+      response: {
+        use: (_ok: unknown, onError: (e: unknown) => Promise<unknown>) => {
+          ;(instance as unknown as { onError?: unknown }).onError = onError
+        },
+      },
+    },
+  }
+  return { default: { create: () => instance } }
+})
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = {
+  get: ReturnType<typeof vi.fn>
+  onError?: (e: unknown) => Promise<unknown>
+}
+
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
+
+type Vm = {
+  connectionStatus: 'unknown' | 'connected' | 'failed'
+  responseTime: number | null
+  testConnection: () => Promise<void>
+}
+
+function mountView(): Vm {
+  return mount(BackendSettings, { global: { plugins: [i18n] } }).vm as unknown as Vm
+}
+
+describe('BackendSettings connection probe (#13079)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    const c = client()
+    c.get.mockReset()
+    c.get.mockResolvedValue({ data: { status: 'ok' }, status: 200 })
+  })
+
+  it('probes GET /health through the shared client and reports connected', async () => {
+    const vm = mountView()
+    await flushPromises()
+    client().get.mockClear()
+
+    await vm.testConnection()
+
+    expect(client().get.mock.calls[0][0]).toBe('/health')
+    expect(vm.connectionStatus).toBe('connected')
+    expect(vm.responseTime).not.toBeNull()
+  })
+
+  it('reports failed on a 401 without clearing the autobot token', async () => {
+    localStorage.setItem('autobot_access_token', 'autobot-token')
+    client().get.mockResolvedValue({ data: {}, status: 401 })
+
+    const vm = mountView()
+    await flushPromises()
+    await vm.testConnection()
+
+    expect(vm.connectionStatus).toBe('failed')
+    // The probe resolved, so the 401 interceptor never ran: an operator
+    // diagnosing a backend outage does not get logged out as a side effect.
+    expect(localStorage.getItem('autobot_access_token')).toBe('autobot-token')
+  })
+
+  it('reports failed when the backend is unreachable', async () => {
+    client().get.mockRejectedValue(new Error('Network Error'))
+
+    const vm = mountView()
+    await flushPromises()
+    await vm.testConnection()
+
+    expect(vm.connectionStatus).toBe('failed')
+  })
+})

--- a/autobot-slm-frontend/src/views/settings/BackendSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/BackendSettings.vue
@@ -11,13 +11,14 @@
 
 import { ref, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
-import { getBackendUrl } from '@/config/ssot-config'
+import { useAutobotApi } from '@/composables/useAutobotApi'
 import { listSettings, upsertSetting } from '@/utils/slmSettingsApi'
 
 // `authStore.getApiUrl()` is retained for DISPLAY only (the "API endpoint"
 // field and the summary row): it reports the SLM host origin the operator is
 // pointed at. Every transport call goes through the canonical client (#13140).
 const authStore = useAuthStore()
+const autobotApi = useAutobotApi()
 const loading = ref(false)
 const saving = ref(false)
 const error = ref<string | null>(null)
@@ -76,16 +77,15 @@ async function testConnection(): Promise<void> {
 
   try {
     const startTime = Date.now()
-    const response = await fetch(`${getBackendUrl()}/health`)
+    // #13079: `probeBackendHealth` accepts every status code, so an
+    // unauthorised backend still reports as reachable and the probe cannot
+    // trip the 401 interceptor that clears `autobot_access_token` — a
+    // connectivity diagnostic must never log the operator out.
+    const probe = await autobotApi.probeBackendHealth()
 
     responseTime.value = Date.now() - startTime
-
-    if (response.ok) {
-      connectionStatus.value = 'connected'
-    } else {
-      connectionStatus.value = 'failed'
-    }
-  } catch (e) {
+    connectionStatus.value = probe.ok ? 'connected' : 'failed'
+  } catch {
     connectionStatus.value = 'failed'
   } finally {
     testingConnection.value = false

--- a/autobot-slm-frontend/src/views/settings/admin/CacheSettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/admin/CacheSettings.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — CacheSettings' Redis-database clear.
+ *
+ * The private `fetch` here never inspected `response.ok`, so a rejected clear
+ * still reported "cleared successfully" to the operator. Routing it through
+ * `useAutobotApi` also fixes that: the client rejects on a non-2xx, so the
+ * banner now reflects the real outcome. That is a deliberate behaviour change
+ * and is pinned below alongside the endpoint path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import axios from 'axios'
+import CacheSettings from './CacheSettings.vue'
+import en from '@/locales/en.json'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ token: 'test-token' }),
+}))
+
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: () => undefined },
+      response: { use: () => undefined },
+    },
+  }
+  return { default: { create: () => instance } }
+})
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> }
+
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
+
+type Vm = {
+  error: string | null
+  success: string | null
+  clearRedisCache: (database: string) => Promise<void>
+}
+
+function mountView(): Vm {
+  return mount(CacheSettings, { global: { plugins: [i18n] } }).vm as unknown as Vm
+}
+
+describe('CacheSettings Redis clear transport (#13079)', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const c = client()
+    c.get.mockReset()
+    c.post.mockReset()
+    c.get.mockResolvedValue({ data: {}, status: 200 })
+    c.post.mockResolvedValue({ data: { cleared: 12 }, status: 200 })
+  })
+
+  it('POSTs /cache/redis/clear/{database} through the shared client', async () => {
+    const vm = mountView()
+    await flushPromises()
+    client().post.mockClear()
+
+    await vm.clearRedisCache('sessions')
+
+    expect(client().post.mock.calls[0][0]).toBe('/cache/redis/clear/sessions')
+    expect(vm.success).toContain('sessions')
+    expect(vm.error).toBeNull()
+  })
+
+  it('reports the failure instead of a false success when the clear is refused', async () => {
+    const vm = mountView()
+    await flushPromises()
+    client().post.mockRejectedValue({ response: { data: { detail: 'database is protected' } } })
+
+    await vm.clearRedisCache('sessions')
+
+    expect(vm.error).toBe('database is protected')
+    expect(vm.success).toBeNull()
+  })
+
+  it('makes no request when the operator cancels the confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const vm = mountView()
+    await flushPromises()
+    client().post.mockClear()
+
+    await vm.clearRedisCache('sessions')
+
+    expect(client().post).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
@@ -12,11 +12,13 @@
 
 import { ref, reactive, computed, onMounted } from 'vue'
 import { formatBytes } from '@/utils/formatHelpers'
-import { useAuthStore } from '@/stores/auth'
-import { useAutobotApi, type CacheConfig, type CacheStats } from '@/composables/useAutobotApi'
-import { getBackendUrl } from '@/config/ssot-config'
+import {
+  useAutobotApi,
+  autobotApiErrorMessage,
+  type CacheConfig,
+  type CacheStats,
+} from '@/composables/useAutobotApi'
 
-const authStore = useAuthStore()
 const api = useAutobotApi()
 
 // State
@@ -138,17 +140,15 @@ async function clearRedisCache(database: string): Promise<void> {
   error.value = null
 
   try {
-    await fetch(`${getBackendUrl()}/cache/redis/clear/${database}`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${authStore.token}`,
-      },
-    })
+    // #13079: the raw `fetch` this replaced never inspected `response.ok`, so
+    // a rejected or failed clear still reported success. The client rejects on
+    // a non-2xx, so the operator now sees the real outcome.
+    await api.clearRedisDatabase(database)
     success.value = `Redis ${database} database cleared successfully`
     await fetchCacheStats()
     setTimeout(() => { success.value = null }, 3000)
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to clear Redis database'
+    error.value = autobotApiErrorMessage(e, 'Failed to clear Redis database')
   } finally {
     clearing.value = false
   }

--- a/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.test.ts
@@ -1,0 +1,155 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — the RBAC bootstrap pair in UserManagementSettings.
+ *
+ * `checkRbacStatus` and `initializeRbac` were the last two raw `fetch` calls in
+ * this view; every other call already went through `useAutobotApi` (autobot
+ * backend) or `useSlmUserApi` (SLM backend). The forked transport meant the
+ * RBAC panel could 401 while the user list beside it loaded fine.
+ *
+ * The heavy sibling composables are stubbed so these tests stay on the two
+ * endpoints that moved.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import axios from 'axios'
+import UserManagementSettings from './UserManagementSettings.vue'
+import en from '@/locales/en.json'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    token: 'test-token',
+    isAdmin: true,
+    isAuthenticated: true,
+    user: { username: 'ops' },
+    logout: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useSlmUserApi', () => ({
+  useSlmUserApi: () => ({
+    listUsers: vi.fn(async () => []),
+    listTeams: vi.fn(async () => []),
+    createUser: vi.fn(),
+    updateUser: vi.fn(),
+    deleteUser: vi.fn(),
+    createTeam: vi.fn(),
+    updateTeam: vi.fn(),
+    deleteTeam: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useSsoApi', () => ({
+  useSsoApi: () => ({
+    listProviders: vi.fn(async () => []),
+    createProvider: vi.fn(),
+    updateProvider: vi.fn(),
+    deleteProvider: vi.fn(),
+    testProvider: vi.fn(),
+  }),
+}))
+
+vi.mock('axios', () => {
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      request: { use: () => undefined },
+      response: { use: () => undefined },
+    },
+  }
+  return { default: { create: () => instance } }
+})
+
+const i18n = createI18n({ legacy: true, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+type MockedClient = { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> }
+
+function client(): MockedClient {
+  return (axios.create as unknown as () => MockedClient)()
+}
+
+type Vm = {
+  error: string | null
+  rbacStatus: { initialized: boolean; message: string }
+  rbacInitOptions: { createAdmin: boolean; adminUsername: string }
+  checkRbacStatus: () => Promise<void>
+  initializeRbac: () => Promise<void>
+}
+
+function mountView(): Vm {
+  return mount(UserManagementSettings, {
+    global: { plugins: [i18n], stubs: { PasswordChangeForm: true } },
+  }).vm as unknown as Vm
+}
+
+describe('UserManagementSettings RBAC transport (#13079)', () => {
+  beforeEach(() => {
+    const c = client()
+    c.get.mockReset()
+    c.post.mockReset()
+    c.get.mockImplementation(async (url: string) => {
+      if (url === '/settings/rbac/status') {
+        return { data: { initialized: true, message: 'RBAC ready' }, status: 200 }
+      }
+      return { data: { users: [] }, status: 200 }
+    })
+    c.post.mockResolvedValue({ data: { message: 'RBAC initialized' }, status: 200 })
+  })
+
+  it('GETs /settings/rbac/status through the shared client', async () => {
+    const vm = mountView()
+    await flushPromises()
+    client().get.mockClear()
+
+    await vm.checkRbacStatus()
+
+    expect(client().get.mock.calls[0][0]).toBe('/settings/rbac/status')
+    expect(vm.rbacStatus.initialized).toBe(true)
+    expect(vm.rbacStatus.message).toBe('RBAC ready')
+  })
+
+  it('POSTs the bootstrap options to /settings/rbac/initialize', async () => {
+    const vm = mountView()
+    await flushPromises()
+    vm.rbacInitOptions.createAdmin = true
+    vm.rbacInitOptions.adminUsername = 'ops'
+
+    await vm.initializeRbac()
+    await flushPromises()
+
+    expect(client().post.mock.calls[0].slice(0, 2)).toEqual([
+      '/settings/rbac/initialize',
+      { create_admin: true, admin_username: 'ops' },
+    ])
+  })
+
+  it('surfaces the backend detail when the bootstrap is refused', async () => {
+    const vm = mountView()
+    await flushPromises()
+    client().post.mockRejectedValue({ response: { data: { detail: 'RBAC already initialized' } } })
+
+    await vm.initializeRbac()
+
+    expect(vm.error).toBe('RBAC already initialized')
+  })
+
+  it('leaves the status message unchanged text when the status probe fails', async () => {
+    const vm = mountView()
+    await flushPromises()
+    client().get.mockRejectedValue(new Error('offline'))
+
+    await vm.checkRbacStatus()
+
+    expect(vm.rbacStatus.message).toBe('Failed to check RBAC status')
+  })
+})

--- a/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
@@ -14,8 +14,12 @@
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { formatDateTime } from '@/composables/useTimezone'
 import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase, getBackendUrl } from '@/config/ssot-config'
-import { useAutobotApi, type UserResponse } from '@/composables/useAutobotApi'
+import { getSlmApiBase } from '@/config/ssot-config'
+import {
+  useAutobotApi,
+  autobotApiErrorMessage,
+  type UserResponse,
+} from '@/composables/useAutobotApi'
 import {
   useSlmUserApi,
   type SlmUserResponse,
@@ -341,15 +345,9 @@ async function checkRbacStatus(): Promise<void> {
   if (!isAdmin.value) return
 
   try {
-    const response = await fetch(`${getBackendUrl()}/settings/rbac/status`, {
-      headers: { Authorization: `Bearer ${authStore.token}` },
-    })
-
-    if (response.ok) {
-      const data = await response.json()
-      rbacStatus.initialized = data.initialized
-      rbacStatus.message = data.message
-    }
+    const data = await autobotApi.getRbacStatus()
+    rbacStatus.initialized = data.initialized
+    rbacStatus.message = data.message
   } catch {
     rbacStatus.message = 'Failed to check RBAC status'
   }
@@ -360,29 +358,15 @@ async function initializeRbac(): Promise<void> {
   error.value = null
 
   try {
-    const response = await fetch(`${getBackendUrl()}/settings/rbac/initialize`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${authStore.token}`,
-      },
-      body: JSON.stringify({
-        create_admin: rbacInitOptions.createAdmin,
-        admin_username: rbacInitOptions.adminUsername,
-      }),
+    const data = await autobotApi.initializeRbac({
+      create_admin: rbacInitOptions.createAdmin,
+      admin_username: rbacInitOptions.adminUsername,
     })
-
-    if (response.ok) {
-      const data = await response.json()
-      showSuccess(data.message || 'RBAC initialized successfully')
-      showRbacModal.value = false
-      await checkRbacStatus()
-    } else {
-      const data = await response.json()
-      throw new Error(data.detail || 'Failed to initialize RBAC')
-    }
+    showSuccess(data.message || 'RBAC initialized successfully')
+    showRbacModal.value = false
+    await checkRbacStatus()
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to initialize RBAC'
+    error.value = autobotApiErrorMessage(e, 'Failed to initialize RBAC')
   } finally {
     isInitializingRbac.value = false
   }

--- a/autobot-slm-frontend/vitest.config.ts
+++ b/autobot-slm-frontend/vitest.config.ts
@@ -18,6 +18,9 @@ export default mergeConfig(
       preserveSymlinks: true,
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
+        // Mirror vite.config.ts (#13079): without this, any test that mounts a
+        // component importing from '@shared' fails to resolve at transform time.
+        '@shared': fileURLToPath(new URL('../autobot_shared', import.meta.url)),
       },
     },
   }),


### PR DESCRIPTION
## Thinking Path

`#13079` lists 7 files and 12 call sites. Re-measured against the current tip: **17 raw `fetch` sites** targeting `getBackendUrl()`. The issue's line numbers were stale and it missed `OrgChartTab.vue:100` (the `POST .../delegate`) and `ProcessMonitorTab.vue:68` entirely.

This is a different backend from #13140. Those sites went to the SLM backend via `getSlmApiBase()` and now route through `slmApiClient`. These go to the **autobot** backend, whose canonical client in this app is `useAutobotApi`. ADR-008 decision rule 3 fixes one client per `(app, backend)` pair, so the two clients stay separate.

Triage of the 17 — every one is a genuine bypass, no legitimate transport exceptions among them:

| Site | Was losing |
|---|---|
| `OrgChartTab.vue` x5 | `autobot_access_token` fallback, 401 cleanup, timeout, base-URL resolution, error shape |
| `ProcessMonitorTab.vue` x4 | same; the logs call also needs a non-JSON body, handled with `responseType: 'text'` |
| `ConfigHistoryTab.vue` x2 | same |
| `RedisServicePanel.vue` x2 | same; worst case — no timeout at all on a 10s poll |
| `UserManagementSettings.vue` x2 | same; the RBAC panel could 401 while the user list beside it loaded |
| `CacheSettings.vue` x1 | same, plus it never inspected `response.ok` |
| `BackendSettings.vue` x1 | unauthenticated probe — converted, but only with `validateStatus` so it cannot trip the 401 interceptor |

Two transports were deliberately **not** migrated because `useAutobotApi` has no equivalent: the live-log **WebSocket** in `ProcessMonitorTab.vue`, and the Prometheus/Grafana probes in `MonitoringSettings.vue`, which target different backends and are out of scope.

## What Changed

**`useAutobotApi.ts`** gains the endpoint paths and payload types for five groups — agent org chart (#1405), agent processes (#1406), config revisions (#1404), Redis service control (#3381), RBAC bootstrap plus the Redis cache clear and the health probe — and an exported `autobotApiErrorMessage` that unwraps the FastAPI `{"detail": ...}` body. Axios otherwise rejects with "Request failed with status code 500", which would have been a visible regression at every converted site.

Two calls carry a non-default config for a real reason. `getProcessLogs` passes `responseType: 'text'` because the log body is plain text, not JSON. `probeBackendHealth` passes `validateStatus: () => true` so a 401 resolves rather than rejects — routing a connectivity diagnostic through a client that clears `autobot_access_token` on 401 would let "check whether the backend is up" log the operator out.

**The seven components** drop their private `fetch`, their inline `headers` computed and their duplicated response interfaces, and call the client.

Three behaviour changes, all intentional:

- `OrgChartTab.selectNode` uses `Promise.allSettled`, not `all`. `fetch` never rejects on a non-2xx, so the old `res.ok ? ... : []` left the other two detail panels populated when one failed. `Promise.all` would have blanked the whole pane.
- `CacheSettings.clearRedisCache` now reports failures. The old `await fetch(...)` ignored `response.ok`, so a refused clear still showed "cleared successfully".
- Every converted site now clears a stale `autobot_access_token` on a 401 instead of swallowing it.

`RedisServicePanel` polls every 10s and `useAutobotApi` performs no retries, so nothing stacks inside a poll interval — pinned by a fake-timer test.

**`vitest.config.ts`** gains the `@shared` alias `vite.config.ts` already had. Without it no test can mount a component importing from `@shared`, which blocked `UserManagementSettings.test.ts` at transform time.

## Verification

Against a `cp`-swapped pristine baseline at `d16ec8e00`, all commands run in `autobot-slm-frontend/`.

| | before | after |
|---|---|---|
| `vue-tsc --noEmit -p tsconfig.json` | clean | clean |
| `eslint .` | 0 errors, 16 warnings | 0 errors, **15** warnings |
| `vitest run` | 34 files / 284 tests passed | **42 files / 342 tests passed** |

The warning count drops because `BackendSettings.vue` no longer needs its unused catch binding.

```
$ grep -rn "fetch(" src/ --include=*.vue --include=*.ts | grep "getBackendUrl"
(no output)
```

**Non-vacuity.** The eight new test files were re-run with the pre-change sources `cp`-swapped back in:

```
Test Files  8 failed (8)
      Tests  46 failed | 12 passed (58)
```

The 12 that still pass are the transport-contract cases — token fallback, 401 cleanup, 30s timeout, base URL. They exercise interceptors that already existed on `useAutobotApi`; they are the evidence of *what the components were losing*, not of the migration, so they pass either way by design. Every assertion that depends on the migration fails without it.

The tests assert real behaviour, not that a function was called: the exact `Authorization` header produced by the real request interceptor when only `localStorage.autobot_access_token` is set (the #13079 defect), that a 401 removes that key and still rejects while a 500 does not, `timeout === 30000` on the created instance, that the health probe's `validateStatus(401)` is `true` and the token survives it, that the log body arrives verbatim, and that the FastAPI `detail` string reaches each component's error banner.

## Model Used

claude-opus-4-6
