### PR TITLE
test(api): mount merge-conflict router on a FastAPI app in tests (#13183)

### DIFF
--- a/autobot-backend/api/merge_conflict_resolution_test.py
+++ b/autobot-backend/api/merge_conflict_resolution_test.py
@@ -10,18 +10,69 @@ Tests REST API endpoints for intelligent merge conflict resolution.
 Part of Issue #246 - Intelligent Merge Conflict Resolution
 """
 
+import os
 import tempfile
 import textwrap
-from unittest.mock import patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-# Mock the auth middleware before importing the router
-with patch("auth_middleware.check_admin_permission", return_value=True):
-    from api.merge_conflict_resolution import router
+from api.merge_conflict_resolution import router
+from auth_middleware import check_admin_permission
 
-client = TestClient(router)
+# Mirror the real mount point so these tests exercise production URLs (#13183).
+# ``api.merge_conflict_resolution`` is registered in
+# initialization/router_registry/feature_routers.py under the registry prefix
+# "/code-intelligence/merge-conflicts", and app_factory._register_routers mounts
+# every registry router at f"/api{prefix}". The router itself is a bare
+# ``APIRouter()`` with no prefix of its own, so there is nothing to double up.
+API_PREFIX = "/api/code-intelligence/merge-conflicts"
+
+# autobot_shared.security.path_validator only permits /opt/autobot and the
+# system temp dir (#2848); anything else is rejected with a generic
+# "Invalid or disallowed path" *before* an endpoint's existence check runs.
+# Point the "missing path" cases at an allowed root so they genuinely exercise
+# the does-not-exist branch they are named for.
+_TMP_ROOT = tempfile.gettempdir()
+MISSING_FILE = os.path.join(_TMP_ROOT, "autobot-merge-conflict-tests", "missing.py")
+MISSING_REPO = os.path.join(_TMP_ROOT, "autobot-merge-conflict-tests", "missing-repo")
+
+
+def payload(response):
+    """Unwrap the standard DataResponse envelope.
+
+    ``utils.response_helpers.create_success_response`` always returns
+    ``{"success": ..., "data": ..., "message": ..., "timestamp": ...}``, so the
+    endpoint payload lives under "data". Indexing (rather than ``.get``) keeps
+    the envelope shape itself under assertion.
+    """
+    return response.json()["data"]
+
+
+@pytest.fixture
+def app():
+    """Create test FastAPI app.
+
+    An ``APIRouter`` is a bare ASGI callable with no middleware stack, so
+    ``AsyncExitStackMiddleware`` never runs and ``fastapi_middleware_astack``
+    never lands in the request scope. The router has to be mounted on a real
+    ``FastAPI`` app for TestClient to reach an endpoint at all (#13183).
+    """
+    app = FastAPI()
+    app.include_router(router, prefix=API_PREFIX)
+    # ``Depends(check_admin_permission)`` captures the function object when the
+    # endpoint module is imported, so patching the ``auth_middleware`` attribute
+    # afterwards can never reach it. Override the dependency instead — the same
+    # pattern api/themes_test.py uses.
+    app.dependency_overrides[check_admin_permission] = lambda: True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """Create test client."""
+    return TestClient(app)
 
 
 @pytest.fixture
@@ -53,72 +104,75 @@ def clean_file():
         yield f.name
 
 
-@pytest.fixture
-def mock_admin():
-    """Mock admin permission check."""
-    with patch("auth_middleware.check_admin_permission", return_value=True):
-        yield
-
-
 class TestAnalyzeConflicts:
     """Test conflict analysis endpoint."""
 
-    def test_analyze_conflicts_success(self, conflict_file, mock_admin):
+    def test_analyze_conflicts_success(self, client, conflict_file):
         """Test successful conflict analysis."""
         response = client.post(
-            "/analyze",
+            f"{API_PREFIX}/analyze",
             json={"file_path": conflict_file},
         )
 
         assert response.status_code == 200
-        data = response.json()
+        data = payload(response)
         assert data["status"] == "success"
         assert data["conflict_count"] == 1
         assert "conflicts" in data
         assert len(data["conflicts"]) == 1
         assert "severity_distribution" in data
 
-    def test_analyze_no_conflicts(self, clean_file, mock_admin):
+    def test_analyze_no_conflicts(self, client, clean_file):
         """Test analysis of file without conflicts."""
         response = client.post(
-            "/analyze",
+            f"{API_PREFIX}/analyze",
             json={"file_path": clean_file},
         )
 
         assert response.status_code == 200
-        data = response.json()
+        data = payload(response)
         assert data["status"] == "success"
         assert data["conflict_count"] == 0
 
-    def test_analyze_nonexistent_file(self, mock_admin):
+    def test_analyze_nonexistent_file(self, client):
         """Test analysis of nonexistent file."""
         response = client.post(
-            "/analyze",
-            json={"file_path": "/nonexistent/file.py"},
+            f"{API_PREFIX}/analyze",
+            json={"file_path": MISSING_FILE},
         )
 
         assert response.status_code == 400
         assert "does not exist" in response.json()["detail"]
 
-    def test_analyze_unsupported_file_type(self, mock_admin):
+    def test_analyze_disallowed_path(self, client):
+        """Test analysis of a path outside the allowed roots (#2848)."""
+        response = client.post(
+            f"{API_PREFIX}/analyze",
+            json={"file_path": "/nonexistent/file.py"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid or disallowed path" in response.json()["detail"]
+
+    def test_analyze_unsupported_file_type(self, client):
         """Test analysis of unsupported file type."""
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
             response = client.post(
-                "/analyze",
+                f"{API_PREFIX}/analyze",
                 json={"file_path": f.name},
             )
 
             assert response.status_code == 400
-            assert "not supported" in response.json()["detail"]
+            assert "Only source code files are supported" in response.json()["detail"]
 
 
 class TestResolveConflicts:
     """Test conflict resolution endpoint."""
 
-    def test_resolve_conflicts_success(self, conflict_file, mock_admin):
+    def test_resolve_conflicts_success(self, client, conflict_file):
         """Test successful conflict resolution."""
         response = client.post(
-            "/resolve",
+            f"{API_PREFIX}/resolve",
             json={
                 "file_path": conflict_file,
                 "strategy": "semantic_merge",
@@ -128,28 +182,32 @@ class TestResolveConflicts:
         )
 
         assert response.status_code == 200
-        data = response.json()
+        data = payload(response)
         assert data["status"] == "success"
-        assert data["resolution_count"] == 1
-        assert "resolutions" in data
-        assert "summary" in data
+        assert data["resolved_count"] == 1
+        assert len(data["results"]) == 1
+        assert data["safe_mode"] is True
+        # safe_mode forces review for every strategy except accept_both /
+        # pattern_based, so this must be True here.
+        assert data["summary"]["requires_review"] is True
+        assert "average_confidence" in data["summary"]
 
-    def test_resolve_no_conflicts(self, clean_file, mock_admin):
+    def test_resolve_no_conflicts(self, client, clean_file):
         """Test resolution of file without conflicts."""
         response = client.post(
-            "/resolve",
+            f"{API_PREFIX}/resolve",
             json={"file_path": clean_file},
         )
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "success"
-        assert "No conflicts" in data["message"]
+        assert payload(response)["status"] == "success"
+        # The "no conflicts" wording lives on the envelope, not the payload.
+        assert "No conflicts" in response.json()["message"]
 
-    def test_resolve_invalid_strategy(self, conflict_file, mock_admin):
+    def test_resolve_invalid_strategy(self, client, conflict_file):
         """Test resolution with invalid strategy."""
         response = client.post(
-            "/resolve",
+            f"{API_PREFIX}/resolve",
             json={
                 "file_path": conflict_file,
                 "strategy": "invalid_strategy",
@@ -159,10 +217,10 @@ class TestResolveConflicts:
         assert response.status_code == 400
         assert "Invalid resolution strategy" in response.json()["detail"]
 
-    def test_resolve_accept_ours(self, conflict_file, mock_admin):
+    def test_resolve_accept_ours(self, client, conflict_file):
         """Test accept ours resolution strategy."""
         response = client.post(
-            "/resolve",
+            f"{API_PREFIX}/resolve",
             json={
                 "file_path": conflict_file,
                 "strategy": "accept_ours",
@@ -170,15 +228,16 @@ class TestResolveConflicts:
         )
 
         assert response.status_code == 200
-        data = response.json()
-        resolutions = data["resolutions"]
-        assert len(resolutions) == 1
-        assert resolutions[0]["strategy"] == "accept_ours"
+        results = payload(response)["results"]
+        assert len(results) == 1
+        assert results[0]["strategy"] == "accept_ours"
+        assert 'return "current"' in results[0]["resolved_content"]
+        assert 'return "incoming"' not in results[0]["resolved_content"]
 
-    def test_resolve_accept_theirs(self, conflict_file, mock_admin):
+    def test_resolve_accept_theirs(self, client, conflict_file):
         """Test accept theirs resolution strategy."""
         response = client.post(
-            "/resolve",
+            f"{API_PREFIX}/resolve",
             json={
                 "file_path": conflict_file,
                 "strategy": "accept_theirs",
@@ -186,15 +245,17 @@ class TestResolveConflicts:
         )
 
         assert response.status_code == 200
-        data = response.json()
-        resolutions = data["resolutions"]
-        assert resolutions[0]["strategy"] == "accept_theirs"
+        results = payload(response)["results"]
+        assert len(results) == 1
+        assert results[0]["strategy"] == "accept_theirs"
+        assert 'return "incoming"' in results[0]["resolved_content"]
+        assert 'return "current"' not in results[0]["resolved_content"]
 
 
 class TestRepositoryAnalysis:
     """Test repository analysis endpoint."""
 
-    def test_analyze_repository_success(self, mock_admin):
+    def test_analyze_repository_success(self, client):
         """Test successful repository analysis."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create a file with conflicts
@@ -202,17 +263,17 @@ class TestRepositoryAnalysis:
                 f.write("<<<<<<< HEAD\nx = 1\n=======\nx = 2\n>>>>>>> branch\n")
 
             response = client.post(
-                "/analyze-repository",
+                f"{API_PREFIX}/analyze-repository",
                 json={"repo_path": tmpdir},
             )
 
             assert response.status_code == 200
-            data = response.json()
+            data = payload(response)
             assert data["status"] == "success"
             assert data["total_files_with_conflicts"] >= 1
             assert data["total_conflicts"] >= 1
 
-    def test_analyze_repository_no_conflicts(self, mock_admin):
+    def test_analyze_repository_no_conflicts(self, client):
         """Test repository analysis with no conflicts."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create a clean file
@@ -220,29 +281,30 @@ class TestRepositoryAnalysis:
                 f.write("def hello():\n    pass\n")
 
             response = client.post(
-                "/analyze-repository",
+                f"{API_PREFIX}/analyze-repository",
                 json={"repo_path": tmpdir},
             )
 
             assert response.status_code == 200
-            data = response.json()
+            data = payload(response)
             assert data["total_files_with_conflicts"] == 0
+            assert data["total_conflicts"] == 0
 
-    def test_analyze_repository_nonexistent(self, mock_admin):
+    def test_analyze_repository_nonexistent(self, client):
         """Test repository analysis with nonexistent path."""
         response = client.post(
-            "/analyze-repository",
-            json={"repo_path": "/nonexistent/path"},
+            f"{API_PREFIX}/analyze-repository",
+            json={"repo_path": MISSING_REPO},
         )
 
         assert response.status_code == 400
         assert "does not exist" in response.json()["detail"]
 
-    def test_analyze_repository_not_directory(self, mock_admin):
+    def test_analyze_repository_not_directory(self, client):
         """Test repository analysis with file path instead of directory."""
         with tempfile.NamedTemporaryFile() as f:
             response = client.post(
-                "/analyze-repository",
+                f"{API_PREFIX}/analyze-repository",
                 json={"repo_path": f.name},
             )
 
@@ -253,12 +315,12 @@ class TestRepositoryAnalysis:
 class TestApplyResolution:
     """Test apply resolution endpoint."""
 
-    def test_apply_resolution_success(self, conflict_file, mock_admin):
+    def test_apply_resolution_success(self, client, conflict_file):
         """Test successful resolution application."""
         resolved_content = "def hello():\n    return 'resolved'\n"
 
         response = client.post(
-            "/apply",
+            f"{API_PREFIX}/apply",
             json={
                 "file_path": conflict_file,
                 "resolved_content": resolved_content,
@@ -267,7 +329,7 @@ class TestApplyResolution:
         )
 
         assert response.status_code == 200
-        data = response.json()
+        data = payload(response)
         assert data["status"] == "success"
         assert data["backup_path"] is not None
 
@@ -276,12 +338,12 @@ class TestApplyResolution:
             content = f.read()
             assert content == resolved_content
 
-    def test_apply_resolution_no_backup(self, conflict_file, mock_admin):
+    def test_apply_resolution_no_backup(self, client, conflict_file):
         """Test resolution application without backup."""
         resolved_content = "def hello():\n    return 'resolved'\n"
 
         response = client.post(
-            "/apply",
+            f"{API_PREFIX}/apply",
             json={
                 "file_path": conflict_file,
                 "resolved_content": resolved_content,
@@ -290,15 +352,14 @@ class TestApplyResolution:
         )
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["backup_path"] is None
+        assert payload(response)["backup_path"] is None
 
-    def test_apply_resolution_nonexistent_file(self, mock_admin):
+    def test_apply_resolution_nonexistent_file(self, client):
         """Test application to nonexistent file."""
         response = client.post(
-            "/apply",
+            f"{API_PREFIX}/apply",
             json={
-                "file_path": "/nonexistent/file.py",
+                "file_path": MISSING_FILE,
                 "resolved_content": "test",
             },
         )
@@ -310,12 +371,12 @@ class TestApplyResolution:
 class TestUtilityEndpoints:
     """Test utility endpoints."""
 
-    def test_get_resolution_strategies(self, mock_admin):
+    def test_get_resolution_strategies(self, client):
         """Test getting available resolution strategies."""
-        response = client.get("/strategies")
+        response = client.get(f"{API_PREFIX}/strategies")
 
         assert response.status_code == 200
-        data = response.json()
+        data = payload(response)
         assert data["status"] == "success"
         assert "strategies" in data
         strategies = data["strategies"]
@@ -326,26 +387,25 @@ class TestUtilityEndpoints:
         assert "pattern_based" in strategies
         assert "manual_review" in strategies
 
-    def test_check_file_conflicts_with_conflicts(self, conflict_file, mock_admin):
+    def test_check_file_conflicts_with_conflicts(self, client, conflict_file):
         """Test checking file with conflicts."""
-        response = client.get(f"/check?file_path={conflict_file}")
+        response = client.get(f"{API_PREFIX}/check", params={"file_path": conflict_file})
 
         assert response.status_code == 200
-        data = response.json()
+        data = payload(response)
         assert data["status"] == "success"
         assert data["has_conflicts"] is True
 
-    def test_check_file_conflicts_without_conflicts(self, clean_file, mock_admin):
+    def test_check_file_conflicts_without_conflicts(self, client, clean_file):
         """Test checking file without conflicts."""
-        response = client.get(f"/check?file_path={clean_file}")
+        response = client.get(f"{API_PREFIX}/check", params={"file_path": clean_file})
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["has_conflicts"] is False
+        assert payload(response)["has_conflicts"] is False
 
-    def test_check_nonexistent_file(self, mock_admin):
+    def test_check_nonexistent_file(self, client):
         """Test checking nonexistent file."""
-        response = client.get("/check?file_path=/nonexistent/file.py")
+        response = client.get(f"{API_PREFIX}/check", params={"file_path": MISSING_FILE})
 
         assert response.status_code == 400
         assert "does not exist" in response.json()["detail"]


### PR DESCRIPTION
Closes #13183

## Thinking Path

The reported cause is real: `merge_conflict_resolution_test.py:24` built its client from `APIRouter`, which is a bare ASGI callable with no middleware stack, so `AsyncExitStackMiddleware` never set `fastapi_middleware_astack` and every request tripped the assertion in `fastapi/routing.py`. All 20 tests in the file went through that one module-level client, so all 20 failed identically.

**Getting the prefix right.** The issue warns that a wrong prefix trades 20 assertion failures for 20 404s, so the mount point was derived rather than assumed:

- `api/merge_conflict_resolution.py:54` is `router = APIRouter()` — no prefix of its own, so there is nothing to double up.
- `initialization/router_registry/feature_routers.py:306-311` registers it with registry prefix `/code-intelligence/merge-conflicts`.
- `app_factory.py:81` mounts every registry router at `f"/api{prefix}"`.

Real production paths are therefore `/api/code-intelligence/merge-conflicts/{analyze,resolve,analyze-repository,apply,strategies,check}`. That matches the convention already used by `api/anti_pattern_cached_test.py` (`prefix="/api/anti-pattern"`, registry prefix `/anti-pattern`) and documented in `api/themes_test.py:20-22`. Cross-checked by extracting all six `@router.<method>` paths from the module and diffing against every path the tests request: no requested path is a non-route (no 404s), and no route is left unexercised.

**The premise was correct but incomplete.** Fixing only the client would have swapped one failure mode for another — three further defects sat behind it, each of which would still have failed all or most of the file:

1. `Depends(check_admin_permission)` captures the function object when the endpoint module is imported. Patching the `auth_middleware` attribute afterwards (the old `mock_admin` fixture) cannot reach the captured reference, so every request would have hit real auth. The `with patch(...)` wrapper around the import was worse than useless: it only bound a `MagicMock` when this module happened to import the endpoint module first, making behaviour import-order dependent across a full-suite run.
2. Endpoints return `DataResponse` (`{"success", "data", "message", "timestamp"}`), so `response.json()["status"]` etc. were reading the envelope, not the payload.
3. Assertions had drifted from the code — see What Changed.

## What Changed

`autobot-backend/api/merge_conflict_resolution_test.py` only. No application code touched.

- Replaced the module-level `TestClient(router)` with `app`/`client` fixtures that mount the router on a real `FastAPI` app at `API_PREFIX = "/api/code-intelligence/merge-conflicts"`, mirroring `api/slm/deployments_api_test.py:29-37`.
- Replaced the ineffective auth patching with `app.dependency_overrides[check_admin_permission] = lambda: True` (the pattern in `api/themes_test.py:23`), and dropped the import-order-dependent `with patch(...)` import guard.
- Added a `payload()` helper to unwrap the `DataResponse` envelope. It indexes `["data"]` rather than using `.get`, so a malformed envelope fails loudly instead of silently yielding `None`.
- Corrected drifted assertions against the actual schema/messages:
  - `resolution_count` -> `resolved_count`, `resolutions` -> `results` (`MergeConflictResolveResponse`).
  - `"not supported"` -> the real message `"Only source code files are supported"`.
  - The three missing-path cases pointed at `/nonexistent/...`, which path validation (#2848) rejects with a generic `"Invalid or disallowed path"` *before* the existence check runs — so they asserted `"does not exist"` against a message that can never contain it. They now use a non-existent path under an allowed root (`tempfile.gettempdir()`), which actually exercises the does-not-exist branch they are named for.
- Added `test_analyze_disallowed_path` so the original `/nonexistent/file.py` input keeps coverage under its true behaviour (the path-traversal rejection). Test count goes 20 -> 21; nothing was dropped.

## Verification

Static analysis only — no application code, service, or suite was executed locally; CI is the execution environment.

```
$ python3 -m black --check --line-length 120 autobot-backend/api/merge_conflict_resolution_test.py
All done! 1 file would be left unchanged.
$ python3 -m isort --check-only ... ; echo $?      -> 0
$ python3 -m flake8 --max-line-length=120 ...      -> 0 (no output)
$ python3 -c "ast.parse(...)"                      -> ast=ok
```

Route/path alignment (AST-extracted routes vs. every path the tests request):

```
real production paths ('/api' + registry prefix + route path):
  GET   /api/code-intelligence/merge-conflicts/check
  GET   /api/code-intelligence/merge-conflicts/strategies
  POST  /api/code-intelligence/merge-conflicts/analyze
  POST  /api/code-intelligence/merge-conflicts/analyze-repository
  POST  /api/code-intelligence/merge-conflicts/apply
  POST  /api/code-intelligence/merge-conflicts/resolve

requested but NOT a real route (would 404): NONE
real routes never exercised:                NONE
```

Fixture/assertion audit — all 21 tests resolve every fixture argument, and none is vacuous (assertion counts per test range 2-9, minimum 2: status code plus at least one behavioural assertion). No test was weakened to a bare status-code check, no test was skipped, and no assertion was deleted without being replaced by one against the actual behaviour.

Not verifiable without executing code (left to CI):

- That `ConflictParser` returns exactly 1 conflict for the fixture file, and that `semantic_merge`/`accept_ours`/`accept_theirs` produce 1 result each. Confirmed by reading `code_intelligence/merge_conflict_resolver.py`: `resolve_file` returns one `ResolutionResult` per parsed conflict, `to_dict()["strategy"]` is `strategy_used.value`, and `strategy_used` is the requested strategy. All strategy paths are pure string/AST work — no LLM, no network, no I/O beyond the temp file.
- `summary["requires_review"] is True` for `semantic_merge` with `safe_mode=True`: derived from the `requires_review` expression, which forces review for every strategy except `accept_both`/`pattern_based`. Deliberately did *not* assert `all_validated is True` — `_simple_semantic_merge` emits two bare `return` statements, which `ValidationEngine.validate_python` correctly rejects as a `SyntaxError`.
- The `/tmp` assumption: `tempfile.gettempdir()` must resolve under an allowed root. This is the same assumption the pre-existing `NamedTemporaryFile` fixtures already make, so no new constraint is introduced.

Expected effect on the full-suite baseline (467 failed / 18790 passed / 49 errors): -20 failures, +21 passes. Per the issue, the other `fastapi_middleware_astack` failures have different root causes and were deliberately left alone.

## Model Used

claude-opus-5
