### PR TITLE
fix(code-intelligence): two production bugs the failing tests were reporting (#13162)

### DIFF
--- a/autobot-backend/code_intelligence/code_evolution_miner.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner.py
@@ -101,7 +101,11 @@ class GitHistoryCrawler:
             all_commits = list(self.repo.iter_commits("HEAD"))
 
             for commit in all_commits:
-                commit_date = datetime.fromtimestamp(commit.committed_date)
+                # #13162: tz-aware UTC. A naive datetime here crashed
+                # calculate_trend, which compares against
+                # datetime.now(tz=timezone.utc), and made month bucketing
+                # depend on the server's local timezone.
+                commit_date = datetime.fromtimestamp(commit.committed_date, tz=timezone.utc)
 
                 # Filter by date range
                 if start_date and commit_date < start_date:
@@ -136,7 +140,8 @@ class GitHistoryCrawler:
                     {
                         "hash": commit.hexsha,
                         "message": commit.message.strip(),
-                        "timestamp": datetime.fromtimestamp(commit.committed_date),
+                        # #13162: tz-aware UTC — see the note above.
+                        "timestamp": datetime.fromtimestamp(commit.committed_date, tz=timezone.utc),
                     }
                 )
         except Exception as e:

--- a/autobot-backend/code_intelligence/code_evolution_miner_test.py
+++ b/autobot-backend/code_intelligence/code_evolution_miner_test.py
@@ -8,7 +8,7 @@ Issue #243 - Code Evolution Mining from Git History
 """
 
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from code_intelligence.code_evolution_miner import (
@@ -27,7 +27,7 @@ class TestPatternOccurrence:
 
     def test_create_occurrence(self):
         """Test creating a pattern occurrence"""
-        timestamp = datetime.now()
+        timestamp = datetime.now(tz=timezone.utc)
         occurrence = PatternOccurrence(
             pattern_type="god_class",
             file_path="test.py",
@@ -64,7 +64,7 @@ class TestPatternLifecycle:
         """Test adding occurrences to lifecycle"""
         lifecycle = PatternLifecycle("god_class", "test.py", 10)
 
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         occurrence1 = PatternOccurrence("god_class", "test.py", 10, "abc", now, "high")
         occurrence2 = PatternOccurrence("god_class", "test.py", 10, "def", now + timedelta(days=1), "high")
 
@@ -86,7 +86,7 @@ class TestPatternLifecycle:
         assert lifecycle.get_lifespan_days() == 0
 
         # Add occurrences
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         lifecycle.add_occurrence(PatternOccurrence("god_class", "test.py", 10, "a", now, "high"))
         lifecycle.add_occurrence(PatternOccurrence("god_class", "test.py", 10, "b", now + timedelta(days=30), "high"))
 
@@ -122,7 +122,7 @@ class TestTemporalEmbedding:
         """Test adding patterns to timeline"""
         embedding = TemporalEmbedding()
 
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         occurrence = PatternOccurrence("god_class", "test.py", 10, "abc", now, "high")
 
         embedding.add_pattern(occurrence)
@@ -133,7 +133,7 @@ class TestTemporalEmbedding:
         """Test monthly pattern counts"""
         embedding = TemporalEmbedding()
 
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         month_key = now.strftime("%Y-%m")
 
         # Add multiple patterns
@@ -151,8 +151,8 @@ class TestTemporalEmbedding:
         """Test trend calculation for emerging patterns"""
         embedding = TemporalEmbedding()
 
-        old_date = datetime.now() - timedelta(days=200)
-        recent_date = datetime.now()
+        old_date = datetime.now(tz=timezone.utc) - timedelta(days=200)
+        recent_date = datetime.now(tz=timezone.utc)
 
         # Add old occurrences
         embedding.add_pattern(PatternOccurrence("god_class", "a.py", 1, "a", old_date, "high"))
@@ -168,8 +168,8 @@ class TestTemporalEmbedding:
         """Test trend calculation for declining patterns"""
         embedding = TemporalEmbedding()
 
-        old_date = datetime.now() - timedelta(days=200)
-        recent_date = datetime.now()
+        old_date = datetime.now(tz=timezone.utc) - timedelta(days=200)
+        recent_date = datetime.now(tz=timezone.utc)
 
         # Add many old occurrences
         for i in range(5):
@@ -185,8 +185,8 @@ class TestTemporalEmbedding:
         """Test trend calculation for stable patterns"""
         embedding = TemporalEmbedding()
 
-        old_date = datetime.now() - timedelta(days=200)
-        recent_date = datetime.now()
+        old_date = datetime.now(tz=timezone.utc) - timedelta(days=200)
+        recent_date = datetime.now(tz=timezone.utc)
 
         # Add equal old and recent occurrences
         for i in range(3):
@@ -204,7 +204,7 @@ class TestPatternEvolutionTracker:
         """Test tracking pattern occurrences"""
         tracker = PatternEvolutionTracker()
 
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         occurrence = PatternOccurrence("god_class", "test.py", 10, "abc", now, "high")
 
         tracker.track_pattern(occurrence)
@@ -216,7 +216,7 @@ class TestPatternEvolutionTracker:
         """Test finding existing lifecycle"""
         tracker = PatternEvolutionTracker()
 
-        now = datetime.now()
+        now = datetime.now(tz=timezone.utc)
         occurrence1 = PatternOccurrence("god_class", "test.py", 10, "abc", now, "high")
         occurrence2 = PatternOccurrence("god_class", "test.py", 12, "def", now + timedelta(days=1), "high")
 
@@ -231,8 +231,8 @@ class TestPatternEvolutionTracker:
         """Test getting emerging patterns"""
         tracker = PatternEvolutionTracker()
 
-        old_date = datetime.now() - timedelta(days=200)
-        recent_date = datetime.now()
+        old_date = datetime.now(tz=timezone.utc) - timedelta(days=200)
+        recent_date = datetime.now(tz=timezone.utc)
 
         # Add old occurrence
         tracker.track_pattern(PatternOccurrence("god_class", "a.py", 1, "a", old_date, "high"))
@@ -251,7 +251,7 @@ class TestPatternEvolutionTracker:
         """Test calculating adoption rate"""
         tracker = PatternEvolutionTracker()
 
-        start = datetime.now() - timedelta(days=60)  # 2 months ago
+        start = datetime.now(tz=timezone.utc) - timedelta(days=60)  # 2 months ago
 
         # Add occurrences over 2 months (6 total)
         for i in range(6):
@@ -299,7 +299,7 @@ class TestCodeEvolutionMiner:
             miner = CodeEvolutionMiner(tmpdir)
 
             # Add some patterns
-            now = datetime.now()
+            now = datetime.now(tz=timezone.utc)
             occurrence = PatternOccurrence("god_class", "test.py", 10, "abc", now, "high")
             miner.tracker.track_pattern(occurrence)
 
@@ -314,7 +314,7 @@ class TestCodeEvolutionMiner:
             miner = CodeEvolutionMiner(tmpdir)
 
             # Add patterns
-            now = datetime.now()
+            now = datetime.now(tz=timezone.utc)
             for i in range(3):
                 occurrence = PatternOccurrence("god_class", f"{i}.py", 1, f"h{i}", now, "high")
                 miner.tracker.track_pattern(occurrence)

--- a/autobot-backend/code_intelligence/merge_conflict_resolver.py
+++ b/autobot-backend/code_intelligence/merge_conflict_resolver.py
@@ -30,6 +30,7 @@ import ast
 import re
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import total_ordering
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -38,14 +39,41 @@ from autobot_shared.logging_manager import get_logger
 logger = get_logger(__name__)
 
 
+@total_ordering
 class ConflictSeverity(Enum):
-    """Severity levels for merge conflicts."""
+    """Severity levels for merge conflicts.
+
+    Ordered, because ``_select_strategy`` asks "is this at least COMPLEX?".
+    A plain ``Enum`` is not comparable, so ``severity >= COMPLEX`` raised
+    ``TypeError`` and **safe mode crashed instead of requiring review** — a
+    safety control that never fired (#13162).
+
+    Ordering is defined by an explicit rank rather than by switching to
+    ``IntEnum``, because the string values are the serialized form and must
+    not change.
+    """
 
     TRIVIAL = "trivial"  # Whitespace, formatting only
     SIMPLE = "simple"  # Non-overlapping logic changes
     MODERATE = "moderate"  # Some semantic overlap
     COMPLEX = "complex"  # Significant semantic conflict
     CRITICAL = "critical"  # Incompatible changes, manual review required
+
+    @property
+    def rank(self) -> int:
+        """Position in the severity order, low to high."""
+        return _SEVERITY_ORDER.index(self.value)
+
+    def __lt__(self, other: "ConflictSeverity") -> bool:
+        if not isinstance(other, ConflictSeverity):
+            return NotImplemented
+        return self.rank < other.rank
+
+
+#: Severity order, low to high. Defined beside the enum so adding a level
+#: without ranking it fails loudly (ValueError) rather than sorting silently
+#: wrong.
+_SEVERITY_ORDER = ("trivial", "simple", "moderate", "complex", "critical")
 
 
 class ResolutionStrategy(Enum):

--- a/autobot-backend/code_intelligence/merge_conflict_resolver_test.py
+++ b/autobot-backend/code_intelligence/merge_conflict_resolver_test.py
@@ -452,3 +452,40 @@ class TestRepositoryAnalysis:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestConflictSeverityOrdering:
+    """Severity must be comparable, or safe mode silently stops working (#13162).
+
+    `_select_strategy` asks `severity >= ConflictSeverity.COMPLEX`. On a plain
+    `Enum` that raises TypeError, so safe mode crashed instead of requiring
+    review — the control existed but never fired.
+    """
+
+    def test_severity_is_ordered_low_to_high(self):
+        assert ConflictSeverity.TRIVIAL < ConflictSeverity.SIMPLE
+        assert ConflictSeverity.SIMPLE < ConflictSeverity.MODERATE
+        assert ConflictSeverity.MODERATE < ConflictSeverity.COMPLEX
+        assert ConflictSeverity.COMPLEX < ConflictSeverity.CRITICAL
+
+    def test_the_comparison_safe_mode_actually_makes(self):
+        """`severity >= COMPLEX` — the exact expression that used to raise."""
+        assert ConflictSeverity.COMPLEX >= ConflictSeverity.COMPLEX
+        assert ConflictSeverity.CRITICAL >= ConflictSeverity.COMPLEX
+        assert not ConflictSeverity.MODERATE >= ConflictSeverity.COMPLEX
+
+    def test_string_values_are_unchanged(self):
+        """The values are the serialized form — ordering must not alter them."""
+        assert ConflictSeverity.CRITICAL.value == "critical"
+        assert [s.value for s in ConflictSeverity] == [
+            "trivial",
+            "simple",
+            "moderate",
+            "complex",
+            "critical",
+        ]
+
+    def test_every_level_is_ranked(self):
+        """A level added without ranking must fail loudly, not sort wrong."""
+        for severity in ConflictSeverity:
+            assert isinstance(severity.rank, int)


### PR DESCRIPTION
Closes #13162

> **Partial — #13162 must stay OPEN.** The close keyword is required by the
> `Validate PR issue link` gate; merging to `Dev_new_gui` does not auto-close.
> This clears **one cluster** of the ~450 failures. Do not add `python-suite`
> to branch protection yet.

## Thinking Path

Took `code_intelligence` — the second-largest failure cluster and the one no
other session is working (others are on `knowledge`, `chat_workflow`,
`research`, `security-api`).

**Both failures turned out to be real production crashes.** The tests were
correct to fail, and "fixing the tests" would have hidden two live bugs — so
both are fixed at the source.

### 1. Naive commit timestamps crash trend analysis

`datetime.fromtimestamp(commit.committed_date)` returns a **naive local**
datetime. Those flow all the way through:

```
mine_repository
  -> PatternOccurrence(timestamp=commit["timestamp"])   # naive
  -> tracker.track_pattern(occurrence)
     -> temporal_embedding.add_pattern(occurrence)
...
  -> calculate_trend()
     -> occ.timestamp > datetime.now(tz=timezone.utc)
        TypeError: can't compare offset-naive and offset-aware datetimes
```

So running the evolution miner over a real repository **raises** — reachable
via `get_emerging_patterns`, `get_declining_patterns` and
`get_pattern_metrics`. Both `fromtimestamp` calls are now tz-aware UTC, which
also stops month bucketing (`strftime("%Y-%m")`) from depending on the
server's local timezone.

The fixtures built `PatternOccurrence` with naive `datetime.now()`, encoding
an assumption the production path never satisfied; they now construct
tz-aware timestamps, matching the real contract.

### 2. Safe mode crashed instead of requiring review

`ConflictSeverity` was a plain `Enum`, so `_select_strategy`'s

```python
if self.safe_mode and conflict.severity >= ConflictSeverity.COMPLEX:
```

raised `TypeError`. **Safe mode never gated anything** — the control existed
but could not fire. Same shape as #12924's inert session revocation and
#12925's missing denial audit: a safety mechanism that looks present and is
not.

The enum is now ordered via `functools.total_ordering` plus an explicit rank,
deliberately **not** by switching to `IntEnum` — the string values are the
serialized form and must not change.

## What Changed

- `code_evolution_miner.py` — both `fromtimestamp` calls tz-aware UTC
- `code_evolution_miner_test.py` — 18 fixture timestamps tz-aware
- `merge_conflict_resolver.py` — `ConflictSeverity` ordered, values unchanged
- `merge_conflict_resolver_test.py` — 4 regression tests

## Verification

```
autobot-backend/code_intelligence   663 passed   (was 6 failing)
bandit                              0 issues
isort · black --line-length=120 · flake8   clean
```

The new tests pin what actually broke: the exact `severity >= COMPLEX`
comparison, that the string values are unchanged, and that every level is
ranked — so adding a severity without ranking it fails loudly rather than
sorting silently wrong.

## Model Used

Claude Opus 5 (1M context)
