### PR TITLE
fix(tests): asyncio.run() in sync tests + keep TracingService real under conftest real-load (#13113, #13094)

### DIFF
--- a/autobot-backend/api/openai_compat_test.py
+++ b/autobot-backend/api/openai_compat_test.py
@@ -31,6 +31,8 @@ from api import openai_compat
 from autobot_shared.rate_limit import IPRateLimiter
 
 
+# #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+# running before any async test on its worker had no current loop for get_event_loop().
 class TestGetUserAsync:
     """MVA-169: _get_user must be async and await get_current_user."""
 
@@ -49,7 +51,7 @@ class TestGetUserAsync:
                 mock_gcu.assert_awaited_once_with(fake_request)
                 assert result == fake_user
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
 
     def test_get_user_propagates_http_exception(self):
         fake_request = MagicMock()
@@ -64,7 +66,7 @@ class TestGetUserAsync:
                     await openai_compat._get_user(fake_request)
                 assert exc_info.value.status_code == 401
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
 
     def test_get_user_converts_unexpected_exception_to_401(self):
         fake_request = MagicMock()
@@ -80,7 +82,7 @@ class TestGetUserAsync:
                 assert exc_info.value.status_code == 401
                 assert exc_info.value.detail == "Unauthorized"
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
 
 
 class TestOAIRateLimitWiring:

--- a/autobot-backend/code_analysis/src/remediation_loop_test.py
+++ b/autobot-backend/code_analysis/src/remediation_loop_test.py
@@ -220,7 +220,9 @@ class TestRecordDeltaComputation:
             with patch.object(self.mod, "_persist_delta", new=AsyncMock()):
                 return await self.loop.record_delta(before, after)
 
-        return asyncio.get_event_loop().run_until_complete(_go())
+        # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+        # running before any async test on its worker had no current loop for get_event_loop().
+        return asyncio.run(_go())
 
     def test_positive_health_delta(self):
         before = {"health_score": 60.0, "total_findings": 20}

--- a/autobot-backend/llc/tests/test_budget_watchdog.py
+++ b/autobot-backend/llc/tests/test_budget_watchdog.py
@@ -180,4 +180,6 @@ def test_watchdog_start_stop() -> None:
             watchdog.stop()
             assert not watchdog._running
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    asyncio.run(_run())

--- a/autobot-backend/llc/tests/test_liveness_monitor.py
+++ b/autobot-backend/llc/tests/test_liveness_monitor.py
@@ -217,4 +217,6 @@ def test_monitor_start_stop() -> None:
             monitor.stop()
             assert not monitor._running
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    asyncio.run(_run())

--- a/autobot-backend/llc/tests/test_poll_loop_scheduler.py
+++ b/autobot-backend/llc/tests/test_poll_loop_scheduler.py
@@ -16,6 +16,12 @@ from llc.scheduler.base import PollLoopScheduler
 # ---------------------------------------------------------------------------
 
 
+# #13113: these sync tests drive coroutines with asyncio.run(). The legacy
+# asyncio.get_event_loop().run_until_complete() raised "There is no current event
+# loop" whenever the test ran before any async test on its xdist worker, because
+# pytest-asyncio's auto mode owns the loop lifecycle and leaves none set.
+
+
 class _CountingScheduler(PollLoopScheduler):
     """Minimal subclass that counts tick invocations."""
 
@@ -60,7 +66,7 @@ def test_start_creates_task_and_sets_running() -> None:
         assert not sched._task.done()
         sched.stop()
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 def test_start_idempotent() -> None:
@@ -74,7 +80,7 @@ def test_start_idempotent() -> None:
         assert sched._task is task_first
         sched.stop()
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 def test_stop_clears_running_flag_and_cancels() -> None:
@@ -89,7 +95,7 @@ def test_stop_clears_running_flag_and_cancels() -> None:
         # Give the event loop a chance to deliver the cancellation
         await asyncio.sleep(0)
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 def test_stop_before_start_is_safe() -> None:
@@ -108,7 +114,7 @@ def test_is_running_false_after_stop() -> None:
         # _running=False → is_running must be False regardless of task state
         assert not sched.is_running
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +132,7 @@ def test_task_name_uses_class_variable() -> None:
         assert sched._task.get_name() == "test-counting-scheduler"
         sched.stop()
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 def test_task_name_falls_back_to_class_name_when_empty() -> None:
@@ -145,7 +151,7 @@ def test_task_name_falls_back_to_class_name_when_empty() -> None:
         assert sched._task.get_name() == "_Unnamed"
         sched.stop()
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_session_checkpointer.py
+++ b/autobot-backend/llc/tests/test_session_checkpointer.py
@@ -196,4 +196,6 @@ def test_checkpointer_start_stop() -> None:
             checkpointer.stop()
             assert not checkpointer._running
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    asyncio.run(_run())

--- a/autobot-backend/pki/test_renewal.py
+++ b/autobot-backend/pki/test_renewal.py
@@ -19,6 +19,11 @@ from pki.config import TLSConfig, VMCertificateInfo
 from pki.generator import CertificateGenerator
 from pki.manager import PKIManager
 
+# #13113: these sync tests drive coroutines with asyncio.run(). The legacy
+# asyncio.get_event_loop().run_until_complete() raised "There is no current event
+# loop" whenever the test ran before any async test on its xdist worker, because
+# pytest-asyncio's auto mode owns the loop lifecycle and leaves none set.
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -70,7 +75,7 @@ def test_renew_no_certs_returns_true(tmp_path):
     manager = _make_manager(tmp_path)
     manager.generator.needs_renewal.return_value = []
 
-    result = asyncio.get_event_loop().run_until_complete(manager.renew())
+    result = asyncio.run(manager.renew())
 
     assert result is True
     manager.generator._renew_service_cert.assert_not_called()
@@ -86,7 +91,7 @@ def test_renew_ca_raises_value_error(tmp_path):
     manager = _make_manager(tmp_path)
 
     with pytest.raises(ValueError, match="CA certificate renewal requires manual steps"):
-        asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["ca"]))
+        asyncio.run(manager.renew(certificates=["ca"]))
 
     manager.generator._renew_service_cert.assert_not_called()
     manager.generator._generate_service_cert.assert_not_called()
