### PR TITLE
fix(chat): reload fidelity for streamed replies — model/sources, turn order, backfill (#13292, #13293, #13295, #13296)

### DIFF
--- a/autobot-backend/chat_history/session_reply_backfill.py
+++ b/autobot-backend/chat_history/session_reply_backfill.py
@@ -1,0 +1,214 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Repair path for Issue #13293 — chat:session:* turns damaged before #13214.
+
+Before #13214 merged, a completed streamed reply was never written to
+``chat:session:{id}`` (the durable, GUI-facing store): every LLM chunk carries
+``metadata.streaming = True`` and both accumulators drop those chunks, and the
+completed-reply text was accepted by ``_persist_workflow_messages`` and then
+silently discarded. A conversational turn from that window therefore reads
+back with the user's message and no assistant reply at all.
+
+``chat:conversation:{id}`` (see ``chat_workflow.conversation``) — the short
+lived ``{user, assistant}`` pair cache used to build LLM context — was
+unaffected: ``_persist_conversation`` always wrote it, bug or no bug. While it
+has not expired (``conversation_history_ttl``, default 24h — see
+``chat_history/cache.py``), it is the only remaining source of the missing
+assistant text, so it is the backfill source of truth here.
+
+This module is a REPAIR PATH, not an auto-run migration: nothing here
+executes on import, there is no scheduled/Celery hook, and the CLI entry
+point requires explicit ``--session-id`` arguments — no bulk "repair
+everything" default. Per #13293 this PR only adds the repair logic and its
+tests; it must never be executed against a live system as part of this
+change.
+"""
+
+import argparse
+import asyncio
+import json
+from typing import Any, Callable, Dict, List, Tuple
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = get_logger(__name__)
+
+# Mirrors chat_workflow.conversation.ConversationHandlerMixin._get_conversation_key.
+_CONVERSATION_KEY_PREFIX = "chat:conversation:"
+
+
+def _conversation_key(session_id: str) -> str:
+    """Redis key holding the ``{user, assistant}`` pair history for *session_id*."""
+    return f"{_CONVERSATION_KEY_PREFIX}{session_id}"
+
+
+def _parse_conversation_pairs(raw: str | bytes | None) -> List[Dict[str, str]]:
+    """Parse the ``chat:conversation:*`` JSON payload into ``{user, assistant}`` pairs.
+
+    Malformed or empty payloads repair to an empty list rather than raising —
+    a single corrupt/expired key must not abort a batch repair run.
+    """
+    if not raw:
+        return []
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    try:
+        pairs = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Malformed chat:conversation payload — skipping repair for this session")
+        return []
+    if not isinstance(pairs, list):
+        return []
+    return [p for p in pairs if isinstance(p, dict) and (p.get("user") or "").strip()]
+
+
+def compute_backfilled_messages(
+    session_messages: List[Dict[str, Any]],
+    conversation_pairs: List[Dict[str, str]],
+    build_assistant_message: Callable[[str], Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Return (repaired_messages, backfilled_count) for one session.
+
+    Pure function: plain dicts in, plain dicts out — no I/O, no Redis client —
+    so the matching logic is independently testable from the load/save seam
+    that ``repair_session`` owns.
+
+    A user turn is "damaged" when no assistant message immediately follows it
+    (before the next user message, if any). For each damaged turn, the first
+    not-yet-consumed ``chat:conversation:*`` pair whose ``user`` text matches
+    byte-for-byte supplies the missing ``assistant`` text, inserted as a new
+    message directly after the user turn — restoring both the reply and the
+    turn ordering a reload should show.
+    """
+    repaired = list(session_messages)
+    used_pair_indices: set = set()
+    backfilled = 0
+
+    i = 0
+    while i < len(repaired):
+        msg = repaired[i]
+        if msg.get("sender") != "user":
+            i += 1
+            continue
+
+        user_text = (msg.get("text") or "").strip()
+        next_is_reply = i + 1 < len(repaired) and repaired[i + 1].get("sender") == "assistant"
+        if next_is_reply or not user_text:
+            i += 1
+            continue
+
+        pair_idx = next(
+            (
+                idx
+                for idx, pair in enumerate(conversation_pairs)
+                if idx not in used_pair_indices and (pair.get("user") or "").strip() == user_text
+            ),
+            None,
+        )
+        if pair_idx is None:
+            i += 1
+            continue
+
+        used_pair_indices.add(pair_idx)
+        assistant_text = (conversation_pairs[pair_idx].get("assistant") or "").strip()
+        if not assistant_text:
+            i += 1
+            continue
+
+        repaired.insert(i + 1, build_assistant_message(assistant_text))
+        backfilled += 1
+        i += 2  # skip past the turn just repaired
+
+    return repaired, backfilled
+
+
+def _build_backfilled_assistant_message(chat_mgr, text: str) -> Dict[str, Any]:
+    """Build the persisted dict for one backfilled assistant turn.
+
+    ``sources: []`` — chat:conversation:* pairs carry no citation metadata, so
+    a backfilled turn cannot claim KB provenance it never recorded (#13292's
+    fidelity fix does not apply retroactively; there is nothing to recover).
+    """
+    return chat_mgr._build_message_dict(
+        "assistant",
+        text,
+        "response",
+        {"message_type": "llm_response", "backfilled_from": "chat:conversation", "streamed": True},
+        None,
+        sources=[],
+    )
+
+
+async def repair_session(session_id: str, chat_mgr, redis_client=None) -> int:
+    """Backfill missing assistant turns for one session. Returns count repaired.
+
+    Args:
+        session_id: The session to repair.
+        chat_mgr: A ``ChatHistoryManager`` (or duck-typed equivalent exposing
+            ``load_session``/``save_session``/``_build_message_dict``).
+        redis_client: Optional async Redis client (``database="main"``); a
+            fresh one is opened when omitted. Injectable so tests never touch
+            a real connection.
+
+    Returns 0 when the session needed no repair, chat:conversation:* has
+    already expired/never existed, or the session itself has no messages.
+    """
+    redis_client = redis_client if redis_client is not None else await get_async_redis_client(database="main")
+    if redis_client is None:
+        logger.warning("No Redis client available — cannot repair session %s", session_id)
+        return 0
+
+    raw = await redis_client.get(_conversation_key(session_id))
+    conversation_pairs = _parse_conversation_pairs(raw)
+    if not conversation_pairs:
+        return 0
+
+    session_messages = await chat_mgr.load_session(session_id)
+    if not session_messages:
+        return 0
+
+    repaired, backfilled = compute_backfilled_messages(
+        session_messages,
+        conversation_pairs,
+        lambda text: _build_backfilled_assistant_message(chat_mgr, text),
+    )
+
+    if backfilled:
+        await chat_mgr.save_session(session_id, messages=repaired)
+        logger.info("Backfilled %d assistant turn(s) for session %s", backfilled, session_id)
+
+    return backfilled
+
+
+async def _main(session_ids: List[str]) -> None:
+    """CLI driver — repairs exactly the sessions named on the command line.
+
+    No bulk/auto-discovery mode by design (#13293): an operator must name
+    every session_id explicitly, so this can never sweep production by
+    accident. Not invoked anywhere in this change.
+    """
+    from chat_history import ChatHistoryManager
+
+    chat_mgr = ChatHistoryManager()
+    total = 0
+    for session_id in session_ids:
+        count = await repair_session(session_id, chat_mgr)
+        total += count
+        logger.info("session=%s backfilled=%d", session_id, count)
+    logger.info("Repair complete: %d turn(s) backfilled across %d session(s)", total, len(session_ids))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Backfill missing chat:session:* assistant turns (#13293).")
+    parser.add_argument(
+        "--session-id",
+        action="append",
+        required=True,
+        dest="session_ids",
+        help="Session ID to repair. Repeat for multiple sessions.",
+    )
+    args = parser.parse_args()
+    asyncio.run(_main(args.session_ids))

--- a/autobot-backend/chat_history/session_reply_backfill.py
+++ b/autobot-backend/chat_history/session_reply_backfill.py
@@ -11,38 +11,57 @@ completed-reply text was accepted by ``_persist_workflow_messages`` and then
 silently discarded. A conversational turn from that window therefore reads
 back with the user's message and no assistant reply at all.
 
-``chat:conversation:{id}`` (see ``chat_workflow.conversation``) — the short
-lived ``{user, assistant}`` pair cache used to build LLM context — was
-unaffected: ``_persist_conversation`` always wrote it, bug or no bug. While it
-has not expired (``conversation_history_ttl``, default 24h — see
-``chat_history/cache.py``), it is the only remaining source of the missing
-assistant text, so it is the backfill source of truth here.
+Two sources can supply the missing text, both written by
+``chat_workflow.conversation._persist_conversation`` regardless of the bug:
+
+1. ``chat:conversation:{id}`` (Redis, ``REDIS_KEY.CHAT_CONVERSATION_PREFIX``)
+   — short-lived, ``conversation_history_ttl`` (default 24h). Fast, but every
+   session damaged by #13214 is in the past, so this has very likely expired
+   by the time anyone runs a repair.
+2. ``data/conversation_transcripts/{id}.json`` (the durable file transcript,
+   ``ChatWorkflowManager.transcript_dir``) — no TTL, one ``{timestamp, user,
+   assistant}`` entry per exchange, the entire session's history (unlike the
+   production loader's last-10 truncation, which exists only to bound LLM
+   context and is irrelevant here).
+
+``repair_session`` tries Redis first (fast path when still warm) and falls
+back to the transcript file — the actual source of truth for anything old
+enough to need this repair.
 
 This module is a REPAIR PATH, not an auto-run migration: nothing here
 executes on import, there is no scheduled/Celery hook, and the CLI entry
 point requires explicit ``--session-id`` arguments — no bulk "repair
 everything" default. Per #13293 this PR only adds the repair logic and its
 tests; it must never be executed against a live system as part of this
-change.
+change. ``repair_session`` is an unlocked read-modify-write over
+``chat_mgr.load_session``/``save_session`` — run it only against a session
+with no concurrent writer (e.g. no active chat) or a late write can be lost.
 """
 
 import argparse
 import asyncio
 import json
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple
+
+import aiofiles
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_constants import REDIS_KEY
 
 logger = get_logger(__name__)
 
-# Mirrors chat_workflow.conversation.ConversationHandlerMixin._get_conversation_key.
-_CONVERSATION_KEY_PREFIX = "chat:conversation:"
+# Mirrors ChatWorkflowManager.transcript_dir (chat_workflow/manager.py) — not
+# yet promoted to a shared SSOT path constant there, so this is a second,
+# clearly-labeled copy of that one existing literal (not a new triplication
+# like the Redis prefix below was).
+_TRANSCRIPT_DIR = "data/conversation_transcripts"
 
 
 def _conversation_key(session_id: str) -> str:
     """Redis key holding the ``{user, assistant}`` pair history for *session_id*."""
-    return f"{_CONVERSATION_KEY_PREFIX}{session_id}"
+    return f"{REDIS_KEY.CHAT_CONVERSATION_PREFIX}{session_id}"
 
 
 def _parse_conversation_pairs(raw: str | bytes | None) -> List[Dict[str, str]]:
@@ -65,6 +84,66 @@ def _parse_conversation_pairs(raw: str | bytes | None) -> List[Dict[str, str]]:
     return [p for p in pairs if isinstance(p, dict) and (p.get("user") or "").strip()]
 
 
+async def _load_transcript_pairs(session_id: str, transcript_dir: str = _TRANSCRIPT_DIR) -> List[Dict[str, str]]:
+    """Read the FULL durable transcript file as ``{user, assistant}`` pairs.
+
+    Unlike ``ChatWorkflowManager._load_transcript`` (which truncates to the
+    last 10 exchanges — a bound for LLM context, not repair), this reads
+    every exchange ever recorded: a #13214-damaged turn can be arbitrarily
+    far back in a long session's history, and it is exactly the case where
+    ``chat:conversation:*`` has already expired.
+    """
+    path = Path(transcript_dir) / f"{session_id}.json"
+    try:
+        async with aiofiles.open(path, "r", encoding="utf-8") as f:
+            content = await f.read()
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        logger.warning("Failed to read transcript file %s: %s", path, exc)
+        return []
+
+    try:
+        transcript = json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning("Malformed transcript file %s — skipping repair for this session", path)
+        return []
+
+    messages = transcript.get("messages", []) if isinstance(transcript, dict) else []
+    if not isinstance(messages, list):
+        return []
+    return [
+        {"user": m.get("user", ""), "assistant": m.get("assistant", "")}
+        for m in messages
+        if isinstance(m, dict) and (m.get("user") or "").strip()
+    ]
+
+
+def _find_turn_end(messages: List[Dict[str, Any]], start: int) -> int:
+    """Index of the next ``sender == "user"`` message after *start*, or ``len(messages)``.
+
+    Defines one turn's message window: everything from a user message up to
+    (not including) the next user message, or the end of the session.
+    """
+    return next((j for j in range(start, len(messages)) if messages[j].get("sender") == "user"), len(messages))
+
+
+def _find_matching_pair_index(
+    user_text: str,
+    conversation_pairs: List[Dict[str, str]],
+    used_pair_indices: set,
+) -> int | None:
+    """First not-yet-consumed pair whose ``user`` text matches *user_text* byte-for-byte."""
+    return next(
+        (
+            idx
+            for idx, pair in enumerate(conversation_pairs)
+            if idx not in used_pair_indices and (pair.get("user") or "").strip() == user_text
+        ),
+        None,
+    )
+
+
 def compute_backfilled_messages(
     session_messages: List[Dict[str, Any]],
     conversation_pairs: List[Dict[str, str]],
@@ -76,12 +155,17 @@ def compute_backfilled_messages(
     so the matching logic is independently testable from the load/save seam
     that ``repair_session`` owns.
 
-    A user turn is "damaged" when no assistant message immediately follows it
-    (before the next user message, if any). For each damaged turn, the first
-    not-yet-consumed ``chat:conversation:*`` pair whose ``user`` text matches
-    byte-for-byte supplies the missing ``assistant`` text, inserted as a new
-    message directly after the user turn — restoring both the reply and the
-    turn ordering a reload should show.
+    A user turn is "damaged" when NO assistant message appears anywhere in its
+    window — from the user message up to (not including) the next user
+    message. Checking only the immediately-following slot is wrong: a healthy
+    tool-using turn persists as ``[user, system(terminal_output), assistant]``
+    (see ``manager.py``'s ``_build_workflow_message_batch``), and would be
+    misjudged damaged by a next-slot-only check, causing a spurious duplicate
+    insertion (#13303 review). For each genuinely damaged turn, the first
+    not-yet-consumed ``chat:conversation:*``/transcript pair whose ``user``
+    text matches byte-for-byte supplies the missing ``assistant`` text,
+    inserted at the end of the turn's window — after any tool/system entries,
+    preserving them.
     """
     repaired = list(session_messages)
     used_pair_indices: set = set()
@@ -94,33 +178,27 @@ def compute_backfilled_messages(
             i += 1
             continue
 
+        turn_end = _find_turn_end(repaired, i + 1)
         user_text = (msg.get("text") or "").strip()
-        next_is_reply = i + 1 < len(repaired) and repaired[i + 1].get("sender") == "assistant"
-        if next_is_reply or not user_text:
-            i += 1
+        has_reply = any(repaired[j].get("sender") == "assistant" for j in range(i + 1, turn_end))
+        if has_reply or not user_text:
+            i = turn_end
             continue
 
-        pair_idx = next(
-            (
-                idx
-                for idx, pair in enumerate(conversation_pairs)
-                if idx not in used_pair_indices and (pair.get("user") or "").strip() == user_text
-            ),
-            None,
-        )
+        pair_idx = _find_matching_pair_index(user_text, conversation_pairs, used_pair_indices)
         if pair_idx is None:
-            i += 1
+            i = turn_end
             continue
 
         used_pair_indices.add(pair_idx)
         assistant_text = (conversation_pairs[pair_idx].get("assistant") or "").strip()
         if not assistant_text:
-            i += 1
+            i = turn_end
             continue
 
-        repaired.insert(i + 1, build_assistant_message(assistant_text))
+        repaired.insert(turn_end, build_assistant_message(assistant_text))
         backfilled += 1
-        i += 2  # skip past the turn just repaired
+        i = turn_end + 1  # skip past the reply just inserted
 
     return repaired, backfilled
 
@@ -128,9 +206,10 @@ def compute_backfilled_messages(
 def _build_backfilled_assistant_message(chat_mgr, text: str) -> Dict[str, Any]:
     """Build the persisted dict for one backfilled assistant turn.
 
-    ``sources: []`` — chat:conversation:* pairs carry no citation metadata, so
-    a backfilled turn cannot claim KB provenance it never recorded (#13292's
-    fidelity fix does not apply retroactively; there is nothing to recover).
+    ``sources: []`` — the conversation-pair/transcript sources carry no
+    citation metadata, so a backfilled turn cannot claim KB provenance it
+    never recorded (#13292's fidelity fix does not apply retroactively;
+    there is nothing to recover).
     """
     return chat_mgr._build_message_dict(
         "assistant",
@@ -142,7 +221,25 @@ def _build_backfilled_assistant_message(chat_mgr, text: str) -> Dict[str, Any]:
     )
 
 
-async def repair_session(session_id: str, chat_mgr, redis_client=None) -> int:
+async def _load_conversation_pairs(session_id: str, redis_client, transcript_dir: str) -> List[Dict[str, str]]:
+    """Redis ``chat:conversation:*`` first (fast, may be TTL-expired), else the
+    durable transcript file — the actual source for anything old enough to
+    need this repair.
+    """
+    if redis_client is not None:
+        raw = await redis_client.get(_conversation_key(session_id))
+        pairs = _parse_conversation_pairs(raw)
+        if pairs:
+            return pairs
+    return await _load_transcript_pairs(session_id, transcript_dir)
+
+
+async def repair_session(
+    session_id: str,
+    chat_mgr,
+    redis_client=None,
+    transcript_dir: str = _TRANSCRIPT_DIR,
+) -> int:
     """Backfill missing assistant turns for one session. Returns count repaired.
 
     Args:
@@ -150,19 +247,23 @@ async def repair_session(session_id: str, chat_mgr, redis_client=None) -> int:
         chat_mgr: A ``ChatHistoryManager`` (or duck-typed equivalent exposing
             ``load_session``/``save_session``/``_build_message_dict``).
         redis_client: Optional async Redis client (``database="main"``); a
-            fresh one is opened when omitted. Injectable so tests never touch
-            a real connection.
+            fresh one is opened when omitted, and Redis is skipped (falling
+            straight to the transcript file) if unavailable.
+        transcript_dir: Override for tests; defaults to production's path.
 
-    Returns 0 when the session needed no repair, chat:conversation:* has
-    already expired/never existed, or the session itself has no messages.
+    Returns 0 when the session needed no repair, or no source (Redis nor
+    transcript) has anything to backfill from.
+
+    Not concurrency-safe: this is a plain read-modify-write over
+    ``load_session``/``save_session`` with no lock. Run it only against a
+    session with no in-flight writer.
     """
-    redis_client = redis_client if redis_client is not None else await get_async_redis_client(database="main")
     if redis_client is None:
-        logger.warning("No Redis client available — cannot repair session %s", session_id)
-        return 0
+        redis_client = await get_async_redis_client(database="main")
+        if redis_client is None:
+            logger.warning("No Redis client available for session %s — using transcript file only", session_id)
 
-    raw = await redis_client.get(_conversation_key(session_id))
-    conversation_pairs = _parse_conversation_pairs(raw)
+    conversation_pairs = await _load_conversation_pairs(session_id, redis_client, transcript_dir)
     if not conversation_pairs:
         return 0
 

--- a/autobot-backend/chat_history/session_reply_backfill_test.py
+++ b/autobot-backend/chat_history/session_reply_backfill_test.py
@@ -11,21 +11,31 @@ a plain conversational turn wrote an empty batch and the session reads back
 with the user's message and no assistant reply.
 
 ``chat:conversation:{id}`` (the short-lived ``{user, assistant}`` pair cache
-used for LLM context, written by ``_persist_conversation`` regardless of the
-bug) still has the missing text while it has not expired. These tests prove
-``repair_session``/``compute_backfilled_messages`` correctly reconstructs the
-damaged sessions from that source — and leaves already-healthy sessions and
-turns untouched.
+used for LLM context) and ``data/conversation_transcripts/{id}.json`` (the
+durable file transcript) are both written by ``_persist_conversation``
+regardless of the bug, and are the two sources this module backfills from —
+Redis first (fast, likely TTL-expired for anything old enough to need this),
+falling back to the transcript file (the actual source of truth once Redis
+has expired).
+
+These tests prove ``repair_session``/``compute_backfilled_messages`` correctly
+reconstructs damaged sessions from both sources, correctly identifies a
+"damaged" turn by scanning its full message window (not just the next slot —
+a healthy tool-using turn is ``[user, system, assistant]`` and must not be
+misjudged damaged), and leaves already-healthy sessions/turns untouched.
 
 This is a repair PATH, not a live run: every test below uses an in-memory
-fake Redis client and a fake chat-history store; nothing here touches a real
-Redis instance or `chat_history.ChatHistoryManager`'s real I/O.
+fake Redis client, a real ``MessagesMixin``-backed in-memory store, and (for
+the transcript-fallback tests) a ``tmp_path``-scoped transcript directory —
+nothing here touches a real Redis instance or production filesystem.
 """
 
+import json
 from typing import Any, Dict, List
 
 import pytest
 
+from chat_history.messages import MessagesMixin
 from chat_history.session_reply_backfill import (
     compute_backfilled_messages,
     repair_session,
@@ -38,8 +48,12 @@ def _user(text: str) -> Dict[str, Any]:
     return {"sender": "user", "text": text, "messageType": "default"}
 
 
-def _assistant(text: str, **metadata: Any) -> Dict[str, Any]:
-    return {"sender": "assistant", "text": text, "messageType": "response", "metadata": metadata}
+def _assistant(text: str, sender: str = "assistant", **metadata: Any) -> Dict[str, Any]:
+    return {"sender": sender, "text": text, "messageType": "response", "metadata": metadata}
+
+
+def _system(text: str) -> Dict[str, Any]:
+    return {"sender": "system", "text": text, "messageType": "terminal_output", "metadata": {}}
 
 
 def _build_message(text: str) -> Dict[str, Any]:
@@ -69,6 +83,40 @@ class TestComputeBackfilledMessagesPureLogic:
 
         assert count == 0
         assert repaired == session_messages
+
+    def test_healthy_tool_turn_with_system_entry_is_not_double_posted(self):
+        """#13303 review finding: [user, system, assistant] must NOT be judged damaged.
+
+        A next-slot-only check sees repaired[i+1] == "system" (not "assistant")
+        and wrongly inserts a duplicate reply. The fix scans the whole turn
+        window (up to the next user message) for ANY assistant entry.
+        """
+        session_messages = [
+            _user("what is uptime?"),
+            _system("uptime: 3 days"),
+            _assistant("Uptime is 3 days."),
+        ]
+        conversation_pairs = [{"user": "what is uptime?", "assistant": "Uptime is 3 days."}]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 0
+        assert repaired == session_messages
+
+    def test_damaged_tool_turn_is_backfilled_after_the_system_entry(self):
+        """A genuinely damaged tool turn ([user, system], no reply) is backfilled
+
+        AFTER the system entry, not immediately after the user message —
+        preserving the tool-output-then-reply order the turn actually has.
+        """
+        session_messages = [_user("what is uptime?"), _system("uptime: 3 days")]
+        conversation_pairs = [{"user": "what is uptime?", "assistant": "Uptime is 3 days."}]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 1
+        assert [m["sender"] for m in repaired] == ["user", "system", "assistant"]
+        assert repaired[2]["text"] == "Uptime is 3 days."
 
     def test_multiple_damaged_turns_are_each_backfilled_in_order(self):
         session_messages = [_user("first question"), _user("second question")]
@@ -110,7 +158,7 @@ class TestComputeBackfilledMessagesPureLogic:
         ]
 
     def test_no_matching_conversation_pair_leaves_turn_damaged(self):
-        """chat:conversation:* expired/never had this turn — nothing to backfill from."""
+        """chat:conversation:*/transcript has nothing for this turn — nothing to backfill from."""
         session_messages = [_user("orphaned question")]
         conversation_pairs = [{"user": "unrelated question", "assistant": "unrelated answer"}]
 
@@ -138,6 +186,18 @@ class TestComputeBackfilledMessagesPureLogic:
         assert count == 0
         assert repaired == session_messages
 
+    def test_idempotent_second_pass_backfills_nothing_more(self):
+        """Running the repair twice must not duplicate the reply it just inserted."""
+        session_messages = [_user("what is uptime?"), _system("uptime: 3 days")]
+        conversation_pairs = [{"user": "what is uptime?", "assistant": "Uptime is 3 days."}]
+
+        once, count_once = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+        twice, count_twice = compute_backfilled_messages(once, conversation_pairs, _build_message)
+
+        assert count_once == 1
+        assert count_twice == 0
+        assert once == twice
+
 
 class _FakeAsyncRedis:
     """Minimal async Redis stand-in exposing only ``.get`` (what repair_session uses)."""
@@ -149,36 +209,45 @@ class _FakeAsyncRedis:
         return self.values.get(key)
 
 
-class _FakeChatHistoryManager:
-    """In-memory chat-history store exercising the real message-dict shape."""
+class _InMemoryChatHistory(MessagesMixin):
+    """In-memory chat-history store.
+
+    Subclasses the REAL ``MessagesMixin`` (as ``streamed_reply_persistence_test.py``
+    does) so ``_build_message_dict``/``add_messages_batch`` are production
+    code — a hand-rolled duck-typed stub previously omitted ``author_id`` and
+    only worked because ``sources`` was passed by keyword (#13303 review).
+    """
 
     def __init__(self, sessions: Dict[str, List[Dict[str, Any]]] | None = None) -> None:
-        self.sessions = sessions or {}
-        self.saved: Dict[str, List[Dict[str, Any]]] = {}
+        self.sessions: Dict[str, List[Dict[str, Any]]] = sessions or {}
 
     async def load_session(self, session_id: str) -> List[Dict[str, Any]]:
         return list(self.sessions.get(session_id, []))
 
-    async def save_session(self, session_id: str, messages=None, **_kwargs) -> None:
-        self.saved[session_id] = list(messages or [])
+    async def save_session(self, session_id: str, messages=None, **_kwargs) -> bool:
         self.sessions[session_id] = list(messages or [])
+        return True
 
-    def _build_message_dict(self, sender, text, message_type, raw_data, tool_markers, sources=None):
-        return {
-            "sender": sender,
-            "text": text,
-            "messageType": message_type,
-            "metadata": raw_data,
-            "sources": sources if sources is not None else [],
-        }
+
+def _write_transcript(tmp_path, session_id: str, exchanges: List[Dict[str, str]]) -> str:
+    """Write a transcript JSON file matching ChatWorkflowManager's on-disk shape."""
+    transcript_dir = tmp_path / "conversation_transcripts"
+    transcript_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": session_id,
+        "messages": [{"timestamp": "2026-01-01 00:00:00", **exchange} for exchange in exchanges],
+        "message_count": len(exchanges),
+    }
+    (transcript_dir / f"{session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+    return str(transcript_dir)
 
 
 class TestRepairSessionEndToEnd:
-    """Exercises the Redis-read + load/save seam repair_session owns."""
+    """Exercises the Redis-read + transcript-fallback + load/save seam repair_session owns."""
 
     @pytest.mark.asyncio
-    async def test_damaged_session_is_backfilled_and_saved(self):
-        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("What is the deploy status?")]})
+    async def test_damaged_session_is_backfilled_from_redis_and_saved(self):
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("What is the deploy status?")]})
         redis_client = _FakeAsyncRedis(
             {"chat:conversation:sess-13293": ('[{"user": "What is the deploy status?", "assistant": "All green."}]')}
         )
