### PR TITLE
fix(security-api): restore dropped response payload, stop swallowing audit-log read errors, correct 7 stale tests (#13258)

### DIFF
--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -145,7 +145,13 @@ def _parse_audit_log_lines(lines: list, limit: int) -> list:
     for line in lines[-limit:]:
         try:
             entry = json.loads(line.strip())
-            entries.append(entry)
+            # #13258: response_model=AuditLogData declares List[Dict[str, Any]], and a
+            # non-object line (null / 123 / [...]) would fail response validation AFTER
+            # this handler returns — past its own try/except — and 500 the whole
+            # endpoint. Only the writer at security_layer.py:585 should ever produce
+            # lines here, so a non-object is corruption; skip it like a malformed line.
+            if isinstance(entry, dict):
+                entries.append(entry)
         except json.JSONDecodeError:
             continue
     return entries

--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -15,7 +15,6 @@ Includes:
 import aiofiles
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from api.schemas_common import DataResponse
 from api.schemas_system import (
     AuditLogData,
     CommandApprovalRequest,
@@ -94,7 +93,7 @@ async def approve_command(request: Request, approval: CommandApprovalRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/pending-approvals", response_model=DataResponse[PendingApprovalsData])
+@router.get("/pending-approvals", response_model=PendingApprovalsData)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_pending_approvals",
@@ -116,7 +115,7 @@ async def get_pending_approvals(request: Request):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/command-history", response_model=DataResponse[CommandHistoryData])
+@router.get("/command-history", response_model=CommandHistoryData)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_command_history",
@@ -159,13 +158,18 @@ async def _read_audit_log_file(log_file: str, limit: int) -> list:
             lines = await f.readlines()
         return _parse_audit_log_lines(lines, limit)
     except FileNotFoundError:
+        # No audit log has been written yet — an empty log is the correct answer.
         return []
     except OSError as e:
+        # Any other read failure (permissions, I/O error) must NOT be reported as
+        # an empty audit log: that silently hides a security artifact the caller
+        # asked for. #288 stated the pattern as "HTTPException with 500 status for
+        # API endpoints" but landed `audit_entries = []` here; #13258 restores it.
         logger.error("Failed to read audit log file: %s", e)
-        return []
+        raise
 
 
-@router.get("/audit-log", response_model=DataResponse[AuditLogData])
+@router.get("/audit-log", response_model=AuditLogData)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_audit_log",

--- a/autobot-backend/api/security_api_test.py
+++ b/autobot-backend/api/security_api_test.py
@@ -6,6 +6,7 @@ Tests REST API functionality for security management
 """
 
 import json
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +15,13 @@ from fastapi.testclient import TestClient
 
 # Import the security API module
 from api.security import CommandApprovalRequest, router
+
+# Logger name used by api/security.py (``get_logger(__name__)``). The endpoints
+# answer with a generic ``detail`` and keep the underlying exception in the log
+# only — see d6659fddf (#1733, CodeQL stack-trace exposure). The error tests below
+# pin both halves of that contract.
+SECURITY_LOGGER = "api.security"
+GENERIC_ERROR_DETAIL = "Internal server error"
 
 
 class TestSecurityAPI:
@@ -67,23 +75,48 @@ class TestSecurityAPI:
         assert data["docker_sandbox_enabled"] is True
         assert len(data["pending_approvals"]) == 2
 
-    def test_get_security_status_fallback_to_basic_security(self):
-        """Test security status fallback when enhanced security not available"""
-        # Remove enhanced security layer, add basic security layer
+    def test_get_security_status_reads_the_layer_currently_on_app_state(self):
+        """Status is read from whichever SecurityLayer app.state holds right now.
+
+        This test used to assert a "fall back to the basic security layer" branch
+        that hard-coded command_security_enabled/docker_sandbox_enabled to False
+        and pending_approvals to []. That branch existed only while there were two
+        classes on two different app.state attributes (enhanced_security_layer vs
+        security_layer); ee20dd6c7 (#10666) folded EnhancedSecurityLayer into the
+        single canonical SecurityLayer, which always defines all four attributes
+        (security_layer.py:99-109), so the branch was correctly removed.
+
+        What is worth pinning on the surviving single-path implementation is that
+        the endpoint re-reads app.state per request — a layer swapped in after
+        startup is the one reported, no new SecurityLayer is constructed while one
+        is present, and every value is mirrored from the layer rather than
+        hard-coded.
+        """
         delattr(self.app.state, "security_layer")
 
-        basic_security = MagicMock()
-        basic_security.enable_auth = True
-        self.app.state.security_layer = basic_security
+        replacement_layer = MagicMock()
+        replacement_layer.enable_auth = True
+        replacement_layer.enable_command_security = False
+        replacement_layer.use_docker_sandbox = False
+        replacement_layer.get_pending_approvals.return_value = []
+        self.app.state.security_layer = replacement_layer
 
-        response = self.client.get("/api/security/status")
+        with patch("api.security.SecurityLayer") as MockSecurityLayer:
+            response = self.client.get("/api/security/status")
 
         assert response.status_code == 200
         data = response.json()
         assert data["security_enabled"] is True
-        assert data["command_security_enabled"] is False  # Not available in basic
-        assert data["docker_sandbox_enabled"] is False  # Not available in basic
-        assert data["pending_approvals"] == []  # Not available in basic
+        assert data["command_security_enabled"] is False
+        assert data["docker_sandbox_enabled"] is False
+        assert data["pending_approvals"] == []
+
+        # The replacement layer was the one consulted...
+        replacement_layer.get_pending_approvals.assert_called_once()
+        # ...the layer removed from app.state was not...
+        self.mock_security_layer.get_pending_approvals.assert_not_called()
+        # ...and no redundant layer was built while one was already installed.
+        MockSecurityLayer.assert_not_called()
 
     def test_get_security_status_on_demand_initialization(self):
         """Test security status with on-demand initialization"""
@@ -108,15 +141,17 @@ class TestSecurityAPI:
             assert hasattr(self.app.state, "security_layer")
             MockSecurityLayer.assert_called_once()
 
-    def test_get_security_status_error(self):
-        """Test security status endpoint error handling"""
+    def test_get_security_status_error(self, caplog):
+        """Failures answer 500 with a generic detail and log the real cause."""
         self.mock_security_layer.get_pending_approvals.side_effect = Exception("Test error")
 
-        response = self.client.get("/api/security/status")
+        with caplog.at_level(logging.ERROR, logger=SECURITY_LOGGER):
+            response = self.client.get("/api/security/status")
 
         assert response.status_code == 500
-        data = response.json()
-        assert "Test error" in data["detail"]
+        assert response.json()["detail"] == GENERIC_ERROR_DETAIL
+        assert "Test error" not in response.text
+        assert "Test error" in caplog.text
 
     def test_approve_command_success(self):
         """Test successful command approval"""
@@ -145,17 +180,19 @@ class TestSecurityAPI:
 
         self.mock_security_layer.approve_command.assert_called_once_with("cmd_456", False)
 
-    def test_approve_command_error(self):
-        """Test command approval error handling"""
+    def test_approve_command_error(self, caplog):
+        """Failures answer 500 with a generic detail and log the real cause."""
         self.mock_security_layer.approve_command.side_effect = Exception("Approval error")
 
         approval_request = {"command_id": "cmd_123", "approved": True}
 
-        response = self.client.post("/api/security/approve-command", json=approval_request)
+        with caplog.at_level(logging.ERROR, logger=SECURITY_LOGGER):
+            response = self.client.post("/api/security/approve-command", json=approval_request)
 
         assert response.status_code == 500
-        data = response.json()
-        assert "Approval error" in data["detail"]
+        assert response.json()["detail"] == GENERIC_ERROR_DETAIL
+        assert "Approval error" not in response.text
+        assert "Approval error" in caplog.text
 
     def test_get_pending_approvals_success(self):
         """Test successful pending approvals retrieval"""
@@ -186,15 +223,17 @@ class TestSecurityAPI:
         assert data["count"] == 0
         assert data["pending_approvals"] == []
 
-    def test_get_pending_approvals_error(self):
-        """Test pending approvals endpoint error handling"""
+    def test_get_pending_approvals_error(self, caplog):
+        """Failures answer 500 with a generic detail and log the real cause."""
         self.mock_security_layer.get_pending_approvals.side_effect = Exception("Database error")
 
-        response = self.client.get("/api/security/pending-approvals")
+        with caplog.at_level(logging.ERROR, logger=SECURITY_LOGGER):
+            response = self.client.get("/api/security/pending-approvals")
 
         assert response.status_code == 500
-        data = response.json()
-        assert "Database error" in data["detail"]
+        assert response.json()["detail"] == GENERIC_ERROR_DETAIL
+        assert "Database error" not in response.text
+        assert "Database error" in caplog.text
 
     def test_get_command_history_success(self):
         """Test successful command history retrieval"""
@@ -247,19 +286,35 @@ class TestSecurityAPI:
         # Verify default parameters
         self.mock_security_layer.get_command_history.assert_called_once_with(user=None, limit=50)
 
-    def test_get_command_history_error(self):
-        """Test command history endpoint error handling"""
+    def test_get_command_history_error(self, caplog):
+        """Failures answer 500 with a generic detail and log the real cause."""
         self.mock_security_layer.get_command_history.side_effect = Exception("History error")
 
-        response = self.client.get("/api/security/command-history")
+        with caplog.at_level(logging.ERROR, logger=SECURITY_LOGGER):
+            response = self.client.get("/api/security/command-history")
 
         assert response.status_code == 500
-        data = response.json()
-        assert "History error" in data["detail"]
+        assert response.json()["detail"] == GENERIC_ERROR_DETAIL
+        assert "History error" not in response.text
+        assert "History error" in caplog.text
 
-    def test_get_audit_log_success(self):
+    def _write_audit_log(self, tmp_path, lines):
+        """Point the security layer at a real audit log file holding ``lines``.
+
+        api/security.py reads the audit log through ``aiofiles.open``, and
+        aiofiles captures the builtin as ``aiofiles.threadpool.sync_open = open``
+        at import time — so the ``patch("builtins.open", ...)`` these tests used
+        to rely on never intercepted anything and the endpoint was silently
+        reading (and failing to find) a literal ``test_audit.log`` in the CWD.
+        A real file on disk exercises the actual read/parse path.
+        """
+        log_file = tmp_path / "audit.log"
+        log_file.write_text("".join(lines), encoding="utf-8")
+        self.mock_security_layer.audit_log_file = str(log_file)
+        return log_file
+
+    def test_get_audit_log_success(self, tmp_path):
         """Test successful audit log retrieval"""
-        # Mock audit log file content
         audit_entries = [
             {
                 "timestamp": "2023-01-01T10:00:00",
@@ -275,80 +330,78 @@ class TestSecurityAPI:
             },
         ]
 
-        self.mock_security_layer.audit_log_file = "test_audit.log"
+        self._write_audit_log(tmp_path, [json.dumps(entry) + "\n" for entry in audit_entries])
 
-        # Mock file reading
-        with patch("builtins.open", create=True) as mock_open:
-            mock_open.return_value.__enter__.return_value.readlines.return_value = [
-                json.dumps(entry) + "\n" for entry in audit_entries
-            ]
+        response = self.client.get("/api/security/audit-log")
 
-            response = self.client.get("/api/security/audit-log")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 2
+        assert data["audit_entries"] == audit_entries
 
-            assert response.status_code == 200
-            data = response.json()
-            assert data["success"] is True
-            assert data["count"] == 2
-            assert len(data["audit_entries"]) == 2
-
-    def test_get_audit_log_with_limit(self):
+    def test_get_audit_log_with_limit(self, tmp_path):
         """Test audit log retrieval with limit parameter"""
-        self.mock_security_layer.audit_log_file = "test_audit.log"
+        self._write_audit_log(tmp_path, ['{"entry": 1}\n', '{"entry": 2}\n', '{"entry": 3}\n'])
 
-        with patch("builtins.open", create=True) as mock_open:
-            mock_open.return_value.__enter__.return_value.readlines.return_value = [
-                '{"entry": 1}\n',
-                '{"entry": 2}\n',
-                '{"entry": 3}\n',
-            ]
+        response = self.client.get("/api/security/audit-log?limit=2")
 
-            response = self.client.get("/api/security/audit-log?limit=2")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 2
+        # The limit keeps the *most recent* entries, not the first two.
+        assert data["audit_entries"] == [{"entry": 2}, {"entry": 3}]
 
-            assert response.status_code == 200
-            data = response.json()
-            assert data["count"] == 2  # Limited to last 2 entries
+    def test_get_audit_log_file_not_found(self, tmp_path):
+        """A log that was never written is an empty log, not an error."""
+        self.mock_security_layer.audit_log_file = str(tmp_path / "nonexistent.log")
 
-    def test_get_audit_log_file_not_found(self):
-        """Test audit log retrieval when file doesn't exist"""
-        self.mock_security_layer.audit_log_file = "nonexistent.log"
+        response = self.client.get("/api/security/audit-log")
 
-        with patch("builtins.open", side_effect=FileNotFoundError()):
-            response = self.client.get("/api/security/audit-log")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 0
+        assert data["audit_entries"] == []
 
-            assert response.status_code == 200
-            data = response.json()
-            assert data["success"] is True
-            assert data["count"] == 0
-            assert data["audit_entries"] == []
-
-    def test_get_audit_log_malformed_json(self):
+    def test_get_audit_log_malformed_json(self, tmp_path):
         """Test audit log retrieval with malformed JSON entries"""
-        self.mock_security_layer.audit_log_file = "test_audit.log"
+        self._write_audit_log(
+            tmp_path,
+            ['{"valid": "entry1"}\n', "invalid json line\n", '{"valid": "entry2"}\n'],
+        )
 
-        with patch("builtins.open", create=True) as mock_open:
-            mock_open.return_value.__enter__.return_value.readlines.return_value = [
-                '{"valid": "entry1"}\n',
-                "invalid json line\n",
-                '{"valid": "entry2"}\n',
-            ]
+        response = self.client.get("/api/security/audit-log")
 
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 2
+        # The unparseable line is skipped; the surrounding valid ones survive.
+        assert data["audit_entries"] == [{"valid": "entry1"}, {"valid": "entry2"}]
+
+    def test_get_audit_log_error(self, tmp_path, caplog):
+        """An unreadable audit log is a 500, never a silent empty log.
+
+        Reporting ``count: 0`` when the file could not be read would tell an
+        admin the audit trail is empty when it is merely inaccessible — see
+        #13258. The exception text stays in the log, out of the response.
+        """
+        self.mock_security_layer.audit_log_file = str(tmp_path / "audit.log")
+
+        with (
+            patch(
+                "api.security.aiofiles.open",
+                side_effect=PermissionError("Permission denied"),
+            ),
+            caplog.at_level(logging.ERROR, logger=SECURITY_LOGGER),
+        ):
             response = self.client.get("/api/security/audit-log")
 
-            assert response.status_code == 200
-            data = response.json()
-            assert data["success"] is True
-            assert data["count"] == 2  # Only valid JSON entries
-
-    def test_get_audit_log_error(self):
-        """Test audit log endpoint error handling"""
-        self.mock_security_layer.audit_log_file = "test_audit.log"
-
-        with patch("builtins.open", side_effect=PermissionError("Permission denied")):
-            response = self.client.get("/api/security/audit-log")
-
-            assert response.status_code == 500
-            data = response.json()
-            assert "Permission denied" in data["detail"]
+        assert response.status_code == 500
+        assert response.json()["detail"] == GENERIC_ERROR_DETAIL
+        assert "Permission denied" not in response.text
+        assert "Permission denied" in caplog.text
 
 
 class TestSecurityAPIModels:
@@ -418,19 +471,25 @@ class TestSecurityAPIIntegration:
         )
         assert approval_response.status_code == 200
 
-    def test_api_error_consistency(self):
+    def test_api_error_consistency(self, caplog):
         """Test that all endpoints handle errors consistently"""
         # Remove enhanced security layer to trigger error
         if hasattr(self.app.state, "security_layer"):
             delattr(self.app.state, "security_layer")
 
-        with patch(
-            "api.security.SecurityLayer",
-            side_effect=Exception("Init error"),
+        with (
+            patch(
+                "api.security.SecurityLayer",
+                side_effect=Exception("Init error"),
+            ),
+            caplog.at_level(logging.ERROR, logger=SECURITY_LOGGER),
         ):
             response = self.client.get("/api/security/status")
-            assert response.status_code == 500
-            assert "Init error" in response.json()["detail"]
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == GENERIC_ERROR_DETAIL
+        assert "Init error" not in response.text
+        assert "Init error" in caplog.text
 
 
 # Run tests

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -66299,21 +66299,6 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** DataResponse[AuditLogData] */
-        DataResponse_AuditLogData_: {
-            /**
-             * Success
-             * @default true
-             */
-            success: boolean;
-            data?: components["schemas"]["AuditLogData"] | null;
-            /** Message */
-            message?: string | null;
-            /** Timestamp */
-            timestamp?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
         /** DataResponse[AuditOperationsData] */
         DataResponse_AuditOperationsData_: {
             /**
@@ -66937,21 +66922,6 @@ export interface components {
              */
             success: boolean;
             data?: components["schemas"]["CodeSearchStatusResultResponse"] | null;
-            /** Message */
-            message?: string | null;
-            /** Timestamp */
-            timestamp?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
-        /** DataResponse[CommandHistoryData] */
-        DataResponse_CommandHistoryData_: {
-            /**
-             * Success
-             * @default true
-             */
-            success: boolean;
-            data?: components["schemas"]["CommandHistoryData"] | null;
             /** Message */
             message?: string | null;
             /** Timestamp */
@@ -68368,21 +68338,6 @@ export interface components {
              */
             success: boolean;
             data?: components["schemas"]["ParseToolOutputData"] | null;
-            /** Message */
-            message?: string | null;
-            /** Timestamp */
-            timestamp?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
-        /** DataResponse[PendingApprovalsData] */
-        DataResponse_PendingApprovalsData_: {
-            /**
-             * Success
-             * @default true
-             */
-            success: boolean;
-            data?: components["schemas"]["PendingApprovalsData"] | null;
             /** Message */
             message?: string | null;
             /** Timestamp */
@@ -149730,7 +149685,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DataResponse_PendingApprovalsData_"];
+                    "application/json": components["schemas"]["PendingApprovalsData"];
                 };
             };
         };
@@ -149753,7 +149708,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DataResponse_CommandHistoryData_"];
+                    "application/json": components["schemas"]["CommandHistoryData"];
                 };
             };
             /** @description Validation Error */
@@ -149784,7 +149739,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DataResponse_AuditLogData_"];
+                    "application/json": components["schemas"]["AuditLogData"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Closes #13258

## Thinking Path

14 failures in `autobot-backend/api/security_api_test.py`. I established for each group, from the code plus `git log`/`git show`, whether the test or the implementation was wrong.

**Cause A — 5 tests, test-wrong (as diagnosed in the issue).** `test_get_security_status_error`, `test_approve_command_error`, `test_get_pending_approvals_error`, `test_get_command_history_error`, `test_api_error_consistency` assert the raw exception text appears in the HTTP body. `d6659fddf` (#1733, CodeQL stack-trace exposure) deliberately replaced `detail=str(e)` with `detail="Internal server error"`. **No endpoint was changed to return `str(e)` or otherwise leak exception text** — the generic detail at `security.py:64, 93, 115, 137, 192, 225, 271, 315` is untouched. The tests now pin both halves of the real contract: the detail is exactly the generic string, the raw text is absent from the whole response body, and it is present in the `api.security` log record.

**Cause B — 7 tests, implementation-wrong.** Not a stale-test problem. `99cc938f7` (#5317/#5834, the bulk "add `response_model=` to all remaining endpoints" pass) put `response_model=DataResponse` on `/pending-approvals`, `/command-history` and `/audit-log`. `DataResponse` (`api/schemas_common.py:58`) is the `{success, data, message, timestamp}` envelope produced by `create_success_response`; these three handlers return a **flat** dict (`security.py:112, 134, 185`). FastAPI validated the flat dict against the envelope, so `count`, `pending_approvals`, `command_history` and `audit_entries` were all discarded and every caller received `{"success": true, "data": null, "message": null, "timestamp": null}`. `65f5733d1` (#6509) later parameterised the wrong envelope (`DataResponse[PendingApprovalsData]`), which changed nothing. The flat shape is the pre-#5834 contract and is what the rest of the suite asserts (`system_integration_test.py:111-112` reads `history_data["count"]` / `pending_data["count"]`). Fixed in the API by declaring the concrete flat models — which already exist and already carry their own `success` field (`schemas_system.py:3946, 3954, 3962`).

**Remainder — 2 tests, one each.**

`test_get_security_status_fallback_to_basic_security` (`assert True is False`) — **test-wrong**. It asserted a "fall back to the basic security layer" branch that hard-coded `command_security_enabled`/`docker_sandbox_enabled` to `False`. That branch existed only while there were two classes on two `app.state` attributes (`enhanced_security_layer` vs `security_layer`) — see the pre-`ee20dd6c7` body of `get_security_status`. `ee20dd6c7` (#10666) folded `EnhancedSecurityLayer` into the single canonical `SecurityLayer`, which unconditionally sets all four attributes (`security_layer.py:99-109`), so the branch was correctly removed. The test only kept "passing"-shaped because a bare `MagicMock` coerces through pydantic (`__index__` → `True` for `bool`, `__iter__` → `[]` for `List[...]`), so it read `True` where it expected `False`.

`test_get_audit_log_error` (`assert 200 == 500`) — **implementation-wrong**. Original contract (`67b1b508e:backend/api/security.py:159-169`): only `FileNotFoundError` was swallowed, everything else surfaced as a 500. `2bc8f86fc` (#288) added an `except OSError` handler whose own commit message states the pattern as *"HTTPException with 500 status for API endpoints"* — but in this file it landed `audit_entries = []`. The result: an audit log that cannot be read is reported to an admin as an audit log that is empty. Restored to surfacing, keeping the specific log line; `FileNotFoundError` still degrades to `[]` because a log that was never written is legitimately empty.

**Separately discovered and filed:** the Cause B mis-application is systemic — an AST scan found 32 more endpoints across 15 files with the same envelope-over-flat-dict mismatch, including `POST /api/auth/refresh`, which discards the refreshed JWT. Filed as #13259 rather than expanded into this PR.

## What Changed

`autobot-backend/api/security.py`
- `response_model=DataResponse[PendingApprovalsData|CommandHistoryData|AuditLogData]` → the concrete flat models, restoring the payload on the wire. `DataResponse` import dropped (no longer referenced in this module).
- `_read_audit_log_file`: non-`FileNotFoundError` `OSError` is logged as before and then re-raised instead of being turned into an empty list.

`autobot-backend/api/security_api_test.py`
- 5 Cause A tests now assert generic detail + raw text absent from the body + raw text present in the log (via `caplog`), instead of asserting the leak.
- `test_get_security_status_fallback_to_basic_security` → `test_get_security_status_reads_the_layer_currently_on_app_state`, retargeted at the surviving single-path behaviour: the layer currently on `app.state` is the one consulted, its values are mirrored rather than hard-coded, the displaced layer is not consulted, and no redundant `SecurityLayer` is constructed.
- The 5 audit-log tests patched `builtins.open`, but the endpoint reads through `aiofiles`, which binds `sync_open = open` at import time — the patches never intercepted anything and the endpoint was reading a literal `test_audit.log` from the CWD. They now write real files via `tmp_path` and assert the parsed entries, not only their count. `test_get_audit_log_error` patches `aiofiles.open` at the I/O boundary.
- The 3 non-audit Cause B tests (`pending_approvals` success/empty, `command_history` success) are **unchanged** — the API fix alone makes them pass.

No test was skipped, xfailed, weakened, or reduced to asserting that an error is an error. Every rewritten assertion is stronger than the one it replaces:

| Test | Was | Now |
|---|---|---|
| 5 error tests | raw text in `detail` | exact generic `detail` + raw text absent from body + raw text in log |
| `..._reads_the_layer_currently_on_app_state` | hard-coded `False` from a deleted branch | values mirrored from the live layer + call-routing + no redundant construction |
| `..._audit_log_success` | `len(entries) == 2` | `entries == audit_entries` |
| `..._audit_log_with_limit` | `count == 2` | `entries == [{"entry": 2}, {"entry": 3}]` (limit keeps the *most recent*) |
| `..._audit_log_malformed_json` | `count == 2` | `entries == [{"valid": "entry1"}, {"valid": "entry2"}]` (bad line skipped, neighbours survive) |
| `..._audit_log_file_not_found` | inert `builtins.open` patch | real missing path on disk |
| `..._audit_log_error` | 500 + `"Permission denied"` in `detail` | 500 + generic `detail` + `"Permission denied"` in log |

## Verification

Static only — no application code, service, or suite was executed here; CI is the execution environment.

Lint on both changed files:

```
python3 -m flake8 --max-line-length=120 autobot-backend/api/security.py autobot-backend/api/security_api_test.py   → 0
python3 -m black --line-length 120 --check ...                                                                     → 2 files would be left unchanged
python3 -m isort --check-only ...                                                                                  → 0
```

Cause B mechanism reproduced with FastAPI/pydantic only, importing no project code — same `DataResponse`/`PendingApprovalsData` definitions, same flat `return`:

```
OLD (response_model=DataResponse[PendingApprovalsData]): {'success': True, 'data': None, 'message': None, 'timestamp': None}
NEW (response_model=PendingApprovalsData):               {'success': True, 'pending_approvals': [{'a': 1}], 'count': 1}
BOOM (HTTPException detail="Internal server error"):     500 {'detail': 'Internal server error'} | body has 'Test error': False
```

The `caplog` + `tmp_path` pattern used by the rewritten tests was confirmed working against that same standalone app (2 passed); `caplog` is already used by 22 test files in this backend, and `conftest.py:699` resolves `get_logger` to a plain `logging.getLogger(name)`, so records from `api.security` propagate normally.

`git show 67b1b508e:backend/api/security.py`, `git show 2bc8f86fc`, `git show ee20dd6c7^:autobot-backend/api/security.py`, `git show 99cc938f7` and `git show 65f5733d1` are the history evidence behind each attribution above.

Not verifiable without executing code, left to CI: the 14 tests actually going green, and the regenerated `autobot-frontend/src/types/generated/api.ts`. The response-model change alters the OpenAPI schema, so `verify-generated-types` will flag drift and `auto-fix-generated-types` regenerates and commits `api.ts` back to this branch — regenerating it locally requires building `app.openapi()`, which means running backend code.

## Model Used

claude-opus-5
