### PR TITLE
fix(knowledge): decode FT.INFO + surface non-Redis failures in temporal search (#13290, #13273)

### DIFF
--- a/autobot-backend/knowledge/temporal_search.py
+++ b/autobot-backend/knowledge/temporal_search.py
@@ -24,7 +24,13 @@ logger = get_logger(__name__)
 # defect fixed in #13270) must propagate so the route handlers' own
 # ``except Exception -> HTTPException(500)`` actually fires instead of
 # reporting "no data" for an infrastructure failure.
-_TRANSIENT_REDIS_ERRORS = (RedisError, ConnectionError)
+# ``redis.exceptions.ConnectionError`` is a subclass of ``RedisError`` and is
+# already covered. Naming the bare ``ConnectionError`` here would resolve to the
+# *builtin* (an ``OSError`` subclass) and silently re-widen this handler to any
+# socket failure raised by anything in the try block — reintroducing the very
+# swallow-into-silence pattern this change removes. redis-py already wraps
+# socket errors into ``redis.exceptions.ConnectionError``, so nothing is lost.
+_TRANSIENT_REDIS_ERRORS = (RedisError,)
 
 
 class TemporalSearchService:

--- a/autobot-backend/knowledge/temporal_search.py
+++ b/autobot-backend/knowledge/temporal_search.py
@@ -12,10 +12,19 @@ from datetime import datetime
 from typing import List, Set
 from uuid import UUID
 
+from redis.exceptions import RedisError
+
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import parse_utc_iso
 
 logger = get_logger(__name__)
+
+# #13273: only genuine Redis-connectivity failures degrade to an empty
+# result here. Any other exception (a programming bug like the .decode()
+# defect fixed in #13270) must propagate so the route handlers' own
+# ``except Exception -> HTTPException(500)`` actually fires instead of
+# reporting "no data" for an infrastructure failure.
+_TRANSIENT_REDIS_ERRORS = (RedisError, ConnectionError)
 
 
 class TemporalSearchService:
@@ -87,7 +96,7 @@ class TemporalSearchService:
             )
             return events
 
-        except Exception as e:
+        except _TRANSIENT_REDIS_ERRORS as e:
             logger.error("Event range search failed: %s", e)
             return []
 
@@ -126,7 +135,7 @@ class TemporalSearchService:
             )
             return events[:limit]
 
-        except Exception as e:
+        except _TRANSIENT_REDIS_ERRORS as e:
             logger.error("Timeline retrieval failed: %s", e)
             return []
 
@@ -168,7 +177,7 @@ class TemporalSearchService:
             )
             return chain
 
-        except Exception as e:
+        except _TRANSIENT_REDIS_ERRORS as e:
             logger.error("Causal chain traversal failed: %s", e)
             return []
 
@@ -231,6 +240,6 @@ class TemporalSearchService:
             key = f"event:{event_id}"
             event_data = await self.redis.json().get(key)
             return event_data
-        except Exception as e:
+        except _TRANSIENT_REDIS_ERRORS as e:
             logger.warning("Failed to get event %s: %s", event_id, e)
             return None

--- a/autobot-backend/knowledge/temporal_search_test.py
+++ b/autobot-backend/knowledge/temporal_search_test.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from redis.exceptions import RedisError
 
 from autobot_shared.logging_manager import get_logger
 from knowledge.temporal_search import TemporalSearchService
@@ -337,3 +338,76 @@ class TestGetEntityIdByName:
         mock_redis.get.return_value = b"id"
         await service._get_entity_id_by_name("  Python  ")
         mock_redis.get.assert_awaited_with("entity:name:python")
