### PR TITLE
fix(tests): repoint stale global_config_manager/config_file/drift-checker test rot (#13112, #13087, #13114)

### DIFF
--- a/autobot-backend/performance_benchmarks_test.py
+++ b/autobot-backend/performance_benchmarks_test.py
@@ -183,23 +183,14 @@ class TestKnowledgeBasePerformance:
         """Set up test environment"""
         self.benchmark = PerformanceBenchmark()
 
-        # Mock configuration for testing
-        with patch("knowledge_base.global_config_manager") as mock_config:
-            mock_config.get_redis_config.return_value = {"enabled": False}  # Use in-memory for testing
-            mock_config.get_llm_config.return_value = {
-                "unified": {
-                    "embedding": {
-                        "provider": "ollama",
-                        "providers": {
-                            "ollama": {
-                                "host": "http://localhost:11434",  # canonical: ignore py-hardcoded-url — test fixture/mock URL, not an executable default
-                                "selected_model": "nomic-embed-text",
-                            }
-                        },
-                    }
-                }
-            }
-            self.kb = KnowledgeBase()
+        # #13112: `KnowledgeBase()` takes no config args and no longer exposes
+        # a `global_config_manager` symbol to patch. `__init__` reads from the
+        # module-level `knowledge.base.config` singleton via plain
+        # `config.get("dotted.key", default)` calls (never `get_redis_config`/
+        # `get_llm_config`, which this fixture used to mock) with safe
+        # defaults, so bare construction is sufficient — same pattern already
+        # exercised by `dependency_injection_test.py::test_knowledge_base_backward_compatibility`.
+        self.kb = KnowledgeBase()
 
     async def test_knowledge_base_search_performance(self):
         """Benchmark knowledge base search operations"""

--- a/autobot-backend/security/config_security_test.py
+++ b/autobot-backend/security/config_security_test.py
@@ -7,11 +7,13 @@ Tests security aspects of configuration loading, environment variables, and sens
 
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from autobot_shared.logging_manager import get_logger
+from config.loader import load_yaml_config
 from config.manager import ConfigManager as ConfigManager
 
 
@@ -20,7 +22,17 @@ class TestConfigurationSecurity:
 
     def test_config_file_path_traversal_protection(self):
         """Test protection against path traversal attacks in config files"""
-        # Test various path traversal attempts
+        # #13087: ConfigManager no longer accepts config_file=<path> — its
+        # constructor only takes config_dir (config/manager.py:72-76) and
+        # always loads the fixed filename "config.yaml" from it, so an
+        # attacker-controlled *file* path can no longer even reach the
+        # constructor. The layer that actually handles arbitrary/malicious
+        # file paths safely today is config.loader.load_yaml_config(): it
+        # never executes anything and falls back to defaults for a
+        # missing/unreadable/invalid path (loader.py:75-95). No production
+        # caller ever passes a variable config_dir either (git grep confirms
+        # only the "config" default is used) so this is the real
+        # attack-relevant unit to exercise.
         malicious_paths = [
             "../../../etc/passwd",
             "..\\..\\..\\windows\\system32\\config\\sam",
@@ -31,11 +43,13 @@ class TestConfigurationSecurity:
 
         for malicious_path in malicious_paths:
             # Should handle malicious paths gracefully
-            config_manager = ConfigManager(config_file=malicious_path)
+            result = load_yaml_config(Path(malicious_path))
 
-            # Should fall back to default config if file doesn't exist or is invalid
-            default_llm = config_manager.get("llm.orchestrator_llm")
-            assert default_llm == "ollama"  # Should use default, not load malicious file
+            # Should fall back to default config, not load/execute the
+            # malicious path. LLM defaults live under backend.llm.local
+            # since the #763 SSOT migration (config/defaults.py:36-48) —
+            # there is no top-level "llm" key.
+            assert result["backend"]["llm"]["local"]["provider"] == "ollama"
 
     def test_environment_variable_injection_protection(self):
         """Test protection against environment variable injection"""
@@ -89,13 +103,16 @@ args: [["echo", "exploit"]]
                 malicious_file = f.name
 
             try:
-                # Should handle malicious YAML safely
-                config_manager = ConfigManager(config_file=malicious_file)
+                # #13087: exercise the actual safety layer directly.
+                # ConfigManager no longer accepts config_file=<path> nor
+                # exposes get_all_config(); config.loader.load_yaml_config()
+                # uses yaml.safe_load() (refuses !!python/object tags) and
+                # catches every exception, falling back to defaults.
+                result = load_yaml_config(Path(malicious_file))
 
                 # Should fall back to defaults, not execute malicious code
-                default_config = config_manager.get_all_config()
-                assert "llm" in default_config  # Should have default config
-                assert default_config["llm"]["orchestrator_llm"] == "ollama"
+                assert "backend" in result  # Should have default config
+                assert result["backend"]["llm"]["local"]["provider"] == "ollama"
 
             finally:
                 os.unlink(malicious_file)
@@ -152,25 +169,31 @@ args: [["echo", "exploit"]]
         """Test handling of config files with various permissions"""
         import stat
 
-        # Create a config file with restricted permissions
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        # #13087: ConfigManager only takes config_dir + a fixed "config.yaml"
+        # filename (config/manager.py:72-76); write the file under that
+        # exact name inside an isolated temp directory. LLM defaults live
+        # under backend.llm.local since the #763 SSOT migration.
+        tmp_dir = tempfile.mkdtemp()
+        restricted_file = os.path.join(tmp_dir, "config.yaml")
+        with open(restricted_file, "w", encoding="utf-8") as f:
             f.write("""
-llm:
-  orchestrator_llm: "test_model"
+backend:
+  llm:
+    local:
+      provider: "test_provider"
 """)
-            restricted_file = f.name
 
         try:
             # Make file readable only by owner
             os.chmod(restricted_file, stat.S_IRUSR)
 
             # Should handle restricted permissions gracefully
-            config_manager = ConfigManager(config_file=restricted_file)
+            config_manager = ConfigManager(config_dir=tmp_dir)
 
             # Should either load the file or fall back to defaults
-            orchestrator_llm = config_manager.get("llm.orchestrator_llm")
-            assert orchestrator_llm in [
-                "test_model",
+            provider = config_manager.get_nested("backend.llm.local.provider")
+            assert provider in [
+                "test_provider",
                 "ollama",
             ]  # Either loaded or default
 
@@ -178,6 +201,7 @@ llm:
             # Clean up - need to restore permissions to delete
             os.chmod(restricted_file, stat.S_IRUSR | stat.S_IWUSR)
             os.unlink(restricted_file)
+            os.rmdir(tmp_dir)
 
     def test_environment_variable_name_sanitization(self):
         """Test that environment variable names are properly sanitized"""
@@ -210,20 +234,22 @@ defaults: &defaults
 production:
   <<: *defaults
   safe_setting: "production_value"
-
-llm:
-  orchestrator_llm: *defaults
 """
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        # #13087: ConfigManager only takes config_dir + fixed "config.yaml".
+        tmp_dir = tempfile.mkdtemp()
+        anchor_file = os.path.join(tmp_dir, "config.yaml")
+        with open(anchor_file, "w", encoding="utf-8") as f:
             f.write(yaml_with_anchors)
-            anchor_file = f.name
 
         try:
-            config_manager = ConfigManager(config_file=anchor_file)
+            config_manager = ConfigManager(config_dir=tmp_dir)
 
-            # Should handle YAML anchors without security issues
-            production_config = config_manager.get_section("production")
+            # Should handle YAML anchors without security issues.
+            # get_config_section() (config/service_config.py:189, a plain
+            # get_nested(section, {}) delegate) is the current equivalent of
+            # the removed get_section().
+            production_config = config_manager.get_config_section("production")
 
             # Values should be loaded but not cause security issues
             if production_config:
@@ -235,6 +261,7 @@ llm:
 
         finally:
             os.unlink(anchor_file)
+            os.rmdir(tmp_dir)
 
     def test_config_size_limits(self):
         """Test handling of excessively large configuration files"""
@@ -243,20 +270,24 @@ llm:
         for i in range(10000):
             large_config += f"  key_{i}: 'value_{i}'\n"
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        # #13087: ConfigManager only takes config_dir + fixed "config.yaml".
+        tmp_dir = tempfile.mkdtemp()
+        large_file = os.path.join(tmp_dir, "config.yaml")
+        with open(large_file, "w", encoding="utf-8") as f:
             f.write(large_config)
-            large_file = f.name
 
         try:
             # Should handle large files without crashing
-            config_manager = ConfigManager(config_file=large_file)
+            config_manager = ConfigManager(config_dir=tmp_dir)
 
-            # Should load successfully or fall back to defaults
-            orchestrator_llm = config_manager.get("llm.orchestrator_llm")
-            assert isinstance(orchestrator_llm, str)
+            # Should load successfully or fall back to defaults. LLM
+            # defaults live under backend.llm.local (#763 SSOT migration).
+            provider = config_manager.get_nested("backend.llm.local.provider")
+            assert isinstance(provider, str)
 
         finally:
             os.unlink(large_file)
+            os.rmdir(tmp_dir)
 
     def test_config_circular_reference_protection(self):
         """Test protection against circular references in config"""
@@ -270,22 +301,29 @@ section_b:
     circular_ref: *ref_a
 """
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        # #13087: ConfigManager only takes config_dir + fixed "config.yaml".
+        # This YAML is actually invalid (an alias referencing an anchor not
+        # yet defined at that point), so yaml.safe_load() raises inside
+        # load_yaml_config(), which catches it and falls back to defaults
+        # rather than propagating or recursing.
+        tmp_dir = tempfile.mkdtemp()
+        circular_file = os.path.join(tmp_dir, "config.yaml")
+        with open(circular_file, "w", encoding="utf-8") as f:
             f.write(circular_yaml)
-            circular_file = f.name
 
         try:
-            # Should handle circular references gracefully
-            config_manager = ConfigManager(config_file=circular_file)
+            # Should handle circular/forward-referencing anchors gracefully
+            config_manager = ConfigManager(config_dir=tmp_dir)
 
             # Should not cause infinite recursion
-            config_manager.get_section("section_a")
+            config_manager.get_config_section("section_a")
 
-            # Should either load with limited depth or fall back to defaults
-            assert isinstance(config_manager.get_all_config(), dict)
+            # Should fall back to sane defaults, not get stuck/corrupted
+            assert config_manager.get_nested("backend.llm.local.provider") == "ollama"
 
         finally:
             os.unlink(circular_file)
+            os.rmdir(tmp_dir)
 
     def test_environment_variable_type_confusion(self):
         """Test protection against type confusion in environment variables"""
@@ -318,40 +356,40 @@ section_b:
 
     def test_config_backup_and_recovery_security(self):
         """Test security of config backup and recovery operations"""
-        config_manager = ConfigManager()
-
-        # Set some sensitive configuration
-        config_manager.set("sensitive.api_key", "very_secret_key")
-        config_manager.set("sensitive.database_password", "super_secret_db_pass")
-
-        # Test saving config
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            backup_file = f.name
+        # #13087: ConfigManager exposes no save(path)/get_section(); the
+        # current persistence primitive is save_settings(), which always
+        # writes <config_dir>/settings.json (config/sync_ops.py:77-92).
+        # Round-trip through an isolated config_dir instead of an arbitrary
+        # backup file path.
+        tmp_dir = tempfile.mkdtemp()
+        settings_file = os.path.join(tmp_dir, "settings.json")
 
         try:
-            # Save config
-            config_manager.save(backup_file)
+            config_manager = ConfigManager(config_dir=tmp_dir)
+
+            # Set some sensitive configuration
+            config_manager.set("sensitive.api_key", "very_secret_key")
+            config_manager.set("sensitive.database_password", "super_secret_db_pass")
+
+            # Persist it
+            config_manager.save_settings()
 
             # Verify file was created
-            assert os.path.exists(backup_file)
+            assert os.path.exists(settings_file)
+            assert os.path.isfile(settings_file)
 
-            # Check file permissions (should not be world-readable for sensitive data)
-            file_stat = os.stat(backup_file)
-            file_stat.st_mode & 0o777
-
-            # File should exist and be readable
-            assert os.path.isfile(backup_file)
-
-            # Create new config manager from backup
-            backup_config_manager = ConfigManager(config_file=backup_file)
+            # Create a fresh config manager reading the same directory —
+            # simulates "recovery" from the persisted state
+            backup_config_manager = ConfigManager(config_dir=tmp_dir)
 
             # Verify sensitive data was preserved
             assert backup_config_manager.get("sensitive.api_key") == "very_secret_key"
             assert backup_config_manager.get("sensitive.database_password") == "super_secret_db_pass"
 
         finally:
-            if os.path.exists(backup_file):
-                os.unlink(backup_file)
+            if os.path.exists(settings_file):
+                os.unlink(settings_file)
+            os.rmdir(tmp_dir)
 
 
 class TestSecretsHandlingInConfig:

--- a/autobot-backend/security/security_edge_cases_test.py
+++ b/autobot-backend/security/security_edge_cases_test.py
@@ -57,8 +57,8 @@ class TestSecurityEdgeCases:
             },
         }
 
-        with patch("security_layer.global_config_manager") as mock_config:
-            mock_config.get.return_value = self.security_config
+        with patch("security_layer.get_config_manager") as mock_get_config_manager:
+            mock_get_config_manager.return_value.get.return_value = self.security_config
             self.security = SecurityLayer()
 
         # #7376: stub `command_executor.run_shell_command` so tests cannot
@@ -372,11 +372,11 @@ class TestSecurityEdgeCases:
         ]
 
         for bypass_config in bypass_attempts:
