### PR TITLE
fix(knowledge): decode-safe entity lookup + await the async Redis mock in temporal search tests (#13270)

### DIFF
--- a/autobot-backend/knowledge/temporal_search.py
+++ b/autobot-backend/knowledge/temporal_search.py
@@ -210,11 +210,20 @@ class TemporalSearchService:
             )
 
     async def _get_entity_id_by_name(self, entity_name: str) -> str | None:
-        """Lookup entity ID by canonical name."""
+        """Lookup entity ID by canonical name.
+
+        The shared Redis client is built with ``decode_responses=True``
+        (``autobot_shared/redis_management/config.py``), so ``get`` yields
+        ``str``.  A bare ``.decode()`` raised ``AttributeError`` on every
+        lookup, which ``get_event_timeline`` swallowed into an empty
+        timeline for every entity.  Handle both wire shapes (#13270).
+        """
         canonical_name = entity_name.lower().strip()
         name_key = f"entity:name:{canonical_name}"
         entity_id = await self.redis.get(name_key)
-        return entity_id.decode() if entity_id else None
+        if not entity_id:
+            return None
+        return entity_id.decode() if isinstance(entity_id, bytes) else entity_id
 
     async def _get_event(self, event_id: str) -> dict | None:
         """Retrieve event data from Redis JSON."""

--- a/autobot-backend/knowledge/temporal_search_test.py
+++ b/autobot-backend/knowledge/temporal_search_test.py
@@ -9,7 +9,7 @@ Issue #1075: Test coverage for temporal search and causal chain traversal.
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -25,9 +25,26 @@ logger = get_logger(__name__)
 
 @pytest.fixture
 def mock_redis():
-    """Create a mock Redis client."""
+    """Create a mock async Redis client.
+
+    ``TemporalSearchService`` awaits every command, so the command methods
+    must be ``AsyncMock``.  A plain ``MagicMock`` returns a non-awaitable,
+    ``await`` raises ``TypeError``, and the service's ``except Exception``
+    handlers turn that into an empty result — every assertion then compared
+    against zero regardless of the fixture data (#13270).
+
+    ``redis.json()`` itself is *synchronous* on ``redis.asyncio.Redis`` (it
+    returns the JSON command group), so it stays a ``MagicMock``; only the
+    commands it exposes are awaitable.
+    """
     redis = MagicMock()
-    redis.json.return_value = MagicMock()
+    redis.get = AsyncMock()
+    redis.smembers = AsyncMock()
+    redis.zrangebyscore = AsyncMock()
+
+    json_commands = MagicMock()
+    json_commands.get = AsyncMock()
+    redis.json.return_value = json_commands
     return redis
 
 
@@ -75,6 +92,8 @@ class TestSearchEventsInRange:
         end = datetime(2024, 12, 31)
         events = await service.search_events_in_range(start, end, event_types=["action"])
         assert len(events) == 0
+        # The event was fetched and then filtered out — not a failed query.
+        mock_redis.json().get.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_filters_by_participant(self, service, mock_redis, sample_event):
@@ -97,6 +116,8 @@ class TestSearchEventsInRange:
         end = datetime(2024, 12, 31)
         events = await service.search_events_in_range(start, end, participants=[uuid4()])
         assert len(events) == 0
+        # The event was fetched and then filtered out — not a failed query.
+        mock_redis.json().get.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_empty_range(self, service, mock_redis):
@@ -105,6 +126,8 @@ class TestSearchEventsInRange:
         end = datetime(2024, 1, 2)
         events = await service.search_events_in_range(start, end)
         assert events == []
+        # Empty range means nothing was fetched at all.
+        mock_redis.json().get.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_skips_missing_events(self, service, mock_redis):
@@ -147,10 +170,32 @@ class TestGetEventTimeline:
         assert events[0]["name"] == "First"
 
     @pytest.mark.asyncio
