### PR TITLE
perf(ci): cut ~20 min from the PR gate — mark four unassertive scripts, fix four slow tests (#13284)

### DIFF
--- a/autobot-backend/agents/web_researcher_test.py
+++ b/autobot-backend/agents/web_researcher_test.py
@@ -78,6 +78,14 @@ class TestAcquireBeforeResearch:
         proceeding — matches the retired local RateLimiter's semantics."""
         researcher = WebResearcher({"enabled": True, "rate_limit_requests": 3, "rate_limit_window": 45})
         researcher.rate_limiter.acquire_window = AsyncMock(return_value=True)
+        # #13284: acquire_window is the only thing under test, but
+        # conduct_research goes on to `asyncio.create_task(self.search_web(...))`
+        # and awaits it under `wait_for(timeout=self.timeout_seconds)`. Left
+        # unmocked that is a real outbound web search, and this test measured
+        # 29.74s on CI — a search timeout expiring, not verification. Stubbing
+        # search_web keeps every assertion below intact (acquire_window must
+        # still be called first, with these arguments) and removes the network.
+        researcher.search_web = AsyncMock(return_value={"status": "success", "results": []})
 
         await researcher.conduct_research("test query")
 

--- a/autobot-backend/api/security_endpoints_e2e_test.py
+++ b/autobot-backend/api/security_endpoints_e2e_test.py
@@ -13,9 +13,20 @@ import sys
 from pathlib import Path
 
 import aiohttp
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from tests.test_helpers import get_test_backend_url
+
+# #13284: this module boots the whole backend — `subprocess.Popen([python,
+# "main.py"])` in its own process group — then polls /api/hello for up to 20
+# seconds before touching any endpoint. That startup budget is the 25.22s the
+# durations report attributes to `test_security_endpoints`; none of it is
+# verification. Like every other check here it carries no assertions (each
+# endpoint result is printed, failures included), so excluding it from the PR
+# gate loses no coverage. `integration` is already filtered by both pytest
+# invocations in .github/workflows/ci.yml.
+pytestmark = pytest.mark.integration
 
 
 async def _poll_server_ready(timeout: float = 2.0) -> bool:

--- a/autobot-backend/auth_rbac_admin_guard_test.py
+++ b/autobot-backend/auth_rbac_admin_guard_test.py
@@ -22,6 +22,7 @@ for both backends, so it needs a cross-backend review rather than a drive-by.
 """
 
 import ast
+import functools
 import pathlib
 
 import pytest
@@ -93,16 +94,55 @@ def _python_files():
         yield path
 
 
-def test_no_hand_rolled_admin_role_comparisons():
-    """Use ``is_admin_role()`` instead — it admits superadmin, as guards do."""
-    offenders = []
+def _may_contain_offender(source: str) -> bool:
+    """Cheap text prefilter: can *source* possibly hold an offending compare?
+
+    ``_offenders_in`` only ever flags a comparison that pairs a ``role``-ish
+    operand (name/attribute/subscript/kwarg all matched on the text ``role``)
+    with one of :data:`ADMIN_ROLE_LITERALS` (all three contain ``admin``). A
+    file whose source contains neither substring cannot produce a hit, so it
+    never needs parsing.
+
+    This is what makes the guard affordable (#13284): ``ast.walk`` plus the
+    per-node loop in ``_offenders_in`` is pure Python, so under ``--cov`` every
+    one of ~2.7M AST nodes is traced. The prefilter is a C-level ``str.lower``
+    and ``in``, and drops ~2,170 backend files to ~90 — a ~96% cut in nodes
+    walked.
+
+    Known limit: a literal spelled indirectly (``"ad" "min"``, ``"\\x61dmin"``)
+    would be skipped. Every call site in this repo spells it plainly, and
+    ``TestGuardDetection`` still pins the AST shapes the matcher must catch.
+    """
+    lowered = source.lower()
+    return "admin" in lowered and "role" in lowered
+
+
+@functools.lru_cache(maxsize=1)
+def _hand_rolled_admin_comparisons() -> tuple[str, ...]:
+    """``path:line`` for every hand-rolled admin-role comparison in the backend.
+
+    Cached so repeat callers (and reruns within a session) pay the sweep once.
+    """
+    offenders: list[str] = []
     for path in _python_files():
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not _may_contain_offender(source):
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
             continue
         for line in _offenders_in(tree):
             offenders.append(f"{path.relative_to(BACKEND_ROOT)}:{line}")
+    return tuple(sorted(offenders))
+
+
+def test_no_hand_rolled_admin_role_comparisons():
+    """Use ``is_admin_role()`` instead — it admits superadmin, as guards do."""
+    offenders = _hand_rolled_admin_comparisons()
 
     assert not offenders, (
         "Hand-rolled admin-role comparison(s) found — a superadmin is admitted by "

--- a/autobot-backend/auth_rbac_admin_guard_test.py
+++ b/autobot-backend/auth_rbac_admin_guard_test.py
@@ -103,6 +103,14 @@ def _may_contain_offender(source: str) -> bool:
     file whose source contains neither substring cannot produce a hit, so it
     never needs parsing.
 
+    Known limit: any *obfuscated* spelling of the literal defeats the prefilter —
+    implicit concatenation (``"ad" "min"``), escape sequences (``"\x61dmin"``,
+    ``"\u0061dmin"``), an escaped subscript key (``d["\x72ole"]``), or an
+    NFKC-normalised identifier (``ｒｏｌｅ``). Each is a hit for the matcher whose
+    source text lacks the substring. Verified zero such constructs exist across
+    all 2,171 backend files; someone writing one is defeating a lint guard
+    deliberately, not tripping one accidentally.
+
     This is what makes the guard affordable (#13284): ``ast.walk`` plus the
     per-node loop in ``_offenders_in`` is pure Python, so under ``--cov`` every
     one of ~2.7M AST nodes is traced. The prefilter is a C-level ``str.lower``
@@ -127,8 +135,14 @@ def _hand_rolled_admin_comparisons() -> tuple[str, ...]:
     for path in _python_files():
         try:
             source = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        except UnicodeDecodeError:
+            # A non-UTF-8 source cannot hold the ASCII literals this guard matches on.
             continue
+        except OSError as exc:
+            # #13284: do NOT skip silently. Before the prefilter this read was not
+            # wrapped, so an unreadable file failed the run. An unreadable file inside
+            # a security guard is exactly where an offender could hide, so keep it loud.
+            raise AssertionError(f"admin-role guard could not read {path}: {exc}") from exc
         if not _may_contain_offender(source):
             continue
         try:

--- a/autobot-backend/security/security_api_e2e_test.py
+++ b/autobot-backend/security/security_api_e2e_test.py
@@ -10,11 +10,27 @@ import asyncio
 import os
 import sys
 
+import pytest
+
 # Add src directory to path
 sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 
 from secure_command_executor import SecureCommandExecutor
 from security_layer import SecurityLayer
+
+# #13284: this module is an operator-facing e2e script, not a unit test. It
+# builds a live SecurityLayer and *actually executes* shell commands through it
+# (`sudo apt update`, `rm -rf /tmp/test`, `mkdir /tmp/secure_test`) and shells
+# out to the `docker` CLI. On a runner with no Docker daemon and no sudo those
+# calls sit on their timeouts — `test_security_layer` measured 600.01s, a flat
+# budget expiring rather than work being done, 15% of the whole suite.
+#
+# It carries no assertions, so the PR gate loses no verification by excluding
+# it; every branch prints its result and swallows the exception. The
+# `integration` marker matches the filename and is already excluded by the two
+# `-m "not integration and not slow and not distributed and not performance"`
+# invocations in .github/workflows/ci.yml.
+pytestmark = pytest.mark.integration
 
 
 async def test_security_layer():

--- a/autobot-backend/security/security_edge_cases_test.py
+++ b/autobot-backend/security/security_edge_cases_test.py
@@ -574,8 +574,25 @@ class TestSecurityBoundaryConditions:
         result = await self.security.execute_command("echo 'test'", user="test", user_role="test")
         assert isinstance(result, dict)
 
+    @pytest.mark.slow
     async def test_maximum_command_length(self):
-        """Test handling of extremely long commands"""
+        """Test handling of extremely long commands.
+
+        #13284: marked ``slow`` (29.39s). Unlike the other entries in that
+        tail this is not an accident — the test deliberately feeds
+        ``assess_command_risk()`` 1.1MB of command text across four lengths and
+        the time is real regex work on a pathological input, so there is
+        nothing to mock away without dropping the 1,000,000-char boundary the
+        test exists to cover. Both pytest invocations in
+        .github/workflows/ci.yml filter ``slow``, and no scheduled workflow
+        currently re-runs marker-excluded tests, so this boundary moves off CI
+        entirely until such a job exists — the one real coverage loss in
+        #13284, recorded there rather than papered over.
+
+        The superlinear cost itself is a separate finding: 29s to classify
+        1.1MB is a resource-exhaustion smell in the risk assessor, not in this
+        test.
+        """
         # Test various command lengths
         lengths = [1000, 10000, 100000, 1000000]
 

--- a/autobot-backend/security/security_edge_cases_test.py
+++ b/autobot-backend/security/security_edge_cases_test.py
@@ -585,13 +585,13 @@ class TestSecurityBoundaryConditions:
         nothing to mock away without dropping the 1,000,000-char boundary the
         test exists to cover. Both pytest invocations in
         .github/workflows/ci.yml filter ``slow``, and no scheduled workflow
-        currently re-runs marker-excluded tests, so this boundary moves off CI
-        entirely until such a job exists — the one real coverage loss in
-        #13284, recorded there rather than papered over.
+        currently re-runs marker-excluded tests (#13286), so this boundary
+        moves off CI entirely until such a job exists — the one real coverage
+        loss in #13284, recorded rather than papered over.
 
-        The superlinear cost itself is a separate finding: 29s to classify
-        1.1MB is a resource-exhaustion smell in the risk assessor, not in this
-        test.
+        The superlinear cost itself is a separate finding (#13285): 29s to
+        classify 1.1MB is a resource-exhaustion smell in the risk assessor,
+        not in this test.
         """
         # Test various command lengths
         lengths = [1000, 10000, 100000, 1000000]

--- a/autobot-backend/security/security_edge_cases_test.py
+++ b/autobot-backend/security/security_edge_cases_test.py
@@ -574,37 +574,39 @@ class TestSecurityBoundaryConditions:
         result = await self.security.execute_command("echo 'test'", user="test", user_role="test")
         assert isinstance(result, dict)
 
-    @pytest.mark.slow
-    async def test_maximum_command_length(self):
+    @pytest.mark.parametrize(
+        "length",
+        [1000, 10000, 100000, pytest.param(1000000, marks=pytest.mark.slow)],
+    )
+    async def test_maximum_command_length(self, length):
         """Test handling of extremely long commands.
 
-        #13284: marked ``slow`` (29.39s). Unlike the other entries in that
-        tail this is not an accident — the test deliberately feeds
-        ``assess_command_risk()`` 1.1MB of command text across four lengths and
-        the time is real regex work on a pathological input, so there is
-        nothing to mock away without dropping the 1,000,000-char boundary the
-        test exists to cover. Both pytest invocations in
-        .github/workflows/ci.yml filter ``slow``, and no scheduled workflow
-        currently re-runs marker-excluded tests (#13286), so this boundary
-        moves off CI entirely until such a job exists — the one real coverage
-        loss in #13284, recorded rather than papered over.
+        #13284: only the 1,000,000-char case is marked ``slow``. The whole test
+        measured 29.39s on CI, but ``assess_command_risk()`` is superlinear
+        (#13285), so the 1M entry is the overwhelming majority of that — even
+        under a purely linear model it is 90% of the 1.111M total characters.
+        The 1K/10K/100K boundaries cost almost nothing and stay on the gate.
 
-        The superlinear cost itself is a separate finding (#13285): 29s to
-        classify 1.1MB is a resource-exhaustion smell in the risk assessor,
-        not in this test.
+        This matters because marking is not relocation: no scheduled workflow
+        selects marker-excluded tests (#13286), so a mark removes a case from CI
+        entirely. Marking the whole test would have dropped three boundaries as
+        collateral for the one that is genuinely expensive.
+
+        Note this asserts no time bound, so it never guarded the superlinearity
+        in #13285 — it would pass just as happily at 29 minutes.
         """
-        # Test various command lengths
-        lengths = [1000, 10000, 100000, 1000000]
-
-        for length in lengths:
-            long_command = "echo '" + "A" * length + "'"
-            try:
-                risk, warnings = self.security.command_executor.assess_command_risk(long_command)
-                # Should handle without crashing
-                assert isinstance(risk, CommandRisk)
-            except Exception as e:
-                # Should be controlled resource limitations
-                assert "too long" in str(e).lower() or "memory" in str(e).lower()
+        long_command = "echo '" + "A" * length + "'"
+        try:
+            risk, warnings = self.security.command_executor.assess_command_risk(long_command)
+        except Exception as e:
+            # Should be controlled resource limitations
+            assert "too long" in str(e).lower() or "memory" in str(e).lower()
+        else:
+            # #13284: asserted outside the try. Previously this sat inside it, so an
+            # AssertionError was caught by `except Exception` and re-judged against
+            # the "too long"/"memory" message — still failing, but with a thoroughly
+            # misleading reason.
+            assert isinstance(risk, CommandRisk)
 
     async def test_zero_length_inputs(self):
         """Test handling of zero-length and minimal inputs"""

--- a/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_web_crawler.py
@@ -636,6 +636,14 @@ class TestFetchPageHttpErrorLabelling:
 
     async def test_connection_failure_labelled_connection(self) -> None:
         connector = WebCrawlerConnector(_make_config(["https://x"]))
+        # #13284: a (None, None) fetch is retryable, so fetch_with_retry burns
+        # its production backoff — backoff_time() is 2**(attempt-1), and
+        # max_attempts=5 means real sleeps of 1+2+4+8 = 15s. That is exactly
+        # the 15.02s the durations report attributes to this test; there is no
+        # network call here (the module mocks all I/O). Collapsing the delay
+        # keeps all five attempts and the retry-exhaustion path intact — only
+        # the wall-clock wait goes.
+        connector.backoff_time = lambda attempt: 0.0
         fetcher = WebFetcher(robots_cache=None)
 
         async def _side_effect(url, timeout=30.0):

--- a/autobot-backend/utils/concurrency_safety_test.py
+++ b/autobot-backend/utils/concurrency_safety_test.py
@@ -52,6 +52,10 @@ class TestTerminalBufferRace:
         # still resets through the same _output_lock path, so the assertion
         # underneath is unchanged.
         terminal.chat_history_manager.add_message = AsyncMock()
+        # #13284: send_output also calls _log_to_transcript, which does a real
+        # aiofiles append per write whenever conversation_id is set — 100 more
+        # filesystem round-trips that have nothing to do with the buffer race.
+        terminal._log_to_transcript = AsyncMock()
 
         # Simulate 100 concurrent output writes
         async def write_output(text: str):

--- a/autobot-backend/utils/concurrency_safety_test.py
+++ b/autobot-backend/utils/concurrency_safety_test.py
@@ -43,6 +43,16 @@ class TestTerminalBufferRace:
             redis_client=mock_redis,
         )
 
+        # #13284: passing conversation_id makes __init__ build a real
+        # ChatHistoryManager, and every "Output i\n" contains a newline, so
+        # _save_to_chat_buffered persists on all 100 writes. That is real chat
+        # persistence, not buffer-race verification, and it measured 51.22s on
+        # CI — the second-largest entry in the suite. Stub the save the same way
+        # test_buffer_lock_prevents_interleaving below already does; the buffer
+        # still resets through the same _output_lock path, so the assertion
+        # underneath is unchanged.
+        terminal.chat_history_manager.add_message = AsyncMock()
+
         # Simulate 100 concurrent output writes
         async def write_output(text: str):
             await terminal.send_output(text)

--- a/autobot-backend/utils/file_locking_test.py
+++ b/autobot-backend/utils/file_locking_test.py
@@ -313,7 +313,15 @@ class TestConcurrentFileWriteSafety:
 
     @pytest.mark.asyncio
     async def test_concurrent_writes_same_file_no_corruption(self):
-        """Test that concurrent writes to same file don't corrupt data"""
+        """Test that concurrent writes to same file don't corrupt data.
+
+        #13284 measured this at 13.62s on CI and deliberately left it alone:
+        it is not the module's first import of api.filesystem_mcp (that is
+        test_file_locks_dict_exists above), so the usual first-import
+        explanation does not apply, and no other cause was identified. The
+        assertions are a real corruption guard (#514) worth keeping on the PR
+        gate, so it is not marked. Cause tracked in #13287.
+        """
         import aiofiles
 
         from api.filesystem_mcp import _get_file_lock

--- a/autobot-backend/utils/simple_optimization_test.py
+++ b/autobot-backend/utils/simple_optimization_test.py
@@ -9,10 +9,25 @@ import asyncio
 import sys
 import time
 
+import pytest
+
 from autobot_shared.ssot_config import config
 
 # Add AutoBot to path
 sys.path.insert(0, config.project_root)
+
+# #13284: this module is a GPU throughput probe, not a unit test — it loads the
+# real embedding model behind `get_optimized_semantic_chunker()`, chunks a
+# sample text and prints sentences/sec. Model load is the 133.00s the durations
+# report attributes to `test_direct_optimization` (3% of the suite), and the
+# number it produces is meaningless on a CI runner with no RTX 4070.
+#
+# Nothing is asserted: every path is wrapped in `try/except` that prints and
+# returns False, so the check cannot fail today and the PR gate loses no
+# verification. `performance` is the accurate marker (the file measures
+# throughput) and is already excluded by both pytest invocations in
+# .github/workflows/ci.yml.
+pytestmark = pytest.mark.performance
 
 
 async def test_direct_optimization():


### PR DESCRIPTION
Closes #13284

## Thinking Path

#13284 measured the tail with `--durations`: nine tests over 10s, ~1,252s of a 4,123s run. The issue's own instinct was right — but "mark it slow" and "fix it" are different answers and the tail needed splitting one test at a time, because marking hides cost whereas fixing keeps the coverage on the gate.

Reading each of the nine gave three distinct categories, not one:

**Not tests at all (4 of the 9, 758.23s).** `security/security_api_e2e_test.py`, `api/security_endpoints_e2e_test.py` and `utils/simple_optimization_test.py` are operator-facing scripts with a `main()`, an `if __name__ == "__main__"`, print-driven output and **zero assertions** — every branch prints its result and swallows the exception, so none of them can fail. The first builds a live `SecurityLayer` and really executes destructive shell commands through it; the second `subprocess.Popen`s the whole backend and polls `/api/hello` for 20s; the third loads the real embedding model to print sentences/sec. They are the clean case for a marker: the gate loses no verification because there was none.

**Accidentally slow (3 of the 9, 95.98s).** Each was paying for production I/O that its assertions never asked for. `TestAcquireBeforeResearch` asserts only that `acquire_window` is called first, then let `conduct_research` run a real outbound web search. `TestTerminalBufferRace` passes a `conversation_id`, which makes `__init__` build a real `ChatHistoryManager`, and every `"Output i\n"` contains a newline — so all 100 writes persisted for real, while the sibling test 30 lines below already stubs exactly that. `TestFetchPageHttpErrorLabelling::test_connection_failure_labelled_connection` is not a network call at all (the module mocks all I/O) — `(None, None)` is retryable, and `2**(attempt-1)` over `max_attempts=5` is `1+2+4+8` = 15s of real `asyncio.sleep`, which is exactly the 15.02s observed. All three are fixed and stay on the gate.

**Real work (1 of the 9, 29.39s).** `test_maximum_command_length` feeds `assess_command_risk()` 1.1MB across four lengths. The time is genuine regex work and nothing can be mocked away without dropping the 1,000,000-char boundary the test exists to cover, so it is marked `slow` — the only real coverage loss here, and 29s to classify 1.1MB is itself a finding (#13285).

The 354.80s AST guard is its own case. The issue proposed `lru_cache`; that alone would have saved **nothing**, because the scan has exactly one caller and runs once. The actual cost is that `ast.walk` plus the per-node loop in `_offenders_in` is pure Python over 2.68M nodes. An offending comparison always pairs a role-ish operand with one of `admin`/`superadmin`/`platform_admin`, so a file whose source contains neither `admin` nor `role` cannot produce a hit and never needs parsing — and that check is C-level. `lru_cache` is added too, but the prefilter is what buys the time.

`file_locking_test.py`'s 13.62s is **left alone**. The first-import explanation that solved the 51.22s sibling does not apply (`api.filesystem_mcp` is already imported 200 lines earlier in the same module), no other cause was found, and marking a real corruption guard to hide 0.3% of the run would be the wrong trade. Recorded in #13287 rather than papered over.

## What Changed

| Test | Was | Action | Why |
|---|---|---|---|
| `security/security_api_e2e_test.py::test_security_layer` | 600.01s | **marked** `integration` (module) | e2e script, zero assertions, executes real destructive shell commands + `docker` CLI |
| `auth_rbac_admin_guard_test.py::test_no_hand_rolled_admin_role_comparisons` | 354.80s | **fixed**, stays on gate | text prefilter before `ast.parse`; + `lru_cache` |
| `utils/simple_optimization_test.py::test_direct_optimization` | 133.00s | **marked** `performance` (module) | GPU throughput probe, zero assertions, loads real model |
| `utils/concurrency_safety_test.py::TestTerminalBufferRace::test_concurrent_buffer_access` | 51.22s | **fixed**, stays on gate | stub `add_message` — 100 real chat persists, as the sibling test already stubs |
| `agents/web_researcher_test.py::TestAcquireBeforeResearch::…` | 29.74s | **fixed**, stays on gate | stub `search_web` — real outbound search under a `wait_for` timeout |
| `security/security_edge_cases_test.py::…::test_maximum_command_length` | 29.39s | **marked** `slow` | genuine regex work on 1.1MB; nothing to mock |
| `api/security_endpoints_e2e_test.py::test_security_endpoints` | 25.22s | **marked** `integration` (module) | boots the backend via `subprocess.Popen`, zero assertions |
| `tests/…/test_web_crawler.py::…::test_connection_failure_labelled_connection` | 15.02s | **fixed**, stays on gate | collapse retry backoff (1+2+4+8s); not a network call |
| `utils/file_locking_test.py::…::test_concurrent_writes_same_file_no_corruption` | 13.62s | **left alone** | cause not identified; real corruption guard (#514); tracked in #13287 |

No assertion is weakened, deleted or made vacuous. Every fixed test keeps its assertions verbatim — only the I/O beneath them is stubbed. The marked modules had no assertions to lose except `test_maximum_command_length`.

Markers used are the ones already registered in `pytest.ini` and already filtered by both invocations in `ci.yml` — no new machinery. Module-level `pytestmark`, not per-test decorators.

## Verification

No application code was executed (static analysis only, per the task constraint).

**AST guard — result-equivalence and cost, measured with a stdlib-only script:**

```
old sweep: 6.36s  offenders=0
new sweep: 0.76s  offenders=0
cached rerun: 2.9us
EQUIVALENT: True
prefilter keeps 89/2171 files
TestGuardDetection cases: OK
```

```
AST nodes walked BEFORE: 2,680,553
AST nodes walked AFTER:    245,943  (9.18%)
```

Both algorithms return byte-identical results; parsed volume drops 26.1MB → 2.5MB; all 11 `TestGuardDetection` cases still classify correctly.

**Marker mechanism**, verified against synthetic files under `--strict-markers` with `pytest.ini`'s registered markers (no application code imported):

```
$ pytest . --collect-only -q -m "not integration and not slow and not distributed and not performance"
sample_slow_test.py::TestBoundary::test_other
1/5 tests collected (4 deselected) in 0.01s
```

Module-level `pytestmark` deselects the whole module including `async def` tests; the per-method `@pytest.mark.slow` deselects only that method — the two shapes used here.

**Lint:** `black --check --line-length 120`, `flake8` and `isort --check-only` all clean on the nine touched files; every file re-parses under `ast.parse`.

**Expected saving.** ~817s removed outright by the four markers (600.01 + 133.00 + 29.39 + 25.22). ~96s removed by the three fixes, which should now cost near zero. The AST guard scales by the measured ~8.4x with 9.18% of the nodes walked, so ~355s → roughly 40s, saving ~315s. **Total ≈ 1,230s (~20 min) off a 4,123s run — about 30%.**

The one figure I cannot pin down is the CI multiplier itself: the guard costs 6.4s locally and 354.8s on CI, and none of the mechanisms I could check statically (coverage omits `*_test.py`; `ast.walk` is stdlib and untraced) explains 55x. Whatever it is, it scales with work done, and the work is down 91% — but the residual could land anywhere from ~10s to ~40s.

**Coverage moved off the PR gate:** exactly one assertion, `test_maximum_command_length`'s 1,000,000-char boundary. There is **no nightly job to catch it** — no workflow anywhere runs a `slow`/`integration`/`performance`/`distributed` test, which is itself filed as #13286. The other three marked modules assert nothing, so nothing moves.

**Not verified without executing code:** that the marked tests are in fact deselected in a real run of this suite; the post-fix durations; and the cause of the 13.62s in `file_locking_test.py`.

**Filed while triaging:** #13285 (`assess_command_risk()` superlinear on large input — a resource-exhaustion smell on the command-execution path), #13286 (marker-excluded tests run in no workflow at all), #13287 (the unexplained 13.62s).

## Model Used

claude-opus-5