@@ -186,64 +255,145 @@ class TestRepairSessionEndToEnd:
         count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
 
         assert count == 1
-        saved = chat_mgr.saved[SESSION_ID]
+        saved = chat_mgr.sessions[SESSION_ID]
         assert [m["sender"] for m in saved] == ["user", "assistant"]
         assert saved[1]["text"] == "All green."
         assert saved[1]["sources"] == []
         assert saved[1]["metadata"]["backfilled_from"] == "chat:conversation"
 
     @pytest.mark.asyncio
+    async def test_healthy_tool_turn_is_not_double_posted_end_to_end(self):
+        """#13303 review: the double-post bug reproduced against the full seam."""
+        original = [
+            _user("what is uptime?"),
+            _system("uptime: 3 days"),
+            _assistant("Uptime is 3 days."),
+        ]
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: list(original)})
+        redis_client = _FakeAsyncRedis(
+            {"chat:conversation:sess-13293": '[{"user": "what is uptime?", "assistant": "Uptime is 3 days."}]'}
+        )
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert count == 0
+        assert chat_mgr.sessions[SESSION_ID] == original
+
+    @pytest.mark.asyncio
     async def test_healthy_session_is_not_saved(self):
         """No write at all when nothing needed repair — avoids no-op session churn."""
-        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("hi"), _assistant("hello")]})
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("hi"), _assistant("hello")]})
         redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": '[{"user": "hi", "assistant": "hello"}]'})
