### PR TITLE
fix(chat): persist the completed streamed reply to chat history (#13214)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2908,13 +2908,16 @@ before summarizing.
         ``llm_response`` arrived here and was dropped, so a conversational streamed
         reply persisted nothing and ``chat:session:*`` read back user-turns only.
 
-        Returns None when there is nothing to add — an empty reply, or an identical
-        assistant turn already present in *batch* (e.g. the ``respond`` tool).
+        Returns None when there is nothing to add — an empty reply, or an assistant
+        entry in *batch* already carrying byte-identical text. The scan is restricted
+        to assistant entries so that a ``terminal_output`` or other system message
+        echoing the reply cannot suppress the assistant turn.
         """
         content = strip_unparsed_tool_tags(llm_response or "").strip()
         if not content:
             return None
-        if any((entry.get("text") or "").strip() == content for entry in batch):
+        assistant_texts = ((e.get("text") or "").strip() for e in batch if e.get("sender") == "assistant")
+        if any(text == content for text in assistant_texts):
             return None
         return chat_mgr._build_message_dict(
             "assistant",
@@ -2994,8 +2997,9 @@ before summarizing.
                 await chat_mgr.add_messages_batch(session_id, batch)
 
             logger.info(
-                "Persisted conversation to chat history: " "session=%s, workflow_messages=%d",
+                "Persisted conversation to chat history: " "session=%s, workflow_messages=%d, persisted=%d",
                 session_id,
+                len(workflow_messages or []),
                 len(batch),
             )
 

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2892,6 +2892,39 @@ before summarizing.
             yield error_msg
             yield ([], [], error_msg)
 
+    def _build_final_response_entry(
+        self,
+        chat_mgr,
+        llm_response: str,
+        batch: List[Dict[str, Any]],
+    ) -> Dict[str, Any] | None:
+        """Build the chat-history entry for the completed streamed reply (#13214).
+
+        Streamed chunks carry ``metadata.streaming = True`` (set unconditionally by
+        ``StreamingMessage.to_workflow_message``) and are deliberately excluded from
+        ``workflow_messages`` by both accumulators — see ``graph._run_llm_iteration``
+        and ``_collect_llm_iteration_response``, whose comment states the complete
+        reply "is persisted in _persist_workflow_messages". That was never true:
+        ``llm_response`` arrived here and was dropped, so a conversational streamed
+        reply persisted nothing and ``chat:session:*`` read back user-turns only.
+
+        Returns None when there is nothing to add — an empty reply, or an identical
+        assistant turn already present in *batch* (e.g. the ``respond`` tool).
+        """
+        content = strip_unparsed_tool_tags(llm_response or "").strip()
+        if not content:
+            return None
+        if any((entry.get("text") or "").strip() == content for entry in batch):
+            return None
+        return chat_mgr._build_message_dict(
+            "assistant",
+            content,
+            "response",
+            {"message_type": "llm_response", "streamed": True},
+            None,
+            sources=[],
+        )
+
     async def _persist_workflow_messages(
         self,
         session_id: str,
@@ -2903,6 +2936,8 @@ before summarizing.
         Issue #332: Original implementation.
         Issue #1316: Batch all messages into one load/save cycle instead
         of N individual add_message() calls.
+        Issue #13214: also persist *llm_response* — the completed streamed reply —
+        which every caller already passes but which was previously ignored.
         """
         from chat_history import ChatHistoryManager
 
@@ -2947,6 +2982,13 @@ before summarizing.
                         sources=sources,
                     )
                 )
+
+            # Issue #13214: append the completed streamed reply. Without this the
+            # batch holds only non-streaming side messages (terminal output, errors)
+            # and a plain conversational turn writes nothing at all.
+            final_entry = self._build_final_response_entry(chat_mgr, llm_response, batch)
+            if final_entry:
+                batch.append(final_entry)
 
             if batch:
                 await chat_mgr.add_messages_batch(session_id, batch)

