### PR TITLE
fix(security): make password change actually revoke sessions on both backends (#12924)

### DIFF
--- a/.session/HANDOFF-issue-12924.md
+++ b/.session/HANDOFF-issue-12924.md
@@ -1,0 +1,59 @@
+# Handoff: issue-12924
+
+status: complete
+gates: shared/user_management=79 PASS (13 new) · backend=65 PASS +1 pre-existing FAIL · slm=35 PASS +1 pre-existing FAIL · isort/black/flake8 PASS
+worktree: .worktrees/issue-12924  (safe to remove after merge)
+
+## The issue's premise was backwards — read this before touching it again
+
+It said "backend invalidates sessions, SLM does not". In effect **neither did**:
+
+- backend wrote a blacklist **nothing reads** — `is_token_blacklisted` has zero
+  production callers, and `_extract_user_from_jwt` is sync so it cannot await
+  Redis at all;
+- SLM had a **working** jti denylist (honoured in `decode_token_async`) that
+  password change never triggered, and no user→jti index to revoke "all other
+  sessions" with.
+
+## Delivered — password epoch (owner's 2026-08-01 decision)
+
+`autobot_shared/user_management/password_epoch.py`: per-**token-subject**
+epoch. One write revokes every outstanding token for that subject.
+
+- `encode_jwt` now stamps `iat` — the epoch check is meaningless without it.
+- Check runs where an await is reachable: backend `get_current_user`
+  (sync extraction now carries `iat` through) and SLM `decode_token_async`.
+- **Three** password-change paths set it, including the backend's config-backed
+  `api/auth.py` self-service endpoint, which never went through
+  `UserService.change_password` and had no revocation whatsoever.
+
+Fails open, loudly, on Redis failure (matches `token_denylist.is_jti_revoked`).
+Pre-#12924 tokens have no `iat` → not revoked, so deploying does not sign
+everyone out.
+
+## Two traps for the next session
+
+1. **`password_epoch.py` deliberately uses stdlib `logging`, not `get_logger`.**
+   `autobot-slm-backend/services/auth.py` imports it at module scope, and that
+   file's test harness (`tests/api/test_auth_logout.py`) loads it with most of
+   the config stack MagicMock'd. `get_logger` builds a RotatingFileHandler from
+   config and raises under that harness — it broke collection until switched.
+   Its sibling `services/token_denylist.py` uses stdlib logging for the same
+   reason. Do not "fix" it back.
+2. **`SessionService` was kept, not removed.** It is still the only mechanism
+   that can spare the caller's *current* token. The epoch is what actually
+   stops the old sessions.
+
+## Pre-existing failures — not from this work, verified on base
+
+- `autobot-backend/api/user_management/users_password_change_test.py::TestPasswordChangeRateLimiting::test_rate_limit_exceeded_returns_429`
+- `autobot-slm-backend/tests/api/test_auth_logout.py::TestRevokeTtlFromToken::test_revoke_called_with_positive_ttl`
+- `autobot_shared/auth/test_slm_permission_parity.py` — collection error on base
+
+## Bearing on #12647
+
+With #12925 (PR #13213) this clears the second of the two files blocking
+"no divergent twin files". `user_service.py`'s divergence is now down to
+backend-only `SessionService` + `memory.ownership_reassign` — the latter is
+inapplicable to SLM (no `memory/` package). Re-run the closure gate on #12647
+once both merge.

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -40,6 +40,7 @@ from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, is_admin_rol
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.password_weakness import check_password_weakness
+from autobot_shared.user_management.password_epoch import set_password_epoch
 from constants.error_constants import ERR_INVALID_CREDENTIALS, ERR_INVALID_TOKEN
 from services.audit.audit import EventType  # GH#8290 Phase 2
 from services.audit.audit import emit as _emit_event  # GH#8290 Phase 2
@@ -491,6 +492,12 @@ async def change_password(request: Request, password_data: ChangePasswordRequest
 
         new_password_hash = get_auth_middleware().hash_password(password_data.new_password)
         _persist_password_change(username, new_password_hash)
+
+        # #12924: stop every session opened with the old password. This is the
+        # config-backed self-service path, which never went through
+        # UserService.change_password and so had no revocation at all. The
+        # epoch is keyed by token subject, which is this username.
+        await set_password_epoch(username)
 
         get_auth_middleware().security_layer.audit_log(
             action="password_changed",

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -28,6 +28,9 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from autobot_shared.time_utils import parse_utc_iso
+from autobot_shared.user_management.password_epoch import (
+    is_token_revoked_by_password_change,
+)
 from config.manager import get_config_manager
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_auth_error
@@ -591,6 +594,14 @@ class AuthenticationMiddleware:
         if token_data.get("org_id"):
             user["org_id"] = token_data["org_id"]
 
+        # #12924: carry ``iat`` through so the async ``get_current_user`` can
+        # reject tokens minted before a password change. This extraction is
+        # synchronous and cannot await Redis itself, which is exactly why the
+        # previous blacklist-based control was unreachable from here.
+        if token_data.get("iat") is not None:
+            user["iat"] = token_data["iat"]
+        user["sub"] = token_data.get("sub") or username
+
         return user
 
     def _extract_user_from_session(self, request: Request) -> Dict | None:
@@ -878,6 +889,18 @@ async def get_current_user(request: Request) -> Dict:
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Device tokens not permitted on this endpoint. Use mobile-specific API.",
             )
+
+        # #12924: a token minted before its subject's password changed is no
+        # longer valid. This is the first point on the request path that can
+        # await, which is why the check lives here rather than in the
+        # synchronous extraction above.
+        if user_data.get("auth_method") == "jwt" and await is_token_revoked_by_password_change(user_data):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token is no longer valid — password was changed. Please sign in again.",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
         return user_data
 
     # Fallback: run-scoped JWT — async because it hits the Redis denylist.

--- a/autobot-backend/user_management/services/user_service.py
+++ b/autobot-backend/user_management/services/user_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import selectinload
 from autobot_shared.auth.jwt_core import hash_password, verify_password
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
+from autobot_shared.user_management.password_epoch import set_password_epoch
 from user_management.models import Role, User, UserRole
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
 from user_management.services.base_service import BaseService, TenantContext
@@ -473,9 +474,17 @@ class UserService(BaseService):
         user.updated_at = now_utc()
         await self.session.flush()
 
-        # Invalidate all sessions except current one
+        # Invalidate all sessions except current one.
+        #
+        # #12924: the blacklist below is kept — it is still the only mechanism
+        # that can spare `current_token` — but on its own it revoked nothing:
+        # `is_token_blacklisted` has no production caller, and this backend's
+        # token extraction is synchronous so it cannot consult Redis. The
+        # password epoch is what actually stops the old sessions; it is checked
+        # on the async auth path in `auth_middleware.get_current_user`.
         session_service = SessionService()
         invalidated_count = await session_service.invalidate_user_sessions(user_id=user_id, except_token=current_token)
+        await set_password_epoch(user.username)
 
         await self._audit_log(
             action=AuditAction.PASSWORD_CHANGED,

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -39,6 +39,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.auth.jwt_core import _peek_alg, decode_jwt_or_none, encode_jwt, hash_password
 from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
+from autobot_shared.user_management.password_epoch import (
+    is_token_revoked_by_password_change,
+)
 from config import settings
 from models.schemas import TokenResponse, UserCreate, UserResponse
 from services.token_denylist import is_jti_revoked
@@ -131,6 +134,16 @@ class AuthService:
                         return None
                 except Exception:
                     logger.warning("jti denylist check failed; failing open", exc_info=True)
+
+            # #12924: the jti denylist revokes one token at a time and there is
+            # no user->jti index, so it cannot express "every session opened
+            # with the old password". The epoch check does that in one lookup.
+            try:
+                if await is_token_revoked_by_password_change(claims):
+                    return None
+            except Exception:
+                logger.warning("password-epoch check failed; failing open", exc_info=True)
+
             return claims
 
         # alg=none or unsupported — reject

--- a/autobot-slm-backend/user_management/services/user_service.py
+++ b/autobot-slm-backend/user_management/services/user_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import selectinload
 from autobot_shared.auth.jwt_core import hash_password, verify_password
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import now_utc
+from autobot_shared.user_management.password_epoch import set_password_epoch
 from user_management.models import Role, User, UserRole
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
 from user_management.services.base_service import BaseService, TenantContext
@@ -470,11 +471,17 @@ class UserService(BaseService):
         user.updated_at = now_utc()
         await self.session.flush()
 
+        # #12924: revoke every session opened with the old password. The jti
+        # denylist this backend already honours can only revoke one token at a
+        # time and there is no user->jti index, so the epoch is what expresses
+        # "all of them". Checked in services/auth.decode_token_async.
+        epoch = await set_password_epoch(user.username)
+
         await self._audit_log(
             action=AuditAction.PASSWORD_CHANGED,
             resource_type=AuditResourceType.USER,
             resource_id=user_id,
-            details={"method": "user_initiated"},
+            details={"method": "user_initiated", "sessions_revoked_from": epoch},
         )
 
         return True

--- a/autobot_shared/auth/jwt_core.py
+++ b/autobot_shared/auth/jwt_core.py
@@ -136,6 +136,14 @@ def encode_jwt(
 
     to_encode = payload.copy()
 
+    # #12924: every minted token carries ``iat`` so password-change revocation
+    # can tell which tokens predate the change. Without it there is no way to
+    # distinguish a token issued before a password change from one issued
+    # after, and revocation has to fall back to per-token bookkeeping.
+    # Callers that set their own ``iat`` are left alone.
+    if "iat" not in to_encode:
+        to_encode["iat"] = datetime.now(tz=timezone.utc)
+
     if "exp" not in to_encode:
         if expires_delta is not None:
             to_encode["exp"] = datetime.now(tz=timezone.utc) + expires_delta

--- a/autobot_shared/user_management/password_epoch.py
+++ b/autobot_shared/user_management/password_epoch.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Password-change token revocation, shared by both backends (#12924).
+
+Changing a password must stop the sessions that were opened with the old one.
+Neither backend actually did that:
+
+- **autobot-backend** called ``SessionService.invalidate_user_sessions`` on
+  password change, which writes blacklist entries to Redis — but
+  ``is_token_blacklisted`` has **zero production callers**, and the backend's
+  token extraction (``auth_middleware._extract_user_from_jwt``) is synchronous
+  so it cannot await a Redis lookup at all. The control was inert.
+- **autobot-slm-backend** has a working per-token JTI denylist that *is*
+  checked on the async decode path, but nothing triggered it on password
+  change, and there is no user→JTI index to revoke a user's other sessions
+  with.
+
+Per the owner's 2026-08-01 decision this uses an **epoch check** rather than
+per-token bookkeeping: record when a subject's password last changed, and
+reject any token issued before that moment. One write invalidates every
+outstanding token for that subject at once — no index to maintain, no TTL
+bookkeeping per token, and it behaves identically on both backends.
+
+**Keyed by token subject, not user id.** Both backends put the username in
+``sub``, and the backend has *two* password-change paths — the config-based
+self-service endpoint in ``api/auth.py`` (which only knows a username) and the
+database-backed ``UserService.change_password`` (which knows a UUID). Keying on
+the subject is the one identifier both paths and both backends share.
+
+**Failure policy: fail open, loudly.** If Redis is unavailable the check
+returns "not revoked" and logs. This matches the existing convention in
+``autobot-slm-backend/services/token_denylist.py`` (``is_jti_revoked`` fails
+open for the same reason): a Redis outage must not lock every user out of the
+platform. The exposure is bounded — an attacker would need to hold a token
+issued before a password change *and* catch Redis down.
+
+**Tokens minted before this shipped have no ``iat``** and are treated as not
+revoked, so deploying this does not sign everyone out. They age out naturally
+at their own ``exp``; #12924's window closes as soon as they do.
+"""
+
+import logging
+import time
+
+from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_constants import TTL_24_HOURS
+
+# Plain stdlib logging, deliberately. This module is imported at module scope by
+# `autobot-slm-backend/services/auth.py`, whose test harness
+# (`tests/api/test_auth_logout.py`) loads that file with most of the config
+# stack replaced by MagicMock. `autobot_shared.logging_manager.get_logger`
+# builds a RotatingFileHandler from config at call time and raises under that
+# harness. Its sibling in the same import chain,
+# `autobot-slm-backend/services/token_denylist.py`, uses stdlib logging for the
+# same reason, and it is what CLAUDE.md's pattern table prescribes.
+logger = logging.getLogger(__name__)
+
+#: Redis key prefix for the per-subject password-change epoch.
+PASSWORD_EPOCH_PREFIX = "auth:pwd_epoch:"
+
+#: How long an epoch marker is kept. It only has to outlive the longest-lived
+#: token that could predate it; after that every such token has expired on its
+#: own and the marker cannot change any decision.
+PASSWORD_EPOCH_TTL_SECONDS = TTL_24_HOURS
+
+
+def _epoch_key(subject: str) -> str:
+    """Redis key holding the password-change epoch for *subject*."""
+    return f"{PASSWORD_EPOCH_PREFIX}{subject}"
+
+
+async def set_password_epoch(subject: str, *, now: int | None = None) -> int | None:
+    """Mark *subject*'s password as changed now, revoking older tokens.
+
+    Returns the epoch written, or ``None`` if Redis was unavailable — in which
+    case **no revocation happened** and the caller should treat the password
+    change as not having invalidated other sessions.
+
+    Args:
+        subject: The token subject (``sub`` claim) whose sessions to revoke.
+        now: Override for the epoch timestamp, for tests.
+    """
+    epoch = int(time.time()) if now is None else now
+
+    redis = await get_async_redis_client()
+    if redis is None:
+        logger.error(
+            "password epoch NOT recorded for subject=%s — Redis unavailable; "
+            "tokens issued before this password change remain valid",
+            subject,
+        )
+        return None
+
+    try:
+        await redis.setex(_epoch_key(subject), PASSWORD_EPOCH_TTL_SECONDS, str(epoch))
+    except Exception as exc:
+        logger.error(
+            "password epoch NOT recorded for subject=%s: %s — tokens issued "
+            "before this password change remain valid",
+            subject,
+            exc,
+        )
+        return None
+
+    logger.info("Password epoch recorded for subject=%s: tokens issued before %s are revoked", subject, epoch)
+    return epoch
+
+
+async def get_password_epoch(subject: str) -> int | None:
+    """Return *subject*'s password-change epoch, or None if unset/unavailable."""
+    redis = await get_async_redis_client()
+    if redis is None:
+        return None
+
+    try:
+        raw = await redis.get(_epoch_key(subject))
+    except Exception as exc:
+        logger.warning("password epoch lookup failed for subject=%s: %s — failing open", subject, exc)
+        return None
+
+    if raw is None:
+        return None
+
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning("password epoch for subject=%s is not an integer: %r — ignoring", subject, raw)
+        return None
+
+
+async def is_token_revoked_by_password_change(claims: dict) -> bool:
+    """True if *claims* describe a token issued before its subject's password change.
+
+    Fails open (returns ``False``) when the subject is unknown, the token
+    carries no ``iat``, or Redis cannot answer — see the module docstring for
+    why. Every one of those cases is logged by the helper that hit it.
+    """
+    subject = claims.get("sub")
+    if not subject:
+        return False
+
+    issued_at = claims.get("iat")
+    if issued_at is None:
+        # Pre-#12924 token: no way to place it relative to the epoch.
+        return False
+
+    epoch = await get_password_epoch(str(subject))
+    if epoch is None:
+        return False
+
+    try:
+        issued_at = int(issued_at)
+    except (TypeError, ValueError):
+        logger.warning("token for subject=%s has a non-integer iat: %r — failing open", subject, issued_at)
+        return False
+
+    if issued_at < epoch:
+        logger.warning(
+            "Token for subject=%s rejected: issued at %s, before password change at %s",
+            subject,
+            issued_at,
+            epoch,
+        )
+        return True
+
+    return False

--- a/autobot_shared/user_management/password_epoch.py
+++ b/autobot_shared/user_management/password_epoch.py
@@ -58,7 +58,9 @@ from autobot_shared.ssot_constants import TTL_24_HOURS
 logger = logging.getLogger(__name__)
 
 #: Redis key prefix for the per-subject password-change epoch.
-PASSWORD_EPOCH_PREFIX = "auth:pwd_epoch:"
+#: nosec B105 — this is a Redis key namespace, not a credential. bandit flags
+#: it only because the constant name contains "PASSWORD".
+PASSWORD_EPOCH_PREFIX = "auth:pwd_epoch:"  # nosec B105
 
 #: How long an epoch marker is kept. It only has to outlive the longest-lived
 #: token that could predate it; after that every such token has expired on its

--- a/autobot_shared/user_management/password_epoch_test.py
+++ b/autobot_shared/user_management/password_epoch_test.py
@@ -1,0 +1,158 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Password-change revocation actually revokes (#12924).
+
+Before this, neither backend stopped a session when its password changed:
+autobot-backend wrote a blacklist nothing read (``is_token_blacklisted`` has no
+production caller, and its token extraction is synchronous so it cannot await
+one), and the SLM had a working jti denylist that password change never
+triggered.
+
+These tests pin the two properties that make the epoch check a real control
+rather than another inert one: a token issued before the change is rejected,
+and a token issued after it is not. The fail-open paths are pinned too, because
+"fails open" is a deliberate availability choice here and a silent change to it
+would lock every user out during a Redis outage.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.user_management.password_epoch import (
+    PASSWORD_EPOCH_PREFIX,
+    get_password_epoch,
+    is_token_revoked_by_password_change,
+    set_password_epoch,
+)
+
+_MOD = "autobot_shared.user_management.password_epoch.get_async_redis_client"
+
+
+def _redis(get_value=None):
+    r = AsyncMock()
+    r.get = AsyncMock(return_value=get_value)
+    r.setex = AsyncMock(return_value=True)
+    return r
+
+
+@pytest.mark.asyncio
+async def test_token_issued_before_the_change_is_revoked():
+    """The whole point of the issue."""
+    with patch(_MOD, AsyncMock(return_value=_redis(get_value="1000"))):
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 999}) is True
+
+
+@pytest.mark.asyncio
+async def test_token_issued_after_the_change_survives():
+    """A password change must not log the user out of the new session."""
+    with patch(_MOD, AsyncMock(return_value=_redis(get_value="1000"))):
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 1000}) is False
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 1001}) is False
+
+
+@pytest.mark.asyncio
+async def test_no_epoch_means_no_revocation():
+    """Users who never changed a password are unaffected."""
+    with patch(_MOD, AsyncMock(return_value=_redis(get_value=None))):
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 1}) is False
+
+
+@pytest.mark.asyncio
+async def test_pre_12924_token_without_iat_is_not_revoked():
+    """Deploying this must not sign out everyone holding an older token."""
+    with patch(_MOD, AsyncMock(return_value=_redis(get_value="1000"))):
+        assert await is_token_revoked_by_password_change({"sub": "alice"}) is False
+
+
+@pytest.mark.asyncio
+async def test_token_without_subject_is_not_revoked():
+    with patch(_MOD, AsyncMock(return_value=_redis(get_value="1000"))):
+        assert await is_token_revoked_by_password_change({"iat": 1}) is False
+
+
+@pytest.mark.asyncio
+async def test_fails_open_when_redis_is_down():
+    """Deliberate: a Redis outage must not lock every user out."""
+    with patch(_MOD, AsyncMock(return_value=None)):
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 1}) is False
+
+
+@pytest.mark.asyncio
+async def test_fails_open_when_redis_raises():
+    r = AsyncMock()
+    r.get = AsyncMock(side_effect=RuntimeError("redis down"))
+    with patch(_MOD, AsyncMock(return_value=r)):
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 1}) is False
+
+
+@pytest.mark.asyncio
+async def test_corrupt_epoch_value_is_ignored():
+    with patch(_MOD, AsyncMock(return_value=_redis(get_value="not-a-number"))):
+        assert await get_password_epoch("alice") is None
+
+
+@pytest.mark.asyncio
+async def test_set_password_epoch_writes_a_ttl_bounded_key():
+    r = _redis()
+    with patch(_MOD, AsyncMock(return_value=r)):
+        epoch = await set_password_epoch("alice", now=1234)
+
+    assert epoch == 1234
+    key, ttl, value = r.setex.await_args.args
+    assert key == f"{PASSWORD_EPOCH_PREFIX}alice"
+    assert ttl > 0, "epoch must expire, or the key set grows without bound"
+    assert value == "1234"
+
+
+@pytest.mark.asyncio
+async def test_set_password_epoch_reports_failure_rather_than_pretending():
+    """Returning None tells the caller no revocation happened."""
+    with patch(_MOD, AsyncMock(return_value=None)):
+        assert await set_password_epoch("alice") is None
+
+    r = AsyncMock()
+    r.setex = AsyncMock(side_effect=RuntimeError("redis down"))
+    with patch(_MOD, AsyncMock(return_value=r)):
+        assert await set_password_epoch("alice") is None
+
+
+@pytest.mark.asyncio
+async def test_epoch_and_check_agree_end_to_end():
+    """Write an epoch, then verify tokens either side of it."""
+    store: dict[str, str] = {}
+    r = AsyncMock()
+    r.setex = AsyncMock(side_effect=lambda k, ttl, v: store.__setitem__(k, v))
+    r.get = AsyncMock(side_effect=lambda k: store.get(k))
+
+    with patch(_MOD, AsyncMock(return_value=r)):
+        epoch = await set_password_epoch("alice", now=5000)
+        assert epoch == 5000
+
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 4999}) is True
+        assert await is_token_revoked_by_password_change({"sub": "alice", "iat": 5000}) is False
+        # a different user is untouched
+        assert await is_token_revoked_by_password_change({"sub": "bob", "iat": 1}) is False
+
+
+def test_encode_jwt_now_stamps_iat():
+    """The epoch check is meaningless without iat on minted tokens (#12924)."""
+    import jwt as pyjwt
+
+    from autobot_shared.auth.jwt_core import encode_jwt
+
+    token = encode_jwt({"sub": "alice"}, secret="s" * 32, expiry_hours=1)
+    claims = pyjwt.decode(token, "s" * 32, algorithms=["HS256"])
+
+    assert "iat" in claims
+
+
+def test_encode_jwt_does_not_override_a_caller_supplied_iat():
+    import jwt as pyjwt
+
+    from autobot_shared.auth.jwt_core import encode_jwt
+
+    token = encode_jwt({"sub": "alice", "iat": 4242}, secret="s" * 32, expiry_hours=1)
+    claims = pyjwt.decode(token, "s" * 32, algorithms=["HS256"])
+
+    assert claims["iat"] == 4242