+        original = list(chat_mgr.sessions[SESSION_ID])
 
         count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
 
         assert count == 0
-        assert SESSION_ID not in chat_mgr.saved
+        assert chat_mgr.sessions[SESSION_ID] == original
 
     @pytest.mark.asyncio
-    async def test_expired_conversation_key_is_a_no_op(self):
-        """chat:conversation:* TTL'd out — nothing to repair from, must not error."""
-        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("orphaned")]})
+    async def test_expired_redis_key_falls_back_to_transcript_file(self, tmp_path):
+        """Blocker #3: chat:conversation:* TTL'd out — repair must still succeed from disk."""
+        transcript_dir = _write_transcript(
+            tmp_path, SESSION_ID, [{"user": "What is the deploy status?", "assistant": "All green."}]
+        )
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("What is the deploy status?")]})
         redis_client = _FakeAsyncRedis({})  # key absent — simulates TTL expiry
 
-        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client, transcript_dir=transcript_dir)
 
-        assert count == 0
-        assert SESSION_ID not in chat_mgr.saved
-
-    @pytest.mark.asyncio
-    async def test_malformed_conversation_payload_does_not_raise(self):
-        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("hi")]})
-        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": "{not valid json"})
-
-        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
-
-        assert count == 0
-        assert SESSION_ID not in chat_mgr.saved
+        assert count == 1
+        saved = chat_mgr.sessions[SESSION_ID]
+        assert [m["sender"] for m in saved] == ["user", "assistant"]
+        assert saved[1]["text"] == "All green."
 
     @pytest.mark.asyncio
-    async def test_unknown_session_is_a_no_op(self):
-        chat_mgr = _FakeChatHistoryManager(sessions={})
-        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": '[{"user": "hi", "assistant": "hi back"}]'})
-
-        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
-
-        assert count == 0
-        assert SESSION_ID not in chat_mgr.saved
-
-    @pytest.mark.asyncio
-    async def test_no_redis_client_available_does_not_raise(self, monkeypatch):
-        """Simulates Redis being fully unavailable (get_async_redis_client() -> None)."""
+    async def test_no_redis_client_available_falls_back_to_transcript_file(self, tmp_path, monkeypatch):
+        """Redis fully unavailable (get_async_redis_client() -> None) — must still repair from disk."""
 
         async def _no_redis(database: str = "main"):
             return None
 
         monkeypatch.setattr("chat_history.session_reply_backfill.get_async_redis_client", _no_redis)
-        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("hi")]})
+        transcript_dir = _write_transcript(tmp_path, SESSION_ID, [{"user": "hi", "assistant": "hello there"}])
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("hi")]})
 
