### PR TITLE
fix(tests): real-load self-poisoned code_intelligence submodules over their conftest stubs (#13111)

### DIFF
--- a/autobot-backend/code_intelligence/conftest.py
+++ b/autobot-backend/code_intelligence/conftest.py
@@ -15,12 +15,20 @@ This conftest runs after autobot-backend/conftest.py (parent-first order)
 and loads the real modules into sys.modules before any test in this
 directory imports them.
 
+Issue #13111 generalised that repair: every code_intelligence submodule that the
+top-level conftest stubs AND that owns a colocated ``<name>_test.py`` is real-loaded
+here, because otherwise the test file's own ``from code_intelligence.<name> import ...``
+resolves to the MagicMock stub and the whole file asserts against mock attributes.
+
 NOTE (session-global side-effect): the sys.modules mutations below affect the
 entire pytest session, not just tests inside code_intelligence/.  Any test
-outside this directory that lazily imports a code_intelligence.security
-submodule will exec the real (heavy) file rather than the top-level stub.
-This is safe today because no such test exists, but be aware when adding new
-test files that import code_intelligence.security indirectly.
+outside this directory that lazily imports one of the real-loaded submodules
+will exec the real file rather than the top-level stub.  This is safe today
+because the only module-level importers outside code_intelligence/ are api/*.py,
+and pytest collects api/ BEFORE code_intelligence/ — those modules have already
+bound the stub by the time this conftest runs.  That ordering is also why
+merge_conflict_resolver (which api/merge_conflict_resolution.py binds at import
+time) is real-loaded in the TOP-LEVEL conftest instead of here.
 """
 
 import importlib
@@ -108,17 +116,25 @@ for _key in list(sys.modules.keys()):
 
 importlib.import_module("code_intelligence.security")
 
-# Replace the stub for the shim module with the real one.
-_load_real(
-    "code_intelligence.security_analyzer",
-    _backend_root / "code_intelligence" / "security_analyzer.py",
-)
 
-# Expose the real security_analyzer on the code_intelligence namespace so that
-# `from code_intelligence.security_analyzer import X` finds the real symbols.
-_real_sa = sys.modules.get("code_intelligence.security_analyzer")
-if _real_sa is not None:
-    setattr(sys.modules["code_intelligence"], "security_analyzer", _real_sa)
+def _load_real_submodule(leaf: str) -> None:
+    """Real-load ``code_intelligence.<leaf>`` over the top-level conftest's stub.
+
+    The namespace bind is load-bearing: ``from code_intelligence.X import Y`` and
+    ``patch("code_intelligence.X.Y")`` both resolve through
+    ``getattr(sys.modules["code_intelligence"], "X")``, and the stubbed parent's
+    catch-all ``__getattr__`` hands back a MagicMock singleton without it — so the
+    real module would load but every consumer would still see mocks.
+    """
+    name = f"code_intelligence.{leaf}"
+    _load_real(name, _backend_root / "code_intelligence" / f"{leaf}.py")
+    real = sys.modules.get(name)
+    if real is not None:
+        setattr(sys.modules["code_intelligence"], leaf, real)
+
+
+# Replace the stub for the shim module with the real one.
+_load_real_submodule("security_analyzer")
 
 # Replace the code_intelligence.performance_analyzer stub with the real module
 # (#12362). The top-level conftest stubs it as a MagicMock (heavy __init__
@@ -127,17 +143,7 @@ if _real_sa is not None:
 # performance_analyzer_test.py silently exercised MagicMock attributes
 # instead of the real PerformanceAnalyzer. Mirrors the security_analyzer
 # real-load above.
-_load_real(
-    "code_intelligence.performance_analyzer",
-    _backend_root / "code_intelligence" / "performance_analyzer.py",
-)
-
-# Expose the real performance_analyzer on the code_intelligence namespace so
-# that `from code_intelligence.performance_analyzer import X` and
-# `patch("code_intelligence.performance_analyzer.Y")` resolve the real module.
-_real_pa = sys.modules.get("code_intelligence.performance_analyzer")
-if _real_pa is not None:
-    setattr(sys.modules["code_intelligence"], "performance_analyzer", _real_pa)
+_load_real_submodule("performance_analyzer")
 
 # Replace the code_intelligence.bug_predictor stub with the real module (#12421).
 # The top-level conftest stubs it as a MagicMock (heavy __init__ chain avoidance),
@@ -149,14 +155,64 @@ if _real_pa is not None:
 # `from code_intelligence.analytics_infrastructure import SemanticAnalysisMixin`
 # resolves the real (import-light) module and BugPredictor inherits the mixin.
 # Mirrors the security_analyzer real-load above.
-_load_real(
-    "code_intelligence.bug_predictor",
-    _backend_root / "code_intelligence" / "bug_predictor.py",
-)
+_load_real_submodule("bug_predictor")
 
-# Expose the real bug_predictor on the code_intelligence namespace so that
-# `from code_intelligence.bug_predictor import X` and `patch("code_intelligence.
-# bug_predictor.Y")` resolve the real module (getattr(parent, child)).
-_real_bp = sys.modules.get("code_intelligence.bug_predictor")
-if _real_bp is not None:
-    setattr(sys.modules["code_intelligence"], "bug_predictor", _real_bp)
+# code_intelligence.code_generation real package (#13111) — llm_code_generator.py is a
+# pure facade that re-exports this package's entire public API, so while the top-level
+# conftest's leaf-only stub (empty __path__) is bound, every symbol
+# llm_code_generator_test.py imports is a MagicMock. Drop the package stub so the real
+# __init__.py loads (its submodules resolve now that code_intelligence.__path__ is
+# repaired above); the package is import-light — stdlib plus a try/except-guarded
+# `from services.llm_service import get_llm_service`, and services.llm_service is itself
+# stubbed by the top-level conftest.
+#
+# The already-real code_intelligence.code_generation.diff entry is deliberately LEFT in
+# sys.modules: __init__.py's `from .diff import DiffGenerator` short-circuits on it, so
+# tools/parallel/executor.py — which imported that module object back at top-level-conftest
+# time — keeps referencing the SAME DiffGenerator class object. Re-executing diff.py would
+# mint a second class and break isinstance identity for the earlier importer (#12839).
+_cg_pkg = sys.modules.get("code_intelligence.code_generation")
+if _cg_pkg is not None and getattr(_cg_pkg, "__file__", None) is None:
+    del sys.modules["code_intelligence.code_generation"]
+_cg_diff = sys.modules.get("code_intelligence.code_generation.diff")
+if _cg_diff is not None and getattr(_cg_diff, "__file__", None) is None:
+    del sys.modules["code_intelligence.code_generation.diff"]
+_real_cg = importlib.import_module("code_intelligence.code_generation")
+setattr(sys.modules["code_intelligence"], "code_generation", _real_cg)
+if "code_intelligence.code_generation.diff" in sys.modules:
+    setattr(_real_cg, "diff", sys.modules["code_intelligence.code_generation.diff"])
+
+# Remaining self-poisoned submodules (#13111). Each of these is stubbed as a MagicMock
+# package by the top-level conftest so that api/*.py can import it without dragging in
+# code_intelligence/__init__.py — but each ALSO owns a colocated <name>_test.py, and that
+# test file's `from code_intelligence.<name> import ...` resolved to the stub, so the
+# whole file asserted against MagicMock attributes rather than real behaviour.
+#
+# Order is load-bearing: anti_pattern_detector must precede code_evolution_miner, whose
+# module-level `from code_intelligence.anti_pattern_detector import AntiPatternDetector`
+# would otherwise capture the stub and leave CodeEvolutionMiner.__init__ holding a mock
+# detector. All of these are import-light in the test environment (verified statically:
+# stdlib + autobot_shared.logging_manager — patched to a stdlib logger by the top-level
+# conftest — plus in-repo code_intelligence subpackages, utils.line_index and
+# constants.threshold_constants; no chromadb/torch/network imports on any path).
+for _leaf in [
+    "anti_pattern_detector",
+    "code_evolution_miner",
+    "code_fingerprinting",
+    "code_review_engine",
+    "conversation_flow_analyzer",
+    "llm_code_generator",
+    "llm_pattern_analyzer",
+    "log_pattern_miner",
+    "precommit_analyzer",
+    "redis_optimizer",
+]:
+    _load_real_submodule(_leaf)
+
+# merge_conflict_resolver is NOT in the list above: it is real-loaded by the TOP-LEVEL
+# conftest instead, because api/merge_conflict_resolution.py binds its symbols at import
+# time and api/ is collected before code_intelligence/ (#13111). Bind it onto the
+# namespace here anyway so patch("code_intelligence.merge_conflict_resolver.X") resolves.
+_real_mcr = sys.modules.get("code_intelligence.merge_conflict_resolver")
+if _real_mcr is not None:
+    setattr(sys.modules["code_intelligence"], "merge_conflict_resolver", _real_mcr)

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -757,15 +757,36 @@ _ci_anti_stub.AntiPatternSeverity = MagicMock()  # type: ignore[attr-defined]
 _ci_anti_stub.AntiPatternResult = MagicMock()  # type: ignore[attr-defined]
 sys.modules["code_intelligence.anti_pattern_detector"] = _ci_anti_stub
 
-_ci_merge_stub = _make_pkg_stub("code_intelligence.merge_conflict_resolver")
-_ci_merge_stub.ConflictBlock = MagicMock()  # type: ignore[attr-defined]
-_ci_merge_stub.ConflictParser = MagicMock()  # type: ignore[attr-defined]
-_ci_merge_stub.ConflictSeverity = MagicMock()  # type: ignore[attr-defined]
-_ci_merge_stub.MergeConflictResolver = MagicMock()  # type: ignore[attr-defined]
-_ci_merge_stub.ResolutionStrategy = MagicMock()  # type: ignore[attr-defined]
-_ci_merge_stub.analyze_repository = MagicMock()  # type: ignore[attr-defined]
-sys.modules["code_intelligence.merge_conflict_resolver"] = _ci_merge_stub
+# code_intelligence.merge_conflict_resolver real-load (#13111) — this module used
+# to be a MagicMock package stub here, which poisoned TWO test files:
+#   * code_intelligence/merge_conflict_resolver_test.py (its own unit tests), and
+#   * api/merge_conflict_resolution_test.py — api/merge_conflict_resolution.py binds
+#     ConflictBlock/ConflictParser/MergeConflictResolver/... into its module globals
+#     at import time, so every TestClient endpoint test dispatched into mocked types.
+# The api/ consumer is why this real-load lives HERE and not in
+# code_intelligence/conftest.py: pytest collects api/ before code_intelligence/, so a
+# subdirectory-conftest fix would land after api/merge_conflict_resolution.py has
+# already bound the stub's mocks.
+# Safe to real-load: merge_conflict_resolver.py is self-contained (stdlib ast/re/
+# dataclasses/enum/pathlib/typing plus autobot_shared.logging_manager, which is
+# patched to a stdlib logger above). Same pattern as code_intelligence.code_generation.diff
+# and code_intelligence.shared.scoring — it bypasses code_intelligence/__init__.py, which
+# stays stubbed. _real_load_and_bind falls back to a package stub if the load ever fails,
+# so import-time behaviour for api/*.py is never worse than the old hand-written stub.
+_real_load_and_bind(
+    "code_intelligence.merge_conflict_resolver",
+    backend_root / "code_intelligence" / "merge_conflict_resolver.py",
+)
 
+# NOTE (#13111): every entry below that also owns a colocated ``<name>_test.py`` is
+# real-loaded again by code_intelligence/conftest.py, which runs after this file and
+# repairs code_intelligence.__path__ so the real submodules resolve. The stubs here
+# must stay: api/*.py imports several of these at module level and is collected
+# BEFORE code_intelligence/, so removing an entry would turn an api-side import into
+# a collection error. Add a matching _load_real_submodule() call over there whenever a
+# new colocated test file is added for a stubbed submodule — otherwise that test
+# silently asserts against MagicMock attributes instead of real behaviour.
+#
 # NOTE: "code_intelligence.test_pattern_analyzer" is intentionally NOT in this
 # list (#12437). Stubbing it here would poison sys.modules before pytest ever
 # collects code_intelligence/test_pattern_analyzer.py itself: with


### PR DESCRIPTION
Closes #13111

## Thinking Path

The issue's headline claim — "these test files test the MagicMock stub of themselves via `--import-mode=importlib`" — is the wrong mechanism, and the precedent it cites does not apply. Verifying first changed the fix.

**What is actually wrong.** `--import-mode=importlib` self-collision only happens when the *test file's own module name* is already bound in `sys.modules`. That is the `code_intelligence/test_pattern_analyzer.py` case (module name `code_intelligence.test_pattern_analyzer` == the stub key), which is why the `conftest.py:769-780` exclusion note exists. The affected files here are named `<name>_test.py`, so their module names (`code_intelligence.conversation_flow_analyzer_test`, …) are **not** stubbed and they import and execute perfectly well. The real defect is one level down: the *module under test* is stubbed, so the test file's own `from code_intelligence.<name> import ...` hands back MagicMock attributes. Same symptom, different mechanism — and the difference matters, because the issue's recommended fix (a) "remove it from the blanket-stub list" would replace assertion failures with collection errors in `api/*.py`, which import several of these at module level and are collected *before* `code_intelligence/`.

**Corrections to the issue's facts.**
- The count is 10 stubbed-plus-self-tested modules, not 11; the title says 11 while the body lists and measures 10. The 11th affected *file* is `api/merge_conflict_resolution_test.py` (the issue's own follow-up comment), so 11 test files, 10 modules.
- `anti_pattern_detector` is stubbed and has `anti_pattern_detector_test.py`, but is **not** affected: that test file loads `code_analysis/src/anti_pattern_detector.py` itself via `spec_from_file_location` under an unqualified name and never touches the stub. It is real-loaded here anyway, because `code_evolution_miner.py` imports `AntiPatternDetector` from it at module level and was holding a mock detector.
- `test_pattern_analyzer` is not a 12th instance of this bug; it is a different failure mode that the existing note already handles correctly. The note is preserved and cross-referenced rather than followed.

**The fix already existed in the codebase.** `code_intelligence/conftest.py` runs after the top-level conftest, repairs `code_intelligence.__path__`, real-loads a submodule over its stub, then binds it onto the parent namespace (the bind is load-bearing — the stub's catch-all `__getattr__` otherwise keeps returning mocks). That is exactly what #9856/#12362/#12421 did for `security_analyzer`, `performance_analyzer` and `bug_predictor`, and what `legacy_analyzer_shim_test.py`'s docstring documents as the reason tests needing real `code_intelligence` subpackages live in that directory. The top-level stubs stay put — they are what lets `api/*.py` import at all.

**Why one module is handled differently.** `merge_conflict_resolver` is real-loaded in the **top-level** conftest, not the subdirectory one. `api/merge_conflict_resolution.py` binds `ConflictBlock`/`ConflictParser`/`MergeConflictResolver`/… into its module globals at import time, and pytest collects `api/` before `code_intelligence/`, so a subdirectory-conftest real-load would arrive after those globals were already bound to mocks and would not fix the 20 endpoint tests. It is safe there because that module needs no `code_intelligence.__path__` repair (stdlib + `autobot_shared.logging_manager` only).

**Per-module verification (static, see Verification).** Every module was checked individually rather than assumed symmetric. Nine need `code_intelligence.__path__` (they pull in-repo subpackages: `llm_pattern_analysis`, `fingerprinting`, `conversation_analysis`, `code_generation`, `anti_pattern_detection`, `analytics_infrastructure`) so they go in the subdirectory conftest. `llm_code_generator` additionally needed its `code_generation` package un-stubbed, with the already-real `code_generation.diff` module object deliberately preserved so `tools/parallel/executor.py` keeps the same `DiffGenerator` class identity (the #12839 trap). Load order is load-bearing: `anti_pattern_detector` before `code_evolution_miner`.

**No test is made to pass vacuously.** None of the 11 test files contains a `skip`, `skipif`, `xfail` or `importorskip` marker, so nothing can start "passing" by being skipped, and no such marker was added. Every name each test file imports from its module under test was confirmed to exist as a real module-level definition or re-export. The one genuinely vacuous pattern found — `TestModuleImports` in `llm_code_generator_test.py` and `llm_pattern_analyzer_test.py` asserting `X is not None` on `from code_intelligence import X`, which passes today only because the package stub's `__getattr__` returns a MagicMock — is **pre-existing and deliberately left unchanged**; fixing it needs the real `code_intelligence/__init__.py`, which is the heavy chain the whole stub system exists to avoid. Called out for a follow-up rather than papered over.

## What Changed

**`autobot-backend/conftest.py`**
- Replaced the hand-written `code_intelligence.merge_conflict_resolver` MagicMock stub with `_real_load_and_bind(...)` from the real file — the same helper already used for `code_generation.diff` and `shared.scoring`. `_real_load_and_bind` falls back to a package stub if the load ever fails, so import-time behaviour for `api/*.py` is never worse than before.
- Added a note above the submodule stub list explaining that stubbed submodules owning a colocated `<name>_test.py` are real-loaded again by `code_intelligence/conftest.py`, that the stubs here must stay (api/ collects first), and that a new colocated test file requires a matching real-load.

**`autobot-backend/code_intelligence/conftest.py`**
- Factored the thrice-repeated `_load_real(...)` + parent-`setattr` pattern into `_load_real_submodule(leaf)` and pointed the three existing call sites (`security_analyzer`, `performance_analyzer`, `bug_predictor`) at it. Their explanatory comments are unchanged.
- Un-stubbed and imported the real `code_intelligence.code_generation` package, keeping the existing real `code_generation.diff` module object in `sys.modules` so its earlier importer keeps the same class identity.
- Real-loaded the remaining nine submodules: `anti_pattern_detector`, `code_evolution_miner`, `code_fingerprinting`, `code_review_engine`, `conversation_flow_analyzer`, `llm_code_generator`, `llm_pattern_analyzer`, `log_pattern_miner`, `precommit_analyzer`, `redis_optimizer`.
- Bound the top-level-loaded `merge_conflict_resolver` onto the `code_intelligence` namespace so `patch("code_intelligence.merge_conflict_resolver.X")` resolves.
- Updated the module docstring: generalised the #9856 rationale, and recorded the api/-collects-first ordering constraint that decides which conftest a real-load belongs in.

No production code changed — this is test-harness wiring only.

## Verification

Static only. The task constraints forbid executing application code, running the backend, or running pytest; CI is the execution environment for this change.

**Dependency safety — the stated risk that un-stubbing drags in heavy deps.** Built an AST-based transitive module-level import walker (guarded `try`/`except ImportError` and `if` branches followed; function-body imports excluded) and pruned the traversal at every module the top-level conftest stubs, reproducing what the import machinery actually sees during a test session. Closure over all 12 real-loaded roots: **78 in-repo modules, 4 external packages — `pydantic`, `pydantic_settings`, `yaml`, `aiofiles`** — all four already imported by `autobot-backend/conftest.py` itself at line 22 (`from autobot_shared.ssot_config import config`). No `chromadb`, no `torch`, no `redis`, no `fastapi`, no network or socket import on any path.

The unpruned walk does surface `llm_shared`/`fastapi`/`numpy`/`opentelemetry` behind `code_generation/generator.py:38`'s `from services.llm_service import get_llm_service` — but that import is `try`/`except ImportError`-guarded *and* `services.llm_service` is itself stubbed by the top-level conftest, so the chain is never entered. This was the single most plausible way the change could have broken collection for other tests, and it is closed on both sides.

**Module-level side effects.** Scanned every file in the pruned closure for module-level statements that are not definitions, imports or literal assignments. All hits are pure: `BUILTIN_PATTERNS`/`BUILTIN_CHECKS` dataclass catalogs, `lazy_singleton(...)` factories (deferred by construction), and a `urlparse()` on a config string. No eager instantiation, no filesystem or network access at import.

**Symbol coverage — proving the tests get real behaviour, not a different mock.** For each of the 10 modules, extracted every name its `<name>_test.py` imports from it and confirmed each resolves to a real module-level `def`/`class`/assignment or re-export (following facade re-exports into `conversation_analysis`, `fingerprinting`, `llm_pattern_analysis`, `code_generation`, `anti_pattern_detection`): **135 imported names across 10 modules, 0 missing.** Spot-checked the issue's own reproducer: `get_intent_categories()` is `conversation_analysis/analyzer.py:889`, `return [category.value for category in IntentCategory]` — a real `list`, satisfying `assert isinstance(categories, list)` and the `"installation" in categories` / `"greeting" in categories` assertions on the following lines, so that test now passes on real behaviour or fails honestly.

**Vacuity check.** `grep` for `skip` / `skipif` / `xfail` / `importorskip` across all 11 affected test files: the only hits are the substring `skip` inside two test *names* and a docstring (`test_fast_mode_skips_expensive_checks`, "excluded directories are skipped"). Zero skip markers exist and zero were added.

**Blast-radius grep.** Repo-wide search for importers of the 10 modules outside `code_intelligence/` itself: only `api/code_intelligence.py`, `api/analytics_precommit.py`, `api/merge_conflict_resolution.py`, `api/analytics_evolution.py`, `api/codebase_analytics/analyzers.py`. All but one bind at module level and are collected before `code_intelligence/`, so they are unaffected by the subdirectory real-loads. The one runtime-lazy importer (`api/analytics_evolution.py:1156`, inside `trigger_evolution_analysis`) has no test exercising that endpoint — confirmed by grep against `api/analytics_evolution_test.py`.

**Syntax/version.** `compile()` over all 47 files brought in by the real-loads (the 11 modules plus every file in the five subpackages plus `code_analysis/src/anti_pattern_detector.py` and `analytics_infrastructure.py`): 0 syntax errors under Python 3.10, a strict subset of CI's 3.14 — so none of these carry the Python-version incompatibility that motivated stubbing `code_intelligence/__init__.py`.

**Lint gates** (the exact CI commands): `black --check --line-length=120`, `isort --check-only --settings-path=.`, `flake8 --config=.flake8` — all clean on both changed files.

**What could not be verified without executing code, and is left to CI:**
- The actual pass/fail delta. The issue cites 433/874 from an earlier commit and the current base has moved; no number from either is repeated here as fact. The expectation is that the 11 files stop asserting against mocks — some individual assertions may now fail *honestly* against real behaviour, which is the correct outcome and strictly better than a mock-green or mock-red result.
- That no real-load raises at collection. `_load_real` deliberately re-raises rather than silently falling back to a stub (the existing contract for `security_analyzer`/`performance_analyzer`/`bug_predictor`), so an unforeseen import failure surfaces as a loud collection error for `code_intelligence/` rather than silently restoring the bug. Static analysis says all ten are import-light, but only CI proves it.
- Whether real-loading changes behaviour for any test that runs *after* collection and lazily imports one of these modules. The grep above found exactly one such call site and no test covering it.

**Known-adjacent, deliberately not fixed here:** `api/analytics_precommit.py` and `api/code_intelligence.py` still bind mocked `precommit_analyzer` / `redis_optimizer` / `anti_pattern_detector` symbols at import time (e.g. `api.analytics_precommit.BUILTIN_CHECKS` silently evaluates to `{}` because iterating a MagicMock yields nothing). That is the same mechanism on the api side and would need top-level real-loads with a blast radius this PR cannot measure without running the suite. Left for a follow-up rather than bundled in.

## Model Used

claude-opus-5
