### PR TITLE
fix(redis): decode-safe reads on the decode_responses=True client — 500 on /kb-conflicts, degraded latency routing (#13272)

### DIFF
--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -46,6 +46,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.models.pagination import PaginationParams
 from autobot_shared.redis_client import get_async_redis_client, get_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from services.batch_job_store import deserialize_job as _deserialize_job
 from services.batch_job_store import get_job_key as _get_job_key
 from services.batch_job_store import get_logs_key as _get_logs_key
@@ -181,14 +182,14 @@ async def list_batch_jobs(
     status_counts: Dict[str, int] = {}
 
     for job_id_bytes in job_ids:
-        job_id = job_id_bytes.decode("utf-8")
+        job_id = decode_redis_value(job_id_bytes)
         job_key = _get_job_key(job_id)
         job_data = redis_client.get(job_key)
 
         if not job_data:
             continue
 
-        job = _deserialize_job(job_data.decode("utf-8"))
+        job = _deserialize_job(decode_redis_value(job_data))
 
         status_counts[job.status.value] = status_counts.get(job.status.value, 0) + 1
 
@@ -237,7 +238,7 @@ async def get_batch_job(
     if not job_data:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
-    return _deserialize_job(job_data.decode("utf-8"))
+    return _deserialize_job(decode_redis_value(job_data))
 
 
 @router.delete("/{job_id}", response_model=BatchJobDeleteResponse)
@@ -271,7 +272,7 @@ async def delete_batch_job(
     if not job_data:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
-    job = _deserialize_job(job_data.decode("utf-8"))
+    job = _deserialize_job(decode_redis_value(job_data))
 
     if job.status == BatchJobStatus.running:
         job.status = BatchJobStatus.cancelled
@@ -321,7 +322,7 @@ async def run_batch_job_now(
     if not job_data:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
-    job = _deserialize_job(job_data.decode("utf-8"))
+    job = _deserialize_job(decode_redis_value(job_data))
     if job.status == BatchJobStatus.running:
         raise HTTPException(status_code=409, detail=f"Job {job_id} is already running")
 
@@ -370,7 +371,7 @@ async def get_job_logs(
 
     logs = []
     for entry_bytes in log_entries:
-        entry = json.loads(entry_bytes.decode("utf-8"))
+        entry = json.loads(decode_redis_value(entry_bytes))
         logs.append(BatchLogEntry(**entry))
 
     return logs
@@ -403,12 +404,12 @@ async def list_batch_templates(
     templates = []
 
     for template_id_bytes in template_ids:
-        template_id = template_id_bytes.decode("utf-8")
+        template_id = decode_redis_value(template_id_bytes)
         template_key = _get_template_key(template_id)
         template_data = redis_client.get(template_key)
 
         if template_data:
-            template_dict = json.loads(template_data.decode("utf-8"))
+            template_dict = json.loads(decode_redis_value(template_data))
             templates.append(BatchTemplate(**template_dict))
 
     return templates
@@ -477,7 +478,7 @@ async def get_batch_template(
     if not template_data:
         raise HTTPException(status_code=404, detail=f"Template {template_id} not found")
 
-    template_dict = json.loads(template_data.decode("utf-8"))
+    template_dict = json.loads(decode_redis_value(template_data))
     return BatchTemplate(**template_dict)
 
 
@@ -538,12 +539,12 @@ async def list_batch_schedules(
     schedules = []
 
     for schedule_id_bytes in schedule_ids:
-        schedule_id = schedule_id_bytes.decode("utf-8")
+        schedule_id = decode_redis_value(schedule_id_bytes)
         schedule_key = _get_schedule_key(schedule_id)
         schedule_data = redis_client.get(schedule_key)
 
         if schedule_data:
-            schedule_dict = json.loads(schedule_data.decode("utf-8"))
+            schedule_dict = json.loads(decode_redis_value(schedule_data))
             schedules.append(BatchSchedule(**schedule_dict))
 
     return schedules
@@ -631,7 +632,7 @@ async def update_batch_schedule(
     if not schedule_data:
         raise HTTPException(status_code=404, detail=f"Schedule {schedule_id} not found")
 
-    schedule = BatchSchedule(**json.loads(schedule_data.decode("utf-8")))
+    schedule = BatchSchedule(**json.loads(decode_redis_value(schedule_data)))
     updates = update.model_dump(exclude_unset=True)
 
     # Issue #12439: recompute next_run when the cron expression changes or the

--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -16,6 +16,7 @@ from typing import Dict, List
 from autobot_shared.env_utils import blank_to_none
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.ssot_config import config
 from utils.file_categorization import FILE_CATEGORY_CODE
 
@@ -372,9 +373,7 @@ async def _clear_redis_codebase_cache(task_id: str, source_id: str | None = None
             # Issue #1220: Preserve file hashes in incremental mode
             if INCREMENTAL_INDEXING_ENABLED:
                 keys_to_delete = [
-                    k
-                    for k in keys_to_delete
-                    if not k.decode("utf-8", errors="ignore").startswith(FILE_HASH_REDIS_PREFIX)
+                    k for k in keys_to_delete if not decode_redis_value(k).startswith(FILE_HASH_REDIS_PREFIX)
                 ]
             if keys_to_delete:
                 await redis_client.delete(*keys_to_delete)

--- a/autobot-backend/api/ide_integration.py
+++ b/autobot-backend/api/ide_integration.py
@@ -55,6 +55,7 @@ from api.system_health import ComponentHealth, register_health_probe
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.singleton_factory import lazy_optional_singleton, lazy_singleton
 from autobot_shared.ssot_constants import TTL_10_SECONDS
 from models.completion_context import CompletionContext
@@ -680,7 +681,7 @@ class IDEIntegrationEngine:
         cached_result = _get_redis_client().get(cache_key)
         if not cached_result:
             return None
-        completions_data = json.loads(cached_result.decode())
+        completions_data = json.loads(decode_redis_value(cached_result))
         elapsed_ms = (_time.time() - start_time) * 1000
         return CompletionResponse(
             completions=[CompletionItem(**c) for c in completions_data],

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -295,6 +295,10 @@ async def list_conflicts(
     for key in conflict_keys:
         conflict_data = await redis.hgetall(key)
         if conflict_data:
+            # The shared client is built with decode_responses=True, so keys() yields
+            # str; a bare .decode() here raised AttributeError and @with_error_handling
+            # turned it into a 500 for any non-empty conflict set (issue #13272).
+            conflict_key = key.decode() if isinstance(key, bytes) else key
             conflict_status = conflict_data.get("status", "pending")
             if status and conflict_status != status:
                 continue
@@ -306,7 +310,7 @@ async def list_conflicts(
 
             conflicts.append(
                 {
-                    "conflict_id": key.decode().split(":")[-1],
+                    "conflict_id": conflict_key.split(":")[-1],
                     "description": (
                         conflict_data.get("description", "").decode()
                         if isinstance(conflict_data.get("description"), bytes)

--- a/autobot-backend/api/knowledge_grounding_conflicts_decode_test.py
+++ b/autobot-backend/api/knowledge_grounding_conflicts_decode_test.py
@@ -1,0 +1,139 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GET /kb-conflicts must not 500 on the decode_responses=True client (#13272).
+
+The shared async Redis client is built with ``decode_responses=True``
+(``connection_manager.py:500`` -> ``redis_management/config.py:61,153``, with no
+per-database override), so ``redis.keys("conflict:*")`` yields ``str``.
+
+``list_conflicts`` called a bare ``key.decode()`` on those keys. Unlike the
+sibling defect fixed in #13271 there is **no local try/except**, so the
+``AttributeError`` propagated into ``@with_error_handling``, which converts any
+non-``HTTPException`` into ``HTTPException(500)``. The endpoint therefore failed
+outright for every non-empty conflict set — it only appeared to work when no
+conflicts existed.
+
+The tell was immediately below the offending line: ``description``, ``severity``,
+``resolution`` and ``timestamp`` were all already ``isinstance(..., bytes)``
+guarded. Only the key was not.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from api import knowledge_grounding
+
+# The live wire shape: decode_responses=True means every field is already str.
+DECODED_CONFLICTS = {
+    "conflict:abc123": {
+        "status": "pending",
+        "severity": "high",
+        "description": "KB says X, source says Y",
+        "timestamp": "1700000000.0",
+    },
+}
+
+# A client without decode_responses; the bytes branch must not regress.
+BYTES_KEY_CONFLICTS = {
+    b"conflict:def456": {
+        "status": "pending",
+        "severity": "low",
+        "description": "legacy bytes key",
+        "timestamp": "1700000001.0",
+    },
+}
+
+
+class _FakeAsyncRedis:
+    """Minimal stand-in for the shared async client used by list_conflicts."""
+
+    def __init__(self, conflicts):
+        self._conflicts = conflicts
+        self.keys_called_with = None
+
+    async def keys(self, pattern):
+        self.keys_called_with = pattern
+        return list(self._conflicts)
+
+    async def hgetall(self, key):
+        return self._conflicts[key]
+
+
+def _install(monkeypatch, conflicts):
+    """list_conflicts imports the factory inside the function body."""
+    import autobot_shared.redis_client as rc
+
+    fake = _FakeAsyncRedis(conflicts)
+
+    async def _factory(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(rc, "get_async_redis_client", _factory)
+    return fake
+
+
+async def _call(**overrides):
+    """Invoke the endpoint with the values FastAPI would resolve the Query/Depends to."""
+    kwargs = {
+        "status": "pending",
+        "severity": None,
+        "limit": 20,
+        "offset": 0,
+        "current_user": "tester",
+        "req": None,
+    }
+    kwargs.update(overrides)
+    return await knowledge_grounding.list_conflicts(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_str_keys_do_not_500(monkeypatch):
+    """The live configuration. Pre-fix this raised HTTPException(500)."""
+    fake = _install(monkeypatch, DECODED_CONFLICTS)
+
+    result = await _call()
+
+    assert fake.keys_called_with == "conflict:*", "the conflict scan never ran"
+    assert result["status"] == "success"
+    assert result["total"] == 1
+    conflict = result["conflicts"][0]
+    assert conflict["conflict_id"] == "abc123"
+    assert conflict["description"] == "KB says X, source says Y"
+    assert conflict["severity"] == "high"
+    assert conflict["resolution"] == "pending"
+    assert conflict["timestamp"] == 1700000000.0
+
+
+@pytest.mark.asyncio
+async def test_non_empty_conflict_set_raises_no_http_error(monkeypatch):
+    """Pin the exact live symptom: a populated conflict set used to 500."""
+    _install(monkeypatch, DECODED_CONFLICTS)
+
+    try:
+        await _call()
+    except HTTPException as exc:
+        pytest.fail(f"GET /kb-conflicts raised HTTP {exc.status_code}: {exc.detail}")
+
+
+@pytest.mark.asyncio
+async def test_bytes_keys_still_work(monkeypatch):
+    """A client without decode_responses must keep working."""
+    _install(monkeypatch, BYTES_KEY_CONFLICTS)
+
+    result = await _call()
+
+    assert result["total"] == 1
+    assert result["conflicts"][0]["conflict_id"] == "def456"
+
+
+@pytest.mark.asyncio
+async def test_empty_conflict_set_returns_empty_list(monkeypatch):
+    """The only case that worked before the fix — it must still work."""
+    _install(monkeypatch, {})
+
+    result = await _call()
+
+    assert result["total"] == 0
+    assert result["conflicts"] == []

--- a/autobot-backend/config/async_ops.py
+++ b/autobot-backend/config/async_ops.py
@@ -99,6 +99,7 @@ class AsyncOperationsMixin:
 
         try:
             from autobot_shared.redis_client import get_async_redis_client
+            from autobot_shared.redis_utils import decode_redis_value
 
             cache_key = self._get_redis_cache_key(config_type)
             redis_client = await get_async_redis_client(database="main")
@@ -106,7 +107,7 @@ class AsyncOperationsMixin:
             if redis_client:
                 cached_data = await redis_client.get(cache_key)
                 if cached_data:
-                    data = json.loads(cached_data.decode())
+                    data = json.loads(decode_redis_value(cached_data))
                     logger.debug("Loaded %s config from Redis cache", config_type)
                     return data
 

--- a/autobot-backend/llm_shared/latency_router_decode_test.py
+++ b/autobot-backend/llm_shared/latency_router_decode_test.py
@@ -1,0 +1,132 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LatencyRouter._refresh_p95 must populate _p95_cache on the decoded client (#13272).
+
+``zrangebyscore`` on the shared client (``decode_responses=True``) yields ``str``
+members. The old comprehension was::
+
+    latencies = [float(m.decode().split(":", 1)[1]) for m in members if b":" in m]
+
+``b":" in m`` raises ``TypeError: 'in <string>' requires string as left operand,
+not bytes`` **before** ``.decode()`` is ever reached, and the surrounding
+``except Exception: logger.debug(...)`` swallowed it. ``_p95_cache`` therefore
+never populated, ``_lowest_latency`` saw ``_DEFAULT_P95_MS`` for every candidate,
+and latency-aware routing silently returned the first candidate forever — with
+only a debug-level log line to show for it.
+
+Both halves are pinned here: the cache must fill from str members, and the
+cached values must actually drive model selection.
+"""
+
+import pytest
+
+from llm_shared.tiered_routing.latency_router import LatencyRouter
+from llm_shared.tiered_routing.tier_config import TierConfig, TierModels
+
+SIMPLE = "model-simple"
+COMPLEX = "model-complex"
+
+
+class _FakeAsyncRedis:
+    """Returns pre-seeded sorted-set members for llm:latency:{model} keys."""
+
+    def __init__(self, samples):
+        self._samples = samples
+        self.queried_keys = []
+
+    async def zrangebyscore(self, key, minimum, maximum):
+        self.queried_keys.append(key)
+        return self._samples.get(key, [])
+
+
+def _install(monkeypatch, samples):
+    from llm_shared.tiered_routing import latency_router as lr
+
+    fake = _FakeAsyncRedis(samples)
+
+    async def _factory(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(lr, "get_async_redis_client", _factory)
+    return fake
+
+
+def _router():
+    return LatencyRouter(TierConfig(models=TierModels(simple=SIMPLE, complex=COMPLEX)))
+
+
+def _members(count, latency_ms, *, as_bytes=False):
+    """Build '{epoch_s}:{latency_ms}' members the way record_latency writes them."""
+    out = [f"{1700000000 + i}:{latency_ms:.1f}" for i in range(count)]
+    return [m.encode() for m in out] if as_bytes else out
+
+
+@pytest.mark.asyncio
+async def test_p95_cache_populates_from_str_members(monkeypatch):
+    """The live configuration. Pre-fix _p95_cache stayed empty."""
+    # 100 samples of 1.0..100.0 ms -> idx = int(0.95 * 100) = 95 -> sorted[95] = 96.0
+    members = [f"{1700000000 + i}:{float(i + 1):.1f}" for i in range(100)]
+    fake = _install(monkeypatch, {f"llm:latency:{SIMPLE}": members})
+    router = _router()
+
+    await router._refresh_p95()
+
+    assert fake.queried_keys, "zrangebyscore was never issued"
+    assert router._p95_cache[SIMPLE] == 96.0
+
+
+@pytest.mark.asyncio
+async def test_cached_p95_drives_model_selection(monkeypatch):
+    """The behavioural consequence: the genuinely faster model must win."""
+    _install(
+        monkeypatch,
+        {
+            f"llm:latency:{SIMPLE}": _members(20, 900.0),
+            f"llm:latency:{COMPLEX}": _members(20, 50.0),
+        },
+    )
+    router = _router()
+
+    await router._refresh_p95()
+
+    assert router._p95_cache == {SIMPLE: 900.0, COMPLEX: 50.0}
+    # Pre-fix the cache was empty, so _lowest_latency scored both candidates at
+    # _DEFAULT_P95_MS and min() returned the first one (SIMPLE) regardless of
+    # the real measured latency.
+    assert router._lowest_latency([SIMPLE, COMPLEX]) == COMPLEX
+
+
+@pytest.mark.asyncio
+async def test_bytes_members_still_work(monkeypatch):
+    """A client without decode_responses must not regress."""
+    members = [f"{1700000000 + i}:{float(i + 1):.1f}".encode() for i in range(100)]
+    _install(monkeypatch, {f"llm:latency:{SIMPLE}": members})
+    router = _router()
+
+    await router._refresh_p95()
+
+    assert router._p95_cache[SIMPLE] == 96.0
+
+
+@pytest.mark.asyncio
+async def test_malformed_members_are_skipped_not_fatal(monkeypatch):
+    """Members without the '{epoch}:{ms}' separator are ignored, the rest still count."""
+    _install(monkeypatch, {f"llm:latency:{SIMPLE}": ["garbage", *_members(20, 120.0)]})
+    router = _router()
+
+    await router._refresh_p95()
+
+    assert router._p95_cache[SIMPLE] == 120.0
+
+
+@pytest.mark.asyncio
+async def test_no_samples_leaves_model_uncached(monkeypatch):
+    """No data must not invent a p95; route() then falls back by design."""
+    _install(monkeypatch, {})
+    router = _router()
+
+    await router._refresh_p95()
+
+    assert router._p95_cache == {}

--- a/autobot-backend/llm_shared/tiered_routing/latency_router.py
+++ b/autobot-backend/llm_shared/tiered_routing/latency_router.py
@@ -136,7 +136,12 @@ class LatencyRouter:
             key = f"llm:latency:{model}"
             try:
                 members = await redis.zrangebyscore(key, cutoff, "+inf")
-                latencies = [float(m.decode().split(":", 1)[1]) for m in members if b":" in m]
+                # decode_responses=True means members are str. The old code tested
+                # `b":" in m` against a str, raising TypeError before .decode() ran;
+                # the except below swallowed it and _p95_cache never populated, so
+                # routing silently used _DEFAULT_P95_MS forever (issue #13272).
+                decoded = [m.decode() if isinstance(m, bytes) else m for m in members]
+                latencies = [float(m.split(":", 1)[1]) for m in decoded if ":" in m]
                 if latencies:
                     latencies.sort()
                     idx = int(_P95_PERCENTILE * len(latencies))

--- a/autobot-backend/services/command_execution_queue.py
+++ b/autobot-backend/services/command_execution_queue.py
@@ -19,6 +19,7 @@ from typing import List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.ttl_constants import TTL_24_HOURS
 from models.command_execution import CommandExecution, CommandState
@@ -28,7 +29,7 @@ logger = get_logger(__name__)
 
 def _decode_command_ids(command_ids: set) -> List[str]:
     """Decode Redis set members to string list. (Issue #315 - extracted)"""
-    return [cid.decode("utf-8") for cid in command_ids]
+    return [decode_redis_value(cid) for cid in command_ids]
 
 
 def _parse_command_data_safe(command_data: bytes, state_filter: CommandState | None = None) -> CommandExecution | None:

--- a/autobot-backend/services/context_analyzer.py
+++ b/autobot-backend/services/context_analyzer.py
@@ -15,6 +15,7 @@ import uuid
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.ssot_constants import TTL_1_HOUR
 from models.completion_context import CompletionContext
 from services.dependency_tracker import DependencyTracker
@@ -275,7 +276,7 @@ class ContextAnalyzer:
         try:
             cached = self.redis_client.get(f"completion_context:{context_id}")
             if cached:
-                return CompletionContext.from_dict(json.loads(cached.decode()))
+                return CompletionContext.from_dict(json.loads(decode_redis_value(cached)))
         except Exception as e:
             logger.warning(f"Failed to get cached context: {e}")
         return None

--- a/autobot-backend/services/feedback_tracker.py
+++ b/autobot-backend/services/feedback_tracker.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import sessionmaker
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from models.code_pattern import CodePattern
 from models.completion_feedback import CompletionFeedback
@@ -156,7 +157,7 @@ class FeedbackTracker:
             # Get feedback count since last retrain
             last_retrain_str = self.redis_client.get(self.last_retrain_key)
             if last_retrain_str:
-                last_retrain = parse_utc_iso(last_retrain_str.decode())
+                last_retrain = parse_utc_iso(decode_redis_value(last_retrain_str))
             else:
                 last_retrain = now_utc() - timedelta(days=30)
 

--- a/autobot-backend/services/skill_management/skill_feedback.py
+++ b/autobot-backend/services/skill_management/skill_feedback.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.ssot_constants import TTL_90_DAYS
 from autobot_shared.time_utils import now_utc
 
@@ -102,7 +103,7 @@ class SkillFeedbackAnalyzer(AsyncRedisClientMixin):
 
                 for entry_raw in feedback_entries:
                     try:
-                        entry = json.loads(entry_raw.decode())
+                        entry = json.loads(decode_redis_value(entry_raw))
                         rating = entry.get("rating", 0)
                         feedback = entry.get("feedback", "")
 


### PR DESCRIPTION
Closes #13272

## Thinking Path

PR #13271 fixed the first instance of a defect class: the shared Redis client is
built with `decode_responses=True`, so reads return `str`, and any bare
`.decode()` on them blows up. I re-verified the premise end to end rather than
taking it on trust — and extended it, because #13271 only established the async
path:

- async pool: `connection_manager.py:500` -> `"decode_responses": config.decode_responses`
- **sync pool: `connection_manager.py:618`** -> same field (so `get_redis_client(async_client=False, ...)` is decoded too)
- `RedisConfig.decode_responses` defaults `True` (`redis_management/config.py:61`)
- the YAML parser defaults it `True` (`:153`), and no database YAML overrides it
- no `decode_responses=False` anywhere in `autobot_shared/` or `autobot-backend/`

That sync-pool leg matters: most of the sweep hits below reach Redis through the
sync client, and they would have been out of scope had it not also been decoded.

The two sites named in the issue fail differently, which is worth keeping in mind
when reading the diff. `/kb-conflicts` has **no** local `try/except`, so the
`AttributeError` reaches `@with_error_handling` and becomes a hard 500. The
latency router's failure is swallowed by `except Exception: logger.debug(...)`,
so it degrades silently — and it fails on the *membership test* (`b":" in m`
against a `str`) before `.decode()` is even reached, so fixing only the decode
would have left it broken.

For the sweep I did not hand-roll the guard 20 more times. `autobot_shared/redis_utils.py`
already exports `decode_redis_value` — null-safe and exactly this idiom — so the
sweep sites reuse it (CLAUDE.md Rule 2). The two sites named in the issue keep the
inline `isinstance` form the issue prescribed, matching their already-guarded
immediate neighbours.

I deliberately did **not** widen either `except Exception` handler; that pattern
is tracked separately in #13273.

## What Changed

**The two sites from the issue**

- `autobot-backend/api/knowledge_grounding.py:309` — `key` from `redis.keys("conflict:*")`
  is guarded before use. Was a hard 500 on `GET /kb-conflicts` for any non-empty
  conflict set; the neighbouring fields were already `isinstance`-guarded, only the
  key was not.
- `autobot-backend/llm_shared/tiered_routing/latency_router.py:139` — members from
  `zrangebyscore` are decoded first and the membership test is now `":" in m`.
  `_p95_cache` had never populated, so latency routing permanently used
  `_DEFAULT_P95_MS`.

**Sweep — 20 further sites, all traced to the shared decoded client**

| File | Sites | Read |
|---|---|---|
| `api/batch_jobs.py` | 12 | `smembers`/`get`/`lrange` for jobs, logs, templates, schedules |
| `api/ide_integration.py` | 1 | cached completions |
| `api/codebase_analytics/chromadb_storage.py` | 1 | `scan()` keys |
| `config/async_ops.py` | 1 | cached config payload |
| `services/context_analyzer.py` | 1 | cached completion context |
| `services/feedback_tracker.py` | 1 | last-retrain timestamp |
| `services/command_execution_queue.py` | 1 | `_decode_command_ids` over `smembers` |
| `services/skill_management/skill_feedback.py` | 1 | `lrange` feedback entries |

In `batch_jobs.py` the `.decode("utf-8")` calls were also redundant — `json.loads`
and `_deserialize_job` already accept `str` — so removing them is the whole fix.
On `chromadb_storage.py:377` the `errors="ignore"` masked nothing, because `str`
has no `.decode` attribute at all.

**Not fixed here, filed instead**

Two sites share the root cause but not the symptom: they look up **bytes keys** in
a dict whose keys are now `str`, so the lookup silently misses and falls through to
a default — no exception, wrong data. `plugin_manager.py:663-668` renders the plugin
capability audit log as blank rows with every grant reading as denied, and
`api/analytics_code_review.py:925` ignores stored code-review pattern preferences.
Different fix shape, so they are **#13274** rather than scope creep here.

## Verification

Static analysis only — no application code was executed.

Sweep classification: every `.decode(` hit across the backend and shared packages
was traced to its source. 20 confirmed against the shared decoded client (fixed),
~220 already `isinstance`-guarded, ~150 genuinely non-Redis (subprocess output,
base64, JWT/Fernet, HTTP bodies, tokenizers), 2 same-root-different-symptom (#13274).

Lint on all 12 changed/added files:

```
black --line-length 120 --target-version py312 --check   -> 12 files would be left unchanged
isort --check-only                                       -> clean
flake8 --max-line-length=120                             -> 0 findings
ast.parse                                                -> all parse
```

Both defects and both fixes reproduced with a stdlib-only script importing no
project code, which also pins the exact constants the new tests assert:

```
OLD str   -> TypeError 'in <string>' requires string as left operand, not bytes
NEW str p95 = 96.0
OLD bytes p95 = 96.0 | NEW bytes p95 = 96.0      (bytes path unchanged)
p95 20x900 = 900.0 | p95 20x50 = 50.0
p95 garbage+20x120 = 120.0                       (malformed members skipped)
lowest pre-fix (empty cache) = model-simple
lowest post-fix              = model-complex
OLD key -> AttributeError 'str' object has no attribute 'decode'
NEW key -> abc123 | NEW bytes key -> def456
```

**Regression tests, and why each fails against the current code**

`autobot-backend/api/knowledge_grounding_conflicts_decode_test.py` — calls
`list_conflicts` through the `@with_error_handling` wrapper with a fake async
client whose `keys()`/`hgetall()` return `str`, the live wire shape. Pre-fix
`key.decode()` raises `AttributeError`, which the decorator converts to
`HTTPException(500)`, so all three populated-set tests fail. It asserts the real
`conflict_id` (`"abc123"`), not merely that no exception escaped. The bytes-key
case and the empty-set case are pinned as no-regression guards.

`autobot-backend/llm_shared/latency_router_decode_test.py` — drives `_refresh_p95`
with `str` members. Pre-fix the `TypeError` is swallowed and `_p95_cache` stays
empty, so `test_p95_cache_populates_from_str_members` fails on `KeyError`. The
behavioural test is the stronger one: with simple at 900ms and complex at 50ms,
`_lowest_latency` pre-fix scores both at `_DEFAULT_P95_MS` and returns the *first*
candidate, so asserting it returns `model-complex` fails on current code and
proves the degradation is actually gone rather than just the exception.

No skips, no xfails, no weakened assertions, no swallowed exceptions, nothing deleted.

**Not verified without executing code:** that the new tests pass under the real
pytest harness (collection, `conftest.py` module stubbing, fixture wiring) — CI's
`python-suite` job is the execution environment. Note that `python-suite` is not a
required check, so the required gate going green does not by itself prove these
tests ran; the job's own log needs reading. Also unverified: live Redis behaviour
against a real server, and runtime behaviour of the 20 swept call sites beyond
static tracing of their client origin.

## Model Used

claude-opus-5