+    async def test_returns_events_with_decoded_responses_client(self, service, mock_redis):
+        """End-to-end guard for #13270.
+
+        The shared client decodes responses, so the entity-id lookup returns
+        ``str``.  ``.decode()`` on that raised AttributeError, which
+        get_event_timeline's ``except Exception`` turned into an empty
+        timeline for *every* entity — a user-visible defect on
+        ``GET /events/{entity_name}/timeline``.
+        """
+        mock_redis.get.return_value = str(uuid4())
+        mock_redis.smembers.return_value = ["e1"]
+        mock_redis.json().get.return_value = {
+            "name": "Only",
+            "timestamp": "2024-03-01T00:00:00",
+        }
+
+        events = await service.get_event_timeline("test_entity")
+        assert len(events) == 1
+        assert events[0]["name"] == "Only"
+
+    @pytest.mark.asyncio
     async def test_entity_not_found(self, service, mock_redis):
         mock_redis.get.return_value = None
         events = await service.get_event_timeline("unknown")
         assert events == []
+        mock_redis.smembers.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_respects_limit(self, service, mock_redis):
@@ -173,6 +218,8 @@ class TestGetEventTimeline:
 
         events = await service.get_event_timeline("entity")
         assert len(events) == 0
+        # The event was fetched and dropped for lacking a timestamp.
+        mock_redis.json().get.assert_awaited_once()
 
 
 # --- Causal Chain Traversal ---
@@ -214,26 +261,45 @@ class TestFindCausalChain:
         mock_redis.smembers.side_effect = [{f"e{i+1}"} for i in range(10)]
 
         chain = await service.find_causal_chain(uuid4(), direction="forward", max_depth=3)
-        assert len(chain) <= 3
+        # Exactly max_depth levels are visited before the recursion stops.
+        assert len(chain) == 3
 
     @pytest.mark.asyncio
     async def test_handles_cycles(self, service, mock_redis):
-        """Cycle detection via visited set prevents infinite recursion."""
-        event1 = {"id": "e1", "name": "A"}
-        event2 = {"id": "e2", "name": "B"}
+        """Cycle detection via visited set prevents infinite recursion.
 
-        mock_redis.json().get.side_effect = [event1, event2]
-        # e1 -> e2 -> e1 (cycle)
-        mock_redis.smembers.side_effect = [{"e2"}, {"e1"}]
+        The traversal starts at ``id_a``, so the ``id_b -> id_a`` edge is a
+        real cycle back to the root.  Keyed lookups (rather than a
+        side_effect list) keep the graph well-defined for every visit, so
+        the assertion proves the visited set stopped the walk instead of a
+        mock running out of values.
+        """
+        id_a = uuid4()
+        id_b = uuid4()
+        events = {
+            f"event:{id_a}": {"id": str(id_a), "name": "A"},
+            f"event:{id_b}": {"id": str(id_b), "name": "B"},
+        }
+        # a -> b -> a (cycle); default max_depth of 5 would otherwise
+        # produce a 5-event chain.
+        links = {
+            f"event:{id_a}:effects": {str(id_b)},
+            f"event:{id_b}:effects": {str(id_a)},
+        }
+        mock_redis.json().get.side_effect = lambda key: events.get(key)
+        mock_redis.smembers.side_effect = lambda key: links.get(key, set())
 
-        chain = await service.find_causal_chain(uuid4(), direction="forward")
+        chain = await service.find_causal_chain(id_a, direction="forward")
         assert len(chain) == 2
+        assert [e["name"] for e in chain] == ["A", "B"]
 
     @pytest.mark.asyncio
     async def test_empty_chain(self, service, mock_redis):
         mock_redis.json().get.return_value = None
         chain = await service.find_causal_chain(uuid4())
         assert chain == []
+        # A missing root event stops the walk before any link lookup.
+        mock_redis.smembers.assert_not_awaited()
 
 
 # --- Entity ID Lookup ---
@@ -242,18 +308,32 @@ class TestFindCausalChain:
 class TestGetEntityIdByName:
     """Tests for _get_entity_id_by_name."""
 
-    def test_found(self, service, mock_redis):
+    @pytest.mark.asyncio
+    async def test_found(self, service, mock_redis):
         mock_redis.get.return_value = b"some-uuid"
-        result = service._get_entity_id_by_name("Python")
+        result = await service._get_entity_id_by_name("Python")
         assert result == "some-uuid"
-        mock_redis.get.assert_called_with("entity:name:python")
+        mock_redis.get.assert_awaited_with("entity:name:python")
 
-    def test_not_found(self, service, mock_redis):
+    @pytest.mark.asyncio
+    async def test_found_with_decoded_responses_client(self, service, mock_redis):
+        """The live client sets decode_responses=True, so get() yields str.
+
+        A bare ``.decode()`` raised AttributeError on this — the shape that
+        actually runs in production (#13270).
+        """
+        mock_redis.get.return_value = "some-uuid"
+        result = await service._get_entity_id_by_name("Python")
+        assert result == "some-uuid"
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, service, mock_redis):
         mock_redis.get.return_value = None
