### PR TITLE
feat(browser): close three contract gaps the first real callers exposed (#13236)

### DIFF
--- a/autobot-backend/browser_backends/conformance_test.py
+++ b/autobot-backend/browser_backends/conformance_test.py
@@ -71,6 +71,59 @@ def test_capability_claims_match_the_audited_matrix():
     assert Capability.SCREENSHOT in worker.capabilities
 
 
+def test_locality_is_declared_and_exclusive():
+    """#13236: callers pin process locality, so every backend must declare it.
+
+    `web_fetch` uses the container deliberately to keep Playwright out of the
+    backend's process. If a backend declared neither — or both — that caller
+    could be routed into the process it is avoiding.
+    """
+    for backend in (InProcessBrowserBackend(), ContainerBrowserBackend(), WorkerBrowserBackend()):
+        locality = backend.capabilities & {Capability.IN_PROCESS, Capability.OUT_OF_PROCESS}
+        assert len(locality) == 1, f"{backend.name} declares {locality or 'no'} locality"
+
+    assert Capability.IN_PROCESS in InProcessBrowserBackend().capabilities
+    assert Capability.OUT_OF_PROCESS in ContainerBrowserBackend().capabilities
+    assert Capability.OUT_OF_PROCESS in WorkerBrowserBackend().capabilities
+
+
+@pytest.mark.asyncio
+async def test_container_extract_renders_html():
+    """#13236: phase 2 under-declared this stack — it has a `render` endpoint."""
+    service = MagicMock()
+    service._post_and_parse = AsyncMock(return_value={"html": "<html>ok</html>"})
+
+    with patch.object(ContainerBrowserBackend, "_service", staticmethod(AsyncMock(return_value=service))):
+        result = await ContainerBrowserBackend().extract(ExtractRequest(url="https://example.com/"))
+
+    assert result.success is True
+    assert result.content == "<html>ok</html>"
+    endpoint, payload = service._post_and_parse.await_args.args
+    assert endpoint == "render" and payload["url"] == "https://example.com/"
+
+
+@pytest.mark.asyncio
+async def test_in_process_navigate_can_extract_in_one_round_trip():
+    """research_url does both; asking twice would navigate twice (#13236)."""
+    manager = MagicMock()
+    manager.research_url = AsyncMock(
+        return_value={
+            "success": True,
+            "status": "completed",
+            "navigation": {"url": "https://example.com/"},
+            "content": {"text_content": "hi", "structured_data": {"h1": ["Title"]}},
+            "session_id": "s",
+        }
+    )
+
+    with patch.object(InProcessBrowserBackend, "_manager", staticmethod(lambda: manager)):
+        result = await InProcessBrowserBackend().navigate(NavigateRequest(url="https://example.com/", extract=True))
+
+    assert manager.research_url.await_args.kwargs["extract_content"] is True
+    assert result.content == "hi"
+    assert result.structured == {"h1": ["Title"]}, "structured_data had no home before #13236"
+
+
 @pytest.mark.asyncio
 async def test_unsupported_operations_refuse_rather_than_raise():
     """The registry never routes these, but they must not explode if reached."""

--- a/autobot-backend/browser_backends/container.py
+++ b/autobot-backend/browser_backends/container.py
@@ -37,7 +37,17 @@ class ContainerBrowserBackend:
     """``PlaywrightService`` behind the canonical contract."""
 
     name = BACKEND_NAME
-    capabilities = frozenset({Capability.SCREENSHOT})
+    capabilities = frozenset(
+        {
+            Capability.SCREENSHOT,
+            # #13236: the container also exposes a `render` endpoint, which
+            # `web_fetch/fetcher.py::_fetch_playwright` already uses for its
+            # JS-render fallback. Phase 2 wrapped only `capture_screenshot`
+            # and under-declared this stack.
+            Capability.EXTRACT,
+            Capability.OUT_OF_PROCESS,
+        }
+    )
 
     @staticmethod
     async def _service():
@@ -64,11 +74,33 @@ class ContainerBrowserBackend:
         )
 
     async def extract(self, request: ExtractRequest) -> BrowserResult:
-        """Not supported — the container is stateless, with no current page."""
+        """Render *url* and return its HTML.
+
+        Stateless: the URL is required because this backend holds no current
+        page. The registry has already validated it (#13236).
+        """
+        if not request.url:
+            return BrowserResult(
+                success=False,
+                backend=BACKEND_NAME,
+                error="container backend needs an explicit url (it holds no session)",
+            )
+
+        service = await self._service()
+        raw = await service._post_and_parse(
+            "render",
+            {"url": request.url, "wait": "networkidle"},
+        )
+        html = raw.get("html") or raw.get("content")
+        if request.max_chars is not None and html:
+            html = html[: request.max_chars]
+
         return BrowserResult(
-            success=False,
+            success=bool(html),
             backend=BACKEND_NAME,
-            error="container backend does not support extract",
+            url=request.url,
+            content=html,
+            error=None if html else raw.get("error", "render returned no content"),
         )
 
     async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:

--- a/autobot-backend/browser_backends/in_process.py
+++ b/autobot-backend/browser_backends/in_process.py
@@ -44,6 +44,7 @@ class InProcessBrowserBackend:
             Capability.MHTML,
             Capability.HUMAN_HANDOFF,
             Capability.PERSISTENT_SESSION,
+            Capability.IN_PROCESS,
         }
     )
 
@@ -67,7 +68,11 @@ class InProcessBrowserBackend:
         """Navigate via ``research_url``, preserving its interaction handoff."""
         manager = self._manager()
         conversation_id = request.session_id or "canonical-browser"
-        raw = await manager.research_url(conversation_id, request.url, extract_content=False)
+        raw = await manager.research_url(
+            conversation_id,
+            request.url,
+            extract_content=request.extract,
+        )
         return self._to_result(raw, requested_url=request.url)
 
     async def extract(self, request: ExtractRequest) -> BrowserResult:
@@ -93,6 +98,7 @@ class InProcessBrowserBackend:
             url=raw.get("url"),
             title=raw.get("title"),
             content=content,
+            structured=raw.get("structured_data") or {},
             error=raw.get("error"),
             details={k: v for k, v in raw.items() if k not in {"success", "url", "title", "text_content", "error"}},
         )
@@ -138,6 +144,7 @@ class InProcessBrowserBackend:
             url=navigation.get("url") or content.get("url") or requested_url,
             title=navigation.get("title") or content.get("title"),
             content=content.get("text_content"),
+            structured=content.get("structured_data") or {},
             session=SessionHandle(session_id=session_id, backend=BACKEND_NAME) if session_id else None,
             interaction_required=raw.get("status") == "interaction_required",
             error=raw.get("error"),

--- a/autobot-backend/browser_backends/worker.py
+++ b/autobot-backend/browser_backends/worker.py
@@ -49,6 +49,7 @@ class WorkerBrowserBackend:
             Capability.INTERACT,
             Capability.ELEMENT_REFS,
             Capability.PERSISTENT_SESSION,
+            Capability.OUT_OF_PROCESS,
         }
     )
 

--- a/autobot_shared/browser/base.py
+++ b/autobot_shared/browser/base.py
@@ -61,6 +61,21 @@ class Capability(str, Enum):
     #: A browser context that outlives a single call, keyed by session.
     PERSISTENT_SESSION = "persistent_session"
 
+    # --- Locality (#13236) -------------------------------------------------
+    # Callers are not always indifferent to *where* a browser runs, and the
+    # first two real migrations proved it: `web_fetch` uses the container
+    # deliberately so Playwright does NOT run in the backend's own process,
+    # and routing it in-process would defeat the reason that fallback exists.
+    # Declaring locality as a capability keeps callers declarative — they say
+    # what they need, not which module to call.
+
+    #: Runs inside the calling process. Fast, but shares its memory and dies
+    #: with it.
+    IN_PROCESS = "in_process"
+    #: Runs outside the calling process. Survives a backend restart and keeps
+    #: browser memory out of it.
+    OUT_OF_PROCESS = "out_of_process"
+
 
 class BrowserError(Exception):
     """Base for every error raised through the canonical browser interface."""