--- a/autobot_shared/user_management/password_epoch_test.py
+++ b/autobot_shared/user_management/password_epoch_test.py
@@ -147,6 +147,26 @@ def test_encode_jwt_now_stamps_iat():
     assert "iat" in claims
 
 
+def test_encoded_iat_is_an_integer_timestamp():
+    """PyJWT >= 2.10 rejects a non-integer ``iat`` on decode.
+
+    ``encode_jwt`` hands PyJWT a ``datetime`` and relies on it normalising to a
+    Unix timestamp. This repo has already been bitten by a non-integer ``iat``
+    once — it silently 401'd every authenticated request and produced a login
+    redirect loop (see the comment on ``create_jwt_token`` in
+    ``autobot-backend/auth_middleware.py``). Pinned so a PyJWT change or a
+    refactor of the encoder cannot reintroduce it quietly.
+    """
+    import jwt as pyjwt
+
+    from autobot_shared.auth.jwt_core import encode_jwt
+
+    token = encode_jwt({"sub": "alice"}, secret="s" * 32, expiry_hours=1)
+    claims = pyjwt.decode(token, "s" * 32, algorithms=["HS256"])
+
+    assert isinstance(claims["iat"], int), f"iat must be an int, got {type(claims['iat']).__name__}"
+
+
 def test_encode_jwt_does_not_override_a_caller_supplied_iat():
     import jwt as pyjwt
 