@@ -97,7 +102,7 @@ def test_renew_ca_mixed_list_raises_before_any_cert(tmp_path):
     manager = _make_manager(tmp_path)
 
     with pytest.raises(ValueError):
-        asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["redis", "ca"]))
+        asyncio.run(manager.renew(certificates=["redis", "ca"]))
 
     manager.generator._renew_service_cert.assert_not_called()
     manager.generator._generate_service_cert.assert_not_called()
@@ -116,7 +121,7 @@ def test_renew_preserve_keys_calls_renew_service_cert(tmp_path):
     manager.config.get_vm_cert_info.return_value = vm_info
 
     with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
-        result = asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["redis"], preserve_keys=True))
+        result = asyncio.run(manager.renew(certificates=["redis"], preserve_keys=True))
 
     assert result is True
     manager.generator._renew_service_cert.assert_called_once_with(vm_info)
@@ -133,7 +138,7 @@ def test_renew_default_preserve_keys_true(tmp_path):
     manager.config.get_vm_cert_info.return_value = vm_info
 
     with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
-        result = asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["redis"]))
+        result = asyncio.run(manager.renew(certificates=["redis"]))
 
     assert result is True
     manager.generator._renew_service_cert.assert_called_once()
@@ -153,7 +158,7 @@ def test_renew_rotate_keys_calls_generate_service_cert(tmp_path):
     manager.config.get_vm_cert_info.return_value = vm_info
 
     with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
-        result = asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["redis"], preserve_keys=False))
+        result = asyncio.run(manager.renew(certificates=["redis"], preserve_keys=False))
 
     assert result is True
     manager.generator._generate_service_cert.assert_called_once_with(vm_info, force=True)
@@ -174,7 +179,7 @@ def test_renew_preserve_keys_failure_returns_false(tmp_path):
     manager.config.get_vm_cert_info.return_value = vm_info
 
     with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
-        result = asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["redis"], preserve_keys=True))
+        result = asyncio.run(manager.renew(certificates=["redis"], preserve_keys=True))
 
     assert result is False
     # Distribution must NOT be called when cert generation failed
@@ -189,7 +194,7 @@ def test_renew_rotate_keys_failure_returns_false(tmp_path):
     manager.config.get_vm_cert_info.return_value = vm_info
 
     with patch("pki.manager.VM_DEFINITIONS", {"redis": "192.168.1.10"}):
