### PR TITLE
feat(browser): canonical browser interface + three backend wrappers, ADR-009 phases 1-2 (#12651)

### DIFF
--- a/.session/HANDOFF-issue-12651-impl.md
+++ b/.session/HANDOFF-issue-12651-impl.md
@@ -1,0 +1,45 @@
+# Handoff: issue-12651-impl
+
+status: complete (ADR-009 phases 1-2 only, per owner scope)
+gates: 30 tests PASS (15 registry + 15 conformance) · isort/black/flake8 PASS · bandit 0 issues
+worktree: .worktrees/issue-12651-impl  (safe to remove after merge)
+
+## Delivered — additive only
+
+**Phase 1** `autobot_shared/browser/` — `Capability`, frozen request/result
+dataclasses, `BrowserBackend` Protocol, capability dispatch with probe-based
+fallback, and the DNS-resolving URL guard enforced **before** any backend sees
+a request.
+
+**Phase 2** `autobot-backend/browser_backends/` — the three stacks wrapped:
+`in_process` (research_browser_manager), `worker` (browser_mcp), `container`
+(playwright_service).
+
+**Nothing is repointed.** No caller changed; `register_all()` is opt-in.
+
+## Two traps
+
+1. **Backends must NOT move to `autobot_shared`.** They wrap this app's
+   transports; shared code importing `research_browser_manager` /
+   `services.playwright_service` / `api.browser_mcp` is the inverted dependency
+   #13201 had to design around. `autobot_shared/browser/registry_test.py`
+   asserts this by AST — if you see that test fail, do not "fix" it by
+   loosening the assertion.
+2. **`Capability` is `(str, Enum)`, not `StrEnum`.** `autobot_shared` targets
+   3.14 where `StrEnum` exists, but this dev box is 3.10 — `StrEnum` makes the
+   whole module unimportable locally, so nothing can be verified before CI.
+   `status_enums.AgentLifecycleStatus` uses the same `(str, Enum)` shape.
+
+## What is deliberately NOT done — steps 3-6
+
+ADR-009's caller migration (`content_reach`, `web_fetch`, `tool_handler`,
+`api/playwright`) is **out of scope** by owner decision (2026-08-01), because
+step 5 is a behaviour change: enforcing the guard starts blocking internal
+URLs that `send_to_browser_vm` accepts today.
+
+**Consequence: #13204 stays OPEN.** The interface closes it structurally only
+once callers route through it. Do not close #13204 on this PR.
+
+**#12651's "Done when" says "callers use it"** — which phases 1-2 do not
+satisfy. Either reword that AC or file a follow-up for steps 3-6 before
+closing #12651.

--- a/autobot-backend/browser_backends/__init__.py
+++ b/autobot-backend/browser_backends/__init__.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""This backend's browser stacks, registered behind the canonical interface (#12651).
+
+`autobot_shared.browser` owns the contract and the dispatch; the three stacks
+live here because they are this app's transports. Shared code must never import
+them — that inverted dependency is what #13201 had to design around for
+`organization_service`, and `autobot_shared/browser/registry_test.py` asserts
+by AST that it has not crept back.
+
+Registration order is preference order per capability set. `in_process` leads
+because it owns interactive research sessions with MHTML and human handoff;
+`worker` follows for element refs and real interaction; `container` last, as
+the stateless render/screenshot fallback that survives a backend restart.
+
+Nothing is repointed by importing this — ADR-009 phases 1–2 are additive.
+Callers keep their existing paths until the migration steps land.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from autobot_shared.browser.registry import register_backend
+from browser_backends.container import ContainerBrowserBackend
+from browser_backends.in_process import InProcessBrowserBackend
+from browser_backends.worker import WorkerBrowserBackend
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ContainerBrowserBackend",
+    "InProcessBrowserBackend",
+    "WorkerBrowserBackend",
+    "register_all",
+]
+
+_registered = False
+
+
+def register_all(*, force: bool = False) -> None:
+    """Register this app's browser backends. Idempotent.
+
+    Safe to call from app startup more than once — `register_backend` replaces
+    by name rather than stacking, and the module-level guard avoids the churn.
+    """
+    global _registered
+    if _registered and not force:
+        return
+
+    register_backend(InProcessBrowserBackend())
+    register_backend(WorkerBrowserBackend())
+    register_backend(ContainerBrowserBackend())
+    _registered = True
+    logger.info("browser: registered in_process, worker, container backends")

