### PR TITLE
test(chat_workflow): stop rebinding utils.errors.RepairableException on the real module (#13223)

### DIFF
--- a/autobot-backend/tests/test_tool_schema_correction.py
+++ b/autobot-backend/tests/test_tool_schema_correction.py
@@ -46,12 +46,23 @@ import pytest
 _BACKEND_ROOT = Path(__file__).parent.parent  # autobot-backend/
 
 
-def _simple_stub(name: str) -> MagicMock:
-    """Register a plain MagicMock as *name* if not already present."""
-    if name not in sys.modules:
-        mod = MagicMock()
-        sys.modules[name] = mod
-    return sys.modules[name]  # type: ignore[return-value]
+def _simple_stub(name: str, **attrs: object) -> MagicMock:
+    """Register a plain MagicMock as *name* if not already present.
+
+    ``attrs`` are applied ONLY to a stub this call creates.  When *name* is
+    already in ``sys.modules`` it is very likely the real module — imported by
+    an earlier test on the same xdist worker — and rebinding attributes on it
+    would leak permanently into every test that runs afterwards (#13223).
+    Such a module is therefore returned untouched.
+    """
+    existing = sys.modules.get(name)
+    if existing is not None:
+        return existing  # type: ignore[return-value]
+    mod = MagicMock()
+    for attr, value in attrs.items():
+        setattr(mod, attr, value)
+    sys.modules[name] = mod
+    return mod
 
 
 def _pkg_stub(name: str) -> types.ModuleType:
@@ -84,32 +95,43 @@ if "async_chat_workflow" not in sys.modules:
     _wf_mod.AsyncChatWorkflow = MagicMock  # type: ignore[attr-defined]
     sys.modules["async_chat_workflow"] = _wf_mod
 
-# utils.errors
-_ue = _simple_stub("utils.errors")
-_ue.RepairableException = Exception  # type: ignore[attr-defined]
+# utils.errors is deliberately NOT stubbed (#13223).  utils/errors.py has no
+# imports of its own and utils/__init__.py is a bare docstring, so the real
+# module always loads — there is no import cost or cycle to avoid.  The former
+# stub rebound RepairableException to builtin Exception on the *real* module
+# object and never restored it, which broke every later test on the same worker
+# that constructed RepairableException with keyword arguments.
 
 # chat_workflow package stub — must exist before chat_workflow.llm_handler /
 # chat_workflow.session_handler sub-stubs are registered.  We use a real
 # ModuleType with __path__ so Python treats it as a package.
 _cw_pkg = _pkg_stub("chat_workflow")
-_cw_pkg.__path__ = [str(_BACKEND_ROOT / "chat_workflow")]  # type: ignore[attr-defined]
+if not getattr(_cw_pkg, "__path__", None):
+    # Only a stub we just created has an empty __path__; if the real package is
+    # already imported its __path__ is correct and must not be overwritten.
+    _cw_pkg.__path__ = [str(_BACKEND_ROOT / "chat_workflow")]  # type: ignore[attr-defined]
 
 # Sub-module stubs for the two imports tool_handler pulls in at module level.
-_lh = _simple_stub("chat_workflow.llm_handler")
-_lh._emit_before_tool_execute = AsyncMock(return_value=True)  # type: ignore[attr-defined]
-_lh._emit_after_tool_execute = AsyncMock(side_effect=lambda t, r, s, m: r)  # type: ignore[attr-defined]
-_lh._emit_tool_error = AsyncMock(return_value=None)  # type: ignore[attr-defined]
-
-_sh = _simple_stub("chat_workflow.session_handler")
-_sh._emit_approval_received = AsyncMock(return_value=None)  # type: ignore[attr-defined]
-_sh._emit_approval_required = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+# The emitter mocks are attached by _simple_stub only when it creates the stub —
+# if the real handler modules are already imported they keep their real emitters,
+# which the tests that exercise them patch on chat_workflow.tool_handler anyway.
+_simple_stub(
+    "chat_workflow.llm_handler",
+    _emit_before_tool_execute=AsyncMock(return_value=True),
+    _emit_after_tool_execute=AsyncMock(side_effect=lambda t, r, s, m: r),
+    _emit_tool_error=AsyncMock(return_value=None),
+)
+_simple_stub(
+    "chat_workflow.session_handler",
+    _emit_approval_received=AsyncMock(return_value=None),
+    _emit_approval_required=AsyncMock(return_value=None),
+)
 
 # services.mcp_dispatch is imported lazily (local import) inside
 # _try_mcp_dispatch.  Pre-register a stub package + module so patch() can
 # resolve "services.mcp_dispatch.get_mcp_dispatcher" correctly.
 _svc_pkg = _pkg_stub("services")
-_mcp_stub = _simple_stub("services.mcp_dispatch")
-_mcp_stub.get_mcp_dispatcher = MagicMock()  # type: ignore[attr-defined]
+_mcp_stub = _simple_stub("services.mcp_dispatch", get_mcp_dispatcher=MagicMock())
 _svc_pkg.mcp_dispatch = _mcp_stub  # type: ignore[attr-defined]
 
 # Load tool_handler directly from its source file, bypassing __init__.py.

--- a/autobot-backend/tests/test_tool_schema_correction.py
+++ b/autobot-backend/tests/test_tool_schema_correction.py
@@ -106,7 +106,7 @@ if "async_chat_workflow" not in sys.modules:
 # chat_workflow.session_handler sub-stubs are registered.  We use a real
 # ModuleType with __path__ so Python treats it as a package.
 _cw_pkg = _pkg_stub("chat_workflow")
-if not getattr(_cw_pkg, "__path__", None):
+if not _cw_pkg.__dict__.get("__path__"):
     # Only a stub we just created has an empty __path__; if the real package is
     # already imported its __path__ is correct and must not be overwritten.
     _cw_pkg.__path__ = [str(_BACKEND_ROOT / "chat_workflow")]  # type: ignore[attr-defined]


### PR DESCRIPTION
Closes #13223

## Thinking Path

The reported premise was re-verified before touching anything.

`autobot-backend/utils/errors.py:14` defines `RepairableException(Exception)` with an
`__init__` at `:43` taking `suggestion` / `original_exception` and calling
`super().__init__(message)` at `:57` — the production class is correct. The defect is
purely cross-test contamination:

`test_tool_schema_correction.py`'s `_simple_stub()` returned `sys.modules[name]` when the
name was already present, i.e. **the real module**. Line 89 then did
`_ue.RepairableException = Exception` on it, permanently, for the rest of that worker's
run. `utils/repairable_exception_test.py` constructs the class with keyword arguments
(`:38`, `:45`, `:55`, `:62`) and reaches it again through `wrap_as_repairable()` and
through `tool_handler._match_repairable_error()` (which re-imports it locally at
`chat_workflow/tool_handler.py:786`), so both the direct and the indirect call sites hit
`TypeError: Exception() takes no keyword arguments`.

**Removed rather than scoped.** `monkeypatch` was not an option — the substitution runs at
module import time, before any fixture exists, and a save/restore fixture would still
leave the real module poisoned for everything collected in between. More importantly the
stub was never needed: `utils/errors.py` has **zero** import statements and
`utils/__init__.py` is a bare docstring, so there is no import cost and no cycle to avoid.
The real module now loads, which is also more faithful to what `tool_handler` does in
production.

Verified by AST that none of the 21 tests in this file exercise `RepairableException`:
`validate_tool_arguments` (`:79-113`), `_format_schema_validation_errors` (`:63-76`) and
`_try_mcp_dispatch` (`:860-994`) contain no reference to it. The stub only ever existed to
satisfy `tool_handler`'s module-level import, so removing it changes no assertion and makes
no test vacuous.

## What Changed

`autobot-backend/tests/test_tool_schema_correction.py`

- **Removed the `utils.errors` stub and the `RepairableException = Exception` rebind**
  entirely, with a comment recording why no stub is needed.
- **`_simple_stub()` now takes the stub attributes as keyword arguments and applies them
  only to a stub it creates.** An already-present module is returned untouched. This closes
  the same defect for three more sites in the file that were mutating real modules:
  `chat_workflow.llm_handler._emit_before_tool_execute` / `_emit_after_tool_execute` /
  `_emit_tool_error` and `chat_workflow.session_handler._emit_approval_received` /
  `_emit_approval_required`. Those five names are imported directly at module level by
  `chat_workflow/wired_hooks_test.py:20-44`, which asserts the real hook dispatch — it was
  a collection-order coin flip whether it got real coroutines or this file's `AsyncMock`s.
- **`chat_workflow.__path__` is only assigned when the stub was freshly created**; the real
  package already has a correct `__path__` and must not be overwritten.

No assertion was weakened, no test was removed, no TODO or swallowed exception added.
The two tests that reach the emitters (`test_valid_args_dispatches_successfully`,
`test_tool_without_input_schema_skips_validation`) already patch them on
`chat_workflow.tool_handler`, so they behave identically either way; the rest return on the
schema-error branch before any emitter is called.

## Verification

Static only — this branch executes no application code and no test suite.

Reproduction of the exact contamination, stdlib-only, old semantics vs new:

```
utils/__init__.py: 0 import statements -> []
utils/errors.py:   0 import statements -> []
OLD: real module contaminated -> TypeError: Exception() takes no keyword arguments
NEW: real module untouched -> RepairableException, suggestion='y'
NEW: fresh stub gets attrs -> 42
```

AST scan for the defect class (module-level `<mod>.<attr> = ...` where `<mod>` is bound
from `sys.modules[...]` or a helper that can return a real module), run against the base
commit and against this branch:

```
base   test_tool_schema_correction.py -> 10 hits (incl. :89 _ue.RepairableException = Exception)
branch test_tool_schema_correction.py ->  1 hit  (_cw_pkg.tool_handler = _th_mod, deliberate)
```

Lint / parse:

```
black --line-length 120 --check   -> 1 file would be left unchanged
isort --check-only                -> clean
flake8 --max-line-length 120      -> 0
python3 -m py_compile             -> OK
```

The AST scan also flagged the same defect class in files outside this issue's scope
(`redis` and `autobot_shared` internals rebound on the real modules). Those are filed as
#13224 rather than swept into this PR.

**Not verifiable without executing code:** the actual failure delta. The expectation is
−14 (the `TypeError` failures) with no new failures; the emitter hardening may also help
`chat_workflow/wired_hooks_test.py` under randomized or xdist ordering. CI is the
measurement.

## Model Used

claude-opus-5