-        count = await repair_session(SESSION_ID, chat_mgr, redis_client=None)
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=None, transcript_dir=transcript_dir)
+
+        assert count == 1
+        assert chat_mgr.sessions[SESSION_ID][1]["text"] == "hello there"
+
+    @pytest.mark.asyncio
+    async def test_no_redis_client_and_no_transcript_does_not_raise(self, tmp_path, monkeypatch):
+        async def _no_redis(database: str = "main"):
+            return None
+
+        monkeypatch.setattr("chat_history.session_reply_backfill.get_async_redis_client", _no_redis)
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("hi")]})
+
+        count = await repair_session(
+            SESSION_ID, chat_mgr, redis_client=None, transcript_dir=str(tmp_path / "does-not-exist")
+        )
 
         assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_redis_pair_preferred_over_transcript_when_both_present(self, tmp_path):
+        """Redis is the fast path — used first when it has the answer, transcript untouched."""
+        transcript_dir = _write_transcript(tmp_path, SESSION_ID, [{"user": "hi", "assistant": "stale transcript"}])
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("hi")]})
+        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": '[{"user": "hi", "assistant": "fresh redis"}]'})
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client, transcript_dir=transcript_dir)
+
+        assert count == 1
+        assert chat_mgr.sessions[SESSION_ID][1]["text"] == "fresh redis"
+
+    @pytest.mark.asyncio
+    async def test_no_source_available_is_a_no_op(self, tmp_path):
+        """Neither Redis nor a transcript file exists — nothing to repair from, no error."""
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("orphaned")]})
+        redis_client = _FakeAsyncRedis({})
+
+        count = await repair_session(
+            SESSION_ID, chat_mgr, redis_client=redis_client, transcript_dir=str(tmp_path / "does-not-exist")
+        )
+
+        assert count == 0
+        assert SESSION_ID in chat_mgr.sessions  # unchanged, not deleted
+
+    @pytest.mark.asyncio
+    async def test_malformed_conversation_payload_falls_back_to_transcript(self, tmp_path):
+        transcript_dir = _write_transcript(tmp_path, SESSION_ID, [{"user": "hi", "assistant": "from transcript"}])
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("hi")]})
+        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": "{not valid json"})
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client, transcript_dir=transcript_dir)
+
+        assert count == 1
+        assert chat_mgr.sessions[SESSION_ID][1]["text"] == "from transcript"
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_is_a_no_op(self):
+        chat_mgr = _InMemoryChatHistory(sessions={})
+        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": '[{"user": "hi", "assistant": "hi back"}]'})
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert count == 0
+        assert SESSION_ID not in chat_mgr.sessions
+
+    @pytest.mark.asyncio
+    async def test_repair_twice_is_idempotent_end_to_end(self):
+        """Blocker D: calling repair_session twice must not duplicate the backfilled turn."""
+        chat_mgr = _InMemoryChatHistory(sessions={SESSION_ID: [_user("what is uptime?"), _system("uptime: 3 days")]})
+        redis_client = _FakeAsyncRedis(
+            {"chat:conversation:sess-13293": '[{"user": "what is uptime?", "assistant": "Uptime is 3 days."}]'}
+        )
+
+        first = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+        second = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert first == 1
+        assert second == 0
+        assert [m["sender"] for m in chat_mgr.sessions[SESSION_ID]] == ["user", "system", "assistant"]

--- a/autobot-backend/chat_history/session_reply_backfill_test.py
+++ b/autobot-backend/chat_history/session_reply_backfill_test.py
@@ -1,0 +1,249 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for Issue #13293 — repair chat:session:* turns damaged by #13214.
+
+Before #13214 merged, a completed streamed reply was computed and shown to
+the user but never persisted to ``chat:session:{id}``: the batch that
+``_persist_workflow_messages`` wrote held only non-streaming side messages, so
+a plain conversational turn wrote an empty batch and the session reads back
+with the user's message and no assistant reply.
+
+``chat:conversation:{id}`` (the short-lived ``{user, assistant}`` pair cache
+used for LLM context, written by ``_persist_conversation`` regardless of the
+bug) still has the missing text while it has not expired. These tests prove
+``repair_session``/``compute_backfilled_messages`` correctly reconstructs the
+damaged sessions from that source — and leaves already-healthy sessions and
+turns untouched.
+
+This is a repair PATH, not a live run: every test below uses an in-memory
+fake Redis client and a fake chat-history store; nothing here touches a real
+Redis instance or `chat_history.ChatHistoryManager`'s real I/O.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from chat_history.session_reply_backfill import (
+    compute_backfilled_messages,
+    repair_session,
+)
+
+SESSION_ID = "sess-13293"
+
+
+def _user(text: str) -> Dict[str, Any]:
+    return {"sender": "user", "text": text, "messageType": "default"}
+
+
+def _assistant(text: str, **metadata: Any) -> Dict[str, Any]:
+    return {"sender": "assistant", "text": text, "messageType": "response", "metadata": metadata}
+
+
+def _build_message(text: str) -> Dict[str, Any]:
+    """Stand-in for chat_mgr._build_message_dict used directly by the pure-logic tests."""
+    return {"sender": "assistant", "text": text, "messageType": "response", "sources": []}
+
+
+class TestComputeBackfilledMessagesPureLogic:
+    """No I/O — proves the matching/insertion algorithm in isolation."""
+
+    def test_missing_reply_is_backfilled_from_matching_pair(self):
+        session_messages = [_user("What is the deploy status?")]
+        conversation_pairs = [{"user": "What is the deploy status?", "assistant": "All green."}]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 1
+        assert [m["sender"] for m in repaired] == ["user", "assistant"]
+        assert repaired[1]["text"] == "All green."
+
+    def test_healthy_turn_is_left_untouched(self):
+        """A user turn already followed by an assistant reply is never touched."""
+        session_messages = [_user("hi"), _assistant("hello there")]
+        conversation_pairs = [{"user": "hi", "assistant": "hello there"}]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 0
+        assert repaired == session_messages
+
+    def test_multiple_damaged_turns_are_each_backfilled_in_order(self):
+        session_messages = [_user("first question"), _user("second question")]
+        conversation_pairs = [
+            {"user": "first question", "assistant": "first answer"},
+            {"user": "second question", "assistant": "second answer"},
+        ]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 2
+        assert [m["text"] for m in repaired] == [
+            "first question",
+            "first answer",
+            "second question",
+            "second answer",
+        ]
+
+    def test_mixed_session_only_damaged_turn_is_backfilled(self):
+        """One turn survived (pre-existing reply), the other didn't — only the second is touched."""
+        session_messages = [
+            _user("first question"),
+            _assistant("first answer"),
+            _user("second question"),
+        ]
+        conversation_pairs = [
+            {"user": "first question", "assistant": "first answer"},
+            {"user": "second question", "assistant": "second answer"},
+        ]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 1
+        assert [m["text"] for m in repaired] == [
+            "first question",
+            "first answer",
+            "second question",
+            "second answer",
+        ]
+
+    def test_no_matching_conversation_pair_leaves_turn_damaged(self):
+        """chat:conversation:* expired/never had this turn — nothing to backfill from."""
+        session_messages = [_user("orphaned question")]
+        conversation_pairs = [{"user": "unrelated question", "assistant": "unrelated answer"}]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 0
+        assert repaired == session_messages
+
+    def test_repeated_identical_user_text_consumes_pairs_in_order(self):
+        """Two damaged turns with identical text must not both grab the same pair."""
+        session_messages = [_user("status?"), _user("status?")]
+        conversation_pairs = [
+            {"user": "status?", "assistant": "answer one"},
+            {"user": "status?", "assistant": "answer two"},
+        ]
+
+        repaired, count = compute_backfilled_messages(session_messages, conversation_pairs, _build_message)
+
+        assert count == 2
+        assert [m["text"] for m in repaired] == ["status?", "answer one", "status?", "answer two"]
+
+    def test_empty_conversation_pairs_is_a_no_op(self):
+        session_messages = [_user("hello")]
+        repaired, count = compute_backfilled_messages(session_messages, [], _build_message)
+        assert count == 0
+        assert repaired == session_messages
+
+
+class _FakeAsyncRedis:
+    """Minimal async Redis stand-in exposing only ``.get`` (what repair_session uses)."""
+
+    def __init__(self, values: Dict[str, str] | None = None) -> None:
+        self.values = values or {}
+
+    async def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+
+class _FakeChatHistoryManager:
+    """In-memory chat-history store exercising the real message-dict shape."""
+
+    def __init__(self, sessions: Dict[str, List[Dict[str, Any]]] | None = None) -> None:
+        self.sessions = sessions or {}
+        self.saved: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def load_session(self, session_id: str) -> List[Dict[str, Any]]:
+        return list(self.sessions.get(session_id, []))
+
+    async def save_session(self, session_id: str, messages=None, **_kwargs) -> None:
+        self.saved[session_id] = list(messages or [])
+        self.sessions[session_id] = list(messages or [])
+
+    def _build_message_dict(self, sender, text, message_type, raw_data, tool_markers, sources=None):
+        return {
+            "sender": sender,
+            "text": text,
+            "messageType": message_type,
+            "metadata": raw_data,
+            "sources": sources if sources is not None else [],
+        }
+
+
+class TestRepairSessionEndToEnd:
+    """Exercises the Redis-read + load/save seam repair_session owns."""
+
+    @pytest.mark.asyncio
+    async def test_damaged_session_is_backfilled_and_saved(self):
+        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("What is the deploy status?")]})
+        redis_client = _FakeAsyncRedis(
+            {"chat:conversation:sess-13293": ('[{"user": "What is the deploy status?", "assistant": "All green."}]')}
+        )
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert count == 1
+        saved = chat_mgr.saved[SESSION_ID]
+        assert [m["sender"] for m in saved] == ["user", "assistant"]
+        assert saved[1]["text"] == "All green."
+        assert saved[1]["sources"] == []
+        assert saved[1]["metadata"]["backfilled_from"] == "chat:conversation"
+
+    @pytest.mark.asyncio
+    async def test_healthy_session_is_not_saved(self):
+        """No write at all when nothing needed repair — avoids no-op session churn."""
+        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("hi"), _assistant("hello")]})
+        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": '[{"user": "hi", "assistant": "hello"}]'})
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert count == 0
+        assert SESSION_ID not in chat_mgr.saved
+
+    @pytest.mark.asyncio
+    async def test_expired_conversation_key_is_a_no_op(self):
+        """chat:conversation:* TTL'd out — nothing to repair from, must not error."""
+        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("orphaned")]})
+        redis_client = _FakeAsyncRedis({})  # key absent — simulates TTL expiry
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert count == 0
+        assert SESSION_ID not in chat_mgr.saved
+
+    @pytest.mark.asyncio
+    async def test_malformed_conversation_payload_does_not_raise(self):
+        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("hi")]})
+        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": "{not valid json"})
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert count == 0
+        assert SESSION_ID not in chat_mgr.saved
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_is_a_no_op(self):
+        chat_mgr = _FakeChatHistoryManager(sessions={})
+        redis_client = _FakeAsyncRedis({"chat:conversation:sess-13293": '[{"user": "hi", "assistant": "hi back"}]'})
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=redis_client)
+
+        assert count == 0
+        assert SESSION_ID not in chat_mgr.saved
+
+    @pytest.mark.asyncio
+    async def test_no_redis_client_available_does_not_raise(self, monkeypatch):
+        """Simulates Redis being fully unavailable (get_async_redis_client() -> None)."""
+
+        async def _no_redis(database: str = "main"):
+            return None
+
+        monkeypatch.setattr("chat_history.session_reply_backfill.get_async_redis_client", _no_redis)
+        chat_mgr = _FakeChatHistoryManager(sessions={SESSION_ID: [_user("hi")]})
+
+        count = await repair_session(SESSION_ID, chat_mgr, redis_client=None)
+
+        assert count == 0

