### PR TITLE
docs(adr): ADR-009 — one canonical browser interface with execution backends (#12651)

### DIFF
--- a/.session/HANDOFF-issue-12651.md
+++ b/.session/HANDOFF-issue-12651.md
@@ -1,0 +1,67 @@
+# Handoff: issue-12651
+
+status: complete (design phase only — no code)
+pr: (see PR)
+gates: docs-only change; no test/lint gates apply
+needs_rebase_before_merge: no
+worktree: .worktrees/issue-12651  (safe to remove after merge)
+
+## Delivered
+
+`docs/adr/009-canonical-browser-interface.md`, status **Proposed**, following
+the ADR-008 precedent set for #12653.
+
+## The finding that matters
+
+**#12651 says two Playwright stacks. There are three**, and the web-search tool
+in `chat_workflow/tool_handler.py` already fans out across all of them:
+
+1. `research_browser_manager.py` — in-process Python Playwright
+2. `services/playwright_service.py` — HTTP to a Playwright container
+3. `api/browser_mcp.py` → `autobot-browser-worker/` — HTTP to the Node worker
+
+None is redundant. MHTML capture and human handoff exist only in (1); stable
+element refs and live interaction only in (3); restart-survival only in (2)/(3).
+So the ADR wraps them as backends rather than deleting any — deleting two would
+lose features the umbrella's own contract forbids losing.
+
+`research_browser_manager.py` has **no** screenshot capability — checked, after
+initially assuming it did. The `/screenshot` endpoint in `api/playwright.py`
+goes through the container service.
+
+## Security finding — filed as #13204
+
+The SSRF guard is **not uniform**, and the agent-reachable path is the weakest:
+
+| path | guard |
+|---|---|
+| `content_reach/backends/browser.py` | `ensure_public_url` + `ensure_robots_allowed` |
+| `research_browser_manager.py` | DNS-rebind re-check (#13018) |
+| `send_to_browser_vm()` | **none** |
+| `services/playwright_service.py` | **none** |
+
+`is_url_allowed()` in `api/browser_mcp.py` guards exactly one HTTP endpoint
+(`POST /mcp/navigate`) — not the `send_to_browser_vm()` helper the agent tool
+path uses — and it is a regex allowlist, so it cannot see where a host
+resolves. Evidence: it does not even allowlist the search domain that
+`_web_search_via_browser_vm` navigates to, so that path demonstrably never
+passes through it.
+
+The ADR puts the guard in the interface so a backend cannot forget it.
+
+## Next step (needs owner acceptance of the ADR first)
+
+Sequencing is in the ADR. Steps 1-2 (interface + capability model, then wrap the
+three stacks as backends) are **additive** — no caller changes, safe to land
+before deciding on steps 3-6 (repointing `content_reach`, `web_fetch`,
+`tool_handler`, `api/playwright`).
+
+Step 5 (repointing `tool_handler`) is the one that closes #13204 on the agent
+path, and it **will** start blocking requests those paths accept today. That
+needs its own callout in the migration PR.
+
+## Also found
+
+**#12653's ADR already exists** — `docs/adr/008-frontend-shared-code-boundary.md`,
+Accepted 2026-07-31. That issue's step 1 is done; only step 2 (de-duplicate
+`useVncControls` and Advanced Control per the ADR) remains. Do not re-write it.

--- a/docs/adr/009-canonical-browser-interface.md
+++ b/docs/adr/009-canonical-browser-interface.md
@@ -1,0 +1,291 @@
+# ADR-009: One Canonical Browser Interface, With Execution Backends Behind It
+
+## Status
+
+**Status**: Proposed
+
+## Date
+
+**Date**: 2026-08-01
+
+## Context
+
+Issue #12651 (under umbrella #12645, and named in #12756 as "the backbone of
+one Browser") asks for a single canonical browser interface, with in-process
+and Docker execution as strategies behind it rather than two independent
+stacks.
+
+**The issue undercounts the problem. There are three execution stacks, not
+two**, and a single tool call already fans out across all three.
+
+| stack | where | process model |
+|---|---|---|
+| **In-process Playwright** | `autobot-backend/research_browser_manager.py` (704 L) | Python Playwright inside the backend process; one `ResearchBrowserSession` per conversation |
+| **Docker/remote render** | `autobot-backend/services/playwright_service.py` (464 L) | HTTP to a Playwright container (`/test-frontend`, `/search` endpoints) |
+| **Live browser worker** | `autobot-backend/api/browser_mcp.py` → `autobot-browser-worker/` (Node) | HTTP to a long-lived Node/Playwright worker; one `BrowserContext` per chat `session_id` |
+
+The web-search tool in `chat_workflow/tool_handler.py` walks all three in one
+fallback chain:
+
+```text
+_execute_web_search
+  └─ _web_search_via_playwright
+       └─ _web_search_structured_entries
+            ├─ registry providers (SearXNG #9022 / Brave #9023)
+            └─ services.playwright_service.search_web_embedded   ← stack 2
+  └─ _web_search_final_fallback
+       └─ _web_search_via_browser_vm
+            └─ api.browser_mcp.send_to_browser_vm                ← stack 3
+
+content_reach/backends/browser.py
+  └─ research_browser_manager.get_research_browser_manager()     ← stack 1
+```
+
+Each stack was built for a real need, and none is redundant:
+
+- the **in-process** one owns interactive research sessions — MHTML capture,
+  "interaction required" detection, human-in-the-loop waiting;
+- the **Docker** one exists so a JS-render fallback does not put Playwright in
+  the backend's own process (`web_fetch/fetcher.py` uses it that way);
+- the **worker** one owns the live, per-conversation browser the user can watch
+  and take over.
+
+So the goal is *not* to delete two of them. It is to stop them being reachable
+as three unrelated APIs with three different sets of guarantees.
+
+### What the divergence already costs
+
+**1. The SSRF guard is not uniform — and the agent-reachable path is the
+weakest.** Filed as #13204.
+
+| path | URL guard |
+|---|---|
+| `content_reach/backends/browser.py` | `ensure_public_url` + `ensure_robots_allowed` |
+| `research_browser_manager.py` | DNS-rebind re-check after navigation (#13018) |
+| `send_to_browser_vm()` | **none** |
+| `services/playwright_service.py` | **none** |
+
+`api/browser_mcp.py` does have `is_url_allowed()`, but it guards exactly one
+HTTP endpoint (`POST /mcp/navigate`), not the `send_to_browser_vm()` helper the
+agent tool path actually uses — and it is a regex allowlist over the URL
+string, so it cannot see where a host resolves.
+
+This is the clearest argument for the interface: a guard belongs at one
+chokepoint, not re-added to three call sites that have already drifted.
+
+**2. Capability gaps are invisible to callers.** A caller picking a stack
+inherits whatever that stack happens to support:
+
+| capability | in-process | Docker | worker |
+|---|---|---|---|
+| navigate + extract text | yes | via `/search`, `/test-frontend` only | yes |
+| screenshot | **no** | `capture_screenshot` (posts to `/test-frontend`) | yes |
+| stable indexed element refs | no | no | yes (`element-index.js`) |
+| click / fill / select | no | no | yes |
+| MHTML capture | yes | no | no |
+| interaction-required detection + human handoff | yes | no | no |
+| per-conversation isolation | per conversation | none (stateless) | per `session_id` |
+| survives backend restart | no | yes | yes |
+
+**3. Fallback logic is hand-rolled per caller.** `tool_handler.py` encodes its
+own cascade, and comments there (#7478) show it has already been debugged for
+re-issuing a call to a stack it had just determined unavailable. That policy
+should live in one place.
+
+## Decision
+
+Introduce **one canonical browser interface in `autobot_shared`**, with the
+three existing stacks as **execution backends** behind it. Callers state
+*what* they need; the interface picks *where* it runs.
+
+### The interface
+
+```python
+# autobot_shared/browser/base.py
+class BrowserBackend(Protocol):
+    name: str
+    capabilities: frozenset[Capability]
+
+    async def probe(self) -> bool: ...
+    async def navigate(self, req: NavigateRequest) -> PageResult: ...
+    async def extract(self, req: ExtractRequest) -> ContentResult: ...
+    async def screenshot(self, req: ScreenshotRequest) -> ImageResult: ...
+    async def act(self, req: ActionRequest) -> ActionResult: ...   # click/fill/select
+    async def release(self, session: SessionHandle) -> None: ...
+```
+
+Backends declare capabilities rather than implementing everything:
+
+```python
+class Capability(StrEnum):
+    NAVIGATE = "navigate"
+    EXTRACT = "extract"
+    SCREENSHOT = "screenshot"
+    INTERACT = "interact"          # click/fill/select, needs element refs
+    ELEMENT_REFS = "element_refs"
+    MHTML = "mhtml"
+    HUMAN_HANDOFF = "human_handoff"
+    PERSISTENT_SESSION = "persistent_session"
+```
+
+A caller asks for capabilities, not a stack:
+
+```python
+browser = await get_browser(requires={Capability.NAVIGATE, Capability.EXTRACT},
+                            session_id=conversation_id)
+result = await browser.navigate(NavigateRequest(url=url))
+```
+
+`get_browser` resolves against a **declared preference order per capability
+set**, skipping backends that fail `probe()`. That replaces every hand-rolled
+cascade, including `tool_handler.py`'s.
+
+### Non-negotiable: the guard lives in the interface
+
+`ensure_public_url` (DNS-resolving) runs in the interface's `navigate`/`extract`
+entry points, **before** dispatch to any backend. A backend never receives an
+unvalidated URL, so a new backend cannot forget the guard. This closes #13204
+by construction rather than by three separate patches.
+
+### What each existing stack becomes
+
+| stack | becomes | keeps |
+|---|---|---|
+| `research_browser_manager.py` | `InProcessBackend` | MHTML, human handoff, per-conversation sessions |
+| `services/playwright_service.py` | `ContainerBackend` | stateless render/screenshot, survives backend restart |
+| `api/browser_mcp.py` + browser worker | `WorkerBackend` | element refs, interaction, live per-`session_id` context |
+
+None is deleted. Each is wrapped, its callers repointed at the interface, and
+its module reduced to the backend implementation.
+
+### Alternatives Considered
+
+1. **Pick one stack, delete the other two.**
+   - Pros: the least code at the end; one thing to reason about.
+   - Cons: rejected on evidence. Each stack holds capabilities the others lack
+     (MHTML and human handoff only in-process; element refs and live
+     interaction only in the worker; restart-survival only out-of-process).
+     Collapsing onto any one loses features the umbrella's own contract
+     forbids losing.
+
+2. **Keep the stacks, add a thin façade that just re-exports them.**
+   - Pros: smallest diff; no behaviour risk.
+   - Cons: does not fix anything. Callers still choose a stack, the guard is
+     still per-stack, and #13204 stays open. A façade that does not own
+     dispatch and validation is documentation, not architecture.
+
+3. **Make the Node browser worker the single backend for everything.**
+   - Pros: richest feature set (element refs, interaction, per-session
+     contexts); already out-of-process.
+   - Cons: pushes Python-side capabilities (MHTML capture, the research
+     session's interaction-required detection) into a Node service that would
+     have to reimplement them; makes every content fetch depend on the worker
+     being up, where today `web_fetch` deliberately has a container fallback.
+     Worth revisiting *after* the interface exists, as a backend-selection
+     policy change rather than an architecture change.
+
+4. **Adopt PinchTab as the control plane.**
+   - Already rejected in #12756: Go vs Python, and it would be a second
+     control plane rather than one. Its patterns are mined instead.
+
+## Consequences
+
+### Positive
+
+- One place to enforce the URL guard — closes #13204 structurally, and any
+  future backend inherits it.
+- Capability gaps become explicit and queryable instead of discovered by a
+  caller getting a worse result from the stack it happened to pick.
+- Fallback policy is declared once; `tool_handler.py` loses its hand-rolled
+  cascade and the bug class that came with it (#7478).
+- The #12756 children (#12757 IDPI sanitisation, #12758 progressive
+  disclosure, #12759 persistent profiles, #12760 audit surface, #12761
+  pooling) each get one place to land rather than three.
+
+### Negative
+
+- A dispatch layer is a new indirection; a caller reading `get_browser(...)`
+  cannot see which stack ran without checking capabilities and probe results.
+  Mitigated by putting the resolved backend name in the result object and in
+  the log line.
+- Migration touches live paths — `chat_workflow/tool_handler.py`,
+  `web_fetch/fetcher.py`, `content_reach/backends/browser.py`, `api/playwright.py`.
+  Sequenced below so no step changes behaviour and structure at once.
+- Adding the DNS-resolving guard to `send_to_browser_vm` and
+  `playwright_service` **will** block requests those paths accept today.
+  That is the point, but it is a behaviour change and needs its own callout in
+  the migration PR.
+
+### Neutral
+
+- The interface lives in `autobot_shared/browser/`, so the SLM backend could
+  consume it later. Nothing in this ADR requires it to.
+
+## Implementation Notes
+
+Sequenced so each step is separately reviewable and reversible:
+
+1. **Interface + capability model, no callers.** `autobot_shared/browser/`
+   with the protocol, request/result types, `Capability`, and the guard in the
+   entry points. Tests only.
+2. **Wrap the three stacks as backends.** No caller changes; each backend is
+   tested against the same conformance suite for the capabilities it declares.
+3. **Repoint `content_reach/backends/browser.py`** — the smallest caller, and
+   already guarded, so a regression is easy to see.
+4. **Repoint `web_fetch/fetcher.py`'s render fallback.**
+5. **Repoint `chat_workflow/tool_handler.py`**, deleting the hand-rolled
+   cascade. This is the step that closes the #13204 gap on the agent path;
+   ship it with the behaviour-change callout.
+6. **Repoint `api/playwright.py`**, and retire `is_url_allowed`'s regex
+   allowlist in favour of the shared guard plus an explicit internal-host
+   exception list.
+
+Steps 1–2 are additive and safe to land ahead of any decision on 3–6.
+
+### Key Files
+
+- `autobot-backend/research_browser_manager.py` — in-process stack; becomes `InProcessBackend`
+- `autobot-backend/services/playwright_service.py` — container stack; becomes `ContainerBackend`
+- `autobot-backend/api/browser_mcp.py` — worker transport; becomes `WorkerBackend`
+- `autobot-backend/chat_workflow/tool_handler.py` — hand-rolled cascade to be replaced
+- `autobot-backend/content_reach/backends/browser.py` — first caller to migrate
+- `autobot-backend/web_fetch/fetcher.py` — render fallback caller
+- `autobot_shared/url_safety.py` — the guard the interface enforces
+
+### Code Examples
+
+```python
+# Before — the caller picks a stack, and inherits its guarantees.
+from services.playwright_service import search_web_embedded
+result = await search_web_embedded(query, max_results=5)
+if not result.get("success"):
+    from api.browser_mcp import send_to_browser_vm      # unguarded
+    await send_to_browser_vm("navigate", {"url": search_url}, session_id=sid)
+
+# After — the caller states requirements; dispatch and guard are the
+# interface's job.
+browser = await get_browser(
+    requires={Capability.NAVIGATE, Capability.EXTRACT},
+    session_id=conversation_id,
+)
+page = await browser.navigate(NavigateRequest(url=search_url))
+```
+
+## Related ADRs
+
+- [ADR-008](008-frontend-shared-code-boundary.md) — the same
+  "one canonical implementation, explicit boundary" question for the two SPAs
+  (#12653, umbrella #12645)
+
+## Related Issues
+
+- #12651 — this ADR's issue
+- #12756 — epic: one canonical AutoBot browser (names #12651 as its backbone)
+- #13204 — SSRF guard not uniform across browser paths (closed structurally by this design)
+- #12757 / #12758 / #12759 / #12760 / #12761 — #12756 children that land on this interface
+- #13018 — the DNS-rebind fix this design generalises to every path
+
+---
+
+**Author**: mrveiss
+**Copyright**: © 2025 mrveiss

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,7 @@ Each ADR follows a consistent template (see [template.md](template.md)):
 | [ADR-006](006-skill-bound-planning.md) | Skill-Bound Planning | Accepted | 2026-05-16 |
 | [ADR-007](007-connector-oauth-token-storage.md) | Connector OAuth Token and Credential Storage | Accepted | 2026-05-30 |
 | [ADR-008](008-frontend-shared-code-boundary.md) | Frontend Shared-Code Boundary Between the Two SPAs | Accepted | 2026-07-31 |
+| [ADR-009](009-canonical-browser-interface.md) | One Canonical Browser Interface, With Execution Backends Behind It | Proposed | 2026-08-01 |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
Closes #12651

> **Design artefact only — no code.** #12651 asks for a canonical browser
> interface; this is the ADR that defines it, following the ADR-008 precedent
> set for #12653 under the same umbrella. Implementation is sequenced inside
> and needs the ADR accepted first.

## Thinking Path

#12651 frames this as two Playwright stacks — in-process vs Docker. **The audit
found three**, and the web-search tool already fans out across all of them in
one hand-rolled fallback chain:

```text
_execute_web_search
  └─ _web_search_via_playwright → _web_search_structured_entries
       └─ services.playwright_service.search_web_embedded        ← Docker
  └─ _web_search_final_fallback → _web_search_via_browser_vm
       └─ api.browser_mcp.send_to_browser_vm                     ← Node worker

content_reach/backends/browser.py
  └─ research_browser_manager.get_research_browser_manager()     ← in-process
```

The obvious move — pick one, delete two — does not survive contact with the
capability matrix:

| capability | in-process | Docker | worker |
|---|---|---|---|
| stable indexed element refs | no | no | **yes** |
| click / fill / select | no | no | **yes** |
| MHTML capture | **yes** | no | no |
| interaction-required + human handoff | **yes** | no | no |
| screenshot | no | **yes** | **yes** |
| survives backend restart | no | **yes** | **yes** |

Each stack is the only home of something. So the ADR **wraps** them as
execution backends behind one interface rather than deleting any — which is
also what the umbrella's own "zero feature loss" contract requires.

## The finding that drives the design

**The SSRF guard is not uniform, and the agent-reachable path is the weakest.**
Filed separately as **#13204**.

| path | URL guard |
|---|---|
| `content_reach/backends/browser.py` | `ensure_public_url` + `ensure_robots_allowed` |
| `research_browser_manager.py` | DNS-rebind re-check (#13018) |
| `send_to_browser_vm()` | **none** |
| `services/playwright_service.py` | **none** |

`api/browser_mcp.py` does define `is_url_allowed()`, but it guards exactly one
HTTP endpoint (`POST /mcp/navigate`) — **not** the `send_to_browser_vm()` helper
that `chat_workflow/tool_handler.py` calls — and it is a regex allowlist over
the URL string, so it cannot see where a hostname resolves.

Corroborating evidence that the agent path never passes through it: the
allowlist does not include the search domain `_web_search_via_browser_vm`
navigates to, yet that fallback works.

This is the strongest argument for the interface. A guard belongs at one
chokepoint; re-adding it to three call sites that have already drifted apart
just creates a fourth thing to keep in sync.

## What Changed

- **New** `docs/adr/009-canonical-browser-interface.md` (Proposed).
- `docs/adr/README.md` index row.

The ADR specifies a capability-declaring `BrowserBackend` protocol in
`autobot_shared/browser/`, callers requesting capabilities instead of naming a
stack, probe-based dispatch replacing every hand-rolled cascade, and the
DNS-resolving guard enforced in the interface's entry points so a backend
cannot receive an unvalidated URL.

Four alternatives are recorded with why each was rejected — including "make the
worker the single backend", which is worth revisiting *after* the interface
exists, as a selection-policy change rather than an architecture change.

## Verification

Docs-only; no test or lint gate applies. Every factual claim was checked
against the code rather than assumed:

- three stacks and their call sites — `git grep` for consumers of each module;
- guard coverage — `is_url_allowed` has exactly **1** call site;
  `url_safety`/`ensure_public_url` references are 2 / 3 / **0** / **0** across
  the four paths;
- the fallback chain — read directly from `tool_handler.py`.

One claim I got wrong on the first pass and corrected: I had listed
`research_browser_manager.py` as having screenshot support. It does not — the
`/screenshot` endpoint in `api/playwright.py` goes through the container
service. The matrix in the ADR reflects the checked result.

## Also found

**#12653's ADR already exists** — `docs/adr/008-frontend-shared-code-boundary.md`,
Accepted 2026-07-31. That issue's step 1 is complete and only step 2
(de-duplicating `useVncControls` and Advanced Control per the ADR) remains,
which is worth knowing before anyone picks it up expecting to write the ADR.

## Model Used

Claude Opus 5 (1M context)