@@ -95,12 +110,19 @@ class NavigateRequest:
     session_id: str | None = None
     wait_for_load: bool = True
     timeout_seconds: float | None = None
+    #: Extract content as part of navigating. Some stacks do both in one
+    #: round trip (`research_url(extract_content=True)`), so asking for it
+    #: here avoids a second navigation (#13236).
+    extract: bool = False
 
 
 @dataclass(frozen=True)
 class ExtractRequest:
     """Read content from the current page of *session_id*."""
 
+    #: Required by stateless backends, which hold no current page. Validated
+    #: by the registry exactly like a navigate URL (#13236).
+    url: str | None = None
     session_id: str | None = None
     selector: str | None = None
     max_chars: int | None = None
@@ -142,6 +164,10 @@ class BrowserResult:
     url: str | None = None
     title: str | None = None
     content: str | None = None
+    #: Structured extraction (headings, links, metadata) where the backend
+    #: produces it. `content_reach` maps this onto `ContentResult.structured`,
+    #: and it had no home in this result until #13236.
+    structured: dict[str, Any] = field(default_factory=dict)
     image_path: str | None = None
     session: SessionHandle | None = None
     interaction_required: bool = False

--- a/autobot_shared/browser/registry.py
+++ b/autobot_shared/browser/registry.py
@@ -143,7 +143,12 @@ class Browser:
         return await self._backend.navigate(request)
 
     async def extract(self, request: ExtractRequest) -> BrowserResult:
-        """Read content from the current page."""
+        """Read content, validating the URL when the request carries one.
+
+        Stateless backends need an explicit URL because they hold no current
+        page; it is guarded exactly like a navigate URL (#13236).
+        """
+        await _guard_url(request.url)
         return await self._backend.extract(request)
 
     async def screenshot(self, request: ScreenshotRequest) -> BrowserResult:

--- a/autobot_shared/browser/registry_test.py
+++ b/autobot_shared/browser/registry_test.py
@@ -121,6 +121,51 @@ async def test_screenshot_url_is_guarded_too():
 
 
 @pytest.mark.asyncio
+async def test_extract_url_is_guarded_for_stateless_backends():
+    """#13236: ExtractRequest gained a url, so it needs the same guard.
+
+    A stateless backend has no current page and must be given a URL; that URL
+    reaches the network exactly like a navigate URL, so it cannot skip the
+    check.
+    """
+    backend = FakeBackend("fake", {Capability.EXTRACT})
+    register_backend(backend)
+
+    with _deny():
+        browser = await get_browser(requires={Capability.EXTRACT})
+        with pytest.raises(UnsafeUrlError):
+            await browser.extract(ExtractRequest(url="http://169.254.169.254/"))
+
+    assert backend.calls == []
+
+
+@pytest.mark.asyncio
+async def test_extract_without_a_url_is_not_blocked():
+    """Session-holding backends read their current page — nothing to validate."""
+    backend = FakeBackend("fake", {Capability.EXTRACT})
+    register_backend(backend)
+
+    with _deny():
+        browser = await get_browser(requires={Capability.EXTRACT})
+        result = await browser.extract(ExtractRequest(session_id="s1"))
+
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_locality_narrows_dispatch():
+    """#13236: a caller that must stay out-of-process cannot be routed in."""
+    in_proc = FakeBackend("in_proc", {Capability.EXTRACT, Capability.IN_PROCESS})
+    out_proc = FakeBackend("out_proc", {Capability.EXTRACT, Capability.OUT_OF_PROCESS})
+    register_backend(in_proc)
+    register_backend(out_proc)
+
+    chosen = await resolve_backend({Capability.EXTRACT, Capability.OUT_OF_PROCESS})
+
+    assert chosen.name == "out_proc", "locality must pin dispatch, not just rank it"
+
+
+@pytest.mark.asyncio
 async def test_empty_url_is_rejected():
     backend = FakeBackend("fake", {Capability.NAVIGATE})
     register_backend(backend)


