### PR TITLE
docs(claude-md): correct the logging pattern to get_logger, with the harness exception (#13222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 |---|---|
 | Redis | `from autobot_shared.redis_client import get_redis_client` |
 | Config | `from autobot_shared.ssot_config import config` / `import { getBackendUrl } from '@/config/ssot-config'` |
-| Logging | `logging.getLogger(__name__)` / `createLogger('Name')` — no `print()` or `console.*` |
+| Logging | `from autobot_shared.logging_manager import get_logger` → `get_logger(__name__)` / `createLogger('Name')` — no `print()` or `console.*`; stdlib `logging` only where a config-mocking test harness forbids it (see `autobot_shared/user_management/password_epoch.py`) |
 | Encoding | Always `encoding='utf-8'` explicitly |
 | Cache TTL | Never hard-code — use module-level constant from env var (see `chat_history/cache.py`) |
 | LEDGER/EXECUTOR | Coordination tools complete instantly — do NOT wait; continue immediately with execution tools |


### PR DESCRIPTION
Closes #13222

## Thinking Path

`CLAUDE.md`'s Essential Patterns table prescribed `logging.getLogger(__name__)`. The codebase does the opposite, re-measured on `Dev_new_gui` just now:

```
get_logger(__name__)          1364 files
logging.getLogger(__name__)    301 files
```

Roughly 4.5:1 the other way. The table is what agents and contributors read when deciding, so it was steering new code toward the minority convention — and it produced a wrong justification in a merged PR of mine (#13178 converged a file onto `get_logger` and cited the table as mandating it; the change was right, the citation was not).

The half that actually matters is the **exception**, which was documented nowhere: `get_logger` builds a `RotatingFileHandler` from config *when called*, so a module imported at module scope by a file whose tests mock the config stack raises at import time. That broke **collection** of `tests/api/test_auth_logout.py` during #12924, and its sibling `services/token_denylist.py` had already hit the same thing. Without it written down, the next person "fixes" `password_epoch.py` back to `get_logger` and re-breaks the test.

## What Changed

One table row in `CLAUDE.md`:

- canonical pattern corrected to `get_logger(__name__)`, with the import path;
- the harness exception recorded in the same line, pointing at
  `autobot_shared/user_management/password_epoch.py` as the exemplar.

Kept to a single row with a pointer — matching the `Cache TTL` row's existing "short rule + `(see file)`" style — rather than the paragraph I first wrote, which would have broken the repo's lean-instructions rule that anything needing more than a line or two belongs in a referenced doc.

## Verification

- Counts re-measured on the current `Dev_new_gui` rather than reused from the issue: **1364 vs 301**.
- The cited exemplar was checked to actually use stdlib `logging` *and* explain why (`password_epoch.py:44,50,58`), so the pointer resolves to a real explanation rather than just an example.
- Docs-only; no code, no tests affected.

## Model Used

Claude Opus 5 (1M context)
