### PR TITLE
fix(llc/scheduler): drain poll loops on shutdown instead of re-arming a full interval (#13085)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1701,6 +1701,7 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
         logger.info("CommunityClusterer: mesh_db not available, skipping periodic loop")
         return
 
+    from llc.scheduler.base import honour_pending_cancellation
     from services.mesh_brain.community_clusterer import CommunityClusterer
 
     _CLUSTER_INTERVAL_SECONDS = 6 * 3600  # 6 hours
@@ -1717,6 +1718,10 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
                 )
             except Exception as exc:
                 logger.warning("CommunityClusterer periodic run failed (non-fatal): %s", exc)
+                # #13085: run() drives DB work that can mask the CancelledError
+                # cleanup_services() sent. Without this the loop would start a
+                # fresh 6-hour sleep and cleanup's gather() would never return.
+                honour_pending_cancellation()
             await asyncio.sleep(_CLUSTER_INTERVAL_SECONDS)
 
     app.state.community_cluster_task = asyncio.create_task(_loop())
@@ -2132,12 +2137,17 @@ async def cleanup_services(app: FastAPI):
         pass  # SLM reconciler now in slm-server
 
         # GH#9028: Stop LLC liveness monitor
+        # #13085: aclose() — stop() only *requests* cancellation and returns, so
+        # the poll task could still be mid-tick (holding an AsyncSession) when
+        # close_database() disposes the engine further down, and its interval
+        # wait was left for whoever tore the event loop down. aclose() drains it
+        # here, where shutdown can observe it.
         if hasattr(app.state, "llc_liveness_monitor") and app.state.llc_liveness_monitor:
-            app.state.llc_liveness_monitor.stop()
+            await app.state.llc_liveness_monitor.aclose()
             logger.info("✅ LLC liveness monitor stopped")
         # GH#9029: Stop LLC budget watchdog
         if hasattr(app.state, "llc_budget_watchdog") and app.state.llc_budget_watchdog:
-            app.state.llc_budget_watchdog.stop()
+            await app.state.llc_budget_watchdog.aclose()
             logger.info("✅ LLC budget watchdog stopped")
         # #12816: Stop MeshBrainScheduler — stop() cancels every per-job task
         # start() spawned, so none survive shutdown.
@@ -2153,9 +2163,9 @@ async def cleanup_services(app: FastAPI):
                 logger.info("✅ MeshBrainScheduler stopped")
             except Exception as mesh_stop_error:
                 logger.warning("MeshBrainScheduler stop failed (non-fatal): %s", mesh_stop_error)
-        # GH#9026: Stop LLC session checkpointer
+        # GH#9026: Stop LLC session checkpointer (#13085: drained, see above)
         if hasattr(app.state, "llc_session_checkpointer") and app.state.llc_session_checkpointer:
-            app.state.llc_session_checkpointer.stop()
+            await app.state.llc_session_checkpointer.aclose()
             logger.info("✅ LLC session checkpointer stopped")
 
         # GH#8257: Stop LLC outbound sync service

--- a/autobot-backend/initialization/lifespan_test.py
+++ b/autobot-backend/initialization/lifespan_test.py
@@ -1,10 +1,11 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """
-Tests for lifespan shutdown ordering (#11679).
+Tests for lifespan shutdown ordering (#11679) and scheduler drain (#13085).
 
 Covers the fast-shutdown race between phase-2 background initialization and
-cleanup_services(), and the executor-drain-before-Redis-close ordering.
+cleanup_services(), the executor-drain-before-Redis-close ordering, and the
+awaited drain of the LLC poll-loop schedulers.
 """
 
 import asyncio
@@ -76,3 +77,66 @@ async def test_cleanup_drains_executor_before_redis_close():
     assert call_order == ["executor_shutdown", "redis_close"]
 
     lifespan_module._executor = None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_drains_llc_poll_schedulers():
