### PR TITLE
fix(tests): drop the code_generation conftest stub so llm_code_generator re-exports real symbols (#13233)

### DIFF
--- a/autobot-backend/code_intelligence/conftest.py
+++ b/autobot-backend/code_intelligence/conftest.py
@@ -117,6 +117,20 @@ for _key in list(sys.modules.keys()):
 importlib.import_module("code_intelligence.security")
 
 
+def _is_conftest_stub(mod: object) -> bool:
+    """True when *mod* is one of the top-level conftest's MagicMock package stubs.
+
+    #13233: ``_make_pkg_stub`` installs a PEP 562 module-level ``__getattr__`` that
+    returns a MagicMock singleton for ANY attribute the stub does not really have —
+    dunders included. So ``getattr(stub, "__file__", None)`` yields that MagicMock
+    and never ``None``, which makes the obvious ``getattr(...) is None`` stub test
+    report "this is already a real module" for every stub. Reading ``__dict__``
+    directly is the only lookup ``__getattr__`` cannot intercept: a real module
+    always carries ``__file__`` there, a stub never does.
+    """
+    return vars(mod).get("__file__") is None if hasattr(mod, "__dict__") else True
+
+
 def _load_real_submodule(leaf: str) -> None:
     """Real-load ``code_intelligence.<leaf>`` over the top-level conftest's stub.
 
@@ -171,13 +185,25 @@ _load_real_submodule("bug_predictor")
 # tools/parallel/executor.py — which imported that module object back at top-level-conftest
 # time — keeps referencing the SAME DiffGenerator class object. Re-executing diff.py would
 # mint a second class and break isinstance identity for the earlier importer (#12839).
+# _is_conftest_stub — NOT `getattr(..., "__file__", None) is None` — decides what to drop:
+# the stub's catch-all __getattr__ answers "__file__" with a MagicMock, so the getattr form
+# kept the stub, importlib.import_module handed it straight back, and llm_code_generator
+# re-exported 25 MagicMocks (#13233).
 _cg_pkg = sys.modules.get("code_intelligence.code_generation")
-if _cg_pkg is not None and getattr(_cg_pkg, "__file__", None) is None:
+if _cg_pkg is not None and _is_conftest_stub(_cg_pkg):
     del sys.modules["code_intelligence.code_generation"]
 _cg_diff = sys.modules.get("code_intelligence.code_generation.diff")
-if _cg_diff is not None and getattr(_cg_diff, "__file__", None) is None:
+if _cg_diff is not None and _is_conftest_stub(_cg_diff):
     del sys.modules["code_intelligence.code_generation.diff"]
 _real_cg = importlib.import_module("code_intelligence.code_generation")
+if _is_conftest_stub(_real_cg):
+    # Fail loudly rather than let llm_code_generator re-export MagicMocks again (#13233):
+    # a stub here silently turns every assertion in llm_code_generator_test.py into a
+    # comparison against mock attributes, which reads as 68 ordinary test failures.
+    raise RuntimeError(
+        "code_intelligence.code_generation is still a conftest stub after real-load; "
+        "llm_code_generator would re-export MagicMocks (#13233)"
+    )
 setattr(sys.modules["code_intelligence"], "code_generation", _real_cg)
 if "code_intelligence.code_generation.diff" in sys.modules:
     setattr(_real_cg, "diff", sys.modules["code_intelligence.code_generation.diff"])


### PR DESCRIPTION
Closes #13233

## Thinking Path

The issue's warning held: "the module is still stubbed" is wrong, and the real cause sits one level deeper. `code_intelligence.llm_code_generator` **is** real-loaded (PR #13180, `37a0950a3`) — but it is a pure facade, and the package it re-exports was still the MagicMock stub.

`code_intelligence/conftest.py` decided whether to drop that stub with:

```python
if _cg_pkg is not None and getattr(_cg_pkg, "__file__", None) is None:
    del sys.modules["code_intelligence.code_generation"]
```

That predicate can never be true for one of these stubs. `_make_pkg_stub` (top-level `conftest.py:37-63`) builds a real `ModuleType` and installs a **PEP 562 module-level `__getattr__`** that returns one shared `MagicMock` for *any* attribute the module does not really have — dunders included. So `getattr(stub, "__file__", None)` yields a `MagicMock`, never `None`.

Consequence chain:

1. the stub is never deleted from `sys.modules`;
2. `importlib.import_module("code_intelligence.code_generation")` hands the stub straight back — the real `__init__.py` never executes;
3. `_load_real_submodule("llm_code_generator")` then execs the **real** `llm_code_generator.py`, whose `from code_intelligence.code_generation import (...)` resolves through the stub's `__getattr__`;
4. all 25 re-exported names — `CodeValidator`, `DiffGenerator`, `LLMCodeGenerator`, `PromptTemplate`, `validate_code`, … — become the *same* MagicMock object.

That single shared mock explains every error shape in the issue table, so the 68 are **one cause, not seven**:

| symptom | mechanism |
|---|---|
| `assert <MagicMock name='mock.validate().is_valid'>` | `CodeValidator` is the mock |
| `assert <MagicMock name='mock().is_valid'>` | `validate_code` is the *same* mock — which is why both reprs share the `name='mock'` root |
| `'MagicMock' object can't be awaited` | `LLMCodeGenerator().generate()` returns a mock |
| `'>=' not supported between 'MagicMock' and 'int'` | `result.complexity_score` |
| `not enough values to unpack (expected 2, got 0)` | `MagicMock.__iter__` yields an empty iterator |
| `assert 0 > 0` | `MagicMock.__len__` returns `0` |
| `isinstance() arg 2 must be a type` | `PromptTemplate` is a mock, not a class |

Confirmed with a stdlib-only reproduction that imports no project code:

```
getattr(stub, '__file__', None) -> <MagicMock id='...'>     # <-- never None
is None -> False
stub.__dict__.get('__file__') -> None                       # <-- the correct probe
len(mock) -> 0
'x' in mock -> False
unpack -> not enough values to unpack (expected 2, got 0)
isinstance -> isinstance() arg 2 must be a type, a tuple of types, or a union
```

Arithmetic check on the blast radius: the file has exactly **75** tests. Walking each assertion against a shared MagicMock, exactly seven survive it — `test_all_refactoring_types_exist` (`hasattr` on a mock is always true), `test_generate_diff_no_changes` (`"@@" not in mock` is true), `test_template_for_extract_function` and `test_template_for_add_error_handling` (`is not None` only), `test_clear_cache` and `test_all_exports_accessible` (`assert True`), and `test_import_from_code_intelligence` (`is not None` against the `code_intelligence` package stub). 75 − 7 = **68**, matching the reported count exactly.

## What Changed

`autobot-backend/code_intelligence/conftest.py` only — one file, no production code touched.

- Added `_is_conftest_stub(mod)`, which reads `vars(mod).get("__file__")`. `__dict__` is the one lookup a module `__getattr__` cannot intercept: a real module always carries `__file__` there, a stub never does.
- Both stub probes (the `code_generation` package and `code_generation.diff`) now use it instead of `getattr(..., "__file__", None) is None`.
- Added a hard `RuntimeError` if `code_generation` is *still* a stub after the real-load, so a future regression surfaces as a loud collection error instead of 68 quiet assertion failures — the same philosophy as `_load_real` re-raising.

**Deliberately not touched:**

- **`code_generation.diff` identity preservation (#12839) is intact.** The real `diff` module is loaded by the top-level conftest and carries a genuine `__file__` in its `__dict__`, so `_is_conftest_stub` returns `False` and it stays in `sys.modules`. `__init__.py`'s `from .diff import DiffGenerator` still short-circuits on it, and `tools/parallel/executor.py` keeps the same `DiffGenerator` class object.
- **Nothing #13180 real-loaded was re-stubbed.** This change only makes a deletion that was already intended actually happen — #13180's repair was correct but has been dead code since it landed.
- **`_make_pkg_stub` itself was left alone.** Narrowing its `__getattr__` to stop fabricating dunders is the general cure, but its blast radius is the whole backend suite and is not measurable under this task's static-analysis constraint. The only place in the repo that depended on the broken behaviour is fixed here; the other `__file__` probe (top-level `conftest.py:91`) compares `== str(path)`, which is already correct against a MagicMock. Filed as **#13234**.

## Verification

Static analysis only — executing the suite was out of scope for this task, so CI is the execution environment.

- `python3 -m py_compile` clean; `black --line-length 120 --target-version py310 --check`, `isort --check-only` and `flake8 --max-line-length 120` all clean.
- Stdlib-only reproduction (imports no project code) confirms both the faulty predicate and every symptom shape — output above.
- **No vacuous passes.** No `skip` / `skipif` / `xfail` / `importorskip` marker exists in `llm_code_generator_test.py` and none was added; no assertion was weakened; the test file is unmodified. The fix only changes which object the imports resolve to.
- Per-group trace of each assertion against the **real** implementation, so the pass is behavioural rather than another accident:
  - **Enums (14 tests)** — every asserted name and value exists in `code_generation/types.py:34-73`.
  - **Dataclasses (9)** — field names and defaults match `types.py:81-168` (`imports=[]`, `start_line=1`, `preserve_behavior=True`, `target_name=None`).
  - **`CodeValidator` (11)** — traced through `validator.py`: `""` and `None` → `INCOMPLETE` via `_validate_input`; `123` raises `AttributeError` on `.strip()` (the test expects `TypeError|AttributeError`); a 175-char line trips the `>100` style warning; a bare `except:` trips `_check_bare_except`; complexity is `1.0` base plus one per `CONTROL_FLOW_TYPES` node, so `if`→2.0, `for`→2.0 and five nested→6.0, satisfying the `>=1/2/2/5` bounds; `compare_behavior` returns a real 2-tuple and detects the `foo(x)`→`foo(x, y)` signature change.
  - **`DiffGenerator` (7)** — `difflib.unified_diff` emits the `---`/`+++` headers and nothing at all for identical input; `generate_side_by_side` prints the literal `ORIGINAL`/`MODIFIED` header; `count_changes` returns the asserted `added`/`removed`/`unchanged` keys with the asserted counts.
  - **`PromptTemplateManager` (7)** — `TEMPLATES` (`prompts.py:20-234`) contains all six requested `RefactoringType` keys with the asserted `name` values (`add_docstring`, `custom`), and `format_prompt` returns a real `(system_prompt, user_prompt)` tuple containing the interpolated code.
  - **`LLMCodeGenerator` and async (12)** — `services.llm_service` stays a conftest stub, so `LLM_INTERFACE_AVAILABLE` is `True` and `__init__` completes (`model_name="codellama:13b"`, `validate_output=True`). Inside `generate()`, `await self.llm_client.chat(...)` raises `TypeError` on the mock, which `generator.py:285` catches and converts into a real `RefactoringResult(status=FAILED)`. The tests assert `isinstance(result, RefactoringResult)` and `status in [SUCCESS, FAILED]` — genuinely satisfied by the real error path, with the `if status == SUCCESS` bodies correctly not entered. These exercise real code; only the LLM boundary is mocked, which is the intended design of the file.
  - **Convenience functions and integration (8)** — real `list`/`str` returns from `generator.py:409-455`.
- Session-global side-effect audit: the only importer of `code_intelligence.code_generation` outside the package is `tools/parallel/executor.py:19`, and it imports `.diff`, which is unchanged. Nothing else in the backend imports the package, so no other test can regress from it becoming real.
- Import-safety audit of the package that now actually executes: `types`/`validator`/`diff`/`prompts` are stdlib-only; `generator.py` adds `autobot_shared.logging_manager` (patched to a stdlib logger by the top-level conftest) and a `try/except ImportError`-guarded `from services.llm_service import get_llm_service` (itself stubbed). No chromadb, torch, redis, fastapi or network import on any path.

**Not verifiable without executing code**, left to CI: the actual pass/fail delta, and that the newly-executing `code_generation/__init__.py` raises nothing at collection. The new `RuntimeError` guard makes a silent relapse impossible — it would be a loud collection error rather than 68 quiet failures.

## Model Used

claude-opus-5
