### PR TITLE
refactor(user-management): converge user_service incidental drift onto the better fork (#12647)

### DIFF
--- a/.session/HANDOFF-issue-12647-user.md
+++ b/.session/HANDOFF-issue-12647-user.md
@@ -1,0 +1,48 @@
+# Handoff: issue-12647-user
+
+status: complete (for its slice)
+pr: (see below)
+base_at_push: origin/Dev_new_gui at push time
+gates: backend/user_management=37 PASS · slm/user_management=26 PASS · isort/black/flake8=PASS · CI=pending
+needs_rebase_before_merge: no
+worktree: .worktrees/issue-12647-user  (safe to remove after merge)
+
+## Delivered
+
+`services/user_service.py` incidental drift converged, 97 -> 48 diff lines.
+SLM adopts `get_logger` / `now_utc`; backend adopts SLM's
+`_build_user_list_base_query` decomposition (#576) and keeps its fuller
+docstring.
+
+## What is deliberately NOT converged
+
+The remaining 48 lines are two backend-only features whose dependencies are
+absent from SLM entirely:
+
+- `SessionService` (password-change session invalidation) — tracked as
+  **#12924**. A security gap, not fork residue; do not try to fold it in here.
+- `memory.ownership_reassign` (delete-user memory reassignment) — SLM has no
+  `memory/` package. Not applicable rather than missing.
+
+## State of #12647 after this
+
+Merged already: `base_service` (#12972), `schemas.user` (#13007),
+`models.base` (#13126), six models (#13130), `UserCore`/`OrganizationCore`
+(#13163), `team_service` (#13164).
+
+Still open:
+- `middleware/rbac_middleware.py` — 316 diff lines, but that is **#12925's**
+  territory: two deliberate cache designs (Redis-backed SLM vs in-process
+  backend) plus the denial-audit gap. Not plain fork residue.
+- `services/organization_service.py` — 545 lines, byte-identical, blocked: it
+  imports the concrete `User`/`Organization` at runtime and those stay
+  backend-local by design (#13163). Needs its own decision (injected model
+  set / registry lookup), not a copy of the `team_service` move.
+
+`config.py` / `database.py` confirmed **not** forks.
+
+## Trap
+
+**#13162** — the required check `Unit & Integration Tests` is the *frontend*
+job; the Python suite is not a required check. A green PR is not evidence the
+Python tests passed. Run them locally.

--- a/autobot-backend/user_management/services/user_service.py
+++ b/autobot-backend/user_management/services/user_service.py
@@ -267,6 +267,29 @@ class UserService(BaseService):
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
+    def _build_user_list_base_query(self, include_inactive: bool, search: str | None):
+        """Build filtered base query for user listing.
+
+        Helper for list_users (Issue #576).
+        """
+        base_query = select(User).where(User.deleted_at.is_(None))
+
+        if not include_inactive:
+            base_query = base_query.where(User.is_active.is_(True))
+
+        base_query = self.apply_tenant_filter(base_query, User)
+
+        if search:
+            search_pattern = f"%{search}%"
+            base_query = base_query.where(
+                or_(
+                    User.email.ilike(search_pattern),
+                    User.username.ilike(search_pattern),
+                    User.display_name.ilike(search_pattern),
+                )
+            )
+        return base_query
+
     async def list_users(
         self,
         limit: int = 50,
@@ -286,22 +309,7 @@ class UserService(BaseService):
         Returns:
             Tuple of (users list, total count)
         """
-        base_query = select(User).where(User.deleted_at.is_(None))
-
-        if not include_inactive:
-            base_query = base_query.where(User.is_active.is_(True))
-
-        base_query = self.apply_tenant_filter(base_query, User)
-
-        if search:
-            search_pattern = f"%{search}%"
-            base_query = base_query.where(
-                or_(
-                    User.email.ilike(search_pattern),
-                    User.username.ilike(search_pattern),
-                    User.display_name.ilike(search_pattern),
-                )
-            )
+        base_query = self._build_user_list_base_query(include_inactive, search)
 
         # Get total count
         count_query = select(func.count()).select_from(base_query.subquery())

--- a/autobot-slm-backend/user_management/services/user_service.py
+++ b/autobot-slm-backend/user_management/services/user_service.py
@@ -9,10 +9,8 @@ Business logic for user management operations including CRUD,
 authentication, and role assignment.
 """
 
-import logging
 import secrets
 import uuid
-from datetime import datetime, timezone
 from typing import List
 
 from sqlalchemy import func, or_, select
@@ -20,11 +18,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from autobot_shared.auth.jwt_core import hash_password, verify_password
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
 from user_management.models import Role, User, UserRole
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
 from user_management.services.base_service import BaseService, TenantContext
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class UserServiceError(Exception):
@@ -296,7 +296,18 @@ class UserService(BaseService):
         include_inactive: bool = False,
         search: str | None = None,
     ) -> tuple[List[User], int]:
-        """List users with pagination and optional search filtering."""
+        """
+        List users with pagination.
+
+        Args:
+            limit: Maximum number of users to return
+            offset: Number of users to skip
+            include_inactive: Include deactivated users
+            search: Search term for email, username, or display_name
+
+        Returns:
+            Tuple of (users list, total count)
+        """
         base_query = self._build_user_list_base_query(include_inactive, search)
 
         # Get total count
@@ -371,7 +382,7 @@ class UserService(BaseService):
 
     async def _finalize_user_update(self, user: User, user_id: uuid.UUID, changes: dict) -> None:
         """Finalize user update with timestamp and audit logging. Issue #620."""
-        user.updated_at = datetime.now(timezone.utc)
+        user.updated_at = now_utc()
         await self.session.flush()
 
         if changes:
@@ -456,7 +467,7 @@ class UserService(BaseService):
                 raise InvalidCredentialsError("Current password is incorrect")
 
         user.password_hash = self.hash_password(new_password)
-        user.updated_at = datetime.now(timezone.utc)
+        user.updated_at = now_utc()
         await self.session.flush()
 
         await self._audit_log(
@@ -486,7 +497,7 @@ class UserService(BaseService):
             raise UserNotFoundError(f"User {user_id} not found")
 
         user.is_active = False
-        user.updated_at = datetime.now(timezone.utc)
+        user.updated_at = now_utc()
         await self.session.flush()
 
         await self._audit_log(
@@ -517,7 +528,7 @@ class UserService(BaseService):
             raise UserNotFoundError(f"User {user_id} not found")
 
         user.is_active = True
-        user.updated_at = datetime.now(timezone.utc)
+        user.updated_at = now_utc()
         await self.session.flush()
 
         await self._audit_log(
@@ -551,7 +562,7 @@ class UserService(BaseService):
         if hard_delete:
             await self.session.delete(user)
         else:
-            user.deleted_at = datetime.now(timezone.utc)
+            user.deleted_at = now_utc()
             user.is_active = False
 
         await self.session.flush()
@@ -634,7 +645,7 @@ class UserService(BaseService):
             return None
 
         # Update last login
-        user.last_login_at = datetime.now(timezone.utc)
+        user.last_login_at = now_utc()
         await self.session.flush()
 
         await self._audit_log(


### PR DESCRIPTION
Closes #12647

> **Partial slice — the issue must stay open after merge.** The close keyword
> is required by the `Validate PR issue link` gate; merging to `Dev_new_gui`
> does not auto-close. Same handling as #13126 / #13130 / #13163 / #13164.

## Thinking Path

`services/user_service.py` differed by **97 lines** between the backends. The
useful question was not "which fork wins" but "how much of this is actually a
feature difference?" — and the answer is: about half.

Splitting the diff by cause:

| drift | cause | resolution |
|---|---|---|
| `logging.getLogger` vs `get_logger` | SLM never adopted the shared helper | SLM adopts backend's |
| `datetime.now(timezone.utc)` ×6 vs `now_utc()` | same | SLM adopts backend's |
| monolithic vs decomposed `list_users` | backend predates #576 | **backend adopts SLM's** |
| session invalidation on password change | `session_service.py` is backend-only | out of scope — **#12924** |
| memory reassignment on delete | `memory/` does not exist in SLM | not applicable |

The first two are not a matter of taste: `get_logger` and `now_utc` are the
patterns `CLAUDE.md` mandates, so SLM was the outlier rather than merely
different. The third goes the other way — backend's `list_users` was a 50-line
function that SLM had already split under #576, so the umbrella's "best
implementation of each behaviour wins, regardless of which fork it came from"
points at SLM here.

## What Changed

**`autobot-slm-backend`** — `get_logger(__name__)`, `now_utc()` at 6 call
sites, imports trimmed accordingly.

**`autobot-backend`** — gains `_build_user_list_base_query`, with `list_users`
reduced to the builder call plus pagination. Backend's fuller `Args`/`Returns`
docstring is kept on top of SLM's decomposition rather than SLM's one-liner.

**Drift: 97 → 48 lines.**

## Verification

```
autobot-backend/user_management      37 passed
autobot-slm-backend/user_management  26 passed
```

Both include `user_service_test.py`. Import smoke on both sides confirms
`UserService.list_users` now routes through `_build_user_list_base_query`.

`isort`, `black --line-length=120`, `flake8 --config=.flake8` clean.

No behaviour changed on either side: `get_logger`/`now_utc` are drop-in
equivalents of what they replace, and the decomposition is a pure extraction
with identical query construction.

## What remains, and why it is not fork residue

The 48 remaining lines are two backend-only features whose **dependencies do
not exist in SLM at all**:

- **Session invalidation on password change** — needs
  `user_management/services/session_service.py`, which is backend-only.
  Already tracked as **#12924** and correctly framed there as a *security gap*
  in SLM, not fork residue. Folding it in here would mean porting
  `SessionService` too, which is that issue's job.
- **Memory ownership reassignment on delete** — needs
  `memory/ownership_reassign.py`. `autobot-slm-backend/memory/` does not
  exist; SLM has no memory subsystem. This is **not applicable** to SLM rather
  than missing from it, so there is nothing to file.

Verified both absences:

```
SLM memory module: ABSENT
SLM session_service: ABSENT
```

## Model Used

Claude Opus 5 (1M context)
