### PR TITLE
fix(terminal): poll() instead of select() so PTY reads survive fd >= 1024 (#13219)

### DIFF
--- a/autobot-backend/agents/interactive_terminal_agent.py
+++ b/autobot-backend/agents/interactive_terminal_agent.py
@@ -11,13 +11,13 @@ import asyncio
 import fcntl
 import os
 import pty
-import select
 import struct
 import termios
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
+from autobot_shared.fd_poll import poll_readable
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import TimingConstants
 from events.bus import PersistStrategy, publish_event
@@ -26,6 +26,11 @@ from .base_agent import AgentRequest
 from .standardized_agent import ActionHandler, StandardizedAgent
 
 logger = get_logger(__name__)
+
+# Issue #13219: the availability check has always been a non-blocking probe
+# (select() timeout 0 seconds == poll() timeout 0 milliseconds); the caller
+# sleeps separately when nothing is ready.
+_NON_BLOCKING_POLL_MS = 0
 
 
 class InteractiveTerminalAgent(StandardizedAgent):
@@ -258,9 +263,10 @@ class InteractiveTerminalAgent(StandardizedAgent):
         if not self.master_fd:
             return False
 
-        # Use select with timeout to check data availability
-        readable, _, _ = select.select([self.master_fd], [], [], 0)
-        return bool(readable)
+        # Non-blocking poll for readability. poll() has no FD_SETSIZE ceiling,
+        # so a PTY fd >= 1024 still works where select() raised
+        # "filedescriptor out of range in select()" (#13219).
+        return poll_readable(self.master_fd, _NON_BLOCKING_POLL_MS)
 
     async def _process_output(self, data: bytes):
         """Process and send terminal output (thread-safe)"""

--- a/autobot-backend/services/simple_pty.py
+++ b/autobot-backend/services/simple_pty.py
@@ -9,11 +9,11 @@ Simple synchronous PTY implementation that works reliably
 import os
 import pty
 import queue
-import select
 import signal
 import subprocess
 import threading
 
+from autobot_shared.fd_poll import poll_readable, seconds_to_poll_timeout_ms
 from autobot_shared.logging_manager import get_logger
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
@@ -22,6 +22,10 @@ logger = get_logger(__name__)
 
 # Issue #380: Module-level frozenset for PTY event types
 _PTY_OUTPUT_EVENTS = frozenset({"output", "eof"})
+
+# Issue #13219: same 10 ms wait the read loop always used, expressed in the
+# milliseconds poll() takes instead of the seconds select() took.
+_READ_POLL_TIMEOUT_MS = seconds_to_poll_timeout_ms(TimingConstants.POLL_INTERVAL)
 
 
 def _read_pty_data(fd: int) -> tuple:
@@ -190,10 +194,10 @@ class SimplePTY:
                 if fd is None:
                     break
 
-                # Check for data with select (0.01s = 10ms for responsive input)
-                ready, _, _ = select.select([fd], [], [], 0.01)
-
-                if ready:
+                # Check for data with poll (10ms for responsive input). poll()
+                # has no FD_SETSIZE ceiling, so a PTY fd >= 1024 still works
+                # where select() raised "filedescriptor out of range" (#13219).
+                if poll_readable(fd, _READ_POLL_TIMEOUT_MS):
                     event_type, content, should_break = _read_pty_data(fd)
                     if event_type in _PTY_OUTPUT_EVENTS:
                         self.output_queue.put((event_type, content))

--- a/autobot-backend/tests/test_pty_read_loop_fd_setsize_13219.py
+++ b/autobot-backend/tests/test_pty_read_loop_fd_setsize_13219.py
@@ -1,0 +1,195 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression tests for #13219 — PTY read loops must not be capped at FD_SETSIZE.
+
+``select.select()`` cannot address a descriptor at or above ``FD_SETSIZE``
+(1024 on Linux) no matter how high ``RLIMIT_NOFILE`` is, so once the long-lived
+single-process backend crosses 1024 open descriptors every new PTY made the read
+loop die with ``ValueError: filedescriptor out of range in select()`` — and the
+failure was permanent for the life of the process.
+
+Two layers of coverage:
+
+1. A behavioural test that drives ``SimplePTY._read_loop`` against a PTY whose
+   master descriptor is deliberately relocated above the ceiling. It fails on
+   the pre-fix code, where the loop raises on the first ``select.select()`` call
+   and emits ``close`` instead of the terminal output.
+2. Source-level assertions that neither PTY readiness path reintroduces
+   ``select.select()``. These fail deterministically against the old code even
+   in an environment that cannot allocate a high descriptor.
+"""
+
+import ast
+import fcntl
+import os
+import pty
+import queue
+import resource
+import select
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from services.simple_pty import SimplePTY
+
+# FD_SETSIZE on Linux: the ceiling select() cannot see past.
+FD_SETSIZE = 1024
+_HIGH_FD_BASE = FD_SETSIZE + 176
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+_PTY_READINESS_SOURCES = (
+    _BACKEND_ROOT / "services" / "simple_pty.py",
+    _BACKEND_ROOT / "agents" / "interactive_terminal_agent.py",
+)
+
+
+def _free_fd_at_or_above(start: int) -> int:
+    """Return an unused descriptor number at or above ``start``."""
+    for candidate in range(start, start + 64):
+        try:
+            fcntl.fcntl(candidate, fcntl.F_GETFD)
+        except OSError:
+            return candidate
+    raise RuntimeError(f"no free descriptor number in [{start}, {start + 64})")
+
+
+@contextmanager
+def _pty_above_fd_setsize():
+    """Yield ``(master_fd, slave_fd)`` with ``master_fd`` >= FD_SETSIZE."""
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target = _free_fd_at_or_above(_HIGH_FD_BASE)
+    raised = False
+    if soft <= target:
+        if hard != resource.RLIM_INFINITY and hard <= target:
+            pytest.skip(f"RLIMIT_NOFILE hard limit {hard} cannot reach descriptor {target}")
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target + 1, hard))
+        raised = True
+
+    master, slave = pty.openpty()
+    try:
+        os.dup2(master, target)
+        os.close(master)
+        yield target, slave
+    finally:
+        for fd in (target, slave):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if raised:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+
+
+def _assert_select_cannot_reach(fd: int) -> None:
+    """Fail the test unless ``fd`` really is out of ``select()``'s reach."""
+    try:
+        select.select([fd], [], [], 0)
+    except ValueError:
+        return
+    pytest.fail(f"descriptor {fd} is still within FD_SETSIZE — the test would prove nothing")
+
+
+def _drain(output_queue: queue.Queue, timeout: float = 5.0):
+    """Return the first queued PTY event."""
+    return output_queue.get(timeout=timeout)
+
+
+class TestSimplePtyReadLoopAboveFdSetsize:
+    """SimplePTY._read_loop drives a real PTY whose master fd is >= 1024."""
+
+    def test_streams_output_from_a_high_numbered_descriptor(self):
+        with _pty_above_fd_setsize() as (master_fd, slave_fd):
+            _assert_select_cannot_reach(master_fd)
+
+            session = SimplePTY("fd-setsize-regression")
+            session.master_fd = master_fd
+            session.running = True
+            reader = threading.Thread(target=session._read_loop, daemon=True)
+            reader.start()
+            try:
+                os.write(slave_fd, b"hello-from-high-fd\n")
+                event_type, content = _drain(session.output_queue)
+
+                # Pre-fix, select() raised immediately, the loop logged the
+                # error, broke, and this first event was ("close", "").
+                assert event_type == "output"
+                assert "hello-from-high-fd" in content
+            finally:
+                session.running = False
+                reader.join(timeout=5.0)
+                assert not reader.is_alive()
+
+    def test_terminates_on_hangup_instead_of_spinning(self):
+        with _pty_above_fd_setsize() as (master_fd, slave_fd):
+            _assert_select_cannot_reach(master_fd)
+
+            session = SimplePTY("fd-setsize-hangup")
+            session.master_fd = master_fd
+            session.running = True
+            reader = threading.Thread(target=session._read_loop, daemon=True)
+            reader.start()
+            try:
+                os.write(slave_fd, b"final line\n")
+                event_type, content = _drain(session.output_queue)
+                assert event_type == "output"
+                assert "final line" in content
+
+                # Closing the slave leaves the master reporting POLLHUP forever.
+                # The loop must read through it (EOF/EIO) and end, not spin.
+                os.close(slave_fd)
+                reader.join(timeout=5.0)
+                assert not reader.is_alive(), "read loop spun on POLLHUP"
+                assert _drain(session.output_queue) == ("close", "")
+            finally:
+                session.running = False
+
+    def test_read_loop_ends_when_the_descriptor_is_closed(self):
+        master, slave = pty.openpty()
+        os.close(master)
+        os.close(slave)
+
+        session = SimplePTY("fd-setsize-closed")
+        session.master_fd = master
+        session.running = True
+        reader = threading.Thread(target=session._read_loop, daemon=True)
+        reader.start()
+        reader.join(timeout=5.0)
+
+        # POLLNVAL surfaces as OSError(EBADF) — the same error select() raised
+        # for a closed descriptor — so the loop still exits rather than looping.
+        assert not reader.is_alive()
+        assert _drain(session.output_queue) == ("close", "")
+
+
+class TestNoSelectSelectInPtyReadinessPaths:
+    """Neither PTY readiness path may reintroduce the FD_SETSIZE-bound API."""
+
+    @pytest.mark.parametrize("source_path", _PTY_READINESS_SOURCES, ids=lambda p: p.name)
+    def test_module_does_not_call_select_select(self, source_path: Path):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        offenders = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "select"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "select"
+        ]
+        assert not offenders, f"{source_path.name} still calls select.select() at line(s) {offenders}"
+
+    @pytest.mark.parametrize("source_path", _PTY_READINESS_SOURCES, ids=lambda p: p.name)
+    def test_module_uses_the_shared_poll_helper(self, source_path: Path):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        imported = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module == "autobot_shared.fd_poll"
+            for alias in node.names
+        }
+        assert "poll_readable" in imported, f"{source_path.name} must use autobot_shared.fd_poll.poll_readable"