--- a/autobot-backend/chat_workflow/conversation.py
+++ b/autobot-backend/chat_workflow/conversation.py
@@ -19,6 +19,7 @@ import aiofiles
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
+from autobot_shared.ssot_constants import REDIS_KEY
 
 from .models import WorkflowSession
 
@@ -30,7 +31,7 @@ class ConversationHandlerMixin:
 
     def _get_conversation_key(self, session_id: str) -> str:
         """Generate Redis key for conversation history."""
-        return f"chat:conversation:{session_id}"
+        return f"{REDIS_KEY.CHAT_CONVERSATION_PREFIX}{session_id}"
 
     async def _try_redis_history(self, session_id: str) -> List[Dict[str, str]] | None:
         """Try to load conversation history from Redis (Issue #332 - extracted helper).

--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -1357,6 +1357,9 @@ async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict
             state["session_id"],
             wf_messages,
             combined_response,
+            selected_model=state.get("llm_params", {}).get("selected_model", ""),
+            rag_citations=state.get("rag_citations", []),
+            used_knowledge=state.get("used_knowledge", False),
         )
 
         logger.info(

--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -1299,6 +1299,48 @@ async def _persist_error_turn(manager, state: ChatState) -> None:
         logger.error("Failed to persist error turn for session %s: %s", session_id, exc, exc_info=True)
 
 
+async def _emit_before_response_send_safe(combined_response: str, session_id: str | None) -> str:
+    """BEFORE_RESPONSE_SEND hook — lets extensions inspect/modify the response.
+
+    Issue #4263. Extracted from ``persist_conversation`` (#13303 review — keep
+    functions short). Failure is non-fatal: the original response is kept.
+    """
+    from chat_workflow.llm_handler import _emit_before_response_send
+
+    try:
+        return await _emit_before_response_send(combined_response, session_id, {})
+    except Exception as hook_exc:  # noqa: BLE001
+        logger.debug("BEFORE_RESPONSE_SEND hook failed (non-fatal): %s", hook_exc)
+        return combined_response
+
+
+async def _emit_after_response_send_safe(combined_response: str, session_id: str | None) -> None:
+    """AFTER_RESPONSE_SEND hook. Issue #4263. Extracted from ``persist_conversation``."""
+    from chat_workflow.llm_handler import _emit_after_response_send
+
+    try:
+        await _emit_after_response_send(combined_response, session_id, {})
+    except Exception as hook_exc:  # noqa: BLE001
+        logger.debug("AFTER_RESPONSE_SEND hook failed (non-fatal): %s", hook_exc)
+
+
+def _build_workflow_messages_from_state(state: ChatState) -> List[Any]:
+    """Rebuild ``WorkflowMessage`` objects from the graph's plain-dict state entries.
+
+    Extracted from ``persist_conversation`` (#13303 review).
+    """
+    from async_chat_workflow import WorkflowMessage
+
+    return [
+        WorkflowMessage(
+            type=msg_dict.get("type", "response"),
+            content=msg_dict.get("content", ""),
+            metadata=msg_dict.get("metadata", {}),
+        )
+        for msg_dict in state.get("workflow_messages", [])
+    ]
+
+
 async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict:
     """Persist conversation to Redis and file storage."""
     if state.get("error"):
@@ -1311,50 +1353,21 @@ async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict
 
     manager = config["configurable"]["manager"]
     session_id = state.get("session_id", "")
-    total_iterations = state.get("iteration_count", 0)
     combined_response = "\n\n".join(state.get("all_llm_responses", []))
 
     # Emit LOOP_COMPLETE hook to notify extensions
-    await _emit_loop_complete(total_iterations, combined_response, session_id)
+    await _emit_loop_complete(state.get("iteration_count", 0), combined_response, session_id)
 
     try:
-        session = await manager.get_or_create_session(state["session_id"])
+        session = await manager.get_or_create_session(session_id)
+        # Issue #4263: allow extensions to inspect/modify response before sending
+        combined_response = await _emit_before_response_send_safe(combined_response, session_id)
 
-        # Issue #4263: Emit BEFORE_RESPONSE_SEND hook before sending response
-        from chat_workflow.llm_handler import _emit_before_response_send
+        await manager._persist_conversation(session_id, session, state["user_message"], combined_response)
 
-        try:
-            # Allow extensions to inspect/modify response before sending
-            combined_response = await _emit_before_response_send(
-                combined_response,
-                state.get("session_id"),
-                {},
-            )
-        except Exception as hook_exc:  # noqa: BLE001
-            logger.debug("BEFORE_RESPONSE_SEND hook failed (non-fatal): %s", hook_exc)
-
-        await manager._persist_conversation(
-            state["session_id"],
-            session,
-            state["user_message"],
-            combined_response,
-        )
-
-        # Persist workflow messages to chat history
-        from async_chat_workflow import WorkflowMessage
-
-        wf_messages = []
-        for msg_dict in state.get("workflow_messages", []):
-            wf_messages.append(
-                WorkflowMessage(
-                    type=msg_dict.get("type", "response"),
-                    content=msg_dict.get("content", ""),
-                    metadata=msg_dict.get("metadata", {}),
-                )
-            )
-
+        wf_messages = _build_workflow_messages_from_state(state)
         await manager._persist_workflow_messages(
-            state["session_id"],
+            session_id,
             wf_messages,
             combined_response,
             selected_model=state.get("llm_params", {}).get("selected_model", ""),
@@ -1364,21 +1377,12 @@ async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict
 
         logger.info(
             "Persisted conversation for session=%s, messages=%d",
-            state["session_id"],
+            session_id,
             len(wf_messages),
         )
 
-        # Issue #4263: Emit AFTER_RESPONSE_SEND hook after response is sent
-        from chat_workflow.llm_handler import _emit_after_response_send
-
-        try:
-            await _emit_after_response_send(
-                combined_response,
-                state.get("session_id"),
-                {},
-            )
-        except Exception as hook_exc:  # noqa: BLE001
-            logger.debug("AFTER_RESPONSE_SEND hook failed (non-fatal): %s", hook_exc)
+        # Issue #4263: notify extensions after the response is sent
+        await _emit_after_response_send_safe(combined_response, session_id)
 
     except Exception as exc:
         logger.error("Failed to persist conversation: %s", exc, exc_info=True)

--- a/autobot-backend/chat_workflow/internal_prompt_filter_test.py
+++ b/autobot-backend/chat_workflow/internal_prompt_filter_test.py
@@ -14,6 +14,8 @@ Proves:
       lived only in models.py; manager.py had 5).
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from chat_workflow.manager import ChatWorkflowManager
@@ -109,7 +111,10 @@ class _FakeManager:
         return {}
 
     def _create_llm_iteration_context(self, *args, **kwargs):
