### PR TITLE
refactor(slm-frontend): retire the last five private axios.create instances and land the no-raw-transport lint rule (#13079)

### DIFF
--- a/autobot-slm-frontend/eslint.config.js
+++ b/autobot-slm-frontend/eslint.config.js
@@ -15,6 +15,48 @@ const tsRuleOverrides = {
   'no-undef': 'off',
 }
 
+// GH-13140 definition-of-done item 4 / GH-13079 — one transport client per
+// (app, backend) pair.
+//
+// Unblocked once the last private transports were retired: the 53 SLM-backend
+// and 17 autobot-backend raw `fetch` sites, and the five private `axios.create`
+// instances in useSkills, useOrchestration, useOrchestrationManagement and
+// useExternalAgents. Every one of them had diverged from its canonical client —
+// missing token fallbacks, missing timeouts, swallowed 401s — so this rule
+// exists to stop the next one appearing.
+//
+// ADR-008 decision rule 3 fixes the allowlist: `utils/ApiClient.ts` (SLM
+// backend), `composables/useAutobotApi.ts` (autobot backend) and the
+// `utils/slmApiCompat.ts` adapter over the former. Genuinely external targets
+// (Prometheus, Grafana) carry an inline disable naming the service.
+const NO_RAW_TRANSPORT = [
+  {
+    selector: "CallExpression[callee.name='fetch']",
+    message:
+      'Raw fetch() is not allowed here. Use slmApiClient (utils/ApiClient.ts) for the SLM backend, or useAutobotApi for the autobot backend - they own base-URL resolution, the bearer token fallback, the request timeout and 401 handling (ADR-008 rule 3).',
+  },
+  {
+    selector: "CallExpression[callee.object.name='window'][callee.property.name='fetch']",
+    message:
+      'Raw window.fetch() is not allowed here. Use slmApiClient or useAutobotApi (ADR-008 rule 3).',
+  },
+  {
+    selector: "CallExpression[callee.object.name='axios'][callee.property.name='create']",
+    message:
+      'A private axios instance re-implements a transport that already exists. Use slmApiClient / makeAxiosCompatClient for the SLM backend, or useAutobotApi for the autobot backend (ADR-008 rule 3).',
+  },
+]
+
+/** Files that legitimately own a raw transport, plus the tests that stub one. */
+const TRANSPORT_OWNERS = [
+  'src/utils/ApiClient.ts',
+  'src/utils/slmApiCompat.ts',
+  'src/composables/useAutobotApi.ts',
+  '**/*.test.ts',
+  '**/*.spec.ts',
+  '**/__tests__/**',
+]
+
 export default tseslint.config(
   {
     name: 'app/files-to-lint',
@@ -43,6 +85,22 @@ export default tseslint.config(
   {
     files: ['**/*.{ts,tsx}'],
     rules: tsRuleOverrides,
+  },
+
+  // No raw transport outside the canonical clients.
+  {
+    name: 'app/no-raw-transport',
+    files: ['src/**/*.{ts,tsx,vue}'],
+    rules: {
+      'no-restricted-syntax': ['error', ...NO_RAW_TRANSPORT],
+    },
+  },
+  {
+    name: 'app/no-raw-transport-owners',
+    files: TRANSPORT_OWNERS,
+    rules: {
+      'no-restricted-syntax': 'off',
+    },
   },
 
   // TypeScript rules for .vue files

--- a/autobot-slm-frontend/src/composables/slmAxiosCompatMigration.test.ts
+++ b/autobot-slm-frontend/src/composables/slmAxiosCompatMigration.test.ts
@@ -1,0 +1,288 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 / #13140 — the three SLM-backend composables migrated off their
+ * private `axios.create` instances onto `slmApiClient` (via `slmApiCompat`).
+ *
+ *   * `useOrchestration.ts:115` — `axios.create({ baseURL: getSlmApiBase() })`,
+ *     **no timeout at all**.
+ *   * `useOrchestrationManagement.ts:86` — same, plus a 30s timeout.
+ *   * `useExternalAgents.ts:23` — a bare `axios.create()`: **no baseURL** (every
+ *     call site pasted `getSlmApiBase()` in) and **no timeout**.
+ *
+ * All three attached the bearer from `sessionStorage.getItem('slm_access_token')`
+ * only — the `localStorage` fallback `stores/auth.ts` seeds from and
+ * `ApiClient.getAuthToken()` (`ApiClient.ts:113`) honours was missing — and none
+ * reproduced the client's 401 session teardown (`:128-151`).
+ *
+ * These tests run the REAL `slmApiClient` with `fetch` stubbed, so they assert
+ * the header that actually goes on the wire, the AbortSignal that actually
+ * bounds the request and the storage that actually gets cleared — not that a
+ * mock was called. Blocks are labelled defect proof vs regression guard.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const TOKEN_KEY = 'slm_access_token'
+
+// useOrchestrationManagement pulls in the fleet store and the SLM WebSocket;
+// neither participates in the transport under test.
+vi.mock('@/stores/fleet', () => ({
+  useFleetStore: () => ({
+    nodes: [],
+    setServiceStatus: vi.fn(),
+    updateServiceStatus: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useSlmWebSocket', () => ({
+  useSlmWebSocket: () => ({
+    connect: vi.fn(),
+    subscribeAll: vi.fn(),
+    onServiceStatus: vi.fn(),
+    connected: { value: false },
+  }),
+}))
+
+import { useOrchestration } from './useOrchestration'
+import { useOrchestrationManagement } from './useOrchestrationManagement'
+import { useExternalAgents } from './useExternalAgents'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+let originalLocation: Location
+
+function lastInit(): RequestInit {
+  const calls = fetchMock.mock.calls
+  return calls[calls.length - 1][1] as RequestInit
+}
+
+function lastUrl(): string {
+  const calls = fetchMock.mock.calls
+  return calls[calls.length - 1][0] as string
+}
+
+function authHeader(): unknown {
+  return (lastInit().headers as Record<string, string>)['Authorization']
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  fetchMock = vi.fn().mockResolvedValue(jsonResponse([]))
+  vi.stubGlobal('fetch', fetchMock)
+
+  originalLocation = window.location
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { pathname: '/orchestration', href: '' } as unknown as Location,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  })
+})
+
+// =============================================================================
+// Defect proofs — transport the private instances did not have.
+// =============================================================================
+
+describe('the localStorage token fallback the private interceptors lacked (#13079)', () => {
+  it('useExternalAgents sends the bearer held only in localStorage', async () => {
+    // `stores/auth.ts` seeds its token ref from sessionStorage WITH a
+    // localStorage fallback, so a session restored from localStorage alone is
+    // real. The private `sessionStorage.getItem(...)` interceptor saw nothing
+    // and the request went out unauthenticated.
+    localStorage.setItem(TOKEN_KEY, 'local-only-token')
+
+    await useExternalAgents().fetchAgents()
+
+    expect(authHeader()).toBe('Bearer local-only-token')
+  })
+
+  it('useOrchestration sends the bearer held only in localStorage', async () => {
+    localStorage.setItem(TOKEN_KEY, 'local-only-token')
+
+    await useOrchestration().fetchServices()
+
+    expect(authHeader()).toBe('Bearer local-only-token')
+  })
+
+  it('useOrchestrationManagement sends the bearer held only in localStorage', async () => {
+    localStorage.setItem(TOKEN_KEY, 'local-only-token')
+
+    await useOrchestrationManagement().fetchServiceDefinitions()
+
+    expect(authHeader()).toBe('Bearer local-only-token')
+  })
+
+  it('still prefers the sessionStorage token when both are present', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'session-token')
+    localStorage.setItem(TOKEN_KEY, 'local-token')
+
+    await useExternalAgents().fetchAgents()
+
+    expect(authHeader()).toBe('Bearer session-token')
+  })
+})
+
+describe('the request timeout the private instances lacked (#13079)', () => {
+  it('useExternalAgents bounds a request that previously had no timeout', async () => {
+    // `axios.create()` with no `timeout` never aborts: a hung
+    // POST /external-agents/{id}/verify (which reaches out to a remote A2A
+    // agent) left the panel spinning indefinitely.
+    await useExternalAgents().verifyAgent(7)
+
+    expect(lastInit().signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('useOrchestration bounds a request that previously had no timeout', async () => {
+    await useOrchestration().fetchFleetStatus()
+
+    expect(lastInit().signal).toBeInstanceOf(AbortSignal)
+  })
+})
+
+describe('the 401 session teardown the private instances lacked (#13079)', () => {
+  it('clears the stored session and redirects when an authenticated call is rejected', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'expired-token')
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'token expired' }, 401))
+
+    await useOrchestrationManagement().fetchServiceDefinitions()
+
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBeNull()
+    expect(window.location.href).toBe('/login')
+  })
+
+  it('does NOT clear the session on a 401 to a token-less call', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'unauthenticated' }, 401))
+
+    await useExternalAgents().fetchAgents()
+
+    expect(window.location.href).toBe('')
+  })
+})
+
+describe('FastAPI detail survives the axios.isAxiosError seam change (#13079)', () => {
+  it('useOrchestration surfaces the backend detail, not "HTTP 500"', async () => {
+    // `slmApiCompat` rejects with an axios-SHAPED error that is NOT an axios
+    // instance, so the composable's original `axios.isAxiosError(e)` guard
+    // would have skipped the detail branch and shown "HTTP 500" instead.
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'orchestrator offline' }, 500))
+
+    const o = useOrchestration()
+    await o.fetchServices()
+
+    expect(o.error.value).toBe('orchestrator offline')
+  })
+
+  it('useOrchestrationManagement surfaces the backend detail on a refused action', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'service is masked' }, 409))
+
+    // The composable returns `reactive(...)`, so `error` is unwrapped.
+    const o = useOrchestrationManagement()
+    await o.startService('autobot-backend')
+
+    expect(o.error).toBe('service is masked')
+  })
+
+  it('useExternalAgents surfaces the backend detail', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: 'agent card unreachable' }, 502))
+
+    const registry = useExternalAgents()
+    await registry.verifyAgent(7)
+
+    expect(registry.error).toBe('agent card unreachable')
+  })
+})
+
+// =============================================================================
+// Regression guards — the wire contract must survive the migration.
+// =============================================================================
+
+describe('endpoints stay relative to the API base (regression guard)', () => {
+  it('useExternalAgents no longer pastes getSlmApiBase() into each path', async () => {
+    await useExternalAgents().fetchAgents()
+
+    expect(lastUrl()).toBe('/api/external-agents')
+    // The old form double-prefixed once the client resolved the base itself.
+    expect(lastUrl()).not.toContain('/api/api/')
+  })
+
+  it('useExternalAgents CRUD paths are unchanged', async () => {
+    const registry = useExternalAgents()
+
+    await registry.getAgent(3)
+    expect(lastUrl()).toBe('/api/external-agents/3')
+
+    await registry.createAgent({ name: 'a' } as never)
+    expect(lastUrl()).toBe('/api/external-agents')
+    expect(lastInit().method).toBe('POST')
+
+    await registry.updateAgent(3, { name: 'b' } as never)
+    expect(lastUrl()).toBe('/api/external-agents/3')
+    expect(lastInit().method).toBe('PUT')
+
+    await registry.deleteAgent(3)
+    expect(lastUrl()).toBe('/api/external-agents/3')
+    expect(lastInit().method).toBe('DELETE')
+
+    await registry.refreshAgentCard(3)
+    expect(lastUrl()).toBe('/api/external-agents/3/refresh')
+
+    await registry.fetchCards()
+    expect(lastUrl()).toBe('/api/external-agents/cards')
+  })
+
+  it('useOrchestration service + fleet reads keep their paths', async () => {
+    const o = useOrchestration()
+
+    await o.fetchServices()
+    expect(lastUrl()).toBe('/api/orchestration/services')
+
+    await o.fetchService('autobot-backend')
+    expect(lastUrl()).toBe('/api/orchestration/services/autobot-backend')
+
+    await o.fetchFleetStatus()
+    expect(lastUrl()).toBe('/api/orchestration/status')
+  })
+
+  it('useOrchestrationManagement fleet + category paths and bodies are unchanged', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ services: [], total_services: 0 }))
+    const o = useOrchestrationManagement()
+
+    await o.fetchFleetServices()
+    expect(lastUrl()).toBe('/api/fleet/services')
+
+    await o.updateServiceCategory('autobot-backend', 'system')
+    expect(lastUrl()).toBe('/api/fleet/services/autobot-backend/category')
+    expect(lastInit().method).toBe('PATCH')
+    expect(JSON.parse(lastInit().body as string)).toEqual({ category: 'system' })
+  })
+
+  it('useOrchestrationManagement sends JSON bodies for service actions', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true }))
+
+    await useOrchestrationManagement().startService('autobot-backend')
+
+    expect(lastInit().method).toBe('POST')
+    expect((lastInit().headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json'
+    )
+  })
+})