### PR DESCRIPTION
Closes #12924

## Thinking Path

This issue says the backend invalidates sessions on password change and the SLM does not. **In effect neither did**, and the backend's half was the more serious.

**autobot-backend's control was inert.** `SessionService.invalidate_user_sessions` writes blacklist entries to Redis, but:

```
$ grep -rn "is_token_blacklisted" --include=*.py .   # excluding tests + the definition
autobot-backend/user_management/services/session_service.py:56:    async def is_token_blacklisted(...)
```

Zero production callers, repo-wide — and it structurally cannot have one on the main path, because the extraction is synchronous:

```python
def _extract_user_from_jwt(self, request: Request) -> Dict | None:   # auth_middleware.py:551
```

so it cannot await a Redis lookup. The `sessions_invalidated` figure in the audit record was the number of keys written, not sessions stopped.

**autobot-slm-backend had the machinery but no trigger.** `services/token_denylist.py` is genuinely honoured in `decode_token_async` — but nothing called `revoke_jti` on password change, and there is no user→jti index, so it cannot express "every session opened with the old password" even if asked.

So the plan in the issue body — port `session_service.py` to the SLM — would have copied the **non-functional** design onto the side that already had a working one.

## What Changed

Per your decision, a **password epoch** rather than per-token bookkeeping.