-        return object()
+        # #13292: production reads ctx.selected_model/rag_citations/used_knowledge
+        # at the _persist_workflow_messages call site — a bare object() no longer
+        # satisfies that attribute access.
+        return SimpleNamespace(selected_model="", rag_citations=[], used_knowledge=False)
 
     async def _execute_llm_continuation_loop(self, ctx):
         # Model echoed the internal prompt then produced the real answer.
@@ -118,7 +123,10 @@ class _FakeManager:
     async def _persist_conversation(self, session_id, session, message, llm_response):
         self.persisted["conversation"] = llm_response
 
-    async def _persist_workflow_messages(self, session_id, workflow_messages, combined_response):
+    async def _persist_workflow_messages(self, session_id, workflow_messages, combined_response, **_kwargs):
+        # #13292: production now calls this with keyword-only selected_model/
+        # rag_citations/used_knowledge — accept and ignore them here since this
+        # fake only asserts on the filtered text, not persisted metadata.
         self.persisted["workflow"] = combined_response
 
     async def _fire_stop_hook(self, *args, **kwargs):

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2961,6 +2961,43 @@ before summarizing.
             sources=sources,
         )
 
+    def _build_workflow_message_batch(self, chat_mgr, workflow_messages: List[WorkflowMessage]) -> List[Dict[str, Any]]:
+        """Build the chat-history message dicts for one turn's WorkflowMessages.
+
+        Issue #13296: extracted from ``_persist_workflow_messages`` (Extract
+        Method, matching the rest of this module's convention for keeping
+        functions short).
+        """
+        batch = []
+        for wf_msg in workflow_messages:
+            # Skip segment_complete markers — internal stream control
+            # messages with empty content (Issue #1141).
+            if wf_msg.type == "segment_complete":
+                continue
+
+            sender = "system" if wf_msg.type == "terminal_output" else "assistant"
+            # #11545 (cosmetic): the persisted chat-history entry is the
+            # final user-visible reply — strip any <TOOL_CALL ...> tag
+            # that never matched the full grammar (genuinely unparsed)
+            # so raw markup never renders. Guarded no-op otherwise.
+            content = strip_unparsed_tool_tags(wf_msg.content)
+            # Issue #4448: Extract KB-only citations into top-level sources list.
+            # metadata.citations includes the always-appended llm_training entry —
+            # filter it out so sources contains only knowledge-base references.
+            raw_citations = (wf_msg.metadata or {}).get("citations", [])
+            kb_citations = [c for c in raw_citations if c.get("type") == "knowledge_base"]
+            batch.append(
+                chat_mgr._build_message_dict(
+                    sender,
+                    content,
+                    wf_msg.type,
+                    wf_msg.metadata,
+                    None,
+                    sources=_kb_sources_from_citations(kb_citations),
+                )
+            )
+        return batch
+
     async def _persist_workflow_messages(
         self,
         session_id: str,
@@ -2992,36 +3029,7 @@ before summarizing.
 
         try:
             chat_mgr = ChatHistoryManager()
-
-            # Build message dicts in memory, then persist in one batch
-            batch = []
-            for wf_msg in workflow_messages:
-                # Skip segment_complete markers — internal stream control
-                # messages with empty content (Issue #1141).
-                if wf_msg.type == "segment_complete":
-                    continue
-
-                sender = "system" if wf_msg.type == "terminal_output" else "assistant"
-                # #11545 (cosmetic): the persisted chat-history entry is the
-                # final user-visible reply — strip any <TOOL_CALL ...> tag
-                # that never matched the full grammar (genuinely unparsed)
-                # so raw markup never renders. Guarded no-op otherwise.
-                content = strip_unparsed_tool_tags(wf_msg.content)
-                # Issue #4448: Extract KB-only citations into top-level sources list.
-                # metadata.citations includes the always-appended llm_training entry —
-                # filter it out so sources contains only knowledge-base references.
-                raw_citations = (wf_msg.metadata or {}).get("citations", [])
-                kb_citations = [c for c in raw_citations if c.get("type") == "knowledge_base"]
-                batch.append(
-                    chat_mgr._build_message_dict(
-                        sender,
-                        content,
-                        wf_msg.type,
-                        wf_msg.metadata,
-                        None,
-                        sources=_kb_sources_from_citations(kb_citations),
-                    )
-                )
+            batch = self._build_workflow_message_batch(chat_mgr, workflow_messages)
 
             # Issue #13214: add the completed streamed reply. Without this the
             # batch holds only non-streaming side messages (terminal output, errors)

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -83,6 +83,27 @@ _TOOL_CALL_OPENING_RE = TOOL_CALL_OPENING_RE
 # canonical `filter_internal_prompts` in chat_workflow.models (imported above).
 
 
+def _kb_sources_from_citations(citations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Map raw knowledge-base citation dicts to the persisted sources shape.
+
+    Issue #13296: extracted from ``_persist_workflow_messages`` — was
+    duplicated inline for the per-``WorkflowMessage`` citation list (already
+    tagged ``type='knowledge_base'`` by ``_build_source_list``) and, per
+    #13292, for the completed streamed reply's citations (the raw
+    ``rag_citations`` list, which never carries the always-appended
+    ``llm_training`` placeholder in the first place).
+    """
+    return [
+        {
+            "title": c.get("title") or c.get("source", ""),
+            "path": c.get("source", ""),
+            "score": c.get("score", 0.0),
+            "chunk_id": c.get("id", ""),
+        }
+        for c in citations
+    ]
+
+
 async def _resolve_reasoning_effort(context: Dict[str, Any]) -> str:
     """Resolve reasoning effort with priority: per-request > user-default > 'auto'.
 
@@ -2897,6 +2918,9 @@ before summarizing.
         chat_mgr,
         llm_response: str,
         batch: List[Dict[str, Any]],
+        selected_model: str = "",
+        rag_citations: List[Dict[str, Any]] | None = None,
+        used_knowledge: bool = False,
     ) -> Dict[str, Any] | None:
         """Build the chat-history entry for the completed streamed reply (#13214).
 
@@ -2907,6 +2931,14 @@ before summarizing.
         reply "is persisted in _persist_workflow_messages". That was never true:
         ``llm_response`` arrived here and was dropped, so a conversational streamed
         reply persisted nothing and ``chat:session:*`` read back user-turns only.
+
+        Issue #13292: the streamed chunks carried ``metadata.model`` and KB
+        citations (built by ``_build_stream_chunk_message``/``_build_source_list``)
+        but, being streaming, were never the entries actually persisted — so the
+        persisted turn had no model badge and ``sources: []`` regardless of
+        whether the knowledge base was used. ``selected_model``/``rag_citations``
+        mirror what the discarded chunks carried, sourced from the same
+        ``LLMIterationContext``/state the caller already threads through RAG.
 
         Returns None when there is nothing to add — an empty reply, or an assistant
         entry in *batch* already carrying byte-identical text. The scan is restricted
@@ -2919,13 +2951,14 @@ before summarizing.
         assistant_texts = ((e.get("text") or "").strip() for e in batch if e.get("sender") == "assistant")
         if any(text == content for text in assistant_texts):
             return None
+        sources = _kb_sources_from_citations(rag_citations or []) if used_knowledge else []
         return chat_mgr._build_message_dict(
             "assistant",
             content,
             "response",
-            {"message_type": "llm_response", "streamed": True},
+            {"message_type": "llm_response", "streamed": True, "model": selected_model},
             None,
-            sources=[],
+            sources=sources,
         )
 
     async def _persist_workflow_messages(
@@ -2933,6 +2966,10 @@ before summarizing.
         session_id: str,
         workflow_messages: List[WorkflowMessage],
         llm_response: str,
+        *,
+        selected_model: str = "",
+        rag_citations: List[Dict[str, Any]] | None = None,
+        used_knowledge: bool = False,
     ) -> None:
         """Persist WorkflowMessages to chat history in a single batch.
 
@@ -2941,6 +2978,15 @@ before summarizing.
         of N individual add_message() calls.
         Issue #13214: also persist *llm_response* — the completed streamed reply —
         which every caller already passes but which was previously ignored.