--- a/autobot-backend/browser_backends/conformance_test.py
+++ b/autobot-backend/browser_backends/conformance_test.py
@@ -1,0 +1,197 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The three backends conform to the canonical browser contract (#12651).
+
+ADR-009 wraps three stacks rather than collapsing onto one, because each is the
+only home of something: MHTML capture and human handoff in-process, stable
+element refs and interaction in the worker, restart-survival out-of-process.
+
+These pin the properties that make that safe — every backend satisfies the
+Protocol, declares capabilities matching what it can actually do, and refuses
+rather than pretends when asked for something it does not have. Transport is
+mocked throughout; nothing here starts a browser.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from autobot_shared.browser.base import (
+    ActionRequest,
+    BrowserBackend,
+    Capability,
+    ExtractRequest,
+    NavigateRequest,
+    ScreenshotRequest,
+    SessionHandle,
+)
+from browser_backends import (
+    ContainerBrowserBackend,
+    InProcessBrowserBackend,
+    WorkerBrowserBackend,
+    register_all,
+)
+
+_ALL = [InProcessBrowserBackend, ContainerBrowserBackend, WorkerBrowserBackend]
+
+
+@pytest.mark.parametrize("cls", _ALL, ids=lambda c: c.name)
+def test_satisfies_the_protocol(cls):
+    assert isinstance(cls(), BrowserBackend)
+
+
+@pytest.mark.parametrize("cls", _ALL, ids=lambda c: c.name)
+def test_declares_a_name_and_capabilities(cls):
+    backend = cls()
+    assert isinstance(backend.name, str) and backend.name
+    assert backend.capabilities
+    assert all(isinstance(c, Capability) for c in backend.capabilities)
+
+
+def test_capability_claims_match_the_audited_matrix():
+    """ADR-009's matrix, pinned. A wrong claim routes work to a stack that cannot do it."""
+    in_process = InProcessBrowserBackend()
+    worker = WorkerBrowserBackend()
+    container = ContainerBrowserBackend()
+
+    # Only in-process captures MHTML and hands off to a human.
+    assert Capability.MHTML in in_process.capabilities
+    assert Capability.HUMAN_HANDOFF in in_process.capabilities
+    assert Capability.MHTML not in worker.capabilities | container.capabilities
+    assert Capability.HUMAN_HANDOFF not in worker.capabilities | container.capabilities
+
+    # Only the worker has stable element refs and interaction.
+    assert {Capability.ELEMENT_REFS, Capability.INTERACT} <= worker.capabilities
+    assert not ({Capability.ELEMENT_REFS, Capability.INTERACT} & in_process.capabilities)
+    assert not ({Capability.ELEMENT_REFS, Capability.INTERACT} & container.capabilities)
+
+    # research_browser_manager has no screenshot path — verified in ADR-009.
+    assert Capability.SCREENSHOT not in in_process.capabilities
+    assert Capability.SCREENSHOT in container.capabilities
+    assert Capability.SCREENSHOT in worker.capabilities
+
+
+@pytest.mark.asyncio
+async def test_unsupported_operations_refuse_rather_than_raise():
+    """The registry never routes these, but they must not explode if reached."""
+    result = await InProcessBrowserBackend().screenshot(ScreenshotRequest(url="https://example.com"))
+    assert result.success is False and "screenshot" in result.error
+
+    result = await ContainerBrowserBackend().act(ActionRequest(action="click"))
+    assert result.success is False and "interaction" in result.error
+
+    result = await ContainerBrowserBackend().navigate(NavigateRequest(url="https://example.com"))
+    assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_in_process_maps_research_url_onto_the_contract():
+    manager = MagicMock()
+    manager.research_url = AsyncMock(
+        return_value={
+            "success": True,
+            "status": "completed",
+            "navigation": {"url": "https://example.com/", "title": "Example"},
+            "content": {"text_content": "hello", "mhtml_backup": "/tmp/p.mhtml"},
+            "session_id": "sess-1",
+            "browser_url": "/browser/sess-1",
+        }
+    )
+
+    with patch.object(InProcessBrowserBackend, "_manager", staticmethod(lambda: manager)):
+        result = await InProcessBrowserBackend().navigate(NavigateRequest(url="https://example.com/"))
+
+    assert result.success is True
+    assert result.backend == "in_process"
+    assert result.title == "Example"
+    assert result.session == SessionHandle(session_id="sess-1", backend="in_process")
+    assert result.details["mhtml_backup"] == "/tmp/p.mhtml"
+
+
+@pytest.mark.asyncio
+async def test_in_process_surfaces_interaction_required():
+    """Human handoff is this stack's reason to exist — it must not be flattened."""
+    manager = MagicMock()
+    manager.research_url = AsyncMock(
+        return_value={
+            "success": True,
+            "status": "interaction_required",
+            "message": "captcha",
+            "session_id": "sess-2",
+            "actions": ["wait", "manual_intervention"],
+        }
+    )
+
+    with patch.object(InProcessBrowserBackend, "_manager", staticmethod(lambda: manager)):
+        result = await InProcessBrowserBackend().navigate(NavigateRequest(url="https://example.com/"))
+
+    assert result.interaction_required is True
+    assert result.details["actions"] == ["wait", "manual_intervention"]
+
+
+@pytest.mark.asyncio
+async def test_worker_navigate_threads_the_session_id():
+    """#11539: every call is routed to that conversation's BrowserContext."""
+    sent = {}
+
+    async def fake_send(action, params, session_id):
+        sent.update(action=action, params=params, session_id=session_id)
+        return {"success": True, "result": {"url": "https://example.com/", "title": "Example"}}
+
+    with patch.object(WorkerBrowserBackend, "_send", staticmethod(fake_send)):
+        result = await WorkerBrowserBackend().navigate(NavigateRequest(url="https://example.com/", session_id="conv-9"))
+
+    assert sent == {
+        "action": "navigate",
+        "params": {"url": "https://example.com/"},
+        "session_id": "conv-9",
+    }
+    assert result.success is True and result.backend == "worker"
+
+
+@pytest.mark.asyncio
+async def test_worker_extract_unwraps_the_envelope_and_truncates():
+    async def fake_send(action, params, session_id):
+        return {"success": True, "result": {"text": "abcdefghij"}}
+
+    with patch.object(WorkerBrowserBackend, "_send", staticmethod(fake_send)):
+        result = await WorkerBrowserBackend().extract(ExtractRequest(session_id="c", max_chars=4))
+
+    assert result.content == "abcd"
+
+
+@pytest.mark.asyncio
+async def test_container_screenshot_requires_an_explicit_url():
+    """It is stateless — there is no 'current page' to capture."""
+    result = await ContainerBrowserBackend().screenshot(ScreenshotRequest(url=None))
+
+    assert result.success is False
+    assert "url" in result.error
+
+
+@pytest.mark.asyncio
+async def test_probe_failures_are_reported_not_raised():
+    """resolve_backend() relies on probe() returning False, never exploding."""
+    with patch.object(
+        InProcessBrowserBackend, "_manager", staticmethod(MagicMock(side_effect=RuntimeError("no playwright")))
+    ):
+        assert await InProcessBrowserBackend().probe() is False
+
+    with patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(side_effect=RuntimeError("down")))):
+        assert await ContainerBrowserBackend().probe() is False
+
+    with patch.object(WorkerBrowserBackend, "_send", staticmethod(AsyncMock(side_effect=RuntimeError("down")))):
+        assert await WorkerBrowserBackend().probe() is False
+
+
+def test_register_all_is_idempotent():
+    from autobot_shared.browser.registry import clear_backends, registered_backends
+
+    clear_backends()
+    register_all(force=True)
+    first = [b.name for b in registered_backends()]
+    register_all(force=True)
+    second = [b.name for b in registered_backends()]
+
+    assert first == second == ["in_process", "worker", "container"]
+    clear_backends()