--- a/autobot_shared/fd_poll.py
+++ b/autobot_shared/fd_poll.py
@@ -1,0 +1,83 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Single-descriptor readiness polling without the ``select()`` FD_SETSIZE ceiling.
+
+``select.select()`` is bound by the C library's ``FD_SETSIZE`` constant (1024 on
+Linux) regardless of ``RLIMIT_NOFILE``, and CPython raises
+``ValueError: filedescriptor out of range in select()`` for any descriptor at or
+above it. A long-lived single-process backend crosses 1024 open descriptors in
+normal operation (sockets, connection pools, HTTP clients, PTYs), after which
+every newly created descriptor lands above the ceiling and the failure is
+permanent for the life of the process (#13219).
+
+``select.poll()`` has no such ceiling and — unlike ``select.epoll()`` — consumes
+no descriptor of its own, which matters precisely in the situation where
+descriptors are already plentiful.
+
+POSIX only: ``select.poll`` is unavailable on Windows, as is the ``pty`` module
+this helper exists to serve.
+"""
+
+import errno
+import select
+
+# POLLIN (data to read) and POLLPRI (out-of-band data) are the conditions we ask
+# for. POLLHUP, POLLERR and POLLNVAL are reported by poll() whether requested or
+# not, so they are deliberately absent from the requested mask.
+_READ_EVENTS = select.POLLIN | select.POLLPRI
+
+
+def poll_readable(fd: int, timeout_ms: int) -> bool:
+    """Return True when ``fd`` is ready for an ``os.read()`` call.
+
+    Behavioural drop-in for ``bool(select.select([fd], [], [], t)[0])``, with the
+    timeout expressed in **milliseconds** (as ``select.poll().poll()`` requires)
+    rather than seconds: ``0`` polls without blocking, a positive value waits at
+    most that many milliseconds, a negative value blocks indefinitely.
+
+    Hangup (``POLLHUP``) and error (``POLLERR``) count as ready, mirroring how
+    ``select()`` reports an at-EOF descriptor as readable. The caller's existing
+    ``os.read()`` therefore still observes EOF or ``EIO`` and terminates its loop
+    instead of spinning on an undrained hangup.
+
+    Args:
+        fd: Open file descriptor to test for readability.
+        timeout_ms: Wait budget in milliseconds (0 = non-blocking poll).
+
+    Returns:
+        True if a read should be attempted, False if the timeout expired first.
+
+    Raises:
+        OSError: ``EBADF`` when the descriptor is not open (``POLLNVAL``), which
+            is what ``select.select()`` raises for a closed descriptor.
+    """
+    poller = select.poll()
+    poller.register(fd, _READ_EVENTS)
+    events = poller.poll(timeout_ms)
+    if not events:
+        return False
+
+    _, revents = events[0]
+    if revents & select.POLLNVAL:
+        raise OSError(errno.EBADF, f"Bad file descriptor: {fd}")
+    return True
+
+
+def seconds_to_poll_timeout_ms(timeout_seconds: float) -> int:
+    """Convert a ``select()``-style seconds timeout to ``poll()`` milliseconds.
+
+    Rounds up so a sub-millisecond budget never collapses to 0 (a busy-spin);
+    an exact 0 stays 0 (a non-blocking poll, as ``select()`` treats it).
+
+    Args:
+        timeout_seconds: Non-negative timeout in seconds.
+
+    Returns:
+        Equivalent timeout in whole milliseconds.
+    """
+    if timeout_seconds <= 0:
+        return 0
+    return max(1, int(timeout_seconds * 1000 + 0.5))

--- a/autobot_shared/fd_poll_test.py
+++ b/autobot_shared/fd_poll_test.py
@@ -1,0 +1,193 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for autobot_shared.fd_poll (#13219).
+
+The point of the module is that it keeps working for descriptors at or above
+``FD_SETSIZE`` (1024), where ``select.select()`` raises
+``ValueError: filedescriptor out of range in select()``. Every readiness test
+below is therefore also asserted against ``select.select()`` on the same
+descriptor, so the suite proves the ceiling is really gone instead of merely
+exercising a low descriptor where ``select()`` would have worked anyway.
+"""
+
+import errno
+import fcntl
+import os
+import pty
+import resource
+import select
+import time
+from contextlib import contextmanager
+
+import pytest
+
+from autobot_shared.fd_poll import poll_readable, seconds_to_poll_timeout_ms
+
+# FD_SETSIZE on Linux. select() cannot address a descriptor at or above it.
+FD_SETSIZE = 1024
+# First descriptor number we try to relocate a PTY to; comfortably past the ceiling.
+_HIGH_FD_BASE = FD_SETSIZE + 76
+
+
+def _free_fd_at_or_above(start: int) -> int:
+    """Return an unused descriptor number at or above ``start``."""
+    for candidate in range(start, start + 64):
+        try:
+            fcntl.fcntl(candidate, fcntl.F_GETFD)
+        except OSError:
+            return candidate
+    raise RuntimeError(f"no free descriptor number in [{start}, {start + 64})")
+
+
+@contextmanager
+def _pty_above_fd_setsize():
+    """Yield ``(master_fd, slave_fd)`` with ``master_fd`` >= FD_SETSIZE."""
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target = _free_fd_at_or_above(_HIGH_FD_BASE)
+    raised = False
+    if soft <= target:
+        if hard != resource.RLIM_INFINITY and hard <= target:
+            pytest.skip(f"RLIMIT_NOFILE hard limit {hard} cannot reach descriptor {target}")
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target + 1, hard))
+        raised = True
+
+    master, slave = pty.openpty()
+    try:
+        os.dup2(master, target)
+        os.close(master)
+        yield target, slave
+    finally:
+        for fd in (target, slave):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if raised:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+
+
+def _select_rejects(fd: int) -> bool:
+    """True when ``select.select()`` cannot handle ``fd`` (the bug being fixed)."""
+    try:
+        select.select([fd], [], [], 0)
+    except ValueError:
+        return True
+    return False
+
+
+class TestSecondsToPollTimeoutMs:
+    """The seconds -> milliseconds translation the call sites depend on."""
+
+    def test_translates_the_pty_read_loop_interval(self):
+        # The PTY read loop waited select.select(..., 0.01) == 10 ms.
+        assert seconds_to_poll_timeout_ms(0.01) == 10
+
+    def test_zero_stays_a_non_blocking_poll(self):
+        # select.select(..., 0) is a non-blocking probe; poll(0) is the same.
+        assert seconds_to_poll_timeout_ms(0) == 0
+
+    def test_sub_millisecond_budget_never_collapses_to_zero(self):
+        # Rounding 0.0001 s down to 0 ms would turn a wait into a busy-spin.
+        assert seconds_to_poll_timeout_ms(0.0001) == 1
+
+    @pytest.mark.parametrize(
+        ("seconds", "expected_ms"),
+        [(0.02, 20), (0.1, 100), (0.5, 500), (1.0, 1000), (30, 30000)],
+    )
+    def test_common_timeouts(self, seconds, expected_ms):
+        assert seconds_to_poll_timeout_ms(seconds) == expected_ms
+
+
+class TestPollReadableAboveFdSetsize:
+    """The regression: readiness checks must survive descriptors >= 1024."""
+
+    def test_reports_pending_data_where_select_raises(self):
+        with _pty_above_fd_setsize() as (master_fd, slave_fd):
+            assert master_fd >= FD_SETSIZE
+            # Guard against a vacuous pass: select() must genuinely fail here.
+            assert _select_rejects(master_fd), "descriptor is below FD_SETSIZE — test proves nothing"
+
+            os.write(slave_fd, b"hello-from-high-fd\n")
+            assert poll_readable(master_fd, 0) is True
+            assert b"hello-from-high-fd" in os.read(master_fd, 4096)
+
+    def test_reports_idle_descriptor_as_not_ready(self):
+        with _pty_above_fd_setsize() as (master_fd, _slave_fd):
+            assert _select_rejects(master_fd)
+            assert poll_readable(master_fd, 0) is False
+
+    def test_honours_the_millisecond_timeout(self):
+        with _pty_above_fd_setsize() as (master_fd, _slave_fd):
+            started = time.monotonic()
+            assert poll_readable(master_fd, 50) is False
+            elapsed = time.monotonic() - started
+            # Waited roughly the requested 50 ms: not an instant spin, and not
+            # the 50 *seconds* a seconds/milliseconds mix-up would produce.
+            assert 0.02 <= elapsed < 5.0
+
+
+class TestPollReadableEventMask:
+    """POLLHUP / POLLERR / POLLNVAL handling — events poll() reports unasked."""
+
+    def test_hangup_is_ready_so_the_reader_terminates(self):
+        with _pty_above_fd_setsize() as (master_fd, slave_fd):
+            os.write(slave_fd, b"line one\n")
+            os.close(slave_fd)
+
+            # A read loop must drain the buffer and then end, never spin on the
+            # hangup. Two iterations suffice: one data read, one EIO.
+            collected = []
+            ended = False
+            for _ in range(50):
+                if not poll_readable(master_fd, 10):
+                    continue
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError as exc:
+                    assert exc.errno == errno.EIO
+                    ended = True
+                    break
+                if not chunk:
+                    ended = True
+                    break
+                collected.append(chunk)
+
+            assert ended, "read loop spun on POLLHUP instead of terminating"
+            assert b"line one" in b"".join(collected)
+
+    def test_closed_descriptor_raises_ebadf_like_select(self):
+        master, slave = pty.openpty()
+        os.close(master)
+        os.close(slave)
+
+        with pytest.raises(OSError) as excinfo:
+            poll_readable(master, 0)
+        assert excinfo.value.errno == errno.EBADF
+
+        # select() reports the same errno for a closed descriptor, so callers
+        # that already handle OSError keep behaving identically.
+        with pytest.raises(OSError) as select_excinfo:
+            select.select([master], [], [], 0)
+        assert select_excinfo.value.errno == errno.EBADF
+
+
+class TestPollReadableLowFdParity:
+    """Behaviour below the ceiling is unchanged from select()."""
+
+    def test_matches_select_for_a_low_descriptor(self):
+        master, slave = pty.openpty()
+        try:
+            if master >= FD_SETSIZE:
+                pytest.skip("process already holds >= FD_SETSIZE descriptors; select() parity is untestable")
+            assert poll_readable(master, 0) is False
+            assert not select.select([master], [], [], 0)[0]
+
+            os.write(slave, b"x\n")
+            assert poll_readable(master, 10) is True
+            assert select.select([master], [], [], 0.01)[0] == [master]
+        finally:
+            os.close(master)
+            os.close(slave)


