### PR TITLE
fix(tests): auth stub must be a real callable, not a bare MagicMock (#13253)

### DIFF
--- a/autobot-backend/api/slm/deployments_api_test.py
+++ b/autobot-backend/api/slm/deployments_api_test.py
@@ -163,6 +163,11 @@ class TestCreateDeployment:
 
         # Pydantic v2 rejects unknown enum values at request validation time (422).
         assert response.status_code == 422
+        # #13253: assert the 422 names the offending BODY field. Without this the
+        # test passed vacuously while a broken auth dependency rejected every
+        # request with a 422 naming spurious ``query`` parameters instead.
+        errors = response.json()["detail"]
+        assert any(err["loc"] == ["body", "strategy"] for err in errors), errors
 
     def test_create_deployment_missing_fields(self, client, mock_orchestrator):
         """Test create with missing required fields — Pydantic returns 422."""
@@ -176,6 +181,10 @@ class TestCreateDeployment:
             )
 
         assert response.status_code == 422
+        # #13253: the 422 must be about the missing body field, not about a
+        # dependency that FastAPI mis-resolved into required query parameters.
+        errors = response.json()["detail"]
+        assert any(err["loc"] == ["body", "target_nodes"] for err in errors), errors
 
 
 class TestGetDeployment:

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -611,13 +611,34 @@ if "llm_shared" not in sys.modules:
 
 # auth_middleware stub — the real module pulls in the full config/Redis chain
 # at import time (config.manager, error_catalog, etc.) which fails in the dev
-# venv.  Tests that exercise openai_compat patch _get_user directly and never
-# call get_current_user, so a lightweight stub is safe here.
+# venv.  Every name exported here must be a real callable with a real
+# signature, because routers capture them in ``Depends(...)`` at import time.
 if "auth_middleware" not in sys.modules:
+    from fastapi import Request as _FastAPIRequest
+
     _auth_stub = types.ModuleType("auth_middleware")
     _auth_stub.__path__ = []  # type: ignore[attr-defined]
     _auth_stub.__package__ = "auth_middleware"
-    _auth_stub.get_current_user = MagicMock()  # type: ignore[attr-defined]
+
+    # get_current_user must be a real callable, not a bare MagicMock (#13253).
+    # ``inspect.signature(MagicMock())`` is ``(*args, **kwargs)``; FastAPI's
+    # get_dependant() does not skip VAR_POSITIONAL/VAR_KEYWORD parameters, so
+    # both become REQUIRED query parameters. Every request to any router that
+    # declares ``Depends(get_current_user)`` then fails validation with
+    # ``422 {'loc': ['query', 'args'], 'msg': 'Field required'}`` before the
+    # handler ever runs — same failure mode as #10472 below.
+    # The ``request`` parameter is annotated ``Request`` so FastAPI injects it
+    # instead of treating it as a request field, and defaults to None so
+    # direct ``get_current_user()`` call sites keep working.
+    def _get_current_user_stub(request: _FastAPIRequest = None) -> dict:  # type: ignore[assignment] # noqa: E301
+        return {
+            "username": "test-user",
+            "user_id": "test-user",
+            "role": "admin",
+            "auth_method": "stub",
+        }
+
+    _auth_stub.get_current_user = _get_current_user_stub  # type: ignore[attr-defined]
 
     # check_admin_permission must be a proper no-arg callable so FastAPI can
     # inspect its signature at route-registration time without producing spurious

--- a/autobot-backend/services/research/routes_test.py
+++ b/autobot-backend/services/research/routes_test.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from services.research.models import Citation, ResearchFactOut, ResearchResponse
@@ -99,20 +99,32 @@ class TestPostResearch:
     def test_route_requires_auth_dependency(self):
         """The route is wired behind ``Depends(get_current_user)`` (not open).
 
-        Exact unauthenticated status code is auth_middleware's own contract
-        (covered by its test suite); this only asserts our route does not
-        bypass the dependency — an unauthenticated call must not reach the
-        orchestrator and must not succeed with 200.
+        Asserts only that our route does not bypass the dependency: a rejected
+        caller must not reach the orchestrator and must not succeed with 200.
+
+        #13253: this installs an explicit denying override rather than relying
+        on the conftest auth stub's behaviour. It previously passed because the
+        stub was a bare ``MagicMock`` whose ``(*args, **kwargs)`` signature made
+        FastAPI demand two required query params, so every call 422'd before
+        reaching the handler — the assertion held for a reason that had nothing
+        to do with authentication. With the stub corrected to a real callable
+        the route authenticates and returns 200, so the guarantee has to be
+        pinned to a real rejection instead.
         """
+        from auth_middleware import get_current_user
         from services.research.routes import router
+
+        def _deny() -> dict:
+            raise HTTPException(status_code=401, detail="Authentication required")
 
         app = FastAPI()
         app.include_router(router, prefix="/research")
         orchestrator = _make_orchestrator(ResearchResponse(answer=""))
         app.state.research_orchestrator = orchestrator