--- a/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
+++ b/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
@@ -1,0 +1,195 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for Issue #13214 — streamed AutoBot replies must survive reload.
+
+The GUI reloads a conversation from the chat-history store (``chat:session:*``,
+served by ``GET /api/chat/sessions/{id}``). The streaming endpoint
+(``POST /api/chats/{id}/message``) has no persistence call of its own — it relies
+on the workflow's ``_persist_workflow_messages``.
+
+Every LLM chunk that workflow emits is stamped ``metadata.streaming = True`` by
+``StreamingMessage.to_workflow_message`` and is therefore dropped by both
+accumulators (``graph._run_llm_iteration`` and
+``ChatWorkflowManager._collect_llm_iteration_response``), whose comments state the
+complete reply "is persisted in _persist_workflow_messages". It was not: the
+``llm_response`` argument was accepted and ignored, so a plain conversational turn
+wrote an empty batch and the session read back user-turns only.
+
+These tests assert the assistant turn is actually READABLE back out of the store
+after a streamed reply — not merely that a write was attempted.
+"""
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+from chat_history.messages import MessagesMixin
+from chat_workflow.manager import ChatWorkflowManager
+from chat_workflow.models import StreamingMessage
+
+SESSION_ID = "sess-13214"
+REPLY = "Hello! I'm AutoBot. How can I help you today?"
+
+
+class _InMemoryChatHistory(MessagesMixin):
+    """Chat-history store backed by a dict.
+
+    Deliberately reuses the REAL ``MessagesMixin`` so ``_build_message_dict`` and
+    ``add_messages_batch`` are production code; only the load/save seam is
+    in-memory. Reads therefore go through the same path the GUI's
+    ``get_session_messages`` uses.
+    """
+
+    def __init__(self) -> None:
+        self.sessions: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def load_session(self, session_id: str) -> List[Dict[str, Any]]:
+        return list(self.sessions.get(session_id, []))
+
+    async def save_session(self, session_id: str, messages=None, **_kwargs) -> bool:
+        self.sessions[session_id] = list(messages or [])
+        return True
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """Patch the store ``_persist_workflow_messages`` constructs internally."""
+    instance = _InMemoryChatHistory()
+    monkeypatch.setattr("chat_history.ChatHistoryManager", lambda: instance)
+    return instance
+
+
+def _manager() -> ChatWorkflowManager:
+    """A manager instance without running the heavyweight __init__.
+
+    ``_persist_workflow_messages`` touches no instance state beyond the helper it
+    calls, so bypassing __init__ keeps the test free of Redis/LLM wiring.
+    """
+    return ChatWorkflowManager.__new__(ChatWorkflowManager)
+
+
+def _assistant_turns(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [m for m in messages if m.get("sender") == "assistant"]
+
+
+class TestStreamingDropsEveryChunk:
+    """Establishes the precondition: streamed chunks never reach workflow_messages."""
+
+    def test_streaming_metadata_is_always_set(self):
+        """Production code stamps streaming=True on every chunk — not a test literal."""
+        msg = StreamingMessage(type="response")
+        msg.stream(REPLY)
+        assert msg.to_workflow_message().metadata["streaming"] is True
+
+    @pytest.mark.asyncio
+    async def test_graph_iteration_accumulates_nothing_from_a_streamed_reply(self, monkeypatch):
+        """``graph._run_llm_iteration`` returns an EMPTY message list for a streamed turn."""
+        from chat_workflow import graph as graph_mod
+
+        monkeypatch.setattr("autobot_shared.http_client.get_http_client", lambda: object())
+
+        streaming_msg = StreamingMessage(type="response")
+
+        class _FakeManager:
+            async def _run_continuation_loop_iteration(self, _client, _prompt, _iteration, _ctx):
+                for chunk in ("Hello! ", "I'm AutoBot. ", "How can I help you today?"):
+                    streaming_msg.stream(chunk)
+                    yield streaming_msg.to_workflow_message()
+                yield (REPLY, False)
+
+        ctx = SimpleNamespace(initial_prompt="hello")
+        messages, llm_response, should_continue = await graph_mod._run_llm_iteration(_FakeManager(), ctx, 1, [], None)
+
+        assert messages == []  # every chunk dropped — nothing left to persist
+        assert llm_response == REPLY  # the complete reply IS known here
+        assert should_continue is False
+
+
+class TestStreamedReplyIsReadableAfterReload:
+    """The regression: the assistant turn must be readable from the GUI-facing store."""
+
+    @pytest.mark.asyncio
+    async def test_conversational_streamed_reply_is_persisted(self, store):
+        """FAILS pre-fix: batch is empty, so the session reads back with zero turns."""
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, [], REPLY)
+
+        persisted = await store.load_session(SESSION_ID)
+        assistant = _assistant_turns(persisted)
+        assert len(assistant) == 1
+        assert assistant[0]["text"] == REPLY
+        assert assistant[0]["messageType"] == "response"
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_stream_then_reload(self, store, monkeypatch):
+        """Drive the real graph accumulator, then persist, then read the store back."""
+        from chat_workflow import graph as graph_mod
+
+        monkeypatch.setattr("autobot_shared.http_client.get_http_client", lambda: object())
+
+        streaming_msg = StreamingMessage(type="response")
+
+        class _FakeManager:
+            async def _run_continuation_loop_iteration(self, _client, _prompt, _iteration, _ctx):
+                for chunk in ("Hello! ", "I'm AutoBot. ", "How can I help you today?"):
+                    streaming_msg.stream(chunk)
+                    yield streaming_msg.to_workflow_message()
+                yield (REPLY, False)
+
+        messages, llm_response, _ = await graph_mod._run_llm_iteration(
+            _FakeManager(), SimpleNamespace(initial_prompt="hello"), 1, [], None
+        )
+        wf_messages = [
+            SimpleNamespace(type=m.get("type", "response"), content=m.get("content", ""), metadata=m.get("metadata"))
+            for m in messages
+        ]
+
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, llm_response)
+
+        reloaded = await store.load_session(SESSION_ID)
+        assert [m["text"] for m in _assistant_turns(reloaded)] == [REPLY]
+
+    @pytest.mark.asyncio
+    async def test_reply_appended_after_tool_output(self, store):
+        """A tool-using turn keeps its terminal output AND gains the final reply, last."""
+        wf_messages = [
+            SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={}),
+        ]
+
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, REPLY)
+
+        persisted = await store.load_session(SESSION_ID)
+        assert [m["sender"] for m in persisted] == ["system", "assistant"]
+        assert persisted[-1]["text"] == REPLY
+
+
+class TestNoDuplicateOrEmptyTurns:
+    """The new write must not duplicate an existing turn or invent an empty one."""
+
+    @pytest.mark.asyncio
+    async def test_empty_llm_response_writes_nothing(self, store):
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, [], "")
+        assert await store.load_session(SESSION_ID) == []
+
+    @pytest.mark.asyncio
+    async def test_identical_existing_turn_is_not_duplicated(self, store):
+        """The ``respond`` tool already emits a non-streaming turn with this text."""
+        wf_messages = [SimpleNamespace(type="response", content=REPLY, metadata={"message_type": "respond_tool"})]
+
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, REPLY)
+
+        persisted = await store.load_session(SESSION_ID)
+        assert len(_assistant_turns(persisted)) == 1
+
+    @pytest.mark.asyncio
+    async def test_error_turn_persist_is_unchanged(self, store):
+        """``_persist_error_turn`` passes llm_response='' — behaviour must not change."""
+        wf_messages = [SimpleNamespace(type="error", content="The assistant could not respond.", metadata={})]
+
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, "")
+
+        persisted = await store.load_session(SESSION_ID)
+        assert len(persisted) == 1
+        assert persisted[0]["text"] == "The assistant could not respond."


### PR DESCRIPTION
Closes #13214

## Thinking Path

The issue's premise (two stores; the GUI-facing one holds user turns only) **holds**, but its diagnosis is **incomplete**, and its proposed fix targets the wrong layer.

Verified stores:
- GUI reload path: `GET /api/chat/sessions/{id}` -> `chat_history_manager.get_session_messages` (`api/chat_sessions.py:329`, `:244`) -> `chat:session:*` (`chat_history/session.py:84`).
- Workflow store: `chat:conversation:*` (`chat_workflow/conversation.py:33`), written by `_persist_conversation` (`chat_workflow/conversation.py:293`) with the full `{user, assistant}` pair — which is why the replies survive there.

The issue says the streaming endpoint "contains no persistence call". True at the API layer (`api/chat.py:1506` returns `_create_streaming_response(_stream_chat_workflow_messages(...))`, which only re-emits SSE), **but persistence into the GUI-facing store already exists one layer down** and runs on every streamed turn: `chat_workflow/graph.py:1356` -> `ChatWorkflowManager._persist_workflow_messages`. The issue's own log evidence proves it ran (`workflow_messages=0`, `messages=0`) — it wrote an empty batch. So adding a second writer in the SSE generator would have duplicated an existing responsibility instead of fixing it.

Actual cause, three links:

1. `chat_workflow/models.py:250` — `StreamingMessage.to_workflow_message()` stamps `metadata["streaming"] = True` **unconditionally**, on every chunk.
2. `chat_workflow/graph.py:468-471` (graph path) and `chat_workflow/manager.py:2378-2380` (legacy path) — both accumulators keep only non-streaming messages: `if not is_streaming: messages.append(...)`. Because `_get_llm_request_payload` always sets `"stream": True` (`manager.py:1985`), **no** assistant message ever survives into `workflow_messages` for a conversational turn. Both sites carry the comment "The final complete response is persisted in `_persist_workflow_messages`".
3. `chat_workflow/manager.py:2895-2965` — `_persist_workflow_messages(session_id, workflow_messages, llm_response)` **accepted `llm_response` and never referenced it**. The parameter was threaded from both call sites (`graph.py:1356`, `manager.py:3239`) for exactly this purpose and silently dropped.

Net: the complete reply was fully known at the persist call and discarded. `_persist_user_message` (`graph.py:226`) has no such gap, which is the reported asymmetry.

Not a swallowed exception: the `except Exception` at `manager.py:2960` never fired — the observed log line is the *success* branch reporting a batch length of 0.

Is streaming the trigger? Yes for the endpoint, no for the mechanism: the workflow's LLM loop always streams, so the workflow path *always* dropped the assistant turn. The non-streaming endpoint (`process_chat_message` -> `_store_and_log_ai_response`, `api/chat.py:790`) never goes through the workflow and persists correctly — which is why only the SSE endpoint shows the bug.

Backfill of already-damaged sessions from `chat:conversation:*` (issue item 4) is deliberately **not** in this PR — it is a data-repair job, separate risk profile from the code fix.

## What Changed

`autobot-backend/chat_workflow/manager.py`
- New `_build_final_response_entry` — builds the assistant chat-history entry from `llm_response`, using the same `chat_mgr._build_message_dict` the surrounding batch already uses. Returns `None` for an empty reply, or when an entry with identical normalized text is already in the batch (the `respond` tool emits a non-streaming turn with the same content).
- `_persist_workflow_messages` appends that entry to the batch before the single `add_messages_batch` write. One writer, one round-trip; no new persistence call sites.

`autobot-backend/chat_workflow/streamed_reply_persistence_test.py` (new)
- Regression tests asserting the assistant turn is **readable back out of the store**.

No change to the SSE endpoint, to `chat_history/`, or to the frontend.

## Verification

Application code was not executed (static analysis only, per the assignment).

Cause chain read directly:
- `models.py:250` `"streaming": True` — unconditional.
- `graph.py:468-471` / `manager.py:2378-2380` — `if not is_streaming: messages.append(...)`.
- `manager.py` pre-fix `_persist_workflow_messages` body — `llm_response` appears in the signature and nowhere else.
- Single caller of the working writer: `grep -n "_store_and_log_ai_response(" api/chat.py` -> `api/chat.py:790` only (non-streaming).

Regression test design (why it fails pre-fix):
- `_InMemoryChatHistory` subclasses the **real** `chat_history.messages.MessagesMixin`, so `_build_message_dict` and `add_messages_batch` are production code; only the load/save seam is in-memory. Assertions read the session back via `load_session` — the same accessor `get_session_messages` uses. It asserts the turn is *readable*, not that a write was attempted.
- `test_conversational_streamed_reply_is_persisted` — pre-fix the batch is empty, `add_messages_batch` is skipped, `load_session` returns `[]`, and the `len(assistant) == 1` assertion fails.
- `test_end_to_end_stream_then_reload` — drives the real `graph._run_llm_iteration` with chunks produced by the real `StreamingMessage.to_workflow_message()` (so `streaming=True` comes from production code, not a test literal), then persists the result and reads the store back. Pre-fix: no assistant text.
- `test_graph_iteration_accumulates_nothing_from_a_streamed_reply` pins the precondition (`messages == []` while `llm_response` holds the full reply).
- Guards against over-writing: empty reply writes nothing; an identical existing turn is not duplicated; the `llm_response=""` call from `_persist_error_turn` (`graph.py:1297`) is unchanged.

Lint/format on the changed files:
```
flake8 --max-line-length 120  -> exit 0
black  --line-length 120 --check -> 2 files would be left unchanged
isort  --profile black --line-length 120 --check-only -> exit 0
```

Not verifiable without executing code: the live Redis round-trip, and that the reloaded turn renders identically in the GUI. `MessageItem.vue:359` strips `TOOL_CALL` markup at render, so a tool-using turn's persisted text renders the same as it streamed.

Known limitation, in the same blast radius as the bug: the persisted final turn carries `sources: []`. KB citations live only on the discarded streaming chunks' metadata and are not available at the persist call without a signature change. Nothing regresses — pre-fix there was no assistant turn at all — and a follow-up issue is filed for citation parity on reload.

## Model Used

claude-opus-5