-        result = asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["redis"], preserve_keys=False))
+        result = asyncio.run(manager.renew(certificates=["redis"], preserve_keys=False))
 
     assert result is False
     manager.distributor._distribute_to_vm.assert_not_awaited()
@@ -204,7 +209,7 @@ def test_renew_unknown_cert_name_skipped(tmp_path):
     manager = _make_manager(tmp_path)
 
     with patch("pki.manager.VM_DEFINITIONS", {}):
-        result = asyncio.get_event_loop().run_until_complete(manager.renew(certificates=["unknown-vm"]))
+        result = asyncio.run(manager.renew(certificates=["unknown-vm"]))
 
     assert result is True
     manager.generator._renew_service_cert.assert_not_called()

--- a/autobot-backend/security/prompt_injection_hardblock_test.py
+++ b/autobot-backend/security/prompt_injection_hardblock_test.py
@@ -186,7 +186,9 @@ class TestContentFirewallHardBlock:
     """ContentFirewall.inspect() must return a BLOCK verdict when a hard-block fires."""
 
     def _run(self, coro):
-        return asyncio.get_event_loop().run_until_complete(coro)
+        # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+        # running before any async test on its worker had no current loop for get_event_loop().
+        return asyncio.run(coro)
 
     def test_firewall_returns_block_verdict_on_hard_block(self):
         firewall = ContentFirewall()

