### PR TITLE
fix(redis): index decoded Redis results with str keys, not bytes literals (#13274)

### DIFF
--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -48,6 +48,7 @@ from api.schemas_code import (
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.time_utils import parse_utc_iso
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_7_DAYS
@@ -917,12 +918,16 @@ async def get_pattern_preferences(
         key = "code_review:pattern_prefs"
         prefs_raw = await asyncio.to_thread(redis.hgetall, key)
 
-        # Build preferences dict with defaults
+        # Build preferences dict with defaults.
+        # The shared client is decode_responses=True, so hgetall yields str keys.
+        # Probing with pattern_id.encode() never matched, so every stored
+        # preference was ignored and disabled patterns silently re-enabled
+        # themselves on the next read (#13274).
         patterns = {}
         for pattern_id in REVIEW_PATTERNS.keys():
             # Check if preference exists in Redis
-            if pattern_id.encode() in prefs_raw:
-                enabled_str = prefs_raw[pattern_id.encode()].decode()
+            if pattern_id in prefs_raw:
+                enabled_str = decode_redis_value(prefs_raw[pattern_id]) or ""
                 enabled = enabled_str.lower() == "true"
             else:
                 # Default to enabled

--- a/autobot-backend/api/analytics_code_review_pattern_prefs_test.py
+++ b/autobot-backend/api/analytics_code_review_pattern_prefs_test.py
@@ -1,0 +1,130 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A disabled code-review pattern must stay disabled across reads (#13274).
+
+``get_pattern_preferences`` builds its sync client with
+``get_redis_client(async_client=False, database="analytics")``. Both shared pools
+are ``decode_responses=True`` (``redis_management/connection_manager.py:500``
+async and ``:618`` sync, from the same ``config.decode_responses`` which defaults
+``True`` with no override), so ``hgetall`` returns a ``str``-keyed dict.
+
+The reader probed that dict with ``pattern_id.encode()``::
+
+    if pattern_id.encode() in prefs_raw:
+        enabled_str = prefs_raw[pattern_id.encode()].decode()
+        enabled = enabled_str.lower() == "true"
+    else:
+        enabled = True
+
+A ``bytes`` key can never match a ``str`` key, so the ``if`` branch was dead and
+every pattern fell through to the ``else`` default of enabled. ``POST
+/patterns/toggle`` persisted the preference to Redis correctly and the very next
+read threw it away — a pattern the user disabled silently re-enabled itself.
+Nothing raised, so the surrounding ``except Exception`` never fired either.
+
+``test_toggle_then_read_round_trips`` drives the real writer and the real reader
+against one shared hash, so writer/reader drift fails the suite.
+"""
+
+import pytest
+
+from api.analytics_code_review import REVIEW_PATTERNS, get_pattern_preferences, toggle_pattern_preference
+from api.schemas_analytics import PatternToggleRequest
+
+PATTERN_ID = next(iter(REVIEW_PATTERNS))
+OTHER_PATTERN_ID = list(REVIEW_PATTERNS)[1]
+PREFS_KEY = "code_review:pattern_prefs"
+
+
+class _FakeSyncRedis:
+    """Dict-backed stand-in with the sync hgetall/hset signatures used here."""
+
+    def __init__(self, initial=None):
+        self._hashes = {PREFS_KEY: dict(initial or {})}
+
+    def hgetall(self, key):
+        return dict(self._hashes.get(key, {}))
+
+    def hset(self, key, field, value):
+        self._hashes.setdefault(key, {})[field] = value
+        return 1
+
+
+def _install(monkeypatch, fake):
+    """Both endpoints import the factory inside the function body."""
+    import autobot_shared.redis_client as rc
+
+    monkeypatch.setattr(rc, "get_redis_client", lambda *a, **k: fake)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_stored_false_preference_is_honoured(monkeypatch):
+    """The live configuration. Pre-fix this read back enabled=True."""
+    _install(monkeypatch, _FakeSyncRedis({PATTERN_ID: "false"}))
+
+    result = await get_pattern_preferences(admin_check=True)
+
+    assert result["patterns"][PATTERN_ID]["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_stored_true_preference_stays_enabled(monkeypatch):
+    """An explicitly enabled pattern must not be flipped by the fix."""
+    _install(monkeypatch, _FakeSyncRedis({PATTERN_ID: "true"}))
+
+    result = await get_pattern_preferences(admin_check=True)
+
+    assert result["patterns"][PATTERN_ID]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_unset_pattern_defaults_to_enabled(monkeypatch):
+    """The documented default for a pattern with no stored preference."""
+    _install(monkeypatch, _FakeSyncRedis({PATTERN_ID: "false"}))
+
+    result = await get_pattern_preferences(admin_check=True)
+
+    assert result["patterns"][OTHER_PATTERN_ID]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_toggle_then_read_round_trips(monkeypatch):
+    """Drive the real writer, then the real reader, over one shared hash."""
+    fake = _install(monkeypatch, _FakeSyncRedis())
+
+    toggled = await toggle_pattern_preference(
+        request=PatternToggleRequest(pattern_id=PATTERN_ID, enabled=False),
+        admin_check=True,
+    )
+    assert toggled["status"] == "success"
+    assert fake.hgetall(PREFS_KEY) == {PATTERN_ID: "false"}, "the writer never persisted the preference"
+
+    result = await get_pattern_preferences(admin_check=True)
+
+    assert result["patterns"][PATTERN_ID]["enabled"] is False, "the pattern silently re-enabled itself"
+
+
+@pytest.mark.asyncio
+async def test_bytes_values_still_work(monkeypatch):
+    """A client without decode_responses must keep working."""
+    _install(monkeypatch, _FakeSyncRedis({PATTERN_ID: b"false"}))
+
+    result = await get_pattern_preferences(admin_check=True)
+
+    assert result["patterns"][PATTERN_ID]["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_no_redis_returns_all_enabled(monkeypatch):
+    """The documented degraded path must be unchanged."""
+    import autobot_shared.redis_client as rc
+
+    monkeypatch.setattr(rc, "get_redis_client", lambda *a, **k: None)
+
+    result = await get_pattern_preferences(admin_check=True)
+
+    assert all(entry["enabled"] is True for entry in result["patterns"].values())
+    assert set(result["patterns"]) == set(REVIEW_PATTERNS)

--- a/autobot-backend/background_vectorization.py
+++ b/autobot-backend/background_vectorization.py
@@ -167,10 +167,13 @@ class BackgroundVectorizer:
         """Extract content and metadata from fact data (Issue #336 - extracted helper)."""
         import json
 
-        content_bytes = fact_data.get(b"content", b"")
-        content = self._decode_bytes(content_bytes)
-        metadata_str = fact_data.get(b"metadata", b"{}")
-        metadata = json.loads(self._decode_bytes(metadata_str, "{}"))
+        # kb.redis() is the shared decode_responses=True client, so hgetall yields
+        # str field names. Probing with bytes literals always missed, so every fact
+        # was vectorized as an empty Document and then marked completed (#13274).
+        content_raw = fact_data.get("content", "")
+        content = self._decode_bytes(content_raw)
+        metadata_raw = fact_data.get("metadata", "{}")
+        metadata = json.loads(self._decode_bytes(metadata_raw, "{}"))
         return content, metadata
 
     async def _mark_vectorization_complete(self, kb, fact_key: str) -> None:

--- a/autobot-backend/background_vectorization_fact_keys_test.py
+++ b/autobot-backend/background_vectorization_fact_keys_test.py
@@ -1,0 +1,70 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Background vectorization must read the fact's real content (#13274).
+
+Facts are written by ``KnowledgeBase`` with ``hset(fact_key, mapping={"content":
+..., "metadata": ...})`` — ``str`` field names — and ``kb.redis()`` is the shared
+async client built with ``decode_responses=True``
+(``redis_management/connection_manager.py:500`` -> ``config.py:61,153``). So
+``hgetall(fact_key)`` returns a ``str``-keyed dict.
+
+``BackgroundVectorizer._extract_fact_content`` probed it with bytes literals::
+
+    content_bytes = fact_data.get(b"content", b"")
+    content = self._decode_bytes(content_bytes)
+
+``b"content"`` never matched, so the ``b""`` default came back, ``_decode_bytes``
+decoded it to ``""`` without complaint, and metadata fell back to ``{}``. Every
+fact was inserted into the vector index as an **empty** ``Document`` and then
+marked ``vectorization_status=completed`` — poisoning the index while reporting
+success. Sibling readers of the same hash (``api/knowledge.py:2168``,
+``knowledge/search_components/keyword_search.py:121``) already probe both key
+types, which is why only this path silently produced empty documents.
+"""
+
+import json
+
+from background_vectorization import BackgroundVectorizer
+
+# Exactly the mapping KnowledgeBase.store_fact writes (knowledge/facts.py:644).
+STORED_FACT = {
+    "content": "Redis keys are bytes on the wire but str on a decoding client.",
+    "metadata": json.dumps({"source": "manual", "tags": ["redis"]}),
+    "timestamp": "2026-08-02T07:00:00+00:00",
+}
+
+
+def test_str_keyed_fact_yields_real_content():
+    """The live configuration. Pre-fix content was "" and metadata was {}."""
+    content, metadata = BackgroundVectorizer()._extract_fact_content(dict(STORED_FACT))
+
+    assert content == STORED_FACT["content"]
+    assert metadata == {"source": "manual", "tags": ["redis"]}
+
+
+def test_empty_content_is_not_silently_vectorized():
+    """Pin the exact symptom: a real fact must never arrive as an empty document."""
+    content, _metadata = BackgroundVectorizer()._extract_fact_content(dict(STORED_FACT))
+
+    assert content != "", "every fact was being vectorized as an empty Document"
+    assert len(content.split()) > 1
+
+
+def test_bytes_values_still_decode():
+    """``_decode_bytes`` keeps handling a bytes value under the correct str key."""
+    raw = {k: v.encode() for k, v in STORED_FACT.items()}
+
+    content, metadata = BackgroundVectorizer()._extract_fact_content(raw)
+
+    assert content == STORED_FACT["content"]
+    assert metadata == {"source": "manual", "tags": ["redis"]}
+
+
+def test_missing_fields_fall_back_to_documented_defaults():
+    """A hash with neither field yields "" / {} rather than raising."""
+    content, metadata = BackgroundVectorizer()._extract_fact_content({"timestamp": "x"})
+
+    assert content == ""
+    assert metadata == {}

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 
 logger = get_logger(__name__)
 
@@ -123,11 +124,14 @@ class SessionTokenTracker:
                     "message_count": 0,
                 }
 
+            # add_message_tokens hincrby's str field names and the shared client is
+            # decode_responses=True, so hgetall yields str keys. Probing with bytes
+            # literals always missed and every counter read back 0 (#13274).
             return {
-                "total_tokens": int(data.get(b"total_tokens", 0)),
-                "prompt_tokens": int(data.get(b"prompt_tokens", 0)),
-                "completion_tokens": int(data.get(b"completion_tokens", 0)),
-                "message_count": int(data.get(b"message_count", 0)),
+                "total_tokens": int(decode_redis_value(data.get("total_tokens")) or 0),
+                "prompt_tokens": int(decode_redis_value(data.get("prompt_tokens")) or 0),
+                "completion_tokens": int(decode_redis_value(data.get("completion_tokens")) or 0),
+                "message_count": int(decode_redis_value(data.get("message_count")) or 0),
             }
         except Exception as e:
             logger.error("Failed to get session usage for %s: %s", session_id, e)

--- a/autobot-backend/chat_history/context_overflow_test.py
+++ b/autobot-backend/chat_history/context_overflow_test.py
@@ -25,11 +25,16 @@ class TestSessionTokenTracker:
 
         # Mock Redis client
         mock_redis = AsyncMock()
+        # #13274: the shared client is decode_responses=True, so hgetall returns
+        # str keys AND str values. This mock previously returned bytes for both —
+        # a shape the live client never produces — and passed only because
+        # get_session_usage probed with matching bytes literals. Test and code
+        # agreed with each other and both disagreed with Redis.
         mock_redis.hgetall.return_value = {
-            b"total_tokens": b"300",
-            b"prompt_tokens": b"200",
-            b"completion_tokens": b"100",
-            b"message_count": b"2",
+            "total_tokens": "300",
+            "prompt_tokens": "200",
+            "completion_tokens": "100",
+            "message_count": "2",
         }
 
         with patch.object(tracker, "_ensure_redis", return_value=mock_redis):

--- a/autobot-backend/chat_history/context_overflow_token_keys_test.py
+++ b/autobot-backend/chat_history/context_overflow_token_keys_test.py
@@ -1,0 +1,139 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Session token counters must read back what add_message_tokens wrote (#13274).
+
+``SessionTokenTracker`` writes with ``hincrby(key, "total_tokens", n)`` — ``str``
+field names — and reads with the shared async client, which is
+``decode_responses=True``. ``hgetall`` therefore returns a ``str``-keyed dict.
+
+``get_session_usage`` probed it with bytes literals::
+
+    "total_tokens": int(data.get(b"total_tokens", 0)),
+
+Every lookup missed, ``int(0)`` returned 0, and nothing raised. The tracker
+reported zero usage for every session no matter how many tokens were recorded,
+so any consumer of these counters saw a permanently empty session.
+"""
+
+import pytest
+
+from chat_history.context_overflow import _TOKEN_TRACKER_KEY_PREFIX, SessionTokenTracker
+
+SESSION = "session-abc"
+SESSION_KEY = f"{_TOKEN_TRACKER_KEY_PREFIX}{SESSION}"
+
+
+class _FakePipeline:
+    """Captures hincrby/expire the way redis-py's pipeline does."""
+
+    def __init__(self, store):
+        self._store = store
+        self.expire_calls = []
+
+    def hincrby(self, key, field, amount):
+        self._store.setdefault(key, {})
+        self._store[key][field] = int(self._store[key].get(field, 0)) + amount
+
+    def expire(self, key, ttl):
+        self.expire_calls.append((key, ttl))
+
+    async def execute(self):
+        return []
+
+
+class _FakeAsyncRedis:
+    """Dict-backed stand-in returning decoded (str) hash field names."""
+
+    def __init__(self, hashes=None, decoded=True):
+        self._hashes = dict(hashes or {})
+        self._decoded = decoded
+
+    def pipeline(self):
+        return _FakePipeline(self._hashes)
+
+    async def hgetall(self, key):
+        raw = self._hashes.get(key, {})
+        if self._decoded:
+            return {str(k): str(v) for k, v in raw.items()}
+        # Field names stay str; only the values arrive as bytes.
+        return {str(k): str(v).encode() for k, v in raw.items()}
+
+
+def _tracker(redis):
+    tracker = SessionTokenTracker()
+    tracker.redis = redis
+    return tracker
+
+
+@pytest.mark.asyncio
+async def test_stored_counters_are_returned():
+    """The live configuration. Pre-fix every counter read back 0."""
+    tracker = _tracker(
+        _FakeAsyncRedis(
+            {
+                SESSION_KEY: {
+                    "total_tokens": 1500,
+                    "prompt_tokens": 900,
+                    "completion_tokens": 600,
+                    "message_count": 7,
+                }
+            }
+        )
+    )
+
+    usage = await tracker.get_session_usage(SESSION)
+
+    assert usage == {
+        "total_tokens": 1500,
+        "prompt_tokens": 900,
+        "completion_tokens": 600,
+        "message_count": 7,
+    }
+
+
+@pytest.mark.asyncio
+async def test_write_then_read_round_trips():
+    """Drive the real writer, then the real reader, over one shared hash."""
+    redis = _FakeAsyncRedis()
+    tracker = _tracker(redis)
+
+    await tracker.add_message_tokens(SESSION, prompt_tokens=120, completion_tokens=80)
+    await tracker.add_message_tokens(SESSION, prompt_tokens=30, completion_tokens=20)
+
+    usage = await tracker.get_session_usage(SESSION)
+
+    assert usage["total_tokens"] == 250, "hincrby wrote str fields the reader could not see"
+    assert usage["prompt_tokens"] == 150
+    assert usage["completion_tokens"] == 100
+    assert usage["message_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_bytes_values_still_work():
+    """``decode_redis_value`` keeps handling a bytes counter value."""
+    redis = _FakeAsyncRedis(decoded=False)
+    tracker = _tracker(redis)
+
+    await tracker.add_message_tokens(SESSION, prompt_tokens=10, completion_tokens=5)
+
+    usage = await tracker.get_session_usage(SESSION)
+
+    assert usage["total_tokens"] == 15
+    assert usage["message_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_session_returns_zeros():
+    """The one case that looked correct before the fix must still work."""
+    tracker = _tracker(_FakeAsyncRedis())
+
+    usage = await tracker.get_session_usage("never-seen")
+
+    assert usage == {
+        "total_tokens": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "message_count": 0,
+    }

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -31,6 +31,7 @@ from autobot_shared.plugin_sdk import (
 from autobot_shared.plugin_sdk.base import PluginLoadError
 from autobot_shared.plugin_sdk.loader import validate_plugin_config
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.ssot_config import config
 from plugin_install import install_from_git, install_from_zip
 
@@ -623,6 +624,18 @@ async def approve_plugin_capabilities(
     }
 
 
+def _audit_field(data: Dict, name: str, default: str = "") -> str:
+    """Read one field from a ``plugin:capability:audit`` stream entry (#13274).
+
+    The shared client is ``decode_responses=True``, so ``xrevrange`` yields ``str``
+    field names. Looking the field up with a ``bytes`` literal never matched, so
+    every entry rendered blank with ``granted`` pinned to ``False``. Indexing by
+    ``str`` fixes that; ``decode_redis_value`` keeps a non-decoding client working.
+    """
+    value = decode_redis_value(data.get(name))
+    return default if value is None else value
+
+
 @router.get("/plugins/audit")
 @with_error_handling(error_code_prefix="PLUGIN_AUDIT_GET")
 async def get_capability_audit_log(
@@ -660,12 +673,14 @@ async def get_capability_audit_log(
     for entry_id, data in entries:
         audit_entries.append(
             CapabilityAuditEntry(
-                timestamp=data.get(b"timestamp", b"").decode("utf-8"),
-                plugin_name=data.get(b"plugin_name", b"").decode("utf-8"),
-                capability=data.get(b"capability", b"").decode("utf-8"),
-                granted=data.get(b"granted", b"false").decode("utf-8") == "true",
-                operation=data.get(b"operation", b"").decode("utf-8"),
-                metadata=data.get(b"metadata", b"").decode("utf-8"),
+                timestamp=_audit_field(data, "timestamp"),
+                plugin_name=_audit_field(data, "plugin_name"),
+                capability=_audit_field(data, "capability"),
+                # CapabilityChecker._log_capability_use writes str(context.granted),
+                # i.e. "True"/"False" -- casefold before comparing (#13274).
+                granted=_audit_field(data, "granted", "false").lower() == "true",
+                operation=_audit_field(data, "operation"),
+                metadata=_audit_field(data, "metadata"),
             )
         )
 

--- a/autobot-backend/plugin_manager_audit_keys_test.py
+++ b/autobot-backend/plugin_manager_audit_keys_test.py
@@ -1,0 +1,200 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GET /plugins/audit must render the real audit fields, not blanks (#13274).
+
+The shared async client is ``decode_responses=True``
+(``redis_management/connection_manager.py:500`` -> ``config.py:61,153``, no
+per-database override), so ``xrevrange`` yields ``str`` field names.
+
+``get_capability_audit_log`` looked every field up with a **bytes literal**::
+
+    timestamp=data.get(b"timestamp", b"").decode("utf-8"),
+    ...
+    granted=data.get(b"granted", b"false").decode("utf-8") == "true",
+
+Every ``.get(b"...")`` missed and returned the *default*, whose ``.decode()``
+then succeeded trivially — so nothing raised and nothing was logged. The
+endpoint emitted one row per real audit record with every string field empty and
+``granted`` pinned to ``False``: the capability audit log reported every grant as
+a denial.
+
+Correcting the key type alone is not enough. The writer,
+``CapabilityChecker._log_capability_use``, stores ``str(context.granted)`` —
+i.e. ``"True"``/``"False"`` — so the reader's ``== "true"`` comparison must
+casefold or grants still read denied. The writer/reader pairing is pinned by
+``test_writer_mapping_round_trips`` below, which drives the real writer and
+feeds exactly what it emitted back into the real reader.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+import plugin_manager
+from autobot_shared.plugin_sdk.capabilities import (
+    Capability,
+    CapabilityChecker,
+    CapabilityContext,
+)
+
+# The live wire shape: decode_responses=True means field names are str.
+GRANTED_ENTRY = {
+    "timestamp": "2026-08-02T07:00:00+00:00",
+    "plugin_name": "demo-plugin",
+    "capability": "kb:read",
+    "granted": "True",  # str(True) — exactly what the writer stores
+    "operation": "kb_query",
+    "metadata": "{'query': 'hello'}",
+}
+
+DENIED_ENTRY = {
+    "timestamp": "2026-08-02T07:00:01+00:00",
+    "plugin_name": "rogue-plugin",
+    "capability": "filesystem:delete",
+    "granted": "False",
+    "operation": "fs_delete",
+    "metadata": "{}",
+}
+
+
+class _FakeAsyncRedis:
+    """Minimal stand-in exposing only what the audit endpoint calls."""
+
+    def __init__(self, entries):
+        self._entries = entries
+        self.xrevrange_calls = []
+        self.xadd_calls = []
+
+    async def xrevrange(self, name, count=None):
+        self.xrevrange_calls.append((name, count))
+        return self._entries
+
+    async def xadd(self, name, fields, maxlen=None):
+        self.xadd_calls.append((name, dict(fields), maxlen))
+        return "1700000000000-0"
+
+
+def _install(monkeypatch, entries, module=plugin_manager):
+    fake = _FakeAsyncRedis(entries)
+
+    async def _factory(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(module, "get_async_redis_client", _factory)
+    return fake
+
+
+async def _call(limit=100):
+    return await plugin_manager.get_capability_audit_log(limit=limit, admin_check=True)
+
+
+@pytest.mark.asyncio
+async def test_granted_entry_reads_back_granted(monkeypatch):
+    """The live configuration. Pre-fix every field was "" and granted was False."""
+    fake = _install(monkeypatch, [("1700000000000-0", GRANTED_ENTRY)])
+
+    result = await _call()
+
+    assert fake.xrevrange_calls == [("plugin:capability:audit", 100)]
+    assert result["total"] == 1
+    entry = result["entries"][0]
+    assert entry.granted is True
+    assert entry.plugin_name == "demo-plugin"
+    assert entry.capability == "kb:read"
+    assert entry.operation == "kb_query"
+    assert entry.timestamp == "2026-08-02T07:00:00+00:00"
+    assert entry.metadata == "{'query': 'hello'}"
+
+
+@pytest.mark.asyncio
+async def test_denied_entry_still_reads_denied(monkeypatch):
+    """A real denial must stay a denial — the fix must not invert the flag."""
+    _install(monkeypatch, [("1700000000001-0", DENIED_ENTRY)])
+
+    result = await _call()
+
+    entry = result["entries"][0]
+    assert entry.granted is False
+    assert entry.plugin_name == "rogue-plugin"
+    assert entry.capability == "filesystem:delete"
+
+
+@pytest.mark.asyncio
+async def test_writer_mapping_round_trips(monkeypatch):
+    """Drive the real writer, then feed its own mapping to the real reader.
+
+    This is the pairing check: if either side changes its field-name or value
+    shape without the other, this test fails.
+    """
+    import autobot_shared.plugin_sdk.capabilities as capabilities_module
+
+    writer_redis = _install(monkeypatch, [], module=capabilities_module)
+    context = CapabilityContext(
+        plugin_name="demo-plugin",
+        capability=Capability.KB_READ,
+        granted=True,
+        timestamp=datetime(2026, 8, 2, 7, 0, 0, tzinfo=timezone.utc),
+        operation="kb_query",
+        metadata={"query": "hello"},
+    )
+
+    await CapabilityChecker()._log_capability_use(context)
+
+    assert writer_redis.xadd_calls, "the writer never reached xadd"
+    stream, written, _maxlen = writer_redis.xadd_calls[0]
+    assert stream == "plugin:capability:audit"
+
+    _install(monkeypatch, [("1700000000000-0", written)])
+    result = await _call()
+
+    entry = result["entries"][0]
+    assert entry.granted is True, f"writer wrote granted={written['granted']!r}, reader read False"
+    assert entry.plugin_name == "demo-plugin"
+    assert entry.capability == "kb:read"
+    assert entry.operation == "kb_query"
+    assert entry.timestamp == "2026-08-02T07:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_bytes_fields_still_work(monkeypatch):
+    """A client without decode_responses must keep working."""
+    _install(
+        monkeypatch,
+        [(b"1700000000000-0", {"plugin_name": b"legacy-plugin", "granted": b"true", "capability": b"llm:call"})],
+    )
+
+    result = await _call()
+
+    entry = result["entries"][0]
+    assert entry.granted is True
+    assert entry.plugin_name == "legacy-plugin"
+    assert entry.capability == "llm:call"
+
+
+@pytest.mark.asyncio
+async def test_missing_fields_fall_back_to_documented_defaults(monkeypatch):
+    """An entry missing fields yields "" and granted=False, not a crash."""
+    _install(monkeypatch, [("1700000000000-0", {"plugin_name": "partial"})])
+
+    result = await _call()
+
+    entry = result["entries"][0]
+    assert entry.plugin_name == "partial"
+    assert entry.timestamp == ""
+    assert entry.capability == ""
+    assert entry.operation == ""
+    assert entry.metadata == ""
+    assert entry.granted is False
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_returns_no_entries(monkeypatch):
+    """The only case that looked correct before the fix must still work."""
+    _install(monkeypatch, [])
+
+    result = await _call()
+
+    assert result["total"] == 0
+    assert result["entries"] == []

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -45,6 +45,7 @@ except ImportError:
 from autobot_shared.env_utils import env_int
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_value
 from autobot_shared.singleton_factory import lazy_optional_singleton
 from autobot_shared.ssot_config import config as _ssot_config
 from constants.ttl_constants import TTL_1_HOUR
@@ -929,9 +930,12 @@ class SecureSandboxExecutor:
             # Issue #361 - avoid blocking
             stats = await asyncio.to_thread(self.redis_client.hgetall, "autobot:sandbox:stats")
 
+            # hincrby at _log_metrics writes str field names and the shared client
+            # is decode_responses=True, so hgetall yields str keys. Probing with
+            # bytes literals always missed and both counters read 0 (#13274).
             return {
-                "successful_executions": int(stats.get(b"successful_executions", 0)),
-                "failed_executions": int(stats.get(b"failed_executions", 0)),
+                "successful_executions": int(decode_redis_value(stats.get("successful_executions")) or 0),
+                "failed_executions": int(decode_redis_value(stats.get("failed_executions")) or 0),
                 "active_containers": len(self.active_containers),
                 "security_levels_available": [level.value for level in SandboxSecurityLevel],
             }

--- a/autobot-backend/secure_sandbox_executor_stats_keys_test.py
+++ b/autobot-backend/secure_sandbox_executor_stats_keys_test.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Sandbox stats must report the counters hincrby actually wrote (#13274).
+
+``SecureSandboxExecutor`` increments with
+``self.redis_client.hincrby("autobot:sandbox:stats", stat_key, 1)`` — ``str``
+field names — and ``self.redis_client`` comes from
+``get_redis_client(async_client=False)``. The shared sync pool is
+``decode_responses=True`` (``redis_management/connection_manager.py:618`` reading
+the same ``config.decode_responses`` that defaults ``True``), so ``hgetall``
+returns a ``str``-keyed dict.
+
+``get_sandbox_stats`` probed it with bytes literals::
+
+    "successful_executions": int(stats.get(b"successful_executions", 0)),
+
+The lookup always missed, the ``0`` default was returned, and ``int(0)``
+succeeded — so the endpoint reported zero executions forever, no matter how many
+sandboxes had actually run, with no exception and no log line.
+
+``SecureSandboxExecutor.__init__`` requires a live Docker SDK, so these tests
+build the instance without it and attach only the two attributes
+``get_sandbox_stats`` touches.
+"""
+
+import pytest
+
+from secure_sandbox_executor import SecureSandboxExecutor
+
+STATS_KEY = "autobot:sandbox:stats"
+
+
+class _FakeSyncRedis:
+    """Dict-backed stand-in with redis-py's sync hincrby/hgetall signatures."""
+
+    def __init__(self, initial=None, decoded=True):
+        self._hashes = {STATS_KEY: dict(initial or {})}
+        self._decoded = decoded
+
+    def hincrby(self, key, field, amount):
+        bucket = self._hashes.setdefault(key, {})
+        bucket[field] = int(bucket.get(field, 0)) + amount
+        return bucket[field]
+
+    def hgetall(self, key):
+        raw = self._hashes.get(key, {})
+        if self._decoded:
+            return {str(k): str(v) for k, v in raw.items()}
+        # Field names stay str; only the values arrive as bytes.
+        return {str(k): str(v).encode() for k, v in raw.items()}
+
+
+def _executor(redis):
+    """Build the executor without running __init__ (it demands the Docker SDK)."""
+    executor = object.__new__(SecureSandboxExecutor)
+    executor.redis_client = redis
+    executor.active_containers = {}
+    return executor
+
+
+@pytest.mark.asyncio
+async def test_stored_counters_are_reported():
+    """The live configuration. Pre-fix both counters read back 0."""
+    executor = _executor(_FakeSyncRedis({"successful_executions": 42, "failed_executions": 7}))
+
+    stats = await executor.get_sandbox_stats()
+
+    assert stats["successful_executions"] == 42
+    assert stats["failed_executions"] == 7
+    assert stats["active_containers"] == 0
+    assert stats["security_levels_available"]
+
+
+@pytest.mark.asyncio
+async def test_hincrby_then_read_round_trips():
+    """Drive the real write shape, then the real reader, over one shared hash."""
+    redis = _FakeSyncRedis()
+    executor = _executor(redis)
+
+    # Exactly what _log_metrics does on a successful then a failed execution.
+    redis.hincrby(STATS_KEY, "successful_executions", 1)
+    redis.hincrby(STATS_KEY, "successful_executions", 1)
+    redis.hincrby(STATS_KEY, "failed_executions", 1)
+
+    stats = await executor.get_sandbox_stats()
+
+    assert stats["successful_executions"] == 2, "hincrby wrote str fields the reader could not see"
+    assert stats["failed_executions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_bytes_values_still_work():
+    """``decode_redis_value`` keeps handling a bytes counter value."""
+    executor = _executor(_FakeSyncRedis({"successful_executions": 5, "failed_executions": 2}, decoded=False))
+
+    stats = await executor.get_sandbox_stats()
+
+    assert stats["successful_executions"] == 5
+    assert stats["failed_executions"] == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_hash_reports_zeros():
+    """The one case that looked correct before the fix must still work."""
+    executor = _executor(_FakeSyncRedis())
+
+    stats = await executor.get_sandbox_stats()
+
+    assert stats["successful_executions"] == 0
+    assert stats["failed_executions"] == 0


### PR DESCRIPTION
Closes #13274

## Thinking Path

Sibling of #13272 (PR #13275), same root cause, different symptom shape. Both shared
Redis pools are built with `decode_responses=True` — `redis_management/connection_manager.py:500`
(async) and `:618` (sync) both read the same `config.decode_responses`, which defaults
`True` in `redis_management/config.py:61,153` with no per-database override anywhere. So
`hgetall` and `xrevrange` return dicts whose **field names are `str`**.

#13272 covered a bare `.decode()` on a value, which raises `AttributeError`. This issue is
the quieter half: a **bytes literal used as the key**. The lookup simply misses, the
default is returned, and nothing raises — so the wrong data has been served silently.
The fix is therefore not "wrap the value in `decode_redis_value`"; the key type is what
was wrong. Values still go through the canonical helper so a non-decoding client keeps
working.

I checked the writer for every site before touching the reader, and that paid off on the
audit log. `CapabilityChecker._log_capability_use` stores `"granted": str(context.granted)`
— i.e. `"True"`, capitalised. Correcting only the key type would still have compared
`"True" == "true"` and reported every grant as a denial. Casefolding is required, and
`test_writer_mapping_round_trips` pins the pairing by driving the real writer and feeding
its own `xadd` mapping into the real reader.

I then swept the whole tree for the same idiom. Most hits use the tolerant dual form
(`data.get(b"x") or data.get("x")`) and are unaffected. Five readers used the bytes form
alone; all five resolve to a shared decoded pool and all five are fixed here.

## What Changed

Five readers now index by `str`, with values passed through
`autobot_shared.redis_utils.decode_redis_value` (the canonical helper adopted in #13272).

| Site | Symptom before |
|---|---|
| `autobot-backend/plugin_manager.py:663` | Capability audit log returned one row per real record with every field `""` and `granted` pinned `False` — **every grant reported as denied** |
| `autobot-backend/api/analytics_code_review.py:924` | The "preference exists" branch was dead; a review pattern the user disabled **silently re-enabled itself** on the next read |
| `autobot-backend/secure_sandbox_executor.py:933` | Sandbox stats always reported **0 executions**, however many had run |
| `autobot-backend/chat_history/context_overflow.py:127` | Session token counters always read **0**, so context-overflow warning/compression never fired |
| `autobot-backend/background_vectorization.py:170` | Every fact was inserted into the vector index as an **empty `Document`**, then marked `vectorization_status=completed` |

`plugin_manager` gains a small `_audit_field` helper so the six-field read stays one line
per field, and casefolds `granted` to match what the writer stores.

Five regression test files, one per site, each failing against the pre-fix code.

### Sweep result

Examined every `.get(b"…")`, `[b"…"]`, `b"…" in …`, `.encode() in …`, `[….encode()]`, and
bytes-field `hget`/`hset`/`hmget`/`hdel`/`sismember` call in the tree.

Fixed (bytes key, single form, shared decoded client): the five above.

Examined and left unchanged, with reason:

- `utils/system_metrics.py:417-418`, `utils/model_optimization/performance_tracking.py:42-49,105-108`,
  `utils/connection_utils.py:117,119`, `knowledge/versioning.py:172`, `knowledge/tags.py:558,564`,
  `knowledge/ownership.py:637`, `knowledge/search_components/keyword_search.py:121`,
  `api/knowledge.py:2168,2173,2353,2355,2443,2460` — all use the tolerant dual form
  `get(b"x") or get("x")`, so the `str` key already resolves. Correct today; only redundant.
- `utils/helpers_reorganization_test.py:225,235-236` — a test file's own standalone
  reimplementation, explicitly typed `Dict[bytes, bytes]` and fed bytes by the test. Not a
  production reader, not the shared client.
- `media/document/pipeline.py:94`, `api/files.py:398`, `secure_sandbox_executor.py:522`,
  `infrastructure/shared/scripts/*` — genuine byte-buffer membership tests on file/stream
  content, unrelated to Redis.
- Test fixtures asserting bytes wire shapes (`tests/fixtures/`, `tests/api/`,
  `security/enterprise/threat_detection/test_learner.py`, …) — deliberate bytes stubs.

No ambiguous site was left undecided; every hit is in one of the buckets above.

## Verification

Static analysis only — no application code, service, or suite was executed locally.

- `black --line-length 120 --check` — 10 files unchanged
- `isort --check-only` — clean
- `flake8` — clean
- `mypy --ignore-missing-imports` on all five changed modules — no new diagnostics on any
  changed line; every error reported is pre-existing (`context_overflow.py` is clean outright)
- Stdlib-only reproduction (imports no project code) of the old vs new expression for each
  of the five sites, confirming the pre-fix result and the post-fix result:

```
1 OLD: {'plugin_name': '', 'granted': False} -> blank + denied
1 NEW: {'plugin_name': 'demo-plugin', 'granted': True}
2 OLD: True  NEW: False
3 OLD: 0  NEW: 42
4 OLD: 0  NEW: 250
5 OLD: ''/{}  NEW: 'real content here'/{'source': 'manual'}

ALL ASSERTIONS PASSED
```

That reproduction also asserts `(entry.get("granted", "false") == "true") is False`, which
is the proof that a str-key-only fix would have left the audit log reporting denials.

Not verifiable without executing code: the five new test files have not been run — CI's
`python-suite` job is the execution environment. Note that `python-suite` is not a required
check, so a green required gate does not prove the Python suite passed; the test results
need reading directly. Backend baseline for comparison: 257 failed / 19070 passed /
26 errors, noise floor ~6 tests.

Nothing here widens an `except Exception` handler — that is tracked separately in #13273.

## Model Used

Claude Opus 5