### PR DESCRIPTION
Closes #13236

> **Partial — #13236 must stay OPEN after merge.** The close keyword is
> required by the `Validate PR issue link` gate; merging to `Dev_new_gui` does
> not auto-close. **No caller is migrated** — this only closes the contract
> gaps that blocked migration. Steps 3–6 and **#13204** remain.

## Thinking Path

I started ADR-009 step 3 and stopped before changing a caller. Reading the first two real consumers found **three gaps in the contract I shipped in #13226** — all mine, and all three would have been papered over by migrating anyway.

**Callers are not indifferent to which stack serves them.** This is the design gap, and the reason I asked rather than guessed. `web_fetch/fetcher.py::_fetch_playwright` uses the container **deliberately**, so Playwright does not run in the backend's own process. Dispatching it to "any `EXTRACT`-capable backend" could route it in-process — precisely what that fallback exists to avoid. `content_reach` similarly wants the research browser specifically: its `probe()` is `rbm.PLAYWRIGHT_AVAILABLE` and its error handling reads `blocked_by_guard`, that stack's #13018 re-check.

**`content_reach` returns two payloads, and the contract carried one.** It maps `research_url(extract_content=True)` onto `ContentResult` with both `text_content` and `structured_data`. `BrowserResult` had `content` but no `structured`, so migrating would have **silently dropped** the structured half.

**A stateless backend cannot serve `ExtractRequest`.** It carried `session_id`/`selector`/`max_chars` but no `url` — fine for the session-holding stacks, impossible for the container. And phase 2 **under-declared** that stack: I wrapped `capture_screenshot` and missed that it also exposes the `render` endpoint `web_fetch` already uses.

## What Changed

**Locality as a capability** (your 2026-08-02 decision): `IN_PROCESS` / `OUT_OF_PROCESS`. Callers stay declarative — they say what they need, not which module to call:

```python
browser = await get_browser(requires={
    Capability.EXTRACT,
    Capability.OUT_OF_PROCESS,   # never in the backend's own process
})
```

Every backend declares exactly one, asserted by test — a backend declaring neither, or both, would let a caller be routed into the process it is avoiding.

**`ExtractRequest.url`**, guarded by the registry exactly like a navigate URL. It reaches the network the same way, so it cannot skip the check.

**`BrowserResult.structured`** and **`NavigateRequest.extract`**. `research_url` does navigation and extraction in one round trip, so asking for extraction on the navigate request avoids navigating twice.

**`ContainerBrowserBackend` now declares `EXTRACT`** and implements it against the container's `render` endpoint, correcting the phase-2 under-declaration.

## Verification

```
autobot_shared/browser              18 passed   (was 15)
autobot-backend/browser_backends    18 passed   (was 15)
bandit                              0 issues
isort · black --line-length=120 · flake8   clean
```

The six new tests pin the properties that made these gaps invisible:

- **locality narrows dispatch, not just ranks it** — an `OUT_OF_PROCESS` requirement cannot resolve to the in-process backend;
- **the extract URL is guarded** — a denied URL never reaches the backend, asserted against its call log;
- **extract without a URL is still allowed** — session-holding backends read their current page, so there is nothing to validate;
- **navigate-with-extract carries `structured_data`** in one round trip, which is the exact thing `content_reach` would have lost;
- **the container's `render` endpoint is reached** with the right payload.

## What this does not do

- **No caller is migrated.** Still additive; nothing is repointed.
- **#13204 is untouched** and stays open — it closes only with the `tool_handler` migration, which is the behaviour change.
- **ADR-009's step order needs revising**, as recorded on #13236: it nominated `content_reach` first as "smallest, already guarded", but it is the caller with the *most* stack-specific behaviour. `web_fetch` is the cleaner first migration now that these gaps are closed.

## Model Used

Claude Opus 5 (1M context)
