### PR TITLE
perf(slm): route 3 raw aiohttp.ClientSession sites through pooled http_client (#13134)

### DIFF
--- a/autobot-slm-backend/services/a2a_card_fetcher.py
+++ b/autobot-slm-backend/services/a2a_card_fetcher.py
@@ -21,6 +21,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
@@ -54,12 +55,13 @@ async def _fetch_one(ip_address: str) -> Dict[str, Any] | None:
         ssl_ctx.verify_mode = ssl.CERT_NONE
     try:
         timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(url, ssl=ssl_ctx) as resp:
-                if resp.status == 200:
-                    return await resp.json(content_type=None)
-                logger.debug("A2A card HTTP %s from %s", resp.status, ip_address)
-                return None
+        # #13134: pooled client instead of a per-call ClientSession. ssl= and
+        # timeout= are per-request kwargs the pooled session forwards as-is.
+        async with get_http_client().tracked_request("GET", url, ssl=ssl_ctx, timeout=timeout) as resp:
+            if resp.status == 200:
+                return await resp.json(content_type=None)
+            logger.debug("A2A card HTTP %s from %s", resp.status, ip_address)
+            return None
     except Exception as exc:
         logger.debug("A2A card fetch failed for %s: %s", ip_address, exc)
         return None
@@ -158,12 +160,12 @@ async def _fetch_external_agent_card(url: str, ssl_ctx, headers: Dict[str, str],
     error_msg = None
     try:
         timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(url, ssl=ssl_ctx, headers=headers) as resp:
-                if resp.status == 200:
-                    card = await resp.json(content_type=None)
-                else:
-                    error_msg = f"HTTP {resp.status}"
+        # #13134: pooled client instead of a per-call ClientSession.
+        async with get_http_client().tracked_request("GET", url, ssl=ssl_ctx, headers=headers, timeout=timeout) as resp:
+            if resp.status == 200:
+                card = await resp.json(content_type=None)
+            else:
+                error_msg = f"HTTP {resp.status}"
     except Exception as exc:
         error_msg = str(exc)
         logger.debug("External agent %s card fetch failed: %s", agent_id, exc)

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -20,6 +20,7 @@ from typing import Dict, List
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.http_client import get_http_client
 from autobot_shared.time_utils import utc_timestamp
 from config import settings
 from models.database import (
@@ -1432,9 +1433,9 @@ class ReconcilerService:
                 ssl_ctx.check_hostname = False
                 ssl_ctx.verify_mode = ssl.CERT_NONE
             timeout = aiohttp.ClientTimeout(total=10)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(url, ssl=ssl_ctx) as resp:
-                    return "healthy" if resp.status < 400 else "unhealthy"
+            # #13134: pooled client instead of a per-call ClientSession.
+            async with get_http_client().tracked_request("GET", url, ssl=ssl_ctx, timeout=timeout) as resp:
+                return "healthy" if resp.status < 400 else "unhealthy"
         except Exception as exc:
             logger.debug("Health check failed for %s: %s", url, exc)
             return "unhealthy"

--- a/autobot-slm-backend/tests/services/test_sso_vault_client.py
+++ b/autobot-slm-backend/tests/services/test_sso_vault_client.py
@@ -42,7 +42,10 @@ if "aiohttp" not in sys.modules:
     sys.modules["aiohttp.ClientTimeout"] = MagicMock()
     sys.modules["aiohttp.ClientSession"] = MagicMock()
 
-# Pre-stub autobot_shared.http_client with the real sign_request signature
+# Pre-stub autobot_shared.http_client with the real sign_request signature.
+# get_http_client is a placeholder here (#13134: vault_client._request() now
+# routes through it) — individual tests replace it via
+# patch.object(_vault_client_mod, "get_http_client", ...) for real behavior.
 _hs_mod = types.ModuleType("autobot_shared.http_client")
 
 
@@ -55,6 +58,7 @@ def _sign_stub(service_id, service_key, method, path, timestamp):
 
 
 _hs_mod.sign_request = _sign_stub  # type: ignore[attr-defined]
+_hs_mod.get_http_client = MagicMock()  # type: ignore[attr-defined]
 sys.modules["autobot_shared.http_client"] = _hs_mod
 if "autobot_shared" not in sys.modules:
     sys.modules["autobot_shared"] = types.ModuleType("autobot_shared")
@@ -107,6 +111,21 @@ def _mock_provider(provider_id: uuid.UUID, config: dict) -> MagicMock:
     p.id = provider_id
     p.config = config
     return p
+
+
+def _fake_http_client(resp_mock: AsyncMock) -> MagicMock:
+    """Build a get_http_client() stand-in whose tracked_request() yields resp_mock.
+
+    Mirrors HTTPClientManager.tracked_request()'s async-context-manager shape
+    (#13134: vault_client._request() no longer opens its own ClientSession).
+    """
+    tracked_cm = AsyncMock()
+    tracked_cm.__aenter__ = AsyncMock(return_value=resp_mock)
+    tracked_cm.__aexit__ = AsyncMock(return_value=False)
+
+    client_mock = MagicMock()
+    client_mock.tracked_request = MagicMock(return_value=tracked_cm)
+    return client_mock
 
 
 # ---------------------------------------------------------------------------
@@ -177,23 +196,12 @@ class TestUnifiedVaultClientConfig:
     async def test_request_raises_secret_not_found_on_404(self, monkeypatch):
         monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
 
-        # Simulate a 404 response from aiohttp
+        # Simulate a 404 response via the pooled client's tracked_request() (#13134)
         resp_mock = AsyncMock()
         resp_mock.status = 404
         resp_mock.ok = False
-        resp_mock.__aenter__ = AsyncMock(return_value=resp_mock)
-        resp_mock.__aexit__ = AsyncMock(return_value=False)
 
-        session_mock = AsyncMock()
-        session_mock.request = MagicMock(return_value=resp_mock)
-        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
-        session_mock.__aexit__ = AsyncMock(return_value=False)
-
-        with patch.object(
-            sys.modules["aiohttp"],
-            "ClientSession",
-            return_value=session_mock,
-        ):
+        with patch.object(_vault_client_mod, "get_http_client", return_value=_fake_http_client(resp_mock)):
             with pytest.raises(_vault_client_mod.VaultSecretNotFound):
                 await _vault_client_mod._request("GET", "/api/v2/secrets/system/some-id")
 
@@ -205,15 +213,8 @@ class TestUnifiedVaultClientConfig:
         resp_mock.status = 500
         resp_mock.ok = False
         resp_mock.text = AsyncMock(return_value="internal error")
-        resp_mock.__aenter__ = AsyncMock(return_value=resp_mock)
-        resp_mock.__aexit__ = AsyncMock(return_value=False)
 
-        session_mock = AsyncMock()
-        session_mock.request = MagicMock(return_value=resp_mock)
-        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
-        session_mock.__aexit__ = AsyncMock(return_value=False)
-
-        with patch.object(sys.modules["aiohttp"], "ClientSession", return_value=session_mock):
+        with patch.object(_vault_client_mod, "get_http_client", return_value=_fake_http_client(resp_mock)):
             with pytest.raises(_vault_client_mod.VaultClientError):
                 await _vault_client_mod._request("GET", "/api/v2/secrets/system/some-id")
 

--- a/autobot-slm-backend/user_management/services/vault_client.py
+++ b/autobot-slm-backend/user_management/services/vault_client.py
@@ -37,7 +37,7 @@ from typing import Any
 
 import aiohttp
 
-from autobot_shared.http_client import sign_request
+from autobot_shared.http_client import get_http_client, sign_request
 
 logger = logging.getLogger(__name__)
 
@@ -105,21 +105,27 @@ def _auth_headers(method: str, path: str) -> dict[str, str]:
 
 
 async def _request(method: str, path: str, **kwargs: Any) -> Any:
-    """Issue one authenticated HTTP request; map status codes to exceptions."""
+    """Issue one authenticated HTTP request; map status codes to exceptions.
+
+    Routed through the shared pooled client (#13134) so vault calls share the
+    same connection pool / resource-exhaustion guard as the rest of the SLM
+    backend, instead of opening a new TCP connection per call. Auth headers
+    (X-Internal-API-Key / HMAC X-Service-*) are unchanged — forwarded as a
+    per-request kwarg exactly as before.
+    """
     _check_configured()
     url = f"{_BACKEND_BASE_URL}{path}"
     headers = _auth_headers(method, path)
     timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_SECONDS)
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        async with session.request(method, url, headers=headers, **kwargs) as resp:
-            if resp.status == 404:
-                raise VaultSecretNotFound(f"secret not found at {path}")
-            if resp.status == 204:
-                return None
-            if not resp.ok:
-                body = await resp.text()
-                raise VaultClientError(f"vault API {method} {path} returned {resp.status}: {body[:200]}")
-            return await resp.json()
+    async with get_http_client().tracked_request(method, url, headers=headers, timeout=timeout, **kwargs) as resp:
+        if resp.status == 404:
+            raise VaultSecretNotFound(f"secret not found at {path}")
+        if resp.status == 204:
+            return None
+        if not resp.ok:
+            body = await resp.text()
+            raise VaultClientError(f"vault API {method} {path} returned {resp.status}: {body[:200]}")
+        return await resp.json()
 
 
 async def vault_create(name: str, secret_type: str, value: str) -> dict[str, Any]:


### PR DESCRIPTION
## Thinking Path

`#12979` converted ~120 raw `aiohttp.ClientSession` sites in `autobot-backend` onto the shared `autobot_shared/http_client.py` singleton. `#13134` asked for the 4 equivalent sites in the SLM control-plane backend to follow the same pattern, listing `vault_client.py`, `a2a_card_fetcher.py` (x2 call sites), `reconciler.py`, and `retry_mechanism.py` (shared module, double blast radius).

Per the issue's PHASE 1 instruction, I re-measured every site with `file:line` before converting anything, since prior batches found the issue's line numbers stale.

**Per-site audit (classify shape + reasoning):**

| Site | Shape | Why |
|---|---|---|
| `vault_client.py::_request` (was L107-122, now L107-131) | `tracked_request()` | Inspects `.status` (404/204) and reads `.text()` on the error path before raising — not JSON-only, not a returned/long-lived session. |
| `a2a_card_fetcher.py::_fetch_one` (was L40-65) | `tracked_request()` | Inspects `.status == 200` to decide `.json(content_type=None)` vs `None` sentinel. |
| `a2a_card_fetcher.py::_fetch_external_agent_card` (was L153-170) | `tracked_request()` | Same shape as `_fetch_one` — a second, previously undercounted call site in the same file (the issue's `:155` line pointed at only one of the two). |
| `reconciler.py::_http_health_check` (was L1420-1440) | `tracked_request()` | Inspects `.status < 400` to return a `"healthy"`/`"unhealthy"` sentinel — same shape as `autobot-backend/api/service_monitor.py::_check_http_health`, the established #12979 precedent for exactly this pattern. |
| `retry_mechanism.py::retry_network_operation` (issue said L508-521, actual L506-526) | **not an actual site — no change** | Re-audited: this function only does `import aiohttp` to reference `aiohttp.ClientError` / `aiohttp.ServerTimeoutError` in a `retryable_exceptions` tuple. It never constructs a `ClientSession` — it's a generic retry wrapper around a caller-supplied `func`, not an HTTP client itself. The issue's own line numbers pointed at the import + exception tuple, not a session construction; there is nothing here to route through `http_client.py`. Confirmed via `git grep -n "ClientSession"` on the file (zero hits) and by reading `autobot-backend/retry_mechanism.py`, a pure re-export shim confirming there's only ever the one shared implementation. **No blast-radius risk realized — nothing was touched.** |

**Carve-outs:** none of the 3 real sites qualify for RAW per the issue's carve-out list (no returned/long-lived session, no SSRF-pinned `connector=`, no WebSocket). Each site's custom `ssl=`/`timeout=` is a per-request kwarg, not connector-level config, so it forwards through `tracked_request()` unchanged — consistent with the issue's explicit note that a custom `timeout=`/`ssl=False` is NOT a carve-out.

**`vault_client.py` special care:** the `X-Internal-API-Key` / HMAC `X-Service-*` auth headers are built by the pre-existing `_auth_headers()` and passed through untouched as a `headers=` kwarg to `tracked_request()` — the credential-selection logic (`AUTOBOT_INTERNAL_API_KEY` denylisted from vault migration per #13128) is not touched by this change; only *how* the request is transported changed.

## What Changed

- `autobot-slm-backend/user_management/services/vault_client.py` — `_request()` now uses `get_http_client().tracked_request(...)` instead of opening its own `aiohttp.ClientSession` per call.
- `autobot-slm-backend/services/a2a_card_fetcher.py` — both `_fetch_one()` and `_fetch_external_agent_card()` converted (2 sites, not 1 — the issue named only `:155`).
- `autobot-slm-backend/services/reconciler.py` — `_http_health_check()` converted, mirroring `autobot-backend/api/service_monitor.py`'s precedent.
- `autobot_shared/retry_mechanism.py` — **untouched**; confirmed not an actual raw-session site (see audit above).
- `autobot-slm-backend/tests/services/test_sso_vault_client.py` — updated: the file pre-stubs `autobot_shared.http_client` in `sys.modules` and directly patched `aiohttp.ClientSession` in `_request()`'s two error-path tests. Added `get_http_client` to the module stub and replaced the `ClientSession` mock with a `tracked_request()`-shaped async-context-manager mock so the two tests exercise the new code path instead of silently no-op'ing against a session type `_request()` no longer constructs.

**Note on the raw-`ClientSession` ceiling guard:** `autobot-backend/tests/test_raw_client_session_ceiling_12992.py` only walks `autobot-backend/` — it neither protects nor blocks SLM-backend changes and was not touched.

**Adjacent, out of scope (not filed — for triage):** `git grep` on `autobot-slm-backend` for `aiohttp.ClientSession(` turns up several sites the issue did NOT name: `slm/agent/agent.py:461` (+ its ansible-synced copy), `scripts/remove_orphaned_node.py:51,63,74`, `monitoring/performance_monitor.py:303`, `monitoring/performance_benchmark.py:193,667`. Left alone per the issue's explicit 4-site scope; flagging here per the filing-policy note ("anything adjacent but not independently actionable goes in the report") rather than opening a new issue.

## Verification

Static only, per the execution constraint (no backend/SLM backend/pytest run locally):
- `python3 -m py_compile` on all 4 touched files — pass.
- `python3 -m flake8 --config=.flake8` (repo config, matches CI) — 0 findings.
- `python3 -m black --check --line-length=120` — unchanged.
- `python3 -m isort --check-only --settings-path=.` — unchanged.
- `python3 -m bandit -c .bandit -r <4 files> --severity-level medium --confidence-level medium` — 0 issues.
- Traced `test_sso_vault_client.py`'s two `_request()` tests by hand against the new `tracked_request()` mock shape to confirm the 404→`VaultSecretNotFound` and 500→`VaultClientError` assertions still hold.
- Confirmed `aiohttp` is present in `requirements-ci/networking.txt` (pulled in by `requirements-ci.txt`), so the CI `Unit&Integration` job and `startup-import-smoke` both have the real dependency available — the top-level `from autobot_shared.http_client import get_http_client` import added to `reconciler.py` / `a2a_card_fetcher.py` will resolve for real there (unlike `test_sso_vault_client.py`, which explicitly stubs the module and needed the fix above).
- Confirmed (via `git grep`) `retry_mechanism.py` has zero `ClientSession` references — the "shared, double blast radius" module was safe to leave untouched because there was nothing in it to convert.

**Unverified pending CI:** no pytest run was performed locally (execution constraint). `startup-import-smoke` (350 modules, required) is the real check that these imports resolve; `Unit&Integration` is the real check that `test_sso_vault_client.py`'s updated mocks and the two `a2a_card_fetcher_test.py`/`reconciler_check_node_health_test.py` files (which don't stub `http_client` and now transitively import real `aiohttp`) still pass, and that no event-loop-binding issue arises from `a2a_card_fetcher_test.py::TestFetchOne` exercising the process-wide `HTTPClientManager` singleton against unreachable test-net addresses under `pytest-xdist`.

## Model Used

Sonnet 5