+        Issue #13292: ``selected_model``/``rag_citations``/``used_knowledge`` let
+        the completed-reply entry carry the same model badge and KB citations the
+        (discarded) streaming chunks carried — keyword-only and defaulted so
+        existing callers (incl. the error-turn path, which never has a model to
+        report) are unaffected.
+        Issue #13295: the completed reply is chronologically the FIRST thing the
+        user watched a tool-using turn stream (prose, then any tool calls/output)
+        — it is inserted at the front of the batch, not appended after the tool
+        entries, so a reload preserves that order instead of inverting it.
         """
         from chat_history import ChatHistoryManager
 
@@ -2965,16 +3011,7 @@ before summarizing.
                 # metadata.citations includes the always-appended llm_training entry —
                 # filter it out so sources contains only knowledge-base references.
                 raw_citations = (wf_msg.metadata or {}).get("citations", [])
-                sources = [
-                    {
-                        "title": c.get("title") or c.get("source", ""),
-                        "path": c.get("source", ""),
-                        "score": c.get("score", 0.0),
-                        "chunk_id": c.get("id", ""),
-                    }
-                    for c in raw_citations
-                    if c.get("type") == "knowledge_base"
-                ]
+                kb_citations = [c for c in raw_citations if c.get("type") == "knowledge_base"]
                 batch.append(
                     chat_mgr._build_message_dict(
                         sender,
@@ -2982,16 +3019,26 @@ before summarizing.
                         wf_msg.type,
                         wf_msg.metadata,
                         None,
-                        sources=sources,
+                        sources=_kb_sources_from_citations(kb_citations),
                     )
                 )
 
-            # Issue #13214: append the completed streamed reply. Without this the
+            # Issue #13214: add the completed streamed reply. Without this the
             # batch holds only non-streaming side messages (terminal output, errors)
             # and a plain conversational turn writes nothing at all.
-            final_entry = self._build_final_response_entry(chat_mgr, llm_response, batch)
+            # Issue #13295: inserted FIRST — it is the reply text the user watched
+            # stream before any tool call in the same turn executed, so a reload
+            # must show it first too, not after the tool output it preceded live.
+            final_entry = self._build_final_response_entry(
+                chat_mgr,
+                llm_response,
+                batch,
+                selected_model=selected_model,
+                rag_citations=rag_citations,
+                used_knowledge=used_knowledge,
+            )
             if final_entry:
-                batch.append(final_entry)
+                batch.insert(0, final_entry)
 
             if batch:
                 await chat_mgr.add_messages_batch(session_id, batch)
@@ -3282,7 +3329,14 @@ before summarizing.
         # internal-prompt echo is present, so legitimate output is never altered.
         combined_response = self._filter_internal_prompts("\n\n".join(all_llm_responses))
         await self._persist_conversation(session_id, session, message, combined_response)
-        await self._persist_workflow_messages(session_id, workflow_messages, combined_response)
+        await self._persist_workflow_messages(
+            session_id,
+            workflow_messages,
+            combined_response,
+            selected_model=ctx.selected_model,
+            rag_citations=ctx.rag_citations,
+            used_knowledge=ctx.used_knowledge,
+        )
 
         # Issue #5073: fire-and-forget memory tasks via stop hook (non-blocking).
         # Replaces the direct verbatim-store asyncio.create_task from #5070 with

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2998,6 +2998,41 @@ before summarizing.
             )
         return batch
 
+    def _build_persist_batch(
+        self,
+        chat_mgr,
+        workflow_messages: List[WorkflowMessage],
+        llm_response: str,
+        selected_model: str,
+        rag_citations: List[Dict[str, Any]] | None,
+        used_knowledge: bool,
+    ) -> List[Dict[str, Any]]:
+        """Build the full persisted batch for one turn: tool entries + completed reply.
+
+        Extracted from ``_persist_workflow_messages`` (#13296 / #13303 review).
+        Issue #13214: the completed reply is appended LAST. Issue #13295
+        (investigated, NOT fixed): that is only correct for the common
+        2+-iteration tool turn (prose1 -> tool_output -> prose2-the-answer,
+        collapsed by ``"\\n\\n".join(all_llm_responses)`` into the one string
+        received here, which legitimately follows the tool output) — it is
+        known-wrong for a single-iteration turn, where the lone prose blob
+        preceded the tool call live. See ``streamed_reply_persistence_test.py``
+        for both cases documented; fixing this needs per-iteration data this
+        signature does not carry (tracked on #13295, out of scope here).
+        """
+        batch = self._build_workflow_message_batch(chat_mgr, workflow_messages)
+        final_entry = self._build_final_response_entry(
+            chat_mgr,
+            llm_response,
+            batch,
+            selected_model=selected_model,
+            rag_citations=rag_citations,
+            used_knowledge=used_knowledge,
+        )
+        if final_entry:
+            batch.append(final_entry)
+        return batch
+
     async def _persist_workflow_messages(
         self,
         session_id: str,
@@ -3019,34 +3054,16 @@ before summarizing.
         the completed-reply entry carry the same model badge and KB citations the
         (discarded) streaming chunks carried — keyword-only and defaulted so
         existing callers (incl. the error-turn path, which never has a model to
-        report) are unaffected.
-        Issue #13295: the completed reply is chronologically the FIRST thing the
-        user watched a tool-using turn stream (prose, then any tool calls/output)
-        — it is inserted at the front of the batch, not appended after the tool
-        entries, so a reload preserves that order instead of inverting it.
+        report) are unaffected. See ``_build_persist_batch`` for turn-ordering
+        details (#13295).
         """
         from chat_history import ChatHistoryManager
 
         try:
             chat_mgr = ChatHistoryManager()
-            batch = self._build_workflow_message_batch(chat_mgr, workflow_messages)
-
-            # Issue #13214: add the completed streamed reply. Without this the
-            # batch holds only non-streaming side messages (terminal output, errors)
-            # and a plain conversational turn writes nothing at all.
-            # Issue #13295: inserted FIRST — it is the reply text the user watched
-            # stream before any tool call in the same turn executed, so a reload
-            # must show it first too, not after the tool output it preceded live.
-            final_entry = self._build_final_response_entry(
-                chat_mgr,
-                llm_response,
-                batch,
-                selected_model=selected_model,
-                rag_citations=rag_citations,
-                used_knowledge=used_knowledge,
+            batch = self._build_persist_batch(
+                chat_mgr, workflow_messages, llm_response, selected_model, rag_citations, used_knowledge
             )
-            if final_entry:
-                batch.insert(0, final_entry)
 
             if batch:
                 await chat_mgr.add_messages_batch(session_id, batch)

--- a/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
+++ b/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
@@ -152,15 +152,27 @@ class TestStreamedReplyIsReadableAfterReload:
         assert [m["text"] for m in _assistant_turns(reloaded)] == [REPLY]
 
     @pytest.mark.asyncio
-    async def test_reply_precedes_tool_output_on_reload(self, store):
-        """Issue #13295: the reload order must match what the user watched live.
+    async def test_reply_appended_after_tool_output(self, store):
+        """Issue #13295 (investigated, NOT fixed here): documents the CURRENT order.
 
-        The completed reply streams to the user BEFORE any tool call in the same
-        turn executes (the model writes its prose, then emits a tool-call tag).
-        ``workflow_messages`` only ever holds the non-streaming tool entries
-        appended chronologically AFTER that prose — so the reply must be
-        inserted first, not appended last, or a reload inverts what was watched
-        (tool output -> reply instead of reply -> tool output).
+        A front-insertion fix was tried and reverted after code review: it
+        assumed the reply is always chronologically first, which only holds
+        for a single-iteration turn. The common case is 2+ iterations —
+        prose1 -> tool call -> terminal_output -> prose2 (the actual answer,
+        a SECOND LLM pass) — and "\n\n".join(all_llm_responses) collapses
+        both prose segments into the one string this function receives, which
+        legitimately belongs AFTER the tool output it was derived from.
+        Appending (this test) is therefore correct for the common case and
+        matches pre-PR behavior.
+
+        It is still WRONG for the single-iteration case (one prose blob
+        emitted BEFORE the only tool call, no second LLM pass) — see
+        ``test_two_iteration_turn_reload_order_matches_live_order`` below for
+        the case this DOES get right, and #13295 for the real fix (needs
+        _persist_workflow_messages to receive the per-iteration response list
+        plus an iteration marker on workflow_messages, so each prose segment
+        can be interleaved at its true position instead of collapsed to one
+        string with a single insertion point).
         """
         wf_messages = [
             SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={}),
@@ -169,8 +181,35 @@ class TestStreamedReplyIsReadableAfterReload:
         await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, REPLY)
 
         persisted = await store.load_session(SESSION_ID)
-        assert [m["sender"] for m in persisted] == ["assistant", "system"]
-        assert persisted[0]["text"] == REPLY
+        assert [m["sender"] for m in persisted] == ["system", "assistant"]
+        assert persisted[-1]["text"] == REPLY
+
+    @pytest.mark.asyncio
+    async def test_two_iteration_turn_reload_order_matches_live_order(self, store):
+        """Baseline for #13295: a genuine 2-iteration tool turn reloads correctly.
+
+        iteration 1: model streams "Let me check." then calls a tool.
+        iteration 2 (continuation, AFTER the tool result comes back): model
+        streams "Uptime is 3 days." — the actual answer.
+        combined_response = "Let me check.\n\nUptime is 3 days." (see
+        manager.py's ``"\n\n".join(all_llm_responses)`` / graph.py's
+        equivalent). The tool output belongs BETWEEN the two prose segments
+        live, but since both collapse into one persisted string, appending
+        that string after the tool output is the closest available
+        approximation with the current signature — not a regression to fix
+        here, just documented as the target the real interleaving fix must
+        preserve.
+        """
+        combined_response = "Let me check.\n\nUptime is 3 days."
+        wf_messages = [
+            SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={}),
+        ]
+
+        await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, combined_response)
+
+        persisted = await store.load_session(SESSION_ID)
+        assert [m["sender"] for m in persisted] == ["system", "assistant"]
+        assert persisted[-1]["text"] == combined_response
 
 
 class TestNoDuplicateOrEmptyTurns:

--- a/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
+++ b/autobot-backend/chat_workflow/streamed_reply_persistence_test.py
@@ -152,8 +152,16 @@ class TestStreamedReplyIsReadableAfterReload:
         assert [m["text"] for m in _assistant_turns(reloaded)] == [REPLY]
 
     @pytest.mark.asyncio
-    async def test_reply_appended_after_tool_output(self, store):
-        """A tool-using turn keeps its terminal output AND gains the final reply, last."""
+    async def test_reply_precedes_tool_output_on_reload(self, store):
+        """Issue #13295: the reload order must match what the user watched live.
+
+        The completed reply streams to the user BEFORE any tool call in the same
+        turn executes (the model writes its prose, then emits a tool-call tag).
+        ``workflow_messages`` only ever holds the non-streaming tool entries
+        appended chronologically AFTER that prose — so the reply must be
+        inserted first, not appended last, or a reload inverts what was watched
+        (tool output -> reply instead of reply -> tool output).
+        """
         wf_messages = [
             SimpleNamespace(type="terminal_output", content="uptime: 3 days", metadata={}),
         ]
@@ -161,8 +169,8 @@ class TestStreamedReplyIsReadableAfterReload:
         await ChatWorkflowManager._persist_workflow_messages(_manager(), SESSION_ID, wf_messages, REPLY)
 
         persisted = await store.load_session(SESSION_ID)
-        assert [m["sender"] for m in persisted] == ["system", "assistant"]
-        assert persisted[-1]["text"] == REPLY
+        assert [m["sender"] for m in persisted] == ["assistant", "system"]
+        assert persisted[0]["text"] == REPLY
 
 
 class TestNoDuplicateOrEmptyTurns:
@@ -193,3 +201,59 @@ class TestNoDuplicateOrEmptyTurns:
         persisted = await store.load_session(SESSION_ID)
         assert len(persisted) == 1
         assert persisted[0]["text"] == "The assistant could not respond."
+
+
+class TestFinalReplyCarriesModelAndCitations:
+    """Issue #13292: the persisted turn must carry the same model badge and KB
+
+    citations the (discarded) streaming chunks carried — not ``sources: []``
+    and no ``model`` regardless of what was actually used to answer.
+    """
+
+    MODEL = "claude-sonnet-5"
+    CITATIONS = [
+        {"title": "Runbook", "source": "kb/runbook.md", "score": 0.91, "id": "chunk-1"},
+    ]
+
+    @pytest.mark.asyncio
+    async def test_model_is_recorded_on_the_persisted_turn(self, store):
+        """FAILS pre-fix: metadata has no 'model' key at all."""
+        await ChatWorkflowManager._persist_workflow_messages(
+            _manager(), SESSION_ID, [], REPLY, selected_model=self.MODEL
+        )
+
+        persisted = await store.load_session(SESSION_ID)
+        assert _assistant_turns(persisted)[0]["metadata"]["model"] == self.MODEL
+
+    @pytest.mark.asyncio
+    async def test_kb_citations_become_sources_when_knowledge_was_used(self, store):
+        """FAILS pre-fix: sources is always [] no matter what rag_citations held."""
+        await ChatWorkflowManager._persist_workflow_messages(
+            _manager(),
+            SESSION_ID,
+            [],
+            REPLY,
+            selected_model=self.MODEL,
+            rag_citations=self.CITATIONS,
+            used_knowledge=True,
+        )
+
+        persisted = await store.load_session(SESSION_ID)
+        sources = _assistant_turns(persisted)[0]["sources"]
+        assert sources == [{"title": "Runbook", "path": "kb/runbook.md", "score": 0.91, "chunk_id": "chunk-1"}]
+
+    @pytest.mark.asyncio
+    async def test_citations_omitted_when_knowledge_was_not_used(self, store):
+        """used_knowledge=False must not leak stale/irrelevant citations into sources."""
+        await ChatWorkflowManager._persist_workflow_messages(
+            _manager(),
+            SESSION_ID,
+            [],
+            REPLY,
+            selected_model=self.MODEL,
+            rag_citations=self.CITATIONS,
+            used_knowledge=False,
+        )
+
+        persisted = await store.load_session(SESSION_ID)
+        assert _assistant_turns(persisted)[0]["sources"] == []

--- a/autobot-backend/tasks/chat_retention.py
+++ b/autobot-backend/tasks/chat_retention.py
@@ -20,6 +20,7 @@ from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config as ssot_config
+from autobot_shared.ssot_constants import REDIS_KEY
 from celery_app import celery_app
 from services.audit.audit import AuditCategory, AuditEvent
 from services.audit.audit import emit as audit_emit
@@ -33,7 +34,9 @@ _CHAT_RETENTION_DAYS = ssot_config.chat_retention_days
 _RECENT_KEY = "chat:recent"
 # Prefix for individual session JSON blobs
 _SESSION_PREFIX = "chat:session:"
-_CONVERSATION_PREFIX = "chat:conversation:"
+# #13303: single source in REDIS_KEY.CHAT_CONVERSATION_PREFIX — was its own
+# duplicated module constant here.
+_CONVERSATION_PREFIX = REDIS_KEY.CHAT_CONVERSATION_PREFIX
 
 
 def _is_keep_forever(raw: bytes) -> bool:

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -441,6 +441,11 @@ class RedisKeyConstants:
     CHAT_RECENT: str = "chat:recent"
     CHAT_FOLDERS: str = "chat:folders:{username}"
     LLM_MODELS_CACHE: str = "llm_models"
+    # #13303: single source for the `{user, assistant}` pair-history prefix —
+    # was duplicated inline in chat_workflow/conversation.py, as
+    # tasks/chat_retention.py's own module constant, and again in
+    # chat_history/session_reply_backfill.py.
+    CHAT_CONVERSATION_PREFIX: str = "chat:conversation:"
 
 
 REDIS_KEY = RedisKeyConstants()


### PR DESCRIPTION
## Thinking Path

#13214 made the completed streamed reply reach `chat:session:*` at all. What it wrote was bare-bones: metadata that existed only on the *discarded* streaming chunks never made it into the persisted entry. This PR fixes that, and — after review — deliberately does **not** attempt two of the four issues it started with.

- **#13292**: `_build_final_response_entry` hardcoded `sources: []` and never wrote `metadata.model`. Those lived only on the dropped streaming chunks (`manager.py:456`, `:632`, `:673`). Fix: thread `selected_model`/`rag_citations`/`used_knowledge` from the same `LLMIterationContext` (legacy loop) / graph `state` (LangGraph path) the caller already holds. Both paths, not one.
- **#13296**: folded in while already inside `_persist_workflow_messages` — extracted the duplicated citation-mapping block into `_kb_sources_from_citations()`, and the per-message loop into `_build_workflow_message_batch()`.

### #13295 and #13293 are NOT closed here — review round 2

**#13295 (reload order)** was originally "fixed" by inserting the reply at the front of the batch. Review showed the premise is false for the common case. The reply is chronologically first only on a **single-iteration** turn. A tool-using turn normally runs two iterations (`manager.py:2841`; `_check_continuation_decision` at `:2515-2555` returns True after a normal tool execution), each appending its own prose (`:2864`), and every segment is collapsed into one string by `"\n\n".join(all_llm_responses)` (`:3338`, `graph.py:1315`). Live order is `prose1 -> tool output -> prose2(the answer)`. Front-insertion therefore put the final answer **before** the tool output it was derived from, and left the session ending on a `sender="system"` terminal dump — a user-visible regression on the most common tool path.

Reverted to `batch.append(final_entry)`. `test_reply_appended_after_tool_output` keeps its original assertion, with a docstring recording why front-insertion is wrong. Added `test_two_iteration_turn_reload_order_matches_live_order` as a documented baseline for the real fix, which needs per-iteration data (`all_llm_responses: list[str]` plus an iteration marker on `workflow_messages`) and is its own change.

**#13293 (backfill)** had two defects, both found by the reviewer running the module:

1. **It double-posted into healthy sessions.** Damage was judged by checking only `i+1`, but pre-#13214 tool turns persist `terminal_output` as `sender="system"` (`manager.py:2967-2978`), so a turn that *did* save its reply reads back as `[user, system, assistant]` and looked damaged — inserting a duplicate reply into a session needing no repair.
2. **It could not repair the sessions it was built for.** It read only `chat:conversation:{id}`, which has a 24h TTL, while every session damaged by #13214 is by definition in the past. It would have reported `0` and exited cleanly.

Both fixed below, but the module has still never run against real data, so it does not clear closure Gate 3. #13293 stays open with a task to run it against real damaged sessions and attach before/after evidence.

## What Changed

**`autobot-backend/chat_workflow/manager.py`**
- New `_kb_sources_from_citations()` helper (#13296).
- `_build_final_response_entry()` accepts `selected_model`/`rag_citations`/`used_knowledge`, sets `metadata.model` and KB-derived `sources` (#13292).
- New `_build_workflow_message_batch()` and `_build_persist_batch()` extracted from `_persist_workflow_messages()` (#13296).
- `_persist_workflow_messages()` gains keyword-only `selected_model`/`rag_citations`/`used_knowledge` (defaulted — existing callers unaffected) and **appends** the completed-reply entry, unchanged from pre-PR order.

**`autobot-backend/chat_workflow/graph.py`** — `persist_conversation` threads the same three values from `state`; decomposed into `_emit_before_response_send_safe`, `_emit_after_response_send_safe`, `_build_workflow_messages_from_state`.

**`autobot-backend/chat_history/session_reply_backfill.py`** (new, unwired)
- `_find_turn_end()` + turn-window scan: a turn is damaged only when **no** assistant entry exists before the next user message. Insertion at `turn_end`, after tool/system entries.
- `_load_conversation_pairs()`: Redis `chat:conversation:*` first, falling back to `_load_transcript_pairs()` reading the full `data/conversation_transcripts/{id}.json` (durable, no TTL — unlike production's last-10-truncated loader).
- Documented as an unlocked read-modify-write: run only against an idle session.

**`autobot_shared/ssot_constants.py`** — added `REDIS_KEY.CHAT_CONVERSATION_PREFIX`; `chat_workflow/conversation.py` and `tasks/chat_retention.py` now import it, removing a triplicated literal.

## Verification

**After:** `chat_workflow/ chat_history/ api/chat_phase2_test.py api/chat_phase4_test.py` -> **460 passed**.

**Before (red state):** production code reverted via `git checkout` with test files kept at their fixed versions -> **10 failures**, including the double-post reproduction (`assert 1 == 0`) and `TypeError: unexpected keyword argument 'transcript_dir'` on every transcript-fallback test. All 10 pass after restoring the fix.

The backfill fake store subclasses the real `MessagesMixin`, so `_build_message_dict`/`add_messages_batch` are production code and only the load/save seam is in-memory. Idempotency is covered both as pure logic and end-to-end.

`black`, `isort`, `flake8` clean on every touched file.

**Not verified:** the repair module against a real Redis instance or real filesystem — only `tmp_path` and fake-Redis/fake-store paths were exercised, per the constraint never to run it against a live system. That is precisely why #13293 remains open.

## Model Used

Sonnet 5

Closes #13292, #13296