+    """#13085: the three LLC poll-loop schedulers must be *drained*, not just
+    asked to stop.
+
+    ``PollLoopScheduler.stop()`` only requests cancellation and returns, so the
+    poll task could still be mid-tick — holding an AsyncSession — when
+    close_database() disposes the engine later in the same cleanup, and its
+    inter-poll wait was left for whoever tore the event loop down. Shutdown must
+    await ``aclose()`` for every one of them.
+    """
+    monitor = SimpleNamespace(aclose=AsyncMock(), stop=lambda: None)
+    watchdog = SimpleNamespace(aclose=AsyncMock(), stop=lambda: None)
+    checkpointer = SimpleNamespace(aclose=AsyncMock(), stop=lambda: None)
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            llc_liveness_monitor=monitor,
+            llc_budget_watchdog=watchdog,
+            llc_session_checkpointer=checkpointer,
+        )
+    )
+
+    with (
+        patch("autobot_shared.redis_client.close_all_redis_connections", new=AsyncMock()),
+        patch.object(lifespan_module, "shutdown_tracing", new=AsyncMock()),
+    ):
+        await cleanup_services(app)
+
+    monitor.aclose.assert_awaited_once()
+    watchdog.aclose.assert_awaited_once()
+    checkpointer.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_drain_uses_the_real_scheduler_contract():
+    """The drain wired into cleanup_services matches PollLoopScheduler's own API.
+
+    Guards against the mock-only version of the test above passing while the
+    real schedulers grow a different method name.
+    """
+    from llc.scheduler.base import PollLoopScheduler
+
+    class _Sched(PollLoopScheduler):
+        async def _tick(self) -> None:
+            await asyncio.sleep(0)
+
+    sched = _Sched(poll_interval=9999.0)
+    sched.start()
+    task = sched._task
+
+    app = SimpleNamespace(state=SimpleNamespace(llc_budget_watchdog=sched))
+
+    with (
+        patch("autobot_shared.redis_client.close_all_redis_connections", new=AsyncMock()),
+        patch.object(lifespan_module, "shutdown_tracing", new=AsyncMock()),
+    ):
+        await asyncio.wait_for(cleanup_services(app), timeout=5.0)
+
+    assert task is not None and task.done(), "cleanup must leave no live poll task"
+    assert not sched.is_running

--- a/autobot-backend/llc/scheduler/base.py
+++ b/autobot-backend/llc/scheduler/base.py
@@ -8,17 +8,33 @@ Provides start/stop/is_running lifecycle management and the ``_loop`` coroutine
 that drives periodic execution.  Subclasses implement only ``_tick()`` — the
 per-poll unit of work.
 
-Error handling contract (preserved from the three concrete schedulers):
-  - ``asyncio.CancelledError`` breaks the loop (not re-raised; task exits cleanly).
+Error handling contract:
+  - ``asyncio.CancelledError`` is re-raised, never swallowed, so the task ends
+    as *cancelled* and every awaiting caller is released immediately.
   - All other exceptions are caught, logged via ``logger.exception()``, and the
     loop continues after the sleep.  This matches BudgetWatchdog, LivenessMonitor,
     and SessionCheckpointer exactly.
-  - The sleep always runs, even when an exception occurs.
+  - The inter-poll wait always runs, even when an exception occurs.
 