--- a/autobot-backend/services/tracing_service.py
+++ b/autobot-backend/services/tracing_service.py
@@ -23,6 +23,13 @@ Features:
 - Redis auto-instrumentation (Issue #697)
 - aiohttp client auto-instrumentation (Issue #697)
 - Configurable sampling strategy (Issue #697)
+
+Optional distributions (#13094): the FastAPI instrumentor and the B3 propagator
+ship as separate pip packages that are not part of the OpenTelemetry API/SDK
+core, so they are imported lazily at their single call site — exactly like the
+Redis and aiohttp instrumentors already were. A missing optional package now
+degrades that one capability instead of making this module unimportable, which
+is what the "graceful fallback when tracing is unavailable" promise above means.
 """
 
 from __future__ import annotations
@@ -33,9 +40,7 @@ from typing import Any, Dict
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.propagate import set_global_textmap
-from opentelemetry.propagators.b3 import B3MultiFormat
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -212,17 +217,22 @@ class TracingService:
     def _finalize_tracer(self) -> None:
         """Helper for initialize. Ref: #1088.
 
-        Registers the provider as the global OTel tracer provider, sets up W3C
-        TraceContext + B3 composite propagator, and acquires the tracer instance.
+        Registers the provider as the global OTel tracer provider, sets up the
+        W3C TraceContext (+ B3, when opentelemetry-propagator-b3 is installed)
+        composite propagator, and acquires the tracer instance.
         """
         trace.set_tracer_provider(self._provider)
-        propagator = CompositePropagator(
-            [
-                TraceContextTextMapPropagator(),
-                B3MultiFormat(),
-            ]
-        )
-        set_global_textmap(propagator)
+        propagators = [TraceContextTextMapPropagator()]
+        try:
+            from opentelemetry.propagators.b3 import B3MultiFormat
+
+            propagators.append(B3MultiFormat())
+        except ImportError:
+            logger.warning(
+                "opentelemetry-propagator-b3 not installed — propagating W3C TraceContext only. "
+                "Run: pip install opentelemetry-propagator-b3"
+            )
+        set_global_textmap(CompositePropagator(propagators))
         self._tracer = trace.get_tracer(
             self._service_name,
             self._service_version,
@@ -290,6 +300,8 @@ class TracingService:
             return False
 
         try:
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
             FastAPIInstrumentor.instrument_app(
                 app,
                 tracer_provider=self._provider,
@@ -297,6 +309,12 @@ class TracingService:
             )
             logger.info("FastAPI instrumented for distributed tracing")
             return True
+        except ImportError:
+            logger.warning(
+                "opentelemetry-instrumentation-fastapi not installed. "
+                "Run: pip install opentelemetry-instrumentation-fastapi"
+            )
+            return False
         except Exception as e:
             logger.error("Failed to instrument FastAPI: %s", e)
             return False

--- a/autobot-backend/tests/api/test_auth_validate_rbac.py
+++ b/autobot-backend/tests/api/test_auth_validate_rbac.py
@@ -37,6 +37,12 @@ from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
 # ---------------------------------------------------------------------------
 
 
+# #13113: these sync tests drive coroutines with asyncio.run(). The legacy
+# asyncio.get_event_loop().run_until_complete() raised "There is no current event
+# loop" whenever the test ran before any async test on its xdist worker, because
+# pytest-asyncio's auto mode owns the loop lifecycle and leaves none set.
+
+
 def _make_request(auth_header: str | None = None) -> MagicMock:
     """Minimal request mock."""
     request = MagicMock()
@@ -247,7 +253,7 @@ class TestValidateRequiresServiceAuth:
         req = _make_request()
 
         with patch("api.auth.get_auth_middleware", return_value=mw):
-            result = asyncio.get_event_loop().run_until_complete(validate_token(request=req, body=body, _=True))
+            result = asyncio.run(validate_token(request=req, body=body, _=True))
         assert result.valid is True
 
     def test_validate_endpoint_blocked_when_dependency_raises(self):
@@ -267,7 +273,7 @@ class TestValidateRequiresServiceAuth:
 
         with patch("api.auth.get_auth_middleware", return_value=mw):
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(_call())
+                asyncio.run(_call())
         assert exc_info.value.status_code == 403
 
 

--- a/autobot-backend/tests/api/test_rum_event.py
+++ b/autobot-backend/tests/api/test_rum_event.py
@@ -108,7 +108,9 @@ class TestLogRumEventHandler:
     )
 
     def _run(self, coro):
-        return asyncio.get_event_loop().run_until_complete(coro)
+        # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+        # running before any async test on its worker had no current loop for get_event_loop().
+        return asyncio.run(coro)
 
     def test_handler_logs_frontend_error_at_error_level(self):
         """#10938: a frontend `javascript_error` must be logged at ERROR level.

--- a/autobot-backend/tests/services/test_tool_output_filter.py
+++ b/autobot-backend/tests/services/test_tool_output_filter.py
@@ -28,6 +28,11 @@ from services.tool_output_filter import (
     short_circuit_git,
 )
 
+# #13113: these sync tests drive coroutines with asyncio.run(). The legacy
+# asyncio.get_event_loop().run_until_complete() raised "There is no current event
+# loop" whenever the test ran before any async test on its xdist worker, because
+# pytest-asyncio's auto mode owns the loop lifecycle and leaves none set.
+
 
 def _make_filter(rules: dict) -> ToolOutputFilter:
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as fh:
@@ -726,7 +731,7 @@ def test_filter_savings_not_inflated_by_tee_hint(tmp_path, monkeypatch):
     async def _run():
         return f2.filter("cmd", big_output)
 
-    result = asyncio.get_event_loop().run_until_complete(_run())
+    result = asyncio.run(_run())
 
     assert "[full output saved:" in result  # tee hint fired
     expected_pre_hint = _tail_lines(big_output, 1)
@@ -759,7 +764,7 @@ def test_filter_savings_includes_hard_cap_delta_on_matched_rule(tmp_path, monkey
     async def _run():
         return filt.filter("huge", output)
 
-    result = asyncio.get_event_loop().run_until_complete(_run())
+    result = asyncio.run(_run())
 
     assert "chars omitted" in result  # hard cap fired
     assert saved == [len(output) - len(result)]
@@ -791,7 +796,7 @@ def test_filter_savings_combines_soft_and_hard_reductions(tmp_path, monkeypatch)
     async def _run():
         return filt.filter("huge", output)
 
-    result = asyncio.get_event_loop().run_until_complete(_run())
+    result = asyncio.run(_run())
 
     assert "lines omitted" in result  # soft filter (max_lines) trimmed content
     assert "chars omitted" in result  # hard cap trimmed further
@@ -819,7 +824,7 @@ def test_filter_savings_recorded_for_unmatched_hard_cap(tmp_path, monkeypatch):
     async def _run():
         return filt.filter("no-such-command", output)
 
-    result = asyncio.get_event_loop().run_until_complete(_run())
+    result = asyncio.run(_run())
 
     assert saved == [len(output) - len(result)]
     assert saved[0] > 0

--- a/autobot-backend/tests/test_background_vectorization_pending_set.py
+++ b/autobot-backend/tests/test_background_vectorization_pending_set.py
@@ -21,7 +21,9 @@ from background_vectorization import FULL_SCAN_EVERY_N_CYCLES, PENDING_SET_KEY, 
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    return asyncio.run(coro)
 
 
 class _FakePipe:

--- a/autobot-backend/utils/thread_safety_test.py
+++ b/autobot-backend/utils/thread_safety_test.py
@@ -22,21 +22,41 @@ from unittest.mock import MagicMock
 import pytest
 
 
+def _require_real_tracing_service() -> None:
+    """Skip when OpenTelemetry is absent; fail when TracingService is a stub.
+
+    #11681: the guarded import had rotted to ``pass`` (autoflake-era), so
+    missing otel instrumentation FAILED these tests instead of skipping them.
+
+    #13094: skipping on ``ImportError`` alone was not enough. conftest's
+    ``_real_load_light_services`` replaces any ``services/*.py`` whose exec
+    raises with a MagicMock package stub, so ``import services.tracing_service``
+    SUCCEEDED while ``TracingService`` resolved to a Mock — two tests failed
+    against the Mock's internals and two passed vacuously (a Mock class returns
+    the same ``return_value`` every call, so the singleton assertions held for
+    the wrong reason). A stub is a defect to surface, not a reason to skip.
+    """
+    try:
+        import opentelemetry  # noqa: F401
+    except ImportError as e:  # pragma: no cover - depends on the environment
+        pytest.skip(f"OpenTelemetry unavailable: {e}")
+    try:
+        from services.tracing_service import TracingService
+    except ImportError as e:  # pragma: no cover - depends on the environment
+        pytest.skip(f"TracingService unavailable: {e}")
+    assert isinstance(TracingService, type), (
+        "services.tracing_service resolved to a conftest MagicMock stub, not the real module — "
+        "the assertions in this file would be vacuous (#13094)"
+    )
+
+
 class TestTracingServiceSingleton:
     """Test thread-safe singleton for TracingService (Issue #481)"""
 
     @pytest.fixture(autouse=True)
     def skip_if_opentelemetry_unavailable(self):
-        """Skip tests if OpenTelemetry has import issues.
-
-        #11681: the guarded import had rotted to ``pass`` (autoflake-era),
-        so missing otel instrumentation FAILED these tests instead of
-        skipping them.
-        """
-        try:
-            import services.tracing_service  # noqa: F401
-        except ImportError as e:
-            pytest.skip(f"TracingService unavailable: {e}")
+        """Guard: real TracingService or skip — never a Mock (#11681, #13094)."""
+        _require_real_tracing_service()
 
     def test_singleton_returns_same_instance(self):
         """Test that TracingService returns same instance on multiple calls"""
@@ -304,16 +324,8 @@ class TestDoubleCheckedLocking:
 
     @pytest.fixture(autouse=True)
     def skip_if_opentelemetry_unavailable(self):
-        """Skip tests if OpenTelemetry has import issues.
-
-        #11681: the guarded import had rotted to ``pass`` (autoflake-era),
-        so missing otel instrumentation FAILED these tests instead of
-        skipping them.
-        """
-        try:
-            import services.tracing_service  # noqa: F401
-        except ImportError as e:
-            pytest.skip(f"TracingService unavailable: {e}")
+        """Guard: real TracingService or skip — never a Mock (#11681, #13094)."""
+        _require_real_tracing_service()
 
     def test_tracing_service_double_check(self):
         """Test TracingService uses double-checked locking"""

--- a/autobot-slm-backend/tests/api/test_apply_secrets.py
+++ b/autobot-slm-backend/tests/api/test_apply_secrets.py
@@ -38,7 +38,9 @@ _BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
 def _run(coro):
     """Run an async route handler synchronously in tests."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    return asyncio.run(coro)
 
 
 _STUB_MODULE_NAMES = [

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -91,7 +91,9 @@ del _MODELS_SNAPSHOT
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/api/test_drift_resolve.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve.py
@@ -132,7 +132,9 @@ _FAKE_USER = {"username": "tester", "is_admin": True}
 
 def _run(coro):
     """Helper to run async route handlers synchronously in tests."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    return asyncio.run(coro)
 
 
 @pytest.fixture

--- a/autobot-slm-backend/tests/api/test_drift_resolve_advances_node_version_11512.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve_advances_node_version_11512.py
@@ -133,7 +133,9 @@ _FAKE_USER = {"username": "tester", "is_admin": True}
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    return asyncio.run(coro)
 
 
 class _FakeJobRow:

--- a/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
+++ b/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
@@ -107,7 +107,9 @@ del _MODELS_SNAPSHOT
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    return asyncio.run(coro)
 
 
 @contextlib.contextmanager

--- a/autobot-slm-backend/tests/api/test_role_migration_extra_vars.py
+++ b/autobot-slm-backend/tests/api/test_role_migration_extra_vars.py
@@ -38,7 +38,9 @@ _STUB_MODULE_NAMES = [
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # #13113: asyncio.run() — pytest-asyncio owns the loop lifecycle, so a sync test
+    # running before any async test on its worker had no current loop for get_event_loop().
+    return asyncio.run(coro)
 
 
 def _load_roles_module():


### PR DESCRIPTION
Closes #13113, #13094

## Thinking Path

Both issues were verified against the source before any code was written. **Both premises were partly wrong**, and #13094's stated root cause was wrong outright.

### #13113 — mechanism correct, file list WRONG

Correct: `asyncio.get_event_loop()` only raises `RuntimeError: There is no current event loop` when the thread never had a loop set. Under `--asyncio-mode=auto`, pytest-asyncio owns the loop lifecycle, so a sync test running before any async test on its xdist worker has no current loop — hence the order dependence.

Wrong: the inventory. The issue lists ~20 files; **9 of them contain zero occurrences** of the pattern, and never did (checked their git history): `agent_loop/tests/test_abstention.py`, `api/chat_embed_test.py`, `code_intelligence/llm_pattern_analyzer_test.py`, `knowledge/temporal_search_test.py`, `media/document/pipeline_test.py`, `services/knowledge/test_doc_indexer.py`, `services/rag_integration_test.py`, `system_benchmarks_performance_test.py`, `system_integration_test.py`. Whatever made those fail in the triage run, it was not this pattern.

Conversely the issue **omits 6 files that do have it**: `api/openai_compat_test.py`, `llc/tests/test_budget_watchdog.py`, `llc/tests/test_liveness_monitor.py`, `llc/tests/test_poll_loop_scheduler.py`, `tests/services/test_tool_output_filter.py`, `tests/test_background_vectorization_pending_set.py` — plus 6 more under `autobot-slm-backend/`, which the issue does not mention at all.

Actual repo-wide inventory: **37 call sites across 18 files.**

The issue's suggested fix (convert every `def test_…` to `async def test_…`) was rejected. This repo has already fixed the identical defect twice — #11834 and #11868 — both with `asyncio.run()` and a comment explaining why. `asyncio.run()` is the canonical local pattern, is a one-token change per site, and avoids the sync→async conversion risks the issue itself flagged.

Checked for a *second* reason for failure: every remaining `asyncio.get_event_loop()` in application code is either inside an `async def` (returns the running loop) or already wrapped in `try/except RuntimeError → new_event_loop()`.

### #13094 — symptom correct, root cause WRONG

The issue attributes this to the #13084 co-collection stub-leak pattern ("conftest … for some test orderings"). That is not what happens: **no conftest mentions `services.tracing_service`**, and the failure is deterministic, not order-dependent.

Real cause, traced end to end:

1. `services/tracing_service.py` imports `FastAPIInstrumentor` (from `opentelemetry-instrumentation-fastapi`) and `B3MultiFormat` (from `opentelemetry-propagator-b3`) at module top. Both are **separate pip distributions**, not part of the OpenTelemetry API/SDK core.
2. `requirements-ci/` pins **no** opentelemetry at all — CI gets `opentelemetry-api`/`sdk`/`exporter-otlp-proto-grpc` only transitively via `chromadb==1.5.9`, which pulls neither the instrumentor nor the B3 propagator.
3. `conftest.py::_real_load_light_services()` (from `pytest_configure`) real-loads **every** `services/*.py`; `tracing_service` is not in `_SERVICES_REAL_LOAD_SKIP`.
4. `_real_load_and_bind()` catches **`except Exception`** and replaces the module with `_make_pkg_stub(name)` — a `ModuleType` whose catch-all `__getattr__` returns a shared `MagicMock`.
5. So `import services.tracing_service` **succeeds**, the guard fixture's `except ImportError` never fires, and `TracingService` is a `MagicMock`. That explains the exact traceback in the issue: `TracingService._lock` returns `NonCallableMock`'s own class-level `RLock` (added in CPython 3.12 for gh-98624; CI runs 3.14), and `inspect.getsource(TracingService.__new__)` yields `NonCallableMock.__new__`.

This also means the issue **undercounts the damage**. Two *more* tests in the same class were passing **vacuously**: `test_singleton_returns_same_instance` and `test_concurrent_singleton_access` hold trivially against a Mock class, because `MagicMock()` returns the same `return_value` on every call and `reset_instance()` is a no-op mock.

Fixing only the guard fixture to skip on a stub was rejected — that trades two visible failures for four silent non-tests. The module's own docstring already promises "graceful fallback when tracing is unavailable", and it already lazy-imports the Redis and aiohttp instrumentors with an `ImportError` fallback; the FastAPI instrumentor and B3 propagator were the two inconsistent holdouts.

## What Changed

**#13113 — 18 files, 37 call sites**

`asyncio.get_event_loop().run_until_complete(coro)` → `asyncio.run(coro)`, with a short comment per file recording why.

- `autobot-backend/`: `api/openai_compat_test.py` (3), `code_analysis/src/remediation_loop_test.py` (1), `llc/tests/test_budget_watchdog.py` (1), `llc/tests/test_liveness_monitor.py` (1), `llc/tests/test_poll_loop_scheduler.py` (6), `llc/tests/test_session_checkpointer.py` (1), `pki/test_renewal.py` (9), `security/prompt_injection_hardblock_test.py` (1), `tests/api/test_auth_validate_rbac.py` (2), `tests/api/test_rum_event.py` (1), `tests/services/test_tool_output_filter.py` (4), `tests/test_background_vectorization_pending_set.py` (1)
- `autobot-slm-backend/` (not in the issue, same defect): `tests/api/test_apply_secrets.py`, `test_component_resolve_job.py`, `test_drift_resolve.py`, `test_drift_resolve_advances_node_version_11512.py`, `test_fleet_node_update_11511.py`, `test_role_migration_extra_vars.py` (1 helper each)

**#13094 — 2 files**

- `autobot-backend/services/tracing_service.py` — `FastAPIInstrumentor` and `B3MultiFormat` moved from module-top imports to their single call sites (`instrument_fastapi()` / `_finalize_tracer()`), each with an `ImportError` branch that warns and degrades one capability (FastAPI instrumentation off; W3C-TraceContext-only propagation) instead of making the module unimportable. Mirrors the pre-existing `instrument_redis()` / `instrument_aiohttp()` handling exactly.
- `autobot-backend/utils/thread_safety_test.py` — the two duplicated guard fixtures now share `_require_real_tracing_service()`, which skips when OpenTelemetry itself is absent but **asserts** `isinstance(TracingService, type)` otherwise. A conftest stub becomes a loud failure instead of four meaningless results.

## Verification

Executing application code was out of scope for this change, so verification is static; CI is the execution environment.

- Inventory is exhaustive: `grep -rn "run_until_complete" --include=*.py` over the repo. After the change the only remaining `get_event_loop().run_until_complete` strings are the explanatory comments plus one docstring in `llm_shared/tests/test_provider_auth.py`.
- Root cause of #13094 pinned with `importlib.util.find_spec` over all 12 otel imports in `tracing_service.py` (third-party packages only): `opentelemetry.instrumentation.fastapi` and `opentelemetry.propagators.b3` MISSING, all ten others OK — the same two that `requirements-ci/` never installs, while `opentelemetry.instrumentation.redis` / `aiohttp_client` (already guarded) are likewise missing.
- Config/constant reads that run at `tracing_service` import (`config.misc.jaeger_endpoint`, `config.trace_console`, `config.trace_sample_rate` via `AutoBotConfig.__getattr__` → `MiscConfig`; `NetworkConstants.*_VM_IP` via `_LazyConfigMeta`) all confirmed to resolve, so nothing else blocks the module from exec'ing once the two optional imports are lazy.
- Grep confirms `FastAPIInstrumentor` and `B3MultiFormat` have no other reference; every other otel name evaluated at class-body time (`SpanKind.INTERNAL` as a default arg) comes from `opentelemetry-api`, which is present.
- `ast.parse` clean on all 20 changed files.
- `black --check --line-length=120`: 20 files unchanged. `isort --check-only --settings-path=.`: clean. `flake8 --config=.flake8`: clean. (One `F841` appears if `autobot-backend/tests/` is passed to flake8 explicitly; it is pre-existing at the base commit and sits under the `.flake8` `tests` exclude, so the CI invocation does not lint it.)

**Per-case reasoning that no test was made vacuous**

`asyncio.run()` still executes the coroutine to completion and still propagates its exceptions, so every assertion downstream of each converted call runs exactly as before. The one behavioural difference is a fresh loop per call instead of a reused ambient loop, so each site was checked for cross-call loop-bound state:

- `pki/test_renewal.py` (9) — one `manager.renew()` per test; mocks are `MagicMock`/`AsyncMock`, which are loop-agnostic. Assertions (`result is True/False`, `assert_called_once_with`, `assert_awaited_once_with`, `assert_not_awaited`) unchanged and still discriminating.
- `api/openai_compat_test.py` (3) — each wraps one `async def run()` holding the `patch(...)` and the assertions; the `pytest.raises` in two of them stays inside the coroutine.
- `code_analysis/src/remediation_loop_test.py` — `_run()` helper, one call per test, returns the real `record_delta` result the numeric assertions check.
- `llc/tests/*` (9 across 4 files) — each test builds a scheduler inside the coroutine, calls `start()`/`stop()`, and asserts on `_task`/`_running` **inside** the same coroutine, so all assertions run on the live loop. `asyncio.run()` additionally cancels the leftover task at exit, which is strictly cleaner than the old leaked-loop behaviour and is asserted by nothing.
- `security/prompt_injection_hardblock_test.py` — helper returns the real `ContentFirewall.inspect()` verdict; the BLOCK/verdict-metadata assertions untouched.
- `tests/api/test_auth_validate_rbac.py` (2) — the first still awaits the real `validate_token` and asserts `result.valid is True`; the second keeps `pytest.raises(HTTPException)` around the call and asserts `status_code == 403`.
- `tests/api/test_rum_event.py` — helper, 4 call sites. One test loops over three event types calling the helper repeatedly; `log_rum_event` holds no loop-bound state (it writes to a module-level logger), and `mock_logger.error.assert_called_once()` is re-checked per iteration against a fresh mock, so the loop still discriminates.
- `tests/services/test_tool_output_filter.py` (4) — each coroutine just calls the sync `filter()`; the byte-math assertions (`saved == [...]`, `saved[0] > 4000`) unchanged.
- `tests/test_background_vectorization_pending_set.py` — helper, one call per test; the reconciler's fakes are `AsyncMock`/`asynccontextmanager` created fresh per test, so no primitive crosses loops.
- `autobot-slm-backend/tests/api/*` (6) — module-level `_run(coro)` helpers invoking route handlers against per-test mocks; no shared async primitives.

For #13094 the fix makes four tests meaningful rather than making any test pass trivially:

- `test_singleton_lock_exists` — was failing; `TracingService._lock` is now the real `threading.Lock()`, so `isinstance(..., type(threading.Lock()))` genuinely checks the lock attribute exists and is a lock.
- `test_tracing_service_double_check` — was failing; `inspect.getsource(TracingService.__new__)` now returns the real `__new__`, which does contain `if cls._instance is None:`, `with cls._lock:`, and two `_instance is None` checks. The assertion would fail if the double-checked locking were ever flattened.
- `test_singleton_returns_same_instance` — was passing **vacuously** (any Mock class returns one `return_value`); it now exercises the real `__new__` singleton branch.
- `test_concurrent_singleton_access` — was passing **vacuously** (`reset_instance()` was a no-op mock); it now really resets the singleton and races 20 threads through the real locked `__new__`.
- The new `_require_real_tracing_service()` guard cannot itself create a vacuous pass: it either skips (only when `opentelemetry` is genuinely unimportable) or asserts the class is real before any test body runs.

**Not verified without executing code:** that `services/tracing_service.py` now exec's cleanly end-to-end under `pytest_configure`, and the actual pass/fail of the 37 converted sites. Both are left to CI.

## Model Used

claude-opus-5