-        result = service._get_entity_id_by_name("Unknown")
+        result = await service._get_entity_id_by_name("Unknown")
         assert result is None
 
-    def test_normalizes_name(self, service, mock_redis):
+    @pytest.mark.asyncio
+    async def test_normalizes_name(self, service, mock_redis):
         mock_redis.get.return_value = b"id"
-        service._get_entity_id_by_name("  Python  ")
-        mock_redis.get.assert_called_with("entity:name:python")
+        await service._get_entity_id_by_name("  Python  ")
+        mock_redis.get.assert_awaited_with("entity:name:python")


### PR DESCRIPTION
Closes #13270

The 11 failures had **two** root causes, split 8 / 3 — not the 8 / 2 / 1 the issue guessed. The `expected call not found` failure shares its cause with the two coroutine failures. One of the two causes is a live production defect.

## Thinking Path

**Attribution came from the archived run artifact, not from re-running.** A prior full-suite JUnit XML plus its captured log pinned every failure to a mechanism:

```
temporal_search.py:91  Event range search failed: object list can't be used in 'await' expression
temporal_search.py:226 Failed to get event <id>: object dict can't be used in 'await' expression
temporal_search.py:130 Timeline retrieval failed: object bytes can't be used in 'await' expression
```

**Group A — 8 zero-count failures: the test is wrong.** `mock_redis` was a plain `MagicMock`, so `await self.redis.zrangebyscore(...)` awaited a `list`, `await self.redis.json().get(...)` awaited a `dict`, `await self.redis.get(...)` awaited `bytes` — the fixture's own `return_value`. Each `TypeError` was caught by the service's `except Exception`, logged, and converted to `[]`. Every assertion then compared against zero regardless of fixture data. The service's await usage is correct; the mock was not awaitable.

**Group B — 2 coroutine + 1 `expected call not found`: the test is wrong, one cause.** All three live in `TestGetEntityIdByName`, which called the `async def` method from `def` tests without `await`. Two asserted on the returned coroutine object; the third (`test_normalizes_name`) additionally failed its `assert_called_with` because an unawaited coroutine never executes its body, so the Redis call was never issued. That is the same defect surfacing through a different assertion, not a third shape.

**Group C — a production defect the suite was masking: the implementation is wrong.** Chasing why the timeline path swallowed `bytes`, `_get_entity_id_by_name` called a bare `.decode()` on the `get()` result. The shared async client is built with `decode_responses=True` (`autobot_shared/redis_management/config.py:61` default, `:153` YAML load; `autobot-infrastructure/shared/config/redis-databases.yaml` sets no override for the `knowledge` database, and nothing repo-wide overrides it). So in production `get()` returns `str`, `.decode()` raises `AttributeError`, and `get_event_timeline`'s `except Exception` returns `[]` — **`GET /events/{entity_name}/timeline` reported an empty timeline for every entity**, including ones `redis_graph_loader._load_entities` had indexed via `set(name_key, str(entity.id))`. The old test hid this by feeding `b"some-uuid"`, a shape the live client never produces. Every other Redis read in `knowledge/` already uses the defensive `isinstance(x, bytes)` idiom (`metadata.py:220`, `versioning.py:120`, `stats.py:100`); `temporal_search.py:217` was the sole outlier. Key normalisation was checked and is *not* a second bug — `entity_extractor._normalize_name` is `name.lower().strip()`, matching `temporal_search.py:214` exactly.

The service fix is a one-line shape guard adopting the package's existing idiom, so it is not the substantial behaviour change that would warrant stopping for an owner decision.

## What Changed

`autobot-backend/knowledge/temporal_search.py`
- `_get_entity_id_by_name` handles both wire shapes via `isinstance(entity_id, bytes)`, with the empty check hoisted so the falsy branch stays explicit.

`autobot-backend/knowledge/temporal_search_test.py`
- `mock_redis` gives `get` / `smembers` / `zrangebyscore` and the JSON command group's `get` as `AsyncMock`. `redis.json()` itself stays a `MagicMock` — it is synchronous on `redis.asyncio.Redis` and returns the command group; only the commands it exposes are awaitable. Making it an `AsyncMock` would have broken `self.redis.json().get(...)`.
- All four `TestGetEntityIdByName` tests are `async` and awaited; call assertions moved to `assert_awaited_with`.