**New `autobot_shared/user_management/password_epoch.py`** — records, per **token subject**, when that subject's password last changed. One write revokes every outstanding token for them: no index to maintain, no per-token TTL bookkeeping, identical on both backends.

Keyed by subject rather than user id because that is the one identifier shared by both backends *and* by both of the backend's two password-change paths.

**`encode_jwt` now stamps `iat`.** Without it there is no way to place a token relative to the epoch. Caller-supplied `iat` is left alone.

**The check runs where an await is reachable** — the backend's async `get_current_user` (the sync extraction now carries `iat` through), and the SLM's `decode_token_async` alongside the existing jti check.

**All three password-change paths set the epoch**, including `autobot-backend/api/auth.py`'s config-backed self-service endpoint — which never went through `UserService.change_password` and therefore had *no* revocation of any kind.

`SessionService` is **kept, not removed**: it remains the only mechanism that can spare the caller's current token.

## Deliberate failure policy

**Fails open, loudly.** If Redis cannot answer, the check returns "not revoked" and logs. This matches the existing convention in `token_denylist.is_jti_revoked` — a Redis outage must not lock every user out of the platform. `set_password_epoch` returns `None` on failure so the caller knows no revocation happened rather than assuming it did.

**Pre-#12924 tokens carry no `iat`** and are treated as not revoked, so deploying this does not sign everyone out. They age out at their own `exp`.

