### PR TITLE
ci: split the Python suite out of security-tests and drop its duplicated static checks (#13162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
               - 'autobot-frontend/**'
               - '.github/workflows/ci.yml'
 
-  security-tests:
+  python-suite:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
@@ -109,41 +109,13 @@ jobs:
           db: 0
         EOF
 
-    - name: Run code quality checks
-      run: |
-        echo "Running code quality checks..."
-
-        # Code formatting check — must match project standard (pyproject.toml
-        # [tool.black] line-length=120). The previous --line-length=88 disagreed
-        # with the codebase and reported 1864 files "would be reformatted"
-        # because long lines that legitimately fit within 120 exceeded the
-        # stricter 88. (#7496)
-        echo "Checking code formatting with black..."
-        black --check autobot-backend/ autobot-slm-backend/ autobot_shared/ --line-length=120
-
-        # Import sorting check — reads pyproject.toml for profile, src_paths, known_first_party (#2679)
-        echo "Checking import sorting with isort..."
-        isort --check-only --settings-path=. autobot-backend/ autobot-slm-backend/ autobot_shared/
-
-        # Linting (uses project .flake8 config — same as pre-commit)
-        echo "Running flake8 linter..."
-        flake8 --config=.flake8 autobot-backend/ autobot-slm-backend/ autobot_shared/
-
-    - name: Run security analysis
-      run: |
-        echo "🔒 Running security analysis..."
-
-        # Security vulnerability scan — fail on medium+ severity/confidence.
-        # -c .bandit applies the centralized skip list (B101/B104/B105/B106/B108/...)
-        # so known false positives don't fail the gate, matching code-quality.yml
-        # and security.yml (#9694). Real medium+ findings still exit non-zero.
-        bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ \
-          --severity-level medium --confidence-level medium \
-          -f json -o bandit-report.json
-        if [ -f bandit-report.json ]; then
-          echo "Security report generated"
-          python -m json.tool < bandit-report.json || true
-        fi
+    # Static checks (black / isort / flake8 / bandit) deliberately live in
+    # code-quality.yml, NOT here (#13162). They were duplicated across both
+    # workflows over the same three trees; code-quality.yml's bandit has no
+    # severity floor where this one filtered to medium+, so it is the stricter
+    # of the two and nothing is lost by removing this copy. Keeping them here
+    # also meant four checks that finish in minutes were gated behind a
+    # ~105-minute pytest run in the same job.
 
     - name: Run unit tests with coverage gate
       run: |
@@ -276,10 +248,10 @@ jobs:
 
   deployment-check:
     runs-on: ubuntu-latest
-    needs: [changes, security-tests, frontend-tests]
+    needs: [changes, python-suite, frontend-tests]
     if: |
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/Dev_new_gui') &&
-      (needs.security-tests.result == 'success' || needs.security-tests.result == 'skipped') &&
+      (needs.python-suite.result == 'success' || needs.python-suite.result == 'skipped') &&
       (needs.frontend-tests.result == 'success' || needs.frontend-tests.result == 'skipped')
 
     steps:
@@ -392,7 +364,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    needs: [changes, security-tests, frontend-tests, deployment-check]
+    needs: [changes, python-suite, frontend-tests, deployment-check]
     if: always()
 
     steps:
@@ -401,7 +373,7 @@ jobs:
         echo "🎯 CI/CD Pipeline Results:"
         echo "=========================="
 
-        if [ "${{ needs.security-tests.result }}" == "success" ]; then
+        if [ "${{ needs.python-suite.result }}" == "success" ]; then
           echo "✅ Security tests: PASSED"
         else
           echo "❌ Security tests: FAILED"
@@ -420,7 +392,7 @@ jobs:
         fi
 
         echo ""
-        if [ "${{ needs.security-tests.result }}" == "success" ] &&
+        if [ "${{ needs.python-suite.result }}" == "success" ] &&
            [ "${{ needs.frontend-tests.result }}" == "success" ] &&
            [ "${{ needs.deployment-check.result }}" == "success" ]; then
           echo "🎉 All checks passed! AutoBot is ready for deployment."


### PR DESCRIPTION
Closes #13162

> **Partial — #13162 must stay OPEN after merge.** The close keyword is
> required by the `Validate PR issue link` gate; merging to `Dev_new_gui` does
> not auto-close. This fixes only the *reporting* half — the **450 failing
> tests remain**, and `python-suite` should not be added to branch protection
> until they are green. Same handling as the earlier partial slices
> (#13126 / #13163 / #13226).

## Thinking Path

#13162 started as "the Python suite is not a required check". Measuring found a third reason it produces no signal, and it is the one that made the other two unfixable:

| | |
|---|---|
| merges to `Dev_new_gui` in a day | **44** |
| median gap between merges | **26 minutes** |
| `security-tests` wall-clock | **~105 minutes** |
| `concurrency.cancel-in-progress` (`ci.yml:17`) | **true** |

The job is cancelled roughly four times over before it can report. So the original plan — green the suite, then require it — **could not have worked even after the 450 failures were fixed**: a 105-minute required job on a branch that merges every 26 minutes would be cancelled by the very merges it was meant to gate.

While splitting it I found the static checks in this job are **duplicates**. `code-quality.yml` already runs the same four tools over the same three trees, and it is already a required check — so the fast checks did not need extracting at all. They needed deleting.

## What Changed

**Renamed `security-tests` → `python-suite`.** The old name is what hid this gap: the required check called `Unit & Integration Tests` is the *frontend* job, and the job actually running Python was called `security-tests`, so the required-check list looked like it covered Python when nothing did.

**Removed its `Run code quality checks` and `Run security analysis` steps.** `code-quality.yml` runs:

```
black --check --line-length=120       autobot-backend/ autobot-slm-backend/ autobot_shared/
isort --check-only --settings-path=.  (same three trees)
flake8 --config=.flake8               (same three trees)
bandit -c .bandit -r                  (same three trees)
```

**Nothing is lost.** This copy filtered bandit to `--severity-level medium --confidence-level medium`; `code-quality.yml` applies **no severity floor**, so the surviving gate is strictly the stronger one. (That difference is not academic — it is exactly why #13221's `B105` false positive failed `code-quality` and not this job.)

Net: four checks that finish in minutes are no longer gated behind a 105-minute pytest run in the same job, and `python-suite` can be made required independently once it is green.

## Verification

- YAML parses; job graph re-checked after the rename:
  ```
  jobs: ['changes', 'python-suite', 'frontend-tests', 'deployment-check', 'notify']
    python-suite.needs      = changes
    deployment-check.needs  = ['changes', 'python-suite', 'frontend-tests']
    notify.needs            = ['changes', 'python-suite', 'frontend-tests', 'deployment-check']
  ```
- **All six** references to the old job name in `deployment-check` and `notify` were repointed — the rename would have silently broken both gates otherwise (`grep -c security-tests` → 0).
- Duplication claim verified by reading both workflows side by side rather than assumed.

## What this does not do

- **Does not close #13162.** The 450 failures are untouched; that is the remaining phase.
- **Does not change branch protection** — that is yours to set. Once `python-suite` is green, adding it to the required list is the final step, and it is now a job that can actually finish.

## Model Used

Claude Opus 5 (1M context)