No assertion was weakened. Vacuous passes the broken fixture had been hiding were tightened instead:
- `test_filters_by_event_type`, `test_no_matching_participants`, `test_skips_events_without_timestamp` asserted `len == 0` and passed only because the query blew up. Each now also asserts the event was actually fetched (`json().get.assert_awaited_once()`), so zero means *filtered out*, not *never queried*.
- `test_empty_range` and `test_entity_not_found` assert the downstream call was never made, so `[]` means the short-circuit fired.
- `test_empty_chain` asserts `smembers` was never awaited — a missing root event stops the walk before any link lookup.
- `test_respects_max_depth`: `<= 3` → `== 3`. `0 <= 3` had passed vacuously.
- `test_handles_cycles` started at a random UUID, so the `e2 -> e1` edge was never a cycle back to the root; it "passed" only because the `side_effect` list ran dry and `StopIteration` got swallowed. It now uses keyed lookups over two real UUIDs (`a -> b -> a`), and the graph stays well-defined for every visit, so `len == 2` proves the visited set stopped the walk.

Two regression tests for the production defect: `test_found_with_decoded_responses_client` (unit) and `test_returns_events_with_decoded_responses_client` (end-to-end through `get_event_timeline`, the user-visible path).

## Verification

Application code was not executed. Evidence is the archived run artifact plus a stdlib-only reproduction that imports no project code — it mirrors the service's await pattern and drives both the old and new fixtures.

Predicted-from-static-analysis failure set, matched test-for-test against the archived JUnit XML before any edit (11/11, exact):

| Test | Reported |
|---|---|
| `TestSearchEventsInRange::test_finds_events` | `assert 0 == 1` |
| `TestSearchEventsInRange::test_filters_by_participant` | `assert 0 == 1` |
| `TestSearchEventsInRange::test_skips_missing_events` | `assert 0 == 1` |
| `TestFindCausalChain::test_forward_chain` | `assert 0 == 2` |
| `TestFindCausalChain::test_backward_chain` | `assert 0 == 2` |
| `TestFindCausalChain::test_handles_cycles` | `assert 0 == 2` |
| `TestGetEventTimeline::test_returns_sorted_events` | `assert 0 == 2` |
| `TestGetEventTimeline::test_respects_limit` | `assert 0 == 2` |
| `TestGetEntityIdByName::test_found` | `assert <coroutine …> == 'some-uuid'` |
| `TestGetEntityIdByName::test_not_found` | `assert <coroutine …> is None` |
| `TestGetEntityIdByName::test_normalizes_name` | `expected call not found.` |

Reproduction — 23/23 checks, covering every test in the file plus both defects:

```
== OLD MagicMock fixture (reproduces the bug) ==
    [search swallowed] TypeError: object list can't be used in 'await' expression
  [PASS] old fixture yields 0 where test expects 1 got 0
== production bug: live decode_responses=True client returns str ==
    [timeline swallowed] AttributeError: 'str' object has no attribute 'decode'
  [PASS] OLD .decode() empties the timeline (the defect) got 0
  [PASS] test_returns_events_with_decoded_responses_client
  ...
  [PASS] test_respects_max_depth == 3 (was vacuous <= 3) got 3
  [PASS] test_handles_cycles (real a->b->a cycle) got 2
  [PASS] cycle assertion is load-bearing (no visited set -> 5) got 5
==== 23/23 checks passed ====
```

The last line is a deliberate negative control: re-running the cycle fixture against a traversal with the visited set removed yields 5, not 2, confirming the rewritten assertion actually exercises the cycle guard.

Static gates on both changed files:

```
black --line-length 120 --check   2 files would be left unchanged
isort  --check-only               (clean)
flake8 --max-line-length 120      0
py_compile                        compile OK
```

AST inventory confirms 20 test functions, all `async` with `@pytest.mark.asyncio`, zero sync leftovers (18 original + 2 regression).

**Not verifiable without executing code:** that the suite is green under the real pytest/pytest-asyncio plugin stack, and that a live Redis returns the shapes the mocks assert. CI is the execution environment for both.

## Model Used

claude-opus-5