## Verification

```
autobot_shared/user_management                    79 passed  (13 new)
autobot-backend/user_management + api/user_management  65 passed, 1 pre-existing failure
autobot-slm-backend/user_management + auth logout      35 passed, 1 pre-existing failure
```

The 13 new tests pin both directions (token before the epoch rejected, token after it kept), every fail-open path, and that `encode_jwt` stamps `iat` without overriding a caller's.

Both remaining failures were verified on the base commit before this branch existed: `users_password_change_test::test_rate_limit_exceeded_returns_429` and `test_auth_logout::test_revoke_called_with_positive_ttl`.

**One regression I introduced and fixed:** the new module's module-level `get_logger` broke *collection* of `tests/api/test_auth_logout.py`, because that harness loads `services/auth.py` with most of the config stack MagicMock'd and `get_logger` builds a RotatingFileHandler from config. Switched to stdlib `logging`, matching its sibling `services/token_denylist.py` in the same import chain, with a comment saying why. Collection is now identical to base.

## A correction on an earlier PR of mine

In #13178 I converged SLM's `user_service` onto `get_logger` and described that as "the pattern CLAUDE.md mandates". That was inaccurate — CLAUDE.md's pattern table actually prescribes `logging.getLogger(__name__)`. The change itself was still right by dominant convention (`get_logger` 1363 files vs `logging.getLogger` 296), but the justification I gave for it was wrong, and the table is worth reconciling with the code.

## Model Used

Claude Opus 5 (1M context)
