### PR TITLE
fix(analytics): embedding usage analytics report $0 forever — two bytes-key readers on a decoded client (#13278)

### DIFF
--- a/autobot-backend/api/analytics_embedding_patterns.py
+++ b/autobot-backend/api/analytics_embedding_patterns.py
@@ -39,6 +39,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientLockedMixin
+from autobot_shared.redis_utils import decode_redis_value
 from constants.ttl_constants import TTL_30_DAYS, TTL_90_DAYS
 
 router = APIRouter()
@@ -244,18 +245,25 @@ class EmbeddingPatternAnalyzer(AsyncRedisClientLockedMixin):
             logger.error("Failed to update embedding stats: %s", e)
 
     def _sum_daily_stats(self, all_stats: list) -> tuple:
-        """Aggregate daily Redis stats into counters. Ref: #1088."""
+        """Aggregate daily Redis stats into counters. Ref: #1088.
+
+        ``_update_stats`` writes these fields with ``hincrby``/``hincrbyfloat``
+        under ``str`` names and the shared client is ``decode_responses=True``,
+        so ``hgetall`` yields ``str`` keys. Probing with bytes literals never
+        matched, so every counter fell through to its default and the whole
+        endpoint reported zero operations and $0.00 cost (#13278).
+        """
         ops = tokens = documents = batch = successful = 0
         cost = processing_time = 0.0
         for stats in all_stats:
             if stats:
-                ops += int(stats.get(b"total_operations", 0))
-                tokens += int(stats.get(b"total_tokens", 0))
-                documents += int(stats.get(b"total_documents", 0))
-                cost += float(stats.get(b"total_cost", 0))
-                processing_time += float(stats.get(b"total_processing_time", 0))
-                batch += int(stats.get(b"total_batch_size", 0))
-                successful += int(stats.get(b"successful_operations", 0))
+                ops += int(decode_redis_value(stats.get("total_operations")) or 0)
+                tokens += int(decode_redis_value(stats.get("total_tokens")) or 0)
+                documents += int(decode_redis_value(stats.get("total_documents")) or 0)
+                cost += float(decode_redis_value(stats.get("total_cost")) or 0)
+                processing_time += float(decode_redis_value(stats.get("total_processing_time")) or 0)
+                batch += int(decode_redis_value(stats.get("total_batch_size")) or 0)
+                successful += int(decode_redis_value(stats.get("successful_operations")) or 0)
         return ops, tokens, documents, cost, processing_time, batch, successful
 
     async def get_stats(
@@ -312,15 +320,20 @@ class EmbeddingPatternAnalyzer(AsyncRedisClientLockedMixin):
             logger.error("Failed to get embedding stats: %s", e)
             return {"status": "error", "error": "Internal server error"}
 
-    def _parse_model_stats(self, key: bytes, stats: dict) -> dict | None:
-        """Parse model stats from Redis hash. (Issue #315 - extracted)"""
+    def _parse_model_stats(self, key: str | bytes, stats: dict) -> dict | None:
+        """Parse model stats from Redis hash. (Issue #315 - extracted)
+
+        Same decoded-client key shape as ``_sum_daily_stats``: the per-model
+        hash is written by ``_update_stats`` with ``str`` field names, so the
+        bytes probes always missed and every model reported 0 ops / $0 (#13278).
+        """
         if not stats:
             return None
-        key_str = key.decode() if isinstance(key, bytes) else key
+        key_str = decode_redis_value(key) or ""
         model_name = key_str.split(":")[-1]
-        total_ops = int(stats.get(b"total_operations", 0))
-        total_tokens = int(stats.get(b"total_tokens", 0))
-        total_cost = float(stats.get(b"total_cost", 0))
+        total_ops = int(decode_redis_value(stats.get("total_operations")) or 0)
+        total_tokens = int(decode_redis_value(stats.get("total_tokens")) or 0)
+        total_cost = float(decode_redis_value(stats.get("total_cost")) or 0)
         return {
             "model": model_name,
             "total_operations": total_ops,

--- a/autobot-backend/api/analytics_embedding_patterns_stats_keys_test.py
+++ b/autobot-backend/api/analytics_embedding_patterns_stats_keys_test.py
@@ -1,0 +1,223 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Embedding analytics must report the figures the writer actually stored (#13278).
+
+``EmbeddingPatternAnalyzer._update_stats`` writes every counter with
+``pipe.hincrby(daily_key, "total_operations", 1)`` and
+``pipe.hincrbyfloat(daily_key, "total_cost", cost)`` — ``str`` field names. Its
+client comes from ``AsyncRedisClientLockedMixin`` →
+``get_async_redis_client(database=RedisDatabase.ANALYTICS)``, and the shared
+async pool is ``decode_responses=True``
+(``redis_management/connection_manager.py:500`` reading
+``config.decode_responses``, which defaults ``True`` at
+``redis_management/config.py:61,153`` with no per-database override). So
+``hgetall`` hands back a ``str``-keyed dict.
+
+Both readers probed it with bytes literals::
+
+    ops  += int(stats.get(b"total_operations", 0))
+    cost += float(stats.get(b"total_cost", 0))
+
+Every lookup missed, every default was returned, and ``int(0)``/``float(0)``
+succeeded — so ``GET .../stats`` and ``GET .../model-comparison`` reported zero
+operations, zero tokens and $0.00 cost forever, no matter how much
+vectorization had run. No exception, no log line.
+
+The round-trip tests below drive the real ``record_usage`` → ``_update_stats``
+writer into the real ``get_stats``/``get_model_comparison`` readers over one
+shared hash, so any future writer/reader key drift breaks the suite rather than
+silently zeroing the endpoint again.
+"""
+
+import pytest
+
+from api.analytics_embedding_patterns import EmbeddingPatternAnalyzer
+from api.schemas_analytics import EmbeddingUsageRequest
+
+# text-embedding-3-small bills 0.02 USD / 1M tokens with no compute cost, so
+# 1500 tokens is a small but strictly non-zero figure — exactly the kind of
+# value the bug replaced with 0.0.
+MODEL = "text-embedding-3-small"
+TOKENS = 1500
+EXPECTED_COST_PER_OP = TOKENS / 1_000_000 * 0.02
+
+
+class _FakePipeline:
+    """Buffered pipeline with redis-py asyncio's awaitable-command shape."""
+
+    def __init__(self, store):
+        self._store = store
+        self._queued = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def hincrby(self, key, field, amount=1):
+        self._queued.append(lambda: self._store.raw_hincrby(key, field, amount))
+
+    async def hincrbyfloat(self, key, field, amount):
+        self._queued.append(lambda: self._store.raw_hincrbyfloat(key, field, amount))
+
+    async def hgetall(self, key):
+        self._queued.append(lambda: self._store.raw_hgetall(key))
+
+    async def expire(self, key, ttl):
+        self._queued.append(lambda: True)
+
+    async def execute(self):
+        results = [op() for op in self._queued]
+        self._queued.clear()
+        return results
+
+
+class _FakeAsyncRedis:
+    """Dict-backed stand-in that stores hash fields the way Redis does.
+
+    HINCRBY and HINCRBYFLOAT both persist their result as a decimal *string*
+    under a ``str`` field name; ``decoded`` selects whether the client hands
+    those values back as ``str`` (the live ``decode_responses=True`` shape) or
+    as ``bytes`` (a client configured without it).
+    """
+
+    def __init__(self, decoded=True):
+        self._hashes = {}
+        self._decoded = decoded
+
+    # -- raw storage ---------------------------------------------------
+    def raw_hincrby(self, key, field, amount):
+        bucket = self._hashes.setdefault(key, {})
+        bucket[field] = str(int(bucket.get(field, "0")) + amount)
+        return int(bucket[field])
+
+    def raw_hincrbyfloat(self, key, field, amount):
+        bucket = self._hashes.setdefault(key, {})
+        bucket[field] = repr(float(bucket.get(field, "0")) + amount)
+        return float(bucket[field])
+
+    def raw_hgetall(self, key):
+        bucket = self._hashes.get(key, {})
+        if self._decoded:
+            return dict(bucket)
+        # Field names stay str; only the values arrive as bytes.
+        return {k: v.encode() for k, v in bucket.items()}
+
+    # -- client surface ------------------------------------------------
+    def pipeline(self):
+        return _FakePipeline(self)
+
+    async def setex(self, key, ttl, value):
+        return True
+
+    async def scan(self, cursor, match=None, count=None):
+        prefix = match[:-1] if match and match.endswith("*") else match
+        keys = [k for k in self._hashes if prefix is None or k.startswith(prefix)]
+        if not self._decoded:
+            keys = [k.encode() for k in keys]
+        return 0, keys
+
+
+def _analyzer(decoded=True):
+    analyzer = EmbeddingPatternAnalyzer()
+    analyzer._redis = _FakeAsyncRedis(decoded=decoded)
+    return analyzer
+
+
+def _request(success=True):
+    return EmbeddingUsageRequest(
+        model=MODEL,
+        token_count=TOKENS,
+        document_count=3,
+        batch_size=10,
+        processing_time=0.5,
+        success=success,
+    )
+
+
+async def _record(analyzer, times=2):
+    for _ in range(times):
+        result = await analyzer.record_usage(_request())
+        assert result["status"] == "recorded", result
+    return analyzer
+
+
+@pytest.mark.asyncio
+async def test_daily_stats_round_trip_through_the_real_writer():
+    """Pre-fix every one of these read back 0 / 0.0."""
+    analyzer = await _record(_analyzer())
+
+    result = await analyzer.get_stats(days=2)
+
+    assert result["status"] == "success", result
+    stats = result["stats"]
+    assert stats["total_operations"] == 2, "hincrby wrote str fields the reader could not see"
+    assert stats["total_tokens"] == 2 * TOKENS
+    assert stats["total_documents"] == 6
+    assert stats["total_cost"] == pytest.approx(2 * EXPECTED_COST_PER_OP, rel=1e-6)
+    assert stats["total_cost"] > 0.0, "a billed embedding run must never report $0.00"
+    assert stats["avg_processing_time"] == pytest.approx(0.5, rel=1e-6)
+    assert stats["avg_batch_size"] == pytest.approx(10.0, rel=1e-6)
+    assert stats["success_rate"] == pytest.approx(1.0, rel=1e-6)
+    assert stats["tokens_per_second"] == pytest.approx(2 * TOKENS / 1.0, rel=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_failed_operations_lower_the_success_rate():
+    """successful_operations is a distinct hincrby field; it too was invisible."""
+    analyzer = _analyzer()
+    await analyzer.record_usage(_request(success=True))
+    await analyzer.record_usage(_request(success=False))
+
+    stats = (await analyzer.get_stats(days=2))["stats"]
+
+    assert stats["total_operations"] == 2
+    assert stats["success_rate"] == pytest.approx(0.5, rel=1e-6), "a 50% failure rate was reported as 100% success"
+
+
+@pytest.mark.asyncio
+async def test_model_comparison_round_trip_through_the_real_writer():
+    """The per-model breakdown had the same bytes probes at _parse_model_stats."""
+    analyzer = await _record(_analyzer())
+
+    result = await analyzer.get_model_comparison()
+
+    assert result["status"] == "success", result
+    assert len(result["models"]) == 1, result["models"]
+    model = result["models"][0]
+    assert model["model"] == MODEL
+    assert model["total_operations"] == 2
+    assert model["total_tokens"] == 2 * TOKENS
+    assert model["total_cost"] == pytest.approx(2 * EXPECTED_COST_PER_OP, rel=1e-6)
+    assert model["total_cost"] > 0.0
+    assert model["tokens_per_operation"] == pytest.approx(float(TOKENS), rel=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_bytes_values_still_work():
+    """decode_redis_value keeps a client without decode_responses working."""
+    analyzer = await _record(_analyzer(decoded=False))
+
+    stats = (await analyzer.get_stats(days=2))["stats"]
+    models = (await analyzer.get_model_comparison())["models"]
+
+    assert stats["total_operations"] == 2
+    assert stats["total_cost"] == pytest.approx(2 * EXPECTED_COST_PER_OP, rel=1e-6)
+    assert models[0]["model"] == MODEL, "a bytes scan key must still parse to the model name"
+    assert models[0]["total_tokens"] == 2 * TOKENS
+
+
+@pytest.mark.asyncio
+async def test_no_usage_reports_zeros():
+    """The one case that looked correct before the fix must still work."""
+    analyzer = _analyzer()
+
+    stats = (await analyzer.get_stats(days=2))["stats"]
+
+    assert stats["total_operations"] == 0
+    assert stats["total_cost"] == 0.0
+    assert stats["success_rate"] == 1.0
+    assert (await analyzer.get_model_comparison())["models"] == []

--- a/autobot-backend/api/analytics_embedding_patterns_stats_keys_test.py
+++ b/autobot-backend/api/analytics_embedding_patterns_stats_keys_test.py
@@ -100,6 +100,10 @@ class _FakeAsyncRedis:
         return float(bucket[field])
 
     def raw_hgetall(self, key):
+        # scan() hands back bytes keys on a non-decoding client, and redis-py
+        # accepts either form for HGETALL regardless of decode_responses.
+        if isinstance(key, bytes):
+            key = key.decode()
         bucket = self._hashes.get(key, {})
         if self._decoded:
             return dict(bucket)

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -40,6 +40,7 @@ from api.schemas_knowledge import (
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_utils import decode_redis_value
 from constants.threshold_constants import QueryDefaults
 from services.grounded_agent import (
     Claim,
@@ -486,32 +487,33 @@ async def get_stats(
     try:
         stats_data = await redis.hgetall("grounding:stats")
 
+        # The shared client is decode_responses=True, so hgetall yields str keys.
+        # These probes used bytes literals and only appeared to work because the
+        # empty-hash fallback below was itself bytes-keyed: the moment a writer
+        # for grounding:stats exists, every field would silently read 0 (#13278).
         if not stats_data:
             # Return empty stats structure
             stats_data = {
-                b"total_responses_grounded": b"0",
-                b"total_claims_extracted": b"0",
-                b"claims_verified": b"0",
-                b"average_confidence": b"0",
+                "total_responses_grounded": "0",
+                "total_claims_extracted": "0",
+                "claims_verified": "0",
+                "average_confidence": "0",
             }
-
-        def decode_val(v):
-            return v.decode() if isinstance(v, bytes) else v
 
         return {
             "status": "success",
             "period": period,
-            "total_responses_grounded": int(decode_val(stats_data.get(b"total_responses_grounded", b"0"))),
-            "total_claims_extracted": int(decode_val(stats_data.get(b"total_claims_extracted", b"0"))),
-            "claims_verified": float(decode_val(stats_data.get(b"claims_verified", b"0"))),
+            "total_responses_grounded": int(decode_redis_value(stats_data.get("total_responses_grounded")) or 0),
+            "total_claims_extracted": int(decode_redis_value(stats_data.get("total_claims_extracted")) or 0),
+            "claims_verified": float(decode_redis_value(stats_data.get("claims_verified")) or 0),
             "claim_sources": {
                 "kb_lookup": 0.65,
                 "external_research": 0.22,
                 "causal_inference": 0.13,
             },
-            "average_confidence": float(decode_val(stats_data.get(b"average_confidence", b"0"))),
-            "conflicts_created": int(decode_val(stats_data.get(b"conflicts_created", b"0"))),
-            "conflicts_resolved": int(decode_val(stats_data.get(b"conflicts_resolved", b"0"))),
+            "average_confidence": float(decode_redis_value(stats_data.get("average_confidence")) or 0),
+            "conflicts_created": int(decode_redis_value(stats_data.get("conflicts_created")) or 0),
+            "conflicts_resolved": int(decode_redis_value(stats_data.get("conflicts_resolved")) or 0),
         }
 
     except Exception as e:

--- a/autobot-backend/api/knowledge_grounding_stats_keys_test.py
+++ b/autobot-backend/api/knowledge_grounding_stats_keys_test.py
@@ -1,0 +1,155 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""GET /kb-stats must read the grounding hash with str keys (#13278).
+
+``get_stats`` calls ``get_async_redis_client()`` and the shared async pool is
+``decode_responses=True`` (``redis_management/connection_manager.py:500`` →
+``redis_management/config.py:61,153``, no per-database override), so
+``hgetall("grounding:stats")`` returns a ``str``-keyed dict.
+
+The endpoint probed it with bytes literals::
+
+    int(decode_val(stats_data.get(b"total_responses_grounded", b"0")))
+
+which could never match. The defect was dormant rather than visible only because
+nothing in the tree writes ``grounding:stats`` yet **and** the empty-hash
+fallback immediately above was itself bytes-keyed — the bytes probes hit that
+hand-built default, so the endpoint returned honest zeros by accident. The first
+writer to land would have turned every field into a permanent silent 0.
+
+``_populate`` below therefore writes through the canonical HINCRBY/HINCRBYFLOAT
+value shape a real writer would use (decimal strings under ``str`` field names),
+so that writer/reader key drift breaks this suite instead of the endpoint.
+"""
+
+import pytest
+
+from api import knowledge_grounding
+
+# A populated grounding hash exactly as a HINCRBY/HINCRBYFLOAT writer leaves it:
+# str field names, decimal-string values, delivered decoded by the shared client.
+LIVE_STATS = {
+    "total_responses_grounded": "1543",
+    "total_claims_extracted": "8204",
+    "claims_verified": "0.87",
+    "average_confidence": "0.89",
+    "conflicts_created": "142",
+    "conflicts_resolved": "128",
+}
+
+
+class _FakeAsyncRedis:
+    """Minimal stand-in for the shared async client used by get_stats."""
+
+    def __init__(self, fields, decoded=True):
+        self._fields = dict(fields)
+        self._decoded = decoded
+        self.hgetall_called_with = None
+
+    def _populate(self, field, amount):
+        """Mirror HINCRBY/HINCRBYFLOAT: accumulate, persist as a decimal string."""
+        current = self._fields.get(field, "0")
+        total = float(current) + amount
+        self._fields[field] = str(int(total)) if float(total).is_integer() else repr(total)
+
+    async def hgetall(self, key):
+        self.hgetall_called_with = key
+        if self._decoded:
+            return dict(self._fields)
+        # Field names stay str; only the values arrive as bytes.
+        return {k: v.encode() for k, v in self._fields.items()}
+
+
+def _install(monkeypatch, fields, decoded=True):
+    """get_stats imports the client factory inside the function body."""
+    import autobot_shared.redis_client as rc
+
+    fake = _FakeAsyncRedis(fields, decoded=decoded)
+
+    async def _factory(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(rc, "get_async_redis_client", _factory)
+    return fake
+
+
+async def _call(period="24h"):
+    return await knowledge_grounding.get_stats(period=period, current_user="tester", req=None)
+
+
+@pytest.mark.asyncio
+async def test_populated_hash_reports_its_real_figures(monkeypatch):
+    """The live configuration. Pre-fix every field read back 0."""
+    fake = _install(monkeypatch, LIVE_STATS)
+
+    result = await _call()
+
+    assert fake.hgetall_called_with == "grounding:stats", "the stats hash was never read"
+    assert result["status"] == "success"
+    assert result["total_responses_grounded"] == 1543, "str field names were probed with bytes literals"
+    assert result["total_claims_extracted"] == 8204
+    assert result["claims_verified"] == pytest.approx(0.87)
+    assert result["average_confidence"] == pytest.approx(0.89)
+    assert result["conflicts_created"] == 142
+    assert result["conflicts_resolved"] == 128
+
+
+@pytest.mark.asyncio
+async def test_incrementing_writer_shape_round_trips(monkeypatch):
+    """Accumulate through the HINCRBY value shape, then read with the real reader."""
+    fake = _install(monkeypatch, {})
+    fake._populate("total_responses_grounded", 1)
+    fake._populate("total_responses_grounded", 1)
+    fake._populate("total_claims_extracted", 7)
+    fake._populate("average_confidence", 0.5)
+
+    result = await _call()
+
+    assert result["total_responses_grounded"] == 2
+    assert result["total_claims_extracted"] == 7
+    assert result["average_confidence"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_bytes_values_still_work(monkeypatch):
+    """decode_redis_value keeps a client without decode_responses working."""
+    _install(monkeypatch, LIVE_STATS, decoded=False)
+
+    result = await _call()
+
+    assert result["total_responses_grounded"] == 1543
+    assert result["claims_verified"] == pytest.approx(0.87)
+    assert result["conflicts_resolved"] == 128
+
+
+@pytest.mark.asyncio
+async def test_empty_hash_reports_zeros(monkeypatch):
+    """The empty-stats fallback is now str-keyed; it must still report zeros."""
+    _install(monkeypatch, {})
+
+    result = await _call()
+
+    assert result["status"] == "success"
+    assert result["total_responses_grounded"] == 0
+    assert result["total_claims_extracted"] == 0
+    assert result["claims_verified"] == 0.0
+    assert result["average_confidence"] == 0.0
+    assert result["conflicts_created"] == 0
+    assert result["conflicts_resolved"] == 0
+
+
+@pytest.mark.asyncio
+async def test_static_claim_source_breakdown_is_unchanged(monkeypatch):
+    """The hard-coded claim_sources block is out of scope for this fix."""
+    _install(monkeypatch, LIVE_STATS)
+
+    result = await _call()
+
+    assert result["claim_sources"] == {
+        "kb_lookup": 0.65,
+        "external_research": 0.22,
+        "causal_inference": 0.13,
+    }
+    assert result["period"] == "24h"


### PR DESCRIPTION
Closes #13278

## Thinking Path

Same defect class as #13274/#13276: the shared Redis client is `decode_responses=True` for **both** pools — `redis_management/connection_manager.py:500` (async) and `:618` (sync) both read `config.decode_responses`, which defaults `True` at `redis_management/config.py:61,153` with no per-database override anywhere. `hgetall` therefore returns `str` field names, a `bytes` key can never match, and the lookup falls through to its default with no exception and no log line.

Per the issue's instruction I checked the **writer** at each site rather than only swapping the key type — in #13276 the `plugin_manager` fix needed casefolding on top of the key change because its writer stored `str(bool)` → `"True"`.

- **Site 1 writer** is `_update_stats` in the same file (`analytics_embedding_patterns.py:220-238`): `pipe.hincrby(daily_key, "total_operations", 1)`, `pipe.hincrbyfloat(daily_key, "total_cost", cost)` — `str` field names throughout, for both the daily hash and the per-model hash. `HINCRBY` persists its result as a decimal integer string and `HINCRBYFLOAT` as a decimal float string; the readers already apply `int()`/`float()` and each field's writer command matches its reader conversion (`total_cost`/`total_processing_time` are the only `hincrbyfloat` fields and are the only two read with `float()`). **No value-shape adjustment is required** — unlike `plugin_manager`.
- **Site 2 has no writer at all.** `grounding:stats` is read at `knowledge_grounding.py:487` and written nowhere in the tree (`grep -rn "grounding:stats"` returns exactly one hit). That is the only reason the defect was dormant: with an empty hash the code substituted a hand-built **bytes-keyed** default dict, which the bytes `.get()`s did hit, so it reported honest zeros by accident. The first writer to land would have turned every field into a permanent silent 0.

Idiom choice: both sites use the canonical `autobot_shared.redis_utils.decode_redis_value` rather than the inline `isinstance` form. Neither site has guarded `get(b"x") or get("x")` neighbours to match (that was the reason #13272 used the inline form at its two sites), and `knowledge_grounding.py` had a hand-rolled local `decode_val` that duplicated the shared helper outright — replacing it satisfies the reuse rule and keeps a non-decoding client working.

**Sweep.** `grep -rnE '\.get\(\s*b["\x27]|\[\s*b["\x27]|b"…" in ' --include=*.py` over the whole tree, minus the `get(b"x") or get("x")` dual form, leaves exactly the two sites named in the issue. Everything else the grep surfaces is genuinely unrelated: real byte-buffer scans (`secure_sandbox_executor.py:523`, `media/document/pipeline.py:94`, `api/files.py:398`) and the dual-form readers the issue's reviewer already re-verified. **One adjacent find, deliberately not fixed here:** `autobot-infrastructure/shared/scripts/create_kb_index.py:93` and `.../setup/knowledge/fresh_kb_setup.py:128` index raw `FT.INFO`/`FT._LIST` command responses with bytes literals while holding a `get_redis_client()` (decoded) client. That is a different shape — RESP array responses, not hash readers — its failure mode is a raised `ValueError` from `info.index(b"attributes")` rather than a silent default, and its only effect is a skipped `logger.info` line in a one-shot setup script. Filed separately rather than folded in, so this PR stays one defect class.

## What Changed

**`autobot-backend/api/analytics_embedding_patterns.py`**
- `_sum_daily_stats:246-265` — all seven counters (`total_operations`, `total_tokens`, `total_documents`, `total_cost`, `total_processing_time`, `total_batch_size`, `successful_operations`) now index with `str` keys through `decode_redis_value`. This is the live bug: every embedding analytics figure read 0/$0.00 permanently, which also zeroed the four derived metrics (`avg_processing_time`, `success_rate`, `avg_batch_size`, `tokens_per_second`).
- `_parse_model_stats:323-336` — same three counters in the per-model breakdown. The `key` parameter is retyped `bytes` → `str | bytes`, because `scan` on a decoded client yields `str` keys; the bytes branch is preserved via `decode_redis_value`.

**`autobot-backend/api/knowledge_grounding.py`**
- `get_stats:487-516` — six fields moved to `str` keys, and the empty-hash fallback dict moved to `str` keys/values so the two halves agree. The local `decode_val` closure is replaced by the shared `decode_redis_value`.

**New tests** — `autobot-backend/api/analytics_embedding_patterns_stats_keys_test.py`, `autobot-backend/api/knowledge_grounding_stats_keys_test.py`.

## Verification

I was explicitly barred from executing application code, so no service, backend or pytest run was performed. Verification is static plus a stdlib-only reproduction that imports no project code.

**1. The defect and the fix, reproduced.** A standalone harness replicating the `decode_responses=True` `hgetall` shape, the real `hincrby`/`hincrbyfloat` writer, and both the pre-fix and post-fix reader bodies:

```
=== PRE-FIX reader on the live decoded shape ===
  pre-fix _sum_daily_stats -> (0, 0, 0, 0.0, 0.0, 0, 0)
  PASS  pre-fix reports 0 operations
  PASS  pre-fix reports $0.00 cost

=== decoded=True (live shape is True) ===
  PASS  total_operations == 2          PASS  total_tokens == 3000
  PASS  total_documents == 6           PASS  total_cost == 6e-05
  PASS  round(cost,6) > 0              PASS  processing_time == 1.0
  PASS  avg_processing_time == 0.5     PASS  avg_batch_size == 10.0
  PASS  success_rate == 1.0            PASS  tokens_per_second == 3000
  PASS  scan matched only the model hash
  PASS  model name parses (text-embedding-3-small)
  PASS  model total_operations == 2    PASS  model total_cost > 0
  PASS  tokens_per_operation == 1500
(identical block passes for decoded=False — the bytes-value client)

=== grounding reader ===
  PASS  str values   -> {'total_responses_grounded': 1543, 'claims_verified': 0.87, ...}
  PASS  bytes values -> {'total_responses_grounded': 1543, 'claims_verified': 0.87, ...}
  PASS  pre-fix grounding reader reports 0
```

Two writer-side facts confirmed by that run rather than assumed: the `hincrby`/`hincrbyfloat` decimal-string values parse cleanly through the readers' existing `int()`/`float()` in both the decoded and bytes-value shapes, and the pre-fix reader returns the all-zero tuple against data the real writer produced.

**2. Regression tests, and why each fails pre-fix.** Every assertion is on a **value**, never on "no exception":

| Test | Pre-fix result |
|---|---|
| `test_daily_stats_round_trip_through_the_real_writer` | `total_operations` 0 (asserts 2), `total_cost` 0.0 (asserts 6e-05 and `> 0.0`), and all four derived metrics zeroed |
| `test_failed_operations_lower_the_success_rate` | a 50% failure rate reported as `success_rate == 1.0` (asserts 0.5) |
| `test_model_comparison_round_trip_through_the_real_writer` | model reports 0 ops / 0 tokens / $0 at a non-zero recorded cost (asserts 2 / 3000 / `> 0.0`) |
| `test_populated_hash_reports_its_real_figures` | every grounding field 0 (asserts 1543, 8204, 0.87, 0.89, 142, 128) |
| `test_incrementing_writer_shape_round_trips` | 0 (asserts 2 / 7 / 0.5) |

The embedding tests drive the **real** `record_usage` → `_update_stats` writer into the **real** `get_stats`/`get_model_comparison` readers over one shared fake hash, so future writer/reader key drift breaks the suite rather than silently re-zeroing the endpoint. Since `grounding:stats` has no writer, its round-trip test accumulates through the canonical `HINCRBY`/`HINCRBYFLOAT` value shape a writer would use, pinning the reader to it in advance. Both files keep a bytes-**value** case (values, not field names, are what `decode_redis_value` tolerates) and the previously-correct empty-hash paths. No skips, no xfails, no widened `except` handlers (#13273 owns that pattern).

**3. Static checks** — clean on all four files:

```
$ python3 -m black --line-length 120 --target-version py310 --check <4 files>
All done! 2 files would be left unchanged.   (source)
All done! 2 files would be left unchanged.   (tests)
$ python3 -m isort --check-only <4 files>     # no output, exit 0
$ python3 -m flake8 --max-line-length=120 <4 files>   # no findings
```

**Not verified without executing code:** that the two new test files actually collect and pass under the repo's pytest configuration, and end-to-end behaviour against a live Redis. `python-suite` on this PR is the only job that runs them, and it is not a required check — a green required gate does not cover these files. The fake clients are modelled on the shapes verified in item 1 and on the reference fakes from #13276, and `pytest.ini:74` sets `--asyncio-mode=auto`, but the collection itself is unproven here.

## Model Used

claude-opus-5