-stop() semantics (preserved):
-  - Sets ``_running = False`` first.
+Shutdown contract (#13085):
+  - The inter-poll wait is an ``asyncio.Event`` wait bounded by the poll
+    interval, NOT a bare ``asyncio.sleep(poll_interval)``.  A bare sleep made
+    shutdown latency equal to a whole poll interval (300 s for BudgetWatchdog,
+    a 6-hour cadence elsewhere) whenever the cancellation never reached the
+    sleep — the loop would keep the event loop alive for a full interval after
+    ``stop()`` had already been called.
+  - ``_tick()`` runs third-party async DB/Redis code that can consume a
+    ``CancelledError`` and re-raise its own error type.  The loop therefore
+    re-checks ``asyncio.current_task().cancelling()`` after a tick failure and
+    honours the pending cancellation instead of starting another poll interval.
+  - ``stop()`` stays synchronous (fire-and-forget) for existing callers;
+    ``aclose()`` is the awaitable drain that shutdown paths must use.
+
+stop() semantics:
+  - Sets ``_running = False`` and signals the stop event first.
   - Cancels the task if it exists and is not already done.
-  - Does NOT await the task (matches all three concrete schedulers).
+  - Does NOT await the task — use ``aclose()`` when the caller needs the task
+    to be fully finished before it proceeds.
 """
 
 import asyncio
@@ -26,6 +42,26 @@ import logging
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+def honour_pending_cancellation() -> None:
+    """Re-raise a cancellation that the surrounding ``except`` arm masked (#13085).
+
+    SQLAlchemy/asyncpg/redis-py all catch ``BaseException`` internally and
+    surface their own error type, so a ``CancelledError`` delivered into an
+    awaited call can reach an ``except Exception`` arm as, say, an
+    ``InterfaceError``.  ``Task.cancelling()`` still records the pending cancel,
+    so a periodic loop must honour it here rather than starting another poll
+    interval — that masking is what let a cancelled background loop keep an
+    event loop alive for a whole interval (300 s, or 6 h for the community
+    clusterer) after shutdown had already asked it to stop.
+
+    Call this from the ``except Exception`` arm of any ``while``-loop that
+    sleeps between iterations.  It is a no-op when no cancel is pending.
+    """
+    current = asyncio.current_task()
+    if current is not None and current.cancelling():
+        raise asyncio.CancelledError from None
 
 
 class PollLoopScheduler:
@@ -49,6 +85,11 @@ class PollLoopScheduler:
         self._poll_interval = poll_interval
         self._running: bool = False
         self._task: Optional[asyncio.Task[None]] = None
+        # Signalled by stop(); makes the inter-poll wait end immediately instead
+        # of running out the full poll interval (#13085).  asyncio.Event binds
+        # no event loop at construction, so building a scheduler outside a
+        # running loop stays valid.
+        self._stop_event = asyncio.Event()
 
     @property
     def is_running(self) -> bool:
@@ -68,19 +109,37 @@ class PollLoopScheduler:
         if self._running:
             return False
         self._running = True
+        self._stop_event.clear()
         task_name = self._task_name or type(self).__name__
         self._task = asyncio.create_task(self._loop(), name=task_name)
         return True
 
     def stop(self) -> None:
-        """Stop the background polling loop.
+        """Stop the background polling loop (synchronous, fire-and-forget).
 
-        Sets ``_running = False`` and cancels the task.  Does not await
-        the task — callers that need a clean drain must do so themselves.
+        Sets ``_running = False``, signals the stop event so an in-progress
+        inter-poll wait ends at once, and cancels the task.  Does not await
+        the task — callers that need the task fully finished before they
+        continue must use :meth:`aclose`.
         """
         self._running = False
+        self._stop_event.set()
         if self._task and not self._task.done():
             self._task.cancel()
+
+    async def aclose(self) -> None:
+        """Stop the loop and await the task's exit — the shutdown drain (#13085).
+
+        ``stop()`` only *requests* cancellation.  Without this drain the poll
+        task can still be mid-``_tick()`` (holding an open AsyncSession) when
+        the caller tears down the database engine and the event loop, which
+        leaves the interval sleep to be paid by whoever closes the loop.
+        Idempotent, and safe on a scheduler that was never started.
+        """
+        self.stop()
+        task = self._task
+        if task is not None:
+            await asyncio.gather(task, return_exceptions=True)
 
     # ------------------------------------------------------------------
     # Internal loop
@@ -90,22 +149,30 @@ class PollLoopScheduler:
         """Drive periodic calls to ``_tick()``.
 
         Catches and logs all exceptions from ``_tick()`` so that a single
-        failing tick does not kill the loop.  ``asyncio.CancelledError``
-        breaks the loop cleanly.  The sleep always runs after each tick
-        (or after an exception), matching the original concrete schedulers.
+        failing tick does not kill the loop.  ``asyncio.CancelledError`` is
+        re-raised so the task ends as cancelled.  The inter-poll wait always
+        runs after a tick (or after an exception) and ends early on ``stop()``.
         """
         while self._running:
             try:
                 await self._tick()
             except asyncio.CancelledError:
-                break
+                raise
             except Exception:
                 # Attribute tick failures to the subclass's module logger so
                 # per-module log-level filtering keeps working as it did
                 # before the extraction; the base logger only carries
                 # lifecycle events.
                 logging.getLogger(type(self).__module__).exception("%s._tick() failed", type(self).__name__)
-            await asyncio.sleep(self._poll_interval)
+                honour_pending_cancellation()
+            await self._wait_between_polls()
+
+    async def _wait_between_polls(self) -> None:
+        """Wait one poll interval, returning as soon as ``stop()`` is signalled."""
+        try:
+            await asyncio.wait_for(self._stop_event.wait(), timeout=self._poll_interval)
+        except asyncio.TimeoutError:
+            pass  # interval elapsed with no stop request — run the next tick
 
     # ------------------------------------------------------------------
     # Hook for subclasses

--- a/autobot-backend/llc/tests/test_poll_loop_scheduler.py
+++ b/autobot-backend/llc/tests/test_poll_loop_scheduler.py
@@ -49,6 +49,31 @@ class _ErrorScheduler(PollLoopScheduler):
         raise RuntimeError("tick exploded")
 
 
+class _MaskingCancelScheduler(PollLoopScheduler):
+    """Subclass whose tick masks CancelledError behind a driver-style error.
+
+    Models what SQLAlchemy/asyncpg/redis-py do: they catch BaseException while
+    unwinding and surface their own exception type, so the cancellation lands in
+    ``_loop``'s ``except Exception`` arm instead of its ``except CancelledError``
+    arm (#13085).
+    """
+
+    _task_name = "test-masking-cancel-scheduler"
+
+    def __init__(self, poll_interval: float = 9999.0) -> None:
+        super().__init__(poll_interval)
+        self.tick_count = 0
+        self.tick_entered = asyncio.Event()
+
+    async def _tick(self) -> None:
+        self.tick_count += 1
+        self.tick_entered.set()
+        try:
+            await asyncio.sleep(9999.0)
+        except asyncio.CancelledError:
+            raise RuntimeError("driver masked the cancellation") from None
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle: start / stop idempotency
 # ---------------------------------------------------------------------------
@@ -206,6 +231,113 @@ async def test_cancellation_breaks_loop_cleanly() -> None:
     sched._task.cancel()
     # Must not raise — CancelledError is caught inside _loop
     await asyncio.gather(sched._task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_marks_the_task_cancelled() -> None:
+    """_loop re-raises CancelledError so the task ends in the cancelled state.
+
+    Swallowing it made the task finish "successfully", which hides a shutdown
+    that never actually completed from anything inspecting the task (#13085).
+    """
+    sched = _CountingScheduler(poll_interval=9999.0)
+    sched.start()
+    assert sched._task is not None
+    await asyncio.sleep(0)  # let the loop reach its inter-poll wait
+    sched._task.cancel()
+    await asyncio.gather(sched._task, return_exceptions=True)
+
+    assert sched._task.cancelled()
+
+
+# ---------------------------------------------------------------------------
+# Shutdown latency (#13085) — stop() must not cost a whole poll interval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_event_ends_the_interval_wait_immediately() -> None:
+    """stop() releases an in-flight inter-poll wait without task cancellation.
+
+    Isolated from cancel() on purpose: no task is started, so the only thing
+    that can end the wait is the stop event.  A bare asyncio.sleep() would keep
+    the waiter pending for the full 9999 s interval.
+    """
+    sched = _CountingScheduler(poll_interval=9999.0)
+    waiter = asyncio.create_task(sched._wait_between_polls())
+    await asyncio.sleep(0)  # let the waiter register on the event
+
+    sched.stop()  # no task exists → only the stop event can release the waiter
+
+    await asyncio.wait_for(waiter, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_masked_cancellation_does_not_start_another_interval() -> None:
+    """A tick that masks CancelledError must not buy the loop a fresh interval.
+
+    Real drivers (SQLAlchemy/asyncpg/redis-py) catch BaseException and re-raise
+    their own error type, so the cancellation reaches ``except Exception``.
+    Before #13085 the loop then slept out a whole poll interval — 300 s for
+    BudgetWatchdog — keeping the event loop alive long after shutdown.
+    """
+    sched = _MaskingCancelScheduler(poll_interval=9999.0)
+    sched.start()
+    assert sched._task is not None
+    await asyncio.wait_for(sched.tick_entered.wait(), timeout=1.0)
+
+    sched._task.cancel()
+
+    # Must settle promptly; a re-armed 9999 s wait would blow the timeout.
+    await asyncio.wait_for(asyncio.gather(sched._task, return_exceptions=True), timeout=1.0)
+    assert sched._task.done()
+    assert sched.tick_count == 1, "the loop must not have started a second tick"
+
+
+# ---------------------------------------------------------------------------
+# aclose() — the awaitable shutdown drain (#13085)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_awaits_the_task_to_completion() -> None:
+    """aclose() returns only once the poll task has actually finished."""
+    sched = _CountingScheduler(poll_interval=9999.0)
+    sched.start()
+    task = sched._task
+    assert task is not None
+
+    await asyncio.wait_for(sched.aclose(), timeout=1.0)
+
+    assert task.done()
+    assert not sched.is_running
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_safe_before_start_and_idempotent() -> None:
+    """aclose() on a never-started scheduler is a no-op, and repeats are safe."""
+    sched = _CountingScheduler(poll_interval=9999.0)
+    await sched.aclose()  # never started — must not raise
+
+    sched.start()
+    await sched.aclose()
+    await sched.aclose()  # second drain — must not raise
+    assert not sched.is_running
+
+
+@pytest.mark.asyncio
+async def test_restart_after_aclose_clears_the_stop_event() -> None:
+    """start() re-arms the stop event so a restarted loop is not born stopped."""
+    sched = _CountingScheduler(poll_interval=0.0)
+    sched.start()
+    await sched.aclose()
+
+    sched.start()
+    await asyncio.sleep(0.05)
+    ticks_after_restart = sched.tick_count
+    await sched.aclose()
+
+    assert ticks_after_restart >= 2, "restarted loop must keep ticking"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #13085

## Thinking Path

The issue's premise did not survive checking, on both halves it named.

**1. Shutdown already stops all three.** `cleanup_services()` calls
`llc_liveness_monitor.stop()`, `llc_budget_watchdog.stop()` and
`llc_session_checkpointer.stop()`, and cancels + gathers `community_cluster_task`.
`PollLoopScheduler.stop()` has cancelled its task since the base class was
extracted in #9842/#10003 — well before this issue was filed. Startup/shutdown
were not asymmetric in the "startup starts, shutdown forgets" sense.

**2. No test exercises the real app lifespan — this is the issue's open question, answered.**
- `create_app()` (the only builder that attaches `create_lifespan_manager()`) is
  instantiated in exactly one test module: `autobot-backend/system_integration_test.py`,
  six times, always as `TestClient(self.app)` with **no** `with` block.
- Starlette 1.0.0's `TestClient` runs the ASGI lifespan **only** in `__enter__`
  (verified: `lifespan` appears in `TestClient.__enter__`, not in `TestClient.request`).
  A non-context-manager `TestClient` never starts phase 1 or phase 2.
- The only other test that imports the real app, `tests/api/test_knowledge_grounding.py`,
  likewise constructs `TestClient(backend_main.app)` without entering it.
- No test calls `initialize_background_services()` or `cleanup_services()` with a
  real scheduler on `app.state`; `llc/tests/_e2e_harness.py` documents that the
  production lifespan "hard-requires Postgres/Redis and cannot boot in-process"
  and builds its own minimal app instead.
- Every direct construction of `BudgetWatchdog` / `LivenessMonitor` /
  `SessionCheckpointer` in the suite either passes `poll_interval=9999` or never
  calls `.start()` at all.

So there is no test-time override to add: nothing in the suite can start these
loops. An `AUTOBOT_ENABLE_LLC_SCHEDULERS` env gate (the issue's suggested
alternative) would have been dead configuration.

**The real defect is in the loop body, and it is a production bug too.**
`PollLoopScheduler._loop()` waited with a bare `asyncio.sleep(poll_interval)` and
swallowed `CancelledError` with `break`:

```python
while self._running:
    try:
        await self._tick()
    except asyncio.CancelledError:
        break
    except Exception:
        logger.exception(...)
    await asyncio.sleep(self._poll_interval)
```

`_tick()` drives SQLAlchemy/asyncpg/redis-py, all of which catch `BaseException`
while unwinding and surface their own error type. A `CancelledError` delivered
into `_tick()` can therefore arrive at the `except Exception` arm as, say, an
`InterfaceError`. The cancellation is consumed at that point, the loop logs it,
and then sleeps a **full, uninterruptible poll interval** — 300 s for
BudgetWatchdog, 6 hours for the community clusterer. `_running` is still `True`
(an external cancel never cleared it), so the next tick fails the same way and
buys another interval. That is the "advances by exactly 300.1 s between dumps,
resolves on its own after ~2 cycles" signature reported in the issue, and the
same masking makes a production shutdown pay the interval instead of finishing.

Reproduced against `origin/Dev_new_gui`'s `base.py` on Python 3.14 with a tick
that masks the cancel: after `task.cancel()` the task was still pending 2 s
later, having re-armed its 300 s wait. Same scenario against this branch settles
in under 0.5 s.

Second, related defect: `cleanup_services()` fired `stop()` and moved on without
awaiting. The poll task could still be inside `_tick()`, holding an open
`AsyncSession`, when `close_database()` disposed the engine a few steps later —
the session's `__aexit__` never ran, and the interval wait was left for whoever
tore the event loop down. Right next to it, `doc_sync_queue_worker_task` and
`community_cluster_task` are both cancelled **and** gathered; the poll-loop
schedulers were the odd ones out.

## What Changed

`autobot-backend/llc/scheduler/base.py`
- Inter-poll wait is now `asyncio.wait_for(self._stop_event.wait(), timeout=poll_interval)`
  instead of `asyncio.sleep(poll_interval)`. `stop()` sets the event, so an
  in-flight wait ends immediately rather than costing a whole interval.
- New module-level `honour_pending_cancellation()`: re-raises `CancelledError`
  when `asyncio.current_task().cancelling()` shows a cancel that the `except`
  arm masked. Called from `_loop`'s `except Exception` arm.
- `_loop` re-raises `CancelledError` instead of `break`ing, so the task ends
  *cancelled* rather than reporting a clean finish for a shutdown that never
  completed.
- New `aclose()` — the awaitable drain (`stop()` + `gather(task)`). `stop()`
  stays synchronous and fire-and-forget for existing callers.
- `start()` clears the stop event so a restarted scheduler is not born stopped.

`autobot-backend/initialization/lifespan.py`
- `cleanup_services()` now `await`s `aclose()` for the liveness monitor, budget
  watchdog and session checkpointer.
- The community-clustering loop calls `honour_pending_cancellation()` in its
  `except Exception` arm. Its interval is 6 hours, and `cleanup_services()`
  `gather`s that task — a masked cancel there would have hung shutdown outright,
  not merely delayed it.

Tests
- `llc/tests/test_poll_loop_scheduler.py`: masked-cancellation settles promptly
  and starts no second tick; `stop()` releases an in-flight wait with no task
  cancellation involved (isolates the event from `cancel()`); `aclose()` drains
  to completion, is safe before `start()`, and is idempotent; restart after
  `aclose()` keeps ticking; cancellation leaves the task in the cancelled state.
- `initialization/lifespan_test.py`: `cleanup_services()` awaits `aclose()` on
  all three schedulers, plus a second test driving a **real** `PollLoopScheduler`
  subclass through `cleanup_services()` so the mock-based test cannot pass while
  the real contract drifts.

No code deleted; no env-var gate, no test-only branch, no skipped work.

## Verification

Static analysis only — this environment must not execute the application or the
test suite. CI is the execution environment.

- `black --line-length 120 --check`: 4 files unchanged.
- `flake8 --max-line-length=120`: clean on all changed files.
- `isort --profile black --line-length 120 --check-only`: clean.
- `mypy --ignore-missing-imports` on `llc/scheduler/base.py`: no findings for the
  file (the repo-wide baseline noise is pre-existing and untouched).
- `py_compile` under Python 3.14 (the version CI pins): clean on all four files.
- Behavioural check of `llc/scheduler/base.py` under Python 3.14, loading the
  module by path (it imports only `asyncio`/`logging`/`typing`, nothing from the
  app) and running each scenario the new tests assert — 11/11 pass: construction
  and `stop()` outside a running loop, `stop()` before `start()`, stop event
  releasing an in-flight wait, masked-cancel settling with exactly one tick,
  `aclose()` draining, `aclose()` idempotency, restart-after-`aclose()`, task
  ending cancelled, tick exceptions not killing the loop, `start()` idempotency,
  base `_tick()` raising `NotImplementedError`.
- Regression proven, not assumed: the same masked-cancel scenario run against
  `origin/Dev_new_gui`'s `base.py` leaves the task pending past a 2 s deadline
  (a re-armed 300 s wait); against this branch it settles in under 0.5 s.
- Starlette lifespan claim verified by introspection: `lifespan` appears in
  `TestClient.__enter__`, not in `TestClient.request` (starlette 1.0.0).

Not verifiable here: that the ~10-minute tail observed in the #10691 baseline run
came from this specific mechanism. No test can start these three schedulers, so
if that particular worker stall had a different source it is a separate defect
and this PR will not move the baseline. What is proven is that the loop could
absorb a cancellation and re-arm a full poll interval, and that it no longer can.

## Model Used

claude-opus-5