+        app.dependency_overrides[get_current_user] = _deny
         client = TestClient(app, raise_server_exceptions=False)
 
         resp = client.post("/research", json={"question": "what is X?"})
 
-        assert resp.status_code != 200
+        assert resp.status_code == 401
         orchestrator.research.assert_not_awaited()


### PR DESCRIPTION
Closes #13253

## Thinking Path

A uniform 422 on every endpoint of one router means FastAPI rejected the request during validation, before any handler ran. The issue already ruled out the test app construction and the endpoint signatures, so the remaining candidate was something in the *dependency* chain.

`api/slm/deployments.py:54` declares auth router-wide:

```python
router = APIRouter(prefix="/slm/deployments", tags=[...], dependencies=[Depends(get_current_user)])
```

`autobot-backend/conftest.py:620` (before this change) exported that name as a bare mock:

```python
_auth_stub.get_current_user = MagicMock()
```

`inspect.signature(MagicMock())` is `(*args, **kwargs)`. FastAPI's `get_dependant()` (`fastapi/dependencies/utils.py:309`) iterates every signature parameter with no filter on `param.kind`, so `VAR_POSITIONAL` and `VAR_KEYWORD` are analysed like ordinary parameters. Each has no annotation and no default, so `analyze_param` (same file, line 517) turns it into `params.Query(default=Required)` — two required query parameters named `args` and `kwargs` on every route on the router.

Reproduced standalone against FastAPI 0.135.2 with no project code imported:

```
BARE MagicMock -> 422 {'detail': [
  {'type': 'missing', 'loc': ['query', 'args'],   'msg': 'Field required'},
  {'type': 'missing', 'loc': ['query', 'kwargs'], 'msg': 'Field required'}]}
no-arg callable -> 200 {'ok': 'deploy-123'}
```

This is the same failure mode the same conftest block already fixed twice — `check_admin_permission` and `require_device_jwt` both carry the comment "must be a proper no-arg callable so FastAPI can inspect its signature at route-registration time without producing spurious `(*args, **kwargs)` query parameters (#10472)". `get_current_user` was simply missed.

The diagnosis is also independently corroborated inside the repo: `tests/integration/test_execution_snapshot_api.py:30-33` documents it verbatim and works around it locally with `dependency_overrides` (#11687). That workaround still functions and is left untouched.

All 18 failures share this single cause. Tests elsewhere that install `app.dependency_overrides[get_current_user]` were unaffected because FastAPI re-derives the dependant from the *override's* signature; `deployments_api_test.py` installs no override, so the mock signature leaked into the route.

## What Changed

**`autobot-backend/conftest.py`** — `get_current_user` is now a real callable returning a user dict, matching the neighbouring `check_admin_permission` / `require_device_jwt` stubs. Its `request` parameter is annotated `Request`, which FastAPI injects rather than treating as a request field, and defaults to `None` so direct `get_current_user()` call sites (e.g. the `test_execution_snapshot_api` override) keep working. It is deliberately sync: `await`-ing the previous `MagicMock` already raised `TypeError`, so no call site regresses.

**`autobot-backend/api/slm/deployments_api_test.py`** — the two tests that already expected 422 were passing for the wrong reason (the auth artifact, not body validation). They now additionally assert the error `loc` is `["body", "strategy"]` / `["body", "target_nodes"]`, so they fail if the 422 ever comes from the wrong place again.

**No production code was touched.** No endpoint signature was relaxed; `api/slm/deployments.py` is unchanged.

## Verification

Static analysis only — application code was not executed.

- Standalone FastAPI reproduction (no project imports) shows `422 {'loc': ['query','args']}` with the bare mock and `200` with a real callable; a second reproduction confirms the replacement stub yields `200` for router-level deps, function-level `Depends`, path params and optional query params, and that the generated OpenAPI schema contains no `args`/`kwargs` parameter.
- A third reproduction confirms that with auth fixed, an invalid enum still yields `422 [['body','strategy']]`, a missing field still yields `422 [['body','target_nodes']]`, and a valid body yields `201` — so the two 422 tests are no longer vacuous.
- Per-test walkthrough against the real `DeploymentContext` / `DeploymentCoordinator` (both real-loaded, not stubbed): `MagicMock(spec=DeploymentCoordinator)` auto-creates `AsyncMock` children for the four `async def` methods and a sync child for `get_deployment`, matching how each handler calls them. All 18 reach their handler and produce the asserted status.
- `black --line-length 120 --check` clean; `flake8` exit 0; `isort --check-only` clean; both files parse via `ast`.
- Blast radius reviewed: 653 `Depends(get_current_user)` sites. Tests using `dependency_overrides` are keyed by function identity and are unaffected. Every backend test asserting `== 422` was reviewed — all send deliberately invalid payloads, so they still validate to 422. mypy in CI covers `autobot_shared/` only, so the annotated-default carries a `type: ignore[assignment]` for local runs.

Not verifiable without executing code: the actual pass/fail of the 18 tests, and whether the fix incidentally repairs other suites that hit auth-dependent routes without an override. CI is the execution environment for both.

## Model Used

Claude Opus 5