-            with patch("security_layer.global_config_manager") as mock_config:
+            with patch("security_layer.get_config_manager") as mock_get_config_manager:
                 # Simulate config change during runtime
                 modified_config = original_config.copy()
                 modified_config.update(bypass_config)
-                mock_config.get.return_value = modified_config
+                mock_get_config_manager.return_value.get.return_value = modified_config
 
                 # Create new security instance
                 new_security = SecurityLayer()
@@ -557,8 +557,8 @@ class TestSecurityBoundaryConditions:
             "audit_log_file": self.temp_audit_file.name,
         }
 
-        with patch("security_layer.global_config_manager") as mock_config:
-            mock_config.get.return_value = self.minimal_config
+        with patch("security_layer.get_config_manager") as mock_get_config_manager:
+            mock_get_config_manager.return_value.get.return_value = self.minimal_config
             self.security = SecurityLayer()
 
     def teardown_method(self):

--- a/autobot-backend/security/security_integration_test.py
+++ b/autobot-backend/security/security_integration_test.py
@@ -34,8 +34,8 @@ def temp_audit_file():
 @pytest.fixture
 def security_layer(temp_audit_file):
     """Create enhanced security layer for testing"""
-    with patch("security_layer.global_config_manager") as mock_config:
-        mock_config.get.return_value = {
+    with patch("security_layer.get_config_manager") as mock_get_config_manager:
+        mock_get_config_manager.return_value.get.return_value = {
             "enable_auth": False,
             "enable_command_security": True,
             "audit_log_file": temp_audit_file,
@@ -240,8 +240,8 @@ class TestDockerSandboxIntegration:
 
     def test_docker_sandbox_configuration(self):
         """Test Docker sandbox configuration in security system"""
-        with patch("security_layer.global_config_manager") as mock_config:
-            mock_config.get.return_value = {
+        with patch("security_layer.get_config_manager") as mock_get_config_manager:
+            mock_get_config_manager.return_value.get.return_value = {
                 "enable_command_security": True,
                 "use_docker_sandbox": True,
             }

--- a/autobot-slm-backend/services/drift_checker_test.py
+++ b/autobot-slm-backend/services/drift_checker_test.py
@@ -434,10 +434,14 @@ class TestGetDefaultDeployedDir:
         assert result == str(Path(custom_root) / "autobot-slm-backend")
 
     def test_component_appended(self, tmp_path):
-        """The component name is appended as a sub-directory of the root."""
+        """The component name is appended as a sub-directory of the root,
+        except for the #12450 nonstandard-path components which are
+        deliberately excluded from this generic convention — see
+        _NONSTANDARD_COMPONENT_PATHS and
+        TestNonstandardComponentPathMap.test_allowed_components_with_overrides_are_the_two_verified_exceptions."""
         root = str(tmp_path)
         with patch.dict(os.environ, {"SLM_DEPLOYED_ROOT": root}):
-            for component in ALLOWED_COMPONENTS:
+            for component in ALLOWED_COMPONENTS - set(_NONSTANDARD_COMPONENT_PATHS):
                 result = get_default_deployed_dir(component)
                 assert result == str(Path(root) / component)
 
@@ -488,6 +492,13 @@ class TestAllowedComponents:
             "autobot-frontend",
             # #10248: the shared library is its own syncable component.
             "autobot_shared",
+            # #12450 phase 2: promoted from EXTRA_VISIBILITY_COMPONENTS once
+            # each had a verified post-sync definition in api/code_sync.py
+            # (_WORKER_COMPONENTS / _WORKER_COMPONENT_PIP / _COMPONENT_SERVICES).
+            "autobot-ai-stack",
+            "autobot-npu-worker",
+            "autobot-browser-worker",
+            "autobot-slm-agent",
         }
         assert expected == set(ALLOWED_COMPONENTS)
 
@@ -830,16 +841,18 @@ class TestComputeDriftPerComponent:
 
 class TestExtraVisibilityComponents:
     """VISIBILITY_COMPONENTS extends drift REPORTING to components with no
-    resolve/restart wiring — ai-stack, npu-worker, browser-worker, slm-agent,
-    plugins. Must never be merged into ALLOWED_COMPONENTS (the resolve gate)."""
+    resolve/restart wiring. #12450 phase 2 promoted ai-stack, npu-worker,
+    browser-worker, and slm-agent out of this set into ALLOWED_COMPONENTS
+    once each had a verified post-sync definition — only `plugins` (no
+    single canonical deployed target, see drift_checker.py:116-119) and
+    `autobot-tts-worker` (templated deploy, not a 1:1 sync, see
+    drift_checker.py:106-112) remain here. Must never be merged into
+    ALLOWED_COMPONENTS (the resolve gate)."""
 
-    def test_extra_components_are_exactly_the_expected_five(self):
+    def test_extra_components_are_exactly_the_expected_two(self):
         assert set(EXTRA_VISIBILITY_COMPONENTS) == {
-            "autobot-ai-stack",
-            "autobot-npu-worker",
-            "autobot-browser-worker",
-            "autobot-slm-agent",
             "plugins",
+            "autobot-tts-worker",
         }
 
     def test_extra_components_disjoint_from_resolve_allowlist(self):
@@ -921,11 +934,19 @@ class TestNonstandardComponentPathMap:
             assert get_default_deployed_dir("autobot-npu-worker") == str(tmp_path / "autobot-npu-worker")
             assert get_default_deployed_dir("autobot-browser-worker") == str(tmp_path / "autobot-browser-worker")
 
-    def test_allowed_components_are_unaffected_by_the_override_map(self):
-        """The original 5 resolve-capable components must have no entry in
-        the override map — their existing standard-path behavior (relied on
-        by /drift/resolve) must not change."""
-        assert _NONSTANDARD_COMPONENT_PATHS.keys().isdisjoint(ALLOWED_COMPONENTS)
+    def test_allowed_components_with_overrides_are_the_two_verified_exceptions(self):
+        """#12450 phase 2 intentionally violates the original "no allowed
+        component needs a path override" invariant for exactly two
+        components — autobot-ai-stack and autobot-slm-agent, both promoted
+        into ALLOWED_COMPONENTS *and* path-overridden (see the
+        test_ai_stack_*/test_slm_agent_* cases above for the verified
+        ansible task references each override traces to). Asserting the
+        overlap is EXACTLY those two still catches an unverified third
+        override silently added to both sets."""
+        assert set(_NONSTANDARD_COMPONENT_PATHS) & ALLOWED_COMPONENTS == {
+            "autobot-ai-stack",
+            "autobot-slm-agent",
+        }
 
     def test_compute_drift_reports_drift_for_ai_stack_style_deployed_path(self, tmp_path):
         """End-to-end: a mocked ai-stack-shaped deployed dir (flat, post


### PR DESCRIPTION
## Thinking Path

All three issues were re-verified against the current code before touching
anything (task Phase 1). All three confirmed as bucket C test rot — the
code is right, the tests were stale — with no production defect hiding
behind any of them. #13087 turned out to need substantially more than its
own evidence described (see below); #13112 and #13114 matched their filed
evidence closely.

- **#13112** — confirmed `git grep -n "global_config_manager"
  autobot-backend/security_layer.py autobot-backend/knowledge_base.py`
  returns nothing. `security_layer.py:90-92` calls
  `get_config_manager().get("security_config", {})` — a function call, not
  a patchable module attribute. `knowledge_base.py` is now a pure re-export
  shim (`from knowledge import KnowledgeBase, ...`); the real
  `KnowledgeBase.__init__(self)` (`knowledge/base.py:125`) takes no config
  args at all and reads a module-level `config = get_config_manager()`
  singleton via plain `.get(dotted.key, default)` calls — it never calls
  `get_redis_config()`/`get_llm_config()`, which is what the fixture's mock
  return values were shaped for.
- **#13087** — confirmed `ConfigManager.__init__` (`config/manager.py:72-76`)
  no longer takes `config_file`. But fixing only the 7 kwarg call sites
  would **not** have made those 7 tests pass: each also called
  `get_all_config()`, `save(path)`, or `get_section()` — none of which
  exist on `ConfigManager` anymore (`git grep` across the whole repo found
  zero production callers of any of the three, confirming this is dead
  test-only surface, not a regression) — or asserted on `"llm.orchestrator_llm"`,
  a flat-dict key that both never existed as a nested path (`.get()` is a
  plain top-level lookup, not `get_nested()`'s dot-path) and, separately,
  moved under `backend.llm.local` in the #763 SSOT migration (already
  documented as a known gotcha in `config_migration_integration_test.py:222-224`).
  The issue's own filed evidence undercounted the true breakage in this
  file — `TestConfigurationSecurity` has 7 tests using the removed kwarg
  (only 2 were cited: lines 34, 93 — "and 5 more in the same class" was
  correct, they just weren't individually enumerated), and each of those 7
  needed its own additional API-shape fix to actually pass.
- **#13114** — corroborated the issue's own hedge ("needs owner
  confirmation") against `api/code_sync.py`: `_WORKER_COMPONENTS`,
  `_WORKER_COMPONENT_PIP`, and `_COMPONENT_SERVICES` all wire the same four
  components (`autobot-ai-stack`, `autobot-npu-worker`,
  `autobot-browser-worker`, `autobot-slm-agent`) with real restart-target
  mappings, confirming `drift_checker.py`'s extensive `#12450`-tracing
  comments reflect the *intended* post-migration state, not a second
  undetected regression.

## What Changed

- `autobot-backend/security/security_integration_test.py`,
  `autobot-backend/security/security_edge_cases_test.py` — repoint the 5
  `patch("security_layer.global_config_manager")` call sites to
  `patch("security_layer.get_config_manager")`, mocking
  `.return_value.get.return_value` instead of `.get.return_value` (matches
  the current `get_config_manager().get("security_config", {})` call
  chain).
- `autobot-backend/performance_benchmarks_test.py` — drop the obsolete
  `patch("knowledge_base.global_config_manager")` in
  `TestKnowledgeBasePerformance.setup_method`; `KnowledgeBase()` already
  constructs safely bare (matching the already-passing
  `dependency_injection_test.py::test_knowledge_base_backward_compatibility`).
- `autobot-backend/security/config_security_test.py` — fixed all 7 methods
  in `TestConfigurationSecurity` that used the removed `config_file=`
  kwarg:
  - `test_config_file_path_traversal_protection` /
    `test_yaml_deserialization_safety` — rewritten to call
    `config.loader.load_yaml_config()` directly (the actual current safety
    layer: `yaml.safe_load()` + catch-all fallback to defaults), since no
    production caller ever passes a variable `config_dir` either, so
    routing through `ConfigManager.__init__`'s `mkdir(parents=True,
    exist_ok=True)` with attacker-controlled directory strings like
    `/etc/shadow` would just exercise unrelated `Path.mkdir()` side effects
    (and could raise `PermissionError`) instead of the property under test.
  - `test_config_file_permissions_handling`,
    `test_config_injection_via_yaml_anchors`, `test_config_size_limits`,
    `test_config_circular_reference_protection` — switched to
    `config_dir=<tmpdir>` with the content written to the fixed
    `config.yaml` filename the constructor requires; `get_section()` calls
    replaced with the live equivalent `get_config_section()`
    (`service_config.py:189`, a plain `get_nested(section, {})` delegate);
    `"llm.orchestrator_llm"` assertions replaced with
    `get_nested("backend.llm.local.provider")`.
  - `test_config_backup_and_recovery_security` — replaced the removed
    `save(path)`/`config_file=path` round-trip with the real persistence
    primitive `save_settings()` (always writes
    `<config_dir>/settings.json`) round-tripped through a second
    `ConfigManager` reading the same `config_dir`.
  - The other 6 methods in this file that call the same removed
    `get_all_config()`/`validate_config()` shape but never used
    `config_file=` are **unrelated pre-existing rot, left untouched** — see
    Verification below.
- `autobot-slm-backend/services/drift_checker_test.py` — updated 4 stale
  invariants to the post-#12450 state: `ALLOWED_COMPONENTS` now includes
  the four promoted worker components;
  `test_extra_components_are_exactly_the_expected_five` renamed to
  `...expected_two` (`EXTRA_VISIBILITY_COMPONENTS` is now `{plugins,
  autobot-tts-worker}`); `test_component_appended` excludes the two
  nonstandard-path components (already covered by dedicated
  `TestNonstandardComponentPathMap` cases);
  `test_allowed_components_are_unaffected_by_the_override_map` renamed and
  rewritten to assert the override/allowlist overlap is *exactly* the two
  verified exceptions (`autobot-ai-stack`, `autobot-slm-agent`) rather than
  empty — preserving the drift-detection intent (an unverified third
  override is still caught) while matching the intentional #12450 state.

## Verification

Execution constraint (#13090): no pytest/backend/Postgres/Redis run locally
— all test execution is CI's job (enabled for PRs by #13174, which this PR
is the first real exercise of).

- `python3 -m py_compile` on all 5 modified files: clean.
- `black --check --line-length=120`, `isort --check-only`, `flake8
  --config=.flake8` on all 5 modified files: clean.
- `git grep` confirmed `global_config_manager` no longer exists in
  `security_layer.py`/`knowledge_base.py`; confirmed zero production
  callers of `ConfigManager.get_all_config()`/`.save()`/`.get_section()`
  anywhere in the repo; confirmed `api/code_sync.py`'s `_WORKER_COMPONENTS`
  wiring for the #13114 corroboration.
- CI's `security-tests` job (backend suite, now real on PRs per #13174)
  is the actual verification for whether these tests pass — baseline from
  two recent post-merge runs is ~870-881 failed / ~18,312 passed / 2,346
  skipped / 76 errors. Failure-count delta will be reported once CI
  completes on this PR.

**Not fixed here (adjacent, out of #13087's scope, found during
investigation):** `TestConfigurationSecurity.test_sensitive_data_exposure_prevention`,
`test_config_validation_against_malicious_values`,
`test_environment_variable_name_sanitization`,
`test_environment_variable_type_confusion`, and
`TestSecretsHandlingInConfig.test_config_serialization_safety` in the same
file call the same removed `get_all_config()`/mismatched
`validate_config()` return shape, or assume arbitrary `AUTOBOT_*` env vars
pass through to `.get()` (they don't — only the fixed `ENV_VAR_MAPPINGS`
allowlist in `config/loader.py` does). None of these used the
`config_file=` kwarg #13087 was filed for, so they were left untouched per
task scope; reported here for the owner to judge whether a follow-up issue
is warranted.

Closes #13112, Closes #13087, Closes #13114

## Model Used

Claude Sonnet 5