### PR DESCRIPTION
Closes #13219

## Thinking Path

`select.select()` is bound by the C library's `FD_SETSIZE` constant — 1024 on Linux — regardless of `RLIMIT_NOFILE` (65536 here). CPython raises `ValueError: filedescriptor out of range in select()` for any descriptor at or above it. The backend is long-lived and single-process, accumulating descriptors across sockets, connection pools, HTTP clients and PTYs, so crossing 1024 is normal operation rather than an exceptional condition — and once crossed the failure is permanent for the life of the process, because every subsequent PTY also lands above the ceiling.

Two readiness sites were affected, both single-descriptor:

- `services/simple_pty.py` — `select.select([fd], [], [], 0.01)` in the reader thread
- `agents/interactive_terminal_agent.py` — `select.select([self.master_fd], [], [], 0)` in `_data_available()`

A repo-wide scan for stdlib `select` usage found no others (every other `select` hit is SQLAlchemy's `select`, or CSS-selector variables).

`select.poll()` is the fix rather than `selectors.DefaultSelector()`: `poll()` has no `FD_SETSIZE` ceiling and, unlike the `epoll` backend `DefaultSelector` picks on Linux, it allocates **no descriptor of its own** — which matters precisely in the situation where descriptors are already plentiful. Both sites are single-fd non-blocking probes, so this stays a drop-in swap; neither loop needed restructuring, and `loop.add_reader()` was rejected as a larger change than the bug warrants (the async site's probe is already non-blocking, and the sync site runs in a thread with no event loop).

## What Changed

**New — `autobot_shared/fd_poll.py`**

- `poll_readable(fd, timeout_ms) -> bool` — behavioural drop-in for `bool(select.select([fd], [], [], t)[0])`, timeout in milliseconds as `poll()` requires.
- `seconds_to_poll_timeout_ms(seconds) -> int` — makes the seconds-to-milliseconds conversion explicit and rounds up so a sub-millisecond budget can never collapse into a busy-spin.

Event-mask handling, since `poll()` reports conditions `select()` folds into "readable":

- `POLLIN`/`POLLPRI` — ready.
- `POLLHUP`/`POLLERR` — ready. This mirrors `select()` reporting an at-EOF descriptor as readable: the caller's existing `os.read()` drains any buffered bytes and then sees EOF or `EIO`, which is what makes the loop `break`. Treating a hangup as *not* ready is what would spin.
- `POLLNVAL` — raises `OSError(EBADF)`, the same errno `select.select()` raises for a closed descriptor, so both loops' existing exception paths terminate exactly as before.

**Call sites**

- `services/simple_pty.py` — `_READ_POLL_TIMEOUT_MS = seconds_to_poll_timeout_ms(TimingConstants.POLL_INTERVAL)` = **10 ms**, the identical wait the loop always used (`TimingConstants.POLL_INTERVAL` is the SSOT `0.01` the literal duplicated).
- `agents/interactive_terminal_agent.py` — `0` seconds becomes `0` milliseconds; both are a non-blocking probe, and the caller keeps doing its own `asyncio.sleep(TimingConstants.POLL_INTERVAL)` when nothing is ready.

No behaviour outside the readiness call changed, and no code was removed beyond the two now-unused `import select` lines.

## Verification

Static analysis only — no application code, service or suite was executed.

`black --check` (line length 120), `isort --check-only`, `flake8` and `mypy` all clean on the five touched files.

A stdlib-only reproduction (importing no project code) confirmed each semantic decision on a real PTY pair with the master relocated to descriptor 1200:

```
1. select() on fd 1200 raised ValueError: filedescriptor out of range in select()
   poll_readable(fd 1200, 0) -> True
   os.read -> b'hello-from-high-fd\r\n'
2. poll_readable(idle, 10ms) -> False elapsed 0.0104s
   poll_readable(idle, 0ms)  -> False elapsed 0.0001s
3. after closing slave, master revents = POLLHUP
   poll_readable -> True
   os.read raised OSError errno=5 (EIO) -> loop breaks
4. revents on closed fd = POLLNVAL
   poll_readable raised OSError errno=9
   select() raised OSError: [Errno 9] Bad file descriptor
5. read loop ended after 2 iteration(s): errno=5
   collected: b'line one\r\n'
```

Step 2 confirms the timeout translation (10 ms waits ~10 ms, not 10 s and not zero); steps 3 and 5 confirm a hangup drains and terminates in two iterations instead of spinning; step 4 confirms `POLLNVAL` and `select()` produce the identical errno.

A second stdlib-only harness ran the post-fix `_read_loop` logic verbatim (copied, not imported) against the same high descriptor, then re-ran it with the pre-fix `select()` line to confirm the new assertion actually discriminates:

```
=== 1. streams output from a high-numbered descriptor ===
   master_fd = 1200 select rejects: True
   first event: ('output', 'hello-from-high-fd\r\n')
=== 2. terminates on hangup instead of spinning ===
   thread alive after slave close: False
   next event: ('close', '')
=== 4. PRE-FIX behaviour with select() on the same high fd ===
   [log] Error in PTY read loop: filedescriptor out of range in select()
   first event (pre-fix): ('close', '') <-- assertion event_type == 'output' FAILS
```

The AST assertions were run directly against both the new and the `origin/Dev_new_gui` versions of the two modules:

```
simple_pty.py offenders: [] | fd_poll imports: ['poll_readable', 'seconds_to_poll_timeout_ms']
interactive_terminal_agent.py offenders: [] | fd_poll imports: ['poll_readable']
PRE-FIX simple_pty.py offenders: [194] | fd_poll imports: []
PRE-FIX interactive_terminal_agent.py offenders: [262] | fd_poll imports: []
```

**Regression tests** (not run here — CI's `python-suite` job executes them):

- `autobot_shared/fd_poll_test.py` — timeout translation, high-descriptor readiness, `POLLHUP` drain-then-terminate, `POLLNVAL`-to-`EBADF` parity with `select()`, and low-descriptor behavioural parity.
- `autobot-backend/tests/test_pty_read_loop_fd_setsize_13219.py` — drives the real `SimplePTY._read_loop` against a PTY master relocated above `FD_SETSIZE`, asserts hangup ends the loop, and AST-asserts neither readiness path reintroduces `select.select()`.

Non-vacuity is enforced structurally: every high-descriptor test first asserts that `select.select()` genuinely raises `ValueError` on that same descriptor and fails the test if it does not, so a run that happened to get a low descriptor cannot pass silently. The AST tests fail deterministically against the pre-fix code even where a high descriptor cannot be allocated.

Not verifiable without executing code: that the fix resolves the live symptom on a running backend that has actually crossed 1024 descriptors. Also out of scope here — whether the descriptor growth is steady-state or a leak, which the issue raises as a separate question and which this change does not address either way.

## Model Used

claude-opus-5
