### PR TITLE
ci: report the slow-test tail so the 99% stall can be diagnosed (#13085)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
           --cov=autobot_shared \
           --cov-report= \
           --tb=short \
+          --durations=25 \
+          --durations-min=10.0 \
           -q
 
         python -m pytest \
@@ -160,6 +162,8 @@ jobs:
           --cov-report=term-missing \
           --cov-fail-under=70 \
           --tb=short \
+          --durations=25 \
+          --durations-min=10.0 \
           -q
 
     - name: Run integration tests


### PR DESCRIPTION
Closes #13085

## Thinking Path

CI keeps stalling near 99%, and every diagnosis so far has been inference rather than observation — because neither pytest invocation reports durations, so the slow tail is invisible.

What the timing data actually shows, across four completed full-suite runs today:

| run | pytest self-reported | job wall-clock | overhead |
|---|---|---|---|
| post-#13271 | 4032s (1:07:12) | 4247s | ~215s |
| post-#13275 | 6296s (1:44:56) | 6473s | ~177s |
| post-#13276 | 6673s (1:51:13) | ~6700s | small |

Two things follow. **The stall is inside pytest, not around it** — setup/teardown is consistently ~3 minutes, so there is no gap outside the run to explain the variance. And **the spread for identical work is 65%** (4032s → 6673s), which is the signature of one worker holding the run open while the rest idle. Under `-n auto --dist loadscope` a single heavy scope lands entirely on one worker.

#13085 attributed the stall to LLC poll loops, on a `py-spy` sample showing a wake time advancing by exactly 300.1s. That fix (PR #13209, `ad7c151a7`) was correct on its own merits — it removed a real production defect where a masked cancellation re-armed a full poll interval — but it could not have been the cause here: **nothing in the suite starts `BudgetWatchdog` / `LivenessMonitor` / `SessionCheckpointer`**, which #13085 itself established. The symptom persists.

## What Changed

`--durations=25 --durations-min=10.0` on both pytest invocations in `.github/workflows/ci.yml`.

`--durations-min=10.0` keeps the output to genuinely slow tests rather than 25 lines of noise on a fast run.

## Verification

`yaml.safe_load` parses the workflow. Both invocations carry the flags. No test, dependency or behaviour change — this only adds reporting to a job that already runs.

This is a **prerequisite for a fix, not a fix**. It makes the tail observable so the next diagnosis can be made from evidence rather than inferred from a sampled stack.

## Model Used

Claude Opus 5
