### PR TITLE
ci: run the backend suite on PRs targeting Dev_new_gui (#10691)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ on:
   push:
     branches: [ main, Dev_new_gui ]
   pull_request:
-    branches: [ main ]
+    # Dev_new_gui is the integration branch every PR targets; without it the
+    # backend suite below only ran post-merge on the push trigger, so backend
+    # regressions were only discovered once already on the shared branch
+    # (#10691). main kept for promotion PRs.
+    branches: [ main, Dev_new_gui ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Step 1 of 3 on #10691. Deliberately **not** `Closes #10691` — the issue stays open for steps 2 (re-establish the baseline from CI runs) and 3 (owner's call on promoting to a required check).

## Thinking Path

The earlier evidence on #10691 claimed no backend test ran in CI at all. The owner corrected that: `.github/workflows/ci.yml` ("AutoBot CI/CD Pipeline") already has a `security-tests` job that runs the full backend suite behind a 70% coverage gate, already carrying #13084's per-backend split invocation. The job exists and works.

The actual defect is trigger scoping. `ci.yml` was triggered by `push` on `[main, Dev_new_gui]` but by `pull_request` on `[main]` only. Every PR in this repository targets `Dev_new_gui`, so the backend suite never ran on a pull request — only *after* merge, on the push trigger. A backend regression was therefore only discovered once it was already on the shared integration branch, and no PR could be blocked by it.

Confirmed against `origin/Dev_new_gui`: the last 30 CI/CD Pipeline runs are **all** `event=push` on `Dev_new_gui`. Zero `pull_request` runs.

Two consequences made this worse than "just late":

- The `concurrency` group is `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Every push to `Dev_new_gui` shares one ref, so a merge landing while the previous run is still going cancels it. In the last 30 runs, 24 are `cancelled` — and since the suite step alone takes 21 min to 1 h 43 min, most merges cancel the previous merge's suite before it finishes. The post-merge signal was not merely late, it was mostly never produced at all.
- `deployment-check` is gated on `github.ref == 'refs/heads/main' || 'refs/heads/Dev_new_gui'`. On a `pull_request` event `github.ref` is `refs/pull/N/merge`, so it stays skipped on PRs. No deployment-shaped work is added by this change.

The fix is the one-line trigger addition. Everything the suite needs already exists.

## What Changed

`.github/workflows/ci.yml` lines 8-9 — `Dev_new_gui` added to the `pull_request` branches list, with a comment recording why.

```diff
   pull_request:
-    branches: [ main ]
+    # Dev_new_gui is the integration branch every PR targets; without it the
+    # backend suite below only ran post-merge on the push trigger, so backend
+    # regressions were only discovered once already on the shared branch
+    # (#10691). main kept for promotion PRs.
+    branches: [ main, Dev_new_gui ]
```

That is the entire diff — one file, 5 insertions, 1 deletion.

**Deliberately out of scope:**

- **Not added to branch protection.** `security-tests` is not in the required-check set and this PR does not put it there. That is the owner's call and step 3. This PR makes the job *run*; it does not make it *block*.
- **Marker exclusions, the 70% coverage threshold and the #13084 per-backend split are untouched.** All three are deliberate.
- **No test was "fixed" to make the suite green.** The point of this change is to surface the true baseline on PRs. **A red advisory job is the expected and desired outcome here**, and is strictly better than the current silence, because today nothing reports at all.

## Verification

**YAML parses, and the triggers are what was intended:**

```
$ python -c "import yaml, json; d = yaml.safe_load(open('.github/workflows/ci.yml')); \
             print('jobs:', list(d['jobs'])); print('on:', json.dumps(d[True]))"
jobs: ['changes', 'security-tests', 'frontend-tests', 'deployment-check', 'notify']
on: {"push": {"branches": ["main", "Dev_new_gui"]}, "pull_request": {"branches": ["main", "Dev_new_gui"]}}
```

**The diff is exactly the trigger change and nothing else** — `git diff` shows one hunk in one file (reproduced in full above); `git diff --stat` is `1 file changed, 5 insertions(+), 1 deletion(-)`.

**The `python` path filter gates this correctly, and needed no widening.** `security-tests` runs only when `needs.changes.outputs.python == 'true'`, whose filter is `**/*.py`, `**/requirements*.txt`, `requirements-ci/**`, `pyproject.toml`, `autobot_shared/pyproject.toml`, `.github/workflows/ci.yml`. `**/*.py` is repo-wide, so a PR touching only the SLM backend or only the shared package *does* satisfy it. The filter is broad, not narrow.

**This PR is itself the first test of the change.** `.github/workflows/ci.yml` is in the `python` filter list, and for `pull_request` events GitHub evaluates the workflow file from the PR's merge ref — so the new trigger applies to this PR, and `security-tests` should appear on it. It is expected to be **red**, reporting the real baseline.

**What is unverified until CI runs.** The job's actual behaviour on a `pull_request` event has not been observed — it never has been, in this repository's history. Per #13090 the suite cannot be run locally as the dev user, so YAML validity plus a static reading of the trigger semantics are the whole of the local evidence. Whether the job starts, and what it reports, is settled only by this PR's own checks.

**Expected wall-clock, from real CI data** (the last two `security-tests` runs that reached the test step; both on `ubuntu-latest` — this workflow does **not** use the self-hosted singleton runner):

| run | unit-test step | pytest summary (first invocation) |
|---|---|---|
| 2026-07-31 20:21 | 21 min 06 s | 881 failed, 18312 passed, 2346 skipped, 76 errors in 1254.84 s |
| 2026-07-31 11:15 | 1 h 43 m 34 s | 870 failed, 18313 passed, 2346 skipped, 76 errors in 6201.93 s |

Near-identical test counts, ~5x wall-clock spread — so runtime is not yet predictable. Both failed inside the *first* pytest invocation, which under the default `bash -e` shell aborts the step before the `autobot-slm-backend` invocation and the coverage gate are reached. Those counts corroborate the post-#13109 figures (874 failed / 76 errors) from CI, which is now the only sanctioned source.

## Model Used

claude-opus-5