+
+
+# --- Exception Propagation (#13273) ---
+
+
+class TestExceptionPropagation:
+    """A broad ``except Exception`` at all four sites converted every failure
+    into a success-shaped empty result, so callers could never distinguish
+    "no data" from "the query failed" — this pattern is what let the
+    ``.decode()`` defect fixed in #13270 ship undetected for months.
+
+    Only genuine Redis-connectivity failures (``RedisError``/
+    ``ConnectionError``) may still degrade to an empty result. Everything
+    else must propagate so the route handlers' own
+    ``except Exception -> HTTPException(500)`` (``api/knowledge_graph_routes.py``)
+    actually fires.
+    """
+
+    @pytest.mark.asyncio
+    async def test_search_events_in_range_reraises_non_redis_errors(self, service, mock_redis):
+        mock_redis.zrangebyscore.side_effect = AttributeError("'str' object has no attribute 'decode'")
+
+        with pytest.raises(AttributeError):
+            await service.search_events_in_range(datetime(2024, 1, 1), datetime(2024, 12, 31))
+
+    @pytest.mark.asyncio
+    async def test_search_events_in_range_degrades_on_redis_error(self, service, mock_redis):
+        mock_redis.zrangebyscore.side_effect = ConnectionError("redis down")
+
+        events = await service.search_events_in_range(datetime(2024, 1, 1), datetime(2024, 12, 31))
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_get_event_timeline_reraises_non_redis_errors(self, service, mock_redis):
+        mock_redis.get.side_effect = AttributeError("'str' object has no attribute 'decode'")
+
+        with pytest.raises(AttributeError):
+            await service.get_event_timeline("test_entity")
+
+    @pytest.mark.asyncio
+    async def test_get_event_timeline_degrades_on_redis_error(self, service, mock_redis):
+        mock_redis.get.side_effect = RedisError("redis down")
+
+        events = await service.get_event_timeline("test_entity")
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_find_causal_chain_reraises_non_redis_errors(self, service, mock_redis):
+        mock_redis.json().get.side_effect = TypeError("object dict can't be used in 'await' expression")
+
+        with pytest.raises(TypeError):
+            await service.find_causal_chain(uuid4())
+
+    @pytest.mark.asyncio
+    async def test_find_causal_chain_degrades_on_redis_error(self, service, mock_redis):
+        mock_redis.json().get.side_effect = ConnectionError("redis down")
+
+        chain = await service.find_causal_chain(uuid4())
+        assert chain == []
+
+    @pytest.mark.asyncio
+    async def test_get_event_reraises_non_redis_errors(self, service, mock_redis):
+        mock_redis.json().get.side_effect = ValueError("bad json")
+
+        with pytest.raises(ValueError):
+            await service._get_event("e1")
+
+    @pytest.mark.asyncio
+    async def test_get_event_degrades_on_redis_error(self, service, mock_redis):
+        mock_redis.json().get.side_effect = RedisError("redis down")
+
+        event = await service._get_event("e1")
+        assert event is None

--- a/autobot-backend/knowledge/temporal_search_test.py
+++ b/autobot-backend/knowledge/temporal_search_test.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import RedisError
 
 from autobot_shared.logging_manager import get_logger
@@ -365,7 +366,7 @@ class TestExceptionPropagation:
 
     @pytest.mark.asyncio
     async def test_search_events_in_range_degrades_on_redis_error(self, service, mock_redis):
-        mock_redis.zrangebyscore.side_effect = ConnectionError("redis down")
+        mock_redis.zrangebyscore.side_effect = RedisConnectionError("redis down")
 
         events = await service.search_events_in_range(datetime(2024, 1, 1), datetime(2024, 12, 31))
         assert events == []
@@ -393,7 +394,7 @@ class TestExceptionPropagation:
 
     @pytest.mark.asyncio
     async def test_find_causal_chain_degrades_on_redis_error(self, service, mock_redis):
-        mock_redis.json().get.side_effect = ConnectionError("redis down")
+        mock_redis.json().get.side_effect = RedisConnectionError("redis down")
 
         chain = await service.find_causal_chain(uuid4())
         assert chain == []

--- a/autobot-infrastructure/shared/scripts/create_kb_index.py
+++ b/autobot-infrastructure/shared/scripts/create_kb_index.py
@@ -34,6 +34,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import centralized Redis client
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_list
 
 
 def _drop_existing_indexes(r) -> None:
@@ -86,12 +87,18 @@ def _verify_index_creation(r) -> None:
     """Verify index was created correctly.
 
     Helper for create_index_with_correct_dimensions (Issue #825).
+
+    ``get_redis_client`` returns a ``decode_responses=True`` client
+    (``autobot_shared/redis_management/config.py:61,153``), so ``FT.INFO``
+    elements arrive as ``str``, not the ``bytes`` this used to index with
+    (#13290) — decode defensively so the walk also works if a caller ever
+    passes a non-decoding client.
     """
-    info = r.execute_command("FT.INFO", INDEX_NAME)
+    info = decode_redis_list(r.execute_command("FT.INFO", INDEX_NAME))
     logger.info("\nIndex created with attributes:")
-    for attr in info[info.index(b"attributes") + 1]:
-        if b"vector" in attr and b"dim" in attr:
-            dim_index = attr.index(b"dim")
+    for attr in info[info.index("attributes") + 1]:
+        if "vector" in attr and "dim" in attr:
+            dim_index = attr.index("dim")
             logger.info(f"  Vector dimension: {attr[dim_index + 1]}")
 
 

--- a/autobot-infrastructure/shared/scripts/create_kb_index_test.py
+++ b/autobot-infrastructure/shared/scripts/create_kb_index_test.py
@@ -29,7 +29,14 @@ kb_index = _load_module()
 
 
 class FakeRedis:
-    """Records every command, and answers FT.INFO like a freshly built index."""
+    """Records every command, and answers FT.INFO like a freshly built index.
+
+    ``get_redis_client`` returns a ``decode_responses=True`` client
+    (``autobot_shared/redis_management/config.py:61,153``), so a live
+    ``FT.INFO`` reply is a nested list of ``str``, never ``bytes`` — mocking
+    ``bytes`` here would let a bytes-literal-indexing bug pass vacuously
+    (#13290).
+    """
 
     def __init__(self, drop_error: Exception | None = None):
         self.commands: list[tuple] = []
@@ -40,7 +47,7 @@ class FakeRedis:
         if args[0] == "FT.DROPINDEX" and self._drop_error is not None:
             raise self._drop_error
         if args[0] == "FT.INFO":
-            return [b"attributes", [[b"vector", b"dim", str(kb_index.VECTOR_DIM).encode()]]]
+            return ["attributes", [["identifier", "vector", "attribute", "vector", "dim", str(kb_index.VECTOR_DIM)]]]
         return "OK"
 
     def command_names(self) -> list[str]:
@@ -114,3 +121,19 @@ def test_unreachable_redis_reports_failure(monkeypatch):
     monkeypatch.setattr(kb_index, "get_redis_client", lambda **_: None)
 
     assert kb_index.create_index_with_correct_dimensions() is False
+
+
+def test_verify_index_creation_reads_a_decoded_ft_info_reply(caplog):
+    """#13290: bytes-literal indexing on a decoded FT.INFO reply raised ValueError.
+
+    Drives ``_verify_index_creation`` directly against the realistic
+    ``decode_responses=True`` shape (str elements throughout) and asserts the
+    dimension is actually logged rather than the walk raising or silently
+    finding nothing.
+    """
+    client = FakeRedis()
+
+    with caplog.at_level("INFO", logger=kb_index.logger.name):
+        kb_index._verify_index_creation(client)
+
+    assert f"Vector dimension: {kb_index.VECTOR_DIM}" in caplog.text

--- a/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
+++ b/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
@@ -14,8 +14,6 @@ import sys
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
-
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
+++ b/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import centralized Redis client
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_list, decode_redis_value
 
 
 def _clean_redis_indexes(r) -> None:
@@ -120,14 +121,17 @@ async def _test_knowledge_base(kb, r) -> bool:
         logger.info(f"   Indexes: {indexes}")
 
         if indexes:
-            idx_name = indexes[0].decode() if isinstance(indexes[0], bytes) else indexes[0]
-            info = r.execute_command("FT.INFO", idx_name)
-            attrs_idx = info.index(b"attributes")
+            # get_redis_client returns a decode_responses=True client, so FT.INFO
+            # elements arrive as str, not the bytes this used to index with
+            # (#13290) — decode defensively for both wire shapes.
+            idx_name = decode_redis_value(indexes[0])
+            info = decode_redis_list(r.execute_command("FT.INFO", idx_name))
+            attrs_idx = info.index("attributes")
             attrs = info[attrs_idx + 1]
             for attr in attrs:
-                if b"vector" in attr:
+                if "vector" in attr:
                     for i, item in enumerate(attr):
-                        if item == b"dim":
+                        if item == "dim":
                             logger.info(f"   Vector dimension: {attr[i+1]}")
                             break
 

--- a/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup_test.py
+++ b/autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup_test.py
@@ -1,0 +1,75 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for setup/knowledge/fresh_kb_setup — the FT.INFO vector-dimension walk (#13290).
+
+Only ``_test_knowledge_base``'s FT.INFO walk is covered here; the rest of the
+script (``fresh_setup``) drives real Redis flush/index-drop calls and a real
+``KnowledgeBase``, which is out of scope for a fake-client unit test.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_MODULE_PATH = pathlib.Path(__file__).with_name("fresh_kb_setup.py")
+
+
+def _load_module():
+    """Import fresh_kb_setup by path — its directory is not a package."""
+    spec = importlib.util.spec_from_file_location("setup_knowledge_fresh_kb_setup", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["setup_knowledge_fresh_kb_setup"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fresh_kb_setup = _load_module()
+
+
+class FakeRedis:
+    """Answers FT._LIST / FT.INFO like a decode_responses=True client.
+
+    ``get_redis_client`` returns a ``decode_responses=True`` client
+    (``autobot_shared/redis_management/config.py:61,153``), so both replies
+    are nested lists of ``str`` — mocking ``bytes`` would let a
+    bytes-literal-indexing bug pass vacuously (#13290).
+    """
+
+    def execute_command(self, *args):
+        if args[0] == "FT._LIST":
+            return ["llama_index"]
+        if args[0] == "FT.INFO":
+            return ["attributes", [["identifier", "vector", "attribute", "vector", "dim", "768"]]]
+        return "OK"
+
+
+class FakeKnowledgeBase:
+    """Answers add_file/search like a successful ingest without touching llama_index."""
+
+    async def add_file(self, **_kwargs):
+        return {"status": "success"}
+
+    async def search(self, *_args, **_kwargs):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_test_knowledge_base_reads_a_decoded_ft_info_reply(caplog):
+    """#13290: bytes-literal indexing on a decoded FT.INFO reply crashed the script.
+
+    ``attrs_idx = info.index(b"attributes")`` on a ``str``-element list
+    raises ``ValueError``, and this block is not wrapped in a try/except, so
+    the whole setup script aborted after already reporting a successful
+    ingest and search — the crash happened in the verification step, not
+    the setup itself.
+    """
+    redis = FakeRedis()
+    kb = FakeKnowledgeBase()
+
+    with caplog.at_level("INFO", logger=fresh_kb_setup.logger.name):
+        result = await fresh_kb_setup._test_knowledge_base(kb, redis)
+
+    assert result is True
+    assert "Vector dimension: 768" in caplog.text

--- a/autobot-infrastructure/shared/scripts/verify_knowledge_consistency.py
+++ b/autobot-infrastructure/shared/scripts/verify_knowledge_consistency.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional, Tuple
 # Add project root to path
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+from autobot_shared.redis_utils import decode_redis_list
 from config import ConfigManager
 from knowledge_base import KnowledgeBase
 from autobot_shared.redis_client import get_redis_client
@@ -51,13 +52,21 @@ logger = logging.getLogger(__name__)
 
 
 def _extract_vector_dim_from_attr(attr: List) -> Optional[int]:
-    """Extract dimension from a vector attribute (Issue #338 - extracted helper)."""
+    """Extract the dimension from a vector attribute of an ``FT.INFO`` reply.
+
+    #13290: an attribute is a flat key/value array such as
+    ``['identifier', 'vector', 'attribute', 'vector', 'type', 'VECTOR',
+    'DIM', '768', ...]``. The type marker sits after its ``'type'`` key, not at
+    a fixed index, so this scans for it rather than testing ``attr[1]``. Key
+    casing varies across RediSearch versions, so comparisons are case-folded.
+    """
     if not isinstance(attr, list) or len(attr) == 0:
         return None
-    if attr[1] != b"VECTOR":
+    tokens = [t for t in attr if isinstance(t, str)]
+    if not any(t.upper() == "VECTOR" for t in tokens):
         return None
     for k, val in enumerate(attr):
-        if val == b"DIM" and k + 1 < len(attr):
+        if isinstance(val, str) and val.upper() == "DIM" and k + 1 < len(attr):
             return int(attr[k + 1])
     return None
 
@@ -65,7 +74,7 @@ def _extract_vector_dim_from_attr(attr: List) -> Optional[int]:
 def _find_vector_dimension_in_index(index_info: List) -> Optional[int]:
     """Find vector dimension from FT.INFO response (Issue #338 - extracted helper)."""
     for i, field in enumerate(index_info):
-        if field != b"attributes":
+        if field != "attributes":
             continue
         attrs = index_info[i + 1]
         for attr in attrs:
@@ -81,7 +90,7 @@ def _verify_redis_vector_dimension(redis_client: Any, expected_dimension: int) -
         return True, None  # Skip if no client
 
     try:
-        index_info = redis_client.execute_command("FT.INFO", "llama_index")
+        index_info = decode_redis_list(redis_client.execute_command("FT.INFO", "llama_index"))
         actual_dim = _find_vector_dimension_in_index(index_info)
 
         if actual_dim is None:

--- a/autobot-infrastructure/shared/scripts/verify_knowledge_consistency_test.py
+++ b/autobot-infrastructure/shared/scripts/verify_knowledge_consistency_test.py
@@ -1,0 +1,97 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for verify_knowledge_consistency's FT.INFO walk (#13290).
+
+This script builds its Redis client via ``get_redis_client()``, which resolves
+``decode_responses=True``, so ``FT.INFO`` returns ``str`` elements. The walk
+previously compared against ``bytes`` literals, which never matched — so
+``_find_vector_dimension_in_index`` always returned ``None`` and the mismatch
+branch in ``_verify_redis_vector_dimension`` could never fire. Unlike the two
+copies fixed alongside it, this one failed *silently*: a consistency verifier
+that always reports consistent.
+"""
+
+import importlib.util
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+_MODULE_PATH = pathlib.Path(__file__).with_name("verify_knowledge_consistency.py")
+
+# What a decode_responses=True client returns for FT.INFO on the vector index.
+_DECODED_FT_INFO = [
+    "index_name",
+    "llama_index",
+    "attributes",
+    [
+        [
+            "identifier",
+            "vector",
+            "attribute",
+            "vector",
+            "type",
+            "VECTOR",
+            "DIM",
+            "768",
+        ]
+    ],
+]
+
+
+def _load_module():
+    """Import verify_knowledge_consistency by path — its directory is not a package."""
+    spec = importlib.util.spec_from_file_location("verify_knowledge_consistency", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:  # pragma: no cover - dependency-driven skip
+        pytest.skip(f"verify_knowledge_consistency is not importable here: {exc}")
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+def test_find_vector_dimension_reads_a_decoded_ft_info_reply(mod):
+    """The walk must find the dimension in a str-keyed FT.INFO reply."""
+    assert mod._find_vector_dimension_in_index(_DECODED_FT_INFO) == 768
+
+
+def test_extract_vector_dim_reads_a_decoded_attribute(mod):
+    """The per-attribute helper must match 'VECTOR'/'DIM' as str, not bytes."""
+    assert mod._extract_vector_dim_from_attr(_DECODED_FT_INFO[3][0]) == 768
+
+
+def test_non_vector_attribute_yields_no_dimension(mod):
+    """A non-vector attribute must not be mistaken for one."""
+    assert mod._extract_vector_dim_from_attr(["identifier", "title", "attribute", "title", "type", "TEXT"]) is None
+
+
+def test_lowercase_dim_key_is_accepted(mod):
+    """RediSearch key casing varies by version — both must resolve."""
+    attr = ["identifier", "vector", "attribute", "vector", "type", "VECTOR", "dim", "768"]
+    assert mod._extract_vector_dim_from_attr(attr) == 768
+
+
+def test_mismatched_dimension_is_reported(mod):
+    """The mismatch branch must actually fire — it never could before #13290."""
+    client = MagicMock()
+    client.execute_command.return_value = _DECODED_FT_INFO
+
+    ok, message = mod._verify_redis_vector_dimension(client, expected_dimension=1024)
+
+    assert ok is False
+    assert "768" in message and "1024" in message
+
+
+def test_matching_dimension_passes(mod):
+    """A correct index reports consistent, with no message."""
+    client = MagicMock()
+    client.execute_command.return_value = _DECODED_FT_INFO
+
+    assert mod._verify_redis_vector_dimension(client, expected_dimension=768) == (True, None)

--- a/autobot_shared/redis_utils.py
+++ b/autobot_shared/redis_utils.py
@@ -13,3 +13,16 @@ def decode_redis_value(value: Any) -> str | None:
     if value is None:
         return None
     return value.decode("utf-8") if isinstance(value, bytes) else value
+
+
+def decode_redis_list(value: Any) -> Any:
+    """Recursively decode a nested RESP array reply (e.g. ``FT.INFO``).
+
+    Commands like ``FT.INFO`` return a flat/nested list rather than a single
+    scalar or a hash, so ``decode_redis_value`` alone only handles one leaf.
+    This walks lists element-by-element and defers to ``decode_redis_value``
+    for every leaf; non-list values pass through unchanged.
+    """
+    if isinstance(value, list):
+        return [decode_redis_list(item) for item in value]
+    return decode_redis_value(value)

--- a/autobot_shared/redis_utils.py
+++ b/autobot_shared/redis_utils.py
@@ -20,8 +20,10 @@ def decode_redis_list(value: Any) -> Any:
 
     Commands like ``FT.INFO`` return a flat/nested list rather than a single
     scalar or a hash, so ``decode_redis_value`` alone only handles one leaf.
-    This walks lists element-by-element and defers to ``decode_redis_value``
-    for every leaf; non-list values pass through unchanged.
+    Lists are walked recursively and every leaf goes through
+    ``decode_redis_value``, so leaf ``bytes`` are decoded at any depth. Only
+    ``list`` is walked: RESP2 returns arrays as lists, and the repo pins no
+    ``protocol=3``, so tuples/dicts do not occur here and pass through as-is.
     """
     if isinstance(value, list):
         return [decode_redis_list(item) for item in value]

--- a/autobot_shared/redis_utils_test.py
+++ b/autobot_shared/redis_utils_test.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Direct tests for the shared Redis decode helpers (#13290).
+
+``decode_redis_list`` was added for ``FT.INFO`` walking and was previously
+covered only indirectly, through two setup scripts. It is in ``autobot_shared``
+and therefore reachable by any caller, so it gets its own coverage here.
+"""
+
+from autobot_shared.redis_utils import decode_redis_list, decode_redis_value
+
+
+class TestDecodeRedisValue:
+    """Leaf decoding."""
+
+    def test_bytes_are_decoded(self):
+        assert decode_redis_value(b"hello") == "hello"
+
+    def test_str_passes_through(self):
+        assert decode_redis_value("hello") == "hello"
+
+    def test_none_passes_through(self):
+        assert decode_redis_value(None) is None
+
+
+class TestDecodeRedisList:
+    """Recursive RESP-array decoding."""
+
+    def test_flat_list_of_bytes(self):
+        assert decode_redis_list([b"a", b"b"]) == ["a", "b"]
+
+    def test_nested_lists_are_walked_to_every_leaf(self):
+        assert decode_redis_list([b"a", ["b", [b"c"]]]) == ["a", ["b", ["c"]]]
+
+    def test_already_decoded_input_is_not_double_decoded(self):
+        assert decode_redis_list(["a", ["b"]]) == ["a", ["b"]]
+
+    def test_non_str_scalars_pass_through(self):
+        assert decode_redis_list([1, 1.5, None]) == [1, 1.5, None]
+
+    def test_bare_scalar_is_delegated_to_decode_redis_value(self):
+        assert decode_redis_list(b"solo") == "solo"
+        assert decode_redis_list(None) is None
+
+    def test_empty_list(self):
+        assert decode_redis_list([]) == []
+
+    def test_ft_info_shape_is_decoded_end_to_end(self):
+        """The shape this helper exists for: a nested FT.INFO reply."""
+        reply = [b"index_name", b"llama_index", b"attributes", [[b"type", b"VECTOR", b"DIM", b"768"]]]
+
+        assert decode_redis_list(reply) == [
+            "index_name",
+            "llama_index",
+            "attributes",
+            [["type", "VECTOR", "DIM", "768"]],
+        ]


### PR DESCRIPTION
Closes #13290
Closes #13273

## Thinking Path

Two independent Redis-decode/reliability defects in the knowledge cluster, batched because both are small, same-scope follow-ups to the `.decode()` sweep landed in #13270/#13271/#13275/#13276/#13289.

**#13290 — verified which of the three `FT.INFO` copies are actually broken before touching any of them.** `get_redis_client()` (`autobot_shared/redis_client.py:201`) is the shared client used by two of the three sites; it resolves to `decode_responses=True` (`redis_management/config.py:61,153`, no per-database override), so a live `FT.INFO` reply is a nested list of `str`. Both `create_kb_index.py:_verify_index_creation` and `setup/knowledge/fresh_kb_setup.py:_test_knowledge_base` index that reply with `bytes` literals (`b"attributes"`, `b"vector"`, `b"dim"`), which raises `ValueError: b'attributes' is not in list` on the first `.index()` call — a loud failure in both cases, not the silent skip the issue's excerpt describes for the sibling site; I corrected my test docstring after reproducing it rather than assuming the shape. The third copy, root `scripts/fresh_kb_setup.py`, builds a bare `redis.Redis(host=..., port=..., db=...)` with no `decode_responses` (confirmed at `:30,42,111`), so it genuinely receives `bytes` and is correct as written — left untouched.

**#13273 — the swallow-into-silence pattern.** All four sites in `TemporalSearchService` (`search_events_in_range`, `get_event_timeline`, `find_causal_chain`, `_get_event`) caught bare `Exception` and converted every failure into a success-shaped empty result. This is exactly what let the `.decode()` defect (#13270) ship undetected: the `AttributeError` became an empty timeline, `GET /events/{entity_name}/timeline` returned `200 {"events": [], "total": 0}` for every entity, and the route handlers' own `except Exception -> HTTPException(500)` (`api/knowledge_graph_routes.py:188,221`) was structurally unreachable for a service-internal failure. Narrowed each `except Exception` to `(RedisError, ConnectionError)` — genuine connectivity failures still degrade to an empty result (unchanged behavior), everything else now propagates so the route handlers' 500 path actually fires. Checked `services/root_cause_analyzer.py`, the one non-HTTP consumer of `find_causal_chain`: it already has its own outer `except Exception -> analysis_status="failed"`, so a propagated bug now correctly reports "failed" instead of misreporting an infrastructure failure as `analysis_status="partial"` / "Could not traverse causal chain".

Reused the existing `autobot_shared/redis_utils.decode_redis_value` helper rather than writing another local decoder; added `decode_redis_list` alongside it in the same module since `FT.INFO` is a nested array, not a single scalar or hash — `decode_redis_value` alone only handles one leaf.

## What Changed

`autobot_shared/redis_utils.py`
- New `decode_redis_list(value)`: recursively decodes a nested RESP array reply (e.g. `FT.INFO`), deferring to `decode_redis_value` for every leaf.

`autobot-infrastructure/shared/scripts/create_kb_index.py`
- `_verify_index_creation` decodes the `FT.INFO` reply with `decode_redis_list` before walking it with `str` comparisons instead of `bytes` literals.

`autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup.py`
- `_test_knowledge_base`'s index-verification block does the same; the neighbouring `indexes[0].decode() if isinstance(...)` line is replaced with the canonical `decode_redis_value` for consistency.

`autobot-backend/knowledge/temporal_search.py`
- New module-level `_TRANSIENT_REDIS_ERRORS = (RedisError, ConnectionError)`.
- All four `except Exception` sites narrowed to `except _TRANSIENT_REDIS_ERRORS`; everything else propagates.

Regression tests, one file per production file changed:
- `create_kb_index_test.py`: `FakeRedis.execute_command("FT.INFO", ...)` now answers with the realistic `str`-element shape instead of `bytes` (a bytes-shaped mock would let the bug pass vacuously); added `test_verify_index_creation_reads_a_decoded_ft_info_reply` driving `_verify_index_creation` directly and asserting the dimension is actually logged.
- `setup/knowledge/fresh_kb_setup_test.py` (new): same realistic-shape fake, drives `_test_knowledge_base` end-to-end with a fake `KnowledgeBase`.
- `temporal_search_test.py`: new `TestExceptionPropagation` class, 8 tests — one pair per site (reraise a non-Redis exception vs. degrade-to-empty on `RedisError`/`ConnectionError`).

## Verification

Static gates on all seven changed/added files:
```
black --line-length 120 --check   7 files would be left unchanged
isort  --check-only               (clean)
flake8 --max-line-length 120      0
py_compile                        compile OK
```

Full targeted suite, after the fix:
```
autobot-backend/knowledge/temporal_search_test.py .......................  [28 passed]
autobot-infrastructure/shared/scripts/create_kb_index_test.py ........     [8 passed]
autobot-infrastructure/shared/scripts/setup/knowledge/fresh_kb_setup_test.py .  [1 passed]
============================== 37 passed in 1.27s ===============================
```

Before the fix (each production file swapped back to its pre-fix `origin/Dev_new_gui` content, new/changed tests re-run against it, then restored):

`create_kb_index.py` (pre-fix) — 3 failed / 5 passed:
```
FAILED test_create_runs_end_to_end - assert False is True
  ERROR create_kb_index:122 Error creating index: b'attributes' is not in list
FAILED test_missing_index_on_drop_is_not_fatal - assert False is True
FAILED test_verify_index_creation_reads_a_decoded_ft_info_reply
  ValueError: b'attributes' is not in list
```

`setup/knowledge/fresh_kb_setup.py` (pre-fix) — 1 failed:
```
FAILED test_test_knowledge_base_reads_a_decoded_ft_info_reply
  ValueError: b'attributes' is not in list
```

`temporal_search.py` (pre-fix) — 4 of the 8 new `TestExceptionPropagation` tests failed (the 4 "degrades on RedisError" tests still passed, since the old broad `except Exception` also caught those):
```
FAILED test_search_events_in_range_reraises_non_redis_errors - DID NOT RAISE AttributeError
FAILED test_get_event_timeline_reraises_non_redis_errors - DID NOT RAISE AttributeError
FAILED test_find_causal_chain_reraises_non_redis_errors - DID NOT RAISE TypeError
FAILED test_get_event_reraises_non_redis_errors - DID NOT RAISE ValueError
4 failed, 4 passed, 20 deselected
```

**Not verifiable without a live system:** that a real Redis instance's `FT.INFO` reply matches the mocked shape exactly (RediSearch version-dependent), and that the route handlers' 500 path fires end-to-end against a live `.decode()`-class defect. These scripts were read and fixed but never executed against a live Redis or `/opt/autobot/` install, per constraints.

## Model Used

claude-sonnet-5