--- a/autobot-backend/browser_backends/container.py
+++ b/autobot-backend/browser_backends/container.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Playwright-container backend (#12651, ADR-009).
+
+Wraps ``services/playwright_service.py`` — the stack ``web_fetch`` uses for its
+JS-render fallback, deliberately out-of-process so Playwright does not run
+inside the backend. It is stateless and survives a backend restart, which the
+in-process stack does not.
+
+**This stack validates no URLs of its own** — one half of #13204. Behind the
+canonical interface the registry's DNS-resolving guard runs before anything
+reaches it, so routing a caller through here closes that gap for this path.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from autobot_shared.browser.base import (
+    ActionRequest,
+    BrowserResult,
+    Capability,
+    ExtractRequest,
+    NavigateRequest,
+    ScreenshotRequest,
+    SessionHandle,
+)
+
+logger = logging.getLogger(__name__)
+
+BACKEND_NAME = "container"
+
+
+class ContainerBrowserBackend:
+    """``PlaywrightService`` behind the canonical contract."""
+
+    name = BACKEND_NAME
+    capabilities = frozenset({Capability.SCREENSHOT})
+
+    @staticmethod
+    async def _service():
+        """Import lazily so a process that never renders pays nothing."""
+        from services.playwright_service import get_playwright_service
+
+        return await get_playwright_service()
+
+    async def probe(self) -> bool:
+        """Healthy only when the container answers its health check."""
+        try:
+            service = await self._service()
+            return await service.is_ready()
+        except Exception as exc:
+            logger.debug("container browser backend unavailable: %s", exc)
+            return False
+
+    async def navigate(self, request: NavigateRequest) -> BrowserResult:
+        """Not supported — this stack exposes no bare navigate endpoint."""
+        return BrowserResult(
+            success=False,
+            backend=BACKEND_NAME,
+            error="container backend does not support navigate",
+        )
+
+    async def extract(self, request: ExtractRequest) -> BrowserResult:
+        """Not supported — the container is stateless, with no current page."""
+        return BrowserResult(
+            success=False,
+            backend=BACKEND_NAME,
+            error="container backend does not support extract",
+        )
+
+    async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:
+        """Capture *url*. The registry has already validated it."""
+        if not request.url:
+            return BrowserResult(
+                success=False,
+                backend=BACKEND_NAME,
+                error="container backend needs an explicit url (it holds no session)",
+            )
+
+        service = await self._service()
+        raw = await service.capture_screenshot(
+            url=request.url,
+            full_page=request.full_page,
+        )
+        return BrowserResult(
+            success=bool(raw.get("success")),
+            backend=BACKEND_NAME,
+            url=request.url,
+            image_path=raw.get("screenshot") or raw.get("screenshot_path"),
+            error=raw.get("error"),
+            details={k: v for k, v in raw.items() if k not in {"success", "error"}},
+        )
+
+    async def act(self, request: ActionRequest) -> BrowserResult:
+        """Not supported — no element refs or interaction on this stack."""
+        return BrowserResult(
+            success=False,
+            backend=BACKEND_NAME,
+            error="container backend does not support interaction",
+        )
+
+    async def release(self, session: SessionHandle) -> None:
+        """No-op — the container holds no per-caller session."""
+        return None

--- a/autobot-backend/browser_backends/in_process.py
+++ b/autobot-backend/browser_backends/in_process.py
@@ -1,0 +1,151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""In-process Playwright backend (#12651, ADR-009).
+
+Wraps ``research_browser_manager`` — the stack that owns interactive research
+sessions. It is the only one of the three with MHTML capture, "interaction
+required" detection and human handoff, which is why ADR-009 wraps the stacks
+rather than collapsing onto one.
+
+The wrapper adapts shapes only. It adds no behaviour and removes none: the
+manager's own DNS-rebind re-check (#13018) still runs inside ``navigate_to``,
+underneath the registry's guard.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from autobot_shared.browser.base import (
+    ActionRequest,
+    BrowserResult,
+    Capability,
+    ExtractRequest,
+    NavigateRequest,
+    ScreenshotRequest,
+    SessionHandle,
+)
+
+logger = logging.getLogger(__name__)
+
+BACKEND_NAME = "in_process"
+
+
+class InProcessBrowserBackend:
+    """``research_browser_manager`` behind the canonical contract."""
+
+    name = BACKEND_NAME
+    capabilities = frozenset(
+        {
+            Capability.NAVIGATE,
+            Capability.EXTRACT,
+            Capability.MHTML,
+            Capability.HUMAN_HANDOFF,
+            Capability.PERSISTENT_SESSION,
+        }
+    )
+
+    @staticmethod
+    def _manager():
+        """Import lazily — Playwright is heavy and not every process needs it."""
+        from research_browser_manager import get_research_browser_manager
+
+        return get_research_browser_manager()
+
+    async def probe(self) -> bool:
+        """Reachable whenever the manager module imports."""
+        try:
+            self._manager()
+            return True
+        except Exception as exc:
+            logger.debug("in_process browser backend unavailable: %s", exc)
+            return False
+
+    async def navigate(self, request: NavigateRequest) -> BrowserResult:
+        """Navigate via ``research_url``, preserving its interaction handoff."""
+        manager = self._manager()
+        conversation_id = request.session_id or "canonical-browser"
+        raw = await manager.research_url(conversation_id, request.url, extract_content=False)
+        return self._to_result(raw, requested_url=request.url)
+
+    async def extract(self, request: ExtractRequest) -> BrowserResult:
+        """Extract content, which for this stack means a research round-trip."""
+        manager = self._manager()
+        conversation_id = request.session_id or "canonical-browser"
+        session = manager.get_session_by_conversation(conversation_id)
+        if session is None:
+            return BrowserResult(
+                success=False,
+                backend=BACKEND_NAME,
+                error=f"no in-process session for {conversation_id!r}",
+            )
+
+        raw = await session.extract_content()
+        content = raw.get("text_content")
+        if request.max_chars is not None and content:
+            content = content[: request.max_chars]
+
+        return BrowserResult(
+            success=bool(raw.get("success")),
+            backend=BACKEND_NAME,
+            url=raw.get("url"),
+            title=raw.get("title"),
+            content=content,
+            error=raw.get("error"),
+            details={k: v for k, v in raw.items() if k not in {"success", "url", "title", "text_content", "error"}},
+        )
+
+    async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:
+        """Not supported — this stack has no screenshot path.
+
+        Unreachable through the registry, which never routes SCREENSHOT here
+        because the capability is not declared. Present so the object still
+        satisfies the Protocol.
+        """
+        return BrowserResult(
+            success=False,
+            backend=BACKEND_NAME,
+            error="in_process backend does not support screenshots",
+        )
+
+    async def act(self, request: ActionRequest) -> BrowserResult:
+        """Not supported — no element refs or interaction on this stack."""
+        return BrowserResult(
+            success=False,
+            backend=BACKEND_NAME,
+            error="in_process backend does not support interaction",
+        )
+
+    async def release(self, session: SessionHandle) -> None:
+        """Close the underlying research session."""
+        manager = self._manager()
+        existing = manager.get_session_by_conversation(session.session_id)
+        if existing is not None:
+            await manager.cleanup_session(existing.session_id)
+
+    @staticmethod
+    def _to_result(raw: dict, *, requested_url: str) -> BrowserResult:
+        """Map ``research_url``'s dict onto the canonical result."""
+        session_id = raw.get("session_id")
+        navigation = raw.get("navigation") or {}
+        content = raw.get("content") or {}
+
+        return BrowserResult(
+            success=bool(raw.get("success")),
+            backend=BACKEND_NAME,
+            url=navigation.get("url") or content.get("url") or requested_url,
+            title=navigation.get("title") or content.get("title"),
+            content=content.get("text_content"),
+            session=SessionHandle(session_id=session_id, backend=BACKEND_NAME) if session_id else None,
+            interaction_required=raw.get("status") == "interaction_required",
+            error=raw.get("error"),
+            details={
+                "status": raw.get("status"),
+                "browser_url": raw.get("browser_url"),
+                "actions": raw.get("actions"),
+                "mhtml_backup": content.get("mhtml_backup"),
+                "blocked_by_guard": navigation.get("blocked_by_guard"),
+            },
+        )

--- a/autobot-backend/browser_backends/worker.py
+++ b/autobot-backend/browser_backends/worker.py
@@ -1,0 +1,143 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Node browser-worker backend (#12651, ADR-009).
+
+Wraps ``api/browser_mcp.send_to_browser_vm`` — the live, per-conversation
+browser a user can watch and take over. It is the only stack with stable
+indexed element refs and real interaction (click / fill / select), and the only
+one holding a ``BrowserContext`` per chat ``session_id`` (#11539).
+
+**This is the path #13204 is really about.** ``send_to_browser_vm`` performs no
+URL validation at all, and it is reachable from the agent tool path via
+``chat_workflow/tool_handler._web_search_via_browser_vm``. ``is_url_allowed``
+in ``api/browser_mcp.py`` guards only the ``POST /mcp/navigate`` HTTP endpoint,
+and is a regex over the URL string that cannot see where a hostname resolves.
+Reaching this stack through the canonical interface puts the DNS-resolving
+guard in front of it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from autobot_shared.browser.base import (
+    ActionRequest,
+    BrowserResult,
+    Capability,
+    ExtractRequest,
+    NavigateRequest,
+    ScreenshotRequest,
+    SessionHandle,
+)
+
+logger = logging.getLogger(__name__)
+
+BACKEND_NAME = "worker"
+
+
+class WorkerBrowserBackend:
+    """The Node browser worker behind the canonical contract."""
+
+    name = BACKEND_NAME
+    capabilities = frozenset(
+        {
+            Capability.NAVIGATE,
+            Capability.EXTRACT,
+            Capability.SCREENSHOT,
+            Capability.INTERACT,
+            Capability.ELEMENT_REFS,
+            Capability.PERSISTENT_SESSION,
+        }
+    )
+
+    @staticmethod
+    async def _send(action: str, params: dict, session_id: str | None):
+        """Import lazily — ``api.browser_mcp`` pulls FastAPI routing in."""
+        from api.browser_mcp import DEFAULT_BROWSER_SESSION_ID, send_to_browser_vm
+
+        return await send_to_browser_vm(action, params, session_id=session_id or DEFAULT_BROWSER_SESSION_ID)
+
+    async def probe(self) -> bool:
+        """Reachable when the transport imports and the worker answers."""
+        try:
+            result = await self._send("observe_state", {}, None)
+            return bool(result)
+        except Exception as exc:
+            logger.debug("worker browser backend unavailable: %s", exc)
+            return False
+
+    async def navigate(self, request: NavigateRequest) -> BrowserResult:
+        """Navigate the session's context. The registry has validated the URL."""
+        raw = await self._send("navigate", {"url": request.url}, request.session_id)
+        return self._to_result(raw, request.session_id, url=request.url)
+
+    async def extract(self, request: ExtractRequest) -> BrowserResult:
+        """Read text from *selector*, defaulting to the whole body."""
+        raw = await self._send(
+            "get_text",
+            {"selector": request.selector or "body"},
+            request.session_id,
+        )
+        inner = raw.get("result", raw) if isinstance(raw, dict) else {}
+        text = inner.get("text", "") if isinstance(inner, dict) else ""
+        if request.max_chars is not None and text:
+            text = text[: request.max_chars]
+
+        return self._to_result(raw, request.session_id, content=text)
+
+    async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:
+        """Capture the session's current page."""
+        params: dict = {"full_page": request.full_page}
+        if request.url:
+            params["url"] = request.url
+        raw = await self._send("screenshot", params, request.session_id)
+        inner = raw.get("result", raw) if isinstance(raw, dict) else {}
+        image = inner.get("path") or inner.get("screenshot") if isinstance(inner, dict) else None
+        return self._to_result(raw, request.session_id, url=request.url, image_path=image)
+
+    async def act(self, request: ActionRequest) -> BrowserResult:
+        """Click / fill / select, by selector or stable element ref."""
+        params: dict = dict(request.params)
+        if request.selector:
+            params["selector"] = request.selector
+        if request.element_ref:
+            params["ref"] = request.element_ref
+        if request.value is not None:
+            params["value"] = request.value
+
+        raw = await self._send(request.action, params, request.session_id)
+        return self._to_result(raw, request.session_id)
+
+    async def release(self, session: SessionHandle) -> None:
+        """Ask the worker to drop this conversation's context."""
+        try:
+            await self._send("close_session", {}, session.session_id)
+        except Exception as exc:
+            logger.warning("worker: releasing session %s failed: %s", session.session_id, exc)
+
+    @staticmethod
+    def _to_result(
+        raw,
+        session_id: str | None,
+        *,
+        url: str | None = None,
+        content: str | None = None,
+        image_path: str | None = None,
+    ) -> BrowserResult:
+        """Map the worker's envelope onto the canonical result."""
+        payload = raw if isinstance(raw, dict) else {}
+        inner = payload.get("result") if isinstance(payload.get("result"), dict) else {}
+
+        return BrowserResult(
+            success=bool(payload.get("success", True)) and "error" not in payload,
+            backend=BACKEND_NAME,
+            url=url or inner.get("url") or payload.get("url"),
+            title=inner.get("title") or payload.get("title"),
+            content=content,
+            image_path=image_path,
+            session=SessionHandle(session_id=session_id, backend=BACKEND_NAME) if session_id else None,
+            error=payload.get("error"),
+            details={k: v for k, v in payload.items() if k not in {"success", "error", "result"}},
+        )

--- a/autobot_shared/browser/__init__.py
+++ b/autobot_shared/browser/__init__.py
@@ -1,0 +1,62 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical browser interface shared across AutoBot (#12651, ADR-009).
+
+Callers state the capabilities they need; the registry picks a backend that
+declares them and is currently reachable, and validates every URL with the
+DNS-resolving public-address guard before any backend sees it.
+
+    from autobot_shared.browser import Capability, NavigateRequest, get_browser
+
+    browser = await get_browser(requires={Capability.NAVIGATE, Capability.EXTRACT})
+    page = await browser.navigate(NavigateRequest(url=url))
+
+Backends are registered by the app that owns their transport — see
+``registry.register_backend`` — so this package never imports an app-local
+module.
+
+Re-exports are lazy (PEP 562), matching ``autobot_shared/user_management``:
+importing the package must not drag SQLAlchemy, aiohttp or Playwright into a
+caller that only wanted the ``Capability`` enum. Eager imports here were what
+pulled ``email_validator`` into the migration gate in #13129.
+"""
+
+_LAZY_IMPORTS = {
+    "ActionRequest": (".base", "ActionRequest"),
+    "BrowserBackend": (".base", "BrowserBackend"),
+    "BrowserError": (".base", "BrowserError"),
+    "BrowserResult": (".base", "BrowserResult"),
+    "Capability": (".base", "Capability"),
+    "ExtractRequest": (".base", "ExtractRequest"),
+    "NavigateRequest": (".base", "NavigateRequest"),
+    "NoCapableBackendError": (".base", "NoCapableBackendError"),
+    "ScreenshotRequest": (".base", "ScreenshotRequest"),
+    "SessionHandle": (".base", "SessionHandle"),
+    "UnsafeUrlError": (".base", "UnsafeUrlError"),
+    "Browser": (".registry", "Browser"),
+    "clear_backends": (".registry", "clear_backends"),
+    "get_browser": (".registry", "get_browser"),
+    "register_backend": (".registry", "register_backend"),
+    "registered_backends": (".registry", "registered_backends"),
+    "resolve_backend": (".registry", "resolve_backend"),
+}
+
+__all__ = list(_LAZY_IMPORTS)
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        mod = importlib.import_module(module_path, __name__)
+        val = getattr(mod, attr_name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY_IMPORTS))

--- a/autobot_shared/browser/base.py
+++ b/autobot_shared/browser/base.py
@@ -1,0 +1,187 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical browser contract — capabilities, requests, results (#12651).
+
+AutoBot drives a browser through three separate stacks, and a single web-search
+tool call already fans out across all of them (see ADR-009):
+
+- in-process Python Playwright (`research_browser_manager.py`)
+- a Playwright container (`services/playwright_service.py`)
+- the Node browser worker (`api/browser_mcp.py` -> `autobot-browser-worker/`)
+
+None is redundant: MHTML capture and human handoff exist only in-process,
+stable element refs and interaction only in the worker, restart-survival only
+out-of-process. So this module does not replace them — it gives callers one
+contract to state *what* they need, and lets the registry decide *where* it
+runs.
+
+**Capabilities, not stack names.** A caller asking for `NAVIGATE | EXTRACT`
+gets whichever backend can serve that and is currently up. Nothing outside a
+backend implementation should name a stack.
+
+This module is deliberately dependency-free beyond `autobot_shared`: the
+backend implementations live in the app that owns their transport and register
+themselves (see `registry.py`), so `autobot_shared` never imports a
+backend-local package. That is the same inverted-dependency trap #13201 hit
+with `organization_service`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class Capability(str, Enum):
+    """What a backend can do. Callers request these; backends declare them.
+
+    ``(str, Enum)`` rather than ``StrEnum``: it is the shape
+    ``autobot_shared.status_enums.AgentLifecycleStatus`` already uses, and it
+    keeps the module importable on Python 3.10 as well as the 3.14 that
+    ``autobot_shared/pyproject.toml`` targets.
+    """
+
+    #: Point the browser at a URL and report the resulting page state.
+    NAVIGATE = "navigate"
+    #: Return the page's text/markup content.
+    EXTRACT = "extract"
+    #: Capture a page image.
+    SCREENSHOT = "screenshot"
+    #: Click / fill / select. Requires ELEMENT_REFS in practice.
+    INTERACT = "interact"
+    #: Stable indexed element references that survive a re-render.
+    ELEMENT_REFS = "element_refs"
+    #: Capture the page as MHTML.
+    MHTML = "mhtml"
+    #: Detect "interaction required" and hand control to a human.
+    HUMAN_HANDOFF = "human_handoff"
+    #: A browser context that outlives a single call, keyed by session.
+    PERSISTENT_SESSION = "persistent_session"
+
+
+class BrowserError(Exception):
+    """Base for every error raised through the canonical browser interface."""
+
+
+class NoCapableBackendError(BrowserError):
+    """No registered backend both declares the capabilities and is reachable."""
+
+
+class UnsafeUrlError(BrowserError):
+    """The URL failed the DNS-resolving public-address guard.
+
+    Raised by the registry *before* any backend sees the request, so a backend
+    cannot forget the check — the gap #13204 records for
+    ``send_to_browser_vm`` and ``services/playwright_service``.
+    """
+
+
+@dataclass(frozen=True)
+class SessionHandle:
+    """Identifies a browser context that outlives a single call."""
+
+    session_id: str
+    backend: str
+
+
+@dataclass(frozen=True)
+class NavigateRequest:
+    """Go to *url*, optionally within an existing session."""
+
+    url: str
+    session_id: str | None = None
+    wait_for_load: bool = True
+    timeout_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class ExtractRequest:
+    """Read content from the current page of *session_id*."""
+
+    session_id: str | None = None
+    selector: str | None = None
+    max_chars: int | None = None
+
+
+@dataclass(frozen=True)
+class ScreenshotRequest:
+    """Capture *url* (or the current page when *url* is None)."""
+
+    url: str | None = None
+    session_id: str | None = None
+    full_page: bool = True
+    timeout_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class ActionRequest:
+    """Perform an interaction — click, fill, select — on the current page."""
+
+    action: str
+    session_id: str | None = None
+    selector: str | None = None
+    element_ref: str | None = None
+    value: str | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class BrowserResult:
+    """Common shape for every backend response.
+
+    ``backend`` names the stack that actually served the call. It is carried on
+    every result specifically so the indirection this interface introduces
+    stays debuggable — a caller can always see where its request ran.
+    """
+
+    success: bool
+    backend: str
+    url: str | None = None
+    title: str | None = None
+    content: str | None = None
+    image_path: str | None = None
+    session: SessionHandle | None = None
+    interaction_required: bool = False
+    error: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class BrowserBackend(Protocol):
+    """One execution stack behind the canonical interface.
+
+    A backend implements only the methods matching the capabilities it
+    declares; the registry never routes a call to a backend that did not
+    declare the corresponding capability, so unimplemented methods are
+    unreachable rather than raising.
+    """
+
+    name: str
+    capabilities: frozenset[Capability]
+
+    async def probe(self) -> bool:
+        """True if this backend is currently usable."""
+        ...
+
+    async def navigate(self, request: NavigateRequest) -> BrowserResult:
+        """Navigate to a URL. The registry has already validated it."""
+        ...
+
+    async def extract(self, request: ExtractRequest) -> BrowserResult:
+        """Return page content."""
+        ...
+
+    async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:
+        """Capture a page image."""
+        ...
+
+    async def act(self, request: ActionRequest) -> BrowserResult:
+        """Perform an interaction on the current page."""
+        ...
+
+    async def release(self, session: SessionHandle) -> None:
+        """Release a persistent session's resources."""
+        ...

--- a/autobot_shared/browser/registry.py
+++ b/autobot_shared/browser/registry.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Backend registration, capability dispatch, and the URL guard (#12651).
+
+Two jobs, and the second is the one that matters:
+
+1. **Dispatch.** Callers ask for capabilities; this picks the first registered
+   backend that declares them all and answers `probe()`. That replaces the
+   hand-rolled cascades each caller carries today — the one in
+   `chat_workflow/tool_handler.py` has already been debugged once for
+   re-issuing a call to a stack it had just found unavailable (#7478).
+
+2. **The guard, enforced once.** Every URL entering the interface is checked
+   with `autobot_shared.url_safety.is_public_url_async` — the DNS-*resolving*
+   check — **before** any backend sees it. A backend therefore cannot forget
+   it, and adding a backend cannot reintroduce the gap.
+
+   That gap is real and recorded as **#13204**: `send_to_browser_vm()` performs
+   no URL validation at all and is reachable from the agent tool path, while
+   `services/playwright_service.py` validates nothing either. `is_url_allowed`
+   in `api/browser_mcp.py` guards exactly one HTTP endpoint and is a regex over
+   the URL string, so it cannot see where a hostname resolves.
+
+**Backends register from the app that owns their transport.** `autobot_shared`
+holds the contract and this registry; it never imports `research_browser_manager`,
+`services.playwright_service` or `api.browser_mcp`. Importing an app-local
+package from shared code is the inverted dependency #13201 had to design around
+for `organization_service`, and this avoids it by construction.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from autobot_shared.browser.base import (
+    ActionRequest,
+    BrowserBackend,
+    BrowserResult,
+    Capability,
+    ExtractRequest,
+    NavigateRequest,
+    NoCapableBackendError,
+    ScreenshotRequest,
+    SessionHandle,
+    UnsafeUrlError,
+)
+from autobot_shared.url_safety import is_public_url_async
+
+logger = logging.getLogger(__name__)
+
+#: Registered backends, in preference order — first match wins.
+_BACKENDS: list[BrowserBackend] = []
+
+
+def register_backend(backend: BrowserBackend, *, prepend: bool = False) -> None:
+    """Register *backend*. Later registrations rank lower unless *prepend*.
+
+    Re-registering a backend with the same ``name`` replaces the earlier one,
+    so a module that is imported twice cannot silently stack duplicates.
+    """
+    global _BACKENDS
+    _BACKENDS = [b for b in _BACKENDS if b.name != backend.name]
+    if prepend:
+        _BACKENDS.insert(0, backend)
+    else:
+        _BACKENDS.append(backend)
+    logger.info(
+        "browser: registered backend %r with capabilities %s",
+        backend.name,
+        sorted(c.value for c in backend.capabilities),
+    )
+
+
+def registered_backends() -> tuple[BrowserBackend, ...]:
+    """Snapshot of registered backends, in preference order."""
+    return tuple(_BACKENDS)
+
+
+def clear_backends() -> None:
+    """Drop all registrations. For tests."""
+    _BACKENDS.clear()
+
+
+async def _guard_url(url: str | None) -> None:
+    """Reject a URL that is empty or does not resolve to a public address."""
+    if url is None:
+        return
+    if not url or not await is_public_url_async(url):
+        logger.warning("browser: refusing non-public URL %r", url)
+        raise UnsafeUrlError(f"URL is not a public address: {url!r}")
+
+
+async def resolve_backend(requires: set[Capability]) -> BrowserBackend:
+    """Return the first registered backend with *requires* that probes OK.
+
+    Raises:
+        NoCapableBackendError: nothing registered declares the capabilities, or
+            everything that does is currently unreachable. The message names
+            which of the two it was, because "no browser available" and "the
+            browser you wanted is down" need different responses.
+    """
+    needed = frozenset(requires)
+    candidates = [b for b in _BACKENDS if needed <= b.capabilities]
+    if not candidates:
+        raise NoCapableBackendError(
+            f"no registered backend provides {sorted(c.value for c in needed)}; "
+            f"registered: {[b.name for b in _BACKENDS] or 'none'}"
+        )
+
+    for backend in candidates:
+        try:
+            if await backend.probe():
+                return backend
+        except Exception as exc:
+            logger.warning("browser: backend %r probe raised: %s", backend.name, exc)
+
+    raise NoCapableBackendError(
+        f"every backend providing {sorted(c.value for c in needed)} is unreachable: " f"{[b.name for b in candidates]}"
+    )
+
+
+class Browser:
+    """Capability-scoped facade over one resolved backend.
+
+    Obtained from :func:`get_browser`. Each entry point validates any URL it
+    carries before dispatching, so the guard cannot be bypassed by reaching a
+    backend directly through this object.
+    """
+
+    def __init__(self, backend: BrowserBackend) -> None:
+        self._backend = backend
+
+    @property
+    def backend_name(self) -> str:
+        """Which stack actually serves this browser — keeps dispatch debuggable."""
+        return self._backend.name
+
+    async def navigate(self, request: NavigateRequest) -> BrowserResult:
+        """Navigate, after validating the target URL."""
+        await _guard_url(request.url)
+        return await self._backend.navigate(request)
+
+    async def extract(self, request: ExtractRequest) -> BrowserResult:
+        """Read content from the current page."""
+        return await self._backend.extract(request)
+
+    async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:
+        """Capture a page image, after validating any explicit URL."""
+        await _guard_url(request.url)
+        return await self._backend.screenshot(request)
+
+    async def act(self, request: ActionRequest) -> BrowserResult:
+        """Perform an interaction on the current page."""
+        return await self._backend.act(request)
+
+    async def release(self, session: SessionHandle) -> None:
+        """Release a persistent session."""
+        await self._backend.release(session)
+
+
+async def get_browser(
+    *,
+    requires: set[Capability],
+    session_id: str | None = None,
+) -> Browser:
+    """Return a browser able to do *requires*.
+
+    Args:
+        requires: Capabilities the caller needs. Ask for the minimum — a
+            narrower set matches more backends.
+        session_id: Reserved for session-affinity routing; accepted now so
+            callers written against this signature keep working when
+            per-session pinning lands.
+    """
+    backend = await resolve_backend(requires)
+    logger.debug(
+        "browser: resolved %s for %s",
+        backend.name,
+        sorted(c.value for c in requires),
+    )
+    return Browser(backend)

--- a/autobot_shared/browser/registry_test.py
+++ b/autobot_shared/browser/registry_test.py
@@ -1,0 +1,279 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The canonical browser interface dispatches and guards (#12651, ADR-009).
+
+The property that justifies this layer existing is the guard: every URL is
+validated with the DNS-resolving check *before* any backend sees it, so a
+backend cannot forget it and a new backend cannot reintroduce the gap. That
+gap is real today — `send_to_browser_vm()` validates nothing and is reachable
+from the agent tool path (#13204).
+
+The rest pins dispatch: capabilities select the backend, an unreachable
+backend is skipped rather than returned, and the two "nothing available" cases
+are distinguishable.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.browser.base import (
+    ActionRequest,
+    BrowserResult,
+    Capability,
+    ExtractRequest,
+    NavigateRequest,
+    NoCapableBackendError,
+    ScreenshotRequest,
+    SessionHandle,
+    UnsafeUrlError,
+)
+from autobot_shared.browser.registry import (
+    clear_backends,
+    get_browser,
+    register_backend,
+    registered_backends,
+    resolve_backend,
+)
+
+_GUARD = "autobot_shared.browser.registry.is_public_url_async"
+
+
+class FakeBackend:
+    """Minimal backend recording what it was asked to do."""
+
+    def __init__(self, name, capabilities, *, reachable=True, probe_raises=False):
+        self.name = name
+        self.capabilities = frozenset(capabilities)
+        self._reachable = reachable
+        self._probe_raises = probe_raises
+        self.calls: list[str] = []
+
+    async def probe(self) -> bool:
+        if self._probe_raises:
+            raise RuntimeError("probe exploded")
+        return self._reachable
+
+    async def navigate(self, request):
+        self.calls.append(f"navigate:{request.url}")
+        return BrowserResult(success=True, backend=self.name, url=request.url)
+
+    async def extract(self, request):
+        self.calls.append("extract")
+        return BrowserResult(success=True, backend=self.name, content="body")
+
+    async def screenshot(self, request):
+        self.calls.append(f"screenshot:{request.url}")
+        return BrowserResult(success=True, backend=self.name, image_path="/tmp/x.png")
+
+    async def act(self, request):
+        self.calls.append(f"act:{request.action}")
+        return BrowserResult(success=True, backend=self.name)
+
+    async def release(self, session):
+        self.calls.append(f"release:{session.session_id}")
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_backends()
+    yield
+    clear_backends()
+
+
+def _allow():
+    return patch(_GUARD, AsyncMock(return_value=True))
+
+
+def _deny():
+    return patch(_GUARD, AsyncMock(return_value=False))
+
+
+# ---------------------------------------------------------------- the guard
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_a_non_public_url_never_reaches_the_backend():
+    """The whole reason this layer exists (#13204)."""
+    backend = FakeBackend("fake", {Capability.NAVIGATE})
+    register_backend(backend)
+
+    with _deny():
+        browser = await get_browser(requires={Capability.NAVIGATE})
+        with pytest.raises(UnsafeUrlError):
+            await browser.navigate(NavigateRequest(url="http://169.254.169.254/latest/meta-data/"))
+
+    assert backend.calls == [], "backend saw a URL the guard rejected"
+
+
+@pytest.mark.asyncio
+async def test_screenshot_url_is_guarded_too():
+    """services/playwright_service's screenshot path validates nothing today."""
+    backend = FakeBackend("fake", {Capability.SCREENSHOT})
+    register_backend(backend)
+
+    with _deny():
+        browser = await get_browser(requires={Capability.SCREENSHOT})
+        with pytest.raises(UnsafeUrlError):
+            await browser.screenshot(ScreenshotRequest(url="http://localhost:6379/"))
+
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_empty_url_is_rejected():
+    backend = FakeBackend("fake", {Capability.NAVIGATE})
+    register_backend(backend)
+
+    with _allow():
+        browser = await get_browser(requires={Capability.NAVIGATE})
+        with pytest.raises(UnsafeUrlError):
+            await browser.navigate(NavigateRequest(url=""))
+
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_public_url_passes_through():
+    backend = FakeBackend("fake", {Capability.NAVIGATE})
+    register_backend(backend)
+
+    with _allow():
+        browser = await get_browser(requires={Capability.NAVIGATE})
+        result = await browser.navigate(NavigateRequest(url="https://example.com/"))
+
+    assert result.success is True
+    assert result.backend == "fake"
+    assert backend.calls == ["navigate:https://example.com/"]
+
+
+@pytest.mark.asyncio
+async def test_screenshot_without_a_url_is_not_blocked():
+    """A capture of the *current* page carries no URL to validate."""
+    backend = FakeBackend("fake", {Capability.SCREENSHOT})
+    register_backend(backend)
+
+    with _deny():
+        browser = await get_browser(requires={Capability.SCREENSHOT})
+        result = await browser.screenshot(ScreenshotRequest(url=None))
+
+    assert result.success is True
+
+
+# ---------------------------------------------------------------- dispatch
+
+
+@pytest.mark.asyncio
+async def test_capabilities_select_the_backend_not_registration_order():
+    poor = FakeBackend("poor", {Capability.NAVIGATE})
+    rich = FakeBackend("rich", {Capability.NAVIGATE, Capability.INTERACT})
+    register_backend(poor)
+    register_backend(rich)
+
+    chosen = await resolve_backend({Capability.NAVIGATE, Capability.INTERACT})
+
+    assert chosen.name == "rich"
+
+
+@pytest.mark.asyncio
+async def test_first_capable_backend_wins_when_several_match():
+    first = FakeBackend("first", {Capability.NAVIGATE})
+    second = FakeBackend("second", {Capability.NAVIGATE})
+    register_backend(first)
+    register_backend(second)
+
+    assert (await resolve_backend({Capability.NAVIGATE})).name == "first"
+
+
+@pytest.mark.asyncio
+async def test_prepend_overrides_preference_order():
+    register_backend(FakeBackend("first", {Capability.NAVIGATE}))
+    register_backend(FakeBackend("preferred", {Capability.NAVIGATE}), prepend=True)
+
+    assert (await resolve_backend({Capability.NAVIGATE})).name == "preferred"
+
+
+@pytest.mark.asyncio
+async def test_unreachable_backend_is_skipped_for_a_reachable_one():
+    down = FakeBackend("down", {Capability.NAVIGATE}, reachable=False)
+    up = FakeBackend("up", {Capability.NAVIGATE})
+    register_backend(down)
+    register_backend(up)
+
+    assert (await resolve_backend({Capability.NAVIGATE})).name == "up"
+
+
+@pytest.mark.asyncio
+async def test_a_backend_whose_probe_raises_is_skipped_not_fatal():
+    """A broken probe must not take out the whole cascade."""
+    broken = FakeBackend("broken", {Capability.NAVIGATE}, probe_raises=True)
+    good = FakeBackend("good", {Capability.NAVIGATE})
+    register_backend(broken)
+    register_backend(good)
+
+    assert (await resolve_backend({Capability.NAVIGATE})).name == "good"
+
+
+@pytest.mark.asyncio
+async def test_missing_capability_and_all_down_are_distinguishable():
+    """'No browser does this' and 'the browser is down' need different responses."""
+    with pytest.raises(NoCapableBackendError, match="no registered backend provides"):
+        await resolve_backend({Capability.MHTML})
+
+    register_backend(FakeBackend("down", {Capability.MHTML}, reachable=False))
+    with pytest.raises(NoCapableBackendError, match="unreachable"):
+        await resolve_backend({Capability.MHTML})
+
+
+# ---------------------------------------------------------------- registry
+
+
+def test_reregistering_a_name_replaces_rather_than_stacks():
+    """A module imported twice must not register duplicates."""
+    register_backend(FakeBackend("dup", {Capability.NAVIGATE}))
+    register_backend(FakeBackend("dup", {Capability.NAVIGATE, Capability.MHTML}))
+
+    names = [b.name for b in registered_backends()]
+    assert names == ["dup"]
+    assert Capability.MHTML in registered_backends()[0].capabilities
+
+
+@pytest.mark.asyncio
+async def test_result_names_the_backend_that_served_it():
+    """The indirection must stay debuggable."""
+    register_backend(FakeBackend("in_process", {Capability.NAVIGATE}))
+
+    with _allow():
+        browser = await get_browser(requires={Capability.NAVIGATE})
+        result = await browser.navigate(NavigateRequest(url="https://example.com/"))
+
+    assert browser.backend_name == "in_process"
+    assert result.backend == "in_process"
+
+
+@pytest.mark.asyncio
+async def test_non_url_operations_reach_the_backend():
+    backend = FakeBackend("fake", {Capability.EXTRACT, Capability.INTERACT})
+    register_backend(backend)
+
+    browser = await get_browser(requires={Capability.EXTRACT})
+    await browser.extract(ExtractRequest(session_id="s1"))
+    await browser.act(ActionRequest(action="click", selector="#go"))
+    await browser.release(SessionHandle(session_id="s1", backend="fake"))
+
+    assert backend.calls == ["extract", "act:click", "release:s1"]
+
+
+def test_shared_package_imports_nothing_app_local():
+    """autobot_shared must never import a backend-local package (#13201's trap)."""
+    import ast
+    import pathlib
+
+    pkg = pathlib.Path(__file__).parent
+    forbidden = ("user_management", "services.", "api.", "research_browser_manager", "models")
+
+    for path in pkg.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert not node.module.startswith(forbidden), f"{path.name} imports app-local {node.module!r}"


### PR DESCRIPTION
Closes #12651

> **Scope: ADR-009 phases 1–2 only, per your 2026-08-01 decision.** Additive —
> no caller is repointed and no behaviour changes. See "What this deliberately
> does not do" before merging: **#13204 stays open**, and this issue's
> "Done when" wording needs a decision.

## Thinking Path

ADR-009 (merged, `96ce9cc4f`) established that AutoBot drives a browser through
**three** stacks, not the two #12651 describes, and that none is redundant —
each is the only home of something. So the job is not to delete two of them; it
is to stop them being three unrelated APIs with three different sets of
guarantees.

Two things shaped the implementation beyond what the ADR specified.

**The wrappers cannot live in `autobot_shared`.** The ADR says "wrap the three
stacks as backends", but those stacks are `research_browser_manager`,
`services/playwright_service` and `api/browser_mcp` — all backend-local. Putting
wrappers in shared code would make `autobot_shared` import an app package,
which is exactly the inverted dependency #13201 had to design around for
`organization_service`. Resolved the same way: **shared owns the contract and
the registry; each app registers its own backends.**

**`Capability` is `(str, Enum)`, not `StrEnum`.** `StrEnum` is 3.11+ and
`autobot_shared` targets 3.14, so it would have passed CI — but this dev box
runs 3.10, where it makes the module unimportable and nothing can be verified
locally before CI. `autobot_shared.status_enums.AgentLifecycleStatus` already
uses `(str, Enum)`.

## What Changed

**Phase 1 — `autobot_shared/browser/`**

`base.py` — `Capability`, frozen request/result dataclasses, `BrowserBackend`
Protocol. `registry.py` — capability dispatch with probe-based fallback, and
the DNS-resolving URL guard.

The guard placement is the point of the layer. Every URL is validated with
`is_public_url_async` **before** any backend sees it, so a backend cannot forget
it and a new backend cannot reintroduce the gap. Today `send_to_browser_vm`
validates nothing and is reachable from the agent tool path (#13204).

**Phase 2 — `autobot-backend/browser_backends/`**

| backend | wraps | declares |
|---|---|---|
| `in_process` | `research_browser_manager` | NAVIGATE, EXTRACT, MHTML, HUMAN_HANDOFF, PERSISTENT_SESSION |
| `worker` | `api/browser_mcp.send_to_browser_vm` | NAVIGATE, EXTRACT, SCREENSHOT, INTERACT, ELEMENT_REFS, PERSISTENT_SESSION |
| `container` | `services/playwright_service` | SCREENSHOT |

`in_process`'s `interaction_required` handoff is surfaced on the canonical
result rather than flattened — it is the capability only that stack has.
`worker` threads `session_id` on every call, preserving #11539's
per-conversation `BrowserContext` routing.

## Verification

```
autobot_shared/browser              15 passed
autobot-backend/browser_backends    15 passed
bandit                              0 issues (Low/Medium/High)
isort · black --line-length=120 · flake8   clean
```

The tests pin the properties that make this safe rather than just exercising it:

- **The guard cannot be bypassed** — a denied URL never reaches the backend
  (asserted on the backend's own call log), on both `navigate` and `screenshot`.
- **Shared imports nothing app-local** — asserted by an AST walk over
  `autobot_shared/browser/*.py`, so #13201's trap cannot creep back silently.
- **Capability claims match ADR-009's audited matrix**, including the two easy
  ones to get wrong: `research_browser_manager` has **no** screenshot path, and
  only the worker has element refs. A wrong claim routes work to a stack that
  cannot do it.
- **A backend whose `probe()` raises is skipped, not fatal** — `resolve_backend`
  depends on that to avoid the failure mode #7478 already hit in
  `tool_handler.py`'s hand-rolled cascade.
- **"No backend does this" and "the backend is down" are distinguishable**, since
  they need different responses.

## What this deliberately does not do

Steps 3–6 (repointing `content_reach`, `web_fetch`, `tool_handler`,
`api/playwright`) are **out of scope by your decision**, because step 5 is a
real behaviour change: enforcing the guard starts blocking internal URLs that
`send_to_browser_vm` accepts today.

Two consequences worth being explicit about:

1. **#13204 stays open.** The interface closes it *structurally* only once
   callers route through it. Nothing here changes the unguarded path.
2. **#12651's "Done when" says "callers use it"**, which phases 1–2 do not
   satisfy. Closing on this scope needs either that AC reworded or a follow-up
   issue for steps 3–6. I have not assumed which — say the word and I will file
   the follow-up.

## Model Used

Claude Opus 5 (1M context)