--- a/autobot-slm-frontend/src/composables/slmAxiosCompatMigration.test.ts
+++ b/autobot-slm-frontend/src/composables/slmAxiosCompatMigration.test.ts
@@ -61,14 +61,29 @@ function jsonResponse(body: unknown, status = 200): Response {
 let fetchMock: ReturnType<typeof vi.fn>
 let originalLocation: Location
 
-function lastInit(): RequestInit {
+/**
+ * The last call that reached the stubbed `fetch`.
+ *
+ * A private `axios.create()` instance issues XHR and never touches `fetch`, so
+ * an unmigrated composable records nothing here. Asserting that explicitly
+ * keeps the pre-change failure legible ("never reached slmApiClient") instead
+ * of an incidental TypeError on an empty mock.
+ */
+function lastFetchCall(): [string, RequestInit] {
   const calls = fetchMock.mock.calls
-  return calls[calls.length - 1][1] as RequestInit
+  expect(
+    calls.length,
+    'the composable never reached slmApiClient — no fetch was issued'
+  ).toBeGreaterThan(0)
+  return calls[calls.length - 1] as [string, RequestInit]
+}
+
+function lastInit(): RequestInit {
+  return lastFetchCall()[1]
 }
 
 function lastUrl(): string {
-  const calls = fetchMock.mock.calls
-  return calls[calls.length - 1][0] as string
+  return lastFetchCall()[0]
 }
 
 function authHeader(): unknown {

--- a/autobot-slm-frontend/src/composables/useAutobotApi.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.ts
@@ -386,6 +386,121 @@ export interface BackendHealthProbe {
   status: number
 }
 
+// =============================================================================
+// Skills + skill governance (#731 / #951 / #13079)
+//
+// These shapes and the `/skills/...` paths below used to live in
+// `useSkills.ts`, which drove them through TWO private `axios.create`
+// instances (one with `baseURL: getBackendUrl() + '/skills/'`, one bare) whose
+// interceptors attached only `Bearer ${authStore.token}` — no
+// `autobot_access_token` fallback, no 401 cleanup. Declaring them beside the
+// canonical client keeps the SLM app's knowledge of the autobot backend in one
+// place (ADR-008 decision rule 3).
+//
+// `useSkills.ts` re-exports every type below so its existing consumers
+// (`SkillsView.vue`, `ReposTab.vue`, `ApprovalsTab.vue`) import unchanged.
+// =============================================================================
+
+/** One field of a skill's `config_schema` (GET /skills/{name}). */
+export interface SkillConfigField {
+  type: string
+  default: unknown
+  description: string
+  required: boolean
+  choices: string[] | null
+}
+
+/** Row of GET /skills/. */
+export interface SkillInfo {
+  name: string
+  version: string
+  description: string
+  author: string
+  category: string
+  status: string
+  enabled: boolean
+  tools: readonly string[]
+  triggers: readonly string[]
+  dependencies: readonly string[]
+  tags: readonly string[]
+}
+
+/** Health block carried by GET /skills/{name}. */
+export interface SkillHealth {
+  name: string
+  status: string
+  version: string
+  message: string | null
+  last_checked: string
+  config_valid: boolean
+  dependencies_met: boolean
+  details: Record<string, unknown>
+}
+
+/** GET /skills/{name}. */
+export interface SkillDetail extends SkillInfo {
+  config_schema: Record<string, SkillConfigField>
+  current_config: Record<string, unknown>
+  health: SkillHealth
+}
+
+/** GET /skills/. */
+export interface SkillListResponse {
+  skills: SkillInfo[]
+  total: number
+  categories: string[]
+}
+
+/** GET /skills/categories. */
+export interface CategoryCounts {
+  categories: Record<string, number>
+}
+
+/** Optional filters accepted by GET /skills/. */
+export interface SkillListQuery {
+  category?: string
+  search?: string
+}
+
+/** Row of GET /skills/repos. */
+export interface SkillRepo {
+  id: string
+  name: string
+  url: string
+  repo_type: 'git' | 'local' | 'http' | 'mcp'
+  skill_count: number
+  status: string
+  last_synced: string | null
+}
+
+/** Body of POST /skills/repos. */
+export type SkillRepoCreate = Omit<SkillRepo, 'id' | 'skill_count' | 'status' | 'last_synced'>
+
+/** Row of GET /skills/governance/approvals. */
+export interface SkillApproval {
+  id: string
+  skill_id: string
+  requested_by: string
+  requested_at: string
+  reason: string
+  status: 'pending' | 'approved' | 'rejected'
+  notes: string | null
+}
+
+/** Body of POST /skills/governance/approvals/{id}. */
+export interface SkillApprovalDecision {
+  approved: boolean
+  notes: string
+  trust_level: string
+}
+
+/** GET/PUT /skills/governance/. */
+export interface GovernanceConfig {
+  mode: 'full_auto' | 'semi_auto' | 'locked'
+  gap_detection_enabled: boolean
+  default_trust_level: string
+}
+
 /**
  * Unwrap the FastAPI `{ "detail": "..." }` error body (#13079).
  *
@@ -1492,7 +1607,158 @@ export function useAutobotApi() {
     return { ok: response.status >= 200 && response.status < 300, status: response.status }
   }
 
+
+  // =============================================================================
+  // Skills + skill governance (#731 / #951 / #13079)
+  //
+  // Paths keep their exact trailing slashes: `useSkills.ts` reached `/skills/`
+  // and `/skills/governance/` through an axios `baseURL` that preserved them,
+  // and FastAPI answers the slash-less form with a 307 redirect that drops the
+  // Authorization header on a cross-origin hop.
+  // =============================================================================
+
+  async function getSkills(query: SkillListQuery = {}): Promise<SkillListResponse> {
+    const params = new URLSearchParams()
+    if (query.category) params.append('category', query.category)
+    if (query.search) params.append('search', query.search)
+    const qs = params.toString()
+    const response = await client.get<SkillListResponse>(`/skills/${qs ? `?${qs}` : ''}`)
+    return response.data
+  }
+
+  async function getSkillCategories(): Promise<CategoryCounts> {
+    const response = await client.get<CategoryCounts>('/skills/categories')
+    return response.data
+  }
+
+  async function getSkillDetail(name: string): Promise<SkillDetail> {
+    const response = await client.get<SkillDetail>(`/skills/${encodeURIComponent(name)}`)
+    return response.data
+  }
+
+  async function enableSkill(name: string): Promise<Record<string, unknown>> {
+    const response = await client.post(`/skills/${encodeURIComponent(name)}/enable`)
+    return response.data
+  }
+
+  async function disableSkill(name: string): Promise<Record<string, unknown>> {
+    const response = await client.post(`/skills/${encodeURIComponent(name)}/disable`)
+    return response.data
+  }
+
+  async function updateSkillConfig(
+    name: string,
+    config: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const response = await client.put(`/skills/${encodeURIComponent(name)}/config`, { config })
+    return response.data
+  }
+
+  async function initializeSkills(): Promise<Record<string, unknown>> {
+    const response = await client.post('/skills/initialize')
+    return response.data
+  }
+
+  async function getSkillRepos(): Promise<SkillRepo[]> {
+    const response = await client.get<SkillRepo[]>('/skills/repos')
+    return response.data ?? []
+  }
+
+  async function addSkillRepo(payload: SkillRepoCreate): Promise<Record<string, unknown>> {
+    const response = await client.post('/skills/repos', payload)
+    return response.data
+  }
+
+  /**
+   * POST /skills/repos/{id}/sync.
+   *
+   * `autobot-backend/api/skills_repos.py:117` awaits `GitRepoSync` inline, so a
+   * cold clone runs for as long as the clone takes. The private instance this
+   * replaced capped it at 15s (see `SKILL_APPROVAL_POLL_TIMEOUT_MS` for why
+   * that number carried no intent), which aborted the very operation it was
+   * meant to cover; the client's 30s default applies instead.
+   */
+  async function syncSkillRepo(repoId: string): Promise<Record<string, unknown>> {
+    const response = await client.post(`/skills/repos/${encodeURIComponent(repoId)}/sync`)
+    return response.data
+  }
+
+  /**
+   * GET /skills/governance/approvals.
+   *
+   * `timeoutMs` exists for the 30s approval poll in `useSkillGovernance`: a tick
+   * that outlived its own interval would overlap the next one, so the polled
+   * read is given a sub-interval budget rather than the client's 30s default.
+   */
+  async function getSkillApprovals(timeoutMs?: number): Promise<SkillApproval[]> {
+    const response = await client.get<SkillApproval[]>(
+      '/skills/governance/approvals',
+      timeoutMs === undefined ? undefined : { timeout: timeoutMs }
+    )
+    return response.data ?? []
+  }
+
+  async function decideSkillApproval(
+    approvalId: string,
+    decision: SkillApprovalDecision
+  ): Promise<Record<string, unknown>> {
+    const response = await client.post(
+      `/skills/governance/approvals/${encodeURIComponent(approvalId)}`,
+      decision
+    )
+    return response.data
+  }
+
+  async function getSkillDrafts(): Promise<Record<string, unknown>[]> {
+    const response = await client.get<Record<string, unknown>[]>('/skills/governance/drafts')
+    return response.data ?? []
+  }
+
+  async function testSkillDraft(skillId: string): Promise<Record<string, unknown>> {
+    const response = await client.post(
+      `/skills/governance/drafts/${encodeURIComponent(skillId)}/test`
+    )
+    return response.data
+  }
+
+  async function promoteSkillDraft(skillId: string): Promise<Record<string, unknown>> {
+    const response = await client.post(
+      `/skills/governance/drafts/${encodeURIComponent(skillId)}/promote`
+    )
+    return response.data
+  }
+
+  async function getSkillGovernance(): Promise<GovernanceConfig> {
+    const response = await client.get<GovernanceConfig>('/skills/governance/')
+    return response.data
+  }
+
+  async function updateSkillGovernanceMode(
+    mode: GovernanceConfig['mode']
+  ): Promise<Record<string, unknown>> {
+    const response = await client.put('/skills/governance/', { mode })
+    return response.data
+  }
+
   return {
+    // Skills + governance (#731 / #951 / #13079)
+    getSkills,
+    getSkillCategories,
+    getSkillDetail,
+    enableSkill,
+    disableSkill,
+    updateSkillConfig,
+    initializeSkills,
+    getSkillRepos,
+    addSkillRepo,
+    syncSkillRepo,
+    getSkillApprovals,
+    decideSkillApproval,
+    getSkillDrafts,
+    testSkillDraft,
+    promoteSkillDraft,
+    getSkillGovernance,
+    updateSkillGovernanceMode,
     // Settings
     getSettings,
     updateSettings,

--- a/autobot-slm-frontend/src/composables/useExternalAgents.ts
+++ b/autobot-slm-frontend/src/composables/useExternalAgents.ts
@@ -10,33 +10,28 @@
  */
 
 import { ref, reactive } from 'vue'
-import axios from 'axios'
+import { makeAxiosCompatClient } from '@/utils/slmApiCompat'
 import type {
   ExternalAgent,
   ExternalAgentCreate,
   ExternalAgentUpdate,
   ExternalAgentCard,
 } from '@/types/slm'
-import { getSlmApiBase } from '@/config/ssot-config'
 
-function makeClient() {
-  const client = axios.create()
-  client.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-  return client
-}
+// SLM backend transport: the canonical `slmApiClient` behind the axios-shaped
+// facade (#13079/#13140). This composable used to hold its own bare
+// `axios.create()` — no baseURL (every call site pasted `getSlmApiBase()` in),
+// NO timeout at all, a `sessionStorage`-only bearer interceptor and no 401
+// handling. `slmApiClient` supplies the sessionStorage->localStorage token
+// fallback (ApiClient.ts:113), the `VITE_SLM_API_TIMEOUT_MS` budget (:44-48)
+// and the 401 session teardown (:128-151), and resolves the base URL itself
+// (:104) — so the endpoints below are relative.
+const client = makeAxiosCompatClient()
 
 export function useExternalAgents() {
   const agents = ref<ExternalAgent[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
-
-  const client = makeClient()
 
   function _extractError(e: unknown, fallback: string): string {
     const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -47,7 +42,7 @@ export function useExternalAgents() {
     isLoading.value = true
     error.value = null
     try {
-      const response = await client.get<ExternalAgent[]>(`${getSlmApiBase()}/external-agents`)
+      const response = await client.get<ExternalAgent[]>('/external-agents')
       agents.value = response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to fetch external agents')
@@ -58,7 +53,7 @@ export function useExternalAgents() {
 
   async function getAgent(agentId: number): Promise<ExternalAgent | null> {
     try {
-      const response = await client.get<ExternalAgent>(`${getSlmApiBase()}/external-agents/${agentId}`)
+      const response = await client.get<ExternalAgent>(`/external-agents/${agentId}`)
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to fetch agent')
@@ -68,7 +63,7 @@ export function useExternalAgents() {
 
   async function createAgent(data: ExternalAgentCreate): Promise<ExternalAgent | null> {
     try {
-      const response = await client.post<ExternalAgent>(`${getSlmApiBase()}/external-agents`, data)
+      const response = await client.post<ExternalAgent>('/external-agents', data)
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to register agent')
@@ -81,7 +76,7 @@ export function useExternalAgents() {
     data: ExternalAgentUpdate
   ): Promise<ExternalAgent | null> {
     try {
-      const response = await client.put<ExternalAgent>(`${getSlmApiBase()}/external-agents/${agentId}`, data)
+      const response = await client.put<ExternalAgent>(`/external-agents/${agentId}`, data)
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to update agent')
@@ -91,7 +86,7 @@ export function useExternalAgents() {
 
   async function deleteAgent(agentId: number): Promise<boolean> {
     try {
-      await client.delete(`${getSlmApiBase()}/external-agents/${agentId}`)
+      await client.delete(`/external-agents/${agentId}`)
       agents.value = agents.value.filter((a) => a.id !== agentId)
       return true
     } catch (e) {
@@ -103,7 +98,7 @@ export function useExternalAgents() {
   async function verifyAgent(agentId: number): Promise<ExternalAgent | null> {
     try {
       const response = await client.post<ExternalAgent & { success: boolean }>(
-        `${getSlmApiBase()}/external-agents/${agentId}/verify`
+        `/external-agents/${agentId}/verify`
       )
       return response.data
     } catch (e) {
@@ -114,7 +109,7 @@ export function useExternalAgents() {
 
   async function refreshAgentCard(agentId: number): Promise<boolean> {
     try {
-      await client.post(`${getSlmApiBase()}/external-agents/${agentId}/refresh`)
+      await client.post(`/external-agents/${agentId}/refresh`)
       return true
     } catch (e) {
       error.value = _extractError(e, 'Failed to queue card refresh')
@@ -124,7 +119,7 @@ export function useExternalAgents() {
 
   async function fetchCards(): Promise<ExternalAgentCard[]> {
     try {
-      const response = await client.get<ExternalAgentCard[]>(`${getSlmApiBase()}/external-agents/cards`)
+      const response = await client.get<ExternalAgentCard[]>('/external-agents/cards')
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to fetch agent cards')

--- a/autobot-slm-frontend/src/composables/useOrchestration.ts
+++ b/autobot-slm-frontend/src/composables/useOrchestration.ts
@@ -13,15 +13,21 @@
  */
 
 import { ref, computed, readonly } from 'vue'
-import axios, { type AxiosInstance } from 'axios'
+import { makeAxiosCompatClient } from '@/utils/slmApiCompat'
 import { createLogger } from '@/utils/debugUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
 import type { components } from '@/types/generated/api'
 
 const logger = createLogger('useOrchestration')
 
-// SLM Admin uses the local SLM backend API
-const API_BASE = getSlmApiBase()
+// SLM backend transport: the canonical `slmApiClient` behind the axios-shaped
+// facade (#13079/#13140). This composable used to hold its own
+// `axios.create({ baseURL: getSlmApiBase() })` with a `sessionStorage`-only
+// bearer interceptor, NO timeout and no 401 handling. `slmApiClient` supplies
+// the sessionStorage->localStorage token fallback (ApiClient.ts:113), the
+// `VITE_SLM_API_TIMEOUT_MS` budget (:44-48) and the 401 session teardown
+// (:128-151). Endpoints below stay relative to the API base, which the client
+// resolves via `getSlmApiBase()` (:104).
+const client = makeAxiosCompatClient()
 
 // =============================================================================
 // Type Definitions
@@ -111,21 +117,6 @@ export type BulkActionResponse = components['schemas']['BulkActionResponse'] & {
 // =============================================================================
 
 export function useOrchestration() {
-  // Create axios client
-  const client: AxiosInstance = axios.create({
-    baseURL: API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-  })
-
-  // Add auth token to all requests
-  client.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
   // ===========================================================================
   // Reactive State
   // ===========================================================================
@@ -159,8 +150,13 @@ export function useOrchestration() {
     e: unknown,
     fallback: string
   ): string {
-    if (axios.isAxiosError(e) && e.response?.data?.detail) {
-      return e.response.data.detail
+    // `slmApiCompat` rejects with an axios-SHAPED error (`err.response.status`
+    // / `.data`) but not an axios instance, so `axios.isAxiosError` would miss
+    // it and every backend `detail` would degrade to `HTTP <n>`. Read the shape
+    // directly instead.
+    const detail = (e as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
+    if (typeof detail === 'string' && detail.length > 0) {
+      return detail
     }
     return e instanceof Error ? e.message : fallback
   }

--- a/autobot-slm-frontend/src/composables/useOrchestrationManagement.ts
+++ b/autobot-slm-frontend/src/composables/useOrchestrationManagement.ts
@@ -16,11 +16,10 @@
  */
 
 import { ref, computed, readonly, reactive } from 'vue'
-import axios, { type AxiosInstance } from 'axios'
+import { makeAxiosCompatClient } from '@/utils/slmApiCompat'
 import { useFleetStore } from '@/stores/fleet'
 import { useSlmWebSocket } from '@/composables/useSlmWebSocket'
 import { createLogger } from '@/utils/debugUtils'
-import { getSlmApiBase } from '@/config/ssot-config'
 import type {
   ServiceDefinition,
   ServiceActionRequest,
@@ -33,7 +32,16 @@ import type {
 import type { components } from '@/types/generated/api'
 
 const logger = createLogger('useOrchestrationManagement')
-const API_BASE = getSlmApiBase()
+
+// SLM backend transport: the canonical `slmApiClient` behind the axios-shaped
+// facade (#13079/#13140). This composable used to hold its own
+// `axios.create({ baseURL: getSlmApiBase(), timeout: 30000 })` with a
+// `sessionStorage`-only bearer interceptor and no 401 handling. `slmApiClient`
+// supplies the sessionStorage->localStorage token fallback (ApiClient.ts:113),
+// an equivalent env-sourced 30s budget (:44-48) and the 401 session teardown
+// (:128-151). Endpoints stay relative to the API base, resolved by the client
+// via `getSlmApiBase()` (:104).
+const client = makeAxiosCompatClient()
 
 // =============================================================================
 // Additional Type Definitions (Fleet Services)
@@ -81,22 +89,6 @@ export function useOrchestrationManagement() {
   // Initialize dependencies
   const fleetStore = useFleetStore()
   const { connect, subscribeAll, onServiceStatus, connected } = useSlmWebSocket()
-
-  // Create axios client with timeout to prevent infinite loading
-  const client: AxiosInstance = axios.create({
-    baseURL: API_BASE,
-    headers: { 'Content-Type': 'application/json' },
-    timeout: 30000, // 30 second timeout
-  })
-
-  // Add auth token to all requests
-  client.interceptors.request.use((config) => {
-    const token = sessionStorage.getItem('slm_access_token')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
 
   // ===========================================================================
   // Reactive State
@@ -147,8 +139,13 @@ export function useOrchestrationManagement() {
   // ===========================================================================
 
   function extractErrorMessage(e: unknown, fallback: string): string {
-    if (axios.isAxiosError(e) && e.response?.data?.detail) {
-      return e.response.data.detail
+    // `slmApiCompat` rejects with an axios-SHAPED error (`err.response.status`
+    // / `.data`) but not an axios instance, so `axios.isAxiosError` would miss
+    // it and every backend `detail` would degrade to `HTTP <n>`. Read the shape
+    // directly instead.
+    const detail = (e as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
+    if (typeof detail === 'string' && detail.length > 0) {
+      return detail
     }
     return e instanceof Error ? e.message : fallback
   }
@@ -234,12 +231,16 @@ export function useOrchestrationManagement() {
       lastRefresh.value = new Date()
       return response.data
     } catch (e) {
-      if (axios.isAxiosError(e)) {
+      // Same reason as `extractErrorMessage`: the compat adapter's rejection is
+      // axios-shaped but not an axios instance. `statusText` is not carried on
+      // that shape (the underlying `Response` is consumed as JSON), so the HTTP
+      // status + body are logged and the text status is dropped.
+      const httpError = e as { response?: { status?: number; data?: unknown } }
+      if (httpError?.response?.status !== undefined) {
         logger.error('Fleet services API error:', {
-          status: e.response?.status,
-          statusText: e.response?.statusText,
-          data: e.response?.data,
-          message: e.message,
+          status: httpError.response.status,
+          data: httpError.response.data,
+          message: e instanceof Error ? e.message : String(e),
         })
       } else {
         logger.error('Failed to fetch fleet services:', e)

--- a/autobot-slm-frontend/src/composables/useSkills.test.ts
+++ b/autobot-slm-frontend/src/composables/useSkills.test.ts
@@ -1,0 +1,389 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * #13079 — useSkills / useSkillGovernance migrated off their two private
+ * `axios.create` instances onto `useAutobotApi`.
+ *
+ * `useSkills` owned `axios.create({ baseURL: getBackendUrl() + '/skills/',
+ * timeout: 15000 })` and `useSkillGovernance` a second, bare
+ * `axios.create({ timeout: 15000 })`. Both attached only
+ * `Bearer ${authStore.token}` — no `autobot_access_token` fallback, no 401
+ * cleanup — which is exactly the fork that made `AdvancedControlTool` 401 while
+ * its ~17 siblings worked (#13077).
+ *
+ * The harness stubs `axios.create` and records the interceptors `useAutobotApi`
+ * registers, then invokes them directly, so these assert the REAL transport
+ * behaviour (header actually attached, 401 actually clearing storage, the
+ * timeout actually configured) rather than that a function was called.
+ *
+ * Which tests prove a defect and which are regression guards is stated per
+ * `describe` block below.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const BACKEND = 'http://autobot.example/autobot-api'
+
+type Headers = Record<string, unknown>
+type RequestConfig = { headers: Headers }
+
+const h = vi.hoisted(() => {
+  const state = {
+    createConfig: null as Record<string, unknown> | null,
+    requestInterceptor: null as ((c: RequestConfig) => RequestConfig) | null,
+    responseErrorInterceptor: null as ((e: unknown) => Promise<unknown>) | null,
+    token: null as string | null,
+  }
+  const instance = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    interceptors: {
+      // Plain functions, not vi.fn: the suite runs with `mockReset: true`,
+      // which would strip a vi.fn implementation before the tests execute.
+      request: {
+        use: (fn: (c: RequestConfig) => RequestConfig) => {
+          state.requestInterceptor = fn
+        },
+      },
+      response: {
+        use: (_ok: unknown, err: (e: unknown) => Promise<unknown>) => {
+          state.responseErrorInterceptor = err
+        },
+      },
+    },
+  }
+  return { state, instance }
+})
+
+vi.mock('axios', () => ({
+  default: {
+    create: (config: Record<string, unknown>) => {
+      h.state.createConfig = config
+      return h.instance
+    },
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({ getBackendUrl: () => BACKEND }))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    get token() {
+      return h.state.token
+    },
+  }),
+}))
+
+import { useSkills, useSkillGovernance } from './useSkills'
+import { SKILL_APPROVAL_POLL_TIMEOUT_MS } from '@/constants/api-timeouts'
+
+/** The single axios instance every call in this module now shares. */
+function calls(verb: 'get' | 'post' | 'put') {
+  return h.instance[verb].mock.calls as unknown[][]
+}
+
+function firstUrl(verb: 'get' | 'post' | 'put'): string {
+  return calls(verb)[0]?.[0] as string
+}
+
+/** An axios-shaped rejection carrying a FastAPI `{ detail }` body. */
+function detailError(status: number, detail: string) {
+  const err = new Error(`Request failed with status code ${status}`) as Error & {
+    response: { status: number; data: { detail: string } }
+  }
+  err.response = { status, data: { detail } }
+  return err
+}
+
+describe('useSkills — migrated onto useAutobotApi (#13079)', () => {
+  beforeEach(() => {
+    h.state.token = null
+    h.state.createConfig = null
+    h.state.requestInterceptor = null
+    h.state.responseErrorInterceptor = null
+    localStorage.clear()
+    h.instance.get.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.post.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.put.mockResolvedValue({ data: {}, status: 200 })
+  })
+
+  // ===========================================================================
+  // Defect proofs — behaviour the private instances did NOT have.
+  // ===========================================================================
+
+  describe('transport the private axios instances lacked', () => {
+    it('attaches the autobot_access_token from localStorage when no SLM token exists', () => {
+      // The private interceptors read `authStore.token` and nothing else, so an
+      // operator holding only an autobot-issued token sent NO Authorization
+      // header at all and every skills call 401'd.
+      localStorage.setItem('autobot_access_token', 'autobot-token')
+      useSkills()
+
+      const headers = h.state.requestInterceptor!({ headers: {} }).headers
+
+      expect(headers.Authorization).toBe('Bearer autobot-token')
+    })
+
+    it('clears the autobot_access_token on a 401', async () => {
+      localStorage.setItem('autobot_access_token', 'stale-token')
+      useSkills()
+
+      await expect(
+        h.state.responseErrorInterceptor!({ response: { status: 401 } })
+      ).rejects.toBeDefined()
+
+      expect(localStorage.getItem('autobot_access_token')).toBeNull()
+    })
+
+    it('drops the unexplained blanket 15s budget for the client default', () => {
+      // 15000 was introduced with the feature (#731) and copied to the second
+      // instance; nothing in history or comment justifies it, and it was too
+      // SHORT for POST /skills/repos/{id}/sync, which awaits a git clone inline
+      // (autobot-backend/api/skills_repos.py:117).
+      useSkills()
+
+      expect(h.state.createConfig?.timeout).toBe(30000)
+      expect(h.state.createConfig?.timeout).not.toBe(15000)
+    })
+
+    it('resolves the base URL through the client rather than a private baseURL', () => {
+      useSkills()
+
+      expect(h.state.createConfig?.baseURL).toBe(BACKEND)
+    })
+  })
+
+  // ===========================================================================
+  // Regression guards — the wire contract must survive the migration.
+  // These pass on both sides by design; they pin the paths, not a defect.
+  // ===========================================================================
+
+  describe('endpoint paths survive the migration (regression guard)', () => {
+    it('fetchSkills GETs /skills/ with the trailing slash preserved', async () => {
+      h.instance.get.mockResolvedValue({ data: { skills: [], categories: [] }, status: 200 })
+
+      await useSkills().fetchSkills()
+
+      expect(firstUrl('get')).toBe('/skills/')
+    })
+
+    it('fetchSkills serialises category + search as query params', async () => {
+      h.instance.get.mockResolvedValue({ data: { skills: [], categories: [] }, status: 200 })
+
+      await useSkills().fetchSkills('automation', 'web')
+
+      expect(firstUrl('get')).toBe('/skills/?category=automation&search=web')
+    })
+
+    it('fetchCategories GETs /skills/categories', async () => {
+      h.instance.get.mockResolvedValue({ data: { categories: { automation: 2 } }, status: 200 })
+
+      const s = useSkills()
+      await s.fetchCategories()
+
+      expect(firstUrl('get')).toBe('/skills/categories')
+      expect(s.categoryCounts.value).toEqual({ automation: 2 })
+    })
+
+    it('fetchSkillDetail GETs /skills/{name}', async () => {
+      h.instance.get.mockResolvedValue({ data: { name: 'web_search' }, status: 200 })
+
+      const s = useSkills()
+      await s.fetchSkillDetail('web_search')
+
+      expect(firstUrl('get')).toBe('/skills/web_search')
+      expect(s.selectedSkill.value).toEqual({ name: 'web_search' })
+    })
+
+    it('enable/disable POST /skills/{name}/{verb}', async () => {
+      h.instance.get.mockResolvedValue({ data: { skills: [], categories: [] }, status: 200 })
+
+      await useSkills().enableSkill('web_search')
+      await useSkills().disableSkill('web_search')
+
+      expect(calls('post')[0][0]).toBe('/skills/web_search/enable')
+      expect(calls('post')[1][0]).toBe('/skills/web_search/disable')
+    })
+
+    it('updateConfig PUTs the config under a `config` key', async () => {
+      await useSkills().updateConfig('web_search', { depth: 3 })
+
+      expect(calls('put')[0][0]).toBe('/skills/web_search/config')
+      expect(calls('put')[0][1]).toEqual({ config: { depth: 3 } })
+    })
+
+    it('initializeSkills POSTs /skills/initialize', async () => {
+      h.instance.get.mockResolvedValue({ data: { skills: [], categories: [] }, status: 200 })
+
+      await useSkills().initializeSkills()
+
+      expect(calls('post')[0][0]).toBe('/skills/initialize')
+    })
+
+    it('percent-encodes a skill name so a slash cannot escape the path', async () => {
+      h.instance.get.mockResolvedValue({ data: { name: 'a/b' }, status: 200 })
+
+      await useSkills().fetchSkillDetail('a/b')
+
+      expect(firstUrl('get')).toBe('/skills/a%2Fb')
+    })
+  })
+
+  describe('error surface', () => {
+    it('surfaces the FastAPI detail rather than the axios message', async () => {
+      h.instance.get.mockRejectedValue(detailError(500, 'skill registry unavailable'))
+
+      const s = useSkills()
+      await s.fetchSkills()
+
+      expect(s.error.value).toBe('skill registry unavailable')
+      expect(s.loading.value).toBe(false)
+    })
+  })
+})
+
+describe('useSkillGovernance — migrated onto useAutobotApi (#13079)', () => {
+  beforeEach(() => {
+    h.state.token = null
+    h.state.createConfig = null
+    localStorage.clear()
+    h.instance.get.mockResolvedValue({ data: [], status: 200 })
+    h.instance.post.mockResolvedValue({ data: {}, status: 200 })
+    h.instance.put.mockResolvedValue({ data: {}, status: 200 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ===========================================================================
+  // Defect proofs.
+  // ===========================================================================
+
+  it('surfaces the FastAPI detail instead of the axios status message', async () => {
+    // The private instance's callers all read `e instanceof Error ? e.message`,
+    // which under axios is the generic "Request failed with status code 403" —
+    // the backend's reason for refusing a governance change never reached the
+    // operator.
+    h.instance.get.mockRejectedValue(detailError(403, 'governance is locked'))
+
+    const g = useSkillGovernance()
+    await g.fetchRepos()
+
+    expect(g.error.value).toBe('governance is locked')
+  })
+
+  it('surfaces the detail on a refused approval decision', async () => {
+    h.instance.post.mockRejectedValue(detailError(409, 'approval already decided'))
+
+    const g = useSkillGovernance()
+    await g.decideApproval('a1', true)
+
+    expect(g.error.value).toBe('approval already decided')
+  })
+
+  it('gives the 30s approval poll a sub-interval timeout so ticks cannot overlap', () => {
+    // The client default is 30s — the same length as the poll interval, so a
+    // tick that ran to its budget would still be in flight as the next fired.
+    vi.useFakeTimers()
+
+    const g = useSkillGovernance()
+    g.startApprovalPolling()
+    vi.advanceTimersByTime(30_000)
+
+    const [url, config] = calls('get')[0] as [string, { timeout: number }]
+    expect(url).toBe('/skills/governance/approvals')
+    expect(config?.timeout).toBe(SKILL_APPROVAL_POLL_TIMEOUT_MS)
+    expect(config.timeout).toBeLessThan(30_000)
+
+    g.stopApprovalPolling()
+  })
+
+  it('leaves an interactive approvals read on the client default budget', async () => {
+    await useSkillGovernance().fetchApprovals()
+
+    const [url, config] = calls('get')[0] as [string, unknown]
+    expect(url).toBe('/skills/governance/approvals')
+    expect(config).toBeUndefined()
+  })
+
+  // ===========================================================================
+  // Regression guards.
+  // ===========================================================================
+
+  describe('endpoint paths survive the migration (regression guard)', () => {
+    it('fetchRepos GETs /skills/repos', async () => {
+      h.instance.get.mockResolvedValue({ data: [{ id: 'r1' }], status: 200 })
+
+      const g = useSkillGovernance()
+      await g.fetchRepos()
+
+      expect(firstUrl('get')).toBe('/skills/repos')
+      expect(g.repos.value).toEqual([{ id: 'r1' }])
+    })
+
+    it('addRepo POSTs the payload to /skills/repos then refreshes', async () => {
+      await useSkillGovernance().addRepo({
+        name: 'core',
+        url: 'https://example.invalid/core.git',
+        repo_type: 'git',
+      })
+
+      expect(calls('post')[0][0]).toBe('/skills/repos')
+      expect(calls('post')[0][1]).toEqual({
+        name: 'core',
+        url: 'https://example.invalid/core.git',
+        repo_type: 'git',
+      })
+      expect(firstUrl('get')).toBe('/skills/repos')
+    })
+
+    it('syncRepo POSTs /skills/repos/{id}/sync', async () => {
+      await useSkillGovernance().syncRepo('r1')
+
+      expect(calls('post')[0][0]).toBe('/skills/repos/r1/sync')
+    })
+
+    it('decideApproval POSTs the decision body to /skills/governance/approvals/{id}', async () => {
+      await useSkillGovernance().decideApproval('a1', true, 'trusted', 'looks fine')
+
+      expect(calls('post')[0][0]).toBe('/skills/governance/approvals/a1')
+      expect(calls('post')[0][1]).toEqual({
+        approved: true,
+        notes: 'looks fine',
+        trust_level: 'trusted',
+      })
+    })
+
+    it('drafts GET /skills/governance/drafts and test/promote POST under it', async () => {
+      h.instance.get.mockResolvedValue({ data: [{ id: 'd1' }], status: 200 })
+
+      const g = useSkillGovernance()
+      await g.fetchDrafts()
+      await g.testDraft('d1')
+      await g.promoteDraft('d1')
+
+      expect(firstUrl('get')).toBe('/skills/governance/drafts')
+      expect(calls('post')[0][0]).toBe('/skills/governance/drafts/d1/test')
+      expect(calls('post')[1][0]).toBe('/skills/governance/drafts/d1/promote')
+    })
+
+    it('governance config GETs and PUTs /skills/governance/ with the trailing slash', async () => {
+      h.instance.get.mockResolvedValue({ data: { mode: 'locked' }, status: 200 })
+
+      const g = useSkillGovernance()
+      await g.fetchGovernance()
+      await g.setGovernanceMode('full_auto')
+
+      expect(firstUrl('get')).toBe('/skills/governance/')
+      expect(calls('put')[0][0]).toBe('/skills/governance/')
+      expect(calls('put')[0][1]).toEqual({ mode: 'full_auto' })
+    })
+  })
+})

--- a/autobot-slm-frontend/src/composables/useSkills.ts
+++ b/autobot-slm-frontend/src/composables/useSkills.ts
@@ -11,61 +11,42 @@
  */
 
 import { ref, computed, readonly, onUnmounted } from 'vue'
-import axios from 'axios'
-import { useAuthStore } from '@/stores/auth'
-import { getBackendUrl } from '@/config/ssot-config'
+import { useAutobotApi, autobotApiErrorMessage } from '@/composables/useAutobotApi'
+import { SKILL_APPROVAL_POLL_TIMEOUT_MS } from '@/constants/api-timeouts'
 
 // =============================================================================
 // Type Definitions
 // =============================================================================
+//
+// The shapes below now live beside the canonical autobot-backend client
+// (`useAutobotApi.ts`) per ADR-008 decision rule 3, together with the
+// `/skills/...` paths that produce them. They are re-exported here unchanged so
+// every existing consumer (`SkillsView.vue`, `ReposTab.vue`, `ApprovalsTab.vue`)
+// keeps importing them from this module.
+// =============================================================================
 
-export interface SkillConfigField {
-  type: string
-  default: unknown
-  description: string
-  required: boolean
-  choices: string[] | null
-}
+import type {
+  SkillConfigField,
+  SkillInfo,
+  SkillDetail,
+  SkillHealth,
+  SkillListResponse,
+  CategoryCounts,
+  SkillRepo,
+  SkillApproval,
+  GovernanceConfig,
+} from '@/composables/useAutobotApi'
 
-export interface SkillInfo {
-  name: string
-  version: string
-  description: string
-  author: string
-  category: string
-  status: string
-  enabled: boolean
-  tools: readonly string[]
-  triggers: readonly string[]
-  dependencies: readonly string[]
-  tags: readonly string[]
-}
-
-export interface SkillDetail extends SkillInfo {
-  config_schema: Record<string, SkillConfigField>
-  current_config: Record<string, unknown>
-  health: SkillHealth
-}
-
-export interface SkillHealth {
-  name: string
-  status: string
-  version: string
-  message: string | null
-  last_checked: string
-  config_valid: boolean
-  dependencies_met: boolean
-  details: Record<string, unknown>
-}
-
-export interface SkillListResponse {
-  skills: SkillInfo[]
-  total: number
-  categories: string[]
-}
-
-export interface CategoryCounts {
-  categories: Record<string, number>
+export type {
+  SkillConfigField,
+  SkillInfo,
+  SkillDetail,
+  SkillHealth,
+  SkillListResponse,
+  CategoryCounts,
+  SkillRepo,
+  SkillApproval,
+  GovernanceConfig,
 }
 
 // =============================================================================
@@ -73,7 +54,14 @@ export interface CategoryCounts {
 // =============================================================================
 
 export function useSkills() {
-  const authStore = useAuthStore()
+  // Transport: the canonical autobot-backend client (#13079). This composable
+  // used to own `axios.create({ baseURL: getBackendUrl() + '/skills/', timeout:
+  // 15000 })` with an interceptor that attached only `Bearer
+  // ${authStore.token}` — so with an autobot-issued token and no SLM token it
+  // 401'd where every tool on `useAutobotApi` worked. The client supplies the
+  // `autobot_access_token` fallback (useAutobotApi.ts:418), the 401 cleanup
+  // (:429-432), a 30s timeout (:412) and shared base-URL resolution (:408).
+  const api = useAutobotApi()
   const skills = ref<SkillInfo[]>([])
   const categories = ref<string[]>([])
   const categoryCounts = ref<Record<string, number>>({})
@@ -81,19 +69,6 @@ export function useSkills() {
   const loading = ref(false)
   const error = ref<string | null>(null)
   const initialized = ref(false)
-
-  const api = axios.create({
-    baseURL: `${getBackendUrl()}/skills/`,
-    timeout: 15000,
-  })
-
-  api.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
 
   // --- Computed ---
 
@@ -124,10 +99,7 @@ export function useSkills() {
     loading.value = true
     error.value = null
     try {
-      const params: Record<string, string> = {}
-      if (category) params.category = category
-      if (search) params.search = search
-      const { data } = await api.get<SkillListResponse>('/', { params })
+      const data = await api.getSkills({ category, search })
       skills.value = data.skills
       categories.value = data.categories
     } catch (err: unknown) {
@@ -139,7 +111,7 @@ export function useSkills() {
 
   async function fetchCategories(): Promise<void> {
     try {
-      const { data } = await api.get<CategoryCounts>('/categories')
+      const data = await api.getSkillCategories()
       categoryCounts.value = data.categories
     } catch (err: unknown) {
       error.value = _extractError(err)
@@ -150,8 +122,7 @@ export function useSkills() {
     loading.value = true
     error.value = null
     try {
-      const { data } = await api.get<SkillDetail>(`/${name}`)
-      selectedSkill.value = data
+      selectedSkill.value = await api.getSkillDetail(name)
     } catch (err: unknown) {
       error.value = _extractError(err)
     } finally {
@@ -161,7 +132,7 @@ export function useSkills() {
 
   async function enableSkill(name: string): Promise<boolean> {
     try {
-      await api.post(`/${name}/enable`)
+      await api.enableSkill(name)
       await fetchSkills()
       return true
     } catch (err: unknown) {
@@ -172,7 +143,7 @@ export function useSkills() {
 
   async function disableSkill(name: string): Promise<boolean> {
     try {
-      await api.post(`/${name}/disable`)
+      await api.disableSkill(name)
       await fetchSkills()
       return true
     } catch (err: unknown) {
@@ -186,7 +157,7 @@ export function useSkills() {
     config: Record<string, unknown>
   ): Promise<boolean> {
     try {
-      await api.put(`/${name}/config`, { config })
+      await api.updateSkillConfig(name, config)
       if (selectedSkill.value?.name === name) {
         await fetchSkillDetail(name)
       }
@@ -201,7 +172,7 @@ export function useSkills() {
     loading.value = true
     error.value = null
     try {
-      await api.post('/initialize')
+      await api.initializeSkills()
       initialized.value = true
       await fetchSkills()
       await fetchCategories()
@@ -244,40 +215,10 @@ export function useSkills() {
 // =============================================================================
 
 function _extractError(err: unknown): string {
-  if (axios.isAxiosError(err)) {
-    return err.response?.data?.detail || err.message
-  }
-  return String(err)
-}
-
-// =============================================================================
-// Skill Governance Types
-// =============================================================================
-
-export interface SkillRepo {
-  id: string
-  name: string
-  url: string
-  repo_type: 'git' | 'local' | 'http' | 'mcp'
-  skill_count: number
-  status: string
-  last_synced: string | null
-}
-
-export interface SkillApproval {
-  id: string
-  skill_id: string
-  requested_by: string
-  requested_at: string
-  reason: string
-  status: 'pending' | 'approved' | 'rejected'
-  notes: string | null
-}
-
-export interface GovernanceConfig {
-  mode: 'full_auto' | 'semi_auto' | 'locked'
-  gap_detection_enabled: boolean
-  default_trust_level: string
+  // `autobotApiErrorMessage` is the one implementation of the FastAPI
+  // `{ detail }` unwrap this used to hand-roll via `axios.isAxiosError`. Its
+  // fallback chain is identical: `response.data.detail`, then `err.message`.
+  return autobotApiErrorMessage(err, String(err))
 }
 
 // =============================================================================
@@ -285,7 +226,11 @@ export interface GovernanceConfig {
 // =============================================================================
 
 export function useSkillGovernance() {
-  const authStore = useAuthStore()
+  // Transport: the canonical autobot-backend client (#13079). This composable
+  // used to own a second, bare `axios.create({ timeout: 15000 })` — no baseURL
+  // (every call site pasted `getBackendUrl()` in), an `authStore.token`-only
+  // interceptor and no 401 cleanup.
+  const api = useAutobotApi()
   const repos = ref<SkillRepo[]>([])
   const approvals = ref<SkillApproval[]>([])
   const drafts = ref<Record<string, unknown>[]>([])
@@ -295,22 +240,12 @@ export function useSkillGovernance() {
   const newDraftNotification = ref<string | null>(null)
   let _pollTimer: ReturnType<typeof setInterval> | null = null
 
-  const api = axios.create({ timeout: 15000 })
-  api.interceptors.request.use((config) => {
-    const token = authStore.token
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  })
-
   async function fetchRepos(): Promise<void> {
     loading.value = true
     try {
-      const { data } = await api.get<SkillRepo[]>(`${getBackendUrl()}/skills/repos`)
-      repos.value = data
+      repos.value = await api.getSkillRepos()
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to fetch repos'
+      error.value = autobotApiErrorMessage(e, 'Failed to fetch repos')
     } finally {
       loading.value = false
     }
@@ -320,32 +255,39 @@ export function useSkillGovernance() {
     payload: Omit<SkillRepo, 'id' | 'skill_count' | 'status' | 'last_synced'>,
   ): Promise<unknown> {
     try {
-      const { data } = await api.post(`${getBackendUrl()}/skills/repos`, payload)
+      const data = await api.addSkillRepo(payload)
       await fetchRepos()
       return data
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to add repo'
+      error.value = autobotApiErrorMessage(e, 'Failed to add repo')
       throw e
     }
   }
 
   async function syncRepo(repoId: string): Promise<unknown> {
     try {
-      const { data } = await api.post(`${getBackendUrl()}/skills/repos/${repoId}/sync`)
+      const data = await api.syncSkillRepo(repoId)
       await fetchRepos()
       return data
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to sync repo'
+      error.value = autobotApiErrorMessage(e, 'Failed to sync repo')
       throw e
     }
   }
 
-  async function fetchApprovals(): Promise<void> {
+  /**
+   * GET /skills/governance/approvals.
+   *
+   * `timeoutMs` is passed only by `startApprovalPolling`, which runs on a 30s
+   * interval — the same length as the client's default budget, so a tick that
+   * ran to its timeout would still be in flight when its successor fired.
+   * Interactive callers keep the default.
+   */
+  async function fetchApprovals(timeoutMs?: number): Promise<void> {
     try {
-      const { data } = await api.get<SkillApproval[]>(`${getBackendUrl()}/skills/governance/approvals`)
-      approvals.value = data
+      approvals.value = await api.getSkillApprovals(timeoutMs)
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to fetch approvals'
+      error.value = autobotApiErrorMessage(e, 'Failed to fetch approvals')
     }
   }
 
@@ -356,62 +298,60 @@ export function useSkillGovernance() {
     notes = '',
   ): Promise<void> {
     try {
-      await api.post(`${getBackendUrl()}/skills/governance/approvals/${approvalId}`, {
+      await api.decideSkillApproval(approvalId, {
         approved,
         notes,
         trust_level: trustLevel,
       })
       await fetchApprovals()
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to process approval'
+      error.value = autobotApiErrorMessage(e, 'Failed to process approval')
     }
   }
 
   async function fetchDrafts(): Promise<void> {
     try {
-      const { data } = await api.get<Record<string, unknown>[]>(`${getBackendUrl()}/skills/governance/drafts`)
+      const data = await api.getSkillDrafts()
       drafts.value = Array.isArray(data) ? data : []
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to fetch drafts'
+      error.value = autobotApiErrorMessage(e, 'Failed to fetch drafts')
     }
   }
 
   async function testDraft(skillId: string): Promise<unknown> {
     try {
-      const { data } = await api.post(`${getBackendUrl()}/skills/governance/drafts/${skillId}/test`)
-      return data
+      return await api.testSkillDraft(skillId)
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Test draft failed'
+      error.value = autobotApiErrorMessage(e, 'Test draft failed')
       throw e
     }
   }
 
   async function promoteDraft(skillId: string): Promise<unknown> {
     try {
-      const { data } = await api.post(`${getBackendUrl()}/skills/governance/drafts/${skillId}/promote`)
+      const data = await api.promoteSkillDraft(skillId)
       await fetchDrafts()
       return data
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to promote draft'
+      error.value = autobotApiErrorMessage(e, 'Failed to promote draft')
       throw e
     }
   }
 
   async function fetchGovernance(): Promise<void> {
     try {
-      const { data } = await api.get<GovernanceConfig>(`${getBackendUrl()}/skills/governance/`)
-      governanceConfig.value = data
+      governanceConfig.value = await api.getSkillGovernance()
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to fetch governance config'
+      error.value = autobotApiErrorMessage(e, 'Failed to fetch governance config')
     }
   }
 
   async function setGovernanceMode(mode: GovernanceConfig['mode']): Promise<void> {
     try {
-      await api.put(`${getBackendUrl()}/skills/governance/`, { mode })
+      await api.updateSkillGovernanceMode(mode)
       await fetchGovernance()
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : 'Failed to update governance mode'
+      error.value = autobotApiErrorMessage(e, 'Failed to update governance mode')
     }
   }
 
@@ -420,7 +360,7 @@ export function useSkillGovernance() {
     if (_pollTimer !== null) return
     _pollTimer = setInterval(async () => {
       const prev = approvals.value.length
-      await fetchApprovals()
+      await fetchApprovals(SKILL_APPROVAL_POLL_TIMEOUT_MS)
       const curr = approvals.value.length
       if (curr > prev) {
         const newest = approvals.value[approvals.value.length - 1]

--- a/autobot-slm-frontend/src/constants/api-timeouts.ts
+++ b/autobot-slm-frontend/src/constants/api-timeouts.ts
@@ -4,7 +4,8 @@
 // Author: mrveiss
 
 /**
- * Request timeouts for SLM endpoints that outlive the client default (#13140).
+ * Named request timeouts for endpoints whose budget differs from the client
+ * default (#13140 for the SLM backend, #13079 for the autobot backend).
  *
  * `slmApiClient` applies `VITE_SLM_API_TIMEOUT_MS` (30s default) to every
  * request. That budget is right for a CRUD read, but the raw `fetch` sites this
@@ -54,3 +55,24 @@ export const HEALTH_PROBE_TIMEOUT_MS = timeoutFromEnv('VITE_SLM_HEALTH_PROBE_TIM
  * the next tick is the retry.
  */
 export const POLLED_READ_MAX_RETRIES = 1
+
+/**
+ * `GET /skills/governance/approvals` when issued from `useSkillGovernance`'s
+ * approval poll (#951), which runs on a **30-second** `setInterval`.
+ *
+ * `useAutobotApi`'s default budget is also 30s, so a tick that ran to its
+ * timeout would still be in flight as the next tick fired. The polled read gets
+ * a sub-interval budget instead, so a tick is always resolved before its
+ * successor starts and the next tick is the retry.
+ *
+ * This is NOT a preservation of the 15s that the private `axios.create` in
+ * `useSkills.ts` applied to every skills call. That 15s predates the poll
+ * (introduced in #731, the poll added later in #951), carries no comment, and
+ * was demonstrably wrong for at least one endpoint it covered —
+ * `POST /skills/repos/{id}/sync` awaits a git clone inline. Only the poll has a
+ * reason for a shorter budget, so only the poll gets one.
+ */
+export const SKILL_APPROVAL_POLL_TIMEOUT_MS = timeoutFromEnv(
+  'VITE_SKILL_APPROVAL_POLL_TIMEOUT_MS',
+  10_000
+)

--- a/autobot-slm-frontend/src/views/settings/MonitoringSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/MonitoringSettings.vue
@@ -75,6 +75,10 @@ async function deployMonitoringRole(): Promise<void> {
 
 async function testPrometheusConnection(): Promise<void> {
   try {
+    // Prometheus is a separate service, not the SLM or autobot backend: it has
+    // its own origin, no SLM bearer token applies, and its liveness endpoint is
+    // deliberately unauthenticated. Neither canonical client can address it.
+    // eslint-disable-next-line no-restricted-syntax
     const response = await fetch(`${getPrometheusUrl()}/-/healthy`)
     if (response.ok) {
       success.value = 'Prometheus connection successful'
@@ -89,6 +93,9 @@ async function testPrometheusConnection(): Promise<void> {
 
 async function testGrafanaConnection(): Promise<void> {
   try {
+    // Grafana, same reasoning as the Prometheus probe above: a different
+    // service on a different origin, outside both canonical clients' scope.
+    // eslint-disable-next-line no-restricted-syntax
     const response = await fetch(`${getGrafanaUrl()}/api/health`)
     if (response.ok) {
       success.value = 'Grafana connection successful'


### PR DESCRIPTION
## Thinking Path

#13171 converted all 17 raw-`fetch` autobot-backend sites and left exactly five private `axios.create` instances. Re-measured them on `da8d0bac8` before touching anything, because only one of the four files is named in #13079 and both issues' line numbers had drifted before.

The measurement disagreed with the framing in one important way. The five instances do **not** all belong to #13079. `useSkills.ts` (2 instances) targets the **autobot** backend via `getBackendUrl()` — that is #13079. The other three target the **SLM** backend via `getSlmApiBase()`, so by ADR-008 rule 3 their canonical client is `slmApiClient`, not `useAutobotApi` — that is #13140's "private axios instances" table. Both halves are here because the lint rule they jointly block is a single switch.

The 15s timeout question was decided on evidence rather than preserved by default. `git log -S"15000"` puts it in #731 (the feature commit) and its copy in `b5fccb252`; `startApprovalPolling` arrives later in `c40e32e24` (#951). So 15s **cannot** have been chosen for the poll it is sometimes credited to, and it carries no comment. It was also demonstrably wrong for at least one endpoint it covered: `POST /skills/repos/{id}/sync` awaits `GitRepoSync` inline (`autobot-backend/api/skills_repos.py:117`), so a cold clone was being aborted at 15s by a budget nothing justified. Verdict: not load-bearing, dropped. But the poll interval hazard is real and separate — the client default is 30s and the poll interval is 30s, so a tick that ran to its budget would still be in flight when its successor fired. Only the poll gets a shorter budget, as a named env-sourced constant.

The two prior slices both found that a mechanical swap breaks something silently (#13077's missing token fallback, #13171's health probe that would have logged the operator out). So each behaviour delta was checked rather than assumed — see below.

## What Changed

**All five private instances retired. None remain.**

| instance | targeted | config divergence from its canonical client | now |
|---|---|---|---|
| `useSkills.ts:85` | autobot | `baseURL getBackendUrl()+'/skills/'`, timeout **15000**, `authStore.token`-only interceptor, no 401 cleanup | `useAutobotApi` |
| `useSkills.ts:298` | autobot | **no baseURL** (call sites pasted `getBackendUrl()` in), timeout **15000**, `authStore.token`-only, no 401 cleanup | `useAutobotApi` |
| `useOrchestration.ts:115` | SLM | `baseURL getSlmApiBase()`, **no timeout at all**, `sessionStorage`-only bearer, no 401 handling | `makeAxiosCompatClient` |
| `useOrchestrationManagement.ts:86` | SLM | `baseURL getSlmApiBase()`, timeout 30000, `sessionStorage`-only bearer, no 401 handling | `makeAxiosCompatClient` |
| `useExternalAgents.ts:23` | SLM | **no baseURL**, **no timeout at all**, `sessionStorage`-only bearer, no 401 handling | `makeAxiosCompatClient` |

51 call sites across 1,703 lines. No `validateStatus`, `transformResponse` or response interceptor existed on any of the five, so nothing of that kind had to be reproduced.

The `/skills/...` paths and payload shapes move beside `useAutobotApi` per ADR-008 rule 3, and `useSkills.ts` **re-exports every type unchanged** so `SkillsView.vue`, `ReposTab.vue` and `ApprovalsTab.vue` import exactly as before. Nothing was deleted.

### Behaviour changes handled deliberately

- **Trailing slashes preserved.** `useSkills` reached `/skills/` and `/skills/governance/` through an axios `baseURL` that kept them. Flattening those to `/skills` would meet a FastAPI 307 that drops the `Authorization` header on a cross-origin hop. Pinned by test.
- **`axios.isAxiosError` no longer matches.** `slmApiCompat` rejects with an axios-**shaped** error that is not an axios instance, so both orchestration composables' `isAxiosError(e) && e.response?.data?.detail` guard would have silently skipped the detail branch and shown `HTTP 500`. They now read the shape directly. The same applied to a logging branch in `fetchFleetServices` (which additionally logged `statusText`, not carried on that shape — the status and body are logged instead, and the omission is commented).
- **`useSkillGovernance` error shape, a pre-existing defect fixed in scope.** All 10 of its call sites used `e instanceof Error ? e.message`, which under axios yields `Request failed with status code 403` — the backend's reason for refusing a governance change never reached the operator. Now `autobotApiErrorMessage`.
- **401 is no longer swallowed.** Previously every one of these 51 sites dropped a 401 into `error.value`. It now clears the stale token (autobot) or tears down the session and redirects (SLM). Checked for the #13171 hazard: none of the five is a health probe or unauthenticated diagnostic, so no `validateStatus: () => true` escape is needed. `ApiClient`'s "only clear when a token was actually attached" guard (`:129-135`) means a token-less call still does not log anyone out — asserted.
- **`useOrchestration` gains a 30s timeout it never had.** Its bulk fleet actions could in principle exceed that. Exposure is nil: it has **no consumers** — `OrchestrationView.vue` uses `useOrchestrationManagement`, which already ran on exactly 30s. Per "never delete code — wire it in", it was migrated rather than removed, and now matches its wired twin.
- **`useExternalAgents` gains a timeout it never had**, including on `POST /external-agents/{id}/verify`, which reaches out to a remote A2A agent. An unbounded hang left the panel spinning forever; a bounded failure is strictly better.

### Genuine exceptions

None among the five — unlike #13140's slices, no streaming, SSE, upload or non-JSON body is involved. The two pre-existing exceptions are untouched and now carry an inline lint disable naming the service: `MonitoringSettings.vue`'s Prometheus `/-/healthy` and Grafana `/api/health` probes, which live on different origins that neither canonical client can address.

### The lint rule (#13140 DoD item 4) — now landed

With the last private transport gone, the rule the DoD was waiting on ships: `no-restricted-syntax` bans bare `fetch()`, `window.fetch()` and `axios.create()` under `src/`, allowlisting `utils/ApiClient.ts`, `utils/slmApiCompat.ts`, `composables/useAutobotApi.ts` and test files.

## Verification

`type-check` clean. `lint` **0 errors / 15 warnings** — identical to the `da8d0bac8` baseline, including with the new rule active. `vitest` **42 files / 342 tests → 44 / 381**, zero failures on both sides.

**Non-vacuity — 38 of 39 new tests fail against `cp`-swapped pristine sources:**

```
expected undefined to be 'Bearer autobot-token'        # the #13077 fork: no Authorization header at all
expected 'expired-token' to be null                    # no 401 teardown
expected 15000 to be 30000                             # the unjustified blanket budget
expected 'Request failed with status code 403' to be 'governance is locked'
expected 'Request failed with status code 409' to be 'approval already decided'
expected 'Request failed with status code 404' to be 'orchestrator offline'
expected '/categories' to be '/skills/categories'      # + 9 more path cases
the composable never reached slmApiClient — no fetch was issued   x11
```

That last message is the point of the harness: a private `axios.create()` instance issues XHR and never touches the stubbed `fetch`, so an unmigrated composable cannot even reach the canonical client. The assertion was added so that reads as intent rather than an incidental TypeError.

The **one** test that passes on both sides — "does NOT clear the session on a 401 to a token-less call" — is a **regression guard**, not a defect proof, and is labelled as such in the file. Every `describe` block is marked defect proof or regression guard.

The tests assert real behaviour, not that a function was called: `useSkills.test.ts` stubs `axios.create` and invokes the interceptors `useAutobotApi` actually registers, so the header attached and the storage cleared are the real ones; `slmAxiosCompatMigration.test.ts` runs the **real** `slmApiClient` with `fetch` stubbed, so the `Authorization` header, the `AbortSignal` bounding the request and the cleared `sessionStorage` are all observed on the wire.

**Lint rule non-vacuity** — run against the same pristine sources, it flags exactly five errors at exactly the reported lines, independently corroborating the measurement:

```
useExternalAgents.ts           23:18  error  no-restricted-syntax
useOrchestration.ts           115:33  error  no-restricted-syntax
useOrchestrationManagement.ts  86:33  error  no-restricted-syntax
useSkills.ts                   85:15  error  no-restricted-syntax
useSkills.ts                  298:15  error  no-restricted-syntax
```

Enabling the rule on the migrated tree flagged only the two known external probes, which is how they came to carry inline disables rather than a blanket file allowlist.

No `Closes` keyword: #13079's own delivery is complete, but #13140 retains a deliberately partial DoD item 2 (`getApiUrl()` kept for its two display-only consumers), so the advisory PR-link gate is left red as an honest signal — #12995.

## Model Used

claude-opus-5
