### PR TITLE
fix(voice): stream first audio and survive a worker without the stream route (#13215, #12886)

### DIFF
--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -12,10 +12,12 @@ bridging the FastAPI layer with the TTS/STT backend services.
 import asyncio
 import os
 import tempfile
+from collections.abc import AsyncIterator
+from contextlib import aclosing
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel
 
 from api.schemas_agent import VoiceCreateResponse
@@ -123,6 +125,48 @@ async def voice_realtime_call_tool(
     return {"is_error": result.is_error, "content": result.content}
 
 
+# #13215: chunked audio wire format for the HTTP synthesis routes.
+#
+# The worker emits independently-decodable ~250ms mini-WAVs; concatenating them
+# into one audio/wav body would be undecodable (only the first RIFF header is
+# valid), so a streamed response repeats ``[4-byte big-endian length][WAV]``
+# instead — the same framing the worker itself uses, forwarded unchanged. The
+# header below lets a client confirm the framing rather than infer it.
+AUDIO_STREAM_MEDIA_TYPE = "application/octet-stream"
+AUDIO_STREAM_FRAMING_HEADER = "X-Audio-Framing"
+AUDIO_STREAM_FRAMING = "length-prefixed-wav"
+
+
+async def _framed_audio_chunks(text: str, voice_id: str, language: str) -> AsyncIterator[bytes]:
+    """Yield length-prefixed WAV chunks as the worker produces them."""
+    tts = get_tts_client()
+    async with aclosing(tts.stream_or_synthesize(text, voice_id=voice_id, language=language)) as stream:
+        async for chunk in stream:
+            yield len(chunk).to_bytes(4, "big") + chunk
+
+
+async def _synthesized_audio_response(text: str, voice_id: str, language: str, stream: bool) -> Response:
+    """Return synthesized speech, chunk-by-chunk when the caller opts in (#13215).
+
+    Without ``stream`` the response is the whole-utterance ``audio/wav`` blob
+    every existing caller expects, so time-to-first-byte equals total synthesis
+    time. With it, bytes leave as soon as the worker produces them.
+    """
+    resolved_voice = resolve_voice_id(voice_id, language)
+    if stream:
+        return StreamingResponse(
+            _framed_audio_chunks(text, resolved_voice, language),
+            media_type=AUDIO_STREAM_MEDIA_TYPE,
+            headers={AUDIO_STREAM_FRAMING_HEADER: AUDIO_STREAM_FRAMING},
+        )
+    wav_bytes = await get_tts_client().synthesize(text, voice_id=resolved_voice, language=language)
+    return Response(
+        content=wav_bytes,
+        media_type="audio/wav",
+        headers={"Content-Disposition": "attachment; filename=speech.wav"},
+    )
+
+
 @router.post("/listen", response_model=VoiceListenResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -170,8 +214,13 @@ async def voice_speak_api(
     voice_id: str = Form(""),
     language: str = Form(""),
     user_role: str = Form("user"),
+    stream: bool = Form(False),
 ):
-    """Converts text to speech and plays it."""
+    """Converts text to speech and plays it.
+
+    ``stream=true`` returns length-prefixed WAV chunks as they are synthesized
+    (#13215); omitting it keeps the whole-utterance ``audio/wav`` contract.
+    """
     security_layer = request.app.state.security_layer
     if not security_layer.check_permission(user_role, "allow_voice_speak"):
         security_layer.audit_log(
@@ -191,14 +240,8 @@ async def voice_speak_api(
     # instead of a misleading 503 that implies TTS is uninstalled.
     voice_interface = getattr(request.app.state, "voice_interface", None)
     if voice_interface is None:
-        resolved_voice = resolve_voice_id(voice_id, language)
-        wav_bytes = await get_tts_client().synthesize(text, voice_id=resolved_voice, language=language)
         security_layer.audit_log("voice_speak", user_role, "success", {"via": "tts_worker", "text_preview": text[:50]})
-        return Response(
-            content=wav_bytes,
-            media_type="audio/wav",
-            headers={"Content-Disposition": "attachment; filename=speech.wav"},
-        )
+        return await _synthesized_audio_response(text, voice_id, language, stream)
 
     result = await voice_interface.speak_text(text)
     if result["status"] == "success":
@@ -229,8 +272,16 @@ async def voice_synthesize_api(
     voice_id: str = Form(""),
     language: str = Form(""),
     user_role: str = Form("user"),
+    stream: bool = Form(False),
 ):
-    """Synthesize speech via Pocket TTS worker. Returns audio/wav stream."""
+    """Synthesize speech via the Pocket TTS worker.
+
+    Returns a whole ``audio/wav`` body by default. With ``stream=true`` the
+    response is ``application/octet-stream`` carrying
+    ``[4-byte length][WAV]`` chunks emitted as the worker produces them, so
+    the caller hears audio after the first ~250ms instead of after the whole
+    utterance (#13215).
+    """
     security_layer = request.app.state.security_layer
     if not security_layer.check_permission(user_role, "allow_voice_speak"):
         security_layer.audit_log("voice_synthesize", user_role, "denied", {"reason": "permission_denied"})
@@ -239,15 +290,8 @@ async def voice_synthesize_api(
             content={"message": "Permission denied to synthesize voice."},
         )
 
-    tts = get_tts_client()
-    resolved_voice = resolve_voice_id(voice_id, language)
-    wav_bytes = await tts.synthesize(text, voice_id=resolved_voice, language=language)
     security_layer.audit_log("voice_synthesize", user_role, "success", {"text_preview": text[:50]})
-    return Response(
-        content=wav_bytes,
-        media_type="audio/wav",
-        headers={"Content-Disposition": "attachment; filename=speech.wav"},
-    )
+    return await _synthesized_audio_response(text, voice_id, language, stream)
 
 
 @router.post("/clone-voice", response_model=None)  # Returns audio/wav Response — no Pydantic schema

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -240,8 +240,11 @@ async def voice_speak_api(
     # instead of a misleading 503 that implies TTS is uninstalled.
     voice_interface = getattr(request.app.state, "voice_interface", None)
     if voice_interface is None:
-        security_layer.audit_log("voice_speak", user_role, "success", {"via": "tts_worker", "text_preview": text[:50]})
-        return await _synthesized_audio_response(text, voice_id, language, stream)
+        # Audit after synthesis — see voice_synthesize_api for why.
+        response = await _synthesized_audio_response(text, voice_id, language, stream)
+        outcome = "accepted" if stream else "success"
+        security_layer.audit_log("voice_speak", user_role, outcome, {"via": "tts_worker", "text_preview": text[:50]})
+        return response
 
     result = await voice_interface.speak_text(text)
     if result["status"] == "success":
@@ -290,8 +293,15 @@ async def voice_synthesize_api(
             content={"message": "Permission denied to synthesize voice."},
         )
 
-    security_layer.audit_log("voice_synthesize", user_role, "success", {"text_preview": text[:50]})
-    return await _synthesized_audio_response(text, voice_id, language, stream)
+    # Synthesise first, then audit. Logging "success" before the worker is
+    # called would record a success for a run that then 500s (#13215 review).
+    # With stream=true the status is committed before the body is produced, so
+    # the outcome is only ever "accepted" — a mid-stream worker failure cannot
+    # be retracted once StreamingResponse has started.
+    response = await _synthesized_audio_response(text, voice_id, language, stream)
+    outcome = "accepted" if stream else "success"
+    security_layer.audit_log("voice_synthesize", user_role, outcome, {"text_preview": text[:50]})
+    return response
 
 
 @router.post("/clone-voice", response_model=None)  # Returns audio/wav Response — no Pydantic schema

--- a/autobot-backend/api/voice_latency_test.py
+++ b/autobot-backend/api/voice_latency_test.py
@@ -28,6 +28,7 @@ import asyncio
 import base64
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlencode
 
 import pytest
 from fastapi import FastAPI
@@ -118,21 +119,69 @@ def _make_app() -> FastAPI:
     return app
 
 
-def _time_to_first_byte(client: TestClient, payload: dict) -> tuple:
-    """POST /api/voice/synthesize; return (seconds-to-first-byte, all bytes)."""
+async def _time_to_first_byte(app: FastAPI, payload: dict) -> tuple:
+    """POST /api/voice/synthesize over raw ASGI; return (TTFB seconds, body).
+
+    Starlette's ``TestClient`` buffers the whole response before returning, so
+    it cannot observe time-to-first-byte at all -- driving the ASGI app
+    directly is the only way to measure the thing this issue is about, and it
+    still exercises the real route, form parsing and StreamingResponse.
+    """
+    encoded = urlencode(payload).encode("utf-8")
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.1"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/api/voice/synthesize",
+        "raw_path": b"/api/voice/synthesize",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"testserver"),
+            (b"content-type", b"application/x-www-form-urlencoded"),
+            (b"content-length", str(len(encoded)).encode("ascii")),
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+    sent = []
     started = time.monotonic()
-    with client.stream("POST", "/api/voice/synthesize", data=payload) as response:
-        assert response.status_code == 200
-        body = b""
-        first_byte_at = None
-        for piece in response.iter_bytes():
-            if piece and first_byte_at is None:
-                first_byte_at = time.monotonic() - started
-            body += piece
+
+    delivered = asyncio.Event()
+
+    async def _receive():
+        # First call delivers the body; every later call is starlette's
+        # disconnect listener, which must block (as a live client would)
+        # rather than spin -- the task group cancels it once the response
+        # generator finishes.
+        if delivered.is_set():
+            await asyncio.Event().wait()
+        delivered.set()
+        return {"type": "http.request", "body": encoded, "more_body": False}
+
+    async def _send(message):
+        sent.append((time.monotonic() - started, message))
+
+    await app(scope, _receive, _send)
+
+    status = next(m["status"] for _, m in sent if m["type"] == "http.response.start")
+    assert status == 200, f"unexpected status {status}"
+    body = b""
+    first_byte_at = None
+    for elapsed, message in sent:
+        if message["type"] != "http.response.body":
+            continue
+        piece = message.get("body", b"")
+        if piece and first_byte_at is None:
+            first_byte_at = elapsed
+        body += piece
     return first_byte_at, body
 
 
-def test_streaming_synthesize_reaches_first_audio_far_sooner():
+@pytest.mark.asyncio
+async def test_streaming_synthesize_reaches_first_audio_far_sooner():
     """Measured: the streaming route must beat the whole-blob route to first audio.
 
     Regression guard for #13215 -- a naive "it called synthesize_stream"
@@ -140,14 +189,13 @@ def test_streaming_synthesize_reaches_first_audio_far_sooner():
     before responding, which is exactly the defect.
     """
     app = _make_app()
-    client = TestClient(app)
     http_client = _make_worker_http_client(serves_stream=True)
 
     with patch("services.tts_client.get_http_client", return_value=http_client):
         with patch("api.voice.get_tts_client", return_value=TTSClient()):
-            blocking_ttfb, blocking_body = _time_to_first_byte(client, {"text": "hi", "user_role": "user"})
-            streaming_ttfb, streaming_body = _time_to_first_byte(
-                client, {"text": "hi", "user_role": "user", "stream": "true"}
+            blocking_ttfb, blocking_body = await _time_to_first_byte(app, {"text": "hi", "user_role": "user"})
+            streaming_ttfb, streaming_body = await _time_to_first_byte(
+                app, {"text": "hi", "user_role": "user", "stream": "true"}
             )
 
     assert blocking_body == WHOLE_WAV
@@ -159,15 +207,15 @@ def test_streaming_synthesize_reaches_first_audio_far_sooner():
     )
 
 
-def test_streaming_response_carries_every_chunk_in_order():
+@pytest.mark.asyncio
+async def test_streaming_response_carries_every_chunk_in_order():
     """The framed body must decode back to the worker's chunks, losing none."""
     app = _make_app()
-    client = TestClient(app)
     http_client = _make_worker_http_client(serves_stream=True)
 
     with patch("services.tts_client.get_http_client", return_value=http_client):
         with patch("api.voice.get_tts_client", return_value=TTSClient()):
-            _, body = _time_to_first_byte(client, {"text": "hi", "user_role": "user", "stream": "true"})
+            _, body = await _time_to_first_byte(app, {"text": "hi", "user_role": "user", "stream": "true"})
 
     decoded, offset = [], 0
     while offset < len(body):

--- a/autobot-backend/api/voice_latency_test.py
+++ b/autobot-backend/api/voice_latency_test.py
@@ -1,0 +1,216 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Time-to-first-audio regression tests for the voice paths (#13215, #12886).
+
+These tests *measure* time-to-first-byte rather than asserting that some
+function was called. A fake TTS worker is driven through the real
+``TTSClient`` (only the pooled HTTP layer is stubbed) so the timing reflects
+the actual client + route code path:
+
+* ``/tts/synthesize``        -- returns the whole WAV after ``SYNTH_SECONDS``.
+* ``/tts/synthesize/stream`` -- emits ``CHUNK_COUNT`` framed mini-WAVs, one
+  every ``CHUNK_SECONDS``, so the first is audible after 1/CHUNK_COUNT of the
+  utterance.
+
+Before #13215, ``/api/voice/synthesize`` always used the whole-blob route, so
+time-to-first-byte equalled total synthesis time (measured 4.7-10.1s live).
+
+The stale-worker test covers #12886 from the backend side: when the deployed
+worker predates ``/tts/synthesize/stream``, the WebSocket voice path used to
+turn the resulting 404 into a ``{"type": "error"}`` frame and no audio at all
+-- the frontend only falls back to HTTP when the *socket* fails, never on a
+per-utterance server error, so the reply was silently dropped.
+"""
+
+import asyncio
+import base64
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketState
+
+from api.voice import router as voice_router
+from api.voice_stream import _stream_chunks_pipelined
+from services.tts_client import TTSClient
+
+SYNTH_SECONDS = 0.5
+CHUNK_COUNT = 5
+CHUNK_SECONDS = SYNTH_SECONDS / CHUNK_COUNT
+WHOLE_WAV = b"RIFF" + b"w" * 64
+STREAM_CHUNKS = [b"RIFF" + bytes([i]) * 16 for i in range(CHUNK_COUNT)]
+STREAM_URL_SUFFIX = "/tts/synthesize/stream"
+
+
+class _PacedStreamReader:
+    """Feeds the worker's ``[4-byte length][WAV]`` framing one chunk per tick."""
+
+    def __init__(self, chunks: list, delay: float) -> None:
+        self._frames = [len(c).to_bytes(4, "big") + c for c in chunks]
+        self._delay = delay
+        self._buf = b""
+        self._index = 0
+
+    async def readexactly(self, n: int) -> bytes:
+        while len(self._buf) < n:
+            if self._index >= len(self._frames):
+                raise asyncio.IncompleteReadError(self._buf, n)
+            await asyncio.sleep(self._delay)
+            self._buf += self._frames[self._index]
+            self._index += 1
+        out, self._buf = self._buf[:n], self._buf[n:]
+        return out
+
+
+def _make_worker_http_client(*, serves_stream: bool) -> MagicMock:
+    """Pooled-HTTP-client stub standing in for a TTS worker with real timing."""
+
+    async def _slow_read() -> bytes:
+        await asyncio.sleep(SYNTH_SECONDS)
+        return WHOLE_WAV
+
+    def _tracked_request(method, url, **kwargs):
+        streaming = url.endswith(STREAM_URL_SUFFIX)
+        resp = MagicMock()
+        resp.status = 200 if (serves_stream or not streaming) else 404
+        resp.text = AsyncMock(return_value="Not Found")
+        resp.read = AsyncMock(side_effect=_slow_read)
+        resp.content = _PacedStreamReader(STREAM_CHUNKS, CHUNK_SECONDS)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    client = MagicMock()
+    client.tracked_request = MagicMock(side_effect=_tracked_request)
+    return client
+
+
+class _MockSecurityLayer:
+    """Minimal security_layer stub that always permits."""
+
+    def check_permission(self, role: str, permission: str) -> bool:
+        return True
+
+    def audit_log(self, *args, **kwargs) -> None:
+        pass
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket stand-in recording every JSON message sent."""
+
+    def __init__(self) -> None:
+        self.client_state = WebSocketState.CONNECTED
+        self.sent: list = []
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(voice_router, prefix="/api/voice")
+    app.state.security_layer = _MockSecurityLayer()
+    return app
+
+
+def _time_to_first_byte(client: TestClient, payload: dict) -> tuple:
+    """POST /api/voice/synthesize; return (seconds-to-first-byte, all bytes)."""
+    started = time.monotonic()
+    with client.stream("POST", "/api/voice/synthesize", data=payload) as response:
+        assert response.status_code == 200
+        body = b""
+        first_byte_at = None
+        for piece in response.iter_bytes():
+            if piece and first_byte_at is None:
+                first_byte_at = time.monotonic() - started
+            body += piece
+    return first_byte_at, body
+
+
+def test_streaming_synthesize_reaches_first_audio_far_sooner():
+    """Measured: the streaming route must beat the whole-blob route to first audio.
+
+    Regression guard for #13215 -- a naive "it called synthesize_stream"
+    assertion would still pass if the route buffered the whole utterance
+    before responding, which is exactly the defect.
+    """
+    app = _make_app()
+    client = TestClient(app)
+    http_client = _make_worker_http_client(serves_stream=True)
+
+    with patch("services.tts_client.get_http_client", return_value=http_client):
+        with patch("api.voice.get_tts_client", return_value=TTSClient()):
+            blocking_ttfb, blocking_body = _time_to_first_byte(client, {"text": "hi", "user_role": "user"})
+            streaming_ttfb, streaming_body = _time_to_first_byte(
+                client, {"text": "hi", "user_role": "user", "stream": "true"}
+            )
+
+    assert blocking_body == WHOLE_WAV
+    assert streaming_body  # framed chunks
+    assert blocking_ttfb >= SYNTH_SECONDS * 0.8, f"blocking TTFB {blocking_ttfb:.3f}s -- fake worker not pacing"
+    assert streaming_ttfb < blocking_ttfb / 2, (
+        f"streaming time-to-first-audio {streaming_ttfb:.3f}s is not materially "
+        f"better than blocking {blocking_ttfb:.3f}s"
+    )
+
+
+def test_streaming_response_carries_every_chunk_in_order():
+    """The framed body must decode back to the worker's chunks, losing none."""
+    app = _make_app()
+    client = TestClient(app)
+    http_client = _make_worker_http_client(serves_stream=True)
+
+    with patch("services.tts_client.get_http_client", return_value=http_client):
+        with patch("api.voice.get_tts_client", return_value=TTSClient()):
+            _, body = _time_to_first_byte(client, {"text": "hi", "user_role": "user", "stream": "true"})
+
+    decoded, offset = [], 0
+    while offset < len(body):
+        size = int.from_bytes(body[offset : offset + 4], "big")
+        offset += 4
+        decoded.append(body[offset : offset + size])
+        offset += size
+    assert decoded == STREAM_CHUNKS
+
+
+def test_non_streaming_synthesize_still_returns_a_single_wav():
+    """Existing callers keep the audio/wav whole-blob contract (no opt-in flag)."""
+    app = _make_app()
+    client = TestClient(app)
+    http_client = _make_worker_http_client(serves_stream=True)
+
+    with patch("services.tts_client.get_http_client", return_value=http_client):
+        with patch("api.voice.get_tts_client", return_value=TTSClient()):
+            response = client.post("/api/voice/synthesize", data={"text": "hi", "user_role": "user"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert response.content == WHOLE_WAV
+
+
+@pytest.mark.asyncio
+async def test_ws_path_still_speaks_when_worker_lacks_stream_route():
+    """A worker predating /tts/synthesize/stream must not silence the WS path (#12886).
+
+    Previously ``_stream_chunks_pipelined`` let the 404 surface as an ``error``
+    frame with zero ``tts_audio`` frames; the frontend logs that and plays
+    nothing, so the whole reply was lost.
+    """
+    ws = _FakeWebSocket()
+    http_client = _make_worker_http_client(serves_stream=False)
+
+    with patch("services.tts_client.get_http_client", return_value=http_client):
+        with patch("api.voice_stream.get_tts_client", return_value=TTSClient()):
+            await _stream_chunks_pipelined(ws, "hello", asyncio.Event(), voice_id="alba")
+
+    types = [m["type"] for m in ws.sent]
+    assert "error" not in types, f"stale worker still surfaced an error frame: {ws.sent}"
+    audio = [m for m in ws.sent if m["type"] == "tts_audio"]
+    assert audio, "stale worker produced no audio at all"
+    assert base64.b64decode(audio[0]["data"]) == WHOLE_WAV
+    assert types[0] == "tts_start" and types[-1] == "tts_end"

--- a/autobot-backend/api/voice_stream.py
+++ b/autobot-backend/api/voice_stream.py
@@ -76,6 +76,13 @@ async def _stream_chunks_pipelined(
     Shared by both ``_synthesize_and_stream`` (full-duplex ``speak``)
     and ``_tts_queue_worker`` (streaming ``speak_sentence``).
 
+    ``stream_or_synthesize`` (not ``synthesize_stream``) is used so a worker
+    deployed before the streaming route existed degrades to the
+    whole-utterance route instead of 404ing (#12886). That 404 used to be
+    forwarded as an ``error`` frame with no audio, and the frontend only falls
+    back to HTTP when the *socket* fails — never on a per-utterance server
+    error — so the spoken reply was dropped in silence.
+
     Sends ``tts_start`` before the first chunk and ``tts_end`` after the
     last, keeping the WS protocol consistent (#1535, #1536).
     *cancel_event* is checked BETWEEN chunks so barge-in can interrupt
@@ -95,7 +102,7 @@ async def _stream_chunks_pipelined(
     tts = get_tts_client()
     index = 0
     try:
-        async with aclosing(tts.synthesize_stream(text, voice_id=voice_id, language=language)) as stream:
+        async with aclosing(tts.stream_or_synthesize(text, voice_id=voice_id, language=language)) as stream:
             async for wav_bytes in stream:
                 if cancel_event.is_set():
                     logger.debug("TTS cancelled mid-stream at chunk %d", index)

--- a/autobot-backend/api/voice_stream_test.py
+++ b/autobot-backend/api/voice_stream_test.py
@@ -34,7 +34,13 @@ class _FakeWebSocket:
 
 
 class _FakeTTSClient:
-    """Stand-in for TTSClient exposing only synthesize_stream (#12501)."""
+    """Stand-in for TTSClient exposing the chunk-stream entry points (#12501).
+
+    ``stream_or_synthesize`` is what ``voice_stream`` calls since #13215/#12886
+    (it degrades to the whole-utterance route on a stale worker); it shares the
+    same generator here because these tests are about the WS framing, not the
+    worker-capability fallback -- that is covered in ``voice_latency_test``.
+    """
 
     def __init__(self, chunks, cancel_event=None, cancel_after=None, closed_flag=None) -> None:
         self._chunks = chunks
@@ -43,6 +49,9 @@ class _FakeTTSClient:
         self._closed_flag = closed_flag
 
     def synthesize_stream(self, text: str, voice_id: str = "", language: str = ""):
+        return self._gen()
+
+    def stream_or_synthesize(self, text: str, voice_id: str = "", language: str = ""):
         return self._gen()
 
     async def _gen(self):
@@ -105,7 +114,7 @@ class TestStreamChunksPipelined:
     @pytest.mark.asyncio
     async def test_synthesis_error_sends_error_and_still_sends_tts_end(self):
         class _FailingClient:
-            def synthesize_stream(self, text, voice_id="", language=""):
+            def stream_or_synthesize(self, text, voice_id="", language=""):
                 async def _gen():
                     yield b"wav-1"
                     raise RuntimeError("worker exploded")

--- a/autobot-backend/services/tts_client.py
+++ b/autobot-backend/services/tts_client.py
@@ -184,9 +184,15 @@ class TTSClient:
         """
         emitted = False
         if not self._streaming_known_absent():
+            degraded = self._stream_absent_until > 0.0
             try:
                 async with aclosing(self.synthesize_stream(text, voice_id=voice_id, language=language)) as stream:
                     async for chunk in stream:
+                        if not emitted and degraded:
+                            # Recovery is otherwise silent, leaving an operator
+                            # unable to tell which route is in use (#13215 review).
+                            logger.info("TTS worker now serves /tts/synthesize/stream; streaming resumed")
+                            self._stream_absent_until = 0.0
                         emitted = True
                         yield chunk
                 return

--- a/autobot-backend/services/tts_client.py
+++ b/autobot-backend/services/tts_client.py
@@ -17,12 +17,16 @@ Usage:
 """
 
 import asyncio
+import time
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 
 import aiohttp
 
+from autobot_shared.env_utils import blank_to_none
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_constants import TTL_5_MINUTES
 from autobot_shared.ssot_config import config, get_config
 
 logger = get_logger(__name__)
@@ -35,7 +39,51 @@ TTS_WORKER_URL = f"http://{TTS_WORKER_HOST}:{TTS_WORKER_PORT}"
 HEALTH_TIMEOUT = 2.0
 SYNTHESIS_TIMEOUT = 60.0
 
+# #12886: a worker deployed before /tts/synthesize/stream existed 404s that
+# route while serving /tts/synthesize normally. The backend caches that
+# negative result for this long so it costs one failed round trip per window
+# instead of one per utterance, and re-probes afterwards so a worker updated
+# in place resumes streaming without a backend restart.
+_STREAM_PROBE_TTL_DEFAULT = TTL_5_MINUTES
+
+
+def _resolve_stream_probe_ttl() -> int:
+    """Return seconds to cache a negative /tts/synthesize/stream probe."""
+    raw = blank_to_none(config.misc.tts_stream_probe_ttl)
+    if raw is None:
+        return _STREAM_PROBE_TTL_DEFAULT
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "AUTOBOT_TTS_STREAM_PROBE_TTL=%r is not an integer; falling back to %ds",
+            raw,
+            _STREAM_PROBE_TTL_DEFAULT,
+        )
+        return _STREAM_PROBE_TTL_DEFAULT
+    if value <= 0:
+        logger.warning(
+            "AUTOBOT_TTS_STREAM_PROBE_TTL=%d must be positive; falling back to %ds",
+            value,
+            _STREAM_PROBE_TTL_DEFAULT,
+        )
+        return _STREAM_PROBE_TTL_DEFAULT
+    return value
+
+
+STREAM_PROBE_TTL = _resolve_stream_probe_ttl()
+
 _client_instance: "TTSClient | None" = None
+
+
+class TTSStreamUnsupported(RuntimeError):
+    """The worker does not serve ``/tts/synthesize/stream`` (#12886).
+
+    Distinct from a generic worker failure: it means the deployed worker's
+    route table predates the backend calling it, so the whole-utterance route
+    is the correct thing to use instead. Any other status is a real error and
+    must not be retried against a different endpoint.
+    """
 
 
 class TTSClient:
@@ -43,6 +91,8 @@ class TTSClient:
 
     def __init__(self, base_url: str = TTS_WORKER_URL) -> None:
         self.base_url = base_url
+        # monotonic deadline until which the streaming route is known-absent
+        self._stream_absent_until: float = 0.0
 
     async def is_available(self) -> bool:
         """Return True if the TTS worker health check passes."""
@@ -98,6 +148,9 @@ class TTSClient:
         async with client.tracked_request(
             "POST", f"{self.base_url}/tts/synthesize/stream", data=data, timeout=timeout
         ) as resp:
+            if resp.status in (404, 405):
+                # Route table skew, not a synthesis failure — see #12886.
+                raise TTSStreamUnsupported(f"TTS worker error {resp.status}: worker does not serve the stream route")
             if resp.status != 200:
                 body = await resp.text()
                 raise RuntimeError(f"TTS worker error {resp.status}: {body}")
@@ -111,6 +164,43 @@ class TTSClient:
                     yield await resp.content.readexactly(chunk_len)
                 except asyncio.IncompleteReadError as e:
                     raise RuntimeError("TTS stream truncated mid-chunk") from e
+
+    def _streaming_known_absent(self) -> bool:
+        """True while a recent probe showed the worker lacks the stream route."""
+        return time.monotonic() < self._stream_absent_until
+
+    async def stream_or_synthesize(self, text: str, voice_id: str = "", language: str = "") -> AsyncIterator[bytes]:
+        """Yield WAV chunks, degrading to the whole-utterance route (#12886, #13215).
+
+        Prefers ``/tts/synthesize/stream`` so the caller can emit audio after
+        the first ~250ms instead of after the whole clip. When the deployed
+        worker predates that route it answers 404 *before* any chunk is sent,
+        so falling back to ``/tts/synthesize`` here cannot duplicate or
+        interleave audio — the fallback yields the whole clip as one chunk.
+
+        Callers get one uniform contract regardless of how current the worker
+        is, which is what keeps a worker/backend skew from turning into
+        silence (WebSocket path) or a hard 404 (HTTP path).
+        """
+        emitted = False
+        if not self._streaming_known_absent():
+            try:
+                async with aclosing(self.synthesize_stream(text, voice_id=voice_id, language=language)) as stream:
+                    async for chunk in stream:
+                        emitted = True
+                        yield chunk
+                return
+            except TTSStreamUnsupported as e:
+                if emitted:
+                    raise  # cannot restart mid-utterance without repeating audio
+                self._stream_absent_until = time.monotonic() + STREAM_PROBE_TTL
+                logger.warning(
+                    "TTS worker does not serve /tts/synthesize/stream (%s); using the "
+                    "whole-utterance route for the next %ds",
+                    e,
+                    STREAM_PROBE_TTL,
+                )
+        yield await self.synthesize(text, voice_id=voice_id, language=language)
 
     async def clone_voice(self, text: str, reference_audio: bytes) -> bytes:
         """Send text + reference audio to TTS worker; returns WAV bytes."""

--- a/autobot-backend/services/tts_client.py
+++ b/autobot-backend/services/tts_client.py
@@ -26,8 +26,8 @@ import aiohttp
 from autobot_shared.env_utils import blank_to_none
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.ssot_constants import TTL_5_MINUTES
 from autobot_shared.ssot_config import config, get_config
+from autobot_shared.ssot_constants import TTL_5_MINUTES
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/services/tts_client_test.py
+++ b/autobot-backend/services/tts_client_test.py
@@ -259,8 +259,12 @@ async def test_stream_or_synthesize_does_not_mask_worker_failures():
     )
     with patch("services.tts_client.get_http_client", return_value=mock_client):
         tts_client = TTSClient()
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as exc:
             async for _ in tts_client.stream_or_synthesize("hello"):
                 pass
 
+    # TTSStreamUnsupported subclasses RuntimeError, so pytest.raises alone would
+    # also pass if a 500 were mistakenly treated as route skew. Pin the exact
+    # type: only 404/405 may degrade to the blocking endpoint.
+    assert type(exc.value) is RuntimeError
     assert not any(u.endswith(BLOCKING_URL_SUFFIX) for u in mock_client.requested_urls)

--- a/autobot-backend/services/tts_client_test.py
+++ b/autobot-backend/services/tts_client_test.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.tts_client import TTSClient
+from services.tts_client import STREAM_PROBE_TTL, TTSClient
 
 
 class _FakeStreamReader:
@@ -119,3 +119,148 @@ async def test_synthesize_stream_empty_body_yields_nothing():
         received = [c async for c in tts_client.synthesize_stream("hello")]
 
     assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Stale-worker fallback + capability probe (#12886, #13215)
+# ---------------------------------------------------------------------------
+
+WHOLE_WAV = b"RIFF-whole-utterance"
+STREAM_URL_SUFFIX = "/tts/synthesize/stream"
+BLOCKING_URL_SUFFIX = "/tts/synthesize"
+
+
+def _make_routing_http_client(responses: dict) -> MagicMock:
+    """Mock pooled HTTP client that dispatches on the request URL.
+
+    ``responses`` maps a URL suffix to ``(status, body)``. Every requested URL
+    is recorded on ``mock_client.requested_urls`` so a test can assert that the
+    stream route was (or was not) attempted -- that is what distinguishes a
+    cached capability probe from a per-request round trip.
+    """
+    requested: list = []
+
+    def _tracked_request(method, url, **kwargs):
+        requested.append(url)
+        status, body = next(
+            ((s, b) for suffix, (s, b) in responses.items() if url.endswith(suffix)),
+            (404, b""),
+        )
+        resp = MagicMock()
+        resp.status = status
+        resp.content = _FakeStreamReader(body)
+        resp.text = AsyncMock(return_value="Not Found")
+        resp.read = AsyncMock(return_value=body)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    client = MagicMock()
+    client.tracked_request = MagicMock(side_effect=_tracked_request)
+    client.requested_urls = requested
+    return client
+
+
+class _FakeClock:
+    """Controllable stand-in for time.monotonic so the probe TTL is testable."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _stale_worker_client() -> MagicMock:
+    """A worker that serves /tts/synthesize but 404s /tts/synthesize/stream."""
+    return _make_routing_http_client(
+        {
+            STREAM_URL_SUFFIX: (404, b""),
+            BLOCKING_URL_SUFFIX: (200, WHOLE_WAV),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_falls_back_when_worker_lacks_stream_route():
+    """A worker predating /tts/synthesize/stream must still produce audio (#12886).
+
+    The deployed worker 404s the streaming route while serving the whole-blob
+    one. Before this fallback existed the caller got a RuntimeError and the
+    user got silence.
+    """
+    mock_client = _stale_worker_client()
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
+        received = [c async for c in tts_client.stream_or_synthesize("hello", voice_id="alba")]
+
+    assert received == [WHOLE_WAV]
+    assert any(u.endswith(STREAM_URL_SUFFIX) for u in mock_client.requested_urls)
+    assert any(u.endswith(BLOCKING_URL_SUFFIX) for u in mock_client.requested_urls)
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_caches_the_negative_probe():
+    """After one 404 the stream route is not re-attempted on every utterance."""
+    mock_client = _stale_worker_client()
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
+        async for _ in tts_client.stream_or_synthesize("first"):
+            pass
+        mock_client.requested_urls.clear()
+        received = [c async for c in tts_client.stream_or_synthesize("second")]
+
+    assert received == [WHOLE_WAV]
+    assert not any(u.endswith(STREAM_URL_SUFFIX) for u in mock_client.requested_urls)
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_reprobes_after_ttl():
+    """A worker updated in place starts streaming again without a backend restart."""
+    mock_client = _stale_worker_client()
+    clock = _FakeClock()
+    with (
+        patch("services.tts_client.get_http_client", return_value=mock_client),
+        patch("services.tts_client.time.monotonic", clock),
+    ):
+        tts_client = TTSClient()
+        async for _ in tts_client.stream_or_synthesize("first"):
+            pass
+        mock_client.requested_urls.clear()
+        clock.now += STREAM_PROBE_TTL + 1
+        async for _ in tts_client.stream_or_synthesize("second"):
+            pass
+
+    assert any(u.endswith(STREAM_URL_SUFFIX) for u in mock_client.requested_urls)
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_streams_when_the_route_is_served():
+    """A current worker streams: every chunk is yielded, the blocking route unused."""
+    chunks = [b"RIFF-one", b"RIFF-two", b"RIFF-three"]
+    mock_client = _make_routing_http_client({STREAM_URL_SUFFIX: (200, _framed(chunks))})
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
+        received = [c async for c in tts_client.stream_or_synthesize("hello")]
+
+    assert received == chunks
+    assert not any(u.endswith(BLOCKING_URL_SUFFIX) for u in mock_client.requested_urls)
+
+
+@pytest.mark.asyncio
+async def test_stream_or_synthesize_does_not_mask_worker_failures():
+    """A 500 is a real failure, not a contract skew -- it must not silently retry."""
+    mock_client = _make_routing_http_client(
+        {
+            STREAM_URL_SUFFIX: (500, b""),
+            BLOCKING_URL_SUFFIX: (200, WHOLE_WAV),
+        }
+    )
+    with patch("services.tts_client.get_http_client", return_value=mock_client):
+        tts_client = TTSClient()
+        with pytest.raises(RuntimeError):
+            async for _ in tts_client.stream_or_synthesize("hello"):
+                pass
+
+    assert not any(u.endswith(BLOCKING_URL_SUFFIX) for u in mock_client.requested_urls)

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.streaming.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.streaming.test.ts
@@ -1,0 +1,217 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// #13215: the HTTP TTS path waited for the whole utterance before any audio
+// existed (measured 4.7-10.1s to first sound). The backend now emits
+// `[4-byte big-endian length][WAV]` frames when `stream=true` is requested;
+// these tests assert the client actually asks for that, splits the frames, and
+// schedules each mini-WAV as it arrives rather than after the stream ends.
+//
+// Splitting matters: the chunks are separate, independently-decodable WAV
+// files, so handing the concatenated body to decodeAudioData would decode only
+// the first one and silently drop the rest of the sentence.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+const mockShowToast = vi.fn()
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+    toasts: { value: [] },
+    removeToast: vi.fn(),
+    clearAllToasts: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useVoiceProfiles', () => ({
+  useVoiceProfiles: () => ({
+    voices: ref([{ id: 'v1' }]),
+    fetchVoices: vi.fn(),
+    effectiveVoiceId: ref('v1'),
+  }),
+}))
+
+vi.mock('@/composables/usePreferences', () => ({
+  usePreferences: () => ({ language: ref('en') }),
+}))
+
+vi.mock('@/utils/fetchWithAuth', () => ({ fetchWithAuth: vi.fn() }))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+  getBackendWsUrl: () => 'ws://test',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { useVoiceOutput } from '../useVoiceOutput'
+
+const FRAMING_HEADER = 'X-Audio-Framing'
+const FRAMING_VALUE = 'length-prefixed-wav'
+
+const CHUNKS = [
+  new Uint8Array([1, 1, 1, 1]),
+  new Uint8Array([2, 2, 2, 2, 2, 2]),
+  new Uint8Array([3, 3]),
+]
+
+let decodedSizes: number[] = []
+let scheduledStarts = 0
+
+class FakeBufferSource {
+  buffer: unknown = null
+  onended: (() => void) | null = null
+  connect() {}
+  start() {
+    scheduledStarts++
+    // Playback "completes" on the next macrotask so the whole-blob path, which
+    // awaits onended, resolves without the test having to drive it by hand.
+    setTimeout(() => this.onended && this.onended(), 0)
+  }
+  stop() {}
+}
+
+class FakeAudioContext {
+  currentTime = 0
+  destination = {}
+  state = 'running'
+  async resume() {}
+  async decodeAudioData(buf: ArrayBuffer) {
+    decodedSizes.push(buf.byteLength)
+    return { duration: 0.05 }
+  }
+  createBufferSource() {
+    return new FakeBufferSource()
+  }
+  createGain() {
+    return { gain: { value: 1 }, connect() {} }
+  }
+}
+
+/** Build the backend's `[4-byte length][WAV]` framing for `chunks`. */
+function frame(chunks: Uint8Array[]): Uint8Array[] {
+  return chunks.map((c) => {
+    const out = new Uint8Array(4 + c.length)
+    new DataView(out.buffer).setUint32(0, c.length, false)
+    out.set(c, 4)
+    return out
+  })
+}
+
+/**
+ * A ReadableStream that emits `pieces` one at a time and records, per piece,
+ * how many buffers had already been scheduled — proving playback starts before
+ * the response finishes rather than after it.
+ */
+function pacedStream(pieces: Uint8Array[], scheduledWhenEmitted: number[]): ReadableStream<Uint8Array> {
+  let index = 0
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (index >= pieces.length) {
+        controller.close()
+        return
+      }
+      scheduledWhenEmitted.push(scheduledStarts)
+      controller.enqueue(pieces[index])
+      index += 1
+    },
+  })
+}
+
+function streamResponse(body: ReadableStream<Uint8Array>): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (name: string) => (name === FRAMING_HEADER ? FRAMING_VALUE : null) },
+    body,
+    blob: async () => {
+      throw new Error('blob() must not be used on a framed response')
+    },
+  } as unknown as Response
+}
+
+let originalAudioContext: unknown
+
+describe('useVoiceOutput — chunked HTTP synthesis (#13215)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    decodedSizes = []
+    scheduledStarts = 0
+    originalAudioContext = (globalThis as Record<string, unknown>).AudioContext
+    ;(globalThis as Record<string, unknown>).AudioContext = FakeAudioContext
+  })
+
+  afterEach(() => {
+    const { stopSpeaking } = useVoiceOutput()
+    stopSpeaking()
+    ;(globalThis as Record<string, unknown>).AudioContext = originalAudioContext
+    vi.restoreAllMocks()
+  })
+
+  it('requests the chunked variant and schedules each frame separately', async () => {
+    const emitted: number[] = []
+    vi.mocked(fetchWithAuth).mockResolvedValue(streamResponse(pacedStream(frame(CHUNKS), emitted)))
+
+    const { speak } = useVoiceOutput()
+    await speak('hello there', true)
+
+    const [, init] = vi.mocked(fetchWithAuth).mock.calls[0]
+    expect((init?.body as FormData).get('stream')).toBe('true')
+    expect(decodedSizes).toEqual(CHUNKS.map((c) => c.length))
+    expect(scheduledStarts).toBe(CHUNKS.length)
+  })
+
+  it('plays the first chunk before the response has finished arriving', async () => {
+    const emitted: number[] = []
+    vi.mocked(fetchWithAuth).mockResolvedValue(streamResponse(pacedStream(frame(CHUNKS), emitted)))
+
+    const { speak } = useVoiceOutput()
+    await speak('hello there', true)
+
+    // The final piece was requested only after earlier chunks were already
+    // scheduled — i.e. audio started while bytes were still in flight. A
+    // buffer-then-play implementation reports 0 here for every piece.
+    expect(emitted[emitted.length - 1]).toBeGreaterThan(0)
+  })
+
+  it('splits frames correctly when they arrive misaligned across reads', async () => {
+    const framed = frame(CHUNKS)
+    const joined = new Uint8Array(framed.reduce((n, f) => n + f.length, 0))
+    let offset = 0
+    for (const f of framed) {
+      joined.set(f, offset)
+      offset += f.length
+    }
+    // Split at byte 3 — mid-header — so a naive per-read parser mis-frames.
+    const pieces = [joined.slice(0, 3), joined.slice(3, 9), joined.slice(9)]
+    vi.mocked(fetchWithAuth).mockResolvedValue(streamResponse(pacedStream(pieces, [])))
+
+    const { speak } = useVoiceOutput()
+    await speak('hello there', true)
+
+    expect(decodedSizes).toEqual(CHUNKS.map((c) => c.length))
+  })
+
+  it('falls back to whole-blob playback when the response is not framed', async () => {
+    const wav = new Uint8Array([9, 9, 9, 9, 9])
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      body: null,
+      blob: async () => ({ arrayBuffer: async () => wav.buffer }),
+    } as unknown as Response)
+
+    const { speak } = useVoiceOutput()
+    await speak('hello there', true)
+
+    expect(decodedSizes).toEqual([wav.length])
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.streaming.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.streaming.test.ts
@@ -163,7 +163,7 @@ describe('useVoiceOutput — chunked HTTP synthesis (#13215)', () => {
     await speak('hello there', true)
 
     const [, init] = vi.mocked(fetchWithAuth).mock.calls[0]
-    expect((init?.body as FormData).get('stream')).toBe('true')
+    expect((init!.body as FormData).get('stream')).toBe('true')
     expect(decodedSizes).toEqual(CHUNKS.map((c) => c.length))
     expect(scheduledStarts).toBe(CHUNKS.length)
   })

--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
@@ -244,6 +244,10 @@ describe('useVoiceOutput — sequential fallback queue (#12502)', () => {
         return {
           ok: true,
           status: 200,
+          // #13215: a real Response always has headers; without the framing
+          // marker the client takes the whole-blob path these tests cover.
+          headers: { get: () => null },
+          body: null,
           blob: async () => ({ arrayBuffer: async () => new ArrayBuffer(8) }),
         }
       },
@@ -288,6 +292,10 @@ describe('useVoiceOutput — sequential fallback queue (#12502)', () => {
         return {
           ok: true,
           status: 200,
+          // #13215: a real Response always has headers; without the framing
+          // marker the client takes the whole-blob path these tests cover.
+          headers: { get: () => null },
+          body: null,
           blob: async () => ({ arrayBuffer: async () => new ArrayBuffer(8) }),
         }
       },

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -22,6 +22,14 @@ const logger = createLogger('useVoiceOutput')
 
 const STORAGE_KEY = 'autobot-voice-output-enabled'
 
+// #13215: chunked TTS wire format. The backend answers /voice/synthesize with
+// `[4-byte big-endian length][WAV]` frames when `stream=true` is sent, marked
+// by this header, so the first ~250ms can play while the rest is still being
+// synthesized. Must stay in step with api/voice.py's AUDIO_STREAM_FRAMING*.
+const FRAMING_HEADER = 'X-Audio-Framing'
+const FRAMING_VALUE = 'length-prefixed-wav'
+const FRAME_HEADER_BYTES = 4
+
 // #9999: user-visible message when a deployment has no TTS voices installed
 // (e.g. no tts-worker provisioned in small topologies). Without this, TTS
 // no-ops silently and the operator gets no feedback.
@@ -418,9 +426,51 @@ function _connectTtsWs(): Promise<WebSocket> {
 }
 
 /**
+ * Read the backend's `[4-byte big-endian length][WAV]` framing, scheduling each
+ * mini-WAV the instant it arrives (#13215).
+ *
+ * The chunks are separate, independently-decodable WAV files — concatenating
+ * them and handing the result to decodeAudioData would only ever decode the
+ * first one, so they must be split here and scheduled individually on the same
+ * gapless timeline the WebSocket path uses.
+ */
+async function _playFramedAudioStream(body: ReadableStream<Uint8Array>): Promise<void> {
+  const reader = body.getReader()
+  let buffer = new Uint8Array(0)
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (value?.length) {
+      const merged = new Uint8Array(buffer.length + value.length)
+      merged.set(buffer)
+      merged.set(value, buffer.length)
+      buffer = merged
+    }
+    // Drain every complete frame currently buffered before reading again.
+    for (;;) {
+      if (buffer.length < FRAME_HEADER_BYTES) break
+      const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+      const size = view.getUint32(0, false)
+      if (buffer.length < FRAME_HEADER_BYTES + size) break
+      const wav = buffer.slice(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + size)
+      buffer = buffer.slice(FRAME_HEADER_BYTES + size)
+      await _scheduleGaplessChunk(wav.buffer as ArrayBuffer)
+    }
+    if (done) break
+  }
+  if (buffer.length > 0) {
+    logger.warn('TTS stream ended mid-frame; dropped', buffer.length, 'trailing bytes')
+  }
+}
+
+/**
  * Synthesize `text` via the HTTP TTS endpoint and play it to completion.
  * Shared by the one-shot speak() and the sequential fallback drainer (#12502).
  * The caller owns the AbortController so it can cancel this request.
+ *
+ * Requests the chunked variant (#13215): the backend then emits each ~250ms
+ * mini-WAV as the worker produces it instead of buffering the whole utterance,
+ * which is what made every spoken reply start after 4.7–10.1s of silence. A
+ * runtime without ReadableStream support still gets the whole-blob response.
  */
 async function _synthesizeAndPlay(text: string, signal: AbortSignal): Promise<void> {
   const { effectiveVoiceId } = useVoiceProfiles()
@@ -434,6 +484,7 @@ async function _synthesizeAndPlay(text: string, signal: AbortSignal): Promise<vo
   if (language) {
     formData.append('language', language)
   }
+  formData.append('stream', 'true')
   const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, { // fetchWithAuth retained: binary audio blob + FormData body — exempt (#6256)
     method: 'POST',
     body: formData,
@@ -445,6 +496,14 @@ async function _synthesizeAndPlay(text: string, signal: AbortSignal): Promise<vo
     if (response.status === 404 || response.status === 503) {
       _notifyNoVoices()
     }
+    return
+  }
+  if (response.headers.get(FRAMING_HEADER) === FRAMING_VALUE && response.body) {
+    // Chunks are scheduled on the shared gapless timeline and are still
+    // sounding when this resolves, so isSpeaking is left to the per-source
+    // onended handler — clearing it here would drop the indicator (and fire
+    // watch(isSpeaking)) while audio is mid-utterance.
+    await _playFramedAudioStream(response.body)
     return
   }
   const blob = await response.blob()

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -437,25 +437,45 @@ function _connectTtsWs(): Promise<WebSocket> {
 async function _playFramedAudioStream(body: ReadableStream<Uint8Array>): Promise<void> {
   const reader = body.getReader()
   let buffer = new Uint8Array(0)
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (value?.length) {
-      const merged = new Uint8Array(buffer.length + value.length)
-      merged.set(buffer)
-      merged.set(value, buffer.length)
-      buffer = merged
-    }
-    // Drain every complete frame currently buffered before reading again.
+  try {
     for (;;) {
-      if (buffer.length < FRAME_HEADER_BYTES) break
-      const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
-      const size = view.getUint32(0, false)
-      if (buffer.length < FRAME_HEADER_BYTES + size) break
-      const wav = buffer.slice(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + size)
-      buffer = buffer.slice(FRAME_HEADER_BYTES + size)
-      await _scheduleGaplessChunk(wav.buffer as ArrayBuffer)
+      const { done, value } = await reader.read()
+      if (value?.length) {
+        const merged = new Uint8Array(buffer.length + value.length)
+        merged.set(buffer)
+        merged.set(value, buffer.length)
+        buffer = merged
+      }
+      // Drain every complete frame currently buffered before reading again.
+      for (;;) {
+        if (buffer.length < FRAME_HEADER_BYTES) break
+        const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+        const size = view.getUint32(0, false)
+        if (buffer.length < FRAME_HEADER_BYTES + size) break
+        // A zero-length frame is reachable: readexactly(0) returns b'' without
+        // raising, so a 0 header from the worker propagates an empty chunk.
+        // decodeAudioData rejects on it, which would abandon every remaining
+        // frame of the utterance — skip it instead.
+        if (size === 0) {
+          buffer = buffer.slice(FRAME_HEADER_BYTES)
+          continue
+        }
+        const wav = buffer.slice(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + size)
+        buffer = buffer.slice(FRAME_HEADER_BYTES + size)
+        // One undecodable frame must not silence the rest of the reply — the
+        // WebSocket path already guards per-chunk this way.
+        try {
+          await _scheduleGaplessChunk(wav.buffer as ArrayBuffer)
+        } catch (error) {
+          logger.warn('TTS frame decode failed; skipping frame', error)
+        }
+      }
+      if (done) break
     }
-    if (done) break
+  } finally {
+    // Releases the response body on an abort or a throw; without this the
+    // stream stays locked and the connection is never cancelled.
+    reader.cancel().catch(() => {})
   }
   if (buffer.length > 0) {
     logger.warn('TTS stream ended mid-frame; dropped', buffer.length, 'trailing bytes')

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -10944,6 +10944,9 @@ export interface paths {
         /**
          * Voice Speak Api
          * @description Converts text to speech and plays it.
+         *
+         *     ``stream=true`` returns length-prefixed WAV chunks as they are synthesized
+         *     (#13215); omitting it keeps the whole-utterance ``audio/wav`` contract.
          */
         post: operations["voice_speak_api_api_voice_speak_post"];
         delete?: never;
@@ -10963,7 +10966,13 @@ export interface paths {
         put?: never;
         /**
          * Voice Synthesize Api
-         * @description Synthesize speech via Pocket TTS worker. Returns audio/wav stream.
+         * @description Synthesize speech via the Pocket TTS worker.
+         *
+         *     Returns a whole ``audio/wav`` body by default. With ``stream=true`` the
+         *     response is ``application/octet-stream`` carrying
+         *     ``[4-byte length][WAV]`` chunks emitted as the worker produces them, so
+         *     the caller hears audio after the first ~250ms instead of after the whole
+         *     utterance (#13215).
          */
         post: operations["voice_synthesize_api_api_voice_synthesize_post"];
         delete?: never;
@@ -58598,6 +58607,11 @@ export interface components {
              * @default user
              */
             user_role: string;
+            /**
+             * Stream
+             * @default false
+             */
+            stream: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -58620,6 +58634,11 @@ export interface components {
              * @default user
              */
             user_role: string;
+            /**
+             * Stream
+             * @default false
+             */
+            stream: boolean;
         } & {
             [key: string]: unknown;
         };

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1703,6 +1703,16 @@ class MiscConfig(BaseSettings):
     tls_key_path: str = Field(default="", alias="AUTOBOT_TLS_KEY_PATH")
     trace_console: str = Field(default="", alias="AUTOBOT_TRACE_CONSOLE")
     trace_sample_rate: float = Field(default=0.0, alias="AUTOBOT_TRACE_SAMPLE_RATE")
+    tts_stream_probe_ttl: str = Field(
+        default="",
+        alias="AUTOBOT_TTS_STREAM_PROBE_TTL",
+        description=(
+            "Seconds the backend remembers that the TTS worker does not serve "
+            "/tts/synthesize/stream before probing again (#12886). Short enough "
+            "that an in-place worker update starts streaming without a backend "
+            "restart, long enough not to cost a 404 round trip per utterance."
+        ),
+    )
     urlhaus_feed_url: str = Field(default="", alias="AUTOBOT_URLHAUS_FEED_URL")
     user_mode: str = Field(default="", alias="AUTOBOT_USER_MODE")
     vue_root: str = Field(default="", alias="AUTOBOT_VUE_ROOT")


### PR DESCRIPTION
## Thinking Path

These two issues were filed as "slow" and "404", but reading the code they are one defect seen from two ends, and #13215's stated premise is partly wrong.

**#13215 says the streaming route "sits unused". It does not.** `api/voice_stream.py:98` has consumed `synthesize_stream()` since #12501 — the WebSocket voice path, which is what speaks chat replies. What never used it is the *HTTP* path (`api/voice.py`).

That matters, because it explains the measurement. Chain, verified in code:

1. A worker older than the backend 404s `/tts/synthesize/stream` (#12886).
2. `synthesize_stream()` raises, `voice_stream.py` catches it and emits `{"type": "error", "message": "TTS synthesis failed: TTS worker error 404: ..."}` — the exact string reported in #12886.
3. The client (`useVoiceOutput.ts`) only falls back to HTTP when the *socket* fails. A per-utterance `error` frame is `logger.warn`-ed and nothing else. The streaming path produces **silence**, not slowness.
4. So every reply that is heard at all arrives via the HTTP fallback — which used the whole-blob route. That is the 4.7–10.1s.

So the naive fix (point `api/voice.py` at the streaming route) makes it strictly worse: it converts the one path that still worked into a second 404. The fix has to be capability-aware, which is why these ship together.

I could **not** verify the deployed worker's route table — that needs a live host, and #12886's history is five rounds of "merged, still not on the host". This change deliberately does not depend on that: it is correct whether or not the route is served.

#13207 is **not** in this PR. It is `multimodal_processor` — a different subsystem, zero file overlap — and it is a behaviour change (threshold 0.7→0.8, timeout 30→15) that needs an owner's decision on which value is intended. Per the closure gate, partial delivery must not close it, so it stays open. Detail in a comment on #13215.

## What Changed

**`services/tts_client.py` — capability probe + fallback (the core).**
`synthesize_stream()` now raises `TTSStreamUnsupported` (not bare `RuntimeError`) on 404/405, distinguishing "the worker's route table predates the backend" from "synthesis failed". New `stream_or_synthesize()` prefers the streaming route and degrades to the whole-utterance route when it is absent. The 404 arrives *before* any chunk, so the fallback cannot duplicate or interleave audio; a guard re-raises rather than restarting if anything was already emitted. The negative result is cached for `AUTOBOT_TTS_STREAM_PROBE_TTL` (module constant, default 5 min) so it costs one failed round trip per window, not one per utterance, and re-probes afterwards — a worker updated in place resumes streaming without a backend restart. A 500 is **not** treated as skew and is never retried against a different endpoint.

**`api/voice_stream.py`** — the WS path uses `stream_or_synthesize`. A stale worker now speaks instead of going silent. This is the #12886 user-facing symptom, fixed independently of deploy state.

**`api/voice.py`** — `/synthesize` and `/speak` take `stream: bool = Form(False)`. Default is unchanged (`audio/wav` whole blob), so every existing caller keeps its contract. With `stream=true` the response is a `StreamingResponse` of the worker's own `[4-byte length][WAV]` framing, forwarded unchanged.

Framing rather than concatenation is required, not stylistic: the chunks are separate, independently-decodable WAV files. Concatenated into one `audio/wav` body only the first RIFF header is valid, so `decodeAudioData` would decode the first ~250ms and silently drop the rest of the sentence.

**`useVoiceOutput.ts`** — requests `stream=true` and, when the framing header is present, splits frames across read boundaries (a frame can straddle two reads, including mid-header) and schedules each mini-WAV on the existing gapless timeline as it arrives. Falls back to the blob path when the header is absent. `isSpeaking` is deliberately *not* force-cleared on the framed path — chunks are still sounding when the response ends; the per-source `onended` owns that transition.

Also regenerated `api.ts` for the new field. Note: the generator bakes the generating machine's CWD/install path and unset-env placeholders into schema defaults, so a local regeneration produces unrelated churn; those hunks were reverted to the committed values and filed as #13298.

## Verification

Regression tests were written first and **fail on the pre-fix tree**:

```
$ pytest api/voice_latency_test.py -q
FAILED test_streaming_synthesize_reaches_first_audio_far_sooner
  AssertionError: streaming time-to-first-audio 0.511s is not materially
  better than blocking 0.520s
FAILED test_streaming_response_carries_every_chunk_in_order
FAILED test_ws_path_still_speaks_when_worker_lacks_stream_route
  AssertionError: stale worker still surfaced an error frame:
  [{'type': 'tts_start', ...},
   {'type': 'error', 'message': 'TTS synthesis failed: TTS worker error 404: Not Found'},
   {'type': 'tts_end'}]
3 failed, 1 passed
```

That third failure message is #12886's reported symptom reproduced in-process from the repo alone.

After:

```
$ pytest api/voice_latency_test.py services/tts_client_test.py \
         api/voice_stream_test.py tests/test_voice_503_guard.py -q
22 passed

$ pytest api/api_endpoint_migrations_test.py ... -q     22 passed, 2111 skipped
$ pytest tests/services/tts_contract_test.py \
         tests/services/drift_checker_test.py \
         tests/test_updater_refreshes_tts_worker_12886.py -q      37 passed
```

**The latency claim is measured, not asserted.** A fake worker paces a 0.5s utterance as 5 chunks; time-to-first-byte is read off the ASGI `http.response.body` messages:

```
MEASURED time-to-first-audio: blocking=0.533s  streaming=0.112s   (4.8x)
```

which is the expected 1/5. Note starlette's `TestClient` buffers the whole response before returning, so it cannot observe TTFB at all — the test drives the ASGI app directly, and still exercises the real route, form parsing and `StreamingResponse`. An "it called synthesize_stream" assertion would pass even if the route buffered the whole utterance, i.e. it would not catch the actual defect.

Frontend, same before/after discipline:

```
$ npx vitest run useVoiceOutput.streaming.test.ts        (pre-fix)
  × requests the chunked variant and schedules each frame separately
  × plays the first chunk before the response has finished arriving
  × splits frames correctly when they arrive misaligned across reads
  ✓ falls back to whole-blob playback when the response is not framed
  3 failed | 1 passed

$ npx vitest run useVoiceOutput.streaming.test.ts \
      useVoiceOutput.playback.test.ts useVoiceOutput.test.ts \
      useVoiceConversation.test.ts                        22 passed
$ npx vue-tsc --noEmit -p tsconfig.app.json               clean
$ npx eslint <changed files>                              clean
```

**Not verified — stated plainly rather than claimed.** I did not execute anything against a live deployment, so I cannot confirm the deployed worker now serves `/tts/synthesize/stream`. That is exactly why this change does not depend on it: on a current worker the WS and HTTP paths stream, and on a stale one both degrade to working whole-blob audio instead of a 404 or silence. The live route probe from #12886's verification block remains the check to run before treating the deploy half as proven.

Closes #13215, #12886

Discovered and filed, not fixed here: #13298 (generated-types gate is machine-dependent), #13299 (a per-utterance WS error frame is only logged, so the sentence is dropped and the HTTP fallback never fires — this PR removes the common *cause* of that frame, not the handling gap).

## Model Used

claude-opus-5
